### PR TITLE
Use fixed value for summarizer node's SummaryHandle id

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1398,6 +1398,13 @@ export class ContainerRuntime
 		});
 
 		const loadedFromSequenceNumber = this.deltaManager.initialSequenceNumber;
+		// If the base snapshot was generated when isolated channels were disabled, set the summary reference
+		// sequence to undefined so that this snapshot will not be used for incremental summaries. This is for
+		// back-compat and will rarely happen so its okay to re-summarize everything in the first summary.
+		const summaryReferenceSequenceNumber =
+			baseSnapshot === undefined || metadata?.disableIsolatedChannels === true
+				? undefined
+				: loadedFromSequenceNumber;
 		this.summarizerNode = createRootSummarizerNodeWithGC(
 			createChildLogger({ logger: this.logger, namespace: "SummarizerNode" }),
 			// Summarize function to call when summarize is called. Summarizer node always tracks summary state.
@@ -1405,8 +1412,7 @@ export class ContainerRuntime
 				this.summarizeInternal(fullTree, trackState, telemetryContext),
 			// Latest change sequence number, no changes since summary applied yet
 			loadedFromSequenceNumber,
-			// Summary reference sequence number, undefined if no summary yet
-			baseSnapshot !== undefined ? loadedFromSequenceNumber : undefined,
+			summaryReferenceSequenceNumber,
 			{
 				// Must set to false to prevent sending summary handle which would be pointing to
 				// a summary with an older protocol state.
@@ -1436,6 +1442,7 @@ export class ContainerRuntime
 					this.summarizerNode.createChild(
 						summarizeInternal,
 						id,
+						channelsTreeName,
 						createParam,
 						undefined,
 						getGCDataFn,

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -947,6 +947,7 @@ export abstract class FluidDataStoreContext
 			this.summarizerNode.createChild(
 				summarizeInternal,
 				id,
+				channelsTreeName,
 				createParam,
 				undefined /* config */,
 				getGCDataFn,

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -163,7 +163,7 @@ export class SummarizerNode implements IRootSummarizerNode {
 						summarySequenceNumber: this.wipReferenceSequenceNumber,
 						latestSummarySequenceNumber: this._latestSummary.referenceSequenceNumber,
 						// TODO: remove summaryPath
-						summaryPath: this._latestSummary.fullPath.path,
+						summaryPath: this.summaryHandleId,
 				  }
 				: undefined;
 

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
@@ -139,6 +139,7 @@ export class SummaryNode {
  * Represents the details needed to create a child summarizer node.
  */
 export interface ICreateChildDetails {
+	summaryHandleId: string;
 	/** Latest summary from server node data */
 	latestSummary: SummaryNode | undefined;
 	/** Sequence number of latest known change to the node */

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -108,6 +108,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 		) => Promise<ISummarizeInternalResult>,
 		config: ISummarizerNodeConfigWithGC,
 		changeSequenceNumber: number,
+		summaryHandleId: string,
 		/** Undefined means created without summary */
 		latestSummary?: SummaryNode,
 		wipSummaryLogger?: ITelemetryBaseLogger,
@@ -132,6 +133,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 				),
 			config,
 			changeSequenceNumber,
+			summaryHandleId,
 			latestSummary,
 			wipSummaryLogger,
 			telemetryId,
@@ -387,6 +389,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 		summarizeInternalFn: SummarizeInternalFn,
 		/** Initial id or path part of this node */
 		id: string,
+		summaryHandlePrefix: string,
 		/**
 		 * Information needed to create the node.
 		 * If it is from a base summary, it will assert that a summary has been seen.
@@ -408,7 +411,11 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			return childNodesBaseGCDetails.get(id) ?? {};
 		};
 
-		const createDetails: ICreateChildDetails = this.getCreateDetailsForChild(id, createParam);
+		const createDetails: ICreateChildDetails = this.getCreateDetailsForChild(
+			id,
+			summaryHandlePrefix,
+			createParam,
+		);
 		const child = new SummarizerNodeWithGC(
 			this.logger,
 			summarizeInternalFn,
@@ -418,6 +425,7 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 				gcDisabled: config.gcDisabled ?? this.gcDisabled,
 			},
 			createDetails.changeSequenceNumber,
+			createDetails.summaryHandleId,
 			createDetails.latestSummary,
 			this.wipSummaryLogger,
 			getGCDataFn,
@@ -555,6 +563,7 @@ export const createRootSummarizerNodeWithGC = (
 		summarizeInternalFn,
 		config,
 		changeSequenceNumber,
+		"" /* summaryHandleId */,
 		referenceSequenceNumber === undefined
 			? undefined
 			: SummaryNode.createForRoot(referenceSequenceNumber),

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -119,6 +119,7 @@ describe("Data Store Context Tests", () => {
 				summarizerNode.createChild(
 					summarizeInternal,
 					dataStoreId,
+					channelsTreeName,
 					{ type: CreateSummarizerNodeSource.Local },
 					undefined,
 					getGCDataFn,
@@ -618,6 +619,7 @@ describe("Data Store Context Tests", () => {
 					summarizerNode.createChild(
 						summarizeInternal,
 						dataStoreId,
+						channelsTreeName,
 						{ type: CreateSummarizerNodeSource.FromSummary },
 						// Disable GC for initialization tests.
 						{ gcDisabled: true },
@@ -766,6 +768,7 @@ describe("Data Store Context Tests", () => {
 					summarizerNode.createChild(
 						summarizeInternal,
 						dataStoreId,
+						channelsTreeName,
 						{ type: CreateSummarizerNodeSource.FromSummary },
 						undefined,
 						getGCDataFn,
@@ -1069,6 +1072,7 @@ describe("Data Store Context Tests", () => {
 				summarizerNode.createChild(
 					summarizeInternal,
 					dataStoreId,
+					channelsTreeName,
 					{ type: CreateSummarizerNodeSource.Local },
 					undefined,
 					getGCDataFn,

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -15,6 +15,7 @@ import {
 	SummarizeInternalFn,
 	CreateChildSummarizerNodeFn,
 	CreateSummarizerNodeSource,
+	channelsTreeName,
 } from "@fluidframework/runtime-definitions";
 import { createChildLogger } from "@fluidframework/telemetry-utils";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
@@ -120,7 +121,9 @@ describe("Data Store Creation Tests", () => {
 				0,
 			);
 			getCreateSummarizerNodeFn = (id: string) => (si: SummarizeInternalFn) =>
-				summarizerNode.createChild(si, id, { type: CreateSummarizerNodeSource.Local });
+				summarizerNode.createChild(si, id, channelsTreeName, {
+					type: CreateSummarizerNodeSource.Local,
+				});
 		});
 
 		it("Valid global dataStore", async () => {

--- a/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
@@ -83,6 +83,7 @@ describe("Runtime", () => {
 				midNode = rootNode.createChild(
 					getSummarizeInternalFn(1),
 					ids[1],
+					channelsTreeName,
 					createParam,
 					config,
 				);
@@ -95,6 +96,7 @@ describe("Runtime", () => {
 				leafNode = midNode?.createChild(
 					getSummarizeInternalFn(2),
 					ids[2],
+					channelsTreeName,
 					createParam,
 					config,
 				);

--- a/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 import { SummaryType } from "@fluidframework/protocol-definitions";
 import {
+	channelsTreeName,
 	CreateChildSummarizerNodeParam,
 	CreateSummarizerNodeSource,
 	IGarbageCollectionData,
@@ -63,6 +64,7 @@ describe("SummarizerNodeWithGC Tests", () => {
 		summarizerNode = rootSummarizerNode.createChild(
 			summarizeInternal,
 			summarizerNodeId,
+			channelsTreeName,
 			{ type: CreateSummarizerNodeSource.FromSummary },
 			undefined,
 			getChildInternalGCData,
@@ -274,11 +276,21 @@ describe("SummarizerNodeWithGC Tests", () => {
 		}
 
 		function createMid(createParam: CreateChildSummarizerNodeParam) {
-			midNode = rootNode.createChild(getSummarizeInternalFn(1), ids[1], createParam);
+			midNode = rootNode.createChild(
+				getSummarizeInternalFn(1),
+				ids[1],
+				channelsTreeName,
+				createParam,
+			);
 		}
 
 		function createLeaf(createParam: CreateChildSummarizerNodeParam) {
-			leafNode = midNode?.createChild(getSummarizeInternalFn(2), ids[2], createParam);
+			leafNode = midNode?.createChild(
+				getSummarizeInternalFn(2),
+				ids[2],
+				channelsTreeName,
+				createParam,
+			);
 		}
 
 		it("summary validation should fail if GC not run on root node", () => {

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -353,7 +353,7 @@ export interface ISummarizerNode {
     // (undocumented)
     createChild(
     summarizeInternalFn: SummarizeInternalFn,
-    id: string,
+    id: string, summaryHandlePrefix: string,
     createParam: CreateChildSummarizerNodeParam,
     config?: ISummarizerNodeConfig): ISummarizerNode;
     // (undocumented)
@@ -381,7 +381,7 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     // (undocumented)
     createChild(
     summarizeInternalFn: SummarizeInternalFn,
-    id: string,
+    id: string, summaryHandlePrefix: string,
     createParam: CreateChildSummarizerNodeParam,
     config?: ISummarizerNodeConfigWithGC, getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
     getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>): ISummarizerNodeWithGC;

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -211,6 +211,10 @@ export interface ISummarizerNode {
 		 */
 		id: string,
 		/**
+		 * The prefix to be added to this node's SummaryHandle.
+		 */
+		summaryHandlePrefix: string,
+		/**
 		 * Information needed to create the node.
 		 * If it is from a base summary, it will assert that a summary has been seen.
 		 * Attach information if it is created from an attach op.
@@ -262,6 +266,7 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
 		 * Initial id or path part of this node
 		 */
 		id: string,
+		summaryHandlePrefix: string,
 		/**
 		 * Information needed to create the node.
 		 * If it is from a base summary, it will assert that a summary has been seen.


### PR DESCRIPTION
## Background
This change is aimed at removing the tracking of basePath, localPath and additionalPath from SummarizerNode. These are used in case a node did not change and it's summary is a SummaryHandle. These paths are used to generate the SummaryHandle's id.

There is no need to track these three paths across summaries of this node because they don't change anymore. They make the summarizer node code complicated and hard to understand / make changes.
Previously, these paths could change from one summary to another because of 2 reasons:
1. When transitioning to writing summary trees under `.channels` sub-tree. We have to support loading from snapshot where summaries were not written under `.channels` sub-tree. This PR adds a fix for that - Regenerate the first summary (i.e., don't use incremental summaries) when loading from such snapshots.
2. Differential summaries where if a node failed to summarize, we would use the previous summary + a blob where its ops would be stored. This is totally removed now and is not supported.

## Description
This PR is one of 2 ways we can acheive removing these paths.  The second one is https://github.com/microsoft/FluidFramework/pull/19014.

Note: It does not remove basePath, localPath and additionalPath from SummarizerNode yet. It removes its usage and can be removed. I didn't remove it to make the change smaller and easier to review. 

In this PR, instead of tracking the above paths, the summarizer node is given the handle id to be used for `SummaryHandle`. This does not change thoughout the life time of the node.
When creating a child node, its id and a prefix to be used for handle id is given as a parameter to the parent. The parent node uses this information to build the handle id for the child and passes it during creation.

[AB#3740](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/3740)