### PR TITLE
tree2: split up schema index

### DIFF
--- a/experimental/dds/tree2/src/core/schema-stored/schema.ts
+++ b/experimental/dds/tree2/src/core/schema-stored/schema.ts
@@ -48,11 +48,6 @@ export const FieldKindIdentifierSchema = brandedStringType<FieldKindIdentifier>(
 /**
  * Schema for what {@link TreeValue} is allowed on a Leaf node.
  * @alpha
- *
- * @privateRemarks
- * This is currently leaked into some persisted formats.
- * A full audit of persisted formats is needed,
- * and all types which are used in them should be moved to locations which indicated they are persisted, or duplicated into a persisted and non-persisted version with explicit encoding between them.
  */
 export enum ValueSchema {
 	Number,

--- a/experimental/dds/tree2/src/feature-libraries/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/index.ts
@@ -72,9 +72,7 @@ export { ForestSummarizer } from "./forestSummarizer";
 export { cursorForMapTreeField, cursorForMapTreeNode, mapTreeFromCursor } from "./mapTreeCursor";
 export { MemoizedIdRangeAllocator, IdRange } from "./memoizedIdRangeAllocator";
 export { buildForest } from "./object-forest";
-export { SchemaSummarizer, SchemaEditor, encodeTreeSchema } from "./schemaSummarizer";
-// This is exported because its useful for doing comparisons of schema in tests.
-export { makeSchemaCodec } from "./schemaIndexFormat";
+export { SchemaSummarizer, SchemaEditor, encodeTreeSchema, makeSchemaCodec } from "./schema-index/";
 export {
 	stackTreeNodeCursor,
 	CursorAdapter,

--- a/experimental/dds/tree2/src/feature-libraries/schema-index/format.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-index/format.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ObjectOptions, Static, Type } from "@sinclair/typebox";
+import { FieldKindIdentifierSchema, FieldKeySchema, TreeSchemaIdentifierSchema } from "../../core";
+
+export const version = "1.0.0" as const;
+
+const FieldSchemaFormatBase = Type.Object({
+	kind: FieldKindIdentifierSchema,
+	types: Type.Optional(Type.Array(TreeSchemaIdentifierSchema)),
+});
+
+const noAdditionalProps: ObjectOptions = { additionalProperties: false };
+
+const FieldSchemaFormat = Type.Composite([FieldSchemaFormatBase], noAdditionalProps);
+
+const NamedFieldSchemaFormat = Type.Composite(
+	[
+		FieldSchemaFormatBase,
+		Type.Object({
+			name: FieldKeySchema,
+		}),
+	],
+	noAdditionalProps,
+);
+
+/**
+ * Persisted version of {@link ValueSchema}.
+ */
+export enum PersistedValueSchema {
+	Number,
+	String,
+	Boolean,
+	FluidHandle,
+	Null,
+}
+
+export const TreeNodeSchemaFormat = Type.Object(
+	{
+		name: TreeSchemaIdentifierSchema,
+		objectNodeFields: Type.Array(NamedFieldSchemaFormat),
+		mapFields: Type.Optional(FieldSchemaFormat),
+		leafValue: Type.Optional(Type.Enum(PersistedValueSchema)),
+	},
+	noAdditionalProps,
+);
+
+/**
+ * Format for encoding as json.
+ *
+ * For consistency all lists are sorted and undefined values are omitted.
+ *
+ * This chooses to use lists of named objects instead of maps:
+ * this choice is somewhat arbitrary, but avoids user data being used as object keys,
+ * which can sometimes be an issue (for example handling that for "__proto__" can require care).
+ * It also makes it simpler to determinately sort by keys.
+ */
+export const Format = Type.Object(
+	{
+		version: Type.Literal(version),
+		nodeSchema: Type.Array(TreeNodeSchemaFormat),
+		rootFieldSchema: FieldSchemaFormat,
+	},
+	noAdditionalProps,
+);
+
+export type Format = Static<typeof Format>;
+export type FieldSchemaFormat = Static<typeof FieldSchemaFormat>;
+export type TreeNodeSchemaFormat = Static<typeof TreeNodeSchemaFormat>;
+export type NamedFieldSchemaFormat = Static<typeof NamedFieldSchemaFormat>;
+
+export const Versioned = Type.Object({
+	version: Type.String(),
+});
+export type Versioned = Static<typeof Versioned>;

--- a/experimental/dds/tree2/src/feature-libraries/schema-index/index.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-index/index.ts
@@ -1,0 +1,7 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { SchemaEditor, SchemaSummarizer, encodeTreeSchema } from "./schemaSummarizer";
+export { makeSchemaCodec } from "./codec";

--- a/experimental/dds/tree2/src/feature-libraries/schema-index/schemaSummarizer.ts
+++ b/experimental/dds/tree2/src/feature-libraries/schema-index/schemaSummarizer.ts
@@ -16,7 +16,7 @@ import {
 	IGarbageCollectionData,
 } from "@fluidframework/runtime-definitions";
 import { createSingleBlobSummary } from "@fluidframework/shared-object-base";
-import { ICodecOptions, IJsonCodec, SchemaValidationFunction } from "../codec";
+import { ICodecOptions, IJsonCodec, SchemaValidationFunction } from "../../codec";
 import {
 	TreeFieldStoredSchema,
 	TreeStoredSchema,
@@ -25,10 +25,15 @@ import {
 	TreeNodeSchemaIdentifier,
 	schemaDataIsEmpty,
 	SchemaEvents,
-} from "../core";
-import { Summarizable, SummaryElementParser, SummaryElementStringifier } from "../shared-tree-core";
-import { isJsonObject, JsonCompatible, JsonCompatibleReadOnly } from "../util";
-import { makeSchemaCodec, Format, encodeRepo } from "./schemaIndexFormat";
+} from "../../core";
+import {
+	Summarizable,
+	SummaryElementParser,
+	SummaryElementStringifier,
+} from "../../shared-tree-core";
+import { isJsonObject, JsonCompatible, JsonCompatibleReadOnly } from "../../util";
+import { Format } from "./format";
+import { encodeRepo, makeSchemaCodec } from "./codec";
 
 /**
  * The storage key for the blob in the summary containing schema data

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-index/codec.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-index/codec.spec.ts
@@ -7,15 +7,17 @@ import { strict as assert } from "assert";
 
 // Allow importing from this specific file which is being tested:
 /* eslint-disable-next-line import/no-internal-modules */
-import { Format, makeSchemaCodec } from "../../feature-libraries/schemaIndexFormat";
+import { makeSchemaCodec } from "../../../feature-libraries/schema-index/codec";
+/* eslint-disable-next-line import/no-internal-modules */
+import { Format } from "../../../feature-libraries/schema-index/format";
 
-import { FieldKindIdentifier, TreeStoredSchema } from "../../core";
-import { typeboxValidator } from "../../external-utilities";
-import { jsonSchema, jsonRoot, SchemaBuilder, leaf } from "../../domains";
-import { defaultSchemaPolicy, allowsRepoSuperset } from "../../feature-libraries";
-import { makeCodecFamily } from "../../codec";
-import { EncodingTestData, makeEncodingTestSuite } from "../utils";
-import { library } from "../testTrees";
+import { FieldKindIdentifier, TreeStoredSchema } from "../../../core";
+import { typeboxValidator } from "../../../external-utilities";
+import { jsonSchema, jsonRoot, SchemaBuilder, leaf } from "../../../domains";
+import { defaultSchemaPolicy, allowsRepoSuperset } from "../../../feature-libraries";
+import { makeCodecFamily } from "../../../codec";
+import { EncodingTestData, makeEncodingTestSuite } from "../../utils";
+import { library } from "../../testTrees";
 
 const codec = makeSchemaCodec({ jsonValidator: typeboxValidator });
 

--- a/experimental/dds/tree2/src/test/feature-libraries/schema-index/schemaSummarizer.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/schema-index/schemaSummarizer.spec.ts
@@ -8,9 +8,9 @@ import { strict as assert } from "node:assert";
 import {
 	encodeTreeSchema,
 	// eslint-disable-next-line import/no-internal-modules
-} from "../../feature-libraries/schemaSummarizer";
-import { storedEmptyFieldSchema } from "../../core";
-import { jsonSequenceRootSchema } from "../utils";
+} from "../../../feature-libraries/schema-index/schemaSummarizer";
+import { storedEmptyFieldSchema } from "../../../core";
+import { jsonSequenceRootSchema } from "../../utils";
 
 describe("schemaSummarizer", () => {
 	describe("encodeTreeSchema", () => {
@@ -46,7 +46,6 @@ describe("schemaSummarizer", () => {
 				},
 				nodeSchema: [
 					{
-						leafValue: undefined,
 						mapFields: undefined,
 						name: "com.fluidframework.json.array",
 						objectNodeFields: [
@@ -65,7 +64,6 @@ describe("schemaSummarizer", () => {
 						],
 					},
 					{
-						leafValue: undefined,
 						mapFields: {
 							kind: "Optional",
 							types: [

--- a/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/sharedTree.spec.ts
@@ -8,7 +8,6 @@ import { ITestFluidObject, waitForContainerConnection } from "@fluidframework/te
 import { IContainerExperimental } from "@fluidframework/container-loader";
 import {
 	cursorForJsonableTreeNode,
-	makeSchemaCodec,
 	jsonableTreeFromCursor,
 	Any,
 	TreeStatus,
@@ -61,17 +60,13 @@ import {
 	rootFieldKey,
 	UpPath,
 	moveToDetachedField,
-	TreeStoredSchema,
 	AllowedUpdateType,
 	storedEmptyFieldSchema,
 } from "../../core";
 import { typeboxValidator } from "../../external-utilities";
 import { EditManager } from "../../shared-tree-core";
 import { leaf, SchemaBuilder } from "../../domains";
-import { noopValidator } from "../../codec";
 import { SchemaFactory, TreeConfiguration } from "../../class-tree";
-
-const schemaCodec = makeSchemaCodec({ jsonValidator: typeboxValidator });
 
 const fooKey: FieldKey = brand("foo");
 
@@ -291,7 +286,6 @@ describe("SharedTree", () => {
 		assert(provider.trees[1].isAttached());
 
 		const value = "42";
-		const expectedSchema = schemaCodec.encode(stringSequenceRootSchema);
 
 		// Apply an edit to the first tree which inserts a node with a value
 		const view1 = provider.trees[0].schematizeInternal({
@@ -302,7 +296,7 @@ describe("SharedTree", () => {
 
 		// Ensure that the first tree has the state we expect
 		assert.deepEqual(view1.editableTree.asArray, [value]);
-		assert.deepEqual(schemaCodec.encode(provider.trees[0].storedSchema), expectedSchema);
+		expectSchemaEqual(provider.trees[0].storedSchema, stringSequenceRootSchema);
 		// Ensure that the second tree receives the expected state from the first tree
 		await provider.ensureSynchronized();
 		validateTreeConsistency(provider.trees[0], provider.trees[1]);
@@ -1262,14 +1256,9 @@ describe("SharedTree", () => {
 			await provider.ensureSynchronized();
 
 			const otherLoadedTree = provider.trees[1];
-			expectSchemaEquality(tree.contentSnapshot().schema, stringSequenceRootSchema);
-			expectSchemaEquality(otherLoadedTree.storedSchema, stringSequenceRootSchema);
+			expectSchemaEqual(tree.contentSnapshot().schema, stringSequenceRootSchema);
+			expectSchemaEqual(otherLoadedTree.storedSchema, stringSequenceRootSchema);
 		});
-
-		function expectSchemaEquality(actual: TreeStoredSchema, expected: TreeStoredSchema): void {
-			const codec = makeSchemaCodec({ jsonValidator: noopValidator });
-			assert.deepEqual(codec.encode(actual), codec.encode(expected));
-		}
 	});
 
 	describe.skip("Fuzz Test fail cases", () => {

--- a/experimental/dds/tree2/src/test/utils.ts
+++ b/experimental/dds/tree2/src/test/utils.ts
@@ -49,7 +49,6 @@ import {
 	createMockNodeKeyManager,
 	TreeFieldSchema,
 	jsonableTreeFromCursor,
-	makeSchemaCodec,
 	mapFieldChanges,
 	mapFieldsChanges,
 	mapMarkList,
@@ -112,6 +111,8 @@ import {
 	leaf,
 } from "../domains";
 import { HasListeners, IEmitter, ISubscribable } from "../events";
+// eslint-disable-next-line import/no-internal-modules
+import { makeSchemaCodec } from "../feature-libraries/schema-index/codec";
 
 // Testing utilities
 

--- a/experimental/dds/tree2/src/util/index.ts
+++ b/experimental/dds/tree2/src/util/index.ts
@@ -77,6 +77,7 @@ export {
 	useDeterministicStableId,
 	useAsyncDeterministicStableId,
 	objectToMap,
+	invertMap,
 	oneFromSet,
 	Named,
 	disposeSymbol,

--- a/experimental/dds/tree2/src/util/utils.ts
+++ b/experimental/dds/tree2/src/util/utils.ts
@@ -435,6 +435,17 @@ export function transformObjectMap<MapKey extends string | number | symbol, MapV
 }
 
 /**
+ * Make an inverted copy of a map.
+ *
+ * @returns a map which can look up the keys from the values of the original map.
+ */
+export function invertMap<Key, Value>(input: Map<Key, Value>): Map<Value, Key> {
+	const result = new Map<Value, Key>(mapIterable(input, ([key, value]) => [value, key]));
+	assert(result.size === input.size, "all values in a map must be unique to invert it");
+	return result;
+}
+
+/**
  * Returns the value from `set` if it contains exactly one item, otherwise `undefined`.
  * @alpha
  */

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
@@ -810,11 +810,6 @@ describe("DefaultVisualizers unit tests", () => {
 											typeMetadata: "undefined",
 											nodeKind: VisualNodeKind.ValueNode,
 										},
-										leafValue: {
-											value: undefined,
-											typeMetadata: "undefined",
-											nodeKind: VisualNodeKind.ValueNode,
-										},
 										objectNodeFields: {
 											children: {
 												"0": {
@@ -861,11 +856,6 @@ describe("DefaultVisualizers unit tests", () => {
 											nodeKind: VisualNodeKind.ValueNode,
 										},
 										mapFields: {
-											value: undefined,
-											typeMetadata: "undefined",
-											nodeKind: VisualNodeKind.ValueNode,
-										},
-										leafValue: {
 											value: undefined,
 											typeMetadata: "undefined",
 											nodeKind: VisualNodeKind.ValueNode,
@@ -954,11 +944,6 @@ describe("DefaultVisualizers unit tests", () => {
 											typeMetadata: "undefined",
 											nodeKind: VisualNodeKind.ValueNode,
 										},
-										leafValue: {
-											value: undefined,
-											typeMetadata: "undefined",
-											nodeKind: VisualNodeKind.ValueNode,
-										},
 										objectNodeFields: {
 											children: {
 												"0": {
@@ -1017,11 +1002,6 @@ describe("DefaultVisualizers unit tests", () => {
 											nodeKind: VisualNodeKind.ValueNode,
 										},
 										mapFields: {
-											value: undefined,
-											typeMetadata: "undefined",
-											nodeKind: VisualNodeKind.ValueNode,
-										},
-										leafValue: {
 											value: undefined,
 											typeMetadata: "undefined",
 											nodeKind: VisualNodeKind.ValueNode,


### PR DESCRIPTION
## Description

Split schema index into format and codec files to better along with docs/main/compatibility.md

Implement todo to not directly consume valueSchema.
Add invertMap utilitiy.
Avoid setting undefined leafSchema field (this has no impact on persisted format as json drops undefined fields, but tidy's up the in memory objects while encoding).

Persisted format is unchanged.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
