### PR TITLE
Allow getting/setting identity-sensitive module globals in SharedTree

### DIFF
--- a/experimental/dds/tree/api-report/experimental-tree.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.api.md
@@ -467,6 +467,9 @@ export interface GenericTransactionPolicy {
     validateOnClose(state: SucceedingTransactionState): ChangeResult;
 }
 
+// @public
+export function getIdentityStableComparators(): IdentityStableComparators;
+
 // @internal @deprecated
 function getSerializedUploadedEditChunkContents(sharedTree: SharedTree): Promise<string>;
 export { getSerializedUploadedEditChunkContents }
@@ -493,6 +496,16 @@ export interface HasVariadicTraits<TChild> {
 export interface ICheckoutEvents extends IErrorEvent {
     // (undocumented)
     (event: 'viewChange', listener: (before: TreeView, after: TreeView) => void): any;
+}
+
+// @public
+export interface IdentityStableComparators {
+    // (undocumented)
+    compareFiniteNumbers<T extends number>(this: void, a: T, b: T): number;
+    // (undocumented)
+    compareFiniteNumbersReversed<T extends number>(this: void, a: T, b: T): number;
+    // (undocumented)
+    compareStrings<T extends string>(this: void, a: T, b: T): number;
 }
 
 // @internal
@@ -860,6 +873,9 @@ export interface SessionUnique {
     // (undocumented)
     readonly SessionUnique: 'cea55054-6b82-4cbf-ad19-1fa645ea3b3e';
 }
+
+// @public
+export function setIdentityStableComparators(identityStableComparators: IdentityStableComparators): void;
 
 // @internal
 export function setTrait(trait: TraitLocation, nodes: BuildNode | TreeNodeSequence<BuildNode>): Change[];

--- a/experimental/dds/tree/src/Forest.ts
+++ b/experimental/dds/tree/src/Forest.ts
@@ -5,7 +5,7 @@
 
 import { BTree } from '@tylerbu/sorted-btree-es6';
 import { assert } from '@fluidframework/core-utils';
-import { fail, copyPropertyIfDefined, compareBtrees, compareFiniteNumbers } from './Common';
+import { fail, copyPropertyIfDefined, compareBtrees, getIdentityStableComparators } from './Common';
 import { NodeId, TraitLabel } from './Identifiers';
 import { comparePayloads } from './PayloadUtilities';
 import { NodeData, Payload } from './persisted-types';
@@ -104,7 +104,7 @@ export class Forest {
 			this.nodes = data.nodes;
 			this.expensiveValidation = data.expensiveValidation;
 		} else {
-			this.nodes = new BTree<NodeId, ForestNode>(undefined, compareFiniteNumbers);
+			this.nodes = new BTree<NodeId, ForestNode>(undefined, getIdentityStableComparators().compareFiniteNumbers);
 			this.expensiveValidation = data ?? false;
 		}
 		if (this.expensiveValidation) {

--- a/experimental/dds/tree/src/RevisionValueCache.ts
+++ b/experimental/dds/tree/src/RevisionValueCache.ts
@@ -6,7 +6,7 @@
 import { assert } from '@fluidframework/core-utils';
 import { BTree } from '@tylerbu/sorted-btree-es6';
 import LRU from 'lru-cache';
-import { fail, compareFiniteNumbers } from './Common';
+import { fail, getIdentityStableComparators } from './Common';
 
 /**
  * A revision corresponds to an index in an `EditLog`.
@@ -40,7 +40,10 @@ export class RevisionValueCache<TValue> {
 	 * This is sorted to allow efficient access to the nearest preceding entry (see getClosestEntry).
 	 * Contains all cached values, regardless of why they are cached (retained, LRU or window).
 	 */
-	private readonly sortedEntries = new BTree<Revision, TValue>(undefined, compareFiniteNumbers);
+	private readonly sortedEntries = new BTree<Revision, TValue>(
+		undefined,
+		getIdentityStableComparators().compareFiniteNumbers
+	);
 
 	/**
 	 * Cache of most recently used evictable entries.

--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -12,11 +12,9 @@ import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import {
 	hasLength,
 	assertNotUndefined,
-	compareFiniteNumbers,
-	compareFiniteNumbersReversed,
 	compareMaps,
-	compareStrings,
 	fail,
+	getIdentityStableComparators,
 	getOrCreate,
 	Mutable,
 	setPropertyIfDefined,
@@ -343,7 +341,9 @@ export class IdCompressor {
 	 * Maps local IDs to override strings. This will contain an entry for every override assigned to a local ID generated during
 	 * the current session, and retains entries for the lifetime of this compressor.
 	 */
-	private readonly localOverrides = new AppendOnlySortedMap<LocalCompressedId, string>(compareFiniteNumbersReversed);
+	private readonly localOverrides = new AppendOnlySortedMap<LocalCompressedId, string>(
+		getIdentityStableComparators().compareFiniteNumbersReversed
+	);
 
 	/**
 	 * Maps local IDs to the final ID they are associated with (if any), and maps final IDs to the corresponding local ID (if any).
@@ -372,7 +372,7 @@ export class IdCompressor {
 	 */
 	private readonly clustersAndOverridesInversion: BTree<InversionKey, CompressionMapping> = new BTree(
 		undefined,
-		compareStrings
+		getIdentityStableComparators().compareStrings
 	);
 
 	/**
@@ -380,7 +380,7 @@ export class IdCompressor {
 	 * Can be searched in O(log n) to determine clusters for any final ID.
 	 */
 	private readonly finalIdToCluster: AppendOnlySortedMap<FinalCompressedId, IdCluster> = new AppendOnlySortedMap(
-		compareFiniteNumbers
+		getIdentityStableComparators().compareFiniteNumbers
 	);
 
 	private readonly logger: ITelemetryLoggerExt;

--- a/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
+++ b/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
 
 import { assert } from '@fluidframework/core-utils';
-import { compareFiniteNumbers, compareFiniteNumbersReversed, fail, Mutable } from '../Common';
+import { fail, getIdentityStableComparators, Mutable } from '../Common';
 import { FinalCompressedId, LocalCompressedId, SessionSpaceCompressedId } from '../Identifiers';
 import { AppendOnlyDoublySortedMap } from './AppendOnlySortedMap';
 import { SerializedSessionIdNormalizer } from './persisted-types';
@@ -56,7 +56,7 @@ export class SessionIdNormalizer<TRangeObject> {
 		[lastLocal: LocalCompressedId, finalRanges: FinalRanges<TRangeObject> | undefined],
 		FinalCompressedId
 	> = new AppendOnlyDoublySortedMap(
-		compareFiniteNumbersReversed,
+		getIdentityStableComparators().compareFiniteNumbersReversed,
 		([_, finalRanges]) => {
 			if (finalRanges !== undefined) {
 				const first = getFirstRange(finalRanges);
@@ -64,7 +64,7 @@ export class SessionIdNormalizer<TRangeObject> {
 			}
 			return Number.POSITIVE_INFINITY as FinalCompressedId;
 		},
-		compareFiniteNumbers
+		getIdentityStableComparators().compareFiniteNumbers
 	);
 
 	public constructor(private readonly expensiveAsserts = false) {}
@@ -166,9 +166,9 @@ export class SessionIdNormalizer<TRangeObject> {
 
 	private static makeFinalRangesMap<TRangeObject>(): FinalRangesMap<TRangeObject> {
 		return new AppendOnlyDoublySortedMap(
-			compareFiniteNumbersReversed,
+			getIdentityStableComparators().compareFiniteNumbersReversed,
 			extractFirstFinalFromRange,
-			compareFiniteNumbers
+			getIdentityStableComparators().compareFiniteNumbers
 		);
 	}
 

--- a/experimental/dds/tree/src/index.ts
+++ b/experimental/dds/tree/src/index.ts
@@ -31,7 +31,14 @@ export {
 	StableRange,
 } from './ChangeTypes';
 export { Checkout, CheckoutEvent, ICheckoutEvents, EditValidationResult } from './Checkout';
-export { isSharedTreeEvent, sharedTreeAssertionErrorType, Result } from './Common';
+export {
+	getIdentityStableComparators,
+	IdentityStableComparators,
+	isSharedTreeEvent,
+	setIdentityStableComparators,
+	sharedTreeAssertionErrorType,
+	Result,
+} from './Common';
 export { EagerCheckout } from './EagerCheckout';
 export type { OrderedEditSet, EditHandle } from './EditLog';
 export {

--- a/experimental/dds/tree/src/test/AppendOnlySortedMap.perf.tests.ts
+++ b/experimental/dds/tree/src/test/AppendOnlySortedMap.perf.tests.ts
@@ -5,7 +5,7 @@
 
 import { benchmark, BenchmarkType } from '@fluid-tools/benchmark';
 import { IRandom, makeRandom } from '@fluid-private/stochastic-test-utils';
-import { compareFiniteNumbers } from '../Common';
+import { getIdentityStableComparators } from '../Common';
 import { AppendOnlySortedMap } from '../id-compressor/AppendOnlySortedMap';
 
 function runAppendOnlyMapPerfTests(mapBuilder: () => AppendOnlySortedMap<number, number>) {
@@ -49,5 +49,5 @@ function runAppendOnlyMapPerfTests(mapBuilder: () => AppendOnlySortedMap<number,
 }
 
 describe('AppendOnlySortedMap Perf', () => {
-	runAppendOnlyMapPerfTests(() => new AppendOnlySortedMap(compareFiniteNumbers));
+	runAppendOnlyMapPerfTests(() => new AppendOnlySortedMap(getIdentityStableComparators().compareFiniteNumbers));
 });

--- a/experimental/dds/tree/src/test/AppendOnlySortedMap.tests.ts
+++ b/experimental/dds/tree/src/test/AppendOnlySortedMap.tests.ts
@@ -8,7 +8,7 @@
 import { strict as assert } from 'assert';
 import { expect } from 'chai';
 import { validateAssertionError } from '@fluidframework/test-runtime-utils';
-import { assertNotUndefined, compareFiniteNumbers } from '../Common';
+import { assertNotUndefined, getIdentityStableComparators } from '../Common';
 import { AppendOnlyDoublySortedMap, AppendOnlySortedMap } from '../id-compressor/AppendOnlySortedMap';
 
 function runAppendOnlyMapTests(mapBuilder: () => AppendOnlySortedMap<number, number>) {
@@ -133,7 +133,7 @@ function runAppendOnlyMapTests(mapBuilder: () => AppendOnlySortedMap<number, num
 	it('can calculate the indexOf a search element', () => {
 		const elements: number[] = [0, 0, 2, 0, 3, 0];
 		const comparator = (search: number, key: number, value: number): number => {
-			return compareFiniteNumbers(search, key);
+			return getIdentityStableComparators().compareFiniteNumbers(search, key);
 		};
 		expect(AppendOnlySortedMap.keyIndexOf(elements, 0, comparator)).to.equal(0);
 		expect(AppendOnlySortedMap.keyIndexOf(elements, 2, comparator)).to.equal(2);
@@ -182,15 +182,15 @@ function runAppendOnlyMapTests(mapBuilder: () => AppendOnlySortedMap<number, num
 }
 
 describe('AppendOnlySortedMap', () => {
-	runAppendOnlyMapTests(() => new AppendOnlySortedMap(compareFiniteNumbers));
+	runAppendOnlyMapTests(() => new AppendOnlySortedMap(getIdentityStableComparators().compareFiniteNumbers));
 });
 
 describe('AppendOnlyDoublySortedMap', () => {
 	const mapBuilder = () =>
 		new AppendOnlyDoublySortedMap<number, number, number>(
-			compareFiniteNumbers,
+			getIdentityStableComparators().compareFiniteNumbers,
 			(value) => value,
-			compareFiniteNumbers
+			getIdentityStableComparators().compareFiniteNumbers
 		);
 	runAppendOnlyMapTests(mapBuilder);
 
@@ -237,9 +237,9 @@ describe('AppendOnlyDoublySortedMap', () => {
 
 	it('validity assertion detects out-of-order keys', () => {
 		const map = new AppendOnlyDoublySortedMap<[number], [number], number>(
-			(a, b) => compareFiniteNumbers(a[0], b[0]),
+			(a, b) => getIdentityStableComparators().compareFiniteNumbers(a[0], b[0]),
 			(value) => value[0],
-			compareFiniteNumbers
+			getIdentityStableComparators().compareFiniteNumbers
 		);
 		map.append([0], [0]);
 		map.append([1], [1]);

--- a/experimental/dds/tree/src/test/NumericUuid.tests.ts
+++ b/experimental/dds/tree/src/test/NumericUuid.tests.ts
@@ -9,7 +9,7 @@ import { strict as assert } from 'assert';
 import { expect } from 'chai';
 import { makeRandom } from '@fluid-private/stochastic-test-utils';
 import { validateAssertionError } from '@fluidframework/test-runtime-utils';
-import { compareStrings } from '../Common';
+import { getIdentityStableComparators } from '../Common';
 import {
 	numericUuidEquals,
 	createSessionId,
@@ -206,7 +206,7 @@ describe('NumericUuid', () => {
 				const numericA = numericUuidFromStableId(stableIdA);
 				const numericB = numericUuidFromStableId(stableIdB);
 				const comparedNumeric = numericUuidEquals(numericA, numericB);
-				const comparedStrings = compareStrings(stableIdA, stableIdB);
+				const comparedStrings = getIdentityStableComparators().compareStrings(stableIdA, stableIdB);
 				expect(comparedNumeric).to.equal(comparedStrings === 0);
 			});
 		});


### PR DESCRIPTION
SharedTree depends on [sorted-btree](https://www.npmjs.com/package/sorted-btree), which takes comparator functions and [will assert here](https://github.com/qwertie/btree-typescript/blob/e54ffd3c042fd066be55262751691b271413794c/b%2Btree.ts#L593) if they don't compare equal as expected.

In some cases it's useful for a Fluid component to be isolated from the host using a sourced iframe, which is made much easier if a  SharedTree instance can be passed across the iframe boundary [as described here](https://stackoverflow.com/questions/36055926/pass-a-javascript-object-to-an-html-iframe-as-an-object#:~:text=One%20can%20simply%20pass%20the,the%20window%20of%20the%20iframe.&text=You%20should%20use%20window.,iFrames%20embedded%20in%20your%20site.).  However, this involves two javascript execution contexts with a different instance of the SharedTree package in each, which means that checks depending on global constants being referentially equal no longer work as expected, and the above assert in sorted-btree occurs.

The PR proposes as a workaround a module-level function that gets/sets the comparator functions.  This allows the two instances to be synced and use the same comparators so that they will be referentially equal.