### PR TITLE
Remove deprecated config types from telemetry-utils

### DIFF
--- a/.changeset/olive-bags-smoke.md
+++ b/.changeset/olive-bags-smoke.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/telemetry-utils": minor
+---
+
+Remove deprecated config types from telemetry-utils
+
+The types ConfigTypes, and IConfigProviderBase were deprecated and are now removed from @fluidframework/telemetry-utils. They continue to exist in @fluidframework/core-interfaces. Please update your reference to use these types from @fluidframework/core-interfaces.

--- a/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
+++ b/azure/packages/test/end-to-end-tests/src/test/AzureClientFactory.ts
@@ -12,11 +12,8 @@ import {
 } from "@fluidframework/azure-client";
 import { InsecureTokenProvider } from "@fluidframework/test-runtime-utils";
 
-import {
-	IConfigProviderBase,
-	MockLogger,
-	createMultiSinkLogger,
-} from "@fluidframework/telemetry-utils";
+import { MockLogger, createMultiSinkLogger } from "@fluidframework/telemetry-utils";
+import { IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { createAzureTokenProvider } from "./AzureTokenFactory";
 
 /**

--- a/experimental/dds/tree/src/test/utilities/TestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/TestUtilities.ts
@@ -25,9 +25,15 @@ import {
 	ITestObjectProvider,
 } from '@fluidframework/test-utils';
 import type { IContainer, IHostLoader } from '@fluidframework/container-definitions';
-import type { IFluidCodeDetails, IFluidHandle, IRequestHeader } from '@fluidframework/core-interfaces';
+import type {
+	ConfigTypes,
+	IConfigProviderBase,
+	IFluidCodeDetails,
+	IFluidHandle,
+	IRequestHeader,
+} from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
-import { ConfigTypes, IConfigProviderBase, createChildLogger } from '@fluidframework/telemetry-utils';
+import { createChildLogger } from '@fluidframework/telemetry-utils';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import {
 	AttributionId,

--- a/packages/framework/attributor/src/test/mixinAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/mixinAttributor.spec.ts
@@ -10,14 +10,10 @@ import {
 	IContainerContext,
 	ICriticalContainerError,
 } from "@fluidframework/container-definitions";
-import {
-	MockLogger,
-	sessionStorageConfigProvider,
-	ConfigTypes,
-} from "@fluidframework/telemetry-utils";
+import { MockLogger, sessionStorageConfigProvider } from "@fluidframework/telemetry-utils";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import { MockDeltaManager, MockQuorumClients } from "@fluidframework/test-runtime-utils";
-import { FluidObject } from "@fluidframework/core-interfaces";
+import { ConfigTypes, FluidObject } from "@fluidframework/core-interfaces";
 import {
 	ISequencedDocumentMessage,
 	ISnapshotTree,

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -15,7 +15,12 @@ import {
 } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions";
-import { IErrorBase, IFluidHandle } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	IErrorBase,
+	IFluidHandle,
+} from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
 	IClientDetails,
@@ -23,8 +28,6 @@ import {
 	SummaryType,
 } from "@fluidframework/protocol-definitions";
 import {
-	ConfigTypes,
-	IConfigProviderBase,
 	mixinMonitoringContext,
 	MonitoringContext,
 	createChildLogger,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -24,9 +24,7 @@ import {
 	NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
 import {
-	ConfigTypes,
 	createChildLogger,
-	IConfigProviderBase,
 	isFluidError,
 	isILoggingError,
 	mixinMonitoringContext,
@@ -34,7 +32,14 @@ import {
 } from "@fluidframework/telemetry-utils";
 import { MockDeltaManager, MockQuorumClients } from "@fluidframework/test-runtime-utils";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { IErrorBase, IResponse, FluidObject, IGenericError } from "@fluidframework/core-interfaces";
+import {
+	IErrorBase,
+	IResponse,
+	FluidObject,
+	IGenericError,
+	ConfigTypes,
+	IConfigProviderBase,
+} from "@fluidframework/core-interfaces";
 import { IDocumentStorageService, ISummaryContext } from "@fluidframework/driver-definitions";
 import {
 	CompressionAlgorithms,

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -6,14 +6,13 @@
 import { strict as assert } from "assert";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
-import { IErrorBase } from "@fluidframework/core-interfaces";
+import { ConfigTypes, IErrorBase } from "@fluidframework/core-interfaces";
 import {
 	IGarbageCollectionData,
 	IGarbageCollectionDetailsBase,
 } from "@fluidframework/runtime-definitions";
 import {
 	MockLogger,
-	ConfigTypes,
 	MonitoringContext,
 	mixinMonitoringContext,
 	createChildLogger,

--- a/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
@@ -9,11 +9,11 @@ import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import { IGarbageCollectionData } from "@fluidframework/runtime-definitions";
 import {
 	MockLogger,
-	ConfigTypes,
 	mixinMonitoringContext,
 	MonitoringContext,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils";
+import { ConfigTypes } from "@fluidframework/core-interfaces";
 import {
 	GarbageCollector,
 	GCNodeType,

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -5,12 +5,11 @@
 
 import { strict as assert } from "assert";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
-import { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
+import { ConfigTypes, ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
 import { IGarbageCollectionData } from "@fluidframework/runtime-definitions";
 import {
 	MockLogger,
 	TelemetryDataTag,
-	ConfigTypes,
 	mixinMonitoringContext,
 	MonitoringContext,
 	createChildLogger,

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -7,7 +7,11 @@ import { strict as assert } from "assert";
 import sinon from "sinon";
 import { Deferred } from "@fluidframework/core-utils";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	ITelemetryBaseEvent,
+} from "@fluidframework/core-interfaces";
 import {
 	IDocumentMessage,
 	ISequencedDocumentMessage,
@@ -17,12 +21,7 @@ import {
 	MessageType,
 	SummaryType,
 } from "@fluidframework/protocol-definitions";
-import {
-	ConfigTypes,
-	IConfigProviderBase,
-	MockLogger,
-	mixinMonitoringContext,
-} from "@fluidframework/telemetry-utils";
+import { MockLogger, mixinMonitoringContext } from "@fluidframework/telemetry-utils";
 import { MockDeltaManager } from "@fluidframework/test-runtime-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions";
 import { IContainerRuntimeEvents } from "@fluidframework/container-runtime-definitions";

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
@@ -2,14 +2,10 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { type ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import { IConfigProviderBase, type ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { OdspClient, OdspConnectionConfig } from "@fluid-experimental/odsp-client";
 
-import {
-	IConfigProviderBase,
-	MockLogger,
-	createMultiSinkLogger,
-} from "@fluidframework/telemetry-utils";
+import { MockLogger, createMultiSinkLogger } from "@fluidframework/telemetry-utils";
 import { OdspTestTokenProvider } from "./OdspTokenFactory";
 
 /**

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMap.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMap.ts
@@ -13,12 +13,13 @@ import {
 	createSummarizerFromFactory,
 	summarizeNow,
 } from "@fluidframework/test-utils";
-import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import {
 	ConfigTypes,
 	IConfigProviderBase,
-	ITelemetryLoggerExt,
-} from "@fluidframework/telemetry-utils";
+	IFluidHandle,
+	IRequest,
+} from "@fluidframework/core-interfaces";
+import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
 
 import {
 	CompressionAlgorithms,

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrix.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrix.ts
@@ -15,15 +15,16 @@ import {
 } from "@fluidframework/aqueduct";
 import { SharedMatrix } from "@fluidframework/matrix";
 import { SharedString } from "@fluidframework/sequence";
-import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
-import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
-import { createSummarizerFromFactory, summarizeNow } from "@fluidframework/test-utils";
-import { assertDocumentTypeInfo, isDocumentMatrixInfo } from "@fluid-private/test-version-utils";
 import {
 	ConfigTypes,
 	IConfigProviderBase,
-	ITelemetryLoggerExt,
-} from "@fluidframework/telemetry-utils";
+	IFluidHandle,
+	IRequest,
+} from "@fluidframework/core-interfaces";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
+import { createSummarizerFromFactory, summarizeNow } from "@fluidframework/test-utils";
+import { assertDocumentTypeInfo, isDocumentMatrixInfo } from "@fluid-private/test-version-utils";
+import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
 import { IDocumentLoaderAndSummarizer, IDocumentProps, ISummarizeResult } from "./DocumentCreator";
 
 const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrixPlain.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMatrixPlain.ts
@@ -15,7 +15,12 @@ import {
 	DataObjectFactory,
 } from "@fluidframework/aqueduct";
 import { SharedMatrix } from "@fluidframework/matrix";
-import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	IFluidHandle,
+	IRequest,
+} from "@fluidframework/core-interfaces";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import {
 	ChannelFactoryRegistry,
@@ -28,11 +33,7 @@ import {
 	assertDocumentTypeInfo,
 	isDocumentMatrixPlainInfo,
 } from "@fluid-private/test-version-utils";
-import {
-	ConfigTypes,
-	IConfigProviderBase,
-	ITelemetryLoggerExt,
-} from "@fluidframework/telemetry-utils";
+import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
 import { IDocumentLoaderAndSummarizer, IDocumentProps, ISummarizeResult } from "./DocumentCreator";
 
 // Tests usually make use of the default data object provided by the test object provider.

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMultipleDataStores.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentMultipleDataStores.ts
@@ -15,18 +15,19 @@ import {
 } from "@fluidframework/aqueduct";
 import { SharedMap } from "@fluidframework/map";
 import { SharedString } from "@fluidframework/sequence";
-import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	IFluidHandle,
+	IRequest,
+} from "@fluidframework/core-interfaces";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { createSummarizerFromFactory, summarizeNow } from "@fluidframework/test-utils";
 import {
 	assertDocumentTypeInfo,
 	isDocumentMultipleDataStoresInfo,
 } from "@fluid-private/test-version-utils";
-import {
-	ConfigTypes,
-	IConfigProviderBase,
-	ITelemetryLoggerExt,
-} from "@fluidframework/telemetry-utils";
+import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
 import {
 	IDocumentLoaderAndSummarizer,
 	IDocumentProps,

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -6,7 +6,13 @@
 import { strict as assert } from "assert";
 import { v4 as uuid } from "uuid";
 import { MockDocumentDeltaConnection } from "@fluid-private/test-loader-utils";
-import { IErrorBase, IRequest, IRequestHeader } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	IErrorBase,
+	IRequest,
+	IRequestHeader,
+} from "@fluidframework/core-interfaces";
 import {
 	ContainerErrorType,
 	IFluidCodeDetails,
@@ -44,11 +50,7 @@ import {
 	describeCompat,
 	itExpects,
 } from "@fluid-private/test-version-utils";
-import {
-	ConfigTypes,
-	DataCorruptionError,
-	IConfigProviderBase,
-} from "@fluidframework/telemetry-utils";
+import { DataCorruptionError } from "@fluidframework/telemetry-utils";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { IClient } from "@fluidframework/protocol-definitions";
 import {

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -13,11 +13,7 @@ import {
 	DefaultSummaryConfiguration,
 } from "@fluidframework/container-runtime";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import {
-	ConfigTypes,
-	IConfigProviderBase,
-	createChildLogger,
-} from "@fluidframework/telemetry-utils";
+import { createChildLogger } from "@fluidframework/telemetry-utils";
 import {
 	ITestFluidObject,
 	ITestObjectProvider,
@@ -27,6 +23,7 @@ import {
 } from "@fluidframework/test-utils";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IDataStore } from "@fluidframework/runtime-definitions";
+import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 
 describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -16,8 +16,9 @@ import {
 	ISummaryRuntimeOptions,
 } from "@fluidframework/container-runtime";
 import { ILoaderOptions } from "@fluidframework/container-loader";
-import { ConfigTypes, LoggingError } from "@fluidframework/telemetry-utils";
+import { LoggingError } from "@fluidframework/telemetry-utils";
 import { TestDriverTypes } from "@fluidframework/test-driver-definitions";
+import { ConfigTypes } from "@fluidframework/core-interfaces";
 import { ILoadTestConfig, OptionOverride } from "./testConfigFile";
 
 const loaderOptionsMatrix: OptionsMatrix<ILoaderOptions> = {

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -6,7 +6,7 @@
 import { OptionsMatrix } from "@fluid-private/test-pairwise-generator";
 import { ILoaderOptions } from "@fluidframework/container-definitions";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
-import { ConfigTypes } from "@fluidframework/telemetry-utils";
+import { ConfigTypes } from "@fluidframework/core-interfaces";
 
 /** Type modeling the structure of the testConfig.json file */
 export interface ITestConfig {

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -11,17 +11,18 @@ import {
 	OdspTestDriver,
 } from "@fluid-private/test-drivers";
 import { makeRandom } from "@fluid-private/stochastic-test-utils";
-import { ITelemetryBaseEvent, LogLevel } from "@fluidframework/core-interfaces";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	ITelemetryBaseEvent,
+	LogLevel,
+} from "@fluidframework/core-interfaces";
 import { assert, LazyPromise } from "@fluidframework/core-utils";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { IDetachedBlobStorage, Loader } from "@fluidframework/container-loader";
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import { ICreateBlobResponse } from "@fluidframework/protocol-definitions";
-import {
-	ConfigTypes,
-	createChildLogger,
-	IConfigProviderBase,
-} from "@fluidframework/telemetry-utils";
+import { createChildLogger } from "@fluidframework/telemetry-utils";
 import {
 	ITelemetryBufferedLogger,
 	ITestDriver,

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -8,7 +8,7 @@
 
 import { EventEmitter } from 'events';
 import { EventEmitterEventType } from '@fluid-internal/client-utils';
-import { IConfigProviderBase as IConfigProviderBase_2 } from '@fluidframework/core-interfaces';
+import { IConfigProviderBase } from '@fluidframework/core-interfaces';
 import { IDisposable } from '@fluidframework/core-interfaces';
 import { IErrorBase } from '@fluidframework/core-interfaces';
 import { IEvent } from '@fluidframework/core-interfaces';
@@ -29,9 +29,6 @@ import { Tagged } from '@fluidframework/core-interfaces';
 import { TelemetryBaseEventPropertyType } from '@fluidframework/core-interfaces';
 import { TelemetryEventPropertyType } from '@fluidframework/core-interfaces';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
-
-// @internal @deprecated
-export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
 
 // @internal (undocumented)
 export const connectedEventName = "connected";
@@ -127,7 +124,7 @@ export const hasErrorInstanceId: (x: unknown) => x is {
 };
 
 // @internal
-export interface IConfigProvider extends IConfigProviderBase_2 {
+export interface IConfigProvider extends IConfigProviderBase {
     // (undocumented)
     getBoolean(name: string): boolean | undefined;
     // (undocumented)
@@ -140,12 +137,6 @@ export interface IConfigProvider extends IConfigProviderBase_2 {
     getString(name: string): string | undefined;
     // (undocumented)
     getStringArray(name: string): string[] | undefined;
-}
-
-// @internal @deprecated
-export interface IConfigProviderBase {
-    // (undocumented)
-    getRawConfig(name: string): ConfigTypes;
 }
 
 // @internal
@@ -282,7 +273,7 @@ export class LoggingError extends Error implements ILoggingError, Omit<IFluidErr
 export function logIfFalse(condition: unknown, logger: ITelemetryBaseLogger, event: string | ITelemetryGenericEvent): condition is true;
 
 // @internal
-export function mixinMonitoringContext<L extends ITelemetryBaseLogger = ITelemetryLoggerExt>(logger: L, ...configs: (IConfigProviderBase_2 | undefined)[]): MonitoringContext<L>;
+export function mixinMonitoringContext<L extends ITelemetryBaseLogger = ITelemetryLoggerExt>(logger: L, ...configs: (IConfigProviderBase | undefined)[]): MonitoringContext<L>;
 
 // @internal
 export class MockLogger implements ITelemetryBaseLogger {
@@ -368,7 +359,7 @@ export class SampledTelemetryHelper implements IDisposable {
 }
 
 // @internal
-export const sessionStorageConfigProvider: Lazy<IConfigProviderBase_2>;
+export const sessionStorageConfigProvider: Lazy<IConfigProviderBase>;
 
 // @internal
 export const tagCodeArtifacts: <T extends Record<string, TelemetryEventPropertyType | (() => TelemetryBaseEventPropertyType)>>(values: T) => { [P in keyof T]: (T[P] extends () => TelemetryBaseEventPropertyType ? () => {

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -117,6 +117,15 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedTypeAliasDeclaration_ConfigTypes": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"RemovedInterfaceDeclaration_IConfigProviderBase": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/utils/telemetry-utils/src/index.ts
+++ b/packages/utils/telemetry-utils/src/index.ts
@@ -80,22 +80,3 @@ export {
 	ITelemetryPropertiesExt,
 	TelemetryEventCategory,
 } from "./telemetryTypes";
-
-/**
- * Types supported by {@link IConfigProviderBase}.
- * @deprecated Use ConfigTypes from fluidFramework/core-interfaces
- *
- * @internal
- */
-export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
-
-/**
- * Base interface for providing configurations to enable/disable/control features.
- *
- * @deprecated Use IConfigProviderBase from fluidFramework/core-interfaces
- *
- * @internal
- */
-export interface IConfigProviderBase {
-	getRawConfig(name: string): ConfigTypes;
-}

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
@@ -24,26 +24,14 @@ type TypeOnly<T> = T extends number
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_ConfigTypes": {"forwardCompat": false}
+* "RemovedTypeAliasDeclaration_ConfigTypes": {"forwardCompat": false}
 */
-declare function get_old_TypeAliasDeclaration_ConfigTypes():
-    TypeOnly<old.ConfigTypes>;
-declare function use_current_TypeAliasDeclaration_ConfigTypes(
-    use: TypeOnly<current.ConfigTypes>): void;
-use_current_TypeAliasDeclaration_ConfigTypes(
-    get_old_TypeAliasDeclaration_ConfigTypes());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_ConfigTypes": {"backCompat": false}
+* "RemovedTypeAliasDeclaration_ConfigTypes": {"backCompat": false}
 */
-declare function get_current_TypeAliasDeclaration_ConfigTypes():
-    TypeOnly<current.ConfigTypes>;
-declare function use_old_TypeAliasDeclaration_ConfigTypes(
-    use: TypeOnly<old.ConfigTypes>): void;
-use_old_TypeAliasDeclaration_ConfigTypes(
-    get_current_TypeAliasDeclaration_ConfigTypes());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -168,26 +156,14 @@ use_old_InterfaceDeclaration_IConfigProvider(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IConfigProviderBase": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IConfigProviderBase": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IConfigProviderBase():
-    TypeOnly<old.IConfigProviderBase>;
-declare function use_current_InterfaceDeclaration_IConfigProviderBase(
-    use: TypeOnly<current.IConfigProviderBase>): void;
-use_current_InterfaceDeclaration_IConfigProviderBase(
-    get_old_InterfaceDeclaration_IConfigProviderBase());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IConfigProviderBase": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IConfigProviderBase": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IConfigProviderBase():
-    TypeOnly<current.IConfigProviderBase>;
-declare function use_old_InterfaceDeclaration_IConfigProviderBase(
-    use: TypeOnly<old.IConfigProviderBase>): void;
-use_old_InterfaceDeclaration_IConfigProviderBase(
-    get_current_InterfaceDeclaration_IConfigProviderBase());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
## Remove deprecated config types from telemetry-utils

The types ConfigTypes, and IConfigProviderBase were deprecated and are now removed from @fluidframework/telemetry-utils. They continue to exist in @fluidframework/core-interfaces. Please update your reference to use these types from @fluidframework/core-interfaces.