### PR TITLE
fix: Revert change to package.json's main field in some packages

### DIFF
--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -12,7 +12,7 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
-	"main": "dist/index.js",
+	"main": "dist/generateSnapshotFiles.js",
 	"types": "dist/generateSnapshotFiles.js",
 	"scripts": {
 		"build": "fluid-build . --task build",

--- a/packages/tools/fetch-tool/package.json
+++ b/packages/tools/fetch-tool/package.json
@@ -10,7 +10,7 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
-	"main": "dist/index.js",
+	"main": "dist/fluidFetch.js",
 	"types": "dist/fluidFetch.d.ts",
 	"bin": {
 		"fluid-fetch": "bin/fluid-fetch"


### PR DESCRIPTION
## Description

https://github.com/microsoft/FluidFramework/pull/18939 made these two changes, probably due to a regex replace, but these packages don't want/need the change, since neither has an `index.js` (snapshot doesn't have a `generateSnapshotFiles.js` either, but better to keep it broken like that, than with a discrepancy between `"main"` and `"types"`).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
