### PR TITLE
GC: Ignore incoming changes to data store that has been deleted

### DIFF
--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -441,15 +441,18 @@ export class DataStores implements IDisposable {
 		localMessageMetadata: unknown,
 	) {
 		const envelope = message.contents as IEnvelope;
+		const transformed = { ...message, contents: envelope.contents };
+		const context = this.contexts.get(envelope.address);
 
 		// If the data store has been deleted, log an error and ignore this message. This helps prevent document
 		// corruption in case a deleted data store accidentally submitted an op.
-		if (this.checkAndLogIfDeleted(envelope.address, "Changed", "processFluidDataStoreOp")) {
+		if (
+			context === undefined &&
+			this.checkAndLogIfDeleted(envelope.address, "Changed", "processFluidDataStoreOp")
+		) {
 			return;
 		}
 
-		const transformed = { ...message, contents: envelope.contents };
-		const context = this.contexts.get(envelope.address);
 		assert(!!context, 0x162 /* "There should be a store context for the op" */);
 		context.process(transformed, local, localMessageMetadata);
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -390,12 +390,15 @@ export class DataStores implements IDisposable {
 
 	public resubmitDataStoreOp(envelope: IEnvelope, localOpMetadata: unknown) {
 		const context = this.contexts.get(envelope.address);
-		// If the data store has been deleted, log an error and ignore this message. This helps prevent document
-		// corruption in case the data store that submitted the op is deleted.
+		// If the data store has been deleted, log an error and throw an error. If there are local changes for a
+		// deleted data store, it can otherwise lead to inconsistent state when compared to other clients.
 		if (
 			this.checkAndLogIfDeleted(envelope.address, context, "Changed", "resubmitDataStoreOp")
 		) {
-			return;
+			throw new DataCorruptionError("Context is deleted!", {
+				callSite: "resubmitDataStoreOp",
+				...tagCodeArtifacts({ id: envelope.address }),
+			});
 		}
 		assert(!!context, 0x160 /* "There should be a store context for the op" */);
 		context.reSubmit(envelope.contents, localOpMetadata);
@@ -403,12 +406,15 @@ export class DataStores implements IDisposable {
 
 	public rollbackDataStoreOp(envelope: IEnvelope, localOpMetadata: unknown) {
 		const context = this.contexts.get(envelope.address);
-		// If the data store has been deleted, log an error and ignore this message. This helps prevent document
-		// corruption in case the data store that submitted the op is deleted.
+		// If the data store has been deleted, log an error and throw an error. If there are local changes for a
+		// deleted data store, it can otherwise lead to inconsistent state when compared to other clients.
 		if (
 			this.checkAndLogIfDeleted(envelope.address, context, "Changed", "rollbackDataStoreOp")
 		) {
-			return;
+			throw new DataCorruptionError("Context is deleted!", {
+				callSite: "rollbackDataStoreOp",
+				...tagCodeArtifacts({ id: envelope.address }),
+			});
 		}
 		assert(!!context, 0x2e8 /* "There should be a store context for the op" */);
 		context.rollback(envelope.contents, localOpMetadata);

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -61,13 +61,8 @@ import {
 } from "./dataStoreContext";
 import { StorageServiceWithAttachBlobs } from "./storageServiceWithAttachBlobs";
 import { IDataStoreAliasMessage, isDataStoreAliasMessage } from "./dataStore";
-import { GCNodeType, disableDatastoreSweepKey, sendGCUnexpectedUsageEvent } from "./gc";
-import {
-	summarizerClientType,
-	IContainerRuntimeMetadata,
-	nonDataStorePaths,
-	rootHasIsolatedChannels,
-} from "./summary";
+import { GCNodeType, disableDatastoreSweepKey } from "./gc";
+import { IContainerRuntimeMetadata, nonDataStorePaths, rootHasIsolatedChannels } from "./summary";
 
 type PendingAliasResolve = (success: boolean) => void;
 
@@ -282,6 +277,18 @@ export class DataStores implements IDisposable {
 
 		const context = this.contexts.get(aliasMessage.internalId);
 		if (context === undefined) {
+			// If the data store has been deleted, log an error and ignore this message. This helps prevent document
+			// corruption in case a deleted data store accidentally submitted a signal.
+			if (
+				this.checkAndLogIfDeleted(
+					aliasMessage.internalId,
+					"Changed",
+					"processAliasMessageCore",
+				)
+			) {
+				return false;
+			}
+
 			this.mc.logger.sendErrorEvent({
 				eventName: "AliasFluidDataStoreNotFound",
 				fluidDataStoreId: aliasMessage.internalId,
@@ -382,18 +389,42 @@ export class DataStores implements IDisposable {
 
 	public resubmitDataStoreOp(envelope: IEnvelope, localOpMetadata: unknown) {
 		const context = this.contexts.get(envelope.address);
+		// If the data store has been deleted, log an error and ignore this message. This helps prevent document
+		// corruption in case the data store that submitted the op is deleted.
+		if (
+			context === undefined &&
+			this.checkAndLogIfDeleted(envelope.address, "Changed", "resubmitDataStoreOp")
+		) {
+			return;
+		}
 		assert(!!context, 0x160 /* "There should be a store context for the op" */);
 		context.reSubmit(envelope.contents, localOpMetadata);
 	}
 
 	public rollbackDataStoreOp(envelope: IEnvelope, localOpMetadata: unknown) {
 		const context = this.contexts.get(envelope.address);
+		// If the data store has been deleted, log an error and ignore this message. This helps prevent document
+		// corruption in case the data store that submitted the op is deleted.
+		if (
+			context === undefined &&
+			this.checkAndLogIfDeleted(envelope.address, "Changed", "rollbackDataStoreOp")
+		) {
+			return;
+		}
 		assert(!!context, 0x2e8 /* "There should be a store context for the op" */);
 		context.rollback(envelope.contents, localOpMetadata);
 	}
 
 	public async applyStashedOp(envelope: IEnvelope): Promise<unknown> {
 		const context = this.contexts.get(envelope.address);
+		// If the data store has been deleted, log an error and ignore this message. This helps prevent document
+		// corruption in case the data store that stashed the op is deleted.
+		if (
+			context === undefined &&
+			this.checkAndLogIfDeleted(envelope.address, "Changed", "applyStashedOp")
+		) {
+			return undefined;
+		}
 		assert(!!context, 0x161 /* "There should be a store context for the op" */);
 		return context.applyStashedOp(envelope.contents);
 	}
@@ -410,8 +441,14 @@ export class DataStores implements IDisposable {
 		localMessageMetadata: unknown,
 	) {
 		const envelope = message.contents as IEnvelope;
+
+		// If the data store has been deleted, log an error and ignore this message. This helps prevent document
+		// corruption in case a deleted data store accidentally submitted an op.
+		if (this.checkAndLogIfDeleted(envelope.address, "Changed", "processFluidDataStoreOp")) {
+			return;
+		}
+
 		const transformed = { ...message, contents: envelope.contents };
-		this.validateNotDeleted(envelope.address);
 		const context = this.contexts.get(envelope.address);
 		assert(!!context, 0x162 /* "There should be a store context for the op" */);
 		context.process(transformed, local, localMessageMetadata);
@@ -430,7 +467,14 @@ export class DataStores implements IDisposable {
 		requestHeaderData: RuntimeHeaderData,
 	): Promise<FluidDataStoreContext> {
 		const headerData = { ...defaultRuntimeHeaderData, ...requestHeaderData };
-		this.validateNotDeleted(id, headerData);
+		if (this.checkAndLogIfDeleted(id, "Requested", "getDataStore", requestHeaderData)) {
+			// The requested data store has been deleted by gc. Create a 404 response exception.
+			const request: IRequest = { url: id };
+			throw responseToException(
+				createResponseError(404, "DataStore was deleted", request),
+				request,
+			);
+		}
 
 		const context = await this.contexts.getBoundOrRemoted(id, headerData.wait);
 		if (context === undefined) {
@@ -448,8 +492,10 @@ export class DataStores implements IDisposable {
 		id: string,
 		requestHeaderData: RuntimeHeaderData,
 	): Promise<FluidDataStoreContext | undefined> {
-		// If the data store has been deleted, return undefined.
-		if (this.checkIfDeleted(id, requestHeaderData)) {
+		// If the data store has been deleted, log an error and return undefined.
+		if (
+			this.checkAndLogIfDeleted(id, "Requested", "getDataStoreIfAvailable", requestHeaderData)
+		) {
 			return undefined;
 		}
 		const headerData = { ...defaultRuntimeHeaderData, ...requestHeaderData };
@@ -461,13 +507,18 @@ export class DataStores implements IDisposable {
 	}
 
 	/**
-	 * Checks if the data store has been deleted by GC.
-	 * @param id - data store id
-	 * @param request - the request information to log if the validation detects the data store has been deleted
-	 * @param requestHeaderData - the request header information to log if the validation detects the data store has been deleted
+	 * Checks if the data store has been deleted by GC. If so, log an error.
+	 * @param id - The data store's id.
+	 * @param callSite - The function name this is called from.
+	 * @param requestHeaderData - The request header information to log if the data store is deleted.
 	 * @returns true if the data store is deleted. Otherwise, returns false.
 	 */
-	private checkIfDeleted(id: string, requestHeaderData?: RuntimeHeaderData) {
+	private checkAndLogIfDeleted(
+		id: string,
+		deletedLogSuffix: string,
+		callSite: string,
+		requestHeaderData?: RuntimeHeaderData,
+	) {
 		const dataStoreNodePath = `/${id}`;
 		if (!this.isDataStoreDeleted(dataStoreNodePath)) {
 			return false;
@@ -476,41 +527,24 @@ export class DataStores implements IDisposable {
 			!this.contexts.has(id),
 			0x570 /* Inconsistent state! GC says the data store is deleted, but the data store is not deleted from the runtime. */,
 		);
-		sendGCUnexpectedUsageEvent(
-			this.mc,
-			{
-				eventName: "GC_Deleted_DataStore_Requested",
-				category: "error",
-				isSummarizerClient: this.runtime.clientDetails.type === summarizerClientType,
-				id,
-				headers: JSON.stringify(requestHeaderData),
-				gcTombstoneEnforcementAllowed: this.runtime.gcTombstoneEnforcementAllowed,
-			},
-			undefined /* packagePath */,
-		);
+		this.mc.logger.sendErrorEvent({
+			eventName: `GC_Deleted_DataStore_${deletedLogSuffix}`,
+			...tagCodeArtifacts({ id }),
+			callSite,
+			headers: JSON.stringify(requestHeaderData),
+		});
 		return true;
 	}
 
-	/**
-	 * Validate that the data store had not been deleted by GC.
-	 * @param id - data store id
-	 * @param requestHeaderData - the request header information to log if the validation detects the data store has been deleted
-	 */
-	private validateNotDeleted(id: string, requestHeaderData?: RuntimeHeaderData) {
-		if (this.checkIfDeleted(id, requestHeaderData)) {
-			// The requested data store is removed by gc. Create a 404 gc response exception.
-			const request: IRequest = { url: id };
-			throw responseToException(
-				createResponseError(404, "DataStore was deleted", request),
-				request,
-			);
-		}
-	}
-
 	public processSignal(fluidDataStoreId: string, message: IInboundSignalMessage, local: boolean) {
-		this.validateNotDeleted(fluidDataStoreId);
 		const context = this.contexts.get(fluidDataStoreId);
 		if (!context) {
+			// If the data store has been deleted, log an error and ignore this message. This helps prevent document
+			// corruption in case a deleted data store accidentally submitted a signal.
+			if (this.checkAndLogIfDeleted(fluidDataStoreId, "Changed", "processSignal")) {
+				return;
+			}
+
 			// Attach message may not have been processed yet
 			assert(!local, 0x163 /* "Missing datastore for local signal" */);
 			this.mc.logger.sendTelemetryEvent({

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -20,7 +20,6 @@ import {
 	waitForContainerConnection,
 	mockConfigProvider,
 	ITestContainerConfig,
-	timeoutPromise,
 } from "@fluidframework/test-utils";
 import {
 	describeCompat,
@@ -169,28 +168,6 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 		};
 	};
 
-	/**
-	 * Returns a promise that will resolve when all the passed in containers have closed dur
-	 * to "DataStore was deleted" error.
-	 */
-	const getContainersClosePromise = async (containers: IContainer[]) => {
-		const closePromises: Promise<void>[] = [];
-		for (const container of containers) {
-			const promise = timeoutPromise((resolve, reject) => {
-				const listener = (error: IErrorBase | undefined) => {
-					if (!error?.message.startsWith("DataStore was deleted:")) {
-						reject(error);
-					}
-					container.off("closed", listener);
-					resolve();
-				};
-				container.on("closed", listener);
-			});
-			closePromises.push(promise);
-		}
-		return Promise.all(closePromises);
-	};
-
 	describe("Using swept data stores not allowed", () => {
 		// If this test starts failing due to runtime is closed errors try first adjusting `sweepTimeoutMs` above
 		itExpects(
@@ -203,6 +180,7 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 				{
 					eventName: "fluid:telemetry:FluidDataStoreContext:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
+					callSite: "submitMessage",
 				},
 			],
 			async () => {
@@ -238,6 +216,7 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 				{
 					eventName: "fluid:telemetry:FluidDataStoreContext:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
+					callSite: "submitSignal",
 				},
 			],
 			async () => {
@@ -262,10 +241,9 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 		);
 	});
 
-	describe("Loading swept data stores not allowed", () => {
-		// TODO: Receive ops scenarios - loaded before and loaded after (are these just context loading errors?)
+	describe("Using deleted data stores", () => {
 		itExpects(
-			"Requesting swept datastores fails in client loaded after sweep timeout and summarizing container",
+			"Requesting swept datastores not allowed",
 			[
 				{
 					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
@@ -274,11 +252,13 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
 					clientType: "interactive",
+					callSite: "getDataStore",
 				},
-				// Summarizer client's request
+				// Summarizer client's request logs an error
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
 					clientType: "noninteractive/summarizer",
+					callSite: "getDataStore",
 				},
 			],
 			async () => {
@@ -336,35 +316,26 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 		);
 
 		itExpects(
-			"Receiving ops for swept datastores fails in client after sweep timeout and summarizing container",
+			"Ops for swept data stores is ignored but logs an error",
 			[
 				{
 					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
 					clientType: "noninteractive/summarizer",
 				},
 				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
+					callSite: "processFluidDataStoreOp",
 				},
 				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
 					clientType: "interactive",
+					callSite: "processFluidDataStoreOp",
 				},
 				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
 					clientType: "interactive",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					clientType: "noninteractive/summarizer",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					clientType: "interactive",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					clientType: "interactive",
+					callSite: "processFluidDataStoreOp",
 				},
 			],
 			async () => {
@@ -391,12 +362,6 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 				const { summaryVersion } = await summarize(summarizer);
 				const receivingContainer = await loadContainer(summaryVersion);
 
-				const closePromise = getContainersClosePromise([
-					sendingContainer,
-					summarizingContainer,
-					receivingContainer,
-				]);
-
 				// Send an op to the swept data store
 				dataObject._root.set("send", "op");
 
@@ -405,54 +370,44 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 
 				// Wait for the GC and the above op to be processed which will close all the containers.
 				await provider.ensureSynchronized();
-				await closePromise;
 
-				// The containers should close
+				// The containers should not close
 				assert(
-					sendingContainer.closed,
-					"Sending container with deleted datastore should close on receiving an op for it",
+					!sendingContainer.closed,
+					"Sending container should not close on receiving an op for deleted data store",
 				);
 				assert(
-					summarizingContainer.closed,
-					"Summarizing container with deleted datastore should close on receiving an op for it",
+					!summarizingContainer.closed,
+					"Summarizing container should not close on receiving an op for deleted data store",
 				);
 				assert(
-					receivingContainer.closed,
-					"Container with deleted datastore should close on receiving an op for it",
+					!receivingContainer.closed,
+					"Receiving container should close on receiving an op for deleted data store",
 				);
 			},
 		);
 
 		itExpects(
-			"Receiving signals for swept datastores fails in client after sweep timeout and summarizing container",
+			"Signals for swept datastores are ignored but logs an error",
 			[
 				{
 					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
 					clientType: "noninteractive/summarizer",
 				},
 				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
+					callSite: "processSignal",
 				},
 				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
 					clientType: "interactive",
+					callSite: "processSignal",
 				},
 				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					clientType: "noninteractive/summarizer",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
 					clientType: "interactive",
-				},
-				{
-					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
-					clientType: "interactive",
-				},
-				{
-					eventName: "fluid:telemetry:Container:ContainerClose",
-					clientType: "interactive",
+					callSite: "processSignal",
 				},
 			],
 			async () => {
@@ -483,12 +438,6 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 				const { summaryVersion } = await summarize(summarizer);
 				const receivingContainer = await loadContainer(summaryVersion);
 
-				const closePromise = getContainersClosePromise([
-					sendingContainer,
-					summarizingContainer,
-					receivingContainer,
-				]);
-
 				// Send a signal to the swept data store
 				dataObject._runtime.submitSignal("a", "signal");
 
@@ -499,21 +448,18 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 				// Once the GC op has been processed, resume the inbound signal queue so that the signal is processed.
 				sendingContainer.deltaManager.inboundSignal.resume();
 
-				// All the containers should have closed now.
-				await closePromise;
-
-				// The containers should close
+				// The containers should not close
 				assert(
-					sendingContainer.closed,
-					"Sending container with deleted datastore should close on receiving an op for it",
+					!sendingContainer.closed,
+					"Sending container should not close on receiving a signal for deleted data store",
 				);
 				assert(
-					summarizingContainer.closed,
-					"Summarizing container with deleted datastore should close on receiving a signal for it",
+					!summarizingContainer.closed,
+					"Summarizing container should not close on receiving a signal for deleted data store",
 				);
 				assert(
-					receivingContainer.closed,
-					"Container with deleted datastore should close on receiving a signal for it",
+					!receivingContainer.closed,
+					"Receiving container should not close on receiving a signal for deleted data store",
 				);
 			},
 		);


### PR DESCRIPTION
After a data store is deleted as a result of sweep, further modification to it must be prevented to cause any data loss. This has been added via a GC sweep op which will be received by all clients https://github.com/microsoft/FluidFramework/pull/18632.
However, due to an unexpected bug, a client could have a (to be) deleted data store loaded and before it receives the GC sweep op, this data store can send an op or signal. These ops must be ignored after the data store is deleted to not cause document corruption. This PR adds this logic. An error is still logged and it can be used to identify if such case ever happens.

[AB#6113](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6113)