### PR TITLE
fix(tree2): bug in transfer of nested changes

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -98,11 +98,14 @@ export function isMoveIn(effect: MarkEffect): effect is MoveIn {
 }
 
 export function getMoveIn(effect: MarkEffect): MoveIn | undefined {
-	return effect.type === "MoveIn"
-		? effect
-		: effect.type === "AttachAndDetach"
-		? getMoveIn(effect.attach)
-		: undefined;
+	switch (effect.type) {
+		case "MoveIn":
+			return effect;
+		case "AttachAndDetach":
+			return getMoveIn(effect.attach);
+		default:
+			return undefined;
+	}
 }
 
 function adjustMoveEffectBasis<T>(effect: MoveEffectWithBasis<T>, newBasis: MoveId): MoveEffect<T> {

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -97,6 +97,14 @@ export function isMoveIn(effect: MarkEffect): effect is MoveIn {
 	return effect.type === "MoveIn";
 }
 
+export function getMoveIn(effect: MarkEffect): MoveIn | undefined {
+	return effect.type === "MoveIn"
+		? effect
+		: effect.type === "AttachAndDetach"
+		? getMoveIn(effect.attach)
+		: undefined;
+}
+
 function adjustMoveEffectBasis<T>(effect: MoveEffectWithBasis<T>, newBasis: MoveId): MoveEffect<T> {
 	if (effect.basis === newBasis) {
 		return effect;

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -1118,6 +1118,23 @@ describe("SequenceField - Compose", () => {
 		assert.deepEqual(composedCA, expected);
 	});
 
+	it("move-in+delete ○ modify", () => {
+		const changes = TestChange.mint([], 42);
+		const [mo, mi] = Mark.move(1, { revision: tag1, localId: brand(1) });
+		const attachDetach = Mark.attachAndDetach(
+			mi,
+			Mark.delete(1, { revision: tag2, localId: brand(2) }),
+		);
+		const base = makeAnonChange([mo, attachDetach]);
+		const modify = tagChange(
+			[Mark.modify(changes, { revision: tag2, localId: brand(2) })],
+			tag3,
+		);
+		const actual = shallowCompose([base, modify]);
+		const expected = [{ ...mo, changes }, attachDetach];
+		assert.deepEqual(actual, expected);
+	});
+
 	it("effect management for [move, modify, move]", () => {
 		const changes = TestChange.mint([], 42);
 		const [mo, mi] = Mark.move(1, brand(0));

--- a/experimental/dds/tree2/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -106,7 +106,6 @@ describe("Fuzz - Top-Level", () => {
 			saveFailures: {
 				directory: failureDirectory,
 			},
-			skip: [42],
 		};
 		createDDSFuzzSuite(model, options);
 	});


### PR DESCRIPTION
Fixes a bug where sequence composition was failing to transfer nested changes to the move source of the base change.