### PR TITLE
refactor(tree): use field cursors in low-level editing API

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -1281,7 +1281,7 @@ export interface Optional extends FlexFieldKind<"Optional", Multiplicity.Optiona
 
 // @internal (undocumented)
 export interface OptionalFieldEditBuilder {
-    set(newContent: ITreeCursor | undefined, wasEmpty: boolean): void;
+    set(newContent: ITreeCursorSynchronous | undefined, wasEmpty: boolean): void;
 }
 
 // @internal
@@ -1530,7 +1530,7 @@ export interface Sequence extends FlexFieldKind<"Sequence", Multiplicity.Sequenc
 // @internal (undocumented)
 export interface SequenceFieldEditBuilder {
     delete(index: number, count: number): void;
-    insert(index: number, newContent: ITreeCursor | readonly ITreeCursor[]): void;
+    insert(index: number, newContent: ITreeCursorSynchronous): void;
     move(sourceIndex: number, count: number, destIndex: number): void;
 }
 
@@ -1946,7 +1946,7 @@ export type Value = undefined | TreeValue;
 
 // @internal (undocumented)
 export interface ValueFieldEditBuilder {
-    set(newContent: ITreeCursor): void;
+    set(newContent: ITreeCursorSynchronous): void;
 }
 
 // @internal

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -11,7 +11,6 @@ import {
 	ChangeFamily,
 	ChangeRebaser,
 	UpPath,
-	ITreeCursor,
 	ChangeFamilyEditor,
 	FieldUpPath,
 	compareFieldUpPaths,
@@ -21,8 +20,10 @@ import {
 	ChangesetLocalId,
 	DeltaDetachedNodeId,
 	ChangeEncodingContext,
+	CursorLocationType,
+	ITreeCursorSynchronous,
 } from "../../core/index.js";
-import { brand, isReadonlyArray } from "../../util/index.js";
+import { brand } from "../../util/index.js";
 import {
 	ModularChangeFamily,
 	ModularEditBuilder,
@@ -174,10 +175,10 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 
 	public valueField(field: FieldUpPath): ValueFieldEditBuilder {
 		return {
-			set: (newContent: ITreeCursor): void => {
+			set: (newContent: ITreeCursorSynchronous): void => {
 				const fillId = this.modularBuilder.generateId();
 
-				const build = this.modularBuilder.buildTrees(fillId, [newContent]);
+				const build = this.modularBuilder.buildTrees(fillId, newContent);
 				const change: FieldChangeset = brand(
 					valueFieldKind.changeHandler.editor.set({
 						fill: fillId,
@@ -198,14 +199,14 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 
 	public optionalField(field: FieldUpPath): OptionalFieldEditBuilder {
 		return {
-			set: (newContent: ITreeCursor | undefined, wasEmpty: boolean): void => {
+			set: (newContent: ITreeCursorSynchronous | undefined, wasEmpty: boolean): void => {
 				const detachId = this.modularBuilder.generateId();
 				let fillId: ChangesetLocalId | undefined;
 				const edits: EditDescription[] = [];
 				let optionalChange: OptionalChangeset;
 				if (newContent !== undefined) {
 					fillId = this.modularBuilder.generateId();
-					const build = this.modularBuilder.buildTrees(fillId, [newContent]);
+					const build = this.modularBuilder.buildTrees(fillId, newContent);
 					edits.push(build);
 
 					optionalChange = optional.changeHandler.editor.set(wasEmpty, {
@@ -313,9 +314,9 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 
 	public sequenceField(field: FieldUpPath): SequenceFieldEditBuilder {
 		return {
-			insert: (index: number, newContent: ITreeCursor | readonly ITreeCursor[]): void => {
-				const content = isReadonlyArray(newContent) ? newContent : [newContent];
-				const length = content.length;
+			insert: (index: number, content: ITreeCursorSynchronous): void => {
+				const length =
+					content.mode === CursorLocationType.Fields ? content.getFieldLength() : 1;
 				if (length === 0) {
 					return;
 				}
@@ -368,9 +369,10 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 export interface ValueFieldEditBuilder {
 	/**
 	 * Issues a change which replaces the current newContent of the field with `newContent`.
-	 * @param newContent - the new content for the field. Must be in Nodes mode.
+	 * @param newContent - the new content for the field.
+	 * The cursor can be in either Field or Node mode and must represent exactly one node.
 	 */
-	set(newContent: ITreeCursor): void;
+	set(newContent: ITreeCursorSynchronous): void;
 }
 
 /**
@@ -379,10 +381,11 @@ export interface ValueFieldEditBuilder {
 export interface OptionalFieldEditBuilder {
 	/**
 	 * Issues a change which replaces the current newContent of the field with `newContent`
-	 * @param newContent - the new content for the field. Must be in Nodes mode.
+	 * @param newContent - the new content for the field.
+	 * If provided, the cursor can be in either Field or Node mode and must represent exactly one node.
 	 * @param wasEmpty - whether the field is empty when creating this change
 	 */
-	set(newContent: ITreeCursor | undefined, wasEmpty: boolean): void;
+	set(newContent: ITreeCursorSynchronous | undefined, wasEmpty: boolean): void;
 }
 
 /**
@@ -392,9 +395,9 @@ export interface SequenceFieldEditBuilder {
 	/**
 	 * Issues a change which inserts the `newContent` at the given `index`.
 	 * @param index - the index at which to insert the `newContent`.
-	 * @param newContent - the new content to be inserted in the field. Cursors must be in Nodes mode.
+	 * @param newContent - the new content to be inserted in the field. Cursor can be in either Field or Node mode.
 	 */
-	insert(index: number, newContent: ITreeCursor | readonly ITreeCursor[]): void;
+	insert(index: number, newContent: ITreeCursorSynchronous): void;
 
 	/**
 	 * Issues a change which deletes `count` elements starting at the given `index`.

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -17,11 +17,10 @@ import {
 	iterateCursorField,
 	isCursor,
 	ITreeCursorSynchronous,
-	mapCursorField,
 } from "../../core/index.js";
 import { FieldKind } from "../modular-schema/index.js";
 // TODO: stop depending on contextuallyTyped
-import { cursorFromContextualData } from "../contextuallyTyped.js";
+import { applyTypesFromContext, cursorFromContextualData } from "../contextuallyTyped.js";
 import {
 	FieldKinds,
 	OptionalFieldEditBuilder,
@@ -37,7 +36,7 @@ import {
 } from "../../util/index.js";
 import { AllowedTypes, TreeFieldSchema } from "../typed-schema/index.js";
 import { LocalNodeKey, StableNodeKey, nodeKeyTreeIdentifier } from "../node-key/index.js";
-import { mapTreeFromCursor, cursorForMapTreeNode } from "../mapTreeCursor.js";
+import { cursorForMapTreeField } from "../mapTreeCursor.js";
 import { Context } from "./context.js";
 import {
 	FlexibleNodeContent,
@@ -307,11 +306,14 @@ export class LazySequence<TTypes extends AllowedTypes>
 
 	public insertAt(index: number, value: FlexibleNodeSubSequence<TTypes>): void {
 		assertValidIndex(index, this, true);
-		const content: ITreeCursorSynchronous[] = isCursor(value)
-			? prepareFieldCursorForInsert(value)
-			: Array.from(value, (item) =>
-					cursorFromContextualData(this.context, this.schema.allowedTypeSet, item),
+		const content: ITreeCursorSynchronous = isCursor(value)
+			? value
+			: cursorForMapTreeField(
+					Array.from(value, (item) =>
+						applyTypesFromContext(this.context, this.schema.allowedTypeSet, item),
+					),
 			  );
+
 		const fieldEditor = this.sequenceEditor();
 		fieldEditor.insert(index, content);
 	}
@@ -580,18 +582,6 @@ const builderList: [FieldKind, Builder][] = [
 ];
 
 const kindToClass: ReadonlyMap<FieldKind, Builder> = new Map(builderList);
-
-/**
- * Prepare a fields cursor (holding a sequence of nodes) for inserting.
- */
-function prepareFieldCursorForInsert(cursor: ITreeCursorSynchronous): ITreeCursorSynchronous[] {
-	// TODO: optionally validate content against schema.
-
-	// Convert from the desired API (single field cursor) to the currently required API (array of node cursors).
-	// This is inefficient, and particularly bad if the data was efficiently chunked using uniform chunks.
-	// TODO: update editing APIs to take in field cursors not arrays of node cursors, then remove this copying conversion.
-	return mapCursorField(cursor, () => cursorForMapTreeNode(mapTreeFromCursor(cursor)));
-}
 
 /**
  * Prepare a node cursor (holding a single node) for inserting.

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -307,7 +307,7 @@ export class LazySequence<TTypes extends AllowedTypes>
 	public insertAt(index: number, value: FlexibleNodeSubSequence<TTypes>): void {
 		assertValidIndex(index, this, true);
 		const content: ITreeCursorSynchronous = isCursor(value)
-			? value
+			? prepareFieldCursorForInsert(value)
 			: cursorForMapTreeField(
 					Array.from(value, (item) =>
 						applyTypesFromContext(this.context, this.schema.allowedTypeSet, item),
@@ -582,6 +582,16 @@ const builderList: [FieldKind, Builder][] = [
 ];
 
 const kindToClass: ReadonlyMap<FieldKind, Builder> = new Map(builderList);
+
+/**
+ * Prepare a fields cursor (holding a sequence of nodes) for inserting.
+ */
+function prepareFieldCursorForInsert(cursor: ITreeCursorSynchronous): ITreeCursorSynchronous {
+	// TODO: optionally validate content against schema.
+
+	assert(cursor.mode === CursorLocationType.Fields, "should be in fields mode");
+	return cursor;
+}
 
 /**
  * Prepare a node cursor (holding a single node) for inserting.

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -26,7 +26,6 @@ import {
 	revisionMetadataSourceFromInfo,
 	ChangeAtomIdMap,
 	makeDetachedNodeId,
-	ITreeCursor,
 	emptyDelta,
 	DeltaFieldMap,
 	DeltaFieldChanges,
@@ -37,6 +36,8 @@ import {
 	ChangeEncodingContext,
 	RevisionTagCodec,
 	mapCursorField,
+	ITreeCursorSynchronous,
+	CursorLocationType,
 } from "../../core/index.js";
 import {
 	brand,
@@ -48,7 +49,6 @@ import {
 	IdAllocator,
 	idAllocatorFromMaxId,
 	idAllocatorFromState,
-	isReadonlyArray,
 	Mutable,
 	tryGetFromNestedMap,
 } from "../../util/index.js";
@@ -58,12 +58,9 @@ import {
 	chunkFieldSingle,
 	defaultChunkPolicy,
 	FieldBatchCodec,
+	chunkTree,
 } from "../chunked-forest/index.js";
-import {
-	cursorForMapTreeField,
-	cursorForMapTreeNode,
-	mapTreeFromCursor,
-} from "../mapTreeCursor.js";
+import { cursorForMapTreeNode, mapTreeFromCursor } from "../mapTreeCursor.js";
 import {
 	CrossFieldManager,
 	CrossFieldMap,
@@ -1273,22 +1270,25 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 		}
 	}
 
+	/**
+	 * @param firstId - The ID to associate with the first node
+	 * @param content - The node(s) to build. Can be in either Field or Node mode.
+	 * @returns A description of the edit that can be passed to `submitChanges`.
+	 */
 	public buildTrees(
 		firstId: ChangesetLocalId,
-		newContent: ITreeCursor | readonly ITreeCursor[],
+		content: ITreeCursorSynchronous,
 	): GlobalEditDescription {
-		const content = isReadonlyArray(newContent) ? newContent : [newContent];
-		const length = content.length;
-		if (length === 0) {
+		if (content.mode === CursorLocationType.Fields && content.getFieldLength() === 0) {
 			return { type: "global" };
 		}
 		const builds: ChangeAtomIdMap<TreeChunk> = new Map();
 		const innerMap = new Map();
 		builds.set(undefined, innerMap);
-
-		const mapTrees = content.map((c) => mapTreeFromCursor(c));
-		const fieldCursor = cursorForMapTreeField(mapTrees);
-		const chunk = chunkFieldSingle(fieldCursor, defaultChunkPolicy);
+		const chunk =
+			content.mode === CursorLocationType.Fields
+				? chunkFieldSingle(content, defaultChunkPolicy)
+				: chunkTree(content, defaultChunkPolicy);
 		innerMap.set(firstId, chunk);
 
 		return {

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -344,10 +344,10 @@ export class SharedTree
 					case FieldKinds.optional.identifier: {
 						const fieldEditor = this.editor.optionalField(field);
 						assert(
-							content.length <= 1,
+							content.getFieldLength() <= 1,
 							0x7f4 /* optional field content should normalize at most one item */,
 						);
-						fieldEditor.set(content.length === 0 ? undefined : content[0], true);
+						fieldEditor.set(content.getFieldLength() === 0 ? undefined : content, true);
 						break;
 					}
 					case FieldKinds.sequence.identifier: {

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -1694,7 +1694,7 @@ describe("Editing", () => {
 				parent: rootNode,
 				field: brand("foo"),
 			});
-			field.insert(1, [cursorForJsonableTreeNode({ type: leaf.string.name, value: "C" })]);
+			field.insert(1, cursorForJsonableTreeNode({ type: leaf.string.name, value: "C" }));
 			assert.equal(valueAfterInsert, "C");
 			unsubscribePathVisitor();
 		});

--- a/packages/dds/tree/src/test/shared-tree/fuzz/anchorStability.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/anchorStability.fuzz.spec.ts
@@ -15,7 +15,7 @@ import { UpPath, Anchor, Value } from "../../../core/index.js";
 import { TreeContent } from "../../../shared-tree/index.js";
 import {
 	cursorsFromContextualData,
-	jsonableTreeFromCursor,
+	jsonableTreeFromFieldCursor,
 	typeNameSymbol,
 } from "../../../feature-libraries/index.js";
 import { SharedTreeTestFactory, createTestUndoRedoStacks, validateTree } from "../../utils.js";
@@ -59,11 +59,9 @@ const config = {
 	},
 } satisfies TreeContent;
 
-const initialTreeJson = cursorsFromContextualData(
-	config,
-	config.schema.rootFieldSchema,
-	config.initialTree,
-).map(jsonableTreeFromCursor);
+const initialTreeJson = jsonableTreeFromFieldCursor(
+	cursorsFromContextualData(config, config.schema.rootFieldSchema, config.initialTree),
+);
 
 /**
  * Fuzz tests in this suite are meant to exercise specific code paths or invariants.

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -300,7 +300,7 @@ describe("SharedTree benchmarks", () => {
 						const before = state.timer.now();
 						for (let value = 1; value <= setCount; value++) {
 							editor.delete(nodeIndex, 1);
-							editor.insert(nodeIndex, [singleJsonCursor(value)]);
+							editor.insert(nodeIndex, singleJsonCursor(value));
 						}
 						const after = state.timer.now();
 						duration = state.timer.toSeconds(before, after);

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -2,12 +2,17 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { cursorForJsonableTreeNode } from "../../feature-libraries/index.js";
-import { leaf, singleJsonCursor } from "../../domains/index.js";
+import { singleJsonCursor } from "../../domains/index.js";
 import { rootFieldKey, UpPath } from "../../core/index.js";
 import { ITreeCheckout } from "../../shared-tree/index.js";
 import { brand, JsonCompatible } from "../../util/index.js";
-import { createTestUndoRedoStacks, expectJsonTree, makeTreeFromJson } from "../utils.js";
+import {
+	createTestUndoRedoStacks,
+	expectJsonTree,
+	insert,
+	makeTreeFromJson,
+	remove,
+} from "../utils.js";
 
 const rootPath: UpPath = {
 	parent: undefined,
@@ -363,25 +368,3 @@ describe("Undo and redo", () => {
 		unsubscribe();
 	});
 });
-
-// TODO: Dedupe with the helpers in editing.spec.ts
-
-/**
- * Helper function to insert node at a given index.
- *
- * @param tree - The tree on which to perform the insert.
- * @param index - The index in the root field at which to insert.
- * @param value - The value of the inserted node.
- */
-function insert(tree: ITreeCheckout, index: number, ...values: string[]): void {
-	const field = tree.editor.sequenceField(rootField);
-	const nodes = values.map((value) =>
-		cursorForJsonableTreeNode({ type: leaf.string.name, value }),
-	);
-	field.insert(index, nodes);
-}
-
-function remove(tree: ITreeCheckout, index: number, count: number): void {
-	const field = tree.editor.sequenceField(rootField);
-	field.delete(index, count);
-}

--- a/packages/dds/tree/src/test/snapshots/testTrees.ts
+++ b/packages/dds/tree/src/test/snapshots/testTrees.ts
@@ -456,7 +456,7 @@ export function generateTestTrees() {
 						parent: undefined,
 						field: rootFieldKey,
 					})
-					.insert(0, [cursorForJsonableTreeNode({ type: seqMapSchema.name })]);
+					.insert(0, cursorForJsonableTreeNode({ type: seqMapSchema.name }));
 				// The nested change
 				view.editor
 					.sequenceField({
@@ -467,7 +467,7 @@ export function generateTestTrees() {
 						},
 						field: brand("foo"),
 					})
-					.insert(0, [cursorForJsonableTreeNode({ type: seqMapSchema.name })]);
+					.insert(0, cursorForJsonableTreeNode({ type: seqMapSchema.name }));
 				view.transaction.commit();
 				idCompressor.finalizeCreationRange(idCompressor.takeNextCreationRange());
 				await takeSnapshot(tree, "final");

--- a/packages/dds/tree/src/test/testTrees.ts
+++ b/packages/dds/tree/src/test/testTrees.ts
@@ -18,7 +18,7 @@ import {
 	FlexTreeSchema,
 	cursorsForTypedFieldData,
 	defaultSchemaPolicy,
-	jsonableTreeFromCursor,
+	jsonableTreeFromFieldCursor,
 	cursorForJsonableTreeNode,
 	typeNameSymbol,
 	valueSymbol,
@@ -61,8 +61,8 @@ function testField<T extends TreeFieldSchema>(
 		name,
 		schemaData: schema,
 		treeFactory: () => {
-			const cursors = cursorsForTypedFieldData({ schema }, schema.rootFieldSchema, data);
-			return cursors.map(jsonableTreeFromCursor);
+			const cursor = cursorsForTypedFieldData({ schema }, schema.rootFieldSchema, data);
+			return jsonableTreeFromFieldCursor(cursor);
 		},
 		policy: defaultSchemaPolicy,
 	};

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -63,7 +63,7 @@ import {
 	buildForest,
 	createMockNodeKeyManager,
 	TreeFieldSchema,
-	jsonableTreeFromCursor,
+	jsonableTreeFromFieldCursor,
 	mapFieldChanges,
 	mapFieldsChanges,
 	mapMarkList,
@@ -78,6 +78,8 @@ import {
 	ContextuallyTypedNodeData,
 	mapRootChanges,
 	intoStoredSchema,
+	cursorForMapTreeField,
+	cursorForMapTreeNode,
 } from "../feature-libraries/index.js";
 import {
 	moveToDetachedField,
@@ -583,11 +585,9 @@ export function validateTreeConsistency(treeA: ISharedTree, treeB: ISharedTree):
 }
 
 function contentToJsonableTree(content: TreeContent): JsonableTree[] {
-	return normalizeNewFieldContent(
-		content,
-		content.schema.rootFieldSchema,
-		content.initialTree,
-	).map(jsonableTreeFromCursor);
+	return jsonableTreeFromFieldCursor(
+		normalizeNewFieldContent(content, content.schema.rootFieldSchema, content.initialTree),
+	);
 }
 
 export function validateTreeContent(tree: ITreeCheckout, content: TreeContent): void {
@@ -688,15 +688,16 @@ export function flexTreeViewWithContent<TRoot extends TreeFieldSchema>(
 
 export function forestWithContent(content: TreeContent): IEditableForest {
 	const forest = buildForest();
-	initializeForest(
-		forest,
-		normalizeNewFieldContent(
-			{ schema: content.schema },
-			content.schema.rootFieldSchema,
-			content.initialTree,
-		),
-		testIdCompressor,
+	const fieldCursor = normalizeNewFieldContent(
+		{ schema: content.schema },
+		content.schema.rootFieldSchema,
+		content.initialTree,
 	);
+	// TODO:AB6712 Made the delta format accept a single cursor in Field mode.
+	const nodeCursors = mapCursorField(fieldCursor, (c) =>
+		cursorForMapTreeNode(mapTreeFromCursor(c)),
+	);
+	initializeForest(forest, nodeCursors, testIdCompressor);
 	return forest;
 }
 
@@ -848,12 +849,15 @@ export function initializeTestTree(
 
 		// Apply an edit to the tree which inserts a node with a value
 		runSynchronous(tree, () => {
-			const writeCursors = state.map(cursorForJsonableTreeNode);
+			const mapTrees = state.map((jsonable) =>
+				mapTreeFromCursor(cursorForJsonableTreeNode(jsonable)),
+			);
+			const fieldCursor = cursorForMapTreeField(mapTrees);
 			const field = tree.editor.sequenceField({
 				parent: undefined,
 				field: rootFieldKey,
 			});
-			field.insert(0, writeCursors);
+			field.insert(0, fieldCursor);
 		});
 	}
 }

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -693,7 +693,7 @@ export function forestWithContent(content: TreeContent): IEditableForest {
 		content.schema.rootFieldSchema,
 		content.initialTree,
 	);
-	// TODO:AB6712 Made the delta format accept a single cursor in Field mode.
+	// TODO:AB6712 Make the delta format accept a single cursor in Field mode.
 	const nodeCursors = mapCursorField(fieldCursor, (c) =>
 		cursorForMapTreeNode(mapTreeFromCursor(c)),
 	);


### PR DESCRIPTION
The goal of this PR is to change the signature of `SequenceFieldEditBuilder.insert` so that it takes a single cursor in Field mode instead of an array of cursors in Node mode. The rest of the changes flowed from there, trying to strike a balance between making fewer changes to the code and adopting Field-mode cursors in more places as appropriate/convenient.

## Breaking Changes

This PR changes internal APIs in ways that make old usages potentially incompatible with the new implementation and makes the old implementation potentially incompatible with new usages. No compatibility attempt has been made since it is expected no host application should be depending on these APIs.

