### PR TITLE
Remove IFluidRouter from DataObject classes

### DIFF
--- a/.changeset/gentle-hats-appear.md
+++ b/.changeset/gentle-hats-appear.md
@@ -4,7 +4,7 @@
 "@fluidframework/test-utils": major
 ---
 
-Remove `IFluidRouter` from DataObject interfaces and classes
+Removed `IFluidRouter` from DataObject interfaces and classes
 
 The `IFluidRouter` property has been removed from a number of DataObject related classes:
 

--- a/.changeset/gentle-hats-appear.md
+++ b/.changeset/gentle-hats-appear.md
@@ -1,0 +1,17 @@
+---
+"@fluidframework/aqueduct": major
+"@fluidframework/data-object-base": major
+"@fluidframework/test-utils": major
+---
+
+Remove `IFluidRouter` from DataObject interfaces and classes
+
+The `IFluidRouter` property has been removed from a number of DataObject related classes:
+
+-   `PureDataObject`
+-   `LazyLoadedDataObject`
+-   `TestFluidObject`
+
+Please migrate to the new `entryPoint` pattern or use the relevant `request` method as necessary.
+
+See [Removing-IFluidRouter.md](https://github.com/microsoft/FluidFramework/blob/main/packages/common/core-interfaces/Removing-IFluidRouter.md) for more details.

--- a/.changeset/nine-coins-send.md
+++ b/.changeset/nine-coins-send.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/aqueduct": major
+---
+
+Removed `IRootDataObjectFactory`
+
+The `IRootDataObjectFactory` interface has been removed. Please remove all usage of it.

--- a/packages/framework/aqueduct/api-report/aqueduct.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.api.md
@@ -23,7 +23,6 @@ import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidDependencySynthesizer } from '@fluidframework/synthesize';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
-import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IProvideFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
 import { IProvideFluidHandle } from '@fluidframework/core-interfaces';
 import { IRequest } from '@fluidframework/core-interfaces';
@@ -105,13 +104,7 @@ export interface IDataObjectProps<I extends DataObjectTypes = DataObjectTypes> {
 }
 
 // @public
