### PR TITLE
[POC] GC: Detect handles in attach ops by parsing JSON during process

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2251,7 +2251,11 @@ export class ContainerRuntime
 		const { local } = messageWithContext;
 		switch (messageWithContext.message.type) {
 			case ContainerMessageType.Attach:
-				this.dataStores.processAttachMessage(messageWithContext.message, local);
+				this.dataStores.processAttachMessage(
+					messageWithContext.message,
+					local,
+					(from, to) => this.garbageCollector.addedOutboundReference(from, to),
+				);
 				break;
 			case ContainerMessageType.Alias:
 				this.dataStores.processAliasMessage(

--- a/packages/runtime/container-runtime/src/test/dataStores.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStores.spec.ts
@@ -194,13 +194,39 @@ describe("Runtime", () => {
 						["/dataStore1/dds1", "routeC"],
 						["/dataStore1/dds1", "routeD"],
 					],
-					"Should find both handles",
+					"Should find all handles",
 				);
 			});
 			it("null contents", () => {
 				detectOutboundReferences({ address: "foo", contents: null }, () => {
 					assert.fail("Should not be called");
 				});
+			});
+			it("Can find handles in JSON.stringify'd value", () => {
+				const outboundReferences: [string, string][] = [];
+				const stringified = JSON.stringify({
+					foo: {
+						hiddenHandle: {
+							type: "__fluid_handle__",
+							url: "routeA",
+						},
+					},
+				});
+				detectOutboundReferences(
+					{
+						address: "dataStore1",
+						contents: { path: "dds1", stuff: stringified }, //* Note: This test fails if contents is string directly, since detectOutboundReferences checks for object at the top
+					},
+					(from, to) => {
+						outboundReferences.push([from, to]);
+					},
+					/* ddsIdKey: */ "path",
+				);
+				assert.deepEqual(
+					outboundReferences,
+					[["/dataStore1/dds1", "routeA"]],
+					"Should find the hidden handle",
+				);
 			});
 		});
 	});

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -541,13 +541,7 @@ describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, 
 			 * The difference from previous test case is that the reference from B to C is added before B is referenced and
 			 * observed by summarizer. So, the summarizer does not see this reference directly but only when B is realized.
 			 */
-			//* ONLY
-			//* ONLY
-			//* ONLY
-			//* ONLY
-			//* ONLY
-			//* ONLY
-			itExpects.only(
+			itExpects(
 				`Scenario 6 - Reference added via new unreferenced nodes and removed`,
 				[], // No gcUnknownOutboundReferences errors
 				async () => {
@@ -619,7 +613,7 @@ describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, 
 			it(`Scenario 7 - Reference added transitively via new nodes and removed`, async () => {
 				// Disable new Reference Detection behavior for now
 				// Same reason as Scenario 6 - The re-referencing happens via attach op which we don't detect yet.
-				settings[detectOutboundRoutesViaDDSKey] = true;
+				//* settings[detectOutboundRoutesViaDDSKey] = true;
 
 				const { summarizer } = await createSummarizer(provider, mainContainer, {
 					loaderProps: { configProvider: mockConfigProvider(settings) },

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -23,8 +23,6 @@ import {
 	TestDataObjectType,
 } from "@fluid-private/test-version-utils";
 import { ConfigTypes } from "@fluidframework/core-interfaces";
-// eslint-disable-next-line import/no-internal-modules
-import { detectOutboundRoutesViaDDSKey } from "@fluidframework/container-runtime/test/gc";
 import { defaultGCConfig } from "./gcTestConfigs.js";
 import { getGCStateFromSummary } from "./gcTestSummaryUtils.js";
 
@@ -35,7 +33,7 @@ import { getGCStateFromSummary } from "./gcTestSummaryUtils.js";
  * Run in FullCompat to get coverage of DataStoreRuntime/ContainerRuntime n/n-1 compatibility
  * (skip all other compat types)
  */
-describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 
 	let provider: ITestObjectProvider;
@@ -70,9 +68,9 @@ describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, 
 		}
 
 		// We only want to do compat testing for Container Runtime and Data Runtime compat
-		//* if (!this.test?.parent?.title.includes("runtime")) {
-		//* 	this.skip();
-		//* }
+		if (!this.test?.parent?.title.includes("runtime")) {
+			this.skip();
+		}
 
 		settings = {};
 		const testContainerConfig = {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -553,7 +553,7 @@ describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, 
 				async () => {
 					// Disable new Reference Detection behavior for now
 					// The re-referencing happens via attach op which we don't detect yet.
-					settings[detectOutboundRoutesViaDDSKey] = true;
+					//* settings[detectOutboundRoutesViaDDSKey] = true;
 
 					const { summarizer } = await createSummarizer(provider, mainContainer, {
 						loaderProps: { configProvider: mockConfigProvider(settings) },

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -182,7 +182,7 @@ export async function loadContainer(
 	// This is to align with the snapshot tests which may upgrade GC Version before the default is changed.
 	settings["Fluid.GarbageCollection.GCVersionUpgradeToV4"] = false;
 	// Due to a bug where references added by an attach op are missed, we need to keep the old code for now.
-	settings["Fluid.GarbageCollection.DetectOutboundRoutesViaDDS"] = true;
+	//* settings["Fluid.GarbageCollection.DetectOutboundRoutesViaDDS"] = true;
 
 	// Load the Fluid document while forcing summarizeProtocolTree option
 	const loader = new Loader({


### PR DESCRIPTION
## Description

Proof-of-concept of a proposed fix for AB#5757

It enhances `detectOutboundReferences` to parse any string that may be a `JSON.stringify`'d object containing handles.  This covers the case for attach op because the DDS's content is transmitted in a stringify'd blob in the attach summary.

## Reviewer Guidance

There are several open questions and todo's covered by `//*` comments.  The whole approach needs to be discussed/reviewed before getting into details of the code change - it's a proof-of-concept for now.

Some potential concerns about this approach:
- Performance impact on critical path of doing all these string checks
- potential false positives in user content (bug might be won't-fix, such a strange scenario)