### PR TITLE
docs(fluid-framework): Fix API report

### DIFF
--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -2124,7 +2124,7 @@ export interface TreeApi {
     key(node: TreeNode): string | number;
     on<K extends keyof TreeNodeEvents>(node: TreeNode, eventName: K, listener: TreeNodeEvents[K]): () => void;
     parent(node: TreeNode): TreeNode | undefined;
-    schema<T extends TreeNode>(node: TreeNode): TreeNodeSchema<string, NodeKind, unknown, T>;
+    schema<T extends TreeNode | TreeLeafValue>(node: T): TreeNodeSchema<string, NodeKind, unknown, T>;
     readonly status: (node: TreeNode) => TreeStatus;
 }
 
@@ -2236,6 +2236,9 @@ export interface TreeFieldStoredSchema {
     readonly kind: FieldKindSpecifier;
     readonly types?: TreeTypeSet;
 }
+
+// @beta
+export type TreeLeafValue = number | string | boolean | IFluidHandle | null;
 
 // @alpha (undocumented)
 export interface TreeLocation {


### PR DESCRIPTION
#18871 Added API bundling of the `tree` package in `fluid-framework`. Some changes were merged into `tree` before `18871` merged. This updates the report to match. Future CI runs should ensure they do not get out of sync again.