### PR TITLE
Added tests to validate that incremental summary works correctly

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/incrementalSummaryContext.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/incrementalSummaryContext.spec.ts
@@ -11,6 +11,7 @@ import {
 	IExperimentalIncrementalSummaryContext,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
+	channelsTreeName,
 } from "@fluidframework/runtime-definitions";
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
 import {
@@ -510,7 +511,7 @@ describeCompat(
 		) {
 			// The handle id for sub-DDS should be under ".channels/<dataStoreId>/.channels/<ddsId>" as that is where
 			// the summary tree for a sub-DDS is.
-			const expectedHandleId = `/.channels/${dataStoreId}/.channels/${ddsId}/${subDDSId}`;
+			const expectedHandleId = `/${channelsTreeName}/${dataStoreId}/${channelsTreeName}/${ddsId}/${subDDSId}`;
 			assert.strictEqual(summaryObject.type, SummaryType.Handle, message);
 			assert.strictEqual(summaryObject.handle, expectedHandleId, message);
 		}

--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
@@ -92,6 +92,10 @@ function validateDDSStateInSummary(
 	assert.strictEqual(ddsSummaryObject.handle, expectedHandleId, "DDS handle is incorrect");
 }
 
+/**
+ * These tests validate that data stores and DDSes do incremental summaries correctly, i.e., if the data
+ * in it does not change, it summaries using a SummaryHandle and not a SummaryTree.
+ */
 describeCompat(
 	"Incremental summaries for data store and DDS",
 	"FullCompat",

--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
@@ -1,0 +1,245 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
+import { IContainerRuntimeBase, channelsTreeName } from "@fluidframework/runtime-definitions";
+import {
+	ITestObjectProvider,
+	createSummarizer,
+	getContainerEntryPointBackCompat,
+	summarizeNow,
+	waitForContainerConnection,
+} from "@fluidframework/test-utils";
+import {
+	ITestDataObject,
+	TestDataObjectType,
+	describeCompat,
+} from "@fluid-private/test-version-utils";
+import { IContainer } from "@fluidframework/container-definitions";
+import { ISummarizer } from "@fluidframework/container-runtime";
+
+/**
+ * Validates that the data store summary is as expected.
+ * If expectHandle is false, the data store summary should be a tree.
+ * If expectHandle is true, the data store summary should be a handle and the handle id should be correct.
+ */
+function validateDataStoreStateInSummary(
+	summaryTree: ISummaryTree,
+	dataStoreId: string,
+	expectHandle: boolean,
+) {
+	const channelsTree = (summaryTree.tree[channelsTreeName] as ISummaryTree).tree;
+	const dataStoreSummaryObject = channelsTree[dataStoreId];
+
+	if (!expectHandle) {
+		assert.strictEqual(
+			dataStoreSummaryObject.type,
+			SummaryType.Tree,
+			"Data store summary should be a tree",
+		);
+		return;
+	}
+
+	// The handle id for data store should be under ".channels" as that is where the summary tree
+	// for a data store is.
+	const expectedHandleId = `/.channels/${dataStoreId}`;
+	assert.strictEqual(
+		dataStoreSummaryObject.type,
+		SummaryType.Handle,
+		"Data store summary should be a handle",
+	);
+	assert.strictEqual(
+		dataStoreSummaryObject.handle,
+		expectedHandleId,
+		"Data store handle is incorrect",
+	);
+}
+
+/**
+ * Validates that the DDS summary is as expected.
+ * If expectHandle is false, the DDS summary should be a tree.
+ * If expectHandle is true, the DDS summary should be a handle and the handle id should be correct.
+ */
+function validateDDSStateInSummary(
+	summaryTree: ISummaryTree,
+	dataStoreId: string,
+	ddsId: string,
+	expectHandle: boolean,
+) {
+	const dataStoreChannelsTree = (summaryTree.tree[channelsTreeName] as ISummaryTree).tree;
+	const dataStoreSummaryTree = dataStoreChannelsTree[dataStoreId];
+	assert.strictEqual(
+		dataStoreSummaryTree.type,
+		SummaryType.Tree,
+		"Data store summary should be a tree",
+	);
+
+	const ddsChannelsTree = (dataStoreSummaryTree.tree[channelsTreeName] as ISummaryTree).tree;
+	const ddsSummaryObject = ddsChannelsTree[ddsId];
+
+	if (!expectHandle) {
+		assert.strictEqual(ddsSummaryObject.type, SummaryType.Tree, "DDS summary should be a tree");
+		return;
+	}
+
+	// The handle id for DDS should be under ".channels/<dataStoreId>/.channels" as that is where the summary tree
+	// for a DDS is.
+	const expectedHandleId = `/.channels/${dataStoreId}/.channels/${ddsId}`;
+	assert.strictEqual(ddsSummaryObject.type, SummaryType.Handle, "DDS summary should be a handle");
+	assert.strictEqual(ddsSummaryObject.handle, expectedHandleId, "DDS handle is incorrect");
+}
+
+describeCompat(
+	"Incremental summaries for data store and DDS",
+	"FullCompat",
+	(getTestObjectProvider, apis) => {
+		const { SharedDirectory } = apis.dds;
+		let provider: ITestObjectProvider;
+		let container: IContainer;
+		let dataObject1: ITestDataObject;
+		let containerRuntime: IContainerRuntimeBase;
+		let summarizer: ISummarizer;
+
+		beforeEach(async function () {
+			provider = getTestObjectProvider({ syncSummarizer: true });
+			if (provider.driver.type !== "local") {
+				this.skip();
+			}
+			container = await provider.makeTestContainer();
+			dataObject1 = await getContainerEntryPointBackCompat(container);
+			containerRuntime = dataObject1._context.containerRuntime;
+			await waitForContainerConnection(container);
+
+			summarizer = (await createSummarizer(provider, container)).summarizer;
+		});
+
+		it("can do incremental data store summary", async () => {
+			const dataStore2 = await containerRuntime.createDataStore(TestDataObjectType);
+			const dataObject2 = (await dataStore2.entryPoint.get()) as ITestDataObject;
+			dataObject1._root.set("dataObject2", dataStore2.entryPoint);
+
+			await provider.ensureSynchronized();
+			let summary = await summarizeNow(summarizer);
+			// Both data stores should be summarized as trees since they both changed since last summary.
+			validateDataStoreStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				false /* expectHandle */,
+			);
+			validateDataStoreStateInSummary(
+				summary.summaryTree,
+				dataObject2._context.id,
+				false /* expectHandle */,
+			);
+
+			await provider.ensureSynchronized();
+			summary = await summarizeNow(summarizer);
+			// Both data stores should be summarized as handles since they didn't change.
+			validateDataStoreStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				true /* expectHandle */,
+			);
+			validateDataStoreStateInSummary(
+				summary.summaryTree,
+				dataObject2._context.id,
+				true /* expectHandle */,
+			);
+
+			dataObject1._root.set("key", "value");
+			await provider.ensureSynchronized();
+			summary = await summarizeNow(summarizer);
+			// Data store 1 should be summarized as a tree since it changed (sent an op).
+			// Data store 2 should be summarized as a handle since it did not change.
+			validateDataStoreStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				false /* expectHandle */,
+			);
+			validateDataStoreStateInSummary(
+				summary.summaryTree,
+				dataObject2._context.id,
+				true /* expectHandle */,
+			);
+		});
+
+		it("can do incremental dds summary", async () => {
+			const directory2 = SharedDirectory.create(dataObject1._runtime);
+			dataObject1._root.set("directory2", directory2.handle);
+
+			const directory3 = SharedDirectory.create(dataObject1._runtime);
+			dataObject1._root.set("directory3", directory3.handle);
+
+			await provider.ensureSynchronized();
+			let summary = await summarizeNow(summarizer);
+			// All 3 DDSes should be summarized as trees because they all changed since last summary.
+			validateDDSStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				dataObject1._root.id,
+				false /* expectHandle */,
+			);
+			validateDDSStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				directory2.id,
+				false /* expectHandle */,
+			);
+			validateDDSStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				directory3.id,
+				false /* expectHandle */,
+			);
+
+			directory3.set("key", "value");
+			await provider.ensureSynchronized();
+			summary = await summarizeNow(summarizer);
+			// Only DDS 3 should be summarized as tree since it changed (sent an op). The rest should be trees.
+			validateDDSStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				dataObject1._root.id,
+				true /* expectHandle */,
+			);
+			validateDDSStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				directory2.id,
+				true /* expectHandle */,
+			);
+			validateDDSStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				directory3.id,
+				false /* expectHandle */,
+			);
+
+			dataObject1._root.set("key", "value");
+			await provider.ensureSynchronized();
+			summary = await summarizeNow(summarizer);
+			// Only DDS 1 should be summarized as tree since it changed (sent an op). The rest should be trees.
+			validateDDSStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				dataObject1._root.id,
+				false /* expectHandle */,
+			);
+			validateDDSStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				directory2.id,
+				true /* expectHandle */,
+			);
+			validateDDSStateInSummary(
+				summary.summaryTree,
+				dataObject1._context.id,
+				directory3.id,
+				true /* expectHandle */,
+			);
+		});
+	},
+);

