### PR TITLE
(docs) remove outdated reference to SharedMap.wait()

### DIFF
--- a/experimental/dds/attributable-map/README.md
+++ b/experimental/dds/attributable-map/README.md
@@ -33,11 +33,6 @@ Unlike the JavaScript `Map`, a `SharedMap`'s keys must be strings. The value mus
 
 In collaborative scenarios, the value is settled with a policy of _last write wins_.
 
-#### `.wait()`
-
-`SharedMap` has a `wait` method in addition to the normal `get`, which returns a `Promise` that resolves to the value
-when the key becomes available.
-
 ### Eventing
 
 `SharedMap` is an `EventEmitter`, and will emit events when other clients make modifications. You should register for these events and respond appropriately as the data is modified. `valueChanged` will be emitted in response to a `set` or `delete`, and provide the key and previous value that was stored at that key. `clear` will be emitted in response to a `clear`.

--- a/packages/dds/map/README.md
+++ b/packages/dds/map/README.md
@@ -41,11 +41,6 @@ Unlike the JavaScript `Map`, a `SharedMap`'s keys must be strings. The value mus
 
 In collaborative scenarios, the value is settled with a policy of _last write wins_.
 
-#### `.wait()`
-
-`SharedMap` has a `wait` method in addition to the normal `get`, which returns a `Promise` that resolves to the value
-when the key becomes available.
-
 ### Eventing
 
 `SharedMap` is an `EventEmitter`, and will emit events when other clients make modifications. You should register for these events and respond appropriately as the data is modified. `valueChanged` will be emitted in response to a `set` or `delete`, and provide the key and previous value that was stored at that key. `clear` will be emitted in response to a `clear`.


### PR DESCRIPTION
## Description

`SharedMap.wait()` is no longer available on the current version of SharedMap or AttributableMap, but it's still referenced in the documentation, which is confusing for app developers. This PR removes the mentions of SharedMap.wait() from the SharedMap and AttributableMap docs.
