### PR TITLE
tree: Clarify and improve schema mutability contract

### DIFF
--- a/experimental/dds/tree2/src/core/index.ts
+++ b/experimental/dds/tree2/src/core/index.ts
@@ -134,7 +134,6 @@ export {
 	SchemaEvents,
 	forbiddenFieldKindIdentifier,
 	storedEmptyFieldSchema,
-	cloneSchemaData,
 	StoredSchemaCollection,
 } from "./schema-stored";
 

--- a/experimental/dds/tree2/src/core/schema-stored/index.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/index.ts
@@ -25,5 +25,4 @@ export {
 	InMemoryStoredSchemaRepository,
 	schemaDataIsEmpty,
 	SchemaEvents,
-	cloneSchemaData,
 } from "./storedSchemaRepository";

--- a/experimental/dds/tree2/src/core/schema-stored/schema.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/schema.ts
@@ -203,7 +203,7 @@ export interface TreeStoredSchema extends StoredSchemaCollection {
  *
  * @remarks
  * Note: the owner of this may modify it over time:
- * thus if needing to hand onto a specific version, make a copy.
+ * thus if needing to hang onto a specific version, make a copy.
  * @alpha
  */
 export interface StoredSchemaCollection {

--- a/experimental/dds/tree2/src/core/schema-stored/storedSchemaRepository.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/storedSchemaRepository.ts
@@ -61,7 +61,7 @@ export class InMemoryStoredSchemaRepository implements StoredSchemaRepository {
 	 * Otherwise, it will be deep-cloned.
 	 *
 	 * We might not want to store schema in maps long term, as we might want a way to reserve a
-	 * large namespace of schema with the same schema.
+	 * large space of schema IDs within a schema.
 	 * The way mapFields has been structured mitigates the need for this, but it still might be useful.
 	 *
 	 * (ex: someone using data as field identifiers might want to

--- a/experimental/dds/tree2/src/core/schema-stored/storedSchemaRepository.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/storedSchemaRepository.ts
@@ -93,7 +93,7 @@ export class InMemoryStoredSchemaRepository implements StoredSchemaRepository {
 	}
 
 	public get rootFieldSchema(): TreeFieldStoredSchema {
-		return this.rootFieldSchema;
+		return this.rootFieldSchemaData;
 	}
 
 	public update(newSchema: TreeStoredSchema): void {

--- a/experimental/dds/tree2/src/core/schema-stored/storedSchemaRepository.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/storedSchemaRepository.ts
@@ -3,8 +3,11 @@
  * Licensed under the MIT License.
  */
 
+import BTree from "sorted-btree";
 import { createEmitter, ISubscribable } from "../../events";
+import { compareStrings } from "../../util";
 import {
+	StoredSchemaCollection,
 	TreeFieldStoredSchema,
 	TreeNodeSchemaIdentifier,
 	TreeNodeStoredSchema,
@@ -49,14 +52,16 @@ export interface StoredSchemaRepository extends ISubscribable<SchemaEvents>, Tre
  * not hooked up to Fluid (does not create Fluid ops when editing).
  */
 export class InMemoryStoredSchemaRepository implements StoredSchemaRepository {
-	protected readonly data: MutableSchemaData;
+	protected nodeSchemaData: BTree<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>;
+	protected rootFieldSchemaData: TreeFieldStoredSchema;
 	protected readonly events = createEmitter<SchemaEvents>();
 
 	/**
-	 * For now, the schema are just scored in maps.
-	 * There are a couple reasons we might not want this simple solution long term:
-	 * 1. We might want an easy/fast copy.
-	 * 2. We might want a way to reserve a large namespace of schema with the same schema.
+	 * Copies in the provided schema. If `data` is an InMemoryStoredSchemaRepository, it will be cheap-cloned.
+	 * Otherwise, it will be deep-cloned.
+	 *
+	 * We might not want to store schema in maps long term, as we might want a way to reserve a
+	 * large namespace of schema with the same schema.
 	 * The way mapFields has been structured mitigates the need for this, but it still might be useful.
 	 *
 	 * (ex: someone using data as field identifiers might want to
@@ -65,51 +70,77 @@ export class InMemoryStoredSchemaRepository implements StoredSchemaRepository {
 	 * that might provide a decent alternative to mapFields (which is a bit odd).
 	 */
 	public constructor(data?: TreeStoredSchema) {
-		this.data = cloneSchemaData(data ?? defaultSchemaData);
+		this.rootFieldSchemaData = storedEmptyFieldSchema;
+		this.nodeSchemaData = new BTree<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>(
+			[],
+			compareStrings,
+		);
+		if (data !== undefined) {
+			this.cloneData(data);
+		}
 	}
 
 	public on<K extends keyof SchemaEvents>(eventName: K, listener: SchemaEvents[K]): () => void {
 		return this.events.on(eventName, listener);
 	}
 
-	public get rootFieldSchema(): TreeFieldStoredSchema {
-		return this.data.rootFieldSchema;
+	public get nodeSchema(): ReadonlyMap<TreeNodeSchemaIdentifier, TreeNodeStoredSchema> {
+		// Btree implements iterator, but not in a type-safe way
+		return this.nodeSchemaData as unknown as ReadonlyMap<
+			TreeNodeSchemaIdentifier,
+			TreeNodeStoredSchema
+		>;
 	}
 
-	public get nodeSchema(): ReadonlyMap<TreeNodeSchemaIdentifier, TreeNodeStoredSchema> {
-		return this.data.nodeSchema;
+	public get rootFieldSchema(): TreeFieldStoredSchema {
+		return this.rootFieldSchema;
 	}
 
 	public update(newSchema: TreeStoredSchema): void {
 		this.events.emit("beforeSchemaChange", newSchema);
-
-		this.data.rootFieldSchema = newSchema.rootFieldSchema;
-
-		this.data.nodeSchema.clear();
-		for (const [name, schema] of newSchema.nodeSchema) {
-			this.data.nodeSchema.set(name, schema);
-		}
+		// In the future, we could use btree's delta functionality to do a more efficient update
+		this.cloneData(newSchema);
 		this.events.emit("afterSchemaChange", newSchema);
 	}
-}
 
-export interface MutableSchemaData extends TreeStoredSchema {
-	rootFieldSchema: TreeFieldStoredSchema;
-	nodeSchema: Map<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>;
+	private cloneData(data: TreeStoredSchema): void {
+		if (data instanceof InMemoryStoredSchemaRepository) {
+			this.rootFieldSchemaData = data.rootFieldSchema;
+			this.nodeSchemaData = data.nodeSchemaData.clone();
+		} else {
+			this.rootFieldSchemaData = cloneFieldSchemaData(data.rootFieldSchema);
+			this.nodeSchemaData = cloneNodeSchemaData(data.nodeSchema);
+		}
+	}
 }
 
 export function schemaDataIsEmpty(data: TreeStoredSchema): boolean {
 	return data.nodeSchema.size === 0;
 }
 
-export const defaultSchemaData: TreeStoredSchema = {
-	nodeSchema: new Map(),
-	rootFieldSchema: storedEmptyFieldSchema,
-};
+function cloneNodeSchemaData(
+	nodeSchema: StoredSchemaCollection["nodeSchema"],
+): BTree<TreeNodeSchemaIdentifier, TreeNodeStoredSchema> {
+	const entries: [TreeNodeSchemaIdentifier, TreeNodeStoredSchema][] = [];
+	for (const [name, schema] of nodeSchema.entries()) {
+		entries.push([
+			name,
+			{
+				mapFields:
+					schema.mapFields === undefined
+						? undefined
+						: cloneFieldSchemaData(schema.mapFields),
+				objectNodeFields: new Map(schema.objectNodeFields),
+				leafValue: schema.leafValue,
+			},
+		]);
+	}
+	return new BTree<TreeNodeSchemaIdentifier, TreeNodeStoredSchema>(entries, compareStrings);
+}
 
-export function cloneSchemaData(data: TreeStoredSchema): MutableSchemaData {
+function cloneFieldSchemaData(fieldSchema: TreeFieldStoredSchema): TreeFieldStoredSchema {
 	return {
-		nodeSchema: new Map(data?.nodeSchema ?? []),
-		rootFieldSchema: data?.rootFieldSchema ?? storedEmptyFieldSchema,
+		kind: fieldSchema.kind,
+		types: fieldSchema.types === undefined ? undefined : new Set(fieldSchema.types),
 	};
 }

--- a/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -40,9 +40,9 @@ class TestSchemaRepository extends InMemoryStoredSchemaRepository {
 	 * @returns true iff update was performed.
 	 */
 	public tryUpdateRootFieldSchema(schema: TreeFieldStoredSchema): boolean {
-		if (allowsFieldSuperset(this.policy, this.data, this.rootFieldSchema, schema)) {
-			this.data.rootFieldSchema = schema;
-			this.events.emit("afterSchemaChange", this.data);
+		if (allowsFieldSuperset(this.policy, this, this.rootFieldSchema, schema)) {
+			this.rootFieldSchemaData = schema;
+			this.events.emit("afterSchemaChange", this);
 			return true;
 		}
 		return false;
@@ -56,9 +56,9 @@ class TestSchemaRepository extends InMemoryStoredSchemaRepository {
 		schema: TreeNodeStoredSchema,
 	): boolean {
 		const original = this.nodeSchema.get(identifier);
-		if (allowsTreeSuperset(this.policy, this.data, original, schema)) {
-			this.data.nodeSchema.set(identifier, schema);
-			this.events.emit("afterSchemaChange", this.data);
+		if (allowsTreeSuperset(this.policy, this, original, schema)) {
+			this.nodeSchemaData.set(identifier, schema);
+			this.events.emit("afterSchemaChange", this);
 			return true;
 		}
 		return false;

--- a/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/schematizeTree.spec.ts
@@ -13,12 +13,7 @@ import {
 	NewFieldContent,
 } from "../../feature-libraries";
 import { CheckoutEvents } from "../../shared-tree";
-import {
-	AllowedUpdateType,
-	InMemoryStoredSchemaRepository,
-	TreeStoredSchema,
-	cloneSchemaData,
-} from "../../core";
+import { AllowedUpdateType, InMemoryStoredSchemaRepository, TreeStoredSchema } from "../../core";
 import { jsonSequenceRootSchema } from "../utils";
 // eslint-disable-next-line import/no-internal-modules
 import { TreeContent, initializeContent, schematize } from "../../shared-tree/schematizedTree";
@@ -77,11 +72,13 @@ describe("schematizeTree", () => {
 					// this test should be updated to use it to greatly increase its validation.
 
 					const storedSchema = new InMemoryStoredSchemaRepository();
-					let previousSchema: TreeStoredSchema = cloneSchemaData(storedSchema);
+					let previousSchema: TreeStoredSchema = new InMemoryStoredSchemaRepository(
+						storedSchema,
+					);
 					expectSchema(storedSchema, previousSchema);
 
 					storedSchema.on("afterSchemaChange", () => {
-						previousSchema = cloneSchemaData(storedSchema);
+						previousSchema = new InMemoryStoredSchemaRepository(storedSchema);
 					});
 
 					let currentData: NewFieldContent;

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -112,7 +112,7 @@ describe("SharedTree", () => {
 
 		it("initialize tree", () => {
 			const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree");
-			assert.equal(tree.contentSnapshot().schema.rootFieldSchema, storedEmptyFieldSchema);
+			assert.deepEqual(tree.contentSnapshot().schema.rootFieldSchema, storedEmptyFieldSchema);
 
 			const view = tree.schematizeInternal({
 				allowedSchemaModifications: AllowedUpdateType.None,

--- a/experimental/dds/tree2/src/util/index.ts
+++ b/experimental/dds/tree2/src/util/index.ts
@@ -84,6 +84,7 @@ export {
 	capitalize,
 	assertValidRangeIndices,
 	transformObjectMap,
+	compareStrings,
 } from "./utils";
 export { ReferenceCountedBase, ReferenceCounted } from "./referenceCounting";
 

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -504,3 +504,10 @@ export function capitalize<S extends string>(s: S): Capitalize<S> {
 
 	return (iterated.value.toUpperCase() + s.slice(iterated.value.length)) as Capitalize<S>;
 }
+
+/**
+ * Compares strings lexically to form a strict partial ordering.
+ */
+export function compareStrings<T extends string>(a: T, b: T): number {
+	return a > b ? 1 : a === b ? 0 : -1;
+}


### PR DESCRIPTION
## Description

This PR updates the in-memory schema repository's mutability contract. It ensures that data is consistently and cleanly copied. Additionally, it introduces efficient cloning in some cases. This improvement will enhance branching efficiency, especially in scenarios where frequent forking of the schema repository occurs. It also aims to reduce bugs related to misunderstandings about the mutability of in-memory schema repository objects.