--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
@@ -45,7 +45,7 @@ function validateDataStoreStateInSummary(
 
 	// The handle id for data store should be under ".channels" as that is where the summary tree
 	// for a data store is.
-	const expectedHandleId = `/.channels/${dataStoreId}`;
+	const expectedHandleId = `/${channelsTreeName}/${dataStoreId}`;
 	assert.strictEqual(
 		dataStoreSummaryObject.type,
 		SummaryType.Handle,
@@ -87,7 +87,7 @@ function validateDDSStateInSummary(
 
 	// The handle id for DDS should be under ".channels/<dataStoreId>/.channels" as that is where the summary tree
 	// for a DDS is.
-	const expectedHandleId = `/.channels/${dataStoreId}/.channels/${ddsId}`;
+	const expectedHandleId = `/${channelsTreeName}/${dataStoreId}/${channelsTreeName}/${ddsId}`;
 	assert.strictEqual(ddsSummaryObject.type, SummaryType.Handle, "DDS summary should be a handle");
 	assert.strictEqual(ddsSummaryObject.handle, expectedHandleId, "DDS handle is incorrect");
 }

--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementallySubDds.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementallySubDds.spec.ts
@@ -454,7 +454,8 @@ class TestIncrementalSummaryTreeDDS extends SharedObject {
 }
 
 /**
- * Validates that incremental summaries can be created at the sub DDS level
+ * Validates that incremental summaries can be performed at the sub DDS level, i.e., a DDS can summarizer its
+ * contents incrementally.
  */
 describeCompat(
 	"Incremental summaries can be generated for DDSes",
@@ -502,18 +503,29 @@ describeCompat(
 			return createSummarizerResult.summarizer;
 		}
 
+		/**
+		 * Validates that the passed summaryObject is a summary handle. Also, the handle id is correct.
+		 */
 		function validateHandle(
 			summaryObject: SummaryObject,
 			dataStoreId: string,
 			ddsId: string,
 			subDDSId: string,
-			message: string,
+			messagePrefix: string,
 		) {
 			// The handle id for sub-DDS should be under ".channels/<dataStoreId>/.channels/<ddsId>" as that is where
 			// the summary tree for a sub-DDS is.
 			const expectedHandleId = `/${channelsTreeName}/${dataStoreId}/${channelsTreeName}/${ddsId}/${subDDSId}`;
-			assert.strictEqual(summaryObject.type, SummaryType.Handle, message);
-			assert.strictEqual(summaryObject.handle, expectedHandleId, message);
+			assert.strictEqual(
+				summaryObject.type,
+				SummaryType.Handle,
+				`${messagePrefix} should be a handle`,
+			);
+			assert.strictEqual(
+				summaryObject.handle,
+				expectedHandleId,
+				`${messagePrefix}'s handle id is incorrect`,
+			);
 		}
 
 		beforeEach(async () => {
@@ -559,27 +571,9 @@ describeCompat(
 			);
 			const ddsTree = dataObjectChannelsTree.tree[dds.id];
 			assert(ddsTree.type === SummaryType.Tree, "Blob dds tree not created");
-			validateHandle(
-				ddsTree.tree["0"],
-				datastore.context.id,
-				dds.id,
-				"0",
-				"Blob 0 handle is incorrect",
-			);
-			validateHandle(
-				ddsTree.tree["1"],
-				datastore.context.id,
-				dds.id,
-				"1",
-				"Blob 1 handle is incorrect",
-			);
-			validateHandle(
-				ddsTree.tree["2"],
-				datastore.context.id,
-				dds.id,
-				"2",
-				"Blob 2 handle is incorrect",
-			);
+			validateHandle(ddsTree.tree["0"], datastore.context.id, dds.id, "0", "Blob 0");
+			validateHandle(ddsTree.tree["1"], datastore.context.id, dds.id, "1", "Blob 1");
+			validateHandle(ddsTree.tree["2"], datastore.context.id, dds.id, "2", "Blob 2");
 			assert(ddsTree.tree["3"].type === SummaryType.Blob, "Blob 3 should be a blob");
 		});
 
@@ -642,7 +636,7 @@ describeCompat(
 				datastore.context.id,
 				dds.id,
 				`${dds.rootNodeName}/a`,
-				"Summary1 - 'a' summary Handle is incorrect",
+				"Summary1 - 'a'",
 			);
 			assert(
 				rootNode.tree.b.type === SummaryType.Tree,
@@ -657,7 +651,7 @@ describeCompat(
 				datastore.context.id,
 				dds.id,
 				`${dds.rootNodeName}/c`,
-				"Summary1 - 'c' summary Handle is incorrect",
+				"Summary1 - 'c'",
 			);
 
 			// Test that we can load from multiple containers
@@ -707,14 +701,14 @@ describeCompat(
 				datastore.context.id,
 				dds.id,
 				`${dds.rootNodeName}/a`,
-				"Summary2 - 'a' summary Handle is incorrect",
+				"Summary2 - 'a'",
 			);
 			validateHandle(
 				rootNode2.tree.b,
 				datastore.context.id,
 				dds.id,
 				`${dds.rootNodeName}/b`,
-				"Summary1 - 'b' summary Handle is incorrect",
+				"Summary1 - 'b'",
 			);
 			assert(
 				rootNode2.tree.c.type === SummaryType.Tree,

--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementallySubDds.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementallySubDds.spec.ts
@@ -458,7 +458,7 @@ class TestIncrementalSummaryTreeDDS extends SharedObject {
  * contents incrementally.
  */
 describeCompat(
-	"Incremental summaries can be generated for DDSes",
+	"Incremental summaries can be generated for DDS content",
 	"NoCompat",
 	(getTestObjectProvider) => {
 		let provider: ITestObjectProvider;

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -13,9 +13,9 @@ import {
 } from "@fluidframework/container-runtime";
 import {
 	ITelemetryBaseLogger,
-	FluidObject,
 	IRequest,
 	IConfigProviderBase,
+	IResponse,
 } from "@fluidframework/core-interfaces";
 import { DriverHeader } from "@fluidframework/driver-definitions";
 import {
@@ -30,6 +30,28 @@ import { timeoutAwait } from "./timeoutUtils";
 import { createContainerRuntimeFactoryWithDefaultDataStore } from "./testContainerRuntimeFactoryWithDefaultDataStore";
 
 const summarizerClientType = "summarizer";
+
+/**
+ * This function should ONLY be used for back compat purposes
+ * LTS versions of the Loader/Container will not have the "getEntryPoint" method, so we need to fallback to "request"
+ * This function can be removed once LTS version of Loader moves to 2.0.0-internal.7.0.0
+ * @internal
+ */
+async function getSummarizerBackCompat(container: IContainer): Promise<ISummarizer> {
+	if (container.getEntryPoint !== undefined) {
+		const entryPoint = await container.getEntryPoint();
+		// Note: We need to also check if the result of `getEntryPoint()` is defined. This is because when running
+		// cross version compat testing scenarios, if we create with 1.X container and load with 2.X then the
+		// function container.getEntryPoint will be defined for the 2.X container. However, it will not return undefined
+		// since the container's runtime will be on version 1.X, which does not have an entry point defined.
+		if (entryPoint !== undefined) {
+			return entryPoint as ISummarizer;
+		}
+	}
+	const response: IResponse = await (container as any).request({ url: "_summarizer" });
+	assert(response.status === 200, "requesting '/' should return default data object");
+	return response.value as ISummarizer;
+}
 
 async function createSummarizerCore(
 	container: IContainer,
@@ -56,8 +78,9 @@ async function createSummarizerCore(
 	const summarizerContainer = await loader.resolve(request);
 	await waitForContainerConnection(summarizerContainer);
 
-	const fluidObject: FluidObject<ISummarizer> | undefined =
-		await summarizerContainer.getEntryPoint();
+	// Old loaders will not have getEntryPoint API on the container. So, use getSummarizerBackCompat which
+	// will use request pattern to get the summarizer in these old loaders.
+	const fluidObject = await getSummarizerBackCompat(summarizerContainer);
 	if (fluidObject?.ISummarizer === undefined) {
 		throw new Error("Fluid object does not implement ISummarizer");
 	}

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -81,7 +81,7 @@ async function createSummarizerCore(
 	// Old loaders will not have getEntryPoint API on the container. So, use getSummarizerBackCompat which
 	// will use request pattern to get the summarizer in these old loaders.
 	const fluidObject = await getSummarizerBackCompat(summarizerContainer);
-	if (fluidObject?.ISummarizer === undefined) {
+	if (fluidObject.ISummarizer === undefined) {
 		throw new Error("Fluid object does not implement ISummarizer");
 	}
 


### PR DESCRIPTION
Added couple of tests for scenarios where a data store / DDS should be summarized as a handle instead of tree. It also validates that the handle id is correct.

Also, added the handle id validation to incremental summary context tests which test incremental summary at DDS level.