### PR TITLE
build(experimental): Enable cross-package release tag compatibility enforcement

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/api-extractor-lint.json
+++ b/experimental/PropertyDDS/packages/property-dds/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }

--- a/experimental/dds/attributable-map/api-extractor-lint.json
+++ b/experimental/dds/attributable-map/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }

--- a/experimental/dds/ot/ot/api-extractor-lint.json
+++ b/experimental/dds/ot/ot/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }

--- a/experimental/dds/ot/sharejs/json1/api-extractor-lint.json
+++ b/experimental/dds/ot/sharejs/json1/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }

--- a/experimental/dds/sequence-deprecated/api-extractor-lint.json
+++ b/experimental/dds/sequence-deprecated/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }

--- a/experimental/dds/tree/api-extractor-lint.json
+++ b/experimental/dds/tree/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }

--- a/experimental/framework/data-objects/api-extractor-lint.json
+++ b/experimental/framework/data-objects/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }

--- a/experimental/framework/last-edited/api-extractor-lint.json
+++ b/experimental/framework/last-edited/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }

--- a/experimental/framework/react-inputs/api-extractor-lint.json
+++ b/experimental/framework/react-inputs/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }

--- a/experimental/framework/tree-react-api/api-extractor-lint.json
+++ b/experimental/framework/tree-react-api/api-extractor-lint.json
@@ -1,4 +1,13 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.json"
+	"extends": "../../../common/build/build-common/api-extractor-lint.json",
+	"messages": {
+		"extractorMessageReporting": {
+			// TODO: remove once base config has this enabled as an error
+			"ae-incompatible-release-tags": {
+				"logLevel": "error",
+				"addToApiReportFile": false
+			}
+		}
+	}
 }


### PR DESCRIPTION
Follow-up to #18412, which added explicit `@internal` release tags to all `experimental` package API members. This PR adds "linter" enforcement that release tags are compatible between these packages and their local (fluid) dependencies.

Note: does not add any enforcement to `PropertyDDS` packages that are not already using api-extractor. This can be done in a future PR as needed.