### PR TITLE
apis directory fix

### DIFF
--- a/docs/api-markdown-documenter/index.js
+++ b/docs/api-markdown-documenter/index.js
@@ -13,6 +13,7 @@
 const chalk = require("chalk");
 const versions = require("../data/versions.json");
 const { renderApiDocumentation } = require("./render-api-documentation");
+const path = require("path");
 
 const renderMultiVersion = process.argv[2];
 
@@ -23,13 +24,27 @@ docVersions = renderMultiVersion
 const apiDocRenders = [];
 
 docVersions.forEach((version) => {
+	const apiReportsDirectoryPath = path.resolve(
+		__dirname,
+		"..",
+		"_api-extractor-temp",
+		version,
+		"_build",
+	);
+
+	// TODO: remove check for 2.0 and just set apiDocsDirectoryPath to include version.
+	// currently publishing to base apis directory until 2.0 release
+	const apiDocsDirectoryPath = (renderMultiVersion) ? 
+		path.resolve(__dirname, "..", "content", "docs", "apis", version) :
+		path.resolve(__dirname, "..", "content", "docs", "apis");
+
 	apiDocRenders.push(
-		renderApiDocumentation(version).then(
+		renderApiDocumentation(apiReportsDirectoryPath, apiDocsDirectoryPath, version).then(
 			() => {
 				console.log(chalk.green(`${version} API docs written!`));
 			},
 			(error) => {
-				throw new error(`${version} API docs could not be written due to an error:`, error);
+				throw new Error(`${version} API docs could not be written due to an error:`, error);
 			},
 		),
 	);

--- a/docs/api-markdown-documenter/render-api-documentation.js
+++ b/docs/api-markdown-documenter/render-api-documentation.js
@@ -29,7 +29,12 @@ async function renderApiDocumentation(version) {
 		version,
 		"_build",
 	);
-	const apiDocsDirectoryPath = path.resolve(__dirname, "..", "content", "docs", "apis", version);
+
+	// TODO: remove check for 2.0 and just set apiDocsDirectoryPath to include version.
+	// currently publishing to base apis directory until 2.0 release
+	const apiDocsDirectoryPath = (version === '2.0') ? 
+		path.resolve(__dirname, "..", "content", "docs", "apis") :
+		path.resolve(__dirname, "..", "content", "docs", "apis", version);
 
 	// Delete existing documentation output
 	console.log("Removing existing generated API docs...");

--- a/docs/api-markdown-documenter/render-api-documentation.js
+++ b/docs/api-markdown-documenter/render-api-documentation.js
@@ -21,31 +21,17 @@ const { buildNavBar } = require("./build-api-nav");
 const { renderAlertNode, renderBlockQuoteNode, renderTableNode } = require("./custom-renderers");
 const { createHugoFrontMatter } = require("./front-matter");
 
-async function renderApiDocumentation(version) {
-	const apiReportsDirectoryPath = path.resolve(
-		__dirname,
-		"..",
-		"_api-extractor-temp",
-		version,
-		"_build",
-	);
-
-	// TODO: remove check for 2.0 and just set apiDocsDirectoryPath to include version.
-	// currently publishing to base apis directory until 2.0 release
-	const apiDocsDirectoryPath = (version === '2.0') ? 
-		path.resolve(__dirname, "..", "content", "docs", "apis") :
-		path.resolve(__dirname, "..", "content", "docs", "apis", version);
-
+async function renderApiDocumentation(inputDir, outputDir, version) {
 	// Delete existing documentation output
 	console.log("Removing existing generated API docs...");
-	await fs.ensureDir(apiDocsDirectoryPath);
-	await fs.emptyDir(apiDocsDirectoryPath);
+	await fs.ensureDir(outputDir);
+	await fs.emptyDir(outputDir);
 
 	// Process API reports
 	console.log("Loading API model...");
 	console.group();
 
-	const apiModel = await loadModel(apiReportsDirectoryPath);
+	const apiModel = await loadModel(inputDir);
 
 	console.groupEnd();
 
@@ -129,7 +115,7 @@ async function renderApiDocumentation(version) {
 				throw error;
 			}
 
-			let filePath = path.join(apiDocsDirectoryPath, `${document.documentPath}.md`);
+			let filePath = path.join(outputDir, `${document.documentPath}.md`);
 
 			try {
 				// Hugo uses a special file-naming syntax to represent documents with "child" documents in the same directory.


### PR DESCRIPTION
Temporary fix to publish api docs back to original apis directory instead of apis/2.0. 
Changes will be reverted back to publish in 2.0 directory after 2.0 release.