### PR TITLE
refactor(build-cli): Handle exports fields in `release setPackageTypesField`

### DIFF
--- a/build-tools/packages/build-cli/docs/release.md
+++ b/build-tools/packages/build-cli/docs/release.md
@@ -238,7 +238,7 @@ _See code: [src/commands/release/report-unreleased.ts](https://github.com/micros
 
 ## `flub release setPackageTypesField`
 
-Updates which .d.ts file is referenced by the `types` field in package.json. This command is used during package publishing (by CI) to select the d.ts file which corresponds to the selected API-Extractor release tag.
+Updates which .d.ts file is referenced by the `types` or `exports` fields in package.json. This command is used during package publishing (by CI) to select the d.ts file which corresponds to the selected API-Extractor release tag.
 
 ```
 USAGE
@@ -282,8 +282,8 @@ PACKAGE FILTER FLAGS
                           excluded. Cannot be used with --scope.
 
 DESCRIPTION
-  Updates which .d.ts file is referenced by the `types` field in package.json. This command is used during package
-  publishing (by CI) to select the d.ts file which corresponds to the selected API-Extractor release tag.
+  Updates which .d.ts file is referenced by the `types` or `exports` fields in package.json. This command is used during
+  package publishing (by CI) to select the d.ts file which corresponds to the selected API-Extractor release tag.
 ```
 
 _See code: [src/commands/release/setPackageTypesField.ts](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/src/commands/release/setPackageTypesField.ts)_

--- a/build-tools/packages/build-cli/src/commands/release/setPackageTypesField.ts
+++ b/build-tools/packages/build-cli/src/commands/release/setPackageTypesField.ts
@@ -7,8 +7,9 @@ import { Package, updatePackageJsonFile, PackageJson } from "@fluidframework/bui
 import { PackageCommand } from "../../BasePackageCommand";
 import { ExtractorConfig } from "@microsoft/api-extractor";
 import { CommandLogger } from "../../logging";
-import path from "node:path";
+import path from "node:path/posix";
 import { strict as assert } from "node:assert";
+import { existsSync } from "node:fs";
 
 /**
  * Represents a list of package categorized into two arrays
@@ -37,7 +38,7 @@ export default class SetReleaseTagPublishingCommand extends PackageCommand<
 	typeof SetReleaseTagPublishingCommand
 > {
 	static readonly description =
-		"Updates which .d.ts file is referenced by the `types` field in package.json. This command is used during package publishing (by CI) to select the d.ts file which corresponds to the selected API-Extractor release tag.";
+		"Updates which .d.ts file is referenced by the `types` or `exports` fields in package.json. This command is used during package publishing (by CI) to select the d.ts file which corresponds to the selected API-Extractor release tag.";
 
 	static readonly enableJsonFlag = true;
 
@@ -66,16 +67,19 @@ export default class SetReleaseTagPublishingCommand extends PackageCommand<
 	};
 
 	protected async processPackage(pkg: Package): Promise<void> {
-		const configOptions = ExtractorConfig.tryLoadForFolder({
+		const apiExtractorFoundConfig = ExtractorConfig.tryLoadForFolder({
 			startingFolder: pkg.directory,
 		});
 
-		if (configOptions === undefined) {
+		if (apiExtractorFoundConfig === undefined) {
 			this.verbose(`No api-extractor config found for ${pkg.name}. Skipping.`);
 			return;
 		}
 
-		updatePackageJsonFile(pkg.directory, (json) => {
+		const esmConfigFileName = path.join(pkg.directory, "api-extractor-esm.json");
+
+		updatePackageJsonFile(pkg.directory, (json: PackageJson) => {
+			// Handle the types/typings fields
 			if (json.types !== undefined && json.typings !== undefined) {
 				throw new Error(
 					"Both 'types' and 'typings' fields are defined in the package.json. Only one should be used.",
@@ -84,25 +88,31 @@ export default class SetReleaseTagPublishingCommand extends PackageCommand<
 
 			const types: string | undefined = json.types ?? json.typings;
 
-			if (types === undefined) {
+			if (types === undefined && json.exports === undefined) {
 				throw new Error(
-					"Neither 'types' nor 'typings' field is defined in the package.json.",
+					"Neither 'types', 'typings', or 'exports' field is defined in the package.json.",
 				);
 			}
 
 			/**
-			 * When preparing the configuration object, folder and file paths referenced in the configuration are checked for existence,
-			 * and an error is reported if they are not found.
+			 * When preparing the configuration object, paths referenced in the configuration are resolved and checked for
+			 * existence, and an error is thrown if they are not found.
 			 */
-			const extractorConfig = ExtractorConfig.prepare({
-				...configOptions,
+			const apiExtractorConfig = ExtractorConfig.prepare({
+				...apiExtractorFoundConfig,
 				ignoreMissingEntryPoint: !this.flags.checkFileExists,
 			});
+
+			const apiExtractorEsm = existsSync(esmConfigFileName)
+				? ExtractorConfig.loadFileAndPrepare(esmConfigFileName)
+				: undefined;
+
 			assert(this.flags.types !== undefined, "--types flag must be provided.");
 
 			const packageUpdated = updatePackageJsonTypes(
 				pkg.directory,
-				extractorConfig,
+				apiExtractorConfig,
+				apiExtractorEsm,
 				this.flags.types,
 				json,
 				this.logger,
@@ -129,51 +139,99 @@ export default class SetReleaseTagPublishingCommand extends PackageCommand<
 }
 
 /**
- * Updates the types/typing field in package.json.
+ * Updates the types/exports field in package.json.
  * @returns true if the update was successful, false otherwise.
  */
+// eslint-disable-next-line max-params
 function updatePackageJsonTypes(
 	directory: string,
-	extractorConfig: ExtractorConfig,
-	dTsType: DtsKind,
+	defaultConfig: ExtractorConfig,
+	esmConfig: ExtractorConfig | undefined,
+	dtsKind: DtsKind,
 	json: PackageJson,
 	log: CommandLogger,
 ): boolean {
 	try {
-		if (extractorConfig.rollupEnabled === true) {
-			let filePath = "";
+		// If there's a typings field, delete it - we're replacing it.
+		delete json.typings;
 
-			switch (dTsType) {
-				case "alpha": {
-					filePath = extractorConfig.alphaTrimmedFilePath;
-					break;
-				}
-				case "beta": {
-					filePath = extractorConfig.betaTrimmedFilePath;
-					break;
-				}
-				case "public": {
-					filePath = extractorConfig.publicTrimmedFilePath;
-					break;
-				}
-				case "untrimmed": {
-					filePath = extractorConfig.untrimmedFilePath;
-					break;
-				}
-				default: {
-					log.errorLog(`${dTsType} is not a valid value.`);
-					break;
-				}
-			}
+		writeTypes(json, "cjs", path.relative(directory, getPathsToTypes(defaultConfig, dtsKind)));
 
-			if (filePath) {
-				delete json.typings;
-				json.types = path.relative(directory, filePath);
-				return true;
-			}
+		if (esmConfig !== undefined) {
+			writeTypes(json, "esm", path.relative(directory, getPathsToTypes(esmConfig, dtsKind)));
 		}
-	} catch {
-		log.verbose(`Unable to update types: ${JSON.stringify(extractorConfig.projectFolder)}`);
+		return true;
+	} catch (error: unknown) {
+		log.errorLog(error as Error);
 	}
 	return false;
+}
+
+function getPathsToTypes(config: ExtractorConfig, dtsType: DtsKind): string {
+	switch (dtsType) {
+		case "alpha": {
+			return config.alphaTrimmedFilePath;
+		}
+		case "beta": {
+			return config.betaTrimmedFilePath;
+		}
+		case "public": {
+			return config.publicTrimmedFilePath;
+		}
+		case "untrimmed": {
+			return config.untrimmedFilePath;
+		}
+		default: {
+			throw new Error(`${dtsType} is not a valid value.`);
+		}
+	}
+}
+
+/**
+ * Normalizes a relative path value so it has a leading './'
+ *
+ * @remarks
+ *
+ * Does not work with absolute paths.
+ */
+function normalizePathField(pathIn: string): string {
+	if (pathIn === "" || pathIn === undefined) {
+		throw new Error(`Invalid path!`);
+	}
+	if (pathIn.startsWith("./")) {
+		return pathIn;
+	}
+	return `./${pathIn}`;
+}
+
+function writeTypes(json: PackageJson, moduleKind: "cjs" | "esm", typesPath: string): void {
+	if (moduleKind === "cjs" && json.types !== undefined) {
+		json.types = typesPath;
+	}
+	if (json.exports === undefined) {
+		return;
+	}
+	// The PackageJson.Exports type complains that "." is not a valid indexer, so it's casted to any to
+	// work around.
+	/* eslint-disable @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment */
+	const rootExport = (json.exports as any)["."];
+	if (rootExport?.types !== undefined) {
+		rootExport.types = normalizePathField(typesPath);
+	}
+
+	if (moduleKind === "cjs") {
+		if (rootExport?.types !== undefined) {
+			rootExport.types = normalizePathField(typesPath);
+		} else if (rootExport?.require !== undefined) {
+			rootExport.require.types = normalizePathField(typesPath);
+		} else if (rootExport?.default !== undefined) {
+			rootExport.default.types = normalizePathField(typesPath);
+		}
+		return;
+	}
+
+	if (moduleKind === "esm" && rootExport?.import !== undefined) {
+		rootExport.import.types = normalizePathField(typesPath);
+	}
+	/* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-assignment */
 }

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -651,7 +651,7 @@ packages:
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1_fw7rjau6lbmauwrvieqeq6x7va
+      ts-node: 10.9.1_typescript@5.1.6
       typescript: 5.1.6
     transitivePeerDependencies:
       - '@swc/core'
@@ -979,9 +979,9 @@ packages:
       '@typescript-eslint/eslint-plugin': 6.7.5_7bsjt2oldhesuugucsaij5mq2u
       '@typescript-eslint/parser': 6.7.5_zo5p53osjv3ha4sgr6kpvl7c7y
       eslint-config-prettier: 9.0.0_eslint@8.51.0
-      eslint-import-resolver-typescript: 3.6.1_qxhubfzaecdfxw3fbbwkggu7pu
+      eslint-import-resolver-typescript: 3.6.1_2ybkzcg7htzqsmycy3sgb343fu
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.51.0
-      eslint-plugin-import: /eslint-plugin-i/2.29.0_gbod4lt6ixhffmpnr3ca5mlrvu
+      eslint-plugin-import: /eslint-plugin-i/2.29.1_gbod4lt6ixhffmpnr3ca5mlrvu
       eslint-plugin-jsdoc: 46.8.2_eslint@8.51.0
       eslint-plugin-promise: 6.1.1_eslint@8.51.0
       eslint-plugin-react: 7.33.2_eslint@8.51.0
@@ -2036,7 +2036,7 @@ packages:
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
-      resolve: 1.22.1
+      resolve: 1.22.8
       semver: 7.3.8
       z-schema: 5.0.5
     dev: true
@@ -3496,7 +3496,7 @@ packages:
   /call-bind/1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
       get-intrinsic: 1.2.1
 
   /callsites/3.1.0:
@@ -4186,7 +4186,7 @@ packages:
     dependencies:
       '@types/node': 18.18.7
       cosmiconfig: 8.2.0
-      ts-node: 10.9.1_fw7rjau6lbmauwrvieqeq6x7va
+      ts-node: 10.9.1_typescript@5.1.6
       typescript: 5.1.6
     dev: true
 
@@ -4749,7 +4749,7 @@ packages:
       define-properties: 1.2.1
       es-abstract: 1.22.2
       es-set-tostringtag: 2.0.1
-      function-bind: 1.1.1
+      function-bind: 1.1.2
       get-intrinsic: 1.2.1
       globalthis: 1.0.3
       has-property-descriptors: 1.0.0
@@ -4851,7 +4851,7 @@ packages:
       '@typescript-eslint/parser': 6.9.0_zo5p53osjv3ha4sgr6kpvl7c7y
       eslint-config-xo-space: 0.34.0_eslint@8.51.0
       eslint-import-resolver-typescript: 3.6.1_pbj6t5jharto5fqavoeoqmeak4
-      eslint-plugin-import: 2.28.1_6g6nc5efqakvgerffobh6ybdam
+      eslint-plugin-import: 2.28.1_edr7onqlhv5m43sbcgkv7mj2nu
       eslint-plugin-mocha: 10.2.0_eslint@8.51.0
       eslint-plugin-node: 11.1.0_eslint@8.51.0
       eslint-plugin-perfectionist: 2.2.0_zo5p53osjv3ha4sgr6kpvl7c7y
@@ -4912,9 +4912,32 @@ packages:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
       debug: 3.2.7
-      is-core-module: 2.13.0
+      is-core-module: 2.13.1
       resolve: 1.22.8
     transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-import-resolver-typescript/3.6.1_2ybkzcg7htzqsmycy3sgb343fu:
+    resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+    dependencies:
+      debug: 4.3.4
+      enhanced-resolve: 5.15.0
+      eslint: 8.51.0
+      eslint-module-utils: 2.8.0_gbod4lt6ixhffmpnr3ca5mlrvu
+      eslint-plugin-import: /eslint-plugin-i/2.29.1_gbod4lt6ixhffmpnr3ca5mlrvu
+      fast-glob: 3.3.1
+      get-tsconfig: 4.7.2
+      is-core-module: 2.13.0
+      is-glob: 4.0.3
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-node
+      - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
@@ -4929,30 +4952,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.51.0
       eslint-module-utils: 2.8.0_6g6nc5efqakvgerffobh6ybdam
-      eslint-plugin-import: 2.28.1_6g6nc5efqakvgerffobh6ybdam
-      fast-glob: 3.3.1
-      get-tsconfig: 4.7.2
-      is-core-module: 2.13.0
-      is-glob: 4.0.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-import-resolver-typescript/3.6.1_qxhubfzaecdfxw3fbbwkggu7pu:
-    resolution: {integrity: sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      eslint-plugin-import: '*'
-    dependencies:
-      debug: 4.3.4
-      enhanced-resolve: 5.15.0
-      eslint: 8.51.0
-      eslint-module-utils: 2.8.0_gbod4lt6ixhffmpnr3ca5mlrvu
-      eslint-plugin-import: /eslint-plugin-i/2.29.0_gbod4lt6ixhffmpnr3ca5mlrvu
+      eslint-plugin-import: 2.28.1_edr7onqlhv5m43sbcgkv7mj2nu
       fast-glob: 3.3.1
       get-tsconfig: 4.7.2
       is-core-module: 2.13.0
@@ -5018,37 +5018,7 @@ packages:
       debug: 3.2.7
       eslint: 8.51.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1_qxhubfzaecdfxw3fbbwkggu7pu
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-module-utils/2.8.0_fnekaoqwpncfjjv5gz5axhcdmi:
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 6.9.0_zo5p53osjv3ha4sgr6kpvl7c7y
-      debug: 3.2.7
-      eslint: 8.51.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1_pbj6t5jharto5fqavoeoqmeak4
+      eslint-import-resolver-typescript: 3.6.1_2ybkzcg7htzqsmycy3sgb343fu
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5077,7 +5047,36 @@ packages:
       '@typescript-eslint/parser': 6.7.5_zo5p53osjv3ha4sgr6kpvl7c7y
       debug: 3.2.7
       eslint: 8.51.0
-      eslint-import-resolver-typescript: 3.6.1_qxhubfzaecdfxw3fbbwkggu7pu
+      eslint-import-resolver-typescript: 3.6.1_2ybkzcg7htzqsmycy3sgb343fu
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils/2.8.0_qwmwxdcaohwfxrln64eehfn3xi:
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.9.0_zo5p53osjv3ha4sgr6kpvl7c7y
+      debug: 3.2.7
+      eslint: 8.51.0
+      eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5104,21 +5103,20 @@ packages:
       ignore: 5.2.4
     dev: true
 
-  /eslint-plugin-i/2.29.0_gbod4lt6ixhffmpnr3ca5mlrvu:
-    resolution: {integrity: sha512-slGeTS3GQzx9267wLJnNYNO8X9EHGsc75AKIAFvnvMYEcTJKotPKL1Ru5PIGVHIVet+2DsugePWp8Oxpx8G22w==}
+  /eslint-plugin-i/2.29.1_gbod4lt6ixhffmpnr3ca5mlrvu:
+    resolution: {integrity: sha512-ORizX37MelIWLbMyqI7hi8VJMf7A0CskMmYkB+lkCX3aF4pkGV7kwx5bSEb4qx7Yce2rAf9s34HqDRPjGRZPNQ==}
     engines: {node: '>=12'}
     peerDependencies:
       eslint: ^7.2.0 || ^8 || 8.51.0
     dependencies:
-      debug: 3.2.7
-      doctrine: 2.1.0
+      debug: 4.3.4
+      doctrine: 3.0.0
       eslint: 8.51.0
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.8.0_7p7cyxr7f6dpdhk7sdropijope
       get-tsconfig: 4.7.2
       is-glob: 4.0.3
       minimatch: 3.1.2
-      resolve: 1.22.8
       semver: 7.5.4
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -5127,7 +5125,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import/2.28.1_6g6nc5efqakvgerffobh6ybdam:
+  /eslint-plugin-import/2.28.1_edr7onqlhv5m43sbcgkv7mj2nu:
     resolution: {integrity: sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5146,9 +5144,9 @@ packages:
       doctrine: 2.1.0
       eslint: 8.51.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0_fnekaoqwpncfjjv5gz5axhcdmi
+      eslint-module-utils: 2.8.0_qwmwxdcaohwfxrln64eehfn3xi
       has: 1.0.3
-      is-core-module: 2.13.0
+      is-core-module: 2.13.1
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.fromentries: 2.0.7
@@ -5840,8 +5838,8 @@ packages:
     dev: true
     optional: true
 
-  /function-bind/1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+  /function-bind/1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   /function.prototype.name/1.1.6:
     resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
@@ -5895,7 +5893,7 @@ packages:
   /get-intrinsic/1.2.1:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
       has: 1.0.3
       has-proto: 1.0.1
       has-symbols: 1.0.3
@@ -6307,7 +6305,13 @@ packages:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
+
+  /hasown/2.0.0:
+    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
 
   /hasurl/1.0.0:
     resolution: {integrity: sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ==}
@@ -6663,6 +6667,11 @@ packages:
     resolution: {integrity: sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==}
     dependencies:
       has: 1.0.3
+
+  /is-core-module/2.13.1:
+    resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
+    dependencies:
+      hasown: 2.0.0
 
   /is-date-object/1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
@@ -8133,7 +8142,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      is-core-module: 2.13.0
+      is-core-module: 2.13.1
       semver: 7.5.4
       validate-npm-package-license: 3.0.4
 
@@ -8142,7 +8151,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       hosted-git-info: 6.1.1
-      is-core-module: 2.13.0
+      is-core-module: 2.13.1
       semver: 7.5.4
       validate-npm-package-license: 3.0.4
 
@@ -9464,14 +9473,14 @@ packages:
   /resolve/1.19.0:
     resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
     dependencies:
-      is-core-module: 2.13.0
+      is-core-module: 2.13.1
       path-parse: 1.0.7
 
   /resolve/1.22.1:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.13.0
+      is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -9487,7 +9496,7 @@ packages:
     resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==}
     hasBin: true
     dependencies:
-      is-core-module: 2.13.0
+      is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -10459,39 +10468,6 @@ packages:
       typescript: 5.1.6
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-
-  /ts-node/10.9.1_fw7rjau6lbmauwrvieqeq6x7va:
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-      '@types/node':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 18.18.7
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.1.6
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
 
   /ts-node/10.9.1_typescript@5.1.6:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}

--- a/packages/drivers/file-driver/api-extractor-esm.json
+++ b/packages/drivers/file-driver/api-extractor-esm.json
@@ -1,5 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-base-esm.json",
-	"mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts"
-}


### PR DESCRIPTION
The `release setPackageTypesField` command is used in our release pipeline to update the primary types a package declares at publish time, so we can publish beta and alpha-types versions.

The changes are primarily to update an exports field if it exists in addition to the `types` field. It assumes the "default" types are CJS - the logic will need to be adjusted if/when we start building ESM first.

If there is no ESM api-extractor config, no ESM types will be updated.

For example, given a package.json that looks like this:

```json
"types": "./dist/index.d.ts",
"exports": {
	".": {
		"import": {
			"types": "./lib/index.d.mts",
			"default": "./lib/index.mjs"
		},
		"require": {
			"types": "./dist/index.d.ts",
			"default": "./dist/index.js"
		}
	}
}
```

The `flub release setPackageTypesField --types alpha` command would change it to:

```json
"types": "./dist/tree-alpha.d.ts",
"exports": {
	".": {
		"import": {
			"types": "./lib/tree-alpha.d.mts",
			"default": "./lib/index.mjs"
		},
		"require": {
			"types": "./dist/tree-alpha.d.ts",
			"default": "./dist/index.js"
		}
	}
}
```

I put this together very quickly so there is no doubt room for improvement, and it doesn't handle all the possible forms an exports field could take. But it is sufficient for the forms we have in the repo at the time of writing.