### PR TITLE
feat(tree2): support for root-level destroy

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -452,6 +452,7 @@ export interface FieldAnchor {
 interface FieldChanges<TTree = ProtoNode> {
     // @deprecated
     readonly build?: readonly DetachedNodeBuild<TTree>[];
+    // @deprecated
     readonly destroy?: readonly DetachedNodeDestruction[];
     readonly global?: readonly DetachedNodeChanges<TTree>[];
     readonly local?: readonly Mark<TTree>[];
@@ -1585,6 +1586,7 @@ export enum RevertResult {
 // @alpha
 interface Root<TTree = ProtoNode> {
     readonly build?: readonly DetachedNodeBuild<TTree>[];
+    readonly destroy?: readonly DetachedNodeDestruction[];
     readonly fields?: FieldMap<TTree>;
 }
 

--- a/experimental/dds/tree2/src/core/tree/delta.ts
+++ b/experimental/dds/tree2/src/core/tree/delta.ts
@@ -83,6 +83,15 @@ export interface Root<TTree = ProtoNode> {
 	 * then the build should be listed under ID A.
 	 */
 	readonly build?: readonly DetachedNodeBuild<TTree>[];
+	/**
+	 * New detached nodes to be destroyed.
+	 * The ordering has no significance.
+	 *
+	 * Destruction instructions for a root that is undergoing a rename should be listed under the final name.
+	 * For example, if one wishes to destroy a tree which is being renamed from ID A to ID B,
+	 * then the destruction should be listed under ID B.
+	 */
+	readonly destroy?: readonly DetachedNodeDestruction[];
 }
 /**
  * The default representation for inserted content.
@@ -225,8 +234,11 @@ export interface FieldChanges<TTree = ProtoNode> {
 	 */
 	readonly build?: readonly DetachedNodeBuild<TTree>[];
 	/**
-	 * New detached nodes to be constructed.
+	 * New detached nodes to be destroyed.
 	 * The ordering has no significance.
+	 *
+	 * @deprecated - Destroys should be set at the root.
+	 * TODO:6308 migrate all reader/writers away from this and remove it.
 	 *
 	 * Destruction instructions for a root that is undergoing a rename should be listed under the final name.
 	 * For example, if one wishes to destroy a tree which is being renamed from ID A to ID B,

--- a/experimental/dds/tree2/src/core/tree/visitDelta.ts
+++ b/experimental/dds/tree2/src/core/tree/visitDelta.ts
@@ -90,6 +90,7 @@ export function visitDelta(
 	};
 	visitFieldMarks(delta.fields, visitor, attachConfig);
 	fixedPointVisitOfRoots(visitor, attachPassRoots, attachConfig);
+	collectDestroys(delta.destroy, attachConfig);
 	for (const { id, count } of rootDestructions) {
 		for (let i = 0; i < count; i += 1) {
 			const offsetId = offsetDetachId(id, i);
@@ -355,9 +356,7 @@ function visitNode(
  */
 function detachPass(delta: Delta.FieldChanges, visitor: DeltaVisitor, config: PassConfig): void {
 	processBuilds(delta.build, config, visitor);
-	if (delta.destroy !== undefined) {
-		config.rootDestructions.push(...delta.destroy);
-	}
+	collectDestroys(delta.destroy, config);
 	if (delta.global !== undefined) {
 		for (const { id, fields } of delta.global) {
 			const root = config.detachedFieldIndex.getEntry(id);
@@ -416,6 +415,15 @@ function processBuilds(
 				}
 			}
 		}
+	}
+}
+
+function collectDestroys(
+	destroys: readonly Delta.DetachedNodeDestruction[] | undefined,
+	config: PassConfig,
+) {
+	if (destroys !== undefined) {
+		config.rootDestructions.push(...destroys);
 	}
 }
 

--- a/experimental/dds/tree2/src/test/tree/visitDelta.spec.ts
+++ b/experimental/dds/tree2/src/test/tree/visitDelta.spec.ts
@@ -442,7 +442,21 @@ describe("visitDelta", () => {
 		testTreeVisit(delta, expected, index);
 		assert.equal(index.entries().next().done, true);
 	});
-	it("build-rename-destroy", () => {
+	it("destroy (root level)", () => {
+		const index = makeDetachedFieldIndex("");
+		const id = { minor: 42 };
+		index.createEntry(id, 2);
+		const delta: Delta.Root = {
+			destroy: [{ id, count: 2 }],
+		};
+		const expected: VisitScript = [
+			["destroy", field0, 1],
+			["destroy", field1, 1],
+		];
+		testVisit(delta, expected, index);
+		assert.equal(index.entries().next().done, true);
+	});
+	it("build-rename-destroy (field level)", () => {
 		const index = makeDetachedFieldIndex("");
 		const buildId = { minor: 42 };
 		const detachId = { minor: 43 };


### PR DESCRIPTION
Add support for node destruction at the root-level of Deltas.
Deprecates support for node destruction in fields.