### PR TITLE
id-compressor: Update ghost session allocation strategy

### DIFF
--- a/.changeset/compressed-ghosts-shrink.md
+++ b/.changeset/compressed-ghosts-shrink.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/id-compressor": minor
+---
+
+This change adjusts the cluster allocation strategy for ghost sessions to exactly fill the cluster instead of needlessly allocating a large cluster.
+It will also not make a cluster at all if IDs are not allocated.
+This change adjusts a computation performed at a consensus point, and thus breaks any sessions collaborating across version numbers.
+The version for the serialized format has been bumped to 2.0, and 1.0 documents will fail to load with the following error:
+IdCompressor version 1.0 is no longer supported.

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -615,7 +615,7 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 		}
 	}
 
-	static deserialize2_0(index: Index, sessionId?: SessionId): IdCompressor {
+	private static deserialize2_0(index: Index, sessionId?: SessionId): IdCompressor {
 		const hasLocalState = readBoolean(index);
 		const sessionCount = readNumber(index);
 		const clusterCount = readNumber(index);

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -49,13 +49,12 @@ import {
 } from "./sessions";
 import { SessionSpaceNormalizer } from "./sessionSpaceNormalizer";
 import { FinalSpace } from "./finalSpace";
-import { ghostClusterInitialSize } from "./types";
 
 /**
  * The version of IdCompressor that is currently persisted.
  * This should not be changed without careful consideration to compatibility.
  */
-const currentWrittenVersion = 1;
+const currentWrittenVersion = 2.0;
 
 /**
  * See {@link IIdCompressor} and {@link IIdCompressorCore}
@@ -105,8 +104,8 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 	private telemetryLocalIdCount = 0;
 	// The number of eager final IDs generated since the last telemetry was sent.
 	private telemetryEagerFinalIdCount = 0;
-	// The cluster for an ongoing ghost session, if one exists.
-	private ongoingGhostSession: IdCluster | undefined = undefined;
+	// The ongoing ghost session, if one exists.
+	private ongoingGhostSession?: { cluster?: IdCluster; ghostSessionId: SessionId };
 
 	// #endregion
 
@@ -167,12 +166,19 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 	}
 
 	public generateCompressedId(): SessionSpaceCompressedId {
+		// This ghost session code inside this block should not be changed without a version bump (it is performed at a consensus point)
 		if (this.ongoingGhostSession) {
-			// This code should not be changed without a version bump (it is performed at a consensus point)
-			this.ongoingGhostSession.capacity++;
-			this.ongoingGhostSession.count++;
+			if (this.ongoingGhostSession.cluster === undefined) {
+				this.ongoingGhostSession.cluster = this.addEmptyCluster(
+					this.sessions.getOrCreate(this.ongoingGhostSession.ghostSessionId),
+					1,
+				);
+			} else {
+				this.ongoingGhostSession.cluster.capacity++;
+			}
+			this.ongoingGhostSession.cluster.count++;
 			return lastFinalizedFinal(
-				this.ongoingGhostSession,
+				this.ongoingGhostSession.cluster,
 			) as unknown as SessionSpaceCompressedId;
 		} else {
 			this.localGenCount++;
@@ -204,10 +210,7 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 	 * {@inheritdoc IIdCompressorCore.beginGhostSession}
 	 */
 	public beginGhostSession(ghostSessionId: SessionId, ghostSessionCallback: () => void) {
-		this.ongoingGhostSession = this.addEmptyCluster(
-			this.sessions.getOrCreate(ghostSessionId),
-			ghostClusterInitialSize,
-		);
+		this.ongoingGhostSession = { ghostSessionId };
 		try {
 			ghostSessionCallback();
 		} finally {
@@ -347,7 +350,7 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 
 	private addEmptyCluster(session: Session, capacity: number): IdCluster {
 		assert(
-			!this.ongoingGhostSession,
+			!this.ongoingGhostSession?.cluster,
 			"IdCompressor should not be operated normally when in a ghost session",
 		);
 		const newCluster = session.addNewCluster(
@@ -602,7 +605,17 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 			bufferUint: new BigUint64Array(buffer),
 		};
 		const version = readNumber(index);
-		assert(version === currentWrittenVersion, 0x75c /* Unknown serialized version. */);
+		switch (version) {
+			case 1.0:
+				throw new Error("IdCompressor version 1.0 is no longer supported.");
+			case 2.0:
+				return IdCompressor.deserialize2_0(index, sessionId);
+			default:
+				throw new Error("Unknown IdCompressor serialized version.");
+		}
+	}
+
+	static deserialize2_0(index: Index, sessionId?: SessionId): IdCompressor {
 		const hasLocalState = readBoolean(index);
 		const sessionCount = readNumber(index);
 		const clusterCount = readNumber(index);

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -6,10 +6,16 @@
 import { strict as assert } from "assert";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { take } from "@fluid-private/stochastic-test-utils";
-import { OpSpaceCompressedId, SessionId, SessionSpaceCompressedId, StableId } from "../";
-import { IdCompressor } from "../idCompressor";
+import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
+import {
+	OpSpaceCompressedId,
+	SerializedIdCompressorWithNoSession,
+	SessionId,
+	SessionSpaceCompressedId,
+	StableId,
+} from "../";
+import { IdCompressor, deserializeIdCompressor } from "../idCompressor";
 import { createSessionId } from "../utilities";
-import { ghostClusterInitialSize } from "../types";
 import {
 	performFuzzActions,
 	sessionIds,
@@ -384,7 +390,7 @@ describe("IdCompressor", () => {
 
 		it("can generate IDs during a ghost session", () => {
 			const compressor = CompressorFactory.createCompressor(Client.Client1);
-			const idCount = ghostClusterInitialSize * 2;
+			const idCount = 10;
 			const ids = new Set<SessionSpaceCompressedId>();
 			const ghostSession = createSessionId();
 			compressor.beginGhostSession(ghostSession, () => {
@@ -396,6 +402,39 @@ describe("IdCompressor", () => {
 				}
 			});
 			assert.equal(ids.size, idCount);
+		});
+
+		it("does not create a cluster for a no-op ghost session", () => {
+			const mockLogger = new MockLogger();
+			const compressor = CompressorFactory.createCompressor(Client.Client1, 5, mockLogger);
+			compressor.serialize(false);
+			mockLogger.assertMatchAny([
+				{
+					eventName: "RuntimeIdCompressor:SerializedIdCompressorSize",
+					clusterCount: 0,
+					sessionCount: 0,
+				},
+			]);
+			compressor.beginGhostSession(createSessionId(), () => {});
+			compressor.serialize(false);
+			mockLogger.assertMatchAny([
+				{
+					eventName: "RuntimeIdCompressor:SerializedIdCompressorSize",
+					clusterCount: 0,
+					sessionCount: 0,
+				},
+			]);
+			compressor.beginGhostSession(createSessionId(), () => {
+				compressor.generateCompressedId();
+			});
+			compressor.serialize(false);
+			mockLogger.assertMatchAny([
+				{
+					eventName: "RuntimeIdCompressor:SerializedIdCompressorSize",
+					clusterCount: 1,
+					sessionCount: 1,
+				},
+			]);
 		});
 	});
 
@@ -768,6 +807,22 @@ describe("IdCompressor", () => {
 					roundtrippedCompressor2,
 					false, // don't compare local state
 				),
+			);
+		});
+
+		it("can detect and fails to load 1.0 documents", () => {
+			const compressor = CompressorFactory.createCompressor(Client.Client1);
+			const base64Content = compressor.serialize(false);
+			const floatView = new Float64Array(stringToBuffer(base64Content, "base64"));
+			// Change the version to 1.0
+			floatView[0] = 1.0;
+			const docString1 = bufferToString(
+				floatView.buffer,
+				"base64",
+			) as SerializedIdCompressorWithNoSession;
+			assert.throws(
+				() => deserializeIdCompressor(docString1, createSessionId()),
+				(e: Error) => e.message === "IdCompressor version 1.0 is no longer supported.",
 			);
 		});
 	});

--- a/packages/runtime/id-compressor/src/types/index.ts
+++ b/packages/runtime/id-compressor/src/types/index.ts
@@ -8,7 +8,6 @@ export {
 	SerializedIdCompressor,
 	SerializedIdCompressorWithNoSession,
 	SerializedIdCompressorWithOngoingSession,
-	ghostClusterInitialSize,
 } from "./persisted-types";
 
 export { IIdCompressorCore, IIdCompressor } from "./idCompressor";

--- a/packages/runtime/id-compressor/src/types/persisted-types/0.0.1.ts
+++ b/packages/runtime/id-compressor/src/types/persisted-types/0.0.1.ts
@@ -56,8 +56,3 @@ export interface IdCreationRange {
 		readonly requestedClusterSize: number;
 	};
 }
-
-/**
- * The size of the cluster to create when initializing a new ghost session.
- */
-export const ghostClusterInitialSize = 512;

--- a/packages/runtime/id-compressor/src/types/persisted-types/index.ts
+++ b/packages/runtime/id-compressor/src/types/persisted-types/index.ts
@@ -8,5 +8,4 @@ export {
 	SerializedIdCompressor,
 	SerializedIdCompressorWithNoSession,
 	SerializedIdCompressorWithOngoingSession,
-	ghostClusterInitialSize,
 } from "./0.0.1";


### PR DESCRIPTION
[How contribute to this
repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull
Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

This PR changes the cluster allocation strategy for ghost sessions to
exactly fill the cluster instead of needlessly allocating a large
cluster. It will also not make a cluster at all if IDs are not
allocated.

## Breaking Changes

This change adjusts a computation performed at a consensus point, and
thus breaks any sessions collaborating across version numbers. There
shouldn't be any compressors doing this (we will be patching the beta-1
release branch prior to release). Additionally, ghost sessions are
extremely unlikely to be used by the public at all until the first data
migration.