### PR TITLE
test(tree2): update state-based axiom test harness to generate appropriate rebase metadata

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -843,6 +843,9 @@ function deltaFromNodeChange(
  * For example, when rebasing change B from a local branch [A, B, C] over a branch [X, Y], the `revInfos` must include
  * the changes [A⁻¹ X, Y, A'] for each rebase step of B.
  * @param baseRevisions - The set of revisions in the changeset being rebased over.
+ * For example, when rebasing change B from a local branch [A, B, C] over a branch [X, Y], the `baseRevisions` must include
+ * revisions [A⁻¹ X, Y, A'] if rebasing over the composition of all those changes, or
+ * revision [A⁻¹] for the first rebase, then [X], etc. if rebasing over edits individually.
  * @returns - RebaseRevisionMetadata to be passed to `FieldChangeRebaser.rebase`*
  */
 export function rebaseRevisionMetadataFromInfo(

--- a/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/experimental/dds/tree2/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -840,7 +840,9 @@ function deltaFromNodeChange(
 /**
  * @alpha
  * @param revInfos - This should describe all revisions in the rebase path, even if not part of the current base changeset.
- * @param baseRevisions - The set of revisions in the changeset being rebased over
+ * For example, when rebasing change B from a local branch [A, B, C] over a branch [X, Y], the `revInfos` must include
+ * the changes [A⁻¹ X, Y, A'] for each rebase step of B.
+ * @param baseRevisions - The set of revisions in the changeset being rebased over.
  * @returns - RebaseRevisionMetadata to be passed to `FieldChangeRebaser.rebase`*
  */
 export function rebaseRevisionMetadataFromInfo(

--- a/experimental/dds/tree2/src/test/exhaustiveRebaserUtils.ts
+++ b/experimental/dds/tree2/src/test/exhaustiveRebaserUtils.ts
@@ -4,6 +4,8 @@
  */
 
 import { RevisionMetadataSource, RevisionTag, TaggedChange } from "../core";
+// eslint-disable-next-line import/no-internal-modules
+import { RebaseRevisionMetadata } from "../feature-libraries/modular-schema";
 
 /**
  * Given a state tree, constructs the sequence of edits which led to that state.
@@ -46,7 +48,7 @@ export interface BoundFieldChangeRebaser<TChangeset> {
 	rebase(
 		change: TChangeset,
 		base: TaggedChange<TChangeset>,
-		metadata?: RevisionMetadataSource,
+		metadata?: RebaseRevisionMetadata,
 	): TChangeset;
 	/**
 	 * Rebase the provided change over the composition of a set of base changes.
@@ -57,7 +59,7 @@ export interface BoundFieldChangeRebaser<TChangeset> {
 	 * on further refactoring would be nice to remove.
 	 */
 	rebaseComposed(
-		metadata: RevisionMetadataSource,
+		metadata: RebaseRevisionMetadata,
 		change: TChangeset,
 		...baseChanges: TaggedChange<TChangeset>[]
 	): TChangeset;

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -386,20 +386,20 @@ const generateChildStates: ChildStateGenerator<TestState, TestChangeset> = funct
 	const iterationCap = Math.min(maxIndex, state.content.length);
 
 	// Undo the most recent edit
-	// if (state.mostRecentEdit !== undefined) {
-	// 	assert(state.parent?.content !== undefined, "Must have parent state to undo");
-	// 	const undoIntention = mintIntention();
-	// 	const invertedEdit = invert(state.mostRecentEdit.changeset);
-	// 	yield {
-	// 		content: state.parent.content,
-	// 		mostRecentEdit: {
-	// 			changeset: tagChange(invertedEdit, tagFromIntention(undoIntention)),
-	// 			intention: undoIntention,
-	// 			description: `Undo:${state.mostRecentEdit.description}`,
-	// 		},
-	// 		parent: state,
-	// 	};
-	// }
+	if (state.mostRecentEdit !== undefined) {
+		assert(state.parent?.content !== undefined, "Must have parent state to undo");
+		const undoIntention = mintIntention();
+		const invertedEdit = invert(state.mostRecentEdit.changeset);
+		yield {
+			content: state.parent.content,
+			mostRecentEdit: {
+				changeset: tagChange(invertedEdit, tagFromIntention(undoIntention)),
+				intention: undoIntention,
+				description: `Undo:${state.mostRecentEdit.description}`,
+			},
+			parent: state,
+		};
+	}
 
 	for (const nodeCount of numNodes) {
 		for (let i = 0; i <= iterationCap; i++) {
@@ -447,46 +447,46 @@ const generateChildStates: ChildStateGenerator<TestState, TestChangeset> = funct
 			}
 
 			// Only generate moves when we're moving less than the length of the whole sequence
-			// if (state.content.length > nodeCount) {
-			// 	// MoveIn nodeCount nodes
-			// 	const moveInIntention = mintIntention();
-			// 	yield {
-			// 		content: state.content,
-			// 		mostRecentEdit: {
-			// 			changeset: tagChange(
-			// 				Change.move(1, nodeCount, i),
-			// 				tagFromIntention(moveInIntention),
-			// 			),
-			// 			intention: moveInIntention,
-			// 			description: `MoveIn${nodeCount}${
-			// 				nodeCount === 1 ? "Node" : "Nodes"
-			// 			}From1To${i}`,
-			// 		},
-			// 		parent: state,
-			// 	};
+			if (state.content.length > nodeCount) {
+				// MoveIn nodeCount nodes
+				const moveInIntention = mintIntention();
+				yield {
+					content: state.content,
+					mostRecentEdit: {
+						changeset: tagChange(
+							Change.move(1, nodeCount, i),
+							tagFromIntention(moveInIntention),
+						),
+						intention: moveInIntention,
+						description: `MoveIn${nodeCount}${
+							nodeCount === 1 ? "Node" : "Nodes"
+						}From1To${i}`,
+					},
+					parent: state,
+				};
 
-			// 	// MoveOut nodeCount nodes
-			// 	const moveOutIntention = mintIntention();
-			// 	yield {
-			// 		content: state.content,
-			// 		mostRecentEdit: {
-			// 			changeset: tagChange(
-			// 				Change.move(i, nodeCount, 1),
-			// 				tagFromIntention(moveOutIntention),
-			// 			),
-			// 			intention: moveOutIntention,
-			// 			description: `MoveOut${nodeCount}${
-			// 				nodeCount === 1 ? "Node" : "Nodes"
-			// 			}From${i}To1`,
-			// 		},
-			// 		parent: state,
-			// 	};
-			// }
+				// MoveOut nodeCount nodes
+				const moveOutIntention = mintIntention();
+				yield {
+					content: state.content,
+					mostRecentEdit: {
+						changeset: tagChange(
+							Change.move(i, nodeCount, 1),
+							tagFromIntention(moveOutIntention),
+						),
+						intention: moveOutIntention,
+						description: `MoveOut${nodeCount}${
+							nodeCount === 1 ? "Node" : "Nodes"
+						}From${i}To1`,
+					},
+					parent: state,
+				};
+			}
 		}
 	}
 };
 
-describe("SequenceField - State-based Rebaser Axioms", () => {
+describe.skip("SequenceField - State-based Rebaser Axioms", () => {
 	runExhaustiveComposeRebaseSuite(
 		[{ content: { length: 4, numNodes: [1], maxIndex: 2 } }],
 		generateChildStates,

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -386,20 +386,20 @@ const generateChildStates: ChildStateGenerator<TestState, TestChangeset> = funct
 	const iterationCap = Math.min(maxIndex, state.content.length);
 
 	// Undo the most recent edit
-	if (state.mostRecentEdit !== undefined) {
-		assert(state.parent?.content !== undefined, "Must have parent state to undo");
-		const undoIntention = mintIntention();
-		const invertedEdit = invert(state.mostRecentEdit.changeset);
-		yield {
-			content: state.parent.content,
-			mostRecentEdit: {
-				changeset: tagChange(invertedEdit, tagFromIntention(undoIntention)),
-				intention: undoIntention,
-				description: `Undo:${state.mostRecentEdit.description}`,
-			},
-			parent: state,
-		};
-	}
+	// if (state.mostRecentEdit !== undefined) {
+	// 	assert(state.parent?.content !== undefined, "Must have parent state to undo");
+	// 	const undoIntention = mintIntention();
+	// 	const invertedEdit = invert(state.mostRecentEdit.changeset);
+	// 	yield {
+	// 		content: state.parent.content,
+	// 		mostRecentEdit: {
+	// 			changeset: tagChange(invertedEdit, tagFromIntention(undoIntention)),
+	// 			intention: undoIntention,
+	// 			description: `Undo:${state.mostRecentEdit.description}`,
+	// 		},
+	// 		parent: state,
+	// 	};
+	// }
 
 	for (const nodeCount of numNodes) {
 		for (let i = 0; i <= iterationCap; i++) {
@@ -447,56 +447,56 @@ const generateChildStates: ChildStateGenerator<TestState, TestChangeset> = funct
 			}
 
 			// Only generate moves when we're moving less than the length of the whole sequence
-			if (state.content.length > nodeCount) {
-				// MoveIn nodeCount nodes
-				const moveInIntention = mintIntention();
-				yield {
-					content: state.content,
-					mostRecentEdit: {
-						changeset: tagChange(
-							Change.move(1, nodeCount, i),
-							tagFromIntention(moveInIntention),
-						),
-						intention: moveInIntention,
-						description: `MoveIn${nodeCount}${
-							nodeCount === 1 ? "Node" : "Nodes"
-						}From1To${i}`,
-					},
-					parent: state,
-				};
+			// if (state.content.length > nodeCount) {
+			// 	// MoveIn nodeCount nodes
+			// 	const moveInIntention = mintIntention();
+			// 	yield {
+			// 		content: state.content,
+			// 		mostRecentEdit: {
+			// 			changeset: tagChange(
+			// 				Change.move(1, nodeCount, i),
+			// 				tagFromIntention(moveInIntention),
+			// 			),
+			// 			intention: moveInIntention,
+			// 			description: `MoveIn${nodeCount}${
+			// 				nodeCount === 1 ? "Node" : "Nodes"
+			// 			}From1To${i}`,
+			// 		},
+			// 		parent: state,
+			// 	};
 
-				// MoveOut nodeCount nodes
-				const moveOutIntention = mintIntention();
-				yield {
-					content: state.content,
-					mostRecentEdit: {
-						changeset: tagChange(
-							Change.move(i, nodeCount, 1),
-							tagFromIntention(moveOutIntention),
-						),
-						intention: moveOutIntention,
-						description: `MoveOut${nodeCount}${
-							nodeCount === 1 ? "Node" : "Nodes"
-						}From${i}To1`,
-					},
-					parent: state,
-				};
-			}
+			// 	// MoveOut nodeCount nodes
+			// 	const moveOutIntention = mintIntention();
+			// 	yield {
+			// 		content: state.content,
+			// 		mostRecentEdit: {
+			// 			changeset: tagChange(
+			// 				Change.move(i, nodeCount, 1),
+			// 				tagFromIntention(moveOutIntention),
+			// 			),
+			// 			intention: moveOutIntention,
+			// 			description: `MoveOut${nodeCount}${
+			// 				nodeCount === 1 ? "Node" : "Nodes"
+			// 			}From${i}To1`,
+			// 		},
+			// 		parent: state,
+			// 	};
+			// }
 		}
 	}
 };
 
-describe.skip("SequenceField - State-based Rebaser Axioms", () => {
+describe("SequenceField - State-based Rebaser Axioms", () => {
 	runExhaustiveComposeRebaseSuite(
-		[{ content: { length: 4, numNodes: [1, 3], maxIndex: 2 } }],
+		[{ content: { length: 4, numNodes: [1], maxIndex: 2 } }],
 		generateChildStates,
 		{
 			rebase,
 			invert,
-			compose: (changes, metadata) => compose(changes),
+			compose: (changes, metadata) => compose(changes, metadata),
 			rebaseComposed: (metadata, change, ...baseChanges) => {
-				const composedChanges = compose(baseChanges);
-				return rebase(change, makeAnonChange(composedChanges));
+				const composedChanges = compose(baseChanges, metadata);
+				return rebase(change, makeAnonChange(composedChanges), metadata);
 			},
 			assertEqual: (change1, change2) => {
 				if (change1 === undefined && change2 === undefined) {
@@ -514,7 +514,9 @@ describe.skip("SequenceField - State-based Rebaser Axioms", () => {
 			},
 		},
 		{
-			groupSubSuites: true,
+			groupSubSuites: false,
+			numberOfEditsToVerifyAssociativity: 3,
+			skipRebaseOverCompose: true,
 		},
 	);
 });

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.ts
@@ -9,6 +9,7 @@ import {
 	ChangesetLocalId,
 	DeltaFieldChanges,
 	RevisionInfo,
+	RevisionMetadataSource,
 	RevisionTag,
 	TaggedChange,
 	makeAnonChange,
@@ -38,7 +39,7 @@ export function composeNoVerify(
 
 export function compose(
 	changes: TaggedChange<TestChangeset>[],
-	revInfos?: RevisionInfo[],
+	revInfos?: RevisionInfo[] | RevisionMetadataSource,
 	childComposer?: (childChanges: TaggedChange<TestChange>[]) => TestChange,
 ): TestChangeset {
 	return composeI(changes, childComposer ?? TestChange.compose, revInfos);
@@ -71,7 +72,7 @@ export function shallowCompose<T>(
 function composeI<T>(
 	changes: TaggedChange<SF.Changeset<T>>[],
 	composer: (childChanges: TaggedChange<T>[]) => T,
-	revInfos?: RevisionInfo[],
+	revInfos?: RevisionInfo[] | RevisionMetadataSource,
 ): SF.Changeset<T> {
 	const moveEffects = SF.newCrossFieldTable();
 	const idAllocator = continuingAllocator(changes);
@@ -81,7 +82,9 @@ function composeI<T>(
 		idAllocator,
 		moveEffects,
 		revInfos !== undefined
-			? revisionMetadataSourceFromInfo(revInfos)
+			? Array.isArray(revInfos)
+				? revisionMetadataSourceFromInfo(revInfos)
+				: revInfos
 			: defaultRevisionMetadataFromChanges(changes),
 	);
 

--- a/experimental/dds/tree2/src/test/rebaserAxiomaticTests.ts
+++ b/experimental/dds/tree2/src/test/rebaserAxiomaticTests.ts
@@ -15,6 +15,7 @@ import {
 	ChildStateGenerator,
 	BoundFieldChangeRebaser,
 	makeIntentionMinter,
+	NamedChangeset,
 } from "./exhaustiveRebaserUtils";
 
 interface ExhaustiveSuiteOptions {
@@ -39,69 +40,39 @@ const defaultSuiteOptions: Required<ExhaustiveSuiteOptions> = {
 	numberOfEditsToVerifyAssociativity: 4,
 };
 
+/**
+ * Rebases `change` over all edits in `rebasePath`.
+ * @param rebase - The rebase function to use.
+ * @param change - The change to rebase
+ * @param rebasePath - The edits to rebase over.
+ * Must contain all the prior edits from the branch that `change` comes from.
+ * For example, if `change` is B in branch [A, B, C], being rebased over edits [X, Y],
+ * then `rebasePath` must be [A⁻¹, X, Y, A'].
+ */
+function rebaseTagged<TChangeset>(
+	rebase: BoundFieldChangeRebaser<TChangeset>["rebase"],
+	change: TaggedChange<TChangeset>,
+	rebasePath: TaggedChange<TChangeset>[],
+): TaggedChange<TChangeset> {
+	let currChange = change;
+	const revisionInfo = defaultRevInfosFromChanges(rebasePath);
+	for (const base of rebasePath) {
+		const metadata = rebaseRevisionMetadataFromInfo(revisionInfo, [base.revision]);
+		currChange = tagChange(rebase(currChange.change, base, metadata), currChange.revision);
+	}
+
+	return currChange;
+}
+
 export function runExhaustiveComposeRebaseSuite<TContent, TChangeset>(
 	initialStates: FieldStateTree<TContent, TChangeset>[],
 	generateChildStates: ChildStateGenerator<TContent, TChangeset>,
-	{ rebase, rebaseComposed, invert, compose, assertEqual }: BoundFieldChangeRebaser<TChangeset>,
+	fieldRebaser: BoundFieldChangeRebaser<TChangeset>,
 	options?: ExhaustiveSuiteOptions,
 ) {
-	const assertDeepEqual = assertEqual ?? ((a, b) => assert.deepEqual(a, b));
+	const assertDeepEqual = getDefaultedEqualityAssert(fieldRebaser);
 	const definedOptions = { ...defaultSuiteOptions, ...options };
 
-	function rebaseTagged(
-		change: TaggedChange<TChangeset>,
-		rebasePath: TaggedChange<TChangeset>[],
-	): TaggedChange<TChangeset> {
-		let currChange = change;
-		const revisionInfo = defaultRevInfosFromChanges(rebasePath);
-		for (const base of rebasePath) {
-			const metadata = rebaseRevisionMetadataFromInfo(revisionInfo, [base.revision]);
-			currChange = tagChange(rebase(currChange.change, base, metadata), currChange.revision);
-		}
-
-		return currChange;
-	}
-
-	function verifyComposeAssociativity(edits: TaggedChange<TChangeset>[]) {
-		const metadata = defaultRevisionMetadataFromChanges(edits);
-		const singlyComposed = makeAnonChange(compose(edits, metadata));
-		const leftPartialCompositions: TaggedChange<TChangeset>[] = [
-			edits.at(0) ?? fail("Expected at least one edit"),
-		];
-		for (let i = 1; i < edits.length; i++) {
-			leftPartialCompositions.push(
-				makeAnonChange(
-					compose(
-						[
-							leftPartialCompositions.at(-1) ?? fail("Expected at least one edit"),
-							edits[i],
-						],
-						metadata,
-					),
-				),
-			);
-		}
-
-		const rightPartialCompositions: TaggedChange<TChangeset>[] = [
-			edits.at(-1) ?? fail("Expected at least one edit"),
-		];
-		for (let i = edits.length - 2; i >= 0; i--) {
-			rightPartialCompositions.push(
-				makeAnonChange(
-					compose(
-						[
-							edits[i],
-							rightPartialCompositions.at(-1) ?? fail("Expected at least one edit"),
-						],
-						metadata,
-					),
-				),
-			);
-		}
-
-		assertDeepEqual(leftPartialCompositions.at(-1), singlyComposed);
-		assertDeepEqual(rightPartialCompositions.at(-1), singlyComposed);
-	}
 	// To limit combinatorial explosion, we test 'rebasing over a compose is equivalent to rebasing over the individual edits'
 	// by:
 	// - Rebasing a single edit over N sequential edits
@@ -152,26 +123,10 @@ export function runExhaustiveComposeRebaseSuite<TContent, TChangeset>(
 						)}`;
 
 						innerFixture(title, () => {
-							const editsToRebaseOver = namedEditsToRebaseOver.map(
-								({ changeset }) => changeset,
-							);
-							const rebaseWithoutCompose = rebaseTagged(
+							rebaseOverSinglesVsRebaseOverCompositions<TChangeset>(
 								edit,
-								editsToRebaseOver,
-							).change;
-							const metadata = rebaseRevisionMetadataFromInfo(
-								defaultRevInfosFromChanges(editsToRebaseOver),
-								editsToRebaseOver.map(({ revision }) => revision),
-							);
-							const rebaseWithCompose = rebaseComposed(
-								metadata,
-								edit.change,
-								...editsToRebaseOver,
-							);
-
-							assertDeepEqual(
-								tagChange(rebaseWithCompose, undefined),
-								tagChange(rebaseWithoutCompose, undefined),
+								namedEditsToRebaseOver,
+								fieldRebaser,
 							);
 						});
 					}
@@ -214,65 +169,28 @@ export function runExhaustiveComposeRebaseSuite<TContent, TChangeset>(
 							const editToRebaseOver = namedEditToRebaseOver;
 							const sourceEdits = namedSourceEdits.map(({ changeset }) => changeset);
 
-							const inverses = sourceEdits.map((change) =>
+							const rollbacks = sourceEdits.map((change) =>
 								tagRollbackInverse(
-									invert(change),
+									fieldRebaser.invert(change),
 									`rollback-${change.revision}` as RevisionTag,
 									change.revision,
 								),
 							);
-							inverses.reverse();
+							rollbacks.reverse();
 
-							const rebasedEditsWithoutCompose: TaggedChange<TChangeset>[] = [];
-							const rebasedEditsWithCompose: TaggedChange<TChangeset>[] = [];
+							const rebasedEditsWithoutCompose = sandwichRebaseWithoutCompose(
+								sourceEdits,
+								rollbacks,
+								editToRebaseOver,
+								fieldRebaser,
+							);
 
-							for (let i = 0; i < sourceEdits.length; i++) {
-								const edit = sourceEdits[i];
-								const rebasePath = [
-									...inverses.slice(sourceEdits.length - i),
-									editToRebaseOver,
-									...rebasedEditsWithoutCompose,
-								];
-								rebasedEditsWithoutCompose.push(rebaseTagged(edit, rebasePath));
-							}
-
-							let currentComposedEdit = editToRebaseOver;
-							// This needs to be used to pass an updated RevisionMetadataSource to rebase.
-							const allTaggedEdits = [...inverses, editToRebaseOver];
-							for (let i = 0; i < sourceEdits.length; i++) {
-								const edit = sourceEdits[i];
-								const rebasePath = [
-									...inverses.slice(sourceEdits.length - i),
-									editToRebaseOver,
-									...rebasedEditsWithoutCompose,
-								];
-								const rebaseMetadata = rebaseRevisionMetadataFromInfo(
-									defaultRevInfosFromChanges(rebasePath),
-									[editToRebaseOver.revision],
-								);
-								const rebasedEdit = tagChange(
-									rebaseComposed(
-										rebaseMetadata,
-										edit.change,
-										currentComposedEdit,
-									),
-									edit.revision,
-								);
-								rebasedEditsWithCompose.push(rebasedEdit);
-								allTaggedEdits.push(rebasedEdit);
-								const composeMetadata =
-									defaultRevisionMetadataFromChanges(allTaggedEdits);
-								currentComposedEdit = makeAnonChange(
-									compose(
-										[
-											inverses[sourceEdits.length - i - 1],
-											currentComposedEdit,
-											rebasedEdit,
-										],
-										composeMetadata,
-									),
-								);
-							}
+							const rebasedEditsWithCompose = sandwichRebaseWithCompose(
+								sourceEdits,
+								rollbacks,
+								editToRebaseOver,
+								fieldRebaser,
+							);
 
 							for (let i = 0; i < rebasedEditsWithoutCompose.length; i++) {
 								assertDeepEqual(
@@ -281,7 +199,13 @@ export function runExhaustiveComposeRebaseSuite<TContent, TChangeset>(
 								);
 							}
 
-							verifyComposeAssociativity(allTaggedEdits);
+							// TODO: consider testing the compose associativity with the `rebasedEditsWithoutCompose` as well.
+							const allTaggedEdits = [
+								...rollbacks,
+								editToRebaseOver,
+								...rebasedEditsWithCompose,
+							];
+							verifyComposeAssociativity(allTaggedEdits, fieldRebaser);
 						});
 					}
 				}
@@ -306,10 +230,148 @@ export function runExhaustiveComposeRebaseSuite<TContent, TChangeset>(
 					// That's covered some by "Composed sandwich rebase over single edit"
 					innerFixture(title, () => {
 						const edits = namedSourceEdits.map(({ changeset }) => changeset);
-						verifyComposeAssociativity(edits);
+						verifyComposeAssociativity(edits, fieldRebaser);
 					});
 				}
 			});
 		}
 	});
+}
+
+function sandwichRebaseWithCompose<TChangeset>(
+	sourceEdits: TaggedChange<TChangeset>[],
+	rollbacks: TaggedChange<TChangeset>[],
+	editToRebaseOver: TaggedChange<TChangeset>,
+	fieldRebaser: BoundFieldChangeRebaser<TChangeset>,
+): TaggedChange<TChangeset>[] {
+	const rebasedEditsWithCompose: TaggedChange<TChangeset>[] = [];
+	let compositionScope: TaggedChange<TChangeset>[] = [editToRebaseOver];
+	let currentComposedEdit = editToRebaseOver;
+	// This needs to be used to pass an updated RevisionMetadataSource to rebase.
+	for (let i = 0; i < sourceEdits.length; i++) {
+		const edit = sourceEdits[i];
+		const rebasePath = [
+			...rollbacks.slice(sourceEdits.length - i),
+			editToRebaseOver,
+			...sourceEdits.slice(0, i),
+		];
+		const rebaseMetadata = rebaseRevisionMetadataFromInfo(
+			defaultRevInfosFromChanges(rebasePath),
+			[editToRebaseOver.revision],
+		);
+		const rebasedEdit = tagChange(
+			fieldRebaser.rebaseComposed(rebaseMetadata, edit.change, currentComposedEdit),
+			edit.revision,
+		);
+		rebasedEditsWithCompose.push(rebasedEdit);
+		compositionScope = [
+			rollbacks[sourceEdits.length - i - 1],
+			...compositionScope,
+			rebasedEdit,
+		];
+		const composeMetadata = defaultRevisionMetadataFromChanges(compositionScope);
+		currentComposedEdit = makeAnonChange(
+			fieldRebaser.compose(
+				[rollbacks[sourceEdits.length - i - 1], currentComposedEdit, rebasedEdit],
+				composeMetadata,
+			),
+		);
+	}
+	return rebasedEditsWithCompose;
+}
+
+function sandwichRebaseWithoutCompose<TChangeset>(
+	sourceEdits: TaggedChange<TChangeset>[],
+	rollbacks: TaggedChange<any>[],
+	editToRebaseOver: TaggedChange<TChangeset>,
+	fieldRebaser: BoundFieldChangeRebaser<TChangeset>,
+): TaggedChange<TChangeset>[] {
+	const rebasedEditsWithoutCompose: TaggedChange<TChangeset>[] = [];
+	for (let i = 0; i < sourceEdits.length; i++) {
+		const edit = sourceEdits[i];
+		const rebasePath = [
+			...rollbacks.slice(sourceEdits.length - i),
+			editToRebaseOver,
+			...rebasedEditsWithoutCompose,
+		];
+		rebasedEditsWithoutCompose.push(rebaseTagged(fieldRebaser.rebase, edit, rebasePath));
+	}
+	return rebasedEditsWithoutCompose;
+}
+
+function rebaseOverSinglesVsRebaseOverCompositions<TChangeset>(
+	edit: TaggedChange<TChangeset>,
+	namedEditsToRebaseOver: NamedChangeset<TChangeset>[],
+	fieldRebaser: BoundFieldChangeRebaser<TChangeset>,
+) {
+	const editsToRebaseOver = namedEditsToRebaseOver.map(({ changeset }) => changeset);
+
+	// Rebase over each base edit individually
+	const rebaseWithoutCompose = rebaseTagged(fieldRebaser.rebase, edit, editsToRebaseOver).change;
+
+	// Rebase over the composition of base edits
+	const metadata = rebaseRevisionMetadataFromInfo(
+		defaultRevInfosFromChanges(editsToRebaseOver),
+		editsToRebaseOver.map(({ revision }) => revision),
+	);
+	const rebaseWithCompose = fieldRebaser.rebaseComposed(
+		metadata,
+		edit.change,
+		...editsToRebaseOver,
+	);
+
+	const assertDeepEqual = getDefaultedEqualityAssert(fieldRebaser);
+	assertDeepEqual(
+		tagChange(rebaseWithCompose, edit.revision),
+		tagChange(rebaseWithoutCompose, edit.revision),
+	);
+}
+
+function verifyComposeAssociativity<TChangeset>(
+	edits: TaggedChange<TChangeset>[],
+	fieldRebaser: BoundFieldChangeRebaser<TChangeset>,
+) {
+	const metadata = defaultRevisionMetadataFromChanges(edits);
+	const singlyComposed = makeAnonChange(fieldRebaser.compose(edits, metadata));
+	const leftPartialCompositions: TaggedChange<TChangeset>[] = [
+		edits.at(0) ?? fail("Expected at least one edit"),
+	];
+	for (let i = 1; i < edits.length; i++) {
+		leftPartialCompositions.push(
+			makeAnonChange(
+				fieldRebaser.compose(
+					[
+						leftPartialCompositions.at(-1) ?? fail("Expected at least one edit"),
+						edits[i],
+					],
+					metadata,
+				),
+			),
+		);
+	}
+
+	const rightPartialCompositions: TaggedChange<TChangeset>[] = [
+		edits.at(-1) ?? fail("Expected at least one edit"),
+	];
+	for (let i = edits.length - 2; i >= 0; i--) {
+		rightPartialCompositions.push(
+			makeAnonChange(
+				fieldRebaser.compose(
+					[
+						edits[i],
+						rightPartialCompositions.at(-1) ?? fail("Expected at least one edit"),
+					],
+					metadata,
+				),
+			),
+		);
+	}
+
+	const assertDeepEqual = getDefaultedEqualityAssert(fieldRebaser);
+	assertDeepEqual(leftPartialCompositions.at(-1), singlyComposed);
+	assertDeepEqual(rightPartialCompositions.at(-1), singlyComposed);
+}
+
+function getDefaultedEqualityAssert<TChangeset>(fieldRebaser: BoundFieldChangeRebaser<TChangeset>) {
+	return fieldRebaser.assertEqual ?? ((a, b) => assert.deepEqual(a, b));
 }

--- a/experimental/dds/tree2/src/test/rebaserAxiomaticTests.ts
+++ b/experimental/dds/tree2/src/test/rebaserAxiomaticTests.ts
@@ -51,14 +51,11 @@ export function runExhaustiveComposeRebaseSuite<TContent, TChangeset>(
 	function rebaseTagged(
 		change: TaggedChange<TChangeset>,
 		rebasePath: TaggedChange<TChangeset>[],
-		baseBranch: TaggedChange<TChangeset>[],
 	): TaggedChange<TChangeset> {
 		let currChange = change;
-		const metadata = rebaseRevisionMetadataFromInfo(
-			defaultRevInfosFromChanges(rebasePath),
-			baseBranch.map(({ revision }) => revision),
-		);
+		const revisionInfo = defaultRevInfosFromChanges(rebasePath);
 		for (const base of rebasePath) {
+			const metadata = rebaseRevisionMetadataFromInfo(revisionInfo, [base.revision]);
 			currChange = tagChange(rebase(currChange.change, base, metadata), currChange.revision);
 		}
 
@@ -161,7 +158,6 @@ export function runExhaustiveComposeRebaseSuite<TContent, TChangeset>(
 							const rebaseWithoutCompose = rebaseTagged(
 								edit,
 								editsToRebaseOver,
-								editsToRebaseOver,
 							).change;
 							const metadata = rebaseRevisionMetadataFromInfo(
 								defaultRevInfosFromChanges(editsToRebaseOver),
@@ -237,9 +233,7 @@ export function runExhaustiveComposeRebaseSuite<TContent, TChangeset>(
 									editToRebaseOver,
 									...rebasedEditsWithoutCompose,
 								];
-								rebasedEditsWithoutCompose.push(
-									rebaseTagged(edit, rebasePath, [editToRebaseOver]),
-								);
+								rebasedEditsWithoutCompose.push(rebaseTagged(edit, rebasePath));
 							}
 
 							let currentComposedEdit = editToRebaseOver;


### PR DESCRIPTION
Updates the state-based axiom test harness to generate appropriate rebase metadata (needed by sequence field).
Refactors some the state-based axiom test harness functions to reduce the number of nested scopes.

Also cuts down the set of generated edits to a smaller set to facilitate debugging failures.