### PR TITLE
test(tree2): fix snapshot path validation for windows

### DIFF
--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -47,7 +47,6 @@ let currentTestFile: string | undefined;
 // Simple filter to avoid tests with a name that would accidentally be parsed as directory traversal or other confusing things.
 const nameCheck = new RegExp(/^[^"/\\]+$/);
 
-console.log(`__dirname: ${__dirname}`);
 assert(__dirname.match(/dist[/\\]test[/\\]snapshots$/));
 const snapshotsFolder = path.join(__dirname, `../../../src/test/snapshots`);
 assert(existsSync(snapshotsFolder));

--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -47,7 +47,8 @@ let currentTestFile: string | undefined;
 // Simple filter to avoid tests with a name that would accidentally be parsed as directory traversal or other confusing things.
 const nameCheck = new RegExp(/^[^"/\\]+$/);
 
-assert(__dirname.endsWith("dist/test/snapshots"));
+console.log(`__dirname: ${__dirname}`);
+assert(__dirname.endsWith("dist/test/snapshots") || __dirname.endsWith("dist\\test\\snapshots"));
 const snapshotsFolder = path.join(__dirname, `../../../src/test/snapshots`);
 assert(existsSync(snapshotsFolder));
 

--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -48,7 +48,7 @@ let currentTestFile: string | undefined;
 const nameCheck = new RegExp(/^[^"/\\]+$/);
 
 console.log(`__dirname: ${__dirname}`);
-assert(__dirname.endsWith("dist/test/snapshots") || __dirname.endsWith("dist\\test\\snapshots"));
+assert(__dirname.match(/dist[/\\]test[/\\]snapshots$/));
 const snapshotsFolder = path.join(__dirname, `../../../src/test/snapshots`);
 assert(existsSync(snapshotsFolder));
 

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -613,7 +613,6 @@ export function validateSnapshotConsistency(
 	// exact set of them. In the future, we will need to relax this expectation and only enforce that whenever two
 	// clients both have data for the same removed tree (as identified by the first two tuple entries), then they
 	// should be consistent about the content being stored (the third tuple entry).
-	console.log(idDifferentiator);
 	const mapA = nestedMapFromFlatList(treeA.removed);
 	const mapB = nestedMapFromFlatList(treeB.removed);
 	assert.deepEqual(


### PR DESCRIPTION
fix snapshot path validation for windows (i.e., tolerates paths with backslashes in it).