### PR TITLE
Enable idCompressor in examples which use @fluidframework/tree

### DIFF
--- a/examples/apps/tree-comparison/src/model/containerCode.ts
+++ b/examples/apps/tree-comparison/src/model/containerCode.ts
@@ -25,7 +25,7 @@ export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeF
 				LegacyTreeInventoryListFactory.registryEntry,
 				NewTreeInventoryListFactory.registryEntry,
 			]), // registryEntries
-			{ enableRuntimeIdCompressor: true }
+			{ enableRuntimeIdCompressor: true },
 		);
 	}
 

--- a/examples/apps/tree-comparison/src/model/containerCode.ts
+++ b/examples/apps/tree-comparison/src/model/containerCode.ts
@@ -25,6 +25,7 @@ export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeF
 				LegacyTreeInventoryListFactory.registryEntry,
 				NewTreeInventoryListFactory.registryEntry,
 			]), // registryEntries
+			{ enableRuntimeIdCompressor: true }
 		);
 	}
 

--- a/examples/apps/tree-comparison/tests/inventoryList.test.ts
+++ b/examples/apps/tree-comparison/tests/inventoryList.test.ts
@@ -11,6 +11,7 @@ describe("inventoryList", () => {
 		// Wait for the page to load first before running any tests
 		// so this time isn't attributed to the first test
 		await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
+		await page.waitForFunction(() => window["fluidStarted"]);
 	}, 45000);
 
 	describe("Smoke test", () => {

--- a/examples/version-migration/live-schema-upgrade/tests/diceRoller.test.ts
+++ b/examples/version-migration/live-schema-upgrade/tests/diceRoller.test.ts
@@ -11,6 +11,7 @@ describe("diceRoller", () => {
 		// Wait for the page to load first before running any tests
 		// so this time isn't attributed to the first test
 		await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
+		await page.waitForFunction(() => window["fluidStarted"]);
 	}, 45000);
 
 	beforeEach(async () => {

--- a/examples/version-migration/same-container/tests/inventoryList.test.ts
+++ b/examples/version-migration/same-container/tests/inventoryList.test.ts
@@ -13,6 +13,7 @@ describe("inventoryList", () => {
 		// Wait for the page to load first before running any tests
 		// so this time isn't attributed to the first test
 		await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
+		await page.waitForFunction(() => window["fluidStarted"]);
 	}, 45000);
 
 	describe("Without summarizer connected", () => {

--- a/examples/version-migration/schema-upgrade/tests/inventoryList.test.ts
+++ b/examples/version-migration/schema-upgrade/tests/inventoryList.test.ts
@@ -13,6 +13,7 @@ describe("inventoryList", () => {
 		// Wait for the page to load first before running any tests
 		// so this time isn't attributed to the first test
 		await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
+		await page.waitForFunction(() => window["fluidStarted"]);
 	}, 45000);
 
 	describe("Without summarizer connected", () => {

--- a/examples/version-migration/tree-shim/src/model/containerCode.ts
+++ b/examples/version-migration/tree-shim/src/model/containerCode.ts
@@ -20,6 +20,7 @@ export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeF
 	public constructor() {
 		super(
 			new Map([InventoryListFactory.registryEntry]), // registryEntries
+			{ enableRuntimeIdCompressor: true }
 		);
 	}
 

--- a/examples/version-migration/tree-shim/src/model/containerCode.ts
+++ b/examples/version-migration/tree-shim/src/model/containerCode.ts
@@ -20,7 +20,7 @@ export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeF
 	public constructor() {
 		super(
 			new Map([InventoryListFactory.registryEntry]), // registryEntries
-			{ enableRuntimeIdCompressor: true }
+			{ enableRuntimeIdCompressor: true },
 		);
 	}
 

--- a/examples/version-migration/tree-shim/tests/inventoryList.test.ts
+++ b/examples/version-migration/tree-shim/tests/inventoryList.test.ts
@@ -11,6 +11,7 @@ describe("inventoryList", () => {
 		// Wait for the page to load first before running any tests
 		// so this time isn't attributed to the first test
 		await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
+		await page.waitForFunction(() => window["fluidStarted"]);
 	}, 45000);
 
 	describe("Smoke test", () => {

--- a/packages/tools/devtools/devtools-example/src/Container.ts
+++ b/packages/tools/devtools/devtools-example/src/Container.ts
@@ -33,6 +33,9 @@ export class RuntimeFactory extends ModelContainerRuntimeFactory<IAppModel> {
 	public constructor() {
 		super(
 			new Map([AppData.getFactory().registryEntry]), // registryEntries
+			{
+				enableRuntimeIdCompressor: true
+			}
 		);
 	}
 

--- a/packages/tools/devtools/devtools-example/src/Container.ts
+++ b/packages/tools/devtools/devtools-example/src/Container.ts
@@ -34,8 +34,8 @@ export class RuntimeFactory extends ModelContainerRuntimeFactory<IAppModel> {
 		super(
 			new Map([AppData.getFactory().registryEntry]), // registryEntries
 			{
-				enableRuntimeIdCompressor: true
-			}
+				enableRuntimeIdCompressor: true,
+			},
 		);
 	}
 

--- a/packages/tools/devtools/devtools-example/src/test/ExampleUi.test.ts
+++ b/packages/tools/devtools/devtools-example/src/test/ExampleUi.test.ts
@@ -33,6 +33,8 @@ describe("End to end tests", () => {
 		// Wait for the page to load first before running any tests
 		// so this time isn't attributed to the first test
 		await page.goto(globals.PATH, { waitUntil: "load", timeout: 0 });
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		await page.waitForFunction(() => globalThis.fluidStarted);
 	}, 45_000);
 
 	beforeEach(async () => {


### PR DESCRIPTION
## Description

This will be required to keep the examples working with #18775.

A note on test changes: our jest tests have a 45 second beforeAll hook which waits for an initial page load before running the tests. Since id-compressor is dynamically imported, it's plausible webpack will serve the main chunk (which includes a page load) before the whole contents of the page are ready. If this happens, the tests can start running before webpack finishes compiling/serving code capable of rendering the example app. Luckily, the example tests were already set up with a mechanism for when Fluid was actually ready to load. That check has been added to the beforeAll hook to ensure tests are ready to run.