### PR TITLE
Tag protocol-definitions and server types necessary for IQuorum to be alpha

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -175,7 +175,7 @@ export interface INackContent {
     type: NackErrorType;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IProcessMessageResult {
     // (undocumented)
     immediateNoOp?: boolean;
@@ -201,7 +201,7 @@ export interface IProtocolState {
     values: [string, ICommittedProposal][];
 }
 
-// @internal
+// @alpha
 export interface IQuorum extends Omit<IQuorumClients, "on" | "once" | "off">, Omit<IQuorumProposals, "on" | "once" | "off"> {
     // (undocumented)
     off: IQuorum["on"];
@@ -242,7 +242,7 @@ export interface IQuorumClientsEvents {
 // @internal @deprecated
 export type IQuorumEvents = IQuorumClientsEvents & IQuorumProposalsEvents;
 
-// @internal
+// @alpha
 export interface IQuorumProposals {
     // (undocumented)
     get(key: string): unknown;

--- a/common/lib/protocol-definitions/src/consensus.ts
+++ b/common/lib/protocol-definitions/src/consensus.ts
@@ -101,7 +101,7 @@ export interface IQuorumClients {
 
 /**
  * Interface for tracking proposals in the Quorum.
- * @internal
+ * @alpha
  */
 export interface IQuorumProposals {
 	propose(key: string, value: unknown): Promise<void>;
@@ -128,7 +128,7 @@ export interface IQuorumProposals {
 
 /**
  * Interface combining tracking of clients as well as proposals in the Quorum.
- * @internal
+ * @alpha
  */
 export interface IQuorum
 	extends Omit<IQuorumClients, "on" | "once" | "off">,
@@ -150,7 +150,7 @@ export interface IProtocolState {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IProcessMessageResult {
 	immediateNoOp?: boolean;


### PR DESCRIPTION
This PR is preparation for changing the tagging on the IQuorum to be alpha. All these types were automatically identified as transitive dependency of the IQuorum class which will be made alpha in a later review.

We will stage these commits and invite review, however review items will generally be added to the backlog as future items, as these type updates are necessary for the current state of the code base.

