### PR TITLE
Update type tests for 7.4 release branch

### DIFF
--- a/azure/packages/azure-client/package.json
+++ b/azure/packages/azure-client/package.json
@@ -78,7 +78,7 @@
 		"@fluid-experimental/tree2": "workspace:~",
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/aqueduct": "workspace:~",
-		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.0.0-internal.7.2.0",
+		"@fluidframework/azure-client-previous": "npm:@fluidframework/azure-client@2.0.0-internal.7.3.0",
 		"@fluidframework/azure-local-service": "workspace:~",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",

--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.13.3",
 		"@fluid-tools/build-cli": "^0.28.0",
-		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.0.0-internal.7.2.0",
+		"@fluidframework/azure-service-utils-previous": "npm:@fluidframework/azure-service-utils@2.0.0-internal.7.3.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",

--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -74,7 +74,7 @@
 		"path-browserify": "^1.0.1"
 	},
 	"devDependencies": {
-		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@2.0.0-internal.7.2.0",
+		"@fluid-experimental/attributable-map-previous": "npm:@fluid-experimental/attributable-map@2.0.0-internal.7.3.0",
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -54,7 +54,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.7.2.0",
+		"@fluidframework/container-definitions-previous": "npm:@fluidframework/container-definitions@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/events": "^3.0.0",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -47,7 +47,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.7.2.0",
+		"@fluidframework/core-interfaces-previous": "npm:@fluidframework/core-interfaces@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/node": "^18.19.0",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -50,7 +50,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.7.2.0",
+		"@fluidframework/driver-definitions-previous": "npm:@fluidframework/driver-definitions@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"copyfiles": "^2.4.1",

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -79,7 +79,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.7.2.0",
+		"@fluidframework/cell-previous": "npm:@fluidframework/cell@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/counter/package.json
+++ b/packages/dds/counter/package.json
@@ -78,7 +78,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.7.2.0",
+		"@fluidframework/counter-previous": "npm:@fluidframework/counter@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -79,7 +79,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.7.2.0",
+		"@fluidframework/ink-previous": "npm:@fluidframework/ink@2.0.0-internal.7.3.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -90,7 +90,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.7.2.0",
+		"@fluidframework/map-previous": "npm:@fluidframework/map@2.0.0-internal.7.3.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -89,7 +89,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.7.2.0",
+		"@fluidframework/matrix-previous": "npm:@fluidframework/matrix@2.0.0-internal.7.3.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
@@ -126,10 +126,6 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_SharedMatrix": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/dds/matrix/src/test/types/validateMatrixPrevious.generated.ts
+++ b/packages/dds/matrix/src/test/types/validateMatrixPrevious.generated.ts
@@ -103,7 +103,6 @@ declare function get_old_ClassDeclaration_SharedMatrix():
 declare function use_current_ClassDeclaration_SharedMatrix(
     use: TypeOnly<current.SharedMatrix>): void;
 use_current_ClassDeclaration_SharedMatrix(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_SharedMatrix());
 
 /*

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -90,7 +90,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.7.2.0",
+		"@fluidframework/merge-tree-previous": "npm:@fluidframework/merge-tree@2.0.0-internal.7.3.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -83,7 +83,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.7.2.0",
+		"@fluidframework/ordered-collection-previous": "npm:@fluidframework/ordered-collection@2.0.0-internal.7.3.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -82,7 +82,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.7.2.0",
+		"@fluidframework/register-collection-previous": "npm:@fluidframework/register-collection@2.0.0-internal.7.3.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",

--- a/packages/dds/sequence/package.json
+++ b/packages/dds/sequence/package.json
@@ -96,7 +96,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.7.2.0",
+		"@fluidframework/sequence-previous": "npm:@fluidframework/sequence@2.0.0-internal.7.3.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/diff": "^3.5.1",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -86,7 +86,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.7.2.0",
+		"@fluidframework/shared-object-base-previous": "npm:@fluidframework/shared-object-base@2.0.0-internal.7.3.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/shared-summary-block/package.json
+++ b/packages/dds/shared-summary-block/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.7.2.0",
+		"@fluidframework/shared-summary-block-previous": "npm:@fluidframework/shared-summary-block@2.0.0-internal.7.3.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/benchmark": "^2.1.0",

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.7.2.0",
+		"@fluidframework/task-manager-previous": "npm:@fluidframework/task-manager@2.0.0-internal.7.3.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",

--- a/packages/drivers/debugger/package.json
+++ b/packages/drivers/debugger/package.json
@@ -50,7 +50,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.7.2.0",
+		"@fluidframework/debugger-previous": "npm:@fluidframework/debugger@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/driver-base/package.json
+++ b/packages/drivers/driver-base/package.json
@@ -78,7 +78,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.7.2.0",
+		"@fluidframework/driver-base-previous": "npm:@fluidframework/driver-base@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",

--- a/packages/drivers/driver-web-cache/package.json
+++ b/packages/drivers/driver-web-cache/package.json
@@ -54,7 +54,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.7.2.0",
+		"@fluidframework/driver-web-cache-previous": "npm:@fluidframework/driver-web-cache@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/jest": "29.5.3",

--- a/packages/drivers/file-driver/package.json
+++ b/packages/drivers/file-driver/package.json
@@ -51,7 +51,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.7.2.0",
+		"@fluidframework/file-driver-previous": "npm:@fluidframework/file-driver@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/node": "^18.19.0",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/fluidapp-odsp-urlResolver/package.json
+++ b/packages/drivers/fluidapp-odsp-urlResolver/package.json
@@ -53,7 +53,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.13.3",
 		"@fluid-tools/build-cli": "^0.28.0",
-		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.2.0",
+		"@fluid-tools/fluidapp-odsp-urlresolver-previous": "npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.3.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -91,7 +91,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.7.2.0",
+		"@fluidframework/local-driver-previous": "npm:@fluidframework/local-driver@2.0.0-internal.7.3.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/jsrsasign": "^8.0.8",

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -48,7 +48,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.7.2.0",
+		"@fluidframework/odsp-driver-definitions-previous": "npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.7.3.0",
 		"@fluidframework/protocol-definitions": "^3.0.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -87,7 +87,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.7.2.0",
+		"@fluidframework/odsp-driver-previous": "npm:@fluidframework/odsp-driver@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/odsp-urlResolver/package.json
+++ b/packages/drivers/odsp-urlResolver/package.json
@@ -55,7 +55,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.7.2.0",
+		"@fluidframework/odsp-urlresolver-previous": "npm:@fluidframework/odsp-urlresolver@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/replay-driver/package.json
+++ b/packages/drivers/replay-driver/package.json
@@ -52,7 +52,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.7.2.0",
+		"@fluidframework/replay-driver-previous": "npm:@fluidframework/replay-driver@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.19.0",

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -89,7 +89,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.7.2.0",
+		"@fluidframework/routerlicious-driver-previous": "npm:@fluidframework/routerlicious-driver@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/nock": "^9.3.0",

--- a/packages/drivers/routerlicious-urlResolver/package.json
+++ b/packages/drivers/routerlicious-urlResolver/package.json
@@ -57,7 +57,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.7.2.0",
+		"@fluidframework/routerlicious-urlresolver-previous": "npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/nconf": "^0.10.0",

--- a/packages/drivers/tinylicious-driver/package.json
+++ b/packages/drivers/tinylicious-driver/package.json
@@ -58,7 +58,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-tools": "^1.0.195075",
-		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.7.2.0",
+		"@fluidframework/tinylicious-driver-previous": "npm:@fluidframework/tinylicious-driver@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -56,7 +56,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.13.3",
 		"@fluid-tools/build-cli": "^0.28.0",
-		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.7.2.0",
+		"@fluidframework/agent-scheduler-previous": "npm:@fluidframework/agent-scheduler@2.0.0-internal.7.3.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -88,7 +88,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.13.3",
 		"@fluid-tools/build-cli": "^0.28.0",
-		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.7.2.0",
+		"@fluidframework/aqueduct-previous": "npm:@fluidframework/aqueduct@2.0.0-internal.7.3.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",

--- a/packages/framework/data-object-base/package.json
+++ b/packages/framework/data-object-base/package.json
@@ -63,7 +63,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.7.2.0",
+		"@fluidframework/data-object-base-previous": "npm:@fluidframework/data-object-base@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/node": "^18.19.0",

--- a/packages/framework/dds-interceptions/package.json
+++ b/packages/framework/dds-interceptions/package.json
@@ -76,7 +76,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.7.2.0",
+		"@fluidframework/dds-interceptions-previous": "npm:@fluidframework/dds-interceptions@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -82,7 +82,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.7.2.0",
+		"@fluidframework/fluid-static-previous": "npm:@fluidframework/fluid-static@2.0.0-internal.7.3.0",
 		"@fluidframework/map": "workspace:~",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",

--- a/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
+++ b/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
@@ -288,6 +288,30 @@ use_old_InterfaceDeclaration_IServiceAudienceEvents(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_InitialObjects": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_InitialObjects():
+    TypeOnly<old.InitialObjects<any>>;
+declare function use_current_TypeAliasDeclaration_InitialObjects(
+    use: TypeOnly<current.InitialObjects<any>>): void;
+use_current_TypeAliasDeclaration_InitialObjects(
+    get_old_TypeAliasDeclaration_InitialObjects());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_InitialObjects": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_InitialObjects():
+    TypeOnly<current.InitialObjects<any>>;
+declare function use_old_TypeAliasDeclaration_InitialObjects(
+    use: TypeOnly<old.InitialObjects<any>>): void;
+use_old_TypeAliasDeclaration_InitialObjects(
+    get_current_TypeAliasDeclaration_InitialObjects());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "TypeAliasDeclaration_LoadableObjectClass": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_LoadableObjectClass():

--- a/packages/framework/request-handler/package.json
+++ b/packages/framework/request-handler/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.7.2.0",
+		"@fluidframework/request-handler-previous": "npm:@fluidframework/request-handler@2.0.0-internal.7.3.0",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/diff": "^3.5.1",

--- a/packages/framework/synthesize/package.json
+++ b/packages/framework/synthesize/package.json
@@ -79,7 +79,7 @@
 		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.7.2.0",
+		"@fluidframework/synthesize-previous": "npm:@fluidframework/synthesize@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -81,7 +81,7 @@
 		"@fluidframework/container-runtime-definitions": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/test-utils": "workspace:~",
-		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.7.2.0",
+		"@fluidframework/tinylicious-client-previous": "npm:@fluidframework/tinylicious-client@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/framework/undo-redo/package.json
+++ b/packages/framework/undo-redo/package.json
@@ -78,7 +78,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
-		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.7.2.0",
+		"@fluidframework/undo-redo-previous": "npm:@fluidframework/undo-redo@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/diff": "^3.5.1",
 		"@types/events": "^3.0.0",

--- a/packages/framework/view-adapters/package.json
+++ b/packages/framework/view-adapters/package.json
@@ -51,7 +51,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.7.2.0",
+		"@fluidframework/view-adapters-previous": "npm:@fluidframework/view-adapters@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/packages/framework/view-interfaces/package.json
+++ b/packages/framework/view-interfaces/package.json
@@ -48,7 +48,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.7.2.0",
+		"@fluidframework/view-interfaces-previous": "npm:@fluidframework/view-interfaces@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -87,7 +87,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.7.2.0",
+		"@fluidframework/container-loader-previous": "npm:@fluidframework/container-loader@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -83,7 +83,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.7.2.0",
+		"@fluidframework/driver-utils-previous": "npm:@fluidframework/driver-utils@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",

--- a/packages/loader/location-redirection-utils/package.json
+++ b/packages/loader/location-redirection-utils/package.json
@@ -72,7 +72,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.7.2.0",
+		"@fluidframework/location-redirection-utils-previous": "npm:@fluidframework/location-redirection-utils@2.0.0-internal.7.3.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -48,7 +48,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.2.0",
+		"@fluidframework/container-runtime-definitions-previous": "npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -93,7 +93,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.7.2.0",
+		"@fluidframework/container-runtime-previous": "npm:@fluidframework/container-runtime@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
@@ -129,13 +129,6 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_ContainerRuntime": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_IGCStats": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -163,7 +163,6 @@ declare function get_current_ClassDeclaration_ContainerRuntime():
 declare function use_old_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<old.ContainerRuntime>): void;
 use_old_ClassDeclaration_ContainerRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_ContainerRuntime());
 
 /*
@@ -800,7 +799,6 @@ declare function get_old_InterfaceDeclaration_IGCStats():
 declare function use_current_InterfaceDeclaration_IGCStats(
     use: TypeOnly<current.IGCStats>): void;
 use_current_InterfaceDeclaration_IGCStats(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IGCStats());
 
 /*

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -48,7 +48,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.7.2.0",
+		"@fluidframework/datastore-definitions-previous": "npm:@fluidframework/datastore-definitions@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -84,7 +84,7 @@
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
-		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.7.2.0",
+		"@fluidframework/datastore-previous": "npm:@fluidframework/datastore@2.0.0-internal.7.3.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
@@ -117,10 +117,6 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_FluidDataStoreRuntime": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
@@ -55,7 +55,6 @@ declare function get_old_ClassDeclaration_FluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_FluidDataStoreRuntime(
     use: TypeOnly<current.FluidDataStoreRuntime>): void;
 use_current_ClassDeclaration_FluidDataStoreRuntime(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_FluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -106,5 +106,8 @@
 				"script": false
 			}
 		}
+	},
+	"typeValidation": {
+		"broken": {}
 	}
 }

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -49,7 +49,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.7.2.0",
+		"@fluidframework/runtime-definitions-previous": "npm:@fluidframework/runtime-definitions@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
@@ -71,15 +71,6 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"TypeAliasDeclaration_IdCreationRangeWithStashedState": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"RemovedTypeAliasDeclaration_IdCreationRangeWithStashedState": {
-				"forwardCompat": false,
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -1032,18 +1032,6 @@ use_old_InterfaceDeclaration_IdCreationRange(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_IdCreationRangeWithStashedState": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedTypeAliasDeclaration_IdCreationRangeWithStashedState": {"backCompat": false}
-*/
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "TypeAliasDeclaration_InboundAttachMessage": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_InboundAttachMessage():

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -82,7 +82,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.7.2.0",
+		"@fluidframework/runtime-utils-previous": "npm:@fluidframework/runtime-utils@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -85,7 +85,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.7.2.0",
+		"@fluidframework/test-runtime-utils-previous": "npm:@fluidframework/test-runtime-utils@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/jsrsasign": "^8.0.8",
 		"@types/mocha": "^9.1.1",

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="mocha" />
-
 // @internal (undocumented)
 export const mochaHooks: {
     beforeAll(): void;

--- a/packages/test/mocha-test-setup/package.json
+++ b/packages/test/mocha-test-setup/package.json
@@ -52,7 +52,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.2.0",
+		"@fluidframework/mocha-test-setup-previous": "npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -52,7 +52,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.7.2.0",
+		"@fluidframework/test-driver-definitions-previous": "npm:@fluidframework/test-driver-definitions@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -94,7 +94,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.7.2.0",
+		"@fluidframework/test-utils-previous": "npm:@fluidframework/test-utils@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/debug": "^4.1.5",
 		"@types/diff": "^3.5.1",
@@ -127,15 +127,6 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"InterfaceDeclaration_ITestObjectProvider": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"ClassDeclaration_TestObjectProvider": {
-				"backCompat": false,
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -199,7 +199,6 @@ declare function get_old_InterfaceDeclaration_ITestObjectProvider():
 declare function use_current_InterfaceDeclaration_ITestObjectProvider(
     use: TypeOnly<current.ITestObjectProvider>): void;
 use_current_InterfaceDeclaration_ITestObjectProvider(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ITestObjectProvider());
 
 /*
@@ -212,7 +211,6 @@ declare function get_current_InterfaceDeclaration_ITestObjectProvider():
 declare function use_old_InterfaceDeclaration_ITestObjectProvider(
     use: TypeOnly<old.ITestObjectProvider>): void;
 use_old_InterfaceDeclaration_ITestObjectProvider(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITestObjectProvider());
 
 /*
@@ -369,7 +367,6 @@ declare function get_old_ClassDeclaration_TestObjectProvider():
 declare function use_current_ClassDeclaration_TestObjectProvider(
     use: TypeOnly<current.TestObjectProvider>): void;
 use_current_ClassDeclaration_TestObjectProvider(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TestObjectProvider());
 
 /*
@@ -382,7 +379,6 @@ declare function get_current_ClassDeclaration_TestObjectProvider():
 declare function use_old_ClassDeclaration_TestObjectProvider(
     use: TypeOnly<old.TestObjectProvider>): void;
 use_old_ClassDeclaration_TestObjectProvider(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_TestObjectProvider());
 
 /*

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -82,7 +82,7 @@
 		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.7.2.0",
+		"@fluid-experimental/devtools-core-previous": "npm:@fluid-experimental/devtools-core@2.0.0-internal.7.3.0",
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -69,7 +69,7 @@
 		"@fluidframework/fluid-static": "workspace:~"
 	},
 	"devDependencies": {
-		"@fluid-experimental/devtools-previous": "npm:@fluid-experimental/devtools@2.0.0-internal.7.2.0",
+		"@fluid-experimental/devtools-previous": "npm:@fluid-experimental/devtools@2.0.0-internal.7.3.0",
 		"@fluid-tools/build-cli": "^0.28.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -50,7 +50,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.13.3",
 		"@fluid-tools/build-cli": "^0.28.0",
-		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.7.2.0",
+		"@fluid-tools/fetch-tool-previous": "npm:@fluid-tools/fetch-tool@2.0.0-internal.7.3.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",

--- a/packages/tools/fluid-runner/package.json
+++ b/packages/tools/fluid-runner/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
-		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.7.2.0",
+		"@fluidframework/fluid-runner-previous": "npm:@fluidframework/fluid-runner@2.0.0-internal.7.3.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/tools/webpack-fluid-loader/package.json
+++ b/packages/tools/webpack-fluid-loader/package.json
@@ -93,7 +93,7 @@
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.13.3",
 		"@fluid-tools/build-cli": "^0.28.0",
-		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.2.0",
+		"@fluid-tools/webpack-fluid-loader-previous": "npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.3.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -81,7 +81,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.7.2.0",
+		"@fluidframework/odsp-doclib-utils-previous": "npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -84,7 +84,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.7.2.0",
+		"@fluidframework/telemetry-utils-previous": "npm:@fluidframework/telemetry-utils@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/debug": "^4.1.5",
 		"@types/events": "^3.0.0",

--- a/packages/utils/tool-utils/package.json
+++ b/packages/utils/tool-utils/package.json
@@ -81,7 +81,7 @@
 		"@fluidframework/build-tools": "^0.28.0",
 		"@fluidframework/eslint-config-fluid": "^3.1.0",
 		"@fluidframework/mocha-test-setup": "workspace:~",
-		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.7.2.0",
+		"@fluidframework/tool-utils-previous": "npm:@fluidframework/tool-utils@2.0.0-internal.7.3.0",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@types/debug": "^4.1.5",
 		"@types/mocha": "^9.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
       '@fluid-experimental/tree2': workspace:~
       '@fluid-tools/build-cli': ^0.28.0
       '@fluidframework/aqueduct': workspace:~
-      '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.7.2.0
+      '@fluidframework/azure-client-previous': npm:@fluidframework/azure-client@2.0.0-internal.7.3.0
       '@fluidframework/azure-local-service': workspace:~
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
@@ -142,7 +142,7 @@ importers:
       '@fluid-experimental/tree2': link:../../../experimental/dds/tree2
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
-      '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.7.2.0
+      '@fluidframework/azure-client-previous': /@fluidframework/azure-client/2.0.0-internal.7.3.0
       '@fluidframework/azure-local-service': link:../azure-local-service
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
@@ -201,7 +201,7 @@ importers:
     specifiers:
       '@arethetypeswrong/cli': ^0.13.3
       '@fluid-tools/build-cli': ^0.28.0
-      '@fluidframework/azure-service-utils-previous': npm:@fluidframework/azure-service-utils@2.0.0-internal.7.2.0
+      '@fluidframework/azure-service-utils-previous': npm:@fluidframework/azure-service-utils@2.0.0-internal.7.3.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/eslint-config-fluid': ^3.1.0
@@ -224,7 +224,7 @@ importers:
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
       '@fluid-tools/build-cli': 0.28.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/azure-service-utils-previous': /@fluidframework/azure-service-utils/2.0.0-internal.7.2.0
+      '@fluidframework/azure-service-utils-previous': /@fluidframework/azure-service-utils/2.0.0-internal.7.3.0
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
@@ -5481,7 +5481,7 @@ importers:
 
   experimental/dds/attributable-map:
     specifiers:
-      '@fluid-experimental/attributable-map-previous': npm:@fluid-experimental/attributable-map@2.0.0-internal.7.2.0
+      '@fluid-experimental/attributable-map-previous': npm:@fluid-experimental/attributable-map@2.0.0-internal.7.3.0
       '@fluid-internal/client-utils': workspace:~
       '@fluid-private/stochastic-test-utils': workspace:~
       '@fluid-private/test-dds-utils': workspace:~
@@ -5527,7 +5527,7 @@ importers:
       '@fluidframework/shared-object-base': link:../../../packages/dds/shared-object-base
       path-browserify: 1.0.1
     devDependencies:
-      '@fluid-experimental/attributable-map-previous': /@fluid-experimental/attributable-map/2.0.0-internal.7.2.0
+      '@fluid-experimental/attributable-map-previous': /@fluid-experimental/attributable-map/2.0.0-internal.7.3.0
       '@fluid-private/stochastic-test-utils': link:../../../packages/test/stochastic-test-utils
       '@fluid-private/test-dds-utils': link:../../../packages/dds/test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
@@ -6218,7 +6218,7 @@ importers:
       '@fluid-tools/build-cli': ^0.28.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
-      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.7.2.0
+      '@fluidframework/container-definitions-previous': npm:@fluidframework/container-definitions@2.0.0-internal.7.3.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
@@ -6242,7 +6242,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
-      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.7.2.0
+      '@fluidframework/container-definitions-previous': /@fluidframework/container-definitions/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm
       '@types/events': 3.0.3
@@ -6259,7 +6259,7 @@ importers:
       '@fluid-tools/build-cli': ^0.28.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
-      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces-previous': npm:@fluidframework/core-interfaces@2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/node': ^18.19.0
@@ -6273,7 +6273,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
-      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.7.2.0
+      '@fluidframework/core-interfaces-previous': /@fluidframework/core-interfaces/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/node': 18.19.1
@@ -6342,7 +6342,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions-previous': npm:@fluidframework/driver-definitions@2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/protocol-definitions': ^3.0.0
       '@microsoft/api-extractor': ^7.38.3
@@ -6359,7 +6359,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
-      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.7.2.0
+      '@fluidframework/driver-definitions-previous': /@fluidframework/driver-definitions/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm
       copyfiles: 2.4.1
@@ -6375,7 +6375,7 @@ importers:
       '@fluid-tools/build-cli': ^0.28.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
-      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.7.2.0
+      '@fluidframework/cell-previous': npm:@fluidframework/cell@2.0.0-internal.7.3.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
@@ -6415,7 +6415,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
-      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.7.2.0
+      '@fluidframework/cell-previous': /@fluidframework/cell/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -6443,7 +6443,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.7.2.0
+      '@fluidframework/counter-previous': npm:@fluidframework/counter@2.0.0-internal.7.3.0
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
@@ -6480,7 +6480,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
-      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.7.2.0
+      '@fluidframework/counter-previous': /@fluidframework/counter/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -6510,7 +6510,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.7.2.0
+      '@fluidframework/ink-previous': npm:@fluidframework/ink@2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6545,7 +6545,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.7.2.0
+      '@fluidframework/ink-previous': /@fluidframework/ink/2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm
@@ -6578,7 +6578,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.7.2.0
+      '@fluidframework/map-previous': npm:@fluidframework/map@2.0.0-internal.7.3.0
       '@fluidframework/merge-tree': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -6626,7 +6626,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.7.2.0
+      '@fluidframework/map-previous': /@fluidframework/map/2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
@@ -6660,7 +6660,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.7.2.0
+      '@fluidframework/matrix-previous': npm:@fluidframework/matrix@2.0.0-internal.7.3.0
       '@fluidframework/merge-tree': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -6715,7 +6715,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.7.2.0
+      '@fluidframework/matrix-previous': /@fluidframework/matrix/2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
@@ -6754,7 +6754,7 @@ importers:
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.7.2.0
+      '@fluidframework/merge-tree-previous': npm:@fluidframework/merge-tree@2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
@@ -6798,7 +6798,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.7.2.0
+      '@fluidframework/merge-tree-previous': /@fluidframework/merge-tree/2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
@@ -6831,7 +6831,7 @@ importers:
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.7.2.0
+      '@fluidframework/ordered-collection-previous': npm:@fluidframework/ordered-collection@2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
@@ -6871,7 +6871,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.7.2.0
+      '@fluidframework/ordered-collection-previous': /@fluidframework/ordered-collection/2.0.0-internal.7.3.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
@@ -6971,7 +6971,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.7.2.0
+      '@fluidframework/register-collection-previous': npm:@fluidframework/register-collection@2.0.0-internal.7.3.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -7007,7 +7007,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.7.2.0
+      '@fluidframework/register-collection-previous': /@fluidframework/register-collection/2.0.0-internal.7.3.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
@@ -7044,7 +7044,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.7.2.0
+      '@fluidframework/sequence-previous': npm:@fluidframework/sequence@2.0.0-internal.7.3.0
       '@fluidframework/shared-object-base': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -7088,7 +7088,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.7.2.0
+      '@fluidframework/sequence-previous': /@fluidframework/sequence/2.0.0-internal.7.3.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/diff': 3.5.8
@@ -7126,7 +7126,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
-      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base-previous': npm:@fluidframework/shared-object-base@2.0.0-internal.7.3.0
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
@@ -7168,7 +7168,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.7.2.0
+      '@fluidframework/shared-object-base-previous': /@fluidframework/shared-object-base/2.0.0-internal.7.3.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/benchmark': 2.1.5
@@ -7203,7 +7203,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
-      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.7.2.0
+      '@fluidframework/shared-summary-block-previous': npm:@fluidframework/shared-summary-block@2.0.0-internal.7.3.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/benchmark': ^2.1.0
@@ -7236,7 +7236,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.7.2.0
+      '@fluidframework/shared-summary-block-previous': /@fluidframework/shared-summary-block/2.0.0-internal.7.3.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/benchmark': 2.1.5
@@ -7275,7 +7275,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/shared-object-base': workspace:~
-      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.7.2.0
+      '@fluidframework/task-manager-previous': npm:@fluidframework/task-manager@2.0.0-internal.7.3.0
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
@@ -7314,7 +7314,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.7.2.0
+      '@fluidframework/task-manager-previous': /@fluidframework/task-manager/2.0.0-internal.7.3.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
@@ -7401,7 +7401,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.7.2.0
+      '@fluidframework/debugger-previous': npm:@fluidframework/debugger@2.0.0-internal.7.3.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
@@ -7428,7 +7428,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
-      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.7.2.0
+      '@fluidframework/debugger-previous': /@fluidframework/debugger/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/node': 18.19.1
@@ -7448,7 +7448,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.7.2.0
+      '@fluidframework/driver-base-previous': npm:@fluidframework/driver-base@2.0.0-internal.7.3.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
@@ -7484,7 +7484,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
-      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.7.2.0
+      '@fluidframework/driver-base-previous': /@fluidframework/driver-base/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
@@ -7512,7 +7512,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.7.2.0
+      '@fluidframework/driver-web-cache-previous': npm:@fluidframework/driver-web-cache@2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
@@ -7539,7 +7539,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
-      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.7.2.0
+      '@fluidframework/driver-web-cache-previous': /@fluidframework/driver-web-cache/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/jest': 29.5.3
@@ -7565,7 +7565,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.7.2.0
+      '@fluidframework/file-driver-previous': npm:@fluidframework/file-driver@2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/replay-driver': workspace:~
       '@microsoft/api-extractor': ^7.38.3
@@ -7589,7 +7589,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.7.2.0
+      '@fluidframework/file-driver-previous': /@fluidframework/file-driver/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/node': 18.19.1
       copyfiles: 2.4.1
@@ -7603,7 +7603,7 @@ importers:
       '@arethetypeswrong/cli': ^0.13.3
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.28.0
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.2.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': npm:@fluid-tools/fluidapp-odsp-urlresolver@2.0.0-internal.7.3.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/core-interfaces': workspace:~
@@ -7637,7 +7637,7 @@ importers:
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
-      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.2.0
+      '@fluid-tools/fluidapp-odsp-urlresolver-previous': /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.3.0
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
@@ -7670,7 +7670,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.7.2.0
+      '@fluidframework/local-driver-previous': npm:@fluidframework/local-driver@2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-base': ^2.0.1
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -7727,7 +7727,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.7.2.0
+      '@fluidframework/local-driver-previous': /@fluidframework/local-driver/2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/jsrsasign': 8.0.13
@@ -7764,7 +7764,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-doclib-utils': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
-      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver-previous': npm:@fluidframework/odsp-driver@2.0.0-internal.7.3.0
       '@fluidframework/protocol-base': ^2.0.1
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/telemetry-utils': workspace:~
@@ -7811,7 +7811,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver-previous': /@fluidframework/odsp-driver/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
@@ -7839,7 +7839,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver-definitions-previous': npm:@fluidframework/odsp-driver-definitions@2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': ^3.0.0
       '@microsoft/api-extractor': ^7.38.3
       copyfiles: ^2.4.1
@@ -7857,7 +7857,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.2.0
+      '@fluidframework/odsp-driver-definitions-previous': /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm
       copyfiles: 2.4.1
@@ -7880,7 +7880,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-driver': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
-      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.7.2.0
+      '@fluidframework/odsp-urlresolver-previous': npm:@fluidframework/odsp-urlresolver@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
@@ -7907,7 +7907,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.7.2.0
+      '@fluidframework/odsp-urlresolver-previous': /@fluidframework/odsp-urlresolver/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
@@ -7936,7 +7936,7 @@ importers:
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.7.2.0
+      '@fluidframework/replay-driver-previous': npm:@fluidframework/replay-driver@2.0.0-internal.7.3.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/nock': ^9.3.0
@@ -7962,7 +7962,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.7.2.0
+      '@fluidframework/replay-driver-previous': /@fluidframework/replay-driver/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/nock': 9.3.1
       '@types/node': 18.19.1
@@ -7991,7 +7991,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-base': ^2.0.1
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.7.2.0
+      '@fluidframework/routerlicious-driver-previous': npm:@fluidframework/routerlicious-driver@2.0.0-internal.7.3.0
       '@fluidframework/server-services-client': ^2.0.1
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
@@ -8045,7 +8045,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.7.2.0
+      '@fluidframework/routerlicious-driver-previous': /@fluidframework/routerlicious-driver/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/nock': 9.3.1
@@ -8081,7 +8081,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.7.2.0
+      '@fluidframework/routerlicious-urlresolver-previous': npm:@fluidframework/routerlicious-urlresolver@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
       '@types/nconf': ^0.10.0
@@ -8114,7 +8114,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.7.2.0
+      '@fluidframework/routerlicious-urlresolver-previous': /@fluidframework/routerlicious-urlresolver/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/nconf': 0.10.6
@@ -8146,7 +8146,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/test-tools': ^1.0.195075
-      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.7.2.0
+      '@fluidframework/tinylicious-driver-previous': npm:@fluidframework/tinylicious-driver@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -8178,7 +8178,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-tools': 1.0.195075
-      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.7.2.0
+      '@fluidframework/tinylicious-driver-previous': /@fluidframework/tinylicious-driver/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -8198,7 +8198,7 @@ importers:
       '@arethetypeswrong/cli': ^0.13.3
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.28.0
-      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.7.2.0
+      '@fluidframework/agent-scheduler-previous': npm:@fluidframework/agent-scheduler@2.0.0-internal.7.3.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/container-definitions': workspace:~
@@ -8237,7 +8237,7 @@ importers:
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
-      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.7.2.0
+      '@fluidframework/agent-scheduler-previous': /@fluidframework/agent-scheduler/2.0.0-internal.7.3.0
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
@@ -8255,7 +8255,7 @@ importers:
       '@arethetypeswrong/cli': ^0.13.3
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.28.0
-      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.7.2.0
+      '@fluidframework/aqueduct-previous': npm:@fluidframework/aqueduct@2.0.0-internal.7.3.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/container-definitions': workspace:~
@@ -8309,7 +8309,7 @@ importers:
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
-      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.7.2.0
+      '@fluidframework/aqueduct-previous': /@fluidframework/aqueduct/2.0.0-internal.7.3.0
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
@@ -8473,7 +8473,7 @@ importers:
       '@fluidframework/container-runtime-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.7.2.0
+      '@fluidframework/data-object-base-previous': npm:@fluidframework/data-object-base@2.0.0-internal.7.3.0
       '@fluidframework/datastore': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
@@ -8507,7 +8507,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
-      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.7.2.0
+      '@fluidframework/data-object-base-previous': /@fluidframework/data-object-base/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/node': 18.19.1
@@ -8525,7 +8525,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/core-utils': workspace:~
-      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.7.2.0
+      '@fluidframework/dds-interceptions-previous': npm:@fluidframework/dds-interceptions@2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/map': workspace:~
       '@fluidframework/merge-tree': workspace:~
@@ -8561,7 +8561,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
-      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.7.2.0
+      '@fluidframework/dds-interceptions-previous': /@fluidframework/dds-interceptions/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
@@ -8640,7 +8640,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.7.2.0
+      '@fluidframework/fluid-static-previous': npm:@fluidframework/fluid-static@2.0.0-internal.7.3.0
       '@fluidframework/map': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -8681,7 +8681,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.7.2.0
+      '@fluidframework/fluid-static-previous': /@fluidframework/fluid-static/2.0.0-internal.7.3.0
       '@fluidframework/map': link:../../dds/map
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/sequence': link:../../dds/sequence
@@ -8757,7 +8757,7 @@ importers:
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.7.2.0
+      '@fluidframework/request-handler-previous': npm:@fluidframework/request-handler@2.0.0-internal.7.3.0
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -8791,7 +8791,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.7.2.0
+      '@fluidframework/request-handler-previous': /@fluidframework/request-handler/2.0.0-internal.7.3.0
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/diff': 3.5.8
@@ -8822,7 +8822,7 @@ importers:
       '@fluidframework/datastore': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.7.2.0
+      '@fluidframework/synthesize-previous': npm:@fluidframework/synthesize@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
@@ -8849,7 +8849,7 @@ importers:
       '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.7.2.0
+      '@fluidframework/synthesize-previous': /@fluidframework/synthesize/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
@@ -8888,7 +8888,7 @@ importers:
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/test-utils': workspace:~
-      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.7.2.0
+      '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.7.3.0
       '@fluidframework/tinylicious-driver': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
@@ -8927,7 +8927,7 @@ importers:
       '@fluidframework/container-runtime-definitions': link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/test-utils': link:../../test/test-utils
-      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.7.2.0
+      '@fluidframework/tinylicious-client-previous': /@fluidframework/tinylicious-client/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
@@ -8954,7 +8954,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/sequence': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
-      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.7.2.0
+      '@fluidframework/undo-redo-previous': npm:@fluidframework/undo-redo@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/diff': ^3.5.1
       '@types/events': ^3.0.0
@@ -8988,7 +8988,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
-      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.7.2.0
+      '@fluidframework/undo-redo-previous': /@fluidframework/undo-redo/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/diff': 3.5.8
       '@types/events': 3.0.3
@@ -9016,7 +9016,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.7.2.0
+      '@fluidframework/view-adapters-previous': npm:@fluidframework/view-adapters@2.0.0-internal.7.3.0
       '@fluidframework/view-interfaces': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/react': ^17.0.44
@@ -9040,7 +9040,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.7.2.0
+      '@fluidframework/view-adapters-previous': /@fluidframework/view-adapters/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -9059,7 +9059,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.7.2.0
+      '@fluidframework/view-interfaces-previous': npm:@fluidframework/view-interfaces@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
@@ -9077,7 +9077,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.7.2.0
+      '@fluidframework/view-interfaces-previous': /@fluidframework/view-interfaces/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
@@ -9097,7 +9097,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.7.2.0
+      '@fluidframework/container-loader-previous': npm:@fluidframework/container-loader@2.0.0-internal.7.3.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/driver-definitions': workspace:~
@@ -9153,7 +9153,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
-      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.7.2.0
+      '@fluidframework/container-loader-previous': /@fluidframework/container-loader/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
@@ -9187,7 +9187,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/driver-definitions': workspace:~
-      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils-previous': npm:@fluidframework/driver-utils@2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/gitresources': ^2.0.1
       '@fluidframework/mocha-test-setup': workspace:~
@@ -9232,7 +9232,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
-      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.7.2.0
+      '@fluidframework/driver-utils-previous': /@fluidframework/driver-utils/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
@@ -9262,7 +9262,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.7.2.0
+      '@fluidframework/location-redirection-utils-previous': npm:@fluidframework/location-redirection-utils@2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
@@ -9291,7 +9291,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.7.2.0
+      '@fluidframework/location-redirection-utils-previous': /@fluidframework/location-redirection-utils/2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
@@ -9355,7 +9355,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/container-runtime-definitions': workspace:~
-      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-previous': npm:@fluidframework/container-runtime@2.0.0-internal.7.3.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore': workspace:~
@@ -9418,7 +9418,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
-      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -9448,7 +9448,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/container-definitions': workspace:~
-      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-definitions-previous': npm:@fluidframework/container-runtime-definitions@2.0.0-internal.7.3.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
@@ -9471,7 +9471,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
-      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.7.2.0
+      '@fluidframework/container-runtime-definitions-previous': /@fluidframework/container-runtime-definitions/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm
       copyfiles: 2.4.1
@@ -9491,7 +9491,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
-      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.7.2.0
+      '@fluidframework/datastore-previous': npm:@fluidframework/datastore@2.0.0-internal.7.3.0
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
@@ -9537,7 +9537,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
-      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.7.2.0
+      '@fluidframework/datastore-previous': /@fluidframework/datastore/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
@@ -9565,7 +9565,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/container-definitions': workspace:~
       '@fluidframework/core-interfaces': workspace:~
-      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.7.2.0
+      '@fluidframework/datastore-definitions-previous': npm:@fluidframework/datastore-definitions@2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/id-compressor': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
@@ -9587,7 +9587,7 @@ importers:
       '@fluid-tools/build-cli': 0.28.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
-      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.7.2.0
+      '@fluidframework/datastore-definitions-previous': /@fluidframework/datastore-definitions/2.0.0-internal.7.3.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm
       copyfiles: 2.4.1
@@ -9667,7 +9667,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/id-compressor': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.7.2.0
+      '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       copyfiles: ^2.4.1
       eslint: ~8.50.0
@@ -9687,7 +9687,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.7.2.0
+      '@fluidframework/runtime-definitions-previous': /@fluidframework/runtime-definitions/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm
       copyfiles: 2.4.1
       eslint: 8.50.0
@@ -9713,7 +9713,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
       '@fluidframework/runtime-definitions': workspace:~
-      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils-previous': npm:@fluidframework/runtime-utils@2.0.0-internal.7.3.0
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
@@ -9749,7 +9749,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.7.2.0
+      '@fluidframework/runtime-utils-previous': /@fluidframework/runtime-utils/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
@@ -9787,7 +9787,7 @@ importers:
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
-      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.7.2.0
+      '@fluidframework/test-runtime-utils-previous': npm:@fluidframework/test-runtime-utils@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/jsrsasign': ^8.0.8
       '@types/mocha': ^9.1.1
@@ -9830,7 +9830,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.7.2.0
+      '@fluidframework/test-runtime-utils-previous': /@fluidframework/test-runtime-utils/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/jsrsasign': 8.0.13
       '@types/mocha': 9.1.1
@@ -10183,7 +10183,7 @@ importers:
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.2.0
+      '@fluidframework/mocha-test-setup-previous': npm:@fluidframework/mocha-test-setup@2.0.0-internal.7.3.0
       '@fluidframework/test-driver-definitions': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@types/mocha': ^9.1.1
@@ -10206,7 +10206,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.7.2.0
+      '@fluidframework/mocha-test-setup-previous': /@fluidframework/mocha-test-setup/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
@@ -10389,7 +10389,7 @@ importers:
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.7.2.0
+      '@fluidframework/test-driver-definitions-previous': npm:@fluidframework/test-driver-definitions@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       copyfiles: ^2.4.1
       eslint: ~8.50.0
@@ -10408,7 +10408,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.7.2.0
+      '@fluidframework/test-driver-definitions-previous': /@fluidframework/test-driver-definitions/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm
       copyfiles: 2.4.1
       eslint: 8.50.0
@@ -10783,7 +10783,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-driver-definitions': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
-      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.7.2.0
+      '@fluidframework/test-utils-previous': npm:@fluidframework/test-utils@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/debug': ^4.1.5
       '@types/diff': ^3.5.1
@@ -10837,7 +10837,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../mocha-test-setup
-      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.7.2.0
+      '@fluidframework/test-utils-previous': /@fluidframework/test-utils/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/debug': 4.1.12
       '@types/diff': 3.5.8
@@ -10977,7 +10977,7 @@ importers:
   packages/tools/devtools/devtools:
     specifiers:
       '@fluid-experimental/devtools-core': workspace:~
-      '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.7.2.0
+      '@fluid-experimental/devtools-previous': npm:@fluid-experimental/devtools@2.0.0-internal.7.3.0
       '@fluid-tools/build-cli': ^0.28.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
@@ -11010,7 +11010,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@fluidframework/fluid-static': link:../../../framework/fluid-static
     devDependencies:
-      '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.7.2.0
+      '@fluid-experimental/devtools-previous': /@fluid-experimental/devtools/2.0.0-internal.7.3.0
       '@fluid-tools/build-cli': 0.28.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
@@ -11184,7 +11184,7 @@ importers:
 
   packages/tools/devtools/devtools-core:
     specifiers:
-      '@fluid-experimental/devtools-core-previous': npm:@fluid-experimental/devtools-core@2.0.0-internal.7.2.0
+      '@fluid-experimental/devtools-core-previous': npm:@fluid-experimental/devtools-core@2.0.0-internal.7.3.0
       '@fluid-experimental/tree2': workspace:~
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.28.0
@@ -11241,7 +11241,7 @@ importers:
       '@fluidframework/shared-object-base': link:../../../dds/shared-object-base
       '@fluidframework/telemetry-utils': link:../../../utils/telemetry-utils
     devDependencies:
-      '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.7.2.0
+      '@fluid-experimental/devtools-core-previous': /@fluid-experimental/devtools-core/2.0.0-internal.7.3.0
       '@fluid-tools/build-cli': 0.28.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0
@@ -11548,7 +11548,7 @@ importers:
       '@arethetypeswrong/cli': ^0.13.3
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': ^0.28.0
-      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.7.2.0
+      '@fluid-tools/fetch-tool-previous': npm:@fluid-tools/fetch-tool@2.0.0-internal.7.3.0
       '@fluid-tools/fluidapp-odsp-urlresolver': workspace:~
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
@@ -11592,7 +11592,7 @@ importers:
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
       '@fluid-tools/build-cli': 0.28.0_mhw3tufvtaceew37hrkkevjcli
-      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.7.2.0
+      '@fluid-tools/fetch-tool-previous': /@fluid-tools/fetch-tool/2.0.0-internal.7.3.0
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
@@ -11614,7 +11614,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
-      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.7.2.0
+      '@fluidframework/fluid-runner-previous': npm:@fluidframework/fluid-runner@2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-driver': workspace:~
       '@fluidframework/odsp-driver-definitions': workspace:~
@@ -11651,7 +11651,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
-      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.7.2.0
+      '@fluidframework/fluid-runner-previous': /@fluidframework/fluid-runner/2.0.0-internal.7.3.0
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
@@ -11756,7 +11756,7 @@ importers:
     specifiers:
       '@arethetypeswrong/cli': ^0.13.3
       '@fluid-tools/build-cli': ^0.28.0
-      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.2.0
+      '@fluid-tools/webpack-fluid-loader-previous': npm:@fluid-tools/webpack-fluid-loader@2.0.0-internal.7.3.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.28.0
       '@fluidframework/container-definitions': workspace:~
@@ -11837,7 +11837,7 @@ importers:
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
       '@fluid-tools/build-cli': 0.28.0_lzbrbjkjqqnlnvbwteayq6k5jm
-      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.2.0_wvskkfkvbt5crqa4uyjlq44kiy
+      '@fluid-tools/webpack-fluid-loader-previous': /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.3.0_wvskkfkvbt5crqa4uyjlq44kiy
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.28.0_h467wi3sy6j67ifywrn7x7qf4m
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
@@ -11876,7 +11876,7 @@ importers:
       '@fluidframework/driver-utils': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/mocha-test-setup': workspace:~
-      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.7.2.0
+      '@fluidframework/odsp-doclib-utils-previous': npm:@fluidframework/odsp-doclib-utils@2.0.0-internal.7.3.0
       '@fluidframework/odsp-driver-definitions': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
@@ -11911,7 +11911,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.2.0
+      '@fluidframework/odsp-doclib-utils-previous': /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
@@ -11940,7 +11940,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^3.1.0
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils-previous': npm:@fluidframework/telemetry-utils@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/debug': ^4.1.5
       '@types/events': ^3.0.0
@@ -11977,7 +11977,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.7.2.0
+      '@fluidframework/telemetry-utils-previous': /@fluidframework/telemetry-utils/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/debug': 4.1.12
       '@types/events': 3.0.3
@@ -12009,7 +12009,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/odsp-doclib-utils': workspace:~
       '@fluidframework/protocol-definitions': ^3.0.0
-      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.7.2.0
+      '@fluidframework/tool-utils-previous': npm:@fluidframework/tool-utils@2.0.0-internal.7.3.0
       '@microsoft/api-extractor': ^7.38.3
       '@types/debug': ^4.1.5
       '@types/mocha': ^9.1.1
@@ -12045,7 +12045,7 @@ importers:
       '@fluidframework/build-tools': 0.28.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.1.0_loebgezstcsvd2poh2d55fifke
       '@fluidframework/mocha-test-setup': link:../../test/mocha-test-setup
-      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.7.2.0
+      '@fluidframework/tool-utils-previous': /@fluidframework/tool-utils/2.0.0-internal.7.3.0
       '@microsoft/api-extractor': 7.38.3_veevzrg6trzjzkr6gaha4thdmm_@types+node@18.19.1
       '@types/debug': 4.1.12
       '@types/mocha': 9.1.1
@@ -15716,91 +15716,69 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@fluid-experimental/attributable-map/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-L3Imq2wNJN90qhK4FDXyaVEa53Vxe8YLtFFHPiTMa0orartRz+yRJKLDw31VxolhH4cGIhXrMX6DkTLtwcepNg==}
+  /@fluid-experimental/attributable-map/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-az00HNOPCLaTFt7xI/RitFt1R18XNASmVINub0UWZj0j4qQPGQKTAHZS7tTi0obDKVW8TlrJG7d+b6bxNSxOkQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools-core/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-0wz1gieoidisI+AsEzMDlpVXKvwOR7SUBhilwu+QvCNybUy7tVKv/BBzStXSgq2Qu3IA2FEh5Y4NPLW/AU1JeQ==}
+  /@fluid-experimental/devtools-core/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-OR25y68u7/+BQqcm6+Bi2Psoc+R3LhWDDxFCy6iYSTDvJkFQU+lKT5BQHewREszwK4la9O7PtWIdIHMan8/quQ==}
     dependencies:
-      '@fluid-experimental/tree2': 2.0.0-internal.7.2.2
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/cell': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-loader': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/counter': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/map': 2.0.0-internal.7.2.2
-      '@fluidframework/matrix': 2.0.0-internal.7.2.2
+      '@fluid-experimental/tree2': 2.0.0-internal.7.3.0
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/cell': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/counter': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/map': 2.0.0-internal.7.3.0
+      '@fluidframework/matrix': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/sequence': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/sequence': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools-core/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-Hdn3z7Qi9pdoFI/j9QVUiU6fXiuGvkCjFynihnwtPYYzwHqk5KqDulZNztmHWEbSuUXMYGLTVE7wClBTmvGU/w==}
+  /@fluid-experimental/devtools/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-u4cbFXaFMv7CADW6UYfZlaPSbHiR1K3+COGRfSfmrVqsMDDzP3FVSg5Dhp2sBA7RMuFoP1SqLjQVR0tILUcRnQ==}
     dependencies:
-      '@fluid-experimental/tree2': 2.0.0-internal.7.2.2
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/cell': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-loader': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/counter': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/map': 2.0.0-internal.7.2.2
-      '@fluidframework/matrix': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/sequence': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluid-experimental/devtools-core': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/fluid-static': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluid-experimental/devtools/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-GTp/PXo7MS3oj8AQUWIZkN9xV2JKZos4tTokpd3u4TzZeA1j80g+zqCOstG/J2cDlihCgcvqXVCF3n1MRbUFwg==}
+  /@fluid-experimental/tree2/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-KvT3LN6K3DGowzTeGjcUf5ahbP3Q6iHUdDyzSVZlcNwIMhTdxx/uacGM5F+tbndUd9PHqW17GdjJ/me2gkq9QA==}
     dependencies:
-      '@fluid-experimental/devtools-core': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/fluid-static': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluid-experimental/tree2/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-qRsDRX9+L1b/y+IDqMDPjE+JqHO6lJ3dB2cvPqxC7TQOLhqato14JLVj7YvV+CKlV9zrVOccDF4wKyXNMGP83w==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
       '@sinclair/typebox': 0.29.6
       '@ungap/structured-clone': 1.2.0
       sorted-btree: 1.8.1
@@ -15810,11 +15788,11 @@ packages:
       - supports-color
     dev: true
 
-  /@fluid-internal/client-utils/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-wYY9T/0CZhXYx1TaQltb3iktNMZA4385PJZ6E6vTMO5MkH8pAgon9/Yz+iXLRXYi/P7WFVsmyLq93i86wxfTlA==}
+  /@fluid-internal/client-utils/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-q+lf7BTbBYvtLfg0AJXvnn4+pdtYt/R44fkD+Srs9s2PenieOM5LEAeIABS0xG99d6ys8K54P4xvqpkctupYqg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
       '@types/events': 3.0.3
       base64-js: 1.5.1
       buffer: 6.0.3
@@ -16045,26 +16023,26 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluid-tools/fetch-tool/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-OFcaC7v7rGg5v39pZiKm7jJV9EDt2HBImuuZ7ordw6Cf2kKMEcht7sZkRcXbLTSBYRV7iAOeIBV6wO7MTpnrHA==}
+  /@fluid-tools/fetch-tool/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-Zff301fjHY9a9vMvEvGZx0tTCpkldOIEqSdfodLD+zDvBXQq4Y4iHD5GPeRpvdEZJ/Bl1d5uGUOkljCJpbTNOQ==}
     hasBin: true
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-urlresolver': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluid-tools/fluidapp-odsp-urlresolver': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-urlresolver': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/tool-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.3.0
+      '@fluidframework/routerlicious-urlresolver': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/tool-utils': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16073,32 +16051,15 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-PD33VTs7enMElsYc2uPdl8lwhQV55AHxa9a1ANQbXpDHCClkVv98jJhwkl0j1aEo5RWwyggmO4qzVGQkwfPAnw==}
+  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-jTAo/Nd7uqrFUtkCLi9hXoeM8VddNfwuPUQNcAWHnPcfbW3q+MU/CUQtfoy4Afhqa4cLOoYqIQxESrR+dU0vuw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluid-tools/fluidapp-odsp-urlresolver/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-jl3uYSzGxBg1ZgLrLA0vVdtv/GVep48Rv34MU41DX+mR36nTDGsi9rvwzqzzj4DNHeY2V0yiZV6GsUZAyottiw==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16124,27 +16085,27 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.2.0_wvskkfkvbt5crqa4uyjlq44kiy:
-    resolution: {integrity: sha512-FkgEQrI8OECrk/ZhALn8dLAzZ5EL8v7Qt85bu/ReDpmsn93RazvpVy0ok1wkv6+SUIAS9c5yl3y0ovTmaBRswA==}
+  /@fluid-tools/webpack-fluid-loader/2.0.0-internal.7.3.0_wvskkfkvbt5crqa4uyjlq44kiy:
+    resolution: {integrity: sha512-Pc6SIM1tkcVJdCAxncNK0j2PhfuDtBfOest2Xd4aVgV+yduEvzDC2JEoD7clAd52OIOu8XQ6ZvdV7FOMV3McFw==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-loader': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/local-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/local-driver': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
       '@fluidframework/server-local-server': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/tool-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/view-interfaces': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/tool-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.7.3.0
       axios: 0.26.1
       buffer: 6.0.3
       express: 4.18.2
@@ -16164,111 +16125,88 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/agent-scheduler/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-mKd8LMJCZqyHxvo9zIQrZ/TJ5v91hsuxqzZ4SOjdUOCr87CTrLMylRQFueRTn28ETGZgEWzNRsYedNR0hL7FSw==}
+  /@fluidframework/agent-scheduler/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-MtvFWW7KpZ3Ld6t5Bb+vQ8R4G2sdsBa9PrjkMkEYeiWVajYkt0352alnV8Iyq7GmlI5cGzKkOYGcQmUo9wFA3w==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/map': 2.0.0-internal.7.2.2
-      '@fluidframework/register-collection': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/map': 2.0.0-internal.7.3.0
+      '@fluidframework/register-collection': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-eG+8E1/eH3cHi8ne8ltvkMR1ycChGZMC+cmBk4eRGbFu1z7KxzwUcXFxeEnE+K6n9j74VK9E5E1u4gwwjP1K3A==}
+  /@fluidframework/aqueduct/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-AgzCzAGpBFl6W3koLFg/cjEZAorbxfLzMM7X8KkpIISNkuw/TOOV74RRTA9/ZJCo9fNi1i4fLytQ/C3QvcT82Q==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/map': 2.0.0-internal.7.2.2
-      '@fluidframework/request-handler': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/synthesize': 2.0.0-internal.7.2.2
-      '@fluidframework/view-interfaces': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/map': 2.0.0-internal.7.3.0
+      '@fluidframework/request-handler': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/synthesize': 2.0.0-internal.7.3.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.7.3.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-l/nU/LTeN14FyYeIvPQLbwRTEbWuEz9boNDzASsjAAASAnyHthvTNihnXgnCYmxLBI+0CintugqoW53AYaSXEg==}
+  /@fluidframework/aqueduct/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-AgzCzAGpBFl6W3koLFg/cjEZAorbxfLzMM7X8KkpIISNkuw/TOOV74RRTA9/ZJCo9fNi1i4fLytQ/C3QvcT82Q==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/map': 2.0.0-internal.7.2.2
-      '@fluidframework/request-handler': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/synthesize': 2.0.0-internal.7.2.2
-      '@fluidframework/view-interfaces': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/map': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/synthesize': 2.0.0-internal.7.3.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.7.3.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/aqueduct/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-l/nU/LTeN14FyYeIvPQLbwRTEbWuEz9boNDzASsjAAASAnyHthvTNihnXgnCYmxLBI+0CintugqoW53AYaSXEg==}
+  /@fluidframework/azure-client/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-FhKRyBHwlXraHbMWekfIFTmdgq6uzxKaEwz7iVt6xgcyIjHt2yfxd2+Bl5yAXy2aw81Veh5pPEQuBBrAnKIlHw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/map': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/request-handler': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/synthesize': 2.0.0-internal.7.2.2
-      '@fluidframework/view-interfaces': 2.0.0-internal.7.2.2
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/azure-client/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-Tn4wDpm0mJ9HiG0MVIHEP/9FV+QshJqcCI5pNkrL26aZVrBppofPpfVoy8VYQ2AnGXTp0zwMuPxFASjAZLGBTA==}
-    dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-loader': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/fluid-static': 2.0.0-internal.7.2.2
-      '@fluidframework/map': 2.0.0-internal.7.2.2
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/fluid-static': 2.0.0-internal.7.3.0
+      '@fluidframework/map': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
       '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       axios: 0.26.1
     transitivePeerDependencies:
       - bufferutil
@@ -16278,8 +16216,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/azure-service-utils/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-e7SFa2tMEmPD0AfEPeWfHY5ZP5KzCyk4vEEeXGic5r02gohrOEX5jjaef9RmNhrdIo/1HE2HJu7EQwEBvssEBQ==}
+  /@fluidframework/azure-service-utils/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-AGmANItS4og+tj1h7iG/sul8TMG0klu/Hk4RibQ4Rvd7lZqkH0oViZmkdgQ0T3nr5Qf9SmVnjb32QMXkr13Igw==}
     dependencies:
       '@fluidframework/protocol-definitions': 3.0.0
       jsrsasign: 10.9.0
@@ -16495,31 +16433,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/cell/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-uO8eApSsjdTalvniwJnqLIJ4wb3Yc8INFWhg5GvOdPh1o/28wcO48qqEsyyx/fVlf/ZN1nmMRTRRTkYAm/4R0A==}
+  /@fluidframework/cell/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-i3Nk1h7ec7gQL21wUVuThSH36/nrYh3E0dLVjxxM4rxj4B65O6QSgUEd+uA4Hk6OshFIkQM/wTQXzcJLnftNpA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/cell/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-upZjobGXev9w163Uvj49HTzkg22f39tqPSpwGvncRSc01rY6DQGbZ65/gyCPjAG2Gm0so8VSuC7s89MQB6F2hQ==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -16539,103 +16462,61 @@ packages:
       lodash: 4.17.21
       sha.js: 2.4.11
 
-  /@fluidframework/container-definitions/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-xjL/lX8+hsXdZ0SW1TX94ONDfhKlOveYvo6GB6IV+28gvRy+05Cnb5rMbwYuuHY7sN0jOnnZDY7wbIC02L9sLw==}
+  /@fluidframework/container-definitions/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-dvwGl7o2H0W3bNRv+W8L4BhnFe3ibUFnkqYb/i1okOxQ/OG05/LSBmq+pLorj7yvskwY8wZX9wc94Pi7/DjMvQ==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
       events: 3.3.0
     dev: true
 
-  /@fluidframework/container-definitions/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-L2YUrJUS2MPJeHb6oeaAEiRw93xfms8ayB655YzPnNTbTXKjojEpo+3ts86rum8V0/NW4QDH1tghGj9ANph83A==}
+  /@fluidframework/container-loader/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-vvLHpcrNRIOz+PyvgqKWi/uDSYMKhTLuP2yEsYeFxxIzDBOaGgN5um7DSWBNKVUPQ4BDSUnEy0e61QHFLUkiiA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      events: 3.3.0
-    dev: true
-
-  /@fluidframework/container-loader/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-Idx1RImCeD2tv2C+R2l6HmRG1HEBu0fQjFNuzxbN3XJokYdns2PMZ5w98vmzDSWDMRpBk1dTDoorMRun8jgFyA==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0_debug@4.3.4
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       debug: 4.3.4
       double-ended-queue: 2.1.0-0
       events: 3.3.0
-      lodash: 4.17.21
       url: 0.11.3
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/container-loader/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-ueU5nrdxrAFAkJEMVcjBUP6FsY4oZbDxRah74MZTlJx4ByT+SqqZbyH7NiB8wEqNeC1fl0cBILLTfUTCYShIGQ==}
+  /@fluidframework/container-runtime-definitions/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-Ay70ze6HZFNzeOj5cgXBEyOW+Iibn1TQWtBQHPug/Agiug6lkzWKITB3RI+L6DxhaBxZnxnk0rniWtoMsaPZBw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      debug: 4.3.4
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lodash: 4.17.21
-      url: 0.11.3
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - supports-color
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
     dev: true
 
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-/vTDa4te1gCCiYr3NvXhxno6NQKD83N238ocdd5EygjFNX4ksilz+JsgH6tIwA/7PnArKtECDUR+LU2xQeXTIw==}
+  /@fluidframework/container-runtime/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-mBtU/T1mq5ggEt+rvPt6PhDrVWK1fkmoUHoZENY4CKmWBpwTAewEDcD/F9nlRUC9naMN0PgluVLSFJDY7HINPQ==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-    dev: true
-
-  /@fluidframework/container-runtime-definitions/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-5hWAyuzzs0XQVPxsiQ7JbIr8UNY5Sbi1eJu/8EmN/VOAw9KnPkSlmtn3AQlngxo8gpHRwM5fRDBe8Rh3d2NbyQ==}
-    dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-    dev: true
-
-  /@fluidframework/container-runtime/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-sKbsOzV4dhQulwlWq856acjQskdLQmmSxGpbhD1Q66tDu1mXLEbm7LgI0nDb1BpC6kVCLtCi8viKmNVXDSaNMQ==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -16646,21 +16527,21 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-9PivQ24LESL7lyCL6Ws9ul5c+pqmJ2qqSZg0Hs3A5rtWYfLSvcusFJ/PCGUPfnZ4dIfaU5v6j5J7uIzTuYxprQ==}
+  /@fluidframework/container-runtime/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-mBtU/T1mq5ggEt+rvPt6PhDrVWK1fkmoUHoZENY4CKmWBpwTAewEDcD/F9nlRUC9naMN0PgluVLSFJDY7HINPQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
@@ -16671,125 +16552,72 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/container-runtime/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-9PivQ24LESL7lyCL6Ws9ul5c+pqmJ2qqSZg0Hs3A5rtWYfLSvcusFJ/PCGUPfnZ4dIfaU5v6j5J7uIzTuYxprQ==}
+  /@fluidframework/core-interfaces/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-pPDhVlcr4Wm340TCgIkGV+QduKRcrYU44mdaEhBaRaubYrf742kjrpaqrT7JvQCP1KVSH9whRo4/WexANuu3BQ==}
+    dev: true
+
+  /@fluidframework/core-utils/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-5yrf+YIWHMzyeZL4UI4w6j4Xrju3QKzbiIWj6H3+QsckrrRQdVzP7reSnj6sp3F59KmClajcJi4CAp4lU5Kx+g==}
+    dev: true
+
+  /@fluidframework/counter/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-3nMuW5R0IzAP88FGJ7OjiQ+q1jt6zGdOrtBnwj6Ff/p5nRUiRR/qnKDtpQaCIY99Sy8fFzAwswWYAQ1tvFgxHg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lz4js: 0.2.0
-      sorted-btree: 1.8.1
-      uuid: 9.0.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/core-interfaces/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-eTGvlJZNN+xWAFHzgkmrOStaLeN3zX8MguWdlSDWS5Jo+QHmuZ5Pxwhz367QitRYjWfAWuyF4BuK4Vz66P4NkQ==}
-    dev: true
-
-  /@fluidframework/core-interfaces/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-RaI37klIYxUpCH5PHeIzkUjxXbA0Omytb22bzc6zoosXzwCDQ4EikFQ02qKqVZpl4wIC6Fw+B6uKIgaR7xNdCg==}
-    dev: true
-
-  /@fluidframework/core-utils/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-UYRRyFDmq1KZXoeSxYIu5ra82XoeLT9S0Y/1HzLu9UnVz813TzgI2gvW+BG7yXC+E9lNIy7CWoSrD7itjjNAWQ==}
-    dev: true
-
-  /@fluidframework/counter/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-QFjtHBAdwPR2eHRVoo7X8nncHdq4y6ZIX0LlEnvtA8WCoGDOALoK5KF40+B3fZ84q8NyDWtcXoU6SJSh/Q/ztA==}
+  /@fluidframework/data-object-base/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-qWyCqERbWvZf22mYPVSJH4o0Me7+/rLhs+5fbB2Q6yP5UuPyxGFoNJtR0xjcJQA01fZYsyudiVVcE7M9cvb6Cw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/request-handler': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/counter/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-e5k6HR1hEXSKWRCOBQyWcyCwsXiO9Hvv+GwMt0pqJskW/wBg9GO4wJbMzCvs571+eErMBM0xbv/UveK5A7RIAQ==}
+  /@fluidframework/datastore-definitions/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-x6Qdo+7TxN1QTmRrbav6zYENayewhh9ALYfAJP2Q7j6kwo9yveVtt6IAUoVQvq1UP9L5CYWTBIHqkRDZ+yIvhg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
     dev: true
 
-  /@fluidframework/data-object-base/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-LHIwp3MoF1Kg144mkN9lIohQN5MrEaY/tLxpd3W8SCr+PqIf5+6hOSLR5WsEXvI4n4NP9w7Qbu3WZuKw/eKyhQ==}
+  /@fluidframework/datastore/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-nG7bCbav+c5323MXeffr4Muhiqtl+b65UvpKSug2gTM4dOvG4/HfkpB6JDf1uZ/k341pYOnxsl0PMu8As0vggA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/request-handler': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/datastore-definitions/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-d1oAFxpxt7vJY+N5R1h7JmWalc8i7hZL6tSCBGQcYMtDGvG5LBv7mHEPJVQOx3/b3AIZuPNfLuzBYjbMy5IioA==}
-    dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-    dev: true
-
-  /@fluidframework/datastore-definitions/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-w6n/vtPllEHLxgyubhIoHkYtwLLpTVlAL2EbEUO2hJGv0Btt4rQscKaumtDBY62sGRKDl74NMHARwWB9wZ99kQ==}
-    dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-    dev: true
-
-  /@fluidframework/datastore/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-abRSJT67NeX918jHWIzHKElMrY5nUxenWSK73ZQMKBhNoCiZ/ThGpy46BgvajutMAuIDa2uOUNUTj7tH2754pA==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       lodash: 4.17.21
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -16797,20 +16625,20 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-uBTvrEkqd2XgsOUSxgFfc1WFo87e3bO6UdcpONd1n706ycaTNXa102eHi4indpRaabOx/hDSdOzLdRemXuBJ+A==}
+  /@fluidframework/datastore/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-nG7bCbav+c5323MXeffr4Muhiqtl+b65UvpKSug2gTM4dOvG4/HfkpB6JDf1uZ/k341pYOnxsl0PMu8As0vggA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       lodash: 4.17.21
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -16818,124 +16646,81 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/datastore/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-uBTvrEkqd2XgsOUSxgFfc1WFo87e3bO6UdcpONd1n706ycaTNXa102eHi4indpRaabOx/hDSdOzLdRemXuBJ+A==}
+  /@fluidframework/dds-interceptions/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-LUF8CAk/N9b98SgOGM3YTM0ybwNGlbkLO5TgfrWODUexkRaOWxXNGg/bAmwCWpUggB14WBuL1ekqwOCFVRYR0Q==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      lodash: 4.17.21
-      uuid: 9.0.1
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/map': 2.0.0-internal.7.3.0
+      '@fluidframework/merge-tree': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/sequence': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/dds-interceptions/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-VdQ/5BONJwza8XFz0MVGUwUTe0vtHjIS/F/U4LwUU/cm2ByfZ3xeE3RAMqAD11fJFuxozdhYO6AihAoJosYOOw==}
+  /@fluidframework/debugger/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-NpELAXUdFZ3s5UIFwg7YlIA1bDFlI2FY4W/+yzFdAiNMmZEZt2S2keLvHoyNKZlsfCk0UI2fm7MCSRZ0EEkceg==}
     dependencies:
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/map': 2.0.0-internal.7.2.2
-      '@fluidframework/merge-tree': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/sequence': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/debugger/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-UzgecmeRFlwS8/XVsn+jltZT1gjw5MN9e8MxeU94Vg5nybAL8SQzGJCbG1ZquBiylefCPEIiB5GcQMrvAWR9Pw==}
-    dependencies:
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/replay-driver': 2.0.0-internal.7.2.2
+      '@fluidframework/replay-driver': 2.0.0-internal.7.3.0
       jsonschema: 1.4.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-wsI6boRw+A1DfChAh4T/prRm66+Upb59xz2yUWQoxMwClLon2DbAr6iVpsODbnJgQN3ZMwQevQg2ltmgZ1tkIQ==}
+  /@fluidframework/driver-base/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-u0HWwGZLdyPVJXjwgb6CSqve0JsvWJFWxgQNGVdsxOFlXDddQXP0ABjm7G0GN38EBVxygIjdaBwFQxNIMdZkDw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-4WftcTXWoyfe52Otdx1BeX+ua2BjsGElWgMNxqpwwXESX40taCp/HSaetxIMsdORWT0XBaH1/DVeOHjM7PQ5bg==}
+  /@fluidframework/driver-base/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-u0HWwGZLdyPVJXjwgb6CSqve0JsvWJFWxgQNGVdsxOFlXDddQXP0ABjm7G0GN38EBVxygIjdaBwFQxNIMdZkDw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/driver-base/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-4WftcTXWoyfe52Otdx1BeX+ua2BjsGElWgMNxqpwwXESX40taCp/HSaetxIMsdORWT0XBaH1/DVeOHjM7PQ5bg==}
+  /@fluidframework/driver-definitions/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-Bl19oLLGNLh4PWfQibrDr2AF+6AVXNfvzOhmHNWjBfdqooO5fpE97+4QRA6JAFjZtatV8idL//rlk9wyvdQ23Q==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/driver-definitions/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-Rr4v/pj0sCRSg7/SzL+t6z5y0auw2HoiZlhZaPd3J94CXun0V+Qe2UztXWNOCOpRvDZH+EHLKY09LDjItb3onQ==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
     dev: true
 
-  /@fluidframework/driver-definitions/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-9YDfxdPxvMv1gOUCQm4lgkkRctJVYxJHANjf5sJscgYxI+rdiXAHwqEZIMebyAPieT6kj8YtTvKvdHoz4kr5Sg==}
+  /@fluidframework/driver-utils/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-LXhWTkNhjembi+FLJ7rtgChQDTn4Pz/Xosu/ZuNi+OVNl3aSs0S19YkfHI6FCuFEhzRSDFr7pFOBTwKQdt10QQ==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-    dev: true
-
-  /@fluidframework/driver-utils/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-7f9MFkCP41z+J8iXtwspvH3Hz6FbU8fjVYT3CEu1FeQZszHb7CMasHFjFmxsiNv6v6vcas/VJuClM5nLpsbxQg==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       axios: 0.26.1
       lz4js: 0.2.0
       url: 0.11.3
@@ -16945,37 +16730,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-utils/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-lubzzAS6ISfPBtuTq9DjtmmFQOAzJHqCndUpwPzfAUUrg72GCvuH/E+oOqHVeMa3vT9CYOZnKo1aMmdJDiFSOw==}
+  /@fluidframework/driver-utils/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-LXhWTkNhjembi+FLJ7rtgChQDTn4Pz/Xosu/ZuNi+OVNl3aSs0S19YkfHI6FCuFEhzRSDFr7pFOBTwKQdt10QQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      axios: 0.26.1
-      lz4js: 0.2.0
-      url: 0.11.3
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/driver-utils/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-lubzzAS6ISfPBtuTq9DjtmmFQOAzJHqCndUpwPzfAUUrg72GCvuH/E+oOqHVeMa3vT9CYOZnKo1aMmdJDiFSOw==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       axios: 0.26.1_debug@4.3.4
       lz4js: 0.2.0
       url: 0.11.3
@@ -16985,13 +16750,13 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/driver-web-cache/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-SSpHINRBok9Apj+vz5u1/ySAU/d7gfTXN8rFQ8JBARL3IC+qJE7N93mCNneXfTc2zm5kEswyUOZ5YEgSOUaJRg==}
+  /@fluidframework/driver-web-cache/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-GqLuF6FR2KdQLazasvWm6v85UlC9V6hdYFUzGxVM1+EJkiahC9k1N4+PojWhKW7G2NzHdDRegpzzxvKP277noQ==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       idb: 6.1.5
     transitivePeerDependencies:
       - supports-color
@@ -17024,33 +16789,33 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/file-driver/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-Bg9uyNHZBfvJIq0KyAg6C57nuoDL3FZA1FzDKUGH+Y3CjfypLo/U40WHPWuBai3s2iEdLvTTc9oHtXCkUpuKlw==}
+  /@fluidframework/file-driver/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-yxqKVth9yZZOJVFGgS59ed4565HLd2UaCW8s/8AN+n7TH9NCpk3AyER0ka0vSezK6fHbGpCyXQ3//HEwnhclAg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/replay-driver': 2.0.0-internal.7.2.2
+      '@fluidframework/replay-driver': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/fluid-runner/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-G9UvSrt1WFpmXr/LfnbobeHLu68D7XECHSWggB+iziPOWdEYiU7aYN06QTTRbVTj1gxz5MW6G6id3dKoyUpBMg==}
+  /@fluidframework/fluid-runner/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-6Esg84nrUefmGUqPvptpyrI9vmX2EeBB5x6McYkg0UlVP7BSI8BtF0DlXFlUKkvde15HuYsd2yTeTrgk3xjktA==}
     hasBin: true
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-loader': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/aqueduct': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       json2csv: 5.0.7
       yargs: 13.2.2
     transitivePeerDependencies:
@@ -17061,39 +16826,20 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/fluid-static/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-Q48ycnQ/2THbND5zHGj12/hh8etnNlGSGCeYaj9q0aB6tJl3h3bwEluJypXwUvXkPzAQNGtGyRABKulcOvHHkg==}
+  /@fluidframework/fluid-static/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-6GUx/J00CgGDldgknOYed9+k3rYNZ4xoeabc+vDkBj89/MY8ymGQFLjoSFEgGQdwhtLEyOh9fZXJ1cUmam6hSg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/aqueduct': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-loader': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/aqueduct': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/request-handler': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/fluid-static/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-FE9xai+9l2Ls5de9YJNlrEGRuQTwe7hQqTRNP+nZAar56YNB/9DyPmatjpeyo0zUlwRAJDyIkypuNTx8b1LaQg==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/aqueduct': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-loader': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/request-handler': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/request-handler': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -17102,38 +16848,38 @@ packages:
   /@fluidframework/gitresources/2.0.2:
     resolution: {integrity: sha512-v9hI+uT8B5kwFAs+x6naqb7rOAX84r9ixjyIrE7Gqa9sBHIZ8pP9zKqNIdcS+Y14IqGiJYGDmwzM7Km6ThILCw==}
 
-  /@fluidframework/ink/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-5HQ9DSt5qe43UWqgsI1dd1Yy6mt65KAv0hgUirnfoOFYb4a48HL0cA4eXTG5a1z3d9B8L6AtCyufAGiZ0seYEg==}
+  /@fluidframework/ink/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-MD/cqNP8CqTC3M5yl/ryN05/9i5Ckhrqbl/NTdGC0mS4cqxYVJRq2ix7SPSkwvlucyjiTvaKDMvbC/VBdSztsg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-iS/fdq4DALV12rlZqyd1JF/6zh+cR86+WoQjNp3SSnuW0YfhAcVTLAsqBR+DMz15GbAKJCg3W/5ENAoYhyYndA==}
+  /@fluidframework/local-driver/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-bHcUDsBiRbwH2fWRsrCTljI9wiorVPPp3OtYXHfKcq/BouNNuNRqdjHtqhgjSGPBHh1+M2UAMNffvvmLzFbWeQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-base': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-base': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.3.0
       '@fluidframework/server-local-server': 2.0.2
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-core': 2.0.2
       '@fluidframework/server-test-utils': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       events: 3.3.0
       jsrsasign: 10.9.0
       url: 0.11.3
@@ -17146,23 +16892,23 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-kWkxKWvs0rzuAbRUUUINXYikzk6dCqiIo55skuIu9Fe9+OWb3RmynZW2jj66uoO2zn5Ot1bV65QSrDHn3F7Ocw==}
+  /@fluidframework/local-driver/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-bHcUDsBiRbwH2fWRsrCTljI9wiorVPPp3OtYXHfKcq/BouNNuNRqdjHtqhgjSGPBHh1+M2UAMNffvvmLzFbWeQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-base': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-base': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0_debug@4.3.4
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.3.0_debug@4.3.4
       '@fluidframework/server-local-server': 2.0.2
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-core': 2.0.2
       '@fluidframework/server-test-utils': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       events: 3.3.0
       jsrsasign: 10.9.0
       url: 0.11.3
@@ -17175,117 +16921,69 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/local-driver/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-kWkxKWvs0rzuAbRUUUINXYikzk6dCqiIo55skuIu9Fe9+OWb3RmynZW2jj66uoO2zn5Ot1bV65QSrDHn3F7Ocw==}
+  /@fluidframework/location-redirection-utils/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-8yX+gaISaEyr4Gz2FeUU45B8ypUNZDo2Eu3gl2KtSFl9nubMipcDKuj6gdfMoJmD/wf1KA6/8DqZL0YAgwPqQw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-base': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/server-local-server': 2.0.2
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-test-utils': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      events: 3.3.0
-      jsrsasign: 10.9.0
-      url: 0.11.3
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/location-redirection-utils/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-dL2/nuBNzh/RfcwQ/dgUYlFnK5r5okLw/mAl0UBFI0kwbcBU3Wv7W2QYrx1YsrlRLsOzyZlSW4BgFCzEgYU0AQ==}
-    dependencies:
-      '@fluidframework/container-loader': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/container-loader': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-wEIB8VM5SRqORjROU7gZF5K2YlE/fnv0KIgatVL9YeuHWWbjBp3D66q3Jvae2KdXKLsLYBHiMYUnl7iH5hTY4A==}
+  /@fluidframework/map/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-E8q4G/fTevSljYe1St5kd7O8PFJy0OXsvzyHc0CI+gy3+rVfhAdteVmIE6zt9vOpJVyT0Q5R3kMP+iCjo9EGDg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-HrbgpiFYpi1+IKQRtNcLGpkC99ng2MRwzvdoAk/MlLp4Xy9A36gVXbN5l2iQE0TMcPh4ZAaHHGjc2je6TdYIug==}
+  /@fluidframework/map/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-E8q4G/fTevSljYe1St5kd7O8PFJy0OXsvzyHc0CI+gy3+rVfhAdteVmIE6zt9vOpJVyT0Q5R3kMP+iCjo9EGDg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/map/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-HrbgpiFYpi1+IKQRtNcLGpkC99ng2MRwzvdoAk/MlLp4Xy9A36gVXbN5l2iQE0TMcPh4ZAaHHGjc2je6TdYIug==}
+  /@fluidframework/matrix/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-2R3IEUaIt2qJS2T/k143BB0KBMm9EXY8APkHuYDV4wCuxycE5T2+vCatbRMyqpB0MqNBim9CmJ/nP9DhVM66Kg==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/merge-tree': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      path-browserify: 1.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/matrix/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-AOUk3Np38A7jVpzT3JXdbgbudX2foSM79MVgc4ox8GYo3SXUbP3p9/zsNL0m9YdEpzjOtAkEMZNXz8gOWUVosg==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/merge-tree': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       '@tiny-calc/nano': 0.0.0-alpha.5
       events: 3.3.0
       tslib: 1.14.1
@@ -17294,83 +16992,43 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/matrix/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-Lqsj5ciOGpYRj03c85C+OQQNfintSd+NvxvJ882D0fbIZefmejpa5QzUJcgKFlKDMWffvSfKGd4iE8tWKCgBkQ==}
+  /@fluidframework/merge-tree/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-UTxeeMWLOufnUO49tj0he/v7E9BKH6JsbHjhfKhnW1RfpzJ2KUXxA1kOc/JIqem9of2A6FjSm6QZVI/+R0mseA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/merge-tree': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      '@tiny-calc/nano': 0.0.0-alpha.5
-      events: 3.3.0
-      tslib: 1.14.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/merge-tree/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-mY4GjFaKJi1lho+TTMYuWKx9BOKWIPSZVLOaa5nlih/YpNka8XA7+39i4xL+EqJoGa+s+Rm9lukdHH/97RMpMg==}
+  /@fluidframework/mocha-test-setup/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-B1/5WUaYm9V5J3SWyULOXs8lnU3xyI3UZO5RioTK+z9aAobvUcZorgmez616p2UkS4R2ewwwa4ugG50lfj5H6w==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/merge-tree/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-AUyznFCKqyRBOVhmvdhTIeg4MlzGI/VqRvKcSsN9xFPZk+CH+5z7VyLYoQceBlwz/nKFK9D6mMPyACkV8/LnLA==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/mocha-test-setup/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-+yaftIRkk9iQPGPRlOLZLDFDMTpW8Cf32XSfL1iV4QqDO4yIN9mLH9lHGIx6JaqwhvBPGcXlvALvZIbl/m96Ig==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.7.3.0
       mocha: 10.2.0
       source-map-support: 0.5.21
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-7A9TrXRWegVTkEoWGGiq6OaSYrQ3Tza6QixQRb2+woCLchKZNaVPYGB350Ooa9vZCo8SAX64KyufBjPwgYXm7w==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-cmv2EipWeLAAJJDucWBckXiwrfZN7aT6Ma0/D97gq7uvotIwM8X6SRH+iXvUK1SrZGzOoPG+qFVJ1PehAm8Yvw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - debug
@@ -17378,16 +17036,16 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-6o2FWV9gB+OOLP9WWcU/M7rg8hTOsbccp8jJqxznY1fVa+P+GRGBlKdjF9XBJybHf3cOPkdkP0s7JKFA1yjdVg==}
+  /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-cmv2EipWeLAAJJDucWBckXiwrfZN7aT6Ma0/D97gq7uvotIwM8X6SRH+iXvUK1SrZGzOoPG+qFVJ1PehAm8Yvw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - debug
@@ -17395,49 +17053,26 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/odsp-doclib-utils/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-6o2FWV9gB+OOLP9WWcU/M7rg8hTOsbccp8jJqxznY1fVa+P+GRGBlKdjF9XBJybHf3cOPkdkP0s7JKFA1yjdVg==}
+  /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-8n6GlK4N87zv7ZEReIMxS/DVVR0FAWillcA0hhkbjkpnH0vxOgWUv1ESooQ6uP2YvBsLbKnRKXf+mX0s8k/bQQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - debug
-      - encoding
-      - supports-color
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
     dev: true
 
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-WfSRN2pQxDEmEv9eDJIYpaznFbRC2Rlp2/BJ3H1OjMnPnUKNRQjAaPJTDYC+kR90zViLIaWm/4eArEIL2caHeA==}
+  /@fluidframework/odsp-driver/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-vciAxLb+9qbi6e9+EIB5tTYHp/jIEW0cZylWnF48Il3C7HfSLLFfJaWdwWfgM670/XOVwTPBaJjDL9keJP0DPA==}
     dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-    dev: true
-
-  /@fluidframework/odsp-driver-definitions/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-/Tpau4r4BL0n5Xst8V0vsUI7prguY0ph0ShsJuVuqzfbkuUzBDjTWl8Y9Z1iEtGSeTF4oZ/YGr8fbQyrQpstPw==}
-    dependencies:
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-    dev: true
-
-  /@fluidframework/odsp-driver/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-XdBx40fY3EDF+5/PR7BiMdb1fougcz+o0qh9fIEUXnUhQIKkN97fPr8j2Fi6MYiAIT5GjPhoCwsysEibnG5qTQ==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-base': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-base': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       node-fetch: 2.7.0
       socket.io-client: 4.7.2_p7f5djbjd3zgfisasebtom74n4
       uuid: 9.0.1
@@ -17449,72 +17084,32 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/odsp-driver/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-4+n/8mGTwV9EWtfcBAwcGc50odW/blbfy+RnV0QPpGRYbEQHM1gzjPBWamaDU7QTUhT9eNFe+U9QyIbawVgsrA==}
+  /@fluidframework/odsp-urlresolver/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-pTfsNJTSyXoRnZt8Nt1Ylj2QJsri5hC3ClYE/Tx71739qN9tLslH9y6HpHygxUOeaYpJguvNjYNHsbDB/ZCFIA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-base': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver': 2.0.0-internal.7.3.0
+      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@fluidframework/ordered-collection/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-JH9tN75Q99CInwR6FQ6s68tZpCg67slsuVAouPwakChTiWSwRjlQIrIKL1HNmp+iKXqKxM42OpmI5eJT2FuTXg==}
+    dependencies:
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      node-fetch: 2.7.0
-      socket.io-client: 4.7.2_p7f5djbjd3zgfisasebtom74n4
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-wz1Ojx37Bkr/fzRR0oq6R14pVhaK8sIO3TV0knj8n/+LtAoJ5rp6GJ823BFYhlyapuxUAy9oUdQjcxoTC70HYQ==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/odsp-urlresolver/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-WtdNgcl5Hj9LOgRLK3KdoDQEG+NIjsipEraj5sNZtskwkxGotssd6d/fmtePC7P0izLjyhHHEVCJJIzHL68fJA==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/odsp-driver-definitions': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/ordered-collection/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-VI0RFAv2rrARPhPVaNn9pubxbx77kwy7psNLpAMMehHIkBerLKcemTiAcUd1H5Q/MtMI9LiNSdhn+rdmn9V6ow==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
@@ -17534,121 +17129,77 @@ packages:
     dependencies:
       '@fluidframework/common-definitions': 1.0.0
 
-  /@fluidframework/register-collection/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-vJ8fIsQSQlVY1b5lZxKKPap3SkU/VhfbFzZS0TUkuiCuBNqv76aiN3/m85C7I9ssDaZHhO79kZVEun2imSNhIA==}
+  /@fluidframework/register-collection/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-T204UjrIILhVvRtFG+Vs2B7fIUaHO5EgQjIxBoP+zWFDRxOWvPUg4DYb0uQgc2fRCNg7eMr9jZgZCS0QBLWVXA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/register-collection/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-+K6vojCvMnNYDNRduYhxX9sMP4bp2DnjM4dlSahwJfPMqo7fRK+0xT6T3N/ssmvuVdG3q909E5LdnOYK1RV3Hg==}
+  /@fluidframework/replay-driver/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-wEfnplWpgvihD3sVPUcqCR+RrQIrS13NCndPy2q1aDcDboM72BOyavZ7NoAbUTa3iXP4ArzT8iQb06DJObGoSQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-9rGc/7jK61ZjzanIsXnuj3YA9H9/9gbiCA1ZaDbRSaaZwpa87eJl6BcDIVIxOJFXtk6pLs6SF1kTzqh3pN/MCw==}
+  /@fluidframework/request-handler/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-AN0oBzTQjx3xXZ2zprblBXmGppWp1Nd9KIi8ssIAMMuZi4b52zrOCMyokJq9cNHhqOFL4ji0h+BkvRFfhYdooA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/replay-driver/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-PYzj6otY0Pl9COcE22scGSuPo4jclUmJp36d+4WC7aqGbxXtAg9OQPPB3ui+AzZrM6R4Q9m74BHBnl3n1OBNxg==}
+  /@fluidframework/request-handler/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-AN0oBzTQjx3xXZ2zprblBXmGppWp1Nd9KIi8ssIAMMuZi4b52zrOCMyokJq9cNHhqOFL4ji0h+BkvRFfhYdooA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0_debug@4.3.4
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/request-handler/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-zY2Gn6AOytcsRRROBkxrtQacFhfojf7mFx5C9MDNpK6hPWEIorTgLyrNqmjR3axgkBMClVxDVRnlWWxeYsGQJw==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-ROXj5HEFRTX51OMNfQDYN7jU2WW1xb02g39wagfiD3smpamjmcVesdoc88aO9x5fjVwxhTq3Nrgo2LiqqWtPhQ==}
     dependencies:
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/request-handler/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-thJOJ1zjNfaqUYALwPxs0rvzGJKGHtFqLGrTs8Teyl8YmzOWXzzqHPb1KfhfK1BTlbhAIx68g7vfKOUlToXQPw==}
-    dependencies:
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/request-handler/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-thJOJ1zjNfaqUYALwPxs0rvzGJKGHtFqLGrTs8Teyl8YmzOWXzzqHPb1KfhfK1BTlbhAIx68g7vfKOUlToXQPw==}
-    dependencies:
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/routerlicious-driver/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-8PbOAQjH20olgJp6vtrZX9gU6Z6utHfEyVLF4g8zOsVft1bjUk/XRhoFYROfImTELssIEk63V/e4nwbDpfrAEg==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-base': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-base': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       cross-fetch: 3.1.8
       json-stringify-safe: 5.0.1
       socket.io-client: 4.7.2_p7f5djbjd3zgfisasebtom74n4
@@ -17662,20 +17213,20 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-Vd2t8ipW4MJzIcZJEEOzyvTItU3MDpXCJvIMCSj1gIaeox2MSp6oQgTZWXllqcUeQsneHEb0lWZYsqBDgWw/0Q==}
+  /@fluidframework/routerlicious-driver/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-ROXj5HEFRTX51OMNfQDYN7jU2WW1xb02g39wagfiD3smpamjmcVesdoc88aO9x5fjVwxhTq3Nrgo2LiqqWtPhQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-base': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-base': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0_debug@4.3.4
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
       '@fluidframework/protocol-definitions': 3.0.0
       '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       cross-fetch: 3.1.8
       json-stringify-safe: 5.0.1
       socket.io-client: 4.7.2_p7f5djbjd3zgfisasebtom74n4
@@ -17689,159 +17240,75 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/routerlicious-driver/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-Vd2t8ipW4MJzIcZJEEOzyvTItU3MDpXCJvIMCSj1gIaeox2MSp6oQgTZWXllqcUeQsneHEb0lWZYsqBDgWw/0Q==}
+  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-Ael+endHcoLZ8wHJxcJSW0t4iA6/swSVOCq5AlhvEldEKx0FOWsfqkO7orH8UysGhByEaB872myKKtfWzEjGOQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-base': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      cross-fetch: 3.1.8
-      json-stringify-safe: 5.0.1
-      socket.io-client: 4.7.2_p7f5djbjd3zgfisasebtom74n4
-      url-parse: 1.5.10
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-3Fo4J/F+G7pwrV8j4ZSGvV7ZlLCUcivrLDaL6wu1LLHJp92vUN0l4mZoO+v3Gga3Z5daOEpJmlnZv+Bv43pGvQ==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
       nconf: 0.12.1
       url: 0.11.3
     dev: true
 
-  /@fluidframework/routerlicious-urlresolver/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-zrbtuBFB8ZkK/+E5NVkdSM6qqrJ1ouU6lqAS9ducpVhwa/CU/utknOTRlcsMO90bavNorYvNZtCIlY4opMWQ0w==}
+  /@fluidframework/runtime-definitions/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-WhtxTvV0FgsSxOtg7sWpojSGTl9wIfDMrfiQyzKXKczkzKTHF4UVxfEBznY3ee4e0GzNWqo3qcjNjRRBfX/eCg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      nconf: 0.12.1
-      url: 0.11.3
-    dev: true
-
-  /@fluidframework/runtime-definitions/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-fuU3+ZZlTyRemNkQp8eFvjVllMnWdx+WKn7apRQiHrmlAmTMRYBBolgS2pyBC1wLhzoBQf0lJzpE42usB4V0vg==}
-    dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
     dev: true
 
-  /@fluidframework/runtime-definitions/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-PilIjF89XymXy8pBUa0JBs/z+adUIrmc12xfWxv6wJpRSsImOi0rmWSm7RKXT8rOf12OUXSucYdcx5DjxyaEig==}
+  /@fluidframework/runtime-utils/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-rbu/Dq1W1RkaSpGqepS6Kf6YNLTfhAZcZXn5x/+Y0xctVdHK7ReBFvplYKU3SdqOCQfklhKza2TXF593p2KL2Q==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-    dev: true
-
-  /@fluidframework/runtime-utils/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-Ccq133fn8Tnh7avT+VAm6jcgvBHCjqT29Y2V2g0crgCaqnN7xwkDYDAM+QUcux2osAtTLyy0Xq4apyZMK6CJjQ==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-1gk9UdRVc4L0qTOU2IZm4rZBWqsR/4baUy+49uDHKjTzdQR1t20ihtwPaq0nR2CndiyoTEUAoU3Fjghxb/33LA==}
+  /@fluidframework/runtime-utils/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-rbu/Dq1W1RkaSpGqepS6Kf6YNLTfhAZcZXn5x/+Y0xctVdHK7ReBFvplYKU3SdqOCQfklhKza2TXF593p2KL2Q==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/runtime-utils/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-1gk9UdRVc4L0qTOU2IZm4rZBWqsR/4baUy+49uDHKjTzdQR1t20ihtwPaq0nR2CndiyoTEUAoU3Fjghxb/33LA==}
+  /@fluidframework/sequence/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-F9qxv/yyEVSMhGr5eRH0Ph0vh5XwwFdujyCZBwclj9q+Mk10RM2t4G1z7D+/zTV4J8EmS4Hxtf7FLUVWOF/MDw==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/merge-tree': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/sequence/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-VBR3eZm22hh6oS8IeBZbrH1nOrYbpJM8iX58ftIjy/I/JfJSmYao3k6Go07VsE4tg/KdqyhtYcQwZGpJb5b+NA==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/merge-tree': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/sequence/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-qDcRWjnS+2MHGBgm+BVikhvdWHwc3EVBdn0WZkf7tCHNwX45dpxBIUxw1hqCEFQIXXGs+F8RrgzHnq+KtwALZw==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/merge-tree': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
@@ -18086,116 +17553,90 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@fluidframework/shared-object-base/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-5wHmGPgd31acYaVMBjamGqzbLvEs8eYWXvfc2cPpvY3NRYa1lbo2xiRIFAFAsBR4I7V/0h1J9N9R4WJ8gNC7rQ==}
+  /@fluidframework/shared-object-base/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-HP0d++WxJIBXTFtCAobM3tuE/MtnPjTpptmiy0R28KoNONAH0lZiGiMbZLhl+ZztJaQi2LPOnuOpOD4FJTfyzA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-QiPaE2COwWlGO2psJ3A8ptwkU7VEqGzK5T/KBu6d8+YZoDwf1FUCJxu7PU4FhWI3BDbIxUvZzFkOnkKhX7+pvw==}
+  /@fluidframework/shared-object-base/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-HP0d++WxJIBXTFtCAobM3tuE/MtnPjTpptmiy0R28KoNONAH0lZiGiMbZLhl+ZztJaQi2LPOnuOpOD4FJTfyzA==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-object-base/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-QiPaE2COwWlGO2psJ3A8ptwkU7VEqGzK5T/KBu6d8+YZoDwf1FUCJxu7PU4FhWI3BDbIxUvZzFkOnkKhX7+pvw==}
+  /@fluidframework/shared-summary-block/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-tdcmRSWY2zE5uiIcg08dms8w+FduI2kOvGbTShWHicBdYDDaeL7Jj6YmtvK1ecsc1oJjiKbcafwia1JsHgjs/A==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      uuid: 9.0.1
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/shared-summary-block/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-fJxPPRlXMWYFgnZ+biLSjcipgSGcMB66uQ7/vU7bkRPNgg0Q5pBw8KBtQZR2vaxJ/86lCCDUombp0VucwZFDEw==}
+  /@fluidframework/synthesize/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-+h39Mm4AaphqJsGcA9U/dK6c6ehNC/1FkOQbdWYJYtkap1SVA3fJVFDWOJSDQPiKmztbFwz/wKufhS9x0Wtmug==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+    dev: true
+
+  /@fluidframework/task-manager/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-v0E5Pl53uTGzdHeZbqFyAniK8txYIHiQ9TdkSyUprVNu5cnDZS10M0ca5mNovj6kF8t4RtPXoIkbVT1WD8hZ5Q==}
+    dependencies:
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/synthesize/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-VENhFUwNZJIz9n1EIRFvZYgGtdqr9CITKIES6S29QiH82cx8AbSginSKYZgooW30JgLHpvXkk35AMixpmhuKcg==}
-    dependencies:
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-    dev: true
-
-  /@fluidframework/synthesize/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-zTQogCUh7/X6TGBXHe8uKnFg0/SfOs6gQtOLOjnO/1x6qAWfWjaYz8pSJbgmP1cZMxJcVpvseZaEFEImDNWfHg==}
-    dependencies:
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-    dev: true
-
-  /@fluidframework/task-manager/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-dSy2SjWy2K52tYcnH8jwLpNKlx8HLPuov0WOhvX/Lg3uynY8F4b9NkK8R1bv8AgBkHIgY45PnbkEleXBjWdm+g==}
-    dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/shared-object-base': 2.0.0-internal.7.2.2
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/shared-object-base': 2.0.0-internal.7.3.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/telemetry-utils/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-4ydYNfLv8SPiKTdAbTNPH/u2P817/7UF/SK8RCRpmTVGHVIB+l+GR85QUsFw7yLkAslA7Og7Cg9j3017v+KQiw==}
+  /@fluidframework/telemetry-utils/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-TSg+Ue86XIjx24+pGVSvGu8G5rZLy40sW+/CP5v6hr1RWnVPEN6uUXzCpSwx+qO0FFQqERUksoEA4mXfX+YawQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
       debug: 4.3.4
       events: 3.3.0
@@ -18204,54 +17645,29 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/telemetry-utils/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-xAsyyQJJQzPJT5ivI79DTAUbiSUaj/XE+6bd7MLVc+6WLpZrDTE6dLEN/ELkxnOFUDUlYgnMpY8q79ih2xUBhQ==}
+  /@fluidframework/test-driver-definitions/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-glw02BgdCBMi89buNA5ep890YWCK63u6x4RTn7dJ9HtgVxKw0YLeLGA5V78kDd4ZQB/CEFVWt9VzY7NBf4JJiQ==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      debug: 4.3.4
-      events: 3.3.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/test-driver-definitions/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-KfPWHI31U2YuG0yNdeQ8gKULjilbdKgvWgAPEzAGEbbg41ZDFG0eAumbvlkUpBl1AM/cQprMKkYloAIQeGZiBQ==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
       uuid: 9.0.1
     dev: true
 
-  /@fluidframework/test-driver-definitions/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-W+LKajmLXgsNKiG4hjCBLZ32KWuf2WrU1JcxAXDMtrCIfTo4jT7KsQXorMPmUUviqDC4JuZEnn09Tk/dAlRhgA==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-z/uNgC5x2BuFB+9rpw7CBWnQewyGBnQMn2aQIohzlAjcJN6ARS5Qz5q0FR/TaK3PtfJutKlTd38uspl+CuGQ2A==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      uuid: 9.0.1
-    dev: true
-
-  /@fluidframework/test-runtime-utils/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-Nj5gENe68wNDJgdKpIWy88rWwUNwlFT3Yq0098MfRcKQTK2Bki7cJXcN4mm6dQ9elUMr0+9X5yNpBMGzSAieAg==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      axios: 0.26.1
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       events: 3.3.0
       jsrsasign: 10.9.0
       uuid: 9.0.1
@@ -18263,49 +17679,20 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/test-runtime-utils/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-11tvL3HFbrflpKT1KBYgPJhpzMSVlrcPOXK+reG+M7I4aFMjwyEEPi/GFUO8y2gdeyvCIpbFGy1yRa95wF3+ew==}
+  /@fluidframework/test-runtime-utils/2.0.0-internal.7.3.0_debug@4.3.4:
+    resolution: {integrity: sha512-z/uNgC5x2BuFB+9rpw7CBWnQewyGBnQMn2aQIohzlAjcJN6ARS5Qz5q0FR/TaK3PtfJutKlTd38uspl+CuGQ2A==}
     dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluid-internal/client-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      axios: 0.26.1
-      events: 3.3.0
-      jsrsasign: 10.9.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/test-runtime-utils/2.0.0-internal.7.2.2_debug@4.3.4:
-    resolution: {integrity: sha512-11tvL3HFbrflpKT1KBYgPJhpzMSVlrcPOXK+reG+M7I4aFMjwyEEPi/GFUO8y2gdeyvCIpbFGy1yRa95wF3+ew==}
-    dependencies:
-      '@fluid-internal/client-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      axios: 0.26.1_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
       events: 3.3.0
       jsrsasign: 10.9.0
       uuid: 9.0.1
@@ -18322,30 +17709,30 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/test-utils/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-gxoh4+4BI2Tztmaq2M7O+u1sUXUnOQA9fCwi+lCn7wqrfjfpUMk3TRd6G8jhQb2dXcp8Y8JInfJOG0wfzkKoFw==}
+  /@fluidframework/test-utils/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-J9AKw6R9+1VAHbknBwU3NOfABy1uz9W5k/Sr9cgrQi0bGYTk15F/pD7Z1ZDRe7lDy9gV+E9Gkz4x4prLA2X8BA==}
     dependencies:
-      '@fluidframework/aqueduct': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-loader': 2.0.0-internal.7.2.2
-      '@fluidframework/container-runtime': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/datastore': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/datastore-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/local-driver': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/map': 2.0.0-internal.7.2.2_debug@4.3.4
+      '@fluidframework/aqueduct': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.3.0
+      '@fluidframework/container-runtime': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/container-runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/datastore': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/datastore-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/local-driver': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/map': 2.0.0-internal.7.3.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/request-handler': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/runtime-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/telemetry-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/test-runtime-utils': 2.0.0-internal.7.2.2_debug@4.3.4
+      '@fluidframework/request-handler': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/runtime-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/telemetry-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/test-driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/test-runtime-utils': 2.0.0-internal.7.3.0_debug@4.3.4
       best-random: 1.0.3
       debug: 4.3.4
       uuid: 9.0.1
@@ -18356,21 +17743,21 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-client/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-bArH0Vrg6FZO+TcyNQLdV9CikoQZaFXgZh1Lhwnd76WCxB7sC7A/huCqYAml9dpcVIU5drz+ZNdxpUIxE1jh1Q==}
+  /@fluidframework/tinylicious-client/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-i6E/kmq8vSP5Ni5r+I+t23qcJY6ctS+mi2sqwF2RO39tSJlUiJpXcnHjf6WNtYCej0eRTFb8j+fVqqnqRBMAng==}
     dependencies:
-      '@fluidframework/container-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/container-loader': 2.0.0-internal.7.2.2
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/fluid-static': 2.0.0-internal.7.2.2
-      '@fluidframework/map': 2.0.0-internal.7.2.2
+      '@fluidframework/container-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/container-loader': 2.0.0-internal.7.3.0
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/fluid-static': 2.0.0-internal.7.3.0
+      '@fluidframework/map': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2
-      '@fluidframework/runtime-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/tinylicious-driver': 2.0.0-internal.7.2.2
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.3.0
+      '@fluidframework/runtime-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/tinylicious-driver': 2.0.0-internal.7.3.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
@@ -18380,14 +17767,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-fMmmD1i5wxM+bXqaGKHDKaFmqS2Y/lSRVwcM3vgDxHcEPppanJPTiu1jPaMEHHFEmhpptv/wI+rA5ItutKZxjA==}
+  /@fluidframework/tinylicious-driver/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-/I9DAzjPG9BSzHPoGus2FI+VxmcYSEzti8AiH4xaySI55NXDkuzVcnDsxe3zySHVBE+aJnfk2+PzX1jhpH1Xyg==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-definitions': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0
       '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2
+      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.3.0
       jsrsasign: 10.9.0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -18398,30 +17785,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/tinylicious-driver/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-BufPBHrXDo76AYi0Mp0AUyu3ayNsFdRDnDhqGUcJz/xqNXkBARUTLrumiCU82RJRhflghAjT0Z99Coq/rnSQvg==}
+  /@fluidframework/tool-utils/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-DJSuyEmTyCNhU+aSi7nq6B8WBqGYNxHceS7lsB7NvZsfogNCGR8C0W1MLtfcCOWqPIN010QnXRt+T3GTic2IQA==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-definitions': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/protocol-definitions': 3.0.0
-      '@fluidframework/routerlicious-driver': 2.0.0-internal.7.2.2
-      jsrsasign: 10.9.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/tool-utils/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-fAmRk+ivfC4nxmbWcey9ATUP4Fnp76ffZVoAUHG+4sD+UKWCT/65Mq1EFx65EPW7Yb/+Mhs68onBfGwIwwgpjQ==}
-    dependencies:
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.2.2_debug@4.3.4
+      '@fluidframework/core-utils': 2.0.0-internal.7.3.0
+      '@fluidframework/driver-utils': 2.0.0-internal.7.3.0_debug@4.3.4
+      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.3.0_debug@4.3.4
       '@fluidframework/protocol-definitions': 3.0.0
       async-mutex: 0.3.2
       debug: 4.3.4
@@ -18432,54 +17801,32 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/tool-utils/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-cyXns6v7SkeTxnslthyzOf0fNHhvvW5DWOj5MUNZXq16qQsFE7QZK1YrmC3tRJPYrSpobK+zju545CjkniUzHg==}
+  /@fluidframework/undo-redo/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-967kwjMrbZam5jmoz+L4/Vx4yCOtBGGCiehrgsufAUZvEpY2wblVcitQsllNkhAnQykZY3ECeDqAovBOhJ5jkg==}
     dependencies:
-      '@fluidframework/core-utils': 2.0.0-internal.7.2.2
-      '@fluidframework/driver-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/odsp-doclib-utils': 2.0.0-internal.7.2.2_debug@4.3.4
-      '@fluidframework/protocol-definitions': 3.0.0
-      async-mutex: 0.3.2
-      debug: 4.3.4
-      jwt-decode: 2.2.0
-      proper-lockfile: 4.1.2
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: true
-
-  /@fluidframework/undo-redo/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-DLx52lSBNEa2Ck6RHEGRTX7qlRARuF5hVw9gQKaqVMivm84mDYfjUrmv2wwwi82mIzN0uTaeNJU34pZzs8t56w==}
-    dependencies:
-      '@fluidframework/map': 2.0.0-internal.7.2.2
-      '@fluidframework/matrix': 2.0.0-internal.7.2.2
-      '@fluidframework/merge-tree': 2.0.0-internal.7.2.2
-      '@fluidframework/sequence': 2.0.0-internal.7.2.2
+      '@fluidframework/map': 2.0.0-internal.7.3.0
+      '@fluidframework/matrix': 2.0.0-internal.7.3.0
+      '@fluidframework/merge-tree': 2.0.0-internal.7.3.0
+      '@fluidframework/sequence': 2.0.0-internal.7.3.0
       events: 3.3.0
     transitivePeerDependencies:
       - debug
       - supports-color
     dev: true
 
-  /@fluidframework/view-adapters/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-oBbiezJ5JwVHxNY7JP2tnoqaV7ytPAXGZawF03nF3Jjlug7hUxPJzduAVFRXMLHrr5bhuWlU1JKOWkOC2kUSHg==}
+  /@fluidframework/view-adapters/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-WoSL07lz27rA59Apfq0jZmfqbaLBZQ4Ro6/p8vDIyVf2rY+2jaN5zJAKj8gndoyONOuoXh+sGo6H6TG70oMUnw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-      '@fluidframework/view-interfaces': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
+      '@fluidframework/view-interfaces': 2.0.0-internal.7.3.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@fluidframework/view-interfaces/2.0.0-internal.7.2.0:
-    resolution: {integrity: sha512-WKVpbwX8l4Qa/qL73qHdVCuNJMM4OA6xwuJx9WWWAWwH8gRfKV4vvKN/RWcvSnrM/tt7bfBcSAbT8niJcE/Uug==}
+  /@fluidframework/view-interfaces/2.0.0-internal.7.3.0:
+    resolution: {integrity: sha512-N9OH1v0zzVnEmTVwvQmcqp5IjJSqLZrdUZDHHr2FnbuEbIxiZc+wOJwdLkT/lMhpUwip9j3ihbcpCJXNE4MRWw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
-    dev: true
-
-  /@fluidframework/view-interfaces/2.0.0-internal.7.2.2:
-    resolution: {integrity: sha512-QRsn/6Lcmo3Jf8+qgTJnFZ8f4hb4VqOQ1y9gsgJH+bHEOt+1yGarqqVi28MFRG+W/UuARfzjeAlEqEbzLqTDXg==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.7.2.2
+      '@fluidframework/core-interfaces': 2.0.0-internal.7.3.0
     dev: true
 
   /@fwouts/vite-tsconfig-paths/4.2.1_ah7snkqdiegnosaxffkwmchslm:


### PR DESCRIPTION
I followed the instructions provided here https://eng.ms/docs/experiences-devices/opg/office-shared/fluid-framework/fluid-framework-internal/fluid-framework/docs/on-call/release/release-minor to update type tests in 7.4 release branch