### PR TITLE
fix(tree2): apply move effects to MovePlaceholder marks

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/compose.ts
@@ -451,27 +451,15 @@ function amendComposeI<TNodeChange>(
 	moveEffects: MoveEffectTable<TNodeChange>,
 ): MarkList<TNodeChange> {
 	const factory = new MarkListFactory<TNodeChange>();
-	const queue = new MarkQueue(
-		marks,
-		undefined,
-		moveEffects,
-		true,
-		fakeIdAllocator,
-		// TODO: Should pass in revision for new changes
-		(a, b) => composeChildChanges(a, b, composeChild),
+	const queue = new MarkQueue(marks, undefined, moveEffects, true, fakeIdAllocator, (a, b) =>
+		composeChildChanges(a, b, composeChild),
 	);
 
 	while (!queue.isEmpty()) {
 		let mark = queue.dequeue();
 		switch (mark.type) {
 			case "Placeholder": {
-				const modifyAfter = getModifyAfter(moveEffects, mark.revision, mark.id, mark.count);
-				if (modifyAfter !== undefined) {
-					const changes = composeChildChanges(mark.changes, modifyAfter, composeChild);
-					mark = createNoopMark(mark.count, changes);
-				} else {
-					mark = createNoopMark(mark.count, mark.changes);
-				}
+				mark = createNoopMark(mark.count, mark.changes);
 			}
 			default:
 				break;

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -7,7 +7,7 @@ import { assert, unreachableCase } from "@fluidframework/core-utils";
 import { ChangeAtomId, RevisionTag, TaggedChange } from "../../core";
 import { CrossFieldManager, CrossFieldTarget } from "../modular-schema";
 import { RangeQueryResult, brand } from "../../util";
-import { CellMark, Mark, MarkEffect, MoveId, MoveIn, MoveOut } from "./types";
+import { CellMark, Mark, MarkEffect, MoveId, MoveIn, MoveOut, MovePlaceholder } from "./types";
 import { areEqualCellIds, cloneMark, isAttachAndDetachEffect, splitMark } from "./utils";
 import { MoveMarkEffect } from "./helperTypes";
 
@@ -150,7 +150,7 @@ function applyMoveEffectsToDest(
 }
 
 function applyMoveEffectsToSource<T>(
-	mark: CellMark<MoveOut, T>,
+	mark: CellMark<MoveOut | MovePlaceholder, T>,
 	revision: RevisionTag | undefined,
 	effects: MoveEffectTable<T>,
 	consumeEffect: boolean,
@@ -173,7 +173,9 @@ function applyMoveEffectsToSource<T>(
 	}
 
 	const newMark = cloneMark(mark);
-	applySourceEffects(newMark, mark.count, revision, effects, consumeEffect);
+	if (isMoveOut(newMark)) {
+		applySourceEffects(newMark, mark.count, revision, effects, consumeEffect);
+	}
 
 	if (nodeChange !== undefined) {
 		newMark.changes = nodeChange;
@@ -359,9 +361,10 @@ export function applyMoveEffectsToMark<T>(
 
 			return [newMark];
 		}
-	} else if (isMoveMark(mark)) {
+	} else if (isMoveMark(mark) || mark.type === "Placeholder") {
 		const type = mark.type;
 		switch (type) {
+			case "Placeholder":
 			case "MoveOut": {
 				const effect = getMoveEffect(
 					effects,

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markQueue.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markQueue.spec.ts
@@ -1,0 +1,77 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+// eslint-disable-next-line import/no-internal-modules
+import { MarkQueue } from "../../../feature-libraries/sequence-field/markQueue";
+// eslint-disable-next-line import/no-internal-modules
+import { MoveEffect, MoveEffectTable } from "../../../feature-libraries/sequence-field";
+import {
+	CellMark,
+	MarkList,
+	MoveId,
+	MovePlaceholder,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../../feature-libraries/sequence-field/types";
+import { CrossFieldTarget, SequenceField as SF } from "../../../feature-libraries";
+import { brand, idAllocatorFromMaxId } from "../../../util";
+import { TestChange } from "../../testChange";
+import { TaggedChange, mintRevisionTag, tagChange } from "../../../core";
+
+const tag1 = mintRevisionTag();
+const tag2 = mintRevisionTag();
+
+describe("SequenceField - MarkQueue", () => {
+	it("applies effects to Placeholder marks", () => {
+		const idAllocator = idAllocatorFromMaxId();
+		const changes = TestChange.mint([], 1);
+		const moveEffects = SF.newCrossFieldTable() as MoveEffectTable<TestChange>;
+		const effect: MoveEffect<TestChange> & { basis: MoveId } = {
+			modifyAfter: tagChange(changes, tag2),
+			basis: brand(0),
+		};
+		moveEffects.set(CrossFieldTarget.Source, tag1, brand(1), 1, effect, false);
+		const placeholder: CellMark<MovePlaceholder, TestChange> = {
+			type: "Placeholder",
+			revision: tag1,
+			id: brand(0),
+			count: 2,
+		};
+		const queue = new MarkQueue<TestChange>(
+			[placeholder],
+			undefined,
+			moveEffects,
+			true,
+			idAllocator,
+			(a: TestChange | undefined, b: TaggedChange<TestChange>) => {
+				assert.equal(a, undefined);
+				assert.equal(b.revision, tag2);
+				assert.equal(b.change, changes);
+				return changes;
+			},
+		);
+		const actual = [];
+		while (!queue.isEmpty()) {
+			actual.push(queue.dequeue());
+		}
+
+		const expected: MarkList<TestChange> = [
+			{
+				type: "Placeholder",
+				revision: tag1,
+				id: brand(0),
+				count: 1,
+			},
+			{
+				type: "Placeholder",
+				revision: tag1,
+				id: brand(1),
+				count: 1,
+				changes,
+			},
+		];
+		assert.deepEqual(actual, expected);
+	});
+});


### PR DESCRIPTION
Fixes a bug in sequence changeset composition where effects were not applied to MovePlaceholder marks by MarkQueue