### PR TITLE
Remove resolveHandle and IFluidHandleContext from ContainerRuntime interfaces

### DIFF
--- a/.changeset/cute-points-obey.md
+++ b/.changeset/cute-points-obey.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/container-runtime-definitions": major
+"@fluidframework/core-interfaces": major
+"@fluidframework/runtime-definitions": major
+---
+
+Removed `resolveHandle` and `IFluidHandleContext` from ContainerRuntime interfaces
+
+The `IContainerRuntime.resolveHandle(...)` method and the `IContainerRuntimeBase.IFluidHandleContext` property have been removed. Please remove all usage of these APIs.
+
+See [Removing-IFluidRouter.md](https://github.com/microsoft/FluidFramework/blob/main/packages/common/core-interfaces/Removing-IFluidRouter.md) for more details.

--- a/.changeset/cute-points-obey.md
+++ b/.changeset/cute-points-obey.md
@@ -1,6 +1,5 @@
 ---
 "@fluidframework/container-runtime-definitions": major
-"@fluidframework/core-interfaces": major
 "@fluidframework/runtime-definitions": major
 ---
 

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -8,7 +8,7 @@ import { assert } from '@fluidframework/core-utils';
 import { v5 as uuidv5 } from 'uuid';
 import { expect } from 'chai';
 import { LocalServerTestDriver } from '@fluid-private/test-drivers';
-import { SummaryCollection, DefaultSummaryConfiguration } from '@fluidframework/container-runtime';
+import { SummaryCollection, DefaultSummaryConfiguration, ContainerRuntime } from '@fluidframework/container-runtime';
 import { IContainerExperimental, Loader, waitContainerToCatchUp } from '@fluidframework/container-loader';
 import {
 	MockContainerRuntimeFactory,
@@ -325,7 +325,8 @@ export async function setUpLocalServerTestSharedTree(
 	}
 	const registry: ChannelFactoryRegistry = [[treeId, factory]];
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		runtime.IFluidHandleContext.resolveHandle(request);
+		// This cast is safe as ContainerRuntime.loadRuntime is used in TestContainerRuntimeFactory
+		(runtime as ContainerRuntime).resolveHandle(request);
 
 	const runtimeFactory = () =>
 		new TestContainerRuntimeFactory(

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -8,7 +8,7 @@ import { assert } from '@fluidframework/core-utils';
 import { v5 as uuidv5 } from 'uuid';
 import { expect } from 'chai';
 import { LocalServerTestDriver } from '@fluid-private/test-drivers';
-import { SummaryCollection, DefaultSummaryConfiguration, ContainerRuntime } from '@fluidframework/container-runtime';
+import { SummaryCollection, DefaultSummaryConfiguration } from '@fluidframework/container-runtime';
 import { IContainerExperimental, Loader, waitContainerToCatchUp } from '@fluidframework/container-loader';
 import {
 	MockContainerRuntimeFactory,
@@ -27,9 +27,8 @@ import {
 import type { IContainer, IHostLoader } from '@fluidframework/container-definitions';
 import type { IFluidCodeDetails, IFluidHandle, IRequestHeader } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
-import { IContainerRuntimeBase } from '@fluidframework/runtime-definitions';
 import { ConfigTypes, IConfigProviderBase, createChildLogger } from '@fluidframework/telemetry-utils';
-import { ITelemetryBaseLogger, IRequest } from '@fluidframework/core-interfaces';
+import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import {
 	AttributionId,
 	DetachedSequenceId,
@@ -324,29 +323,21 @@ export async function setUpLocalServerTestSharedTree(
 		factory = SharedTree.getFactory(writeFormat ?? WriteFormat.v0_1_1, options);
 	}
 	const registry: ChannelFactoryRegistry = [[treeId, factory]];
-	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		// This cast is safe as ContainerRuntime.loadRuntime is used in TestContainerRuntimeFactory
-		(runtime as ContainerRuntime).resolveHandle(request);
 
 	const runtimeFactory = () =>
-		new TestContainerRuntimeFactory(
-			TestDataStoreType,
-			new TestFluidObjectFactory(registry),
-			{
-				summaryOptions: {
-					summaryConfigOverrides: {
-						...DefaultSummaryConfiguration,
-						...{
-							minIdleTime: 1000, // Manually set idle times so some SharedTree tests don't timeout.
-							maxIdleTime: 1000,
-							maxTime: 1000 * 12,
-							initialSummarizerDelayMs: 0,
-						},
+		new TestContainerRuntimeFactory(TestDataStoreType, new TestFluidObjectFactory(registry), {
+			summaryOptions: {
+				summaryConfigOverrides: {
+					...DefaultSummaryConfiguration,
+					...{
+						minIdleTime: 1000, // Manually set idle times so some SharedTree tests don't timeout.
+						maxIdleTime: 1000,
+						maxTime: 1000 * 12,
+						initialSummarizerDelayMs: 0,
 					},
 				},
 			},
-			[innerRequestHandler]
-		);
+		});
 
 	const defaultCodeDetails: IFluidCodeDetails = {
 		package: 'defaultTestPackage',

--- a/packages/common/core-interfaces/Removing-IFluidRouter.md
+++ b/packages/common/core-interfaces/Removing-IFluidRouter.md
@@ -106,8 +106,8 @@ const entryPoint = await container.getEntryPoint();
 | `request` and `IFluidRouter` on `IFluidDataStoreRuntime` and `FluidDataStoreRuntime`         | 2.0.0-internal.6.0.0 |                      |
 | `request` and `IFluidRouter` on `IFluidDataStoreChannel`                                     | 2.0.0-internal.6.0.0 |                      |
 | `getRootDataStore` on `IContainerRuntime` and `ContainerRuntime`                             | 2.0.0-internal.6.0.0 |                      |
-| `resolveHandle` on `IContainerRuntime`                                                       | 2.0.0-internal.7.0.0 |                      |
-| `IFluidHandleContext` on `IContainerRuntimeBase`                                             | 2.0.0-internal.7.0.0 |                      |
+| `resolveHandle` on `IContainerRuntime`                                                       | 2.0.0-internal.7.0.0 | 2.0.0-internal.8.0.0 |
+| `IFluidHandleContext` on `IContainerRuntimeBase`                                             | 2.0.0-internal.7.0.0 | 2.0.0-internal.8.0.0 |
 | `requestHandler` property in `ContainerRuntime.loadRuntime(...)`                             | 2.0.0-internal.7.0.0 |                      |
 | `RuntimeRequestHandler` and `RuntimeRequestHandlerBuilder`                                   | 2.0.0-internal.7.0.0 |                      |
 | `request` and `IFluidRouter` on `IContainer` and `Container`                                 | 2.0.0-internal.7.0.0 | 2.0.0-internal.8.0.0 |

--- a/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.api.md
+++ b/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.api.md
@@ -45,8 +45,6 @@ export interface IContainerRuntime extends IProvideFluidDataStoreRegistry, ICont
     readonly isDirty: boolean;
     // (undocumented)
     readonly options: ILoaderOptions;
-    // @deprecated
-    resolveHandle(request: IRequest): Promise<IResponse>;
     // (undocumented)
     readonly scope: FluidObject;
     // (undocumented)

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -115,11 +115,4 @@ export interface IContainerRuntime
 	 * @param relativeUrl - A relative request within the container
 	 */
 	getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
-
-	/**
-	 * Resolves handle URI
-	 * @param request - request to resolve
-	 * @deprecated Will be removed in future major release. Migrate all usage of resolveHandle to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
-	 */
-	resolveHandle(request: IRequest): Promise<IResponse>;
 }

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -15,7 +15,6 @@ import { IDocumentStorageService } from '@fluidframework/driver-definitions';
 import { IEvent } from '@fluidframework/core-interfaces';
 import { IEventProvider } from '@fluidframework/core-interfaces';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
-import { IFluidHandleContext } from '@fluidframework/core-interfaces';
 import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { ILoaderOptions } from '@fluidframework/container-definitions';
 import { IProvideFluidHandleContext } from '@fluidframework/core-interfaces';
@@ -126,8 +125,6 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
     getAudience(): IAudience;
     getQuorum(): IQuorumClients;
-    // @deprecated (undocumented)
-    readonly IFluidHandleContext: IFluidHandleContext;
     // (undocumented)
     readonly logger: ITelemetryBaseLogger;
     orderSequentially(callback: () => void): void;

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -15,7 +15,6 @@ import {
 	IRequest,
 	IResponse,
 	FluidObject,
-	IFluidHandleContext,
 } from "@fluidframework/core-interfaces";
 import {
 	IAudience,
@@ -246,11 +245,6 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
 	 * Returns the current audience.
 	 */
 	getAudience(): IAudience;
-
-	/**
-	 * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
-	 */
-	readonly IFluidHandleContext: IFluidHandleContext;
 }
 
 /**

--- a/packages/test/local-server-tests/src/test/connectionMode.spec.ts
+++ b/packages/test/local-server-tests/src/test/connectionMode.spec.ts
@@ -24,6 +24,7 @@ import {
 } from "@fluidframework/test-utils";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 describe("Logging Last Connection Mode ", () => {
 	const documentId = "connectionModeTest";
@@ -69,7 +70,7 @@ describe("Logging Last Connection Mode ", () => {
 		);
 
 		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			runtime.IFluidHandleContext.resolveHandle(request);
+			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 			defaultFactory,
 			registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],

--- a/packages/test/local-server-tests/src/test/connectionMode.spec.ts
+++ b/packages/test/local-server-tests/src/test/connectionMode.spec.ts
@@ -7,7 +7,6 @@ import { strict as assert } from "assert";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { ConnectionState, Loader } from "@fluidframework/container-loader";
-import { IRequest } from "@fluidframework/core-interfaces";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { SharedMap } from "@fluidframework/map";
 import {
@@ -23,8 +22,6 @@ import {
 	TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
 import { MockLogger } from "@fluidframework/telemetry-utils";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
-import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 describe("Logging Last Connection Mode ", () => {
 	const documentId = "connectionModeTest";
@@ -69,12 +66,9 @@ describe("Logging Last Connection Mode ", () => {
 			"default",
 		);
 
-		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 			defaultFactory,
 			registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
-			requestHandlers: [innerRequestHandler],
 		});
 
 		const urlResolver = new LocalResolver();

--- a/packages/test/local-server-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/local-server-tests/src/test/documentDirty.spec.ts
@@ -24,6 +24,7 @@ import {
 	TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 describe("Document Dirty", () => {
 	const documentId = "documentDirtyTest";
@@ -119,7 +120,7 @@ describe("Document Dirty", () => {
 			);
 
 			const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-				runtime.IFluidHandleContext.resolveHandle(request);
+				(runtime as ContainerRuntime).resolveHandle(request);
 			const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 				defaultFactory,
 				registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
@@ -441,7 +442,7 @@ describe("Document Dirty", () => {
 			);
 
 			const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-				runtime.IFluidHandleContext.resolveHandle(request);
+				(runtime as ContainerRuntime).resolveHandle(request);
 			const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 				defaultFactory,
 				registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],

--- a/packages/test/local-server-tests/src/test/documentDirty.spec.ts
+++ b/packages/test/local-server-tests/src/test/documentDirty.spec.ts
@@ -8,7 +8,6 @@ import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqu
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { ConnectionState, Loader } from "@fluidframework/container-loader";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { IRequest } from "@fluidframework/core-interfaces";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { SharedMap } from "@fluidframework/map";
 import {
@@ -23,8 +22,6 @@ import {
 	LocalCodeLoader,
 	TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
-import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 describe("Document Dirty", () => {
 	const documentId = "documentDirtyTest";
@@ -119,12 +116,9 @@ describe("Document Dirty", () => {
 				"default",
 			);
 
-			const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-				(runtime as ContainerRuntime).resolveHandle(request);
 			const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 				defaultFactory,
 				registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
-				requestHandlers: [innerRequestHandler],
 			});
 
 			const urlResolver = new LocalResolver();
@@ -441,12 +435,9 @@ describe("Document Dirty", () => {
 				"default",
 			);
 
-			const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-				(runtime as ContainerRuntime).resolveHandle(request);
 			const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 				defaultFactory,
 				registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
-				requestHandlers: [innerRequestHandler],
 			});
 
 			const urlResolver = new LocalResolver();

--- a/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
@@ -7,16 +7,12 @@ import { strict as assert } from "assert";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
 import { IContainer, IHostLoader, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { ConnectionState, Loader } from "@fluidframework/container-loader";
-import {
-	ContainerMessageType,
-	ContainerRuntime,
-	IContainerRuntimeOptions,
-} from "@fluidframework/container-runtime";
-import { IFluidHandle, IFluidLoadable, IRequest } from "@fluidframework/core-interfaces";
+import { ContainerMessageType, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { IEnvelope, FlushMode, IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { IEnvelope, FlushMode } from "@fluidframework/runtime-definitions";
 import { createDataStoreFactory } from "@fluidframework/runtime-utils";
 import {
 	ILocalDeltaConnectionServer,
@@ -66,15 +62,12 @@ describe("Ops on Reconnect", () => {
 
 		const defaultFactory = createDataStoreFactory("default", factory);
 		const dataObject2Factory = createDataStoreFactory("dataObject2", factory);
-		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 			defaultFactory,
 			registryEntries: [
 				[defaultFactory.type, Promise.resolve(defaultFactory)],
 				[dataObject2Factory.type, Promise.resolve(dataObject2Factory)],
 			],
-			requestHandlers: [innerRequestHandler],
 			runtimeOptions,
 		});
 

--- a/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
@@ -7,7 +7,11 @@ import { strict as assert } from "assert";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
 import { IContainer, IHostLoader, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { ConnectionState, Loader } from "@fluidframework/container-loader";
-import { ContainerMessageType, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import {
+	ContainerMessageType,
+	ContainerRuntime,
+	IContainerRuntimeOptions,
+} from "@fluidframework/container-runtime";
 import { IFluidHandle, IFluidLoadable, IRequest } from "@fluidframework/core-interfaces";
 import { LocalDocumentServiceFactory, LocalResolver } from "@fluidframework/local-driver";
 import { SharedMap, SharedDirectory } from "@fluidframework/map";
@@ -63,7 +67,7 @@ describe("Ops on Reconnect", () => {
 		const defaultFactory = createDataStoreFactory("default", factory);
 		const dataObject2Factory = createDataStoreFactory("dataObject2", factory);
 		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			runtime.IFluidHandleContext.resolveHandle(request);
+			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 			defaultFactory,
 			registryEntries: [

--- a/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
@@ -12,7 +12,7 @@ import {
 	ISummarizer,
 	ISummarizeResults,
 } from "@fluidframework/container-runtime";
-import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { readAndParse } from "@fluidframework/driver-utils";
 import { seqFromTree } from "@fluidframework/runtime-utils";
 import {
@@ -23,7 +23,7 @@ import {
 	createContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/test-utils";
 import { describeNoCompat, getContainerRuntimeApi } from "@fluid-private/test-version-utils";
-import { IContainerRuntimeBase, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ISummaryContext } from "@fluidframework/driver-definitions";
 import { SharedMatrix } from "@fluidframework/matrix";
@@ -72,8 +72,6 @@ const dataStoreFactory1 = new DataObjectFactory(
 	[],
 	[],
 );
-const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-	(runtime as ContainerRuntime).resolveHandle(request);
 
 const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
 	[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
@@ -87,7 +85,6 @@ const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 	{
 		defaultFactory: dataStoreFactory1,
 		registryEntries: registryStoreEntries,
-		requestHandlers: [innerRequestHandler],
 		runtimeOptions,
 	},
 );

--- a/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
@@ -73,7 +73,7 @@ const dataStoreFactory1 = new DataObjectFactory(
 	[],
 );
 const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-	runtime.IFluidHandleContext.resolveHandle(request);
+	(runtime as ContainerRuntime).resolveHandle(request);
 
 const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
 	[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
@@ -6,12 +6,8 @@
 import { strict as assert } from "assert";
 import { DataObject, DataObjectFactory, PureDataObject } from "@fluidframework/aqueduct";
 import { IContainer } from "@fluidframework/container-definitions";
-import {
-	ContainerRuntime,
-	IContainerRuntimeOptions,
-	ISummarizer,
-} from "@fluidframework/container-runtime";
-import { FluidObject, IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
+import { IContainerRuntimeOptions, ISummarizer } from "@fluidframework/container-runtime";
+import { FluidObject, IFluidHandle } from "@fluidframework/core-interfaces";
 import { FluidDataStoreRuntime, mixinSummaryHandler } from "@fluidframework/datastore";
 import { SharedMatrix } from "@fluidframework/matrix";
 import { SharedMap } from "@fluidframework/map";
@@ -23,7 +19,7 @@ import {
 	createContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/test-utils";
 import { describeNoCompat, getContainerRuntimeApi } from "@fluid-private/test-version-utils";
-import { IContainerRuntimeBase, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { pkgVersion } from "../packageVersion.js";
 
 interface ProvideSearchContent {
@@ -128,8 +124,6 @@ const dataStoreFactory2 = new DataObjectFactory(
 	[],
 	createDataStoreRuntime(),
 );
-const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-	(runtime as ContainerRuntime).resolveHandle(request);
 
 const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
 	[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
@@ -142,7 +136,6 @@ const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 	{
 		defaultFactory: dataStoreFactory1,
 		registryEntries: registryStoreEntries,
-		requestHandlers: [innerRequestHandler],
 		runtimeOptions,
 	},
 );

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
@@ -6,7 +6,11 @@
 import { strict as assert } from "assert";
 import { DataObject, DataObjectFactory, PureDataObject } from "@fluidframework/aqueduct";
 import { IContainer } from "@fluidframework/container-definitions";
-import { IContainerRuntimeOptions, ISummarizer } from "@fluidframework/container-runtime";
+import {
+	ContainerRuntime,
+	IContainerRuntimeOptions,
+	ISummarizer,
+} from "@fluidframework/container-runtime";
 import { FluidObject, IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import { FluidDataStoreRuntime, mixinSummaryHandler } from "@fluidframework/datastore";
 import { SharedMatrix } from "@fluidframework/matrix";
@@ -125,7 +129,7 @@ const dataStoreFactory2 = new DataObjectFactory(
 	createDataStoreRuntime(),
 );
 const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-	runtime.IFluidHandleContext.resolveHandle(request);
+	(runtime as ContainerRuntime).resolveHandle(request);
 
 const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
 	[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -21,7 +21,7 @@ import {
 	neverCancelledSummaryToken,
 	SummaryCollection,
 } from "@fluidframework/container-runtime";
-import { FluidObject, IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
+import { FluidObject, IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter";
 import { FluidDataStoreRuntime, mixinSummaryHandler } from "@fluidframework/datastore";
 import { DriverHeader, ISummaryContext } from "@fluidframework/driver-definitions";
@@ -31,7 +31,7 @@ import {
 	ISummaryTree,
 	MessageType,
 } from "@fluidframework/protocol-definitions";
-import { IContainerRuntimeBase, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import {
 	ITestObjectProvider,
 	wrapDocumentServiceFactory,
@@ -250,8 +250,6 @@ describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider
 	const runtimeOptions: IContainerRuntimeOptions = {
 		gcOptions: { gcAllowed: true },
 	};
-	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		(runtime as ContainerRuntime).resolveHandle(request);
 	const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
 		[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
 		[dataStoreFactory2.type, Promise.resolve(dataStoreFactory2)],
@@ -259,7 +257,6 @@ describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider
 	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 		defaultFactory: dataStoreFactory1,
 		registryEntries: registryStoreEntries,
-		requestHandlers: [innerRequestHandler],
 		runtimeOptions,
 	});
 	const logger = createChildLogger();

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -251,7 +251,7 @@ describeNoCompat("Prepare for Summary with Search Blobs", (getTestObjectProvider
 		gcOptions: { gcAllowed: true },
 	};
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		runtime.IFluidHandleContext.resolveHandle(request);
+		(runtime as ContainerRuntime).resolveHandle(request);
 	const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
 		[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
 		[dataStoreFactory2.type, Promise.resolve(dataStoreFactory2)],

--- a/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
@@ -12,10 +12,7 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils";
 import { describeFullCompat } from "@fluid-private/test-version-utils";
-import { IRequest } from "@fluidframework/core-interfaces";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { IContainer } from "@fluidframework/container-definitions";
-import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 describeFullCompat("Audience correctness", (getTestObjectProvider, apis) => {
 	class TestDataObject extends apis.dataRuntime.DataObject {
@@ -31,14 +28,11 @@ describeFullCompat("Audience correctness", (getTestObjectProvider, apis) => {
 		[],
 		[],
 	);
-	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 		apis.containerRuntime.ContainerRuntimeFactoryWithDefaultDataStore,
 		{
 			defaultFactory: dataObjectFactory,
 			registryEntries: [[dataObjectFactory.type, Promise.resolve(dataObjectFactory)]],
-			requestHandlers: [innerRequestHandler],
 			// Disable summaries so the summarizer client doesn't interfere with the audience
 			runtimeOptions: {
 				summaryOptions: {

--- a/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/audience.spec.ts
@@ -15,6 +15,7 @@ import { describeFullCompat } from "@fluid-private/test-version-utils";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { IContainer } from "@fluidframework/container-definitions";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 describeFullCompat("Audience correctness", (getTestObjectProvider, apis) => {
 	class TestDataObject extends apis.dataRuntime.DataObject {
@@ -31,7 +32,7 @@ describeFullCompat("Audience correctness", (getTestObjectProvider, apis) => {
 		[],
 	);
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		runtime.IFluidHandleContext.resolveHandle(request);
+		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 		apis.containerRuntime.ContainerRuntimeFactoryWithDefaultDataStore,
 		{

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -294,7 +294,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 
 	it("Delta manager receives readonly event when calling container.forceReadonly()", async () => {
 		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			runtime.IFluidHandleContext.resolveHandle(request);
+			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = (_?: unknown) =>
 			new TestContainerRuntimeFactory(TestDataObjectType, getDataStoreFactory(), {}, [
 				innerRequestHandler,
@@ -384,7 +384,7 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 
 	it("can control op processing with connect() and disconnect()", async () => {
 		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			runtime.IFluidHandleContext.resolveHandle(request);
+			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = (_?: unknown) =>
 			new TestContainerRuntimeFactory(TestDataObjectType, getDataStoreFactory(), {}, [
 				innerRequestHandler,

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -44,7 +44,6 @@ import {
 	describeNoCompat,
 	itExpects,
 } from "@fluid-private/test-version-utils";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import {
 	ConfigTypes,
 	DataCorruptionError,
@@ -293,12 +292,8 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 	});
 
 	it("Delta manager receives readonly event when calling container.forceReadonly()", async () => {
-		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = (_?: unknown) =>
-			new TestContainerRuntimeFactory(TestDataObjectType, getDataStoreFactory(), {}, [
-				innerRequestHandler,
-			]);
+			new TestContainerRuntimeFactory(TestDataObjectType, getDataStoreFactory(), {});
 
 		const localTestObjectProvider = new TestObjectProvider(
 			Loader,
@@ -383,12 +378,8 @@ describeNoCompat("Container", (getTestObjectProvider) => {
 	});
 
 	it("can control op processing with connect() and disconnect()", async () => {
-		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = (_?: unknown) =>
-			new TestContainerRuntimeFactory(TestDataObjectType, getDataStoreFactory(), {}, [
-				innerRequestHandler,
-			]);
+			new TestContainerRuntimeFactory(TestDataObjectType, getDataStoreFactory(), {});
 
 		const localTestObjectProvider = new TestObjectProvider(
 			Loader,

--- a/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
@@ -12,10 +12,7 @@ import {
 	IContainerRuntimeOptions,
 	SummaryCollection,
 	ISummaryConfiguration,
-	ContainerRuntime,
 } from "@fluidframework/container-runtime";
-import { IRequest } from "@fluidframework/core-interfaces";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { MockLogger, createChildLogger } from "@fluidframework/telemetry-utils";
 import {
 	ITestObjectProvider,
@@ -60,14 +57,11 @@ describeNoCompat("Generate Summary Stats", (getTestObjectProvider, apis) => {
 			gcAllowed: true,
 		},
 	};
-	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 		ContainerRuntimeFactoryWithDefaultDataStore,
 		{
 			defaultFactory: dataObjectFactory,
 			registryEntries: [[dataObjectFactory.type, Promise.resolve(dataObjectFactory)]],
-			requestHandlers: [innerRequestHandler],
 			runtimeOptions,
 		},
 	);

--- a/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
@@ -12,6 +12,7 @@ import {
 	IContainerRuntimeOptions,
 	SummaryCollection,
 	ISummaryConfiguration,
+	ContainerRuntime,
 } from "@fluidframework/container-runtime";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
@@ -60,7 +61,7 @@ describeNoCompat("Generate Summary Stats", (getTestObjectProvider, apis) => {
 		},
 	};
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		runtime.IFluidHandleContext.resolveHandle(request);
+		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 		ContainerRuntimeFactoryWithDefaultDataStore,
 		{

--- a/packages/test/test-end-to-end-tests/src/test/dataStoreRetrieval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/dataStoreRetrieval.spec.ts
@@ -4,15 +4,13 @@
  */
 
 import { strict as assert } from "assert";
-import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
 import {
 	ITestObjectProvider,
 	createContainerRuntimeFactoryWithDefaultDataStore,
 	getContainerEntryPointBackCompat,
 } from "@fluidframework/test-utils";
 import { describeFullCompat, ITestDataObject } from "@fluid-private/test-version-utils";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
-import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 /**
  * These tests retrieve a data store after its creation but at different stages of visibility.
@@ -87,8 +85,6 @@ describeFullCompat(
 		);
 
 		let provider: ITestObjectProvider;
-		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			(runtime as ContainerRuntime).resolveHandle(request);
 
 		beforeEach(() => {
 			provider = getTestObjectProvider();
@@ -103,7 +99,6 @@ describeFullCompat(
 						[outerDataObjectFactory.type, Promise.resolve(outerDataObjectFactory)],
 						[innerDataObjectFactory.type, Promise.resolve(innerDataObjectFactory)],
 					],
-					requestHandlers: [innerRequestHandler],
 				},
 			);
 			const request = provider.driver.createCreateNewRequest(provider.documentId);
@@ -129,7 +124,6 @@ describeFullCompat(
 						[outerDataObjectFactory.type, Promise.resolve(outerDataObjectFactory)],
 						[innerDataObjectFactory.type, Promise.resolve(innerDataObjectFactory)],
 					],
-					requestHandlers: [innerRequestHandler],
 				},
 			);
 			const request = provider.driver.createCreateNewRequest(provider.documentId);

--- a/packages/test/test-end-to-end-tests/src/test/dataStoreRetrieval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/dataStoreRetrieval.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "@fluidframework/test-utils";
 import { describeFullCompat, ITestDataObject } from "@fluid-private/test-version-utils";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 /**
  * These tests retrieve a data store after its creation but at different stages of visibility.
@@ -87,7 +88,7 @@ describeFullCompat(
 
 		let provider: ITestObjectProvider;
 		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			runtime.IFluidHandleContext.resolveHandle(request);
+			(runtime as ContainerRuntime).resolveHandle(request);
 
 		beforeEach(() => {
 			provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/fluidObjectHandle.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/fluidObjectHandle.spec.ts
@@ -16,6 +16,7 @@ import {
 	ITestDataObject,
 	TestDataObjectType,
 } from "@fluid-private/test-version-utils";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 describeFullCompat("FluidObjectHandle", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
@@ -49,8 +50,9 @@ describeFullCompat("FluidObjectHandle", (getTestObjectProvider) => {
 		const absolutePath = "";
 
 		// Verify that the local client's ContainerRuntime has the correct absolute path.
-		const containerRuntime1 =
-			firstContainerObject1._context.containerRuntime.IFluidHandleContext;
+		const containerRuntime1 = (
+			firstContainerObject1._context.containerRuntime as ContainerRuntime
+		).IFluidHandleContext;
 		assert.equal(
 			containerRuntime1.absolutePath,
 			absolutePath,
@@ -58,8 +60,9 @@ describeFullCompat("FluidObjectHandle", (getTestObjectProvider) => {
 		);
 
 		// Verify that the remote client's ContainerRuntime has the correct absolute path.
-		const containerRuntime2 =
-			secondContainerObject1._context.containerRuntime.IFluidHandleContext;
+		const containerRuntime2 = (
+			secondContainerObject1._context.containerRuntime as ContainerRuntime
+		).IFluidHandleContext;
 		assert.equal(
 			containerRuntime2.absolutePath,
 			absolutePath,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
@@ -6,10 +6,8 @@
 import { strict as assert } from "assert";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
 import { IContainer } from "@fluidframework/container-definitions";
-import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
-import { IRequest } from "@fluidframework/core-interfaces";
+import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import {
 	ITestFluidObject,
 	ITestObjectProvider,
@@ -47,12 +45,9 @@ describeFullCompat.skip("GC summary compatibility tests", (getTestObjectProvider
 			},
 			gcOptions: { gcAllowed: true },
 		};
-		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 			defaultFactory: dataObjectFactory,
 			registryEntries: [[dataObjectFactory.type, Promise.resolve(dataObjectFactory)]],
-			requestHandlers: [innerRequestHandler],
 			runtimeOptions,
 		});
 		return provider.createContainer(runtimeFactory, { configProvider: mockConfigProvider() });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
 import { IContainer } from "@fluidframework/container-definitions";
-import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IRequest } from "@fluidframework/core-interfaces";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
@@ -48,7 +48,7 @@ describeFullCompat.skip("GC summary compatibility tests", (getTestObjectProvider
 			gcOptions: { gcAllowed: true },
 		};
 		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			runtime.IFluidHandleContext.resolveHandle(request);
+			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 			defaultFactory: dataObjectFactory,
 			registryEntries: [[dataObjectFactory.type, Promise.resolve(dataObjectFactory)]],

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -18,10 +18,9 @@ import {
 	SummarizerStopReason,
 	SummaryCollection,
 } from "@fluidframework/container-runtime";
-import { IRequest } from "@fluidframework/core-interfaces";
 import { DriverHeader, ISummaryContext } from "@fluidframework/driver-definitions";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
-import { gcTreeKey, IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { gcTreeKey } from "@fluidframework/runtime-definitions";
 import {
 	ITestFluidObject,
 	ITestObjectProvider,
@@ -188,14 +187,11 @@ describeNoCompat("GC Tree stored as a handle in summaries", (getTestObjectProvid
 	const runtimeOptions: IContainerRuntimeOptions = {
 		gcOptions: { gcAllowed: true },
 	};
-	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 		ContainerRuntimeFactoryWithDefaultDataStore,
 		{
 			defaultFactory,
 			registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
-			requestHandlers: [innerRequestHandler],
 			runtimeOptions,
 		},
 	);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -189,7 +189,7 @@ describeNoCompat("GC Tree stored as a handle in summaries", (getTestObjectProvid
 		gcOptions: { gcAllowed: true },
 	};
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		runtime.IFluidHandleContext.resolveHandle(request);
+		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 		ContainerRuntimeFactoryWithDefaultDataStore,
 		{

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
@@ -5,18 +5,10 @@
 
 import { strict as assert } from "assert";
 import { IContainer } from "@fluidframework/container-definitions";
-import {
-	ContainerRuntime,
-	IContainerRuntimeOptions,
-	ISummarizer,
-} from "@fluidframework/container-runtime";
+import { IContainerRuntimeOptions, ISummarizer } from "@fluidframework/container-runtime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
-import {
-	channelsTreeName,
-	gcTreeKey,
-	IContainerRuntimeBase,
-} from "@fluidframework/runtime-definitions";
+import { channelsTreeName, gcTreeKey } from "@fluidframework/runtime-definitions";
 import {
 	ITestFluidObject,
 	ITestObjectProvider,
@@ -27,7 +19,6 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
-import { IRequest } from "@fluidframework/core-interfaces";
 import {
 	IGCMetadata,
 	IGarbageCollector,
@@ -59,15 +50,11 @@ describeNoCompat("GC version update", (getTestObjectProvider, apis) => {
 		gcOptions: { gcAllowed: true },
 	};
 
-	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		(runtime as ContainerRuntime).resolveHandle(request);
-
 	const defaultRuntimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 		ContainerRuntimeFactoryWithDefaultDataStore,
 		{
 			defaultFactory,
 			registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
-			requestHandlers: [innerRequestHandler],
 			runtimeOptions,
 		},
 	);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
@@ -5,7 +5,11 @@
 
 import { strict as assert } from "assert";
 import { IContainer } from "@fluidframework/container-definitions";
-import { IContainerRuntimeOptions, ISummarizer } from "@fluidframework/container-runtime";
+import {
+	ContainerRuntime,
+	IContainerRuntimeOptions,
+	ISummarizer,
+} from "@fluidframework/container-runtime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import {
@@ -56,7 +60,7 @@ describeNoCompat("GC version update", (getTestObjectProvider, apis) => {
 	};
 
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		runtime.IFluidHandleContext.resolveHandle(request);
+		(runtime as ContainerRuntime).resolveHandle(request);
 
 	const defaultRuntimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 		ContainerRuntimeFactoryWithDefaultDataStore,

--- a/packages/test/test-end-to-end-tests/src/test/incrementalSummaryContext.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/incrementalSummaryContext.spec.ts
@@ -6,10 +6,8 @@
 import { strict as assert } from "assert";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
-import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
-import { IRequest } from "@fluidframework/core-interfaces";
+import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import {
-	IContainerRuntimeBase,
 	IExperimentalIncrementalSummaryContext,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -471,12 +469,9 @@ describeNoCompat("Incremental summaries can be generated for DDSes", (getTestObj
 	const runtimeOptions: IContainerRuntimeOptions = {
 		summaryOptions: { summaryConfigOverrides: { state: "disabled" } },
 	};
-	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 		defaultFactory,
 		registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
-		requestHandlers: [innerRequestHandler],
 		runtimeOptions,
 	});
 

--- a/packages/test/test-end-to-end-tests/src/test/incrementalSummaryContext.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/incrementalSummaryContext.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
-import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IRequest } from "@fluidframework/core-interfaces";
 import {
 	IContainerRuntimeBase,
@@ -472,7 +472,7 @@ describeNoCompat("Incremental summaries can be generated for DDSes", (getTestObj
 		summaryOptions: { summaryConfigOverrides: { state: "disabled" } },
 	};
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		runtime.IFluidHandleContext.resolveHandle(request);
+		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 		defaultFactory,
 		registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],

--- a/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
@@ -19,9 +19,7 @@ import {
 	getDataRuntimeApi,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
-import { FlushMode, IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
-import { IRequest } from "@fluidframework/core-interfaces";
-import { ContainerRuntime } from "@fluidframework/container-runtime";
+import { FlushMode } from "@fluidframework/runtime-definitions";
 
 const versionWithChunking = "0.56.0";
 
@@ -39,8 +37,6 @@ describeInstallVersions(
 	});
 	afterEach(async () => provider.reset());
 
-	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		(runtime as ContainerRuntime).resolveHandle(request);
 	const mapId = "map";
 	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
 	const testContainerConfig: ITestContainerConfig = {
@@ -64,7 +60,6 @@ describeInstallVersions(
 			oldDataObjectFactory,
 			[[oldDataObjectFactory.type, Promise.resolve(oldDataObjectFactory)]],
 			undefined,
-			[innerRequestHandler],
 			{
 				// Chunking did not work with FlushMode.TurnBased,
 				// as it was breaking batching semantics. So we need

--- a/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/legacyChunking.spec.ts
@@ -21,6 +21,7 @@ import {
 import { IContainer } from "@fluidframework/container-definitions";
 import { FlushMode, IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { IRequest } from "@fluidframework/core-interfaces";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 const versionWithChunking = "0.56.0";
 
@@ -39,7 +40,7 @@ describeInstallVersions(
 	afterEach(async () => provider.reset());
 
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		runtime.IFluidHandleContext.resolveHandle(request);
+		(runtime as ContainerRuntime).resolveHandle(request);
 	const mapId = "map";
 	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
 	const testContainerConfig: ITestContainerConfig = {

--- a/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
@@ -11,10 +11,10 @@ import {
 	IDataObjectProps,
 } from "@fluidframework/aqueduct";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
-import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import { IContainerRuntimeBase, IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
+import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { SharedString } from "@fluidframework/sequence";
 import {
 	createAndAttachContainer,
@@ -28,7 +28,6 @@ import {
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
-import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 const counterKey = "count";
 
@@ -116,12 +115,9 @@ describeNoCompat("LocalLoader", (getTestObjectProvider) => {
 		documentId: string,
 		defaultFactory: IFluidDataStoreFactory,
 	): Promise<IContainer> {
-		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 			defaultFactory,
 			registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
-			requestHandlers: [innerRequestHandler],
 		});
 		const loader = createLoader(
 			[[codeDetails, runtimeFactory]],
@@ -143,12 +139,9 @@ describeNoCompat("LocalLoader", (getTestObjectProvider) => {
 		containerUrl: IResolvedUrl | undefined,
 		defaultFactory: IFluidDataStoreFactory,
 	): Promise<IContainer> {
-		const inner = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 			defaultFactory,
 			registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
-			requestHandlers: [inner],
 		});
 		const loader = createLoader(
 			[[codeDetails, runtimeFactory]],

--- a/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
@@ -28,6 +28,7 @@ import {
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 const counterKey = "count";
 
@@ -116,7 +117,7 @@ describeNoCompat("LocalLoader", (getTestObjectProvider) => {
 		defaultFactory: IFluidDataStoreFactory,
 	): Promise<IContainer> {
 		const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			runtime.IFluidHandleContext.resolveHandle(request);
+			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 			defaultFactory,
 			registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
@@ -143,7 +144,7 @@ describeNoCompat("LocalLoader", (getTestObjectProvider) => {
 		defaultFactory: IFluidDataStoreFactory,
 	): Promise<IContainer> {
 		const inner = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-			runtime.IFluidHandleContext.resolveHandle(request);
+			(runtime as ContainerRuntime).resolveHandle(request);
 		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 			defaultFactory,
 			registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],

--- a/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
@@ -15,10 +15,8 @@ import {
 	SummaryCollection,
 	ISummaryConfiguration,
 	DefaultSummaryConfiguration,
-	ContainerRuntime,
 } from "@fluidframework/container-runtime";
-import { ITelemetryBaseEvent, IRequest } from "@fluidframework/core-interfaces";
-import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
+import { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
 import { MockLogger, createChildLogger } from "@fluidframework/telemetry-utils";
 import { ITestObjectProvider, timeoutAwait } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
@@ -59,12 +57,9 @@ describeNoCompat("Generate Summary Stats", (getTestObjectProvider) => {
 			gcAllowed: true,
 		},
 	};
-	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 		defaultFactory: dataObjectFactory,
 		registryEntries: [[dataObjectFactory.type, Promise.resolve(dataObjectFactory)]],
-		requestHandlers: [innerRequestHandler],
 		runtimeOptions,
 	});
 

--- a/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
@@ -15,6 +15,7 @@ import {
 	SummaryCollection,
 	ISummaryConfiguration,
 	DefaultSummaryConfiguration,
+	ContainerRuntime,
 } from "@fluidframework/container-runtime";
 import { ITelemetryBaseEvent, IRequest } from "@fluidframework/core-interfaces";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
@@ -59,7 +60,7 @@ describeNoCompat("Generate Summary Stats", (getTestObjectProvider) => {
 		},
 	};
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		runtime.IFluidHandleContext.resolveHandle(request);
+		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 		defaultFactory: dataObjectFactory,
 		registryEntries: [[dataObjectFactory.type, Promise.resolve(dataObjectFactory)]],

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -10,7 +10,7 @@ import {
 	DataObject,
 	DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISharedCounter, SharedCounter } from "@fluidframework/counter";
 import { ITaskManager, TaskManager } from "@fluidframework/task-manager";
 import { IDirectory, ISharedDirectory, ISharedMap, SharedMap } from "@fluidframework/map";
@@ -748,10 +748,6 @@ const LoadTestDataStoreInstantiationFactory = new DataObjectFactory(
 	{},
 );
 
-const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-	// This cast is safe as ContainerRuntime.loadRuntime is used in ContainerRuntimeFactoryWithDefaultDataStore
-	(runtime as ContainerRuntime).resolveHandle(request);
-
 export const createFluidExport = (runtimeOptions: IContainerRuntimeOptions) =>
 	new ContainerRuntimeFactoryWithDefaultDataStore({
 		defaultFactory: LoadTestDataStoreInstantiationFactory,
@@ -761,6 +757,5 @@ export const createFluidExport = (runtimeOptions: IContainerRuntimeOptions) =>
 				Promise.resolve(LoadTestDataStoreInstantiationFactory),
 			],
 		]),
-		requestHandlers: [innerRequestHandler],
 		runtimeOptions,
 	});

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -749,7 +749,8 @@ const LoadTestDataStoreInstantiationFactory = new DataObjectFactory(
 );
 
 const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-	runtime.IFluidHandleContext.resolveHandle(request);
+	// This cast is safe as ContainerRuntime.loadRuntime is used in ContainerRuntimeFactoryWithDefaultDataStore
+	(runtime as ContainerRuntime).resolveHandle(request);
 
 export const createFluidExport = (runtimeOptions: IContainerRuntimeOptions) =>
 	new ContainerRuntimeFactoryWithDefaultDataStore({

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -7,6 +7,7 @@ import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqu
 import { assert } from "@fluidframework/core-utils";
 import { IContainer, IHostLoader, LoaderHeader } from "@fluidframework/container-definitions";
 import {
+	ContainerRuntime,
 	IOnDemandSummarizeOptions,
 	ISummarizer,
 	ISummaryRuntimeOptions,
@@ -89,7 +90,8 @@ export async function createSummarizerFromFactory(
 	configProvider: IConfigProviderBase = mockConfigProvider(),
 ): Promise<{ container: IContainer; summarizer: ISummarizer }> {
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		runtime.IFluidHandleContext.resolveHandle(request);
+		// This cast is safe as ContainerRuntime.loadRuntime is used in ContainerRuntimeFactoryWithDefaultDataStore
+		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 		containerRuntimeFactoryType,
 		{

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -7,7 +7,6 @@ import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqu
 import { assert } from "@fluidframework/core-utils";
 import { IContainer, IHostLoader, LoaderHeader } from "@fluidframework/container-definitions";
 import {
-	ContainerRuntime,
 	IOnDemandSummarizeOptions,
 	ISummarizer,
 	ISummaryRuntimeOptions,
@@ -15,7 +14,6 @@ import {
 import { ITelemetryBaseLogger, FluidObject, IRequest } from "@fluidframework/core-interfaces";
 import { DriverHeader } from "@fluidframework/driver-definitions";
 import {
-	IContainerRuntimeBase,
 	IFluidDataStoreFactory,
 	NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
@@ -89,9 +87,6 @@ export async function createSummarizerFromFactory(
 	logger?: ITelemetryBaseLogger,
 	configProvider: IConfigProviderBase = mockConfigProvider(),
 ): Promise<{ container: IContainer; summarizer: ISummarizer }> {
-	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		// This cast is safe as ContainerRuntime.loadRuntime is used in ContainerRuntimeFactoryWithDefaultDataStore
-		(runtime as ContainerRuntime).resolveHandle(request);
 	const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 		containerRuntimeFactoryType,
 		{
@@ -99,7 +94,6 @@ export async function createSummarizerFromFactory(
 			registryEntries: registryEntries ?? [
 				[dataStoreFactory.type, Promise.resolve(dataStoreFactory)],
 			],
-			requestHandlers: [innerRequestHandler],
 			runtimeOptions: { summaryOptions: defaultSummaryOptions },
 		},
 	);

--- a/packages/test/test-utils/src/localCodeLoader.ts
+++ b/packages/test/test-utils/src/localCodeLoader.ts
@@ -13,14 +13,12 @@ import {
 	ICodeDetailsLoader,
 	IFluidModuleWithDetails,
 } from "@fluidframework/container-definitions";
-import { IRequest } from "@fluidframework/core-interfaces";
 import {
-	IContainerRuntimeBase,
 	IProvideFluidDataStoreFactory,
 	IProvideFluidDataStoreRegistry,
 } from "@fluidframework/runtime-definitions";
 import { createDataStoreFactory } from "@fluidframework/runtime-utils";
-import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 
 export type SupportedExportInterfaces = Partial<
 	IProvideRuntimeFactory &
@@ -64,12 +62,6 @@ export class LocalCodeLoader implements ICodeDetailsLoader {
 						"default",
 						maybeExport.IFluidDataStoreFactory,
 					);
-					const innerRequestHandler = async (
-						request: IRequest,
-						runtime: IContainerRuntimeBase,
-					) =>
-						// This cast is safe as ContainerRuntime.loadRuntime is used in ContainerRuntimeFactoryWithDefaultDataStore
-						(runtime as ContainerRuntime).resolveHandle(request);
 					fluidModule = {
 						fluidExport: {
 							...maybeExport,
@@ -78,7 +70,6 @@ export class LocalCodeLoader implements ICodeDetailsLoader {
 								registryEntries: [
 									[defaultFactory.type, Promise.resolve(defaultFactory)],
 								],
-								requestHandlers: [innerRequestHandler],
 								runtimeOptions,
 							}),
 						},

--- a/packages/test/test-utils/src/localCodeLoader.ts
+++ b/packages/test/test-utils/src/localCodeLoader.ts
@@ -20,7 +20,7 @@ import {
 	IProvideFluidDataStoreRegistry,
 } from "@fluidframework/runtime-definitions";
 import { createDataStoreFactory } from "@fluidframework/runtime-utils";
-import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 
 export type SupportedExportInterfaces = Partial<
 	IProvideRuntimeFactory &
@@ -67,7 +67,9 @@ export class LocalCodeLoader implements ICodeDetailsLoader {
 					const innerRequestHandler = async (
 						request: IRequest,
 						runtime: IContainerRuntimeBase,
-					) => runtime.IFluidHandleContext.resolveHandle(request);
+					) =>
+						// This cast is safe as ContainerRuntime.loadRuntime is used in ContainerRuntimeFactoryWithDefaultDataStore
+						(runtime as ContainerRuntime).resolveHandle(request);
 					fluidModule = {
 						fluidExport: {
 							...maybeExport,

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -4,9 +4,8 @@
  */
 
 import { FluidTestDriverConfig, createFluidTestDriver } from "@fluid-private/test-drivers";
-import { IFluidLoadable, IRequest } from "@fluidframework/core-interfaces";
+import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import {
-	IContainerRuntimeBase,
 	IFluidDataStoreContext,
 	IFluidDataStoreFactory,
 } from "@fluidframework/runtime-definitions";
@@ -22,7 +21,6 @@ import {
 } from "@fluidframework/test-utils";
 import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
 import { mixinAttributor } from "@fluid-experimental/attributor";
-import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { pkgVersion } from "./packageVersion.js";
 import {
 	getLoaderApi,
@@ -121,9 +119,6 @@ export async function getVersionedTestObjectProviderFromApis(
 		driverConfig?.config,
 		apis.driver,
 	);
-	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		// This cast is safe as ContainerRuntime.loadRuntime is used in ContainerRuntimeFactoryWithDefaultDataStore
-		(runtime as ContainerRuntime).resolveHandle(request);
 
 	const getDataStoreFactoryFn = createGetDataStoreFactoryFunction(apis.dataRuntime);
 	const containerFactoryFn = (containerOptions?: ITestContainerConfig) => {
@@ -137,7 +132,6 @@ export async function getVersionedTestObjectProviderFromApis(
 			TestDataObjectType,
 			dataStoreFactory,
 			containerOptions?.runtimeOptions,
-			[innerRequestHandler],
 		);
 	};
 

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -22,6 +22,7 @@ import {
 } from "@fluidframework/test-utils";
 import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
 import { mixinAttributor } from "@fluid-experimental/attributor";
+import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { pkgVersion } from "./packageVersion.js";
 import {
 	getLoaderApi,
@@ -121,7 +122,8 @@ export async function getVersionedTestObjectProviderFromApis(
 		apis.driver,
 	);
 	const innerRequestHandler = async (request: IRequest, runtime: IContainerRuntimeBase) =>
-		runtime.IFluidHandleContext.resolveHandle(request);
+		// This cast is safe as ContainerRuntime.loadRuntime is used in ContainerRuntimeFactoryWithDefaultDataStore
+		(runtime as ContainerRuntime).resolveHandle(request);
 
 	const getDataStoreFactoryFn = createGetDataStoreFactoryFunction(apis.dataRuntime);
 	const containerFactoryFn = (containerOptions?: ITestContainerConfig) => {


### PR DESCRIPTION
## Breaking Changes

### Removed `resolveHandle` and `IFluidHandleContext` from ContainerRuntime interfaces

The `IContainerRuntime.resolveHandle(...)` method and the `IContainerRuntimeBase.IFluidHandleContext` property have been removed. Please remove all usage of these APIs.

See [Removing-IFluidRouter.md](https://github.com/microsoft/FluidFramework/blob/main/packages/common/core-interfaces/Removing-IFluidRouter.md) for more details.

[AB#5593](https://dev.azure.com/fluidframework/internal/_workitems/edit/5593)