### PR TITLE
fix(tree2): jsonCursor should preserve empty arrays

### DIFF
--- a/experimental/dds/tree2/src/domains/json/jsonCursor.ts
+++ b/experimental/dds/tree2/src/domains/json/jsonCursor.ts
@@ -50,10 +50,7 @@ const adapter: CursorAdapter<JsonCompatible> = {
 				} else if (Array.isArray(node)) {
 					return node.length === 0 ? [] : [EmptyKey];
 				} else {
-					return (Object.keys(node) as FieldKey[]).filter((key) => {
-						const value = node[key];
-						return !Array.isArray(value) || value.length !== 0;
-					});
+					return Object.keys(node) as FieldKey[];
 				}
 			default:
 				return [];

--- a/experimental/dds/tree2/src/test/domains/json/jsonCursor.spec.ts
+++ b/experimental/dds/tree2/src/test/domains/json/jsonCursor.spec.ts
@@ -19,8 +19,8 @@ const testCases: readonly [string, readonly JsonCompatible[]][] = [
 	// ["non-finite", [NaN, -Infinity, +Infinity]],
 	// ["minus zero", [-0]],
 	["string", ["", '\\"\b\f\n\r\t', "😀"]],
-	["object", [{}, { one: "field" }, { nested: { depth: 1 } }]],
-	["array", [[], ["oneItem"], [["nested depth 1"]]]],
+	["object", [{}, { one: "field" }, { nested: { depth: 1 } }, { emptyArray: [] }]],
+	["array", [[], [[]], ["oneItem"], [["nested depth 1"]]]],
 	[
 		"composite",
 		[


### PR DESCRIPTION
Fixes a bug in `jsonCursor` that made `{ foo: [] }` appear as `{ }`