### PR TITLE
fix(version-utils): Update internalSchema to handle rc releases

### DIFF
--- a/packages/test/test-version-utils/src/test/versionUtils.spec.ts
+++ b/packages/test/test-version-utils/src/test/versionUtils.spec.ts
@@ -330,6 +330,18 @@ describe("versionUtils", () => {
 				adjustPublicMajor,
 				"^1.0.0-0",
 			);
+			checkRequestedVersionSatisfies(
+				"2.0.0-dev-rc.1.0.0.223149",
+				-1,
+				adjustPublicMajor,
+				"^2.0.0-internal.8.0.0",
+			);
+			checkRequestedVersionSatisfies(
+				"2.0.0-dev-rc.1.5.3.223149",
+				-2,
+				adjustPublicMajor,
+				"^2.0.0-internal.7.0.0",
+			);
 		});
 	});
 

--- a/packages/test/test-version-utils/src/test/versionUtils.spec.ts
+++ b/packages/test/test-version-utils/src/test/versionUtils.spec.ts
@@ -24,11 +24,17 @@ const checkRequestedVersionSatisfies = (
 	adjustPublicMajor,
 	expectedVersion,
 ) => {
-	const version = getRequestedVersion(baseVersion, requested, adjustPublicMajor);
-	assert(
-		satisfies(version, expectedVersion),
-		`getRequestedVersion("${baseVersion}", ${requested}) -> ${version} does not satisfy ${expectedVersion}`,
-	);
+	try {
+		const version = getRequestedVersion(baseVersion, requested, adjustPublicMajor);
+		assert(
+			satisfies(version, expectedVersion),
+			`getRequestedVersion("${baseVersion}", ${requested}) -> ${version} does not satisfy ${expectedVersion}`,
+		);
+	} catch (e) {
+		throw new Error(
+			`Failed to resolve getRequestedVersion("${baseVersion}", ${requested}) -> ${expectedVersion}: ${e}`,
+		);
+	}
 };
 
 describe("versionUtils", () => {
@@ -48,6 +54,7 @@ describe("versionUtils", () => {
 			checkRequestedVersionSatisfies("2.0.0-internal.1.1.1", -1, adjustPublicMajor, "^1.0.0");
 			checkRequestedVersionSatisfies("2.0.0-internal.1.2.3", -1, adjustPublicMajor, "^1.0.0");
 			checkRequestedVersionSatisfies("2.0.0-internal.1.4.2", -1, adjustPublicMajor, "^1.0.0");
+
 			checkRequestedVersionSatisfies(
 				"2.0.0-internal.1.4.2",
 				-2,
@@ -64,7 +71,7 @@ describe("versionUtils", () => {
 			checkRequestedVersionSatisfies("2.0.0-internal.2.0.1", -2, adjustPublicMajor, "^1.0.0");
 		});
 
-		it("bumping internal releases to public releases (adjustPublicMajor = true)", () => {
+		it("bumping internal/rc releases to public releases (adjustPublicMajor = true)", () => {
 			const adjustPublicMajor = true;
 			checkRequestedVersionSatisfies("2.0.0-internal.1.0.0", -1, adjustPublicMajor, "^1.0.0");
 			checkRequestedVersionSatisfies("2.0.0-internal.2.0.0", -1, adjustPublicMajor, "^1.0.0");
@@ -81,6 +88,12 @@ describe("versionUtils", () => {
 				"^0.59.0",
 			);
 			checkRequestedVersionSatisfies("2.0.0-internal.6.4.0", -1, adjustPublicMajor, "^1.0.0");
+
+			checkRequestedVersionSatisfies("2.0.0-rc.1.0.0", -1, adjustPublicMajor, "^1.0.0");
+			checkRequestedVersionSatisfies("2.0.0-rc.2.0.0", -1, adjustPublicMajor, "^1.0.0");
+			checkRequestedVersionSatisfies("2.0.0-rc.1.0.0", -2, adjustPublicMajor, "^0.59.0");
+			checkRequestedVersionSatisfies("2.0.0-rc.2.0.0", -2, adjustPublicMajor, "^0.59.0");
+			checkRequestedVersionSatisfies("2.0.0-rc.6.4.0", -1, adjustPublicMajor, "^1.0.0");
 		});
 
 		it("bumping internal releases to other internal releases", () => {
@@ -193,6 +206,54 @@ describe("versionUtils", () => {
 				adjustPublicMajor,
 				"^2.0.0-internal.3.0.0-0",
 			);
+		});
+
+		it("bumping rc releases to other rc/internal releases", () => {
+			const adjustPublicMajor = false;
+			checkRequestedVersionSatisfies(
+				"2.0.0-rc.1.0.0",
+				-1,
+				adjustPublicMajor,
+				"^2.0.0-internal.8.0.0",
+			);
+			checkRequestedVersionSatisfies(
+				"2.0.0-rc.1.2.0",
+				-1,
+				adjustPublicMajor,
+				"^2.0.0-internal.8.0.0",
+			);
+			checkRequestedVersionSatisfies(
+				"2.0.0-rc.1.2.4",
+				-1,
+				adjustPublicMajor,
+				"^2.0.0-internal.8.0.0",
+			);
+			checkRequestedVersionSatisfies(
+				"2.0.0-rc.1.3.4",
+				-1,
+				adjustPublicMajor,
+				"^2.0.0-internal.8.0.0",
+			);
+			checkRequestedVersionSatisfies(
+				"2.0.0-rc.1.3.4",
+				-2,
+				adjustPublicMajor,
+				"^2.0.0-internal.7.0.0",
+			);
+
+			// These tests should be enabled once 2.0.0-rc.1.0.0 is released (currently throws trying to fetch the unreleased packages)
+			// checkRequestedVersionSatisfies(
+			// 	"2.0.0-rc.2.0.0",
+			// 	-1,
+			// 	adjustPublicMajor,
+			// 	"^2.0.0-rc.1.0.0",
+			// );
+			// checkRequestedVersionSatisfies(
+			// 	"2.0.0-rc.2.0.0",
+			// 	-2,
+			// 	adjustPublicMajor,
+			// 	"^2.0.0-internal.8.0.0",
+			// );
 		});
 
 		it("error cases for malformed versions", () => {

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -420,7 +420,7 @@ function internalSchema(
 ): string {
 	// Here we handle edge cases of converting the early rc/internal releases.
 	// We convert early rc releases to internal releases, and early internal releases to public releases.
-	if (prereleaseIdentifier === "rc") {
+	if (prereleaseIdentifier === "rc" || prereleaseIdentifier === "dev-rc") {
 		if (semver.eq(publicVersion, "2.0.0") && semver.lt(internalVersion, "2.0.0")) {
 			if (requested === -1) {
 				return `^2.0.0-internal.8.0.0`;

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -370,7 +370,7 @@ export function getRequestedVersion(
 
 	// if the baseVersion passed is an internal version
 	if (adjustPublicMajor === false && (scheme === "internal" || scheme === "internalPrerelease")) {
-		const [publicVersion, internalVersion /* prereleaseIdentifier */] = fromInternalScheme(
+		const [publicVersion, internalVersion, prereleaseIdentifier] = fromInternalScheme(
 			baseVersion,
 			/** allowPrereleases */ true,
 			/** allowAnyPrereleaseId */ true,
@@ -379,6 +379,7 @@ export function getRequestedVersion(
 		const internalSchemeRange = internalSchema(
 			publicVersion.version,
 			internalVersion.version,
+			prereleaseIdentifier,
 			requested,
 		);
 		return resolveVersion(internalSchemeRange, false);
@@ -411,8 +412,25 @@ export function getRequestedVersion(
 	return resolveVersion(`^0.${requestedMinorVersion}.0-0`, false);
 }
 
-function internalSchema(publicVersion: string, internalVersion: string, requested: number): string {
-	if (semver.eq(publicVersion, "2.0.0") && semver.lt(internalVersion, "2.0.0")) {
+function internalSchema(
+	publicVersion: string,
+	internalVersion: string,
+	prereleaseIdentifier: string,
+	requested: number,
+): string {
+	// Here we handle edge cases of converting the early rc/internal releases.
+	// We convert early rc releases to internal releases, and early internal releases to public releases.
+	if (prereleaseIdentifier === "rc") {
+		if (semver.eq(publicVersion, "2.0.0") && semver.lt(internalVersion, "2.0.0")) {
+			if (requested === -1) {
+				return `^2.0.0-internal.8.0.0`;
+			}
+
+			if (requested === -2) {
+				return `^2.0.0-internal.7.0.0`;
+			}
+		}
+	} else if (semver.eq(publicVersion, "2.0.0") && semver.lt(internalVersion, "2.0.0")) {
 		if (requested === -1) {
 			return `^1.0.0-0`;
 		}
@@ -457,9 +475,13 @@ function internalSchema(publicVersion: string, internalVersion: string, requeste
 		throw new Error(err as string);
 	}
 
-	return `>=${publicVersion}-internal.${parsedVersion.major - 1}.0.0 <${publicVersion}-internal.${
-		parsedVersion.major
-	}.0.0`;
+	// We treat internal and rc as valid; other values should be coerced to "internal"
+	const idToUse = ["internal", "rc"].includes(prereleaseIdentifier)
+		? prereleaseIdentifier
+		: "internal";
+	return `>=${publicVersion}-${idToUse}.${
+		parsedVersion.major - 1
+	}.0.0 <${publicVersion}-${idToUse}.${parsedVersion.major}.0.0`;
 }
 
 /**


### PR DESCRIPTION
## Description

This PR updates our version tooling, specifically `internalSchema()` to properly handle RC releases in compat testing.