### PR TITLE
Tree: Fix bug with comparing sequence field lineages

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
@@ -1134,7 +1134,7 @@ export function compareLineages(
 			} else if (youngerOffset > olderOffset) {
 				return olderFirst;
 			}
-		} else {
+		} else if (metadata.tryGetInfo(event.revision) === undefined) {
 			// We've found a cell C that became empty before the younger cell was created.
 			// The younger cell should come before any such cell, so if the older cell comes after C
 			// then we know that the younger cell should come before the older cell.

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -664,6 +664,36 @@ describe("SequenceField - Sandwich composing", () => {
 
 		assert.deepEqual(composed, expected);
 	});
+
+	it("[insert, insert] ↷ adjacent delete", () => {
+		const deleteT = tagChange([Mark.delete(1, brand(0))], tag1);
+		const insertA = tagChange([Mark.skip(1), Mark.insert(1, brand(0))], tag2);
+		const insertA2 = rebaseTagged(insertA, deleteT);
+		const inverseA = tagRollbackInverse(invert(insertA), tag4, tag2);
+		const insertB = tagChange([Mark.skip(1), Mark.insert(1, brand(0))], tag3);
+		const insertB2 = rebaseOverChanges(insertB, [inverseA, deleteT, insertA2]);
+		const TAB = compose([deleteT, insertA2, insertB2]);
+		const AiTAB = compose(
+			[inverseA, makeAnonChange(TAB)],
+			[
+				{ revision: tag4, rollbackOf: tag2 },
+				{ revision: tag1 },
+				{ revision: tag2 },
+				{ revision: tag3 },
+			],
+		);
+
+		const expected = [
+			Mark.delete(1, { revision: tag1, localId: brand(0) }),
+			Mark.insert(1, {
+				revision: tag3,
+				localId: brand(0),
+				lineage: [{ revision: tag1, id: brand(0), count: 1, offset: 1 }],
+			}),
+		];
+
+		assert.deepEqual(AiTAB, expected);
+	});
 });
 
 describe("SequenceField - Composed sandwich rebasing", () => {


### PR DESCRIPTION
## Description

Fixed a bug where lineage comparison was examining lineage events for non-trunk changes.