### PR TITLE
ci: Update the PR labeler to address mislabeled PRs

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -25,6 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Label base branches and external contributors
     steps:
-      - uses: srvaroa/labeler@953347905ec8e4884e85c9957d24508e24119fc3 # ratchet:srvaroa/labeler@v1.3
+      - uses: srvaroa/labeler@50320c5cb41e9208947c68a1a05a85261155958e # ratchet:srvaroa/labeler@v1.8.1
         env:
           GITHUB_TOKEN: "${{ github.token }}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -25,6 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Label base branches and external contributors
     steps:
-      - uses: srvaroa/labeler@50320c5cb41e9208947c68a1a05a85261155958e # ratchet:srvaroa/labeler@v1.8.1
+      - uses: srvaroa/labeler@5789c3303e99162cb381c2873ddddd88b0a76e91 # ratchet:srvaroa/labeler@v1
         env:
           GITHUB_TOKEN: "${{ github.token }}"


### PR DESCRIPTION
All PRs are being labeled "community-contribution". This is probably because of https://github.com/srvaroa/labeler/issues/123, which has been resolved in the latest v1 release. I updated the version of the action to the latest v1 version.