### PR TITLE
[GC stress] Added default values for GC options to ensure GC is always enabled

### DIFF
--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -62,13 +62,14 @@ export const generateLoaderOptions = (
 	);
 };
 
+// GC options are set via the test config file. This has some default value to ensure GC us always enabled.
 const gcOptionsMatrix: OptionsMatrix<IGCRuntimeOptions> = {
-	disableGC: booleanCases,
-	gcAllowed: booleanCases,
-	runFullGC: booleanCases,
-	sessionExpiryTimeoutMs: [undefined], // Don't want sessions to expire at a fixed time
-	enableGCSweep: [undefined], // Don't need coverage here, GC sweep is tested separately
-	sweepGracePeriodMs: [undefined], // Don't need coverage here, GC sweep is tested separately
+	disableGC: [false],
+	gcAllowed: [true],
+	runFullGC: [false],
+	sessionExpiryTimeoutMs: [undefined],
+	enableGCSweep: [undefined],
+	sweepGracePeriodMs: [undefined],
 };
 
 const summaryOptionsMatrix: OptionsMatrix<ISummaryRuntimeOptions> = {

--- a/packages/test/test-service-load/src/workloads/gc/testConfig.json
+++ b/packages/test/test-service-load/src/workloads/gc/testConfig.json
@@ -10,7 +10,7 @@
 				"max": 60000
 			},
 			"optionOverrides": {
-				"comment": "SessionExpiry: 20 seconds. Inactive / Sweep Timeout: 40 seconds.",
+				"comment": "SessionExpiry: 20 seconds. Inactive / Sweep Timeout: 40 seconds. Sweep Grace Period: 5 seconds",
 				"tinylicious": {
 					"configurations": {
 						"Fluid.GarbageCollection.TestOverride.SweepTimeoutMs": [40000],
@@ -20,12 +20,10 @@
 					},
 					"container": {
 						"gcOptions": {
-							"disableGC": [false],
-							"runFullGC": [false],
 							"inactiveTimeoutMs": [40000],
 							"sessionExpiryTimeoutMs": [20000],
 							"enableGCSweep": [true],
-							"sweepGracePeriodMs": [10000]
+							"sweepGracePeriodMs": [5000]
 						}
 					}
 				},
@@ -38,8 +36,6 @@
 					},
 					"container": {
 						"gcOptions": {
-							"disableGC": [false],
-							"runFullGC": [false],
 							"inactiveTimeoutMs": [40000],
 							"sessionExpiryTimeoutMs": [20000]
 						}
@@ -67,8 +63,6 @@
 					},
 					"container": {
 						"gcOptions": {
-							"disableGC": [false],
-							"runFullGC": [false],
 							"inactiveTimeoutMs": [1200000],
 							"sessionExpiryTimeoutMs": [900000]
 						}
@@ -85,8 +79,6 @@
 					},
 					"container": {
 						"gcOptions": {
-							"disableGC": [false],
-							"runFullGC": [false],
 							"inactiveTimeoutMs": [1500000],
 							"sessionExpiryTimeoutMs": [900000]
 						}
@@ -113,8 +105,6 @@
 					},
 					"container": {
 						"gcOptions": {
-							"disableGC": [false],
-							"runFullGC": [false],
 							"enableGCSweep": [true],
 							"inactiveTimeoutMs": [1200000],
 							"sessionExpiryTimeoutMs": [900000],
@@ -132,8 +122,6 @@
 					},
 					"container": {
 						"gcOptions": {
-							"disableGC": [false],
-							"runFullGC": [false],
 							"enableGCSweep": [true],
 							"inactiveTimeoutMs": [1500000],
 							"sessionExpiryTimeoutMs": [900000],


### PR DESCRIPTION
Updated the GC options in options matrix to always enable GC. With the last change (#18855), `gcAllowed` could be false because of the values in options matrix.