### PR TITLE
Remove deprecated SingleRT flow in odsp-driver

### DIFF
--- a/.changeset/slow-seas-rhyme.md
+++ b/.changeset/slow-seas-rhyme.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/odsp-driver": major
+"@fluidframework/odsp-driver-definitions": major
+---
+
+Removed deprecated implementation of SigleRT feature which was enabled via enableShareLinkWithCreate boolean flag in HostStoragePolicy
+
+Removed the deprecated logic of creating sharing-links with container attach (called SingleRT) which was enabled via enableShareLinkWithCreate flag in HostStoragePolicy. This change removes SharingLinkTypes interface definition, removes other deprecated properties from the odsp-driver's resolvedUrl object and also removes the enableShareLinkWithCreate flag. The newer version of SingleRT feature continues to exist, which can be enabled via enableSingleRequestForShareLinkWithCreate feature flag in HostStoragePolicy.

--- a/.changeset/slow-seas-rhyme.md
+++ b/.changeset/slow-seas-rhyme.md
@@ -3,6 +3,6 @@
 "@fluidframework/odsp-driver-definitions": major
 ---
 
-Removed deprecated implementation of SigleRT feature which was enabled via enableShareLinkWithCreate boolean flag in HostStoragePolicy
+Removed deprecated implementation of SingleRT feature which was enabled via enableShareLinkWithCreate boolean flag in HostStoragePolicy
 
 Removed the deprecated logic of creating sharing-links with container attach (called SingleRT) which was enabled via enableShareLinkWithCreate flag in HostStoragePolicy. This change removes SharingLinkTypes interface definition, removes other deprecated properties from the odsp-driver's resolvedUrl object and also removes the enableShareLinkWithCreate flag. The newer version of SingleRT feature continues to exist, which can be enabled via enableSingleRequestForShareLinkWithCreate feature flag in HostStoragePolicy.

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
@@ -244,7 +244,6 @@ export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
 // @alpha
 export interface ShareLinkInfoType {
     createLink?: {
-        type?: ShareLinkTypes | ISharingLinkKind;
         link?: string | ISharingLink;
         error?: any;
         shareId?: string;
@@ -252,13 +251,7 @@ export interface ShareLinkInfoType {
     sharingLinkToRedeem?: string;
 }
 
-// @alpha @deprecated (undocumented)
-export enum ShareLinkTypes {
-    // (undocumented)
-    csl = "csl"
-}
-
-// @alpha
+// @internal
 export enum SharingLinkRole {
     // (undocumented)
     edit = "edit",

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
@@ -244,14 +244,14 @@ export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
 // @alpha
 export interface ShareLinkInfoType {
     createLink?: {
-        link?: string | ISharingLink;
+        link?: ISharingLink;
         error?: any;
         shareId?: string;
     };
     sharingLinkToRedeem?: string;
 }
 
-// @internal
+// @alpha
 export enum SharingLinkRole {
     // (undocumented)
     edit = "edit",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -128,6 +128,10 @@
 			"RemovedEnumDeclaration_OdspErrorType": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"RemovedEnumDeclaration_ShareLinkTypes": {
+				"backCompat": false,
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/drivers/odsp-driver-definitions/src/index.ts
+++ b/packages/drivers/odsp-driver-definitions/src/index.ts
@@ -25,7 +25,6 @@ export {
 	ISharingLink,
 	ISharingLinkKind,
 	ShareLinkInfoType,
-	ShareLinkTypes,
 	SharingLinkRole,
 	SharingLinkScope,
 } from "./resolvedUrl";

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -74,7 +74,7 @@ export interface ShareLinkInfoType {
 		/**
 		 * Share link created when the file is created for the first time with /snapshot api call.
 		 */
-		link?: string | ISharingLink;
+		link?: ISharingLink;
 
 		/**
 		 * Error message if creation of sharing link fails with /snapshot api call

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -15,15 +15,6 @@ export interface IOdspUrlParts {
 }
 
 /**
- * @deprecated Use ISharingLinkKind type instead.
- * Type of shareLink requested/created when creating the file for the first time.
- * @alpha
- */
-export enum ShareLinkTypes {
-	csl = "csl",
-}
-
-/**
  * Sharing scope of the share links created for a file.
  * @alpha
  */
@@ -80,14 +71,6 @@ export interface ShareLinkInfoType {
 	 * from the /snapshot api response.
 	 */
 	createLink?: {
-		/**
-		 * @deprecated
-		 * Type of shareLink requested/created when creating the file for the first time. The 'type' property here
-		 * represents the type of sharing link requested.
-		 * Will be deprecated soon. Type of sharing link will be present in the link:ISharingLink property below.
-		 */
-		type?: ShareLinkTypes | ISharingLinkKind;
-
 		/**
 		 * Share link created when the file is created for the first time with /snapshot api call.
 		 */

--- a/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
+++ b/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
@@ -638,24 +638,12 @@ use_old_InterfaceDeclaration_ShareLinkInfoType(
 * If breaking change required, add in package.json under typeValidation.broken:
 * "RemovedEnumDeclaration_ShareLinkTypes": {"forwardCompat": false}
 */
-declare function get_old_EnumDeclaration_ShareLinkTypes():
-    TypeOnly<old.ShareLinkTypes>;
-declare function use_current_RemovedEnumDeclaration_ShareLinkTypes(
-    use: TypeOnly<current.ShareLinkTypes>): void;
-use_current_RemovedEnumDeclaration_ShareLinkTypes(
-    get_old_EnumDeclaration_ShareLinkTypes());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
 * "RemovedEnumDeclaration_ShareLinkTypes": {"backCompat": false}
 */
-declare function get_current_RemovedEnumDeclaration_ShareLinkTypes():
-    TypeOnly<current.ShareLinkTypes>;
-declare function use_old_EnumDeclaration_ShareLinkTypes(
-    use: TypeOnly<old.ShareLinkTypes>): void;
-use_old_EnumDeclaration_ShareLinkTypes(
-    get_current_RemovedEnumDeclaration_ShareLinkTypes());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
+++ b/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
@@ -636,26 +636,26 @@ use_old_InterfaceDeclaration_ShareLinkInfoType(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "EnumDeclaration_ShareLinkTypes": {"forwardCompat": false}
+* "RemovedEnumDeclaration_ShareLinkTypes": {"forwardCompat": false}
 */
 declare function get_old_EnumDeclaration_ShareLinkTypes():
     TypeOnly<old.ShareLinkTypes>;
-declare function use_current_EnumDeclaration_ShareLinkTypes(
+declare function use_current_RemovedEnumDeclaration_ShareLinkTypes(
     use: TypeOnly<current.ShareLinkTypes>): void;
-use_current_EnumDeclaration_ShareLinkTypes(
+use_current_RemovedEnumDeclaration_ShareLinkTypes(
     get_old_EnumDeclaration_ShareLinkTypes());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "EnumDeclaration_ShareLinkTypes": {"backCompat": false}
+* "RemovedEnumDeclaration_ShareLinkTypes": {"backCompat": false}
 */
-declare function get_current_EnumDeclaration_ShareLinkTypes():
+declare function get_current_RemovedEnumDeclaration_ShareLinkTypes():
     TypeOnly<current.ShareLinkTypes>;
 declare function use_old_EnumDeclaration_ShareLinkTypes(
     use: TypeOnly<old.ShareLinkTypes>): void;
 use_old_EnumDeclaration_ShareLinkTypes(
-    get_current_EnumDeclaration_ShareLinkTypes());
+    get_current_RemovedEnumDeclaration_ShareLinkTypes());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
@@ -47,7 +47,7 @@ export enum ClpCompliantAppHeader {
 export function createLocalOdspDocumentServiceFactory(localSnapshot: Uint8Array | string): IDocumentServiceFactory;
 
 // @alpha
-export function createOdspCreateContainerRequest(siteUrl: string, driveId: string, filePath: string, fileName: string, createShareLinkType?: ShareLinkTypes | ISharingLinkKind): IRequest;
+export function createOdspCreateContainerRequest(siteUrl: string, driveId: string, filePath: string, fileName: string, createShareLinkType?: ISharingLinkKind): IRequest;
 
 // @alpha
 export function createOdspUrl(l: OdspFluidDataStoreLocator): string;

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
@@ -32,7 +32,6 @@ import { IUrlResolver } from '@fluidframework/driver-definitions';
 import { OdspResourceTokenFetchOptions } from '@fluidframework/odsp-driver-definitions';
 import { PromiseCache } from '@fluidframework/core-utils';
 import { RateLimiter } from '@fluidframework/driver-utils';
-import { ShareLinkTypes } from '@fluidframework/odsp-driver-definitions';
 import { TokenFetcher } from '@fluidframework/odsp-driver-definitions';
 
 // @alpha

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -127,7 +127,7 @@ export async function createNewFluidFile(
 
 /**
  * If user requested creation of a sharing link along with the creation of the file by providing
- * createLinkScope in the request parameters then extract and save the sharing link information from 
+ * createLinkScope in the request parameters then extract and save the sharing link information from
  * the response if it is available.
  * In case there was an error in creation of the sharing link, error is provided back in the response,
  * and does not impact the creation of file in ODSP.

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -58,7 +58,6 @@ export async function createNewFluidFile(
 	forceAccessTokenViaAuthorizationHeader: boolean,
 	isClpCompliantApp?: boolean,
 	enableSingleRequestForShareLinkWithCreate?: boolean,
-	enableShareLinkWithCreate?: boolean,
 ): Promise<IOdspResolvedUrl> {
 	// Check for valid filename before the request to create file is actually made.
 	if (isInvalidFileName(newFileInfo.filename)) {
@@ -97,7 +96,6 @@ export async function createNewFluidFile(
 			newFileInfo.createLinkType,
 			content,
 			enableSingleRequestForShareLinkWithCreate,
-			enableShareLinkWithCreate,
 		);
 	}
 
@@ -139,7 +137,6 @@ function extractShareLinkData(
 	requestedSharingLinkKind: ISharingLinkKind | undefined,
 	response: ICreateFileResponse,
 	enableSingleRequestForShareLinkWithCreate?: boolean,
-	enableShareLinkWithCreate?: boolean,
 ): ShareLinkInfoType | undefined {
 	if (!requestedSharingLinkKind) {
 		return;

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -12,7 +12,6 @@ import {
 	IOdspResolvedUrl,
 	OdspErrorTypes,
 	ShareLinkInfoType,
-	ISharingLinkKind,
 	IFileEntry,
 } from "@fluidframework/odsp-driver-definitions";
 import { ICreateFileResponse } from "./contracts";
@@ -92,11 +91,7 @@ export async function createNewFluidFile(
 		itemId = content.itemId;
 		summaryHandle = content.id;
 
-		shareLinkInfo = extractShareLinkData(
-			newFileInfo.createLinkType,
-			content,
-			enableSingleRequestForShareLinkWithCreate,
-		);
+		shareLinkInfo = extractShareLinkData(content, enableSingleRequestForShareLinkWithCreate);
 	}
 
 	const odspUrl = createOdspUrl({ ...newFileInfo, itemId, dataStorePath: "/" });
@@ -134,13 +129,9 @@ export async function createNewFluidFile(
  * @returns Sharing link information received in the response from a successful creation of a file.
  */
 function extractShareLinkData(
-	requestedSharingLinkKind: ISharingLinkKind | undefined,
 	response: ICreateFileResponse,
 	enableSingleRequestForShareLinkWithCreate?: boolean,
 ): ShareLinkInfoType | undefined {
-	if (!requestedSharingLinkKind) {
-		return;
-	}
 	let shareLinkInfo: ShareLinkInfoType | undefined;
 	if (enableSingleRequestForShareLinkWithCreate) {
 		const { sharing } = response;

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -126,9 +126,9 @@ export async function createNewFluidFile(
 }
 
 /**
- * If user requested creation of a sharing link along with the creation of the file by providing either
- * createLinkType (now deprecated) or createLinkScope in the request parameters, extract and save
- * sharing link information from the response if it is available.
+ * If user requested creation of a sharing link along with the creation of the file by providing
+ * createLinkScope in the request parameters then extract and save the sharing link information from 
+ * the response if it is available.
  * In case there was an error in creation of the sharing link, error is provided back in the response,
  * and does not impact the creation of file in ODSP.
  * @param requestedSharingLinkKind - Kind of sharing link requested to be created along with the creation of file.
@@ -152,7 +152,6 @@ function extractShareLinkData(
 		}
 		shareLinkInfo = {
 			createLink: {
-				type: requestedSharingLinkKind,
 				link: sharing.sharingLink
 					? {
 							scope: sharing.sharingLink.scope,

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -13,7 +13,6 @@ import {
 	OdspErrorTypes,
 	ShareLinkInfoType,
 	ISharingLinkKind,
-	ShareLinkTypes,
 	IFileEntry,
 } from "@fluidframework/odsp-driver-definitions";
 import { ICreateFileResponse } from "./contracts";
@@ -137,7 +136,7 @@ export async function createNewFluidFile(
  * @returns Sharing link information received in the response from a successful creation of a file.
  */
 function extractShareLinkData(
-	requestedSharingLinkKind: ShareLinkTypes | ISharingLinkKind | undefined,
+	requestedSharingLinkKind: ISharingLinkKind | undefined,
 	response: ICreateFileResponse,
 	enableSingleRequestForShareLinkWithCreate?: boolean,
 	enableShareLinkWithCreate?: boolean,
@@ -164,19 +163,6 @@ function extractShareLinkData(
 					: undefined,
 				error: sharing.error,
 				shareId: sharing.shareId,
-			},
-		};
-	} else if (enableShareLinkWithCreate) {
-		const { sharing, sharingLink, sharingLinkErrorReason } = response;
-		if (!sharingLink && !sharingLinkErrorReason) {
-			return;
-		}
-		shareLinkInfo = {
-			createLink: {
-				type: requestedSharingLinkKind,
-				link: sharingLink,
-				error: sharingLinkErrorReason,
-				shareId: sharing?.shareId,
 			},
 		};
 	}

--- a/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
+++ b/packages/drivers/odsp-driver/src/createOdspCreateContainerRequest.ts
@@ -4,7 +4,7 @@
  */
 import { IRequest } from "@fluidframework/core-interfaces";
 import { DriverHeader } from "@fluidframework/driver-definitions";
-import { ShareLinkTypes, ISharingLinkKind } from "@fluidframework/odsp-driver-definitions";
+import { ISharingLinkKind } from "@fluidframework/odsp-driver-definitions";
 import { buildOdspShareLinkReqParams } from "./odspUtils";
 
 /**
@@ -22,7 +22,7 @@ export function createOdspCreateContainerRequest(
 	driveId: string,
 	filePath: string,
 	fileName: string,
-	createShareLinkType?: ShareLinkTypes | ISharingLinkKind,
+	createShareLinkType?: ISharingLinkKind,
 ): IRequest {
 	const shareLinkRequestParams = buildOdspShareLinkReqParams(createShareLinkType);
 	const createNewRequest: IRequest = {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -160,7 +160,6 @@ export class OdspDocumentServiceFactoryCore
 				createShareLinkParam: createShareLinkParam
 					? JSON.stringify(createShareLinkParam)
 					: undefined,
-				enableShareLinkWithCreate: this.hostPolicy.enableShareLinkWithCreate,
 				enableSingleRequestForShareLinkWithCreate:
 					this.hostPolicy.enableSingleRequestForShareLinkWithCreate,
 			},
@@ -201,7 +200,6 @@ export class OdspDocumentServiceFactoryCore
 								?.forceAccessTokenViaAuthorizationHeader,
 							odspResolvedUrl.isClpCompliantApp,
 							this.hostPolicy.enableSingleRequestForShareLinkWithCreate,
-							this.hostPolicy.enableShareLinkWithCreate,
 					  )
 					: await module.createNewContainerOnExistingFile(
 							getStorageToken,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -26,7 +26,6 @@ import {
 	IOdspUrlParts,
 	SharingLinkScope,
 	SharingLinkRole,
-	ShareLinkTypes,
 	ISharingLinkKind,
 	ISocketStorageDiscovery,
 	IRelaySessionAwareDriverFactory,
@@ -102,7 +101,7 @@ export class OdspDocumentServiceFactoryCore
 		};
 
 		let fileInfo: INewFileInfo | IExistingFileInfo;
-		let createShareLinkParam: ShareLinkTypes | ISharingLinkKind | undefined;
+		let createShareLinkParam: ISharingLinkKind | undefined;
 		if (odspResolvedUrl.itemId) {
 			fileInfo = {
 				type: "Existing",
@@ -330,9 +329,9 @@ export class OdspDocumentServiceFactoryCore
 function getSharingLinkParams(
 	hostPolicy: HostStoragePolicy,
 	searchParams: URLSearchParams,
-): ShareLinkTypes | ISharingLinkKind | undefined {
+): ISharingLinkKind | undefined {
 	// extract request parameters for creation of sharing link (if provided) if the feature is enabled
-	let createShareLinkParam: ShareLinkTypes | ISharingLinkKind | undefined;
+	let createShareLinkParam: ISharingLinkKind | undefined;
 	if (hostPolicy.enableSingleRequestForShareLinkWithCreate) {
 		const createLinkScope = searchParams.get("createLinkScope");
 		const createLinkRole = searchParams.get("createLinkRole");
@@ -343,11 +342,6 @@ function getSharingLinkParams(
 					? { role: SharingLinkRole[createLinkRole] }
 					: {}),
 			};
-		}
-	} else if (hostPolicy.enableShareLinkWithCreate) {
-		const createLinkType = searchParams.get("createLinkType");
-		if (createLinkType && ShareLinkTypes[createLinkType]) {
-			createShareLinkParam = ShareLinkTypes[createLinkType || ""];
 		}
 	}
 	return createShareLinkParam;

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -13,8 +13,6 @@ import {
 import {
 	IOdspResolvedUrl,
 	OdspErrorTypes,
-	ShareLinkTypes,
-	ShareLinkInfoType,
 } from "@fluidframework/odsp-driver-definitions";
 import { NonRetryableError } from "@fluidframework/driver-utils";
 import { createOdspUrl } from "./createOdspUrl";

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -127,6 +127,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 					containerPackageName: packageName ?? undefined,
 				},
 				fileVersion: undefined,
+				shareLinkInfo: undefined,
 				isClpCompliantApp: request.headers?.[ClpCompliantAppHeader.isClpCompliantApp],
 			};
 		}

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -97,7 +97,6 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 			const driveID = searchParams.get("driveId");
 			const filePath = searchParams.get("path");
 			const packageName = searchParams.get("containerPackageName");
-			const createLinkType = searchParams.get("createLinkType");
 			// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- false positive
 			if (!(fileName && siteURL && driveID && filePath !== null && filePath !== undefined)) {
 				throw new NonRetryableError(
@@ -105,14 +104,6 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 					OdspErrorTypes.genericError,
 					{ driverVersion: pkgVersion },
 				);
-			}
-			let shareLinkInfo: ShareLinkInfoType | undefined;
-			if (createLinkType && createLinkType in ShareLinkTypes) {
-				shareLinkInfo = {
-					createLink: {
-						type: ShareLinkTypes[createLinkType],
-					},
-				};
 			}
 			return {
 				endpoints: {
@@ -136,7 +127,6 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 					containerPackageName: packageName ?? undefined,
 				},
 				fileVersion: undefined,
-				shareLinkInfo,
 				isClpCompliantApp: request.headers?.[ClpCompliantAppHeader.isClpCompliantApp],
 			};
 		}

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -10,10 +10,7 @@ import {
 	IResolvedUrl,
 	IUrlResolver,
 } from "@fluidframework/driver-definitions";
-import {
-	IOdspResolvedUrl,
-	OdspErrorTypes,
-} from "@fluidframework/odsp-driver-definitions";
+import { IOdspResolvedUrl, OdspErrorTypes } from "@fluidframework/odsp-driver-definitions";
 import { NonRetryableError } from "@fluidframework/driver-utils";
 import { createOdspUrl } from "./createOdspUrl";
 import { getApiRoot } from "./odspUrlHelper";

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -447,9 +447,9 @@ export function buildOdspShareLinkReqParams(shareLinkType: ISharingLinkKind | un
 	if (!shareLinkType) {
 		return;
 	}
-	const scope = (shareLinkType as ISharingLinkKind).scope;
+	const scope = shareLinkType.scope;
 	let shareLinkRequestParams = `createLinkScope=${scope}`;
-	const role = (shareLinkType as ISharingLinkKind).role;
+	const role = shareLinkType.role;
 	shareLinkRequestParams = role
 		? `${shareLinkRequestParams}&createLinkRole=${role}`
 		: shareLinkRequestParams;

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -443,9 +443,7 @@ export const maxUmpPostBodySize = 79872;
  * @param shareLinkType - Kind of sharing link requested
  * @returns A string of request parameters that can be concatenated with the base URI
  */
-export function buildOdspShareLinkReqParams(
-	shareLinkType: ISharingLinkKind | undefined,
-) {
+export function buildOdspShareLinkReqParams(shareLinkType: ISharingLinkKind | undefined) {
 	if (!shareLinkType) {
 		return;
 	}

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -33,7 +33,6 @@ import {
 	tokenFromResponse,
 	isTokenFromCache,
 	OdspResourceTokenFetchOptions,
-	ShareLinkTypes,
 	ISharingLinkKind,
 	TokenFetcher,
 	ICacheEntry,
@@ -283,11 +282,8 @@ export interface INewFileInfo extends IFileInfoBase {
 	/**
 	 * application can request creation of a share link along with the creation of a new file
 	 * by passing in an optional param to specify the kind of sharing link
-	 * (at the time of adding this comment Sept/2021), odsp only supports csl
-	 * ShareLinkTypes will deprecated in future. Use ISharingLinkKind instead which specifies both
-	 * share link type and the role type.
 	 */
-	createLinkType?: ShareLinkTypes | ISharingLinkKind;
+	createLinkType?: ISharingLinkKind;
 }
 
 export interface IExistingFileInfo extends IFileInfoBase {

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -448,16 +448,12 @@ export const maxUmpPostBodySize = 79872;
  * @returns A string of request parameters that can be concatenated with the base URI
  */
 export function buildOdspShareLinkReqParams(
-	shareLinkType: ShareLinkTypes | ISharingLinkKind | undefined,
+	shareLinkType: ISharingLinkKind | undefined,
 ) {
 	if (!shareLinkType) {
 		return;
 	}
 	const scope = (shareLinkType as ISharingLinkKind).scope;
-	if (!scope) {
-		// eslint-disable-next-line @typescript-eslint/no-base-to-string
-		return `createLinkType=${shareLinkType}`;
-	}
 	let shareLinkRequestParams = `createLinkScope=${scope}`;
 	const role = (shareLinkType as ISharingLinkKind).role;
 	shareLinkRequestParams = role

--- a/packages/drivers/odsp-driver/src/test/buildOdspShareLinkReqParams.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/buildOdspShareLinkReqParams.spec.ts
@@ -4,10 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import {
-	SharingLinkRole,
-	SharingLinkScope,
-} from "@fluidframework/odsp-driver-definitions";
+import { SharingLinkRole, SharingLinkScope } from "@fluidframework/odsp-driver-definitions";
 import { buildOdspShareLinkReqParams } from "../odspUtils";
 
 describe("buildOdspShareLinkReqParams", () => {
@@ -26,7 +23,6 @@ describe("buildOdspShareLinkReqParams", () => {
 			`createLinkScope=${SharingLinkScope.organization}&createLinkRole=${SharingLinkRole.view}`,
 		);
 	});
-
 
 	it("Should return undefined when the input is undefined", async () => {
 		const result = buildOdspShareLinkReqParams(undefined);

--- a/packages/drivers/odsp-driver/src/test/buildOdspShareLinkReqParams.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/buildOdspShareLinkReqParams.spec.ts
@@ -7,7 +7,6 @@ import { strict as assert } from "assert";
 import {
 	SharingLinkRole,
 	SharingLinkScope,
-	ShareLinkTypes,
 } from "@fluidframework/odsp-driver-definitions";
 import { buildOdspShareLinkReqParams } from "../odspUtils";
 
@@ -28,10 +27,6 @@ describe("buildOdspShareLinkReqParams", () => {
 		);
 	});
 
-	it("Should return appropriate query parameters when a ShareLinkTypes enum value is provided", async () => {
-		const result = buildOdspShareLinkReqParams(ShareLinkTypes.csl);
-		assert.strictEqual(result, `createLinkType=${ShareLinkTypes.csl}`);
-	});
 
 	it("Should return undefined when the input is undefined", async () => {
 		const result = buildOdspShareLinkReqParams(undefined);

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -228,7 +228,6 @@ describe("Create New Utils Tests", () => {
 					false /* forceAccessTokenViaAuthorizationHeader */,
 					undefined /* isClpCompliantApp */,
 					true /* enableSingleRequestForShareLinkWithCreate */,
-					false /* enableShareLinkWithCreate */,
 				),
 			{
 				itemId: "mockItemId",
@@ -275,7 +274,6 @@ describe("Create New Utils Tests", () => {
 					false /* forceAccessTokenViaAuthorizationHeader */,
 					undefined /* isClpCompliantApp */,
 					true /* enableSingleRequestForShareLinkWithCreate */,
-					false /* enableShareLinkWithCreate */,
 				),
 			{
 				itemId: "mockItemId",

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -238,7 +238,6 @@ describe("Create New Utils Tests", () => {
 			{ "x-fluid-epoch": "epoch1" },
 		);
 		assert.deepStrictEqual(odspResolvedUrl.shareLinkInfo?.createLink, {
-			type: createLinkType,
 			shareId: mockSharingData.shareId,
 			link: {
 				role: mockSharingData.sharingLink.type,
@@ -284,7 +283,6 @@ describe("Create New Utils Tests", () => {
 			{ "x-fluid-epoch": "epoch1" },
 		);
 		assert.deepStrictEqual(odspResolvedUrl.shareLinkInfo?.createLink, {
-			type: createLinkType,
 			shareId: undefined,
 			link: undefined,
 			error: mockSharingError.error,

--- a/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/createNewUtilsTests.spec.ts
@@ -9,7 +9,6 @@ import { bufferToString } from "@fluid-internal/client-utils";
 import {
 	IFileEntry,
 	IOdspResolvedUrl,
-	ShareLinkTypes,
 	ISharingLinkKind,
 	SharingLinkRole,
 	SharingLinkScope,
@@ -190,86 +189,6 @@ describe("Create New Utils Tests", () => {
 		);
 		const snapshot = await epochTracker.get(createCacheSnapshotKey(odspResolvedUrl));
 		test(snapshot);
-		await epochTracker.removeEntries().catch(() => {});
-	});
-
-	it("Should save CSL specific share link information received during createNewFluidFile", async () => {
-		const createLinkType = ShareLinkTypes.csl;
-		newFileParams.createLinkType = createLinkType;
-
-		// Test that sharing link is set appropriately when it is received in the response from ODSP
-		const mockSharingLink = "mockSharingLink";
-		const mockSharingId = "mockSharingId";
-		let odspResolvedUrl = await mockFetchOk(
-			async () =>
-				createNewFluidFile(
-					async (_options) => "token",
-					newFileParams,
-					createChildLogger(),
-					createSummary(),
-					epochTracker,
-					fileEntry,
-					false /* createNewCaching */,
-					false /* forceAccessTokenViaAuthorizationHeader */,
-					undefined /* isClpCompliantApp */,
-					false /* enableSingleRequestForShareLinkWithCreate */,
-					true /* enableShareLinkWithCreate */,
-				),
-			{
-				itemId: "mockItemId",
-				id: "mockId",
-				sharingLink: mockSharingLink,
-				sharingLinkErrorReason: undefined,
-				sharing: {
-					shareId: mockSharingId,
-					shareLink: {
-						scope: "organization",
-						type: "edit",
-						webUrl: "webUrl",
-					},
-				},
-			},
-			{ "x-fluid-epoch": "epoch1" },
-		);
-		assert.deepStrictEqual(odspResolvedUrl.shareLinkInfo?.createLink, {
-			type: createLinkType,
-			link: mockSharingLink,
-			shareId: mockSharingId,
-			error: undefined,
-		});
-
-		// Test that error message is set appropriately when it is received in the response from ODSP
-		const mockError = "mockError";
-		odspResolvedUrl = await mockFetchOk(
-			async () =>
-				createNewFluidFile(
-					async (_options) => "token",
-					newFileParams,
-					createChildLogger(),
-					createSummary(),
-					epochTracker,
-					fileEntry,
-					false /* createNewCaching */,
-					false /* forceAccessTokenViaAuthorizationHeader */,
-					undefined /* isClpCompliantApp */,
-					false /* enableSingleRequestForShareLinkWithCreate */,
-					true /* enableShareLinkWithCreate */,
-				),
-			{
-				itemId: "mockItemId",
-				id: "mockId",
-				sharingLink: undefined,
-				sharingLinkErrorReason: mockError,
-				sharing: { error: {} },
-			},
-			{ "x-fluid-epoch": "epoch1" },
-		);
-		assert.deepStrictEqual(odspResolvedUrl.shareLinkInfo?.createLink, {
-			type: createLinkType,
-			link: undefined,
-			shareId: undefined,
-			error: mockError,
-		});
 		await epochTracker.removeEntries().catch(() => {});
 	});
 

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -104,16 +104,6 @@ describe("Odsp Driver Resolver", () => {
 		);
 	});
 
-	it("Should add shareLinkInfo with link type if request contains createLinkType", async () => {
-		const newRequest = request;
-		const createLinkType = "csl";
-		newRequest.url += `&createLinkType=${createLinkType}`;
-		const resolvedUrl = await resolver.resolve(request);
-		assert(resolvedUrl.shareLinkInfo !== undefined);
-		assert(resolvedUrl.shareLinkInfo.createLink !== undefined);
-		assert.strictEqual(resolvedUrl.shareLinkInfo.createLink.type, createLinkType);
-	});
-
 	it("Should resolve url with a string in the codeDetails package", async () => {
 		const resolvedUrl = await resolver.resolve(request);
 		const codeDetails = { package: packageName };


### PR DESCRIPTION
This PR removes an old deprecated path of SingleRT feature in the odsp-driver code. This code was marked as deprecated in https://github.com/microsoft/FluidFramework/pull/11177 and was marked to be removed with FF version 2.0.0-internal.1.1.0.

The code being removed corresponds to an earlier version of SingleRT feature https://github.com/microsoft/FluidFramework/pull/7554 where creation of odsp-file and creation of it's sharing link was done through a single network call, by providing the enableShareLinkWithCreate boolean flag to the HostStoragePolicy of odsp-driver.

The newer version of SingleRT feature https://github.com/microsoft/FluidFramework/pull/11177 is still valid and available to use in the odsp-driver code through enableSingleRoundTripForShareLinkWithCreate boolean flag in HostStoragePolicy. No new changes are done to it.

Motivation of this PR is to cleanup the code, before I make further incremental changes in the same code path which I plan to implement in the coming week