### PR TITLE
ci: Remove broken labeling of externally contributed PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,7 +8,3 @@ labels:
   base-branch: "next"
 - label: "base: release"
   base-branch: "^release/.*"
-
-  # PRs from contributors without write access to the repo should be labeled
-- label: "community-contribution"
-  author-can-merge: False


### PR DESCRIPTION
The labeling logic is broken, it seems, and we don't rely on the label today, so removing.