### PR TITLE
Add some comments around protection of resubmitting same op

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3724,6 +3724,7 @@ export class ContainerRuntime
 	/**
 	 * Finds the right store and asks it to resubmit the message. This typically happens when we
 	 * reconnect and there are pending messages.
+	 * ! Note: successfully resubmitting an op that has been successfully sequenced is not possible due to checks in the ConnectionStateHandler (Loader layer)
 	 * @param message - The original LocalContainerRuntimeMessage.
 	 * @param localOpMetadata - The local metadata associated with the original message.
 	 */

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -331,6 +331,7 @@ export class PendingStateManager implements IDisposable {
 	/**
 	 * Called when the Container's connection state changes. If the Container gets connected, it replays all the pending
 	 * states in its queue. This includes triggering resubmission of unacked ops.
+	 * ! Note: successfully resubmitting an op that has been successfully sequenced is not possible due to checks in the ConnectionStateHandler (Loader layer)
 	 */
 	public replayPendingStates() {
 		assert(


### PR DESCRIPTION
We have mechanisms in place that help prevent ops from being resubmitted if they were successfully sequenced by service (but our client didn't have time to see the ack before disconnecting).
Added comments in some key places so people interested can quickly find the code that prevents this.

Example scenario:

| **Step** | **clientId value** | **PendingStateManager** |
|--------------------------------------------|----------------|---------------------|
| Client A sends op 1 | Client A | [op 1] |
| Client A disconnects | Client A | [op 1] |
| Client A reconnects as Client B | Client A | [op 1] |
| **Start wait to see "leave" op from Client A** | Client A | [op 1] |
| See ack for op 1 | Client A | **[]** |
| See "leave" for Client A | **Client B** | [] |