### PR TITLE
Finalize IDs immediately when attaching a detached container

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2679,6 +2679,12 @@ export class ContainerRuntime
 			this.blobManager.setRedirectTable(blobRedirectTable);
 		}
 
+		// We can finalize any allocated IDs since we're the only client
+		const idRange = this.idCompressor?.takeNextCreationRange();
+		if (idRange !== undefined) {
+			this.idCompressor?.finalizeCreationRange(idRange);
+		}
+
 		const summarizeResult = this.dataStores.createSummary(telemetryContext);
 		// Wrap data store summaries in .channels subtree.
 		wrapSummaryInChannelsTree(summarizeResult);

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -618,6 +618,8 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 	});
 });
 
+// No-compat: 2.0.0-internal.8.x and earlier versions of container-runtime don't finalize ids prior to attaching.
+// Even older versions of the runtime also don't have an id compression feature enabled.
 describeCompat("IdCompressor in detached container", "NoCompat", (getTestObjectProvider, apis) => {
 	let provider: ITestObjectProvider;
 	let request: IRequest;
@@ -665,10 +667,11 @@ describeCompat("IdCompressor in detached container", "NoCompat", (getTestObjectP
 
 		await provider.ensureSynchronized();
 
-		// Compressor from second container will get the first 512 Ids (0-511)
-		assert.strictEqual((testChannel2 as any).runtime.idCompressor.normalizeToOpSpace(-1), 0);
-		// Compressor from first container gets second cluster starting at 512 after sending an op
-		assert.strictEqual((testChannel1 as any).runtime.idCompressor.normalizeToOpSpace(-1), 513);
+		// Compressor from first container will get the first 512 Ids (0-511) as its id should be finalized
+		// on attach
+		assert.strictEqual((testChannel1 as any).runtime.idCompressor.normalizeToOpSpace(-1), 0);
+		// Compressor from second container gets second cluster starting at 512 after sending an op
+		assert.strictEqual((testChannel2 as any).runtime.idCompressor.normalizeToOpSpace(-1), 513);
 	});
 });
 


### PR DESCRIPTION
## Description
Prior to this if a client generated IDs using the `IdCompressor` while detached it could end up serializing un-finalized IDs in the attach summary. Since we're the only client, we don't need to wait on consensus and can immediately claim a cluster and finalize the range. 

There's not test in this PR, but `SharedTree` has a PR following this up which has test failures without this change. Writing a unit test here to test this is a part of https://dev.azure.com/fluidframework/internal/_workitems/edit/6675 as follow-up to this work

