### PR TITLE
Make OptionalField child changes be keyed on input register id

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/optional-field/optionalFieldChangeTypes.ts
+++ b/experimental/dds/tree2/src/feature-libraries/optional-field/optionalFieldChangeTypes.ts
@@ -47,9 +47,7 @@ export interface OptionalChangeset {
 	/**
 	 * Nested changes to nodes that occupy registers.
 	 *
-	 * Nodes are identified by the register they occupy in the *output* context of the changeset.
-	 * Note that this is different from the delta format.
-	 * Switching this to be consistent is tracked by AB#6296.
+	 * Nodes are identified by the register they occupy in the *input* context of the changeset.
 	 */
 	childChanges: [register: RegisterId, childChange: NodeChangeset][];
 

--- a/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
@@ -105,7 +105,7 @@ describe("defaultFieldKinds", () => {
 				[{ localId: brand(41) }, "self", "nodeTargeting"],
 				["self", { localId: brand(1) }, "cellTargeting"],
 			],
-			childChanges: [["self", nodeChange1]],
+			childChanges: [[{ localId: brand(41) }, nodeChange1]],
 		};
 
 		/**
@@ -167,7 +167,9 @@ describe("defaultFieldKinds", () => {
 							"cellTargeting",
 						],
 					],
-					childChanges: [["self", nodeChange1]],
+					childChanges: [
+						[{ localId: brand(41), revision: change1.revision }, nodeChange1],
+					],
 				};
 				const actual = fieldHandler.rebaser.compose(
 					[change1, taggedChildChange1],
@@ -206,9 +208,7 @@ describe("defaultFieldKinds", () => {
 							"cellTargeting",
 						],
 					],
-					childChanges: [
-						[{ revision: change1.revision, localId: brand(1) }, nodeChange1],
-					],
+					childChanges: [["self", nodeChange1]],
 				};
 				assertEqual(makeAnonChange(actual), makeAnonChange(expected2));
 			});
@@ -260,9 +260,7 @@ describe("defaultFieldKinds", () => {
 							"cellTargeting",
 						],
 					],
-					childChanges: [
-						[{ localId: brand(41), revision: taggedChange.revision }, nodeChange2],
-					],
+					childChanges: [["self", nodeChange2]],
 				}),
 			);
 		});

--- a/experimental/dds/tree2/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -97,7 +97,7 @@ const change1: TaggedChange<OptionalChangeset> = tagChange(
 	{
 		build: [{ id: { localId: brand(41) }, set: testTree("tree1") }],
 		moves: [[{ localId: brand(41) }, "self", "nodeTargeting"]],
-		childChanges: [["self", nodeChange1]],
+		childChanges: [[{ localId: brand(41) }, nodeChange1]],
 		reservedDetachId: { localId: brand(1) },
 	},
 	tag,
@@ -185,7 +185,7 @@ describe("optionalField", () => {
 					],
 					[{ localId: brand(42), revision: change2.revision }, "self", "nodeTargeting"],
 				],
-				childChanges: [[{ localId: brand(2), revision: change2.revision }, nodeChange1]],
+				childChanges: [[{ localId: brand(41), revision: change1.revision }, nodeChange1]],
 				reservedDetachId: { localId: brand(1), revision: change1.revision },
 			};
 
@@ -203,7 +203,9 @@ describe("optionalField", () => {
 				moves: [
 					[{ localId: brand(41), revision: change1.revision }, "self", "nodeTargeting"],
 				],
-				childChanges: [["self", arbitraryChildChange]],
+				childChanges: [
+					[{ localId: brand(41), revision: change1.revision }, arbitraryChildChange],
+				],
 				reservedDetachId: { localId: brand(1), revision: change1.revision },
 			};
 
@@ -236,7 +238,7 @@ describe("optionalField", () => {
 				moves: [
 					["self", { localId: brand(41), revision: change1.revision }, "cellTargeting"],
 				],
-				childChanges: [[{ localId: brand(41), revision: change1.revision }, nodeChange2]],
+				childChanges: [["self", nodeChange2]],
 			};
 
 			assert.deepEqual(
@@ -367,7 +369,7 @@ describe("optionalField", () => {
 				const baseChange: OptionalChangeset = {
 					build: [],
 					moves: [["self", { localId: brand(0) }, "cellTargeting"]],
-					childChanges: [[{ localId: brand(0) }, nodeChange1]],
+					childChanges: [["self", nodeChange1]],
 				};
 				const taggedBaseChange = tagChange(baseChange, mintRevisionTag());
 
@@ -381,7 +383,7 @@ describe("optionalField", () => {
 						[{ localId: brand(41) }, "self", "nodeTargeting"],
 						["self", { localId: brand(1) }, "cellTargeting"],
 					],
-					childChanges: [[{ localId: brand(1) }, nodeChange2]],
+					childChanges: [["self", nodeChange2]],
 				};
 
 				const childRebaser = (
@@ -397,15 +399,13 @@ describe("optionalField", () => {
 					build: [
 						{ id: { localId: brand(41) }, set: { type: brand("value"), value: "X" } },
 					],
-					// TODO:AB#6298: This test case demonstrates a problem with rebasing transactions:
-					// we don't realize that { localId: brand(1) } no longer refers to the right node
-					// because we rebased over a change that detaches that node. We either need to augment
-					// this with a move from { localId: brand(0), revision: taggedBaseChange.revision } => { localId: brand(1) }
-					// OR update the child change here to refer to { localId: brand(0), revision: taggedBaseChange.revision }!
-					// Right now we do things inconsistently with 'self' due to how renamedDsts works in optional field, which causes this bug.
 					moves: [[{ localId: brand(41) }, "self", "nodeTargeting"]],
-					childChanges: [[{ localId: brand(1) }, arbitraryChildChange]],
-					// See comment above: this may need to change as well.
+					childChanges: [
+						[
+							{ localId: brand(0), revision: taggedBaseChange.revision },
+							arbitraryChildChange,
+						],
+					],
 					reservedDetachId: { localId: brand(1) },
 				};
 

--- a/experimental/dds/tree2/src/test/snapshots/files/optional-field-scenarios-final.json
+++ b/experimental/dds/tree2/src/test/snapshots/files/optional-field-scenarios-final.json
@@ -1,0 +1,721 @@
+{
+  "type": "tree",
+  "tree": {
+    "type": "tree",
+    "indexes": {
+      "type": "tree",
+      "entries": [
+        {
+          "type": "tree",
+          "EditManager": {
+            "type": "tree",
+            "tree": {
+              "type": "blob",
+              "String": {
+                "type": "blob",
+                "content": {
+                  "trunk": [
+                    {
+                      "change": {
+                        "changes": [
+                          {
+                            "fieldKey": "rootFieldKey",
+                            "fieldKind": "ModularEditBuilder.Generic",
+                            "change": [
+                              {
+                                "index": 0,
+                                "nodeChange": {
+                                  "fieldChanges": [
+                                    {
+                                      "fieldKey": "root 1 child",
+                                      "fieldKind": "Optional",
+                                      "change": {
+                                        "b": [
+                                          [
+                                            {
+                                              "localId": 1
+                                            },
+                                            {
+                                              "type": "com.fluidframework.leaf.number",
+                                              "value": 40
+                                            }
+                                          ]
+                                        ],
+                                        "m": [
+                                          [
+                                            {
+                                              "localId": 1
+                                            },
+                                            0,
+                                            true
+                                          ]
+                                        ],
+                                        "d": {
+                                          "localId": 2
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      "revision": "beefbeef-beef-4000-8000-000000000006",
+                      "sequenceNumber": 4,
+                      "sessionId": "beefbeef-beef-4000-8000-000000000002"
+                    },
+                    {
+                      "change": {
+                        "changes": [
+                          {
+                            "fieldKey": "rootFieldKey",
+                            "fieldKind": "Optional",
+                            "change": {
+                              "b": [
+                                [
+                                  {
+                                    "localId": 4
+                                  },
+                                  {
+                                    "type": "optional-field.TestNode",
+                                    "fields": {
+                                      "root 2 child": [
+                                        {
+                                          "type": "com.fluidframework.leaf.number",
+                                          "value": 41
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              ],
+                              "m": [
+                                [
+                                  {
+                                    "localId": 4
+                                  },
+                                  0,
+                                  true
+                                ],
+                                [
+                                  0,
+                                  {
+                                    "localId": 5
+                                  },
+                                  false
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "revision": "beefbeef-beef-4000-8000-000000000007",
+                      "sequenceNumber": 5,
+                      "sessionId": "beefbeef-beef-4000-8000-000000000002"
+                    },
+                    {
+                      "change": {
+                        "changes": [
+                          {
+                            "fieldKey": "rootFieldKey",
+                            "fieldKind": "Optional",
+                            "change": {
+                              "b": [
+                                [
+                                  {
+                                    "localId": 4
+                                  },
+                                  {
+                                    "type": "optional-field.TestNode"
+                                  }
+                                ]
+                              ],
+                              "m": [
+                                [
+                                  {
+                                    "localId": 4
+                                  },
+                                  0,
+                                  true
+                                ],
+                                [
+                                  0,
+                                  {
+                                    "localId": 5
+                                  },
+                                  false
+                                ]
+                              ],
+                              "c": [
+                                [
+                                  {
+                                    "revision": "beefbeef-beef-4000-8000-000000000007",
+                                    "localId": 5
+                                  },
+                                  {
+                                    "fieldChanges": [
+                                      {
+                                        "fieldKey": "root 1 child",
+                                        "fieldKind": "Optional",
+                                        "change": {
+                                          "b": [
+                                            [
+                                              {
+                                                "localId": 1
+                                              },
+                                              {
+                                                "type": "com.fluidframework.leaf.number",
+                                                "value": 42
+                                              }
+                                            ]
+                                          ],
+                                          "m": [
+                                            [
+                                              {
+                                                "localId": 1
+                                              },
+                                              0,
+                                              true
+                                            ],
+                                            [
+                                              0,
+                                              {
+                                                "localId": 2
+                                              },
+                                              false
+                                            ]
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                [
+                                  {
+                                    "localId": 4
+                                  },
+                                  {
+                                    "fieldChanges": [
+                                      {
+                                        "fieldKey": "root 3 child",
+                                        "fieldKind": "Optional",
+                                        "change": {
+                                          "b": [
+                                            [
+                                              {
+                                                "localId": 7
+                                              },
+                                              {
+                                                "type": "com.fluidframework.leaf.number",
+                                                "value": 43
+                                              }
+                                            ]
+                                          ],
+                                          "m": [
+                                            [
+                                              {
+                                                "localId": 7
+                                              },
+                                              0,
+                                              true
+                                            ]
+                                          ],
+                                          "d": {
+                                            "localId": 8
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "revision": "beefbeef-beef-4000-8000-00000000000b",
+                      "sequenceNumber": 6,
+                      "sessionId": "beefbeef-beef-4000-8000-000000000001"
+                    },
+                    {
+                      "change": {
+                        "changes": [
+                          {
+                            "fieldKey": "rootFieldKey",
+                            "fieldKind": "Optional",
+                            "change": {
+                              "c": [
+                                [
+                                  0,
+                                  {
+                                    "fieldChanges": [
+                                      {
+                                        "fieldKey": "root 3 child",
+                                        "fieldKind": "Optional",
+                                        "change": {
+                                          "b": [
+                                            [
+                                              {
+                                                "localId": 1
+                                              },
+                                              {
+                                                "type": "com.fluidframework.leaf.number",
+                                                "value": 44
+                                              }
+                                            ]
+                                          ],
+                                          "m": [
+                                            [
+                                              {
+                                                "localId": 1
+                                              },
+                                              0,
+                                              true
+                                            ],
+                                            [
+                                              0,
+                                              {
+                                                "localId": 2
+                                              },
+                                              false
+                                            ]
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "revision": "beefbeef-beef-4000-8000-00000000000c",
+                      "sequenceNumber": 7,
+                      "sessionId": "beefbeef-beef-4000-8000-000000000001"
+                    }
+                  ],
+                  "branches": [
+                    [
+                      "beefbeef-beef-4000-8000-000000000002",
+                      {
+                        "base": "beefbeef-beef-4000-8000-000000000007",
+                        "commits": []
+                      }
+                    ]
+                  ]
+                },
+                "encoding": "utf-8"
+              }
+            }
+          }
+        },
+        {
+          "type": "tree",
+          "Schema": {
+            "type": "tree",
+            "tree": {
+              "type": "blob",
+              "SchemaString": {
+                "type": "blob",
+                "content": {
+                  "version": "1.0.0",
+                  "nodeSchema": [
+                    {
+                      "name": "com.fluidframework.leaf.boolean",
+                      "objectNodeFields": [],
+                      "leafValue": 2
+                    },
+                    {
+                      "name": "com.fluidframework.leaf.handle",
+                      "objectNodeFields": [],
+                      "leafValue": 3
+                    },
+                    {
+                      "name": "com.fluidframework.leaf.null",
+                      "objectNodeFields": [],
+                      "leafValue": 4
+                    },
+                    {
+                      "name": "com.fluidframework.leaf.number",
+                      "objectNodeFields": [],
+                      "leafValue": 0
+                    },
+                    {
+                      "name": "com.fluidframework.leaf.string",
+                      "objectNodeFields": [],
+                      "leafValue": 1
+                    },
+                    {
+                      "name": "optional-field.TestNode",
+                      "mapFields": {
+                        "kind": "Optional",
+                        "types": [
+                          "com.fluidframework.leaf.handle",
+                          "com.fluidframework.leaf.null",
+                          "com.fluidframework.leaf.number",
+                          "com.fluidframework.leaf.boolean",
+                          "com.fluidframework.leaf.string"
+                        ]
+                      },
+                      "objectNodeFields": []
+                    }
+                  ],
+                  "rootFieldSchema": {
+                    "kind": "Optional",
+                    "types": [
+                      "optional-field.TestNode"
+                    ]
+                  }
+                },
+                "encoding": "utf-8"
+              }
+            }
+          }
+        },
+        {
+          "type": "tree",
+          "Forest": {
+            "type": "tree",
+            "tree": {
+              "type": "blob",
+              "ForestTree": {
+                "type": "blob",
+                "content": {
+                  "version": 1,
+                  "data": [
+                    [
+                      "rootFieldKey",
+                      {
+                        "version": 1,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1,
+                              "fields": []
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          1,
+                          [
+                            "optional-field.TestNode",
+                            false,
+                            [
+                              "root 3 child",
+                              [
+                                "com.fluidframework.leaf.number",
+                                true,
+                                44,
+                                []
+                              ]
+                            ]
+                          ]
+                        ]
+                      }
+                    ],
+                    [
+                      "repair-6",
+                      {
+                        "version": 1,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1,
+                              "fields": []
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          1,
+                          [
+                            "com.fluidframework.leaf.number",
+                            true,
+                            43,
+                            []
+                          ]
+                        ]
+                      }
+                    ],
+                    [
+                      "repair-7",
+                      {
+                        "version": 1,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1,
+                              "fields": []
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          1,
+                          [
+                            "optional-field.TestNode",
+                            false,
+                            []
+                          ]
+                        ]
+                      }
+                    ],
+                    [
+                      "repair-8",
+                      {
+                        "version": 1,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1,
+                              "fields": []
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          1,
+                          [
+                            "com.fluidframework.leaf.number",
+                            true,
+                            43,
+                            []
+                          ]
+                        ]
+                      }
+                    ],
+                    [
+                      "repair-9",
+                      {
+                        "version": 1,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1,
+                              "fields": []
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          1,
+                          [
+                            "com.fluidframework.leaf.number",
+                            true,
+                            44,
+                            []
+                          ]
+                        ]
+                      }
+                    ],
+                    [
+                      "repair-11",
+                      {
+                        "version": 1,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1,
+                              "fields": []
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          1,
+                          [
+                            "com.fluidframework.leaf.number",
+                            true,
+                            42,
+                            []
+                          ]
+                        ]
+                      }
+                    ],
+                    [
+                      "repair-12",
+                      {
+                        "version": 1,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1,
+                              "fields": []
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          1,
+                          [
+                            "com.fluidframework.leaf.number",
+                            true,
+                            40,
+                            []
+                          ]
+                        ]
+                      }
+                    ],
+                    [
+                      "repair-14",
+                      {
+                        "version": 1,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1,
+                              "fields": []
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          1,
+                          [
+                            "optional-field.TestNode",
+                            false,
+                            [
+                              "root 1 child",
+                              [
+                                "com.fluidframework.leaf.number",
+                                true,
+                                42,
+                                []
+                              ]
+                            ]
+                          ]
+                        ]
+                      }
+                    ],
+                    [
+                      "repair-15",
+                      {
+                        "version": 1,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1,
+                              "fields": []
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          1,
+                          [
+                            "optional-field.TestNode",
+                            false,
+                            [
+                              "root 2 child",
+                              [
+                                "com.fluidframework.leaf.number",
+                                true,
+                                41,
+                                []
+                              ]
+                            ]
+                          ]
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                "encoding": "utf-8"
+              }
+            }
+          }
+        },
+        {
+          "type": "tree",
+          "DetachedFieldIndex": {
+            "type": "tree",
+            "tree": {
+              "type": "blob",
+              "DetachedFieldIndexBlob": {
+                "type": "blob",
+                "content": {
+                  "version": 1,
+                  "data": [
+                    [
+                      "beefbeef-beef-4000-8000-00000000000b",
+                      4,
+                      7
+                    ],
+                    [
+                      "beefbeef-beef-4000-8000-00000000000b",
+                      7,
+                      8
+                    ],
+                    [
+                      "beefbeef-beef-4000-8000-00000000000b",
+                      1,
+                      11
+                    ],
+                    [
+                      "beefbeef-beef-4000-8000-00000000000b",
+                      2,
+                      12
+                    ],
+                    [
+                      "beefbeef-beef-4000-8000-00000000000b",
+                      5,
+                      15
+                    ],
+                    [
+                      "beefbeef-beef-4000-8000-00000000000c",
+                      2,
+                      6
+                    ],
+                    [
+                      "beefbeef-beef-4000-8000-00000000000c",
+                      1,
+                      9
+                    ],
+                    [
+                      "beefbeef-beef-4000-8000-000000000007",
+                      5,
+                      14
+                    ]
+                  ],
+                  "maxId": 15
+                },
+                "encoding": "utf-8"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/experimental/dds/tree2/src/test/snapshots/testTrees.ts
+++ b/experimental/dds/tree2/src/test/snapshots/testTrees.ts
@@ -18,6 +18,8 @@ import {
 	TreeFieldSchema,
 	TreeCompressionStrategy,
 	cursorForJsonableTreeNode,
+	cursorForTypedTreeData,
+	TreeNodeSchema,
 } from "../../feature-libraries";
 import { typeboxValidator } from "../../external-utilities";
 import {
@@ -29,8 +31,24 @@ import {
 	remove,
 	wrongSchema,
 } from "../utils";
-import { AllowedUpdateType, FieldKey, JsonableTree, UpPath, rootFieldKey } from "../../core";
+import {
+	AllowedUpdateType,
+	FieldKey,
+	FieldUpPath,
+	ITreeCursorSynchronous,
+	JsonableTree,
+	UpPath,
+	rootFieldKey,
+} from "../../core";
 import { leaf, SchemaBuilder } from "../../domains";
+import { TypedNode } from "../../feature-libraries/schema-aware";
+
+const rootField: FieldUpPath = { parent: undefined, field: rootFieldKey };
+const rootNode: UpPath = {
+	parent: undefined,
+	parentField: rootFieldKey,
+	parentIndex: 0,
+};
 
 const factory = new SharedTreeFactory({
 	jsonValidator: typeboxValidator,
@@ -197,6 +215,69 @@ export function generateTestTrees() {
 
 				await takeSnapshot(provider.trees[0], "tree-0-final");
 				await takeSnapshot(provider.trees[1], "tree-1-final");
+			},
+		},
+		{
+			/**
+			 * Aims to exercise interesting scenarios that can happen within an optional field with respect to
+			 * EditManager's persisted format.
+			 */
+			name: "optional-field-scenarios",
+			runScenario: async (takeSnapshot) => {
+				const innerBuilder = new SchemaBuilder({
+					scope: "optional-field",
+					libraries: [leaf.library],
+				});
+				const testNode = innerBuilder.map("TestNode", leaf.all);
+				const docSchema = innerBuilder.intoSchema(SchemaBuilder.optional(testNode));
+
+				const config = {
+					allowedSchemaModifications: AllowedUpdateType.None,
+					schema: docSchema,
+					initialTree: undefined,
+				} as const;
+
+				// Enables below editing code to be slightly less verbose
+				const makeCursor = <T extends TreeNodeSchema>(
+					schema: T,
+					data: TypedNode<T>,
+				): ITreeCursorSynchronous =>
+					cursorForTypedTreeData({ schema: docSchema }, schema, data);
+
+				const provider = new TestTreeProviderLite(2);
+				const tree = provider.trees[0].schematizeInternal(config);
+				const view = tree.checkout;
+				view.editor.optionalField(rootField).set(makeCursor(testNode, {}), true);
+				provider.processMessages();
+				const view2 = provider.trees[1].schematizeInternal(config).checkout;
+
+				view2.editor
+					.optionalField({ parent: rootNode, field: brand("root 1 child") })
+					.set(makeCursor(leaf.number, 40), true);
+				view2.editor
+					.optionalField(rootField)
+					.set(makeCursor(testNode, { "root 2 child": 41 }), false);
+
+				// Transaction with a root and child change
+				runSynchronous(view, () => {
+					view.editor
+						.optionalField({ parent: rootNode, field: brand("root 1 child") })
+						.set(makeCursor(leaf.number, 42), true);
+					view.editor.optionalField(rootField).set(makeCursor(testNode, {}), false);
+					view.editor
+						.optionalField({ parent: rootNode, field: brand("root 3 child") })
+						.set(makeCursor(leaf.number, 43), true);
+				});
+
+				view.editor
+					.optionalField({ parent: rootNode, field: brand("root 3 child") })
+					.set(cursorForTypedTreeData({ schema: docSchema }, leaf.number, 44), false);
+
+				provider.processMessages();
+
+				// EditManager snapshot should involve information about rebasing tree1's edits (a transaction with root & child changes)
+				// over tree2's edits (a root change and a child change outside of the transaction).
+				await takeSnapshot(provider.trees[0], "final");
 			},
 		},
 		{

--- a/experimental/dds/tree2/src/test/snapshots/testTrees.ts
+++ b/experimental/dds/tree2/src/test/snapshots/testTrees.ts
@@ -41,6 +41,7 @@ import {
 	rootFieldKey,
 } from "../../core";
 import { leaf, SchemaBuilder } from "../../domains";
+// eslint-disable-next-line import/no-internal-modules
 import { TypedNode } from "../../feature-libraries/schema-aware";
 
 const rootField: FieldUpPath = { parent: undefined, field: rootFieldKey };


### PR DESCRIPTION
## Description

Converts OptionalField's format to refer to child node changes using the RegisterId that the node occupies in the input context of the change rather than the output context.
This makes it consistent with the delta format (which is not necessary, but convenient) and generally simplifies some of the ChangeRebaser logic.

## Breaking Changes

This is a breaking change to OptionalField's format semantics, since child changes refer to the node occupied by a register in the input context rather than the output context. I was mildly disturbed that this didn't already result in snapshot test failure, so I added a snapshot scenario which exercises most of optional-field's interesting scenarios from the edit manager perspective (this snapshot test would have been broken had it existed before this change). As usual, no back-compat attempt was made as the format is not yet stable.