### PR TITLE
fix(ci): Make test coverage logic get applied again

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -312,6 +312,7 @@ stages:
               parameters:
                 taskTestStep: ${{ taskTestStep }}
                 buildDirectory: ${{ parameters.buildDirectory }}
+                testCoverage: ${{ eq(variables['testCoverage'], true) }}
 
           # Test - Upload coverage results
           # Some webpacked file using externals introduce file name with quotes in them

--- a/tools/pipelines/templates/include-test-stability.yml
+++ b/tools/pipelines/templates/include-test-stability.yml
@@ -90,13 +90,13 @@ jobs:
 
     - template: include-use-node-version.yml
 
-    - template: include-install.yml 
+    - template: include-install.yml
       parameters:
         packageManager: ${{ parameters.packageManager }}
         buildDirectory: ${{ parameters.buildDirectory }}
         packageManagerInstallCommand: ${{ parameters.packageManagerInstallCommand }}
 
-    - template: include-build-lint.yml 
+    - template: include-build-lint.yml
       parameters:
         taskBuild: ${{ parameters.taskBuild }}
         taskLint: ${{ parameters.taskLint }}
@@ -115,7 +115,8 @@ jobs:
           parameters:
             taskTestStep: ${{ taskTestStep }}
             buildDirectory: ${{ parameters.buildDirectory }}
-            
+            testCoverage: ${{ eq(variables['testCoverage'], true) }}
+
         # Verify if the tinylicious log exists
         - task: Bash@3
           displayName: Validate Tinylicious Log

--- a/tools/pipelines/templates/include-test-task.yml
+++ b/tools/pipelines/templates/include-test-task.yml
@@ -5,14 +5,18 @@
 
 parameters:
 - name: taskTestStep
-  type: string 
+  type: string
 
 - name: buildDirectory
-  type: string 
+  type: string
 
-steps: 
+- name: testCoverage
+  type: boolean
+  default: false
+
+steps:
 # Test - With coverage
-- ${{ if and(eq(variables['testCoverage'], true), startsWith(parameters.taskTestStep, 'ci:test')) }}:
+- ${{ if and(parameters.testCoverage, startsWith(parameters.taskTestStep, 'ci:test')) }}:
   - task: Npm@1
     displayName: npm run ${{ parameters.taskTestStep }}:coverage
     inputs:

--- a/tools/pipelines/templates/include-test-task.yml
+++ b/tools/pipelines/templates/include-test-task.yml
@@ -22,7 +22,7 @@ steps:
     inputs:
       command: 'custom'
       workingDir: ${{ parameters.buildDirectory }}
-      customCommand: 'run ${{ taskTestStep }}:coverage'
+      customCommand: 'run ${{ parameters.taskTestStep }}:coverage'
     condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
     env:
       # Tests can use this environment variable to behave differently when running from a test branch


### PR DESCRIPTION
## Description

When we moved test execution in the pipelines to a separate template [here](https://github.com/microsoft/FluidFramework/pull/17875), we missed the fact that test coverage was not being applied anymore when it should.

I believe this is because `variables[]`, when used in compile-time syntax in a pipeline, can only reference variables defined in the file where the syntax appears, so in this case the template did not get access to the `variable['testCoverage']` from the "caller" file and the corresponding condition never evaluated to true. Before the PR linked above, all the code lived in the same file so things worked.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

CI runs in the internal ADO project should always do test coverage, but instead we're getting the non-coverage versions of test scripts ([example](https://dev.azure.com/fluidframework/internal/_build/results?buildId=223666&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=5cfe65a4-d7cb-5934-e953-1c67617821f4)). [Run on a test branch](https://dev.azure.com/fluidframework/internal/_build/results?buildId=223733&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=5cfe65a4-d7cb-5934-e953-1c67617821f4) that shows `:coverage` being applied again. (Links Microsoft internal)
