### PR TITLE
build(client): update to node 18 types

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/test-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/azure/packages/external-controller/package.json
+++ b/azure/packages/external-controller/package.json
@@ -78,7 +78,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/uuid": "^9.0.2",
 		"clean-webpack-plugin": "^4.0.0",

--- a/azure/packages/test/end-to-end-tests/package.json
+++ b/azure/packages/test/end-to-end-tests/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",
 		"eslint": "~8.50.0",

--- a/azure/packages/test/scenario-runner/package.json
+++ b/azure/packages/test/scenario-runner/package.json
@@ -94,7 +94,7 @@
 		"@types/js-yaml": "^4.0.5",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",
 		"eslint": "~8.50.0",

--- a/examples/apps/attributable-map/package.json
+++ b/examples/apps/attributable-map/package.json
@@ -52,7 +52,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -60,7 +60,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -57,7 +57,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"clean-webpack-plugin": "^4.0.0",
 		"cross-env": "^7.0.3",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -73,7 +73,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/prop-types": "^15",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",

--- a/examples/apps/presence-tracker/package.json
+++ b/examples/apps/presence-tracker/package.json
@@ -58,7 +58,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -58,7 +58,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"clean-webpack-plugin": "^4.0.0",
 		"cross-env": "^7.0.3",

--- a/examples/apps/tree-comparison/package.json
+++ b/examples/apps/tree-comparison/package.json
@@ -68,7 +68,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/benchmarks/bubblebench/baseline/package.json
+++ b/examples/benchmarks/bubblebench/baseline/package.json
@@ -59,7 +59,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-tools": "^1.0.195075",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",
 		"c8": "^7.7.1",

--- a/examples/benchmarks/bubblebench/editable-shared-tree/package.json
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/package.json
@@ -61,7 +61,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/benchmarks/bubblebench/ot/package.json
+++ b/examples/benchmarks/bubblebench/ot/package.json
@@ -61,7 +61,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/benchmarks/bubblebench/sharedtree/package.json
+++ b/examples/benchmarks/bubblebench/sharedtree/package.json
@@ -60,7 +60,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@types/express": "^4.11.0",
 		"@types/fs-extra": "^9.0.11",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"buffer": "^6.0.3",
 		"c8": "^7.7.1",
 		"css-loader": "^1.0.0",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -55,7 +55,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -58,7 +58,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/data-objects/codemirror/package.json
+++ b/examples/data-objects/codemirror/package.json
@@ -65,7 +65,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@types/codemirror": "5.60.7",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/react": "^17.0.44",
 		"copyfiles": "^2.4.1",
 		"css-loader": "^1.0.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -55,7 +55,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/data-objects/inventory-app/package.json
+++ b/examples/data-objects/inventory-app/package.json
@@ -56,7 +56,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -55,7 +55,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -54,7 +54,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -67,7 +67,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -53,7 +53,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -36,7 +36,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@types/expect-puppeteer": "2.2.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -53,7 +53,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -53,7 +53,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -53,7 +53,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -74,7 +74,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/orderedmap": "^1.0.0",
 		"@types/prosemirror-model": "^1.17.0",
 		"@types/prosemirror-schema-list": "^1.2.0",

--- a/examples/data-objects/shared-text/package.json
+++ b/examples/data-objects/shared-text/package.json
@@ -73,7 +73,7 @@
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
 		"@types/loader-utils": "^1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/prop-types": "^15",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/examples/data-objects/table-view/package.json
+++ b/examples/data-objects/table-view/package.json
@@ -58,7 +58,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/react": "^17.0.44",
 		"copyfiles": "^2.4.1",
 		"css-loader": "^1.0.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -64,7 +64,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/data-objects/webflow/package.json
+++ b/examples/data-objects/webflow/package.json
@@ -100,7 +100,7 @@
 		"@fluidframework/test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",
 		"c8": "^7.7.1",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -93,7 +93,7 @@
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
 		"@types/lodash.isequal": "^4.5.6",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/node-fetch": "^2.5.10",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -47,7 +47,7 @@
 		"@fluidframework/bundle-size-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@mixer/webpack-bundle-compare": "^0.1.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/examples/utils/example-utils/package.json
+++ b/examples/utils/example-utils/package.json
@@ -64,7 +64,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -59,7 +59,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"clean-webpack-plugin": "^4.0.0",
 		"cross-env": "^7.0.3",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -70,7 +70,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/version-migration/schema-upgrade/package.json
+++ b/examples/version-migration/schema-upgrade/package.json
@@ -70,7 +70,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/version-migration/tree-shim/package.json
+++ b/examples/version-migration/tree-shim/package.json
@@ -69,7 +69,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -57,7 +57,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -53,7 +53,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"clean-webpack-plugin": "^4.0.0",
 		"cross-env": "^7.0.3",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -56,7 +56,7 @@
 		"@types/expect-puppeteer": "2.2.1",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/experimental/PropertyDDS/packages/property-binder/package.json
+++ b/experimental/PropertyDDS/packages/property-binder/package.json
@@ -84,7 +84,7 @@
 		"@fluidframework/test-utils": "workspace:~",
 		"@types/jest": "29.5.3",
 		"@types/lodash": "^4.14.118",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/underscore": "^1.11.4",
 		"async": "^3.2.2",
 		"babel-eslint": "^10.1.0",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"chai": "^4.2.0",
 		"cross-env": "^7.0.3",

--- a/experimental/PropertyDDS/packages/property-common/package.json
+++ b/experimental/PropertyDDS/packages/property-common/package.json
@@ -74,7 +74,7 @@
 		"@types/debug": "^4.1.5",
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/semver": "^7.5.0",
 		"c8": "^7.7.1",
 		"chai": "^4.2.0",

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -75,7 +75,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"chai": "^4.2.0",
 		"cross-env": "^7.0.3",
 		"easy-table": "^1.1.1",

--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -76,7 +76,7 @@
 		"@types/cheerio": "0.22.31",
 		"@types/enzyme": "3.10.12",
 		"@types/jest": "29.5.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",
 		"@types/sinon": "^7.0.13",

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"chai": "^4.2.0",
 		"cross-env": "^7.0.3",

--- a/experimental/PropertyDDS/packages/property-proxy/package.json
+++ b/experimental/PropertyDDS/packages/property-proxy/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@types/jest": "29.5.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"babel-loader": "^8.0.5",
 		"eslint": "~8.50.0",
 		"jest": "^29.6.2",

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/package.json
@@ -42,7 +42,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@types/jest": "29.5.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"eslint": "~8.50.0",
 		"eslint-config-prettier": "~9.0.0",
 		"jest": "^29.6.2",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/path-browserify": "^1.0.0",
 		"c8": "^7.7.1",
 		"cross-env": "^7.0.3",

--- a/experimental/dds/ot/ot/package.json
+++ b/experimental/dds/ot/ot/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"best-random": "^1.0.0",
 		"c8": "^7.7.1",
 		"cross-env": "^7.0.3",

--- a/experimental/dds/ot/sharejs/json1/package.json
+++ b/experimental/dds/ot/sharejs/json1/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"best-random": "^1.0.0",
 		"c8": "^7.7.1",
 		"concurrently": "^8.2.1",

--- a/experimental/dds/sequence-deprecated/package.json
+++ b/experimental/dds/sequence-deprecated/package.json
@@ -79,7 +79,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"cross-env": "^7.0.3",
 		"diff": "^3.5.0",

--- a/experimental/dds/tree2/package.json
+++ b/experimental/dds/tree2/package.json
@@ -102,7 +102,7 @@
 		"@types/diff": "^3.5.1",
 		"@types/easy-table": "^0.0.32",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/ungap__structured-clone": "^0.3.0",
 		"@types/uuid": "^9.0.2",
 		"ajv": "^8.12.0",

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -46,7 +46,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -68,7 +68,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",

--- a/experimental/framework/react-inputs/package.json
+++ b/experimental/framework/react-inputs/package.json
@@ -45,7 +45,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/react": "^17.0.44",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/experimental/framework/tree-react-api/package.json
+++ b/experimental/framework/tree-react-api/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/react": "^17.0.44",
 		"@types/sinon": "^7.0.13",
 		"c8": "^7.7.1",

