### PR TITLE
Tag AzureClient and OdspClient as alpha

### DIFF
--- a/azure/packages/azure-client/api-report/azure-client.api.md
+++ b/azure/packages/azure-client/api-report/azure-client.api.md
@@ -25,7 +25,7 @@ export class AzureAudience extends ServiceAudience<AzureMember> implements IAzur
     protected createServiceMember(audienceMember: IClient): AzureMember;
 }
 
-// @internal
+// @alpha
 export class AzureClient {
     constructor(properties: AzureClientProps);
     copyContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version?: AzureContainerVersion): Promise<{
@@ -43,7 +43,7 @@ export class AzureClient {
     getContainerVersions(id: string, options?: AzureGetVersionsOptions): Promise<AzureContainerVersion[]>;
 }
 
-// @internal
+// @alpha
 export interface AzureClientProps {
     readonly configProvider?: IConfigProviderBase;
     readonly connection: AzureRemoteConnectionConfig | AzureLocalConnectionConfig;
@@ -52,22 +52,22 @@ export interface AzureClientProps {
     readonly summaryCompression?: boolean | ICompressionStorageConfig;
 }
 
-// @internal
+// @alpha
 export interface AzureConnectionConfig {
     endpoint: string;
     tokenProvider: ITokenProvider;
     type: AzureConnectionConfigType;
 }
 
-// @internal
+// @alpha
 export type AzureConnectionConfigType = "local" | "remote";
 
-// @internal
+// @alpha
 export interface AzureContainerServices {
     audience: IAzureAudience;
 }
 
-// @internal
+// @alpha
 export interface AzureContainerVersion {
     date?: string;
     id: string;
@@ -82,23 +82,23 @@ export class AzureFunctionTokenProvider implements ITokenProvider {
     fetchStorageToken(tenantId: string, documentId: string): Promise<ITokenResponse>;
 }
 
-// @internal
+// @alpha
 export interface AzureGetVersionsOptions {
     maxCount: number;
 }
 
-// @internal
+// @alpha
 export interface AzureLocalConnectionConfig extends AzureConnectionConfig {
     type: "local";
 }
 
-// @internal
+// @alpha
 export interface AzureMember<T = any> extends IMember {
     additionalDetails?: T;
     userName: string;
 }
 
-// @internal
+// @alpha
 export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     tenantId: string;
     type: "remote";
@@ -110,7 +110,7 @@ export interface AzureUser<T = any> extends IUser {
     name: string;
 }
 
-// @internal
+// @alpha
 export type IAzureAudience = IServiceAudience<AzureMember>;
 
 export { ITelemetryBaseEvent }

--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -52,7 +52,7 @@ const MAX_VERSION_COUNT = 5;
 /**
  * AzureClient provides the ability to have a Fluid object backed by the Azure Fluid Relay or,
  * when running with local tenantId, have it be backed by a local Azure Fluid Relay instance.
- * @internal
+ * @alpha
  */
 export class AzureClient {
 	private readonly documentServiceFactory: IDocumentServiceFactory;

--- a/azure/packages/azure-client/src/interfaces.ts
+++ b/azure/packages/azure-client/src/interfaces.ts
@@ -13,7 +13,7 @@ import { type ICompressionStorageConfig } from "@fluidframework/driver-utils";
 
 /**
  * Props for initializing a new AzureClient instance
- * @internal
+ * @alpha
  */
 export interface AzureClientProps {
 	/**
@@ -35,7 +35,7 @@ export interface AzureClientProps {
 
 /**
  * Container version metadata.
- * @internal
+ * @alpha
  */
 export interface AzureContainerVersion {
 	/**
@@ -52,7 +52,7 @@ export interface AzureContainerVersion {
 
 /**
  * Options for "Get Container Versions" API.
- * @internal
+ * @alpha
  */
 export interface AzureGetVersionsOptions {
 	/**
@@ -67,13 +67,13 @@ export interface AzureGetVersionsOptions {
  * - "local" for local connections to a Fluid relay instance running on the localhost
  *
  * - "remote" for client connections to the Azure Fluid Relay service
- * @internal
+ * @alpha
  */
 export type AzureConnectionConfigType = "local" | "remote";
 
 /**
  * Parameters for establishing a connection with the Azure Fluid Relay.
- * @internal
+ * @alpha
  */
 export interface AzureConnectionConfig {
 	/**
@@ -92,7 +92,7 @@ export interface AzureConnectionConfig {
 
 /**
  * Parameters for establishing a remote connection with the Azure Fluid Relay.
- * @internal
+ * @alpha
  */
 export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
 	/**
@@ -107,7 +107,7 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
 
 /**
  * Parameters for establishing a local connection with a local instance of the Azure Fluid Relay.
- * @internal
+ * @alpha
  */
 export interface AzureLocalConnectionConfig extends AzureConnectionConfig {
 	/**
@@ -126,7 +126,7 @@ export interface AzureLocalConnectionConfig extends AzureConnectionConfig {
  *
  * Any functionality regarding how the data is handled within the FluidContainer itself, i.e. which data objects
  * or DDSes to use, will not be included here but rather on the FluidContainer class itself.
- * @internal
+ * @alpha
  */
 export interface AzureContainerServices {
 	/**
@@ -167,7 +167,7 @@ export interface AzureUser<T = any> extends IUser {
  * @typeParam T - See {@link AzureMember.additionalDetails}.
  * Note: must be JSON-serializable.
  * Passing a non-serializable object (e.g. a `class`) will result in undefined behavior.
- * @internal
+ * @alpha
  */
 // TODO: this should be updated to use something other than `any` (unknown)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -185,6 +185,6 @@ export interface AzureMember<T = any> extends IMember {
 
 /**
  * Audience object for Azure Fluid Relay containers
- * @internal
+ * @alpha
  */
 export type IAzureAudience = IServiceAudience<AzureMember>;

--- a/common/lib/protocol-definitions/src/tokens.ts
+++ b/common/lib/protocol-definitions/src/tokens.ts
@@ -6,12 +6,10 @@
 import { IUser } from "./users";
 
 /**
- * @alpha
- *
  * {@link https://jwt.io/introduction/ | JSON Web Token (JWT)} Claims
  *
  * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4}
- *
+ * @alpha
  */
 export interface ITokenClaims {
 	/**

--- a/common/lib/protocol-definitions/src/tokens.ts
+++ b/common/lib/protocol-definitions/src/tokens.ts
@@ -6,10 +6,12 @@
 import { IUser } from "./users";
 
 /**
+ * @alpha
+ *
  * {@link https://jwt.io/introduction/ | JSON Web Token (JWT)} Claims
  *
  * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4}
- * @alpha
+ *
  */
 export interface ITokenClaims {
 	/**

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
@@ -309,7 +309,7 @@ export interface TokenFetchOptions {
 // @internal
 export const tokenFromResponse: (tokenResponse: string | TokenResponse | null | undefined) => string | null;
 
-// @internal
+// @alpha
 export interface TokenResponse {
     fromCache?: boolean;
     token: string;

--- a/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
@@ -5,7 +5,7 @@
 
 /**
  * Represents token response
- * @internal
+ * @alpha
  */
 export interface TokenResponse {
 	/** Token value */

--- a/packages/drivers/routerlicious-driver/api-report/routerlicious-driver.api.md
+++ b/packages/drivers/routerlicious-driver/api-report/routerlicious-driver.api.md
@@ -44,14 +44,14 @@ export interface IRouterliciousDriverPolicies {
     maxConcurrentStorageRequests: number;
 }
 
-// @internal
+// @alpha
 export interface ITokenProvider {
     documentPostCreateCallback?(documentId: string, creationToken: string): Promise<void>;
     fetchOrdererToken(tenantId: string, documentId?: string, refresh?: boolean): Promise<ITokenResponse>;
     fetchStorageToken(tenantId: string, documentId: string, refresh?: boolean): Promise<ITokenResponse>;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ITokenResponse {
     fromCache?: boolean;
     jwt: string;

--- a/packages/drivers/routerlicious-driver/src/tokens.ts
+++ b/packages/drivers/routerlicious-driver/src/tokens.ts
@@ -18,7 +18,7 @@ export interface ITokenService {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ITokenResponse {
 	/**
@@ -37,7 +37,7 @@ export interface ITokenResponse {
 /**
  * Abstracts the token fetching mechanism for a hosting application.
  * The hosting application is responsible for providing an implementation.
- * @internal
+ * @alpha
  */
 export interface ITokenProvider {
 	/**

--- a/packages/framework/fluid-static/api-report/fluid-static.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.api.md
@@ -20,7 +20,7 @@ import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { IRuntimeFactory } from '@fluidframework/container-definitions';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
-// @internal
+// @alpha
 export interface ContainerSchema {
     dynamicObjectTypes?: LoadableObjectClass<any>[];
     initialObjects: LoadableObjectClassRecord;
@@ -43,7 +43,7 @@ export function createServiceAudience<M extends IMember = IMember>(props: {
     createServiceMember: (audienceMember: IClient) => M;
 }): IServiceAudience<M>;
 
-// @internal
+// @alpha
 export type DataObjectClass<T extends IFluidLoadable> = {
     readonly factory: IFluidDataStoreFactory;
 } & LoadableObjectCtor<T>;
@@ -77,7 +77,7 @@ export interface IConnection {
     mode: "write" | "read";
 }
 
-// @internal
+// @alpha
 export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
     attach(): Promise<string>;
     readonly attachState: AttachState;
@@ -91,7 +91,7 @@ export interface IFluidContainer<TContainerSchema extends ContainerSchema = Cont
     readonly isDirty: boolean;
 }
 
-// @internal
+// @alpha
 export interface IFluidContainerEvents extends IEvent {
     (event: "connected", listener: () => void): void;
     (event: "disconnected", listener: () => void): void;
@@ -106,7 +106,7 @@ export interface IMember {
     userId: string;
 }
 
-// @internal
+// @alpha
 export type InitialObjects<T extends ContainerSchema> = {
     [K in keyof T["initialObjects"]]: T["initialObjects"][K] extends LoadableObjectClass<infer TChannel> ? TChannel : never;
 };
@@ -139,16 +139,16 @@ export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
     (event: "memberRemoved", listener: MemberChangedListener<M>): void;
 }
 
-// @internal
+// @alpha
 export type LoadableObjectClass<T extends IFluidLoadable> = DataObjectClass<T> | SharedObjectClass<T>;
 
-// @internal
+// @alpha
 export type LoadableObjectClassRecord = Record<string, LoadableObjectClass<any>>;
 
-// @internal
+// @alpha
 export type LoadableObjectCtor<T extends IFluidLoadable> = new (...args: any[]) => T;
 
-// @internal
+// @alpha
 export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 
 // @internal
@@ -172,7 +172,7 @@ export abstract class ServiceAudience<M extends IMember = IMember> extends Typed
     protected shouldIncludeAsMember(member: IClient): boolean;
 }
 
-// @internal
+// @alpha
 export type SharedObjectClass<T extends IFluidLoadable> = {
     readonly getFactory: () => IChannelFactory;
 } & LoadableObjectCtor<T>;

--- a/packages/framework/fluid-static/api-report/fluid-static.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.api.md
@@ -71,7 +71,7 @@ export class FluidContainer<TContainerSchema extends ContainerSchema = Container
     get isDirty(): boolean;
 }
 
-// @internal
+// @alpha
 export interface IConnection {
     id: string;
     mode: "write" | "read";
@@ -100,7 +100,7 @@ export interface IFluidContainerEvents extends IEvent {
     (event: "disposed", listener: (error?: ICriticalContainerError) => void): any;
 }
 
-// @internal
+// @alpha
 export interface IMember {
     connections: IConnection[];
     userId: string;
@@ -123,13 +123,13 @@ export interface IRootDataObject extends IProvideRootDataObject {
     readonly initialObjects: LoadableObjectRecord;
 }
 
-// @internal
+// @alpha
 export interface IServiceAudience<M extends IMember> extends IEventProvider<IServiceAudienceEvents<M>> {
     getMembers(): Map<string, M>;
     getMyself(): Myself<M> | undefined;
 }
 
-// @internal
+// @alpha
 export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
     // @eventProperty
     (event: "membersChanged", listener: () => void): void;
@@ -151,10 +151,10 @@ export type LoadableObjectCtor<T extends IFluidLoadable> = new (...args: any[]) 
 // @alpha
 export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 
-// @internal
+// @alpha
 export type MemberChangedListener<M extends IMember> = (clientId: string, member: M) => void;
 
-// @internal
+// @alpha
 export type Myself<M extends IMember = IMember> = M & {
     currentConnection: string;
 };

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -14,7 +14,7 @@ import type { ContainerSchema, IRootDataObject, LoadableObjectClass } from "./ty
 
 /**
  * Extract the type of 'initialObjects' from the given {@link ContainerSchema} type.
- * @internal
+ * @alpha
  */
 export type InitialObjects<T extends ContainerSchema> = {
 	// Construct a LoadableObjectRecord type by enumerating the keys of
@@ -31,7 +31,7 @@ export type InitialObjects<T extends ContainerSchema> = {
 
 /**
  * Events emitted from {@link IFluidContainer}.
- * @internal
+ * @alpha
  */
 export interface IFluidContainerEvents extends IEvent {
 	/**
@@ -96,7 +96,7 @@ export interface IFluidContainerEvents extends IEvent {
  * @typeparam TContainerSchema - Used to determine the type of 'initialObjects'.
  *
  * @remarks Note: external implementations of this interface are not supported.
- * @internal
+ * @alpha
  */
 export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema>
 	extends IEventProvider<IFluidContainerEvents> {

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -9,14 +9,14 @@ import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 
 /**
  * A mapping of string identifiers to instantiated `DataObject`s or `SharedObject`s.
- * @internal
+ * @alpha
  */
 export type LoadableObjectRecord = Record<string, IFluidLoadable>;
 
 /**
  * A mapping of string identifiers to classes that will later be used to instantiate a corresponding `DataObject`
  * or `SharedObject` in a {@link LoadableObjectRecord}.
- * @internal
+ * @alpha
  */
 export type LoadableObjectClassRecord = Record<string, LoadableObjectClass<any>>;
 
@@ -24,7 +24,7 @@ export type LoadableObjectClassRecord = Record<string, LoadableObjectClass<any>>
  * A class object of `DataObject` or `SharedObject`.
  *
  * @typeParam T - The class of the `DataObject` or `SharedObject`.
- * @internal
+ * @alpha
  */
 export type LoadableObjectClass<T extends IFluidLoadable> =
 	| DataObjectClass<T>
@@ -35,7 +35,7 @@ export type LoadableObjectClass<T extends IFluidLoadable> =
  * constructor that will return the type of the `DataObject`.
  *
  * @typeParam T - The class of the `DataObject`.
- * @internal
+ * @alpha
  */
 export type DataObjectClass<T extends IFluidLoadable> = {
 	readonly factory: IFluidDataStoreFactory;
@@ -46,7 +46,7 @@ export type DataObjectClass<T extends IFluidLoadable> = {
  * constructor that will return the type of the `DataObject`.
  *
  * @typeParam T - The class of the `SharedObject`.
- * @internal
+ * @alpha
  */
 export type SharedObjectClass<T extends IFluidLoadable> = {
 	readonly getFactory: () => IChannelFactory;
@@ -56,7 +56,7 @@ export type SharedObjectClass<T extends IFluidLoadable> = {
  * An object with a constructor that will return an {@link @fluidframework/core-interfaces#IFluidLoadable}.
  *
  * @typeParam T - The class of the loadable object.
- * @internal
+ * @alpha
  */
 export type LoadableObjectCtor<T extends IFluidLoadable> = new (...args: any[]) => T;
 
@@ -67,7 +67,7 @@ export type LoadableObjectCtor<T extends IFluidLoadable> = new (...args: any[]) 
  *
  * It includes both the instances of objects that are initially available upon `Container` creation, as well
  * as the types of objects that may be dynamically created throughout the lifetime of the `Container`.
- * @internal
+ * @alpha
  */
 export interface ContainerSchema {
 	/**
@@ -138,7 +138,7 @@ export interface IRootDataObject extends IProvideRootDataObject {
  * @param member - The service-specific member object for the client.
  *
  * @see See {@link IServiceAudienceEvents} for usage details.
- * @internal
+ * @alpha
  */
 export type MemberChangedListener<M extends IMember> = (clientId: string, member: M) => void;
 
@@ -151,7 +151,7 @@ export type MemberChangedListener<M extends IMember> = (clientId: string, member
  * {@link IServiceAudience.getMembers} method will emit events.
  *
  * @typeParam M - A service-specific {@link IMember} implementation.
- * @internal
+ * @alpha
  */
 export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
 	/**
@@ -185,7 +185,7 @@ export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
  * details about the connecting client, such as device information, environment, or a username.
  *
  * @typeParam M - A service-specific {@link IMember} type.
- * @internal
+ * @alpha
  */
 export interface IServiceAudience<M extends IMember>
 	extends IEventProvider<IServiceAudienceEvents<M>> {
@@ -206,7 +206,7 @@ export interface IServiceAudience<M extends IMember>
  * Base interface for information for each connection made to the Fluid session.
  *
  * @remarks This interface can be extended to provide additional information specific to each service.
- * @internal
+ * @alpha
  */
 export interface IConnection {
 	/**
@@ -224,7 +224,7 @@ export interface IConnection {
  * Base interface to be implemented to fetch each service's member.
  *
  * @remarks This interface can be extended by each service to provide additional service-specific user metadata.
- * @internal
+ * @alpha
  */
 export interface IMember {
 	/**
@@ -240,6 +240,6 @@ export interface IMember {
 
 /**
  * An extended member object that includes currentConnection
- * @internal
+ * @alpha
  */
 export type Myself<M extends IMember = IMember> = M & { currentConnection: string };

--- a/packages/loader/driver-utils/api-report/driver-utils.api.md
+++ b/packages/loader/driver-utils/api-report/driver-utils.api.md
@@ -194,7 +194,7 @@ export const getRetryDelayFromError: (error: any) => number | undefined;
 // @internal
 export const getRetryDelaySecondsFromError: (error: any) => number | undefined;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ICompressionStorageConfig {
     // (undocumented)
     algorithm: SummaryCompressionAlgorithm;
@@ -355,7 +355,7 @@ export function streamFromMessages(messagesArg: Promise<ISequencedDocumentMessag
 // @internal (undocumented)
 export function streamObserver<T>(stream: IStream<T>, handler: (value: IStreamResult<T>) => void): IStream<T>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export enum SummaryCompressionAlgorithm {
     // (undocumented)
     LZ4 = 1,

--- a/packages/loader/driver-utils/src/adapters/compression/compressionTypes.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/compressionTypes.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * @internal
+ * @alpha
  */
 export enum SummaryCompressionAlgorithm {
 	None = 0,
@@ -12,7 +12,7 @@ export enum SummaryCompressionAlgorithm {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ICompressionStorageConfig {
 	algorithm: SummaryCompressionAlgorithm;

--- a/packages/service-clients/odsp-client/api-report/odsp-client.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.api.md
@@ -12,16 +12,16 @@ import type { IServiceAudience } from '@fluidframework/fluid-static';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { TokenResponse } from '@fluidframework/odsp-driver-definitions';
 
-// @internal
+// @alpha
 export type IOdspAudience = IServiceAudience<OdspMember>;
 
-// @internal
+// @alpha
 export interface IOdspTokenProvider {
     fetchStorageToken(siteUrl: string, refresh: boolean): Promise<TokenResponse>;
     fetchWebsocketToken(siteUrl: string, refresh: boolean): Promise<TokenResponse>;
 }
 
-// @internal @sealed
+// @alpha @sealed
 export class OdspClient {
     constructor(properties: OdspClientProps);
     // (undocumented)
@@ -36,26 +36,26 @@ export class OdspClient {
     }>;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface OdspClientProps {
     readonly configProvider?: IConfigProviderBase;
     readonly connection: OdspConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @internal
+// @alpha
 export interface OdspConnectionConfig {
     driveId: string;
     siteUrl: string;
     tokenProvider: IOdspTokenProvider;
 }
 
-// @internal
+// @alpha
 export interface OdspContainerServices {
     audience: IOdspAudience;
 }
 
-// @internal
+// @alpha
 export interface OdspMember extends IMember {
     // (undocumented)
     email: string;

--- a/packages/service-clients/odsp-client/src/interfaces.ts
+++ b/packages/service-clients/odsp-client/src/interfaces.ts
@@ -12,7 +12,7 @@ import { IOdspTokenProvider } from "./token";
  * Defines the necessary properties that will be applied to all containers
  * created by an OdspClient instance. This includes callbacks for the authentication tokens
  * required for ODSP.
- * @internal
+ * @alpha
  */
 export interface OdspConnectionConfig {
 	/**
@@ -31,7 +31,7 @@ export interface OdspConnectionConfig {
 	driveId: string;
 }
 /**
- * @internal
+ * @alpha
  */
 export interface OdspClientProps {
 	/**
@@ -56,7 +56,7 @@ export interface OdspClientProps {
  * FluidContainer is persisted in the backend and consumed by users. Any functionality regarding
  * how the data is handled within the FluidContainer itself, i.e. which data objects or DDSes to
  * use, will not be included here but rather on the FluidContainer class itself.
- * @internal
+ * @alpha
  */
 export interface OdspContainerServices {
 	/**
@@ -86,7 +86,7 @@ export interface OdspUser extends IUser {
  * Since ODSP provides user names and email for all of its members, we extend the
  * {@link @fluidframework/protocol-definitions#IMember} interface to include this service-specific value.
  * It will be returned for all audience members connected.
- * @internal
+ * @alpha
  */
 export interface OdspMember extends IMember {
 	name: string;
@@ -95,6 +95,6 @@ export interface OdspMember extends IMember {
 
 /**
  * Audience object for ODSP containers
- * @internal
+ * @alpha
  */
 export type IOdspAudience = IServiceAudience<OdspMember>;

--- a/packages/service-clients/odsp-client/src/odspClient.ts
+++ b/packages/service-clients/odsp-client/src/odspClient.ts
@@ -38,7 +38,7 @@ import { createOdspAudienceMember } from "./odspAudience";
 /**
  * OdspClient provides the ability to have a Fluid object backed by the ODSP service within the context of Microsoft 365 (M365) tenants.
  * @sealed
- * @internal
+ * @alpha
  */
 export class OdspClient {
 	private readonly documentServiceFactory: IDocumentServiceFactory;

--- a/packages/service-clients/odsp-client/src/token.ts
+++ b/packages/service-clients/odsp-client/src/token.ts
@@ -8,7 +8,7 @@ import { TokenResponse } from "@fluidframework/odsp-driver-definitions";
 /**
  * Abstracts the token fetching mechanism for a hosting application.
  * The hosting application is responsible for providing an implementation.
- * @internal
+ * @alpha
  */
 export interface IOdspTokenProvider {
 	/**


### PR DESCRIPTION
This PR tags AzureClient and OdspClient as alpha. All these types were automatically identified as transitive dependency of AzureClient and OdspClient

We will stage these commits and invite review, however review items will generally be added to the backlog as future items, as these type updates are necessary for the current state of the code base.

Note: AzureClient and OdspClient will eventually move to public and beta respectively, but we are starting with alpha, and will bring them and their dependencies forward in a later PR