### PR TITLE
Update shared matrix FWW policy to immediately switch mode on switch rather than on ack

### DIFF
--- a/packages/dds/matrix/README.md
+++ b/packages/dds/matrix/README.md
@@ -119,3 +119,42 @@ return undefined; // Empty region
 A benefit of storing the cell data in [Z-order](https://en.wikipedia.org/wiki/Z-order_curve) is that both row-major and
 col-major traversal benefit from prefetching and cache coherence. Reading/writing to the physical storage along either
 axis is typically within an order of magnitude compared to sequentially accessing a cache hot native JavaScript array.
+
+### Switching From Last Write Win(LWW) to First Write Win(FWW) mode
+
+Shared Matrix allows to make to make one way switch from LWW to FWW. This is introduced in order to handle conflict
+when multiple clients at once initialize a cell. Using FWW, will help clients to receive a `conflict` event in case
+their change was rejected. They can resolve conflict with the new information that they received in the event.
+This event is only emitted when the SetCell Resolution Policy is First Write Win(FWW). This is emitted when two clients
+race and send changes without observing each other changes, the changes that gets sequenced last would be rejected, and
+only client who's changes rejected would be notified via this event, with expectation that it will merge its changes
+back by accounting new information (state from winner of the race).
+
+Some cases which documents how the Set op changes are applied or rejected during LWW -> FWW switch as some clients will
+be in FWW mode and some will in LWW mode. When app calls `switchSetCellPolicy` the policy is changed to FWW mode
+immediately and then later communicated to other clients via next SetOp which is made on the matrix.
+
+Case 1: When all clients have switched to FWW mode, then any race between 2 Set Op, will result in a `conflict` event at
+the loser client until it receives its own latest Set op. For example, client has sent op for cell C1. It receives remote
+ops R1 and R2 for cell C1. It will first raise `conflict` event when it receives R1 and then another `conflict` event when
+it receives R2. This will keep happening until it receives its own op, so that its changes are not lost due to conflict.
+
+Case 2: Client switches policy to FWW locally. No SetOp is made yet. This client has no pending changes yet. On receiving
+remote Set ops, this client will apply them all.
+
+Case 3: Client switches policy to FWW locally. This client has pending changes for cell C1. On
+receiving remote LWW Set op for C1, this client will reject it as its own op will finally be applied. So the first FWW
+SetOp is still treated as LWW op in a way. Now lets say it has received a remote FWW op for C1 instead of a LWW op, then
+the remote op would have been applied causing client's policy to shift to FWW with that op. It will also raise a conflict
+event locally as its Op for cell c1 will be rejected by other clients as it is a loser op.
+
+Case 4: In FWW mode, when there is no conflict, clients will still be able to overwrite cells. We track the sequence number
+for each cell when it was last edited and also track the clientId which made that change. If the receive a Op for cell C1,
+and its ref Sequence number is >= to sequence number at which it was last edited, then the cell would be overwritten. Otherwise,
+if the same client made the changes, then the op will still be applied as the client knew about the previous edit.
+
+Case 5: Reconnection: When a client makes an op in LWW mode in disconnected state for cell C1, then when it comes online
+later on, and catches up it sees a FWW op for C1, it will raise a `conflict` event for C1 and will not send it own op.
+It can receive many ops for C1 during catchup and will raise `conflict` event for each of those in case they are winner
+ops for C1.
+

--- a/packages/dds/matrix/README.md
+++ b/packages/dds/matrix/README.md
@@ -134,27 +134,27 @@ Some cases which documents how the Set op changes are applied or rejected during
 be in FWW mode and some will in LWW mode. When app calls `switchSetCellPolicy` the policy is changed to FWW mode
 immediately and then later communicated to other clients via next SetOp which is made on the matrix.
 
-Case 1: When all clients have switched to FWW mode, then any race between 2 Set Op, will result in a `conflict` event at
-the loser client until it receives its own latest Set op. For example, client has sent op for cell C1. It receives remote
+**Case 1:** When all clients have switched to FWW mode, then any race between 2 Set Op, will result in a `conflict` event
+at the loser client until it receives its own latest Set op. For example, client has sent op for cell C1. It receives remote
 ops R1 and R2 for cell C1. It will first raise `conflict` event when it receives R1 and then another `conflict` event when
 it receives R2. This will keep happening until it receives its own op, so that its changes are not lost due to conflict.
 
-Case 2: Client switches policy to FWW locally. No SetOp is made yet. This client has no pending changes yet. On receiving
+**Case 2:** Client switches policy to FWW locally. No SetOp is made yet. This client has no pending changes yet. On receiving
 remote Set ops, this client will apply them all.
 
-Case 3: Client switches policy to FWW locally. This client has pending changes for cell C1. On
+**Case 3:** Client switches policy to FWW locally. This client has pending changes for cell C1. On
 receiving remote LWW Set op for C1, this client will reject it as its own op will finally be applied. So the first FWW
 SetOp is still treated as LWW op in a way. Now lets say it has received a remote FWW op for C1 instead of a LWW op, then
 the remote op would have been applied causing client's policy to shift to FWW with that op. It will also raise a conflict
 event locally as its Op for cell c1 will be rejected by other clients as it is a loser op.
 
-Case 4: In FWW mode, when there is no conflict, clients will still be able to overwrite cells. We track the sequence number
-for each cell when it was last edited and also track the clientId which made that change. If the receive a Op for cell C1,
-and its ref Sequence number is >= to sequence number at which it was last edited, then the cell would be overwritten. Otherwise,
-if the same client made the changes, then the op will still be applied as the client knew about the previous edit.
+**Case 4:** In FWW mode, when there is no conflict, clients will still be able to overwrite cells. We track the sequence
+number for each cell when it was last edited and also track the clientId which made that change. If the receive a Op for
+cell C1, and its ref Sequence number is >= to sequence number at which it was last edited, then the cell would be
+overwritten. Otherwise, if the same client made the changes, then the op will still be applied as the client knew about
+the previous edit.
 
-Case 5: Reconnection: When a client makes an op in LWW mode in disconnected state for cell C1, then when it comes online
+**Case 5: Reconnection:** When a client makes an op in LWW mode in disconnected state for cell C1, then when it comes online
 later on, and catches up it sees a FWW op for C1, it will raise a `conflict` event for C1 and will not send it own op.
 It can receive many ops for C1 during catchup and will raise `conflict` event for each of those in case they are winner
 ops for C1.
-

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -744,6 +744,10 @@ export class SharedMatrix<T = any>
 		colHandle: Handle,
 		message: ISequencedDocumentMessage,
 	) {
+		assert(
+			this.setCellLwwToFwwPolicySwitchOpSeqNumber > -1,
+			"should be in Fww mode when calling this method",
+		);
 		assert(message.clientId !== null, "clientId should not be null");
 		const lastCellModificationDetails = this.cellLastWriteTracker.getCell(rowHandle, colHandle);
 		// If someone tried to Overwrite the cell value or first write on this cell or

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -917,7 +917,7 @@ export class SharedMatrix<T = any>
 
 	/**
 	 * Api to switch Set Op policy from Last Writer Win to First Writer Win. It only switches from LWW to FWW
-	 * and not from FWW to LWW. An op will be sent to communicate this to other clients.
+	 * and not from FWW to LWW. The next SetOp which is sent will communicate this policy to other clients.
 	 */
 	public switchSetCellPolicy() {
 		if (this.setCellLwwToFwwPolicySwitchOpSeqNumber === -1) {

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -243,8 +243,8 @@ export class SharedMatrix<T = any>
 		return this.cols.getLength();
 	}
 
-	public isSetCellConflictResolutionPolicyFWW() {
-		return this.setCellLwwToFwwPolicySwitchOpSeqNumber > -1;
+	public get isSetCellConflictResolutionPolicyFWW() {
+		return this.setCellLwwToFwwPolicySwitchOpSeqNumber > -1 || this.userSwitchedSetCellPolicy;
 	}
 
 	public getCell(row: number, col: number): MatrixItem<T> {

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -53,6 +53,7 @@ interface ISetOp<T> {
 	row: number;
 	col: number;
 	value: MatrixItem<T>;
+	fwwMode?: boolean;
 }
 
 interface ISetOpMetadata {
@@ -62,10 +63,6 @@ interface ISetOpMetadata {
 	rowsRefSeq: number;
 	colsRefSeq: number;
 	referenceSeqNumber: number;
-}
-
-interface ISetCellChangePolicyOp {
-	type: MatrixOp.changeSetCellPolicy;
 }
 
 /**
@@ -154,6 +151,8 @@ export class SharedMatrix<T = any>
 	private cellLastWriteTracker = new SparseArray2D<CellLastWriteTrackerItem>(); // Tracks last writes sequence number and clientId in a cell.
 	// Tracks the seq number of Op at which policy switch happens from Last Write Win to First Write Win.
 	private setCellLwwToFwwPolicySwitchOpSeqNumber: number;
+	private userSwitchedSetCellPolicy = false; // Set to true when the user calls switchPolicy.
+
 	// Used to track if there is any reentrancy in setCell code.
 	private reentrantCount: number = 0;
 
@@ -367,6 +366,8 @@ export class SharedMatrix<T = any>
 			row,
 			col,
 			value,
+			fwwMode:
+				this.userSwitchedSetCellPolicy || this.setCellLwwToFwwPolicySwitchOpSeqNumber > -1,
 		};
 
 		const metadata: ISetOpMetadata = {
@@ -645,12 +646,6 @@ export class SharedMatrix<T = any>
 				);
 				break;
 			default: {
-				if (content.type === MatrixOp.changeSetCellPolicy) {
-					this.submitLocalMessage({
-						type: MatrixOp.changeSetCellPolicy,
-					});
-					break;
-				}
 				assert(
 					content.type === MatrixOp.set,
 					0x020 /* "Unknown SharedMatrix 'op' type." */,
@@ -695,6 +690,9 @@ export class SharedMatrix<T = any>
 							rowsRefSeq,
 							colsRefSeq,
 						);
+					} else if (this.pending.getCell(rowHandle, colHandle) !== undefined) {
+						// Clear the pending changes if any as we are not sending the op.
+						this.pending.setCell(rowHandle, colHandle, undefined);
 					}
 				}
 				break;
@@ -757,20 +755,6 @@ export class SharedMatrix<T = any>
 		);
 	}
 
