### PR TITLE
update dds stress test pipeline to point to correct path for tree

### DIFF
--- a/tools/pipelines/test-dds-stress.yml
+++ b/tools/pipelines/test-dds-stress.yml
@@ -41,7 +41,7 @@ stages:
         testCommand: test:stress
       - name: "@fluidframework/tree"
         affectedPaths:
-        - experimental/dds/tree2
+        - packages/dds/tree
         testFileTarName: tree
         testCommand: test:stress
       testWorkspace: ${{ variables.testWorkspace }}


### PR DESCRIPTION
DDS stress test pipeline seemed to have been failing due to the path of tree not being updated in the test pipeline. (tree package directory was recently moved from experimental to packages)