### PR TITLE
tree2: Remove support for simple-tree with flex-tree-schema outside of tree2 package

### DIFF
--- a/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/src/schema.ts
@@ -4,9 +4,16 @@
  */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { SchemaAware, SchemaBuilder, FlexTreeTyped, leaf } from "@fluid-experimental/tree2";
+import {
+	SchemaAware,
+	SchemaBuilderBase,
+	FlexTreeTyped,
+	leaf,
+	FieldKinds,
+	TreeFieldSchema,
+} from "@fluid-experimental/tree2";
 
-const builder = new SchemaBuilder({ scope: "bubble-bench" });
+const builder = new SchemaBuilderBase(FieldKinds.required, { scope: "bubble-bench" });
 
 export const bubbleSchema = builder.object("BubbleBenchAppStateBubble-1.0.0", {
 	x: leaf.number,
@@ -19,10 +26,10 @@ export const bubbleSchema = builder.object("BubbleBenchAppStateBubble-1.0.0", {
 export const clientSchema = builder.object("BubbleBenchAppStateClient-1.0.0", {
 	clientId: leaf.string,
 	color: leaf.string,
-	bubbles: builder.sequence(bubbleSchema),
+	bubbles: TreeFieldSchema.create(FieldKinds.sequence, [bubbleSchema]),
 });
 
-export const rootAppStateSchema = SchemaBuilder.sequence(clientSchema);
+export const rootAppStateSchema = TreeFieldSchema.create(FieldKinds.sequence, [clientSchema]);
 
 export const appSchemaData = builder.intoSchema(rootAppStateSchema);
 

--- a/examples/data-objects/inventory-app/src/inventoryList.ts
+++ b/examples/data-objects/inventory-app/src/inventoryList.ts
@@ -7,7 +7,7 @@ import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import {
 	ForestType,
 	TreeFactory,
-	TreeViewOld,
+	TreeView,
 	typeboxValidator,
 	ITree,
 } from "@fluid-experimental/tree2";
@@ -26,7 +26,7 @@ const factory = new TreeFactory({
  */
 export class InventoryList extends DataObject {
 	#tree?: ITree;
-	#view?: TreeViewOld<Inventory>;
+	#view?: TreeView<Inventory>;
 
 	public get inventory(): Inventory {
 		if (this.#view === undefined)

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/src/schemaConverter.ts
@@ -8,7 +8,7 @@ import {
 	fail,
 	FieldKinds,
 	TreeFieldSchema,
-	SchemaBuilder,
+	SchemaBuilderBase,
 	FieldKind,
 	Any,
 	FlexTreeNodeSchema as TreeNodeSchema,
@@ -78,6 +78,8 @@ function getAllInheritingChildrenTypes(): InheritingChildrenByType {
 	return inheritingChildrenByType;
 }
 
+type SchemaBuilder = SchemaBuilderBase<string, typeof FieldKinds.required>;
+
 function buildTreeNodeSchema(
 	builder: SchemaBuilder,
 	nodeSchemaMap: Map<string, LazyTreeNodeSchema>,
@@ -142,7 +144,10 @@ function buildTreeNodeSchema(
 					!fields.has(nodePropertyField),
 					0x712 /* name collision for nodePropertyField */,
 				);
-				fields.set(nodePropertyField, SchemaBuilder.required(nodePropertySchema));
+				fields.set(
+					nodePropertyField,
+					TreeFieldSchema.create(FieldKinds.required, [nodePropertySchema]),
+				);
 			}
 			const fieldsObject = mapToObject(fields);
 			cache.nodeSchema = builder.object(typeid, fieldsObject);
@@ -309,11 +314,11 @@ function buildFieldSchema<Kind extends FieldKind = FieldKind>(
 		}
 	}
 	return isAny
-		? SchemaBuilder.field(fieldKind, Any)
-		: SchemaBuilder.field(fieldKind, [...allowedTypes]);
+		? TreeFieldSchema.create(fieldKind, [Any])
+		: TreeFieldSchema.create(fieldKind, [...allowedTypes]);
 }
 
-const builtinBuilder = new SchemaBuilder({
+const builtinBuilder: SchemaBuilder = new SchemaBuilderBase(FieldKinds.required, {
 	scope: "com.fluidframework.PropertyDDSBuiltIn",
 	name: "PropertyDDS to SharedTree builtin schema builder",
 	libraries: [leaf.library],
@@ -323,7 +328,7 @@ const builtinBuilder = new SchemaBuilder({
 // to be put into one library like this.
 export const nodePropertySchema = builtinBuilder.map(
 	nodePropertyType,
-	builtinBuilder.optional(Any),
+	TreeFieldSchema.create(FieldKinds.optional, [Any]),
 );
 const builtinLibrary = builtinBuilder.intoLibrary();
 
@@ -342,7 +347,7 @@ export function convertPropertyToSharedTreeSchema<Kind extends FieldKind = Field
 	allowedRootTypes: Any | ReadonlySet<string>,
 	extraTypes?: ReadonlySet<string>,
 ) {
-	const builder = new SchemaBuilder({
+	const builder = new SchemaBuilderBase(FieldKinds.required, {
 		scope: "converted",
 		name: "PropertyDDS to SharedTree schema builder",
 		libraries: [builtinLibrary],

--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -281,7 +281,7 @@ export interface CursorAdapter<TNode> {
 }
 
 // @alpha
-export function cursorForTypedTreeData<T extends FlexTreeNodeSchema>(context: TreeDataContext, schema: T, data: TypedNode_2<T>): ITreeCursorSynchronous;
+export function cursorForTypedTreeData<T extends FlexTreeNodeSchema>(context: TreeDataContext, schema: T, data: TypedNode<T>): ITreeCursorSynchronous;
 
 // @alpha
 export function cursorFromContextualData(context: TreeDataContext, typeSet: TreeTypeSet, data: ContextuallyTypedNodeData): ITreeCursorSynchronous;
@@ -291,9 +291,6 @@ export const enum CursorLocationType {
     Fields = 1,
     Nodes = 0
 }
-
-// @alpha
-export function cursorToJsonObject(reader: ITreeCursor): JsonCompatible;
 
 // @alpha
 export interface CursorWithNode<TNode> extends ITreeCursorSynchronous {
@@ -440,17 +437,6 @@ type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? 
 
 // @alpha (undocumented)
 type ExtractListItemType<List extends FlexList> = List extends FlexList<infer Item> ? Item : unknown;
-
-// @alpha
-type FactoryObjectNodeSchema<TScope extends string, Name extends number | string, T extends RestrictiveReadonlyRecord<string, FlexImplicitFieldSchema>> = FactoryTreeSchema<ObjectNodeSchema<`${TScope}.${Name}`, {
-    [key in keyof T]: NormalizeField<T[key], Required_2>;
-}>>;
-
-// @alpha
-type FactoryObjectNodeSchemaRecursive<TScope extends string, Name extends number | string, T extends Unenforced<RestrictiveReadonlyRecord<string, FlexImplicitFieldSchema>>> = FactoryTreeSchema<ObjectNodeSchema<`${TScope}.${Name}`, T>>;
-
-// @alpha
-export type FactoryTreeSchema<TSchema extends TreeNodeSchemaBase> = TSchema & TreeObjectFactory<TSchema>;
 
 // @alpha (undocumented)
 export function fail(message: string): never;
@@ -949,38 +935,14 @@ type InsertableObjectFromSchemaRecord<T extends RestrictiveReadonlyRecord<string
     readonly [Property in keyof T]: InsertableTreeFieldFromImplicitField<T[Property]>;
 };
 
-// @alpha
-type InsertableTreeField<TSchema extends TreeFieldSchema = TreeFieldSchema> = InsertableTreeFieldInner<TSchema["kind"], TSchema["allowedTypes"]>;
-
 // @beta
 type InsertableTreeFieldFromImplicitField<TSchema extends ImplicitFieldSchema = FieldSchema> = TSchema extends FieldSchema<infer Kind, infer Types> ? ApplyKind<InsertableTreeNodeFromImplicitAllowedTypes<Types>, Kind> : TSchema extends ImplicitAllowedTypes_2 ? InsertableTreeNodeFromImplicitAllowedTypes<TSchema> : unknown;
 
-// @alpha
-type InsertableTreeFieldInner<Kind extends FieldKind, TTypes extends AllowedTypes> = Kind extends typeof FieldKinds.sequence ? never : Kind extends typeof FieldKinds.required ? InsertableTreeNodeUnion<TTypes> : Kind extends typeof FieldKinds.optional ? InsertableTreeNodeUnion<TTypes> | undefined : unknown;
+// @beta
+type InsertableTreeNodeFromImplicitAllowedTypes<TSchema extends ImplicitAllowedTypes_2 = TreeNodeSchema> = TSchema extends TreeNodeSchema ? InsertableTypedNode<TSchema> : TSchema extends AllowedTypes_2 ? InsertableTypedNode<FlexListToUnion<TSchema>> : unknown;
 
 // @beta
-type InsertableTreeNodeFromImplicitAllowedTypes<TSchema extends ImplicitAllowedTypes_2 = TreeNodeSchema> = TSchema extends TreeNodeSchema ? InsertableTypedNode_2<TSchema> : TSchema extends AllowedTypes_2 ? InsertableTypedNode_2<FlexListToUnion<TSchema>> : unknown;
-
-// @alpha
-type InsertableTreeNodeUnion<TTypes extends AllowedTypes> = TTypes extends readonly [Any] ? unknown : {
-    [Index in keyof TTypes]: TTypes[Index] extends InternalTypedSchemaTypes.LazyItem<infer InnerType> ? InnerType extends FlexTreeNodeSchema ? InsertableTypedNode<InnerType> : never : never;
-}[number];
-
-// @alpha
-type InsertableTreeObjectNode<TSchema extends ObjectNodeSchema> = InsertableTreeObjectNodeFields<TSchema["objectNodeFieldsObject"]>;
-
-// @alpha
-type InsertableTreeObjectNodeFields<TFields extends RestrictiveReadonlyRecord<string, TreeFieldSchema>> = {
-    readonly [key in keyof TFields]?: InsertableTreeField<TFields[key]>;
-} & {
-    readonly [key in keyof TFields as TFields[key]["kind"] extends typeof FieldKinds.optional ? never : key]-?: InsertableTreeField<TFields[key]>;
-};
-
-// @alpha
-type InsertableTypedNode<TSchema extends FlexTreeNodeSchema> = TSchema extends LeafNodeSchema ? TreeValue<TSchema["info"]> : TSchema extends MapNodeSchema ? ReadonlyMap<string, InsertableTreeField<TSchema["info"]>> : TSchema extends FieldNodeSchema ? readonly InsertableTreeNodeUnion<TSchema["info"]["allowedTypes"]>[] : TSchema extends ObjectNodeSchema ? InsertableTreeObjectNode<TSchema> : unknown;
-
-// @beta
-type InsertableTypedNode_2<T extends TreeNodeSchema> = NodeBuilderData<T> | Unhydrated<NodeFromSchema<T>>;
+type InsertableTypedNode<T extends TreeNodeSchema> = NodeBuilderData<T> | Unhydrated<NodeFromSchema<T>>;
 
 declare namespace InternalClassTreeTypes {
     export {
@@ -994,7 +956,7 @@ declare namespace InternalClassTreeTypes {
         FieldSchema,
         ApplyKind,
         InsertableTreeNodeFromImplicitAllowedTypes,
-        InsertableTypedNode_2 as InsertableTypedNode,
+        InsertableTypedNode,
         NodeBuilderData,
         testRecursiveDomain
     }
@@ -1030,7 +992,7 @@ declare namespace InternalTypedSchemaTypes {
         UnbrandList,
         ArrayToUnion,
         NormalizeObjectNodeFields,
-        NormalizeField_2 as NormalizeField,
+        NormalizeField,
         Fields,
         MapFieldSchema,
         FlexList,
@@ -1065,27 +1027,19 @@ declare namespace InternalTypes {
         isAny,
         RestrictiveReadonlyRecord,
         BrandedKeyContent,
-        NormalizeField,
+        NormalizeField_2 as NormalizeField,
         NormalizeAllowedTypes,
         Required_2 as Required,
         Optional,
         NodeKeyFieldKind,
         Forbidden,
         Sequence,
-        FactoryObjectNodeSchema,
-        FactoryObjectNodeSchemaRecursive,
         NodeKind,
         TreeNodeSchemaClass,
         TreeNodeSchemaNonClass,
         TreeNodeSchemaCore,
         InternalClassTreeTypes as InternalEditableTreeTypes,
-        TreeListNodeBase,
-        InsertableTreeField,
-        InsertableTreeFieldInner,
-        InsertableTreeNodeUnion,
-        InsertableTreeObjectNode,
-        InsertableTreeObjectNodeFields,
-        InsertableTypedNode
+        TreeListNodeBase
     }
 }
 export { InternalTypes }
@@ -1135,7 +1089,7 @@ export function isContextuallyTypedNodeDataObject(data: ContextuallyTypedNodeDat
 export type IsEvent<Event> = Event extends (...args: any[]) => any ? true : false;
 
 // @alpha
-export interface ISharedTree extends ISharedObject, ITreeOld, ITree {
+export interface ISharedTree extends ISharedObject, ITree {
     contentSnapshot(): SharedTreeContentSnapshot;
     requireSchema<TRoot extends TreeFieldSchema>(schema: TreeSchema<TRoot>, onSchemaIncompatible: () => void): FlexTreeView<TRoot> | undefined;
     schematizeInternal<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): FlexTreeView<TRoot>;
@@ -1224,11 +1178,6 @@ export interface ITreeCursorSynchronous extends ITreeCursor {
 }
 
 // @alpha
-export interface ITreeOld extends IChannel {
-    schematizeOld<TRoot extends TreeFieldSchema>(config: InitializeAndSchematizeConfiguration<TRoot>): TreeViewOld<TreeField<TRoot>>;
-}
-
-// @alpha
 export interface ITreeSubscriptionCursor extends ITreeCursor {
     buildAnchor(): Anchor;
     buildFieldAnchor(): FieldAnchor;
@@ -1259,9 +1208,6 @@ export interface JsonableTree extends GenericTreeNode<JsonableTree> {
 // @alpha
 export function jsonableTreeFromCursor(cursor: ITreeCursor): JsonableTree;
 
-// @alpha (undocumented)
-export const jsonArray: FieldNodeSchema<"com.fluidframework.json.array", TreeFieldSchema<Sequence, readonly [() => MapNodeSchema<"com.fluidframework.json.object", TreeFieldSchema<Optional, readonly [any, () => FieldNodeSchema<"com.fluidframework.json.array", TreeFieldSchema<Sequence, readonly [any, any, LeafNodeSchema<"com.fluidframework.leaf.number", ValueSchema.Number>, LeafNodeSchema<"com.fluidframework.leaf.boolean", ValueSchema.Boolean>, LeafNodeSchema<"com.fluidframework.leaf.string", ValueSchema.String>, LeafNodeSchema<"com.fluidframework.leaf.null", ValueSchema.Null>]>>, LeafNodeSchema<"com.fluidframework.leaf.number", ValueSchema.Number>, LeafNodeSchema<"com.fluidframework.leaf.boolean", ValueSchema.Boolean>, LeafNodeSchema<"com.fluidframework.leaf.string", ValueSchema.String>, LeafNodeSchema<"com.fluidframework.leaf.null", ValueSchema.Null>]>>, () => FieldNodeSchema<"com.fluidframework.json.array", TreeFieldSchema<Sequence, readonly [() => MapNodeSchema<"com.fluidframework.json.object", TreeFieldSchema<Optional, readonly [any, any, LeafNodeSchema<"com.fluidframework.leaf.number", ValueSchema.Number>, LeafNodeSchema<"com.fluidframework.leaf.boolean", ValueSchema.Boolean>, LeafNodeSchema<"com.fluidframework.leaf.string", ValueSchema.String>, LeafNodeSchema<"com.fluidframework.leaf.null", ValueSchema.Null>]>>, any, LeafNodeSchema<"com.fluidframework.leaf.number", ValueSchema.Number>, LeafNodeSchema<"com.fluidframework.leaf.boolean", ValueSchema.Boolean>, LeafNodeSchema<"com.fluidframework.leaf.string", ValueSchema.String>, LeafNodeSchema<"com.fluidframework.leaf.null", ValueSchema.Null>]>>, LeafNodeSchema<"com.fluidframework.leaf.number", ValueSchema.Number>, LeafNodeSchema<"com.fluidframework.leaf.boolean", ValueSchema.Boolean>, LeafNodeSchema<"com.fluidframework.leaf.string", ValueSchema.String>, LeafNodeSchema<"com.fluidframework.leaf.null", ValueSchema.Null>]>>;
-
 // @alpha
 export type JsonCompatible = string | number | boolean | null | JsonCompatible[] | JsonCompatibleObject;
 
@@ -1274,12 +1220,6 @@ export type JsonCompatibleObject = {
 export type JsonCompatibleReadOnly = string | number | boolean | null | readonly JsonCompatibleReadOnly[] | {
     readonly [P in string]?: JsonCompatibleReadOnly;
 };
-
-// @alpha (undocumented)
-export const jsonObject: MapNodeSchema<"com.fluidframework.json.object", TreeFieldSchema<Optional, readonly [() => MapNodeSchema<"com.fluidframework.json.object", TreeFieldSchema<Optional, readonly [any, () => FieldNodeSchema<"com.fluidframework.json.array", TreeFieldSchema<Sequence, readonly [any, any, LeafNodeSchema<"com.fluidframework.leaf.number", ValueSchema.Number>, LeafNodeSchema<"com.fluidframework.leaf.boolean", ValueSchema.Boolean>, LeafNodeSchema<"com.fluidframework.leaf.string", ValueSchema.String>, LeafNodeSchema<"com.fluidframework.leaf.null", ValueSchema.Null>]>>, LeafNodeSchema<"com.fluidframework.leaf.number", ValueSchema.Number>, LeafNodeSchema<"com.fluidframework.leaf.boolean", ValueSchema.Boolean>, LeafNodeSchema<"com.fluidframework.leaf.string", ValueSchema.String>, LeafNodeSchema<"com.fluidframework.leaf.null", ValueSchema.Null>]>>, () => FieldNodeSchema<"com.fluidframework.json.array", TreeFieldSchema<Sequence, readonly [() => MapNodeSchema<"com.fluidframework.json.object", TreeFieldSchema<Optional, readonly [any, any, LeafNodeSchema<"com.fluidframework.leaf.number", ValueSchema.Number>, LeafNodeSchema<"com.fluidframework.leaf.boolean", ValueSchema.Boolean>, LeafNodeSchema<"com.fluidframework.leaf.string", ValueSchema.String>, LeafNodeSchema<"com.fluidframework.leaf.null", ValueSchema.Null>]>>, any, LeafNodeSchema<"com.fluidframework.leaf.number", ValueSchema.Number>, LeafNodeSchema<"com.fluidframework.leaf.boolean", ValueSchema.Boolean>, LeafNodeSchema<"com.fluidframework.leaf.string", ValueSchema.String>, LeafNodeSchema<"com.fluidframework.leaf.null", ValueSchema.Null>]>>, LeafNodeSchema<"com.fluidframework.leaf.number", ValueSchema.Number>, LeafNodeSchema<"com.fluidframework.leaf.boolean", ValueSchema.Boolean>, LeafNodeSchema<"com.fluidframework.leaf.string", ValueSchema.String>, LeafNodeSchema<"com.fluidframework.leaf.null", ValueSchema.Null>]>>;
-
-// @alpha (undocumented)
-export const jsonSchema: SchemaLibrary;
 
 // @alpha
 export interface JsonValidator {
@@ -1425,11 +1365,6 @@ export type NodeFromSchema<T extends TreeNodeSchema> = T extends TreeNodeSchema<
 export type NodeIndex = number;
 
 // @alpha
-export const nodeKeyField: {
-    __n_id__: TreeFieldSchema<NodeKeyFieldKind, readonly [LeafNodeSchema<"com.fluidframework.nodeKey.NodeKey", ValueSchema.String>]>;
-};
-
-// @alpha
 export const nodeKeyFieldKey = "__n_id__";
 
 // @alpha (undocumented)
@@ -1443,9 +1378,6 @@ interface NodeKeys {
     readonly map: ReadonlyMap<LocalNodeKey, FlexTreeObjectNode>;
     stabilize(key: LocalNodeKey): StableNodeKey;
 }
-
-// @alpha
-export const nodeKeySchema: SchemaLibrary;
 
 // @beta
 enum NodeKind {
@@ -1472,14 +1404,14 @@ type NormalizeAllowedTypes<TSchema extends ImplicitAllowedTypes> = TSchema exten
 type NormalizedFlexList<Item> = readonly Item[];
 
 // @alpha
-type NormalizeField<TSchema extends FlexImplicitFieldSchema, TDefault extends FieldKind> = TSchema extends TreeFieldSchema ? TSchema : TreeFieldSchema<TDefault, NormalizeAllowedTypes<Assume<TSchema, ImplicitAllowedTypes>>>;
+type NormalizeField<T extends TreeFieldSchema | undefined> = T extends TreeFieldSchema ? T : TreeFieldSchema<typeof FieldKinds.forbidden, []>;
 
 // @alpha
-type NormalizeField_2<T extends TreeFieldSchema | undefined> = T extends TreeFieldSchema ? T : TreeFieldSchema<typeof FieldKinds.forbidden, []>;
+type NormalizeField_2<TSchema extends FlexImplicitFieldSchema, TDefault extends FieldKind> = TSchema extends TreeFieldSchema ? TSchema : TreeFieldSchema<TDefault, NormalizeAllowedTypes<Assume<TSchema, ImplicitAllowedTypes>>>;
 
 // @alpha (undocumented)
 type NormalizeObjectNodeFields<T extends Fields> = {
-    readonly [Property in keyof T]: NormalizeField_2<T[Property]>;
+    readonly [Property in keyof T]: NormalizeField<T[Property]>;
 };
 
 // @beta
@@ -1673,7 +1605,7 @@ export function runSynchronous(view: ITreeCheckout, transaction: (view: ITreeChe
 
 declare namespace SchemaAware {
     export {
-        TypedNode_2 as TypedNode,
+        TypedNode,
         TypedField,
         AllowedTypesToTypedTrees,
         InternalTypes_2 as InternalTypes
@@ -1681,53 +1613,23 @@ declare namespace SchemaAware {
 }
 export { SchemaAware }
 
-// @alpha @sealed
-export class SchemaBuilder<TScope extends string = string, TName extends string | number = string> extends SchemaBuilderBase<TScope, typeof FieldKinds.required, TName> {
-    constructor(options: SchemaBuilderOptions<TScope>);
-    // (undocumented)
-    readonly boolean: LeafNodeSchema<"com.fluidframework.leaf.boolean", import("..").ValueSchema.Boolean>;
-    fixRecursiveReference<T extends AllowedTypes>(...types: T): void;
-    // (undocumented)
-    readonly handle: LeafNodeSchema<"com.fluidframework.leaf.handle", import("..").ValueSchema.FluidHandle>;
-    list<const T extends FlexTreeNodeSchema | Any | readonly FlexTreeNodeSchema[]>(allowedTypes: T): FieldNodeSchema<`${TScope}.List<${string}>`, TreeFieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>>;
-    list<Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): FieldNodeSchema<`${TScope}.${Name}`, TreeFieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>>;
-    map<const T extends FlexTreeNodeSchema | Any | readonly FlexTreeNodeSchema[]>(allowedTypes: T): MapNodeSchema<`${TScope}.Map<${string}>`, NormalizeField<T, typeof FieldKinds.optional>>;
-    map<Name extends TName, const T extends MapFieldSchema | ImplicitAllowedTypes>(name: Name, fieldSchema: T): MapNodeSchema<`${TScope}.${Name}`, NormalizeField<T, typeof FieldKinds.optional>>;
-    // (undocumented)
-    readonly null: LeafNodeSchema<"com.fluidframework.leaf.null", import("..").ValueSchema.Null>;
-    // (undocumented)
-    readonly number: LeafNodeSchema<"com.fluidframework.leaf.number", import("..").ValueSchema.Number>;
-    // (undocumented)
-    object<const Name extends TName, const T extends RestrictiveReadonlyRecord<string, FlexImplicitFieldSchema>>(name: Name, t: T): FactoryObjectNodeSchema<TScope, Name, T>;
-    // (undocumented)
-    objectRecursive<const Name extends TName, const T extends Unenforced<RestrictiveReadonlyRecord<string, FlexImplicitFieldSchema>>>(name: Name, t: T): FactoryObjectNodeSchemaRecursive<TScope, Name, T>;
-    static optional: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => TreeFieldSchema<Optional, NormalizeAllowedTypes<T>>;
-    readonly optional: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => TreeFieldSchema<Optional, NormalizeAllowedTypes<T>>;
-    static required: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => TreeFieldSchema<Required_2, NormalizeAllowedTypes<T>>;
-    readonly required: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => TreeFieldSchema<Required_2, NormalizeAllowedTypes<T>>;
-    static sequence: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => TreeFieldSchema<Sequence, NormalizeAllowedTypes<T>>;
-    readonly sequence: <const T extends ImplicitAllowedTypes>(allowedTypes: T) => TreeFieldSchema<Sequence, NormalizeAllowedTypes<T>>;
-    // (undocumented)
-    readonly string: LeafNodeSchema<"com.fluidframework.leaf.string", import("..").ValueSchema.String>;
-}
-
 // @alpha
 export class SchemaBuilderBase<TScope extends string, TDefaultKind extends FieldKind, TName extends number | string = string> {
     constructor(defaultKind: TDefaultKind, options: SchemaBuilderOptions<TScope>);
     // (undocumented)
     protected addNodeSchema<T extends FlexTreeNodeSchema>(schema: T): void;
     static field<Kind extends FieldKind, T extends ImplicitAllowedTypes>(kind: Kind, allowedTypes: T): TreeFieldSchema<Kind, NormalizeAllowedTypes<T>>;
-    fieldNode<Name extends TName, const T extends FlexImplicitFieldSchema>(name: Name, fieldSchema: T): FieldNodeSchema<`${TScope}.${Name}`, NormalizeField<T, TDefaultKind>>;
+    fieldNode<Name extends TName, const T extends FlexImplicitFieldSchema>(name: Name, fieldSchema: T): FieldNodeSchema<`${TScope}.${Name}`, NormalizeField_2<T, TDefaultKind>>;
     fieldNodeRecursive<Name extends TName, const T extends Unenforced<FlexImplicitFieldSchema>>(name: Name, t: T): FieldNodeSchema<`${TScope}.${Name}`, T>;
     static fieldRecursive<Kind extends FieldKind, T extends FlexList<Unenforced<FlexTreeNodeSchema>>>(kind: Kind, ...allowedTypes: T): TreeFieldSchema<Kind, T>;
     intoLibrary(): SchemaLibrary;
-    intoSchema<const TSchema extends FlexImplicitFieldSchema>(root: TSchema): TreeSchema<NormalizeField<TSchema, TDefaultKind>>;
+    intoSchema<const TSchema extends FlexImplicitFieldSchema>(root: TSchema): TreeSchema<NormalizeField_2<TSchema, TDefaultKind>>;
     map<Name extends TName, const T extends MapFieldSchema>(name: Name, fieldSchema: T): MapNodeSchema<`${TScope}.${Name}`, T>;
     mapRecursive<Name extends TName, const T extends Unenforced<MapFieldSchema>>(name: Name, t: T): MapNodeSchema<`${TScope}.${Name}`, T>;
     readonly name: string;
-    protected normalizeField<TSchema extends FlexImplicitFieldSchema>(schema: TSchema): NormalizeField<TSchema, TDefaultKind>;
+    protected normalizeField<TSchema extends FlexImplicitFieldSchema>(schema: TSchema): NormalizeField_2<TSchema, TDefaultKind>;
     object<const Name extends TName, const T extends RestrictiveReadonlyRecord<string, FlexImplicitFieldSchema>>(name: Name, t: T): ObjectNodeSchema<`${TScope}.${Name}`, {
-        [key in keyof T]: NormalizeField<T[key], TDefaultKind>;
+        [key in keyof T]: NormalizeField_2<T[key], TDefaultKind>;
     }>;
     objectRecursive<const Name extends TName, const T extends Unenforced<RestrictiveReadonlyRecord<string, FlexImplicitFieldSchema>>>(name: Name, t: T): ObjectNodeSchema<`${TScope}.${Name}`, T>;
     readonly scope: TScope;
@@ -1874,9 +1776,6 @@ export class SimpleDependee implements Dependee {
 }
 
 // @alpha
-export function singleJsonCursor(root: JsonCompatible): ITreeCursorSynchronous;
-
-// @alpha
 export function singleTextCursor(root: JsonableTree): ITreeCursorSynchronous;
 
 // @alpha
@@ -1933,16 +1832,6 @@ export interface TreeApi {
 }
 
 // @alpha
-export interface TreeApiOld {
-    readonly is: <TSchema extends FlexTreeNodeSchema>(value: unknown, schema: TSchema) => value is TypedNode<TSchema>;
-    readonly key: (node: TreeNode) => string | number;
-    readonly on: <K extends keyof EditableTreeEvents>(node: TreeNode, eventName: K, listener: EditableTreeEvents[K]) => () => void;
-    readonly parent: (node: TreeNode) => TreeNode | undefined;
-    readonly schema: (node: TreeNode) => FlexTreeNodeSchema;
-    readonly status: (node: TreeNode) => TreeStatus;
-}
-
-// @alpha
 export enum TreeCompressionStrategy {
     Compressed = 0,
     Uncompressed = 1
@@ -1994,14 +1883,8 @@ export class TreeFactory implements IChannelFactory {
     readonly type: string;
 }
 
-// @alpha
-export type TreeField<TSchema extends TreeFieldSchema = TreeFieldSchema, Emptiness extends "maybeEmpty" | "notEmpty" = "maybeEmpty"> = TreeFieldInner<TSchema["kind"], TSchema["allowedTypes"], Emptiness>;
-
 // @beta
 export type TreeFieldFromImplicitField<TSchema extends ImplicitFieldSchema = FieldSchema> = TSchema extends FieldSchema<infer Kind, infer Types> ? ApplyKind<TreeNodeFromImplicitAllowedTypes<Types>, Kind> : TSchema extends ImplicitAllowedTypes_2 ? TreeNodeFromImplicitAllowedTypes<TSchema> : unknown;
-
-// @alpha
-export type TreeFieldInner<Kind extends FieldKind, TTypes extends AllowedTypes, Emptiness extends "maybeEmpty" | "notEmpty"> = Kind extends typeof FieldKinds.sequence ? never : Kind extends typeof FieldKinds.required ? TreeNodeUnion<TTypes> : Kind extends typeof FieldKinds.optional ? TreeNodeUnion<TTypes> | (Emptiness extends "notEmpty" ? never : undefined) : unknown;
 
 // @alpha @sealed
 export class TreeFieldSchema<out TKind extends FieldKind = FieldKind, const out TTypes extends Unenforced<AllowedTypes> = AllowedTypes> implements TreeFieldStoredSchema {
@@ -2058,20 +1941,12 @@ interface TreeListNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T
     removeRange(start?: number, end?: number): void;
 }
 
-// @alpha
-export interface TreeListNodeOld<out TTypes extends AllowedTypes = AllowedTypes> extends TreeListNodeBase<TreeNodeUnion<TTypes>, InsertableTreeNodeUnion<TTypes>, TreeListNodeOld> {
-}
-
 // @alpha (undocumented)
 export interface TreeLocation {
     // (undocumented)
     readonly index: number;
     // (undocumented)
     readonly range: FieldLocation | DetachedField;
-}
-
-// @alpha
-export interface TreeMapNode<TSchema extends MapNodeSchema = MapNodeSchema> extends TreeMapNodeBase<TreeField<TSchema["info"], "notEmpty">> {
 }
 
 // @beta
@@ -2086,9 +1961,6 @@ export const enum TreeNavigationResult {
     Ok = 1,
     Pending = 0
 }
-
-// @alpha
-export type TreeNode = TreeListNodeOld | TreeObjectNode<ObjectNodeSchema> | TreeMapNode;
 
 // @beta
 export interface TreeNodeEvents {
@@ -2155,33 +2027,6 @@ export interface TreeNodeStoredSchema {
 }
 
 // @alpha
-export type TreeNodeUnion<TTypes extends AllowedTypes> = TTypes extends readonly [Any] ? unknown : {
-    [Index in keyof TTypes]: TTypes[Index] extends InternalTypedSchemaTypes.LazyItem<infer InnerType> ? InnerType extends FlexTreeNodeSchema ? TypedNode<InnerType> : never : never;
-}[number];
-
-// @alpha
-export interface TreeObjectFactory<TSchema extends TreeNodeSchemaBase> {
-    create(content: InsertableTypedNode<Assume<TSchema, ObjectNodeSchema>>): TreeObjectNode<Assume<TSchema, ObjectNodeSchema>>;
-}
-
-// @alpha
-export type TreeObjectNode<TSchema extends ObjectNodeSchema> = TreeObjectNodeFields<TSchema["objectNodeFieldsObject"]>;
-
-// @alpha
-export type TreeObjectNodeFields<TFields extends RestrictiveReadonlyRecord<string, TreeFieldSchema>> = {
-    -readonly [key in keyof TFields as TFields[key]["kind"] extends AssignableFieldKinds ? TFields[key]["kind"] extends typeof FieldKinds.optional ? key : never : never]?: TreeField<TFields[key]>;
-} & {
-    -readonly [key in keyof TFields as TFields[key]["kind"] extends AssignableFieldKinds ? TFields[key]["kind"] extends typeof FieldKinds.optional ? never : key : never]-?: TreeField<TFields[key]>;
-} & {
-    readonly [key in keyof TFields as TFields[key]["kind"] extends AssignableFieldKinds ? never : TFields[key]["kind"] extends typeof FieldKinds.optional ? key : never]?: TreeField<TFields[key]>;
-} & {
-    readonly [key in keyof TFields as TFields[key]["kind"] extends AssignableFieldKinds ? never : TFields[key]["kind"] extends typeof FieldKinds.optional ? never : key]-?: TreeField<TFields[key]>;
-};
-
-// @alpha
-export const TreeOld: TreeApiOld;
-
-// @alpha
 export interface TreeOptions extends SharedTreeOptions {
     readonly subtype?: string;
 }
@@ -2232,12 +2077,6 @@ export interface TreeView<in out TRoot> extends IDisposable {
 }
 
 // @alpha
-export interface TreeViewOld<in out TRoot> extends IDisposable {
-    readonly events: ISubscribable<CheckoutEvents>;
-    readonly root: TRoot;
-}
-
-// @alpha
 type TypeArrayToTypedFlexTreeArray<T extends readonly FlexTreeNodeSchema[]> = [
 ArrayHasFixedLength<T> extends false ? T extends readonly (infer InnerT)[] ? [FlexTreeTypedNode<Assume<InnerT, FlexTreeNodeSchema>>] : never : FixedSizeTypeArrayToTypedFlexTree<T>
 ][_InlineTrick];
@@ -2245,7 +2084,7 @@ ArrayHasFixedLength<T> extends false ? T extends readonly (infer InnerT)[] ? [Fl
 // @alpha
 type TypeArrayToTypedTreeArray<T extends readonly FlexTreeNodeSchema[]> = [
 T extends readonly [infer Head, ...infer Tail] ? [
-TypedNode_2<Assume<Head, FlexTreeNodeSchema>>,
+TypedNode<Assume<Head, FlexTreeNodeSchema>>,
 ...TypeArrayToTypedTreeArray<Assume<Tail, readonly FlexTreeNodeSchema[]>>
 ] : []
 ][_InlineTrick];
@@ -2270,32 +2109,11 @@ TFields extends {
 ][_InlineTrick];
 
 // @alpha
-export type TypedNode<TSchema extends FlexTreeNodeSchema> = TSchema extends LeafNodeSchema ? TreeValue<TSchema["info"]> : TSchema extends MapNodeSchema ? TreeMapNode<TSchema> : TSchema extends FieldNodeSchema ? TreeListNodeOld<TSchema["info"]["allowedTypes"]> : TSchema extends ObjectNodeSchema ? TreeObjectNode<TSchema> : unknown;
-
-// @alpha
-type TypedNode_2<TSchema extends FlexTreeNodeSchema> = FlattenKeys<CollectOptions<TSchema extends ObjectNodeSchema<string, infer TFields extends Fields> ? TypedFields<TFields> : TSchema extends FieldNodeSchema<string, infer TField extends TreeFieldSchema> ? {
+type TypedNode<TSchema extends FlexTreeNodeSchema> = FlattenKeys<CollectOptions<TSchema extends ObjectNodeSchema<string, infer TFields extends Fields> ? TypedFields<TFields> : TSchema extends FieldNodeSchema<string, infer TField extends TreeFieldSchema> ? {
     "": TypedField<TField>;
 } : TSchema extends MapNodeSchema<string, infer TField extends TreeFieldSchema> ? {
     readonly [P in string]: TypedField<TField>;
 } : EmptyObject, TSchema extends LeafNodeSchema<string, infer TValueSchema> ? TValueSchema : undefined, TSchema["name"]>>;
-
-// @alpha
-export class TypedTreeFactory implements IChannelFactory {
-    constructor(options: TypedTreeOptions);
-    // (undocumented)
-    readonly attributes: IChannelAttributes;
-    // (undocumented)
-    create(runtime: IFluidDataStoreRuntime, id: string): ITreeOld;
-    // (undocumented)
-    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, channelAttributes: Readonly<IChannelAttributes>): Promise<ITreeOld>;
-    // (undocumented)
-    readonly type: string;
-}
-
-// @alpha
-export interface TypedTreeOptions extends SharedTreeOptions {
-    readonly subtype: string;
-}
 
 // @alpha
 type TypedValueOrUndefined<TValue extends ValueSchema | undefined> = TValue extends ValueSchema ? TreeValue<TValue> : undefined;

--- a/experimental/dds/tree2/src/class-tree/schemaFactory.ts
+++ b/experimental/dds/tree2/src/class-tree/schemaFactory.ts
@@ -242,7 +242,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 	}
 
 	/**
-	 * Define a structurally typed {@link TreeNodeSchema} for a {@link TreeMapNode}.
+	 * Define a structurally typed {@link TreeNodeSchema} for a {@link TreeMapNodeBase}.
 	 *
 	 * @remarks
 	 * The {@link TreeNodeSchemaIdentifier} for this Map is defined as a function of the provided types.
@@ -274,7 +274,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 	>;
 
 	/**
-	 * Define a {@link TreeNodeSchema} for a {@link TreeMapNode}.
+	 * Define a {@link TreeNodeSchema} for a {@link TreeMapNodeBase}.
 	 *
 	 * @param name - Unique identifier for this schema within this factory's scope.
 	 *

--- a/experimental/dds/tree2/src/class-tree/treeApi.ts
+++ b/experimental/dds/tree2/src/class-tree/treeApi.ts
@@ -11,12 +11,13 @@ import { NodeBase, NodeFromSchema, NodeKind, TreeNodeSchema } from "./schemaType
 import { getFlexSchema } from "./toFlexSchema";
 
 /**
- * Provides various functions for analyzing {@link TreeNode}s.
- * @beta
+ * Provides various functions for analyzing {@link NodeBase}s.
+ *
  * @privateRemarks
  * Inlining the typing of this interface onto the `Tree` object provides slightly different .d.ts generation,
  * which avoids typescript expanding the type of TreeNodeSchema and thus encountering
  * https://github.com/microsoft/rushstack/issues/1958.
+ * @beta
  */
 export interface TreeApi {
 	/**
@@ -64,7 +65,7 @@ export interface TreeApi {
 }
 
 /**
- * The `Tree` object holds various functions for analyzing {@link TreeNode}s.
+ * The `Tree` object holds various functions for analyzing {@link NodeBase}s.
  * @beta
  */
 export const nodeApi: TreeApi = {

--- a/experimental/dds/tree2/src/domains/json/jsonCursor.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonCursor.ts
@@ -91,7 +91,6 @@ const adapter: CursorAdapter<JsonCompatible> = {
  * Used to read a Jsonable tree for testing and benchmarking.
  *
  * @returns an {@link ITreeCursorSynchronous} for a single {@link JsonCompatible}.
- * @alpha
  */
 export function singleJsonCursor(root: JsonCompatible): ITreeCursorSynchronous {
 	return stackTreeNodeCursor(adapter, root);
@@ -100,7 +99,6 @@ export function singleJsonCursor(root: JsonCompatible): ITreeCursorSynchronous {
 /**
  * Extract a JS object tree from the contents of the given ITreeCursor.
  * Assumes that ITreeCursor contains only unaugmented JsonTypes.
- * @alpha
  */
 export function cursorToJsonObject(reader: ITreeCursor): JsonCompatible {
 	const type = reader.type;

--- a/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
@@ -28,7 +28,6 @@ const jsonPrimitives = [...leaf.primitives, leaf.null] as const;
 
 /**
  * Types allowed as roots of Json content.
- * @alpha
  */
 export const jsonRoot = [() => jsonObject, () => jsonArray, ...jsonPrimitives] as const;
 
@@ -38,7 +37,6 @@ export const jsonRoot = [() => jsonObject, () => jsonArray, ...jsonPrimitives] a
 }
 
 /**
- * @alpha
  */
 export const jsonObject = builder.mapRecursive(
 	"object",
@@ -46,7 +44,6 @@ export const jsonObject = builder.mapRecursive(
 );
 
 /**
- * @alpha
  */
 export const jsonArray = builder.fieldNodeRecursive(
 	"array",
@@ -54,6 +51,5 @@ export const jsonArray = builder.fieldNodeRecursive(
 );
 
 /**
- * @alpha
  */
 export const jsonSchema = builder.intoLibrary();

--- a/experimental/dds/tree2/src/domains/leafDomain.ts
+++ b/experimental/dds/tree2/src/domains/leafDomain.ts
@@ -91,7 +91,7 @@ export const leaf = {
 	/**
 	 * {@link SchemaLibrary} of the {@link LeafNodeSchema}.
 	 *
-	 * @remarks
+	 * @privateRemarks
 	 * This is included by default in schema produced with {@link SchemaBuilder}.
 	 */
 	library,

--- a/experimental/dds/tree2/src/domains/nodeKey/nodeKeySchema.ts
+++ b/experimental/dds/tree2/src/domains/nodeKey/nodeKeySchema.ts
@@ -17,7 +17,6 @@ const builder = new SchemaBuilderInternal({ scope: "com.fluidframework.nodeKey" 
 
 /**
  * Schema for a node which holds a {@link StableNodeKey}.
- * @alpha
  *
  * @privateRemarks
  * This being a leaf may cause issues with leaf unboxing plans.
@@ -32,7 +31,6 @@ assert(nodeKeyTreeSchema.name === nodeKeyTreeIdentifier, 0x7ae /* mismatched ide
  * This object can be expanded into a schema to add the field.
  *
  * Requires including {@link nodeKeySchema}.
- * @alpha
  */
 export const nodeKeyField = {
 	[nodeKeyFieldKey]: TreeFieldSchema.create(FieldKinds.nodeKey, [nodeKeyTreeSchema]),
@@ -41,6 +39,5 @@ export const nodeKeyField = {
 /**
  * The schema library for working with {@link StableNodeKey}s in a tree.
  * Required to use {@link nodeKeyField}.
- * @alpha
  */
 export const nodeKeySchema = builder.intoLibrary();

--- a/experimental/dds/tree2/src/domains/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/domains/schemaBuilder.ts
@@ -34,7 +34,6 @@ import { leaf } from "./leafDomain";
  * A {@link ObjectNodeSchema} that satisfies the {@link TreeObjectFactory} and therefore can create {@link TreeObjectNode}s.
  * @privateRemarks
  * This type exists because TypeScript is not able to correlate the two places where it is used if the body of this type is inlined.
- * @alpha
  */
 export type FactoryObjectNodeSchema<
 	TScope extends string,
@@ -51,7 +50,6 @@ export type FactoryObjectNodeSchema<
  * See {@link Unenforced} for details.
  *
  * TODO: Make this work with ImplicitFieldSchema.
- * @alpha
  */
 export type FactoryObjectNodeSchemaRecursive<
 	TScope extends string,

--- a/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
+++ b/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
@@ -18,7 +18,6 @@ import { SchemaBuilder } from "./schemaBuilder";
 const builder = new SchemaBuilder({ scope: "Test Recursive Domain" });
 
 /**
- * @alpha
  */
 export const recursiveObject = builder.objectRecursive("object", {
 	recursive: TreeFieldSchema.createUnsafe(FieldKinds.optional, [() => recursiveObject]),
@@ -29,7 +28,6 @@ const recursiveReference = () => recursiveObject2;
 builder.fixRecursiveReference(recursiveReference);
 
 /**
- * @alpha
  */
 export const recursiveObject2 = builder.object("object2", {
 	recursive: TreeFieldSchema.create(FieldKinds.optional, [recursiveReference]),
@@ -44,7 +42,6 @@ type _1 = requireTrue<
 	>
 >;
 /**
- * @alpha
  */
 export const library = builder.intoLibrary();
 

--- a/experimental/dds/tree2/src/index.ts
+++ b/experimental/dds/tree2/src/index.ts
@@ -120,17 +120,7 @@ export {
 	HasListeners,
 } from "./events";
 
-export {
-	cursorToJsonObject,
-	singleJsonCursor,
-	jsonArray,
-	jsonObject,
-	jsonSchema,
-	nodeKeyField,
-	nodeKeySchema,
-	leaf,
-	SchemaBuilder,
-} from "./domains";
+export { leaf } from "./domains";
 
 export {
 	FieldKind,
@@ -226,25 +216,7 @@ export {
 	stackTreeFieldCursor,
 } from "./feature-libraries";
 
-export {
-	TreeObjectNodeFields,
-	TreeField,
-	TreeFieldInner,
-	TypedNode,
-	TreeNodeUnion,
-	TreeListNode,
-	TreeListNodeOld,
-	TreeMapNode,
-	TreeObjectNode,
-	Tree as TreeOld,
-	TreeApi as TreeApiOld,
-	TreeNode,
-	TreeObjectFactory,
-	FactoryTreeSchema,
-	TreeMapNodeBase,
-	Unhydrated,
-	IterableTreeListContent,
-} from "./simple-tree";
+export { TreeListNode, TreeMapNodeBase, Unhydrated, IterableTreeListContent } from "./simple-tree";
 
 export {
 	ISharedTree,
@@ -260,12 +232,8 @@ export {
 	InitializeAndSchematizeConfiguration,
 	SchemaConfiguration,
 	ForestType,
-	TypedTreeFactory,
-	TypedTreeOptions,
-	ITree as ITreeOld,
 	SharedTreeContentSnapshot,
 	FlexTreeView,
-	TreeView as TreeViewOld,
 	ITreeViewFork,
 	buildTreeConfiguration,
 } from "./shared-tree";

--- a/experimental/dds/tree2/src/internal.ts
+++ b/experimental/dds/tree2/src/internal.ts
@@ -37,8 +37,6 @@ export {
 	Sequence,
 } from "./feature-libraries";
 
-export { FactoryObjectNodeSchema, FactoryObjectNodeSchemaRecursive } from "./domains";
-
 export {
 	NodeKind,
 	TreeNodeSchemaClass,
@@ -47,12 +45,4 @@ export {
 	InternalEditableTreeTypes,
 } from "./class-tree";
 
-export {
-	TreeListNodeBase,
-	InsertableTreeField,
-	InsertableTreeFieldInner,
-	InsertableTreeNodeUnion,
-	InsertableTreeObjectNode,
-	InsertableTreeObjectNodeFields,
-	InsertableTypedNode,
-} from "./simple-tree";
+export { TreeListNodeBase } from "./simple-tree";

--- a/experimental/dds/tree2/src/shared-tree/sharedTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/sharedTree.ts
@@ -99,7 +99,7 @@ export interface SharedTreeContentSnapshot {
  * See [the README](../../README.md) for details.
  * @alpha
  */
-export interface ISharedTree extends ISharedObject, OldSimpleTree, ITree {
+export interface ISharedTree extends ISharedObject, ITree {
 	/**
 	 * Provides a copy of the current content of the tree.
 	 * This can be useful for inspecting the tree when no suitable view schema is available.
@@ -110,7 +110,7 @@ export interface ISharedTree extends ISharedObject, OldSimpleTree, ITree {
 	contentSnapshot(): SharedTreeContentSnapshot;
 
 	/**
-	 * Like {@link ITreeOld.schematizeOld}, but returns a more powerful type exposing more package internal information.
+	 * Like {@link ITree.schematize}, but uses the flex-tree schema system and exposes the tree as a flex-tree.
 	 * @privateRemarks
 	 * This has to avoid its name colliding with `schematize`.
 	 * TODO: Either ITree and ISharedTree should be split into separate objects, the methods should be merged or a better convention for resolving such name conflicts should be selected.
@@ -147,7 +147,7 @@ export interface ISharedTree extends ISharedObject, OldSimpleTree, ITree {
  */
 export class SharedTree
 	extends SharedTreeCore<DefaultEditBuilder, DefaultChangeset>
-	implements ISharedTree
+	implements ISharedTree, OldSimpleTree
 {
 	private readonly _events: ISubscribable<CheckoutEvents> &
 		IEmitter<CheckoutEvents> &

--- a/experimental/dds/tree2/src/shared-tree/simpleTree.ts
+++ b/experimental/dds/tree2/src/shared-tree/simpleTree.ts
@@ -20,7 +20,6 @@ import { CheckoutEvents } from "./treeCheckout";
 
 /**
  * Configuration to specialize a Tree DDS for a particular use.
- * @alpha
  */
 export interface TypedTreeOptions extends SharedTreeOptions {
 	/**
@@ -34,7 +33,6 @@ export interface TypedTreeOptions extends SharedTreeOptions {
 
 /**
  * Channel for a Tree DDS.
- * @alpha
  */
 export interface ITree extends IChannel {
 	/**
@@ -81,7 +79,6 @@ export interface ITree extends IChannel {
  * This is a wrapper around ITreeView that adjusted it for the public package API.
  * TODO:
  * Establish a naming conversion between these internal and wrapper types.
- * @alpha
  */
 export interface TreeView<in out TRoot> extends IDisposable {
 	/**
@@ -99,7 +96,6 @@ export interface TreeView<in out TRoot> extends IDisposable {
 
 /**
  * A channel factory that creates an {@link ITree}.
- * @alpha
  */
 export class TypedTreeFactory implements IChannelFactory {
 	public readonly type: string;

--- a/experimental/dds/tree2/src/simple-tree/insertable.ts
+++ b/experimental/dds/tree2/src/simple-tree/insertable.ts
@@ -22,14 +22,12 @@ import {
 
 /**
  * Data from which a {@link TreeObjectNode} can be built.
- * @alpha
  */
 export type InsertableTreeObjectNode<TSchema extends ObjectNodeSchema> =
 	InsertableTreeObjectNodeFields<TSchema["objectNodeFieldsObject"]>;
 
 /**
  * Helper for generating the properties of a InsertableTreeObjectNode.
- * @alpha
  */
 export type InsertableTreeObjectNodeFields<
 	TFields extends RestrictiveReadonlyRecord<string, TreeFieldSchema>,
@@ -45,14 +43,12 @@ export type InsertableTreeObjectNodeFields<
 
 /**
  * Data from which a {@link TreeField} can be built.
- * @alpha
  */
 export type InsertableTreeField<TSchema extends TreeFieldSchema = TreeFieldSchema> =
 	InsertableTreeFieldInner<TSchema["kind"], TSchema["allowedTypes"]>;
 
 /**
  * Helper for implementing InsertableTreeField.
- * @alpha
  */
 export type InsertableTreeFieldInner<
 	Kind extends FieldKind,
@@ -69,7 +65,6 @@ export type InsertableTreeFieldInner<
  * Given multiple node schema types, return the corresponding object type union from which the node could be built.
  *
  * If the types are ambagious, use the schema's factory to construct a unhydrated node instance with the desired type.
- * @alpha
  */
 export type InsertableTreeNodeUnion<TTypes extends AllowedTypes> = TTypes extends readonly [Any]
 	? unknown
@@ -88,7 +83,6 @@ export type InsertableTreeNodeUnion<TTypes extends AllowedTypes> = TTypes extend
 
 /**
  * Given a node's schema, return the corresponding object from which the node could be built.
- * @alpha
  */
 export type InsertableTypedNode<TSchema extends TreeNodeSchema> = TSchema extends LeafNodeSchema
 	? TreeValue<TSchema["info"]>

--- a/experimental/dds/tree2/src/simple-tree/node.ts
+++ b/experimental/dds/tree2/src/simple-tree/node.ts
@@ -15,7 +15,6 @@ import { TypedNode, TreeNode } from "./types";
 
 /**
  * Provides various functions for analyzing {@link TreeNode}s.
- * @alpha
  * @privateRemarks
  * Inlining the typing of this interface onto the `Tree` object provides slightly different .d.ts generation,
  * which avoids typescript expanding the type of TreeNodeSchema and thus encountering
@@ -68,7 +67,6 @@ export interface TreeApi {
 
 /**
  * The `Tree` object holds various functions for analyzing {@link TreeNode}s.
- * @alpha
  */
 export const nodeApi: TreeApi = {
 	schema: (node: TreeNode) => {

--- a/experimental/dds/tree2/src/simple-tree/objectFactory.ts
+++ b/experimental/dds/tree2/src/simple-tree/objectFactory.ts
@@ -25,7 +25,6 @@ export function addFactory<TSchema extends ObjectNodeSchema<string, any>>(
 
 /**
  * Creates `{@link TreeObjectNode}`s of the given schema type via a `create` method.
- * @alpha
  */
 export interface TreeObjectFactory<TSchema extends TreeNodeSchemaBase> {
 	/**
@@ -42,7 +41,6 @@ export interface TreeObjectFactory<TSchema extends TreeNodeSchemaBase> {
 
 /**
  * A {@link TreeNodeSchema} which is also a {@link TreeObjectFactory}.
- * @alpha
  */
 export type FactoryTreeSchema<TSchema extends TreeNodeSchemaBase> = TSchema &
 	TreeObjectFactory<TSchema>;

--- a/experimental/dds/tree2/src/simple-tree/treeListNode.ts
+++ b/experimental/dds/tree2/src/simple-tree/treeListNode.ts
@@ -10,7 +10,6 @@ import { TreeListNodeBase, TreeNodeUnion, Unhydrated } from "./types";
 
 /**
  * A {@link TreeNode} which implements 'readonly T[]' and the list mutation APIs.
- * @alpha
  */
 export interface TreeListNodeOld<out TTypes extends AllowedTypes = AllowedTypes>
 	extends TreeListNodeBase<
@@ -20,7 +19,7 @@ export interface TreeListNodeOld<out TTypes extends AllowedTypes = AllowedTypes>
 	> {}
 
 /**
- * A {@link TreeNode} which implements 'readonly T[]' and the list mutation APIs.
+ * A {@link NodeBase} which implements 'readonly T[]' and the list mutation APIs.
  * @beta
  */
 export interface TreeListNode<TTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes>
@@ -31,14 +30,14 @@ export interface TreeListNode<TTypes extends ImplicitAllowedTypes = ImplicitAllo
 	> {}
 
 /**
- * A {@link TreeNode} which implements 'readonly T[]' and the list mutation APIs.
+ * A {@link NodeBase} which implements 'readonly T[]' and the list mutation APIs.
  * @beta
  */
 export const TreeListNode = {
 	/**
 	 * Wrap an iterable of items to inserted as consecutive items in a list.
 	 * @remarks
-	 * The object returned by this function can be inserted into a {@link TreeListNodeOld}.
+	 * The object returned by this function can be inserted into a {@link (TreeListNode:interface)}.
 	 * Its contents will be inserted consecutively in the corresponding location in the list.
 	 * @example
 	 * ```ts

--- a/experimental/dds/tree2/src/simple-tree/types.ts
+++ b/experimental/dds/tree2/src/simple-tree/types.ts
@@ -42,7 +42,6 @@ export type Unhydrated<T> = T;
  * TODO: Type tests to ensure that various tree node types are actually assignable to this.
  *
  * Using default parameters, this could be combined with TypedNode.
- * @alpha
  */
 export type TreeNode = TreeListNodeOld | TreeObjectNode<ObjectNodeSchema> | TreeMapNode;
 
@@ -201,7 +200,6 @@ export interface TreeListNodeBase<out T, in TNew, in TMoveFrom> extends Readonly
 
 /**
  * An object which supports property-based access to fields.
- * @alpha
  */
 export type TreeObjectNode<TSchema extends ObjectNodeSchema> = TreeObjectNodeFields<
 	TSchema["objectNodeFieldsObject"]
@@ -213,7 +211,6 @@ export type TreeObjectNode<TSchema extends ObjectNodeSchema> = TreeObjectNodeFie
  * This type is composed of four subtypes for each mutually exclusive combination of "readonly" and "optional".
  * If it were possible to map to getters and setters separately, the "readonly" cases would collapse, but this is not currently a feature in TS.
  * See https://github.com/microsoft/TypeScript/issues/43826 for more details on this limitation.
- * @alpha
  */
 export type TreeObjectNodeFields<
 	TFields extends RestrictiveReadonlyRecord<string, TreeFieldSchema>,
@@ -253,7 +250,6 @@ export type TreeObjectNodeFields<
  * @privateRemarks
  * Add support for `clear` once we have established merge semantics for it.
  *
- * @alpha
  */
 export interface TreeMapNode<TSchema extends MapNodeSchema = MapNodeSchema>
 	extends TreeMapNodeBase<TreeField<TSchema["info"], "notEmpty">> {}
@@ -297,7 +293,6 @@ export interface TreeMapNodeBase<TOut, TIn = TOut> extends ReadonlyMap<string, T
 
 /**
  * Given a field's schema, return the corresponding object in the proxy-based API.
- * @alpha
  */
 export type TreeField<
 	TSchema extends TreeFieldSchema = TreeFieldSchema,
@@ -307,7 +302,6 @@ export type TreeField<
 
 /**
  * Helper for implementing {@link InternalEditableTreeTypes#ProxyField}.
- * @alpha
  */
 export type TreeFieldInner<
 	Kind extends FieldKind,
@@ -323,7 +317,6 @@ export type TreeFieldInner<
 
 /**
  * Given multiple node schema types, return the corresponding object type union in the proxy-based API.
- * @alpha
  */
 export type TreeNodeUnion<TTypes extends AllowedTypes> = TTypes extends readonly [Any]
 	? unknown
@@ -342,7 +335,6 @@ export type TreeNodeUnion<TTypes extends AllowedTypes> = TTypes extends readonly
 
 /**
  * Given a node's schema, return the corresponding object in the proxy-based API.
- * @alpha
  */
 export type TypedNode<TSchema extends TreeNodeSchema> = TSchema extends LeafNodeSchema
 	? TreeValue<TSchema["info"]>

--- a/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
+++ b/experimental/dds/tree2/src/test/domains/json/jsonCursor.bench.ts
@@ -5,16 +5,14 @@
 
 import { strict as assert } from "assert";
 import { benchmark, BenchmarkType, isInPerformanceTestingMode } from "@fluid-tools/benchmark";
+import { ITreeCursor, jsonableTreeFromCursor, EmptyKey, JsonCompatible, brand } from "../../..";
 import {
-	ITreeCursor,
 	singleJsonCursor,
-	jsonableTreeFromCursor,
-	EmptyKey,
 	cursorToJsonObject,
 	jsonSchema,
-	JsonCompatible,
-	brand,
-} from "../../..";
+	jsonRoot,
+	SchemaBuilder,
+} from "../../../domains";
 import {
 	buildForest,
 	defaultSchemaPolicy,
@@ -36,7 +34,6 @@ import {
 	makeTreeChunker,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/chunked-forest/chunkTree";
-import { jsonRoot, SchemaBuilder } from "../../../domains";
 import { Canada, generateCanada } from "./canada";
 import { averageTwoValues, sum, sumMap } from "./benchmarks";
 import { generateTwitterJsonByByteSize } from "./twitter";

--- a/experimental/dds/tree2/src/test/feature-libraries/flex-tree/events.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/flex-tree/events.spec.ts
@@ -9,10 +9,11 @@ import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { FieldKinds } from "../../../feature-libraries";
 import { ForestType, SharedTreeFactory } from "../../../shared-tree";
 import { typeboxValidator } from "../../../external-utilities";
-import { AllowedUpdateType, SchemaBuilder, leaf } from "../../..";
+import { SchemaBuilder, leaf } from "../../../domains";
 import { flexTreeViewWithContent } from "../../utils";
 // eslint-disable-next-line import/no-internal-modules
 import { onNextChange } from "../../../feature-libraries/flex-tree/flexTreeTypes";
+import { AllowedUpdateType } from "../../../core";
 
 describe("beforeChange/afterChange events", () => {
 	const builder = new SchemaBuilder({

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-aware/schemaSimple.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { SchemaAware, typeNameSymbol, SchemaBuilder, leaf } from "../../../";
+import { SchemaBuilder, leaf } from "../../../domains";
+import { SchemaAware, typeNameSymbol } from "../../../feature-libraries";
 
 const builder = new SchemaBuilder({ scope: "Simple Schema" });
 

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -105,12 +105,12 @@ describe("SharedTree", () => {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
 			assert.equal(tree.contentSnapshot().schema.rootFieldSchema, storedEmptyFieldSchema);
 
-			const view = tree.schematizeOld({
+			const view = tree.schematizeInternal({
 				allowedSchemaModifications: AllowedUpdateType.None,
 				initialTree: 10,
 				schema,
 			});
-			assert.equal(view.root, 10);
+			assert.equal(view.editableTree.content, 10);
 		});
 
 		it("noop upgrade", () => {

--- a/experimental/dds/tree2/src/test/snapshots/gc.spec.ts
+++ b/experimental/dds/tree2/src/test/snapshots/gc.spec.ts
@@ -10,14 +10,12 @@ import {
 	MockFluidDataStoreRuntime,
 	MockStorage,
 } from "@fluidframework/test-runtime-utils";
-import { ISharedTree, SharedTree, SharedTreeFactory, TreeView } from "../../shared-tree";
+import { SharedTree, SharedTreeFactory } from "../../shared-tree";
 import { typeboxValidator } from "../../external-utilities";
-import { SchemaBuilder } from "../../domains";
-import { AllowedUpdateType } from "../../core";
-import { TreeField } from "../../simple-tree";
+import { SchemaFactory, TreeConfiguration } from "../../class-tree";
 
-const builder = new SchemaBuilder({ scope: "test" });
-const someType = builder.object("foo", {
+const builder = new SchemaFactory("test");
+class SomeType extends builder.object("foo", {
 	handles: builder.list(builder.handle),
 	nested: builder.optional(
 		builder.object("bar", {
@@ -25,21 +23,13 @@ const someType = builder.object("foo", {
 		}),
 	),
 	bump: builder.optional(builder.number),
-});
+}) {}
 
-const schema = builder.intoSchema(SchemaBuilder.required(someType));
-
-function getNewTreeView(tree: ISharedTree): TreeView<TreeField<typeof schema.rootFieldSchema>> {
-	return tree.schematizeOld({
-		initialTree: {
-			handles: { "": [] },
-			nested: undefined,
-			bump: undefined,
-		},
-		allowedSchemaModifications: AllowedUpdateType.None,
-		schema,
-	});
-}
+const config = new TreeConfiguration(SomeType, () => ({
+	handles: [],
+	nested: undefined,
+	bump: undefined,
+}));
 
 function createConnectedTree(id: string, runtimeFactory: MockContainerRuntimeFactory) {
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
@@ -79,7 +69,7 @@ describe("Garbage Collection", () => {
 			this.tree1 = createConnectedTree("tree1", this.containerRuntimeFactory);
 			this.tree2 = createConnectedTree("tree2", this.containerRuntimeFactory);
 
-			this.tree1View = getNewTreeView(this.tree1).root;
+			this.tree1View = this.tree1.schematize(config).root;
 		}
 
 		public get sharedObject() {


### PR DESCRIPTION
## Description

All out of package use of tree2 now has to pick between the:

- simple-tree abstraction using the new class based schema. This focuses on node kinds, has List nodes etc. and exposes minimal functionality and leverages implicit defaults. This is marked `@beta`
- flex-tree abstraction using schema-builder-base. This focuses on nodes + fields and FieldKinds, and exposes maximal functionality and is more explicit. This is marked `@alpha`.

This change also fixes several doc links which used to go to the wrong places (ex: from the beta API to the alpha API) but were not caught until those members were removed from the API.

This change specifically avoids renames and non-required doc updates. Ex: NodeBase should probably take over the no longer exported TreeNode type name, but this just updates links to it, and does not do any of the renames. This should help keep this PR focused and easier to merge and review.

## Breaking Changes

Users of simple-tree with flex-tree schema will have to port to the new SchemaFactory (from SchemaBuilder).

Users of flex-tree with have to port from SchemaBuilder to SchemaBuilderBase, and directly refer to TreeFieldSchema.create when needed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
