### PR TITLE
Tag protocol-definitions and server types necessary for  local-driver to be alpha

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -109,7 +109,7 @@ export interface IConnect {
     versions: string[];
 }
 
-// @internal
+// @alpha
 export interface IConnected {
     checkpointSequenceNumber?: number;
     claims: ITokenClaims;

--- a/common/lib/protocol-definitions/src/sockets.ts
+++ b/common/lib/protocol-definitions/src/sockets.ts
@@ -79,7 +79,7 @@ export interface IConnect {
 
 /**
  * Message sent to indicate a client has connected to the server.
- * @internal
+ * @alpha
  */
 export interface IConnected {
 	/**

--- a/server/routerlicious/packages/gitresources/api-report/gitresources.api.md
+++ b/server/routerlicious/packages/gitresources/api-report/gitresources.api.md
@@ -110,7 +110,7 @@ export interface ICreateCommitParams {
     tree: string;
 }
 
-// @internal
+// @alpha
 export interface ICreateRefParams {
     // (undocumented)
     ref: string;
@@ -166,7 +166,7 @@ export interface IHeader {
     tree: ITree;
 }
 
-// @internal
+// @alpha
 export interface IPatchRefParams {
     // (undocumented)
     force: boolean;

--- a/server/routerlicious/packages/gitresources/src/resources.ts
+++ b/server/routerlicious/packages/gitresources/src/resources.ts
@@ -133,7 +133,7 @@ export interface IRef {
 
 /**
  * Required params to create ref
- * @internal
+ * @alpha
  */
 export interface ICreateRefParams {
 	ref: string;
@@ -142,7 +142,7 @@ export interface ICreateRefParams {
 
 /**
  * Required params to patch ref
- * @internal
+ * @alpha
  */
 export interface IPatchRefParams {
 	sha: string;

--- a/server/routerlicious/packages/local-server/api-report/server-local-server.api.md
+++ b/server/routerlicious/packages/local-server/api-report/server-local-server.api.md
@@ -20,7 +20,7 @@ import { ITestDbFactory } from '@fluidframework/server-test-utils';
 import { IWebSocket } from '@fluidframework/server-services-core';
 import { IWebSocketServer } from '@fluidframework/server-services-core';
 
-// @internal
+// @alpha
 export interface ILocalDeltaConnectionServer {
     // (undocumented)
     close(): Promise<void>;

--- a/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
+++ b/server/routerlicious/packages/local-server/src/localDeltaConnectionServer.ts
@@ -39,7 +39,7 @@ import { LocalWebSocketServer } from "./localWebSocketServer";
 
 /**
  * Items needed for handling deltas.
- * @internal
+ * @alpha
  */
 export interface ILocalDeltaConnectionServer {
 	webSocketServer: IWebSocketServer;

--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -375,7 +375,7 @@ export interface IPatchRefParamsExternal extends resources.IPatchRefParams {
     config?: IExternalWriterConfig;
 }
 
-// @internal
+// @alpha
 export interface ISession {
     deltaStreamUrl: string;
     historianUrl: string;

--- a/server/routerlicious/packages/services-client/src/interfaces.ts
+++ b/server/routerlicious/packages/services-client/src/interfaces.ts
@@ -13,7 +13,7 @@ export interface IAlfredTenant {
 
 /**
  * Session information that includes the server urls and session status
- * @internal
+ * @alpha
  */
 export interface ISession {
 	/**

--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -9,7 +9,7 @@ import { INode } from "./orderer";
 
 /**
  * Interface to abstract the backend database
- * @internal
+ * @alpha
  */
 export interface IDatabaseManager {
 	/**
@@ -267,12 +267,12 @@ export function isRetryEnabled<T>(collection: ICollection<T>): boolean {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type IDbEvents = "close" | "reconnect" | "error" | "reconnectFailed";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IDb {
 	close(): Promise<void>;
@@ -294,7 +294,7 @@ export interface IDb {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IDbFactory {
 	connect(global: boolean): Promise<IDb>;

--- a/server/routerlicious/packages/services-core/src/document.ts
+++ b/server/routerlicious/packages/services-core/src/document.ts
@@ -151,7 +151,7 @@ export interface IScribe {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IDocument {
 	// Schema version
@@ -185,7 +185,7 @@ export interface IDocument {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ICheckpoint {
 	_id: string;

--- a/server/routerlicious/packages/services-core/src/http.ts
+++ b/server/routerlicious/packages/services-core/src/http.ts
@@ -21,7 +21,7 @@ export interface IWebServerFactory {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IWebSocket {
 	id: string;
@@ -58,7 +58,7 @@ export interface IWebServer {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IWebSocketServer {
 	on(event: string, listener: (...args: any[]) => void);

--- a/server/routerlicious/packages/services-core/src/messages.ts
+++ b/server/routerlicious/packages/services-core/src/messages.ts
@@ -49,7 +49,7 @@ export const BoxcarType = "boxcar";
 
 /**
  * Base class for messages placed on the distributed log
- * @internal
+ * @alpha
  */
 export interface IMessage {
 	// The type of the message
@@ -69,7 +69,7 @@ export enum SystemOperations {
 
 /**
  * Object that indicates a specific session/document in the system
- * @internal
+ * @alpha
  */
 export interface IRoutingKey {
 	// The tenant id
@@ -140,7 +140,7 @@ export interface IRawOperationMessageBatch extends IRoutingKey {
 
 // Need to change this name - it isn't necessarily ticketed
 /**
- * @internal
+ * @alpha
  */
 export interface ITicketedMessage extends IMessage, IRoutingKey {}
 
@@ -181,7 +181,7 @@ export interface ITicketedSignalMessage extends ITicketedMessage {
 
 /**
  * A sequenced operation
- * @internal
+ * @alpha
  */
 export interface ISequencedOperationMessage extends ITicketedMessage {
 	// The type of the message

--- a/server/routerlicious/packages/services-core/src/orderer.ts
+++ b/server/routerlicious/packages/services-core/src/orderer.ts
@@ -9,7 +9,7 @@ import { IWebSocket } from "./http";
 
 /**
  * Identifier for an ordering node in the system
- * @internal
+ * @alpha
  */
 export interface INode {
 	// Unique identifier for the node

--- a/server/routerlicious/packages/test-utils/src/testCollection.ts
+++ b/server/routerlicious/packages/test-utils/src/testCollection.ts
@@ -223,7 +223,7 @@ export class TestDb implements IDb {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ITestDbFactory extends IDbFactory {
 	readonly testDatabase: IDb;


### PR DESCRIPTION
This PR is preparation for changing the tagging on the local-driver to be alpha. All these types were automatically identified as transitive dependency of the  local-driver which will be made alpha in a later review.

We will stage these commits and invite review, however review items will generally be added to the backlog as future items, as these type updates are necessary for the current state of the code base.