### PR TITLE
Fix auth in odsp-client example

### DIFF
--- a/examples/service-clients/odsp-client/shared-tree-demo/.eslintrc.js
+++ b/examples/service-clients/odsp-client/shared-tree-demo/.eslintrc.js
@@ -4,6 +4,6 @@
  */
 
 module.exports = {
-	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid/recommended"), "prettier"],
 	rules: {},
 };

--- a/examples/service-clients/odsp-client/shared-tree-demo/README.md
+++ b/examples/service-clients/odsp-client/shared-tree-demo/README.md
@@ -7,3 +7,12 @@ This app demonstrates how to create a simple tree data structure and build a Rea
 ## Gettting started
 
 All the code required to set up the Fluid Framework and SharedTree data structure is in the `fluid.ts` source file. Most of this code will be the same for any app. However, because SharedTree is still in the alpha stage, the code to set it up isn't optimized yet.
+
+You can run this example using the following steps:
+
+1. To kick off the example, update the credentials in the `clientProps.ts` file by replacing siteUrl, driveId, and clientId with your own.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
+    - For an even faster build, you can add the package name to the build command, like this:
+      `pnpm run build:fast --nolint @fluid-example/shared-tree-demo`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+1. Login with your M365 tenant email and password to see the example in action on your web browser.

