### PR TITLE
Tag SharedString, SharedMatrix, SharedMap, and SharedDirectory as alpha

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -565,7 +565,7 @@ export enum SignalType {
 // @alpha
 export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISummaryAttachment;
 
-// @internal
+// @alpha
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 
 // @alpha

--- a/common/lib/protocol-definitions/src/summary.ts
+++ b/common/lib/protocol-definitions/src/summary.ts
@@ -14,7 +14,7 @@ export type SummaryObject = ISummaryTree | ISummaryBlob | ISummaryHandle | ISumm
 
 /**
  * The root of the summary tree.
- * @internal
+ * @alpha
  */
 export type SummaryTree = ISummaryTree | ISummaryHandle;
 

--- a/packages/common/core-utils/api-report/core-utils.api.md
+++ b/packages/common/core-utils/api-report/core-utils.api.md
@@ -10,7 +10,7 @@ export function assert(condition: boolean, message: string | number): asserts co
 // @internal
 export const compareArrays: <T>(left: readonly T[], right: readonly T[], comparator?: (leftItem: T, rightItem: T, index: number) => boolean) => boolean;
 
-// @internal
+// @alpha
 export class Deferred<T> {
     constructor();
     get isCompleted(): boolean;

--- a/packages/common/core-utils/src/promises.ts
+++ b/packages/common/core-utils/src/promises.ts
@@ -5,7 +5,7 @@
 
 /**
  * A deferred creates a promise and the ability to resolve or reject it
- * @internal
+ * @alpha
  */
 export class Deferred<T> {
 	private readonly p: Promise<T>;

--- a/packages/dds/map/api-report/map.api.md
+++ b/packages/dds/map/api-report/map.api.md
@@ -22,7 +22,7 @@ import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base';
 
-// @internal @sealed
+// @alpha @sealed
 export class DirectoryFactory implements IChannelFactory {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;
@@ -38,13 +38,13 @@ export class DirectoryFactory implements IChannelFactory {
     get type(): string;
 }
 
-// @internal
+// @alpha
 export interface ICreateInfo {
     ccIds: string[];
     csn: number;
 }
 
-// @internal
+// @alpha
 export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryEvents>, Partial<IDisposable> {
     readonly absolutePath: string;
     countSubDirectory?(): number;
@@ -58,20 +58,20 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
     subdirectories(): IterableIterator<[string, IDirectory]>;
 }
 
-// @internal
+// @alpha
 export interface IDirectoryClearOperation {
     path: string;
     type: "clear";
 }
 
-// @internal
+// @alpha
 export interface IDirectoryCreateSubDirectoryOperation {
     path: string;
     subdirName: string;
     type: "createSubDirectory";
 }
 
-// @internal
+// @alpha
 export interface IDirectoryDataObject {
     ci?: ICreateInfo;
     storage?: {
@@ -82,21 +82,21 @@ export interface IDirectoryDataObject {
     };
 }
 
-// @internal
+// @alpha
 export interface IDirectoryDeleteOperation {
     key: string;
     path: string;
     type: "delete";
 }
 
-// @internal
+// @alpha
 export interface IDirectoryDeleteSubDirectoryOperation {
     path: string;
     subdirName: string;
     type: "deleteSubDirectory";
 }
 
-// @internal
+// @alpha
 export interface IDirectoryEvents extends IEvent {
     (event: "containedValueChanged", listener: (changed: IValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "subDirectoryCreated", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
@@ -105,7 +105,7 @@ export interface IDirectoryEvents extends IEvent {
     (event: "undisposed", listener: (target: IEventThisPlaceHolder) => void): any;
 }
 
-// @internal
+// @alpha
 export type IDirectoryKeyOperation = IDirectorySetOperation | IDirectoryDeleteOperation;
 
 // @internal
@@ -114,10 +114,10 @@ export interface IDirectoryNewStorageFormat {
     content: IDirectoryDataObject;
 }
 
-// @internal
+// @alpha
 export type IDirectoryOperation = IDirectoryStorageOperation | IDirectorySubDirectoryOperation;
 
-// @internal
+// @alpha
 export interface IDirectorySetOperation {
     key: string;
     path: string;
@@ -125,37 +125,37 @@ export interface IDirectorySetOperation {
     value: ISerializableValue;
 }
 
-// @internal
+// @alpha
 export type IDirectoryStorageOperation = IDirectoryKeyOperation | IDirectoryClearOperation;
 
-// @internal
+// @alpha
 export type IDirectorySubDirectoryOperation = IDirectoryCreateSubDirectoryOperation | IDirectoryDeleteSubDirectoryOperation;
 
-// @internal
+// @alpha
 export interface IDirectoryValueChanged extends IValueChanged {
     path: string;
 }
 
-// @internal
+// @alpha
 export interface ILocalValue {
     makeSerialized(serializer: IFluidSerializer, bind: IFluidHandle): ISerializedValue;
     readonly type: string;
     readonly value: any;
 }
 
-// @internal @deprecated
+// @alpha @deprecated
 export interface ISerializableValue {
     type: string;
     value: any;
 }
 
-// @internal
+// @alpha
 export interface ISerializedValue {
     type: string;
     value: string | undefined;
 }
 
-// @internal
+// @alpha
 export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents & IDirectoryEvents>, Omit<IDirectory, "on" | "once" | "off"> {
     // (undocumented)
     [Symbol.iterator](): IterableIterator<[string, any]>;
@@ -163,7 +163,7 @@ export interface ISharedDirectory extends ISharedObject<ISharedDirectoryEvents &
     readonly [Symbol.toStringTag]: string;
 }
 
-// @internal
+// @alpha
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IDirectoryValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
@@ -171,32 +171,32 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
     (event: "subDirectoryDeleted", listener: (path: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @internal
+// @alpha
 export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string, any> {
     get<T = any>(key: string): T | undefined;
     set<T = unknown>(key: string, value: T): this;
 }
 
-// @internal
+// @alpha
 export interface ISharedMapEvents extends ISharedObjectEvents {
     (event: "valueChanged", listener: (changed: IValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
     (event: "clear", listener: (local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @internal
+// @alpha
 export interface IValueChanged {
     key: string;
     previousValue: any;
 }
 
-// @internal
+// @alpha
 export class LocalValueMaker {
     constructor(serializer: IFluidSerializer);
     fromInMemory(value: unknown): ILocalValue;
     fromSerializable(serializable: ISerializableValue): ILocalValue;
 }
 
-// @internal @sealed
+// @alpha @sealed
 export class MapFactory implements IChannelFactory {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;
@@ -212,7 +212,7 @@ export class MapFactory implements IChannelFactory {
     get type(): string;
 }
 
-// @internal @sealed
+// @alpha @sealed
 export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implements ISharedDirectory {
     [Symbol.iterator](): IterableIterator<[string, any]>;
     [Symbol.toStringTag]: string;
@@ -261,7 +261,7 @@ export class SharedDirectory extends SharedObject<ISharedDirectoryEvents> implem
     values(): IterableIterator<any>;
 }
 
-// @internal
+// @alpha
 export class SharedMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
     [Symbol.iterator](): IterableIterator<[string, any]>;
     readonly [Symbol.toStringTag]: string;

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -71,7 +71,7 @@ interface IDirectoryMessageHandler {
 
 /**
  * Operation indicating a value should be set for a key.
- * @internal
+ * @alpha
  */
 export interface IDirectorySetOperation {
 	/**
@@ -98,7 +98,7 @@ export interface IDirectorySetOperation {
 
 /**
  * Operation indicating a key should be deleted from the directory.
- * @internal
+ * @alpha
  */
 export interface IDirectoryDeleteOperation {
 	/**
@@ -119,13 +119,13 @@ export interface IDirectoryDeleteOperation {
 
 /**
  * An operation on a specific key within a directory.
- * @internal
+ * @alpha
  */
 export type IDirectoryKeyOperation = IDirectorySetOperation | IDirectoryDeleteOperation;
 
 /**
  * Operation indicating the directory should be cleared.
- * @internal
+ * @alpha
  */
 export interface IDirectoryClearOperation {
 	/**
@@ -141,13 +141,13 @@ export interface IDirectoryClearOperation {
 
 /**
  * An operation on one or more of the keys within a directory.
- * @internal
+ * @alpha
  */
 export type IDirectoryStorageOperation = IDirectoryKeyOperation | IDirectoryClearOperation;
 
 /**
  * Operation indicating a subdirectory should be created.
- * @internal
+ * @alpha
  */
 export interface IDirectoryCreateSubDirectoryOperation {
 	/**
@@ -168,7 +168,7 @@ export interface IDirectoryCreateSubDirectoryOperation {
 
 /**
  * Operation indicating a subdirectory should be deleted.
- * @internal
+ * @alpha
  */
 export interface IDirectoryDeleteSubDirectoryOperation {
 	/**
@@ -189,7 +189,7 @@ export interface IDirectoryDeleteSubDirectoryOperation {
 
 /**
  * An operation on the subdirectories within a directory.
- * @internal
+ * @alpha
  */
 export type IDirectorySubDirectoryOperation =
 	| IDirectoryCreateSubDirectoryOperation
@@ -197,13 +197,13 @@ export type IDirectorySubDirectoryOperation =
 
 /**
  * Any operation on a directory.
- * @internal
+ * @alpha
  */
 export type IDirectoryOperation = IDirectoryStorageOperation | IDirectorySubDirectoryOperation;
 
 /**
  * Create info for the subdirectory.
- * @internal
+ * @alpha
  */
 export interface ICreateInfo {
 	/**
@@ -224,7 +224,7 @@ export interface ICreateInfo {
  * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
  * | JSON.stringify}, direct result from
  * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse | JSON.parse}.
- * @internal
+ * @alpha
  */
 export interface IDirectoryDataObject {
 	/**
@@ -269,7 +269,7 @@ export interface IDirectoryNewStorageFormat {
  * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link SharedDirectory}.
  *
  * @sealed
- * @internal
+ * @alpha
  */
 export class DirectoryFactory implements IChannelFactory {
 	/**
@@ -447,7 +447,7 @@ class DirectoryCreationTracker {
  * ```
  *
  * @sealed
- * @internal
+ * @alpha
  */
 export class SharedDirectory
 	extends SharedObject<ISharedDirectoryEvents>

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -13,7 +13,7 @@ import {
 
 /**
  * Type of "valueChanged" event parameter.
- * @internal
+ * @alpha
  */
 export interface IValueChanged {
 	/**
@@ -33,7 +33,7 @@ export interface IValueChanged {
  * Interface describing actions on a directory.
  *
  * @remarks When used as a Map, operates on its keys.
- * @internal
+ * @alpha
  */
 // TODO: Use `unknown` instead (breaking change).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -117,7 +117,7 @@ export interface IDirectory
  *
  * @remarks
  * These events only emit on the {@link ISharedDirectory} itself, and not on subdirectories.
- * @internal
+ * @alpha
  */
 export interface ISharedDirectoryEvents extends ISharedObjectEvents {
 	/**
@@ -190,7 +190,7 @@ export interface ISharedDirectoryEvents extends ISharedObjectEvents {
 
 /**
  * Events emitted in response to changes to the directory data.
- * @internal
+ * @alpha
  */
 export interface IDirectoryEvents extends IEvent {
 	/**
@@ -271,7 +271,7 @@ export interface IDirectoryEvents extends IEvent {
  * Provides a hierarchical organization of map-like data structures as SubDirectories.
  * The values stored within can be accessed like a map, and the hierarchy can be navigated using path syntax.
  * SubDirectories can be retrieved for use as working directories.
- * @internal
+ * @alpha
  */
 export interface ISharedDirectory
 	extends ISharedObject<ISharedDirectoryEvents & IDirectoryEvents>,
@@ -286,7 +286,7 @@ export interface ISharedDirectory
 
 /**
  * Type of "valueChanged" event parameter for {@link ISharedDirectory}.
- * @internal
+ * @alpha
  */
 export interface IDirectoryValueChanged extends IValueChanged {
 	/**
@@ -297,7 +297,7 @@ export interface IDirectoryValueChanged extends IValueChanged {
 
 /**
  * Events emitted in response to changes to the {@link ISharedMap | map} data.
- * @internal
+ * @alpha
  */
 export interface ISharedMapEvents extends ISharedObjectEvents {
 	/**
@@ -336,7 +336,7 @@ export interface ISharedMapEvents extends ISharedObjectEvents {
  * {@link @fluidframework/datastore#FluidObjectHandle}.
  *
  * For more information, including example usages, see {@link https://fluidframework.com/docs/data-structures/map/}.
- * @internal
+ * @alpha
  */
 // TODO: Use `unknown` instead (breaking change).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -381,7 +381,7 @@ export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string,
  * channel ID.
  *
  * @deprecated This type is legacy and deprecated.
- * @internal
+ * @alpha
  */
 export interface ISerializableValue {
 	/**
@@ -398,7 +398,7 @@ export interface ISerializableValue {
 
 /**
  * Serialized {@link ISerializableValue} counterpart.
- * @internal
+ * @alpha
  */
 export interface ISerializedValue {
 	/**

--- a/packages/dds/map/src/localValues.ts
+++ b/packages/dds/map/src/localValues.ts
@@ -16,7 +16,7 @@ import { ISerializableValue, ISerializedValue } from "./interfaces";
 
 /**
  * A local value to be stored in a container type Distributed Data Store (DDS).
- * @internal
+ * @alpha
  */
 export interface ILocalValue {
 	/**
@@ -98,7 +98,7 @@ export class PlainLocalValue implements ILocalValue {
 /**
  * Enables a container type {@link https://fluidframework.com/docs/build/dds/ | DDS} to produce and store local
  * values with minimal awareness of how those objects are stored, serialized, and deserialized.
- * @internal
+ * @alpha
  */
 export class LocalValueMaker {
 	/**

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -30,7 +30,7 @@ const snapshotFileName = "header";
  * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link SharedMap}.
  *
  * @sealed
- * @internal
+ * @alpha
  */
 export class MapFactory implements IChannelFactory {
 	/**
@@ -89,7 +89,7 @@ export class MapFactory implements IChannelFactory {
 
 /**
  * {@inheritDoc ISharedMap}
- * @internal
+ * @alpha
  */
 export class SharedMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
 	/**

--- a/packages/dds/matrix/api-report/matrix.api.md
+++ b/packages/dds/matrix/api-report/matrix.api.md
@@ -24,7 +24,7 @@ import { Serializable } from '@fluidframework/datastore-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base';
 import { SummarySerializer } from '@fluidframework/shared-object-base';
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IRevertible {
     // (undocumented)
     discard(): any;
@@ -32,21 +32,21 @@ export interface IRevertible {
     revert(): any;
 }
 
-// @internal
+// @alpha
 export interface ISharedMatrixEvents<T> extends ISharedObjectEvents {
     (event: "conflict", listener: (row: number, col: number, currentValue: MatrixItem<T>, conflictingValue: MatrixItem<T>, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IUndoConsumer {
     // (undocumented)
     pushToCurrentOperation(revertible: IRevertible): any;
 }
 
-// @internal
+// @alpha
 export type MatrixItem<T> = Serializable<Exclude<T, null>> | undefined;
 
-// @internal
+// @alpha
 export class SharedMatrix<T = any> extends SharedObject<ISharedMatrixEvents<T>> implements IMatrixProducer<MatrixItem<T>>, IMatrixReader<MatrixItem<T>>, IMatrixWriter<MatrixItem<T>> {
     constructor(runtime: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes, _isSetCellConflictResolutionPolicyFWW?: boolean);
     // (undocumented)
@@ -110,7 +110,7 @@ export class SharedMatrix<T = any> extends SharedObject<ISharedMatrixEvents<T>> 
     _undoRemoveRows(rowStart: number, spec: IJSONSegment): void;
 }
 
-// @internal
+// @alpha
 export class SharedMatrixFactory implements IChannelFactory {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -70,7 +70,7 @@ interface ISetCellChangePolicyOp {
 
 /**
  * Events emitted by Shared Matrix.
- * @internal
+ * @alpha
  */
 export interface ISharedMatrixEvents<T> extends ISharedObjectEvents {
 	/**
@@ -115,7 +115,7 @@ interface CellLastWriteTrackerItem {
 /**
  * A matrix cell value may be undefined (indicating an empty cell) or any serializable type,
  * excluding null.  (However, nulls may be embedded inside objects and arrays.)
- * @internal
+ * @alpha
  */
 // eslint-disable-next-line @rushstack/no-new-null -- Using 'null' to disallow 'null'.
 export type MatrixItem<T> = Serializable<Exclude<T, null>> | undefined;
@@ -131,7 +131,7 @@ export type MatrixItem<T> = Serializable<Exclude<T, null>> | undefined;
  * matrix data and physically stores data in Z-order to leverage CPU caches and
  * prefetching when reading in either row or column major order.  (See README.md
  * for more details.)
- * @internal
+ * @alpha
  */
 export class SharedMatrix<T = any>
 	extends SharedObject<ISharedMatrixEvents<T>>

--- a/packages/dds/matrix/src/runtime.ts
+++ b/packages/dds/matrix/src/runtime.ts
@@ -15,7 +15,7 @@ import { SharedMatrix } from "./matrix";
 
 /**
  * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link SharedMatrix}.
- * @internal
+ * @alpha
  */
 export class SharedMatrixFactory implements IChannelFactory {
 	public static Type = "https://graph.microsoft.com/types/sharedmatrix";

--- a/packages/dds/matrix/src/types.ts
+++ b/packages/dds/matrix/src/types.ts
@@ -7,7 +7,7 @@
 //       of SharedMatrix undo while we decide on the correct layering for undo.
 
 /**
- * @internal
+ * @alpha
  */
 export interface IRevertible {
 	revert();
@@ -15,7 +15,7 @@ export interface IRevertible {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IUndoConsumer {
 	pushToCurrentOperation(revertible: IRevertible);

--- a/packages/dds/merge-tree/api-report/merge-tree.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.api.md
@@ -30,7 +30,7 @@ export interface AttributionPolicy {
     serializer: IAttributionCollectionSerializer;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export abstract class BaseSegment extends MergeNode implements ISegment {
     // @deprecated (undocumented)
     ack(segmentGroup: SegmentGroup, opArgs: IMergeTreeDeltaOpArgs): boolean;
@@ -84,7 +84,7 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
     abstract readonly type: string;
 }
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export class Client extends TypedEventEmitter<IClientEvents> {
     constructor(specToSegment: (spec: IJSONSegment) => ISegment, logger: ITelemetryLoggerExt, options?: PropertySet);
     // (undocumented)
@@ -190,7 +190,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 // @internal @deprecated (undocumented)
 export function clone<T>(extension: MapLike<T> | undefined): MapLike<T> | undefined;
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export class CollaborationWindow {
     // (undocumented)
     clientId: number;
@@ -281,7 +281,7 @@ export function getSlideToSegoff(segoff: {
     offset: number | undefined;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IAttributionCollection<T> {
     // (undocumented)
     append(other: IAttributionCollection<T>): void;
@@ -307,7 +307,7 @@ export interface IAttributionCollectionSerializer {
     }>): SerializedAttributionCollection;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IAttributionCollectionSpec<T> {
     // (undocumented)
     channels?: {
@@ -325,7 +325,7 @@ export interface IAttributionCollectionSpec<T> {
     }>;
 }
 
-// @internal
+// @alpha
 export interface IClientEvents {
     // (undocumented)
     (event: "normalize", listener: (target: IEventThisPlaceHolder) => void): any;
@@ -335,7 +335,7 @@ export interface IClientEvents {
     (event: "maintenance", listener: (args: IMergeTreeMaintenanceCallbackArgs, deltaArgs: IMergeTreeDeltaOpArgs | undefined, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export interface ICombiningOp {
     // (undocumented)
     defaultValue?: any;
@@ -371,13 +371,13 @@ export interface IIntegerRange {
     start: number;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IJSONMarkerSegment extends IJSONSegment {
     // (undocumented)
     marker: IMarkerDef;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IJSONSegment {
     // (undocumented)
     props?: Record<string, any>;
@@ -389,7 +389,7 @@ export interface IJSONTextSegment extends IJSONSegment {
     text: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IMarkerDef {
     // (undocumented)
     refType?: ReferenceType;
@@ -401,7 +401,7 @@ export interface IMarkerModifiedAction {
     (marker: Marker): void;
 }
 
-// @internal
+// @alpha
 export interface IMergeNodeCommon {
     index: number;
     // (undocumented)
@@ -409,7 +409,7 @@ export interface IMergeNodeCommon {
     ordinal: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
     // @deprecated (undocumented)
     combiningOp?: ICombiningOp;
@@ -443,12 +443,12 @@ export interface IMergeTreeClientSequenceArgs {
     readonly sequenceNumber: number;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IMergeTreeDelta {
     type: MergeTreeDeltaType;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IMergeTreeDeltaCallbackArgs<TOperationType extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType> {
     // (undocumented)
     readonly deltaSegments: IMergeTreeSegmentDelta[];
@@ -456,10 +456,10 @@ export interface IMergeTreeDeltaCallbackArgs<TOperationType extends MergeTreeDel
     readonly operation: TOperationType;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type IMergeTreeDeltaOp = IMergeTreeInsertMsg | IMergeTreeRemoveMsg | IMergeTreeAnnotateMsg;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IMergeTreeDeltaOpArgs {
     readonly groupOp?: IMergeTreeGroupMsg;
     readonly op: IMergeTreeOp;
@@ -467,7 +467,7 @@ export interface IMergeTreeDeltaOpArgs {
     readonly stashed?: boolean;
 }
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
     // (undocumented)
     ops: IMergeTreeDeltaOp[];
@@ -475,7 +475,7 @@ export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
     type: typeof MergeTreeDeltaType.GROUP;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
     // (undocumented)
     pos1?: number;
@@ -491,11 +491,11 @@ export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
     type: typeof MergeTreeDeltaType.INSERT;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IMergeTreeMaintenanceCallbackArgs extends IMergeTreeDeltaCallbackArgs<MergeTreeMaintenanceType> {
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type IMergeTreeOp = IMergeTreeDeltaOp | IMergeTreeGroupMsg;
 
 // @internal (undocumented)
@@ -509,7 +509,7 @@ export interface IMergeTreeOptions {
     newMergeTreeSnapshotFormat?: boolean;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
     // (undocumented)
     pos1?: number;
@@ -523,7 +523,7 @@ export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
     type: typeof MergeTreeDeltaType.REMOVE;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IMergeTreeSegmentDelta {
     // (undocumented)
     propertyDeltas?: PropertySet;
@@ -531,7 +531,7 @@ export interface IMergeTreeSegmentDelta {
     segment: ISegment;
 }
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export interface IMergeTreeTextHelper {
     // (undocumented)
     getText(refSeq: number, clientId: number, placeholder: string, start?: number, end?: number): string;
@@ -554,21 +554,21 @@ export interface IRBMatcher<TKey, TData> {
     matchNode(node: RBNode<TKey, TData> | undefined, key: TKey): boolean;
 }
 
-// @internal
+// @alpha
 export interface IRelativePosition {
     before?: boolean;
     id?: string;
     offset?: number;
 }
 
-// @internal
+// @alpha
 export interface IRemovalInfo {
     localRemovedSeq?: number;
     removedClientIds: number[];
     removedSeq: number;
 }
 
-// @internal
+// @alpha
 export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
     // @deprecated
     ack(segmentGroup: SegmentGroup, opArgs: IMergeTreeDeltaOpArgs): boolean;
@@ -602,7 +602,7 @@ export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
     readonly type: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISegmentAction<TClientData> {
     // (undocumented)
     (segment: ISegment, pos: number, refSeq: number, clientId: number, start: number, end: number, accum: TClientData): boolean;
@@ -611,7 +611,7 @@ export interface ISegmentAction<TClientData> {
 // @internal
 export function isMergeTreeDeltaRevertible(x: unknown): x is MergeTreeDeltaRevertible;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ITrackingGroup {
     // (undocumented)
     has(trackable: Trackable): boolean;
@@ -634,7 +634,7 @@ export interface KeyComparer<TKey> {
 // @internal @deprecated (undocumented)
 export const LocalClientId = -1;
 
-// @internal
+// @alpha
 export class LocalReferenceCollection {
     // (undocumented)
     [Symbol.iterator](): {
@@ -670,7 +670,7 @@ export class LocalReferenceCollection {
     walkReferences(visitor: (lref: LocalReferencePosition) => boolean | void | undefined, start?: LocalReferencePosition, forward?: boolean): boolean;
 }
 
-// @internal @sealed (undocumented)
+// @alpha @sealed (undocumented)
 export interface LocalReferencePosition extends ReferencePosition {
     // (undocumented)
     callbacks?: Partial<Record<"beforeSlide" | "afterSlide", (ref: LocalReferencePosition) => void>>;
@@ -679,13 +679,13 @@ export interface LocalReferencePosition extends ReferencePosition {
     readonly trackingCollection: TrackingGroupCollection;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface MapLike<T> {
     // (undocumented)
     [index: string]: T;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export class Marker extends BaseSegment implements ReferencePosition {
     constructor(refType: ReferenceType);
     // (undocumented)
@@ -730,7 +730,7 @@ export function matchProperties(a: PropertySet | undefined, b: PropertySet | und
 // @internal (undocumented)
 export function maxReferencePosition<T extends ReferencePosition>(a: T, b: T): T;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export class MergeNode implements IMergeNodeCommon {
     // (undocumented)
     cachedLength: number;
@@ -745,10 +745,10 @@ export class MergeNode implements IMergeNodeCommon {
 // @internal @deprecated (undocumented)
 export type MergeTreeDeltaCallback = (opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs) => void;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type MergeTreeDeltaOperationType = typeof MergeTreeDeltaType.ANNOTATE | typeof MergeTreeDeltaType.INSERT | typeof MergeTreeDeltaType.REMOVE;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType | MergeTreeMaintenanceType;
 
 // @internal (undocumented)
@@ -764,7 +764,7 @@ export type MergeTreeDeltaRevertible = {
     propertyDeltas: PropertySet;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const MergeTreeDeltaType: {
     readonly INSERT: 0;
     readonly REMOVE: 1;
@@ -772,13 +772,13 @@ export const MergeTreeDeltaType: {
     readonly GROUP: 3;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type MergeTreeDeltaType = (typeof MergeTreeDeltaType)[keyof typeof MergeTreeDeltaType];
 
 // @internal @deprecated (undocumented)
 export type MergeTreeMaintenanceCallback = (MaintenanceArgs: IMergeTreeMaintenanceCallbackArgs, opArgs: IMergeTreeDeltaOpArgs | undefined) => void;
 
-// @internal
+// @alpha
 export const MergeTreeMaintenanceType: {
     readonly APPEND: -1;
     readonly SPLIT: -2;
@@ -786,10 +786,10 @@ export const MergeTreeMaintenanceType: {
     readonly ACKNOWLEDGED: -4;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type MergeTreeMaintenanceType = (typeof MergeTreeMaintenanceType)[keyof typeof MergeTreeMaintenanceType];
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface MergeTreeRevertibleDriver {
     // (undocumented)
     annotateRange(start: number, end: number, props: PropertySet): any;
@@ -805,7 +805,7 @@ export function minReferencePosition<T extends ReferencePosition>(a: T, b: T): T
 // @internal @deprecated (undocumented)
 export const NonCollabClient = -2;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export class PropertiesManager {
     constructor();
     // (undocumented)
@@ -820,7 +820,7 @@ export class PropertiesManager {
     hasPendingProperty(key: string): boolean;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export enum PropertiesRollback {
     None = 0,
     // @deprecated
@@ -842,7 +842,7 @@ export interface PropertyAction<TKey, TData> {
     <TAccum>(p: Property<TKey, TData>, accum?: TAccum): boolean;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type PropertySet = MapLike<any>;
 
 // @internal (undocumented)
@@ -853,7 +853,7 @@ export interface QProperty<TKey, TData> {
     key?: TKey;
 }
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export type RangeStackMap = MapLike<Stack<ReferencePosition>>;
 
 // @internal (undocumented)
@@ -933,7 +933,7 @@ export class RedBlackTree<TKey, TData> implements SortedDictionary<TKey, TData> 
     walkExactMatchesForward(compareFn: (node: RBNode<TKey, TData>) => number, actionFn: (node: RBNode<TKey, TData>) => void, continueLeftFn: (number: number) => boolean, continueRightFn: (number: number) => boolean): void;
 }
 
-// @internal
+// @alpha
 export interface ReferencePosition {
     // (undocumented)
     addProperties(newProps: PropertySet, op?: ICombiningOp): void;
@@ -948,7 +948,7 @@ export interface ReferencePosition {
     slidingPreference?: SlidingPreference;
 }
 
-// @internal
+// @alpha
 export enum ReferenceType {
     // @deprecated (undocumented)
     NestBegin = 2,
@@ -1008,7 +1008,7 @@ export interface SegmentAccumulator {
     segments: ISegment[];
 }
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export interface SegmentGroup {
     // (undocumented)
     localSeq: number;
@@ -1020,7 +1020,7 @@ export interface SegmentGroup {
     segments: ISegment[];
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export class SegmentGroupCollection {
     constructor(segment: ISegment);
     // (undocumented)
@@ -1054,13 +1054,13 @@ export interface SerializedAttributionCollection extends SequenceOffsets {
     length: number;
 }
 
-// @internal
+// @alpha
 export const SlidingPreference: {
     readonly BACKWARD: 0;
     readonly FORWARD: 1;
 };
 
-// @internal
+// @alpha
 export type SlidingPreference = (typeof SlidingPreference)[keyof typeof SlidingPreference];
 
 // @internal (undocumented)
@@ -1112,7 +1112,7 @@ export abstract class SortedSet<T, U extends string | number> {
     get size(): number;
 }
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export class Stack<T> {
     // (undocumented)
     empty(): boolean;
@@ -1126,7 +1126,7 @@ export class Stack<T> {
     top(): T | undefined;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export class TextSegment extends BaseSegment {
     constructor(text: string);
     // (undocumented)
@@ -1163,10 +1163,10 @@ export class TextSegment extends BaseSegment {
 // @internal @deprecated (undocumented)
 export function toRemovalInfo(maybe: Partial<IRemovalInfo> | undefined): IRemovalInfo | undefined;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type Trackable = ISegment | LocalReferencePosition;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export class TrackingGroup implements ITrackingGroup {
     constructor();
     // (undocumented)
@@ -1181,7 +1181,7 @@ export class TrackingGroup implements ITrackingGroup {
     unlink(trackable: Trackable): boolean;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export class TrackingGroupCollection {
     constructor(trackable: Trackable);
     // (undocumented)

--- a/packages/dds/merge-tree/src/attributionCollection.ts
+++ b/packages/dds/merge-tree/src/attributionCollection.ts
@@ -41,7 +41,7 @@ export interface SerializedAttributionCollection extends SequenceOffsets {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IAttributionCollectionSpec<T> {
 	root: Iterable<{ offset: number; key: T | null }>;
@@ -72,7 +72,7 @@ export interface IAttributionCollectionSerializer {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IAttributionCollection<T> {
 	/**

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -73,8 +73,7 @@ type IMergeTreeDeltaRemoteOpArgs = Omit<IMergeTreeDeltaOpArgs, "sequencedMessage
  * Emitted before this client's merge-tree normalizes its segments on reconnect, potentially
  * ordering them. Useful for DDS-like consumers built atop the merge-tree to compute any information
  * they need for rebasing their ops on reconnection.
- *
- * @internal
+ * @alpha
  */
 export interface IClientEvents {
 	(event: "normalize", listener: (target: IEventThisPlaceHolder) => void);
@@ -98,8 +97,7 @@ export interface IClientEvents {
 
 /**
  * @deprecated This functionality was not meant to be exported and will be removed in a future release
- *
- * @internal
+ * @alpha
  */
 export class Client extends TypedEventEmitter<IClientEvents> {
 	public longClientId: string | undefined;

--- a/packages/dds/merge-tree/src/collections/stack.ts
+++ b/packages/dds/merge-tree/src/collections/stack.ts
@@ -6,7 +6,7 @@
 /**
  * @deprecated This functionality was not intended for public export and will
  * be removed in a future release.
- * @internal
+ * @alpha
  */
 export class Stack<T> {
 	public items: T[] = [];

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -22,7 +22,7 @@ import {
 /**
  * Dictates the preferential direction for a {@link ReferencePosition} to slide
  * in a merge-tree
- * @internal
+ * @alpha
  */
 export const SlidingPreference = {
 	/**
@@ -38,7 +38,7 @@ export const SlidingPreference = {
 /**
  * Dictates the preferential direction for a {@link ReferencePosition} to slide
  * in a merge-tree
- * @internal
+ * @alpha
  */
 export type SlidingPreference = (typeof SlidingPreference)[keyof typeof SlidingPreference];
 
@@ -64,7 +64,7 @@ function _validateReferenceType(refType: ReferenceType) {
 }
 /**
  * @sealed
- * @internal
+ * @alpha
  */
 export interface LocalReferencePosition extends ReferencePosition {
 	callbacks?: Partial<
@@ -208,7 +208,7 @@ export function* filterLocalReferencePositions(
 
 /**
  * Represents a collection of {@link LocalReferencePosition}s associated with one segment in a merge-tree.
- * @internal
+ * @alpha
  */
 export class LocalReferenceCollection {
 	public static append(seg1: ISegment, seg2: ISegment) {

--- a/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
+++ b/packages/dds/merge-tree/src/mergeTreeDeltaCallback.ts
@@ -9,7 +9,7 @@ import { PropertySet } from "./properties";
 import { ISegment } from "./mergeTreeNodes";
 
 /**
- * @internal
+ * @alpha
  */
 export type MergeTreeDeltaOperationType =
 	| typeof MergeTreeDeltaType.ANNOTATE
@@ -21,7 +21,7 @@ export type MergeTreeDeltaOperationType =
  * Maintenance events correspond to structural segment changes or acks of pending segments.
  *
  * Note: these values are assigned negative integers to avoid clashing with `MergeTreeDeltaType`.
- * @internal
+ * @alpha
  */
 export const MergeTreeMaintenanceType = {
 	/**
@@ -51,18 +51,18 @@ export const MergeTreeMaintenanceType = {
 	ACKNOWLEDGED: -4,
 } as const;
 /**
- * @internal
+ * @alpha
  */
 export type MergeTreeMaintenanceType =
 	(typeof MergeTreeMaintenanceType)[keyof typeof MergeTreeMaintenanceType];
 
 /**
- * @internal
+ * @alpha
  */
 export type MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType | MergeTreeMaintenanceType;
 
 /**
- * @internal
+ * @alpha
  */
 export interface IMergeTreeDeltaCallbackArgs<
 	TOperationType extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationType,
@@ -72,7 +72,7 @@ export interface IMergeTreeDeltaCallbackArgs<
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IMergeTreeSegmentDelta {
 	segment: ISegment;
@@ -80,7 +80,7 @@ export interface IMergeTreeSegmentDelta {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IMergeTreeDeltaOpArgs {
 	/**
@@ -124,7 +124,7 @@ export type MergeTreeDeltaCallback = (
 ) => void;
 
 /**
- * @internal
+ * @alpha
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IMergeTreeMaintenanceCallbackArgs

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -29,7 +29,7 @@ import { PropertiesManager, PropertiesRollback } from "./segmentPropertiesManage
 
 /**
  * Common properties for a node in a merge tree.
- * @internal
+ * @alpha
  */
 export interface IMergeNodeCommon {
 	/**
@@ -95,7 +95,7 @@ export interface IHierBlock extends IMergeBlock {
 
 /**
  * Contains removal information associated to an {@link ISegment}.
- * @internal
+ * @alpha
  */
 export interface IRemovalInfo {
 	/**
@@ -132,7 +132,7 @@ export function toRemovalInfo(maybe: Partial<IRemovalInfo> | undefined): IRemova
 /**
  * A segment representing a portion of the merge tree.
  * Segments are leaf nodes of the merge tree and contain data.
- * @internal
+ * @alpha
  */
 export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo> {
 	readonly type: string;
@@ -247,7 +247,7 @@ export interface IMarkerModifiedAction {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISegmentAction<TClientData> {
 	// eslint-disable-next-line @typescript-eslint/prefer-function-type
@@ -359,7 +359,7 @@ export interface SearchResult {
 
 /**
  * @deprecated This functionality was not meant to be exported and will be removed in a future release
- * @internal
+ * @alpha
  */
 export interface SegmentGroup {
 	segments: ISegment[];
@@ -369,7 +369,7 @@ export interface SegmentGroup {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export class MergeNode implements IMergeNodeCommon {
 	index: number = 0;
@@ -433,7 +433,7 @@ export function seqLTE(seq: number, minOrRefSeq: number) {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export abstract class BaseSegment extends MergeNode implements ISegment {
 	public clientId: number = LocalClientId;
@@ -628,14 +628,14 @@ export const reservedMarkerIdKey = "markerId";
 export const reservedMarkerSimpleTypeKey = "markerSimpleType";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IJSONMarkerSegment extends IJSONSegment {
 	marker: IMarkerDef;
 }
 
 /**
- * @internal
+ * @alpha
  */
 export class Marker extends BaseSegment implements ReferencePosition {
 	public static readonly type = "Marker";
@@ -740,7 +740,7 @@ export class IncrementalMapState<TContext> {
 
 /**
  * @deprecated This functionality was not meant to be exported and will be removed in a future release
- * @internal
+ * @alpha
  */
 export class CollaborationWindow {
 	clientId = LocalClientId;

--- a/packages/dds/merge-tree/src/mergeTreeTracking.ts
+++ b/packages/dds/merge-tree/src/mergeTreeTracking.ts
@@ -10,12 +10,12 @@ import { ISegment } from "./mergeTreeNodes";
 import { SortedSegmentSet } from "./sortedSegmentSet";
 
 /**
- * @internal
+ * @alpha
  */
 export type Trackable = ISegment | LocalReferencePosition;
 
 /**
- * @internal
+ * @alpha
  */
 export interface ITrackingGroup {
 	tracked: readonly Trackable[];
@@ -26,7 +26,7 @@ export interface ITrackingGroup {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export class TrackingGroup implements ITrackingGroup {
 	private readonly trackedSet: SortedSegmentSet<Trackable>;
@@ -102,7 +102,7 @@ export class UnorderedTrackingGroup implements ITrackingGroup {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export class TrackingGroupCollection {
 	private readonly _trackingGroups: Set<ITrackingGroup>;

--- a/packages/dds/merge-tree/src/ops.ts
+++ b/packages/dds/merge-tree/src/ops.ts
@@ -5,7 +5,7 @@
 
 /**
  * Flags enum that dictates behavior of a ReferencePosition
- * @internal
+ * @alpha
  */
 export enum ReferenceType {
 	Simple = 0x0,
@@ -43,7 +43,7 @@ export enum ReferenceType {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IMarkerDef {
 	refType?: ReferenceType;
@@ -51,7 +51,7 @@ export interface IMarkerDef {
 
 // Note: Assigned positive integers to avoid clashing with MergeTreeMaintenanceType
 /**
- * @internal
+ * @alpha
  */
 export const MergeTreeDeltaType = {
 	INSERT: 0,
@@ -64,12 +64,12 @@ export const MergeTreeDeltaType = {
 } as const;
 
 /**
- * @internal
+ * @alpha
  */
 export type MergeTreeDeltaType = (typeof MergeTreeDeltaType)[keyof typeof MergeTreeDeltaType];
 
 /**
- * @internal
+ * @alpha
  */
 export interface IMergeTreeDelta {
 	/**
@@ -80,7 +80,7 @@ export interface IMergeTreeDelta {
 
 /**
  * A position specified relative to a segment.
- * @internal
+ * @alpha
  */
 export interface IRelativePosition {
 	/**
@@ -100,7 +100,7 @@ export interface IRelativePosition {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.INSERT;
@@ -112,7 +112,7 @@ export interface IMergeTreeInsertMsg extends IMergeTreeDelta {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.REMOVE;
@@ -126,7 +126,7 @@ export interface IMergeTreeRemoveMsg extends IMergeTreeDelta {
  * @deprecated We no longer intend to support this functionality and it will
  * be removed in a future release. There is no replacement for this
  * functionality.
- * @internal
+ * @alpha
  */
 export interface ICombiningOp {
 	name: string;
@@ -136,7 +136,7 @@ export interface ICombiningOp {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.ANNOTATE;
@@ -155,7 +155,7 @@ export interface IMergeTreeAnnotateMsg extends IMergeTreeDelta {
 
 /**
  * @deprecated The ability to create group ops will be removed in an upcoming release, as group ops are redundant with the native batching capabilities of the runtime
- * @internal
+ * @alpha
  */
 export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
 	type: typeof MergeTreeDeltaType.GROUP;
@@ -163,18 +163,18 @@ export interface IMergeTreeGroupMsg extends IMergeTreeDelta {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IJSONSegment {
 	props?: Record<string, any>;
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type IMergeTreeDeltaOp = IMergeTreeInsertMsg | IMergeTreeRemoveMsg | IMergeTreeAnnotateMsg;
 
 /**
- * @internal
+ * @alpha
  */
 export type IMergeTreeOp = IMergeTreeDeltaOp | IMergeTreeGroupMsg;

--- a/packages/dds/merge-tree/src/properties.ts
+++ b/packages/dds/merge-tree/src/properties.ts
@@ -8,7 +8,7 @@
 import { ICombiningOp } from "./ops";
 
 /**
- * @internal
+ * @alpha
  */
 export interface MapLike<T> {
 	[index: string]: T;
@@ -18,7 +18,7 @@ export interface MapLike<T> {
 // such as toJSON(), JSON.stringify accepts most types other
 // than functions
 /**
- * @internal
+ * @alpha
  */
 export type PropertySet = MapLike<any>;
 

--- a/packages/dds/merge-tree/src/referencePositions.ts
+++ b/packages/dds/merge-tree/src/referencePositions.ts
@@ -87,7 +87,7 @@ export function refHasRangeLabels(refPos: ReferencePosition): boolean {
  * Represents a reference to a place within a merge tree. This place conceptually remains stable over time
  * by referring to a particular segment and offset within that segment.
  * Thus, this reference's character position changes as the tree is edited.
- * @internal
+ * @alpha
  */
 export interface ReferencePosition {
 	/**
@@ -130,7 +130,7 @@ export interface ReferencePosition {
 
 /**
  * @deprecated This functionality is deprecated and will be removed in a future release.
- * @internal
+ * @alpha
  */
 export type RangeStackMap = MapLike<Stack<ReferencePosition>>;
 

--- a/packages/dds/merge-tree/src/revertibles.ts
+++ b/packages/dds/merge-tree/src/revertibles.ts
@@ -61,7 +61,7 @@ interface RemoveSegmentRefProperties {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface MergeTreeRevertibleDriver {
 	insertFromSpec(pos: number, spec: IJSONSegment);

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -9,7 +9,7 @@ import { List, walkList } from "./collections";
 import { ISegment, SegmentGroup } from "./mergeTreeNodes";
 
 /**
- * @internal
+ * @alpha
  */
 export class SegmentGroupCollection {
 	private readonly segmentGroups: List<SegmentGroup>;

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -12,7 +12,7 @@ import { ICombiningOp, IMergeTreeAnnotateMsg } from "./ops";
 import { combine, createMap, MapLike, PropertySet } from "./properties";
 
 /**
- * @internal
+ * @alpha
  */
 export enum PropertiesRollback {
 	/** Not in a rollback */
@@ -32,7 +32,7 @@ export enum PropertiesRollback {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export class PropertiesManager {
 	private pendingKeyUpdateCount: MapLike<number> | undefined;

--- a/packages/dds/merge-tree/src/textSegment.ts
+++ b/packages/dds/merge-tree/src/textSegment.ts
@@ -27,7 +27,7 @@ export interface IJSONTextSegment extends IJSONSegment {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export class TextSegment extends BaseSegment {
 	public static readonly type = "TextSegment";
@@ -122,7 +122,7 @@ export class TextSegment extends BaseSegment {
 
 /**
  * @deprecated This functionality was not meant to be exported and will be removed in a future release
- * @internal
+ * @alpha
  */
 export interface IMergeTreeTextHelper {
 	getText(

--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -83,7 +83,7 @@ export function createOverlappingSequenceIntervalsIndex(sharedString: SharedStri
 // @internal (undocumented)
 export function createStartpointInRangeIndex(sharedString: SharedString): IStartpointInRangeIndex<SequenceInterval>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type DeserializeCallback = (properties: PropertySet) => void;
 
 // @internal
@@ -117,7 +117,7 @@ export interface IIdIntervalIndex<TInterval extends ISerializableInterval> exten
     getIntervalById(id: string): TInterval | undefined;
 }
 
-// @internal
+// @alpha
 export interface IInterval {
     // (undocumented)
     clone(): IInterval;
@@ -130,7 +130,7 @@ export interface IInterval {
     union(b: IInterval): IInterval;
 }
 
-// @internal
+// @alpha
 export interface IIntervalCollection<TInterval extends ISerializableInterval> extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<TInterval>;
@@ -170,7 +170,7 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval> ex
     removeIntervalById(id: string): TInterval | undefined;
 }
 
-// @internal
+// @alpha
 export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval> extends IEvent {
     (event: "changeInterval", listener: (interval: TInterval, previousInterval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): any;
     (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): any;
@@ -195,7 +195,7 @@ export interface IMapMessageLocalMetadata {
     localSeq: number;
 }
 
-// @internal
+// @alpha
 export interface InteriorSequencePlace {
     // (undocumented)
     pos: number;
@@ -236,7 +236,7 @@ export class Interval implements ISerializableInterval {
     union(b: Interval): Interval;
 }
 
-// @internal
+// @alpha
 export interface IntervalIndex<TInterval extends ISerializableInterval> {
     add(interval: TInterval): void;
     remove(interval: TInterval): void;
@@ -297,7 +297,7 @@ export type IntervalRevertible = {
     mergeTreeRevertible: MergeTreeDeltaRevertible;
 };
 
-// @internal
+// @alpha
 export const IntervalStickiness: {
     readonly NONE: 0;
     readonly START: 1;
@@ -305,16 +305,17 @@ export const IntervalStickiness: {
     readonly FULL: 3;
 };
 
-// @internal
+// @alpha
 export type IntervalStickiness = (typeof IntervalStickiness)[keyof typeof IntervalStickiness];
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export enum IntervalType {
     // @deprecated (undocumented)
     Nest = 1,
     // (undocumented)
     Simple = 0,
     SlideOnRemove = 2,
+    // @internal
     Transient = 4
 }
 
@@ -325,7 +326,7 @@ export interface IOverlappingIntervalsIndex<TInterval extends ISerializableInter
     gatherIterationResults(results: TInterval[], iteratesForward: boolean, start?: SequencePlace, end?: SequencePlace): void;
 }
 
-// @internal
+// @alpha
 export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
     operation: TOperation;
     position: number;
@@ -333,7 +334,7 @@ export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationT
     segment: ISegment;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISerializableInterval extends IInterval {
     // (undocumented)
     addProperties(props: PropertySet, collaborating?: boolean, seq?: number): PropertySet | undefined;
@@ -345,7 +346,7 @@ export interface ISerializableInterval extends IInterval {
     serialize(): ISerializedInterval;
 }
 
-// @internal
+// @alpha
 export interface ISerializedInterval {
     end: number | "start" | "end";
     // (undocumented)
@@ -359,13 +360,13 @@ export interface ISerializedInterval {
     stickiness?: IntervalStickiness;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISharedIntervalCollection<TInterval extends ISerializableInterval> {
     // (undocumented)
     getIntervalCollection(label: string): IIntervalCollection<TInterval>;
 }
 
-// @internal
+// @alpha
 export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
     // (undocumented)
     (event: "createIntervalCollection", listener: (label: string, local: boolean, target: IEventThisPlaceHolder) => void): any;
@@ -375,7 +376,7 @@ export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
     (event: "maintenance", listener: (event: SequenceMaintenanceEvent, target: IEventThisPlaceHolder) => void): any;
 }
 
-// @internal
+// @alpha
 export interface ISharedString extends SharedSegmentSequence<SharedStringSegment> {
     insertMarker(pos: number, refType: ReferenceType, props?: PropertySet): IMergeTreeInsertMsg | undefined;
     insertText(pos: number, text: string, props?: PropertySet): void;
@@ -397,7 +398,7 @@ export interface IValueOpEmitter {
 // @internal
 export function revertSharedStringRevertibles(sharedString: SharedString, revertibles: SharedStringRevertible[]): void;
 
-// @internal
+// @alpha
 export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
     constructor(opArgs: IMergeTreeDeltaOpArgs, deltaArgs: IMergeTreeDeltaCallbackArgs, mergeTreeClient: Client);
     readonly isLocal: boolean;
@@ -405,7 +406,7 @@ export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationTyp
     readonly opArgs: IMergeTreeDeltaOpArgs;
 }
 
-// @internal
+// @alpha
 export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
     constructor(deltaArgs: IMergeTreeDeltaCallbackArgs<TOperation>, mergeTreeClient: Client);
     get clientId(): string | undefined;
@@ -418,7 +419,7 @@ export abstract class SequenceEvent<TOperation extends MergeTreeDeltaOperationTy
     get ranges(): readonly Readonly<ISequenceDeltaRange<TOperation>>[];
 }
 
-// @internal
+// @alpha
 export class SequenceInterval implements ISerializableInterval {
     constructor(client: Client,
     start: LocalReferencePosition,
@@ -472,7 +473,7 @@ export namespace SequenceIntervalIndexes {
     }
 }
 
-// @internal
+// @alpha
 export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
     constructor(opArgs: IMergeTreeDeltaOpArgs | undefined, deltaArgs: IMergeTreeMaintenanceCallbackArgs, mergeTreeClient: Client);
     // (undocumented)
@@ -487,7 +488,7 @@ export interface SequenceOptions {
     mergeTreeReferencesCanSlideToEndpoint: boolean;
 }
 
-// @internal
+// @alpha
 export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
 
 // @internal
@@ -533,7 +534,7 @@ export class SharedIntervalCollectionFactory implements IChannelFactory {
     get type(): string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export abstract class SharedSegmentSequence<T extends ISegment> extends SharedObject<ISharedSegmentSequenceEvents> implements ISharedIntervalCollection<SequenceInterval>, MergeTreeRevertibleDriver {
     constructor(dataStoreRuntime: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes, segmentFromSpec: (spec: IJSONSegment) => ISegment);
     annotateRange(start: number, end: number, props: PropertySet, combiningOp?: ICombiningOp): void;
@@ -616,7 +617,7 @@ export class SharedSequence<T> extends SharedSegmentSequence<SubSequence<T>> {
     remove(start: number, end: number): void;
 }
 
-// @internal
+// @alpha
 export class SharedString extends SharedSegmentSequence<SharedStringSegment> implements ISharedString {
     constructor(document: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes);
     annotateMarker(marker: Marker, props: PropertySet, combiningOp?: ICombiningOp): void;
@@ -648,7 +649,7 @@ export class SharedString extends SharedSegmentSequence<SharedStringSegment> imp
     searchForMarker(startPos: number, markerLabel: string, forwards?: boolean): Marker | undefined;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export class SharedStringFactory implements IChannelFactory {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;
@@ -669,10 +670,10 @@ export class SharedStringFactory implements IChannelFactory {
 // @internal
 export type SharedStringRevertible = MergeTreeDeltaRevertible | IntervalRevertible;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type SharedStringSegment = TextSegment | Marker;
 
-// @internal
+// @alpha
 export enum Side {
     // (undocumented)
     After = 1,

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -87,7 +87,7 @@ import {
  * If a SequencePlace is the endpoint of a range (e.g. start/end of an interval or search range),
  * the Side value means it is exclusive if it is nearer to the other position and inclusive if it is farther.
  * E.g. the start of a range with Side.After is exclusive of the character at the position.
- * @internal
+ * @alpha
  */
 export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
 
@@ -95,7 +95,7 @@ export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
  * A sequence place that does not refer to the special endpoint segments.
  *
  * See {@link SequencePlace} for additional context.
- * @internal
+ * @alpha
  */
 export interface InteriorSequencePlace {
 	pos: number;
@@ -106,7 +106,7 @@ export interface InteriorSequencePlace {
  * Defines a side relative to a character in a sequence.
  *
  * @remarks See {@link SequencePlace} for additional context on usage.
- * @internal
+ * @alpha
  */
 export enum Side {
 	Before = 0,
@@ -626,7 +626,7 @@ export function makeOpsMap<T extends ISerializableInterval>(): Map<
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type DeserializeCallback = (properties: PropertySet) => void;
 
@@ -665,7 +665,7 @@ class IntervalCollectionIterator<TInterval extends ISerializableInterval>
 
 /**
  * Change events emitted by `IntervalCollection`s
- * @internal
+ * @alpha
  */
 export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval> extends IEvent {
 	/**
@@ -733,7 +733,7 @@ const isSequencePlace = (place: any): place is SequencePlace => {
 /**
  * Collection of intervals that supports addition, modification, removal, and efficient spatial querying.
  * Changes to this collection will be incur updates on collaborating clients (i.e. they are not local-only).
- * @internal
+ * @alpha
  */
 export interface IIntervalCollection<TInterval extends ISerializableInterval>
 	extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>> {

--- a/packages/dds/sequence/src/intervalIndex/intervalIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/intervalIndex.ts
@@ -13,7 +13,7 @@ import { ISerializableInterval } from "../intervals";
  * - "find all intervals with start endpoint between these two points"
  * - "find all intervals which overlap this range"
  * etc.
- * @internal
+ * @alpha
  */
 export interface IntervalIndex<TInterval extends ISerializableInterval> {
 	/**

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -17,7 +17,7 @@ import { SequencePlace, Side } from "../intervalCollection";
 
 /**
  * Basic interval abstraction
- * @internal
+ * @alpha
  */
 export interface IInterval {
 	/**
@@ -84,7 +84,7 @@ export const IntervalOpType = {
  */
 export type IntervalOpType = (typeof IntervalOpType)[keyof typeof IntervalOpType];
 /**
- * @internal
+ * @alpha
  */
 export enum IntervalType {
 	Simple = 0x0,
@@ -111,7 +111,7 @@ export enum IntervalType {
 /**
  * Serialized object representation of an interval.
  * This representation is used for ops that create or change intervals.
- * @internal
+ * @alpha
  */
 export interface ISerializedInterval {
 	/**
@@ -139,7 +139,7 @@ export interface ISerializedInterval {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISerializableInterval extends IInterval {
 	/** Serializable bag of properties associated with the interval. */
@@ -240,7 +240,7 @@ export interface IIntervalHelpers<TInterval extends ISerializableInterval> {
  * Note that interval stickiness is currently an experimental feature and must
  * be explicitly enabled with the `intervalStickinessEnabled` flag
  *
- * @internal
+ * @alpha
  */
 export const IntervalStickiness = {
 	/**
@@ -272,8 +272,7 @@ export const IntervalStickiness = {
  *
  * Note that interval stickiness is currently an experimental feature and must
  * be explicitly enabled with the `intervalStickinessEnabled` flag
- *
- * @internal
+ * @alpha
  */
 export type IntervalStickiness = (typeof IntervalStickiness)[keyof typeof IntervalStickiness];
 

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -100,7 +100,7 @@ function maxSide(sideA: Side, sideB: Side): Side {
  * `mergeTreeReferencesCanSlideToEndpoint` feature flag set to true, the endpoints
  * of the interval that are exclusive will have the ability to slide to these
  * special endpoint segments.
- * @internal
+ * @alpha
  */
 export class SequenceInterval implements ISerializableInterval {
 	/**

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -98,7 +98,7 @@ const contentPath = "content";
  * - `event` - Various information on the segments that were modified.
  *
  * - `target` - The sequence itself.
- * @internal
+ * @alpha
  */
 export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
 	(
@@ -116,7 +116,7 @@ export interface ISharedSegmentSequenceEvents extends ISharedObjectEvents {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export abstract class SharedSegmentSequence<T extends ISegment>
 	extends SharedObject<ISharedSegmentSequenceEvents>

--- a/packages/dds/sequence/src/sequenceDeltaEvent.ts
+++ b/packages/dds/sequence/src/sequenceDeltaEvent.ts
@@ -25,7 +25,7 @@ import {
  * The properties of this object and its sub-objects represent the state of the sequence at the
  * point in time at which the operation was applied.
  * They will not take into any future modifications performed to the underlying sequence and merge tree.
- * @internal
+ * @alpha
  */
 export abstract class SequenceEvent<
 	TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes,
@@ -108,7 +108,7 @@ export abstract class SequenceEvent<
  * For group ops, each op will get its own event, and the group op property will be set on the op args.
  *
  * Ops may get multiple events. For instance, an insert-replace will get a remove then an insert event.
- * @internal
+ * @alpha
  */
 export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationType> {
 	/**
@@ -132,7 +132,7 @@ export class SequenceDeltaEvent extends SequenceEvent<MergeTreeDeltaOperationTyp
  * The properties of this object and its sub-objects represent the state of the sequence at the
  * point in time at which the operation was applied.
  * They will not take into consideration any future modifications performed to the underlying sequence and merge tree.
- * @internal
+ * @alpha
  */
 export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenanceType> {
 	constructor(
@@ -146,7 +146,7 @@ export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenance
 
 /**
  * A range that has changed corresponding to a segment modification.
- * @internal
+ * @alpha
  */
 export interface ISequenceDeltaRange<
 	TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes,

--- a/packages/dds/sequence/src/sequenceFactory.ts
+++ b/packages/dds/sequence/src/sequenceFactory.ts
@@ -14,7 +14,7 @@ import { pkgVersion } from "./packageVersion";
 import { SharedString, SharedStringSegment } from "./sharedString";
 
 /**
- * @internal
+ * @alpha
  */
 export class SharedStringFactory implements IChannelFactory {
 	// TODO rename back to https://graph.microsoft.com/types/mergeTree/string once paparazzi is able to dynamically

--- a/packages/dds/sequence/src/sharedIntervalCollection.ts
+++ b/packages/dds/sequence/src/sharedIntervalCollection.ts
@@ -76,7 +76,7 @@ export class SharedIntervalCollectionFactory implements IChannelFactory {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISharedIntervalCollection<TInterval extends ISerializableInterval> {
 	getIntervalCollection(label: string): IIntervalCollection<TInterval>;

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -24,7 +24,7 @@ import { SharedStringFactory } from "./sequenceFactory";
 
 /**
  * Fluid object interface describing access methods on a SharedString
- * @internal
+ * @alpha
  */
 export interface ISharedString extends SharedSegmentSequence<SharedStringSegment> {
 	/**
@@ -54,7 +54,7 @@ export interface ISharedString extends SharedSegmentSequence<SharedStringSegment
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type SharedStringSegment = TextSegment | Marker;
 
@@ -66,7 +66,7 @@ export type SharedStringSegment = TextSegment | Marker;
  * In addition to text, a Shared String can also contain markers. Markers can be
  * used to store metadata at positions within the text, like the details of an
  * image or Fluid object that should be rendered with the text.
- * @internal
+ * @alpha
  */
 export class SharedString
 	extends SharedSegmentSequence<SharedStringSegment>

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -144,12 +144,12 @@ export interface IFluidDataStoreRuntimeEvents extends IEvent {
     (event: "connected", listener: (clientId: string) => void): any;
 }
 
-// @internal
+// @alpha
 export type Jsonable<T = any, TReplaced = void> = T extends undefined | null | boolean | number | string | TReplaced ? T : Extract<T, Function> extends never ? {
     [K in keyof T]: Extract<K, symbol> extends never ? Jsonable<T[K], TReplaced> : never;
 } : never;
 
-// @internal
+// @alpha
 export type Serializable<T = any> = Jsonable<T, IFluidHandle>;
 
 ```

--- a/packages/runtime/datastore-definitions/src/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/jsonable.ts
@@ -40,7 +40,7 @@
  * ```typescript
  * function foo<T>(value: Jsonable<T>) { ... }
  * ```
- * @internal
+ * @alpha
  */
 export type Jsonable<T = any, TReplaced = void> = T extends
 	| undefined

--- a/packages/runtime/datastore-definitions/src/serializable.ts
+++ b/packages/runtime/datastore-definitions/src/serializable.ts
@@ -22,6 +22,6 @@ import { Jsonable } from "./jsonable";
  * ```typescript
  * function serialize<T>(value: Serializable<T>) { ... }
  * ```
- * @internal
+ * @alpha
  */
 export type Serializable<T = any> = Jsonable<T, IFluidHandle>;

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -41,7 +41,7 @@ export interface AttributionInfo {
     user: IUser;
 }
 
-// @internal
+// @alpha
 export type AttributionKey = OpAttributionKey | DetachedAttributionKey | LocalAttributionKey;
 
 // @internal (undocumented)
@@ -75,7 +75,7 @@ export enum CreateSummarizerNodeSource {
     Local = 2
 }
 
-// @internal
+// @alpha
 export interface DetachedAttributionKey {
     id: 0;
     // (undocumented)
@@ -453,7 +453,7 @@ export interface ITelemetryContext {
     setMultiple(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;
 }
 
-// @internal
+// @alpha
 export interface LocalAttributionKey {
     // (undocumented)
     type: "local";
@@ -465,7 +465,7 @@ export type NamedFluidDataStoreRegistryEntries = Iterable<NamedFluidDataStoreReg
 // @alpha
 export type NamedFluidDataStoreRegistryEntry = [string, Promise<FluidDataStoreRegistryEntry>];
 
-// @internal
+// @alpha
 export interface OpAttributionKey {
     seq: number;
     type: "op";

--- a/packages/runtime/runtime-definitions/src/attribution.ts
+++ b/packages/runtime/runtime-definitions/src/attribution.ts
@@ -8,7 +8,7 @@ import type { IUser } from "@fluidframework/protocol-definitions";
 /**
  * AttributionKey representing a reference to some op in the op stream.
  * Content associated with this key aligns with content modified by that op.
- * @internal
+ * @alpha
  */
 export interface OpAttributionKey {
 	/**
@@ -32,7 +32,7 @@ export interface OpAttributionKey {
  * is currently unsupported, as applications can effectively modify content anonymously while detached.
  * The runtime has no mechanism for reliably obtaining the user. It would be reasonable to start supporting
  * this functionality if the host provided additional context to their attributor or attach calls.
- * @internal
+ * @alpha
  */
 export interface DetachedAttributionKey {
 	type: "detached";
@@ -50,7 +50,7 @@ export interface DetachedAttributionKey {
 
 /**
  * AttributionKey associated with content that has been made locally but not yet acked by the server.
- * @internal
+ * @alpha
  */
 export interface LocalAttributionKey {
 	type: "local";
@@ -58,7 +58,7 @@ export interface LocalAttributionKey {
 
 /**
  * Can be indexed into the ContainerRuntime in order to retrieve {@link AttributionInfo}.
- * @internal
+ * @alpha
  */
 export type AttributionKey = OpAttributionKey | DetachedAttributionKey | LocalAttributionKey;
 


### PR DESCRIPTION
This PR tags the SharedString, SharedMatrix, SharedMap, and SharedDirectory as alpha. All these types were automatically identified as transitive dependency of the SharedString, SharedMatrix, SharedMap, and SharedDirectory.

We will stage these commits and invite review, however review items will generally be added to the backlog as future items, as these type updates are necessary for the current state of the code base.