### PR TITLE
test(tree2): fix test harness for exhaustive sequence editing

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -1845,6 +1845,8 @@ describe("Editing", () => {
 					// Represented as an integer (0: removed, 1: present) to facilitate summing.
 					// Used to compute the index of the next node to remove.
 					const present = makeArray(nbPeers, () => makeArray(nbNodes, () => 1));
+					// Same as `present` but for `tree` branch.
+					const presentOnTree = makeArray(nbNodes, () => 1);
 					// The number of remaining undos available for each peer.
 					const undoQueues: number[][] = makeArray(nbPeers, () => []);
 
@@ -1880,13 +1882,15 @@ describe("Editing", () => {
 								unreachableCase(step);
 						}
 						tree.merge(peer, false);
+						presentOnTree[affectedNode] = presence;
 						// We only let peers with a higher index learn of this edit.
 						// This breaks the symmetry between scenarios where the permutation of actions is the same
 						// except for which peer does which set of actions.
 						// It also helps simulate different peers learning of the same edit at different times.
 						for (let downhillPeer = iPeer + 1; downhillPeer < nbPeers; downhillPeer++) {
 							peers[downhillPeer].rebaseOnto(tree);
-							present[downhillPeer][affectedNode] = presence;
+							// The peer should now be in the same state as `tree`.
+							present[downhillPeer] = [...presentOnTree];
 						}
 						present[iPeer][affectedNode] = presence;
 					}


### PR DESCRIPTION
Fixes a bug in the test logic for the "Exhaustive removal tests" suite.