### PR TITLE
build: Enable trimmed d.ts rollup generation by default

### DIFF
--- a/azure/packages/azure-client/api-extractor.json
+++ b/azure/packages/azure-client/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/azure/packages/azure-service-utils/api-extractor.json
+++ b/azure/packages/azure-service-utils/api-extractor.json
@@ -1,7 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	}
+	"extends": "../../../common/build/build-common/api-extractor-base.json"
 }

--- a/common/build/build-common/api-extractor-base.json
+++ b/common/build/build-common/api-extractor-base.json
@@ -35,7 +35,7 @@
 	 * Configures how the .d.ts rollup file will be generated.
 	 */
 	"dtsRollup": {
-		"enabled": false,
+		"enabled": true,
 		"alphaTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-alpha.d.ts",
 		"betaTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-beta.d.ts",
 		"publicTrimmedFilePath": "<projectFolder>/dist/<unscopedPackageName>-public.d.ts",

--- a/experimental/dds/tree2/api-extractor.json
+++ b/experimental/dds/tree2/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/common/client-utils/api-extractor.json
+++ b/packages/common/client-utils/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/common/container-definitions/api-extractor.json
+++ b/packages/common/container-definitions/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/common/core-interfaces/api-extractor.json
+++ b/packages/common/core-interfaces/api-extractor.json
@@ -8,8 +8,5 @@
 				"logLevel": "none"
 			}
 		}
-	},
-	"dtsRollup": {
-		"enabled": true
 	}
 }

--- a/packages/common/core-utils/api-extractor.json
+++ b/packages/common/core-utils/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/common/driver-definitions/api-extractor.json
+++ b/packages/common/driver-definitions/api-extractor.json
@@ -8,8 +8,5 @@
 				"logLevel": "none"
 			}
 		}
-	},
-	"dtsRollup": {
-		"enabled": true
 	}
 }

--- a/packages/dds/cell/api-extractor.json
+++ b/packages/dds/cell/api-extractor.json
@@ -8,8 +8,5 @@
 				"logLevel": "none"
 			}
 		}
-	},
-	"dtsRollup": {
-		"enabled": true
 	}
 }

--- a/packages/dds/counter/api-extractor.json
+++ b/packages/dds/counter/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/dds/ink/api-extractor.json
+++ b/packages/dds/ink/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/dds/map/api-extractor.json
+++ b/packages/dds/map/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/dds/matrix/api-extractor.json
+++ b/packages/dds/matrix/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/dds/merge-tree/api-extractor.json
+++ b/packages/dds/merge-tree/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Fix violations and remove this rule override

--- a/packages/dds/ordered-collection/api-extractor.json
+++ b/packages/dds/ordered-collection/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/dds/pact-map/api-extractor.json
+++ b/packages/dds/pact-map/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/dds/register-collection/api-extractor.json
+++ b/packages/dds/register-collection/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/dds/sequence/api-extractor.json
+++ b/packages/dds/sequence/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/dds/shared-object-base/api-extractor.json
+++ b/packages/dds/shared-object-base/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/dds/shared-summary-block/api-extractor.json
+++ b/packages/dds/shared-summary-block/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/dds/task-manager/api-extractor.json
+++ b/packages/dds/task-manager/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/dds/test-dds-utils/api-extractor.json
+++ b/packages/dds/test-dds-utils/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/debugger/api-extractor.json
+++ b/packages/drivers/debugger/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/driver-base/api-extractor.json
+++ b/packages/drivers/driver-base/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/driver-web-cache/api-extractor.json
+++ b/packages/drivers/driver-web-cache/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/file-driver/api-extractor.json
+++ b/packages/drivers/file-driver/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/fluidapp-odsp-urlResolver/api-extractor.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/local-driver/api-extractor.json
+++ b/packages/drivers/local-driver/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/odsp-driver-definitions/api-extractor.json
+++ b/packages/drivers/odsp-driver-definitions/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/odsp-driver/api-extractor.json
+++ b/packages/drivers/odsp-driver/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/odsp-urlResolver/api-extractor.json
+++ b/packages/drivers/odsp-urlResolver/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/replay-driver/api-extractor.json
+++ b/packages/drivers/replay-driver/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/routerlicious-driver/api-extractor.json
+++ b/packages/drivers/routerlicious-driver/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/routerlicious-urlResolver/api-extractor.json
+++ b/packages/drivers/routerlicious-urlResolver/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/drivers/tinylicious-driver/api-extractor.json
+++ b/packages/drivers/tinylicious-driver/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/agent-scheduler/api-extractor.json
+++ b/packages/framework/agent-scheduler/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/aqueduct/api-extractor.json
+++ b/packages/framework/aqueduct/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/attributor/api-extractor.json
+++ b/packages/framework/attributor/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/client-logger/app-insights-logger/api-extractor.json
+++ b/packages/framework/client-logger/app-insights-logger/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		// The following overrides are workarounds for API-Extractor incorrectly running analysis on our application
 		// insights dependency.

--- a/packages/framework/data-object-base/api-extractor.json
+++ b/packages/framework/data-object-base/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/dds-interceptions/api-extractor.json
+++ b/packages/framework/dds-interceptions/api-extractor.json
@@ -1,7 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	}
+	"extends": "../../../common/build/build-common/api-extractor-base.json"
 }

--- a/packages/framework/fluid-framework/api-extractor.json
+++ b/packages/framework/fluid-framework/api-extractor.json
@@ -1,7 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	}
+	"extends": "../../../common/build/build-common/api-extractor-base.json"
 }

