### PR TITLE
docs(tree2): Typos and improvements

### DIFF
--- a/experimental/dds/tree2/src/class-tree/schemaFactory.ts
+++ b/experimental/dds/tree2/src/class-tree/schemaFactory.ts
@@ -158,7 +158,7 @@ export class SchemaFactory<TScope extends string, TName extends number | string 
 	 *
 	 * @remarks
 	 * There are good [reasons to avoid using null](https://www.npmjs.com/package/%40rushstack/eslint-plugin#rushstackno-new-null) in JavaScript, however sometimes it is desired.
-	 * This {@link TreeNodeSchema} node provide the option to include nulls in trees when desired.
+	 * This {@link TreeNodeSchema} node provides the option to include nulls in trees when desired.
 	 * Unless directly inter-operating with existing data using null, consider other approaches, like wrapping the value in an optional field, or using a more specifically named empty object node.
 	 */
 	public readonly null = nullSchema;

--- a/experimental/dds/tree2/src/class-tree/tree.ts
+++ b/experimental/dds/tree2/src/class-tree/tree.ts
@@ -26,34 +26,35 @@ export interface ITree extends IChannel {
 	 * Returns a tree that is known to be compatible with the provided schema. The returned tree exposes an API that is schema-aware.
 	 *
 	 * @remarks
-	 * If the tree is uninitialized (has no schema and no content), the tree is initialized with the provided `initialTree` and `schema`.
+	 * If the tree is uninitialized (has no schema and no content), the tree is initialized with the `initialTree` and
+	 * view `schema` in the provided `config`.
 	 *
-	 * The tree (now known to have been initialized) has its stored schema checked against the provided view `schema`.
+	 * The tree (now known to have been initialized) has its stored schema checked against the provided view schema.
 	 *
-	 * If the schema are compatible (including updating the stored schema if permitted via `allowedSchemaModifications`),
-	 * a {@link TreeView} is returned, with a schema aware API based on the provided view schema.
+	 * If the schemas are compatible (including updating the stored schema if permitted via `allowedSchemaModifications`),
+	 * a {@link TreeView} is returned, with a schema-aware API based on the provided view schema.
 	 *
-	 * If the schema are not compatible, and exception is thrown.
+	 * If the schemas are not compatible, an exception is thrown.
 	 *
 	 * @privateRemarks
 	 * TODO: make the mismatch case recoverable.
 	 * - Provide a way to make a generic view schema for any document.
-	 * - Produce/throw the error in a document recoverable way (ex: specific exception type or return value).
+	 * - Produce/throw the error in a document-recoverable way (ex: specific exception type or return value).
 	 * TODO: Document and handle what happens when the stored schema changes after schematize has returned. Is some invalidation contract needed? How does editable tree behave?
 	 * TODO: Clarify lifetimes. Ensure calling schematize multiple times does not leak.
-	 * TODO: Support adapters for handling out of schema data.
+	 * TODO: Support adapters for handling out-of-schema data.
 	 *
 	 * Doing initialization here, regardless of `AllowedUpdateType`, allows a small API that is hard to use incorrectly.
-	 * Other approach tend to have leave easy to make mistakes.
-	 * For example, having a separate initialization function means apps can forget to call it, making an app that can only open existing document,
+	 * Other approaches tend to have easy-to-make mistakes.
+	 * For example, having a separate initialization function means apps can forget to call it, making an app that can only open existing documents,
 	 * or call it unconditionally leaving an app that can only create new documents.
-	 * It also would require the schema to be passed into to separate places and could cause issues if they didn't match.
+	 * It also would require the schema to be passed in to separate places and could cause issues if they didn't match.
 	 * Since the initialization function couldn't return a typed tree, the type checking wouldn't help catch that.
 	 * Also, if an app manages to create a document, but the initialization fails to get persisted, an app that only calls the initialization function
 	 * on the create code-path (for example how a schematized factory might do it),
 	 * would leave the document in an unusable state which could not be repaired when it is reopened (by the same or other clients).
 	 * Additionally, once out of schema content adapters are properly supported (with lazy document updates),
-	 * this initialization could become just another out of schema content adapter: at tha point it clearly belong here in schematize.
+	 * this initialization could become just another out of schema content adapter: at that point it clearly belongs here in schematize.
 	 */
 	schematize<TRoot extends ImplicitFieldSchema>(
 		config: TreeConfiguration<TRoot>,

--- a/experimental/dds/tree2/src/class-tree/tree.ts
+++ b/experimental/dds/tree2/src/class-tree/tree.ts
@@ -68,9 +68,9 @@ export interface ITree extends IChannel {
 export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {
 	/**
 	 * @param schema - The schema which the application wants to view the tree with.
-	 * @param initialTree - Default tree content to initialize the tree with iff the tree is uninitialized
+	 * @param initialTree - Function that returns the default tree content to initialize the tree with iff the tree is uninitialized
 	 * (meaning it does not even have any schema set at all).
-	 * If the `initialTree` returns any actual node instances, they should be recreated each time the `initialTree` runs.
+	 * If `initialTree` returns any actual node instances, they should be recreated each time `initialTree` runs.
 	 * This is because if the config is used a second time any nodes that were not recreated could error since nodes cannot be inserted into the tree multiple times.
 	 */
 	public constructor(

--- a/experimental/dds/tree2/src/class-tree/tree.ts
+++ b/experimental/dds/tree2/src/class-tree/tree.ts
@@ -48,7 +48,7 @@ export interface ITree extends IChannel {
 	 * Other approaches tend to have easy-to-make mistakes.
 	 * For example, having a separate initialization function means apps can forget to call it, making an app that can only open existing documents,
 	 * or call it unconditionally leaving an app that can only create new documents.
-	 * It also would require the schema to be passed in to separate places and could cause issues if they didn't match.
+	 * It also would require the schema to be passed into separate places and could cause issues if they didn't match.
 	 * Since the initialization function couldn't return a typed tree, the type checking wouldn't help catch that.
 	 * Also, if an app manages to create a document, but the initialization fails to get persisted, an app that only calls the initialization function
 	 * on the create code-path (for example how a schematized factory might do it),

--- a/experimental/dds/tree2/src/class-tree/tree.ts
+++ b/experimental/dds/tree2/src/class-tree/tree.ts
@@ -68,7 +68,7 @@ export interface ITree extends IChannel {
 export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {
 	/**
 	 * @param schema - The schema which the application wants to view the tree with.
-	 * @param initialTree - Function that returns the default tree content to initialize the tree with iff the tree is uninitialized
+	 * @param initialTree - A function that returns the default tree content to initialize the tree with iff the tree is uninitialized
 	 * (meaning it does not even have any schema set at all).
 	 * If `initialTree` returns any actual node instances, they should be recreated each time `initialTree` runs.
 	 * This is because if the config is used a second time any nodes that were not recreated could error since nodes cannot be inserted into the tree multiple times.

--- a/experimental/dds/tree2/src/domains/leafDomain.ts
+++ b/experimental/dds/tree2/src/domains/leafDomain.ts
@@ -73,7 +73,7 @@ export const leaf = {
 	 *
 	 * @remarks
 	 * There are good [reasons to avoid using null](https://www.npmjs.com/package/%40rushstack/eslint-plugin#rushstackno-new-null) in JavaScript, however sometimes it is desired.
-	 * This {@link LeafNodeSchema} node provide the option to include nulls in trees when desired.
+	 * This {@link LeafNodeSchema} node provides the option to include nulls in trees when desired.
 	 * Unless directly inter-operating with existing data using null, consider other approaches, like wrapping the value in an optional field, or using a more specifically named empty object node.
 	 */
 	null: nullSchema,


### PR DESCRIPTION
## Description

Fixing typos and trying to improve SharedTree's public API documentation.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
