### PR TITLE
test(tree2): more mark-based test cases

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
@@ -41,6 +41,7 @@ const Insert = Type.Composite([HasMoveId, HasRevisionTag], noAdditionalProps);
 
 const HasMoveFields = Type.Composite([
 	HasMoveId,
+	HasRevisionTag,
 	Type.Object({ finalEndpoint: Type.Optional(EncodedChangeAtomId) }),
 ]);
 
@@ -62,6 +63,8 @@ const Delete = Type.Composite(
 );
 
 const MoveOut = Type.Composite([HasMoveFields, InverseAttachFields], noAdditionalProps);
+
+const MovePlaceholder = Type.Composite([HasMoveId, HasRevisionTag], noAdditionalProps);
 
 const Attach = Type.Object(
 	{
@@ -91,6 +94,7 @@ const MarkEffect = Type.Object(
 		moveIn: Type.Optional(MoveIn),
 		delete: Type.Optional(Delete),
 		moveOut: Type.Optional(MoveOut),
+		placeholder: Type.Optional(MovePlaceholder),
 		attachAndDetach: Type.Optional(AttachAndDetach),
 	},
 	unionOptions,
@@ -132,6 +136,7 @@ export namespace Encoded {
 	export type MoveIn = Static<typeof MoveIn>;
 	export type Delete = Static<typeof Delete>;
 	export type MoveOut = Static<typeof MoveOut>;
+	export type MovePlaceholder = Static<typeof MovePlaceholder>;
 	export type Attach = Static<typeof Attach>;
 	export type Detach = Static<typeof Detach>;
 	export type AttachAndDetach = Static<typeof AttachAndDetach>;

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
@@ -42,6 +42,7 @@ import {
 	MarkEffect,
 	InverseAttachFields,
 	IdRange,
+	MovePlaceholder,
 } from "./types";
 import { MarkListFactory } from "./markListFactory";
 import { isMoveMark, MoveEffectTable } from "./moveEffectTable";
@@ -533,8 +534,8 @@ function areMergeableCellIds(
  * Attempts to extend `lhs` to include the effects of `rhs`.
  * @param lhs - The mark to extend.
  * @param rhs - The effect so extend `rhs` with.
- * @returns `true` iff the function was able to mutate `lhs` to include the effects of `rhs`.
- * When `false` is returned, `lhs` is left untouched.
+ * @returns `lhs` iff the function was able to mutate `lhs` to include the effects of `rhs`.
+ * When `undefined` is returned, `lhs` is left untouched.
  */
 export function tryMergeMarks<T>(lhs: Mark<T>, rhs: Readonly<Mark<T>>): Mark<T> | undefined {
 	if (rhs.type !== lhs.type) {
@@ -637,8 +638,13 @@ function tryMergeEffects(
 			}
 			break;
 		}
-		case "Placeholder":
+		case "Placeholder": {
+			const lhsPlaceholder = lhs as MovePlaceholder;
+			if ((lhsPlaceholder.id as number) + lhsCount === rhs.id) {
+				return lhsPlaceholder;
+			}
 			break;
+		}
 		default:
 			unreachableCase(type);
 	}
@@ -1090,8 +1096,13 @@ function splitMarkEffect<TEffect extends MarkEffect>(
 
 			return [effect1, effect2];
 		}
-		case "Placeholder":
-			fail("TODO");
+		case "Placeholder": {
+			const effect2: MovePlaceholder = {
+				...effect,
+				id: brand((effect.id as number) + length),
+			};
+			return [effect, effect2 as TEffect];
+		}
 		default:
 			unreachableCase(type);
 	}

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/populatedMarks.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/populatedMarks.ts
@@ -1,0 +1,91 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { SequenceField as SF } from "../../../feature-libraries";
+// eslint-disable-next-line import/no-internal-modules
+import { brand, Populated } from "../../../util";
+import { ChangeAtomId, mintRevisionTag, RevisionTag } from "../../../core";
+import { TestChange } from "../../testChange";
+// eslint-disable-next-line import/no-internal-modules
+import { CellMark } from "../../../feature-libraries/sequence-field";
+// eslint-disable-next-line import/no-internal-modules
+import { Attach, Detach, MarkEffect } from "../../../feature-libraries/sequence-field/types";
+
+const tag: RevisionTag = mintRevisionTag();
+
+export type PopulatedMark<TNodeChange = TestChange> = Populated<
+	CellMark<Populated<MarkEffect>, TNodeChange>
+>;
+
+const lineageEvent: Populated<SF.LineageEvent> = {
+	count: 2,
+	id: brand(0),
+	offset: 1,
+	revision: tag,
+};
+const adjacentCell: Populated<SF.IdRange> = { count: 2, id: brand(0) };
+const atomId: Populated<ChangeAtomId> = { localId: brand(0), revision: tag };
+const cellId: Populated<SF.CellId> = {
+	localId: brand(0),
+	revision: tag,
+	lineage: [lineageEvent],
+	adjacentCells: [adjacentCell],
+};
+const changes = TestChange.mint([], 1);
+const attach: Populated<Attach> = {
+	type: "MoveIn",
+	id: brand(0),
+	revision: tag,
+	finalEndpoint: atomId,
+};
+const detach: Populated<Detach> = {
+	type: "MoveOut",
+	id: brand(0),
+	revision: tag,
+	finalEndpoint: atomId,
+	detachIdOverride: atomId,
+};
+
+export const populatedMarks: PopulatedMark[] = [
+	{ count: 1, cellId, changes },
+	{ type: "Placeholder", count: 1, cellId, changes, id: brand(0), revision: tag },
+	{ type: "Insert", count: 1, cellId, changes, id: brand(0), revision: tag },
+	{
+		type: "MoveIn",
+		count: 1,
+		cellId,
+		changes,
+		id: brand(0),
+		revision: tag,
+		finalEndpoint: atomId,
+	},
+	{
+		type: "MoveOut",
+		count: 1,
+		cellId,
+		changes,
+		id: brand(0),
+		revision: tag,
+		finalEndpoint: atomId,
+		detachIdOverride: atomId,
+	},
+	{
+		type: "Delete",
+		count: 1,
+		cellId,
+		changes,
+		id: brand(0),
+		revision: tag,
+		detachIdOverride: atomId,
+	},
+	{
+		type: "AttachAndDetach",
+		count: 1,
+		cellId,
+		changes,
+		attach,
+		detach,
+	},
+];

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.spec.ts
@@ -11,6 +11,7 @@ import { RevisionTagCodec } from "../../../shared-tree-core";
 import { brand } from "../../../util";
 import { TestChange } from "../../testChange";
 import { EncodingTestData, makeEncodingTestSuite } from "../../utils";
+import { populatedMarks } from "./populatedMarks";
 import { ChangeMaker as Change, cases } from "./testEdits";
 
 const encodingTestData: EncodingTestData<Changeset<TestChange>, unknown> = {
@@ -21,10 +22,11 @@ const encodingTestData: EncodingTestData<Changeset<TestChange>, unknown> = {
 			"with repair data",
 			Change.revive(0, 1, { revision: mintRevisionTag(), localId: brand(10) }),
 		],
-		// TODO: Include revive case here or in other encode/decode tests in this file.
-		// It's likely we need a different notion of equality, as revive involves a ProtoNode type
-		// and deep equality of that test case fails on comparing two `StackCursor`s.
-		...Object.entries(cases).filter(([key]) => key !== "revive"),
+		...Object.entries(cases),
+		...populatedMarks.map((mark): [string, Changeset<TestChange>] => [
+			"type" in mark ? mark.type : "NoOp",
+			[mark],
+		]),
 	],
 };
 

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/utils.spec.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { SequenceField as SF } from "../../../feature-libraries";
+// eslint-disable-next-line import/no-internal-modules
+import { splitMark, tryMergeMarks } from "../../../feature-libraries/sequence-field/utils";
+import { deepFreeze } from "../../utils";
+import { TestChange } from "../../testChange";
+import { populatedMarks } from "./populatedMarks";
+
+describe("SequenceField - Utils", () => {
+	describe("round-trip splitMark and tryMergeMarks", () => {
+		populatedMarks.forEach((mark, index) => {
+			it(`${index}: ${"type" in mark ? mark.type : "NoOp"}`, () => {
+				const splitable: SF.Mark<TestChange> = { ...mark, count: 3 };
+				delete splitable.changes;
+				deepFreeze(splitable);
+				const [part1, part2] = splitMark(splitable, 2);
+				const merged = tryMergeMarks(part1, part2);
+				assert.deepEqual(merged, splitable);
+			});
+		});
+	});
+});

--- a/experimental/dds/tree2/src/util/index.ts
+++ b/experimental/dds/tree2/src/util/index.ts
@@ -66,6 +66,7 @@ export {
 	makeArray,
 	mapIterable,
 	Mutable,
+	Populated,
 	RecursiveReadonly,
 	zipIterables,
 	Assume,

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -33,6 +33,13 @@ export type RecursiveReadonly<T> = {
 export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 
 /**
+ * Make all field required and omits fields whose ony valid value would be `undefined`.
+ */
+export type Populated<T> = {
+	[P in keyof T as Exclude<P, T[P] extends undefined ? P : never>]-?: T[P];
+};
+
+/**
  * Casts a readonly object to a mutable one.
  * Better than casting to `Mutable<Foo>` because it doesn't risk casting a non-`Foo` to a `Mutable<Foo>`.
  * @param readonly - The object with readonly fields.

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -34,6 +34,7 @@ export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 
 /**
  * Make all field required and omits fields whose ony valid value would be `undefined`.
+ * This is analogous to `Required<T>` except it tolerates 'optional undefined'.
  */
 export type Populated<T> = {
 	[P in keyof T as Exclude<P, T[P] extends undefined ? P : never>]-?: T[P];


### PR DESCRIPTION
Adds a set of test values (one for each mark type) with all fields populated.
Uses those test values for: 
- encoding and decoding tests
- mark splitting and merging tests

Fixes bugs found by the above.
Note that this PR adds encoding/decoding for Placeholder marks. Those are not supposed to exist outside the scope of `compose` operations, but they currently do leak out so, until that is addressed, encoding/decoding has been added for them.