### PR TITLE
fix(tree2): rebasing over re-detaches

### DIFF
--- a/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
+++ b/experimental/dds/tree2/src/feature-libraries/sequence-field/rebase.ts
@@ -152,13 +152,7 @@ function rebaseMarkList<TNodeChange>(
 			nodeExistenceState,
 		);
 
-		// Inverse attaches do not contribute to lineage as they are effectively reinstating
-		// an older detach which cells should already have any necessary lineage for.
-		if (
-			(markEmptiesCells(baseMark) ||
-				isImpactfulCellRename(baseMark, baseRevision, metadata)) &&
-			!isRedetach(baseMark)
-		) {
+		if (markEmptiesCells(baseMark) || isImpactfulCellRename(baseMark, baseRevision, metadata)) {
 			// Note that we want the revision in the detach ID to be the actual revision, not the intention.
 			// We don't pass a `RevisionMetadataSource` to `getOutputCellId` so that we get the true revision.
 			const detachId = getOutputCellId(baseMark, baseRevision, undefined);
@@ -186,7 +180,22 @@ function rebaseMarkList<TNodeChange>(
 				0x817 /* Mark should have empty input cells after rebasing over a cell-emptying mark */,
 			);
 
-			setMarkAdjacentCells(rebasedMark, detachBlock);
+			// A re-detach sports a cell ID with the adjacent cells from the original detach.
+			// Marks that are rebased over such a re-detach will adopt this cell ID as-is and do not need to have the
+			// adjacent cells be updated. Moreover, the base changeset may not have all the detaches from the original
+			// detach revision, so using such re-detach marks to compile the list of adjacent cells would run the risk
+			// of ending up with incomplete adjacent cell information in the rebased mark.
+			if (!isRedetach(baseMark)) {
+				// BUG#6604:
+				// We track blocks of adjacent cells for rollbacks separately from that of the original revision
+				// that they are a rollback of, but all rebased marks use the original revision in their `CellId`.
+				// This means we assign adjacent cells information for the rollback to a `CellId` that advertises
+				// itself as being about the original revision.
+				// This could lead to a situation where we try to compare two cells and fail to order them correctly
+				// because one sports adjacent cells information for the original revision and the other sports
+				// adjacent cells information for the rollback.
+				setMarkAdjacentCells(rebasedMark, detachBlock);
+			}
 		}
 
 		if (areInputCellsEmpty(rebasedMark)) {
@@ -714,7 +723,12 @@ function updateLineageState(
 	const detachRevisionIndex = getDetachRevisionIndex(metadata, baseMark, baseRevision);
 	for (const revision of detachBlocks.keys()) {
 		const revisionIndex = getRevisionIndex(metadata, revision);
-		if (attachRevisionIndex <= revisionIndex && revisionIndex < detachRevisionIndex) {
+		// revisionIndex can be -Infinity if it is from a re-detach
+		if (
+			revisionIndex > -Infinity &&
+			attachRevisionIndex <= revisionIndex &&
+			revisionIndex < detachRevisionIndex
+		) {
 			detachBlocks.delete(revision);
 		}
 	}
@@ -896,6 +910,13 @@ function shouldReceiveLineage(
 	const rollbackOf = metadata.tryGetInfo(detachRevision)?.rollbackOf;
 	const detachIntention = rollbackOf ?? detachRevision;
 	const detachRevisionIndex = getRevisionIndex(metadata, detachIntention);
+	if (detachRevisionIndex === undefined) {
+		// This case means that these cells are being "re-detached" through a `redetachId`.
+		// We could use the revision of the re-detach to determine whether or not this cell needs this lineage entry.
+		// But to be conservative we always add lineage here.
+		return true;
+	}
+
 	const isRollback = rollbackOf !== undefined;
 	return isRollback
 		? detachRevisionIndex < cellRevisionIndex

--- a/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
+++ b/experimental/dds/tree2/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.spec.ts
@@ -687,6 +687,22 @@ describe("SequenceField - Sandwich Rebasing", () => {
 		const expected = [{ count: 1 }, Mark.insert(1, brand(0))];
 		assert.deepEqual(insertB2.change, expected);
 	});
+
+	it("[revive, insert] ↷ no change", () => {
+		const reviveA = tagChange([Mark.revive(2, { revision: tag1, localId: brand(0) })], tag2);
+		const insertB = tagChange([Mark.skip(1), Mark.insert(1, brand(0))], tag3);
+		const inverseA = tagRollbackInverse(invert(reviveA), tag4, tag2);
+		const insertB2 = rebaseOverChanges(insertB, [inverseA, reviveA]);
+		const expected = [
+			Mark.skip(1),
+			Mark.insert(1, {
+				localId: brand(0),
+				lineage: [{ revision: tag1, id: brand(0), count: 2, offset: 1 }],
+			}),
+		];
+
+		assert.deepEqual(insertB2.change, expected);
+	});
 });
 
 describe("SequenceField - Sandwich composing", () => {

--- a/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree/editing.spec.ts
@@ -1698,6 +1698,28 @@ describe("Editing", () => {
 			unsubscribePathVisitor();
 		});
 
+		it("rebase insert within revive", () => {
+			const tree = makeTreeFromJson(["y"]);
+			const tree1 = tree.fork();
+
+			const { undoStack } = createTestUndoRedoStacks(tree1.events);
+			insert(tree1, 1, "a", "c");
+			remove(tree1, 1, 2); // Remove ac
+
+			const tree2 = tree1.fork();
+
+			undoStack.pop()?.revert(); // Restores ac
+			insert(tree1, 2, "b");
+			expectJsonTree(tree1, ["y", "a", "b", "c"]);
+
+			insert(tree2, 0, "x");
+			tree1.rebaseOnto(tree2);
+			tree2.merge(tree1);
+
+			const expected = ["x", "y", "a", "b", "c"];
+			expectJsonTree([tree1, tree2], expected);
+		});
+
 		describe("Exhaustive removal tests", () => {
 			// Toggle the constant below to run each scenario as a separate test.
 			// This is useful to debug a specific scenario but makes CI and the test browser slower.


### PR DESCRIPTION
This fixes a bug where lineage was not added for re-detaches.

Note that the code in this PR talks about how `adjacentCells` information is populated on re-detaches.
This computation of `adjacentCells` is currently missing and will be the focus of the next PR.