### PR TITLE
refactor(docs): Update API model artifact download script

### DIFF
--- a/docs/download-apis.js
+++ b/docs/download-apis.js
@@ -3,41 +3,54 @@
  * Licensed under the MIT License.
  */
 
-/**
+/*
  * This download script is used in docs/package.json to download the api json docs from the azure storage.
- * This script accepts an optional boolean parameter which controls if all versions or only the latest version 
- * of the doc models get downloaded. (pass in true for all versions)
+ * This script accepts an optional boolean parameter which controls if all versions or only the latest version
+ * of the doc models get downloaded (pass in true for all versions).
  * e.g. "node ./download-apis.js true"
  */
 
 const chalk = require("chalk");
 const download = require("download");
+const fs = require("fs-extra");
+const path = require("path");
 const versions = require("./data/versions.json");
 
 const renderMultiVersion = process.argv[2];
 
-docVersions = renderMultiVersion
+const docVersions = renderMultiVersion
 	? versions.params.previousVersions.concat(versions.params.currentVersion)
 	: [versions.params.currentVersion];
 
-const downloadConfigs = [];
-
-docVersions.forEach((version) => {
-	version = version === versions.params.currentVersion ? "" : "-" + version;
-	const url = `https://fluidframework.blob.core.windows.net/api-extractor-json/latest${version}.tar.gz`;
-	const destination = `../_api-extractor-temp${version}/doc-models/`;
-
-	downloadConfigs.push(download(url, destination, { extract: true }));
-});
-
 Promise.all(
-	downloadConfigs
+	docVersions.map(async (version) => {
+		// We don't add a version-postfix for "current" version, since local website builds want to use the
+		// locally generated API doc models when present.
+		const versionPostfix = version === versions.params.currentVersion ? "" : `-${version}`;
+		const url = `https://fluidframework.blob.core.windows.net/api-extractor-json/latest${versionPostfix}.tar.gz`;
+		const destination = path.resolve(
+			__dirname,
+			"..",
+			`_api-extractor-temp${versionPostfix}`,
+			"doc-models",
+		);
+
+		// Delete any existing contents in the directory before downloading artifact
+		await fs.ensureDir(destination);
+		await fs.emptyDir(destination);
+
+		// Download the artifacts
+		return download(url, destination, { extract: true });
+	}),
 ).then(
 	() => {
-		console.log(chalk.green("API doc models downloaded!"));
+		console.log(chalk.green("API doc model artifacts downloaded!"));
 		process.exit(0);
 	},
 	(error) => {
+		console.error(
+			chalk.red("Could not download API doc model artifacts due to one or more errors:"),
+		);
 		console.error(error);
 		process.exit(1);
 	},

--- a/docs/download-apis.js
+++ b/docs/download-apis.js
@@ -24,8 +24,8 @@ const docVersions = renderMultiVersion
 
 Promise.all(
 	docVersions.map(async (version) => {
-		// We don't add a version-postfix for "current" version, since local website builds want to use the
-		// locally generated API doc models when present.
+		// We don't add a version-postfix directory name for "current" version, since local website builds want to use
+		// the locally generated API doc models when present.
 		const versionPostfix = version === versions.params.currentVersion ? "" : `-${version}`;
 		const url = `https://fluidframework.blob.core.windows.net/api-extractor-json/latest${versionPostfix}.tar.gz`;
 		const destination = path.resolve(


### PR DESCRIPTION
Refactors the script to ensure the output directories have been emptied before downloading artifacts - this prevents issues that could arise when building locally if one or more packages have been removed from a more recent version of an artifact relative to one that was already downloaded.

It also simplifies some of the promise structure and enhances error logging a bit,