### PR TITLE
Generate SummaryHandle ids as the summary moves up the layers

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1398,6 +1398,13 @@ export class ContainerRuntime
 		});
 
 		const loadedFromSequenceNumber = this.deltaManager.initialSequenceNumber;
+		// If the base snapshot was generated when isolated channels were disabled, set the summary reference
+		// sequence to undefined so that this snapshot will not be used for incremental summaries. This is for
+		// back-compat and will rarely happen so its okay to re-summarize everything in the first summary.
+		const summaryReferenceSequenceNumber =
+			baseSnapshot === undefined || metadata?.disableIsolatedChannels === true
+				? undefined
+				: loadedFromSequenceNumber;
 		this.summarizerNode = createRootSummarizerNodeWithGC(
 			createChildLogger({ logger: this.logger, namespace: "SummarizerNode" }),
 			// Summarize function to call when summarize is called. Summarizer node always tracks summary state.
@@ -1405,8 +1412,7 @@ export class ContainerRuntime
 				this.summarizeInternal(fullTree, trackState, telemetryContext),
 			// Latest change sequence number, no changes since summary applied yet
 			loadedFromSequenceNumber,
-			// Summary reference sequence number, undefined if no summary yet
-			baseSnapshot !== undefined ? loadedFromSequenceNumber : undefined,
+			summaryReferenceSequenceNumber,
 			{
 				// Must set to false to prevent sending summary handle which would be pointing to
 				// a summary with an older protocol state.

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -635,7 +635,7 @@ export class DataStores implements IDisposable {
 	): Promise<ISummaryTreeWithStats> {
 		const summaryBuilder = new SummaryTreeBuilder();
 
-		// Iterate over each store and ask it to snapshot
+		// Iterate over each store and ask it to summarize.
 		await Promise.all(
 			Array.from(this.contexts)
 				.filter(([_, context]) => {
@@ -658,7 +658,14 @@ export class DataStores implements IDisposable {
 						trackState,
 						telemetryContext,
 					);
-					summaryBuilder.addWithStats(contextId, contextSummary);
+					// Add the context's summary to the summary tree. Also, prefix all handles in its summary tree with
+					// "channelsTreeName" name and its id since that is where its previous summary would be. The context
+					// only adds the handle id relative to its path.
+					summaryBuilder.addWithStatsAndPrefixHandles(
+						`${channelsTreeName}/${contextId}`,
+						contextId,
+						contextSummary,
+					);
 				}),
 		);
 

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -142,7 +142,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 				return {
 					summary: {
 						type: SummaryType.Handle,
-						handle: latestSummary.fullPath.path,
+						handle: "/",
 						handleType: SummaryType.Tree,
 					},
 					stats,
@@ -162,7 +162,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 						summarySequenceNumber: this.wipReferenceSequenceNumber,
 						latestSummarySequenceNumber: this._latestSummary.referenceSequenceNumber,
 						// TODO: remove summaryPath
-						summaryPath: this._latestSummary.fullPath.path,
+						summaryPath: "",
 				  }
 				: undefined;
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -52,6 +52,7 @@ import {
 	VisibilityState,
 	ITelemetryContext,
 	IIdCompressor,
+	channelsTreeName,
 } from "@fluidframework/runtime-definitions";
 import {
 	convertSnapshotTreeToSummaryTree,
@@ -804,7 +805,14 @@ export class FluidDataStoreRuntime
 						trackState,
 						telemetryContext,
 					);
-					summaryBuilder.addWithStats(contextId, contextSummary);
+					// Add the context's summary to the summary tree. Also, prefix all handles in its summary tree with
+					// "channelsTreeName" name and its id since that is where its previous summary would be. The context
+					// only adds the handle id relative to its path.
+					summaryBuilder.addWithStatsAndPrefixHandles(
+						`${channelsTreeName}/${contextId}`,
+						contextId,
+						contextSummary,
+					);
 				}),
 		);
 

--- a/packages/runtime/runtime-utils/api-report/runtime-utils.api.md
+++ b/packages/runtime/runtime-utils/api-report/runtime-utils.api.md
@@ -181,6 +181,7 @@ export class SummaryTreeBuilder implements ISummaryTreeWithStats {
     addHandle(key: string, handleType: SummaryType.Tree | SummaryType.Blob | SummaryType.Attachment, handle: string): void;
     // (undocumented)
     addWithStats(key: string, summarizeResult: ISummarizeResult): void;
+    addWithStatsAndPrefixHandles(prefix: string, key: string, summarizeResult: ISummarizeResult): void;
     // (undocumented)
     getSummaryTree(): ISummaryTreeWithStats;
     // (undocumented)

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -166,6 +166,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_SummaryTreeBuilder": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
@@ -175,6 +175,7 @@ declare function get_old_ClassDeclaration_SummaryTreeBuilder():
 declare function use_current_ClassDeclaration_SummaryTreeBuilder(
     use: TypeOnly<current.SummaryTreeBuilder>): void;
 use_current_ClassDeclaration_SummaryTreeBuilder(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_SummaryTreeBuilder());
 
 /*


### PR DESCRIPTION
## Background
This change is aimed at removing the tracking of basePath, localPath and additionalPath from SummarizerNode. These are used in case a node did not change and it's summary is a `SummaryHandle`. These paths are used to generate the SummaryHandle's id.

There is no need to track these three paths across summaries of this node because they don't change anymore. They make the summarizer node code complicated and hard to understand / make changes.
Previously, these paths could change from one summary to another because of 2 reasons:
1. When transitioning to writing summary trees under `.channels` sub-tree. We have to support loading from snapshot where summaries were not written under `.channels` sub-tree. This PR adds a fix for that - Regenerate the first summary (i.e., don't use incremental summaries) when loading from such snapshots.
2. Differential summaries where if a node failed to summarize, we would use the previous summary + a blob where its ops would be stored. 

## Description
This PR is one of 2 ways we can acheive removing these paths. The second one is #19015.

Note: It does not remove basePath, localPath and additionalPath from SummarizerNode yet. It removes its usage and can be removed. I didn't remove it to make the change smaller and easier to review.

It completely removes any handle is tracking from summarizer node. A summarizer node always returns "/" as its SummaryHandle id. The parent layers prefix the rest of the path as this summary makes it way up to the container runtime.
Basically, the SummaryHandle is relative to this node. It's saying that all of itts my previous summary ("/"). This becomes interesting when doing incremental summaries at sub-DDS layer which will set the SummaryHandle id relative to the DDS - something like "/subDDSTree1/blob1".

This is consistent with how the summary tree is generated where each node just returns its summary tree and doesn't know or care about its id. The parent node is the one that adds its summary tree against its id. GC also works similarly.
The idea being that a node only knows about the world under it and if you cut-off the object tree at this point, this node is self-sufficient and can summarize / run GC for its sub-tree.

This fix is slightly expensive than https://github.com/microsoft/FluidFramework/pull/19015 because it requires iterating through the entire summary tree and update handles. However, this is more consistent with the rest of the system.

## Sub-DDS incremental summary 
Additionally, with this change, `IExperimentalIncrementalSummaryContext` doesn't need `summaryPath` to do incremental summaries at sub-dds level. The handle id for any SummaryHandle in the DDS content has to be relative to the DDS. This is the correct usage pattern anyway. DDSes should not care about what the path to it is. That is controlled by the runtime and DDS has no control over it. All it needs to say when using a SummaryHandle is - Use this path from me from the previous summary for this sub-tree summary.

[AB#3740](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3740)