### PR TITLE
Tag the Loader class alpha

### DIFF
--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -388,7 +388,7 @@ export interface IGetPendingLocalStateProps {
     readonly stopBlobAttachingSignal?: AbortSignal;
 }
 
-// @internal
+// @alpha
 export interface IHostLoader extends ILoader {
     createDetachedContainer(codeDetails: IFluidCodeDetails, createDetachedProps?: {
         canReconnect?: boolean;

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -541,7 +541,7 @@ export interface ILoader extends Partial<IProvideLoader> {
 
 /**
  * The Host's view of the Loader, used for loading Containers
- * @internal
+ * @alpha
  */
 export interface IHostLoader extends ILoader {
 	/**

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @internal
+// @alpha
 export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
 
 // @alpha
@@ -33,7 +33,7 @@ export type FluidObjectKeys<T> = keyof FluidObject<T>;
 // @alpha
 export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string extends TProp ? never : number extends TProp ? never : TProp extends keyof Required<T>[TProp] ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] ? TProp : never : never;
 
-// @internal
+// @alpha
 export interface IConfigProviderBase {
     getRawConfig(name: string): ConfigTypes;
 }

--- a/packages/common/core-interfaces/src/config.ts
+++ b/packages/common/core-interfaces/src/config.ts
@@ -5,13 +5,13 @@
 
 /**
  * Types supported by {@link IConfigProviderBase}.
- * @internal
+ * @alpha
  */
 export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
 
 /**
  * Base interface for providing configurations to enable/disable/control features.
- * @internal
+ * @alpha
  */
 export interface IConfigProviderBase {
 	/**

--- a/packages/loader/container-loader/api-report/container-loader.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.api.md
@@ -7,7 +7,7 @@
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { IAudienceOwner } from '@fluidframework/container-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
-import { IConfigProviderBase } from '@fluidframework/telemetry-utils';
+import { IConfigProviderBase } from '@fluidframework/core-interfaces';
 import { IContainer } from '@fluidframework/container-definitions';
 import { IDocumentAttributes } from '@fluidframework/protocol-definitions';
 import { IDocumentServiceFactory } from '@fluidframework/driver-definitions';
@@ -37,7 +37,7 @@ export enum ConnectionState {
     EstablishingConnection = 3
 }
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {
     load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
 }
@@ -48,25 +48,25 @@ export interface IContainerExperimental extends IContainer {
     getPendingLocalState?(): Promise<string>;
 }
 
-// @internal
+// @alpha
 export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | "readBlob"> & {
     size: number;
     getBlobIds(): string[];
 };
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export interface IFluidModuleWithDetails {
     details: IFluidCodeDetails;
     module: IFluidModule;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ILoaderOptions extends ILoaderOptions_2 {
     // (undocumented)
     summarizeProtocolTree?: boolean;
 }
 
-// @internal
+// @alpha
 export interface ILoaderProps {
     readonly codeLoader: ICodeDetailsLoader;
     readonly configProvider?: IConfigProviderBase;
@@ -79,7 +79,7 @@ export interface ILoaderProps {
     readonly urlResolver: IUrlResolver;
 }
 
-// @internal
+// @alpha
 export interface ILoaderServices {
     readonly codeLoader: ICodeDetailsLoader;
     readonly detachedBlobStorage?: IDetachedBlobStorage;
@@ -99,7 +99,7 @@ export interface IParsedUrl {
     version: string | null | undefined;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IProtocolHandler extends IProtocolHandler_2 {
     // (undocumented)
     readonly audience: IAudienceOwner;
@@ -110,7 +110,7 @@ export interface IProtocolHandler extends IProtocolHandler_2 {
 // @internal
 export function isLocationRedirectionError(error: any): error is ILocationRedirectionError;
 
-// @internal
+// @alpha
 export class Loader implements IHostLoader {
     constructor(loaderProps: ILoaderProps);
     // (undocumented)
@@ -133,7 +133,7 @@ export class Loader implements IHostLoader {
     readonly services: ILoaderServices;
 }
 
-// @internal
+// @alpha
 export type ProtocolHandlerBuilder = (attributes: IDocumentAttributes, snapshot: IQuorumSnapshot, sendProposal: (key: string, value: any) => number) => IProtocolHandler;
 
 // @internal @deprecated

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -6,7 +6,6 @@
 import { v4 as uuid } from "uuid";
 import {
 	ITelemetryLoggerExt,
-	IConfigProviderBase,
 	mixinMonitoringContext,
 	MonitoringContext,
 	PerformanceEvent,
@@ -22,6 +21,7 @@ import {
 	IRequest,
 	IRequestHeader,
 	IResponse,
+	IConfigProviderBase,
 } from "@fluidframework/core-interfaces";
 import {
 	IContainer,
@@ -114,7 +114,7 @@ export class RelativeLoader implements ILoader {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ILoaderOptions extends ILoaderOptions1 {
 	summarizeProtocolTree?: boolean;
@@ -125,7 +125,7 @@ export interface ILoaderOptions extends ILoaderOptions1 {
  * {@link @fluidframework/container-definitions#IFluidModuleWithDetails}
  * to have all the code loading modules in one package. #8193
  * Encapsulates a module entry point with corresponding code details.
- * @internal
+ * @alpha
  */
 export interface IFluidModuleWithDetails {
 	/** Fluid code module that implements the runtime factory needed to instantiate the container runtime. */
@@ -143,7 +143,7 @@ export interface IFluidModuleWithDetails {
  * to have code loading modules in one package. #8193
  * Fluid code loader resolves a code module matching the document schema, i.e. code details, such as
  * a package name and package version range.
- * @internal
+ * @alpha
  */
 export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComparer> {
 	/**
@@ -157,7 +157,7 @@ export interface ICodeDetailsLoader extends Partial<IProvideFluidCodeDetailsComp
 
 /**
  * Services and properties necessary for creating a loader
- * @internal
+ * @alpha
  */
 export interface ILoaderProps {
 	/**
@@ -214,7 +214,7 @@ export interface ILoaderProps {
 
 /**
  * Services and properties used by and exposed by the loader
- * @internal
+ * @alpha
  */
 export interface ILoaderServices {
 	/**
@@ -267,7 +267,7 @@ export interface ILoaderServices {
 /**
  * Subset of IDocumentStorageService which only supports createBlob() and readBlob(). This is used to support
  * blobs in detached containers.
- * @internal
+ * @alpha
  */
 export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | "readBlob"> & {
 	size: number;
@@ -307,7 +307,7 @@ export async function requestResolvedObjectFromContainer(
 
 /**
  * Manages Fluid resource loading
- * @internal
+ * @alpha
  */
 export class Loader implements IHostLoader {
 	public readonly services: ILoaderServices;

--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -28,7 +28,7 @@ export enum SignalType {
 
 /**
  * Function to be used for creating a protocol handler.
- * @internal
+ * @alpha
  */
 export type ProtocolHandlerBuilder = (
 	attributes: IDocumentAttributes,
@@ -37,7 +37,7 @@ export type ProtocolHandlerBuilder = (
 ) => IProtocolHandler;
 
 /**
- * @internal
+ * @alpha
  */
 export interface IProtocolHandler extends IBaseProtocolHandler {
 	readonly audience: IAudienceOwner;


### PR DESCRIPTION
This PR tags the Loader class as alpha. All these types were automatically identified as transitive dependency of the Loader class.

We will stage these commits and invite review, however review items will generally be added to the backlog as future items, as these type updates are necessary for the current state of the code base.