### PR TITLE
ci: Stop removing manually added changeset-required labels

### DIFF
--- a/.github/labeler-areas.yml
+++ b/.github/labeler-areas.yml
@@ -1,5 +1,7 @@
 # This file is a map of labels to repo glob paths. See https://github.com/marketplace/actions/labeler
-# for more details.
+# for more details about the config format. The labels in this file will be added AND removed from PRs as the files
+# edited in the PR change. See https://github.com/microsoft/FluidFramework/blob/main/.github/workflows/pr-labeler.yml to
+# see how this config file is used.
 
 "area: build":
   - ".github/*"
@@ -85,7 +87,3 @@ documentation:
 # flag changes to public APIs so they can be reviewed to see if they're breaking
 "public api change":
   - "**/api-report/**"
-
-# Require changesets for server public API changes
-"changeset-required":
-  - "**/routerlicious/api-report/**"

--- a/.github/labeler-changesets.yml
+++ b/.github/labeler-changesets.yml
@@ -1,0 +1,8 @@
+# This file is a map of labels to repo glob paths. See https://github.com/marketplace/actions/labeler for more details
+# about the config format. The labels in this file will be added BUT NOT removed from PRs as the files edited in the PR
+# change. See https://github.com/microsoft/FluidFramework/blob/main/.github/workflows/pr-labeler.yml to see how this
+# config file is used.
+
+# Require changesets for server public API changes
+"changeset-required":
+  - "**/routerlicious/api-report/**"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,13 +1,13 @@
 name: "Pull Request Labeler"
 on:
   pull_request_target:
-    types: [ opened, synchronize, reopened, labeled, unlabeled ]
-    branches: [ main, next, release/* ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main, next, release/*]
 
 jobs:
-  paths_label:
+  areas_label:
     runs-on: ubuntu-latest
-    name: Label based on file paths
+    name: Label areas
     # Skip labeling main-next merge PRs. The area labels are noisy and distracting for main-next PRs because they can
     # contain many commits, and thus touch nearly the whole repo in a single commit. Skipping these labels makes it
     # easier to focus on the more relevant main-next labels.
@@ -18,9 +18,20 @@ jobs:
       - uses: actions/labeler@5c7539237e04b714afd8ad9b4aed733815b9fab4 # ratchet:actions/labeler@v4.0.2
         if: "github.event.pull_request.title != 'Automation: main-next integrate'"
         with:
-          configuration-path: ".github/actions-labeler.yml"
+          configuration-path: ".github/labeler-areas.yml"
           repo-token: "${{ github.token }}"
           sync-labels: true # add/remove labels as modified paths in the PR change
+  # Changes to some paths should automatically add the changeset-required label. This label is often added manually, so
+  # this CI job calls the labeler action wuth sync-labels=false, so the label won't be removed automatically.
+  changesets_label:
+    runs-on: ubuntu-latest
+    name: Label changeset-required
+    steps:
+      - uses: actions/labeler@5c7539237e04b714afd8ad9b4aed733815b9fab4 # ratchet:actions/labeler@v4.0.2
+        with:
+          configuration-path: ".github/labeler-changesets.yml"
+          repo-token: "${{ github.token }}"
+          sync-labels: false # The changeset-required label is often added manually, so don't remove it.
   branches_label:
     runs-on: ubuntu-latest
     name: Label base branches and external contributors


### PR DESCRIPTION
The labeler job is removing manually added changeset-required labels. This change splits the changeset-required labeler job into its own config and calls the labeler action in a way that doesn't remove the changeset-required label.