### PR TITLE
tree: More List to Array renames

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -1504,7 +1504,7 @@ export interface SchemaEvents {
 // @beta @sealed
 export class SchemaFactory<TScope extends string = string, TName extends number | string = string> {
     constructor(scope: TScope);
-    array<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchema<`${TScope}.List<${string}>`, NodeKind.Array, TreeArrayNode<T>, Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>, true>;
+    array<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchema<`${TScope}.Array<${string}>`, NodeKind.Array, TreeArrayNode<T>, Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>, true>;
     array<const Name extends TName, const T extends ImplicitAllowedTypes_2>(name: Name, allowedTypes: T): TreeNodeSchemaClass<`${TScope}.${Name}`, NodeKind.Array, TreeArrayNode<T>, Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>, true>;
     readonly boolean: TreeNodeSchema<"com.fluidframework.leaf.boolean", NodeKind.Leaf, boolean, boolean>;
     fixRecursiveReference<T extends AllowedTypes_2>(...types: T): void;

--- a/packages/dds/tree/src/class-tree/schemaFactory.ts
+++ b/packages/dds/tree/src/class-tree/schemaFactory.ts
@@ -23,7 +23,7 @@ import {
 	createRawNodeProxy,
 	getClassSchema,
 	getSequenceField,
-	listPrototypeProperties,
+	arrayNodePrototypeProperties as arrayNodePrototypeProperties,
 	mapStaticDispatchMap,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../simple-tree/proxies";
@@ -312,7 +312,7 @@ export class SchemaFactory<TScope extends string = string, TName extends number 
 	 * factory.object("Foo", {myMap: factory.map(factory.number)});
 	 * ```
 	 * @privateRemarks
-	 * See note on list.
+	 * See note on array.
 	 */
 	public map<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(
 		allowedTypes: T,
@@ -446,26 +446,26 @@ export class SchemaFactory<TScope extends string = string, TName extends number 
 	 * Define a structurally typed {@link TreeNodeSchema} for a {@link (TreeArrayNode:interface)}.
 	 *
 	 * @remarks
-	 * The identifier for this List is defined as a function of the provided types.
+	 * The identifier for this Array is defined as a function of the provided types.
 	 * It is still scoped to this SchemaFactory, but multiple calls with the same arguments will return the same schema object, providing somewhat structural typing.
 	 * This does not support recursive types.
 	 *
-	 * If using these structurally named lists, other types in this schema builder should avoid names of the form `List<${string}>`.
+	 * If using these structurally named arrays, other types in this schema builder should avoid names of the form `Array<${string}>`.
 	 *
 	 * @example
 	 * The returned schema should be used as a schema directly:
 	 * ```typescript
-	 * const MyList = factory.list(factory.number);
-	 * type MyList = NodeFromSchema<typeof MyList>;
+	 * const MyArray = factory.array(factory.number);
+	 * type MyArray = NodeFromSchema<typeof MyArray>;
 	 * ```
 	 * Or inline:
 	 * ```typescript
-	 * factory.object("Foo", {myList: factory.list(factory.number)});
+	 * factory.object("Foo", {myArray: factory.array(factory.number)});
 	 * ```
 	 * @privateRemarks
 	 * The name produced at the type level here is not as specific as it could be, however doing type level sorting and escaping is a real mess.
 	 * There are cases where not having this full type provided will be less than ideal since TypeScript's structural types.
-	 * For example attempts to narrow unions of structural lists by name won't work.
+	 * For example attempts to narrow unions of structural arrays by name won't work.
 	 * Planned future changes to move to a class based schema system as well as factor function based node construction should mostly avoid these issues,
 	 * though there may still be some problematic cases even after that work is done.
 	 *
@@ -476,7 +476,7 @@ export class SchemaFactory<TScope extends string = string, TName extends number 
 	public array<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(
 		allowedTypes: T,
 	): TreeNodeSchema<
-		`${TScope}.List<${string}>`,
+		`${TScope}.Array<${string}>`,
 		NodeKind.Array,
 		TreeArrayNode<T>,
 		Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>,
@@ -490,7 +490,7 @@ export class SchemaFactory<TScope extends string = string, TName extends number 
 	 *
 	 * @example
 	 * ```typescript
-	 * class NamedList extends factory.list("name", factory.number) {}
+	 * class NamedArray extends factory.array("name", factory.number) {}
 	 * ```
 	 */
 	public array<const Name extends TName, const T extends ImplicitAllowedTypes>(
@@ -516,7 +516,7 @@ export class SchemaFactory<TScope extends string = string, TName extends number 
 	> {
 		if (allowedTypes === undefined) {
 			const types = nameOrAllowedTypes as (T & TreeNodeSchema) | readonly TreeNodeSchema[];
-			const fullName = structuralName("List", types);
+			const fullName = structuralName("Array", types);
 			return getOrCreate(this.structuralTypes, fullName, () =>
 				this.namedArray(fullName, nameOrAllowedTypes as T, false, true),
 			) as TreeNodeSchemaClass<
@@ -536,13 +536,13 @@ export class SchemaFactory<TScope extends string = string, TName extends number 
 	 * @param name - Unique identifier for this schema within this factory's scope.
 	 *
 	 * @remarks
-	 * This is not intended to be used directly, use the overload of `list` which takes a name instead.
+	 * This is not intended to be used directly, use the overload of `array` which takes a name instead.
 	 * This is only public to work around a compiler limitation.
 	 *
 	 * @privateRemarks
 	 * TODO: this should be made private or protected.
 	 * Doing so breaks due to:
-	 * `src/class-tree/schemaFactoryRecursive.ts:42:9 - error TS2310: Type 'List' recursively references itself as a base type.`
+	 * `src/class-tree/schemaFactoryRecursive.ts:42:9 - error TS2310: Type 'Array' recursively references itself as a base type.`
 	 * Once recursive APIs are better sorted out and integrated into this class, switch this back to private.
 	 */
 	public namedArray<
@@ -593,8 +593,8 @@ export class SchemaFactory<TScope extends string = string, TName extends number 
 			}
 		}
 
-		// Setup list functionality
-		Object.defineProperties(schema.prototype, listPrototypeProperties);
+		// Setup array functionality
+		Object.defineProperties(schema.prototype, arrayNodePrototypeProperties);
 
 		return schema as unknown as TreeNodeSchemaClass<
 			`${TScope}.${Name}`,

--- a/packages/dds/tree/src/class-tree/schemaFactory.ts
+++ b/packages/dds/tree/src/class-tree/schemaFactory.ts
@@ -23,7 +23,7 @@ import {
 	createRawNodeProxy,
 	getClassSchema,
 	getSequenceField,
-	arrayNodePrototypeProperties as arrayNodePrototypeProperties,
+	arrayNodePrototypeProperties,
 	mapStaticDispatchMap,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../simple-tree/proxies";

--- a/packages/dds/tree/src/class-tree/schemaFactoryRecursive.ts
+++ b/packages/dds/tree/src/class-tree/schemaFactoryRecursive.ts
@@ -26,13 +26,13 @@ export class SchemaFactoryRecursive<
 	TName extends number | string = string,
 > extends SchemaFactory<TScope, TName> {
 	/**
-	 * For unknown reasons, recursive lists work better (compile in more cases)
+	 * For unknown reasons, recursive arrays work better (compile in more cases)
 	 * if their constructor takes in an object with a member containing the iterable,
 	 * rather than taking the iterable as a parameter directly.
 	 *
-	 * This version of `list` leverages this fact, and has a constructor that requires its data be passed in like:
+	 * This version of `array` leverages this fact, and has a constructor that requires its data be passed in like:
 	 * ```typescript
-	 * new MyRecursiveList({x: theData});
+	 * new MyRecursiveArray({x: theData});
 	 * ```
 	 */
 	public arrayRecursive<const Name extends TName, const T extends ImplicitAllowedTypes>(

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -298,7 +298,7 @@ function contextualizeInsertedListContent(
 /**
  * PropertyDescriptorMap used to build the prototype for our SharedListNode dispatch object.
  */
-export const listPrototypeProperties: PropertyDescriptorMap = {
+export const arrayNodePrototypeProperties: PropertyDescriptorMap = {
 	// We manually add [Symbol.iterator] to the dispatch map rather than use '[fn.name] = fn' as
 	// below when adding 'Array.prototype.*' properties to this map because 'Array.prototype[Symbol.iterator].name'
 	// returns "values" (i.e., Symbol.iterator is an alias for the '.values()' function.)
@@ -529,12 +529,12 @@ export const listPrototypeProperties: PropertyDescriptorMap = {
 	// Array.prototype.unshift,
 	Array.prototype.values,
 ].forEach((fn) => {
-	listPrototypeProperties[fn.name] = { value: fn };
+	arrayNodePrototypeProperties[fn.name] = { value: fn };
 });
 
 /* eslint-enable @typescript-eslint/unbound-method */
 
-const listPrototype = Object.create(Object.prototype, listPrototypeProperties);
+const arrayNodePrototype = Object.create(Object.prototype, arrayNodePrototypeProperties);
 
 // #endregion
 
@@ -559,7 +559,7 @@ function asIndex(key: string | symbol, length: number) {
  * Otherwise setting of unexpected properties will error.
  * @param customTargetObject - Target object of the proxy.
  * If not provided `[]` is used for the target and a separate object created to dispatch list methods.
- * If provided, the customTargetObject will be used as both the dispatch object and the proxy target, and therefor must provide `length` and the list functionality from {@link listPrototype}.
+ * If provided, the customTargetObject will be used as both the dispatch object and the proxy target, and therefor must provide `length` and the list functionality from {@link arrayNodePrototype}.
  */
 function createListProxy<TTypes extends AllowedTypes>(
 	allowAdditionalProperties: boolean,
@@ -575,7 +575,7 @@ function createListProxy<TTypes extends AllowedTypes>(
 	// Properties normally inherited from 'Array.prototype' are surfaced via the prototype chain.
 	const dispatch: object =
 		customTargetObject ??
-		Object.create(listPrototype, {
+		Object.create(arrayNodePrototype, {
 			length: {
 				get(this: TreeListNodeOld) {
 					return getSequenceField(this).length;

--- a/packages/dds/tree/src/test/class-tree/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/class-tree/schemaFactory.spec.ts
@@ -268,8 +268,8 @@ describe("schemaFactory", () => {
 		assert.equal(s, "hi");
 	});
 
-	describe("List", () => {
-		it("Nested List", () => {
+	describe("Array", () => {
+		it("Nested Array", () => {
 			const builder = new SchemaFactory("test");
 
 			class Inventory extends builder.object("Inventory", {
@@ -305,6 +305,8 @@ describe("schemaFactory", () => {
 				// @ts-expect-error structural list schema are not typed as classes.
 				class NotAClass extends factory.array(factory.number) {}
 			}
+
+			assert.equal(MyList.identifier, `test.Array<["${factory.number.identifier}"]>`);
 		});
 
 		it("Named", () => {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -1840,7 +1840,7 @@ export interface SchemaEvents {
 // @beta @sealed
 export class SchemaFactory<TScope extends string = string, TName extends number | string = string> {
     constructor(scope: TScope);
-    array<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchema<`${TScope}.List<${string}>`, NodeKind.Array, TreeArrayNode<T>, Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>, true>;
+    array<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchema<`${TScope}.Array<${string}>`, NodeKind.Array, TreeArrayNode<T>, Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>, true>;
     array<const Name extends TName, const T extends ImplicitAllowedTypes_2>(name: Name, allowedTypes: T): TreeNodeSchemaClass<`${TScope}.${Name}`, NodeKind.Array, TreeArrayNode<T>, Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>, true>;
     readonly boolean: TreeNodeSchema<"com.fluidframework.leaf.boolean", NodeKind.Leaf, boolean, boolean>;
     fixRecursiveReference<T extends AllowedTypes_2>(...types: T): void;

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.test.ts
@@ -478,7 +478,7 @@ describe("DefaultVisualizers unit tests", () => {
 												"0": {
 													children: {
 														type: {
-															value: 'DefaultVisualizer_SharedTree_Test.List<["DefaultVisualizer_SharedTree_Test.child-item"]>',
+															value: 'DefaultVisualizer_SharedTree_Test.Array<["DefaultVisualizer_SharedTree_Test.child-item"]>',
 															typeMetadata: "string",
 															nodeKind: VisualNodeKind.ValueNode,
 														},
@@ -691,7 +691,7 @@ describe("DefaultVisualizers unit tests", () => {
 								"0": {
 									children: {
 										name: {
-											value: 'DefaultVisualizer_SharedTree_Test.List<["DefaultVisualizer_SharedTree_Test.child-item"]>',
+											value: 'DefaultVisualizer_SharedTree_Test.Array<["DefaultVisualizer_SharedTree_Test.child-item"]>',
 											typeMetadata: "string",
 											nodeKind: VisualNodeKind.ValueNode,
 										},
@@ -867,7 +867,7 @@ describe("DefaultVisualizers unit tests", () => {
 																types: {
 																	children: {
 																		"0": {
-																			value: 'DefaultVisualizer_SharedTree_Test.List<["DefaultVisualizer_SharedTree_Test.child-item"]>',
+																			value: 'DefaultVisualizer_SharedTree_Test.Array<["DefaultVisualizer_SharedTree_Test.child-item"]>',
 																			typeMetadata: "string",
 																			nodeKind:
 																				VisualNodeKind.ValueNode,


### PR DESCRIPTION
## Description

Fix a few places that missed the list to array rename, including in structually named schema names.

## Breaking Changes

Documents using structurally named array schema will be broken or need to manually provide the old name.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

