### PR TITLE
id-compressor: Verify stateful takeNextRange behavior

### DIFF
--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -314,6 +314,17 @@ describe("IdCompressor", () => {
 		});
 	});
 
+	it("does not return the same non-empty range twice", () => {
+		const rangeCompressor = CompressorFactory.createCompressor(Client.Client1);
+		generateCompressedIds(rangeCompressor, 3);
+		const range1 = rangeCompressor.takeNextCreationRange();
+		assert.notEqual(range1.ids, undefined);
+		const range2 = rangeCompressor.takeNextCreationRange();
+		assert.equal(range2.ids, undefined);
+		rangeCompressor.finalizeCreationRange(range1);
+		rangeCompressor.finalizeCreationRange(range2);
+	});
+
 	describe("Finalizing", () => {
 		it("prevents attempts to finalize ranges twice", () => {
 			const rangeCompressor = CompressorFactory.createCompressor(Client.Client1);


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

This PR confirms that the compressor maintained a stateful takeNextRange through the recent rewrite (it was suspected that it had not).
