### PR TITLE
Tag server types necessary for the Loader class to be alpha

### DIFF
--- a/server/routerlicious/api-report/protocol-base.api.md
+++ b/server/routerlicious/api-report/protocol-base.api.md
@@ -45,7 +45,7 @@ export interface IProtocolHandler {
     snapshot(): IQuorumSnapshot;
 }
 
-// @internal
+// @alpha
 export interface IQuorumSnapshot {
     // (undocumented)
     members: QuorumClientsSnapshot;
@@ -130,7 +130,7 @@ export class QuorumClients extends TypedEventEmitter<IQuorumClients["on"]> imple
     snapshot(): QuorumClientsSnapshot;
 }
 
-// @internal
+// @alpha
 export type QuorumClientsSnapshot = [string, ISequencedClient][];
 
 // @internal
@@ -152,7 +152,7 @@ export class QuorumProposals extends TypedEventEmitter<IQuorumProposals["on"]> i
     updateMinimumSequenceNumber(message: ISequencedDocumentMessage): void;
 }
 
-// @internal
+// @alpha
 export type QuorumProposalsSnapshot = {
     proposals: [number, ISequencedProposal, string[]][];
     values: [string, ICommittedProposal][];

--- a/server/routerlicious/packages/protocol-base/src/quorum.ts
+++ b/server/routerlicious/packages/protocol-base/src/quorum.ts
@@ -30,13 +30,13 @@ class PendingProposal implements ISequencedProposal {
 
 /**
  * Snapshot format for a QuorumClients
- * @internal
+ * @alpha
  */
 export type QuorumClientsSnapshot = [string, ISequencedClient][];
 
 /**
  * Snapshot format for a QuorumProposals
- * @internal
+ * @alpha
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type QuorumProposalsSnapshot = {
@@ -46,7 +46,7 @@ export type QuorumProposalsSnapshot = {
 
 /**
  * Snapshot format for a Quorum
- * @internal
+ * @alpha
  */
 export interface IQuorumSnapshot {
 	members: QuorumClientsSnapshot;


### PR DESCRIPTION
This PR is preparation for changing the tagging on the Loader class to alpha. All these types were automatically identified a transitive dependency of the Loader class which will be made alpha in a later review.

We will stage these commits the invite review, however review items will generally be added to the backlog as future items, as these type updates are necessary for the current state of the code base.