### PR TITLE
test(tree2): Add a (currently skipped) test verifying support of unhydrated `initialTree` input

### DIFF
--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -168,7 +168,7 @@ describe("SharedTree", () => {
 
 			const unhydratedInitialTree = new Foo({});
 			const view = tree.schematize(new TreeConfiguration(Foo, () => unhydratedInitialTree));
-			assert.equal(view.root, unhydratedInitialTree);
+			assert(view.root === unhydratedInitialTree);
 		});
 	});
 

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -69,6 +69,7 @@ import { typeboxValidator } from "../../external-utilities";
 import { EditManager } from "../../shared-tree-core";
 import { leaf, SchemaBuilder } from "../../domains";
 import { noopValidator } from "../../codec";
+import { SchemaFactory, TreeConfiguration } from "../../class-tree";
 
 const schemaCodec = makeSchemaCodec({ jsonValidator: typeboxValidator });
 
@@ -157,6 +158,17 @@ describe("SharedTree", () => {
 			});
 			// Initial tree should not be applied
 			assert.equal(schematized.editableTree.content, undefined);
+		});
+
+		// TODO: ensure unhydrated initialTree input is correctly hydrated.
+		it.skip("unhydrated tree input", () => {
+			const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree") as SharedTree;
+			const sb = new SchemaFactory("test-factory");
+			class Foo extends sb.object("Foo", {}) {}
+
+			const unhydratedInitialTree = new Foo({});
+			const view = tree.schematize(new TreeConfiguration(Foo, () => unhydratedInitialTree));
+			assert.equal(view.root, unhydratedInitialTree);
 		});
 	});
 


### PR DESCRIPTION
Disabled test illustrates a currently unsupported input case that we will want to address in the future.