### PR TITLE
feat(docs): Add version string to front-matter in generated API docs

### DIFF
--- a/docs/api-markdown-documenter/front-matter.js
+++ b/docs/api-markdown-documenter/front-matter.js
@@ -20,12 +20,15 @@ const generatedContentNotice =
  * This will be appended to the top of the generated API documents.
  *
  * @param {ApiItem} apiItem - The root API item of the document being rendered.
- * @param {MarkdownDocumenterConfiguration} config - See
+ * @param {@fluid-tools/api-markdown-documenter#MarkdownDocumenterConfiguration} config - See
  * {@link @fluid-tools/api-markdown-documenter#MarkdownDocumenterConfiguration}.
+ * @param {@fluid-tools/api-markdown-documenter#MarkdownRenderers} - Custom renderers to use.
+ * @param {string} version - Version label string.
+ * Will be inserted as the `version` metadata in the generated document front-matter.
  *
  * @returns The JSON-formatted Hugo front-matter as a `string`.
  */
-function createHugoFrontMatter(apiItem, config, customRenderers) {
+function createHugoFrontMatter(apiItem, config, customRenderers, version) {
 	function extractSummary() {
 		const summaryParagraph = transformTsdocNode(
 			apiItem.tsdocComment.summarySection,
@@ -46,6 +49,8 @@ function createHugoFrontMatter(apiItem, config, customRenderers) {
 
 	const frontMatter = {};
 	frontMatter.title = apiItem.displayName.replace(/"/g, "").replace(/!/g, "");
+	frontMatter.version = version;
+
 	let apiMembers = apiItem.members;
 	switch (apiItem.kind) {
 		case ApiItemKind.Model:

--- a/docs/api-markdown-documenter/render-api-documentation.js
+++ b/docs/api-markdown-documenter/render-api-documentation.js
@@ -21,6 +21,14 @@ const { buildNavBar } = require("./build-api-nav");
 const { renderAlertNode, renderBlockQuoteNode, renderTableNode } = require("./custom-renderers");
 const { createHugoFrontMatter } = require("./front-matter");
 
+/**
+ * Generates a documentation suite for the API model saved under `inputDir`, saving the output to `outputDir`.
+ * @param {string} inputDir - The directory path containing the API model to be processed.
+ * @param {string} outputDir - The directory path under which the generated documentation suite will be saved.
+ * @param {string} uriRootDir - The base for all links between API members.
+ * @param {string} apiVersionNum - The API model version string used to differentiate different major versions of the
+ * framework for which API documentation is presented on the website.
+ */
 async function renderApiDocumentation(inputDir, outputDir, uriRootDir, apiVersionNum) {
 	// Delete existing documentation output
 	console.log("Removing existing generated API docs...");
@@ -69,7 +77,8 @@ async function renderApiDocumentation(inputDir, outputDir, uriRootDir, apiVersio
 				? "index"
 				: DefaultPolicies.defaultFileNamePolicy(apiItem);
 		},
-		frontMatter: (apiItem) => createHugoFrontMatter(apiItem, config, customRenderers),
+		frontMatter: (apiItem) =>
+			createHugoFrontMatter(apiItem, config, customRenderers, apiVersionNum),
 		// TODO: enable the following once we have finished gettings the repo's release tags sorted out for 2.0.
 		// minimumReleaseLevel: ReleaseTag.Beta, // Don't include `@alpha` or `@internal` items in docs published to the public website.
 	});


### PR DESCRIPTION
This is in preparation for publishing multiple versions of API docs on the website. Future changes will utilize this metadata to differentiate between API documents at different versions.

Also adds some function documentation.