### PR TITLE
Tree: Fix bug with creating default revision info for tests

### DIFF
--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
@@ -142,7 +142,7 @@ export function rebaseOverChanges(
 	revInfos?: RevisionInfo[],
 ): TaggedChange<TestChangeset> {
 	let currChange = change;
-	const revisionInfo = revInfos ?? defaultRevInfosForRebase(baseChanges);
+	const revisionInfo = revInfos ?? defaultRevInfosFromChanges(baseChanges);
 	for (const base of baseChanges) {
 		currChange = tagChange(
 			rebase(
@@ -155,38 +155,6 @@ export function rebaseOverChanges(
 	}
 
 	return currChange;
-}
-
-function defaultRevInfosForRebase(baseChanges: TaggedChange<TestChangeset>[]): RevisionInfo[] {
-	const revInfos: RevisionInfo[] = [];
-	const revisions = new Set<RevisionTag>();
-	const rolledBackRevisions: RevisionTag[] = [];
-	for (const baseChange of baseChanges) {
-		if (baseChange.revision !== undefined) {
-			revInfos.push({
-				revision: baseChange.revision,
-				rollbackOf: baseChange.rollbackOf,
-			});
-
-			revisions.add(baseChange.revision);
-			if (baseChange.rollbackOf !== undefined) {
-				assert(
-					!revisions.has(baseChange.rollbackOf),
-					"A rollback should not come before the corresponding roll-forward",
-				);
-				rolledBackRevisions.push(baseChange.rollbackOf);
-			}
-		}
-	}
-
-	rolledBackRevisions.reverse();
-	for (const revision of rolledBackRevisions) {
-		if (!revisions.has(revision)) {
-			revInfos.push({ revision });
-		}
-	}
-
-	return revInfos;
 }
 
 export function rebaseOverComposition(

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -96,6 +96,7 @@ import {
 	RevisionMetadataSource,
 	revisionMetadataSourceFromInfo,
 	RevisionInfo,
+	RevisionTag,
 } from "../core";
 import { JsonCompatible, brand } from "../util";
 import { ICodecFamily, withSchemaValidation } from "../codec";
@@ -949,14 +950,29 @@ export function defaultRevInfosFromChanges(
 	changes: readonly TaggedChange<unknown>[],
 ): RevisionInfo[] {
 	const revInfos: RevisionInfo[] = [];
+	const revisions = new Set<RevisionTag>();
+	const rolledBackRevisions: RevisionTag[] = [];
 	for (const change of changes) {
 		if (change.revision !== undefined) {
 			revInfos.push({
 				revision: change.revision,
 				rollbackOf: change.rollbackOf,
 			});
+
+			revisions.add(change.revision);
+			if (change.rollbackOf !== undefined) {
+				rolledBackRevisions.push(change.rollbackOf);
+			}
 		}
 	}
+
+	rolledBackRevisions.reverse();
+	for (const revision of rolledBackRevisions) {
+		if (!revisions.has(revision)) {
+			revInfos.push({ revision });
+		}
+	}
+
 	return revInfos;
 }
 


### PR DESCRIPTION
## Description

This change fixes an issue with generating test `RevisionInfo`s where entries for roll-forwards could be duplicated.
This also makes all test revision metadata generation create roll-forward revisions as needed, instead of only for rebase tests.