### PR TITLE
Gitrest: Revert blobCache improvements

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/utils/wholeSummary/coreWriteUtils.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/wholeSummary/coreWriteUtils.ts
@@ -153,7 +153,7 @@ async function getShaFromTreeHandleEntry(
 	const gitTree: IFullGitTree = await buildFullGitTreeFromGitTree(
 		parentTree,
 		options.repoManager,
-		options.blobCache /* blobCache */,
+		{} /* blobCache */,
 		// Parse inner git tree blobs so that we can properly reference blob shas in new summary.
 		true /* parseInnerFullGitTrees */,
 		// We only need shas here, so don't waste resources retrieving blobs that are not included in fullGitTrees.

--- a/server/gitrest/packages/gitrest-base/src/utils/wholeSummary/lowIoWriteUtils.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/wholeSummary/lowIoWriteUtils.ts
@@ -44,7 +44,7 @@ async function retrieveMissingGitTreeIntoMemory(
 	const fullTree = await buildFullGitTreeFromGitTree(
 		missingTree,
 		writeSummaryTreeOptions.repoManager,
-		writeSummaryTreeOptions.blobCache /* blobCache */,
+		{} /* blobCache */,
 		false /* parseInnerFullGitTrees */,
 		true /* retrieveBlobs */,
 	);


### PR DESCRIPTION
## Description

#18221 tred to optimize summary read/writes, but it over-used the local cache, which caused a bug when reading older summaries.

## Reviewer Guidance

I was able to repro the summary read bug locally, then could not repro after fix. However, I will be adding UTs/Regression tests after this PR is in, because we need to patch this in AFR to unblock deployment.