### PR TITLE
build: Remove declarationDir setting from tsconfigs

### DIFF
--- a/examples/utils/example-utils/tsconfig.json
+++ b/examples/utils/example-utils/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@fluidframework/build-common/ts-common-config.json",
 	"compilerOptions": {
-		"declarationDir": "./dist",
 		"rootDir": "./src",
 		"outDir": "./dist",
 	},

--- a/experimental/PropertyDDS/packages/property-changeset/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-changeset/tsconfig.json
@@ -3,7 +3,6 @@
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"strict": false,
-		"declarationDir": "./dist",
 		"rootDir": "./src",
 		"outDir": "./dist",
 		"composite": true,

--- a/experimental/PropertyDDS/packages/property-inspector-table/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/tsconfig.json
@@ -4,7 +4,6 @@
 		"jsx": "react",
 		"resolveJsonModule": true,
 		"typeRoots": ["../node_modules/@types"],
-		"declarationDir": "./dist",
 		"outDir": "./dist",
 	},
 	"exclude": ["dist", "node_modules"],

--- a/experimental/framework/react-inputs/tsconfig.json
+++ b/experimental/framework/react-inputs/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@fluidframework/build-common/ts-common-config.json",
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
-		"declarationDir": "./dist",
 		"rootDir": "./src",
 		"outDir": "./dist",
 		"jsx": "react",

--- a/packages/framework/aqueduct/tsconfig.json
+++ b/packages/framework/aqueduct/tsconfig.json
@@ -6,7 +6,6 @@
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"declarationDir": "./dist",
 		"rootDir": "./src",
 		"outDir": "./dist",
 	},

--- a/packages/framework/data-object-base/tsconfig.json
+++ b/packages/framework/data-object-base/tsconfig.json
@@ -6,7 +6,6 @@
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"declarationDir": "./dist",
 		"rootDir": "./src",
 		"outDir": "./dist",
 	},

--- a/packages/framework/synthesize/tsconfig.json
+++ b/packages/framework/synthesize/tsconfig.json
@@ -6,7 +6,6 @@
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"declarationDir": "./dist",
 		"rootDir": "./src",
 		"outDir": "./dist",
 	},

--- a/packages/framework/view-adapters/tsconfig.json
+++ b/packages/framework/view-adapters/tsconfig.json
@@ -6,7 +6,6 @@
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"declarationDir": "./dist",
 		"rootDir": "./src",
 		"outDir": "./dist",
 	},

--- a/packages/framework/view-interfaces/tsconfig.json
+++ b/packages/framework/view-interfaces/tsconfig.json
@@ -6,7 +6,6 @@
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"declarationDir": "./dist",
 		"rootDir": "./src",
 		"outDir": "./dist",
 	},


### PR DESCRIPTION
Projects no longer need to explicitly define a declarationDir in their tsconfig, and those that did were causing ESM type output to be placed alongside CJS source in ./dist. This PR removes the declarationDir setting from all tsconfigs.