--- a/examples/service-clients/odsp-client/shared-tree-demo/package.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/package.json
@@ -33,6 +33,7 @@
 		"webpack:dev": "webpack --env development"
 	},
 	"dependencies": {
+		"@azure/msal-browser": "^2.34.0",
 		"@fluid-experimental/odsp-client": "workspace:~",
 		"@fluid-experimental/tree2": "workspace:~",
 		"@fluidframework/container-definitions": "workspace:~",

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
@@ -18,7 +18,7 @@ export const props: OdspTestCredentials = {
 };
 
 const connectionConfig: OdspConnectionConfig = {
-	tokenProvider: new OdspTestTokenProvider(),
+	tokenProvider: new OdspTestTokenProvider(props.clientId),
 	siteUrl: props.siteUrl,
 	driveId: props.driveId,
 };
@@ -26,7 +26,3 @@ const connectionConfig: OdspConnectionConfig = {
 export const clientProps: OdspClientProps = {
 	connection: connectionConfig,
 };
-
-export const STORAGE_TOKEN = "STORAGE_TOKEN";
-
-export const WEBSOCKET_TOKEN = "WEBSOCKET_TOKEN";

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
@@ -6,28 +6,27 @@ import { OdspClientProps, OdspConnectionConfig } from "@fluid-experimental/odsp-
 import { OdspTestTokenProvider } from "./tokenProvider";
 
 export interface OdspTestCredentials {
+	siteUrl: string;
+	driveId: string;
 	clientId: string;
-	clientSecret: string;
-	username: string;
-	password: string;
 }
 
-/**
- * Default test credentials for odsp-client.
- */
-const clientCreds: OdspTestCredentials = {
-	clientId: "<client_id>",
-	clientSecret: "<client_secret>",
-	username: "<email_id>",
-	password: "<password>",
+export const props: OdspTestCredentials = {
+	siteUrl: "<site__url>",
+	driveId: "<drive__id>",
+	clientId: "<client__id>",
 };
 
 const connectionConfig: OdspConnectionConfig = {
-	tokenProvider: new OdspTestTokenProvider(clientCreds), // Token provider using the provided test credentials.
-	siteUrl: "<site_url>",
-	driveId: "<raas_drive_id>",
+	tokenProvider: new OdspTestTokenProvider(),
+	siteUrl: props.siteUrl,
+	driveId: props.driveId,
 };
 
 export const clientProps: OdspClientProps = {
 	connection: connectionConfig,
 };
+
+export const STORAGE_TOKEN = "STORAGE_TOKEN";
+
+export const WEBSOCKET_TOKEN = "WEBSOCKET_TOKEN";

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
@@ -12,14 +12,8 @@ import { treeConfiguration, Letter } from "./schema";
 // eslint-disable-next-line import/no-unassigned-import
 import "./output.css";
 import { ReactApp } from "./reactApp";
-import { fetchTokens } from "./tokenProvider";
-import { WEBSOCKET_TOKEN, STORAGE_TOKEN, props } from "./clientProps";
 
 async function start() {
-	const tokens = await fetchTokens(props.siteUrl, props.clientId);
-	localStorage.setItem(STORAGE_TOKEN, tokens.storageToken);
-	localStorage.setItem(WEBSOCKET_TOKEN, tokens.pushToken);
-	// create the root element for React
 	const app = document.createElement("div");
 	app.id = "app";
 	document.body.appendChild(app);
@@ -86,6 +80,18 @@ async function start() {
 					id++;
 				}
 			});
+
+		// Update the application state or components without forcing a full page reload
+		ReactDOM.render(
+			<ReactApp
+				data={appData}
+				container={container}
+				canvasSize={canvasSize}
+				cellSize={cellSize}
+			/>,
+			app,
+		);
+
 		// If the app is in a `createNew` state - no itemId, and the container is detached, we attach the container.
 		// This uploads the container to the service and connects to the collaboration session.
 		itemId = await container.attach();

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
@@ -13,15 +13,15 @@ import { treeConfiguration, Letter } from "./schema";
 import "./output.css";
 import { ReactApp } from "./reactApp";
 
-async function start() {
+async function start(): Promise<void> {
 	const app = document.createElement("div");
 	app.id = "app";
-	document.body.appendChild(app);
+	document.body.append(app);
 
 	// Get the root item id from the URL
 	// If there is no item id, then the app will make
 	// a new container.
-	let itemId = location.hash.substring(1);
+	let itemId: string = location.hash.slice(1);
 	const createNew = itemId.length === 0;
 	let container: IFluidContainer;
 
@@ -54,32 +54,27 @@ async function start() {
 	if (createNew) {
 		const used: { x: number; y: number }[] = [];
 		let id = 0;
-		"HELLOWORLD"
-			.repeat(500)
-			.split("")
-			.map((character) => {
-				const x = Math.round(
-					Math.floor((Math.random() * (canvasSize.x * cellSize.x)) / cellSize.x) *
-						cellSize.x,
+		[..."HELLOWORLD".repeat(500)].map((character) => {
+			const x = Math.round(
+				Math.floor((Math.random() * (canvasSize.x * cellSize.x)) / cellSize.x) * cellSize.x,
+			);
+			const y = Math.round(
+				Math.floor((Math.random() * (canvasSize.y * cellSize.y)) / cellSize.y) * cellSize.y,
+			);
+			if (!used.some((element) => element.x === x && element.y === y)) {
+				const pos = { x, y };
+				used.push(pos);
+				appData.root.letters.insertAtEnd(
+					// TODO: error when not adding wrapping [] is inscrutable
+					new Letter({
+						position: pos,
+						character,
+						id: id.toString(),
+					}),
 				);
-				const y = Math.round(
-					Math.floor((Math.random() * (canvasSize.y * cellSize.y)) / cellSize.y) *
-						cellSize.y,
-				);
-				if (!used.find((element) => element.x === x && element.y === y)) {
-					const pos = { x, y };
-					used.push(pos);
-					appData.root.letters.insertAtEnd(
-						// TODO: error when not adding wrapping [] is inscrutable
-						new Letter({
-							position: pos,
-							character,
-							id: id.toString(),
-						}),
-					);
-					id++;
-				}
-			});
+				id++;
+			}
+		});
 
 		// Update the application state or components without forcing a full page reload
 		ReactDOM.render(
@@ -97,8 +92,10 @@ async function start() {
 		itemId = await container.attach();
 
 		// The newly attached container is given a unique ID that can be used to access the container in another session
+		// eslint-disable-next-line require-atomic-updates
 		location.hash = itemId;
 	}
 }
 
+// eslint-disable-next-line unicorn/prefer-top-level-await
 start().catch(console.error);

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
@@ -12,8 +12,13 @@ import { treeConfiguration, Letter } from "./schema";
 // eslint-disable-next-line import/no-unassigned-import
 import "./output.css";
 import { ReactApp } from "./reactApp";
+import { fetchTokens } from "./tokenProvider";
+import { WEBSOCKET_TOKEN, STORAGE_TOKEN, props } from "./clientProps";
 
 async function start() {
+	const tokens = await fetchTokens(props.siteUrl, props.clientId);
+	localStorage.setItem(STORAGE_TOKEN, tokens.storageToken);
+	localStorage.setItem(WEBSOCKET_TOKEN, tokens.pushToken);
 	// create the root element for React
 	const app = document.createElement("div");
 	app.id = "app";

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 /* eslint-disable prefer-template */
+
 import React, { ReactNode, useEffect, useState } from "react";
 import { TreeView, Tree } from "@fluid-experimental/tree2";
 import { IFluidContainer } from "@fluidframework/fluid-static";
@@ -41,8 +42,8 @@ function CanvasLetter(props: {
 		<div
 			className="transition-all hover:scale-110 text-center cursor-pointer select-none absolute text-xl"
 			style={style}
-			onClick={() => {
-				const index = props.app.letters.indexOf(props.letter);
+			onClick={(): void => {
+				const index: number = props.app.letters.indexOf(props.letter);
 				if (index !== -1) props.app.word.moveToEnd(index, props.app.letters);
 			}}
 		>
@@ -74,7 +75,7 @@ function TopLetter(props: { app: App; letter: Letter }): JSX.Element {
 	return (
 		<div
 			className={classes}
-			onClick={() => {
+			onClick={(): void => {
 				const index = props.app.word.indexOf(props.letter);
 				if (index !== -1) props.app.letters.moveToEnd(index, props.app.word);
 			}}
@@ -98,7 +99,7 @@ function Canvas(props: {
 		<div
 			className="relative w-full h-full self-center bg-transparent"
 			style={style}
-			onClick={(e: React.MouseEvent) => {
+			onClick={(e: React.MouseEvent): void => {
 				e.preventDefault();
 			}}
 		>

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 /* eslint-disable prefer-template */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import React, { ReactNode, useEffect, useState } from "react";
 import { TreeView, Tree } from "@fluid-experimental/tree2";
 import { IFluidContainer } from "@fluidframework/fluid-static";

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
@@ -10,7 +10,6 @@ import {
 } from "@azure/msal-browser";
 import { IOdspTokenProvider } from "@fluid-experimental/odsp-client";
 import { TokenResponse } from "@fluidframework/odsp-driver-definitions";
-import { WEBSOCKET_TOKEN, STORAGE_TOKEN } from "./clientProps";
 
 export async function fetchTokens(
 	siteUrl: string,
@@ -83,16 +82,86 @@ export class OdspTestTokenProvider implements IOdspTokenProvider {
 	constructor() {}
 
 	public async fetchWebsocketToken(siteUrl: string, refresh: boolean): Promise<TokenResponse> {
+		const token = await this.fetchTokens(siteUrl, "");
 		return {
 			fromCache: true,
-			token: localStorage.get(WEBSOCKET_TOKEN),
+			token: token.pushToken,
 		};
 	}
 
 	public async fetchStorageToken(siteUrl: string, refresh: boolean): Promise<TokenResponse> {
+		const token = await this.fetchTokens(siteUrl, "");
 		return {
 			fromCache: true,
-			token: localStorage.get(STORAGE_TOKEN),
+			token: token.storageToken,
 		};
+	}
+
+	private async fetchTokens(
+		siteUrl: string,
+		clientId: string,
+	): Promise<{ storageToken: string; pushToken: string }> {
+		const msalConfig = {
+			auth: {
+				clientId,
+				authority: "https://login.microsoftonline.com/common/",
+			},
+		};
+
+		const graphScopes = ["FileStorageContainer.Selected"];
+
+		const msalInstance = new PublicClientApplication(msalConfig);
+		const pushScope = ["offline_access https://pushchannel.1drv.ms/PushChannel.ReadWrite.All"];
+		const storageScope = [`${siteUrl}/Container.Selected`];
+		const response = await msalInstance.loginPopup({ scopes: graphScopes });
+
+		msalInstance.setActiveAccount(response.account);
+
+		try {
+			// Attempt to acquire token silently
+			const storageRequest = {
+				scopes: storageScope,
+			};
+			const storageResult: AuthenticationResult =
+				await msalInstance.acquireTokenSilent(storageRequest);
+
+			const pushRequest = {
+				scopes: pushScope,
+			};
+			const pushResult: AuthenticationResult =
+				await msalInstance.acquireTokenSilent(pushRequest);
+
+			// Return token
+			return {
+				storageToken: storageResult.accessToken,
+				pushToken: pushResult.accessToken,
+			};
+		} catch (error) {
+			if (error instanceof InteractionRequiredAuthError) {
+				msalInstance.setActiveAccount(null);
+				// If silent token acquisition fails, fall back to interactive flow
+				const storageRequest = {
+					scopes: storageScope,
+				};
+				const storageResult: AuthenticationResult =
+					await msalInstance.acquireTokenPopup(storageRequest);
+
+				const pushRequest = {
+					scopes: pushScope,
+				};
+				const pushResult: AuthenticationResult =
+					await msalInstance.acquireTokenSilent(pushRequest);
+
+				// Return token
+				return {
+					storageToken: storageResult.accessToken,
+					pushToken: pushResult.accessToken,
+				};
+			} else {
+				// Handle any other error
+				console.error(error);
+				throw error;
+			}
+		}
 	}
 }

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
@@ -56,6 +56,7 @@ export class OdspTestTokenProvider implements IOdspTokenProvider {
 			response = { account: accounts[0] };
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
 		this.msalInstance.setActiveAccount(response.account);
 
 		try {

--- a/examples/service-clients/odsp-client/shared-tree-demo/webpack.config.js
+++ b/examples/service-clients/odsp-client/shared-tree-demo/webpack.config.js
@@ -60,12 +60,6 @@ module.exports = (env) => {
 				}),
 				// new CleanWebpackPlugin(),
 			],
-			devServer: {
-				// keep port in sync with VS Code launch.json
-				port: 3000,
-				// Hot-reloading, the sole reason to use webpack here <3
-				hot: true,
-			},
 		},
 		isProduction ? require("./webpack.prod") : require("./webpack.dev"),
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3485,6 +3485,7 @@ importers:
 
   examples/service-clients/odsp-client/shared-tree-demo:
     specifiers:
+      '@azure/msal-browser': ^2.34.0
       '@fluid-experimental/odsp-client': workspace:~
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/build-cli': ^0.28.0
@@ -3523,6 +3524,7 @@ importers:
       webpack-dev-server: ~4.6.0
       webpack-merge: ^5.8.0
     dependencies:
+      '@azure/msal-browser': 2.38.3
       '@fluid-experimental/odsp-client': link:../../../../packages/service-clients/odsp-client
       '@fluid-experimental/tree2': link:../../../../experimental/dds/tree2
       '@fluidframework/container-definitions': link:../../../../packages/common/container-definitions
@@ -12103,6 +12105,19 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
+    dev: false
+
+  /@azure/msal-browser/2.38.3:
+    resolution: {integrity: sha512-2WuLFnWWPR1IdvhhysT18cBbkXx1z0YIchVss5AwVA95g7CU5CpT3d+5BcgVGNXDXbUU7/5p0xYHV99V5z8C/A==}
+    engines: {node: '>=0.8.0'}
+    deprecated: A newer major version of this library is available. Please upgrade to the latest available version.
+    dependencies:
+      '@azure/msal-common': 13.3.1
+    dev: false
+
+  /@azure/msal-common/13.3.1:
+    resolution: {integrity: sha512-Lrk1ozoAtaP/cp53May3v6HtcFSVxdFrg2Pa/1xu5oIvsIwhxW6zSPibKefCOVgd5osgykMi5jjcZHv8XkzZEQ==}
+    engines: {node: '>=0.8.0'}
     dev: false
 
   /@azure/opentelemetry-instrumentation-azure-sdk/1.0.0-beta.5:


### PR DESCRIPTION
The auth in shared-tree-demo was returning the storage token as undefined. `password` grant type is not generally recommended for browser-side applications This PR replaces the auth using msal. 

![image](https://github.com/microsoft/FluidFramework/assets/48232592/0a265b37-d72f-4571-b51d-fdd992a94403)