-	/**
-	 * Tells whether the client made the op in First Write Win mode or not.
-	 * @param message - Op to process.
-	 */
-	private isSetCellOpMadeInFWWPolicy(message: ISequencedDocumentMessage) {
-		if (
-			this.setCellLwwToFwwPolicySwitchOpSeqNumber !== -1 &&
-			message.referenceSequenceNumber >= this.setCellLwwToFwwPolicySwitchOpSeqNumber
-		) {
-			return true;
-		}
-		return false;
-	}
-
 	protected processCore(
 		rawMessage: ISequencedDocumentMessage,
 		local: boolean,
@@ -788,36 +772,43 @@ export class SharedMatrix<T = any>
 				this.rows.applyMsg(msg, local);
 				break;
 			default: {
-				if (contents.type === MatrixOp.changeSetCellPolicy) {
-					this.setCellLwwToFwwPolicySwitchOpSeqNumber = rawMessage.sequenceNumber;
-					return;
-				}
-
 				assert(
 					contents.type === MatrixOp.set,
 					0x021 /* "SharedMatrix message contents have unexpected type!" */,
 				);
 
-				const { row, col, value } = contents;
+				const { row, col, value, fwwMode } = contents;
+				const isPreviousSetCellPolicyModeFWW =
+					this.setCellLwwToFwwPolicySwitchOpSeqNumber > -1;
+				// If this is the first op notifying us of the policy change, then set the policy change seq number.
+				if (this.setCellLwwToFwwPolicySwitchOpSeqNumber === -1 && fwwMode === true) {
+					this.setCellLwwToFwwPolicySwitchOpSeqNumber = rawMessage.sequenceNumber;
+				}
+
 				assert(rawMessage.clientId !== null, "clientId should not be null!!");
 				if (local) {
 					// We are receiving the ACK for a local pending set operation.
 					const { rowHandle, colHandle, localSeq } = localOpMetadata as ISetOpMetadata;
-					if (this.isSetCellOpMadeInFWWPolicy(rawMessage)) {
-						if (this.shouldSetCellBasedOnFWW(rowHandle, colHandle, rawMessage)) {
-							this.cellLastWriteTracker.setCell(rowHandle, colHandle, {
-								seqNum: rawMessage.sequenceNumber,
-								clientId: rawMessage.clientId,
-							});
-						}
-					} else {
-						if (this.isLatestPendingWrite(rowHandle, colHandle, localSeq)) {
-							this.pending.setCell(rowHandle, colHandle, undefined);
-							this.cellLastWriteTracker.setCell(rowHandle, colHandle, {
-								seqNum: rawMessage.sequenceNumber,
-								clientId: rawMessage.clientId,
-							});
-						}
+					const isLatestPendingOp = this.isLatestPendingWrite(
+						rowHandle,
+						colHandle,
+						localSeq,
+					);
+					// If policy is switched and cell should be modified too based on policy, then update the tracker.
+					// If policy is not switched, then also update the tracker in case it is the latest.
+					if (
+						(this.setCellLwwToFwwPolicySwitchOpSeqNumber > -1 &&
+							this.shouldSetCellBasedOnFWW(rowHandle, colHandle, rawMessage)) ||
+						(this.setCellLwwToFwwPolicySwitchOpSeqNumber === -1 && isLatestPendingOp)
+					) {
+						this.cellLastWriteTracker.setCell(rowHandle, colHandle, {
+							seqNum: rawMessage.sequenceNumber,
+							clientId: rawMessage.clientId,
+						});
+					}
+
+					if (isLatestPendingOp) {
+						this.pending.setCell(rowHandle, colHandle, undefined);
 					}
 				} else {
 					const adjustedRow = this.rows.adjustPosition(row, rawMessage);
@@ -832,10 +823,12 @@ export class SharedMatrix<T = any>
 								isHandleValid(rowHandle) && isHandleValid(colHandle),
 								0x022 /* "SharedMatrix row and/or col handles are invalid!" */,
 							);
-							if (this.isSetCellOpMadeInFWWPolicy(rawMessage)) {
+							if (this.setCellLwwToFwwPolicySwitchOpSeqNumber > -1) {
 								// If someone tried to Overwrite the cell value or first write on this cell or
-								// same client tried to modify the cell.
+								// same client tried to modify the cell or if the previous mode was LWW, then we need to still
+								// overwrite the cell and raise conflict if we have pending changes as our change is going to be lost.
 								if (
+									!isPreviousSetCellPolicyModeFWW ||
 									this.shouldSetCellBasedOnFWW(rowHandle, colHandle, rawMessage)
 								) {
 									const previousValue = this.cells.getCell(rowHandle, colHandle);
@@ -849,7 +842,8 @@ export class SharedMatrix<T = any>
 									}
 									// Check is there are any pending changes, which will be rejected. If so raise conflict.
 									if (this.pending.getCell(rowHandle, colHandle) !== undefined) {
-										this.pending.setCell(rowHandle, colHandle, undefined);
+										// Don't reset the pending value yet, as there maybe more fww op from same client, so we want
+										// to raise conflict event for that op also.
 										this.emit(
 											"conflict",
 											row,
@@ -860,18 +854,16 @@ export class SharedMatrix<T = any>
 										);
 									}
 								}
-							} else {
+							} else if (this.pending.getCell(rowHandle, colHandle) === undefined) {
 								// If there is a pending (unACKed) local write to the same cell, skip the current op
 								// since it "happened before" the pending write.
-								if (this.pending.getCell(rowHandle, colHandle) === undefined) {
-									this.cells.setCell(rowHandle, colHandle, value);
-									this.cellLastWriteTracker.setCell(rowHandle, colHandle, {
-										seqNum: rawMessage.sequenceNumber,
-										clientId: rawMessage.clientId,
-									});
-									for (const consumer of this.consumers.values()) {
-										consumer.cellsChanged(adjustedRow, adjustedCol, 1, 1, this);
-									}
+								this.cells.setCell(rowHandle, colHandle, value);
+								this.cellLastWriteTracker.setCell(rowHandle, colHandle, {
+									seqNum: rawMessage.sequenceNumber,
+									clientId: rawMessage.clientId,
+								});
+								for (const consumer of this.consumers.values()) {
+									consumer.cellsChanged(adjustedRow, adjustedCol, 1, 1, this);
 								}
 							}
 						}
@@ -926,11 +918,7 @@ export class SharedMatrix<T = any>
 	public switchSetCellPolicy() {
 		if (this.setCellLwwToFwwPolicySwitchOpSeqNumber === -1) {
 			if (this.isAttached()) {
-				const op: ISetCellChangePolicyOp = {
-					type: MatrixOp.changeSetCellPolicy,
-				};
-
-				this.submitLocalMessage(op);
+				this.userSwitchedSetCellPolicy = true;
 			} else {
 				this.setCellLwwToFwwPolicySwitchOpSeqNumber = 0;
 			}

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -243,7 +243,7 @@ export class SharedMatrix<T = any>
 		return this.cols.getLength();
 	}
 
-	public get isSetCellConflictResolutionPolicyFWW() {
+	public isSetCellConflictResolutionPolicyFWW() {
 		return this.setCellLwwToFwwPolicySwitchOpSeqNumber > -1 || this.userSwitchedSetCellPolicy;
 	}
 

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -1096,7 +1096,6 @@ describe("Matrix1", () => {
 			let containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
 			let containerRuntime1: MockContainerRuntimeForReconnection;
 			let containerRuntime2: MockContainerRuntimeForReconnection;
-			let mockHandle: MockHandle<unknown>;
 
 			const expect = async (
 				expected?: readonly (readonly any[])[],
@@ -1181,8 +1180,6 @@ describe("Matrix1", () => {
 				matrix2 = response2.matrix;
 				containerRuntime2 = response2.containerRuntime;
 				consumer2 = new TestConsumer(matrix2);
-
-				mockHandle = new MockHandle({});
 			});
 
 			afterEach(async () => {
@@ -1199,11 +1196,10 @@ describe("Matrix1", () => {
 			it("Loser gets the conflict event in case of race condition", async () => {
 				// Insert a row and a column in the first shared matrix.
 				matrix1.insertRows(/* rowStart: */ 0, /* rowCount: */ 1);
-				matrix1.insertCols(/* colStart: */ 0, /* colCount: */ 1);
+				matrix1.insertCols(/* colStart: */ 0, /* colCount: */ 2);
 
-				await expect([[undefined]]);
+				await expect([[undefined, undefined]]);
 				switchPolicy(matrix1);
-				containerRuntimeFactory.processAllMessages();
 
 				let eventRaised = false;
 				matrix2.on("conflict", (row, col, currentVal, rejectedVal, instance) => {
@@ -1222,14 +1218,15 @@ describe("Matrix1", () => {
 				matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["A"]);
 				matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["B"]);
 
+				matrix2.setCells(0, 1, 1, ["C"]);
 				containerRuntime1.connected = true;
 				containerRuntime2.connected = true;
 
-				await expect([["A"]]);
+				await expect([["A", "C"]]);
 				assert(eventRaised, "conflict event should be raised");
 			});
 
-			it("Client should behave as LWW if op refSeqNum < Policy switch op seqNum", async () => {
+			it("Client should behave as FWW if op refSeqNum < Policy switch op seqNum but locally it was changed for that client", async () => {
 				// Insert a row and a column in the first shared matrix.
 				matrix1.insertRows(/* rowStart: */ 0, /* rowCount: */ 1);
 				matrix1.insertCols(/* colStart: */ 0, /* colCount: */ 1);
@@ -1247,7 +1244,7 @@ describe("Matrix1", () => {
 				containerRuntime1.connected = true;
 				containerRuntime2.connected = true;
 
-				await expect([["B"]]);
+				await expect([["A"]]);
 			});
 
 			it("Client Should be able to overwrite", async () => {
@@ -1274,7 +1271,6 @@ describe("Matrix1", () => {
 
 				await expect([[undefined]]);
 				switchPolicy(matrix1);
-				containerRuntimeFactory.processAllMessages();
 
 				let eventRaised = false;
 				matrix2.on("conflict", (row, col, currentVal, rejectedVal, instance) => {
@@ -1340,7 +1336,6 @@ describe("Matrix1", () => {
 
 				// Now switch the Policy
 				switchPolicy(matrix1);
-				containerRuntimeFactory.processAllMessages();
 
 				// Disconnect the client.
 				containerRuntime1.connected = false;
@@ -1380,12 +1375,85 @@ describe("Matrix1", () => {
 				// Reconnect the client.
 				containerRuntime1.connected = true;
 				containerRuntime2.connected = true;
-
 				// Verify that both the matrices have expected content. Matrix2 switched the policy and also made the set op, so it should be set.
 				await expect([["4th"]]);
 			});
 
-			it("Client should send op and also apply when policy is switched to FWW but op refSeqNum < Policy switch seq number", async () => {
+			it("Client should behave correctly when policy is switched to FWW during disconnected state and cell set by other client", async () => {
+				// Insert a row and a column in the first shared matrix.
+				matrix1.insertCols(0, 1);
+				matrix1.insertRows(0, 1);
+				// Verify that both the matrices have expected content.
+				await expect([[undefined]]);
+
+				let eventRaisedCount = 0;
+				matrix2.on("conflict", (row, col, currentVal, rejectedVal, instance) => {
+					assert(row === 0, "row should be correct");
+					assert(col === 0, "col should be correct");
+					assert(
+						currentVal === (eventRaisedCount === 0 ? "1st" : "3rd"),
+						"currentVal should be correct",
+					);
+					assert(
+						rejectedVal === (eventRaisedCount === 0 ? "4th" : "1st"),
+						"rejectedVal should be correct",
+					);
+					assert((instance.id = "matrix2"), "matrix should be correct");
+					eventRaisedCount++;
+				});
+
+				// Disconnect the client.
+				containerRuntime1.connected = false;
+				containerRuntime2.connected = false;
+
+				matrix1.setCell(0, 0, "1st");
+				matrix2.setCell(0, 0, "2nd");
+
+				// Now switch the Policy
+				switchPolicy(matrix1);
+
+				matrix1.setCell(0, 0, "3rd");
+				matrix2.setCell(0, 0, "4th");
+
+				// Reconnect the client.
+				containerRuntime1.connected = true;
+				containerRuntime2.connected = true;
+				// Verify that both the matrices have expected content.
+				await expect([["3rd"]]);
+				assert(eventRaisedCount === 2, "conflict event should have been raised");
+			});
+
+			it("Client should get multiple conflict till its latest pending is received", async () => {
+				// Insert a row and a column in the first shared matrix.
+				matrix1.insertCols(0, 1);
+				matrix1.insertRows(0, 1);
+				// Verify that both the matrices have expected content.
+				await expect([[undefined]]);
+
+				let eventRaisedCount = 0;
+				matrix2.on("conflict", (row, col, currentVal, rejectedVal, instance) => {
+					assert(row === 0, "row should be correct");
+					assert(col === 0, "col should be correct");
+					assert((instance.id = "matrix2"), "matrix should be correct");
+					eventRaisedCount++;
+				});
+
+				// Now switch the Policy
+				switchPolicy(matrix1);
+
+				matrix1.setCell(0, 0, "1st");
+				matrix2.setCell(0, 0, "2nd");
+				matrix1.setCell(0, 0, "3rd");
+				matrix2.setCell(0, 0, "4th");
+				containerRuntimeFactory.processAllMessages();
+				matrix1.setCell(0, 0, "5th");
+
+				// Verify that both the matrices have expected content.
+				await expect([["5th"]]);
+				assert(eventRaisedCount === 2, "conflict event should have been raised");
+			});
+
+			it("Client should send op and also apply when policy is switched to FWW but no op is sent to notify", async () => {
 				// Insert a row and a column in the first shared matrix.
 				matrix1.insertCols(0, 1);
 				matrix1.insertRows(0, 1);
@@ -1396,7 +1464,7 @@ describe("Matrix1", () => {
 				containerRuntime2.connected = false;
 
 				matrix1.setCell(0, 0, "1st");
-
+				containerRuntimeFactory.processOneMessage();
 				// Disconnect the client.
 				containerRuntime1.connected = false;
 
@@ -1414,25 +1482,7 @@ describe("Matrix1", () => {
 				await expect([["4th"]]);
 			});
 
-			it("Client should behave as LWW if op refSeqNum < Policy switch op seqNum and policy is switched by same client sending the set op", async () => {
-				// Insert a row and a column in the first shared matrix.
-				matrix1.insertRows(/* rowStart: */ 0, /* rowCount: */ 1);
-				matrix1.insertCols(/* colStart: */ 0, /* colCount: */ 1);
-				await expect([[undefined]]);
-
-				matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["B"]);
-				containerRuntimeFactory.processAllMessages();
-				await expect([["B"]]);
-
-				switchPolicy(matrix1);
-
-				matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["A"]);
-
-				// Should still behave as LWW as ref seq number of ops < switch policy seq number
-				await expect([["A"]]);
-			});
-
-			it("Client should behave as LWW if op refSeqNum < Policy switch op seqNum and policy is switched by different client sending the set op", async () => {
+			it("Client should behave as LWW if op refSeqNum < Policy switch op seqNum and policy is switched by different client which didn't send op to notify", async () => {
 				// Insert a row and a column in the first shared matrix.
 				matrix1.insertRows(/* rowStart: */ 0, /* rowCount: */ 1);
 				matrix1.insertCols(/* colStart: */ 0, /* colCount: */ 1);
@@ -1467,7 +1517,7 @@ describe("Matrix1", () => {
 				matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["C"]);
 
 				// Should still behave as LWW as ref seq number of ops < switch policy seq number
-				await expect([["C"]]);
+				await expect([["A"]]);
 
 				matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["D"]);
 				matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["E"]);
@@ -1488,7 +1538,6 @@ describe("Matrix1", () => {
 				]);
 
 				switchPolicy(matrix1);
-				containerRuntimeFactory.processAllMessages();
 
 				containerRuntime1.connected = false;
 				matrix1.setCells(/* row: */ 1, /* col: */ 1, /* colCount: */ 1, ["B"]);
@@ -1516,7 +1565,6 @@ describe("Matrix1", () => {
 				await expect([[undefined]]);
 
 				switchPolicy(matrix1);
-				containerRuntimeFactory.processAllMessages();
 				matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["A"]);
 				matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["B"]);
 				containerRuntimeFactory.processOneMessage();
@@ -1529,7 +1577,7 @@ describe("Matrix1", () => {
 				await expect([["A"]], [{ ...newClient }]);
 			});
 
-			it("New client loads from summary made in LWW mode and follow LWW for ops before switching and FWW after switching", async () => {
+			it("New client loads from summary made in LWW mode and immediately starts following the new policy when switched", async () => {
 				// Insert a row and a column in the first shared matrix.
 				matrix1.insertRows(/* rowStart: */ 0, /* rowCount: */ 1);
 				matrix1.insertCols(/* colStart: */ 0, /* colCount: */ 1);
@@ -1545,12 +1593,31 @@ describe("Matrix1", () => {
 				matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["B"]);
 				matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["C"]);
 				matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["C1"]);
-				await expect([["C1"]], [{ ...newClient }]);
+				await expect([["C"]], [{ ...newClient }]);
 
 				matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["D"]);
 				matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["E"]);
 
 				await expect([["D"]], [{ ...newClient }]);
+			});
+
+			it("Client switching policy should avoid changes from other client in case pending change is present, otherwise apply remote op", async () => {
+				// Insert a row and a column in the first shared matrix.
+				matrix1.insertRows(/* rowStart: */ 0, /* rowCount: */ 1);
+				matrix1.insertCols(/* colStart: */ 0, /* colCount: */ 2);
+				await expect([[undefined, undefined]]);
+
+				switchPolicy(matrix1);
+				matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["B"]);
+				matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["C"]);
+				matrix2.setCells(/* row: */ 0, /* col: */ 1, /* colCount: */ 1, ["C1"]);
+				await expect([["B", "C1"]]);
+
+				matrix1.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["D"]);
+				matrix2.setCells(/* row: */ 0, /* col: */ 0, /* colCount: */ 1, ["E"]);
+				matrix2.setCells(/* row: */ 0, /* col: */ 1, /* colCount: */ 1, ["D"]);
+				matrix1.setCells(/* row: */ 0, /* col: */ 1, /* colCount: */ 1, ["E"]);
+				await expect([["D", "D"]]);
 			});
 		});
 	});


### PR DESCRIPTION
## Description

Update shared matrix FWW policy to immediately switch mode on switch rather than on ack. Currently we were sending policy switch op separately to change policy from LWW to FWW and local changes after that were still treated as LWW.
With these changes, any local changes after policy switch will also be treated as FWW and there will be no separate op for policy switch. This would help the app when switching policy on open, to not change the last edit time for the user. The policy will be communicated by first setCell op after the user has switched policy locally.
