### PR TITLE
ci(local-server): Increase test timeout

### DIFF
--- a/server/routerlicious/packages/local-server/src/test/webpack.spec.ts
+++ b/server/routerlicious/packages/local-server/src/test/webpack.spec.ts
@@ -58,5 +58,5 @@ describe("Local server", () => {
 				}
 			});
 		});
-	}).timeout(20000);
+	}).timeout(30000);
 });


### PR DESCRIPTION
## Description

This test has timed out a few times in the past, because it can normally take 15s+ to run and depending on the workload on the build agent, it can go past the 20s timeout.

Increasing timeout to prevent this going forward. (It's also blocking testing of the migration to 1ES pipeline templates).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#6333](https://dev.azure.com/fluidframework/internal/_workitems/edit/6333)