### PR TITLE
fix(tree2): revertibles should work after rebasing a branch

### DIFF
--- a/experimental/dds/tree2/src/shared-tree-core/branch.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/branch.ts
@@ -468,6 +468,14 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const { newSourceHead, commits } = rebaseResult;
 		const { deletedSourceCommits, targetCommits, sourceCommits } = commits;
 
+		// It's possible that the target branch already contained some of the commits that
+		// were on this branch. When that's the case, we adopt the commit objects from the target branch.
+		// Because of that, we need to make sure that any revertibles that were based on the old commit objects
+		// now point to the new object that were adopted from the target branch.
+		for (const targetCommit of targetCommits) {
+			this.updateRevertibleCommit(targetCommit);
+		}
+
 		const newCommits = targetCommits.concat(sourceCommits);
 		const changeEvent = {
 			type: "replace",

--- a/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/branch.spec.ts
@@ -22,6 +22,7 @@ import {
 } from "../../feature-libraries";
 import { brand, fail } from "../../util";
 import { noopValidator } from "../../codec";
+import { createTestUndoRedoStacks } from "../utils";
 
 const defaultChangeFamily = new DefaultChangeFamily({ jsonValidator: noopValidator });
 
@@ -157,6 +158,7 @@ describe("Branches", () => {
 		// Create a parent branch and a child fork
 		const parent = create();
 		const child = parent.fork();
+		const stacks = createTestUndoRedoStacks(child);
 		// Apply a change to the parent
 		const tagParent = change(parent);
 		// Apply a change to the child
@@ -170,6 +172,15 @@ describe("Branches", () => {
 		child.rebaseOnto(parent);
 		assertBased(child, parent);
 		assertHistory(child, tagParent, tagChild, tagParent2, tagChild2);
+
+		// It should still be possible to revert the the child branch's revertibles
+		assert.equal(stacks.undoStack.length, 2);
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		stacks.undoStack.pop()!.revert();
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		stacks.undoStack.pop()!.revert();
+
+		stacks.unsubscribe();
 	});
 
 	it("emit a change event after each change", () => {


### PR DESCRIPTION
Fixes a bug where a branch would be unable to revert some of its commits after rebasing onto a branch that already had a copy of those commits.