### PR TITLE
Use forked btree

### DIFF
--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -51,10 +51,10 @@
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@fluidframework/tree": "workspace:~",
+		"@tylerbu/sorted-btree-es6": "^1.8.0",
 		"buffer": "^6.0.3",
 		"denque": "^1.5.1",
 		"lru-cache": "^6.0.0",
-		"sorted-btree": "^1.8.0",
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {

--- a/experimental/dds/tree/src/Common.ts
+++ b/experimental/dds/tree/src/Common.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryBaseEvent, ITelemetryProperties } from '@fluidframework/core-interfaces';
-import BTree from '@tylerbu/sorted-btree-es6';
+import { BTree } from '@tylerbu/sorted-btree-es6';
 
 const defaultFailMessage = 'Assertion failed';
 

--- a/experimental/dds/tree/src/Common.ts
+++ b/experimental/dds/tree/src/Common.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryBaseEvent, ITelemetryProperties } from '@fluidframework/core-interfaces';
-import BTree from 'sorted-btree';
+import BTree from '@tylerbu/sorted-btree-es6';
 
 const defaultFailMessage = 'Assertion failed';
 

--- a/experimental/dds/tree/src/EditLog.ts
+++ b/experimental/dds/tree/src/EditLog.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import BTree from '@tylerbu/sorted-btree-es6';
+import { BTree } from '@tylerbu/sorted-btree-es6';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 import { assert, compareArrays } from '@fluidframework/core-utils';
 import type { IEvent } from '@fluidframework/core-interfaces';

--- a/experimental/dds/tree/src/EditLog.ts
+++ b/experimental/dds/tree/src/EditLog.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import BTree from 'sorted-btree';
+import BTree from '@tylerbu/sorted-btree-es6';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 import { assert, compareArrays } from '@fluidframework/core-utils';
 import type { IEvent } from '@fluidframework/core-interfaces';

--- a/experimental/dds/tree/src/Forest.ts
+++ b/experimental/dds/tree/src/Forest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import BTree from 'sorted-btree';
+import BTree from '@tylerbu/sorted-btree-es6';
 import { assert } from '@fluidframework/core-utils';
 import { fail, copyPropertyIfDefined, compareBtrees, compareFiniteNumbers } from './Common';
 import { NodeId, TraitLabel } from './Identifiers';

--- a/experimental/dds/tree/src/Forest.ts
+++ b/experimental/dds/tree/src/Forest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import BTree from '@tylerbu/sorted-btree-es6';
+import { BTree } from '@tylerbu/sorted-btree-es6';
 import { assert } from '@fluidframework/core-utils';
 import { fail, copyPropertyIfDefined, compareBtrees, compareFiniteNumbers } from './Common';
 import { NodeId, TraitLabel } from './Identifiers';

--- a/experimental/dds/tree/src/RevisionValueCache.ts
+++ b/experimental/dds/tree/src/RevisionValueCache.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from '@fluidframework/core-utils';
-import BTree from 'sorted-btree';
+import BTree from '@tylerbu/sorted-btree-es6';
 import LRU from 'lru-cache';
 import { fail, compareFiniteNumbers } from './Common';
 

--- a/experimental/dds/tree/src/RevisionValueCache.ts
+++ b/experimental/dds/tree/src/RevisionValueCache.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert } from '@fluidframework/core-utils';
-import BTree from '@tylerbu/sorted-btree-es6';
+import { BTree } from '@tylerbu/sorted-btree-es6';
 import LRU from 'lru-cache';
 import { fail, compareFiniteNumbers } from './Common';
 

--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -7,7 +7,7 @@
 
 import { assert } from '@fluidframework/core-utils';
 import { ITelemetryLoggerExt, createChildLogger } from '@fluidframework/telemetry-utils';
