### PR TITLE
Bump client build timeout

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -166,6 +166,7 @@ stages:
       # Job - Build
       - job: build
         displayName: Build
+        timeoutInMinutes: 90
         pool: ${{ parameters.poolBuild }}
         variables:
           testCoverage: ${{ ne(variables['Build.Reason'], 'PullRequest') }}


### PR DESCRIPTION
## Description

The internal CI for client packages has timed out the last few runs due to long tinylicious test runs. Bumping the timeout to mitigate while we investigate the source of the time increase.
