### PR TITLE
Fix duplicate join session events

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -238,6 +238,8 @@ export class OdspDelayLoadedDeltaStream {
 
 		await new Promise<void>((resolve, reject) => {
 			this.joinSessionRefreshTimer = setTimeout(() => {
+				this.clearJoinSessionTimer();
+				// Clear the timer as it is going to be scheduled again as part of refreshing join session.
 				getWithRetryForTokenRefresh(async (options) => {
 					await this.joinSession(
 						requestSocketToken,


### PR DESCRIPTION
## Description

ADO item: https://dev.azure.com/fluidframework/internal/_workitems/edit/6385

We see a lot of "DuplicateJoinSessionRefresh" events in the telemetry. This PR fixes that. Need to clear the timer before scheduling another one,