### PR TITLE
tree: Make commit eviction policy slightly less aggressive

### DIFF
--- a/experimental/dds/tree2/src/shared-tree-core/editManagerFormat.ts
+++ b/experimental/dds/tree2/src/shared-tree-core/editManagerFormat.ts
@@ -4,7 +4,7 @@
  */
 
 import { TSchema, Type, ObjectOptions } from "@sinclair/typebox";
-import { Brand, brandedNumberType } from "../util";
+import { Brand, brand, brandedNumberType } from "../util";
 import {
 	SessionId,
 	SessionIdSchema,
@@ -59,6 +59,16 @@ export const sequenceIdComparator = (a: SequenceId, b: SequenceId) =>
 export const equalSequenceIds = (a: SequenceId, b: SequenceId) => sequenceIdComparator(a, b) === 0;
 export const minSequenceId = (a: SequenceId, b: SequenceId) =>
 	sequenceIdComparator(a, b) < 0 ? a : b;
+export const maxSequenceId = (a: SequenceId, b: SequenceId) =>
+	sequenceIdComparator(a, b) > 0 ? a : b;
+export const decrementSequenceId = (sequenceId: SequenceId): SequenceId => {
+	return sequenceId.indexInBatch !== undefined
+		? {
+				sequenceNumber: brand(sequenceId.sequenceNumber),
+				indexInBatch: sequenceId.indexInBatch - 1,
+		  }
+		: { sequenceNumber: brand(sequenceId.sequenceNumber - 1) };
+};
 
 /**
  * A commit with a sequence number but no parentage; used for serializing the `EditManager` into a summary

--- a/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/editManager.spec.ts
@@ -356,7 +356,7 @@ describe("EditManager", () => {
 				manager.addSequencedChange(local, brand(2), brand(1));
 				checkChangeList(manager, [1, 2]);
 				manager.advanceMinimumSequenceNumber(brand(2));
-				checkChangeList(manager, [2]);
+				checkChangeList(manager, [1, 2]);
 				fork.dispose();
 				checkChangeList(manager, []);
 			});
@@ -373,11 +373,11 @@ describe("EditManager", () => {
 				manager.advanceMinimumSequenceNumber(brand(2));
 				checkChangeList(manager, [1, 2]);
 				fork1.rebaseOnto(fork2);
-				checkChangeList(manager, [2]);
+				checkChangeList(manager, [1, 2]);
 				fork1.rebaseOnto(manager.localBranch);
-				checkChangeList(manager, [2]);
+				checkChangeList(manager, [1, 2]);
 				fork2.rebaseOnto(manager.localBranch);
-				checkChangeList(manager, []);
+				checkChangeList(manager, [2]);
 			});
 
 			it("Evicts properly when changes come in batches having the same sequence number", () => {

--- a/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/experimental/dds/tree2/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -200,6 +200,8 @@ describe("SharedTreeCore", () => {
 		// Calling `factory.processAllMessages()` will result in the minimum sequence number being set to the the
 		// sequence number just before the most recently received changed. Thus, eviction from this point of view
 		// is "off by one"; a commit is only evicted once another commit is sequenced after it.
+		// Eviction is performed up to the trunk commit that no branch has as its trunk base.
+		// Additionally, by policy, the base commit of the trunk is never evicted, which adds another "off by one".
 		//
 		//                                            trunk: [seqNum1, (branchBaseA, branchBaseB, ...), seqNum2, ...]
 		changeTree(tree);
@@ -212,25 +214,25 @@ describe("SharedTreeCore", () => {
 		factory.processAllMessages(); //                     [x (b1, b2, b3), 2]
 		changeTree(tree);
 		factory.processAllMessages(); //                     [x (b1, b2, b3), 2, 3]
-		assert.equal(getTrunkLength(tree), 2);
+		assert.equal(getTrunkLength(tree), 3);
 		branch1.dispose(); //                                [x (b2, b3), 2, 3]
-		assert.equal(getTrunkLength(tree), 2);
+		assert.equal(getTrunkLength(tree), 3);
 		branch2.dispose(); //                                [x (b3), 2, 3]
-		assert.equal(getTrunkLength(tree), 2);
+		assert.equal(getTrunkLength(tree), 3);
 		branch3.dispose(); //                                [x, x, 3]
 		assert.equal(getTrunkLength(tree), 1);
 		const branch4 = tree.getLocalBranch().fork(); //     [x, x, 3 (b4)]
 		changeTree(tree);
 		changeTree(tree);
 		factory.processAllMessages(); //                     [x, x, x (b4), 4, 5]
-		assert.equal(getTrunkLength(tree), 2);
+		assert.equal(getTrunkLength(tree), 3);
 		const branch5 = tree.getLocalBranch().fork(); //     [x, x, x (b4), 4, 5 (b5)]
 		branch4.rebaseOnto(branch5); //                      [x, x, x, 4, 5 (b4, b5)]
 		branch4.dispose(); //                                [x, x, x, 4, 5 (b5)]
 		assert.equal(getTrunkLength(tree), 2);
 		changeTree(tree);
 		factory.processAllMessages(); //                     [x, x, x, x, 5 (b5), 6]
-		assert.equal(getTrunkLength(tree), 1);
+		assert.equal(getTrunkLength(tree), 2);
 		changeTree(tree);
 		branch5.dispose(); //                                [x, x, x, x, x, x, 7]
 		assert.equal(getTrunkLength(tree), 1);


### PR DESCRIPTION
## Description

This PR changes the edit manager eviction policy to never evict/mutate the base trunk commit of any branches. This generally makes it easier to reason about the state of branches and what they can rely on being truly immutable. It also allows branches to track their transaction stacks by revision ID rather than by commit object identity, fixing a bug in which eviction occurs during an ongoing transaction and mutates away the revision IDs being tracked.