### PR TITLE
build(docs): Fix page jump when clicking on interfaces, classes or enums

### DIFF
--- a/docs/themes/thxvscode/assets/scss/includes/_docs.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_docs.scss
@@ -163,7 +163,8 @@
 }
 
 #docs-navbar .nav {
-	li a {
+	li a,
+	li div {
 		border-left: 1px solid $gray;
 		display: block;
 
@@ -179,6 +180,11 @@
 		}
 	}
 
+	/* Increased padding for API category/group items */
+	.api-item-kind {
+		padding: 5px 35px;
+	}
+
 	> li > a {
 		padding: 8px 15px;
 		font-size: 14px;
@@ -188,10 +194,6 @@
 		padding: 5px 25px;
 		position: relative;
 
-		/* Increased padding for API category/group items */
-		&.api-item-kind {
-			padding: 5px 35px;
-		}
 
 		/* Further increased padding for specific API endpoints */
 		&.leaf-node {
@@ -220,18 +222,32 @@
 			margin-right: 40px;
 		}
 
-		&.expanded a {
-			border-color: $link-color;
+		&.expanded, &.collapsed {
+			a, div {
+				&:hover {
+					background-size: 24px;
+					background-repeat: no-repeat;
+					background-position: 110px 5px;
+				}
+			}
 		}
-
-		&.expanded > a:hover {
-			background: url("/expand-up.svg") 110px 5px no-repeat;
-			background-size: 24px;
+	
+		&.expanded {
+			a, div {
+				border-color: $link-color;
+	
+				&:hover {
+					background-image: url("/expand-up.svg");
+				}
+			}
 		}
-
-		&.collapsed > a:hover {
-			background: url("/expand-down.svg") 110px 5px no-repeat;
-			background-size: 24px;
+	
+		&.collapsed {
+			a, div {
+				&:hover {
+					background-image: url("/expand-down.svg");
+				}
+			}
 		}
 	}
 
@@ -274,14 +290,19 @@
 
 /* Main Nav active */
 #docs-navbar > .nav > .active > a,
-#docs-navbar > .nav > .active .active > a {
-	color: $link-color !important;
+#docs-navbar > .nav > .active .active > a,
+#docs-navbar > .nav > .active > div,
+#docs-navbar > .nav > .active .active > div {
+    color: $link-color !important;
 }
 
+#docs-navbar > .nav > .active > div:not(.area),
+#docs-navbar > .nav > .active .active > div,
 #docs-navbar > .nav > .active > a:not(.area),
 #docs-navbar > .nav > .active .active > a {
-	font-weight: bold;
+    font-weight: bold;
 }
+
 
 #docs-navbar > .nav .active:not(.active-leaf) > .packages:before {
 	content: "";

--- a/docs/themes/thxvscode/assets/scss/includes/_docs.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_docs.scss
@@ -296,10 +296,10 @@
     color: $link-color !important;
 }
 
-#docs-navbar > .nav > .active > div:not(.area),
-#docs-navbar > .nav > .active .active > div,
 #docs-navbar > .nav > .active > a:not(.area),
-#docs-navbar > .nav > .active .active > a {
+#docs-navbar > .nav > .active .active > a,
+#docs-navbar > .nav > .active > div:not(.area),
+#docs-navbar > .nav > .active .active > div{
     font-weight: bold;
 }
 

--- a/docs/themes/thxvscode/layouts/partials/apiNav.html
+++ b/docs/themes/thxvscode/layouts/partials/apiNav.html
@@ -150,11 +150,11 @@
                                             {{ $categoryPlural := index $plurals $category }}
 
                                             <li class="panel type-definitions {{ if $isCategoryActive }}active expanded{{ else }}collapsed{{ end }}">
-                                                <a href="#" class="api-item-kind {{ $categoryLower }}-link" 
+                                                <div href="#" class="api-item-kind {{ $categoryLower }}-link" 
                                                     data-toggle="collapse" data-target="#{{ $categoryLower }}-{{ $isCurrentPage }}-content"
                                                 >
                                                     {{ $categoryPlural }}
-                                                </a>
+                                                </div>
                                                 
                                                 <ul id="{{ $categoryLower }}-{{ $isCurrentPage }}-content" class="collapse {{ if $isCategoryActive }}in{{ end }}">
                                                     {{ range $item := index $apiDetails $category }}


### PR DESCRIPTION
When clicking on things on the same level as interfaces, classes and enums, the ui jumps to the top, this PR aims to fix that, we still have not fixed the api items below this level yet

UI:
![image](https://github.com/microsoft/FluidFramework/assets/107130183/349feed1-31c0-4960-ab35-839d81ed9771)

AB#6573