### PR TITLE
tree2: Fix typing bugs for insert types

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -1525,20 +1525,20 @@ export interface SchemaEvents {
 // @beta @sealed
 export class SchemaFactory<TScope extends string, TName extends number | string = string> {
     constructor(scope: TScope);
-    readonly boolean: TreeNodeSchema<"com.fluidframework.leaf.boolean", NodeKind.Leaf, boolean>;
+    readonly boolean: TreeNodeSchema<"com.fluidframework.leaf.boolean", NodeKind.Leaf, boolean, boolean>;
     fixRecursiveReference<T extends AllowedTypes_2>(...types: T): void;
-    readonly handle: TreeNodeSchema<"com.fluidframework.leaf.handle", NodeKind.Leaf, IFluidHandle<FluidObject & IFluidLoadable>>;
-    list<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchema<`${TScope}.List<${string}>`, NodeKind.List, TreeListNode<T>, Iterable<TreeNodeFromImplicitAllowedTypes<T>>>;
+    readonly handle: TreeNodeSchema<"com.fluidframework.leaf.handle", NodeKind.Leaf, IFluidHandle<FluidObject & IFluidLoadable>, IFluidHandle<FluidObject & IFluidLoadable>>;
+    list<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchema<`${TScope}.List<${string}>`, NodeKind.List, TreeListNode<T>, Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>>;
     list<const Name extends TName, const T extends ImplicitAllowedTypes_2>(name: Name, allowedTypes: T): TreeNodeSchemaClass<`${TScope}.${Name}`, NodeKind.List, TreeListNode<T>, Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>>;
     map<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchema<`${TScope}.Map<${string}>`, NodeKind.Map, TreeMapNodeBase<TreeNodeFromImplicitAllowedTypes<T>>, ReadonlyMap<string, TreeNodeFromImplicitAllowedTypes<T>>>;
     map<Name extends TName, const T extends ImplicitAllowedTypes_2>(name: Name, allowedTypes: T): TreeNodeSchemaClass<`${TScope}.${Name}`, NodeKind.Map, TreeMapNodeBase<TreeNodeFromImplicitAllowedTypes<T>>, ReadonlyMap<string, TreeNodeFromImplicitAllowedTypes<T>>>;
-    readonly null: TreeNodeSchema<"com.fluidframework.leaf.null", NodeKind.Leaf, null>;
-    readonly number: TreeNodeSchema<"com.fluidframework.leaf.number", NodeKind.Leaf, number>;
+    readonly null: TreeNodeSchema<"com.fluidframework.leaf.null", NodeKind.Leaf, null, null>;
+    readonly number: TreeNodeSchema<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number>;
     object<const Name extends TName, const T extends RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>(name: Name, t: T): TreeNodeSchemaClass<`${TScope}.${Name}`, NodeKind.Object, ObjectFromSchemaRecord<T>, InsertableObjectFromSchemaRecord<T>>;
     optional<const T extends ImplicitAllowedTypes_2>(t: T): FieldSchema<FieldKind_2.Optional, T>;
     // (undocumented)
     readonly scope: TScope;
-    readonly string: TreeNodeSchema<"com.fluidframework.leaf.string", NodeKind.Leaf, string>;
+    readonly string: TreeNodeSchema<"com.fluidframework.leaf.string", NodeKind.Leaf, string, string>;
 }
 
 // @alpha
@@ -1691,10 +1691,10 @@ export class test_RecursiveObject extends test_RecursiveObject_base {
 // @alpha
 export const test_RecursiveObject_base: TreeNodeSchemaClass<"Test Recursive Domain.testObject", NodeKind.Object, ObjectFromSchemaRecord<    {
 readonly recursive: FieldSchema<import("./schemaTypes").FieldKind.Optional, readonly [() => typeof test_RecursiveObject]>;
-readonly number: TreeNodeSchema<"com.fluidframework.leaf.number", NodeKind.Leaf, number>;
+readonly number: TreeNodeSchema<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number>;
 }>, InsertableObjectFromSchemaRecord<    {
 readonly recursive: FieldSchema<import("./schemaTypes").FieldKind.Optional, readonly [() => typeof test_RecursiveObject]>;
-readonly number: TreeNodeSchema<"com.fluidframework.leaf.number", NodeKind.Leaf, number>;
+readonly number: TreeNodeSchema<"com.fluidframework.leaf.number", NodeKind.Leaf, number, number>;
 }>>;
 
 // @alpha

--- a/experimental/dds/tree2/src/class-tree/schemaFactory.ts
+++ b/experimental/dds/tree2/src/class-tree/schemaFactory.ts
@@ -78,7 +78,7 @@ class LeafNodeSchema<T extends FlexLeafNodeSchema>
  */
 function makeLeaf<T extends FlexLeafNodeSchema>(
 	schema: T,
-): TreeNodeSchema<UnbrandedName<T>, NodeKind.Leaf, TreeValue<T["info"]>> {
+): TreeNodeSchema<UnbrandedName<T>, NodeKind.Leaf, TreeValue<T["info"]>, TreeValue<T["info"]>> {
 	return new LeafNodeSchema(schema);
 }
 
@@ -405,7 +405,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 		`${TScope}.List<${string}>`,
 		NodeKind.List,
 		TreeListNode<T>,
-		Iterable<TreeNodeFromImplicitAllowedTypes<T>>
+		Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>
 	>;
 
 	/**
@@ -435,7 +435,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 		`${TScope}.${string}`,
 		NodeKind.List,
 		TreeListNode<T>,
-		Iterable<TreeNodeFromImplicitAllowedTypes<T>>
+		Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>
 	> {
 		if (allowedTypes === undefined) {
 			const types = nameOrAllowedTypes as (T & TreeNodeSchema) | readonly TreeNodeSchema[];
@@ -446,7 +446,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 				`${TScope}.${string}`,
 				NodeKind.List,
 				TreeListNode<T>,
-				Iterable<TreeNodeFromImplicitAllowedTypes<T>>
+				Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>
 			>;
 		}
 		return this.namedList(nameOrAllowedTypes as TName, allowedTypes, true);
@@ -465,7 +465,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 		`${TScope}.${Name}`,
 		NodeKind.List,
 		TreeListNode<T>,
-		Iterable<TreeNodeFromImplicitAllowedTypes<T>>
+		Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>
 	> {
 		// This class returns a proxy from its constructor to handle numeric indexing.
 		// Alternatively it could extend a normal class which gets tons of numeric properties added.
@@ -474,7 +474,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 			public get length(): number {
 				return getSequenceField(this as unknown as TreeListNode).length;
 			}
-			public constructor(input: Iterable<TreeNodeFromImplicitAllowedTypes<T>>) {
+			public constructor(input: Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>) {
 				super(input);
 				if (isFlexTreeNode(input)) {
 					return createNodeProxy(

--- a/experimental/dds/tree2/src/class-tree/schemaFactory.ts
+++ b/experimental/dds/tree2/src/class-tree/schemaFactory.ts
@@ -501,7 +501,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 			`${TScope}.${Name}`,
 			NodeKind.List,
 			TreeListNode<T>,
-			Iterable<TreeNodeFromImplicitAllowedTypes<T>>
+			Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>
 		>;
 	}
 

--- a/experimental/dds/tree2/src/test/class-tree/schemaTypes.spec.ts
+++ b/experimental/dds/tree2/src/test/class-tree/schemaTypes.spec.ts
@@ -1,0 +1,86 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { SchemaFactory } from "../../class-tree";
+
+import {
+	InsertableTreeFieldFromImplicitField,
+	InsertableTypedNode,
+	NodeBuilderData,
+	NodeFromSchema,
+	TreeFieldFromImplicitField,
+	TreeNodeFromImplicitAllowedTypes,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../class-tree/schemaTypes";
+import { TreeFactory } from "../../treeFactory";
+import { areSafelyAssignable, requireAssignableTo, requireTrue } from "../../util";
+
+const schema = new SchemaFactory("com.example");
+
+const factory = new TreeFactory({});
+
+describe("schemaTypes", () => {
+	describe("insertable", () => {
+		it("Lists", () => {
+			const List = schema.list(schema.number);
+			const NestedList = schema.list(List);
+
+			const list: number[] = [5];
+			const nestedList: number[][] = [[5]];
+
+			// Not nested
+			{
+				type I1 = InsertableTreeFieldFromImplicitField<typeof schema.number>;
+				type I2 = InsertableTypedNode<typeof schema.number>;
+				type I3 = NodeBuilderData<typeof schema.number>;
+
+				type N1 = NodeFromSchema<typeof schema.number>;
+				type N2 = TreeNodeFromImplicitAllowedTypes<typeof schema.number>;
+				type N3 = TreeFieldFromImplicitField<typeof schema.number>;
+
+				type _check1 = requireTrue<areSafelyAssignable<I1, number>>;
+				type _check2 = requireTrue<areSafelyAssignable<I2, number>>;
+				type _check3 = requireTrue<areSafelyAssignable<I3, number>>;
+				type _check4 = requireTrue<areSafelyAssignable<N1, number>>;
+				type _check5 = requireTrue<areSafelyAssignable<N2, number>>;
+				type _check6 = requireTrue<areSafelyAssignable<N3, number>>;
+			}
+
+			// Not nested
+			{
+				type I1 = InsertableTreeFieldFromImplicitField<typeof List>;
+				type I2 = InsertableTypedNode<typeof List>;
+				type I3 = NodeBuilderData<typeof List>;
+
+				type N1 = NodeFromSchema<typeof List>;
+				type N2 = TreeNodeFromImplicitAllowedTypes<typeof List>;
+				type N3 = TreeFieldFromImplicitField<typeof List>;
+
+				type _check1 = requireTrue<areSafelyAssignable<I1, I2>>;
+				type _check2 = requireTrue<areSafelyAssignable<I2, N1 | Iterable<number>>>;
+				type _check3 = requireTrue<areSafelyAssignable<I3, Iterable<number>>>;
+				type _check4 = requireTrue<areSafelyAssignable<N1, N2>>;
+				type _check5 = requireTrue<areSafelyAssignable<N2, N3>>;
+			}
+
+			// Nested
+			{
+				type I1 = InsertableTreeFieldFromImplicitField<typeof NestedList>;
+				type I2 = InsertableTypedNode<typeof NestedList>;
+				type I3 = NodeBuilderData<typeof NestedList>;
+
+				type N1 = NodeFromSchema<typeof NestedList>;
+				type N2 = TreeNodeFromImplicitAllowedTypes<typeof NestedList>;
+				type N3 = TreeFieldFromImplicitField<typeof NestedList>;
+
+				type _check1 = requireTrue<areSafelyAssignable<I1, I2>>;
+				type _check2 = requireTrue<areSafelyAssignable<I2, N1 | I3>>;
+				type _check3 = requireAssignableTo<Iterable<Iterable<number>>, I3>;
+				type _check4 = requireTrue<areSafelyAssignable<N1, N2>>;
+				type _check5 = requireTrue<areSafelyAssignable<N2, N3>>;
+			}
+		});
+	});
+});

--- a/experimental/dds/tree2/src/test/class-tree/tree.spec.ts
+++ b/experimental/dds/tree2/src/test/class-tree/tree.spec.ts
@@ -22,14 +22,14 @@ describe("class-tree tree", () => {
 		const config = new TreeConfiguration(NodeList, () => new NodeList(["a", "b"]));
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "tree");
 		const view: TreeView<NodeList> = tree.schematize(config);
-		assert.deepEqual(view, ["a", "b"]);
+		assert.deepEqual([...view.root], ["a", "b"]);
 	});
 
 	it("Implicit ListRoot", () => {
 		const config = new TreeConfiguration(NodeList, () => ["a", "b"]);
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "tree");
 		const view: TreeView<NodeList> = tree.schematize(config);
-		assert.deepEqual(view, ["a", "b"]);
+		assert.deepEqual([...view.root], ["a", "b"]);
 	});
 
 	it("ObjectRoot - Data", () => {
@@ -70,10 +70,10 @@ describe("class-tree tree", () => {
 		const config = new TreeConfiguration(nestedList, () => [["a"]]);
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "tree");
 		const view = tree.schematize(config);
-		assert.equal(view.root?.length, "1");
+		assert.equal(view.root?.length, 1);
 		const child = view.root[0];
-		assert.equal(child.length, "1");
-		const child2 = view.root[0];
+		assert.equal(child.length, 1);
+		const child2 = child[0];
 		assert.equal(child2, "a");
 	});
 });

--- a/experimental/dds/tree2/src/test/class-tree/tree.spec.ts
+++ b/experimental/dds/tree2/src/test/class-tree/tree.spec.ts
@@ -18,10 +18,18 @@ class Canvas extends schema.object("Canvas", { stuff: [NodeMap, NodeList] }) {}
 const factory = new TreeFactory({});
 
 describe("class-tree tree", () => {
-	it.skip("ListRoot", () => {
+	it("ListRoot", () => {
 		const config = new TreeConfiguration(NodeList, () => new NodeList(["a", "b"]));
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "tree");
 		const view: TreeView<NodeList> = tree.schematize(config);
+		assert.deepEqual(view, ["a", "b"]);
+	});
+
+	it("Implicit ListRoot", () => {
+		const config = new TreeConfiguration(NodeList, () => ["a", "b"]);
+		const tree = factory.create(new MockFluidDataStoreRuntime(), "tree");
+		const view: TreeView<NodeList> = tree.schematize(config);
+		assert.deepEqual(view, ["a", "b"]);
 	});
 
 	it("ObjectRoot - Data", () => {
@@ -55,5 +63,17 @@ describe("class-tree tree", () => {
 		const tree = factory.create(new MockFluidDataStoreRuntime(), "tree");
 		const view: TreeView<undefined | string> = tree.schematize(config);
 		assert.equal(view.root, "x");
+	});
+
+	it("Nested list", () => {
+		const nestedList = schema.list(schema.list(schema.string));
+		const config = new TreeConfiguration(nestedList, () => [["a"]]);
+		const tree = factory.create(new MockFluidDataStoreRuntime(), "tree");
+		const view = tree.schematize(config);
+		assert.equal(view.root?.length, "1");
+		const child = view.root[0];
+		assert.equal(child.length, "1");
+		const child2 = view.root[0];
+		assert.equal(child2, "a");
 	});
 });


### PR DESCRIPTION
## Description

There were a couple bugs with the handling of insertable types in the class based schema API.
This adds some tests and some fixes.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