--- a/package.json
+++ b/package.json
@@ -349,7 +349,7 @@
 		],
 		"overrides": {
 			"@microsoft/api-extractor>typescript": "$typescript",
-			"@types/node": "^16.18.38",
+			"@types/node@<18": "^18.19.0",
 			"node-fetch": "^2.6.9",
 			"good-fences>nodegit": "npm:empty-npm-package@1.0.0",
 			"qs": "^6.11.0",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -90,7 +90,7 @@
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
 		"@types/rewire": "^2.5.28",
 		"@types/sha.js": "^2.4.4",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -48,7 +48,7 @@
 		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -74,7 +74,7 @@
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/sinon": "^7.0.13",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -95,7 +95,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -94,7 +94,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -93,7 +93,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/path-browserify": "^1.0.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -105,7 +105,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@tiny-calc/micro": "0.0.0-alpha.5",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"best-random": "^1.0.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -94,7 +94,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -97,7 +97,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/dds/pact-map/package.json
+++ b/packages/dds/pact-map/package.json
@@ -93,7 +93,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/events": "^3.0.0",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -96,7 +96,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -99,7 +99,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/random-js": "^1.0.31",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -101,7 +101,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/benchmark": "^2.1.0",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"benchmark": "^2.1.4",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -95,7 +95,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/benchmark": "^2.1.0",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"benchmark": "^2.1.4",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -99,7 +99,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -84,7 +84,7 @@
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -63,7 +63,7 @@
 		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -93,7 +93,7 @@
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -68,7 +68,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/jest": "29.5.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"fake-indexeddb": "3.1.4",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -51,7 +51,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -70,7 +70,7 @@
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -106,7 +106,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/node-fetch": "^2.5.10",
 		"@types/sinon": "^7.0.13",
 		"c8": "^7.7.1",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -56,7 +56,7 @@
 		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/nock": "^9.3.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"nock": "^13.3.3",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -103,7 +103,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/sinon": "^7.0.13",
 		"@types/url-parse": "1.4.4",
 		"@types/uuid": "^9.0.2",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -71,7 +71,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/nconf": "^0.10.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"assert": "^2.0.0",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -72,7 +72,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -71,7 +71,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -106,7 +106,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/events": "^3.0.0",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/framework/attributor/package.json
+++ b/packages/framework/attributor/package.json
@@ -101,7 +101,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -51,7 +51,7 @@
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/sinon": "^7.0.13",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.7.2.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -93,7 +93,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -63,7 +63,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -98,7 +98,7 @@
 		"@fluidframework/sequence": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/framework/oldest-client-observer/package.json
+++ b/packages/framework/oldest-client-observer/package.json
@@ -84,7 +84,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -92,7 +92,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -92,7 +92,7 @@
 		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -82,7 +82,7 @@
 		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"mocha": "^10.2.0",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -93,7 +93,7 @@
 		"@types/diff": "^3.5.1",
 		"@types/events": "^3.0.0",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -93,7 +93,7 @@
 		"@types/double-ended-queue": "^2.1.0",
 		"@types/events": "^3.0.0",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/sinon": "^7.0.13",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/sinon": "^7.0.13",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -88,7 +88,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -86,7 +86,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/service-clients/end-to-end-tests/odsp-client/package.json
+++ b/packages/service-clients/end-to-end-tests/odsp-client/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",
 		"eslint": "~8.50.0",

--- a/packages/service-clients/odsp-client/package.json
+++ b/packages/service-clients/odsp-client/package.json
@@ -81,7 +81,7 @@
 		"@fluidframework/test-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/test/functional-tests/package.json
+++ b/packages/test/functional-tests/package.json
@@ -71,7 +71,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@types/events": "^3.0.0",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/packages/test/local-server-tests/package.json
+++ b/packages/test/local-server-tests/package.json
@@ -94,7 +94,7 @@
 		"@fluidframework/test-utils": "workspace:~",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",
 		"cross-env": "^7.0.3",

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -53,7 +53,7 @@
 		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -87,7 +87,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -72,7 +72,7 @@
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/random-js": "^1.0.31",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/test/test-app-insights-logger/package.json
+++ b/packages/test/test-app-insights-logger/package.json
@@ -40,7 +40,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -132,7 +132,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",
 		"eslint": "~8.50.0",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -71,7 +71,7 @@
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/random-js": "^1.0.31",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -110,7 +110,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -97,7 +97,7 @@
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -99,7 +99,7 @@
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/semver": "^7.5.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -102,7 +102,7 @@
 		"@types/jsdom": "^21.1.1",
 		"@types/jsdom-global": "^3.0.4",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/proxyquire": "^1.3.28",
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",

--- a/packages/tools/devtools/devtools-example/package.json
+++ b/packages/tools/devtools/devtools-example/package.json
@@ -84,7 +84,7 @@
 		"@testing-library/user-event": "^14.4.3",
 		"@types/jest": "29.5.3",
 		"@types/jest-environment-puppeteer": "2.2.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",
 		"@types/testing-library__jest-dom": "^5.14.5",

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -88,7 +88,7 @@
 		"@types/chai": "^4.0.0",
 		"@types/jest": "29.5.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",
 		"@types/recharts": "^1.8.24",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -52,7 +52,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.7.2.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/yargs": "^13",
 		"c8": "^7.7.1",
 		"cross-env": "^7.0.3",

--- a/packages/tools/replay-tool/package.json
+++ b/packages/tools/replay-tool/package.json
@@ -72,7 +72,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/json-stable-stringify": "^1.0.32",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -99,7 +99,7 @@
 		"@types/express": "^4.11.0",
 		"@types/fs-extra": "^9.0.11",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",
 		"cross-env": "^7.0.3",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -82,7 +82,7 @@
 		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.7.2.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/node-fetch": "^2.5.10",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -87,7 +87,7 @@
 		"@types/debug": "^4.1.5",
 		"@types/events": "^3.0.0",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -84,7 +84,7 @@
 		"@types/debug": "^4.1.5",
 		"@types/jwt-decode": "^2.2.1",
 		"@types/mocha": "^9.1.1",
-		"@types/node": "^16.18.38",
+		"@types/node": "^18.19.0",
 		"c8": "^7.7.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 overrides:
   '@microsoft/api-extractor>typescript': ~5.1.6
-  '@types/node': ^16.18.38
+  '@types/node@<18': ^18.19.0
   node-fetch: ^2.6.9
   good-fences>nodegit: npm:empty-npm-package@1.0.0
   qs: ^6.11.0
@@ -103,7 +103,7 @@ importers:
       '@fluidframework/test-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       axios: ^0.26.0
       copyfiles: ^2.4.1
@@ -133,19 +133,19 @@ importers:
       '@fluidframework/telemetry-utils': link:../../../packages/utils/telemetry-utils
       axios: 0.26.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
       '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.7.2.0
       '@fluidframework/azure-local-service': link:../azure-local-service
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/counter': link:../../../packages/dds/counter
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -246,7 +246,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/uuid': ^9.0.2
       assert: ^2.0.0
@@ -288,7 +288,7 @@ importers:
     devDependencies:
       '@fluid-experimental/devtools': link:../../../packages/tools/devtools/devtools
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/container-definitions': link:../../../packages/common/container-definitions
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
@@ -300,14 +300,14 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/uuid': 9.0.7
       clean-webpack-plugin: 4.0.0_webpack@5.89.0
       cross-env: 7.0.3
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 4.4.0
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
@@ -347,7 +347,7 @@ importers:
       '@fluidframework/test-utils': workspace:~
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       c8: ^7.7.1
       cross-env: ^7.0.3
@@ -391,11 +391,11 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 7.14.0
       eslint: 8.50.0
@@ -428,7 +428,7 @@ importers:
       '@types/js-yaml': ^4.0.5
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       c8: ^7.7.1
       commander: ^5.1.0
@@ -470,14 +470,14 @@ importers:
       tinylicious: 2.0.2
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@types/js-yaml': 4.0.9
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 7.14.0
       eslint: 8.50.0
@@ -506,7 +506,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       cross-env: ^7.0.3
       eslint: ~8.50.0
@@ -537,20 +537,20 @@ importers:
       '@fluidframework/runtime-definitions': link:../../../packages/runtime/runtime-definitions
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       cross-env: 7.0.3
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -585,7 +585,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -625,23 +625,23 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       style-loader: 1.3.0_webpack@5.89.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       cross-env: 7.0.3
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -672,7 +672,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       clean-webpack-plugin: ^4.0.0
       cross-env: ^7.0.3
@@ -710,21 +710,21 @@ importers:
       style-loader: 1.3.0_webpack@5.89.0
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       clean-webpack-plugin: 4.0.0_webpack@5.89.0
       cross-env: 7.0.3
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -766,7 +766,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/prop-types': ^15
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
@@ -828,15 +828,15 @@ importers:
       scheduler: 0.20.2
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/prop-types': 15.7.11
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
@@ -848,7 +848,7 @@ importers:
       eslint: 8.50.0
       html-loader: 3.1.2_webpack@5.89.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -886,7 +886,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       cross-env: ^7.0.3
       eslint: ~8.50.0
@@ -920,20 +920,20 @@ importers:
       fluid-framework: link:../../../packages/framework/fluid-framework
       process: 0.11.10
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       cross-env: 7.0.3
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -967,7 +967,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       clean-webpack-plugin: ^4.0.0
       cross-env: ^7.0.3
@@ -1003,21 +1003,21 @@ importers:
       css-loader: 1.0.1_webpack@5.89.0
       style-loader: 1.3.0_webpack@5.89.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       clean-webpack-plugin: 4.0.0_webpack@5.89.0
       cross-env: 7.0.3
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -1059,7 +1059,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -1112,15 +1112,15 @@ importers:
       tiny-typed-emitter: 2.1.0
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -1129,7 +1129,7 @@ importers:
       css-loader: 1.0.1_webpack@5.89.0
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -1162,7 +1162,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -1194,19 +1194,19 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       cross-env: 7.0.3
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -1236,7 +1236,7 @@ importers:
       '@fluidframework/test-tools': ^1.0.195075
       '@fluidframework/view-interfaces': workspace:~
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
       best-random: ^1.0.0
@@ -1266,14 +1266,14 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       use-resize-observer: 7.1.0_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@fluidframework/test-tools': 1.0.195075
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       c8: 7.14.0
@@ -1306,7 +1306,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -1341,19 +1341,19 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       cross-env: 7.0.3
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -1386,7 +1386,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -1421,19 +1421,19 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       cross-env: 7.0.3
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -1465,7 +1465,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -1498,19 +1498,19 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       cross-env: 7.0.3
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -1539,7 +1539,7 @@ importers:
       '@fluidframework/tool-utils': workspace:~
       '@types/express': ^4.11.0
       '@types/fs-extra': ^9.0.11
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       buffer: ^6.0.3
       c8: ^7.7.1
       css-loader: ^1.0.0
@@ -1571,13 +1571,13 @@ importers:
       nconf: 0.12.1
       webpack-dev-server: 4.6.0_wvskkfkvbt5crqa4uyjlq44kiy
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@types/express': 4.17.21
       '@types/fs-extra': 9.0.13
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       buffer: 6.0.3
       c8: 7.14.0
       css-loader: 1.0.1_webpack@5.89.0
@@ -1706,7 +1706,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -1739,20 +1739,20 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       cross-env: 7.0.3
       css-loader: 1.0.1_webpack@5.89.0
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       less: 3.9.0
@@ -1786,7 +1786,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -1817,20 +1817,20 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       cross-env: 7.0.3
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -1867,7 +1867,7 @@ importers:
       '@fluidframework/view-adapters': workspace:~
       '@fluidframework/view-interfaces': workspace:~
       '@types/codemirror': 5.60.7
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/react': ^17.0.44
       codemirror: ^5.48.4
       copyfiles: ^2.4.1
@@ -1907,10 +1907,10 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@types/codemirror': 5.60.7
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/react': 17.0.71
       copyfiles: 2.4.1
       css-loader: 1.0.1_webpack@5.89.0
@@ -1939,7 +1939,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -1968,19 +1968,19 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       cross-env: 7.0.3
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -2009,7 +2009,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -2039,19 +2039,19 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       cross-env: 7.0.3
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -2149,7 +2149,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       cross-env: ^7.0.3
       eslint: ~8.50.0
@@ -2175,17 +2175,17 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       cross-env: 7.0.3
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -2211,7 +2211,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -2241,13 +2241,13 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -2255,7 +2255,7 @@ importers:
       cross-env: 7.0.3
       css-loader: 1.0.1_webpack@5.89.0
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -2295,7 +2295,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -2338,13 +2338,13 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -2352,7 +2352,7 @@ importers:
       cross-env: 7.0.3
       css-loader: 1.0.1_webpack@5.89.0
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -2380,7 +2380,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       cross-env: ^7.0.3
       eslint: ~8.50.0
@@ -2404,17 +2404,17 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       cross-env: 7.0.3
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -2435,7 +2435,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@types/expect-puppeteer': 2.2.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -2450,12 +2450,12 @@ importers:
       webpack-dev-server: ~4.6.0
       webpack-merge: ^5.8.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@types/expect-puppeteer': 2.2.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -2481,7 +2481,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -2510,13 +2510,13 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -2524,7 +2524,7 @@ importers:
       cross-env: 7.0.3
       css-loader: 1.0.1_webpack@5.89.0
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -2550,7 +2550,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -2579,13 +2579,13 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -2593,7 +2593,7 @@ importers:
       cross-env: 7.0.3
       css-loader: 1.0.1_webpack@5.89.0
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -2619,7 +2619,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -2648,13 +2648,13 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -2662,7 +2662,7 @@ importers:
       cross-env: 7.0.3
       css-loader: 1.0.1_webpack@5.89.0
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -2700,7 +2700,7 @@ importers:
       '@fluidframework/sequence': workspace:~
       '@fluidframework/view-adapters': workspace:~
       '@fluidframework/view-interfaces': workspace:~
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/orderedmap': ^1.0.0
       '@types/prosemirror-model': ^1.17.0
       '@types/prosemirror-schema-list': ^1.2.0
@@ -2763,9 +2763,9 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/orderedmap': 1.0.0
       '@types/prosemirror-model': 1.17.0
       '@types/prosemirror-schema-list': 1.2.0
@@ -2812,7 +2812,7 @@ importers:
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
       '@types/loader-utils': ^1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/prop-types': ^15
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
@@ -2869,13 +2869,13 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
       '@types/loader-utils': 1.1.9
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/prop-types': 15.7.11
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
@@ -2883,7 +2883,7 @@ importers:
       cross-env: 7.0.3
       css-loader: 1.0.1_webpack@5.89.0
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_c74ur6dz4zjug5kosl76nqtepy
       jsdom: 16.7.0
@@ -3005,7 +3005,7 @@ importers:
       '@fluidframework/test-utils': workspace:~
       '@types/debug': ^4.1.5
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       cross-env: ^7.0.3
       debug: ^4.3.4
@@ -3031,9 +3031,9 @@ importers:
       debug: 4.3.4
     devDependencies:
       '@fluid-private/test-version-utils': link:../../../packages/test/test-version-utils
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
@@ -3041,7 +3041,7 @@ importers:
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
       '@types/debug': 4.1.12
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       cross-env: 7.0.3
       eslint: 8.50.0
@@ -3069,7 +3069,7 @@ importers:
       '@fluidframework/sequence': workspace:~
       '@fluidframework/view-interfaces': workspace:~
       '@tiny-calc/micro': 0.0.0-alpha.5
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/react': ^17.0.44
       copyfiles: ^2.4.1
       css-loader: ^1.0.0
@@ -3101,9 +3101,9 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/react': 17.0.71
       copyfiles: 2.4.1
       css-loader: 1.0.1_webpack@5.89.0
@@ -3141,7 +3141,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -3182,21 +3182,21 @@ importers:
     devDependencies:
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       cross-env: 7.0.3
       css-loader: 1.0.1_webpack@5.89.0
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -3233,7 +3233,7 @@ importers:
       '@fluidframework/view-interfaces': workspace:~
       '@types/debug': ^4.1.5
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
       assert: ^2.0.0
@@ -3288,14 +3288,14 @@ importers:
       '@fluid-private/test-version-utils': link:../../../packages/test/test-version-utils
       '@fluid-tools/webpack-fluid-loader': link:../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
       '@types/debug': 4.1.12
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       c8: 7.14.0
@@ -3317,7 +3317,7 @@ importers:
       source-map-loader: 2.0.2_webpack@5.89.0
       style-loader: 1.3.0_webpack@5.89.0
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
-      ts-node: 10.9.1_jnhzrdmjzh6qsf7xvhnyy55kui
+      ts-node: 10.9.1_ggysxzqxruqvydtrq6zb2nxvwm
       typescript: 5.1.6
       url-loader: 2.3.0_ruxgrfgnxdbqodrinftcho7vqi
       webpack: 5.89.0_webpack-cli@4.10.0
@@ -3360,7 +3360,7 @@ importers:
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
       '@types/lodash.isequal': ^4.5.6
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/node-fetch': ^2.5.10
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
@@ -3434,7 +3434,7 @@ importers:
       valid-url: 1.0.9
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/cors': 2.8.17
@@ -3444,7 +3444,7 @@ importers:
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
       '@types/lodash.isequal': 4.5.8
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/node-fetch': 2.6.9
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
@@ -3456,7 +3456,7 @@ importers:
       eslint-config-prettier: 9.0.0_eslint@8.50.0
       good-fences: 1.2.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -3493,7 +3493,7 @@ importers:
       '@fluidframework/odsp-driver': workspace:~
       '@fluidframework/sequence': workspace:~
       '@mixer/webpack-bundle-compare': ^0.1.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       cross-env: ^7.0.3
       eslint: ~8.50.0
@@ -3521,11 +3521,11 @@ importers:
       '@cerner/duplicate-package-checker-webpack-plugin': 2.3.0_webpack@5.89.0
       '@fluid-tools/version-tools': 0.28.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/bundle-size-tools': 0.28.0_webpack-cli@4.10.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@mixer/webpack-bundle-compare': 0.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       cross-env: 7.0.3
       eslint: 8.50.0
@@ -3568,7 +3568,7 @@ importers:
       '@fluidframework/view-adapters': workspace:~
       '@fluidframework/view-interfaces': workspace:~
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       eslint: ~8.50.0
       prettier: ~3.0.3
@@ -3601,12 +3601,12 @@ importers:
       '@fluidframework/view-interfaces': link:../../../packages/framework/view-interfaces
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       eslint: 8.50.0
       prettier: 3.0.3
@@ -3634,7 +3634,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       clean-webpack-plugin: ^4.0.0
       cross-env: ^7.0.3
@@ -3671,21 +3671,21 @@ importers:
       css-loader: 1.0.1_webpack@5.89.0
       style-loader: 1.3.0_webpack@5.89.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       clean-webpack-plugin: 4.0.0_webpack@5.89.0
       cross-env: 7.0.3
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -3730,7 +3730,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -3786,15 +3786,15 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -3805,7 +3805,7 @@ importers:
       eslint: 8.50.0
       eslint-config-prettier: 9.0.0_eslint@8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -3851,7 +3851,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -3907,15 +3907,15 @@ importers:
       react-dom: 17.0.2_react@17.0.2
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -3926,7 +3926,7 @@ importers:
       eslint: 8.50.0
       eslint-config-prettier: 9.0.0_eslint@8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -3969,7 +3969,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -4024,15 +4024,15 @@ importers:
       tiny-typed-emitter: 2.1.0
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -4041,7 +4041,7 @@ importers:
       css-loader: 1.0.1_webpack@5.89.0
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -4079,7 +4079,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -4116,15 +4116,15 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -4132,7 +4132,7 @@ importers:
       cross-env: 7.0.3
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -4161,7 +4161,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       clean-webpack-plugin: ^4.0.0
       cross-env: ^7.0.3
@@ -4192,21 +4192,21 @@ importers:
       css-loader: 1.0.1_webpack@5.89.0
       style-loader: 1.3.0_webpack@5.89.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       clean-webpack-plugin: 4.0.0_webpack@5.89.0
       cross-env: 7.0.3
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -4236,7 +4236,7 @@ importers:
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -4275,15 +4275,15 @@ importers:
       style-loader: 1.3.0_webpack@5.89.0
       vue: 2.6.14
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-tools': 1.0.195075
       '@types/expect-puppeteer': 2.2.1
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -4291,7 +4291,7 @@ importers:
       cross-env: 7.0.3
       eslint: 8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       prettier: 3.0.3
@@ -4611,7 +4611,7 @@ importers:
       '@fluidframework/test-utils': workspace:~
       '@types/jest': 29.5.3
       '@types/lodash': ^4.14.118
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/underscore': ^1.11.4
       async: ^3.2.2
       babel-eslint: ^10.1.0
@@ -4652,12 +4652,12 @@ importers:
       '@babel/plugin-transform-runtime': 7.23.4_@babel+core@7.23.3
       '@babel/preset-env': 7.23.3_@babel+core@7.23.3
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils
       '@fluidframework/test-utils': link:../../../../packages/test/test-utils
       '@types/jest': 29.5.3
       '@types/lodash': 4.14.202
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/underscore': 1.11.15
       async: 3.2.5
       babel-eslint: 10.1.0_eslint@8.50.0
@@ -4672,7 +4672,7 @@ importers:
       c8: 7.14.0
       chai: 4.3.10
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jsdoc: 3.6.7
       lighthouse: 5.6.0
@@ -4691,7 +4691,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@types/lodash': ^4.14.118
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       ajv: ^8.12.0
       ajv-keywords: ^5.1.0
       async: ^3.2.2
@@ -4723,11 +4723,11 @@ importers:
       traverse: 0.6.6
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@types/lodash': 4.14.202
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       chai: 4.3.10
       cross-env: 7.0.3
@@ -4753,7 +4753,7 @@ importers:
       '@types/debug': ^4.1.5
       '@types/lodash': ^4.14.118
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/semver': ^7.5.0
       ajv: ^8.12.0
       async: ^3.2.2
@@ -4789,15 +4789,15 @@ importers:
       traverse: 0.6.6
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/chai': 4.3.11
       '@types/debug': 4.1.12
       '@types/lodash': 4.14.202
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/semver': 7.5.6
       c8: 7.14.0
       chai: 4.3.10
@@ -4845,7 +4845,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/lodash': ^4.14.118
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       axios: ^0.26.0
       buffer: ^6.0.3
       chai: ^4.2.0
@@ -4889,7 +4889,7 @@ importers:
       '@fluid-experimental/property-common': link:../property-common
       '@fluid-private/test-drivers': link:../../../../packages/test/test-drivers
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/container-loader': link:../../../../packages/loader/container-loader
       '@fluidframework/container-runtime': link:../../../../packages/runtime/container-runtime
       '@fluidframework/driver-definitions': link:../../../../packages/common/driver-definitions
@@ -4900,10 +4900,10 @@ importers:
       '@fluidframework/server-local-server': 2.0.2
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils
       '@fluidframework/test-utils': link:../../../../packages/test/test-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/lodash': 4.14.202
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       chai: 4.3.10
       cross-env: 7.0.3
       easy-table: 1.2.0
@@ -4941,7 +4941,7 @@ importers:
       '@types/cheerio': 0.22.31
       '@types/enzyme': 3.10.12
       '@types/jest': 29.5.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
       '@types/sinon': ^7.0.13
@@ -5012,7 +5012,7 @@ importers:
       '@fluid-experimental/property-proxy': link:../property-proxy
       '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@storybook/addon-actions': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-essentials': 6.5.16_sdxtpqmqsvmmcipp3b6cu7uj3u
       '@storybook/addon-links': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
@@ -5022,7 +5022,7 @@ importers:
       '@types/cheerio': 0.22.31
       '@types/enzyme': 3.10.12
       '@types/jest': 29.5.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       '@types/sinon': 7.5.2
@@ -5036,7 +5036,7 @@ importers:
       html-webpack-plugin: 5.5.3_webpack@5.89.0
       identity-obj-proxy: 3.0.0
       istanbul-instrumenter-loader: 3.0.1_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       jest-transform-file: 1.1.1
       jsdoc: 3.6.7
@@ -5066,7 +5066,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       ajv: ^8.12.0
       async: ^3.2.2
       c8: ^7.7.1
@@ -5099,10 +5099,10 @@ importers:
       underscore: 1.13.6
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       chai: 4.3.10
       cross-env: 7.0.3
@@ -5128,7 +5128,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@types/jest': 29.5.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       babel-loader: ^8.0.5
       eslint: ~8.50.0
       jest: ^29.6.2
@@ -5148,13 +5148,13 @@ importers:
       '@babel/plugin-transform-runtime': 7.23.4_@babel+core@7.23.3
       '@babel/preset-env': 7.23.3_@babel+core@7.23.3
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@types/jest': 29.5.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       babel-loader: 8.3.0_rwp5n2556mrumtrwbeu2k2rar4
       eslint: 8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       prettier: 3.0.3
       rimraf: 4.4.1
@@ -5227,7 +5227,7 @@ importers:
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
       '@types/jest': 29.5.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       eslint: ~8.50.0
       eslint-config-prettier: ~9.0.0
       jest: ^29.6.2
@@ -5243,13 +5243,13 @@ importers:
       '@fluidframework/core-utils': link:../../../../packages/common/core-utils
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils
       '@types/jest': 29.5.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       eslint: 8.50.0
       eslint-config-prettier: 9.0.0_eslint@8.50.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       prettier: 3.0.3
       rimraf: 4.4.1
@@ -5410,7 +5410,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/path-browserify': ^1.0.0
       c8: ^7.7.1
       cross-env: ^7.0.3
@@ -5439,15 +5439,15 @@ importers:
       '@fluid-private/stochastic-test-utils': link:../../../packages/test/stochastic-test-utils
       '@fluid-private/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/path-browserify': 1.0.2
       c8: 7.14.0
       cross-env: 7.0.3
@@ -5477,7 +5477,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       best-random: ^1.0.0
       c8: ^7.7.1
       cross-env: ^7.0.3
@@ -5501,13 +5501,13 @@ importers:
     devDependencies:
       '@fluid-private/test-dds-utils': link:../../../../packages/dds/test-dds-utils
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../packages/test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../../packages/runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       best-random: 1.0.3
       c8: 7.14.0
       cross-env: 7.0.3
@@ -5536,7 +5536,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       best-random: ^1.0.0
       c8: ^7.7.1
       concurrently: ^8.2.1
@@ -5560,13 +5560,13 @@ importers:
     devDependencies:
       '@fluid-private/test-dds-utils': link:../../../../../packages/dds/test-dds-utils
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../../../packages/test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../../../packages/runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       best-random: 1.0.3
       c8: 7.14.0
       concurrently: 8.2.2
@@ -5598,7 +5598,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/diff': ^3.5.1
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       cross-env: ^7.0.3
       diff: ^3.5.0
@@ -5619,16 +5619,16 @@ importers:
       '@fluidframework/shared-object-base': link:../../../packages/dds/shared-object-base
     devDependencies:
       '@fluid-private/test-dds-utils': link:../../../packages/dds/test-dds-utils
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/diff': 3.5.8
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       cross-env: 7.0.3
       diff: 3.5.0
@@ -5772,7 +5772,7 @@ importers:
       '@types/diff': ^3.5.1
       '@types/easy-table': ^0.0.32
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/ungap__structured-clone': ^0.3.0
       '@types/uuid': ^9.0.2
       '@ungap/structured-clone': ^1.2.0
@@ -5813,9 +5813,9 @@ importers:
       '@fluid-private/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-private/test-drivers': link:../../../packages/test/test-drivers
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/container-definitions': link:../../../packages/common/container-definitions
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
@@ -5823,11 +5823,11 @@ importers:
       '@fluidframework/telemetry-utils': link:../../../packages/utils/telemetry-utils
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
       '@fluidframework/test-utils': link:../../../packages/test/test-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/diff': 3.5.8
       '@types/easy-table': 0.0.32
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/ungap__structured-clone': 0.3.3
       '@types/uuid': 9.0.7
       ajv: 8.12.0
@@ -5861,7 +5861,7 @@ importers:
       '@fluidframework/map': workspace:~
       '@fluidframework/runtime-definitions': workspace:~
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       cross-env: ^7.0.3
       eslint: ~8.50.0
       events: ^3.1.0
@@ -5878,12 +5878,12 @@ importers:
       '@fluidframework/runtime-definitions': link:../../../packages/runtime/runtime-definitions
       events: 3.3.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       cross-env: 7.0.3
       eslint: 8.50.0
       prettier: 3.0.3
@@ -5905,7 +5905,7 @@ importers:
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/shared-summary-block': workspace:~
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       eslint: ~8.50.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
@@ -5919,13 +5919,13 @@ importers:
       '@fluidframework/runtime-utils': link:../../../packages/runtime/runtime-utils
       '@fluidframework/shared-summary-block': link:../../../packages/dds/shared-summary-block
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       eslint: 8.50.0
       prettier: 3.0.3
       rimraf: 4.4.1
@@ -5943,7 +5943,7 @@ importers:
       '@fluidframework/merge-tree': workspace:~
       '@fluidframework/sequence': workspace:~
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/react': ^17.0.44
       eslint: ~8.50.0
       prettier: ~3.0.3
@@ -5958,12 +5958,12 @@ importers:
       '@fluidframework/sequence': link:../../../packages/dds/sequence
       react: 17.0.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       '@types/react': 17.0.71
       eslint: 8.50.0
       prettier: 3.0.3
@@ -5983,7 +5983,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/react': ^17.0.44
       '@types/sinon': ^7.0.13
       c8: ^7.7.1
@@ -6002,15 +6002,15 @@ importers:
       react: 17.0.2
     devDependencies:
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../packages/test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../../packages/runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/react': 17.0.71
       '@types/sinon': 7.5.2
       c8: 7.14.0
@@ -6038,7 +6038,7 @@ importers:
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
       '@types/rewire': ^2.5.28
       '@types/sha.js': ^2.4.4
@@ -6079,17 +6079,17 @@ importers:
       lodash: 4.17.21
       sha.js: 2.4.11
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/base64-js': 1.3.2
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
       '@types/rewire': 2.5.30
       '@types/sha.js': 2.4.4
@@ -6100,7 +6100,7 @@ importers:
       cross-env: 7.0.3
       eslint: 8.50.0
       eslint-config-prettier: 9.0.0_eslint@8.50.0
-      jest: 29.7.0_zcphfowolnmvjsbjiiyfg3ai2q
+      jest: 29.7.0_5hr63yjncn3tlo6qh7e6tsd2me
       jest-junit: 10.0.0
       jest-puppeteer: 6.2.0_puppeteer@17.1.3
       mocha: 10.2.0
@@ -6113,7 +6113,7 @@ importers:
       rimraf: 4.4.1
       sinon: 7.5.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
-      ts-node: 10.9.1_jnhzrdmjzh6qsf7xvhnyy55kui
+      ts-node: 10.9.1_ggysxzqxruqvydtrq6zb2nxvwm
       typescript: 5.1.6
 
   packages/common/container-definitions:
@@ -6163,20 +6163,20 @@ importers:
       '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
       typescript: ~5.1.6
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       eslint: 8.50.0
       prettier: 3.0.3
@@ -6193,7 +6193,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/sinon': ^7.0.13
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -6210,14 +6210,14 @@ importers:
       typescript: ~5.1.6
     devDependencies:
       '@fluid-tools/benchmark': 0.47.0
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/sinon': 7.5.2
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -6283,7 +6283,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -6306,16 +6306,16 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
       '@fluid-private/test-dds-utils': link:../test-dds-utils
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -6347,7 +6347,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -6369,16 +6369,16 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -6478,7 +6478,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/path-browserify': ^1.0.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -6510,16 +6510,16 @@ importers:
       '@fluid-private/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-private/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/path-browserify': 1.0.2
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -6560,7 +6560,7 @@ importers:
       '@tiny-calc/micro': 0.0.0-alpha.5
       '@tiny-calc/nano': 0.0.0-alpha.5
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       best-random: ^1.0.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -6597,17 +6597,17 @@ importers:
     devDependencies:
       '@fluid-private/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@tiny-calc/micro': 0.0.0-alpha.5
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       best-random: 1.0.3
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -6620,7 +6620,7 @@ importers:
       moment: 2.29.4
       prettier: 3.0.3
       rimraf: 4.4.1
-      ts-node: 10.9.1_jnhzrdmjzh6qsf7xvhnyy55kui
+      ts-node: 10.9.1_ggysxzqxruqvydtrq6zb2nxvwm
       tsc-multi: 1.1.0_typescript@5.1.6
       typescript: 5.1.6
       uuid: 9.0.1
@@ -6650,7 +6650,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/diff': ^3.5.1
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -6678,17 +6678,17 @@ importers:
       '@fluid-private/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-private/test-pairwise-generator': link:../../test/test-pairwise-generator
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/diff': 3.5.8
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -6722,7 +6722,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -6748,16 +6748,16 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-private/test-dds-utils': link:../test-dds-utils
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -6789,7 +6789,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/events': ^3.0.0
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -6816,14 +6816,14 @@ importers:
     devDependencies:
       '@fluid-private/test-dds-utils': link:../test-dds-utils
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/events': 3.0.3
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -6858,7 +6858,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -6882,16 +6882,16 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
       '@fluid-private/test-dds-utils': link:../test-dds-utils
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -6930,7 +6930,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/diff': ^3.5.1
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/random-js': ^1.0.31
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -6962,17 +6962,17 @@ importers:
       '@fluid-private/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-private/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/diff': 3.5.8
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/random-js': 1.0.31
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -7011,7 +7011,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/benchmark': ^2.1.0
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       benchmark: ^2.1.4
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -7041,17 +7041,17 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/benchmark': 2.1.5
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       benchmark: 2.1.4
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -7063,7 +7063,7 @@ importers:
       moment: 2.29.4
       prettier: 3.0.3
       rimraf: 4.4.1
-      ts-node: 10.9.1_jnhzrdmjzh6qsf7xvhnyy55kui
+      ts-node: 10.9.1_ggysxzqxruqvydtrq6zb2nxvwm
       tsc-multi: 1.1.0_typescript@5.1.6
       typescript: 5.1.6
 
@@ -7085,7 +7085,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/benchmark': ^2.1.0
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       benchmark: ^2.1.4
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -7107,17 +7107,17 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/shared-object-base': link:../shared-object-base
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/benchmark': 2.1.5
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       benchmark: 2.1.4
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -7154,7 +7154,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -7183,16 +7183,16 @@ importers:
     devDependencies:
       '@fluid-private/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-private/test-dds-utils': link:../test-dds-utils
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -7223,7 +7223,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -7246,15 +7246,15 @@ importers:
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       mocha: 10.2.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -7281,7 +7281,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/replay-driver': workspace:~
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       jsonschema: ^1.2.6
@@ -7297,13 +7297,13 @@ importers:
       '@fluidframework/replay-driver': link:../replay-driver
       jsonschema: 1.4.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       eslint: 8.50.0
       prettier: 3.0.3
@@ -7328,7 +7328,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -7351,15 +7351,15 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -7387,7 +7387,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/jest': 29.5.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       fake-indexeddb: 3.1.4
@@ -7404,18 +7404,18 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       idb: 6.1.5
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/jest': 29.5.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       eslint: 8.50.0
       fake-indexeddb: 3.1.4
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       prettier: 3.0.3
       rimraf: 4.4.1
       tsc-multi: 1.1.0_typescript@5.1.6
@@ -7436,7 +7436,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/replay-driver': workspace:~
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       prettier: ~3.0.3
@@ -7451,13 +7451,13 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/replay-driver': link:../replay-driver
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       eslint: 8.50.0
       prettier: 3.0.3
@@ -7480,7 +7480,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
       eslint: ~8.50.0
@@ -7500,15 +7500,15 @@ importers:
       '@fluidframework/odsp-driver': link:../odsp-driver
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.2.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       cross-env: 7.0.3
       eslint: 8.50.0
@@ -7546,7 +7546,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -7585,16 +7585,16 @@ importers:
       url: 0.11.3
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -7631,7 +7631,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/node-fetch': ^2.5.10
       '@types/sinon': ^7.0.13
       c8: ^7.7.1
@@ -7666,15 +7666,15 @@ importers:
       socket.io-client: 4.7.2_p7f5djbjd3zgfisasebtom74n4
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/node-fetch': 2.6.9
       '@types/sinon': 7.5.2
       c8: 7.14.0
@@ -7740,7 +7740,7 @@ importers:
       '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
       eslint: ~8.50.0
@@ -7758,15 +7758,15 @@ importers:
       '@fluidframework/odsp-driver': link:../odsp-driver
       '@fluidframework/odsp-driver-definitions': link:../odsp-driver-definitions
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       cross-env: 7.0.3
       eslint: 8.50.0
@@ -7795,7 +7795,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/nock': ^9.3.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       nock: ^13.3.3
@@ -7812,14 +7812,14 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/nock': 9.3.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       eslint: 8.50.0
       nock: 13.4.0
@@ -7850,7 +7850,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/sinon': ^7.0.13
       '@types/url-parse': 1.4.4
       '@types/uuid': ^9.0.2
@@ -7892,16 +7892,16 @@ importers:
       url-parse: 1.5.10
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/sinon': 7.5.2
       '@types/url-parse': 1.4.4
       '@types/uuid': 9.0.7
@@ -7936,7 +7936,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
       '@types/nconf': ^0.10.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       assert: ^2.0.0
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -7959,16 +7959,16 @@ importers:
       nconf: 0.12.1
       url: 0.11.3
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/nconf': 0.10.6
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       assert: 2.1.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -7999,7 +7999,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -8020,17 +8020,17 @@ importers:
       jsrsasign: 10.9.0
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-tools': 1.0.195075
       '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -8060,7 +8060,7 @@ importers:
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       prettier: ~3.0.3
@@ -8082,13 +8082,13 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.7.2.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       eslint: 8.50.0
       prettier: 3.0.3
@@ -8121,7 +8121,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/events': ^3.0.0
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -8152,16 +8152,16 @@ importers:
       '@fluidframework/view-interfaces': link:../view-interfaces
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.7.2.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/events': 3.0.3
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -8200,7 +8200,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -8229,18 +8229,18 @@ importers:
       lz4js: 0.2.0
     devDependencies:
       '@fluid-private/stochastic-test-utils': link:../../test/stochastic-test-utils
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/merge-tree': link:../../dds/merge-tree
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence': link:../../dds/sequence
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -8264,7 +8264,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@microsoft/applicationinsights-web': ^2.8.11
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/sinon': ^7.0.13
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -8285,11 +8285,11 @@ importers:
       '@microsoft/applicationinsights-web': 2.8.16_tslib@1.14.1
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/sinon': 7.5.2
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -8325,7 +8325,7 @@ importers:
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/shared-object-base': workspace:~
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       prettier: ~3.0.3
@@ -8346,13 +8346,13 @@ importers:
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
       '@fluidframework/shared-object-base': link:../../dds/shared-object-base
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       eslint: 8.50.0
       prettier: 3.0.3
@@ -8377,7 +8377,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/diff': ^3.5.1
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -8398,17 +8398,17 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/sequence': link:../../dds/sequence
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/diff': 3.5.8
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -8436,7 +8436,7 @@ importers:
       '@fluidframework/map': workspace:~
       '@fluidframework/sequence': workspace:~
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       prettier: ~3.0.3
@@ -8451,12 +8451,12 @@ importers:
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/sequence': link:../../dds/sequence
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       eslint: 8.50.0
       prettier: 3.0.3
@@ -8487,7 +8487,7 @@ importers:
       '@fluidframework/sequence': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -8513,17 +8513,17 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.7.2.0
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence': link:../../dds/sequence
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -8551,7 +8551,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
       eslint: ~8.50.0
@@ -8567,13 +8567,13 @@ importers:
       '@fluidframework/protocol-definitions': 3.0.0
     devDependencies:
       '@fluid-private/test-dds-utils': link:../../dds/test-dds-utils
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       cross-env: 7.0.3
       eslint: 8.50.0
@@ -8599,7 +8599,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/diff': ^3.5.1
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -8620,17 +8620,17 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.7.2.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/diff': 3.5.8
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -8658,7 +8658,7 @@ importers:
       '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.7.2.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -8674,17 +8674,17 @@ importers:
     dependencies:
       '@fluidframework/core-utils': link:../../common/core-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -8723,7 +8723,7 @@ importers:
       '@fluidframework/tinylicious-driver': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       mocha: ^10.2.0
@@ -8749,18 +8749,18 @@ importers:
       '@fluidframework/tinylicious-driver': link:../../drivers/tinylicious-driver
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/aqueduct': link:../aqueduct
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/container-runtime': link:../../runtime/container-runtime
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-utils': link:../../test/test-utils
       '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       eslint: 8.50.0
       mocha: 10.2.0
@@ -8788,7 +8788,7 @@ importers:
       '@types/diff': ^3.5.1
       '@types/events': ^3.0.0
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -8810,18 +8810,18 @@ importers:
       '@fluidframework/sequence': link:../../dds/sequence
       events: 3.3.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/diff': 3.5.8
       '@types/events': 3.0.3
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -8935,7 +8935,7 @@ importers:
       '@types/double-ended-queue': ^2.1.0
       '@types/events': ^3.0.0
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/sinon': ^7.0.13
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -8972,18 +8972,18 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluid-private/test-loader-utils': link:../test-loader-utils
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/debug': 4.1.12
       '@types/double-ended-queue': 2.1.7
       '@types/events': 3.0.3
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/sinon': 7.5.2
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -9017,7 +9017,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/sinon': ^7.0.13
       axios: ^0.26.0
       c8: ^7.7.1
@@ -9049,15 +9049,15 @@ importers:
       url: 0.11.3
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/sinon': 7.5.2
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -9087,7 +9087,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -9105,16 +9105,16 @@ importers:
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -9314,7 +9314,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -9344,16 +9344,16 @@ importers:
       lodash: 4.17.21
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.7.2.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -9459,7 +9459,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -9485,15 +9485,15 @@ importers:
       '@fluidframework/runtime-definitions': link:../runtime-definitions
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -9505,7 +9505,7 @@ importers:
       prettier: 3.0.3
       rimraf: 4.4.1
       sinon: 7.5.0
-      ts-node: 10.9.1_jnhzrdmjzh6qsf7xvhnyy55kui
+      ts-node: 10.9.1_ggysxzqxruqvydtrq6zb2nxvwm
       typescript: 5.1.6
 
   packages/runtime/test-runtime-utils:
@@ -9530,7 +9530,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -9562,16 +9562,16 @@ importers:
       jsrsasign: 10.9.0
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -9608,7 +9608,7 @@ importers:
       '@fluidframework/test-utils': workspace:~
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       c8: ^7.7.1
       cross-env: ^7.0.3
@@ -9650,11 +9650,11 @@ importers:
       uuid: 9.0.1
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 7.14.0
       eslint: 8.50.0
@@ -9684,7 +9684,7 @@ importers:
       '@fluidframework/test-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -9709,15 +9709,15 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-utils': link:../../test/test-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -9743,7 +9743,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@types/events': ^3.0.0
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       cross-env: ^7.0.3
       eslint: ~8.50.0
@@ -9762,9 +9762,9 @@ importers:
       events: 3.3.0
     devDependencies:
       '@fluid-private/test-loader-utils': link:../../loader/test-loader-utils
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/container-loader': link:../../loader/container-loader
       '@fluidframework/container-runtime': link:../../runtime/container-runtime
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
@@ -9775,7 +9775,7 @@ importers:
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       '@types/events': 3.0.3
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       cross-env: 7.0.3
       eslint: 8.50.0
@@ -9834,7 +9834,7 @@ importers:
       '@fluidframework/test-utils': workspace:~
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       c8: ^7.7.1
       cross-env: ^7.0.3
@@ -9857,7 +9857,7 @@ importers:
       '@fluid-private/test-pairwise-generator': link:../test-pairwise-generator
       '@fluidframework/aqueduct': link:../../framework/aqueduct
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/cell': link:../../dds/cell
       '@fluidframework/container-definitions': link:../../common/container-definitions
       '@fluidframework/container-loader': link:../../loader/container-loader
@@ -9894,7 +9894,7 @@ importers:
       '@fluidframework/test-utils': link:../test-utils
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 7.14.0
       cross-env: 7.0.3
@@ -9923,7 +9923,7 @@ importers:
       '@fluidframework/test-driver-definitions': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       mocha: ^10.2.0
@@ -9937,14 +9937,14 @@ importers:
       mocha: 10.2.0
       source-map-support: 0.5.21
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       eslint: 8.50.0
       prettier: 3.0.3
@@ -9981,7 +9981,7 @@ importers:
       '@fluidframework/server-local-server': ^2.0.1
       '@fluidframework/test-utils': workspace:~
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       cross-env: ^7.0.3
       eslint: ~8.50.0
@@ -10017,13 +10017,13 @@ importers:
       '@fluidframework/test-utils': link:../test-utils
       mocha: 10.2.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       cross-env: 7.0.3
       eslint: 8.50.0
@@ -10044,7 +10044,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/random-js': ^1.0.31
       best-random: ^1.0.0
       c8: ^7.7.1
@@ -10065,12 +10065,12 @@ importers:
     devDependencies:
       '@fluid-tools/benchmark': 0.48.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/random-js': 1.0.31
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -10093,7 +10093,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/test-driver-definitions': workspace:~
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       applicationinsights: ^2.1.9
       eslint: ~8.50.0
       prettier: ~3.0.3
@@ -10104,11 +10104,11 @@ importers:
       '@fluidframework/test-driver-definitions': link:../test-driver-definitions
       applicationinsights: 2.9.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       eslint: 8.50.0
       prettier: 3.0.3
       rimraf: 4.4.1
@@ -10173,7 +10173,7 @@ importers:
       '@fluidframework/tinylicious-driver': workspace:~
       '@fluidframework/tool-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       agentkeepalive: ^4.5.0
       axios: ^0.26.0
       c8: ^7.7.1
@@ -10207,12 +10207,12 @@ importers:
       semver: 7.5.4
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@types/node': 16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       eslint: 8.50.0
@@ -10271,7 +10271,7 @@ importers:
       '@fluidframework/undo-redo': workspace:~
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       c8: ^7.7.1
       cross-env: ^7.0.3
@@ -10343,13 +10343,13 @@ importers:
       url: 0.11.3
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 7.14.0
       eslint: 8.50.0
@@ -10370,7 +10370,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/random-js': ^1.0.31
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -10384,14 +10384,14 @@ importers:
     dependencies:
       random-js: 1.0.8
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/random-js': 1.0.31
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -10433,7 +10433,7 @@ importers:
       '@fluidframework/test-utils': workspace:~
       '@fluidframework/tool-utils': workspace:~
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       c8: ^7.7.1
       commander: ^5.1.0
       cross-env: ^7.0.3
@@ -10474,13 +10474,13 @@ importers:
       start-server-and-test: 1.15.5
       tinylicious: 2.0.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       cross-env: 7.0.3
       eslint: 8.50.0
@@ -10522,7 +10522,7 @@ importers:
       '@types/debug': ^4.1.5
       '@types/diff': ^3.5.1
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       best-random: ^1.0.0
       c8: ^7.7.1
@@ -10565,17 +10565,17 @@ importers:
       debug: 4.3.4
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
       '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/debug': 4.1.12
       '@types/diff': 3.5.8
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -10626,7 +10626,7 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
       '@types/nock': ^9.3.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/semver': ^7.5.0
       '@types/uuid': ^9.0.2
       c8: ^7.7.1
@@ -10679,15 +10679,15 @@ importers:
       proper-lockfile: 4.1.2
       semver: 7.5.4
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/semver': 7.5.6
       '@types/uuid': 9.0.7
       c8: 7.14.0
@@ -10800,7 +10800,7 @@ importers:
       '@types/jsdom': ^21.1.1
       '@types/jsdom-global': ^3.0.4
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/proxyquire': ^1.3.28
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
@@ -10858,7 +10858,7 @@ importers:
       '@fluid-experimental/react-inputs': link:../../../../experimental/framework/react-inputs
       '@fluidframework/aqueduct': link:../../../framework/aqueduct
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/container-definitions': link:../../../common/container-definitions
       '@fluidframework/container-loader': link:../../../loader/container-loader
       '@fluidframework/container-runtime-definitions': link:../../../runtime/container-runtime-definitions
@@ -10867,7 +10867,7 @@ importers:
       '@fluidframework/runtime-utils': link:../../../runtime/runtime-utils
       '@fluidframework/sequence': link:../../../dds/sequence
       '@fluidframework/test-utils': link:../../../test/test-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/chai': 4.3.11
       '@types/chrome': 0.0.232
       '@types/expect-puppeteer': 2.2.1
@@ -10876,7 +10876,7 @@ importers:
       '@types/jsdom': 21.1.6
       '@types/jsdom-global': 3.0.7
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/proxyquire': 1.3.31
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
@@ -10894,7 +10894,7 @@ importers:
       eslint-plugin-chai-expect: 3.0.0_eslint@8.50.0
       good-fences: 1.2.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-dev-server: 4.4.0
       jest-environment-puppeteer: 4.4.0
       jest-junit: 10.0.0
@@ -11041,7 +11041,7 @@ importers:
       '@testing-library/user-event': ^14.4.3
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
       '@types/testing-library__jest-dom': ^5.14.5
@@ -11103,17 +11103,17 @@ importers:
       scheduler: 0.20.2
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-utils': link:../../../test/test-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@testing-library/dom': 8.20.1
       '@testing-library/jest-dom': 5.17.0
       '@testing-library/react': 12.1.5_sfoxds7t5ydpegc3knd667wn6m
       '@testing-library/user-event': 14.5.1_szfc7t2zqsdonxwckqxkjn2the
       '@types/jest': 29.5.3
       '@types/jest-environment-puppeteer': 2.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       '@types/testing-library__jest-dom': 5.14.9
@@ -11124,7 +11124,7 @@ importers:
       eslint-plugin-react: 7.33.2_eslint@8.50.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.50.0
       html-webpack-plugin: 5.5.3_webpack@5.89.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-dev-server: 4.4.0
       jest-environment-jsdom: 29.7.0
       jest-junit: 10.0.0
@@ -11172,7 +11172,7 @@ importers:
       '@types/chai': ^4.0.0
       '@types/jest': 29.5.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
       '@types/recharts': ^1.8.24
@@ -11228,16 +11228,16 @@ importers:
       scheduler: 0.20.2
     devDependencies:
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../../test/mocha-test-setup
       '@fluidframework/shared-object-base': link:../../../dds/shared-object-base
       '@fluidframework/test-runtime-utils': link:../../../runtime/test-runtime-utils
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@previewjs/api': 13.0.0
-      '@previewjs/chromeless': 7.0.3_@types+node@16.18.65
-      '@previewjs/core': 23.0.1_@types+node@16.18.65
-      '@previewjs/plugin-react': 11.0.0_ngildvgwpwl47jfy3nxndwrvoa
+      '@previewjs/chromeless': 7.0.3_@types+node@18.19.1
+      '@previewjs/core': 23.0.1_@types+node@18.19.1
+      '@previewjs/plugin-react': 11.0.0_mfm7mnpb4icxq5kiedhdm45pzu
       '@testing-library/dom': 8.20.1
       '@testing-library/jest-dom': 5.17.0
       '@testing-library/react': 12.1.5_sfoxds7t5ydpegc3knd667wn6m
@@ -11245,7 +11245,7 @@ importers:
       '@types/chai': 4.3.11
       '@types/jest': 29.5.3
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
       '@types/recharts': 1.8.28
@@ -11261,7 +11261,7 @@ importers:
       eslint-plugin-react: 7.33.2_eslint@8.50.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.50.0
       globby: 13.2.2
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-junit: 10.0.0
       mocha: 10.2.0
       mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
@@ -11274,7 +11274,7 @@ importers:
       simple-git: 3.21.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       typescript: 5.1.6
-      vite: 4.5.0_@types+node@16.18.65
+      vite: 4.5.0_@types+node@18.19.1
 
   packages/tools/fetch-tool:
     specifiers:
@@ -11299,7 +11299,7 @@ importers:
       '@fluidframework/routerlicious-urlresolver': workspace:~
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/tool-utils': workspace:~
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       eslint: ~8.50.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
@@ -11322,12 +11322,12 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/tool-utils': link:../../utils/tool-utils
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.7.2.0
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       eslint: 8.50.0
       prettier: 3.0.3
       rimraf: 4.4.1
@@ -11350,7 +11350,7 @@ importers:
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/yargs': ^13
       c8: ^7.7.1
       cross-env: ^7.0.3
@@ -11376,14 +11376,14 @@ importers:
       json2csv: 5.0.7
       yargs: 13.2.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.7.2.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/yargs': 13.0.12
       c8: 7.14.0
       cross-env: 7.0.3
@@ -11431,7 +11431,7 @@ importers:
       '@fluidframework/tool-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/json-stable-stringify': ^1.0.32
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       json-stable-stringify: ^1.0.1
@@ -11468,13 +11468,13 @@ importers:
       '@fluidframework/tool-utils': link:../../utils/tool-utils
       json-stable-stringify: 1.1.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/json-stable-stringify': 1.0.36
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       copyfiles: 2.4.1
       eslint: 8.50.0
       prettier: 3.0.3
@@ -11510,7 +11510,7 @@ importers:
       '@types/express': ^4.11.0
       '@types/fs-extra': ^9.0.11
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       axios: ^0.26.0
       buffer: ^6.0.3
@@ -11563,16 +11563,16 @@ importers:
       uuid: 9.0.1
       webpack-dev-server: 4.6.0_wvskkfkvbt5crqa4uyjlq44kiy
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_odqn5ikgnr4m4a2pux7lzjasre
+      '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
       '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.2.0_wvskkfkvbt5crqa4uyjlq44kiy
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@types/express': 4.17.21
       '@types/fs-extra': 9.0.13
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 7.14.0
       cross-env: 7.0.3
@@ -11607,7 +11607,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/node-fetch': ^2.5.10
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -11631,15 +11631,15 @@ importers:
       '@fluidframework/telemetry-utils': link:../telemetry-utils
       node-fetch: 2.7.0
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/node-fetch': 2.6.9
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -11669,7 +11669,7 @@ importers:
       '@types/debug': ^4.1.5
       '@types/events': ^3.0.0
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -11695,17 +11695,17 @@ importers:
       events: 3.3.0
       uuid: 9.0.1
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/debug': 4.1.12
       '@types/events': 3.0.3
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 7.14.0
       copyfiles: 2.4.1
@@ -11736,7 +11736,7 @@ importers:
       '@types/debug': ^4.1.5
       '@types/jwt-decode': ^2.2.1
       '@types/mocha': ^9.1.1
-      '@types/node': ^16.18.38
+      '@types/node': ^18.19.0
       async-mutex: ^0.3.1
       c8: ^7.7.1
       copyfiles: ^2.4.1
@@ -11762,17 +11762,17 @@ importers:
       jwt-decode: 2.2.0
       proper-lockfile: 4.1.2
     devDependencies:
-      '@fluid-tools/build-cli': 0.28.0_dgt3pekvdbgd2jliwm43ktglpe
+      '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.7.2.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@types/debug': 4.1.12
       '@types/jwt-decode': 2.2.1
       '@types/mocha': 9.1.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       c8: 7.14.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -15526,71 +15526,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluid-tools/build-cli/0.28.0_dgt3pekvdbgd2jliwm43ktglpe:
-    resolution: {integrity: sha512-TwulWjE8GHj1fRgpr/9yifrmom94aoxRyYAHuL3dc2d58LbmB13nqVw9+HBLjiA1SnH4Ko/UvSreVIFYJi1GtQ==}
-    engines: {node: '>=14.17.0'}
-    hasBin: true
-    dependencies:
-      '@fluid-tools/version-tools': 0.28.0
-      '@fluidframework/build-tools': 0.28.0_@types+node@16.18.65
-      '@fluidframework/bundle-size-tools': 0.28.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
-      '@oclif/core': 2.4.0
-      '@oclif/plugin-autocomplete': 2.3.10
-      '@oclif/plugin-commands': 3.0.7
-      '@oclif/plugin-help': 6.0.7
-      '@oclif/plugin-not-found': 3.0.4
-      '@oclif/plugin-plugins': 3.9.4
-      '@oclif/test': 2.3.33
-      '@octokit/core': 4.2.4
-      '@rushstack/node-core-library': 3.61.0_@types+node@16.18.65
-      async: 3.2.5
-      chalk: 2.4.2
-      danger: 11.3.0
-      date-fns: 2.30.0
-      execa: 5.1.1
-      fs-extra: 9.1.0
-      globby: 11.1.0
-      gray-matter: 4.0.3
-      human-id: 4.1.0
-      inquirer: 8.2.6
-      jssm: 5.90.1
-      jssm-viz-cli: 5.90.1
-      latest-version: 5.1.0
-      minimatch: 7.4.6
-      node-fetch: 2.7.0
-      npm-check-updates: 16.14.11
-      oclif: 4.0.4_loebgezstcsvd2poh2d55fifke
-      prettier: 3.0.3
-      prompts: 2.4.2
-      read-pkg-up: 7.0.1
-      semver: 7.5.4
-      semver-utils: 1.1.4
-      simple-git: 3.21.0
-      sort-json: 2.0.1
-      sort-package-json: 1.57.0
-      strip-ansi: 6.0.1
-      table: 6.8.1
-      ts-morph: 17.0.1
-      type-fest: 2.19.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@types/node'
-      - astro-eslint-parser
-      - bluebird
-      - encoding
-      - esbuild
-      - eslint
-      - mem-fs
-      - supports-color
-      - svelte
-      - svelte-eslint-parser
-      - typescript
-      - uglify-js
-      - vue-eslint-parser
-      - webpack-cli
-    dev: true
-
   /@fluid-tools/build-cli/0.28.0_loebgezstcsvd2poh2d55fifke:
     resolution: {integrity: sha512-TwulWjE8GHj1fRgpr/9yifrmom94aoxRyYAHuL3dc2d58LbmB13nqVw9+HBLjiA1SnH4Ko/UvSreVIFYJi1GtQ==}
     engines: {node: '>=14.17.0'}
@@ -15656,15 +15591,15 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/build-cli/0.28.0_odqn5ikgnr4m4a2pux7lzjasre:
+  /@fluid-tools/build-cli/0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm:
     resolution: {integrity: sha512-TwulWjE8GHj1fRgpr/9yifrmom94aoxRyYAHuL3dc2d58LbmB13nqVw9+HBLjiA1SnH4Ko/UvSreVIFYJi1GtQ==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
       '@fluid-tools/version-tools': 0.28.0
-      '@fluidframework/build-tools': 0.28.0_5zfdhjqbashqwl2j3jeah6v2xm
+      '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/bundle-size-tools': 0.28.0_webpack-cli@4.10.0
-      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
       '@oclif/core': 2.4.0
       '@oclif/plugin-autocomplete': 2.3.10
       '@oclif/plugin-commands': 3.0.7
@@ -15673,7 +15608,72 @@ packages:
       '@oclif/plugin-plugins': 3.9.4
       '@oclif/test': 2.3.33
       '@octokit/core': 4.2.4
-      '@rushstack/node-core-library': 3.61.0_@types+node@16.18.65
+      '@rushstack/node-core-library': 3.61.0_@types+node@18.19.1
+      async: 3.2.5
+      chalk: 2.4.2
+      danger: 11.3.0
+      date-fns: 2.30.0
+      execa: 5.1.1
+      fs-extra: 9.1.0
+      globby: 11.1.0
+      gray-matter: 4.0.3
+      human-id: 4.1.0
+      inquirer: 8.2.6
+      jssm: 5.90.1
+      jssm-viz-cli: 5.90.1
+      latest-version: 5.1.0
+      minimatch: 7.4.6
+      node-fetch: 2.7.0
+      npm-check-updates: 16.14.11
+      oclif: 4.0.4_loebgezstcsvd2poh2d55fifke
+      prettier: 3.0.3
+      prompts: 2.4.2
+      read-pkg-up: 7.0.1
+      semver: 7.5.4
+      semver-utils: 1.1.4
+      simple-git: 3.21.0
+      sort-json: 2.0.1
+      sort-package-json: 1.57.0
+      strip-ansi: 6.0.1
+      table: 6.8.1
+      ts-morph: 17.0.1
+      type-fest: 2.19.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@types/node'
+      - astro-eslint-parser
+      - bluebird
+      - encoding
+      - esbuild
+      - eslint
+      - mem-fs
+      - supports-color
+      - svelte
+      - svelte-eslint-parser
+      - typescript
+      - uglify-js
+      - vue-eslint-parser
+      - webpack-cli
+    dev: true
+
+  /@fluid-tools/build-cli/0.28.0_mhw3tufvtaceew37hrkkevjcli:
+    resolution: {integrity: sha512-TwulWjE8GHj1fRgpr/9yifrmom94aoxRyYAHuL3dc2d58LbmB13nqVw9+HBLjiA1SnH4Ko/UvSreVIFYJi1GtQ==}
+    engines: {node: '>=14.17.0'}
+    hasBin: true
+    dependencies:
+      '@fluid-tools/version-tools': 0.28.0
+      '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
+      '@fluidframework/bundle-size-tools': 0.28.0
+      '@microsoft/api-extractor': 7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1
+      '@oclif/core': 2.4.0
+      '@oclif/plugin-autocomplete': 2.3.10
+      '@oclif/plugin-commands': 3.0.7
+      '@oclif/plugin-help': 6.0.7
+      '@oclif/plugin-not-found': 3.0.4
+      '@oclif/plugin-plugins': 3.9.4
+      '@oclif/test': 2.3.33
+      '@octokit/core': 4.2.4
+      '@rushstack/node-core-library': 3.61.0_@types+node@18.19.1
       async: 3.2.5
       chalk: 2.4.2
       danger: 11.3.0
@@ -16010,16 +16010,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/build-tools/0.28.0_5zfdhjqbashqwl2j3jeah6v2xm:
+  /@fluidframework/build-tools/0.28.0_@types+node@18.19.1:
     resolution: {integrity: sha512-Fh3R9aogjl2+UbZBewWfGd26vZdJDu85u6xRqv2mESGivrNodDk/IOIs8jlBTyeH9Y2lh/HK94PbVctB0pbG7A==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
       '@fluid-tools/version-tools': 0.28.0
-      '@fluidframework/bundle-size-tools': 0.28.0_webpack-cli@4.10.0
+      '@fluidframework/bundle-size-tools': 0.28.0
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
-      '@rushstack/node-core-library': 3.61.0_@types+node@16.18.65
+      '@rushstack/node-core-library': 3.61.0_@types+node@18.19.1
       async: 3.2.5
       chalk: 2.4.2
       cosmiconfig: 8.3.6_typescript@5.1.6
@@ -16053,16 +16053,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/build-tools/0.28.0_@types+node@16.18.65:
+  /@fluidframework/build-tools/0.28.0_h467wi3sy6j67ifywrn7x7qf4m:
     resolution: {integrity: sha512-Fh3R9aogjl2+UbZBewWfGd26vZdJDu85u6xRqv2mESGivrNodDk/IOIs8jlBTyeH9Y2lh/HK94PbVctB0pbG7A==}
     engines: {node: '>=14.17.0'}
     hasBin: true
     dependencies:
       '@fluid-tools/version-tools': 0.28.0
-      '@fluidframework/bundle-size-tools': 0.28.0
+      '@fluidframework/bundle-size-tools': 0.28.0_webpack-cli@4.10.0
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
-      '@rushstack/node-core-library': 3.61.0_@types+node@16.18.65
+      '@rushstack/node-core-library': 3.61.0_@types+node@18.19.1
       async: 3.2.5
       chalk: 2.4.2
       cosmiconfig: 8.3.6_typescript@5.1.6
@@ -17631,7 +17631,7 @@ packages:
       '@types/debug': 4.1.12
       '@types/double-ended-queue': 2.1.7
       '@types/lodash': 4.14.202
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/ws': 6.0.4
       assert: 2.1.0
       debug: 4.3.4
@@ -17674,7 +17674,7 @@ packages:
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-telemetry': 2.0.2
       '@types/nconf': 0.10.6
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       debug: 4.3.4
       events: 3.3.0
       nconf: 0.12.1
@@ -18170,7 +18170,7 @@ packages:
       debug: 4.3.4
       globrex: 0.1.2
       tsconfck: 2.1.2_typescript@5.1.6
-      vite: 4.5.0_@types+node@16.18.65
+      vite: 4.5.0_@types+node@18.19.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -18344,7 +18344,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -18365,14 +18365,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0_@types+node@16.18.65
+      jest-config: 29.7.0_@types+node@18.19.1
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -18408,14 +18408,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0_zcphfowolnmvjsbjiiyfg3ai2q
+      jest-config: 29.7.0_5hr63yjncn3tlo6qh7e6tsd2me
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -18443,7 +18443,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       jest-mock: 27.5.1
     dev: true
 
@@ -18453,7 +18453,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       jest-mock: 29.7.0
     dev: true
 
@@ -18480,7 +18480,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -18492,7 +18492,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -18525,7 +18525,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.20
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -18644,7 +18644,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/yargs': 15.0.19
       chalk: 4.1.2
     dev: true
@@ -18655,7 +18655,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/yargs': 16.0.9
       chalk: 4.1.2
     dev: true
@@ -18667,7 +18667,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: true
@@ -18730,7 +18730,7 @@ packages:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
       '@babel/runtime': 7.23.4
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       find-up: 4.1.0
       fs-extra: 8.1.0
     dev: true
@@ -19098,12 +19098,12 @@ packages:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor-model/7.28.2_@types+node@16.18.65:
+  /@microsoft/api-extractor-model/7.28.2_@types+node@18.19.1:
     resolution: {integrity: sha512-vkojrM2fo3q4n4oPh4uUZdjJ2DxQ2+RnDQL/xhTWSRUNPF6P4QyrvY357HBxbnltKcYu+nNNolVqc6TIGQ73Ig==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.61.0_@types+node@16.18.65
+      '@rushstack/node-core-library': 3.61.0_@types+node@18.19.1
     transitivePeerDependencies:
       - '@types/node'
     dev: true
@@ -19129,14 +19129,14 @@ packages:
     dev: true
     patched: true
 
-  /@microsoft/api-extractor/7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@16.18.65:
+  /@microsoft/api-extractor/7.38.3_p4gemz6xo2owxftfuvjusnappy_@types+node@18.19.1:
     resolution: {integrity: sha512-xt9iYyC5f39281j77JTA9C3ISJpW1XWkCcnw+2vM78CPnro6KhPfwQdPDfwS5JCPNuq0grm8cMdPUOPvrchDWw==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.2_@types+node@16.18.65
+      '@microsoft/api-extractor-model': 7.28.2_@types+node@18.19.1
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.61.0_@types+node@16.18.65
+      '@rushstack/node-core-library': 3.61.0_@types+node@18.19.1
       '@rushstack/rig-package': 0.5.1
       '@rushstack/ts-command-line': 4.17.1
       colors: 1.2.5
@@ -20015,11 +20015,11 @@ packages:
       - debug
     dev: true
 
-  /@previewjs/chromeless/7.0.3_@types+node@16.18.65:
+  /@previewjs/chromeless/7.0.3_@types+node@18.19.1:
     resolution: {integrity: sha512-KuO9U58uj0JPGjN1EcE3RanYcn1Vdd9FIHXL0h/zxH+hAkFRVvmeL3MMfBz7zWA0oKIDfAy7/0jhdgF2GLj1wg==}
     dependencies:
       '@previewjs/api': 13.0.0
-      '@previewjs/core': 23.0.1_@types+node@16.18.65
+      '@previewjs/core': 23.0.1_@types+node@18.19.1
       '@previewjs/iframe': 11.0.1
       '@previewjs/properties': 3.0.3
       '@previewjs/vfs': 2.1.0
@@ -20046,7 +20046,7 @@ packages:
     resolution: {integrity: sha512-31C3JyfBYysfG+LE5E6bVaemqx2H+mXuKsbWXiRaVu6n8C+CnHh725t/U+WHOn1eVFuS041FauhtRaNHxoi2tg==}
     dev: true
 
-  /@previewjs/core/23.0.1_@types+node@16.18.65:
+  /@previewjs/core/23.0.1_@types+node@18.19.1:
     resolution: {integrity: sha512-WBbZMzDOsnsDdKXFi2zOSw0RpBp496zCYc56g4YskQikdS8A48UlBEE1oO8OOFHK4wwbVTH2HQ46ordDKyczBA==}
     dependencies:
       '@fwouts/vite-tsconfig-paths': 4.2.1_ah7snkqdiegnosaxffkwmchslm
@@ -20068,10 +20068,10 @@ packages:
       http-terminator: 3.2.0
       pino: 8.16.2
       rollup-plugin-friendly-type-imports: 1.0.3
-      ts-node: 10.9.1_jnhzrdmjzh6qsf7xvhnyy55kui
+      ts-node: 10.9.1_ggysxzqxruqvydtrq6zb2nxvwm
       tsconfig-paths: 4.2.0
       typescript: 5.1.6
-      vite: 4.5.0_@types+node@16.18.65
+      vite: 4.5.0_@types+node@18.19.1
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -20090,12 +20090,12 @@ packages:
     resolution: {integrity: sha512-VJrzAzQotZnH9uLRJsgdukwcYVJBBCyzg7V2ucLTGPJNyuPY0XI4AUcfVBpFI2kwgVZWh8bmumj+2NAIUK0Vsw==}
     dev: true
 
-  /@previewjs/plugin-react/11.0.0_ngildvgwpwl47jfy3nxndwrvoa:
+  /@previewjs/plugin-react/11.0.0_mfm7mnpb4icxq5kiedhdm45pzu:
     resolution: {integrity: sha512-0394TdKvoqtsNgsj8p7TeQLkhJQI/dWd6tIAc+9yijNIN2XmFBzLiPsnY1/LWOfi0RR+8meGC9QaBM9MuMVqQw==}
     dependencies:
       '@previewjs/api': 13.0.0
       '@previewjs/serializable-values': 7.0.3
-      '@previewjs/storybook-helpers': 3.0.0_@types+node@16.18.65
+      '@previewjs/storybook-helpers': 3.0.0_@types+node@18.19.1
       '@previewjs/type-analyzer': 8.0.2
       '@previewjs/vfs': 2.1.0
       '@vitejs/plugin-react': 4.2.0_vite@4.5.0
@@ -20132,11 +20132,11 @@ packages:
       typescript: 5.1.6
     dev: true
 
-  /@previewjs/storybook-helpers/3.0.0_@types+node@16.18.65:
+  /@previewjs/storybook-helpers/3.0.0_@types+node@18.19.1:
     resolution: {integrity: sha512-u/FyVXKOWDU11mel0wEaY9zTSU5h9ULNovTTTBtTPXY6iHNL2DzqwzKWvHl/5ch96roNfIXpAtglWcxTDN1z6Q==}
     dependencies:
       '@previewjs/api': 13.0.0
-      '@previewjs/core': 23.0.1_@types+node@16.18.65
+      '@previewjs/core': 23.0.1_@types+node@18.19.1
       '@previewjs/serializable-values': 7.0.3
       '@previewjs/type-analyzer': 8.0.2
       typescript: 5.1.6
@@ -20228,7 +20228,7 @@ packages:
       z-schema: 5.0.5
     dev: true
 
-  /@rushstack/node-core-library/3.61.0_@types+node@16.18.65:
+  /@rushstack/node-core-library/3.61.0_@types+node@18.19.1:
     resolution: {integrity: sha512-tdOjdErme+/YOu4gPed3sFS72GhtWCgNV9oDsHDnoLY5oDfwjKUc9Z+JOZZ37uAxcm/OCahDHfuu2ugqrfWAVQ==}
     peerDependencies:
       '@types/node': '*'
@@ -20236,7 +20236,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       colors: 1.2.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
@@ -20823,7 +20823,7 @@ packages:
       '@storybook/store': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/theming': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/ui': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/webpack': 4.41.38
       autoprefixer: 9.8.8
       babel-loader: 8.3.0_lszqs7mecrjwx3zyaab7kt6jhi
@@ -20891,7 +20891,7 @@ packages:
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/theming': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       babel-loader: 8.3.0_rwp5n2556mrumtrwbeu2k2rar4
       babel-plugin-named-exports-order: 0.0.2
       browser-assert: 1.2.1
@@ -21120,7 +21120,7 @@ packages:
       '@babel/register': 7.22.15_@babel+core@7.23.3
       '@storybook/node-logger': 6.5.16
       '@storybook/semver': 7.3.2
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/pretty-hrtime': 1.0.3
       babel-loader: 8.3.0_lszqs7mecrjwx3zyaab7kt6jhi
       babel-plugin-macros: 3.1.0
@@ -21193,7 +21193,7 @@ packages:
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/telemetry': 6.5.16_3ls3x4cyx7vazwgunpof2kmgs4
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/node-fetch': 2.6.9
       '@types/pretty-hrtime': 1.0.3
       '@types/webpack': 4.41.38
@@ -21347,7 +21347,7 @@ packages:
       '@storybook/node-logger': 6.5.16
       '@storybook/theming': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/ui': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/webpack': 4.41.38
       babel-loader: 8.3.0_lszqs7mecrjwx3zyaab7kt6jhi
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -21405,7 +21405,7 @@ packages:
       '@storybook/node-logger': 6.5.16
       '@storybook/theming': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/ui': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       babel-loader: 8.3.0_rwp5n2556mrumtrwbeu2k2rar4
       case-sensitive-paths-webpack-plugin: 2.4.0
       chalk: 4.1.2
@@ -21568,7 +21568,7 @@ packages:
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.16_sfoxds7t5ydpegc3knd667wn6m
       '@types/estree': 0.0.51
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/webpack-env': 1.18.4
       acorn: 7.4.1
       acorn-jsx: 5.3.2_acorn@7.4.1
@@ -21998,14 +21998,14 @@ packages:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
 
   /@types/cacheable-request/6.0.3:
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/responselike': 1.0.3
     dev: true
 
@@ -22016,7 +22016,7 @@ packages:
   /@types/cheerio/0.22.31:
     resolution: {integrity: sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/chrome/0.0.232:
@@ -22029,7 +22029,7 @@ packages:
   /@types/cli-progress/3.11.5:
     resolution: {integrity: sha512-D4PbNRbviKyppS5ivBGyFO29POlySLmA2HyUFE4p5QGazAMM3CwkKWcvTl8gvElSuxRh6FPKL8XmidX873ou4g==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
 
   /@types/codemirror/5.60.7:
     resolution: {integrity: sha512-QXIC+RPzt/1BGSuD6iFn6UMC9TDp+9hkOANYNPVsjjrDdzKphfRkwQDKGp2YaC54Yhz0g6P5uYTCCibZZEiMAA==}
@@ -22040,13 +22040,13 @@ packages:
   /@types/concat-stream/1.6.1:
     resolution: {integrity: sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/connect/3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
 
   /@types/cookie/0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
@@ -22054,7 +22054,7 @@ packages:
   /@types/cors/2.8.17:
     resolution: {integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
 
   /@types/d3-array/3.2.1:
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
@@ -22167,7 +22167,7 @@ packages:
   /@types/express-serve-static-core/4.17.41:
     resolution: {integrity: sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/qs': 6.9.10
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -22193,39 +22193,39 @@ packages:
   /@types/form-data/0.0.33:
     resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/fs-extra/5.1.0:
     resolution: {integrity: sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/glob/7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/glob/8.1.0:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/graceful-fs/4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/handlebars/4.1.0:
@@ -22267,7 +22267,7 @@ packages:
   /@types/http-proxy/1.17.14:
     resolution: {integrity: sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
 
   /@types/is-ci/3.0.4:
     resolution: {integrity: sha512-AkCYCmwlXeuH89DagDCzvCAyltI2v9lh3U3DqSg/GrBYoReAaWwxfXCqMx9UV5MajLZ4ZFwZzV4cABGIxk2XRw==}
@@ -22328,7 +22328,7 @@ packages:
   /@types/jsdom/20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/tough-cookie': 4.0.5
       parse5: 7.1.2
     dev: true
@@ -22336,7 +22336,7 @@ packages:
   /@types/jsdom/21.1.6:
     resolution: {integrity: sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/tough-cookie': 4.0.5
       parse5: 7.1.2
     dev: true
@@ -22363,13 +22363,13 @@ packages:
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/loader-utils/1.1.9:
     resolution: {integrity: sha512-2NrfPIjGI8ZuEBtMQHQ71Rf+dyZayiuf4EyJYBTvh5fbNLAmQ7AIpjbPRJ5CXEBJVfSgtoi02pI/yNaVAgxMYg==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/webpack': 4.41.38
     dev: true
 
@@ -22431,18 +22431,20 @@ packages:
   /@types/nock/9.3.1:
     resolution: {integrity: sha512-eOVHXS5RnWOjTVhu3deCM/ruy9E6JCgeix2g7wpFiekQh3AaEAK1cz43tZDukKmtSmQnwvSySq7ubijCA32I7Q==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/node-fetch/2.6.9:
     resolution: {integrity: sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       form-data: 4.0.0
     dev: true
 
-  /@types/node/16.18.65:
-    resolution: {integrity: sha512-5E9WgTy95B7i90oISjui9U5Zu7iExUPfU4ygtv4yXEy6zJFE3oQYHCnh5H1jZRPkjphJt2Ml3oQW6M0qtK534A==}
+  /@types/node/18.19.1:
+    resolution: {integrity: sha512-mZJ9V11gG5Vp0Ox2oERpeFDl+JvCwK24PGy76vVY/UgBtjwJWc5rYBThFxmbnYOm9UPZNm6wEl/sxHt2SU7x9A==}
+    dependencies:
+      undici-types: 5.26.5
 
   /@types/normalize-package-data/2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -22451,7 +22453,7 @@ packages:
   /@types/npmlog/4.1.6:
     resolution: {integrity: sha512-0l3z16vnlJGl2Mi/rgJFrdwfLZ4jfNYgE6ZShEpjqhHuGTqdEzNles03NpYHwUMVYZa+Tj46UxKIEpE78lQ3DQ==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/orderedmap/1.0.0:
@@ -22505,7 +22507,7 @@ packages:
     resolution: {integrity: sha512-kp1R8cTYymvYezTYWSECtSEDbxnCQaNe3i+fdsZh3dVz7umB8q6LATv0VdJp1DT0evS8YqCrFI5+DaDYJYo6Vg==}
     dependencies:
       '@types/events': 3.0.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/q/1.5.8:
@@ -22550,7 +22552,7 @@ packages:
   /@types/responselike/1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/retry/0.12.0:
@@ -22570,26 +22572,26 @@ packages:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
 
   /@types/serve-static/1.15.5:
     resolution: {integrity: sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==}
     dependencies:
       '@types/http-errors': 2.0.4
       '@types/mime': 3.0.4
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
 
   /@types/sha.js/2.4.4:
     resolution: {integrity: sha512-Qukd+D6S2Hm0wLVt2Vh+/eWBIoUt+wF8jWjBsG4F8EFQRwKtYvtXCPcNl2OEUQ1R+eTr3xuSaBYUyM3WD1x/Qw==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/shelljs/0.8.15:
     resolution: {integrity: sha512-vzmnCHl6hViPu9GNLQJ+DZFd6BQI2DBTUeOvYHqkWQLMfKAAQYMb/xAmZkTogZI/vqXHCWkqDRymDI5p0QTi5Q==}
     dependencies:
       '@types/glob': 7.2.0
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/shimmer/1.0.5:
@@ -22676,7 +22678,7 @@ packages:
     resolution: {integrity: sha512-vPXzCLmRp74e9LsP8oltnWKTH+jBwt86WgRUb4Pc9Lf3pkMVGyvIo2gm9bODeGfCay2DBB/hAWDuvf07JcK4rw==}
     dependencies:
       '@types/expect': 1.20.4
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /@types/webpack-env/1.18.4:
@@ -22686,7 +22688,7 @@ packages:
   /@types/webpack-sources/3.2.3:
     resolution: {integrity: sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/source-list-map': 0.1.6
       source-map: 0.7.4
     dev: true
@@ -22694,7 +22696,7 @@ packages:
   /@types/webpack/4.41.38:
     resolution: {integrity: sha512-oOW7E931XJU1mVfCnxCVgv8GLFL768pDO5u2Gzk82i8yTIgX6i7cntyZOkZYb/JtYM8252SN9bQp9tgkVDSsRw==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/tapable': 1.0.12
       '@types/uglify-js': 3.17.4
       '@types/webpack-sources': 3.2.3
@@ -22705,7 +22707,7 @@ packages:
   /@types/ws/6.0.4:
     resolution: {integrity: sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
 
   /@types/yargs-parser/21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -22739,7 +22741,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
     optional: true
 
@@ -23086,7 +23088,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3_@babel+core@7.23.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 4.5.0_@types+node@16.18.65
+      vite: 4.5.0_@types+node@18.19.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -25678,7 +25680,7 @@ packages:
   /chrome-launcher/0.11.2:
     resolution: {integrity: sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
       mkdirp: 0.5.1
@@ -26624,7 +26626,7 @@ packages:
       - ts-node
     dev: true
 
-  /create-jest/29.7.0_@types+node@16.18.65:
+  /create-jest/29.7.0_5hr63yjncn3tlo6qh7e6tsd2me:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -26633,7 +26635,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0_@types+node@16.18.65
+      jest-config: 29.7.0_5hr63yjncn3tlo6qh7e6tsd2me
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -26643,7 +26645,7 @@ packages:
       - ts-node
     dev: true
 
-  /create-jest/29.7.0_zcphfowolnmvjsbjiiyfg3ai2q:
+  /create-jest/29.7.0_@types+node@18.19.1:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -26652,7 +26654,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0_zcphfowolnmvjsbjiiyfg3ai2q
+      jest-config: 29.7.0_@types+node@18.19.1
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -28028,7 +28030,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.17
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -29335,7 +29337,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.11
       '@types/lodash': 4.14.202
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/sinon': 7.5.2
       lodash: 4.17.21
       mock-stdin: 1.0.0
@@ -31366,7 +31368,7 @@ packages:
   /http-response-object/3.0.2:
     resolution: {integrity: sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /http-signature/1.2.0:
@@ -32626,7 +32628,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -32675,35 +32677,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-cli/29.7.0_@types+node@16.18.65:
-    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0_@types+node@16.18.65
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0_@types+node@16.18.65
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
-  /jest-cli/29.7.0_zcphfowolnmvjsbjiiyfg3ai2q:
+  /jest-cli/29.7.0_5hr63yjncn3tlo6qh7e6tsd2me:
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -32717,10 +32691,38 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0_zcphfowolnmvjsbjiiyfg3ai2q
+      create-jest: 29.7.0_5hr63yjncn3tlo6qh7e6tsd2me
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0_zcphfowolnmvjsbjiiyfg3ai2q
+      jest-config: 29.7.0_5hr63yjncn3tlo6qh7e6tsd2me
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
+  /jest-cli/29.7.0_@types+node@18.19.1:
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0_@types+node@18.19.1
+      exit: 0.1.2
+      import-local: 3.1.0
+      jest-config: 29.7.0_@types+node@18.19.1
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -32770,7 +32772,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-config/29.7.0_@types+node@16.18.65:
+  /jest-config/29.7.0_5hr63yjncn3tlo6qh7e6tsd2me:
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -32785,7 +32787,7 @@ packages:
       '@babel/core': 7.23.3
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       babel-jest: 29.7.0_@babel+core@7.23.3
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -32805,12 +32807,13 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
+      ts-node: 10.9.1_ggysxzqxruqvydtrq6zb2nxvwm
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
     dev: true
 
-  /jest-config/29.7.0_zcphfowolnmvjsbjiiyfg3ai2q:
+  /jest-config/29.7.0_@types+node@18.19.1:
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -32825,7 +32828,7 @@ packages:
       '@babel/core': 7.23.3
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       babel-jest: 29.7.0_@babel+core@7.23.3
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -32845,7 +32848,6 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_jnhzrdmjzh6qsf7xvhnyy55kui
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -32936,7 +32938,7 @@ packages:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -32953,7 +32955,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -32965,7 +32967,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -33023,7 +33025,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.9
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -33046,7 +33048,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -33123,7 +33125,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
     dev: true
 
   /jest-mock/29.7.0:
@@ -33131,7 +33133,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       jest-util: 29.7.0
     dev: true
 
@@ -33217,7 +33219,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -33248,7 +33250,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       chalk: 4.1.2
       cjs-module-lexer: 1.2.3
       collect-v8-coverage: 1.0.2
@@ -33271,7 +33273,7 @@ packages:
     resolution: {integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       graceful-fs: 4.2.11
     dev: true
 
@@ -33312,7 +33314,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       chalk: 4.1.2
       graceful-fs: 4.2.11
       is-ci: 2.0.0
@@ -33324,7 +33326,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -33336,7 +33338,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -33373,7 +33375,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -33385,7 +33387,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -33394,7 +33396,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -33402,7 +33404,7 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -33429,28 +33431,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest/29.7.0_@types+node@16.18.65:
-    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0_@types+node@16.18.65
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
-  /jest/29.7.0_zcphfowolnmvjsbjiiyfg3ai2q:
+  /jest/29.7.0_5hr63yjncn3tlo6qh7e6tsd2me:
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -33463,7 +33444,28 @@ packages:
       '@jest/core': 29.7.0_ts-node@10.9.1
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0_zcphfowolnmvjsbjiiyfg3ai2q
+      jest-cli: 29.7.0_5hr63yjncn3tlo6qh7e6tsd2me
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
+  /jest/29.7.0_@types+node@18.19.1:
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.1.0
+      jest-cli: 29.7.0_@types+node@18.19.1
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -35162,7 +35164,7 @@ packages:
     resolution: {integrity: sha512-GftCCBs6EN8sz3BoWO1bCj8t7YBtT713d8bUgbhg9Iel5kFSqnSvCK06TYIDJAtJ51cSiWkM/YemlT0dfoFycw==}
     engines: {node: '>=12'}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/vinyl': 2.0.11
       vinyl: 2.2.1
       vinyl-file: 3.0.0
@@ -40959,7 +40961,7 @@ packages:
     resolution: {integrity: sha512-9/5CApkKKl6bS6jJ2D0DQllwz/1xq3cyJCR6DLgAQnkj5djCuq8NbflEdD2TI01p8qzS9qaKjzxM9cHT11ezmg==}
     engines: {node: '>=5.0'}
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       image-ssim: 0.2.0
       jpeg-js: 0.1.2
     dev: true
@@ -41961,7 +41963,7 @@ packages:
     dependencies:
       '@types/concat-stream': 1.6.1
       '@types/form-data': 0.0.33
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       '@types/qs': 6.9.10
       caseless: 0.12.0
       concat-stream: 1.6.2
@@ -42276,7 +42278,7 @@ packages:
       '@babel/core': 7.23.3
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -42309,7 +42311,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0_@types+node@16.18.65
+      jest: 29.7.0_@types+node@18.19.1
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -42342,7 +42344,7 @@ packages:
       code-block-writer: 11.0.3
     dev: true
 
-  /ts-node/10.9.1_jnhzrdmjzh6qsf7xvhnyy55kui:
+  /ts-node/10.9.1_ggysxzqxruqvydtrq6zb2nxvwm:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -42363,7 +42365,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       acorn: 8.11.2
       acorn-walk: 8.3.0
       arg: 4.1.3
@@ -42823,6 +42825,9 @@ packages:
 
   /underscore/1.13.6:
     resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
+
+  /undici-types/5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   /unfetch/4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
@@ -43499,7 +43504,7 @@ packages:
       replace-ext: 1.0.1
     dev: true
 
-  /vite/4.5.0_@types+node@16.18.65:
+  /vite/4.5.0_@types+node@18.19.1:
     resolution: {integrity: sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -43527,7 +43532,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 16.18.65
+      '@types/node': 18.19.1
       esbuild: 0.18.20
       postcss: 8.4.31
       rollup: 3.29.4


### PR DESCRIPTION
client packages are set to ^18 dependencies

Within repo any node types dependencies <18 are overridden to ^18.