### PR TITLE
Decrease pipeline timeout back to 60 minutes

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -166,7 +166,17 @@ stages:
       # Job - Build
       - job: build
         displayName: Build
-        timeoutInMinutes: 90
+        ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+          timeoutInMinutes: 60
+        ${{ else }}:
+          # CI builds run more aggressive compat configurations which can take longer.
+          # See "FullCompat" under packages\test\test-version-utils\README.md for more details.
+          # At the time of adding this comment, the full compat config is on the smaller side and so
+          # CI builds consistently pass with a 60 minutes timeout. However, it will naturally grow
+          # over time and it might be necessary to bump it.
+          # AB#6680 is also relevant here, which tracks rethinking how and where we run tests (likely with
+          # a focus on e2e tests)
+          timeoutInMinutes: 60
         pool: ${{ parameters.poolBuild }}
         variables:
           testCoverage: ${{ ne(variables['Build.Reason'], 'PullRequest') }}


### PR DESCRIPTION
## Description

Reverts the timeout increase implemented in #18831 and add some notes for posterity on when we might need to bump it again.

The bulk of the reason for this increase was increased numbers of e2e full compat tests running. This is dependent on number of previous major/minor/etc versions that we test against, which was reduced with the upcoming release candidate changes (we don't test the current build against all of 2.0.0-internal.x.0.0, just some of it).