### PR TITLE
remove user details from quorum members

### DIFF
--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -154,10 +154,27 @@ export class ProtocolOpHandler implements IProtocolHandler {
 	public getProtocolState(): IScribeProtocolState {
 		// return a new object every time
 		// this ensures future state changes will not affect outside callers
+
+		const snapshot = this._quorum.snapshot();
+
+		const quorumMembers = snapshot.members;
+
+		// Removing any identifying client information
+		quorumMembers.forEach((member) => {
+			member[1] = {
+				...member[1],
+				client: {
+					...member[1].client,
+					user: { id: "" },
+				},
+			};
+		});
+
 		return {
 			sequenceNumber: this.sequenceNumber,
 			minimumSequenceNumber: this.minimumSequenceNumber,
 			...this._quorum.snapshot(),
+			members: quorumMembers,
 		};
 	}
 }


### PR DESCRIPTION
Sets the user property of the IScribeProtocolState to null to remove this information from all checkpoints
This is so we do not store any personably identifiable information stored with the metadata in our checkpoints