### PR TITLE
tree2: Document beta APIs

### DIFF
--- a/experimental/dds/tree2/api-report/tree2.api.md
+++ b/experimental/dds/tree2/api-report/tree2.api.md
@@ -434,7 +434,7 @@ export type ExtractFromOpaque<TOpaque extends BrandedType<any, string>> = TOpaqu
 // @alpha
 export function extractFromOpaque<TOpaque extends BrandedType<any, string>>(value: TOpaque): ExtractFromOpaque<TOpaque>;
 
-// @beta (undocumented)
+// @beta
 type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? Result : Item;
 
 // @alpha (undocumented)
@@ -464,9 +464,7 @@ export abstract class FieldKind<TName extends string = string, TMultiplicity ext
 
 // @beta
 enum FieldKind_2 {
-    // (undocumented)
     Optional = 0,
-    // (undocumented)
     Required = 1
 }
 
@@ -531,7 +529,6 @@ class FieldSchema<out Kind extends FieldKind_2 = FieldKind_2, out Types extends 
     readonly allowedTypes: Types;
     // (undocumented)
     readonly kind: Kind;
-    // (undocumented)
     protected _typeCheck?: MakeNominal;
 }
 
@@ -1002,9 +999,7 @@ export interface ISubscribable<E extends Events<E>> {
 
 // @beta
 export class IterableTreeListContent<T> implements Iterable<T> {
-    // (undocumented)
     static [create]<T>(content: Iterable<T>): IterableTreeListContent<T>;
-    // (undocumented)
     [Symbol.iterator](): Iterator<T>;
 }
 
@@ -1270,13 +1265,9 @@ export interface NodeKeys {
 
 // @beta
 enum NodeKind {
-    // (undocumented)
     Leaf = 3,
-    // (undocumented)
     List = 1,
-    // (undocumented)
     Map = 0,
-    // (undocumented)
     Object = 2
 }
 
@@ -1436,7 +1427,6 @@ type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
 export interface Revertible {
     discard(): DiscardResult;
     readonly kind: RevertibleKind;
-    // (undocumented)
     readonly origin: {
         readonly isLocal: boolean;
     };
@@ -1728,7 +1718,7 @@ export enum TreeCompressionStrategy {
     Uncompressed = 1
 }
 
-// @beta (undocumented)
+// @beta
 export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {
     constructor(schema: TSchema, initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>);
     // (undocumented)
@@ -1887,8 +1877,8 @@ export abstract class TreeNodeSchemaBase<const out Name extends string = string,
 
 // @beta
 interface TreeNodeSchemaClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never> extends TreeNodeSchemaCore<Name, Kind> {
-    // (undocumented)
-    new (data: TInsertable): TNode;
+    // @sealed
+    new (data: TInsertable): Unhydrated<TNode>;
 }
 
 // @beta

--- a/experimental/dds/tree2/src/class-tree/schemaTypes.ts
+++ b/experimental/dds/tree2/src/class-tree/schemaTypes.ts
@@ -94,7 +94,14 @@ export interface TreeNodeSchemaClass<
 	out TNode = unknown,
 	in TInsertable = never,
 > extends TreeNodeSchemaCore<Name, Kind> {
-	new (data: TInsertable): TNode;
+	/**
+	 * Constructs an {@link Unhydrated} node with this schema.
+	 * @remarks
+	 * This constructor is also used internally to construct hydrated nodes with a different parameter type.
+	 * Therefor overriding this constructor is not type-safe and is not supported.
+	 * @sealed
+	 */
+	new (data: TInsertable): Unhydrated<TNode>;
 }
 
 /**
@@ -122,7 +129,17 @@ export type AllowedTypes = readonly LazyItem<TreeNodeSchema>[];
  * @beta
  */
 export enum FieldKind {
+	/**
+	 * A field which can be empty or filled.
+	 * @remarks
+	 * Allows 0 or one child.
+	 */
 	Optional,
+	/**
+	 * A field which must always be filled.
+	 * @remarks
+	 * Only allows exactly one child.
+	 */
 	Required,
 }
 
@@ -131,9 +148,23 @@ export enum FieldKind {
  * @beta
  */
 export enum NodeKind {
+	/**
+	 * Node which serves as a map, storing children under string keys.
+	 */
 	Map,
+	/**
+	 * Node which serves as a list, storing children in an ordered sequence.
+	 */
 	List,
+	/**
+	 * Node which stores a heterogenous collection of children in named fields.
+	 * @remarks
+	 * Each field gets its own schema.
+	 */
 	Object,
+	/**
+	 * Node which stores a single leaf value.
+	 */
 	Leaf,
 }
 
@@ -148,7 +179,10 @@ export class FieldSchema<
 	out Kind extends FieldKind = FieldKind,
 	out Types extends ImplicitAllowedTypes = ImplicitAllowedTypes,
 > {
-	// This class is used with instanceof, and therefore should have nominal typing.
+	/**
+	 * This class is used with instanceof, and therefore should have nominal typing.
+	 * This field enforces that.
+	 */
 	protected _typeCheck?: MakeNominal;
 
 	/**

--- a/experimental/dds/tree2/src/class-tree/schemaTypes.ts
+++ b/experimental/dds/tree2/src/class-tree/schemaTypes.ts
@@ -149,21 +149,21 @@ export enum FieldKind {
  */
 export enum NodeKind {
 	/**
-	 * Node which serves as a map, storing children under string keys.
+	 * A node which serves as a map, storing children under string keys.
 	 */
 	Map,
 	/**
-	 * Node which serves as a list, storing children in an ordered sequence.
+	 * A node which serves as a list, storing children in an ordered sequence.
 	 */
 	List,
 	/**
-	 * Node which stores a heterogenous collection of children in named fields.
+	 * A node which stores a heterogenous collection of children in named fields.
 	 * @remarks
 	 * Each field gets its own schema.
 	 */
 	Object,
 	/**
-	 * Node which stores a single leaf value.
+	 * A node which stores a single leaf value.
 	 */
 	Leaf,
 }

--- a/experimental/dds/tree2/src/class-tree/tree.ts
+++ b/experimental/dds/tree2/src/class-tree/tree.ts
@@ -61,7 +61,7 @@ export interface ITree extends IChannel {
 }
 
 /**
- * Configuration for how to schematize a tree.
+ * Configuration for how to {@link ITree.schematize|schematize} a tree.
  * @beta
  */
 export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {

--- a/experimental/dds/tree2/src/class-tree/tree.ts
+++ b/experimental/dds/tree2/src/class-tree/tree.ts
@@ -14,8 +14,11 @@ import {
 	InsertableTreeFieldFromImplicitField,
 	TreeFieldFromImplicitField,
 } from "./schemaTypes";
+
 /**
- * Channel for a Tree DDS.
+ * Channel for a Fluid Tree DDS.
+ * @remarks
+ * Allows storing and collaboratively editing schema aware hierarchial data.
  * @beta
  */
 export interface ITree extends IChannel {
@@ -58,6 +61,7 @@ export interface ITree extends IChannel {
 }
 
 /**
+ * Configuration for how to schematize a tree.
  * @beta
  */
 export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {

--- a/experimental/dds/tree2/src/class-tree/tree.ts
+++ b/experimental/dds/tree2/src/class-tree/tree.ts
@@ -18,7 +18,7 @@ import {
 /**
  * Channel for a Fluid Tree DDS.
  * @remarks
- * Allows storing and collaboratively editing schema aware hierarchial data.
+ * Allows storing and collaboratively editing schema-aware hierarchial data.
  * @beta
  */
 export interface ITree extends IChannel {

--- a/experimental/dds/tree2/src/core/revertible/revertible.ts
+++ b/experimental/dds/tree2/src/core/revertible/revertible.ts
@@ -12,6 +12,9 @@
 export interface Revertible {
 	/** Indicates the type of edit that produced this revertible. */
 	readonly kind: RevertibleKind;
+	/**
+	 * Information about which client created the edit.
+	 */
 	readonly origin: {
 		readonly isLocal: boolean;
 	};

--- a/experimental/dds/tree2/src/core/revertible/revertible.ts
+++ b/experimental/dds/tree2/src/core/revertible/revertible.ts
@@ -16,6 +16,9 @@ export interface Revertible {
 	 * Information about which client created the edit.
 	 */
 	readonly origin: {
+		/**
+		 * Indicates if the {@link Revertible} is from the local client (true) or a remote client (false).
+		 */
 		readonly isLocal: boolean;
 	};
 	/**

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/flexList.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/flexList.ts
@@ -94,6 +94,7 @@ export type NormalizedFlexList<Item> = readonly Item[];
 export type NormalizedLazyFlexList<Item> = (() => Item)[];
 
 /**
+ * Get the `Item` type from a `LazyItem<Item>`.
  * @beta
  */
 export type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result

--- a/experimental/dds/tree2/src/simple-tree/treeListNode.ts
+++ b/experimental/dds/tree2/src/simple-tree/treeListNode.ts
@@ -55,15 +55,22 @@ const create = Symbol("Create IterableTreeListContent");
 /**
  * Used to insert iterable content into a {@link (TreeListNode:interface)}.
  * Use {@link (TreeListNode:variable).inline} to create an instance of this type.
- * @privateRemarks
- * TODO: Figure out how to link {@link TreeListNode.inline} above such that it works with API-Extractor.
  * @beta
  */
 export class IterableTreeListContent<T> implements Iterable<T> {
 	private constructor(private readonly content: Iterable<T>) {}
+
+	/**
+	 * Package internal construction API.
+	 * Use {@link (TreeListNode:variable).inline} to create an instance of this type instead.
+	 */
 	public static [create]<T>(content: Iterable<T>): IterableTreeListContent<T> {
 		return new IterableTreeListContent(content);
 	}
+
+	/**
+	 * Iterates over content for nodes to insert.
+	 */
 	public [Symbol.iterator](): Iterator<T> {
 		return this.content[Symbol.iterator]();
 	}


### PR DESCRIPTION
## Description

Document all `@beta` APIs API-Extractor reported as undocumented.

This fixed all non-parameter property undocumented warnings for beta APIs. Parameter properties are currently incorrectly reporting as undocumented, as noted in https://github.com/microsoft/rushstack/issues/3462#issuecomment-1216986905

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