-export interface IRootDataObjectFactory extends IFluidDataStoreFactory {
-    // (undocumented)
-    createRootInstance(rootDataStoreId: string, runtime: IContainerRuntime): Promise<IFluidRouter>;
-}
-
-// @public
-export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes> extends TypedEventEmitter<I["Events"] & IEvent> implements IFluidLoadable, IFluidRouter, IProvideFluidHandle {
+export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes> extends TypedEventEmitter<I["Events"] & IEvent> implements IFluidLoadable, IProvideFluidHandle {
     constructor(props: IDataObjectProps<I>);
     protected readonly context: IFluidDataStoreContext;
     finishInitialization(existing: boolean): Promise<void>;
@@ -125,8 +118,6 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
     get IFluidHandle(): IFluidHandle<this>;
     // (undocumented)
     get IFluidLoadable(): this;
-    // @deprecated (undocumented)
-    get IFluidRouter(): this;
     initializeInternal(existing: boolean): Promise<void>;
     // (undocumented)
     protected initializeP: Promise<void> | undefined;
@@ -141,7 +132,7 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 }
 
 // @public
-export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry>, IRootDataObjectFactory {
+export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry> {
     constructor(type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[], optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime);
     createChildInstance(parentContext: IFluidDataStoreContext, initialState?: I["InitialState"]): Promise<TObj>;
     createInstance(runtime: IContainerRuntimeBase, initialState?: I["InitialState"]): Promise<TObj>;

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -156,6 +156,16 @@
 			"RemovedVariableDeclaration_mountableViewRequestHandler": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"ClassDeclaration_DataObject": {
+				"backCompat": false
+			},
+			"RemovedInterfaceDeclaration_IRootDataObjectFactory": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"ClassDeclaration_PureDataObject": {
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/framework/aqueduct/src/data-object-factories/index.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/index.ts
@@ -4,4 +4,4 @@
  */
 
 export { DataObjectFactory } from "./dataObjectFactory";
-export { IRootDataObjectFactory, PureDataObjectFactory } from "./pureDataObjectFactory";
+export { PureDataObjectFactory } from "./pureDataObjectFactory";

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -3,8 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-deprecated
-import { IRequest, IFluidRouter, FluidObject } from "@fluidframework/core-interfaces";
+import { IRequest, FluidObject } from "@fluidframework/core-interfaces";
 import {
 	FluidDataStoreRuntime,
 	ISharedObjectRegistry,
@@ -31,14 +30,6 @@ import {
 
 import { assert } from "@fluidframework/core-utils";
 import { IDataObjectProps, PureDataObject, DataObjectTypes } from "../data-objects";
-/**
- * Useful interface in places where it's useful to do type erasure for PureDataObject generic
- * @public
- */
-export interface IRootDataObjectFactory extends IFluidDataStoreFactory {
-	// eslint-disable-next-line import/no-deprecated
-	createRootInstance(rootDataStoreId: string, runtime: IContainerRuntime): Promise<IFluidRouter>;
-}
 
 /**
  * Proxy over PureDataObject
@@ -135,10 +126,7 @@ export class PureDataObjectFactory<
 		TObj extends PureDataObject<I>,
 		I extends DataObjectTypes = DataObjectTypes,
 	>
-	implements
-		IFluidDataStoreFactory,
-		Partial<IProvideFluidDataStoreRegistry>,
-		IRootDataObjectFactory
+	implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry>
 {
 	private readonly sharedObjectRegistry: ISharedObjectRegistry;
 	private readonly registry: IFluidDataStoreRegistry | undefined;

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -9,8 +9,6 @@ import {
 	IEvent,
 	IFluidHandle,
 	IFluidLoadable,
-	// eslint-disable-next-line import/no-deprecated
-	IFluidRouter,
 	IProvideFluidHandle,
 	IRequest,
 	IResponse,
@@ -32,7 +30,7 @@ import { DataObjectTypes, IDataObjectProps } from "./types";
 export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes>
 	extends TypedEventEmitter<I["Events"] & IEvent>
 	// eslint-disable-next-line import/no-deprecated
-	implements IFluidLoadable, IFluidRouter, IProvideFluidHandle
+	implements IFluidLoadable, IProvideFluidHandle
 {
 	/**
 	 * This is your FluidDataStoreRuntime object
@@ -59,13 +57,6 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 
 	public get id() {
 		return this.runtime.id;
-	}
-	/**
-	 * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
-	 */
-	// eslint-disable-next-line import/no-deprecated
-	public get IFluidRouter() {
-		return this;
 	}
 	public get IFluidLoadable() {
 		return this;

--- a/packages/framework/aqueduct/src/index.ts
+++ b/packages/framework/aqueduct/src/index.ts
@@ -18,11 +18,7 @@
  * @packageDocumentation
  */
 
-export {
-	DataObjectFactory,
-	IRootDataObjectFactory,
-	PureDataObjectFactory,
-} from "./data-object-factories";
+export { DataObjectFactory, PureDataObjectFactory } from "./data-object-factories";
 export { DataObject, DataObjectTypes, IDataObjectProps, PureDataObject } from "./data-objects";
 export {
 	BaseContainerRuntimeFactory,

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -91,6 +91,7 @@ declare function get_current_ClassDeclaration_DataObject():
 declare function use_old_ClassDeclaration_DataObject(
     use: TypeOnly<old.DataObject>): void;
 use_old_ClassDeclaration_DataObject(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_DataObject());
 
 /*
@@ -168,26 +169,14 @@ use_old_InterfaceDeclaration_IDataObjectProps(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IRootDataObjectFactory": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IRootDataObjectFactory": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IRootDataObjectFactory():
-    TypeOnly<old.IRootDataObjectFactory>;
-declare function use_current_InterfaceDeclaration_IRootDataObjectFactory(
-    use: TypeOnly<current.IRootDataObjectFactory>): void;
-use_current_InterfaceDeclaration_IRootDataObjectFactory(
-    get_old_InterfaceDeclaration_IRootDataObjectFactory());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IRootDataObjectFactory": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IRootDataObjectFactory": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IRootDataObjectFactory():
-    TypeOnly<current.IRootDataObjectFactory>;
-declare function use_old_InterfaceDeclaration_IRootDataObjectFactory(
-    use: TypeOnly<old.IRootDataObjectFactory>): void;
-use_old_InterfaceDeclaration_IRootDataObjectFactory(
-    get_current_InterfaceDeclaration_IRootDataObjectFactory());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -211,6 +200,7 @@ declare function get_current_ClassDeclaration_PureDataObject():
 declare function use_old_ClassDeclaration_PureDataObject(
     use: TypeOnly<old.PureDataObject>): void;
 use_old_ClassDeclaration_PureDataObject(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_PureDataObject());
 
 /*

--- a/packages/framework/data-object-base/api-report/data-object-base.api.md
+++ b/packages/framework/data-object-base/api-report/data-object-base.api.md
@@ -18,7 +18,6 @@ import { IFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
-import { IFluidRouter } from '@fluidframework/core-interfaces';
 import { IProvideFluidHandle } from '@fluidframework/core-interfaces';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResponse } from '@fluidframework/core-interfaces';
@@ -28,7 +27,7 @@ import { RuntimeFactoryHelper } from '@fluidframework/runtime-utils';
 import { RuntimeRequestHandler } from '@fluidframework/request-handler';
 
 // @public (undocumented)
-export abstract class LazyLoadedDataObject<TRoot extends ISharedObject = ISharedObject, TEvents extends IEvent = IEvent> extends EventForwarder<TEvents> implements IFluidLoadable, IProvideFluidHandle, IFluidRouter {
+export abstract class LazyLoadedDataObject<TRoot extends ISharedObject = ISharedObject, TEvents extends IEvent = IEvent> extends EventForwarder<TEvents> implements IFluidLoadable, IProvideFluidHandle {
     constructor(context: IFluidDataStoreContext, runtime: IFluidDataStoreRuntime, root: ISharedObject);
     // (undocumented)
     protected readonly context: IFluidDataStoreContext;
@@ -40,8 +39,6 @@ export abstract class LazyLoadedDataObject<TRoot extends ISharedObject = IShared
     get IFluidHandle(): IFluidHandle<this>;
     // (undocumented)
     get IFluidLoadable(): this;
-    // @deprecated (undocumented)
-    get IFluidRouter(): this;
     // (undocumented)
     get IProvideFluidHandle(): this;
     // (undocumented)

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -96,6 +96,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_LazyLoadedDataObject": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
@@ -10,8 +10,6 @@ import {
 	IRequest,
 	IResponse,
 	IProvideFluidHandle,
-	// eslint-disable-next-line import/no-deprecated
-	IFluidRouter,
 } from "@fluidframework/core-interfaces";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
@@ -29,17 +27,10 @@ export abstract class LazyLoadedDataObject<
 	>
 	extends EventForwarder<TEvents>
 	// eslint-disable-next-line import/no-deprecated
-	implements IFluidLoadable, IProvideFluidHandle, IFluidRouter
+	implements IFluidLoadable, IProvideFluidHandle
 {
 	private _handle?: IFluidHandle<this>;
 
-	/**
-	 * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
-	 */
-	// eslint-disable-next-line import/no-deprecated
-	public get IFluidRouter() {
-		return this;
-	}
 	public get IFluidLoadable() {
 		return this;
 	}
@@ -61,15 +52,11 @@ export abstract class LazyLoadedDataObject<
 		this.root = root as TRoot;
 	}
 
-	// #region IFluidRouter
-
 	public async request(r: IRequest): Promise<IResponse> {
 		return r.url === "" || r.url === "/"
 			? { status: 200, mimeType: "fluid/object", value: this }
 			: create404Response(r);
 	}
-
-	// #endregion IFluidRouter
 
 	// #region IFluidLoadable
 

--- a/packages/framework/data-object-base/src/test/types/validateDataObjectBasePrevious.generated.ts
+++ b/packages/framework/data-object-base/src/test/types/validateDataObjectBasePrevious.generated.ts
@@ -43,6 +43,7 @@ declare function get_current_ClassDeclaration_LazyLoadedDataObject():
 declare function use_old_ClassDeclaration_LazyLoadedDataObject(
     use: TypeOnly<old.LazyLoadedDataObject>): void;
 use_old_ClassDeclaration_LazyLoadedDataObject(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_LazyLoadedDataObject());
 
 /*

--- a/packages/test/test-utils/api-report/test-utils.api.md
+++ b/packages/test/test-utils/api-report/test-utils.api.md
@@ -281,13 +281,11 @@ export class TestFluidObject implements ITestFluidObject {
     get handle(): IFluidHandle<this>;
     // (undocumented)
     get IFluidLoadable(): this;
-    // @deprecated (undocumented)
-    get IFluidRouter(): this;
     // (undocumented)
     initialize(existing: boolean): Promise<void>;
     // (undocumented)
     get ITestFluidObject(): this;
-    // @deprecated (undocumented)
+    // (undocumented)
     request(request: IRequest): Promise<IResponse>;
     // (undocumented)
     root: ISharedMap;

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -124,6 +124,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_TestFluidObject": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -331,6 +331,7 @@ declare function get_current_ClassDeclaration_TestFluidObject():
 declare function use_old_ClassDeclaration_TestFluidObject(
     use: TypeOnly<old.TestFluidObject>): void;
 use_old_ClassDeclaration_TestFluidObject(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_TestFluidObject());
 
 /*

--- a/packages/test/test-utils/src/testFluidObject.ts
+++ b/packages/test/test-utils/src/testFluidObject.ts
@@ -34,13 +34,6 @@ export class TestFluidObject implements ITestFluidObject {
 		return this;
 	}
 
-	/**
-	 * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
-	 */
-	public get IFluidRouter() {
-		return this;
-	}
-
 	public get handle(): IFluidHandle<this> {
 		return this.innerHandle;
 	}
@@ -84,9 +77,6 @@ export class TestFluidObject implements ITestFluidObject {
 		throw new Error(`Shared object with id ${id} not found.`);
 	}
 
-	/**
-	 * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
-	 */
 	public async request(request: IRequest): Promise<IResponse> {
 		return request.url === "" || request.url === "/" || request.url.startsWith("/?")
 			? { mimeType: "fluid/object", status: 200, value: this }


### PR DESCRIPTION
## Breaking Changes

### Removed `IFluidRouter` from DataObject interfaces and classes

The `IFluidRouter` property has been removed from a number of DataObject related classes:

-   `PureDataObject`
-   `LazyLoadedDataObject`
-   `TestFluidObject`

Please migrate to the new `entryPoint` pattern or use the relevant `request` method as necessary.

See [Removing-IFluidRouter.md](https://github.com/microsoft/FluidFramework/blob/main/packages/common/core-interfaces/Removing-IFluidRouter.md) for more details.

### Removed `IRootDataObjectFactory`

The `IRootDataObjectFactory` interface has been removed. Please remove all usage of it.

[AB#4991](https://dev.azure.com/fluidframework/internal/_workitems/edit/4991)