### PR TITLE
Tag client packages types necessary for the ContainerRuntime class to be alpha

### DIFF
--- a/packages/common/client-utils/api-report/client-utils.api.md
+++ b/packages/common/client-utils/api-report/client-utils.api.md
@@ -26,7 +26,7 @@ export { Buffer_2 as Buffer }
 // @internal
 export const bufferToString: (blob: ArrayBufferLike, encoding: "utf8" | "utf-8" | "base64") => string;
 
-// @internal
+// @alpha
 export type EventEmitterEventType = EventEmitter extends {
     on(event: infer E, listener: any): any;
 } ? E : never;
@@ -97,7 +97,7 @@ export class Trace {
     trace(): ITraceEvent;
 }
 
-// @internal
+// @alpha
 export class TypedEventEmitter<TEvent> extends EventEmitter implements IEventProvider<TEvent & IEvent> {
     constructor();
     // (undocumented)
@@ -116,7 +116,7 @@ export class TypedEventEmitter<TEvent> extends EventEmitter implements IEventPro
     readonly removeListener: TypedEventTransform<this, TEvent>;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type TypedEventTransform<TThis, TEvent> = TransformedEvent<TThis, "newListener" | "removeListener", Parameters<(event: string, listener: (...args: any[]) => void) => void>> & IEventTransformer<TThis, TEvent & IEvent> & TransformedEvent<TThis, EventEmitterEventType, any[]>;
 
 // @internal

--- a/packages/common/client-utils/src/typedEventEmitter.ts
+++ b/packages/common/client-utils/src/typedEventEmitter.ts
@@ -19,7 +19,7 @@ import {
  *
  * This type allow us to correctly handle either type
  *
- * @internal
+ * @alpha
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type EventEmitterEventType = EventEmitter extends { on(event: infer E, listener: any) }
@@ -27,7 +27,7 @@ export type EventEmitterEventType = EventEmitter extends { on(event: infer E, li
 	: never;
 
 /**
- * @internal
+ * @alpha
  */
 export type TypedEventTransform<TThis, TEvent> =
 	// Event emitter supports some special events for the emitter itself to use
@@ -49,7 +49,7 @@ export type TypedEventTransform<TThis, TEvent> =
 /**
  * Event Emitter helper class the supports emitting typed events
  *
- * @internal
+ * @alpha
  */
 export class TypedEventEmitter<TEvent>
 	extends EventEmitter

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -27,7 +27,7 @@ export type FluidObject<T = unknown> = {
     [P in FluidObjectProviderKeys<T>]?: T[P];
 };
 
-// @internal
+// @alpha
 export type FluidObjectKeys<T> = keyof FluidObject<T>;
 
 // @alpha
@@ -251,10 +251,10 @@ export interface IFluidCodeDetailsConfig {
     readonly [key: string]: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const IFluidHandle: keyof IProvideFluidHandle;
 
-// @internal
+// @alpha
 export interface IFluidHandle<T = FluidObject & IFluidLoadable> extends IProvideFluidHandle {
     // @deprecated (undocumented)
     readonly absolutePath: string;
@@ -266,10 +266,10 @@ export interface IFluidHandle<T = FluidObject & IFluidLoadable> extends IProvide
     readonly isAttached: boolean;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const IFluidHandleContext: keyof IProvideFluidHandleContext;
 
-// @internal
+// @alpha
 export interface IFluidHandleContext extends IProvideFluidHandleContext {
     readonly absolutePath: string;
     attachGraph(): void;
@@ -279,10 +279,10 @@ export interface IFluidHandleContext extends IProvideFluidHandleContext {
     readonly routeContext?: IFluidHandleContext;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const IFluidLoadable: keyof IProvideFluidLoadable;
 
-// @internal
+// @alpha
 export interface IFluidLoadable extends IProvideFluidLoadable {
     // (undocumented)
     handle: IFluidHandle;
@@ -343,19 +343,19 @@ export interface IProvideFluidCodeDetailsComparer {
     readonly IFluidCodeDetailsComparer: IFluidCodeDetailsComparer;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IProvideFluidHandle {
     // (undocumented)
     readonly IFluidHandle: IFluidHandle;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IProvideFluidHandleContext {
     // (undocumented)
     readonly IFluidHandleContext: IFluidHandleContext;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IProvideFluidLoadable {
     // (undocumented)
     readonly IFluidLoadable: IFluidLoadable;

--- a/packages/common/core-interfaces/src/fluidLoadable.ts
+++ b/packages/common/core-interfaces/src/fluidLoadable.ts
@@ -6,19 +6,19 @@
 import { IFluidHandle } from "./handles";
 
 /**
- * @internal
+ * @alpha
  */
 export const IFluidLoadable: keyof IProvideFluidLoadable = "IFluidLoadable";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IProvideFluidLoadable {
 	readonly IFluidLoadable: IFluidLoadable;
 }
 /**
  * A shared FluidObject has a URL from which it can be referenced
- * @internal
+ * @alpha
  */
 export interface IFluidLoadable extends IProvideFluidLoadable {
 	// Handle to the loadable FluidObject

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -8,12 +8,12 @@ import { IFluidLoadable } from "./fluidLoadable";
 import { FluidObject } from "./provider";
 
 /**
- * @internal
+ * @alpha
  */
 export const IFluidHandleContext: keyof IProvideFluidHandleContext = "IFluidHandleContext";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IProvideFluidHandleContext {
 	readonly IFluidHandleContext: IFluidHandleContext;
@@ -21,7 +21,7 @@ export interface IProvideFluidHandleContext {
 
 /**
  * Describes a routing context from which other `IFluidHandleContext`s are defined.
- * @internal
+ * @alpha
  */
 export interface IFluidHandleContext extends IProvideFluidHandleContext {
 	/**
@@ -49,12 +49,12 @@ export interface IFluidHandleContext extends IProvideFluidHandleContext {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export const IFluidHandle: keyof IProvideFluidHandle = "IFluidHandle";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IProvideFluidHandle {
 	readonly IFluidHandle: IFluidHandle;
@@ -62,7 +62,7 @@ export interface IProvideFluidHandle {
 
 /**
  * Handle to a shared {@link FluidObject}.
- * @internal
+ * @alpha
  */
 export interface IFluidHandle<
 	// REVIEW: Constrain `T` to something? How do we support dds and datastores safely?

--- a/packages/common/core-interfaces/src/provider.ts
+++ b/packages/common/core-interfaces/src/provider.ts
@@ -83,6 +83,6 @@ export type FluidObject<T = unknown> = {
  * See {@link FluidObject}
  *
  * For example `FluidObjectKeys<IFoo & IBar>` would result in `"IFoo" | "IBar"`
- * @internal
+ * @alpha
  */
 export type FluidObjectKeys<T> = keyof FluidObject<T>;

--- a/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.api.md
+++ b/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.api.md
@@ -24,7 +24,7 @@ import { IRequest } from '@fluidframework/core-interfaces';
 import { IResponse } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 
-// @internal
+// @alpha
 export interface IContainerRuntime extends IProvideFluidDataStoreRegistry, IContainerRuntimeBaseWithCombinedEvents {
     readonly attachState: AttachState;
     // (undocumented)
@@ -53,10 +53,10 @@ export interface IContainerRuntime extends IProvideFluidDataStoreRegistry, ICont
     readonly storage: IDocumentStorageService;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type IContainerRuntimeBaseWithCombinedEvents = IContainerRuntimeBase & IEventProvider<IContainerRuntimeEvents>;
 
-// @internal
+// @alpha
 export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
     // (undocumented)
     (event: "dirty" | "disconnected" | "dispose" | "saved" | "attached", listener: () => void): any;
@@ -64,7 +64,7 @@ export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
     (event: "connected", listener: (clientId: string) => void): any;
 }
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export interface IContainerRuntimeWithResolveHandle_Deprecated extends IContainerRuntime {
     // (undocumented)
     readonly IFluidHandleContext: IFluidHandleContext;

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -30,7 +30,7 @@ import {
 
 /**
  * @deprecated Will be removed in future major release. Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
- * @internal
+ * @alpha
  */
 export interface IContainerRuntimeWithResolveHandle_Deprecated extends IContainerRuntime {
 	readonly IFluidHandleContext: IFluidHandleContext;
@@ -39,7 +39,7 @@ export interface IContainerRuntimeWithResolveHandle_Deprecated extends IContaine
 
 /**
  * Events emitted by {@link IContainerRuntime}.
- * @internal
+ * @alpha
  */
 export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
 	(event: "dirty" | "disconnected" | "dispose" | "saved" | "attached", listener: () => void);
@@ -47,14 +47,14 @@ export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type IContainerRuntimeBaseWithCombinedEvents = IContainerRuntimeBase &
 	IEventProvider<IContainerRuntimeEvents>;
 
 /**
  * Represents the runtime of the container. Contains helper functions/state of the container.
- * @internal
+ * @alpha
  */
 export interface IContainerRuntime
 	extends IProvideFluidDataStoreRegistry,

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -72,7 +72,7 @@ export type CompatModeBehavior =
 /** Fail processing immediately. (The container will close) */
 | "FailToProcess";
 
-// @internal
+// @alpha
 export enum CompressionAlgorithms {
     // (undocumented)
     lz4 = "lz4"
@@ -95,7 +95,7 @@ export enum ContainerMessageType {
     Rejoin = "rejoin"
 }
 
-// @internal
+// @alpha
 export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents & ISummarizerEvents> implements IContainerRuntime, IRuntime, ISummarizerRuntime, ISummarizerInternalsProvider, IProvideFluidHandleContext {
     protected constructor(context: IContainerContext, registry: IFluidDataStoreRegistry, metadata: IContainerRuntimeMetadata | undefined, electedSummarizerData: ISerializedElection | undefined, chunks: [string, string[]][], dataStoreAliasMap: [string, string][], runtimeOptions: Readonly<Required<IContainerRuntimeOptions>>, containerScope: FluidObject, logger: ITelemetryLoggerExt, existing: boolean, blobManagerSnapshot: IBlobManagerLoadInfo, _storage: IDocumentStorageService, idCompressor: (IIdCompressor & IIdCompressorCore) | undefined, provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>, requestHandler?: ((request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>) | undefined, summaryConfiguration?: ISummaryConfiguration);
     // (undocumented)
@@ -242,7 +242,7 @@ export interface ContainerRuntimeMessage {
 // @internal (undocumented)
 export const DefaultSummaryConfiguration: ISummaryConfiguration;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type EnqueueSummarizeResult = (ISummarizeResults & {
     readonly alreadyEnqueued?: undefined;
 }) | (ISummarizeResults & {
@@ -262,13 +262,13 @@ export class FluidDataStoreRegistry implements IFluidDataStoreRegistry {
     get IFluidDataStoreRegistry(): this;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface GCFeatureMatrix {
     sweepGeneration?: number;
     tombstoneGeneration?: number;
 }
 
-// @internal
+// @alpha
 export const GCNodeType: {
     DataStore: string;
     SubDataStore: string;
@@ -276,10 +276,10 @@ export const GCNodeType: {
     Other: string;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type GCNodeType = (typeof GCNodeType)[keyof typeof GCNodeType];
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type GCVersion = number;
 
 // @internal
@@ -293,7 +293,7 @@ export interface IAckedSummary {
     readonly summaryOp: ISummaryOpMessage;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IAckSummaryResult {
     // (undocumented)
     readonly ackNackDuration: number;
@@ -301,7 +301,7 @@ export interface IAckSummaryResult {
     readonly summaryAckOp: ISummaryAckMessage;
 }
 
-// @internal
+// @alpha
 export interface IBaseSummarizeResult {
     readonly error: any;
     // (undocumented)
@@ -311,7 +311,7 @@ export interface IBaseSummarizeResult {
     readonly stage: "base";
 }
 
-// @internal
+// @alpha
 export interface IBlobManagerLoadInfo {
     // (undocumented)
     ids?: string[];
@@ -319,7 +319,7 @@ export interface IBlobManagerLoadInfo {
     redirectTable?: [string, string][];
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IBroadcastSummaryResult {
     // (undocumented)
     readonly broadcastDuration: number;
@@ -333,7 +333,7 @@ export interface ICancellableSummarizerController extends ISummaryCancellationTo
     stop(reason: SummarizerStopReason): void;
 }
 
-// @internal
+// @alpha
 export interface ICancellationToken<T> {
     readonly cancelled: boolean;
     readonly waitCancelled: Promise<T>;
@@ -363,13 +363,13 @@ export interface IClientSummaryWatcher extends IDisposable {
     watchSummary(clientSequenceNumber: number): ISummary;
 }
 
-// @internal
+// @alpha
 export interface ICompressionRuntimeOptions {
     readonly compressionAlgorithm: CompressionAlgorithms;
     readonly minimumBatchSizeInBytes: number;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IConnectableRuntime {
     // (undocumented)
     readonly clientId: string | undefined;
@@ -386,7 +386,7 @@ export interface IContainerRuntimeMessageCompatDetails {
     behavior: CompatModeBehavior;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IContainerRuntimeMetadata extends ICreateContainerMetadata, IGCMetadata {
     readonly disableIsolatedChannels?: true;
     readonly idCompressorEnabled?: boolean;
@@ -397,7 +397,7 @@ export interface IContainerRuntimeMetadata extends ICreateContainerMetadata, IGC
     readonly telemetryDocumentId?: string;
 }
 
-// @internal
+// @alpha
 export interface IContainerRuntimeOptions {
     readonly chunkSizeInBytes?: number;
     readonly compressionOptions?: ICompressionRuntimeOptions;
@@ -413,19 +413,19 @@ export interface IContainerRuntimeOptions {
     readonly summaryOptions?: ISummaryRuntimeOptions;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ICreateContainerMetadata {
     createContainerRuntimeVersion?: string;
     createContainerTimestamp?: number;
 }
 
-// @internal
+// @alpha
 export interface IEnqueueSummarizeOptions extends IOnDemandSummarizeOptions {
     readonly afterSequenceNumber?: number;
     readonly override?: boolean;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IGCMetadata {
     readonly gcFeature?: GCVersion;
     readonly gcFeatureMatrix?: GCFeatureMatrix;
@@ -435,7 +435,7 @@ export interface IGCMetadata {
     readonly sweepTimeoutMs?: number;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IGCRuntimeOptions {
     [key: string]: any;
     disableGC?: boolean;
@@ -444,11 +444,11 @@ export interface IGCRuntimeOptions {
     sessionExpiryTimeoutMs?: number;
 }
 
-// @internal
+// @alpha
 export interface IGCStats extends IMarkPhaseStats, ISweepPhaseStats {
 }
 
-// @internal
+// @alpha
 export interface IGeneratedSummaryStats extends ISummaryStats {
     readonly dataStoreCount: number;
     readonly gcBlobNodeCount?: number;
@@ -458,7 +458,7 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
     readonly summaryNumber: number;
 }
 
-// @internal
+// @alpha
 export interface IGenerateSummaryTreeResult extends Omit<IBaseSummarizeResult, "stage"> {
     readonly forcedFullTree: boolean;
     readonly generateDuration: number;
@@ -468,7 +468,7 @@ export interface IGenerateSummaryTreeResult extends Omit<IBaseSummarizeResult, "
     readonly summaryTree: ISummaryTree;
 }
 
-// @internal
+// @alpha
 export interface IMarkPhaseStats {
     attachmentBlobCount: number;
     dataStoreCount: number;
@@ -481,7 +481,7 @@ export interface IMarkPhaseStats {
     updatedNodeCount: number;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface INackSummaryResult extends IRetriableFailureResult {
     // (undocumented)
     readonly ackNackDuration: number;
@@ -492,12 +492,12 @@ export interface INackSummaryResult extends IRetriableFailureResult {
 // @internal
 export const InactiveResponseHeaderKey = "isInactive";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IOnDemandSummarizeOptions extends ISummarizeOptions {
     readonly reason: string;
 }
 
-// @internal
+// @alpha
 export interface IRefreshSummaryAckOptions {
     readonly ackHandle: string;
     readonly proposalHandle: string | undefined;
@@ -505,13 +505,13 @@ export interface IRefreshSummaryAckOptions {
     readonly summaryRefSeq: number;
 }
 
-// @internal
+// @alpha
 export interface IRetriableFailureResult {
     // (undocumented)
     readonly retryAfterSeconds?: number;
 }
 
-// @internal
+// @alpha
 export interface ISerializedElection {
     readonly electedClientId: string | undefined;
     readonly electedParentId: string | undefined;
@@ -524,7 +524,7 @@ export function isRuntimeMessage(message: ISequencedDocumentMessage): boolean;
 // @internal
 export function isStableId(str: string): str is StableId;
 
-// @internal
+// @alpha
 export interface ISubmitSummaryOpResult extends Omit<IUploadSummaryResult, "stage" | "error"> {
     readonly clientSequenceNumber: number;
     // (undocumented)
@@ -532,14 +532,14 @@ export interface ISubmitSummaryOpResult extends Omit<IUploadSummaryResult, "stag
     readonly submitOpDuration: number;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISubmitSummaryOptions extends ISummarizeOptions {
     readonly cancellationToken: ISummaryCancellationToken;
     readonly finalAttempt?: boolean;
     readonly summaryLogger: ITelemetryLoggerExt;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummarizeEventProps {
     // (undocumented)
     currentAttempt: number;
@@ -551,7 +551,7 @@ export interface ISummarizeEventProps {
     result: "success" | "failure" | "canceled";
 }
 
-// @internal
+// @alpha
 export interface ISummarizeOptions {
     readonly fullTree?: boolean;
     // @deprecated
@@ -571,26 +571,26 @@ export interface ISummarizer extends IEventProvider<ISummarizerEvents> {
     summarizeOnDemand(options: IOnDemandSummarizeOptions): ISummarizeResults;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummarizeResults {
     readonly receivedSummaryAckOrNack: Promise<SummarizeResultPart<IAckSummaryResult, INackSummaryResult>>;
     readonly summaryOpBroadcasted: Promise<SummarizeResultPart<IBroadcastSummaryResult>>;
     readonly summarySubmitted: Promise<SummarizeResultPart<SubmitSummaryResult, SubmitSummaryFailureData>>;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummarizerEvents extends IEvent {
     // (undocumented)
     (event: "summarize", listener: (props: ISummarizeEventProps) => void): any;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummarizerInternalsProvider {
     refreshLatestSummaryAck(options: IRefreshSummaryAckOptions): Promise<void>;
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummarizerRuntime extends IConnectableRuntime {
     // (undocumented)
     closeFn(): void;
@@ -627,7 +627,7 @@ export interface ISummary {
     waitBroadcast(): Promise<ISummaryOpMessage>;
 }
 
-// @internal
+// @alpha
 export interface ISummaryAckMessage extends ISequencedDocumentMessage {
     // (undocumented)
     contents: ISummaryAck;
@@ -635,14 +635,14 @@ export interface ISummaryAckMessage extends ISequencedDocumentMessage {
     type: MessageType.SummaryAck;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummaryBaseConfiguration {
     initialSummarizerDelayMs: number;
     maxAckWaitTime: number;
     maxOpsSinceLastSummary: number;
 }
 
-// @internal
+// @alpha
 export type ISummaryCancellationToken = ICancellationToken<SummarizerStopReason>;
 
 // @internal (undocumented)
@@ -651,22 +651,22 @@ export interface ISummaryCollectionOpEvents extends IEvent {
     (event: OpActionEventName, listener: OpActionEventListener): any;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type ISummaryConfiguration = ISummaryConfigurationDisableSummarizer | ISummaryConfigurationDisableHeuristics | ISummaryConfigurationHeuristics;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummaryConfigurationDisableHeuristics extends ISummaryBaseConfiguration {
     // (undocumented)
     state: "disableHeuristics";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummaryConfigurationDisableSummarizer {
     // (undocumented)
     state: "disabled";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfiguration {
     maxIdleTime: number;
     maxOps: number;
@@ -680,10 +680,10 @@ export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfigurati
     state: "enabled";
 }
 
-// @internal
+// @alpha
 export type ISummaryMetadataMessage = Pick<ISequencedDocumentMessage, "clientId" | "clientSequenceNumber" | "minimumSequenceNumber" | "referenceSequenceNumber" | "sequenceNumber" | "timestamp" | "type">;
 
-// @internal
+// @alpha
 export interface ISummaryNackMessage extends ISequencedDocumentMessage {
     // (undocumented)
     contents: ISummaryNack;
@@ -691,7 +691,7 @@ export interface ISummaryNackMessage extends ISequencedDocumentMessage {
     type: MessageType.SummaryNack;
 }
 
-// @internal
+// @alpha
 export interface ISummaryOpMessage extends ISequencedDocumentMessage {
     // (undocumented)
     contents: ISummaryContent;
@@ -699,14 +699,14 @@ export interface ISummaryOpMessage extends ISequencedDocumentMessage {
     type: MessageType.Summarize;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummaryRuntimeOptions {
     // @deprecated
     initialSummarizerDelayMs?: number;
     summaryConfigOverrides?: ISummaryConfiguration;
 }
 
-// @internal
+// @alpha
 export interface ISweepPhaseStats {
     deletedAttachmentBlobCount: number;
     deletedDataStoreCount: number;
@@ -716,7 +716,7 @@ export interface ISweepPhaseStats {
     lifetimeNodeCount: number;
 }
 
-// @internal
+// @alpha
 export interface IUploadSummaryResult extends Omit<IGenerateSummaryTreeResult, "stage"> {
     readonly handle: string;
     // (undocumented)
@@ -762,13 +762,13 @@ export enum RuntimeMessage {
     Rejoin = "rejoin"
 }
 
-// @internal
+// @alpha
 export interface SubmitSummaryFailureData extends IRetriableFailureResult {
     // (undocumented)
     stage: SummaryStage;
 }
 
-// @internal
+// @alpha
 export type SubmitSummaryResult = IBaseSummarizeResult | IGenerateSummaryTreeResult | IUploadSummaryResult | ISubmitSummaryOpResult;
 
 // @internal
@@ -797,7 +797,7 @@ export class Summarizer extends TypedEventEmitter<ISummarizerEvents> implements 
     readonly summaryCollection: SummaryCollection;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type SummarizeResultPart<TSuccess, TFailure = undefined> = {
     success: true;
     data: TSuccess;
@@ -808,7 +808,7 @@ export type SummarizeResultPart<TSuccess, TFailure = undefined> = {
     error: any;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type SummarizerStopReason =
 /** Summarizer client failed to summarize in all 3 consecutive attempts. */
 "failToSummarize"
@@ -859,7 +859,7 @@ export class SummaryCollection extends TypedEventEmitter<ISummaryCollectionOpEve
     waitSummaryAck(referenceSequenceNumber: number): Promise<IAckedSummary>;
 }
 
-// @internal
+// @alpha
 export type SummaryStage = SubmitSummaryResult["stage"] | "unknown";
 
 // @internal

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -85,7 +85,7 @@ export class BlobHandle implements IFluidHandle<ArrayBufferLike> {
 
 /**
  * Information from a snapshot needed to load BlobManager
- * @internal
+ * @alpha
  */
 export interface IBlobManagerLoadInfo {
 	ids?: string[];

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -213,7 +213,7 @@ function compatBehaviorAllowsMessageType(
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummaryBaseConfiguration {
 	/**
@@ -235,7 +235,7 @@ export interface ISummaryBaseConfiguration {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfiguration {
 	state: "enabled";
@@ -298,21 +298,21 @@ export interface ISummaryConfigurationHeuristics extends ISummaryBaseConfigurati
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummaryConfigurationDisableSummarizer {
 	state: "disabled";
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummaryConfigurationDisableHeuristics extends ISummaryBaseConfiguration {
 	state: "disableHeuristics";
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type ISummaryConfiguration =
 	| ISummaryConfigurationDisableSummarizer
@@ -349,7 +349,7 @@ export const DefaultSummaryConfiguration: ISummaryConfiguration = {
 };
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummaryRuntimeOptions {
 	/** Override summary configurations set by the server. */
@@ -366,7 +366,7 @@ export interface ISummaryRuntimeOptions {
 
 /**
  * Options for op compression.
- * @internal
+ * @alpha
  */
 export interface ICompressionRuntimeOptions {
 	/**
@@ -384,7 +384,7 @@ export interface ICompressionRuntimeOptions {
 
 /**
  * Options for container runtime.
- * @internal
+ * @alpha
  */
 export interface IContainerRuntimeOptions {
 	readonly summaryOptions?: ISummaryRuntimeOptions;
@@ -516,7 +516,7 @@ export const defaultRuntimeHeaderData: Required<RuntimeHeaderData> = {
 
 /**
  * Available compression algorithms for op compression.
- * @internal
+ * @alpha
  */
 export enum CompressionAlgorithms {
 	lz4 = "lz4",
@@ -718,7 +718,7 @@ export async function TEST_requestSummarizer(loader: ILoader, url: string): Prom
 /**
  * Represents the runtime of the container. Contains helper functions/state of the container.
  * It will define the store level mappings.
- * @internal
+ * @alpha
  */
 export class ContainerRuntime
 	extends TypedEventEmitter<IContainerRuntimeEvents & ISummarizerEvents>

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -22,7 +22,7 @@ import {
 import { RuntimeHeaderData } from "../containerRuntime";
 
 /**
- * @internal
+ * @alpha
  */
 export type GCVersion = number;
 
@@ -92,7 +92,7 @@ export const defaultSessionExpiryDurationMs = 30 * oneDayMs; // 30 days
 
 /**
  * @see IGCMetadata.gcFeatureMatrix
- * @internal
+ * @alpha
  */
 export interface GCFeatureMatrix {
 	/**
@@ -110,7 +110,7 @@ export interface GCFeatureMatrix {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IGCMetadata {
 	/**
@@ -150,7 +150,7 @@ export interface IGCMetadata {
 
 /**
  * The statistics of the system state after a garbage collection mark phase run.
- * @internal
+ * @alpha
  */
 export interface IMarkPhaseStats {
 	/** The number of nodes in the container. */
@@ -175,7 +175,7 @@ export interface IMarkPhaseStats {
 
 /**
  * The statistics of the system state after a garbage collection sweep phase run.
- * @internal
+ * @alpha
  */
 export interface ISweepPhaseStats {
 	/** The number of nodes in the lifetime of the container. */
@@ -194,13 +194,13 @@ export interface ISweepPhaseStats {
 
 /**
  * The statistics of the system state after a garbage collection run.
- * @internal
+ * @alpha
  */
 export interface IGCStats extends IMarkPhaseStats, ISweepPhaseStats {}
 
 /**
  * The types of GC nodes in the GC reference graph.
- * @internal
+ * @alpha
  */
 export const GCNodeType = {
 	// Nodes that are for data stores.
@@ -214,7 +214,7 @@ export const GCNodeType = {
 };
 
 /**
- * @internal
+ * @alpha
  */
 export type GCNodeType = (typeof GCNodeType)[keyof typeof GCNodeType];
 
@@ -320,7 +320,7 @@ export interface IGarbageCollectorCreateParams {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IGCRuntimeOptions {
 	/**

--- a/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
+++ b/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
@@ -227,7 +227,7 @@ export interface IOrderedClientElectionEvents extends IEvent {
 
 /**
  * Serialized state of IOrderedClientElection.
- * @internal
+ * @alpha
  */
 export interface ISerializedElection {
 	/** Sequence number at the time of the latest election. */

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -19,7 +19,7 @@ import { SummarizeReason } from "./summaryGenerator";
 /**
  * Similar to AbortSignal, but using promise instead of events
  * @param T - cancellation reason type
- * @internal
+ * @alpha
  */
 export interface ICancellationToken<T> {
 	/** Tells if this cancellable token is cancelled */
@@ -33,13 +33,13 @@ export interface ICancellationToken<T> {
 
 /**
  * Similar to AbortSignal, but using promise instead of events
- * @internal
+ * @alpha
  */
 export type ISummaryCancellationToken = ICancellationToken<SummarizerStopReason>;
 
 /**
  * Data required to update internal tracking state after receiving a Summary Ack.
- * @internal
+ * @alpha
  */
 export interface IRefreshSummaryAckOptions {
 	/** Handle from the ack's summary op. */
@@ -53,7 +53,7 @@ export interface IRefreshSummaryAckOptions {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummarizerInternalsProvider {
 	/** Encapsulates the work to walk the internals of the running container to generate a summary */
@@ -86,7 +86,7 @@ export interface ISummarizingWarning extends ContainerWarning {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IConnectableRuntime {
 	readonly disposed: boolean;
@@ -96,7 +96,7 @@ export interface IConnectableRuntime {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummarizerRuntime extends IConnectableRuntime {
 	readonly logger: ITelemetryLoggerExt;
@@ -117,7 +117,7 @@ export interface ISummarizerRuntime extends IConnectableRuntime {
 
 /**
  * Options affecting summarize behavior.
- * @internal
+ * @alpha
  */
 export interface ISummarizeOptions {
 	/** True to generate the full tree with no handle reuse optimizations; defaults to false */
@@ -132,7 +132,7 @@ export interface ISummarizeOptions {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISubmitSummaryOptions extends ISummarizeOptions {
 	/** Logger to use for correlated summary events */
@@ -144,7 +144,7 @@ export interface ISubmitSummaryOptions extends ISummarizeOptions {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IOnDemandSummarizeOptions extends ISummarizeOptions {
 	/** Reason for generating summary. */
@@ -153,7 +153,7 @@ export interface IOnDemandSummarizeOptions extends ISummarizeOptions {
 
 /**
  * Options to use when enqueueing a summarize attempt.
- * @internal
+ * @alpha
  */
 export interface IEnqueueSummarizeOptions extends IOnDemandSummarizeOptions {
 	/** If specified, The summarize attempt will not occur until after this sequence number. */
@@ -171,7 +171,7 @@ export interface IEnqueueSummarizeOptions extends IOnDemandSummarizeOptions {
 /**
  * In addition to the normal summary tree + stats, this contains additional stats
  * only relevant at the root of the tree.
- * @internal
+ * @alpha
  */
 export interface IGeneratedSummaryStats extends ISummaryStats {
 	/** The total number of data stores in the container. */
@@ -190,7 +190,7 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
 
 /**
  * Base results for all submitSummary attempts.
- * @internal
+ * @alpha
  */
 export interface IBaseSummarizeResult {
 	readonly stage: "base";
@@ -203,7 +203,7 @@ export interface IBaseSummarizeResult {
 
 /**
  * Results of submitSummary after generating the summary tree.
- * @internal
+ * @alpha
  */
 export interface IGenerateSummaryTreeResult extends Omit<IBaseSummarizeResult, "stage"> {
 	readonly stage: "generate";
@@ -219,7 +219,7 @@ export interface IGenerateSummaryTreeResult extends Omit<IBaseSummarizeResult, "
 
 /**
  * Results of submitSummary after uploading the tree to storage.
- * @internal
+ * @alpha
  */
 export interface IUploadSummaryResult extends Omit<IGenerateSummaryTreeResult, "stage"> {
 	readonly stage: "upload";
@@ -231,7 +231,7 @@ export interface IUploadSummaryResult extends Omit<IGenerateSummaryTreeResult, "
 
 /**
  * Results of submitSummary after submitting the summarize op.
- * @internal
+ * @alpha
  */
 export interface ISubmitSummaryOpResult extends Omit<IUploadSummaryResult, "stage" | "error"> {
 	readonly stage: "submit";
@@ -256,7 +256,7 @@ export interface ISubmitSummaryOpResult extends Omit<IUploadSummaryResult, "stag
  * 3. "upload" - the summary was uploaded to storage, and the result contains the server-provided handle
  *
  * 4. "submit" - the summarize op was submitted, and the result contains the op client sequence number.
- * @internal
+ * @alpha
  */
 export type SubmitSummaryResult =
 	| IBaseSummarizeResult
@@ -266,13 +266,13 @@ export type SubmitSummaryResult =
 
 /**
  * The stages of Summarize, used to describe how far progress succeeded in case of a failure at a later stage.
- * @internal
+ * @alpha
  */
 export type SummaryStage = SubmitSummaryResult["stage"] | "unknown";
 
 /**
  * Type for summarization failures that are retriable.
- * @internal
+ * @alpha
  */
 export interface IRetriableFailureResult {
 	readonly retryAfterSeconds?: number;
@@ -280,14 +280,14 @@ export interface IRetriableFailureResult {
 
 /**
  * The data in summarizer result when submit summary stage fails.
- * @internal
+ * @alpha
  */
 export interface SubmitSummaryFailureData extends IRetriableFailureResult {
 	stage: SummaryStage;
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IBroadcastSummaryResult {
 	readonly summarizeOp: ISummaryOpMessage;
@@ -295,7 +295,7 @@ export interface IBroadcastSummaryResult {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IAckSummaryResult {
 	readonly summaryAckOp: ISummaryAckMessage;
@@ -303,7 +303,7 @@ export interface IAckSummaryResult {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface INackSummaryResult extends IRetriableFailureResult {
 	readonly summaryNackOp: ISummaryNackMessage;
@@ -311,7 +311,7 @@ export interface INackSummaryResult extends IRetriableFailureResult {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type SummarizeResultPart<TSuccess, TFailure = undefined> =
 	| {
@@ -326,7 +326,7 @@ export type SummarizeResultPart<TSuccess, TFailure = undefined> =
 	  };
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummarizeResults {
 	/** Resolves when we generate, upload, and submit the summary. */
@@ -342,7 +342,7 @@ export interface ISummarizeResults {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type EnqueueSummarizeResult =
 	| (ISummarizeResults & {
@@ -372,7 +372,7 @@ export type EnqueueSummarizeResult =
 	  };
 
 /**
- * @internal
+ * @alpha
  */
 export type SummarizerStopReason =
 	/** Summarizer client failed to summarize in all 3 consecutive attempts. */
@@ -401,7 +401,7 @@ export type SummarizerStopReason =
 	| "latestSummaryStateStale";
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummarizeEventProps {
 	result: "success" | "failure" | "canceled";
@@ -411,7 +411,7 @@ export interface ISummarizeEventProps {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummarizerEvents extends IEvent {
 	(event: "summarize", listener: (props: ISummarizeEventProps) => void);

--- a/packages/runtime/container-runtime/src/summary/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryCollection.ts
@@ -19,7 +19,7 @@ import {
 
 /**
  * Interface for summary op messages with typed contents.
- * @internal
+ * @alpha
  */
 export interface ISummaryOpMessage extends ISequencedDocumentMessage {
 	type: MessageType.Summarize;
@@ -28,7 +28,7 @@ export interface ISummaryOpMessage extends ISequencedDocumentMessage {
 
 /**
  * Interface for summary ack messages with typed contents.
- * @internal
+ * @alpha
  */
 export interface ISummaryAckMessage extends ISequencedDocumentMessage {
 	type: MessageType.SummaryAck;
@@ -37,7 +37,7 @@ export interface ISummaryAckMessage extends ISequencedDocumentMessage {
 
 /**
  * Interface for summary nack messages with typed contents.
- * @internal
+ * @alpha
  */
 export interface ISummaryNackMessage extends ISequencedDocumentMessage {
 	type: MessageType.SummaryNack;

--- a/packages/runtime/container-runtime/src/summary/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryFormat.ts
@@ -86,7 +86,7 @@ export function hasIsolatedChannels(attributes: ReadFluidDataStoreAttributes): b
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IContainerRuntimeMetadata extends ICreateContainerMetadata, IGCMetadata {
 	readonly summaryFormatVersion: 1;
@@ -103,7 +103,7 @@ export interface IContainerRuntimeMetadata extends ICreateContainerMetadata, IGC
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ICreateContainerMetadata {
 	/** Runtime version of the container when it was first created */
@@ -114,7 +114,7 @@ export interface ICreateContainerMetadata {
 
 /**
  * The properties of an ISequencedDocumentMessage to be stored in the metadata blob in summary.
- * @internal
+ * @alpha
  */
 export type ISummaryMetadataMessage = Pick<
 	ISequencedDocumentMessage,

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -32,7 +32,7 @@ import type { IUser } from '@fluidframework/protocol-definitions';
 import { SummaryTree } from '@fluidframework/protocol-definitions';
 import { TelemetryEventPropertyType } from '@fluidframework/core-interfaces';
 
-// @internal
+// @alpha
 export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
 
 // @internal
@@ -50,11 +50,11 @@ export const blobCountPropertyName = "BlobCount";
 // @internal (undocumented)
 export const channelsTreeName = ".channels";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type CreateChildSummarizerNodeFn = (summarizeInternal: SummarizeInternalFn, getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
 getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>) => ISummarizerNodeWithGC;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type CreateChildSummarizerNodeParam = {
     type: CreateSummarizerNodeSource.FromSummary;
 } | {
@@ -65,7 +65,7 @@ export type CreateChildSummarizerNodeParam = {
     type: CreateSummarizerNodeSource.Local;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export enum CreateSummarizerNodeSource {
     // (undocumented)
     FromAttach = 1,
@@ -82,10 +82,10 @@ export interface DetachedAttributionKey {
     type: "detached";
 }
 
-// @internal
+// @alpha
 export type FluidDataStoreRegistryEntry = Readonly<Partial<IProvideFluidDataStoreRegistry & IProvideFluidDataStoreFactory>>;
 
-// @internal
+// @alpha
 export enum FlushMode {
     Immediate = 0,
     TurnBased = 1
@@ -115,7 +115,7 @@ export interface IAttachMessage {
     type: string;
 }
 
-// @internal
+// @alpha
 export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeBaseEvents> {
     // (undocumented)
     readonly clientDetails: IClientDetails;
@@ -138,7 +138,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IContainerRuntimeBaseEvents extends IEvent {
     // (undocumented)
     (event: "batchBegin", listener: (op: ISequencedDocumentMessage) => void): any;
@@ -150,7 +150,7 @@ export interface IContainerRuntimeBaseEvents extends IEvent {
     (event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): any;
 }
 
-// @internal
+// @alpha
 export interface IDataStore {
     readonly entryPoint: IFluidHandle<FluidObject>;
     // @deprecated (undocumented)
@@ -165,7 +165,7 @@ export interface IDataStore {
     trySetAlias(alias: string): Promise<AliasResult>;
 }
 
-// @internal
+// @alpha
 export interface IdCreationRange {
     // (undocumented)
     readonly ids?: {
@@ -182,14 +182,14 @@ export interface IEnvelope {
     contents: any;
 }
 
-// @internal
+// @alpha
 export interface IExperimentalIncrementalSummaryContext {
     latestSummarySequenceNumber: number;
     summaryPath: string;
     summarySequenceNumber: number;
 }
 
-// @internal
+// @alpha
 export interface IFluidDataStoreChannel extends IDisposable {
     // (undocumented)
     applyStashedOp(content: any): Promise<unknown>;
@@ -217,7 +217,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
     readonly visibilityState: VisibilityState;
 }
 
-// @internal
+// @alpha
 export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreContextEvents>, Partial<IProvideFluidDataStoreRegistry>, IProvideFluidHandleContext {
     addedGCOutboundReference?(srcHandle: IFluidHandle, outboundHandle: IFluidHandle): void;
     readonly attachState: AttachState;
@@ -266,49 +266,49 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IFluidDataStoreContextDetached extends IFluidDataStoreContext {
     attachRuntime(factory: IProvideFluidDataStoreFactory, dataStoreRuntime: IFluidDataStoreChannel): Promise<void>;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IFluidDataStoreContextEvents extends IEvent {
     // (undocumented)
     (event: "attaching" | "attached", listener: () => void): any;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const IFluidDataStoreFactory: keyof IProvideFluidDataStoreFactory;
 
-// @internal
+// @alpha
 export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
     instantiateDataStore(context: IFluidDataStoreContext, existing: boolean): Promise<IFluidDataStoreChannel>;
     type: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const IFluidDataStoreRegistry: keyof IProvideFluidDataStoreRegistry;
 
-// @internal
+// @alpha
 export interface IFluidDataStoreRegistry extends IProvideFluidDataStoreRegistry {
     // (undocumented)
     get(name: string): Promise<FluidDataStoreRegistryEntry | undefined>;
 }
 
-// @internal
+// @alpha
 export interface IGarbageCollectionData {
     gcNodes: {
         [id: string]: string[];
     };
 }
 
-// @internal
+// @alpha
 export interface IGarbageCollectionDetailsBase {
     gcData?: IGarbageCollectionData;
     usedRoutes?: string[];
 }
 
-// @internal
+// @alpha
 export interface IIdCompressor {
     decompress(id: SessionSpaceCompressedId): StableId;
     generateCompressedId(): SessionSpaceCompressedId;
@@ -320,7 +320,7 @@ export interface IIdCompressor {
     tryRecompress(uncompressed: StableId): SessionSpaceCompressedId | undefined;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IIdCompressorCore {
     finalizeCreationRange(range: IdCreationRange): void;
     serialize(withSession: true): SerializedIdCompressorWithOngoingSession;
@@ -328,7 +328,7 @@ export interface IIdCompressorCore {
     takeNextCreationRange(): IdCreationRange;
 }
 
-// @internal
+// @alpha
 export interface IInboundSignalMessage extends ISignalMessage {
     // (undocumented)
     type: string;
@@ -342,13 +342,13 @@ export type InboundAttachMessage = Omit<IAttachMessage, "snapshot"> & {
 // @internal
 export const initialClusterCapacity = 512;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IProvideFluidDataStoreFactory {
     // (undocumented)
     readonly IFluidDataStoreFactory: IFluidDataStoreFactory;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IProvideFluidDataStoreRegistry {
     // (undocumented)
     readonly IFluidDataStoreRegistry: IFluidDataStoreRegistry;
@@ -364,14 +364,14 @@ export interface ISignalEnvelope {
     };
 }
 
-// @internal
+// @alpha
 export interface ISummarizeInternalResult extends ISummarizeResult {
     // (undocumented)
     id: string;
     pathPartsForChildren?: string[];
 }
 
-// @internal
+// @alpha
 export interface ISummarizeResult {
     // (undocumented)
     stats: ISummaryStats;
@@ -379,7 +379,7 @@ export interface ISummarizeResult {
     summary: SummaryTree;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummarizerNode {
     // (undocumented)
     createChild(
@@ -397,18 +397,18 @@ export interface ISummarizerNode {
     updateBaseSummaryState(snapshot: ISnapshotTree): void;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummarizerNodeConfig {
     readonly canReuseHandle?: boolean;
     readonly throwOnFailure?: true;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
     readonly gcDisabled?: boolean;
 }
 
-// @internal
+// @alpha
 export interface ISummarizerNodeWithGC extends ISummarizerNode {
     // (undocumented)
     createChild(
@@ -425,7 +425,7 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     updateUsedRoutes(usedRoutes: string[]): void;
 }
 
-// @internal
+// @alpha
 export interface ISummaryStats {
     // (undocumented)
     blobNodeCount: number;
@@ -439,13 +439,13 @@ export interface ISummaryStats {
     unreferencedBlobSize: number;
 }
 
-// @internal
+// @alpha
 export interface ISummaryTreeWithStats {
     stats: ISummaryStats;
     summary: ISummaryTree;
 }
 
-// @internal
+// @alpha
 export interface ITelemetryContext {
     get(prefix: string, property: string): TelemetryEventPropertyType;
     serialize(): string;
@@ -459,10 +459,10 @@ export interface LocalAttributionKey {
     type: "local";
 }
 
-// @internal
+// @alpha
 export type NamedFluidDataStoreRegistryEntries = Iterable<NamedFluidDataStoreRegistryEntry>;
 
-// @internal
+// @alpha
 export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRegistryEntry>];
 
 // @internal
@@ -471,55 +471,55 @@ export interface OpAttributionKey {
     type: "op";
 }
 
-// @internal
+// @alpha
 export type OpSpaceCompressedId = number & {
     readonly OpNormalized: "9209432d-a959-4df7-b2ad-767ead4dbcae";
 };
 
-// @internal
+// @alpha
 export type SerializedIdCompressor = string & {
     readonly _serializedIdCompressor: "8c73c57c-1cf4-4278-8915-6444cb4f6af5";
 };
 
-// @internal
+// @alpha
 export type SerializedIdCompressorWithNoSession = SerializedIdCompressor & {
     readonly _noLocalState: "3aa2e1e8-cc28-4ea7-bc1a-a11dc3f26dfb";
 };
 
-// @internal
+// @alpha
 export type SerializedIdCompressorWithOngoingSession = SerializedIdCompressor & {
     readonly _hasLocalState: "1281acae-6d14-47e7-bc92-71c8ee0819cb";
 };
 
-// @internal
+// @alpha
 export type SessionId = StableId & {
     readonly SessionId: "4498f850-e14e-4be9-8db0-89ec00997e58";
 };
 
-// @internal
+// @alpha
 export type SessionSpaceCompressedId = number & {
     readonly SessionUnique: "cea55054-6b82-4cbf-ad19-1fa645ea3b3e";
 };
 
-// @internal
+// @alpha
 export type StableId = string & {
     readonly StableId: "53172b0d-a3d5-41ea-bd75-b43839c97f5a";
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext) => Promise<ISummarizeInternalResult>;
 
 // @internal (undocumented)
 export const totalBlobSizePropertyName = "TotalBlobSize";
 
-// @internal
+// @alpha
 export const VisibilityState: {
     NotVisible: string;
     LocallyVisible: string;
     GloballyVisible: string;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 
 // (No @packageDocumentation comment for this package)

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -46,7 +46,7 @@ import { IIdCompressor } from "./id-compressor";
 
 /**
  * Runtime flush mode handling
- * @internal
+ * @alpha
  */
 export enum FlushMode {
 	/**
@@ -80,7 +80,7 @@ export enum FlushModeExperimental {
 /**
  * This tells the visibility state of a Fluid object. It basically tracks whether the object is not visible, visible
  * locally within the container only or visible globally to all clients.
- * @internal
+ * @alpha
  */
 export const VisibilityState = {
 	/**
@@ -107,12 +107,12 @@ export const VisibilityState = {
 	GloballyVisible: "GloballyVisible",
 };
 /**
- * @internal
+ * @alpha
  */
 export type VisibilityState = (typeof VisibilityState)[keyof typeof VisibilityState];
 
 /**
- * @internal
+ * @alpha
  */
 export interface IContainerRuntimeBaseEvents extends IEvent {
 	(event: "batchBegin", listener: (op: ISequencedDocumentMessage) => void);
@@ -133,7 +133,7 @@ export interface IContainerRuntimeBaseEvents extends IEvent {
  * the `IContainerRuntime.getAliasedDataStoreEntryPoint` function. The current datastore should be discarded
  * and will be garbage collected. The current datastore cannot be aliased to a different value.
  * 'AlreadyAliased' - the datastore has already been previously bound to another alias name.
- * @internal
+ * @alpha
  */
 export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
 
@@ -142,7 +142,7 @@ export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
  * - Handle to the data store's entryPoint
  * - Fluid router for the data store
  * - Can be assigned an alias
- * @internal
+ * @alpha
  */
 export interface IDataStore {
 	/**
@@ -197,7 +197,7 @@ export interface IDataStore {
 /**
  * A reduced set of functionality of IContainerRuntime that a data store context/data store runtime will need
  * TODO: this should be merged into IFluidDataStoreContext
- * @internal
+ * @alpha
  */
 export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeBaseEvents> {
 	readonly logger: ITelemetryBaseLogger;
@@ -277,7 +277,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
  *
  * Functionality include attach, snapshot, op/signal processing, request routes, expose an entryPoint,
  * and connection state notifications
- * @internal
+ * @alpha
  */
 export interface IFluidDataStoreChannel extends IDisposable {
 	readonly id: string;
@@ -384,7 +384,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type CreateChildSummarizerNodeFn = (
 	summarizeInternal: SummarizeInternalFn,
@@ -396,7 +396,7 @@ export type CreateChildSummarizerNodeFn = (
 ) => ISummarizerNodeWithGC;
 
 /**
- * @internal
+ * @alpha
  */
 export interface IFluidDataStoreContextEvents extends IEvent {
 	(event: "attaching" | "attached", listener: () => void);
@@ -405,7 +405,7 @@ export interface IFluidDataStoreContextEvents extends IEvent {
 /**
  * Represents the context for the data store. It is used by the data store runtime to
  * get information and call functionality to the container.
- * @internal
+ * @alpha
  */
 export interface IFluidDataStoreContext
 	extends IEventProvider<IFluidDataStoreContextEvents>,
@@ -542,7 +542,7 @@ export interface IFluidDataStoreContext
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IFluidDataStoreContextDetached extends IFluidDataStoreContext {
 	/**

--- a/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreFactory.ts
@@ -6,12 +6,12 @@
 import { IFluidDataStoreContext, IFluidDataStoreChannel } from "./dataStoreContext";
 
 /**
- * @internal
+ * @alpha
  */
 export const IFluidDataStoreFactory: keyof IProvideFluidDataStoreFactory = "IFluidDataStoreFactory";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IProvideFluidDataStoreFactory {
 	readonly IFluidDataStoreFactory: IFluidDataStoreFactory;
@@ -20,7 +20,7 @@ export interface IProvideFluidDataStoreFactory {
 /**
  * IFluidDataStoreFactory create data stores.  It is associated with an identifier (its `type` member)
  * and usually provided to consumers using this mapping through a data store registry.
- * @internal
+ * @alpha
  */
 export interface IFluidDataStoreFactory extends IProvideFluidDataStoreFactory {
 	/**

--- a/packages/runtime/runtime-definitions/src/dataStoreRegistry.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreRegistry.ts
@@ -8,7 +8,7 @@ import { IProvideFluidDataStoreFactory } from "./dataStoreFactory";
 /**
  * A single registry entry that may be used to create data stores
  * It has to have either factory or registry, or both.
- * @internal
+ * @alpha
  */
 export type FluidDataStoreRegistryEntry = Readonly<
 	Partial<IProvideFluidDataStoreRegistry & IProvideFluidDataStoreFactory>
@@ -16,23 +16,23 @@ export type FluidDataStoreRegistryEntry = Readonly<
 /**
  * An associated pair of an identifier and registry entry.  Registry entries
  * may be dynamically loaded.
- * @internal
+ * @alpha
  */
 export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRegistryEntry>];
 /**
  * An iterable identifier/registry entry pair list
- * @internal
+ * @alpha
  */
 export type NamedFluidDataStoreRegistryEntries = Iterable<NamedFluidDataStoreRegistryEntry>;
 
 /**
- * @internal
+ * @alpha
  */
 export const IFluidDataStoreRegistry: keyof IProvideFluidDataStoreRegistry =
 	"IFluidDataStoreRegistry";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IProvideFluidDataStoreRegistry {
 	readonly IFluidDataStoreRegistry: IFluidDataStoreRegistry;
@@ -41,7 +41,7 @@ export interface IProvideFluidDataStoreRegistry {
 /**
  * An association of identifiers to data store registry entries, where the
  * entries can be used to create data stores.
- * @internal
+ * @alpha
  */
 export interface IFluidDataStoreRegistry extends IProvideFluidDataStoreRegistry {
 	get(name: string): Promise<FluidDataStoreRegistryEntry | undefined>;

--- a/packages/runtime/runtime-definitions/src/garbageCollection.ts
+++ b/packages/runtime/runtime-definitions/src/garbageCollection.ts
@@ -31,7 +31,7 @@ export const gcDeletedBlobKey = "__deletedNodes";
 /**
  * Garbage collection data returned by nodes in a Container.
  * Used for running GC in the Container.
- * @internal
+ * @alpha
  */
 export interface IGarbageCollectionData {
 	/**
@@ -42,7 +42,7 @@ export interface IGarbageCollectionData {
 
 /**
  * GC details provided to each node during creation.
- * @internal
+ * @alpha
  */
 export interface IGarbageCollectionDetailsBase {
 	/**

--- a/packages/runtime/runtime-definitions/src/id-compressor/idCompressor.ts
+++ b/packages/runtime/runtime-definitions/src/id-compressor/idCompressor.ts
@@ -11,7 +11,7 @@ import {
 } from "./persisted-types";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IIdCompressorCore {
 	/**
@@ -101,7 +101,7 @@ export interface IIdCompressorCore {
  *
  * These two spaces naturally define a rule: consumers of compressed IDs should use session-space IDs, but serialized forms such as ops
  * should use op-space IDs.
- * @internal
+ * @alpha
  */
 export interface IIdCompressor {
 	localSessionId: SessionId;

--- a/packages/runtime/runtime-definitions/src/id-compressor/identifiers.ts
+++ b/packages/runtime/runtime-definitions/src/id-compressor/identifiers.ts
@@ -7,7 +7,7 @@
  * A compressed ID that has been normalized into "session space" (see `IdCompressor` for more).
  * Consumer-facing APIs and data structures should use session-space IDs as their lifetime and equality is stable and tied to
  * the scope of the session (i.e. compressor) that produced them.
- * @internal
+ * @alpha
  */
 export type SessionSpaceCompressedId = number & {
 	readonly SessionUnique: "cea55054-6b82-4cbf-ad19-1fa645ea3b3e";
@@ -17,7 +17,7 @@ export type SessionSpaceCompressedId = number & {
  * A compressed ID that has been normalized into "op space".
  * Serialized/persisted structures (e.g. ops) should use op-space IDs as a performance optimization, as they require less normalizing when
  * received by a remote client due to the fact that op space for a given compressor is session space for all other compressors.
- * @internal
+ * @alpha
  */
 export type OpSpaceCompressedId = number & {
 	readonly OpNormalized: "9209432d-a959-4df7-b2ad-767ead4dbcae";
@@ -28,12 +28,12 @@ export type OpSpaceCompressedId = number & {
  * A 128-bit Universally Unique IDentifier. Represented here
  * with a string of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,
  * where x is a lowercase hex digit.
- * @internal
+ * @alpha
  */
 export type StableId = string & { readonly StableId: "53172b0d-a3d5-41ea-bd75-b43839c97f5a" };
 
 /**
  * A StableId which is suitable for use as a session identifier
- * @internal
+ * @alpha
  */
 export type SessionId = StableId & { readonly SessionId: "4498f850-e14e-4be9-8db0-89ec00997e58" };

--- a/packages/runtime/runtime-definitions/src/id-compressor/persisted-types/0.0.1.ts
+++ b/packages/runtime/runtime-definitions/src/id-compressor/persisted-types/0.0.1.ts
@@ -7,7 +7,7 @@ import type { SessionId } from "../identifiers";
 
 /**
  * The serialized contents of an IdCompressor, suitable for persistence in a summary.
- * @internal
+ * @alpha
  */
 export type SerializedIdCompressor = string & {
 	readonly _serializedIdCompressor: "8c73c57c-1cf4-4278-8915-6444cb4f6af5";
@@ -15,7 +15,7 @@ export type SerializedIdCompressor = string & {
 
 /**
  * The serialized contents of an IdCompressor, suitable for persistence in a summary.
- * @internal
+ * @alpha
  */
 export type SerializedIdCompressorWithNoSession = SerializedIdCompressor & {
 	readonly _noLocalState: "3aa2e1e8-cc28-4ea7-bc1a-a11dc3f26dfb";
@@ -23,7 +23,7 @@ export type SerializedIdCompressorWithNoSession = SerializedIdCompressor & {
 
 /**
  * The serialized contents of an IdCompressor, suitable for persistence in a summary.
- * @internal
+ * @alpha
  */
 export type SerializedIdCompressorWithOngoingSession = SerializedIdCompressor & {
 	readonly _hasLocalState: "1281acae-6d14-47e7-bc92-71c8ee0819cb";
@@ -33,7 +33,7 @@ export type SerializedIdCompressorWithOngoingSession = SerializedIdCompressor & 
  * Data describing a range of session-local IDs (from a remote or local session).
  *
  * A range is composed of local IDs that were generated.
- * @internal
+ * @alpha
  */
 export interface IdCreationRange {
 	readonly sessionId: SessionId;

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -46,7 +46,7 @@ export interface ISignalEnvelope {
 
 /**
  * Represents ISignalMessage with its type.
- * @internal
+ * @alpha
  */
 export interface IInboundSignalMessage extends ISignalMessage {
 	type: string;

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -15,7 +15,7 @@ import { IGarbageCollectionData, IGarbageCollectionDetailsBase } from "./garbage
 
 /**
  * Contains the aggregation data from a Tree/Subtree.
- * @internal
+ * @alpha
  */
 export interface ISummaryStats {
 	treeNodeCount: number;
@@ -31,7 +31,7 @@ export interface ISummaryStats {
  * each of its DDS.
  * Any component that implements IChannelContext, IFluidDataStoreChannel or extends SharedObject
  * will be taking part of the summarization process.
- * @internal
+ * @alpha
  */
 export interface ISummaryTreeWithStats {
 	/**
@@ -47,7 +47,7 @@ export interface ISummaryTreeWithStats {
 
 /**
  * Represents a summary at a current sequence number.
- * @internal
+ * @alpha
  */
 export interface ISummarizeResult {
 	stats: ISummaryStats;
@@ -68,7 +68,7 @@ export interface ISummarizeResult {
  *   ...
  *     "path1":
  * ```
- * @internal
+ * @alpha
  */
 export interface ISummarizeInternalResult extends ISummarizeResult {
 	id: string;
@@ -81,7 +81,7 @@ export interface ISummarizeInternalResult extends ISummarizeResult {
 /**
  * @experimental - Can be deleted/changed at any time
  * Contains the necessary information to allow DDSes to do incremental summaries
- * @internal
+ * @alpha
  */
 export interface IExperimentalIncrementalSummaryContext {
 	/**
@@ -107,7 +107,7 @@ export interface IExperimentalIncrementalSummaryContext {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type SummarizeInternalFn = (
 	fullTree: boolean,
@@ -117,7 +117,7 @@ export type SummarizeInternalFn = (
 ) => Promise<ISummarizeInternalResult>;
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummarizerNodeConfig {
 	/**
@@ -138,7 +138,7 @@ export interface ISummarizerNodeConfig {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
 	/**
@@ -149,7 +149,7 @@ export interface ISummarizerNodeConfigWithGC extends ISummarizerNodeConfig {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export enum CreateSummarizerNodeSource {
 	FromSummary,
@@ -157,7 +157,7 @@ export enum CreateSummarizerNodeSource {
 	Local,
 }
 /**
- * @internal
+ * @alpha
  */
 export type CreateChildSummarizerNodeParam =
 	| {
@@ -173,7 +173,7 @@ export type CreateChildSummarizerNodeParam =
 	  };
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISummarizerNode {
 	/**
@@ -263,7 +263,7 @@ export interface ISummarizerNode {
  * `isReferenced`: This tells whether this node is referenced in the document or not.
  *
  * `updateUsedRoutes`: Used to notify this node of routes that are currently in use in it.
- * @internal
+ * @alpha
  */
 export interface ISummarizerNodeWithGC extends ISummarizerNode {
 	createChild(
@@ -330,7 +330,7 @@ export const channelsTreeName = ".channels";
 /**
  * Contains telemetry data relevant to summarization workflows.
  * This object is expected to be modified directly by various summarize methods.
- * @internal
+ * @alpha
  */
 export interface ITelemetryContext {
 	/**

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -208,7 +208,7 @@ export interface ITaggedTelemetryPropertyTypeExt {
     value: TelemetryEventPropertyTypeExt;
 }
 
-// @internal
+// @alpha
 export interface ITelemetryErrorEventExt extends ITelemetryPropertiesExt {
     // (undocumented)
     eventName: string;
@@ -222,7 +222,7 @@ export interface ITelemetryEventExt extends ITelemetryPropertiesExt {
     eventName: string;
 }
 
-// @internal
+// @alpha
 export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
     // (undocumented)
     category?: TelemetryEventCategory;
@@ -230,7 +230,7 @@ export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
     eventName: string;
 }
 
-// @internal
+// @alpha
 export interface ITelemetryLoggerExt extends ITelemetryBaseLogger {
     sendErrorEvent(event: ITelemetryErrorEventExt, error?: unknown): void;
     sendPerformanceEvent(event: ITelemetryPerformanceEventExt, error?: unknown, logLevel?: typeof LogLevel.verbose | typeof LogLevel.default): void;
@@ -251,13 +251,13 @@ export interface ITelemetryLoggerPropertyBags {
     error?: ITelemetryLoggerPropertyBag;
 }
 
-// @internal
+// @alpha
 export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt {
     // (undocumented)
     duration?: number;
 }
 
-// @internal
+// @alpha
 export interface ITelemetryPropertiesExt {
     // (undocumented)
     [index: string]: TelemetryEventPropertyTypeExt | Tagged<TelemetryEventPropertyTypeExt>;
@@ -401,10 +401,10 @@ export enum TelemetryDataTag {
     UserData = "UserData"
 }
 
-// @internal
+// @alpha
 export type TelemetryEventCategory = "generic" | "error" | "performance";
 
-// @internal
+// @alpha
 export type TelemetryEventPropertyTypeExt = string | number | boolean | undefined | (string | number | boolean)[] | {
     [key: string]: // Flat objects can have the same properties as the event itself
     string | number | boolean | undefined | (string | number | boolean)[];

--- a/packages/utils/telemetry-utils/src/telemetryTypes.ts
+++ b/packages/utils/telemetry-utils/src/telemetryTypes.ts
@@ -13,8 +13,7 @@ import { ITelemetryBaseLogger, LogLevel, Tagged } from "@fluidframework/core-int
  * error - Error log event, ideally 0 of these are logged during a session
  *
  * performance - Includes duration, and often has _start, _end, or _cancel suffixes for activity tracking
- *
- * @internal
+ * @alpha
  */
 export type TelemetryEventCategory = "generic" | "error" | "performance";
 
@@ -25,7 +24,7 @@ export type TelemetryEventCategory = "generic" | "error" | "performance";
  * Includes extra types beyond {@link @fluidframework/core-interfaces#TelemetryBaseEventPropertyType}, which must be
  * converted before sending to a base logger.
  *
- * @internal
+ * @alpha
  */
 export type TelemetryEventPropertyTypeExt =
 	| string
@@ -54,7 +53,7 @@ export interface ITaggedTelemetryPropertyTypeExt {
 /**
  * JSON-serializable properties, which will be logged with telemetry.
  *
- * @internal
+ * @alpha
  */
 export interface ITelemetryPropertiesExt {
 	[index: string]: TelemetryEventPropertyTypeExt | Tagged<TelemetryEventPropertyTypeExt>;
@@ -76,8 +75,7 @@ export interface ITelemetryEventExt extends ITelemetryPropertiesExt {
 /**
  * Informational (non-error) telemetry event
  * @remarks Maps to category = "generic"
- *
- * @internal
+ * @alpha
  */
 export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
 	eventName: string;
@@ -87,8 +85,7 @@ export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
 /**
  * Error telemetry event.
  * @remarks Maps to category = "error"
- *
- * @internal
+ * @alpha
  */
 export interface ITelemetryErrorEventExt extends ITelemetryPropertiesExt {
 	eventName: string;
@@ -97,8 +94,7 @@ export interface ITelemetryErrorEventExt extends ITelemetryPropertiesExt {
 /**
  * Performance telemetry event.
  * @remarks Maps to category = "performance"
- *
- * @internal
+ * @alpha
  */
 export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt {
 	duration?: number; // Duration of event (optional)
@@ -110,8 +106,7 @@ export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt
  * @remarks
  * This interface is meant to be used internally within the Fluid Framework,
  * and `ITelemetryBaseLogger` should be used when loggers are passed between layers.
- *
- * @internal
+ * @alpha
  */
 export interface ITelemetryLoggerExt extends ITelemetryBaseLogger {
 	/**


### PR DESCRIPTION
This PR updates tagging so the ContainerRuntime class can be alpha. All these types were automatically identified as transitive dependency of the ContainerRuntime class is made alpha.

We will stage these commits and invite review, however review items will generally be added to the backlog as future items, as these type updates are necessary for the current state of the code base.