### PR TITLE
Remove initialSummary and throwOnFailure from summarizer nodes

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1411,9 +1411,6 @@ export class ContainerRuntime
 				// Must set to false to prevent sending summary handle which would be pointing to
 				// a summary with an older protocol state.
 				canReuseHandle: false,
-				// Must set to true to throw on any data stores failure that was too severe to be handled.
-				// We also are not decoding the base summaries at the root.
-				throwOnFailure: true,
 				// If GC should not run, let the summarizer node know so that it does not track GC state.
 				gcDisabled: !this.garbageCollector.shouldRunGC,
 			},

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -948,8 +948,7 @@ export abstract class FluidDataStoreContext
 				summarizeInternal,
 				id,
 				createParam,
-				// DDS will not create failure summaries
-				{ throwOnFailure: true },
+				undefined /* config */,
 				getGCDataFn,
 			);
 	}

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
@@ -4,8 +4,8 @@
  */
 
 import { ITelemetryLoggerExt, TelemetryDataTag } from "@fluidframework/telemetry-utils";
-import { ISnapshotTree, ISummaryTree, SummaryObject } from "@fluidframework/protocol-definitions";
-import { channelsTreeName, ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
+import { ISnapshotTree, SummaryObject } from "@fluidframework/protocol-definitions";
+import { channelsTreeName } from "@fluidframework/runtime-definitions";
 
 export interface IRefreshSummaryResult {
 	/** Tells whether this summary is tracked by this client. */
@@ -136,20 +136,9 @@ export class SummaryNode {
 }
 
 /**
- * Information about the initial summary tree found from an attach op.
- */
-export interface IInitialSummary {
-	sequenceNumber: number;
-	id: string;
-	summary: ISummaryTreeWithStats | undefined;
-}
-
-/**
  * Represents the details needed to create a child summarizer node.
  */
 export interface ICreateChildDetails {
-	/** Summary from attach op if known */
-	initialSummary: IInitialSummary | undefined;
 	/** Latest summary from server node data */
 	latestSummary: SummaryNode | undefined;
 	/** Sequence number of latest known change to the node */
@@ -181,26 +170,6 @@ export function parseSummaryForSubtrees(baseSummary: ISnapshotTree): ISubtreeInf
 	}
 	return {
 		childrenTree: baseSummary,
-		childrenPathPart: undefined,
-	};
-}
-
-/**
- * Checks if the summary contains .channels subtree where the children subtrees
- * would be located if exists.
- * @param baseSummary - summary to check
- */
-export function parseSummaryTreeForSubtrees(summary: ISummaryTree): ISubtreeInfo<SummaryObject> {
-	// New versions of snapshots have child nodes isolated in .channels subtree
-	const channelsSubtree = summary.tree[channelsTreeName];
-	if (channelsSubtree !== undefined) {
-		return {
-			childrenTree: channelsSubtree,
-			childrenPathPart: channelsTreeName,
-		};
-	}
-	return {
-		childrenTree: summary,
 		childrenPathPart: undefined,
 	};
 }

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -29,7 +29,6 @@ import { SummarizerNode } from "./summarizerNode";
 import {
 	EscapedPath,
 	ICreateChildDetails,
-	IInitialSummary,
 	ISummarizerNodeRootContract,
 	SummaryNode,
 	ValidateSummaryResult,
@@ -111,7 +110,6 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 		changeSequenceNumber: number,
 		/** Undefined means created without summary */
 		latestSummary?: SummaryNode,
-		initialSummary?: IInitialSummary,
 		wipSummaryLogger?: ITelemetryBaseLogger,
 		private readonly getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
 		getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
@@ -135,7 +133,6 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			config,
 			changeSequenceNumber,
 			latestSummary,
-			initialSummary,
 			wipSummaryLogger,
 			telemetryId,
 		);
@@ -398,7 +395,6 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 		createParam: CreateChildSummarizerNodeParam,
 		config: ISummarizerNodeConfigWithGC = {},
 		getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-		getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
 	): ISummarizerNodeWithGC {
 		assert(!this.children.has(id), 0x1b6 /* "Create SummarizerNode child already exists" */);
 		/**
@@ -423,7 +419,6 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			},
 			createDetails.changeSequenceNumber,
 			createDetails.latestSummary,
-			createDetails.initialSummary,
 			this.wipSummaryLogger,
 			getGCDataFn,
 			getChildBaseGCDetailsFn,
@@ -563,7 +558,6 @@ export const createRootSummarizerNodeWithGC = (
 		referenceSequenceNumber === undefined
 			? undefined
 			: SummaryNode.createForRoot(referenceSequenceNumber),
-		undefined /* initialSummary */,
 		undefined /* wipSummaryLogger */,
 		getGCDataFn,
 		getBaseGCDetailsFn,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -120,8 +120,7 @@ describe("Data Store Context Tests", () => {
 					summarizeInternal,
 					dataStoreId,
 					{ type: CreateSummarizerNodeSource.Local },
-					// DDS will not create failure summaries
-					{ throwOnFailure: true },
+					undefined,
 					getGCDataFn,
 				);
 			containerRuntime = createContainerRuntime();
@@ -1071,8 +1070,7 @@ describe("Data Store Context Tests", () => {
 					summarizeInternal,
 					dataStoreId,
 					{ type: CreateSummarizerNodeSource.Local },
-					// DDS will not create failure summaries
-					{ throwOnFailure: true },
+					undefined,
 					getGCDataFn,
 				);
 

--- a/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
@@ -175,17 +175,6 @@ describe("Runtime", () => {
 			});
 
 			describe("Create Child", () => {
-				it("Should fail to create child from summary if parent does not have summary", () => {
-					createRoot();
-					expectThrow(
-						() => createMid({ type: CreateSummarizerNodeSource.FromSummary }),
-						"create child",
-						"no parent summary",
-						"0x1ac",
-					);
-					assert(midNode === undefined, "should not be created");
-				});
-
 				it("Should fail to create child with same id", () => {
 					createRoot();
 					createMid({ type: CreateSummarizerNodeSource.Local });

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -369,7 +369,6 @@ export interface ISummarizerNode {
 // @alpha (undocumented)
 export interface ISummarizerNodeConfig {
     readonly canReuseHandle?: boolean;
-    readonly throwOnFailure?: true;
 }
 
 // @alpha (undocumented)

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -125,16 +125,6 @@ export interface ISummarizerNodeConfig {
 	 * Defaults to true.
 	 */
 	readonly canReuseHandle?: boolean;
-	/**
-	 * True to always stop execution on error during summarize, or false to
-	 * attempt creating a summary that is a pointer ot the last acked summary
-	 * plus outstanding ops in case of internal summarize failure.
-	 * Defaults to false.
-	 *
-	 * BUG BUG: Default to true while we investigate problem
-	 * with differential summaries
-	 */
-	readonly throwOnFailure?: true;
 }
 
 /**
@@ -187,9 +177,6 @@ export interface ISummarizerNode {
 	invalidate(sequenceNumber: number): void;
 	/**
 	 * Calls the internal summarize function and handles internal state tracking.
-	 * If unchanged and fullTree is false, it will reuse previous summary subtree.
-	 * If an error is encountered and throwOnFailure is false, it will try to make
-	 * a summary with a pointer to the previous summary + a blob of outstanding ops.
 	 * @param fullTree - true to skip optimizations and always generate the full tree
 	 * @param trackState - indicates whether the summarizer node should track the state of the summary or not
 	 * @param telemetryContext - summary data passed through the layers for telemetry purposes


### PR DESCRIPTION
`initialSummary` and `throwOnFailure` are no longer used by summarizer node. Removing them and the logic around them.

[AB#3738](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3738)