### PR TITLE
Support DDS usage of id-compessor in the fuzz harness

### DIFF
--- a/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
+++ b/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
@@ -8,12 +8,15 @@ import { AsyncGenerator as AsyncGenerator_2 } from '@fluid-private/stochastic-te
 import { AsyncReducer } from '@fluid-private/stochastic-test-utils';
 import { BaseFuzzTestState } from '@fluid-private/stochastic-test-utils';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
+import { IIdCompressor } from '@fluidframework/id-compressor';
+import { IIdCompressorCore } from '@fluidframework/id-compressor';
 import { IMockContainerRuntimeOptions } from '@fluidframework/test-runtime-utils';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { MockContainerRuntimeFactoryForReconnection } from '@fluidframework/test-runtime-utils';
 import { MockContainerRuntimeForReconnection } from '@fluidframework/test-runtime-utils';
 import { MockFluidDataStoreRuntime } from '@fluidframework/test-runtime-utils';
 import { SaveInfo } from '@fluid-private/stochastic-test-utils';
+import { SerializedIdCompressorWithNoSession } from '@fluidframework/id-compressor';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
 // @internal (undocumented)
@@ -93,6 +96,7 @@ export interface DDSFuzzSuiteOptions {
         enabled: boolean;
     };
     emitter: TypedEventEmitter<DDSFuzzHarnessEvents>;
+    idCompressorFactory?: (summary?: SerializedIdCompressorWithNoSession) => IIdCompressor & IIdCompressorCore;
     numberOfClients: number;
     only: Iterable<number>;
     // (undocumented)

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -63,6 +63,7 @@
 		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",
+		"@fluidframework/id-compressor": "workspace:~",
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"mocha": "^10.2.0"

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -8,6 +8,11 @@ import { mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import {
+	IIdCompressor,
+	IIdCompressorCore,
+	SerializedIdCompressorWithNoSession,
+} from "@fluidframework/id-compressor";
+import {
 	BaseFuzzTestState,
 	createFuzzDescribe,
 	defaultOptions,
@@ -443,6 +448,13 @@ export interface DDSFuzzSuiteOptions {
 	 * test case. See {@link MinimizationTransform} for additional context.
 	 */
 	skipMinimization?: boolean;
+
+	/**
+	 * An optional IdCompressor that can will be passed to the constructed MockDataStoreRuntime instance.
+	 */
+	idCompressorFactory?: (
+		summary?: SerializedIdCompressorWithNoSession,
+	) => IIdCompressor & IIdCompressorCore;
 }
 
 /**
@@ -628,6 +640,13 @@ export function mixinAttach<
 				objectStorage: new MockStorage(),
 			};
 			clientA.channel.connect(services);
+
+			// This is necessary to get al IdCreationRanges finalized before connecting further clients.
+			// The production codepath also finalizes ids before attaching. It's difficult for the mocks
+			// to be more direct about this as they don't directly manage any state related to attach
+			// (it's up to the user of the mocks to set them up how they want)
+			state.containerRuntimeFactory.processAllMessages();
+
 			const clients = await Promise.all(
 				Array.from({ length: options.numberOfClients }, async (_, index) =>
 					loadClient(
@@ -939,9 +958,13 @@ function createDetachedClient<TChannelFactory extends IChannelFactory>(
 	containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection,
 	factory: TChannelFactory,
 	clientId: string,
-	options: Pick<DDSFuzzSuiteOptions, "emitter">,
+	options: Omit<DDSFuzzSuiteOptions, "only" | "skip">,
 ): Client<TChannelFactory> {
-	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId });
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({
+		clientId,
+		idCompressor:
+			options.idCompressorFactory === undefined ? undefined : options.idCompressorFactory(),
+	});
 	// Note: we re-use the clientId for the channel id here despite connecting all clients to the same channel:
 	// this isn't how it would work in a real scenario, but the mocks don't use the channel id for any message
 	// routing behavior and making all of the object ids consistent helps with debugging and writing more informative
@@ -965,10 +988,23 @@ async function loadClient<TChannelFactory extends IChannelFactory>(
 	summarizerClient: Client<TChannelFactory>,
 	factory: TChannelFactory,
 	clientId: string,
-	options: Pick<DDSFuzzSuiteOptions, "emitter">,
+	options: Omit<DDSFuzzSuiteOptions, "only" | "skip">,
 ): Promise<Client<TChannelFactory>> {
+	containerRuntimeFactory.synchronizeIdCompressors();
+
 	const { summary } = summarizerClient.channel.getAttachSummary();
-	const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId });
+	let idCompressorSummary: SerializedIdCompressorWithNoSession | undefined;
+	if (summarizerClient.dataStoreRuntime.idCompressor !== undefined) {
+		idCompressorSummary = summarizerClient.dataStoreRuntime.idCompressor.serialize(false);
+	}
+
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({
+		clientId,
+		idCompressor:
+			options.idCompressorFactory === undefined
+				? undefined
+				: options.idCompressorFactory(idCompressorSummary),
+	});
 	const containerRuntime = containerRuntimeFactory.createContainerRuntime(dataStoreRuntime, {
 		minimumSequenceNumber: containerRuntimeFactory.sequenceNumber,
 	});

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -450,7 +450,7 @@ export interface DDSFuzzSuiteOptions {
 	skipMinimization?: boolean;
 
 	/**
-	 * An optional IdCompressor that can will be passed to the constructed MockDataStoreRuntime instance.
+	 * An optional IdCompressor that will be passed to the constructed MockDataStoreRuntime instance.
 	 */
 	idCompressorFactory?: (
 		summary?: SerializedIdCompressorWithNoSession,
@@ -641,7 +641,7 @@ export function mixinAttach<
 			};
 			clientA.channel.connect(services);
 
-			// This is necessary to get al IdCreationRanges finalized before connecting further clients.
+			// This is necessary to get all IdCreationRanges finalized before connecting further clients.
 			// The production codepath also finalizes ids before attaching. It's difficult for the mocks
 			// to be more direct about this as they don't directly manage any state related to attach
 			// (it's up to the user of the mocks to set them up how they want)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7105,6 +7105,7 @@ importers:
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/eslint-config-fluid': ^3.1.0
+      '@fluidframework/id-compressor': workspace:~
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/shared-object-base': workspace:~
@@ -7130,6 +7131,7 @@ importers:
       '@fluid-private/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluidframework/core-utils': link:../../common/core-utils
       '@fluidframework/datastore-definitions': link:../../runtime/datastore-definitions
+      '@fluidframework/id-compressor': link:../../runtime/id-compressor
       '@fluidframework/shared-object-base': link:../shared-object-base
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       mocha: 10.2.0


### PR DESCRIPTION
## Description

Upcoming changes to `SharedTree` will make it leverage the runtime's id compression scheme. This adds support within the fuzz test harness to optionally set up an id compressor on each created client.

The changes here are split off from #18775, which updates the tree fuzz tests to use this functionality.
