### PR TITLE
refactor(tree2): rename and clarify purpose of detachIdOverride

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/format.ts
@@ -47,8 +47,8 @@ const HasMoveFields = Type.Composite([
 
 const MoveIn = Type.Composite([HasMoveFields], noAdditionalProps);
 
-const InverseAttachFields = Type.Object({
-	detachIdOverride: Type.Optional(EncodedChangeAtomId),
+const RedetachFields = Type.Object({
+	redetachId: Type.Optional(CellId),
 });
 
 const Delete = Type.Composite(
@@ -57,12 +57,12 @@ const Delete = Type.Composite(
 			id: ChangesetLocalIdSchema,
 		}),
 		HasRevisionTag,
-		InverseAttachFields,
+		RedetachFields,
 	],
 	noAdditionalProps,
 );
 
-const MoveOut = Type.Composite([HasMoveFields, InverseAttachFields], noAdditionalProps);
+const MoveOut = Type.Composite([HasMoveFields, RedetachFields], noAdditionalProps);
 
 const MovePlaceholder = Type.Composite([HasMoveId, HasRevisionTag], noAdditionalProps);
 

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/invert.ts
@@ -120,7 +120,7 @@ function invertMark<TNodeChange>(
 							id: mark.id,
 							cellId: outputId,
 							count: mark.count,
-							detachIdOverride: getInputCellId(mark, revision, revisionMetadata),
+							redetachId: getInputCellId(mark, revision, revisionMetadata),
 					  };
 			return [withNodeChange(inverse, invertNodeChange(mark.changes, invertChild))];
 		}
@@ -133,7 +133,7 @@ function invertMark<TNodeChange>(
 			};
 
 			if (isReattach(mark)) {
-				deleteMark.detachIdOverride = mark.cellId;
+				deleteMark.redetachId = mark.cellId;
 			}
 
 			const inverse = withNodeChange(deleteMark, invertNodeChange(mark.changes, invertChild));
@@ -182,7 +182,7 @@ function invertMark<TNodeChange>(
 					detach: {
 						type: "Delete",
 						id: mark.id,
-						detachIdOverride: getInputCellId(mark, revision, revisionMetadata),
+						redetachId: getInputCellId(mark, revision, revisionMetadata),
 					},
 				};
 			}