--- a/packages/framework/fluid-static/api-extractor.json
+++ b/packages/framework/fluid-static/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/oldest-client-observer/api-extractor.json
+++ b/packages/framework/oldest-client-observer/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/request-handler/api-extractor.json
+++ b/packages/framework/request-handler/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/synthesize/api-extractor.json
+++ b/packages/framework/synthesize/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/tinylicious-client/api-extractor.json
+++ b/packages/framework/tinylicious-client/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/undo-redo/api-extractor.json
+++ b/packages/framework/undo-redo/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/view-adapters/api-extractor.json
+++ b/packages/framework/view-adapters/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/framework/view-interfaces/api-extractor.json
+++ b/packages/framework/view-interfaces/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/loader/container-loader/api-extractor.json
+++ b/packages/loader/container-loader/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/loader/driver-utils/api-extractor.json
+++ b/packages/loader/driver-utils/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/loader/location-redirection-utils/api-extractor.json
+++ b/packages/loader/location-redirection-utils/api-extractor.json
@@ -1,7 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	}
+	"extends": "../../../common/build/build-common/api-extractor-base.json"
 }

--- a/packages/loader/test-loader-utils/api-extractor.json
+++ b/packages/loader/test-loader-utils/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/runtime/container-runtime-definitions/api-extractor.json
+++ b/packages/runtime/container-runtime-definitions/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/runtime/container-runtime/api-extractor.json
+++ b/packages/runtime/container-runtime/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/runtime/datastore-definitions/api-extractor.json
+++ b/packages/runtime/datastore-definitions/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/runtime/datastore/api-extractor.json
+++ b/packages/runtime/datastore/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/runtime/runtime-definitions/api-extractor.json
+++ b/packages/runtime/runtime-definitions/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/runtime/runtime-utils/api-extractor.json
+++ b/packages/runtime/runtime-utils/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/runtime/test-runtime-utils/api-extractor.json
+++ b/packages/runtime/test-runtime-utils/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/service-clients/odsp-client/api-extractor.json
+++ b/packages/service-clients/odsp-client/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/test/mocha-test-setup/api-extractor.json
+++ b/packages/test/mocha-test-setup/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/test/stochastic-test-utils/api-extractor.json
+++ b/packages/test/stochastic-test-utils/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/test/test-driver-definitions/api-extractor.json
+++ b/packages/test/test-driver-definitions/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/test/test-drivers/api-extractor.json
+++ b/packages/test/test-drivers/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/test/test-pairwise-generator/api-extractor.json
+++ b/packages/test/test-pairwise-generator/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/test/test-utils/api-extractor.json
+++ b/packages/test/test-utils/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/test/test-version-utils/api-extractor.json
+++ b/packages/test/test-version-utils/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Add missing documentation and remove this rule override

--- a/packages/tools/devtools/devtools-core/api-extractor.json
+++ b/packages/tools/devtools/devtools-core/api-extractor.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	},
 	// TODO: Fix violations and remove these rule overrides
 	"messages": {
 		"extractorMessageReporting": {

--- a/packages/tools/devtools/devtools-view/api-extractor.json
+++ b/packages/tools/devtools/devtools-view/api-extractor.json
@@ -1,7 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	}
+	"extends": "../../../../common/build/build-common/api-extractor-base.json"
 }

--- a/packages/tools/devtools/devtools/api-extractor.json
+++ b/packages/tools/devtools/devtools/api-extractor.json
@@ -1,7 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	}
+	"extends": "../../../../common/build/build-common/api-extractor-base.json"
 }

--- a/packages/tools/replay-tool/api-extractor.json
+++ b/packages/tools/replay-tool/api-extractor.json
@@ -1,8 +1,5 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "@fluidframework/build-common/api-extractor-common.json",
-	"mainEntryPointFilePath": "<projectFolder>/dist/replayTool.d.ts",
-	"dtsRollup": {
-		"enabled": true
-	}
+	"mainEntryPointFilePath": "<projectFolder>/dist/replayTool.d.ts"
 }

--- a/packages/utils/odsp-doclib-utils/api-extractor.json
+++ b/packages/utils/odsp-doclib-utils/api-extractor.json
@@ -8,8 +8,5 @@
 				"logLevel": "none"
 			}
 		}
-	},
-	"dtsRollup": {
-		"enabled": true
 	}
 }

--- a/packages/utils/telemetry-utils/api-extractor.json
+++ b/packages/utils/telemetry-utils/api-extractor.json
@@ -8,8 +8,5 @@
 				"logLevel": "none"
 			}
 		}
-	},
-	"dtsRollup": {
-		"enabled": true
 	}
 }

--- a/packages/utils/tool-utils/api-extractor.json
+++ b/packages/utils/tool-utils/api-extractor.json
@@ -8,8 +8,5 @@
 				"logLevel": "none"
 			}
 		}
-	},
-	"dtsRollup": {
-		"enabled": true
 	}
 }

--- a/tools/api-markdown-documenter/api-extractor.json
+++ b/tools/api-markdown-documenter/api-extractor.json
@@ -1,7 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../common/build/build-common/api-extractor-base.json",
-	"dtsRollup": {
-		"enabled": true
-	}
+	"extends": "../../common/build/build-common/api-extractor-base.json"
 }


### PR DESCRIPTION
Enables d.ts trimmed rollup generation by default across the repo. Makes no changes to how the rollups are consumed, just adds generation to the build.