### PR TITLE
fix(tree2): missing revision data in composed builds

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -199,7 +199,9 @@ export class ModularChangeFamily
 			0x59b /* Should not need more than one amend pass. */,
 		);
 		const allBuilds: ChangeAtomIdMap<JsonableTree> = new Map();
-		for (const { revision, change } of changes) {
+		for (const taggedChange of changes) {
+			const revision = revisionFromTaggedChange(taggedChange);
+			const change = taggedChange.change;
 			if (change.builds) {
 				for (const [revisionKey, innerMap] of change.builds) {
 					const setRevisionKey = revisionKey ?? revision;

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -94,6 +94,7 @@ const family = new ModularChangeFamily(fieldKinds, { jsonValidator: typeboxValid
 
 const tag1: RevisionTag = mintRevisionTag();
 const tag2: RevisionTag = mintRevisionTag();
+const tag3: RevisionTag = mintRevisionTag();
 
 const fieldA: FieldKey = brand("a");
 const fieldB: FieldKey = brand("b");
@@ -303,6 +304,8 @@ const rootChangeWithoutNodeFieldChanges: ModularChangeset = {
 		],
 	]),
 };
+
+const node1 = singleJsonCursor(1);
 
 describe("ModularChangeFamily", () => {
 	describe("compose", () => {
@@ -519,6 +522,53 @@ describe("ModularChangeFamily", () => {
 							fieldKind: singleNodeField.identifier,
 							change: brand(expectedNodeChange),
 						},
+					],
+				]),
+				revisions: [{ revision: tag1 }, { revision: tag2 }],
+			};
+
+			assert.deepEqual(composed, expected);
+		});
+
+		it("builds", () => {
+			const change1: TaggedChange<ModularChangeset> = tagChange(
+				{
+					fieldChanges: new Map([]),
+					builds: new Map([
+						[undefined, new Map([[brand(0), node1]])],
+						[tag3, new Map([[brand(0), node1]])],
+					]),
+				},
+				tag1,
+			);
+
+			const change2: TaggedChange<ModularChangeset> = tagChange(
+				{
+					fieldChanges: new Map([]),
+					builds: new Map([
+						[undefined, new Map([[brand(2), node1]])],
+						[tag3, new Map([[brand(2), node1]])],
+					]),
+					revisions: [{ revision: tag2 }],
+				},
+				undefined,
+			);
+
+			deepFreeze(change1);
+			deepFreeze(change2);
+			const composed = family.compose([change1, change2]);
+
+			const expected: ModularChangeset = {
+				fieldChanges: new Map(),
+				builds: new Map([
+					[tag1, new Map([[brand(0), node1]])],
+					[tag2, new Map([[brand(2), node1]])],
+					[
+						tag3,
+						new Map([
+							[brand(0), node1],
+							[brand(2), node1],
+						]),
 					],
 				]),
 				revisions: [{ revision: tag1 }, { revision: tag2 }],

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -148,6 +148,9 @@ function freezeObjectMethods<T>(object: T, methods: (keyof T)[]): void {
  * @param object - The object to freeze.
  */
 export function deepFreeze<T>(object: T): void {
+	if (object === undefined || object === null) {
+		return;
+	}
 	if (object instanceof Map) {
 		for (const [key, value] of object.entries()) {
 			deepFreeze(key);


### PR DESCRIPTION
Fixes a bug where `ModularChangeFamily` would fail to attribute a build to a revision.