### PR TITLE
Remove IntervalCollection.add signature with an IntervalType parameter

### DIFF
--- a/.changeset/cute-walls-share.md
+++ b/.changeset/cute-walls-share.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/sequence": minor
+---
+
+Remove the signature of IntervalCollection.add that takes a type parameter
+
+The previously deprecated signature of IntervalCollection.add that takes an IntervalType as a parameter is now being removed. The new signature is called without the type parameter and takes the start, end, and properties parameters as a single object.

--- a/examples/data-objects/table-document/src/document.ts
+++ b/examples/data-objects/table-document/src/document.ts
@@ -7,7 +7,6 @@ import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IEvent, IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {
-	IntervalType,
 	SequenceDeltaEvent,
 	ReferencePosition,
 	PropertySet,
@@ -154,7 +153,7 @@ export class TableDocument extends DataObject<{ Events: ITableDocumentEvents }> 
 		const start = rowColToPosition(minRow, minCol);
 		const end = rowColToPosition(maxRow, maxCol);
 		const intervals = this.matrix.getIntervalCollection(label);
-		intervals.add(start, end, IntervalType.SlideOnRemove);
+		intervals.add({ start, end });
 	}
 
 	public insertRows(startRow: number, numRows: number) {

--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -136,8 +136,6 @@ export interface IInterval {
 export interface IIntervalCollection<TInterval extends ISerializableInterval> extends TypedEventEmitter<IIntervalCollectionEvent<TInterval>> {
     // (undocumented)
     [Symbol.iterator](): Iterator<TInterval>;
-    // @deprecated
-    add(start: SequencePlace, end: SequencePlace, intervalType: IntervalType, props?: PropertySet): TInterval;
     add({ start, end, props, }: {
         start: SequencePlace;
         end: SequencePlace;

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -762,12 +762,10 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval>
 	getIntervalById(id: string): TInterval | undefined;
 	/**
 	 * Creates a new interval and add it to the collection.
-	 * @deprecated call IntervalCollection.add without specifying an intervalType
 	 * @param start - interval start position (inclusive)
 	 * @param end - interval end position (exclusive)
-	 * @param intervalType - type of the interval. All intervals are SlideOnRemove. Intervals may not be Transient.
 	 * @param props - properties of the interval
-	 * @returns The created interval
+	 * @returns - the created interval
 	 * @remarks See documentation on {@link SequenceInterval} for comments on
 	 * interval endpoint semantics: there are subtleties with how the current
 	 * half-open behavior is represented.
@@ -832,21 +830,6 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval>
 	 * @privateRemarks TODO: ADO:5205 the above comment regarding behavior in
 	 * the case that the entire interval has been deleted should be resolved at
 	 * the same time as this ticket
-	 */
-	add(
-		start: SequencePlace,
-		end: SequencePlace,
-		intervalType: IntervalType,
-		props?: PropertySet,
-	): TInterval;
-	/**
-	 * Creates a new interval and add it to the collection.
-	 * @param start - interval start position (inclusive)
-	 * @param end - interval end position (exclusive)
-	 * @param props - properties of the interval
-	 * @returns - the created interval
-	 * @remarks - See documentation on {@link SequenceInterval} for comments on interval endpoint semantics: there are subtleties
-	 * with how the current half-open behavior is represented.
 	 */
 	add({
 		start,
@@ -1257,15 +1240,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 	/**
 	 * {@inheritdoc IIntervalCollection.add}
-	 * @deprecated call IntervalCollection.add without specifying an intervalType
 	 */
-	public add(
-		start: SequencePlace,
-		end: SequencePlace,
-		intervalType: IntervalType,
-		props?: PropertySet,
-	): TInterval;
-
 	public add({
 		start,
 		end,
@@ -1274,47 +1249,12 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 		start: SequencePlace;
 		end: SequencePlace;
 		props?: PropertySet;
-	}): TInterval;
-
-	public add(
-		start:
-			| SequencePlace
-			| {
-					start: SequencePlace;
-					end: SequencePlace;
-					props?: PropertySet;
-			  },
-		end?: SequencePlace,
-		intervalType?: IntervalType,
-		props?: PropertySet,
-	): TInterval {
-		let intStart: SequencePlace;
-		let intEnd: SequencePlace;
-		let type: IntervalType;
-		let properties: PropertySet | undefined;
-
-		if (isSequencePlace(start)) {
-			intStart = start;
-			assert(end !== undefined, 0x7c0 /* end must be defined */);
-			intEnd = end;
-			assert(intervalType !== undefined, 0x7c1 /* intervalType must be defined */);
-			type = intervalType;
-			properties = props;
-		} else {
-			intStart = start.start;
-			intEnd = start.end;
-			type = IntervalType.SlideOnRemove;
-			properties = start.props;
-		}
-
+	}): TInterval {
 		if (!this.localCollection) {
 			throw new LoggingError("attach must be called prior to adding intervals");
 		}
-		if (type & IntervalType.Transient) {
-			throw new LoggingError("Can not add transient intervals");
-		}
 
-		const { startSide, endSide, startPos, endPos } = endpointPosAndSide(intStart, intEnd);
+		const { startSide, endSide, startPos, endPos } = endpointPosAndSide(start, end);
 
 		assert(
 			startPos !== undefined &&
@@ -1326,13 +1266,13 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 
 		const stickiness = computeStickinessFromSide(startPos, startSide, endPos, endSide);
 
-		this.assertStickinessEnabled(intStart, intEnd);
+		this.assertStickinessEnabled(start, end);
 
 		const interval: TInterval = this.localCollection.addInterval(
 			toSequencePlace(startPos, startSide),
 			toSequencePlace(endPos, endSide),
-			type,
-			properties,
+			IntervalType.SlideOnRemove,
+			props,
 		);
 
 		if (interval) {
@@ -1343,7 +1283,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			const serializedInterval: ISerializedInterval = {
 				start: startPos,
 				end: endPos,
-				intervalType: type,
+				intervalType: IntervalType.SlideOnRemove,
 				properties: interval.properties,
 				sequenceNumber: this.client?.getCurrentSeq() ?? 0,
 				stickiness,

--- a/packages/dds/sequence/src/test/intervalRebasing.spec.ts
+++ b/packages/dds/sequence/src/test/intervalRebasing.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "@fluidframework/test-runtime-utils";
 import { SharedStringFactory } from "../sequenceFactory";
 import { SharedString } from "../sharedString";
-import { IntervalStickiness, IntervalType } from "../intervals";
+import { IntervalStickiness } from "../intervals";
 import { Side } from "../intervalCollection";
 import { assertConsistent, Client } from "./intervalTestUtils";
 
@@ -135,8 +135,12 @@ describe("interval rebasing", () => {
 
 		clients[0].sharedString.insertText(0, "ABC");
 		const collection_0 = clients[0].sharedString.getIntervalCollection("comments");
-		collection_0.add(0, 2, IntervalType.SlideOnRemove, {
-			intervalId: "a",
+		collection_0.add({
+			start: 0,
+			end: 2,
+			props: {
+				intervalId: "a",
+			},
 		});
 		clients[0].sharedString.obliterateRange(1, 3);
 		containerRuntimeFactory.processAllMessages();
@@ -149,8 +153,12 @@ describe("interval rebasing", () => {
 		clients[1].sharedString.insertText(0, "F");
 		clients[0].sharedString.insertText(0, "PC");
 		const collection_0 = clients[0].sharedString.getIntervalCollection("comments");
-		collection_0.add(0, 1, IntervalType.SlideOnRemove, {
-			intervalId: "a",
+		collection_0.add({
+			start: 0,
+			end: 1,
+			props: {
+				intervalId: "a",
+			},
 		});
 		clients[1].sharedString.insertText(0, "L");
 		clients[1].sharedString.obliterateRange(0, 2);
@@ -218,8 +226,12 @@ describe("interval rebasing", () => {
 		containerRuntimeFactory.processAllMessages();
 		assertConsistent(clients);
 		const collection_1 = clients[1].sharedString.getIntervalCollection("comments");
-		const interval1 = collection_1.add("start", "end", IntervalType.SlideOnRemove, {
-			intervalId: "2",
+		const interval1 = collection_1.add({
+			start: "start",
+			end: "end",
+			props: {
+				intervalId: "2",
+			},
 		});
 		assert.equal(interval1.stickiness, IntervalStickiness.FULL);
 		clients[0].sharedString.removeRange(0, 1);
@@ -341,27 +353,25 @@ describe("interval rebasing", () => {
 		clients[0].sharedString.insertText(0, "AB");
 		clients[0].sharedString.insertText(0, "C");
 		const collection_1 = clients[0].sharedString.getIntervalCollection("comments");
-		const interval1 = collection_1.add(
-			{ pos: 0, side: Side.After },
-			"end",
-			IntervalType.SlideOnRemove,
-			{
+		const interval1 = collection_1.add({
+			start: { pos: 0, side: Side.After },
+			end: "end",
+			props: {
 				intervalId: "1",
 			},
-		);
+		});
 		assert.equal(interval1.stickiness, IntervalStickiness.FULL);
 		containerRuntimeFactory.processAllMessages();
 		assertConsistent(clients);
 		clients[2].sharedString.removeRange(1, 2);
 		const collection_2 = clients[1].sharedString.getIntervalCollection("comments");
-		const interval2 = collection_2.add(
-			"start",
-			{ pos: 2, side: Side.Before },
-			IntervalType.SlideOnRemove,
-			{
+		const interval2 = collection_2.add({
+			start: "start",
+			end: { pos: 2, side: Side.Before },
+			props: {
 				intervalId: "2",
 			},
-		);
+		});
 		assert.equal(interval2.stickiness, IntervalStickiness.FULL);
 		containerRuntimeFactory.processAllMessages();
 		assertConsistent(clients);
@@ -374,8 +384,12 @@ describe("interval rebasing", () => {
 		clients[0].sharedString.removeRange(0, 1);
 		clients[0].sharedString.insertText(0, "D");
 		const collection_1 = clients[1].sharedString.getIntervalCollection("comments");
-		collection_1.add({ pos: 0, side: Side.After }, 1, IntervalType.SlideOnRemove, {
-			intervalId: "1",
+		collection_1.add({
+			start: { pos: 0, side: Side.After },
+			end: 1,
+			props: {
+				intervalId: "1",
+			},
 		});
 		clients[2].sharedString.removeRange(1, 2);
 		containerRuntimeFactory.processAllMessages();
@@ -386,8 +400,12 @@ describe("interval rebasing", () => {
 		clients[0].sharedString.insertText(0, "D");
 		clients[0].containerRuntime.connected = false;
 		const collection_1 = clients[0].sharedString.getIntervalCollection("comments");
-		const interval = collection_1.add("start", 0, IntervalType.SlideOnRemove, {
-			intervalId: "1",
+		const interval = collection_1.add({
+			start: "start",
+			end: 0,
+			props: {
+				intervalId: "1",
+			},
 		});
 		assert.equal(interval.stickiness, IntervalStickiness.FULL);
 		clients[0].containerRuntime.connected = true;
@@ -399,14 +417,13 @@ describe("interval rebasing", () => {
 		clients[0].sharedString.insertText(0, "D");
 		clients[0].containerRuntime.connected = false;
 		const collection_1 = clients[0].sharedString.getIntervalCollection("comments");
-		const interval = collection_1.add(
-			{ pos: 0, side: Side.After },
-			0,
-			IntervalType.SlideOnRemove,
-			{
+		const interval = collection_1.add({
+			start: { pos: 0, side: Side.After },
+			end: 0,
+			props: {
 				intervalId: "1",
 			},
-		);
+		});
 		assert.equal(interval.stickiness, IntervalStickiness.FULL);
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();

--- a/packages/dds/sequence/src/test/overlappingSequenceIntervalsIndex.spec.ts
+++ b/packages/dds/sequence/src/test/overlappingSequenceIntervalsIndex.spec.ts
@@ -9,7 +9,7 @@ import { strict as assert } from "assert";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 import { LocalReferencePosition, compareReferencePositions } from "@fluidframework/merge-tree";
 import { makeRandom } from "@fluid-private/stochastic-test-utils";
-import { IntervalType, SequenceInterval } from "../intervals";
+import { SequenceInterval } from "../intervals";
 import { SharedString } from "../sharedString";
 import { SharedStringFactory } from "../sequenceFactory";
 import {
@@ -105,31 +105,31 @@ describe("findOverlappingIntervalsBySegoff", () => {
 		});
 
 		it("when all intervals in index are above the query range", () => {
-			collection.add(5, 6, IntervalType.SlideOnRemove);
+			collection.add({ start: 5, end: 6 });
 			results = queryIntervalsByPositions(0, 2);
 			assert.equal(results.length, 0);
 		});
 
 		it("when all intervals in index are below the query range", () => {
-			collection.add(1, 1, IntervalType.SlideOnRemove);
+			collection.add({ start: 1, end: 1 });
 			results = queryIntervalsByPositions(2, 5);
 			assert.equal(results.length, 0);
 		});
 
 		it("when startSegment occurs `after` the endSegment", () => {
-			collection.add(1, 1, IntervalType.SlideOnRemove);
+			collection.add({ start: 1, end: 1 });
 			results = queryIntervalsByPositions(2, 0);
 			assert.equal(results.length, 0);
 		});
 
 		it("when the segments are the same but startOffset occurs `after` the endOffset", () => {
-			collection.add(1, 1, IntervalType.SlideOnRemove);
+			collection.add({ start: 1, end: 1 });
 			results = queryIntervalsByPositions(1, 0);
 			assert.equal(results.length, 0);
 		});
 
 		it("when the endSegment does not exist (out of bound)", () => {
-			collection.add(1, 1, IntervalType.SlideOnRemove);
+			collection.add({ start: 1, end: 1 });
 			results = queryIntervalsByPositions(1, 1000);
 			assert.equal(results.length, 0);
 		});
@@ -144,9 +144,9 @@ describe("findOverlappingIntervalsBySegoff", () => {
 			testSharedString.insertText(0, "ab");
 			testSharedString.insertText(2, "cde");
 			testSharedString.insertText(5, "fg");
-			interval1 = collection.add(1, 1, IntervalType.SlideOnRemove).getIntervalId();
-			interval2 = collection.add(2, 3, IntervalType.SlideOnRemove).getIntervalId();
-			interval3 = collection.add(5, 6, IntervalType.SlideOnRemove).getIntervalId();
+			interval1 = collection.add({ start: 1, end: 1 }).getIntervalId();
+			interval2 = collection.add({ start: 2, end: 3 }).getIntervalId();
+			interval3 = collection.add({ start: 5, end: 6 }).getIntervalId();
 		});
 
 		it("when each interval is within a single segment", () => {
@@ -178,9 +178,9 @@ describe("findOverlappingIntervalsBySegoff", () => {
 
 		it("when existing interval across multiple segments", () => {
 			// Add intervals which are across more than one segments
-			collection.add(1, 3, IntervalType.SlideOnRemove);
-			collection.add(2, 5, IntervalType.SlideOnRemove);
-			collection.add(1, 6, IntervalType.SlideOnRemove);
+			collection.add({ start: 1, end: 3 });
+			collection.add({ start: 2, end: 5 });
+			collection.add({ start: 1, end: 6 });
 
 			results = queryIntervalsByPositions(0, 1);
 			assertSequenceIntervalsEqual(testSharedString, results, [
@@ -207,9 +207,9 @@ describe("findOverlappingIntervalsBySegoff", () => {
 		});
 
 		it("when adding duplicate intervals to the index", () => {
-			collection.add(1, 1, IntervalType.SlideOnRemove);
-			collection.add(2, 3, IntervalType.SlideOnRemove);
-			collection.add(1, 1, IntervalType.SlideOnRemove);
+			collection.add({ start: 1, end: 1 });
+			collection.add({ start: 2, end: 3 });
+			collection.add({ start: 1, end: 1 });
 
 			results = queryIntervalsByPositions(1, 6);
 			assertSequenceIntervalsEqual(testSharedString, results, [
@@ -231,7 +231,7 @@ describe("findOverlappingIntervalsBySegoff", () => {
 			]);
 
 			// Add and remove duplicate intervals
-			const interval4 = collection.add(1, 1, IntervalType.SlideOnRemove).getIntervalId();
+			const interval4 = collection.add({ start: 1, end: 1 }).getIntervalId();
 			collection.removeIntervalById(interval1);
 			results = queryIntervalsByPositions(1, 6);
 			assertSequenceIntervalsEqual(testSharedString, results, [
@@ -247,7 +247,7 @@ describe("findOverlappingIntervalsBySegoff", () => {
 		it("when inserting or appending additional segments to the string", () => {
 			// Append a segment to the end of the string
 			testSharedString.insertText(7, "hijk");
-			collection.add(7, 9, IntervalType.SlideOnRemove); // `interval4` in below graphs
+			collection.add({ start: 7, end: 9 }); // `interval4` in below graphs
 
 			/**
 			 * Visualization of intervals within the string after the last insertion:
@@ -398,7 +398,7 @@ describe("findOverlappingIntervalsBySegoff", () => {
 			for (let i = 0; i < count; ++i) {
 				const start = random.integer(min, max);
 				const end = random.integer(start, max);
-				collection.add(start, end, IntervalType.SlideOnRemove);
+				collection.add({ start, end });
 			}
 		};
 

--- a/packages/dds/sequence/src/test/sharedIntervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/sharedIntervalCollection.spec.ts
@@ -17,7 +17,7 @@ import {
 	SharedIntervalCollectionFactory,
 } from "../sharedIntervalCollection";
 import { IIntervalCollection } from "../intervalCollection";
-import { Interval, IntervalType, intervalHelpers } from "../intervals";
+import { Interval, intervalHelpers } from "../intervals";
 import { IOverlappingIntervalsIndex, OverlappingIntervalsIndex } from "../intervalIndex";
 
 const assertIntervals = (
@@ -120,8 +120,8 @@ describe("SharedIntervalCollection", () => {
 		});
 
 		it("Can add intervals from multiple clients", () => {
-			collection1.add(0, 20, IntervalType.Simple);
-			collection2.add(10, 30, IntervalType.Simple);
+			collection1.add({ start: 0, end: 20 });
+			collection2.add({ start: 10, end: 30 });
 			assertIntervals(collection1, [{ start: 0, end: 20 }], overlappingIntervalsIndex1);
 			assertIntervals(collection2, [{ start: 10, end: 30 }], overlappingIntervalsIndex2);
 
@@ -145,8 +145,8 @@ describe("SharedIntervalCollection", () => {
 		});
 
 		it("Can remove intervals that were added", () => {
-			const interval = collection1.add(0, 20, IntervalType.Simple);
-			collection2.add(10, 30, IntervalType.Simple);
+			const interval = collection1.add({ start: 0, end: 20 });
+			collection2.add({ start: 10, end: 30 });
 			runtimeFactory.processAllMessages();
 
 			const id = interval.getIntervalId() ?? assert.fail("expected interval to have id");
@@ -167,8 +167,8 @@ describe("SharedIntervalCollection", () => {
 		});
 
 		it("Can change intervals", () => {
-			const interval = collection1.add(0, 20, IntervalType.Simple);
-			collection2.add(10, 30, IntervalType.Simple);
+			const interval = collection1.add({ start: 0, end: 20 });
+			collection2.add({ start: 10, end: 30 });
 			runtimeFactory.processAllMessages();
 
 			const id = interval.getIntervalId() ?? assert.fail("expected interval to have id");
@@ -251,7 +251,7 @@ describe("SharedIntervalCollection", () => {
 
 		it("can rebase add ops", () => {
 			runtime1.connected = false;
-			collection1.add(15, 17, IntervalType.Simple);
+			collection1.add({ start: 15, end: 17 });
 			runtimeFactory.processAllMessages();
 
 			assertIntervals(collection1, [{ start: 15, end: 17 }], overlappingIntervalsIndex1);

--- a/packages/dds/sequence/src/test/snapshotVersion.spec.ts
+++ b/packages/dds/sequence/src/test/snapshotVersion.spec.ts
@@ -14,7 +14,6 @@ import {
 } from "@fluidframework/test-runtime-utils";
 import { SharedString } from "../sharedString";
 import { SharedStringFactory } from "../sequenceFactory";
-import { IntervalType } from "../intervals";
 import { generateStrings, LocationBase } from "./generateSharedStrings";
 
 function assertIntervalCollectionsAreEquivalent(
@@ -172,7 +171,7 @@ describe("SharedString Snapshot Version", () => {
 		originalString.initializeLocal();
 		originalString.insertText(0, "ABCD");
 		const collectionId = "015e0f46-efa3-42d7-a9ab-970ecc376df9";
-		originalString.getIntervalCollection(collectionId).add(1, 2, IntervalType.SlideOnRemove);
+		originalString.getIntervalCollection(collectionId).add({ start: 1, end: 2 });
 		const summaryTree = originalString.getAttachSummary().summary;
 		const snapshotTree = convertSummaryTreeToITree(summaryTree);
 		const serializedSnapshot = JSON.stringify(snapshotTree);

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -29,7 +29,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
-import { IntervalType, SequenceInterval, SharedString } from "@fluidframework/sequence";
+import { SequenceInterval, SharedString } from "@fluidframework/sequence";
 import { SharedCell } from "@fluidframework/cell";
 import { Ink } from "@fluidframework/ink";
 import { SharedMatrix } from "@fluidframework/matrix";
@@ -535,16 +535,8 @@ describeCompat(`Dehydrate Rehydrate Container Test`, "FullCompat", (getTestObjec
 				await defaultDataStoreBefore.getSharedObject<SharedString>(sharedStringId);
 			const intervalsBefore = sharedStringBefore.getIntervalCollection("intervals");
 			sharedStringBefore.insertText(0, "Hello");
-			let interval0: SequenceInterval | undefined = intervalsBefore.add(
-				0,
-				0,
-				IntervalType.SlideOnRemove,
-			);
-			let interval1: SequenceInterval | undefined = intervalsBefore.add(
-				0,
-				1,
-				IntervalType.SlideOnRemove,
-			);
+			let interval0: SequenceInterval | undefined = intervalsBefore.add({ start: 0, end: 0 });
+			let interval1: SequenceInterval | undefined = intervalsBefore.add({ start: 0, end: 1 });
 			let id0;
 			let id1;
 


### PR DESCRIPTION
Remove the signature of the add method deprecated in #17165. The new signature removes the type parameter from the signature and takes the start, end, and properties parameters as a single object.   