### PR TITLE
build: Don't distribute test files generated during build

### DIFF
--- a/azure/packages/azure-client/.npmignore
+++ b/azure/packages/azure-client/.npmignore
@@ -4,3 +4,6 @@ nyc
 src/test
 dist/test
 **/_api-extractor-temp/**
+
+# These are large test files that we don't need to distribute.
+**/*.test-files.tar

--- a/experimental/dds/attributable-map/.npmignore
+++ b/experimental/dds/attributable-map/.npmignore
@@ -4,3 +4,6 @@ nyc
 src/test
 dist/test
 **/_api-extractor-temp/**
+
+# These are large test files that we don't need to distribute.
+**/*.test-files.tar

--- a/experimental/dds/tree/.npmignore
+++ b/experimental/dds/tree/.npmignore
@@ -4,3 +4,6 @@ nyc
 src/test
 dist/test
 **/_api-extractor-temp/**
+
+# These are large test files that we don't need to distribute.
+**/*.test-files.tar

--- a/packages/dds/map/.npmignore
+++ b/packages/dds/map/.npmignore
@@ -4,3 +4,6 @@ nyc
 src/test
 dist/test
 **/_api-extractor-temp/**
+
+# These are large test files that we don't need to distribute.
+**/*.test-files.tar

--- a/packages/dds/matrix/.npmignore
+++ b/packages/dds/matrix/.npmignore
@@ -6,3 +6,6 @@ dist/test
 **/_api-extractor-temp/**
 
 bench/
+
+# These are large test files that we don't need to distribute.
+**/*.test-files.tar

--- a/packages/dds/merge-tree/.npmignore
+++ b/packages/dds/merge-tree/.npmignore
@@ -4,6 +4,9 @@ nyc
 src/test
 **/_api-extractor-temp/**
 
+# This is a very large test file that we don't need to distribute.
+**/merge-tree.test-files.tar
+
 docs/
 .vscode/
 

--- a/packages/dds/merge-tree/.npmignore
+++ b/packages/dds/merge-tree/.npmignore
@@ -7,13 +7,13 @@ src/test
 docs/
 .vscode/
 
-# This is a very large test file that we don't need to distribute.
-**/merge-tree.test-files.tar
-
-# This is a very large file that we don't need to distribute.
+# These are large test files that we don't need to distribute.
+**/*.test-files.tar
 **/mergeTreeExample1.pdf
 
 # We technically don't need to distribute the compiled test code, but because it's imported in the sequence package,
 # including it in the package makes it a lot easier to test using standardized tools. If we don't include the test code,
-# then the ./test export is invalid, so it will fail to import anywhere outside the repo.
+# then the ./test export is invalid, so it will fail to import anywhere outside the repo. However, some of the contents
+# of the test folder is not needed for testing, so we exclude additional paths.
 # dist/test
+dist/test/types

--- a/packages/dds/merge-tree/.npmignore
+++ b/packages/dds/merge-tree/.npmignore
@@ -4,11 +4,14 @@ nyc
 src/test
 **/_api-extractor-temp/**
 
+docs/
+.vscode/
+
 # This is a very large test file that we don't need to distribute.
 **/merge-tree.test-files.tar
 
-docs/
-.vscode/
+# This is a very large file that we don't need to distribute.
+**/mergeTreeExample1.pdf
 
 # We technically don't need to distribute the compiled test code, but because it's imported in the sequence package,
 # including it in the package makes it a lot easier to test using standardized tools. If we don't include the test code,

--- a/packages/dds/sequence/.npmignore
+++ b/packages/dds/sequence/.npmignore
@@ -6,3 +6,6 @@ dist/test
 **/_api-extractor-temp/**
 
 .vscode/
+
+# These are large test files that we don't need to distribute.
+**/*.test-files.tar

--- a/packages/dds/tree/.npmignore
+++ b/packages/dds/tree/.npmignore
@@ -4,3 +4,6 @@ nyc
 src/test
 dist/test
 **/_api-extractor-temp/**
+
+# These are large test files that we don't need to distribute.
+**/*.test-files.tar


### PR DESCRIPTION
I noticed our recent merge-tree release was ~9MB with an unpacked size of over 47MB. The main culprit is the inclusion of test files, which is explained in a comment in the npmignore file. However, there is a tar file generated during testing that we don't need to distribute, so I added an entry to ignore that file to all packages that generate one.