### PR TITLE
fix(ci): Update stage dependencies for accurate telemetry reporting

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -134,7 +134,7 @@ extends:
     publishDocs: true
     # We only care about pipeline run telemetry for the CI runs on the internal project, not for PR runs in the public
     # one. And since we don't batch commits for CI pipeline runs, the only reason we see for automated runs is IndividualCI.
-    telemetry: ${{ or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranchName'], 'refs/heads/test/alejandrovi/fix-telemetry-timing')) }}
+    telemetry: ${{ or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranchName'], 'test/alejandrovi/fix-telemetry-timing')) }}
     taskTest:
     - webpack
     - ci:test:mocha

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -134,7 +134,7 @@ extends:
     publishDocs: true
     # We only care about pipeline run telemetry for the CI runs on the internal project, not for PR runs in the public
     # one. And since we don't batch commits for CI pipeline runs, the only reason we see for automated runs is IndividualCI.
-    telemetry: ${{ or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/test/alejandrovi/fix-telemetry-timing')) }}
+    telemetry: ${{ eq(variables['Build.Reason'], 'IndividualCI') }}
     taskTest:
     - webpack
     - ci:test:mocha

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -134,7 +134,7 @@ extends:
     publishDocs: true
     # We only care about pipeline run telemetry for the CI runs on the internal project, not for PR runs in the public
     # one. And since we don't batch commits for CI pipeline runs, the only reason we see for automated runs is IndividualCI.
-    telemetry: ${{ or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranchName'], 'test/alejandrovi/fix-telemetry-timing')) }}
+    telemetry: ${{ or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/test/alejandrovi/fix-telemetry-timing')) }}
     taskTest:
     - webpack
     - ci:test:mocha

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -134,7 +134,7 @@ extends:
     publishDocs: true
     # We only care about pipeline run telemetry for the CI runs on the internal project, not for PR runs in the public
     # one. And since we don't batch commits for CI pipeline runs, the only reason we see for automated runs is IndividualCI.
-    telemetry: ${{ eq(variables['Build.Reason'], 'IndividualCI') }}
+    telemetry: ${{ or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranchName'], 'refs/heads/test/alejandrovi/fix-telemetry-timing')) }}
     taskTest:
     - webpack
     - ci:test:mocha

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -544,6 +544,20 @@ stages:
       condition: succeededOrFailed()
       dependsOn:
         - build
+        # NOTE: This is brittle; we need to only apply these stage dependencies when the corresponding stages actually
+        # get created in the pipeline, in the include-publish-npm-package.yml file, so we want to match the compile-time
+        # conditions that exist there. At some point it might be preferable to always create the stages, control their
+        # execution with 'condition:', and update this stage to always depend on all previous stages (while still
+        # running if some of the dependencies were skipped).
+        - ${{ if eq(variables.publish, true) }}:
+          - ${{ if eq(variables['testBuild'], true) }}:
+            - publish_npm_internal_test
+          - ${{ if eq(variables['testBuild'], false) }}:
+            - publish_npm_internal_build
+          - ${{ if and(eq(variables['testBuild'], false), eq(parameters.isReleaseGroup, true)) }}:
+            - publish_npm_internal_dev
+          - ${{ if or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')) }}:
+            - publish_npm_public
       jobs:
         - job: upload_run_telemetry
           displayName: Upload pipeline run telemetry to Kusto

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -546,9 +546,9 @@ stages:
         - build
         # NOTE: This is brittle; we need to only apply these stage dependencies when the corresponding stages actually
         # get created in the pipeline, in the include-publish-npm-package.yml file, so we want to match the compile-time
-        # conditions that exist there. At some point it might be preferable to always create the stages, control their
-        # execution with 'condition:', and update this stage to always depend on all previous stages (while still
-        # running if some of the dependencies were skipped).
+        # conditions *and exact stage names* that exist there. At some point it might be preferable to always create the
+        # stages, control their execution with 'condition:', and update this stage to always depend on all previous
+        # stages (while still running if some of the dependencies were skipped).
         - ${{ if eq(variables.publish, true) }}:
           - ${{ if eq(variables['testBuild'], true) }}:
             - publish_npm_internal_test


### PR DESCRIPTION
## Description

This PR updates the stage dependencies for the stage that uploads pipeline telemetry to Kusto, so it runs after the stages that publish npm packages (if they exist).

This addresses an issue where failures in the stages that publish npm packages do not create IcM incidents because the telemetry reported them as "in progress" when the telemetry-reporting stage ran, and didn't see them fail once they completed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[This run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=221710&view=results) (msft internal) for this test branch (plus a small update to the condition that enables the telemetry-reporting stage, so it would show up for a manually triggered run) shows things looking as expected.