### PR TITLE
fix(tree2): associate `modifyAfter` with revision

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/markQueue.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/markQueue.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from "@fluidframework/core-utils";
-import { RevisionTag } from "../../core";
+import { RevisionTag, TaggedChange } from "../../core";
 import { IdAllocator } from "../../util";
 import { Mark } from "./types";
 import { applyMoveEffectsToMark, MoveEffectTable } from "./moveEffectTable";
@@ -20,11 +20,7 @@ export class MarkQueue<T> {
 		private readonly moveEffects: MoveEffectTable<T>,
 		private readonly consumeEffects: boolean,
 		private readonly genId: IdAllocator,
-		private readonly composeChanges?: (
-			a: T | undefined,
-			b: T | undefined,
-			bRevision: RevisionTag | undefined,
-		) => T | undefined,
+		private readonly composeChanges?: (a: T | undefined, b: TaggedChange<T>) => T | undefined,
 	) {
 		this.list = list;
 	}

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/markQueue.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/markQueue.ts
@@ -20,7 +20,11 @@ export class MarkQueue<T> {
 		private readonly moveEffects: MoveEffectTable<T>,
 		private readonly consumeEffects: boolean,
 		private readonly genId: IdAllocator,
-		private readonly composeChanges?: (a: T | undefined, b: T | undefined) => T | undefined,
+		private readonly composeChanges?: (
+			a: T | undefined,
+			b: T | undefined,
+			bRevision: RevisionTag | undefined,
+		) => T | undefined,
 	) {
 		this.list = list;
 	}

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -14,6 +14,7 @@ import {
 	ChangesetLocalId,
 	ChangeAtomId,
 	RevisionInfo,
+	TaggedChange,
 } from "../../../core";
 import { SequenceField as SF } from "../../../feature-libraries";
 import { brand } from "../../../util";
@@ -1115,5 +1116,20 @@ describe("SequenceField - Compose", () => {
 
 		assert.deepEqual(composedAC, expected);
 		assert.deepEqual(composedCA, expected);
+	});
+
+	it("effect management for [move, modify, move]", () => {
+		const changes = TestChange.mint([], 42);
+		const [mo, mi] = Mark.move(1, brand(0));
+		const move = tagChange([mo, mi], tag1);
+		const modify = tagChange([Mark.modify(changes)], tag2);
+		const moveBack = tagChange([mi, mo], tag3);
+		const childComposer = (childChanges: TaggedChange<TestChange>[]): TestChange => {
+			assert.equal(childChanges.length, 1);
+			assert.deepEqual(childChanges[0].change, changes);
+			assert.equal(childChanges[0].revision, tag2);
+			return TestChange.compose(childChanges);
+		};
+		compose([move, modify, moveBack], undefined, childComposer);
 	});
 });


### PR DESCRIPTION
Fixes a bug where the composition logic assumed that `modifyAfter` effects, when present, are always attributed to the new changeset being composed. The logic now keeps track of the revision associated with the effect.