### PR TITLE
Remove IFluidRouter

### DIFF
--- a/.changeset/sweet-pandas-chew.md
+++ b/.changeset/sweet-pandas-chew.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/core-interfaces": major
+---
+
+Removed `IFluidRouter` and `IProvideFluidRouter`
+
+The `IFluidRouter` and `IProvideFluidRouter` interfaces have been removed. Please migrate all usage to the new `entryPoint` pattern.
+
+See [Removing-IFluidRouter.md](https://github.com/microsoft/FluidFramework/blob/main/packages/common/core-interfaces/Removing-IFluidRouter.md) for more details.

--- a/packages/common/core-interfaces/Removing-IFluidRouter.md
+++ b/packages/common/core-interfaces/Removing-IFluidRouter.md
@@ -112,7 +112,7 @@ const entryPoint = await container.getEntryPoint();
 | `RuntimeRequestHandler` and `RuntimeRequestHandlerBuilder`                                   | 2.0.0-internal.7.0.0 |                      |
 | `request` and `IFluidRouter` on `IContainer` and `Container`                                 | 2.0.0-internal.7.0.0 | 2.0.0-internal.8.0.0 |
 | `request` on `IDataStore`                                                                    | 2.0.0-internal.7.0.0 | 2.0.0-internal.8.0.0 |
-| `IFluidRouter` and `IProvideFluidRouter`                                                     | 2.0.0-internal.7.0.0 |                      |
+| `IFluidRouter` and `IProvideFluidRouter`                                                     | 2.0.0-internal.7.0.0 | 2.0.0-internal.8.0.0 |
 | `requestFluidObject`                                                                         | 2.0.0-internal.7.0.0 | 2.0.0-internal.8.0.0 |
 | `requestResolvedObjectFromContainer`                                                         | 2.0.0-internal.7.0.0 | 2.0.0-internal.8.0.0 |
 | `getDefaultObjectFromContainer`, `getObjectWithIdFromContainer` and `getObjectFromContainer` | 2.0.0-internal.7.0.0 | 2.0.0-internal.8.0.0 |

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -297,15 +297,6 @@ export interface IFluidPackageEnvironment {
     };
 }
 
-// @public @deprecated (undocumented)
-export const IFluidRouter: keyof IProvideFluidRouter;
-
-// @public @deprecated (undocumented)
-export interface IFluidRouter extends IProvideFluidRouter {
-    // (undocumented)
-    request(request: IRequest): Promise<IResponse>;
-}
-
 // @public (undocumented)
 export const IFluidRunnable: keyof IProvideFluidRunnable;
 
