### PR TITLE
[GC stress] Stop the base class runner when multi collab object stops

### DIFF
--- a/packages/test/test-service-load/src/workloads/gc/gcDataStores.ts
+++ b/packages/test/test-service-load/src/workloads/gc/gcDataStores.ts
@@ -944,6 +944,7 @@ export class MultiCollabDataObject extends SingleCollabDataObject implements IGC
 		this.partnerActivityObjectsRunning.forEach((activityObject) => {
 			activityObject.stop();
 		});
+		super.stop();
 	}
 }
 


### PR DESCRIPTION
When the `MultiCollaDataObject` stops, it should call stop on the base class (`SingleCollabDataObject`) as well. Otherwise, the base class may keep running the activity after an object has been unreferenced.