### PR TITLE
Tag protocol definition types necessary for the Loader class to be alpha

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @internal
+// @alpha
 export type ConnectionMode = "write" | "read";
 
 // @internal (undocumented)
@@ -25,7 +25,7 @@ export interface IActorClient {
     sub: string;
 }
 
-// @internal
+// @alpha
 export type IApprovedProposal = {
     approvalSequenceNumber: number;
 } & ISequencedProposal;
@@ -42,19 +42,19 @@ export interface IBlob {
     encoding: "utf-8" | "base64";
 }
 
-// @internal
+// @alpha
 export interface IBranchOrigin {
     id: string;
     minimumSequenceNumber: number;
     sequenceNumber: number;
 }
 
-// @internal
+// @alpha
 export interface ICapabilities {
     interactive: boolean;
 }
 
-// @internal
+// @alpha
 export interface IClient {
     details: IClientDetails;
     mode: ConnectionMode;
@@ -65,7 +65,7 @@ export interface IClient {
     user: IUser;
 }
 
-// @internal
+// @alpha
 export interface IClientConfiguration {
     blockSize: number;
     maxMessageSize: number;
@@ -73,7 +73,7 @@ export interface IClientConfiguration {
     noopTimeFrequency?: number;
 }
 
-// @internal
+// @alpha
 export interface IClientDetails {
     capabilities: ICapabilities;
     // (undocumented)
@@ -89,7 +89,7 @@ export interface IClientJoin {
     detail: IClient;
 }
 
-// @internal
+// @alpha
 export type ICommittedProposal = {
     commitSequenceNumber: number;
 } & IApprovedProposal;
@@ -130,19 +130,19 @@ export interface IConnected {
     version: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ICreateBlobResponse {
     // (undocumented)
     id: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IDocumentAttributes {
     minimumSequenceNumber: number;
     sequenceNumber: number;
 }
 
-// @internal
+// @alpha
 export interface IDocumentMessage {
     clientSequenceNumber: number;
     compression?: string;
@@ -160,14 +160,14 @@ export interface IDocumentSystemMessage extends IDocumentMessage {
     data: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface INack {
     content: INackContent;
     operation: IDocumentMessage | undefined;
     sequenceNumber: number;
 }
 
-// @internal
+// @alpha
 export interface INackContent {
     code: number;
     message: string;
@@ -181,7 +181,7 @@ export interface IProcessMessageResult {
     immediateNoOp?: boolean;
 }
 
-// @internal
+// @alpha
 export interface IProposal {
     key: string;
     value: unknown;
@@ -211,7 +211,7 @@ export interface IQuorum extends Omit<IQuorumClients, "on" | "once" | "off">, Om
     once: IQuorum["on"];
 }
 
-// @internal
+// @alpha
 export interface IQuorumClients {
     // (undocumented)
     getMember(clientId: string): ISequencedClient | undefined;
@@ -277,7 +277,7 @@ export interface ISentSignalMessage extends ISignalMessageBase {
     targetClientId?: string;
 }
 
-// @internal
+// @alpha
 export interface ISequencedClient {
     client: IClient;
     sequenceNumber: number;
@@ -289,7 +289,7 @@ export interface ISequencedDocumentAugmentedMessage extends ISequencedDocumentMe
     additionalContent: string;
 }
 
-// @internal
+// @alpha
 export interface ISequencedDocumentMessage {
     clientId: string | null;
     clientSequenceNumber: number;
@@ -322,7 +322,7 @@ export interface ISequencedDocumentSystemMessage extends ISequencedDocumentMessa
     data: string;
 }
 
-// @internal
+// @alpha
 export type ISequencedProposal = {
     sequenceNumber: number;
 } & IProposal;
@@ -332,7 +332,7 @@ export interface IServerError {
     errorMessage: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISignalClient {
     client: IClient;
     clientConnectionNumber?: number;
@@ -340,12 +340,12 @@ export interface ISignalClient {
     referenceSequenceNumber?: number;
 }
 
-// @internal
+// @alpha
 export interface ISignalMessage extends ISignalMessageBase {
     clientId: string | null;
 }
 
-// @internal
+// @alpha
 export interface ISignalMessageBase {
     clientConnectionNumber?: number;
     content: unknown;
@@ -353,7 +353,7 @@ export interface ISignalMessageBase {
     type?: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISnapshotTree {
     // (undocumented)
     blobs: {
@@ -378,7 +378,7 @@ export interface ISnapshotTreeEx extends ISnapshotTree {
     };
 }
 
-// @internal
+// @alpha
 export type IsoDate = string;
 
 // @internal
@@ -387,7 +387,7 @@ export interface ISummaryAck {
     summaryProposal: ISummaryProposal;
 }
 
-// @internal
+// @alpha
 export interface ISummaryAttachment {
     // (undocumented)
     id: string;
@@ -395,7 +395,7 @@ export interface ISummaryAttachment {
     type: SummaryType.Attachment;
 }
 
-// @internal
+// @alpha
 export interface ISummaryBlob {
     // (undocumented)
     content: string | Uint8Array;
@@ -403,7 +403,7 @@ export interface ISummaryBlob {
     type: SummaryType.Blob;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummaryContent {
     details?: IUploadedSummaryDetails;
     handle: string;
@@ -412,7 +412,7 @@ export interface ISummaryContent {
     parents: string[];
 }
 
-// @internal
+// @alpha
 export interface ISummaryHandle {
     handle: string;
     handleType: SummaryTypeNoHandle;
@@ -443,7 +443,7 @@ export interface ISummaryTokenClaims {
     sub: string;
 }
 
-// @internal
+// @alpha
 export interface ISummaryTree {
     // (undocumented)
     tree: {
@@ -454,7 +454,7 @@ export interface ISummaryTree {
     unreferenced?: true;
 }
 
-// @internal
+// @alpha
 export interface ITokenClaims {
     documentId: string;
     exp: number;
@@ -477,7 +477,7 @@ export interface ITokenService {
     extractClaims(token: string): ITokenClaims;
 }
 
-// @internal
+// @alpha
 export interface ITrace {
     action: string;
     service: string;
@@ -507,24 +507,24 @@ export type ITreeEntry = {
     value: IAttachment;
 });
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IUploadedSummaryDetails {
     includesProtocolTree?: boolean;
 }
 
-// @internal
+// @alpha
 export interface IUser {
     id: string;
 }
 
-// @internal
+// @alpha
 export interface IVersion {
     date?: IsoDate;
     id: string;
     treeId: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export enum MessageType {
     Accept = "accept",
     ClientJoin = "join",
@@ -541,7 +541,7 @@ export enum MessageType {
     SummaryNack = "summaryNack"
 }
 
-// @internal
+// @alpha
 export enum NackErrorType {
     BadRequestError = "BadRequestError",
     InvalidScopeError = "InvalidScopeError",
@@ -562,21 +562,21 @@ export enum SignalType {
     ClientLeave = "leave"
 }
 
-// @internal
+// @alpha
 export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISummaryAttachment;
 
 // @internal
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 
-// @internal
+// @alpha
 export namespace SummaryType {
-    // (undocumented)
+    // @internal (undocumented)
     export type Attachment = 4;
-    // (undocumented)
+    // @internal (undocumented)
     export type Blob = 2;
-    // (undocumented)
+    // @internal (undocumented)
     export type Handle = 3;
-    // (undocumented)
+    // @internal (undocumented)
     export type Tree = 1;
     const Tree: Tree;
     const Blob: Blob;
@@ -584,10 +584,10 @@ export namespace SummaryType {
     const Attachment: Attachment;
 }
 
-// @internal
+// @alpha
 export type SummaryType = SummaryType.Attachment | SummaryType.Blob | SummaryType.Handle | SummaryType.Tree;
 
-// @internal
+// @alpha
 export type SummaryTypeNoHandle = SummaryType.Tree | SummaryType.Blob | SummaryType.Attachment;
 
 // @internal

--- a/common/lib/protocol-definitions/src/clients.ts
+++ b/common/lib/protocol-definitions/src/clients.ts
@@ -12,14 +12,14 @@ import { IUser } from "./users";
  *
  * Note: a user's connection mode is dependent on their permissions.
  * E.g. a user with read-only permissions will not be allowed a "write" connection mode.
- * @internal
+ * @alpha
  */
 export type ConnectionMode = "write" | "read";
 
 /**
  * Capabilities of a Client.
  * In particular, whether or not the client is {@link ICapabilities.interactive}.
- * @internal
+ * @alpha
  */
 export interface ICapabilities {
 	/**
@@ -36,7 +36,7 @@ export interface ICapabilities {
 
 /**
  * {@link IClient} connection / environment metadata.
- * @internal
+ * @alpha
  */
 export interface IClientDetails {
 	/**
@@ -63,7 +63,7 @@ export interface IClientDetails {
 
 /**
  * Represents a client connected to a Fluid service, including associated user details, permissions, and connection mode.
- * @internal
+ * @alpha
  */
 export interface IClient {
 	/**
@@ -96,7 +96,7 @@ export interface IClient {
 
 /**
  * A {@link IClient} that has been acknowledged by the sequencer.
- * @internal
+ * @alpha
  */
 export interface ISequencedClient {
 	/**
@@ -111,7 +111,7 @@ export interface ISequencedClient {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISignalClient {
 	/**

--- a/common/lib/protocol-definitions/src/config.ts
+++ b/common/lib/protocol-definitions/src/config.ts
@@ -5,7 +5,7 @@
 
 /**
  * Key value store of service configuration properties provided to the client as part of connection.
- * @internal
+ * @alpha
  */
 export interface IClientConfiguration {
 	/**

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -12,7 +12,7 @@ import { ISequencedClient } from "./clients";
  * Consensus on the proposal is achieved if the MSN is \>= the sequence number
  * at which the proposal is made and no client within the collaboration window rejects
  * the proposal.
- * @internal
+ * @alpha
  */
 export interface IProposal {
 	/**
@@ -28,19 +28,19 @@ export interface IProposal {
 
 /**
  * Similar to {@link IProposal} except it also includes the sequence number when it was made.
- * @internal
+ * @alpha
  */
 export type ISequencedProposal = { sequenceNumber: number } & IProposal;
 
 /**
  * Adds the sequence number at which the message was approved to an {@link ISequencedProposal}.
- * @internal
+ * @alpha
  */
 export type IApprovedProposal = { approvalSequenceNumber: number } & ISequencedProposal;
 
 /**
  * Adds the sequence number at which the message was committed to an {@link IApprovedProposal}.
- * @internal
+ * @alpha
  */
 export type ICommittedProposal = { commitSequenceNumber: number } & IApprovedProposal;
 
@@ -86,7 +86,7 @@ export type IQuorumEvents = IQuorumClientsEvents & IQuorumProposalsEvents;
 
 /**
  * Interface for tracking clients in the Quorum.
- * @internal
+ * @alpha
  */
 export interface IQuorumClients {
 	getMembers(): Map<string, ISequencedClient>;

--- a/common/lib/protocol-definitions/src/date.ts
+++ b/common/lib/protocol-definitions/src/date.ts
@@ -5,6 +5,6 @@
 
 /**
  * {@link https://www.iso.org/iso-8601-date-and-time-format.html | ISO 8601 format} date: `YYYY-MM-DDTHH:MM:SSZ`.
- * @internal
+ * @alpha
  */
 export type IsoDate = string;

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * @internal
+ * @alpha
  */
 export enum MessageType {
 	/**
@@ -93,7 +93,7 @@ export enum SignalType {
 
 /**
  * Messages to track latency trace.
- * @internal
+ * @alpha
  */
 export interface ITrace {
 	/**
@@ -113,7 +113,7 @@ export interface ITrace {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface INack {
 	/**
@@ -134,7 +134,7 @@ export interface INack {
 
 /**
  * Document-specific message.
- * @internal
+ * @alpha
  */
 export interface IDocumentMessage {
 	/**
@@ -189,7 +189,7 @@ export interface IDocumentSystemMessage extends IDocumentMessage {
 
 /**
  * Branch origin information.
- * @internal
+ * @alpha
  */
 export interface IBranchOrigin {
 	/**
@@ -210,7 +210,7 @@ export interface IBranchOrigin {
 
 /**
  * Sequenced message for a distributed document.
- * @internal
+ * @alpha
  */
 export interface ISequencedDocumentMessage {
 	/**
@@ -332,7 +332,7 @@ export interface ISequencedDocumentAugmentedMessage extends ISequencedDocumentMe
 
 /**
  * Common interface between incoming and outgoing signals.
- * @internal
+ * @alpha
  */
 export interface ISignalMessageBase {
 	/**
@@ -358,7 +358,7 @@ export interface ISignalMessageBase {
 
 /**
  * Interface for signals sent by the server to clients.
- * @internal
+ * @alpha
  */
 export interface ISignalMessage extends ISignalMessageBase {
 	/**
@@ -381,7 +381,7 @@ export interface ISentSignalMessage extends ISignalMessageBase {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IUploadedSummaryDetails {
 	/**
@@ -391,7 +391,7 @@ export interface IUploadedSummaryDetails {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummaryContent {
 	/**
@@ -494,7 +494,7 @@ export interface ISummaryNack {
 
 /**
  * Interface for nack content.
- * @internal
+ * @alpha
  */
 export interface INackContent {
 	/**
@@ -524,7 +524,7 @@ export interface INackContent {
 
 /**
  * Type of the nack.
- * @internal
+ * @alpha
  */
 export enum NackErrorType {
 	/**

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -6,7 +6,7 @@
 import { IsoDate } from "./date";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IDocumentAttributes {
 	/**
@@ -54,7 +54,7 @@ export interface IAttachment {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ICreateBlobResponse {
 	id: string;
@@ -119,7 +119,7 @@ export interface ITree {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISnapshotTree {
 	id?: string;
@@ -142,7 +142,7 @@ export interface ISnapshotTreeEx extends ISnapshotTree {
 
 /**
  * Represents a version of the snapshot of a data store.
- * @internal
+ * @alpha
  */
 export interface IVersion {
 	/**

--- a/common/lib/protocol-definitions/src/summary.ts
+++ b/common/lib/protocol-definitions/src/summary.ts
@@ -8,7 +8,7 @@
  *
  * @remarks
  * If any particular node is an {@link ISummaryTree}, it can contain additional `SummaryObject`s as its children.
- * @internal
+ * @alpha
  */
 export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISummaryAttachment;
 
@@ -20,7 +20,7 @@ export type SummaryTree = ISummaryTree | ISummaryHandle;
 
 /**
  * Type tag used to distinguish different types of nodes in a {@link ISummaryTree}.
- * @internal
+ * @alpha
  */
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace SummaryType {
@@ -43,7 +43,7 @@ export namespace SummaryType {
 
 	/**
 	 * Represents a sub-tree in the summary.
-	 * @internal
+	 * @alpha
 	 */
 	export const Tree: Tree = 1 as const;
 
@@ -51,13 +51,13 @@ export namespace SummaryType {
 	 * Represents a blob of data that is added to the summary.
 	 * Such as the user data that is added to the DDS or metadata added by runtime
 	 * such as data store / channel attributes.
-	 * @internal
+	 * @alpha
 	 */
 	export const Blob: Blob = 2 as const;
 
 	/**
 	 * Path to a summary tree object from the last successful summary.
-	 * @internal
+	 * @alpha
 	 */
 	export const Handle: Handle = 3 as const;
 
@@ -65,14 +65,14 @@ export namespace SummaryType {
 	 * Unique identifier to larger blobs uploaded outside of the summary.
 	 * Ex. DDS has large images or video that will be uploaded by the BlobManager and
 	 * receive an Id that can be used in the summary.
-	 * @internal
+	 * @alpha
 	 */
 	export const Attachment: Attachment = 4 as const;
 }
 
 /**
  * {@inheritDoc (SummaryType:namespace)}
- * @internal
+ * @alpha
  */
 export type SummaryType =
 	| SummaryType.Attachment
@@ -86,7 +86,7 @@ export type SummaryType =
  * @remarks
  * Summary handles are often used to point to summary tree objects contained within older summaries, thus avoiding
  * the need to re-send the entire subtree if summary object has not changed.
- * @internal
+ * @alpha
  */
 export type SummaryTypeNoHandle = SummaryType.Tree | SummaryType.Blob | SummaryType.Attachment;
 
@@ -98,7 +98,7 @@ export type SummaryTypeNoHandle = SummaryType.Tree | SummaryType.Blob | SummaryT
  * To illustrate, if a DataStore did not change since last summary, the framework runtime will use a handle for the
  * entire DataStore instead of re-sending the entire subtree. The same concept applies for a DDS.
  * An example of handle would be: '/<DataStoreId>/<DDSId>'.
- * @internal
+ * @alpha
  */
 export interface ISummaryHandle {
 	type: SummaryType.Handle;
@@ -124,7 +124,7 @@ export interface ISummaryHandle {
  * @example
  * "content": "\{ \"pkg\":\"[\\\"OfficeRootComponent\\\",\\\"LastEditedComponent\\\"]\",
  *                    \"summaryFormatVersion\":2,\"isRootDataStore\":false \}"
- * @internal
+ * @alpha
  */
 export interface ISummaryBlob {
 	type: SummaryType.Blob;
@@ -142,7 +142,7 @@ export interface ISummaryBlob {
  *
  * @example
  * "id": "bQAQKARDdMdTgqICmBa_ZB86YXwGP"
- * @internal
+ * @alpha
  */
 export interface ISummaryAttachment {
 	type: SummaryType.Attachment;
@@ -152,7 +152,7 @@ export interface ISummaryAttachment {
 /**
  * Tree Node data structure with children that are nodes of SummaryObject type:
  * Blob, Handle, Attachment or another Tree.
- * @internal
+ * @alpha
  */
 export interface ISummaryTree {
 	type: SummaryType.Tree;

--- a/common/lib/protocol-definitions/src/tokens.ts
+++ b/common/lib/protocol-definitions/src/tokens.ts
@@ -9,7 +9,7 @@ import { IUser } from "./users";
  * {@link https://jwt.io/introduction/ | JSON Web Token (JWT)} Claims
  *
  * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4}
- * @internal
+ * @alpha
  */
 export interface ITokenClaims {
 	/**

--- a/common/lib/protocol-definitions/src/users.ts
+++ b/common/lib/protocol-definitions/src/users.ts
@@ -5,7 +5,7 @@
 
 /**
  * Base user definition. It is valid to extend this interface when adding new details to the user object.
- * @internal
+ * @alpha
  */
 export interface IUser {
 	/**


### PR DESCRIPTION
This PR is preparation for changing the tagging on the Loader class to alpha. All these types were automatically identified a transitive dependency of the Loader class which will be made alpha in a later review.

We will stage these commits the invite review, however review items will generally be added to the backlog as future items, as these type updates are necessary for the current state of the code base. 