### PR TITLE
change uri Root to point to correct directory

### DIFF
--- a/docs/api-markdown-documenter/index.js
+++ b/docs/api-markdown-documenter/index.js
@@ -37,9 +37,15 @@ docVersions.forEach((version) => {
 	const apiDocsDirectoryPath = (renderMultiVersion) ? 
 		path.resolve(__dirname, "..", "content", "docs", "apis", version) :
 		path.resolve(__dirname, "..", "content", "docs", "apis");
+	
+	// TODO: remove check for 2.0 and just set uriDirectoryPath to include version.
+	// currently publishing to base apis directory until 2.0 release
+	const uriRootDirectoryPath = (renderMultiVersion) ? 
+		`/docs/apis/${version}` :
+		`/docs/apis`;
 
 	apiDocRenders.push(
-		renderApiDocumentation(apiReportsDirectoryPath, apiDocsDirectoryPath, version).then(
+		renderApiDocumentation(apiReportsDirectoryPath, apiDocsDirectoryPath, uriRootDirectoryPath).then(
 			() => {
 				console.log(chalk.green(`${version} API docs written!`));
 			},

--- a/docs/api-markdown-documenter/render-api-documentation.js
+++ b/docs/api-markdown-documenter/render-api-documentation.js
@@ -21,7 +21,7 @@ const { buildNavBar } = require("./build-api-nav");
 const { renderAlertNode, renderBlockQuoteNode, renderTableNode } = require("./custom-renderers");
 const { createHugoFrontMatter } = require("./front-matter");
 
-async function renderApiDocumentation(inputDir, outputDir, version) {
+async function renderApiDocumentation(inputDir, outputDir, uriRootDir) {
 	// Delete existing documentation output
 	console.log("Removing existing generated API docs...");
 	await fs.ensureDir(outputDir);
@@ -51,7 +51,7 @@ async function renderApiDocumentation(inputDir, outputDir, version) {
 			ApiItemKind.Namespace,
 		],
 		newlineKind: "lf",
-		uriRoot: `/docs/apis/${version}`,
+		uriRoot: uriRootDir,
 		includeBreadcrumb: false, // Hugo will now be used to generate the breadcrumb
 		includeTopLevelDocumentHeading: false, // This will be added automatically by Hugo
 		createDefaultLayout: layoutContent,


### PR DESCRIPTION
Update uriRoot to not point to a versioned directory in render-api-documentation.

After 2.0 release, we will revert back to the versioned directory for uriRoot