-import BTree from 'sorted-btree';
+import BTree from '@tylerbu/sorted-btree-es6';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import {
 	hasLength,

--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -7,7 +7,7 @@
 
 import { assert } from '@fluidframework/core-utils';
 import { ITelemetryLoggerExt, createChildLogger } from '@fluidframework/telemetry-utils';
-import BTree from '@tylerbu/sorted-btree-es6';
+import { BTree } from '@tylerbu/sorted-btree-es6';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import {
 	hasLength,

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -82,8 +82,8 @@
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@sinclair/typebox": "^0.29.4",
+		"@tylerbu/sorted-btree-es6": "^1.8.0",
 		"@ungap/structured-clone": "^1.2.0",
-		"sorted-btree": "^1.8.0",
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {

--- a/packages/dds/tree/src/core/schema-stored/storedSchemaRepository.ts
+++ b/packages/dds/tree/src/core/schema-stored/storedSchemaRepository.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import BTree from "@tylerbu/sorted-btree-es6";
+import { BTree } from "@tylerbu/sorted-btree-es6";
 import { createEmitter, ISubscribable } from "../../events";
 import { compareStrings } from "../../util";
 import {

--- a/packages/dds/tree/src/core/schema-stored/storedSchemaRepository.ts
+++ b/packages/dds/tree/src/core/schema-stored/storedSchemaRepository.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import BTree from "sorted-btree";
+import BTree from "@tylerbu/sorted-btree-es6";
 import { createEmitter, ISubscribable } from "../../events";
 import { compareStrings } from "../../util";
 import {

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import BTree from "sorted-btree";
+import BTree from "@tylerbu/sorted-btree-es6";
 import { assert } from "@fluidframework/core-utils";
 import { brand, fail, getOrCreate, mapIterable, Mutable, RecursiveReadonly } from "../util";
 import {

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import BTree from "@tylerbu/sorted-btree-es6";
+import { BTree } from "@tylerbu/sorted-btree-es6";
 import { assert } from "@fluidframework/core-utils";
 import { brand, fail, getOrCreate, mapIterable, Mutable, RecursiveReadonly } from "../util";
 import {

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -186,10 +186,10 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
+		"@tylerbu/sorted-btree-es6": "^1.8.0",
 		"double-ended-queue": "^2.1.0-0",
 		"events": "^3.1.0",
 		"lz4js": "^0.2.0",
-		"sorted-btree": "^1.8.0",
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -69,7 +69,7 @@
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"sorted-btree": "^1.8.0",
+		"@tylerbu/sorted-btree-es6": "^1.8.0",
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {

--- a/packages/runtime/id-compressor/src/sessions.ts
+++ b/packages/runtime/id-compressor/src/sessions.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import BTree from "@tylerbu/sorted-btree-es6";
+import { BTree } from "@tylerbu/sorted-btree-es6";
 import { assert } from "@fluidframework/core-utils";
 import { SessionId, StableId } from "./types";
 import {

--- a/packages/runtime/id-compressor/src/sessions.ts
+++ b/packages/runtime/id-compressor/src/sessions.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import BTree from "sorted-btree";
+import BTree from "@tylerbu/sorted-btree-es6";
 import { assert } from "@fluidframework/core-utils";
 import { SessionId, StableId } from "./types";
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5637,6 +5637,7 @@ importers:
       '@fluidframework/tree': workspace:~
       '@fluidframework/undo-redo': workspace:~
       '@microsoft/api-extractor': ^7.38.3
+      '@tylerbu/sorted-btree-es6': ^1.8.0
       '@types/chai': ^4.0.0
       '@types/lru-cache': ^5.1.0
       '@types/mocha': ^9.1.1
@@ -5657,7 +5658,6 @@ importers:
       moment: ^2.21.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
-      sorted-btree: ^1.8.0
       typescript: ~5.1.6
       uuid: ^9.0.0
     dependencies:
@@ -5671,10 +5671,10 @@ importers:
       '@fluidframework/shared-object-base': link:../../../packages/dds/shared-object-base
       '@fluidframework/telemetry-utils': link:../../../packages/utils/telemetry-utils
       '@fluidframework/tree': link:../../../packages/dds/tree
+      '@tylerbu/sorted-btree-es6': 1.8.0
       buffer: 6.0.3
       denque: 1.5.1
       lru-cache: 6.0.0
-      sorted-btree: 1.8.1
       uuid: 9.0.1
     devDependencies:
       '@fluid-private/stochastic-test-utils': link:../../../packages/test/stochastic-test-utils
@@ -7190,6 +7190,7 @@ importers:
       '@fluidframework/test-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
       '@sinclair/typebox': ^0.29.4
+      '@tylerbu/sorted-btree-es6': ^1.8.0
       '@types/diff': ^3.5.1
       '@types/easy-table': ^0.0.32
       '@types/mocha': ^9.1.1
@@ -7212,7 +7213,6 @@ importers:
       moment: ^2.21.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
-      sorted-btree: ^1.8.0
       typescript: ~5.1.6
       uuid: ^9.0.0
     dependencies:
@@ -7228,8 +7228,8 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       '@sinclair/typebox': 0.29.6
+      '@tylerbu/sorted-btree-es6': 1.8.0
       '@ungap/structured-clone': 1.2.0
-      sorted-btree: 1.8.1
       uuid: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
@@ -9205,6 +9205,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
+      '@tylerbu/sorted-btree-es6': ^1.8.0
       '@types/double-ended-queue': ^2.1.0
       '@types/events': ^3.0.0
       '@types/mocha': ^9.1.1
@@ -9224,7 +9225,6 @@ importers:
       prettier: ~3.0.3
       rimraf: ^4.4.0
       sinon: ^7.4.2
-      sorted-btree: ^1.8.0
       tsc-multi: ^1.1.0
       typescript: ~5.1.6
       uuid: ^9.0.0
@@ -9242,10 +9242,10 @@ importers:
       '@fluidframework/runtime-definitions': link:../runtime-definitions
       '@fluidframework/runtime-utils': link:../runtime-utils
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
+      '@tylerbu/sorted-btree-es6': 1.8.0
       double-ended-queue: 2.1.0-0
       events: 3.3.0
       lz4js: 0.2.0
-      sorted-btree: 1.8.1
       uuid: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
@@ -9453,6 +9453,7 @@ importers:
       '@fluidframework/mocha-test-setup': workspace:~
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.38.3
+      '@tylerbu/sorted-btree-es6': ^1.8.0
       '@types/mocha': ^9.1.1
       '@types/uuid': ^9.0.2
       c8: ^8.0.1
@@ -9465,7 +9466,6 @@ importers:
       moment: ^2.21.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
-      sorted-btree: ^1.8.0
       tsc-multi: ^1.1.0
       typescript: ~5.1.6
       uuid: ^9.0.0
@@ -9474,7 +9474,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
       '@fluidframework/core-utils': link:../../common/core-utils
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
-      sorted-btree: 1.8.1
+      '@tylerbu/sorted-btree-es6': 1.8.0
       uuid: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
@@ -21703,6 +21703,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@tylerbu/sorted-btree-es6/1.8.0:
+    resolution: {integrity: sha512-qkwgE0G5OGn7F+1fMkFZLwyjc99xCy4kmQ8p7N0Jj540HD6xU0jTPjcqELogH4f5YGMPXLqd8sQ7uOYC0QRBeg==}
+    dev: false
 
   /@types/argparse/1.0.38:
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -40712,6 +40716,7 @@ packages:
 
   /sorted-btree/1.8.1:
     resolution: {integrity: sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ==}
+    dev: true
 
   /source-list-map/2.0.1:
     resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}


### PR DESCRIPTION
## Description

References a forked version of the sorted-btree packages which is importable from ESM files without errors. See relevant [README comments](https://www.npmjs.com/package/@tylerbu/sorted-btree-es6#this-is-a-fork).

Longer-term, we'd like to upstream some changes to make the package usable in this context without breaking ES5 compat.
