### PR TITLE
refactor(docs): Simplify async logic in api docs gen

### DIFF
--- a/docs/api-markdown-documenter/index.js
+++ b/docs/api-markdown-documenter/index.js
@@ -21,49 +21,45 @@ docVersions = renderMultiVersion
 	? versions.params.previousVersions.concat(versions.params.currentVersion)
 	: [versions.params.currentVersion];
 
-const apiDocRenders = [];
+Promise.all(
+	docVersions.map(async (version) => {
+		// We don't add a version-postfix directory name for "current" version, since local website builds want to use the
+		// locally generated API doc models when present.
+		const versionPostfix = version === versions.params.currentVersion ? "" : `-${version}`;
 
-docVersions.forEach((version) => {
-	// We don't add a version-postfix directory name for "current" version, since local website builds want to use the
-	// locally generated API doc models when present.
-	const versionPostfix = version === versions.params.currentVersion ? "" : `-${version}`;
+		const apiReportsDirectoryPath = path.resolve(
+			__dirname,
+			"..",
+			"..",
+			`_api-extractor-temp${versionPostfix}`,
+			"doc-models",
+		);
 
-	const apiReportsDirectoryPath = path.resolve(
-		__dirname,
-		"..",
-		"..",
-		`_api-extractor-temp${versionPostfix}`,
-		"doc-models",
-	);
+		// TODO: remove check for 2.0 and just set apiDocsDirectoryPath to include version.
+		// currently publishing to base apis directory until 2.0 release
+		const apiDocsDirectoryPath = renderMultiVersion
+			? path.resolve(__dirname, "..", "content", "docs", "api", version)
+			: path.resolve(__dirname, "..", "content", "docs", "api");
 
-	// TODO: remove check for 2.0 and just set apiDocsDirectoryPath to include version.
-	// currently publishing to base apis directory until 2.0 release
-	const apiDocsDirectoryPath = renderMultiVersion
-		? path.resolve(__dirname, "..", "content", "docs", "api", version)
-		: path.resolve(__dirname, "..", "content", "docs", "api");
+		// TODO: remove check for 2.0 and just set uriDirectoryPath to include version.
+		// currently publishing to base apis directory until 2.0 release
+		const uriRootDirectoryPath = renderMultiVersion ? `/docs/api/${version}` : `/docs/api`;
 
-	// TODO: remove check for 2.0 and just set uriDirectoryPath to include version.
-	// currently publishing to base apis directory until 2.0 release
-	const uriRootDirectoryPath = renderMultiVersion ? `/docs/api/${version}` : `/docs/api`;
-
-	apiDocRenders.push(
-		renderApiDocumentation(
+		await renderApiDocumentation(
 			apiReportsDirectoryPath,
 			apiDocsDirectoryPath,
 			uriRootDirectoryPath,
 			version,
-		).then(() => {
-			console.log(chalk.green(`(${version}) API docs written!`));
-		}),
-	);
-});
+		);
 
-Promise.all(apiDocRenders).then(
+		console.log(chalk.green(`(${version}) API docs written!`));
+	}),
+).then(
 	() => {
 		console.log(chalk.green("All API docs written!"));
 		process.exit(0);
 	},
-	(error) => {
+	() => {
 		process.exit(1);
 	},
 );


### PR DESCRIPTION
Inlines the callback logic into `Promise.all` and utilizes `async` syntax.