### PR TITLE
Move config base types from telemetry-utils to core-interfaces

### DIFF
--- a/azure/packages/azure-client/api-report/azure-client.api.md
+++ b/azure/packages/azure-client/api-report/azure-client.api.md
@@ -7,7 +7,7 @@
 import { ContainerSchema } from '@fluidframework/fluid-static';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { ICompressionStorageConfig } from '@fluidframework/driver-utils';
-import { IConfigProviderBase } from '@fluidframework/telemetry-utils';
+import { IConfigProviderBase } from '@fluidframework/core-interfaces';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -24,8 +24,7 @@ import {
 import { type IClient, SummaryType } from "@fluidframework/protocol-definitions";
 import { RouterliciousDocumentServiceFactory } from "@fluidframework/routerlicious-driver";
 
-import { type IConfigProviderBase } from "@fluidframework/telemetry-utils";
-import { type FluidObject } from "@fluidframework/core-interfaces";
+import { type IConfigProviderBase, type FluidObject } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils";
 import { createAzureAudienceMember } from "./AzureAudience";
 import { AzureUrlResolver, createAzureCreateNewRequest } from "./AzureUrlResolver";

--- a/azure/packages/azure-client/src/interfaces.ts
+++ b/azure/packages/azure-client/src/interfaces.ts
@@ -2,11 +2,13 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { type ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import {
+	type IConfigProviderBase,
+	type ITelemetryBaseLogger,
+} from "@fluidframework/core-interfaces";
 import { type IMember, type IServiceAudience } from "@fluidframework/fluid-static";
 import { type IUser } from "@fluidframework/protocol-definitions";
 import { type ITokenProvider } from "@fluidframework/routerlicious-driver";
-import { type IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { type ICompressionStorageConfig } from "@fluidframework/driver-utils";
 
 /**

--- a/azure/packages/test/end-to-end-tests/src/test/audience.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/audience.spec.ts
@@ -11,7 +11,7 @@ import { SharedMap } from "@fluidframework/map";
 import { timeoutPromise } from "@fluidframework/test-utils";
 
 import { ConnectionState } from "@fluidframework/container-loader";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { createAzureClient } from "./AzureClientFactory";
 import { waitForMember } from "./utils";
 

--- a/azure/packages/test/end-to-end-tests/src/test/containerCreate.spec.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/containerCreate.spec.ts
@@ -10,8 +10,9 @@ import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map";
 import { timeoutPromise } from "@fluidframework/test-utils";
 
-import { ConfigTypes, IConfigProviderBase, MockLogger } from "@fluidframework/telemetry-utils";
+import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ConnectionState } from "@fluidframework/container-loader";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { createAzureClient } from "./AzureClientFactory";
 
 const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -29,7 +29,7 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils";
 import { ISummarizer } from "@fluidframework/container-runtime";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import {
 	ISharedTree,
 	ITreeCheckout,

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -5,6 +5,9 @@
 ```ts
 
 // @internal
+export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
+
+// @internal
 export type ExtendEventProvider<TBaseEvent extends IEvent, TBase extends IEventProvider<TBaseEvent>, TEvent extends TBaseEvent> = Omit<Omit<Omit<TBase, "on">, "once">, "off"> & IEventProvider<TBaseEvent> & IEventProvider<TEvent>;
 
 // @internal
@@ -29,6 +32,12 @@ export type FluidObjectKeys<T> = keyof FluidObject<T>;
 
 // @internal
 export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string extends TProp ? never : number extends TProp ? never : TProp extends keyof Required<T>[TProp] ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] ? TProp : never : never;
+
+// @internal
+export interface IConfigProviderBase {
+    // (undocumented)
+    getRawConfig(name: string): ConfigTypes;
+}
 
 // @internal
 export interface IDisposable {

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -35,7 +35,6 @@ export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string
 
 // @internal
 export interface IConfigProviderBase {
-    // (undocumented)
     getRawConfig(name: string): ConfigTypes;
 }
 

--- a/packages/common/core-interfaces/src/config.ts
+++ b/packages/common/core-interfaces/src/config.ts
@@ -22,7 +22,7 @@ export interface IConfigProviderBase {
 	 * return values in a natural way from whatever source they retrieve them.
 	 *
 	 * For instance a value of 1 maybe be returned as a string or a number.
-	 * For array types a json string or and object are allowable.
+	 * For array types a json string or an object are allowable.
 	 *
 	 * It should return undefined if there is no value available for the config name.
 	 *

--- a/packages/common/core-interfaces/src/config.ts
+++ b/packages/common/core-interfaces/src/config.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Types supported by {@link IConfigProviderBase}.
+ * @internal
+ */
+export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
+
+/**
+ * Base interface for providing configurations to enable/disable/control features.
+ * @internal
+ */
+export interface IConfigProviderBase {
+	getRawConfig(name: string): ConfigTypes;
+}

--- a/packages/common/core-interfaces/src/config.ts
+++ b/packages/common/core-interfaces/src/config.ts
@@ -14,5 +14,23 @@ export type ConfigTypes = string | number | boolean | number[] | string[] | bool
  * @internal
  */
 export interface IConfigProviderBase {
+	/**
+	 * For the specified config name this function gets the value.
+	 *
+	 * This type is meant be easy to implement by fluid framework consumers
+	 * so the returned valued needs minimal type coercion, and allows consumers to
+	 * return values in a natural way from whatever source they retrieve them.
+	 *
+	 * For instance a value of 1 maybe be returned as a string or a number.
+	 * For array types a json string or and object are allowable.
+	 *
+	 * It should return undefined if there is no value available for the config name.
+	 *
+	 * @param name - The name of the config to get the value for.
+	 *
+	 * @privateRemarks Generally, this type should only be taken as input, and be wrapped by an
+	 * internal monitoring context from the fluidframework/telemetry-utils package. That will provide
+	 * a wrapper with provides strongly typed access to values via consistent type coercion.
+	 */
 	getRawConfig(name: string): ConfigTypes;
 }

--- a/packages/common/core-interfaces/src/config.ts
+++ b/packages/common/core-interfaces/src/config.ts
@@ -17,7 +17,7 @@ export interface IConfigProviderBase {
 	/**
 	 * For the specified config name this function gets the value.
 	 *
-	 * This type is meant be easy to implement by fluid framework consumers
+	 * This type is meant be easy to implement by Fluid Framework consumers
 	 * so the returned valued needs minimal type coercion, and allows consumers to
 	 * return values in a natural way from whatever source they retrieve them.
 	 *

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -78,3 +78,4 @@ export type {
 } from "./logger";
 export { LogLevel } from "./logger";
 export { FluidObjectProviderKeys, FluidObject, FluidObjectKeys } from "./provider";
+export { ConfigTypes, IConfigProviderBase } from "./config";

--- a/packages/runtime/container-runtime/src/test/gc/gcUnitTestHelpers.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcUnitTestHelpers.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
 
 export const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
@@ -11,7 +11,7 @@ import { SharedMap } from "@fluidframework/map";
 import { timeoutPromise } from "@fluidframework/test-utils";
 
 import { ConnectionState } from "@fluidframework/container-loader";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { createOdspClient, OdspTestCredentials } from "./OdspClientFactory";
 import { waitForMember } from "./utils";
 

--- a/packages/service-clients/odsp-client/api-report/odsp-client.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 import { ContainerSchema } from '@fluidframework/fluid-static';
-import { IConfigProviderBase } from '@fluidframework/telemetry-utils';
+import { IConfigProviderBase } from '@fluidframework/core-interfaces';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 import type { IMember } from '@fluidframework/fluid-static';
 import type { IServiceAudience } from '@fluidframework/fluid-static';

--- a/packages/service-clients/odsp-client/src/interfaces.ts
+++ b/packages/service-clients/odsp-client/src/interfaces.ts
@@ -5,7 +5,7 @@
 import { type ITelemetryBaseLogger } from "@fluidframework/common-definitions";
 import type { IMember, IServiceAudience } from "@fluidframework/fluid-static";
 import { type IUser } from "@fluidframework/protocol-definitions";
-import { type IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { IOdspTokenProvider } from "./token";
 
 /**

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="mocha" />
-
 // @internal (undocumented)
 export const mochaHooks: {
     beforeAll(): void;

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="mocha" />
+
 // @internal (undocumented)
 export const mochaHooks: {
     beforeAll(): void;

--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -24,8 +24,8 @@ import {
 	itSkipsFailureOnSpecificDrivers,
 } from "@fluid-private/test-version-utils";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { createInsertOnlyAttributionPolicy } from "@fluidframework/merge-tree";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 
 const stringId = "sharedStringKey";
 const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -25,8 +25,7 @@ import {
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
-
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 const map1Id = "map1Key";
 const map2Id = "map2Key";
 const registry: ChannelFactoryRegistry = [

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -10,7 +10,12 @@ import {
 	ContainerMessageType,
 	DefaultSummaryConfiguration,
 } from "@fluidframework/container-runtime";
-import { IErrorBase, IFluidHandle } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	IErrorBase,
+	IFluidHandle,
+} from "@fluidframework/core-interfaces";
 import { ReferenceType } from "@fluidframework/merge-tree";
 import { SharedString } from "@fluidframework/sequence";
 import {
@@ -27,7 +32,6 @@ import {
 	itExpects,
 } from "@fluid-private/test-version-utils";
 import { v4 as uuid } from "uuid";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import {
 	driverSupportsBlobs,
 	getUrlFromDetachedBlobStorage,

--- a/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
@@ -24,8 +24,7 @@ import {
 	itSkipsFailureOnSpecificDrivers,
 } from "@fluid-private/test-version-utils";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
-
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 const cellId = "sharedCellKey";
 const registry: ChannelFactoryRegistry = [[cellId, SharedCell.getFactory()]];
 const testContainerConfig: ITestContainerConfig = {

--- a/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { ISharedCell, SharedCell } from "@fluidframework/cell";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { ConfigTypes, IConfigProviderBase, IFluidHandle } from "@fluidframework/core-interfaces";
 import {
 	ITestObjectProvider,
 	ITestContainerConfig,
@@ -17,7 +17,6 @@ import {
 import { describeFullCompat, describeNoCompat } from "@fluid-private/test-version-utils";
 
 import { ContainerRuntime } from "@fluidframework/container-runtime";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { Serializable } from "@fluidframework/datastore-definitions";
 import { IContainer } from "@fluidframework/container-definitions";
 

--- a/packages/test/test-end-to-end-tests/src/test/containerDirtyFlag.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerDirtyFlag.spec.ts
@@ -16,8 +16,8 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluid-private/test-version-utils";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { IContainerExperimental } from "@fluidframework/container-loader";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 
 const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
 	getRawConfig: (name: string): ConfigTypes => settings[name],

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -16,8 +16,8 @@ import {
 import { describeFullCompat, describeNoCompat, itExpects } from "@fluid-private/test-version-utils";
 import { ContainerErrorType, IContainer } from "@fluidframework/container-definitions";
 
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 
 const counterId = "counterKey";
 const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];

--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 
 import { ContainerRuntime } from "@fluidframework/container-runtime";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { ConfigTypes, IConfigProviderBase, IFluidHandle } from "@fluidframework/core-interfaces";
 import {
 	IDirectory,
 	IDirectoryValueChanged,
@@ -15,7 +15,6 @@ import {
 	SharedDirectory,
 	SharedMap,
 } from "@fluidframework/map";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import {
 	ITestObjectProvider,
 	ITestContainerConfig,

--- a/packages/test/test-end-to-end-tests/src/test/fewerBatches.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/fewerBatches.spec.ts
@@ -18,8 +18,7 @@ import {
 } from "@fluidframework/test-utils";
 import { FlushMode, FlushModeExperimental } from "@fluidframework/runtime-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
-
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 describeNoCompat("Fewer batches", (getTestObjectProvider) => {
 	const mapId = "mapId";
 	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -4,11 +4,15 @@
  */
 
 import { strict as assert } from "assert";
-import { IErrorBase, IFluidHandle } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	IErrorBase,
+	IFluidHandle,
+} from "@fluidframework/core-interfaces";
 
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { ISharedMap, IValueChanged, SharedMap } from "@fluidframework/map";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import {
 	ITestObjectProvider,
 	ITestContainerConfig,

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -17,7 +17,12 @@ import {
 } from "@fluidframework/test-utils";
 import { describeNoCompat, itExpects } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
-import { FluidErrorTypes, IErrorBase } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	FluidErrorTypes,
+	IConfigProviderBase,
+	IErrorBase,
+} from "@fluidframework/core-interfaces";
 import { FlushMode } from "@fluidframework/runtime-definitions";
 import { CompressionAlgorithms, ContainerMessageType } from "@fluidframework/container-runtime";
 import {
@@ -25,8 +30,7 @@ import {
 	ISequencedDocumentMessage,
 	MessageType,
 } from "@fluidframework/protocol-definitions";
-import { ConfigTypes, GenericError, IConfigProviderBase } from "@fluidframework/telemetry-utils";
-
+import { GenericError } from "@fluidframework/telemetry-utils";
 describeNoCompat("Message size", (getTestObjectProvider) => {
 	const mapId = "mapId";
 	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];

--- a/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 
 import { SharedDirectory, SharedMap } from "@fluidframework/map";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import {
 	ChannelFactoryRegistry,
 	DataObjectFactoryType,
@@ -20,6 +19,7 @@ import { SharedString } from "@fluidframework/sequence";
 import { IContainer } from "@fluidframework/container-definitions";
 import { IMergeTreeInsertMsg } from "@fluidframework/merge-tree";
 import { FlushMode } from "@fluidframework/runtime-definitions";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 
 describeNoCompat("Concurrent op processing via DDS event handlers", (getTestObjectProvider) => {
 	const mapId = "mapKey";

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -16,9 +16,9 @@ import {
 import { describeNoCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { IValueChanged, SharedDirectory, SharedMap } from "@fluidframework/map";
 import { SharedCell } from "@fluidframework/cell";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 
 const stringId = "sharedStringKey";
 const string2Id = "sharedString2Key";

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -34,14 +34,17 @@ import {
 import { ConnectionState, IContainerExperimental } from "@fluidframework/container-loader";
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
 import { Deferred } from "@fluidframework/core-utils";
-import { IRequest, IRequestHeader } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	IRequest,
+	IRequestHeader,
+} from "@fluidframework/core-interfaces";
 import {
 	ContainerRuntime,
 	DefaultSummaryConfiguration,
 	type RecentlyAddedContainerRuntimeMessageDetails,
 } from "@fluidframework/container-runtime";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
-
 const mapId = "map";
 const stringId = "sharedStringKey";
 const cellId = "cellKey";

--- a/packages/test/test-utils/api-report/test-utils.api.md
+++ b/packages/test/test-utils/api-report/test-utils.api.md
@@ -4,14 +4,14 @@
 
 ```ts
 
-import { ConfigTypes } from '@fluidframework/telemetry-utils';
+import { ConfigTypes } from '@fluidframework/core-interfaces';
 import { ContainerRuntime } from '@fluidframework/container-runtime';
 import { ContainerRuntimeFactoryWithDefaultDataStore } from '@fluidframework/aqueduct';
 import { FluidDataStoreRuntime } from '@fluidframework/datastore';
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { ICodeDetailsLoader } from '@fluidframework/container-definitions';
-import { IConfigProviderBase } from '@fluidframework/telemetry-utils';
+import { IConfigProviderBase } from '@fluidframework/core-interfaces';
 import { IContainer } from '@fluidframework/container-definitions';
 import { IContainerContext } from '@fluidframework/container-definitions';
 import { IContainerRuntime } from '@fluidframework/container-runtime-definitions';

--- a/packages/test/test-utils/src/TestConfigs.ts
+++ b/packages/test/test-utils/src/TestConfigs.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 
 /**
  * @internal

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -11,14 +11,18 @@ import {
 	ISummarizer,
 	ISummaryRuntimeOptions,
 } from "@fluidframework/container-runtime";
-import { ITelemetryBaseLogger, FluidObject, IRequest } from "@fluidframework/core-interfaces";
+import {
+	ITelemetryBaseLogger,
+	FluidObject,
+	IRequest,
+	IConfigProviderBase,
+} from "@fluidframework/core-interfaces";
 import { DriverHeader } from "@fluidframework/driver-definitions";
 import {
 	IContainerRuntimeBase,
 	IFluidDataStoreFactory,
 	NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
-import { IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { ITestContainerConfig, ITestObjectProvider } from "./testObjectProvider";
 import { mockConfigProvider } from "./TestConfigs";
 import { waitForContainerConnection } from "./containerUtils";

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -10,10 +10,14 @@ import { ILoaderOptions, Loader } from "@fluidframework/container-loader";
 import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { IFileSnapshot } from "@fluidframework/replay-driver";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/telemetry-utils";
 import { getNormalizedSnapshot, ISnapshotNormalizerConfig } from "@fluidframework/tool-utils";
 import stringify from "json-stable-stringify";
-import { FluidObject, ITelemetryLogger } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	FluidObject,
+	IConfigProviderBase,
+	ITelemetryLogger,
+} from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils";
 import {
 	excludeChannelContentDdsFactories,

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -8,6 +8,7 @@
 
 import { EventEmitter } from 'events';
 import { EventEmitterEventType } from '@fluid-internal/client-utils';
+import { IConfigProviderBase as IConfigProviderBase_2 } from '@fluidframework/core-interfaces';
 import { IDisposable } from '@fluidframework/core-interfaces';
 import { IErrorBase } from '@fluidframework/core-interfaces';
 import { IEvent } from '@fluidframework/core-interfaces';
@@ -29,7 +30,7 @@ import { TelemetryBaseEventPropertyType } from '@fluidframework/core-interfaces'
 import { TelemetryEventPropertyType } from '@fluidframework/core-interfaces';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
-// @internal
+// @internal @deprecated
 export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
 
 // @internal (undocumented)
@@ -126,7 +127,7 @@ export const hasErrorInstanceId: (x: unknown) => x is {
 };
 
 // @internal
-export interface IConfigProvider extends IConfigProviderBase {
+export interface IConfigProvider extends IConfigProviderBase_2 {
     // (undocumented)
     getBoolean(name: string): boolean | undefined;
     // (undocumented)
@@ -141,7 +142,7 @@ export interface IConfigProvider extends IConfigProviderBase {
     getStringArray(name: string): string[] | undefined;
 }
 
-// @internal
+// @internal @deprecated
 export interface IConfigProviderBase {
     // (undocumented)
     getRawConfig(name: string): ConfigTypes;
@@ -281,7 +282,7 @@ export class LoggingError extends Error implements ILoggingError, Omit<IFluidErr
 export function logIfFalse(condition: unknown, logger: ITelemetryBaseLogger, event: string | ITelemetryGenericEvent): condition is true;
 
 // @internal
-export function mixinMonitoringContext<L extends ITelemetryBaseLogger = ITelemetryLoggerExt>(logger: L, ...configs: (IConfigProviderBase | undefined)[]): MonitoringContext<L>;
+export function mixinMonitoringContext<L extends ITelemetryBaseLogger = ITelemetryLoggerExt>(logger: L, ...configs: (IConfigProviderBase_2 | undefined)[]): MonitoringContext<L>;
 
 // @internal
 export class MockLogger implements ITelemetryBaseLogger {
@@ -367,7 +368,7 @@ export class SampledTelemetryHelper implements IDisposable {
 }
 
 // @internal
-export const sessionStorageConfigProvider: Lazy<IConfigProviderBase>;
+export const sessionStorageConfigProvider: Lazy<IConfigProviderBase_2>;
 
 // @internal
 export const tagCodeArtifacts: <T extends Record<string, TelemetryEventPropertyType | (() => TelemetryBaseEventPropertyType)>>(values: T) => { [P in keyof T]: (T[P] extends () => TelemetryBaseEventPropertyType ? () => {

--- a/packages/utils/telemetry-utils/src/config.ts
+++ b/packages/utils/telemetry-utils/src/config.ts
@@ -2,26 +2,14 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import {
+	ITelemetryBaseLogger,
+	IConfigProviderBase,
+	ConfigTypes,
+} from "@fluidframework/core-interfaces";
 import { Lazy } from "@fluidframework/core-utils";
 import { createChildLogger, tagCodeArtifacts } from "./logger";
 import { ITelemetryLoggerExt } from "./telemetryTypes";
-
-/**
- * Types supported by {@link IConfigProviderBase}.
- *
- * @internal
- */
-export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
-
-/**
- * Base interface for providing configurations to enable/disable/control features.
- *
- * @internal
- */
-export interface IConfigProviderBase {
-	getRawConfig(name: string): ConfigTypes;
-}
 
 /**
  * Explicitly typed interface for reading configurations.

--- a/packages/utils/telemetry-utils/src/index.ts
+++ b/packages/utils/telemetry-utils/src/index.ts
@@ -5,11 +5,9 @@
 export {
 	createChildMonitoringContext,
 	MonitoringContext,
-	IConfigProviderBase,
 	sessionStorageConfigProvider,
 	mixinMonitoringContext,
 	IConfigProvider,
-	ConfigTypes,
 	loggerToMonitoringContext,
 } from "./config";
 export {
@@ -81,3 +79,22 @@ export {
 	ITelemetryPropertiesExt,
 	TelemetryEventCategory,
 } from "./telemetryTypes";
+
+/**
+ * Types supported by {@link IConfigProviderBase}.
+ * @deprecated Use ConfigTypes from fluidFramework/core-interfaces
+ *
+ * @internal
+ */
+export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
+
+/**
+ * Base interface for providing configurations to enable/disable/control features.
+ *
+ * @deprecated Use IConfigProviderBase from fluidFramework/core-interfaces
+ *
+ * @internal
+ */
+export interface IConfigProviderBase {
+	getRawConfig(name: string): ConfigTypes;
+}

--- a/packages/utils/telemetry-utils/src/test/config.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/config.spec.ts
@@ -4,12 +4,8 @@
  */
 
 import { strict as assert } from "node:assert";
-import {
-	CachedConfigProvider,
-	ConfigTypes,
-	IConfigProviderBase,
-	inMemoryConfigProvider,
-} from "../config";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
+import { CachedConfigProvider, inMemoryConfigProvider } from "../config";
 import { TelemetryDataTag } from "../logger";
 import { MockLogger } from "../mockLogger";
 

--- a/packages/utils/telemetry-utils/src/test/utils.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/utils.spec.ts
@@ -4,10 +4,15 @@
  */
 
 import { strict as assert } from "node:assert";
-import { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	ITelemetryBaseEvent,
+	ITelemetryBaseLogger,
+} from "@fluidframework/core-interfaces";
 import { IEventSampler, createSampledLogger, logIfFalse } from "../utils";
 import { TelemetryDataTag, tagCodeArtifacts, tagData } from "../logger";
-import { ConfigTypes, IConfigProviderBase, mixinMonitoringContext } from "../config";
+import { mixinMonitoringContext } from "../config";
 import { ITelemetryGenericEventExt, ITelemetryLoggerExt } from "../telemetryTypes";
 
 class TestLogger implements ITelemetryBaseLogger {


### PR DESCRIPTION
The types ConfigTypes, and IConfigProviderBase have been deprecated in the @fluidframework/telemetry-utils and copied to the @fluidframework/core-interfaces. Please update your reference to use these types from @fluidframework/core-interfaces.

A benefit of this change is it helps keep the telemetry-utils primarily an internal package: 

[AB#6372](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6372)