### PR TITLE
build(docs): Remove bottom attribute to fix 5793

### DIFF
--- a/docs/themes/thxvscode/assets/scss/includes/_footer.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_footer.scss
@@ -113,7 +113,6 @@ footer {
 	}
 	.ctas {
 		min-height: $ctaHeight;
-		bottom: $footerheight;
 	}
 }
 

--- a/docs/themes/thxvscode/assets/scss/includes/_footer.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_footer.scss
@@ -134,7 +134,6 @@ footer {
 	.ctas {
 		min-height: $ctaHeight;
 		// min-height: $ctaHeight;
-		bottom: $footerheight;
 	}
 }
 


### PR DESCRIPTION
In resize, text under the community should not be overlapped with the 'contribute' card. The text and the card should be visible separately. 

Before;
![image](https://github.com/microsoft/FluidFramework/assets/107130183/d7a8bcb1-f7a0-409f-bec2-c3ac8b1f09df)

After;
![image](https://github.com/microsoft/FluidFramework/assets/107130183/2f0298e7-2701-4cf6-8892-85d930c4fe1a)

AB#5793