### PR TITLE
Add deprecated IContainer interface for better back-compat typing

### DIFF
--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -301,6 +301,14 @@ export type ConnectionState =
 	| ConnectionState.Connected;
 
 /**
+ * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
+ * @internal
+ */
+export interface LegacyIContainerWithRequest_Deprecated extends IContainer {
+	request(request: IRequest): Promise<IResponse>;
+}
+
+/**
  * The Host's view of a Container and its connection to storage
  * @internal
  */


### PR DESCRIPTION
Add `LegacyIContainerWithRequest_Deprecated` for better typing when handling back-compat scenarios:
Code references newer type for `IContainer`, but at runtime the version may be older.