### PR TITLE
move multiplicity to out of modular-schema

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -17,12 +17,13 @@ import {
 	TreeStoredSchema,
 	StoredSchemaCollection,
 } from "../../core";
-import { FullSchemaPolicy, Multiplicity } from "../modular-schema";
+import { FullSchemaPolicy } from "../modular-schema";
 import { fail } from "../../util";
 import { TreeChunk, tryGetChunk } from "./chunk";
 import { BasicChunk } from "./basicChunk";
 import { FieldShape, TreeShape, UniformChunk } from "./uniformChunk";
 import { SequenceChunk } from "./sequenceChunk";
+import { Multiplicity } from "../multiplicity";
 
 export interface Disposable {
 	/**

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -19,11 +19,11 @@ import {
 } from "../../core";
 import { FullSchemaPolicy } from "../modular-schema";
 import { fail } from "../../util";
+import { Multiplicity } from "../multiplicity";
 import { TreeChunk, tryGetChunk } from "./chunk";
 import { BasicChunk } from "./basicChunk";
 import { FieldShape, TreeShape, UniformChunk } from "./uniformChunk";
 import { SequenceChunk } from "./sequenceChunk";
-import { Multiplicity } from "../multiplicity";
 
 export interface Disposable {
 	/**

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/schemaBasedEncoding.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/schemaBasedEncoding.ts
@@ -14,7 +14,6 @@ import {
 import { FullSchemaPolicy } from "../../modular-schema";
 import { fail } from "../../../util";
 import { Multiplicity } from "../../multiplicity";
-import { FullSchemaPolicy } from "../../modular-schema";
 import { EncodedChunk, EncodedValueShape } from "./format";
 import {
 	EncoderCache,

--- a/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/schemaBasedEncoding.ts
+++ b/experimental/dds/tree2/src/feature-libraries/chunked-forest/codec/schemaBasedEncoding.ts
@@ -11,9 +11,10 @@ import {
 	TreeNodeSchemaIdentifier,
 	ValueSchema,
 } from "../../../core";
-import { FieldKind, FullSchemaPolicy, Multiplicity } from "../../modular-schema";
+import { FieldKind, FullSchemaPolicy } from "../../modular-schema";
 import { fail } from "../../../util";
 import { fieldKinds } from "../../default-schema";
+import { Multiplicity } from "../../multiplicity";
 import { EncodedChunk, EncodedValueShape } from "./format";
 import {
 	EncoderCache,

--- a/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
+++ b/experimental/dds/tree2/src/feature-libraries/contextuallyTyped.ts
@@ -23,7 +23,7 @@ import {
 // This module currently is assuming use of default-field-kinds.
 // The field kinds should instead come from a view schema registry thats provided somewhere.
 import { fieldKinds } from "./default-schema";
-import { FieldKind, Multiplicity } from "./modular-schema";
+import { FieldKind } from "./modular-schema";
 import {
 	AllowedTypes,
 	TreeFieldSchema,
@@ -38,6 +38,7 @@ import {
 } from "./schema-aware";
 import { isFluidHandle, allowsValue } from "./valueUtilities";
 import { TreeDataContext } from "./fieldGenerator";
+import { Multiplicity } from "./multiplicity";
 
 /**
  * This library defines a tree data format that can infer its types from context.

--- a/experimental/dds/tree2/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/experimental/dds/tree2/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -14,7 +14,6 @@ import {
 import { fail } from "../../util";
 import {
 	FieldKind,
-	Multiplicity,
 	allowsTreeSchemaIdentifierSuperset,
 	ToDelta,
 	FieldChangeHandler,
@@ -29,6 +28,7 @@ import {
 	optionalChangeHandler,
 	optionalFieldEditor,
 } from "../optional-field";
+import { Multiplicity } from "../multiplicity";
 
 /**
  * ChangeHandler that only handles no-op / identity changes.

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -114,7 +114,6 @@ export {
 	CrossFieldManager,
 	CrossFieldTarget,
 	FieldKind,
-	Multiplicity,
 	FullSchemaPolicy,
 	allowsRepoSuperset,
 	GenericChangeset,
@@ -125,6 +124,8 @@ export {
 	FieldKindWithEditor,
 	RelevantRemovedRootsFromChild,
 } from "./modular-schema";
+
+export { Multiplicity } from "./multiplicity";
 
 export {
 	TreeNodeSchema,

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/comparison.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/comparison.ts
@@ -13,7 +13,8 @@ import {
 	TreeStoredSchema,
 	storedEmptyFieldSchema,
 } from "../../core";
-import { FullSchemaPolicy, Multiplicity, withEditor } from "./fieldKind";
+import { Multiplicity } from "../multiplicity";
+import { FullSchemaPolicy, withEditor } from "./fieldKind";
 
 /**
  * @returns true iff `superset` is a superset of `original`.

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldKind.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/fieldKind.ts
@@ -11,6 +11,7 @@ import {
 	FieldKindSpecifier,
 	TreeTypeSet,
 } from "../../core";
+import { Multiplicity } from "../multiplicity";
 import { isNeverField } from "./comparison";
 import { FieldChangeHandler, FieldEditor } from "./fieldChangeHandler";
 
@@ -145,55 +146,4 @@ export interface FullSchemaPolicy {
 	 * and will be unable to process any changes that use those FieldKinds.
 	 */
 	readonly fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKind>;
-}
-
-/**
- * Describes how a particular field functions.
- *
- * This determine its reading and editing APIs, multiplicity, and what merge resolution policies it will use.
- * @alpha
- */
-export enum Multiplicity {
-	/**
-	 * Exactly one item.
-	 */
-	Single,
-	/**
-	 * 0 or 1 items.
-	 */
-	Optional,
-	/**
-	 * 0 or more items.
-	 */
-	Sequence,
-	/**
-	 * Exactly 0 items.
-	 *
-	 * Using Forbidden makes what types are listed for allowed in a field irrelevant
-	 * since the field will never have values in it.
-	 *
-	 * Using Forbidden is equivalent to picking a kind that permits empty (like sequence or optional)
-	 * and having no allowed types (or only never types).
-	 * Because of this, its possible to express everything constraint wise without Forbidden,
-	 * but using Forbidden can be more semantically clear than optional with no allowed types.
-	 *
-	 * For view schema, this can be useful if you need to:
-	 * - run a specific out of schema handler when a field is present,
-	 * but otherwise are ignoring or tolerating (ex: via extra fields) unmentioned fields.
-	 * - prevent a specific field from being used as an extra field
-	 * (perhaps for some past of future compatibility reason)
-	 * - keep a field in a schema for metadata purposes
-	 * (ex: for improved error messaging, error handling or documentation)
-	 * that is not used in this specific version of the schema (ex: to document what it was or will be used for).
-	 *
-	 * For stored schema, this can be useful if you need to:
-	 * - have a field which can have its schema updated to Optional or Sequence of any type.
-	 * - to exclude a field from extra fields
-	 * - for the schema system to use as a default for fields which aren't declared
-	 * (ex: when updating a field that did not exist into one that does)
-	 *
-	 * @privateRemarks
-	 * See storedEmptyFieldSchema for a constant, reusable field using Forbidden.
-	 */
-	Forbidden,
 }

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -13,6 +13,7 @@ import {
 	TaggedChange,
 } from "../../core";
 import { fail, IdAllocator } from "../../util";
