### PR TITLE
improvement(docs): Improve console logging and error propagation in API docs generation

### DIFF
--- a/docs/api-markdown-documenter/index.js
+++ b/docs/api-markdown-documenter/index.js
@@ -45,11 +45,11 @@ docVersions.forEach((version) => {
 			version,
 		).then(
 			() => {
-				console.log(chalk.green(`${version} API docs written!`));
+				console.log(chalk.green(`(${version}) API docs written!`));
 			},
 			(error) => {
 				throw new Error(
-					`${version} API docs could not be written due to an error: ${error}`,
+					`(${version}) API docs could not be written due to an error: ${error}`,
 				);
 			},
 		),

--- a/docs/api-markdown-documenter/index.js
+++ b/docs/api-markdown-documenter/index.js
@@ -43,16 +43,9 @@ docVersions.forEach((version) => {
 			apiDocsDirectoryPath,
 			uriRootDirectoryPath,
 			version,
-		).then(
-			() => {
-				console.log(chalk.green(`(${version}) API docs written!`));
-			},
-			(error) => {
-				throw new Error(
-					`(${version}) API docs could not be written due to an error: ${error}`,
-				);
-			},
-		),
+		).then(() => {
+			console.log(chalk.green(`(${version}) API docs written!`));
+		}),
 	);
 });
 
@@ -62,7 +55,6 @@ Promise.all(apiDocRenders).then(
 		process.exit(0);
 	},
 	(error) => {
-		console.error(error);
 		process.exit(1);
 	},
 );

--- a/docs/api-markdown-documenter/render-api-documentation.js
+++ b/docs/api-markdown-documenter/render-api-documentation.js
@@ -29,11 +29,8 @@ async function renderApiDocumentation(inputDir, outputDir, uriRootDir, apiVersio
 
 	// Process API reports
 	console.log("Loading API model...");
-	console.group();
 
 	const apiModel = await loadModel(inputDir);
-
-	console.groupEnd();
 
 	// Custom renderers that utilize Hugo syntax for certain kinds of documentation elements.
 	const customRenderers = {
@@ -68,7 +65,6 @@ async function renderApiDocumentation(inputDir, outputDir, uriRootDir, apiVersio
 	});
 
 	console.log("Generating API documentation...");
-	console.group();
 
 	let documents;
 	try {
@@ -78,9 +74,6 @@ async function renderApiDocumentation(inputDir, outputDir, uriRootDir, apiVersio
 		throw error;
 	}
 
-	console.groupEnd();
-
-	console.group();
 	console.log("Generating nav contents...");
 
 	try {
@@ -90,10 +83,7 @@ async function renderApiDocumentation(inputDir, outputDir, uriRootDir, apiVersio
 		throw error;
 	}
 
-	console.groupEnd();
-
 	console.log("Writing API documents to disk...");
-	console.group();
 
 	await Promise.all(
 		documents.map(async (document) => {
@@ -130,8 +120,6 @@ async function renderApiDocumentation(inputDir, outputDir, uriRootDir, apiVersio
 			}
 		}),
 	);
-
-	console.groupEnd();
 }
 
 module.exports = {


### PR DESCRIPTION
Makes a few improvements to the console logging done in API docs generation:
* Removes console grouping, which doesn't work nicely with parallel async tasks (which occurs when we enable multi-version API docs generation)
* Adds utility functions to capture common logging logic
* Renders error messages in red
* Prefaces logging messages (including errors) with the version string associated with the generation to help differentiate parallel task logging.
* Removes unnecessary error re-throwing in `api-markdown-documenter/index.js`, which resulted in the same errors being logged multiple times.

Example of new output:
![image](https://github.com/microsoft/FluidFramework/assets/54606601/6aa45442-8332-434f-862b-b68dc5ff5552)
