### PR TITLE
Add IdCompressor support to mock runtime

### DIFF
--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -19,6 +19,7 @@ import { IChannelStorageService } from '@fluidframework/datastore-definitions';
 import { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
 import { IContainerRuntimeBase } from '@fluidframework/runtime-definitions';
+import { IdCreationRange } from '@fluidframework/id-compressor';
 import { IDeltaConnection } from '@fluidframework/datastore-definitions';
 import { IDeltaHandler } from '@fluidframework/datastore-definitions';
 import { IDeltaManager } from '@fluidframework/container-definitions';
@@ -113,7 +114,11 @@ export class MockContainerRuntime {
     dirty(): void;
     // (undocumented)
     protected readonly factory: MockContainerRuntimeFactory;
+    // (undocumented)
+    finalizeIdRange(range: IdCreationRange): void;
     flush(): void;
+    // (undocumented)
+    getGeneratedIdRange(): IdCreationRange | undefined;
     // (undocumented)
     protected readonly overrides?: {
         minimumSequenceNumber?: number | undefined;
@@ -153,6 +158,8 @@ export class MockContainerRuntimeFactory {
     protected readonly runtimes: MockContainerRuntime[];
     // (undocumented)
     sequenceNumber: number;
+    // (undocumented)
+    synchronizeIdCompressors(): void;
 }
 
 // @alpha
@@ -380,6 +387,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
         entryPoint?: IFluidHandle<FluidObject>;
         id?: string;
         logger?: ITelemetryLoggerExt;
+        idCompressor?: IIdCompressor & IIdCompressorCore;
     });
     // (undocumented)
     get absolutePath(): string;
@@ -439,6 +447,8 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     getQuorum(): IQuorumClients;
     // (undocumented)
     readonly id: string;
+    // (undocumented)
+    idCompressor?: IIdCompressor & IIdCompressorCore;
     // (undocumented)
     get IFluidHandleContext(): IFluidHandleContext;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -160,6 +160,22 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_MockContainerRuntimeForReconnection": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_MockFluidDataStoreRuntime": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_MockContainerRuntime": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_MockContainerRuntimeFactoryForReconnection": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_MockContainerRuntimeFactory": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -5,6 +5,7 @@
 
 import { EventEmitter } from "events";
 import { stringToBuffer } from "@fluid-internal/client-utils";
+import { IIdCompressor, IIdCompressorCore, IdCreationRange } from "@fluidframework/id-compressor";
 import { assert } from "@fluidframework/core-utils";
 import { ITelemetryLoggerExt, createChildLogger } from "@fluidframework/telemetry-utils";
 import {
@@ -104,6 +105,13 @@ export interface IMockContainerRuntimePendingMessage {
 	localOpMetadata: unknown;
 }
 
+interface IMockContainerRuntimeIdAllocationMessage {
+	contents: {
+		type: "idAllocation";
+		contents: IdCreationRange;
+	};
+}
+
 /**
  * Options for the container runtime mock.
  * @alpha
@@ -200,6 +208,19 @@ export class MockContainerRuntime {
 		return deltaConnection;
 	}
 
+	public getGeneratedIdRange(): IdCreationRange | undefined {
+		const range = this.dataStoreRuntime.idCompressor?.takeNextCreationRange();
+		return range?.ids === undefined ? undefined : range;
+	}
+
+	public finalizeIdRange(range: IdCreationRange) {
+		assert(
+			this.dataStoreRuntime.idCompressor !== undefined,
+			"Shouldn't try to finalize IdRanges without an IdCompressor",
+		);
+		this.dataStoreRuntime.idCompressor.finalizeCreationRange(range);
+	}
+
 	public submit(messageContent: any, localOpMetadata: unknown): number {
 		const clientSequenceNumber = this.clientSequenceNumber;
 		const message = {
@@ -278,6 +299,22 @@ export class MockContainerRuntime {
 	}
 
 	private submitInternal(message: IInternalMockRuntimeMessage, clientSequenceNumber: number) {
+		// This mimics the runtime behavior of the IdCompressor by generating an IdAllocationOp
+		// and sticking it in front of any op that might rely on that Id. It differs slightly in that
+		// in the actual runtime it would get put in its own separate batch
+		const idRange = this.getGeneratedIdRange();
+		if (idRange !== undefined) {
+			const idAllocationMessage = { type: "idAllocation", contents: idRange };
+			this.factory.pushMessage({
+				clientId: this.clientId,
+				clientSequenceNumber,
+				contents: idAllocationMessage,
+				referenceSequenceNumber: this.referenceSequenceNumber,
+				type: MessageType.Operation,
+			});
+			this.addPendingMessage(idAllocationMessage, undefined, clientSequenceNumber);
+		}
+
 		this.factory.pushMessage({
 			clientId: this.clientId,
 			clientSequenceNumber,
@@ -293,7 +330,14 @@ export class MockContainerRuntime {
 		this.deltaManager.lastMessage = message;
 		this.deltaManager.minimumSequenceNumber = message.minimumSequenceNumber;
 		const [local, localOpMetadata] = this.processInternal(message);
-		this.dataStoreRuntime.process(message, local, localOpMetadata);
+
+		if (
+			(message as IMockContainerRuntimeIdAllocationMessage).contents.type === "idAllocation"
+		) {
+			this.finalizeIdRange((message as any).contents.contents as IdCreationRange);
+		} else {
+			this.dataStoreRuntime.process(message, local, localOpMetadata);
+		}
 	}
 
 	protected addPendingMessage(
@@ -402,6 +446,17 @@ export class MockContainerRuntimeFactory {
 		);
 		this.runtimes.push(containerRuntime);
 		return containerRuntime;
+	}
+
+	public synchronizeIdCompressors() {
+		for (const runtime of this.runtimes) {
+			const range = runtime.getGeneratedIdRange();
+			if (range !== undefined) {
+				for (const nestedRuntime of this.runtimes) {
+					nestedRuntime.finalizeIdRange(range);
+				}
+			}
+		}
 	}
 
 	public pushMessage(msg: Partial<ISequencedDocumentMessage>) {
@@ -590,6 +645,7 @@ export class MockFluidDataStoreRuntime
 		entryPoint?: IFluidHandle<FluidObject>;
 		id?: string;
 		logger?: ITelemetryLoggerExt;
+		idCompressor?: IIdCompressor & IIdCompressorCore;
 	}) {
 		super();
 		this.clientId = overrides?.clientId ?? uuid();
@@ -599,6 +655,7 @@ export class MockFluidDataStoreRuntime
 			logger: overrides?.logger,
 			namespace: "fluid:MockFluidDataStoreRuntime",
 		});
+		this.idCompressor = overrides?.idCompressor;
 	}
 
 	public readonly entryPoint: IFluidHandle<FluidObject>;
@@ -628,6 +685,7 @@ export class MockFluidDataStoreRuntime
 	public readonly logger: ITelemetryLoggerExt;
 	public quorum = new MockQuorumClients();
 	public containerRuntime?: MockContainerRuntime;
+	public idCompressor?: IIdCompressor & IIdCompressorCore;
 	private readonly deltaConnections: MockDeltaConnection[] = [];
 	public createDeltaConnection(): MockDeltaConnection {
 		const deltaConnection = new MockDeltaConnection(

--- a/packages/runtime/test-runtime-utils/src/test/mocks.tests.ts
+++ b/packages/runtime/test-runtime-utils/src/test/mocks.tests.ts
@@ -4,6 +4,7 @@
  */
 
 import { strict as assert } from "assert";
+import { createIdCompressor } from "@fluidframework/id-compressor";
 import { MockContainerRuntimeFactory, MockFluidDataStoreRuntime } from "../mocks";
 
 describe("MockContainerRuntime", () => {
@@ -13,5 +14,50 @@ describe("MockContainerRuntime", () => {
 		const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId: id });
 		const containerRuntime = factory.createContainerRuntime(dataStoreRuntime);
 		assert.equal(containerRuntime.clientId, id);
+	});
+
+	it("generates and finalizes IdCreationRanges when generating an op", () => {
+		const firstIdCompressor = createIdCompressor();
+		const secondIdCompressor = createIdCompressor();
+		const factory = new MockContainerRuntimeFactory();
+		const firstDataStoreRuntime = new MockFluidDataStoreRuntime({
+			idCompressor: firstIdCompressor,
+		});
+		const secondDataStoreRuntime = new MockFluidDataStoreRuntime({
+			idCompressor: secondIdCompressor,
+		});
+
+		const firstContainerRuntime = factory.createContainerRuntime(firstDataStoreRuntime);
+		const secondContainerRuntime = factory.createContainerRuntime(secondDataStoreRuntime);
+		// Generate an ID in the first client
+		const id = firstIdCompressor.generateCompressedId();
+		const opSpaceId = firstIdCompressor.normalizeToOpSpace(id);
+
+		// Generate an ID in the first client
+		const secondId = secondIdCompressor.generateCompressedId();
+		const secondOpSpaceId = secondIdCompressor.normalizeToOpSpace(secondId);
+
+		// Generate a "dummy" op to trigger IdAllocationOp
+		firstContainerRuntime.submit({}, undefined);
+		secondContainerRuntime.submit({}, undefined);
+
+		factory.processAllMessages();
+
+		const normalizedId = secondDataStoreRuntime.idCompressor?.normalizeToSessionSpace(
+			opSpaceId,
+			firstIdCompressor.localSessionId,
+		);
+
+		const secondNormalizedId = firstDataStoreRuntime.idCompressor?.normalizeToSessionSpace(
+			secondOpSpaceId,
+			secondIdCompressor.localSessionId,
+		);
+
+		assert.strictEqual(normalizedId, 0, "Should have finalized the ID in both containers.");
+		assert.strictEqual(
+			secondNormalizedId,
+			513,
+			"Should have finalized the ID in both containers.",
+		);
 	});
 });

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -127,6 +127,7 @@ declare function get_old_ClassDeclaration_MockContainerRuntime():
 declare function use_current_ClassDeclaration_MockContainerRuntime(
     use: TypeOnly<current.MockContainerRuntime>): void;
 use_current_ClassDeclaration_MockContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockContainerRuntime());
 
 /*
@@ -151,6 +152,7 @@ declare function get_old_ClassDeclaration_MockContainerRuntimeFactory():
 declare function use_current_ClassDeclaration_MockContainerRuntimeFactory(
     use: TypeOnly<current.MockContainerRuntimeFactory>): void;
 use_current_ClassDeclaration_MockContainerRuntimeFactory(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockContainerRuntimeFactory());
 
 /*
@@ -175,6 +177,7 @@ declare function get_old_ClassDeclaration_MockContainerRuntimeFactoryForReconnec
 declare function use_current_ClassDeclaration_MockContainerRuntimeFactoryForReconnection(
     use: TypeOnly<current.MockContainerRuntimeFactoryForReconnection>): void;
 use_current_ClassDeclaration_MockContainerRuntimeFactoryForReconnection(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockContainerRuntimeFactoryForReconnection());
 
 /*
@@ -199,6 +202,7 @@ declare function get_old_ClassDeclaration_MockContainerRuntimeForReconnection():
 declare function use_current_ClassDeclaration_MockContainerRuntimeForReconnection(
     use: TypeOnly<current.MockContainerRuntimeForReconnection>): void;
 use_current_ClassDeclaration_MockContainerRuntimeForReconnection(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockContainerRuntimeForReconnection());
 
 /*
@@ -343,6 +347,7 @@ declare function get_old_ClassDeclaration_MockFluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_MockFluidDataStoreRuntime(
     use: TypeOnly<current.MockFluidDataStoreRuntime>): void;
 use_current_ClassDeclaration_MockFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockFluidDataStoreRuntime());
 
 /*


### PR DESCRIPTION
## Description
Adds support for an IdCompressor to the mock runtime. The compressor is given to as an option to the `MockDataStoreRuntime` and the `MockContainerRuntimeFactory` handles keeping the compressors synchronized.