+import { Multiplicity } from "../multiplicity";
 import { CrossFieldManager } from "./crossFieldQueries";
 import {
 	FieldChangeHandler,
@@ -23,7 +24,7 @@ import {
 	RelevantRemovedRootsFromChild,
 	NodeChangePruner,
 } from "./fieldChangeHandler";
-import { FieldKindWithEditor, Multiplicity } from "./fieldKind";
+import { FieldKindWithEditor } from "./fieldKind";
 import { makeGenericChangeCodec } from "./genericFieldKindCodecs";
 import { GenericChange, GenericChangeset } from "./genericFieldKindTypes";
 import { NodeChangeset } from "./modularChangeTypes";

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/index.ts
@@ -20,7 +20,7 @@ export {
 	setInCrossFieldMap,
 } from "./crossFieldQueries";
 export { ChangesetLocalIdSchema, EncodedChangeAtomId } from "./modularChangeFormat";
-export { FieldKind, FullSchemaPolicy, Multiplicity, FieldKindWithEditor } from "./fieldKind";
+export { FieldKind, FullSchemaPolicy, FieldKindWithEditor } from "./fieldKind";
 export {
 	FieldChangeHandler,
 	FieldChangeRebaser,

--- a/experimental/dds/tree2/src/feature-libraries/multiplicity.ts
+++ b/experimental/dds/tree2/src/feature-libraries/multiplicity.ts
@@ -1,0 +1,54 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+/**
+ * Describes how a particular field functions.
+ *
+ * This determine its reading and editing APIs, multiplicity, and what merge resolution policies it will use.
+ * @alpha
+ */
+export enum Multiplicity {
+	/**
+	 * Exactly one item.
+	 */
+	Single,
+	/**
+	 * 0 or 1 items.
+	 */
+	Optional,
+	/**
+	 * 0 or more items.
+	 */
+	Sequence,
+	/**
+	 * Exactly 0 items.
+	 *
+	 * Using Forbidden makes what types are listed for allowed in a field irrelevant
+	 * since the field will never have values in it.
+	 *
+	 * Using Forbidden is equivalent to picking a kind that permits empty (like sequence or optional)
+	 * and having no allowed types (or only never types).
+	 * Because of this, its possible to express everything constraint wise without Forbidden,
+	 * but using Forbidden can be more semantically clear than optional with no allowed types.
+	 *
+	 * For view schema, this can be useful if you need to:
+	 * - run a specific out of schema handler when a field is present,
+	 * but otherwise are ignoring or tolerating (ex: via extra fields) unmentioned fields.
+	 * - prevent a specific field from being used as an extra field
+	 * (perhaps for some past of future compatibility reason)
+	 * - keep a field in a schema for metadata purposes
+	 * (ex: for improved error messaging, error handling or documentation)
+	 * that is not used in this specific version of the schema (ex: to document what it was or will be used for).
+	 *
+	 * For stored schema, this can be useful if you need to:
+	 * - have a field which can have its schema updated to Optional or Sequence of any type.
+	 * - to exclude a field from extra fields
+	 * - for the schema system to use as a default for fields which aren't declared
+	 * (ex: when updating a field that did not exist into one that does)
+	 *
+	 * @privateRemarks
+	 * See storedEmptyFieldSchema for a constant, reusable field using Forbidden.
+	 */
+	Forbidden,
+}

--- a/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-aware/schemaAware.ts
@@ -5,7 +5,6 @@
 
 import { TreeNodeSchemaIdentifier, TreeValue, ValueSchema } from "../../core";
 import { ContextuallyTypedNodeData, typeNameSymbol, valueSymbol } from "../contextuallyTyped";
-import { Multiplicity } from "../modular-schema";
 import {
 	TreeFieldSchema,
 	TreeNodeSchema,
@@ -19,6 +18,7 @@ import {
 	LazyItem,
 } from "../typed-schema";
 import { Assume, FlattenKeys, _InlineTrick } from "../../util";
+import { Multiplicity } from "../multiplicity";
 
 /**
  * Empty Object for use in type computations that should contribute no fields when `&`ed with another type.

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaCollection.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaCollection.ts
@@ -5,7 +5,6 @@
 
 import { assert } from "@fluidframework/core-utils";
 import { Adapters, TreeAdapter, TreeNodeSchemaIdentifier } from "../../core";
-import { Multiplicity } from "../modular-schema";
 import { capitalize, fail, requireAssignableTo } from "../../util";
 import { defaultSchemaPolicy, FieldKinds } from "../default-schema";
 import {
@@ -20,6 +19,7 @@ import {
 } from "./typedTreeSchema";
 import { normalizeFlexListEager } from "./flexList";
 import { Sourced } from "./view";
+import { Multiplicity } from "../multiplicity";
 
 // TODO: tests for this file
 

--- a/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaCollection.ts
+++ b/experimental/dds/tree2/src/feature-libraries/typed-schema/schemaCollection.ts
@@ -7,6 +7,7 @@ import { assert } from "@fluidframework/core-utils";
 import { Adapters, TreeAdapter, TreeNodeSchemaIdentifier } from "../../core";
 import { capitalize, fail, requireAssignableTo } from "../../util";
 import { defaultSchemaPolicy, FieldKinds } from "../default-schema";
+import { Multiplicity } from "../multiplicity";
 import {
 	TreeFieldSchema,
 	TreeNodeSchema,
@@ -19,7 +20,6 @@ import {
 } from "./typedTreeSchema";
 import { normalizeFlexListEager } from "./flexList";
 import { Sourced } from "./view";
-import { Multiplicity } from "../multiplicity";
 
 // TODO: tests for this file
 

--- a/experimental/dds/tree2/src/test/counterFieldKind.ts
+++ b/experimental/dds/tree2/src/test/counterFieldKind.ts
@@ -8,12 +8,12 @@ import { ICodecFamily, makeCodecFamily, makeValueCodec } from "../codec";
 import {
 	FieldChangeHandler,
 	FieldChangeRebaser,
+	Multiplicity,
 	cursorForJsonableTreeNode,
 } from "../feature-libraries";
 // This is imported directly to implement an example of a field kind.
 import {
 	FieldKindWithEditor,
-	Multiplicity,
 	referenceFreeFieldChangeRebaser,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../feature-libraries/modular-schema";

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/basicRebasers.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/basicRebasers.ts
@@ -9,7 +9,6 @@ import {
 	FieldChangeHandler,
 	FieldChangeRebaser,
 	FieldKindWithEditor,
-	Multiplicity,
 	referenceFreeFieldChangeRebaser,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/modular-schema";
@@ -17,6 +16,7 @@ import { Mutable, fail } from "../../../util";
 import { makeCodecFamily, makeValueCodec } from "../../../codec";
 import { singleJsonCursor } from "../../../domains";
 import { DeltaFieldChanges, makeDetachedNodeId } from "../../../core";
+import { Multiplicity } from "../../../feature-libraries";
 
 /**
  * Picks the last value written.


### PR DESCRIPTION
## Description

This PR moves the `Multiplicity` enum out from `modular-schema` to the parent directory `feature-libraries`, to make chunkTree stop depending on `Multiplicity`, to help mitigate circular dependency issues.