### PR TITLE
build(azure): Enable cross-package release tag compatibility enforcement

### DIFF
--- a/azure/packages/azure-client/api-extractor-lint.json
+++ b/azure/packages/azure-client/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }

--- a/azure/packages/azure-local-service/api-extractor-lint.json
+++ b/azure/packages/azure-local-service/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }

--- a/azure/packages/azure-service-utils/api-extractor-lint.json
+++ b/azure/packages/azure-service-utils/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }


### PR DESCRIPTION
Follow-up to #18409, which added explicit `@internal` release tags to all API members. This PR adds "linter" enforcement that release tags are compatible between these packages and their local (fluid) dependencies.