### PR TITLE
Tag odsp-driver alpha

### DIFF
--- a/packages/common/core-utils/api-report/core-utils.api.md
+++ b/packages/common/core-utils/api-report/core-utils.api.md
@@ -90,7 +90,7 @@ export class LazyPromise<T> implements Promise<T> {
 // @internal
 export const NumberComparer: IComparer<number>;
 
-// @internal
+// @alpha
 export class PromiseCache<TKey, TResult> {
     constructor({ expiry, removeOnError, }?: PromiseCacheOptions);
     add(key: TKey, asyncFn: () => Promise<TResult>): boolean;
@@ -102,7 +102,7 @@ export class PromiseCache<TKey, TResult> {
     remove(key: TKey): boolean;
 }
 
-// @internal
+// @alpha
 export type PromiseCacheExpiry = {
     policy: "indefinite";
 } | {
@@ -110,7 +110,7 @@ export type PromiseCacheExpiry = {
     durationMs: number;
 };
 
-// @internal
+// @alpha
 export interface PromiseCacheOptions {
     expiry?: PromiseCacheExpiry;
     removeOnError?: (error: any) => boolean;

--- a/packages/common/core-utils/src/promiseCache.ts
+++ b/packages/common/core-utils/src/promiseCache.ts
@@ -8,7 +8,7 @@
  * - indefinite: entries don't expire and must be explicitly removed
  * - absolute: entries expire after the given duration in MS, even if accessed multiple times in the mean time
  * - sliding: entries expire after the given duration in MS of inactivity (i.e. get resets the clock)
- * @internal
+ * @alpha
  */
 export type PromiseCacheExpiry =
 	| {
@@ -21,7 +21,7 @@ export type PromiseCacheExpiry =
 
 /**
  * Options for configuring the {@link PromiseCache}
- * @internal
+ * @alpha
  */
 export interface PromiseCacheOptions {
 	/**
@@ -89,7 +89,7 @@ class GarbageCollector<TKey> {
 /**
  * A specialized cache for async work, allowing you to safely cache the promised result of some async work
  * without fear of running it multiple times or losing track of errors.
- * @internal
+ * @alpha
  */
 export class PromiseCache<TKey, TResult> {
 	private readonly cache = new Map<TKey, Promise<TResult>>();

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
@@ -296,7 +296,7 @@ export enum SharingLinkScope {
 // @internal
 export const snapshotKey = "snapshot";
 
-// @internal
+// @alpha
 export type TokenFetcher<T> = (options: T) => Promise<string | TokenResponse | null>;
 
 // @alpha
@@ -309,7 +309,7 @@ export interface TokenFetchOptions {
 // @internal
 export const tokenFromResponse: (tokenResponse: string | TokenResponse | null | undefined) => string | null;
 
-// @internal
+// @alpha
 export interface TokenResponse {
     fromCache?: boolean;
     token: string;

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
@@ -8,13 +8,13 @@ import { DriverError } from '@fluidframework/driver-definitions';
 import { IDriverErrorBase } from '@fluidframework/driver-definitions';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type CacheContentType = "snapshot" | "ops";
 
 // @internal
 export function getKeyForCacheEntry(entry: ICacheEntry): string;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface HostStoragePolicy {
     avoidPrefetchSnapshotCache?: boolean;
     cacheCreateNewSummary?: boolean;
@@ -37,12 +37,12 @@ export interface HostStoragePolicy {
     snapshotOptions?: ISnapshotOptions;
 }
 
-// @internal
+// @alpha
 export interface ICacheEntry extends IEntry {
     file: IFileEntry;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ICollabSessionOptions {
     // @deprecated (undocumented)
     forceAccessTokenViaAuthorizationHeader?: boolean;
@@ -52,13 +52,13 @@ export interface ICollabSessionOptions {
 // @internal
 export type IdentityType = "Consumer" | "Enterprise";
 
-// @internal
+// @alpha
 export interface IEntry {
     key: string;
     type: CacheContentType;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IFileEntry {
     docId: string;
     resolvedUrl: IResolvedUrl;
@@ -80,7 +80,7 @@ export interface IOdspErrorAugmentations {
     serverEpoch?: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
     // (undocumented)
     codeHint?: {
@@ -116,7 +116,7 @@ export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
     url: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IOdspUrlParts {
     // (undocumented)
     driveId: string;
@@ -126,39 +126,39 @@ export interface IOdspUrlParts {
     siteUrl: string;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IOpsCachingPolicy {
     batchSize?: number;
     timerGranularity?: number;
     totalOpsToCache?: number;
 }
 
-// @internal
+// @alpha
 export interface IPersistedCache {
     get(entry: ICacheEntry): Promise<any>;
     put(entry: ICacheEntry, value: any): Promise<void>;
     removeEntries(file: IFileEntry): Promise<void>;
 }
 
-// @internal
+// @alpha
 export interface IProvideSessionAwareDriverFactory {
     // (undocumented)
     readonly IRelaySessionAwareDriverFactory: IRelaySessionAwareDriverFactory;
 }
 
-// @internal
+// @alpha
 export interface IRelaySessionAwareDriverFactory extends IProvideSessionAwareDriverFactory {
     // (undocumented)
     getRelayServiceSessionInfo(resolvedUrl: IResolvedUrl): Promise<ISocketStorageDiscovery | undefined>;
 }
 
-// @internal
+// @alpha
 export interface ISharingLink extends ISharingLinkKind {
     // (undocumented)
     webUrl: string;
 }
 
-// @internal
+// @alpha
 export interface ISharingLinkKind {
     // (undocumented)
     role?: SharingLinkRole;
@@ -166,7 +166,7 @@ export interface ISharingLinkKind {
     scope: SharingLinkScope;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISnapshotOptions {
     // (undocumented)
     blobs?: number;
@@ -180,7 +180,7 @@ export interface ISnapshotOptions {
     timeout?: number;
 }
 
-// @internal
+// @alpha
 export interface ISocketStorageDiscovery {
     // (undocumented)
     deltaStorageUrl: string;
@@ -249,14 +249,14 @@ export const OdspErrorTypes: {
 // @internal (undocumented)
 export type OdspErrorTypes = (typeof OdspErrorTypes)[keyof typeof OdspErrorTypes];
 
-// @internal
+// @alpha
 export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
     driveId?: string;
     itemId?: string;
     siteUrl: string;
 }
 
-// @internal
+// @alpha
 export interface ShareLinkInfoType {
     createLink?: {
         type?: ShareLinkTypes | ISharingLinkKind;
@@ -267,13 +267,13 @@ export interface ShareLinkInfoType {
     sharingLinkToRedeem?: string;
 }
 
-// @internal @deprecated (undocumented)
+// @alpha @deprecated (undocumented)
 export enum ShareLinkTypes {
     // (undocumented)
     csl = "csl"
 }
 
-// @internal
+// @alpha
 export enum SharingLinkRole {
     // (undocumented)
     edit = "edit",
@@ -281,7 +281,7 @@ export enum SharingLinkRole {
     view = "view"
 }
 
-// @internal
+// @alpha
 export enum SharingLinkScope {
     // (undocumented)
     anonymous = "anonymous",
@@ -299,7 +299,7 @@ export const snapshotKey = "snapshot";
 // @internal
 export type TokenFetcher<T> = (options: T) => Promise<string | TokenResponse | null>;
 
-// @internal
+// @alpha
 export interface TokenFetchOptions {
     claims?: string;
     refresh: boolean;

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISnapshotOptions {
 	blobs?: number;
@@ -26,7 +26,7 @@ export interface ISnapshotOptions {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IOpsCachingPolicy {
 	/**
@@ -57,7 +57,7 @@ export interface IOpsCachingPolicy {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ICollabSessionOptions {
 	/**
@@ -79,7 +79,7 @@ export interface ICollabSessionOptions {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface HostStoragePolicy {
 	snapshotOptions?: ISnapshotOptions;

--- a/packages/drivers/odsp-driver-definitions/src/odspCache.ts
+++ b/packages/drivers/odsp-driver-definitions/src/odspCache.ts
@@ -11,7 +11,7 @@ import { IResolvedUrl } from "@fluidframework/driver-definitions";
  */
 export const snapshotKey = "snapshot";
 /**
- * @internal
+ * @alpha
  */
 export type CacheContentType = "snapshot" | "ops";
 
@@ -21,7 +21,7 @@ export type CacheContentType = "snapshot" | "ops";
  * to implement storage / identify files.
  */
 /**
- * @internal
+ * @alpha
  */
 export interface IFileEntry {
 	/**
@@ -40,7 +40,7 @@ export interface IFileEntry {
 
 /**
  * Cache entry. Identifies file that this entry belongs to, and type of content stored in it.
- * @internal
+ * @alpha
  */
 export interface IEntry {
 	/**
@@ -63,7 +63,7 @@ export interface IEntry {
 
 /**
  * Cache entry. Identifies file that this entry belongs to, and type of content stored in it.
- * @internal
+ * @alpha
  */
 export interface ICacheEntry extends IEntry {
 	/**
@@ -78,7 +78,7 @@ export interface ICacheEntry extends IEntry {
  * cache implementation that does not survive across sessions. Snapshot entires stored in the
  * IPersistedCache will be considered stale and removed after 2 days. Read the README for more
  * information.
- * @internal
+ * @alpha
  */
 export interface IPersistedCache {
 	/**

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -6,7 +6,7 @@
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IOdspUrlParts {
 	siteUrl: string;
@@ -17,7 +17,7 @@ export interface IOdspUrlParts {
 /**
  * @deprecated Use ISharingLinkKind type instead.
  * Type of shareLink requested/created when creating the file for the first time.
- * @internal
+ * @alpha
  */
 export enum ShareLinkTypes {
 	csl = "csl",
@@ -25,7 +25,7 @@ export enum ShareLinkTypes {
 
 /**
  * Sharing scope of the share links created for a file.
- * @internal
+ * @alpha
  */
 export enum SharingLinkScope {
 	organization = "organization",
@@ -36,7 +36,7 @@ export enum SharingLinkScope {
 
 /**
  * View/edit permission role for a sharing link.
- * @internal
+ * @alpha
  */
 export enum SharingLinkRole {
 	view = "view",
@@ -46,7 +46,7 @@ export enum SharingLinkRole {
 /**
  * Defines the permissions scope for a share link requested to be created during the creation the file in ODSP.
  * Providing these properties to the /snapshot api will also create and return the requested kind of sharing link.
- * @internal
+ * @alpha
  */
 export interface ISharingLinkKind {
 	scope: SharingLinkScope;
@@ -59,7 +59,7 @@ export interface ISharingLinkKind {
 
 /**
  * Sharing link data received from the /snapshot api response.
- * @internal
+ * @alpha
  */
 export interface ISharingLink extends ISharingLinkKind {
 	webUrl: string;
@@ -69,7 +69,7 @@ export interface ISharingLink extends ISharingLinkKind {
  * Sharing link data created for the ODSP item.
  * Contains information about either sharing link created while creating a new file or
  * a redeemable share link created when loading an existing file
- * @internal
+ * @alpha
  */
 export interface ShareLinkInfoType {
 	/**
@@ -108,7 +108,7 @@ export interface ShareLinkInfoType {
 	sharingLinkToRedeem?: string;
 }
 /**
- * @internal
+ * @alpha
  */
 export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
 	type: "fluid";

--- a/packages/drivers/odsp-driver-definitions/src/sessionProvider.ts
+++ b/packages/drivers/odsp-driver-definitions/src/sessionProvider.ts
@@ -7,7 +7,7 @@ import { IResolvedUrl } from "@fluidframework/driver-definitions";
 
 /**
  * Socket storage discovery api response
- * @internal
+ * @alpha
  */
 export interface ISocketStorageDiscovery {
 	// The id of the web socket
@@ -43,7 +43,7 @@ export interface ISocketStorageDiscovery {
 /**
  * An interface that allows a concrete instance of a driver factory to interrogate itself
  * to find out if it is session aware.
- * @internal
+ * @alpha
  */
 export interface IProvideSessionAwareDriverFactory {
 	readonly IRelaySessionAwareDriverFactory: IRelaySessionAwareDriverFactory;
@@ -52,7 +52,7 @@ export interface IProvideSessionAwareDriverFactory {
 /**
  * An interface that allows a concrete instance of a driver factory to call the `getRelayServiceSessionInfo`
  * function if it session aware.
- * @internal
+ * @alpha
  */
 export interface IRelaySessionAwareDriverFactory extends IProvideSessionAwareDriverFactory {
 	getRelayServiceSessionInfo(

--- a/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
@@ -17,7 +17,7 @@ export interface TokenResponse {
 
 /**
  * Represents access token fetch options
- * @internal
+ * @alpha
  */
 export interface TokenFetchOptions {
 	/**
@@ -42,7 +42,7 @@ export interface TokenFetchOptions {
 
 /**
  * Represents access token fetch options for ODSP resource
- * @internal
+ * @alpha
  */
 export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
 	/** Site url representing ODSP resource location */
@@ -61,7 +61,7 @@ export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
  * @returns If successful, TokenResponse object representing token value along with flag indicating
  * whether token came from cache. Legacy implementation may return a string for token value;
  * in this case it should be assumes that fromCache signal is undefined. Null is returned in case of failure.
- * @internal
+ * @alpha
  */
 export type TokenFetcher<T> = (options: T) => Promise<string | TokenResponse | null>;
 

--- a/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
@@ -5,7 +5,7 @@
 
 /**
  * Represents token response
- * @internal
+ * @alpha
  */
 export interface TokenResponse {
 	/** Token value */

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
@@ -57,7 +57,7 @@ export function createOdspUrl(l: OdspFluidDataStoreLocator): string;
 // @internal
 export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocator): string;
 
-// @internal
+// @alpha
 export class EpochTracker implements IPersistedFileCache {
     constructor(cache: IPersistedCache, fileEntry: IFileEntry, logger: ITelemetryLoggerExt, clientIsSummarizer?: boolean | undefined);
     // (undocumented)
@@ -91,10 +91,10 @@ export class EpochTracker implements IPersistedFileCache {
     protected validateEpochFromResponse(epochFromResponse: string | undefined, fetchType: FetchTypeInternal, fromCache?: boolean): void;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type FetchType = "blob" | "createBlob" | "createFile" | "joinSession" | "ops" | "test" | "snapshotTree" | "treesLatest" | "uploadSummary" | "push" | "versions";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type FetchTypeInternal = FetchType | "cache";
 
 // @internal
@@ -109,7 +109,7 @@ export function getLocatorFromOdspUrl(url: URL, requireFluidSignature?: boolean)
 // @internal
 export function getOdspUrlParts(url: URL): Promise<IOdspUrlParts | undefined>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ICacheAndTracker {
     // (undocumented)
     cache: IOdspCache;
@@ -123,7 +123,7 @@ export interface IClpCompliantAppHeader {
     [ClpCompliantAppHeader.isClpCompliantApp]: boolean;
 }
 
-// @internal
+// @alpha
 export interface INonPersistentCache {
     readonly fileUrlCache: PromiseCache<string, IOdspResolvedUrl>;
     readonly sessionJoinCache: PromiseCache<string, {
@@ -133,12 +133,12 @@ export interface INonPersistentCache {
     readonly snapshotPrefetchResultCache: PromiseCache<string, IPrefetchSnapshotContents>;
 }
 
-// @internal
+// @alpha
 export interface IOdspCache extends INonPersistentCache {
     readonly persistedCache: IPersistedFileCache;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IOdspResponse<T> {
     // (undocumented)
     content: T;
@@ -150,7 +150,7 @@ export interface IOdspResponse<T> {
     propsToLog: ITelemetryProperties;
 }
 
-// @internal
+// @alpha
 export interface IPersistedFileCache {
     // (undocumented)
     get(entry: IEntry): Promise<any>;
@@ -160,7 +160,7 @@ export interface IPersistedFileCache {
     removeEntries(): Promise<void>;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IPrefetchSnapshotContents extends ISnapshotContents {
     // (undocumented)
     fluidEpoch: string;
@@ -174,7 +174,7 @@ export interface ISharingLinkHeader {
     [SharingLinkHeader.isSharingLinkToRedeem]: boolean;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ISnapshotContents {
     // (undocumented)
     blobs: Map<string, ArrayBuffer>;
@@ -213,12 +213,12 @@ export const OdcApiSiteOrigin = "https://my.microsoftpersonalcontent.com";
 // @internal (undocumented)
 export const OdcFileSiteOrigin = "https://1drv.ms";
 
-// @internal
+// @alpha
 export class OdspDocumentServiceFactory extends OdspDocumentServiceFactoryCore {
     constructor(getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions> | undefined, persistedCache?: IPersistedCache, hostPolicy?: HostStoragePolicy);
 }
 
-// @internal
+// @alpha
 export class OdspDocumentServiceFactoryCore implements IDocumentServiceFactory, IRelaySessionAwareDriverFactory {
     constructor(getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions> | undefined, persistedCache?: IPersistedCache, hostPolicy?: HostStoragePolicy);
     // (undocumented)
@@ -241,7 +241,7 @@ export class OdspDocumentServiceFactoryWithCodeSplit extends OdspDocumentService
     constructor(getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions> | undefined, persistedCache?: IPersistedCache, hostPolicy?: HostStoragePolicy);
 }
 
-// @internal
+// @alpha
 export class OdspDriverUrlResolver implements IUrlResolver {
     constructor();
     getAbsoluteUrl(resolvedUrl: IResolvedUrl, relativeUrl: string, packageInfoSource?: IContainerPackageInfo): Promise<string>;

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -44,7 +44,7 @@ import { pkgVersion as driverVersion } from "./packageVersion";
 import { patchOdspResolvedUrl } from "./odspLocationRedirection";
 
 /**
- * @internal
+ * @alpha
  */
 export type FetchType =
 	| "blob"
@@ -60,7 +60,7 @@ export type FetchType =
 	| "versions";
 
 /**
- * @internal
+ * @alpha
  */
 export type FetchTypeInternal = FetchType | "cache";
 
@@ -83,7 +83,7 @@ export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000; // 2
  * server can match it with its epoch value in order to match the version.
  * It also validates the epoch value received in response of fetch calls. If the epoch does not match,
  * then it also clears all the cached entries for the given container.
- * @internal
+ * @alpha
  */
 export class EpochTracker implements IPersistedFileCache {
 	private _fluidEpoch: string | undefined;
@@ -603,7 +603,7 @@ export class EpochTrackerWithRedemption extends EpochTracker {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ICacheAndTracker {
 	cache: IOdspCache;

--- a/packages/drivers/odsp-driver/src/odspCache.ts
+++ b/packages/drivers/odsp-driver/src/odspCache.ts
@@ -16,7 +16,7 @@ import { ISnapshotContents } from "./odspPublicUtils";
 
 /**
  * Similar to IPersistedCache, but exposes cache interface for single file
- * @internal
+ * @alpha
  */
 export interface IPersistedFileCache {
 	get(entry: IEntry): Promise<any>;
@@ -91,7 +91,7 @@ export class PromiseCacheWithOneHourSlidingExpiry<T> extends PromiseCache<string
 
 /**
  * Internal cache interface used within driver only
- * @internal
+ * @alpha
  */
 export interface INonPersistentCache {
 	/**
@@ -116,7 +116,7 @@ export interface INonPersistentCache {
 
 /**
  * Internal cache interface used within driver only
- * @internal
+ * @alpha
  */
 export interface IOdspCache extends INonPersistentCache {
 	/**
@@ -140,7 +140,7 @@ export class NonPersistentCache implements INonPersistentCache {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IPrefetchSnapshotContents extends ISnapshotContents {
 	fluidEpoch: string;

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactory.ts
@@ -17,7 +17,7 @@ import { LocalOdspDocumentServiceFactory } from "./localOdspDriver/localOdspDocu
 /**
  * Factory for creating the sharepoint document service. Use this if you want to
  * use the sharepoint implementation.
- * @internal
+ * @alpha
  */
 export class OdspDocumentServiceFactory extends OdspDocumentServiceFactoryCore {
 	constructor(

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -50,7 +50,7 @@ import {
  *
  * This constructor should be used by environments that support dynamic imports and that wish
  * to leverage code splitting as a means to keep bundles as small as possible.
- * @internal
+ * @alpha
  */
 export class OdspDocumentServiceFactoryCore
 	implements IDocumentServiceFactory, IRelaySessionAwareDriverFactory

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -80,7 +80,7 @@ function removeBeginningSlash(str: string): string {
 /**
  * Resolver to resolve urls like the ones created by createOdspUrl which is driver inner
  * url format. Ex: `${siteUrl}?driveId=${driveId}&itemId=${itemId}&path=${path}`
- * @internal
+ * @alpha
  */
 export class OdspDriverUrlResolver implements IUrlResolver {
 	constructor() {}

--- a/packages/drivers/odsp-driver/src/odspPublicUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspPublicUtils.ts
@@ -15,7 +15,7 @@ export async function getHashedDocumentId(driveId: string, itemId: string): Prom
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ISnapshotContents {
 	snapshotTree: ISnapshotTree;

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -51,7 +51,7 @@ export const getWithRetryForTokenRefreshRepeat = "getWithRetryForTokenRefreshRep
 export const getOrigin = (url: string) => new URL(url).origin;
 
 /**
- * @internal
+ * @alpha
  */
 export interface IOdspResponse<T> {
 	content: T;


### PR DESCRIPTION
This PR tags the odsp-driver as alpha. All these types were automatically identified as transitive dependency of the odsp-driver.

We will stage these commits and invite review, however review items will generally be added to the backlog as future items, as these type updates are necessary for the current state of the code base.