### PR TITLE
Tag protocol-definitions types necessary for the ContainerRuntime class to be alpha

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -7,7 +7,7 @@
 // @alpha
 export type ConnectionMode = "write" | "read";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export enum FileMode {
     // (undocumented)
     Directory = "040000",
@@ -30,13 +30,13 @@ export type IApprovedProposal = {
     approvalSequenceNumber: number;
 } & ISequencedProposal;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IAttachment {
     // (undocumented)
     id: string;
 }
 
-// @internal
+// @alpha
 export interface IBlob {
     contents: string;
     encoding: "utf-8" | "base64";
@@ -381,7 +381,7 @@ export interface ISnapshotTreeEx extends ISnapshotTree {
 // @alpha
 export type IsoDate = string;
 
-// @internal
+// @alpha
 export interface ISummaryAck {
     handle: string;
     summaryProposal: ISummaryProposal;
@@ -420,7 +420,7 @@ export interface ISummaryHandle {
     type: SummaryType.Handle;
 }
 
-// @internal
+// @alpha
 export interface ISummaryNack {
     code?: number;
     message?: string;
@@ -428,7 +428,7 @@ export interface ISummaryNack {
     summaryProposal: ISummaryProposal;
 }
 
-// @internal
+// @alpha
 export interface ISummaryProposal {
     summarySequenceNumber: number;
 }
@@ -484,7 +484,7 @@ export interface ITrace {
     timestamp: number;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ITree {
     // (undocumented)
     entries: ITreeEntry[];
@@ -492,7 +492,7 @@ export interface ITree {
     unreferenced?: true;
 }
 
-// @internal
+// @alpha
 export type ITreeEntry = {
     path: string;
     mode: FileMode;
@@ -590,7 +590,7 @@ export type SummaryType = SummaryType.Attachment | SummaryType.Blob | SummaryTyp
 // @alpha
 export type SummaryTypeNoHandle = SummaryType.Tree | SummaryType.Blob | SummaryType.Attachment;
 
-// @internal
+// @alpha
 export enum TreeEntry {
     // (undocumented)
     Attachment = "Attachment",

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -437,7 +437,7 @@ export interface IServerError {
 
 /**
  * Data about the original proposed summary message.
- * @internal
+ * @alpha
  */
 export interface ISummaryProposal {
 	/**
@@ -448,7 +448,7 @@ export interface ISummaryProposal {
 
 /**
  * Contents of summary ack expected from the server.
- * @internal
+ * @alpha
  */
 export interface ISummaryAck {
 	/**
@@ -464,7 +464,7 @@ export interface ISummaryAck {
 
 /**
  * Contents of summary nack expected from the server.
- * @internal
+ * @alpha
  */
 export interface ISummaryNack {
 	/**

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -21,7 +21,7 @@ export interface IDocumentAttributes {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export enum FileMode {
 	File = "100644",
@@ -32,7 +32,7 @@ export enum FileMode {
 
 /**
  * Raw blob stored within the tree.
- * @internal
+ * @alpha
  */
 export interface IBlob {
 	/**
@@ -47,7 +47,7 @@ export interface IBlob {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IAttachment {
 	id: string;
@@ -62,7 +62,7 @@ export interface ICreateBlobResponse {
 
 /**
  * A tree entry wraps a path with a type of node.
- * @internal
+ * @alpha
  */
 export type ITreeEntry = {
 	/**
@@ -92,7 +92,7 @@ export type ITreeEntry = {
 
 /**
  * Type of entries that can be stored in a tree.
- * @internal
+ * @alpha
  */
 export enum TreeEntry {
 	Blob = "Blob",
@@ -101,7 +101,7 @@ export enum TreeEntry {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ITree {
 	entries: ITreeEntry[];


### PR DESCRIPTION
This PR is preparation for changing the tagging on the ContainerRuntime class to be alpha. All these types were automatically identified as transitive dependency of the ContainerRuntime class which will be made alpha in a later review.

We will stage these commits and invite review, however review items will generally be added to the backlog as future items, as these type updates are necessary for the current state of the code base.