@@ -200,7 +200,7 @@ function invertMark<TNodeChange>(
 			}
 
 			if (isReattach(mark)) {
-				invertedMark.detachIdOverride = mark.cellId;
+				invertedMark.redetachId = mark.cellId;
 			}
 
 			return applyMovedChanges(invertedMark, revision, crossFieldManager);

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -157,7 +157,7 @@ function rebaseMarkList<TNodeChange>(
 		if (
 			(markEmptiesCells(baseMark) ||
 				isImpactfulCellRename(baseMark, baseRevision, metadata)) &&
-			!isInverseAttach(baseMark)
+			!isRedetach(baseMark)
 		) {
 			// Note that we want the revision in the detach ID to be the actual revision, not the intention.
 			// We don't pass a `RevisionMetadataSource` to `getOutputCellId` so that we get the true revision.
@@ -215,13 +215,13 @@ function mergeMarkList<T>(marks: Mark<T>[]): Mark<T>[] {
 	return factory.list;
 }
 
-function isInverseAttach(effect: MarkEffect): boolean {
+function isRedetach(effect: MarkEffect): boolean {
 	switch (effect.type) {
 		case "Delete":
 		case "MoveOut":
-			return effect.detachIdOverride !== undefined;
+			return effect.redetachId !== undefined;
 		case "AttachAndDetach":
-			return isInverseAttach(effect.detach);
+			return isRedetach(effect.detach);
 		default:
 			return false;
 	}

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
@@ -70,10 +70,10 @@ function makeV0Codec<TNodeChange>(
 								effect.revision === undefined
 									? undefined
 									: revisionTagCodec.encode(effect.revision),
-							detachIdOverride:
-								effect.detachIdOverride === undefined
+							redetachId:
+								effect.redetachId === undefined
 									? undefined
-									: encodeChangeAtomId(revisionTagCodec, effect.detachIdOverride),
+									: cellIdCodec.encode(effect.redetachId),
 							id: effect.id,
 						},
 					};
@@ -88,10 +88,10 @@ function makeV0Codec<TNodeChange>(
 								effect.finalEndpoint === undefined
 									? undefined
 									: encodeChangeAtomId(revisionTagCodec, effect.finalEndpoint),
-							detachIdOverride:
-								effect.detachIdOverride === undefined
+							redetachId:
+								effect.redetachId === undefined
 									? undefined
-									: encodeChangeAtomId(revisionTagCodec, effect.detachIdOverride),
+									: cellIdCodec.encode(effect.redetachId),
 							id: effect.id,
 						},
 					};
@@ -154,7 +154,7 @@ function makeV0Codec<TNodeChange>(
 			return mark;
 		},
 		delete(encoded: Encoded.Delete): Delete {
-			const { id, revision, detachIdOverride } = encoded;
+			const { id, revision, redetachId } = encoded;
 			const mark: Delete = {
 				type: "Delete",
 				id,
@@ -162,13 +162,13 @@ function makeV0Codec<TNodeChange>(
 			if (revision !== undefined) {
 				mark.revision = revisionTagCodec.decode(revision);
 			}
-			if (detachIdOverride !== undefined) {
-				mark.detachIdOverride = decodeChangeAtomId(revisionTagCodec, detachIdOverride);
+			if (redetachId !== undefined) {
+				mark.redetachId = cellIdCodec.decode(redetachId);
 			}
 			return mark;
 		},
 		moveOut(encoded: Encoded.MoveOut): MoveOut {
-			const { id, finalEndpoint, detachIdOverride, revision } = encoded;
+			const { id, finalEndpoint, redetachId, revision } = encoded;
 			const mark: MoveOut = {
 				type: "MoveOut",
 				id,
@@ -179,8 +179,8 @@ function makeV0Codec<TNodeChange>(
 			if (finalEndpoint !== undefined) {
 				mark.finalEndpoint = decodeChangeAtomId(revisionTagCodec, finalEndpoint);
 			}
-			if (detachIdOverride !== undefined) {
-				mark.detachIdOverride = decodeChangeAtomId(revisionTagCodec, detachIdOverride);
+			if (redetachId !== undefined) {
+				mark.redetachId = cellIdCodec.decode(redetachId);
 			}
 			return mark;
 		},

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/types.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/types.ts
@@ -143,8 +143,16 @@ export interface MoveIn extends HasMoveFields {
 	type: "MoveIn";
 }
 
-export interface InverseAttachFields {
-	detachIdOverride?: ChangeAtomId;
+export interface RedetachFields {
+	/**
+	 * When set, the detach effect is reapplying a prior detach.
+	 * The cell ID specified is used in two ways:
+	 * - It indicates the location of the cell (including adjacent cell information) so that rebasing over this detach
+	 * can contribute the correct lineage information to the rebased mark.
+	 * - It specifies the revision and local ID that should be used to characterize the cell in the output context of
+	 * detach.
+	 */
+	redetachId?: CellId;
 }
 
 /**
@@ -155,7 +163,7 @@ export interface InverseAttachFields {
  * Rebasing this mark never causes it to target different set of nodes.
  * Rebasing this mark can cause it to clear a different set of cells.
  */
-export interface Delete extends HasRevisionTag, InverseAttachFields {
+export interface Delete extends HasRevisionTag, RedetachFields {
 	type: "Delete";
 	id: ChangesetLocalId;
 }
@@ -168,7 +176,7 @@ export interface Delete extends HasRevisionTag, InverseAttachFields {
  * Rebasing this mark never causes it to target different set of nodes.
  * Rebasing this mark can cause it to clear a different set of cells.
  */
-export interface MoveOut extends HasMoveFields, InverseAttachFields {
+export interface MoveOut extends HasMoveFields, RedetachFields {
 	type: "MoveOut";
 }
 

--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/utils.ts
@@ -40,7 +40,7 @@ import {
 	CellMark,
 	AttachAndDetach,
 	MarkEffect,
-	InverseAttachFields,
+	RedetachFields,
 	IdRange,
 	MovePlaceholder,
 } from "./types";
@@ -153,7 +153,7 @@ export function getDetachOutputId(
 	metadata: RevisionMetadataSource | undefined,
 ): ChangeAtomId {
 	return (
-		mark.detachIdOverride ?? {
+		mark.redetachId ?? {
 			revision: getIntentionIfMetadataProvided(mark.revision ?? revision, metadata),
 			localId: mark.id,
 		}
@@ -513,11 +513,11 @@ function areAdjacentIdRanges(
 }
 
 function haveMergeableIdOverrides(
-	lhs: InverseAttachFields,
+	lhs: RedetachFields,
 	lhsCount: number,
-	rhs: InverseAttachFields,
+	rhs: RedetachFields,
 ): boolean {
-	return areMergeableChangeAtoms(lhs.detachIdOverride, lhsCount, rhs.detachIdOverride);
+	return areMergeableChangeAtoms(lhs.redetachId, lhsCount, rhs.redetachId);
 }
 
 function areMergeableCellIds(
@@ -593,7 +593,7 @@ function tryMergeEffects(
 	if (
 		isDetach(lhs) &&
 		isDetach(rhs) &&
-		!areMergeableCellIds(lhs.detachIdOverride, lhsCount, rhs.detachIdOverride)
+		!areMergeableCellIds(lhs.redetachId, lhsCount, rhs.redetachId)
 	) {
 		return undefined;
 	}
@@ -1054,11 +1054,8 @@ function splitMarkEffect<TEffect extends MarkEffect>(
 			const id2: ChangesetLocalId = brand((effect.id as number) + length);
 			const effect2 = { ...effect, id: id2 };
 			const effect2Delete = effect2 as Delete;
-			if (effect2Delete.detachIdOverride !== undefined) {
-				effect2Delete.detachIdOverride = splitDetachEvent(
-					effect2Delete.detachIdOverride,
-					length,
-				);
+			if (effect2Delete.redetachId !== undefined) {
+				effect2Delete.redetachId = splitDetachEvent(effect2Delete.redetachId, length);
 			}
 			return [effect1, effect2];
 		}
@@ -1070,8 +1067,8 @@ function splitMarkEffect<TEffect extends MarkEffect>(
 
 			const return2 = effect2 as MoveOut;
 
-			if (return2.detachIdOverride !== undefined) {
-				return2.detachIdOverride = splitDetachEvent(return2.detachIdOverride, length);
+			if (return2.redetachId !== undefined) {
+				return2.redetachId = splitDetachEvent(return2.redetachId, length);
 			}
 
 			if (return2.finalEndpoint !== undefined) {

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/compose.spec.ts
@@ -973,7 +973,7 @@ describe("SequenceField - Compose", () => {
 				Mark.returnTo(1, brand(0), { revision: tag1, localId: brand(0) }),
 				{ count: 1 },
 				Mark.moveOut(1, brand(0), {
-					detachIdOverride: { revision: tag1, localId: brand(0) },
+					redetachId: { revision: tag1, localId: brand(0) },
 				}),
 			],
 			tag3,

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
@@ -92,9 +92,9 @@ describe("SequenceField - Invert", () => {
 	});
 
 	it("delete => revive (with override ID)", () => {
-		const detachIdOverride: ChangeAtomId = { revision: tag2, localId: brand(0) };
-		const input: TestChangeset = [Mark.delete(2, brand(5), { detachIdOverride })];
-		const expected = [Mark.revive(2, detachIdOverride, { id: brand(5) })];
+		const redetachId: ChangeAtomId = { revision: tag2, localId: brand(0) };
+		const input: TestChangeset = [Mark.delete(2, brand(5), { redetachId })];
+		const expected = [Mark.revive(2, redetachId, { id: brand(5) })];
 		const actual = invert(input);
 		assert.deepEqual(actual, expected);
 	});
@@ -102,7 +102,7 @@ describe("SequenceField - Invert", () => {
 	it("active revive => delete", () => {
 		const cellId: ChangeAtomId = { revision: tag1, localId: brand(0) };
 		const input = Change.revive(0, 2, cellId);
-		const expected: TestChangeset = [Mark.delete(2, brand(0), { detachIdOverride: cellId })];
+		const expected: TestChangeset = [Mark.delete(2, brand(0), { redetachId: cellId })];
 		const actual = invert(input);
 		assert.deepEqual(actual, expected);
 	});
@@ -154,11 +154,11 @@ describe("SequenceField - Invert", () => {
 			Mark.returnTo(2, brand(42), { revision: tag1, localId: brand(42) }),
 			{ count: 3 },
 			Mark.moveOut(1, brand(42), {
-				detachIdOverride: cellId,
+				redetachId: cellId,
 				changes: inverseChildChange1,
 			}),
 			Mark.moveOut(1, brand(43), {
-				detachIdOverride: { ...cellId, localId: brand(1) },
+				redetachId: { ...cellId, localId: brand(1) },
 			}),
 		];
 		const actual = invert(input);
@@ -177,7 +177,7 @@ describe("SequenceField - Invert", () => {
 		const input = [Mark.pin(1, brand(0), { cellId, changes: childChange1 })];
 		const expected: TestChangeset = [
 			Mark.delete(1, brand(0), {
-				detachIdOverride: cellId,
+				redetachId: cellId,
 				changes: inverseChildChange1,
 			}),
 		];
@@ -218,7 +218,7 @@ describe("SequenceField - Invert", () => {
 			Mark.delete(1, detachId.localId, {
 				cellId: detachId,
 				changes: inverseChildChange1,
-				detachIdOverride: startId,
+				redetachId: startId,
 			}),
 		];
 		assert.deepEqual(inverse, expected);
@@ -263,7 +263,7 @@ describe("SequenceField - Invert", () => {
 			Mark.attachAndDetach(
 				Mark.returnTo(1, detachId.localId, detachId),
 				Mark.delete(1, detachId.localId, {
-					detachIdOverride: startId,
+					redetachId: startId,
 				}),
 			),
 			{ count: 1 },
@@ -365,7 +365,7 @@ describe("SequenceField - Invert", () => {
 				Mark.delete(1, brand(0), {
 					changes: inverseChildChange1,
 					cellId: endId,
-					detachIdOverride: startId,
+					redetachId: startId,
 				}),
 			];
 			assert.deepEqual(actual, expected);

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/invert.spec.ts
@@ -12,6 +12,8 @@ import {
 	tagChange,
 	tagRollbackInverse,
 } from "../../../core";
+// eslint-disable-next-line import/no-internal-modules
+import { CellId } from "../../../feature-libraries/sequence-field";
 import { TestChange } from "../../testChange";
 import { deepFreeze } from "../../utils";
 import { brand } from "../../../util";
@@ -100,7 +102,11 @@ describe("SequenceField - Invert", () => {
 	});
 
 	it("active revive => delete", () => {
-		const cellId: ChangeAtomId = { revision: tag1, localId: brand(0) };
+		const cellId: CellId = {
+			revision: tag1,
+			localId: brand(0),
+			lineage: [{ revision: tag2, id: brand(42), count: 2, offset: 1 }],
+		};
 		const input = Change.revive(0, 2, cellId);
 		const expected: TestChangeset = [Mark.delete(2, brand(0), { redetachId: cellId })];
 		const actual = invert(input);

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/markListFactory.spec.ts
@@ -70,16 +70,16 @@ describe("SequenceField - MarkListFactory", () => {
 	it("Can merge consecutive deletes", () => {
 		const factory = new SF.MarkListFactory();
 		const delete1 = Mark.delete(1, brand(0), {
-			detachIdOverride: { revision: detachedBy, localId: brand(10) },
+			redetachId: { revision: detachedBy, localId: brand(10) },
 		});
 		const delete2 = Mark.delete(1, brand(1), {
-			detachIdOverride: { revision: detachedBy, localId: brand(11) },
+			redetachId: { revision: detachedBy, localId: brand(11) },
 		});
 		factory.pushContent(delete1);
 		factory.pushContent(delete2);
 		assert.deepStrictEqual(factory.list, [
 			Mark.delete(2, brand(0), {
-				detachIdOverride: { revision: detachedBy, localId: brand(10) },
+				redetachId: { revision: detachedBy, localId: brand(10) },
 			}),
 		]);
 	});
@@ -87,10 +87,10 @@ describe("SequenceField - MarkListFactory", () => {
 	it("Does not merge consecutive deletes with discontinuous detach overrides", () => {
 		const factory = new SF.MarkListFactory();
 		const delete1 = Mark.delete(1, brand(0), {
-			detachIdOverride: { revision: detachedBy, localId: brand(10) },
+			redetachId: { revision: detachedBy, localId: brand(10) },
 		});
 		const delete2 = Mark.delete(1, brand(1), {
-			detachIdOverride: { revision: detachedBy, localId: brand(42) },
+			redetachId: { revision: detachedBy, localId: brand(42) },
 		});
 		factory.pushContent(delete1);
 		factory.pushContent(delete2);
@@ -180,15 +180,15 @@ describe("SequenceField - MarkListFactory", () => {
 	it("Can merge consecutive move-out", () => {
 		const factory = new SF.MarkListFactory();
 		const return1 = Mark.moveOut(1, brand(0), {
-			detachIdOverride: { revision: detachedBy, localId: brand(10) },
+			redetachId: { revision: detachedBy, localId: brand(10) },
 		});
 		const return2 = Mark.moveOut(2, brand(1), {
-			detachIdOverride: { revision: detachedBy, localId: brand(11) },
+			redetachId: { revision: detachedBy, localId: brand(11) },
 		});
 		factory.pushContent(return1);
 		factory.pushContent(return2);
 		const expected = Mark.moveOut(3, brand(0), {
-			detachIdOverride: { revision: detachedBy, localId: brand(10) },
+			redetachId: { revision: detachedBy, localId: brand(10) },
 		});
 		assert.deepStrictEqual(factory.list, [expected]);
 	});
@@ -196,10 +196,10 @@ describe("SequenceField - MarkListFactory", () => {
 	it("Does not merge consecutive move-out with discontinuous detach overrides", () => {
 		const factory = new SF.MarkListFactory();
 		const return1 = Mark.moveOut(1, brand(0), {
-			detachIdOverride: { revision: detachedBy, localId: brand(10) },
+			redetachId: { revision: detachedBy, localId: brand(10) },
 		});
 		const return2 = Mark.moveOut(2, brand(1), {
-			detachIdOverride: { revision: detachedBy, localId: brand(42) },
+			redetachId: { revision: detachedBy, localId: brand(42) },
 		});
 		factory.pushContent(return1);
 		factory.pushContent(return2);

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/populatedMarks.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/populatedMarks.ts
@@ -45,7 +45,7 @@ const detach: Populated<Detach> = {
 	id: brand(0),
 	revision: tag,
 	finalEndpoint: atomId,
-	detachIdOverride: atomId,
+	redetachId: atomId,
 };
 
 export const populatedMarks: PopulatedMark[] = [
@@ -69,7 +69,7 @@ export const populatedMarks: PopulatedMark[] = [
 		id: brand(0),
 		revision: tag,
 		finalEndpoint: atomId,
-		detachIdOverride: atomId,
+		redetachId: atomId,
 	},
 	{
 		type: "Delete",
@@ -78,7 +78,7 @@ export const populatedMarks: PopulatedMark[] = [
 		changes,
 		id: brand(0),
 		revision: tag,
-		detachIdOverride: atomId,
+		redetachId: atomId,
 	},
 	{
 		type: "AttachAndDetach",

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -760,3 +760,22 @@ describe("SequenceField - Composed sandwich rebasing", () => {
 		assert.deepEqual(insertB2.change, insertB.change);
 	});
 });
+
+describe("SequenceField - Examples", () => {
+	it("a detach can end up with a redetachId that contains lineage", () => {
+		const revive = tagChange([Mark.revive(1, { revision: tag1, localId: brand(0) })], tag3);
+		const concurrentRemove = tagChange([Mark.delete(1, brand(42))], tag2);
+		const rebasedRevive = rebaseTagged(revive, concurrentRemove);
+		const redetach = invert(rebasedRevive);
+		const expected = [
+			Mark.delete(1, brand(0), {
+				redetachId: {
+					revision: tag1,
+					localId: brand(0),
+					lineage: [{ revision: tag2, id: brand(42), count: 1, offset: 0 }],
+				},
+			}),
+		];
+		assert.deepEqual(redetach, expected);
+	});
+});

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.spec.ts
@@ -147,7 +147,7 @@ describe("SequenceField - toDelta", () => {
 
 	it("delete with override", () => {
 		const changeset = [
-			Mark.delete(10, brand(42), { detachIdOverride: { revision: tag2, localId: brand(1) } }),
+			Mark.delete(10, brand(42), { redetachId: { revision: tag2, localId: brand(1) } }),
 		];
 		const expected: DeltaFieldChanges = {
 			local: [


### PR DESCRIPTION
Rename and clarify purpose of `detachIdOverride`

Fixes to the usage of `detachIdOverride` (now `redetachId`) will soon follow.