### PR TITLE
fix(fluid-build): incremental ts2esm task

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/leafTask.ts
@@ -542,7 +542,13 @@ export class UnknownLeafTask extends LeafTask {
 }
 
 export abstract class LeafWithFileStatDoneFileTask extends LeafWithDoneFileTask {
+	/**
+	 * @returns the list of files that this task depends on. The files are relative to the package directory.
+	 */
 	protected abstract getInputFiles(): Promise<string[]>;
+	/**
+	 * @returns the list of files that this task generates. The files are relative to the package directory.
+	 */
 	protected abstract getOutputFiles(): Promise<string[]>;
 	protected get useHashes(): boolean {
 		return false;
@@ -557,8 +563,16 @@ export abstract class LeafWithFileStatDoneFileTask extends LeafWithDoneFileTask 
 		try {
 			const srcFiles = await this.getInputFiles();
 			const dstFiles = await this.getOutputFiles();
-			const srcTimesP = Promise.all(srcFiles.map((match) => statAsync(match)));
-			const dstTimesP = Promise.all(dstFiles.map((match) => statAsync(match)));
+			const srcTimesP = Promise.all(
+				srcFiles
+					.map((match) => this.getPackageFileFullPath(match))
+					.map((match) => statAsync(match)),
+			);
+			const dstTimesP = Promise.all(
+				dstFiles
+					.map((match) => this.getPackageFileFullPath(match))
+					.map((match) => statAsync(match)),
+			);
 			const [srcTimes, dstTimes] = await Promise.all([srcTimesP, dstTimesP]);
 
 			const srcInfo = srcTimes.map((srcTime) => {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/ts2EsmTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/ts2EsmTask.ts
@@ -4,7 +4,7 @@
  */
 
 import * as JSON5 from "json5";
-import { lstatSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import type { TsConfigJson } from "type-fest";
 import { globFn } from "../../../common/utils";
@@ -27,38 +27,34 @@ export class Ts2EsmTask extends LeafWithFileStatDoneFileTask {
 		const configs = split.slice(1).map((filePath) => this.getPackageFileFullPath(filePath));
 
 		for (const configPath of configs) {
+			const configDir = path.dirname(configPath);
 			const tsConfig = JSON5.parse(readFileSync(configPath, "utf8")) as TsConfigJson;
 			if (tsConfig.files !== undefined) {
-				inputFiles.push(...tsConfig.files);
+				// Config might not be relative to package; get an absolute path.
+				// Note: repo has no tsconfig's with files; so this is untested in real use.
+				inputFiles.push(
+					...tsConfig.files.map((filePath) => path.resolve(filePath, configDir)),
+				);
 			}
 			if (tsConfig.include !== undefined) {
 				for (const glob of tsConfig.include) {
-					const configDir = path.dirname(configPath);
-					const globPaths = await globFn(glob, {
-						// We need to interpret the globs from the tsconfig directory
-						cwd: configDir,
-						// Return absolute paths so we can more easily make them package-relative instead of relative to the
-						// tsconfig directory
-						absolute: true,
-					});
 					inputFiles.push(
-						// To keep absolute paths out of the cache file, make the path relative to the package
-						...globPaths.map((filePath) =>
-							path.relative(this.package.directory, filePath),
-						),
+						...(await globFn(glob, {
+							// We need to interpret the globs from the tsconfig directory
+							cwd: configDir,
+							// Return absolute paths so we can more easily make them package-relative instead of relative to the
+							// tsconfig directory
+							absolute: true,
+							// Don't return directories, only files.
+							nodir: true,
+						})),
 					);
 				}
 			}
 		}
 
-		// filter out directories
-		const filtered = inputFiles.filter((file) => {
-			const fileStat = lstatSync(file);
-			const isDirectory = fileStat.isDirectory();
-			return !isDirectory;
-		});
-
-		return filtered;
+		// To keep absolute paths out of the cache file, make the path relative to the package.
+		return inputFiles.map((filePath) => path.relative(this.package.directory, filePath));
 	}
 
 	protected async getOutputFiles(): Promise<string[]> {


### PR DESCRIPTION
LeafWithFileStatDoneFileTask expected absolute paths, but Ts2EsmTask was providing relative. This would work in the context of leaf directory but not elsewhere.

Additionally correct directory/file filter by just using glob functionality. (Prior code was also not filtering per relative path and cwd context.)

And speculatively handle tsconfig `files` pathing. (No tsconfig files found in repo with `files` specified.)