### PR TITLE
Revert node16 module resolution for test-service-load

### DIFF
--- a/packages/test/test-service-load/src/test/tsconfig.json
+++ b/packages/test/test-service-load/src/test/tsconfig.json
@@ -1,17 +1,16 @@
 {
-	"extends": [
-		"../../../../../common/build/build-common/tsconfig.base.json",
-		"../../../../../common/build/build-common/tsconfig.test.json",
-	],
+	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../../dist/test",
+		"types": ["node", "mocha"],
+		"declaration": false,
+		"declarationMap": false,
+	},
 	"include": ["./**/*"],
 	"references": [
 		{
 			"path": "../..",
 		},
 	],
-	"compilerOptions": {
-		"rootDir": "./",
-		"outDir": "../../dist/test",
-		"types": ["node", "mocha"],
-	},
 }

--- a/packages/test/test-service-load/tsconfig.json
+++ b/packages/test/test-service-load/tsconfig.json
@@ -1,13 +1,11 @@
 {
-	"extends": [
-		"../../../common/build/build-common/tsconfig.base.json",
-		"../../../common/build/build-common/tsconfig.cjs.json",
-	],
-	"include": ["src/**/*"],
+	"extends": "@fluidframework/build-common/ts-common-config.json",
 	"exclude": ["src/test/**/*"],
+	"include": ["src/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./dist",
 		"types": ["node"],
+		"composite": true,
 	},
 }


### PR DESCRIPTION
## Description

Reverts the portion of #18826 applying to test-service-load, which has a dynamic import of a logger for stress runs that appears to not resolve using node16 resolution, causing failure in stress tests currently.
