### PR TITLE
Mark Server Protocol Handler Alpha

### DIFF
--- a/server/routerlicious/packages/protocol-base/api-report/protocol-base.api.md
+++ b/server/routerlicious/packages/protocol-base/api-report/protocol-base.api.md
@@ -27,7 +27,7 @@ export function getGitMode(value: SummaryObject): string;
 // @internal
 export function getGitType(value: SummaryObject): "blob" | "tree";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IProtocolHandler {
     // (undocumented)
     readonly attributes: IDocumentAttributes;
@@ -55,7 +55,7 @@ export interface IQuorumSnapshot {
     values: QuorumProposalsSnapshot["values"];
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IScribeProtocolState {
     // (undocumented)
     members: [string, ISequencedClient][];

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -19,7 +19,7 @@ import {
 import { IQuorumSnapshot, Quorum } from "./quorum";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IScribeProtocolState {
 	sequenceNumber: number;
@@ -30,7 +30,7 @@ export interface IScribeProtocolState {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IProtocolHandler {
 	readonly quorum: IQuorum;


### PR DESCRIPTION
This is used on the alpha surface of client, so also need to be marked alpha:
https://github.com/microsoft/FluidFramework/blob/b3e6b6bbd57222548a5d914da1220cb2c1a89be0/packages/loader/container-loader/src/protocol.ts#L9