### PR TITLE
Disable ODSP for LTS branch service load and e2e tests

### DIFF
--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -37,6 +37,8 @@ stages:
   # stress tests odsp
   - stage:
     displayName:  Stress tests - Odsp
+    # disable as the lts version, 1.0.0 is no longer supported for all features on odsp, specifically "Received summaryNack: Upgrade to a newer version of the Fluid client packages to summarize."
+    condition: "false"
     dependsOn: []
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -123,6 +123,8 @@ stages:
   # end-to-end tests odsp
   - stage:
     displayName:  e2e - odsp
+    # disable as the lts version, 1.0.0 is no longer supported for all features on odsp, specifically "Received summaryNack: Upgrade to a newer version of the Fluid client packages to summarize."
+    condition: "false"
     dependsOn: []
     # use a variable group with exclusive lock force only one run at a time and avoid overloading the server/throttling
     variables:


### PR DESCRIPTION
the lts version, 1.0.0 is no longer supported for all features on odsp, specifically "Received summaryNack: Upgrade to a newer version of the Fluid client packages to summarize."

Related to https://github.com/microsoft/FluidFramework/pull/18531

[AB#6724](https://dev.azure.com/fluidframework/internal/_workitems/edit/6724)