### PR TITLE
Updated GC trailing ops test to check for deletion and other fixes

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
@@ -45,6 +45,7 @@ describeCompat("GC trailing ops tests", "NoCompat", (getTestObjectProvider) => {
 
 		/**
 		 * Validates that the data store is not deleted from the data store and GC trees in the summary.
+		 * Also, it is referenced / unreferenced as expected.
 		 */
 		function validateDataStoreStateInSummary(
 			summaryTree: ISummaryTree,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
@@ -188,7 +188,7 @@ describeCompat("GC trailing ops tests", "NoCompat", (getTestObjectProvider) => {
 				referenced,
 			);
 
-			// The referenced state will not change.
+			// The reference state will transition now due to the trailing op sent next.
 			referenced = !referenced;
 
 			// If beforeSweepTimeout, send the trailing op that transitions the data store's reference state first
@@ -226,8 +226,8 @@ describeCompat("GC trailing ops tests", "NoCompat", (getTestObjectProvider) => {
 				summary1.summaryVersion,
 			);
 
-			// Ensure trailing ops are processed and summarize.
-			await provider.ensureSynchronized();
+			// Summarize now. The trailing ops will be processed before summarize happens because summarizer connects
+			// in write mode and so, all ops sequenced before its join op are processed before it connects.
 			const summary2 = await summarizeNow(summarizer);
 
 			// Validate that the data store has transitioned correctly


### PR DESCRIPTION
The GC trailing ops test runs in two modes - tombstone enabled and disabled. However, the tombstone / sweep part is not properly implemented. The sweep timeout is 1ms (which is too small to be meaningful) and the test doesn't wait for this timeout before or after sending trailing ops which is contrary to the test title.

This PR changes the sweep timeout to 100ms, waits for this timeout before or after sending trailing ops. It also validates that the data store is not deleted when the container is opened after sweep timeout and sweep phase runs.

[AB#6611](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6611)