### PR TITLE
Add telemetry to detect invalid server response for quorum members

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1896,6 +1896,14 @@ export class Container
 				]);
 		}
 
+		// Basic validation that the quorum members are in a format we expect, to rule out an erroneous server
+		// response as the root cause of later 0x1cf errors (e.g. a response of null).
+		if (!Array.isArray(quorumSnapshot.members)) {
+			this.mc.logger.sendErrorEvent({
+				eventName: "quorumMembersNotArray",
+			});
+		}
+
 		this.initializeProtocolState(attributes, quorumSnapshot);
 	}
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1901,6 +1901,7 @@ export class Container
 		if (!Array.isArray(quorumSnapshot.members)) {
 			this.mc.logger.sendErrorEvent({
 				eventName: "quorumMembersNotArray",
+				details: typeof quorumSnapshot.members,
 			});
 		}
 


### PR DESCRIPTION
AB#6083

We periodically see 0x1cf errors from odsp and odsp-df in both stress and production.  This could indicate a service-specific bug since we don't repro from the other services.

Most likely the server is responding with a member list that simply doesn't include a client that we later see a "leave" from.  But it could be possible that we're getting a malformed response (e.g. expect `[client1, client2]` but instead get `null`) that doesn't throw and is able to initialize the member map to an empty map.

I'm simultaneously seeking to investigate a repro document if I'm able to obtain one, but this could help us shave off one possible root cause if that doesn't pan out.

I opted for telemetry instead of an assert since the repro documents seen in production seem to self-recover naturally (non-error connections are made after the repro) and it would be nice to see both the new telemetry + 0x1cf in 1:1 correlation to build confidence in the root cause (rather than just replacing the 0x1cf instances, if it ends up being the root cause).