### PR TITLE
tree: Make snapshot tests easier to write

### DIFF
--- a/packages/dds/tree/src/test/snapshots/schema.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/schema.spec.ts
@@ -3,38 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import path from "path";
 import { encodeTreeSchema, intoStoredSchema } from "../../feature-libraries";
-import { testTrees as schemaTestTrees } from "../testTrees";
-import {
-	createSchemaSnapshot,
-	dirPathTail,
-	regenTestDirectory,
-	regenerateSnapshots,
-	verifyEqualPastSchemaSnapshot,
-} from "./utils";
-
-const schemaDirPath = path.join(__dirname, `../../../${dirPathTail}/schema-files`);
-
-function getSchemaFilepath(name: string): string {
-	return path.join(schemaDirPath, `${name}.json`);
-}
+import { testTrees } from "../testTrees";
+import { takeJsonSnapshot, useTestDirectory } from "./snapshotTools";
 
 describe("schema snapshots", () => {
-	if (regenerateSnapshots) {
-		regenTestDirectory(schemaDirPath);
-	}
+	useTestDirectory("schema-files");
 
-	for (const { name, schemaData } of schemaTestTrees) {
-		it(`${regenerateSnapshots ? "regenerate " : ""}for ${name}`, async () => {
+	for (const { name, schemaData } of testTrees) {
+		it(name, () => {
 			const encoded = encodeTreeSchema(intoStoredSchema(schemaData));
-
-			// eslint-disable-next-line unicorn/prefer-ternary
-			if (regenerateSnapshots) {
-				await createSchemaSnapshot(getSchemaFilepath(name), encoded);
-			} else {
-				await verifyEqualPastSchemaSnapshot(getSchemaFilepath(name), encoded, name);
-			}
+			takeJsonSnapshot(encoded);
 		});
 	}
 });

--- a/packages/dds/tree/src/test/snapshots/schema.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/schema.spec.ts
@@ -5,10 +5,10 @@
 
 import { encodeTreeSchema, intoStoredSchema } from "../../feature-libraries";
 import { testTrees } from "../testTrees";
-import { takeJsonSnapshot, useTestDirectory } from "./snapshotTools";
+import { takeJsonSnapshot, useSnapshotDirectory } from "./snapshotTools";
 
 describe("schema snapshots", () => {
-	useTestDirectory("schema-files");
+	useSnapshotDirectory("schema-files");
 
 	for (const { name, schemaData } of testTrees) {
 		it(name, () => {

--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -1,0 +1,83 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import path from "path";
+import { strict as assert } from "assert";
+import { existsSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "fs";
+import { JsonCompatibleReadOnly } from "../../util";
+
+const regenerateSnapshots = process.argv.includes("--snapshot");
+
+export function takeJsonSnapshot(data: JsonCompatibleReadOnly, suffix: string = ""): void {
+	const dataStr = JSON.stringify(data, undefined, 2);
+	return takeSnapshot(dataStr, `${suffix}.json`);
+}
+
+export function takeSnapshot(data: string, suffix: string): void {
+	assert(
+		currentTestName !== undefined,
+		"use `useTestDirectory` to configure the tests containing describe block to take snapshots",
+	);
+	assert(currentTestFile !== undefined);
+
+	// Ensure test name doesn't accidentally navigate up directories or things like that.
+	// Done here instead of in beforeEach so errors surface better.
+	if (nameCheck.test(currentTestName) === false) {
+		assert.fail(`Expected test name to pass sanitization: "${currentTestName}"`);
+	}
+
+	const fullFile = currentTestFile + suffix;
+
+	const exists = existsSync(fullFile);
+	if (regenerateSnapshots) {
+		assert(exists === false, "snapshot should not already exist: possible name collision.");
+		writeFileSync(fullFile, data);
+	} else {
+		assert(exists, `test schema snapshot file does not exist: "${fullFile}"`);
+		const pastData = readFileSync(fullFile, "utf-8");
+		assert.equal(data, pastData, `snapshot different for "${currentTestName}"`);
+	}
+}
+
+let currentTestName: string | undefined;
+let currentTestFile: string | undefined;
+
+// Simple filter to avoid tests with a name that would accidentally be parsed as directory traversal or other confusing things.
+const nameCheck = new RegExp(/^[^"/\\]+$/);
+
+assert(__dirname.endsWith("dist/test/snapshots"));
+const snapshotsFolder = path.join(__dirname, `../../../src/test/snapshots`);
+assert(existsSync(snapshotsFolder));
+
+/**
+ * Delete the existing test file directory and recreate it.
+ *
+ * If the directory does not already exist, this will create it.
+ *
+ * @param dirPath - The path within the `snapshots` directory.
+ */
+export function useTestDirectory(dirPath: string = "files"): void {
+	const normalizedDir = path.join(snapshotsFolder, dirPath);
+	// Basic sanity check to avoid bugs like accidentally recursively deleting everything under `/` if something went wrong (like dirPath navigated up directories a lot).
+	assert(normalizedDir.startsWith(snapshotsFolder));
+
+	if (regenerateSnapshots) {
+		if (existsSync(normalizedDir)) {
+			console.log(`removing snapshot directory: ${normalizedDir}`);
+			rmSync(normalizedDir, { recursive: true, force: true });
+		}
+		mkdirSync(normalizedDir, { recursive: true });
+	}
+
+	beforeEach(function (): void {
+		currentTestName = this.currentTest?.title ?? assert.fail();
+		currentTestFile = path.join(normalizedDir, currentTestName);
+	});
+
+	afterEach(() => {
+		currentTestFile = undefined;
+		currentTestName = undefined;
+	});
+}

--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -18,7 +18,7 @@ export function takeJsonSnapshot(data: JsonCompatibleReadOnly, suffix: string = 
 export function takeSnapshot(data: string, suffix: string): void {
 	assert(
 		currentTestName !== undefined,
-		"use `useTestDirectory` to configure the tests containing describe block to take snapshots",
+		"use `useSnapshotDirectory` to configure the tests containing describe block to take snapshots",
 	);
 	assert(currentTestFile !== undefined);
 
@@ -58,7 +58,7 @@ assert(existsSync(snapshotsFolder));
  *
  * @param dirPath - The path within the `snapshots` directory.
  */
-export function useTestDirectory(dirPath: string = "files"): void {
+export function useSnapshotDirectory(dirPath: string = "files"): void {
 	const normalizedDir = path.join(snapshotsFolder, dirPath);
 	// Basic sanity check to avoid bugs like accidentally recursively deleting everything under `/` if something went wrong (like dirPath navigated up directories a lot).
 	assert(normalizedDir.startsWith(snapshotsFolder));

--- a/packages/dds/tree/src/test/snapshots/summary.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/summary.spec.ts
@@ -6,10 +6,10 @@
 import { useAsyncDeterministicStableId } from "../../util";
 import { takeSummarySnapshot } from "./utils";
 import { generateTestTrees } from "./testTrees";
-import { useTestDirectory } from "./snapshotTools";
+import { useSnapshotDirectory } from "./snapshotTools";
 
 describe("snapshot tests", () => {
-	useTestDirectory();
+	useSnapshotDirectory();
 
 	const testTrees = generateTestTrees();
 

--- a/packages/dds/tree/src/test/snapshots/summary.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/summary.spec.ts
@@ -3,53 +3,24 @@
  * Licensed under the MIT License.
  */
 
-import path from "path";
 import { useAsyncDeterministicStableId } from "../../util";
-import {
-	createSnapshot,
-	dirPathTail,
-	regenTestDirectory,
-	regenerateSnapshots,
-	verifyEqualPastSnapshot,
-} from "./utils";
+import { takeSummarySnapshot } from "./utils";
 import { generateTestTrees } from "./testTrees";
-
-const dirPath = path.join(__dirname, `../../../${dirPathTail}/files`);
-
-function getFilepath(name: string): string {
-	return path.join(dirPath, `${name}.json`);
-}
-
-const testNames = new Set<string>();
+import { useTestDirectory } from "./snapshotTools";
 
 describe("snapshot tests", () => {
-	if (regenerateSnapshots) {
-		regenTestDirectory(dirPath);
-	}
+	useTestDirectory();
 
 	const testTrees = generateTestTrees();
 
 	for (const { name: testName, runScenario, skip = false, only = false } of testTrees) {
 		const itFn = only ? it.only : skip ? it.skip : it;
 
-		itFn(`${regenerateSnapshots ? "regenerate " : ""}for ${testName}`, async () => {
+		itFn(testName, async () => {
 			await useAsyncDeterministicStableId(async () => {
 				return runScenario(async (tree, innerName) => {
-					const fullName = `${testName}-${innerName}`;
-
-					if (testNames.has(fullName)) {
-						throw new Error(`Duplicate snapshot name: ${fullName}`);
-					}
-
-					testNames.add(fullName);
-
 					const { summary } = await tree.summarize(true);
-					// eslint-disable-next-line unicorn/prefer-ternary
-					if (regenerateSnapshots) {
-						await createSnapshot(getFilepath(fullName), summary);
-					} else {
-						await verifyEqualPastSnapshot(getFilepath(fullName), summary, fullName);
-					}
+					takeSummarySnapshot(summary, `-${innerName}`);
 				});
 			});
 		});


### PR DESCRIPTION
## Description

Factor out snapshotting logic from summary and schema specific stuff.
Simplify file path and name management: use mocha test names.
Unify bassline and comparison withing tests so they don't have to worry about it.
Centralize and sanitize path management to reduce risk of bad paths deleting lots of files.

Generation of new baselines (with --snapshot just like before) and checking that tests fail when appropriate were both manually tested.

No baselines were changed since the naming happened to put them all in exactly the same place.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).