### PR TITLE
tree2: Deprecate SchemaBuilder

### DIFF
--- a/experimental/dds/tree2/src/domains/index.ts
+++ b/experimental/dds/tree2/src/domains/index.ts
@@ -3,12 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export {
-	SchemaBuilder,
-	FactoryObjectNodeSchema,
-	FactoryObjectNodeSchemaRecursive,
-} from "./schemaBuilder";
-
+export { SchemaBuilder } from "./schemaBuilder";
 export {
 	cursorToJsonObject,
 	jsonArray,

--- a/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonDomainSchema.ts
@@ -36,20 +36,14 @@ export const jsonRoot = [() => jsonObject, () => jsonArray, ...jsonPrimitives] a
 	type _check = requireAssignableTo<typeof jsonRoot, AllowedTypes>;
 }
 
-/**
- */
 export const jsonObject = builder.mapRecursive(
 	"object",
 	TreeFieldSchema.createUnsafe(FieldKinds.optional, jsonRoot),
 );
 
-/**
- */
 export const jsonArray = builder.fieldNodeRecursive(
 	"array",
 	TreeFieldSchema.createUnsafe(FieldKinds.sequence, jsonRoot),
 );
 
-/**
- */
 export const jsonSchema = builder.intoLibrary();

--- a/experimental/dds/tree2/src/domains/schemaBuilder.ts
+++ b/experimental/dds/tree2/src/domains/schemaBuilder.ts
@@ -76,7 +76,8 @@ export type FactoryObjectNodeSchemaRecursive<
  * TODO: Maybe rename to DefaultSchemaBuilder1 because of the versioning implications above.
  * Same applies to SchemaBuilder.
  * TODO: figure out a way to link `leaf` above without breaking API Extractor.
- * @sealed @alpha
+ * @sealed
+ * @deprecated Users of this class should either use {@link SchemaBuilderBase} and explicitly work with {@link TreeFieldSchema}, or use SchemaFactory and work at its higher level of abstraction.
  */
 export class SchemaBuilder<
 	TScope extends string = string,

--- a/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
+++ b/experimental/dds/tree2/src/domains/testRecursiveDomain.ts
@@ -10,25 +10,22 @@
  * Currently we do not have tooling in place to test this in our test suite, and exporting these types here is a temporary crutch to aid in diagnosing this issue.
  */
 
-import { FieldKinds, TreeFieldSchema } from "../feature-libraries";
+import { AllowedTypes, FieldKinds, SchemaBuilderBase, TreeFieldSchema } from "../feature-libraries";
 import { areSafelyAssignable, isAny, requireFalse, requireTrue } from "../util";
 import { leaf } from "./leafDomain";
-import { SchemaBuilder } from "./schemaBuilder";
 
-const builder = new SchemaBuilder({ scope: "Test Recursive Domain" });
+const builder = new SchemaBuilderBase(FieldKinds.optional, { scope: "Test Recursive Domain" });
 
-/**
- */
 export const recursiveObject = builder.objectRecursive("object", {
 	recursive: TreeFieldSchema.createUnsafe(FieldKinds.optional, [() => recursiveObject]),
 	number: leaf.number,
 });
 
-const recursiveReference = () => recursiveObject2;
-builder.fixRecursiveReference(recursiveReference);
+function fixRecursiveReference<T extends AllowedTypes>(...types: T): void {}
 
-/**
- */
+const recursiveReference = () => recursiveObject2;
+fixRecursiveReference(recursiveReference);
+
 export const recursiveObject2 = builder.object("object2", {
 	recursive: TreeFieldSchema.create(FieldKinds.optional, [recursiveReference]),
 	number: leaf.number,
@@ -41,12 +38,11 @@ type _1 = requireTrue<
 		ReturnType<(typeof recursiveObject2.objectNodeFieldsObject.recursive.allowedTypes)[0]>
 	>
 >;
-/**
- */
+
 export const library = builder.intoLibrary();
 
 {
-	const b = new SchemaBuilder({ scope: "Test Recursive Domain" });
+	const b = new SchemaBuilderBase(FieldKinds.optional, { scope: "Test Recursive Domain" });
 	const node = b.objectRecursive("object", {
 		child: TreeFieldSchema.createUnsafe(FieldKinds.optional, [() => node]),
 	});


### PR DESCRIPTION
## Description

Deprecate SchemaBuilder, and related cleanup.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
