### PR TITLE
fix(docs): rollup-api-json-helper

### DIFF
--- a/docs/rollup-api-json-helper.js
+++ b/docs/rollup-api-json-helper.js
@@ -41,7 +41,7 @@ async function stageMetadata(version) {
 			error,
 		);
 	}
-	console.log(chalk.green(`SUCCESS: ${version} API log files staged!`));
+	console.log(chalk.green(`SUCCESS: ${version} API metadata staged!`));
 }
 
 Promise.all(docVersions.map(stageMetadata)).then(

--- a/docs/rollup-api-json-helper.js
+++ b/docs/rollup-api-json-helper.js
@@ -5,19 +5,19 @@
 
 /**
  * This helper function is used to optionally run rollup-api-json.js multiple times based on the
- * versions described in versions.json. In docs/package.json, "build:api-rollup:multi-version" and 
+ * versions described in versions.json. In docs/package.json, "build:api-rollup:multi-version" and
  * "build:api-rollup" calls this script. Note that this script allows for an optional boolean parameter
- * to be passed in the script call. 
+ * to be passed in the script call.
  * e.g. "node ./rollup-api-json-helper.js true"
  * This boolean parameter determines if the rollup will be executed on all versions or only the
  * latest version (pass in true for all versions).
  */
 
 const chalk = require("chalk");
+const fs = require("fs-extra");
 const path = require("path");
 const versions = require("./data/versions.json");
 const { main } = require("./rollup-api-json");
-const { rimraf } = require("rimraf");
 
 const renderMultiVersion = process.argv[2];
 
@@ -25,22 +25,32 @@ docVersions = renderMultiVersion
 	? versions.params.previousVersions.concat(versions.params.currentVersion)
 	: [versions.params.currentVersion];
 
-docVersions.forEach((version) => {
+async function stageMetadata(version) {
 	const targetPath = path.resolve(".", "_api-extractor-temp", version);
 	// change to empty string since current build:docs doesn't append version number to _api-extractor-temp
 	version = version === versions.params.currentVersion ? "" : "-" + version;
 	const originalPath = path.resolve("..", "_api-extractor-temp" + version, "doc-models");
 
-	rimraf(targetPath);
+	await fs.emptyDir(targetPath);
 
-	main(originalPath, targetPath).then(
-		() => {
-			console.log(chalk.green("SUCCESS: API log files staged!"));
-			process.exit(0);
-		},
-		(error) => {
-			console.error("FAILURE: API log files could not be staged due to an error.", error);
-			process.exit(1);
-		},
-	);
-});
+	try {
+		await main(originalPath, targetPath);
+	} catch (error) {
+		throw new Error(
+			`FAILURE: ${version} API metadata could not be staged due to an error.`,
+			error,
+		);
+	}
+	console.log(chalk.green(`SUCCESS: ${version} API log files staged!`));
+}
+
+Promise.all(docVersions.map(stageMetadata)).then(
+	() => {
+		console.log(chalk.green("SUCCESS: All API metadata staged!"));
+		process.exit(0);
+	},
+	(error) => {
+		console.error("FAILURE: API metadata could not be staged due to an error.", error);
+		process.exit(1);
+	},
+);


### PR DESCRIPTION
The first of potentially parallel tasks was killing the process on completion or error, preventing the other tasks from completing.