### PR TITLE
fix(client): repair CommonJs config for core-utils

### DIFF
--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -11,6 +11,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
+	"type": "commonjs",
 	"exports": {
 		".": {
 			"import": {
@@ -19,12 +20,11 @@
 			},
 			"require": {
 				"types": "./dist/index.d.ts",
-				"default": "./dist/index.cjs"
+				"default": "./dist/index.js"
 			}
 		}
 	},
-	"main": "dist/index.cjs",
-	"module": "lib/index.mjs",
+	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
@@ -37,7 +37,7 @@
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "fluid-build . --task api",
 		"build:esnext": "tsc-multi --config ../../../common/build/build-common/tsc-multi.esm.json",
-		"build:test": "tsc-multi --config ./tsc-multi.test.json",
+		"build:test": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack",
 		"check:release-tags": "api-extractor run --local --config ./api-extractor-lint.json",
 		"ci:build:docs": "api-extractor run",
@@ -54,7 +54,7 @@
 		"test:coverage": "c8 npm test",
 		"test:mocha": "mocha",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
-		"tsc": "tsc-multi --config ../../../common/build/build-common/tsc-multi.cjs.json",
+		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},

--- a/packages/common/core-utils/tsc-multi.test.json
+++ b/packages/common/core-utils/tsc-multi.test.json
@@ -1,4 +1,0 @@
-{
-	"targets": [{ "extname": ".cjs", "module": "CommonJS", "moduleResolution": "Node16" }],
-	"projects": ["./tsconfig.json", "./src/test/tsconfig.json"]
-}


### PR DESCRIPTION
make built package understandable from tsconfig.json:
 - package should have declared type - use CommonJS
 - build with just tsc (for tests too)

This should restore VSCode import inferences.