@@ -351,12 +342,6 @@ export interface IProvideFluidHandleContext {
 export interface IProvideFluidLoadable {
     // (undocumented)
     readonly IFluidLoadable: IFluidLoadable;
-}
-
-// @public @deprecated
-export interface IProvideFluidRouter {
-    // (undocumented)
-    readonly IFluidRouter: IFluidRouter;
 }
 
 // @public (undocumented)

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -67,6 +67,19 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedVariableDeclaration_IFluidRouter": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"RemovedInterfaceDeclaration_IFluidRouter": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"RemovedInterfaceDeclaration_IProvideFluidRouter": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/common/core-interfaces/src/fluidRouter.ts
+++ b/packages/common/core-interfaces/src/fluidRouter.ts
@@ -25,23 +25,3 @@ export interface IResponse {
 	headers?: { [key: string]: any };
 	stack?: string;
 }
-
-/**
- * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
- */
-export const IFluidRouter: keyof IProvideFluidRouter = "IFluidRouter";
-
-/**
- * Request routing
- * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
- */
-export interface IProvideFluidRouter {
-	readonly IFluidRouter: IFluidRouter;
-}
-
-/**
- * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
- */
-export interface IFluidRouter extends IProvideFluidRouter {
-	request(request: IRequest): Promise<IResponse>;
-}

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -45,13 +45,7 @@ export {
 // TypeScript forgets the index signature when customers augment IRequestHeader if we export *.
 // So we export the explicit members as a workaround:
 // https://github.com/microsoft/TypeScript/issues/18877#issuecomment-476921038
-export {
-	IRequest,
-	IRequestHeader,
-	IResponse,
-	IProvideFluidRouter,
-	IFluidRouter,
-} from "./fluidRouter";
+export { IRequest, IRequestHeader, IResponse } from "./fluidRouter";
 
 export {
 	IFluidHandleContext,

--- a/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
+++ b/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
@@ -624,50 +624,26 @@ use_old_InterfaceDeclaration_IFluidPackageEnvironment(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "VariableDeclaration_IFluidRouter": {"forwardCompat": false}
+* "RemovedVariableDeclaration_IFluidRouter": {"forwardCompat": false}
 */
-declare function get_old_VariableDeclaration_IFluidRouter():
-    TypeOnly<typeof old.IFluidRouter>;
-declare function use_current_VariableDeclaration_IFluidRouter(
-    use: TypeOnly<typeof current.IFluidRouter>): void;
-use_current_VariableDeclaration_IFluidRouter(
-    get_old_VariableDeclaration_IFluidRouter());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "VariableDeclaration_IFluidRouter": {"backCompat": false}
+* "RemovedVariableDeclaration_IFluidRouter": {"backCompat": false}
 */
-declare function get_current_VariableDeclaration_IFluidRouter():
-    TypeOnly<typeof current.IFluidRouter>;
-declare function use_old_VariableDeclaration_IFluidRouter(
-    use: TypeOnly<typeof old.IFluidRouter>): void;
-use_old_VariableDeclaration_IFluidRouter(
-    get_current_VariableDeclaration_IFluidRouter());
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IFluidRouter": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IFluidRouter": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IFluidRouter():
-    TypeOnly<old.IFluidRouter>;
-declare function use_current_InterfaceDeclaration_IFluidRouter(
-    use: TypeOnly<current.IFluidRouter>): void;
-use_current_InterfaceDeclaration_IFluidRouter(
-    get_old_InterfaceDeclaration_IFluidRouter());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IFluidRouter": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IFluidRouter": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IFluidRouter():
-    TypeOnly<current.IFluidRouter>;
-declare function use_old_InterfaceDeclaration_IFluidRouter(
-    use: TypeOnly<old.IFluidRouter>): void;
-use_old_InterfaceDeclaration_IFluidRouter(
-    get_current_InterfaceDeclaration_IFluidRouter());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -864,26 +840,14 @@ use_old_InterfaceDeclaration_IProvideFluidLoadable(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IProvideFluidRouter": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IProvideFluidRouter": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IProvideFluidRouter():
-    TypeOnly<old.IProvideFluidRouter>;
-declare function use_current_InterfaceDeclaration_IProvideFluidRouter(
-    use: TypeOnly<current.IProvideFluidRouter>): void;
-use_current_InterfaceDeclaration_IProvideFluidRouter(
-    get_old_InterfaceDeclaration_IProvideFluidRouter());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IProvideFluidRouter": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IProvideFluidRouter": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IProvideFluidRouter():
-    TypeOnly<current.IProvideFluidRouter>;
-declare function use_old_InterfaceDeclaration_IProvideFluidRouter(
-    use: TypeOnly<old.IProvideFluidRouter>): void;
-use_old_InterfaceDeclaration_IProvideFluidRouter(
-    get_current_InterfaceDeclaration_IProvideFluidRouter());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -10,10 +10,8 @@ import {
 	IFluidHandleContext,
 	IFluidHandle,
 	IProvideFluidLoadable,
-	IProvideFluidRouter,
 	IProvideFluidHandle,
 	FluidObject,
-	IFluidRouter,
 } from "@fluidframework/core-interfaces";
 import { FluidObjectHandle } from "@fluidframework/datastore";
 
@@ -44,20 +42,21 @@ class MockLoadable implements IFluidLoadable {
 	}
 }
 
-class MockFluidRouter implements IFluidRouter {
-	public get IFluidRouter() {
+export const ISomeObject: keyof IProvideSomeObject = "ISomeObject";
+interface IProvideSomeObject {
+	readonly ISomeObject: ISomeObject;
+}
+interface ISomeObject extends IProvideSomeObject {
+	value: number;
+}
+class MockSomeObject implements ISomeObject {
+	public get ISomeObject() {
 		return this;
 	}
-	public async request() {
-		return {
-			mimeType: "",
-			status: 200,
-			value: "",
-		};
-	}
+	public readonly value = 0;
 }
 
-describe("Routerlicious", () => {
+describe("someObjectlicious", () => {
 	describe("Aqueduct", () => {
 		describe("DependencyContainer", () => {
 			it(`One Optional Provider registered via value`, async () => {
@@ -245,73 +244,73 @@ describe("Routerlicious", () => {
 			});
 
 			it(`Two Optional Modules all registered`, async () => {
-				const dc = new DependencyContainer<FluidObject<IFluidLoadable & IFluidRouter>>();
+				const dc = new DependencyContainer<FluidObject<IFluidLoadable & ISomeObject>>();
 				const loadableMock = new MockLoadable();
 				dc.register(IFluidLoadable, loadableMock);
-				const routerMock = new MockFluidRouter();
-				dc.register(IFluidRouter, routerMock);
+				const someObjectMock = new MockSomeObject();
+				dc.register(ISomeObject, someObjectMock);
 
-				const s = dc.synthesize<IFluidLoadable & IFluidRouter>(
-					{ IFluidLoadable, IFluidRouter },
+				const s = dc.synthesize<IFluidLoadable & ISomeObject>(
+					{ IFluidLoadable, ISomeObject },
 					undefined,
 				);
 				const loadable = await s.IFluidLoadable;
 				assert(loadable, "Optional IFluidLoadable was registered");
 				assert(loadable === loadableMock, "IFluidLoadable is expected");
 
-				const router = await s.IFluidRouter;
-				assert(router, "Optional IFluidRouter was registered");
-				assert(router === routerMock, "IFluidRouter is expected");
+				const someObject = await s.ISomeObject;
+				assert(someObject, "Optional ISomeObject was registered");
+				assert(someObject === someObjectMock, "ISomeObject is expected");
 			});
 
 			it(`Two Optional Modules one registered`, async () => {
-				const dc = new DependencyContainer<FluidObject<IFluidLoadable & IFluidRouter>>();
+				const dc = new DependencyContainer<FluidObject<IFluidLoadable & ISomeObject>>();
 				const loadableMock = new MockLoadable();
 				dc.register(IFluidLoadable, loadableMock);
 
-				const s = dc.synthesize<IFluidLoadable & IFluidRouter>(
-					{ IFluidLoadable, IFluidRouter },
+				const s = dc.synthesize<IFluidLoadable & ISomeObject>(
+					{ IFluidLoadable, ISomeObject },
 					undefined,
 				);
 				const loadable = await s.IFluidLoadable;
 				assert(loadable, "Optional IFluidLoadable was registered");
 				assert(loadable === loadableMock, "IFluidLoadable is expected");
 
-				const router = await s.IFluidRouter;
-				assert(!router, "Optional IFluidRouter was not registered");
+				const someObject = await s.ISomeObject;
+				assert(!someObject, "Optional ISomeObject was not registered");
 			});
 
 			it(`Two Optional Modules none registered`, async () => {
-				const dc = new DependencyContainer<FluidObject<IFluidLoadable & IFluidRouter>>();
+				const dc = new DependencyContainer<FluidObject<IFluidLoadable & ISomeObject>>();
 
-				const s = dc.synthesize<IFluidLoadable & IFluidRouter>(
-					{ IFluidLoadable, IFluidRouter },
+				const s = dc.synthesize<IFluidLoadable & ISomeObject>(
+					{ IFluidLoadable, ISomeObject },
 					undefined,
 				);
 				const loadable = await s.IFluidLoadable;
 				assert(!loadable, "Optional IFluidLoadable was not registered");
-				const router = await s.IFluidRouter;
-				assert(!router, "Optional IFluidRouter was not registered");
+				const someObject = await s.ISomeObject;
+				assert(!someObject, "Optional ISomeObject was not registered");
 			});
 
 			it(`Two Required Modules all registered`, async () => {
-				const dc = new DependencyContainer<FluidObject<IFluidLoadable & IFluidRouter>>();
+				const dc = new DependencyContainer<FluidObject<IFluidLoadable & ISomeObject>>();
 				const loadableMock = new MockLoadable();
 				dc.register(IFluidLoadable, loadableMock);
-				const routerMock = new MockFluidRouter();
-				dc.register(IFluidRouter, routerMock);
+				const someObjectMock = new MockSomeObject();
+				dc.register(ISomeObject, someObjectMock);
 
-				const s = dc.synthesize<undefined, IProvideFluidLoadable & IProvideFluidRouter>(
+				const s = dc.synthesize<undefined, IProvideFluidLoadable & IProvideSomeObject>(
 					undefined,
-					{ IFluidLoadable, IFluidRouter },
+					{ IFluidLoadable, ISomeObject },
 				);
 				const loadable = await s.IFluidLoadable;
 				assert(loadable, "Required IFluidLoadable was registered");
 				assert(loadable === loadableMock, "IFluidLoadable is expected");
 
-				const router = await s.IFluidRouter;
-				assert(router, "Required IFluidRouter was registered");
-				assert(router === routerMock, "IFluidRouter is expected");
+				const someObject = await s.ISomeObject;
+				assert(someObject, "Required ISomeObject was registered");
+				assert(someObject === someObjectMock, "ISomeObject is expected");
 			});
 
 			it(`Required Provider not registered should throw`, async () => {
@@ -346,21 +345,21 @@ describe("Routerlicious", () => {
 				const parentDc = new DependencyContainer<FluidObject<IFluidLoadable>>();
 				const loadableMock = new MockLoadable();
 				parentDc.register(IFluidLoadable, loadableMock);
-				const dc = new DependencyContainer<FluidObject<IFluidRouter>>(parentDc);
-				const routerMock = new MockFluidRouter();
-				dc.register(IFluidRouter, routerMock);
+				const dc = new DependencyContainer<FluidObject<ISomeObject>>(parentDc);
+				const someObjectMock = new MockSomeObject();
+				dc.register(ISomeObject, someObjectMock);
 
-				const s = dc.synthesize<IFluidLoadable & IFluidRouter>(
-					{ IFluidLoadable, IFluidRouter },
+				const s = dc.synthesize<IFluidLoadable & ISomeObject>(
+					{ IFluidLoadable, ISomeObject },
 					undefined,
 				);
 				const loadable = await s.IFluidLoadable;
 				assert(loadable, "Optional IFluidLoadable was registered");
 				assert(loadable === loadableMock, "IFluidLoadable is expected");
 
-				const router = await s.IFluidRouter;
-				assert(router, "Optional IFluidRouter was registered");
-				assert(router === routerMock, "IFluidRouter is expected");
+				const someObject = await s.ISomeObject;
+				assert(someObject, "Optional ISomeObject was registered");
+				assert(someObject === someObjectMock, "ISomeObject is expected");
 			});
 
 			it(`Optional Provider found in Parent and Child resolves Child`, async () => {
@@ -398,21 +397,21 @@ describe("Routerlicious", () => {
 				const parentDc = new DependencyContainer<FluidObject<IFluidLoadable>>();
 				const loadableMock = new MockLoadable();
 				parentDc.register(IFluidLoadable, loadableMock);
-				const dc = new DependencyContainer<FluidObject<IFluidRouter>>(parentDc);
-				const routerMock = new MockFluidRouter();
-				dc.register(IFluidRouter, routerMock);
+				const dc = new DependencyContainer<FluidObject<ISomeObject>>(parentDc);
+				const someObjectMock = new MockSomeObject();
+				dc.register(ISomeObject, someObjectMock);
 
-				const s = dc.synthesize<undefined, IProvideFluidLoadable & IProvideFluidRouter>(
+				const s = dc.synthesize<undefined, IProvideFluidLoadable & IProvideSomeObject>(
 					undefined,
-					{ IFluidLoadable, IFluidRouter },
+					{ IFluidLoadable, ISomeObject },
 				);
 				const loadable = await s.IFluidLoadable;
 				assert(loadable, "Required IFluidLoadable was registered");
 				assert(loadable === loadableMock, "IFluidLoadable is expected");
 
-				const router = await s.IFluidRouter;
-				assert(router, "Required IFluidRouter was registered");
-				assert(router === routerMock, "IFluidRouter is expected");
+				const someObject = await s.ISomeObject;
+				assert(someObject, "Required ISomeObject was registered");
+				assert(someObject === someObjectMock, "ISomeObject is expected");
 			});
 
 			it(`Required Provider found in Parent and Child resolves Child`, async () => {
@@ -458,14 +457,14 @@ describe("Routerlicious", () => {
 			});
 
 			it(`has() resolves correctly in all variations`, async () => {
-				const dc = new DependencyContainer<FluidObject<IFluidLoadable & IFluidRouter>>();
+				const dc = new DependencyContainer<FluidObject<IFluidLoadable & ISomeObject>>();
 				dc.register(IFluidLoadable, new MockLoadable());
-				dc.register(IFluidRouter, new MockFluidRouter());
+				dc.register(ISomeObject, new MockSomeObject());
 				assert(dc.has(IFluidLoadable), "Manager has IFluidLoadable");
-				assert(dc.has(IFluidRouter), "Manager has IFluidRouter");
+				assert(dc.has(ISomeObject), "Manager has ISomeObject");
 				assert(
-					dc.has(IFluidLoadable) && dc.has(IFluidRouter),
-					"Manager has IFluidLoadable & IFluidRouter",
+					dc.has(IFluidLoadable) && dc.has(ISomeObject),
+					"Manager has IFluidLoadable & ISomeObject",
 				);
 			});
 
@@ -473,16 +472,16 @@ describe("Routerlicious", () => {
 				const parentDc = new DependencyContainer<FluidObject<IFluidLoadable>>();
 				const loadableMock = new MockLoadable();
 				parentDc.register(IFluidLoadable, loadableMock);
-				const dc = new DependencyContainer<FluidObject<IFluidRouter>>(parentDc);
-				const routerMock = new MockFluidRouter();
-				dc.register(IFluidRouter, routerMock);
+				const dc = new DependencyContainer<FluidObject<ISomeObject>>(parentDc);
+				const someObjectMock = new MockSomeObject();
+				dc.register(ISomeObject, someObjectMock);
 
 				assert(dc.has(IFluidLoadable), "has includes parent registered");
 				assert(
 					!dc.has(IFluidLoadable, true),
 					"has does not include excluded parent registered",
 				);
-				assert(dc.has(IFluidRouter), "has includes registered");
+				assert(dc.has(ISomeObject), "has includes registered");
 				assert(!dc.has(IFluidHandle), "does not include not registered");
 			});
 

--- a/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
+++ b/packages/framework/synthesize/src/test/dependencyContainer.spec.ts
@@ -42,7 +42,7 @@ class MockLoadable implements IFluidLoadable {
 	}
 }
 
-export const ISomeObject: keyof IProvideSomeObject = "ISomeObject";
+const ISomeObject: keyof IProvideSomeObject = "ISomeObject";
 interface IProvideSomeObject {
 	readonly ISomeObject: ISomeObject;
 }

--- a/packages/loader/container-loader/src/test/container.spec.ts
+++ b/packages/loader/container-loader/src/test/container.spec.ts
@@ -14,7 +14,6 @@ import {
 	ReadOnlyInfo,
 } from "@fluidframework/container-definitions";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IFluidRouter } from "@fluidframework/core-interfaces";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
 import { ISequencedDocumentMessage, IDocumentMessage } from "@fluidframework/protocol-definitions";
 import { waitContainerToCatchUp } from "../container";
@@ -47,7 +46,6 @@ class MockContainer
 	audience?: IAudience | undefined;
 	clientId?: string | undefined;
 	readOnlyInfo?: ReadOnlyInfo | undefined;
-	IFluidRouter?: IFluidRouter | undefined;
 
 	get mockDeltaManager() {
 		return this.deltaManager as any as MockDeltaManager;


### PR DESCRIPTION
## Breaking Changes

### Removed `IFluidRouter` and `IProvideFluidRouter`

The `IFluidRouter` and `IProvideFluidRouter` interfaces have been removed. Please migrate all usage to the new `entryPoint` pattern.

See [Removing-IFluidRouter.md](https://github.com/microsoft/FluidFramework/blob/main/packages/common/core-interfaces/Removing-IFluidRouter.md) for more details.

[AB#4991](https://dev.azure.com/fluidframework/internal/_workitems/edit/4991)