### PR TITLE
Added test config provider that provides options to set and clear config values

### DIFF
--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -9,7 +9,7 @@ import {
 	ContainerErrorTypes,
 	ICriticalContainerError,
 } from "@fluidframework/container-definitions";
-import { IErrorBase, ITelemetryBaseEvent, ConfigTypes } from "@fluidframework/core-interfaces";
+import { IErrorBase, ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
 import { ISnapshotTree, SummaryType } from "@fluidframework/protocol-definitions";
 import {
 	gcBlobPrefix,
@@ -61,7 +61,7 @@ import {
 	metadataBlobName,
 } from "../../summary";
 import { pkgVersion } from "../../packageVersion";
-import { configProvider } from "./gcUnitTestHelpers";
+import { createTestConfigProvider } from "./gcUnitTestHelpers";
 
 type GcWithPrivates = IGarbageCollector & {
 	readonly runtime: IGarbageCollectionRuntime;
@@ -90,8 +90,8 @@ describe("Garbage Collection Tests", () => {
 	// Nodes in the reference graph.
 	const nodes: string[] = ["/node1", "/node2", "/node3", "/node4", "/node5", "/node6"];
 	const testPkgPath = ["testPkg"];
+	const configProvider = createTestConfigProvider();
 
-	let injectedSettings: Record<string, ConfigTypes> = {};
 	let mockLogger: MockLogger;
 	let mc: MonitoringContext<MockLogger>;
 	let clock: SinonFakeTimers;
@@ -192,13 +192,13 @@ describe("Garbage Collection Tests", () => {
 	beforeEach(() => {
 		gc = undefined;
 		mockLogger = new MockLogger();
-		mc = mixinMonitoringContext(mockLogger, configProvider(injectedSettings));
+		mc = mixinMonitoringContext(mockLogger, configProvider);
 	});
 
 	afterEach(() => {
 		clock.reset();
 		mockLogger.clear();
-		injectedSettings = {};
+		configProvider.clear();
 		defaultGCData = { gcNodes: {} };
 		gc?.dispose();
 	});
@@ -933,8 +933,10 @@ describe("Garbage Collection Tests", () => {
 			const inactiveTimeoutMs = 500;
 
 			beforeEach(() => {
-				injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
-					inactiveTimeoutMs;
+				configProvider.set(
+					"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs",
+					inactiveTimeoutMs,
+				);
 			});
 
 			summarizerContainerTests(
@@ -1116,8 +1118,10 @@ describe("Garbage Collection Tests", () => {
 
 		it("Unreferenced nodes transition through Inactive, TombstoneReady and SweepReady states", async () => {
 			const inactiveTimeoutMs = 500;
-			injectedSettings["Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs"] =
-				inactiveTimeoutMs;
+			configProvider.set(
+				"Fluid.GarbageCollection.TestOverride.InactiveTimeoutMs",
+				inactiveTimeoutMs,
+			);
 
 			const garbageCollector = createGarbageCollector({});
 

--- a/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
@@ -13,7 +13,6 @@ import {
 	MonitoringContext,
 	createChildLogger,
 } from "@fluidframework/telemetry-utils";
-import { ConfigTypes } from "@fluidframework/core-interfaces";
 import {
 	GarbageCollector,
 	GCNodeType,
@@ -29,14 +28,12 @@ import {
 } from "../../gc";
 import { ContainerRuntimeGCMessage } from "../../messageTypes";
 import { pkgVersion } from "../../packageVersion";
-import { configProvider } from "./gcUnitTestHelpers";
 
 describe("Garbage Collection Stats", () => {
 	// Nodes in the reference graph.
 	const nodes: string[] = ["/node1", "/node2", "/node3", "/node4", "/node5", "/node6"];
 	const testPkgPath = ["testPkg"];
 
-	let injectedSettings: Record<string, ConfigTypes> = {};
 	let mockLogger: MockLogger;
 	let mc: MonitoringContext<MockLogger>;
 	let clock: SinonFakeTimers;
@@ -133,7 +130,7 @@ describe("Garbage Collection Stats", () => {
 	beforeEach(() => {
 		lastGCMessage = undefined;
 		mockLogger = new MockLogger();
-		mc = mixinMonitoringContext(mockLogger, configProvider(injectedSettings));
+		mc = mixinMonitoringContext(mockLogger);
 
 		// Set up initial GC graph with 5 nodes and 2 are unreferenced.
 		defaultGCData.gcNodes["/"] = [nodes[0]];
@@ -165,7 +162,6 @@ describe("Garbage Collection Stats", () => {
 	afterEach(() => {
 		clock.reset();
 		mockLogger.clear();
-		injectedSettings = {};
 		defaultGCData = { gcNodes: {} };
 	});
 

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
-import { ConfigTypes, ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
 import { IGarbageCollectionData } from "@fluidframework/runtime-definitions";
 import {
 	MockLogger,
@@ -27,7 +27,6 @@ import {
 } from "../../gc";
 import { pkgVersion } from "../../packageVersion";
 import { BlobManager } from "../../blobManager";
-import { configProvider } from "./gcUnitTestHelpers";
 
 describe("GC Telemetry Tracker", () => {
 	const defaultSnapshotCacheExpiryMs = 5 * 24 * 60 * 60 * 1000;
@@ -42,7 +41,6 @@ describe("GC Telemetry Tracker", () => {
 	// The package data is tagged in the telemetry event.
 	const eventPkg = { value: testPkgPath.join("/"), tag: TelemetryDataTag.CodeArtifact };
 
-	let injectedSettings: Record<string, ConfigTypes> = {};
 	let mockLogger: MockLogger;
 	let mc: MonitoringContext;
 	let clock: SinonFakeTimers;
@@ -176,7 +174,6 @@ describe("GC Telemetry Tracker", () => {
 		mockLogger = new MockLogger();
 		mc = mixinMonitoringContext(
 			createChildLogger({ logger: mockLogger, namespace: "GarbageCollector" }),
-			configProvider(injectedSettings),
 		);
 		unreferencedNodesState = new Map();
 	});
@@ -184,7 +181,6 @@ describe("GC Telemetry Tracker", () => {
 	afterEach(() => {
 		clock.reset();
 		mockLogger.clear();
-		injectedSettings = {};
 		sweepGracePeriodMs = 1000; // Default case for these tests
 	});
 

--- a/packages/runtime/container-runtime/src/test/gc/gcUnitTestHelpers.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcUnitTestHelpers.ts
@@ -3,12 +3,28 @@
  * Licensed under the MIT License.
  */
 
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
+import { ConfigTypes } from "@fluidframework/core-interfaces";
 import { ReadAndParseBlob } from "@fluidframework/runtime-utils";
 
-export const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
-	getRawConfig: (name: string): ConfigTypes => settings[name],
-});
+/**
+ * Creates a test config provider with the ability to set configs values and clear all config values.
+ * @internal
+ */
+export const createTestConfigProvider = () => {
+	const settings: Record<string, ConfigTypes> = {};
+	return {
+		getRawConfig: (name: string): ConfigTypes => settings[name],
+		set: (key: string, value: ConfigTypes) => {
+			settings[key] = value;
+		},
+		clear: () => {
+			Object.keys(settings).forEach((key) => {
+				// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+				delete settings[key];
+			});
+		},
+	};
+};
 
 export const parseNothing: ReadAndParseBlob = async <T>() => {
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
@@ -12,7 +12,6 @@ import {
 	ITestFluidObject,
 	ITestObjectProvider,
 	TestFluidObjectFactory,
-	mockConfigProvider,
 	createSummarizerFromFactory,
 	waitForContainerConnection,
 	summarizeNow,
@@ -50,7 +49,7 @@ describeCompat.skip("GC summary compatibility tests", "FullCompat", (getTestObje
 			registryEntries: [[dataObjectFactory.type, Promise.resolve(dataObjectFactory)]],
 			runtimeOptions,
 		});
-		return provider.createContainer(runtimeFactory, { configProvider: mockConfigProvider() });
+		return provider.createContainer(runtimeFactory);
 	}
 
 	beforeEach("setupContainer", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
@@ -9,10 +9,10 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import {
+	createTestConfigProvider,
 	createSummarizer,
 	ITestContainerConfig,
 	ITestObjectProvider,
-	mockConfigProvider,
 	summarizeNow,
 	timeoutPromise,
 	waitForContainerConnection,
@@ -35,12 +35,11 @@ describeCompat("GC loading from older summaries", "NoCompat", (getTestObjectProv
 	let containerRuntime: IContainerRuntime;
 	let dataStoreA: ITestDataObject;
 
-	const settings = {
-		"Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs": 10,
-	};
+	const configProvider = createTestConfigProvider();
+	configProvider.set("Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs", 10);
 	const testConfig: ITestContainerConfig = {
 		...defaultGCConfig,
-		loaderProps: { configProvider: mockConfigProvider(settings) },
+		loaderProps: { configProvider },
 	};
 
 	/**
@@ -122,7 +121,7 @@ describeCompat("GC loading from older summaries", "NoCompat", (getTestObjectProv
 		const { container: container2, summarizer: summarizer2 } = await createSummarizer(
 			provider,
 			mainContainer,
-			{ loaderProps: { configProvider: mockConfigProvider(settings) } },
+			{ loaderProps: { configProvider } },
 			summaryResult1.summaryVersion,
 		);
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
@@ -15,8 +15,8 @@ import {
 import {
 	ITestContainerConfig,
 	ITestObjectProvider,
+	createTestConfigProvider,
 	createSummarizer,
-	mockConfigProvider,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils";
 import {
@@ -37,9 +37,9 @@ import { getGCStateFromSummary } from "./gcTestSummaryUtils.js";
 describeCompat("GC state reset in summaries", "NoCompat", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;
-	const settings = {
-		"Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs": 10,
-	};
+
+	const configProvider = createTestConfigProvider();
+	configProvider.set("Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs", 10);
 
 	/** Creates a new container with the GC enabled / disabled as per gcAllowed param. */
 	const createContainer = async (gcAllowed: boolean): Promise<IContainer> => {
@@ -51,7 +51,7 @@ describeCompat("GC state reset in summaries", "NoCompat", (getTestObjectProvider
 					gcAllowed,
 				},
 			},
-			loaderProps: { configProvider: mockConfigProvider(settings) },
+			loaderProps: { configProvider },
 		};
 		return provider.makeTestContainer(testContainerConfig);
 	};

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -15,8 +15,8 @@ import {
 	createSummarizer,
 	summarizeNow,
 	waitForContainerConnection,
-	mockConfigProvider,
 	ITestContainerConfig,
+	createTestConfigProvider,
 } from "@fluidframework/test-utils";
 import { describeCompat, ITestDataObject, itExpects } from "@fluid-private/test-version-utils";
 import { stringToBuffer } from "@fluid-internal/client-utils";
@@ -110,8 +110,23 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 	};
 
 	let provider: ITestObjectProvider;
-	let settings = {};
-	let testContainerConfig: ITestContainerConfig;
+	const configProvider = createTestConfigProvider();
+	const testContainerConfig: ITestContainerConfig = {
+		runtimeOptions: {
+			summaryOptions: {
+				summaryConfigOverrides: {
+					state: "disabled",
+				},
+			},
+			gcOptions,
+		},
+		loaderProps: { configProvider },
+	};
+
+	const summarizerContainerConfig: ITestContainerConfig = {
+		runtimeOptions: { gcOptions },
+		loaderProps: { configProvider },
+	};
 
 	async function loadContainer(summaryVersion: string) {
 		return provider.loadTestContainer(testContainerConfig, {
@@ -155,7 +170,7 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 			container,
 			{
 				runtimeOptions: { gcOptions },
-				loaderProps: { configProvider: mockConfigProvider(settings) },
+				loaderProps: { configProvider },
 			},
 		);
 
@@ -164,22 +179,15 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 
 	beforeEach("setup", async function () {
 		provider = getTestObjectProvider({ syncSummarizer: true });
-		settings["Fluid.GarbageCollection.TestOverride.TombstoneTimeoutMs"] = tombstoneTimeoutMs;
-		testContainerConfig = {
-			runtimeOptions: {
-				summaryOptions: {
-					summaryConfigOverrides: {
-						state: "disabled",
-					},
-				},
-				gcOptions,
-			},
-			loaderProps: { configProvider: mockConfigProvider(settings) },
-		};
+
+		configProvider.set(
+			"Fluid.GarbageCollection.TestOverride.TombstoneTimeoutMs",
+			tombstoneTimeoutMs,
+		);
 	});
 
 	afterEach(() => {
-		settings = {};
+		configProvider.clear();
 	});
 
 	describe("Attachment blobs in attached container", () => {
@@ -478,10 +486,7 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 				const { summarizer, container: summarizerContainer } = await createSummarizer(
 					provider,
 					mainContainer,
-					{
-						runtimeOptions: { gcOptions },
-						loaderProps: { configProvider: mockConfigProvider(settings) },
-					},
+					summarizerContainerConfig,
 				);
 
 				// Remove the blob's handle to unreference it.
@@ -586,10 +591,7 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 				const { summarizer, container: summarizerContainer } = await createSummarizer(
 					provider,
 					mainContainer,
-					{
-						runtimeOptions: { gcOptions },
-						loaderProps: { configProvider: mockConfigProvider(settings) },
-					},
+					summarizerContainerConfig,
 				);
 
 				// Summarize so that the above attachment blob is marked unreferenced.
@@ -688,10 +690,7 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 				const { summarizer, container: summarizerContainer } = await createSummarizer(
 					provider,
 					mainContainer,
-					{
-						runtimeOptions: { gcOptions },
-						loaderProps: { configProvider: mockConfigProvider(settings) },
-					},
+					summarizerContainerConfig,
 				);
 
 				// Add the blob handles to reference them.
@@ -785,10 +784,7 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 			const { summarizer, container: summarizerContainer } = await createSummarizer(
 				provider,
 				container,
-				{
-					runtimeOptions: { gcOptions },
-					loaderProps: { configProvider: mockConfigProvider(settings) },
-				},
+				summarizerContainerConfig,
 			);
 			await provider.ensureSynchronized();
 			await summarizeNow(summarizer);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
@@ -5,10 +5,10 @@
 
 import { strict as assert } from "assert";
 import {
+	createTestConfigProvider,
 	createSummarizer,
 	ITestContainerConfig,
 	ITestObjectProvider,
-	mockConfigProvider,
 	summarizeNow,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils";
@@ -37,7 +37,7 @@ describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 	const tombstoneTimeoutMs = 200; // Tombstone at 200ms
 	const sweepGracePeriodMs = 100; // Sweep at 300ms
 
-	const settings = {};
+	const configProvider = createTestConfigProvider();
 	const gcOptions: IGCRuntimeOptions = {
 		inactiveTimeoutMs: tombstoneTimeoutMs / 2, // Required to avoid an error
 		enableGCSweep: true,
@@ -52,7 +52,7 @@ describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 			},
 			gcOptions,
 		},
-		loaderProps: { configProvider: mockConfigProvider(settings) },
+		loaderProps: { configProvider },
 	};
 
 	let provider: ITestObjectProvider;
@@ -63,7 +63,7 @@ describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 			container,
 			{
 				runtimeOptions: { gcOptions },
-				loaderProps: { configProvider: mockConfigProvider(settings) },
+				loaderProps: { configProvider },
 			},
 			summaryVersion,
 		);
@@ -85,9 +85,16 @@ describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 			this.skip();
 		}
 
-		settings["Fluid.GarbageCollection.DisableAttachmentBlobSweep"] = true; // Only sweep DataStores
-		settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
-		settings["Fluid.GarbageCollection.TestOverride.TombstoneTimeoutMs"] = tombstoneTimeoutMs;
+		configProvider.set("Fluid.GarbageCollection.DisableAttachmentBlobSweep", true); // Only sweep DataStores
+		configProvider.set("Fluid.GarbageCollection.ThrowOnTombstoneUsage", true);
+		configProvider.set(
+			"Fluid.GarbageCollection.TestOverride.TombstoneTimeoutMs",
+			tombstoneTimeoutMs,
+		);
+	});
+
+	afterEach(() => {
+		configProvider.clear();
 	});
 
 	it("Unreferenced objects follow the sequence [unreferenced, tombstoned, deleted]", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTestConfigs.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTestConfigs.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITestContainerConfig, mockConfigProvider } from "@fluidframework/test-utils";
+import { ITestContainerConfig, createTestConfigProvider } from "@fluidframework/test-utils";
 
 /**
  * Default test container configs used by GC tests to create / load containers.
@@ -15,5 +15,5 @@ export const defaultGCConfig: ITestContainerConfig = {
 		},
 		gcOptions: { gcAllowed: true },
 	},
-	loaderProps: { configProvider: mockConfigProvider() },
+	loaderProps: { configProvider: createTestConfigProvider() },
 };

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
@@ -10,7 +10,7 @@ import {
 	createSummarizer,
 	summarizeNow,
 	ITestContainerConfig,
-	mockConfigProvider,
+	createTestConfigProvider,
 } from "@fluidframework/test-utils";
 import {
 	describeCompat,
@@ -44,17 +44,29 @@ describeCompat("GC trailing ops tests", "NoCompat", (getTestObjectProvider) => {
 	) => {
 		// Skip Tombstone stage, these tests focus on Sweep
 		const sweepGracePeriodMs = 0;
-
-		let provider: ITestObjectProvider;
-		let settings = {};
-		let testContainerConfig: ITestContainerConfig;
-		let summarizerContainerConfig: ITestContainerConfig;
-
 		const sweepTimeoutMs = 100;
 		const gcOptions: IGCRuntimeOptions = {
 			inactiveTimeoutMs: 0,
 			enableGCSweep: true,
 			sweepGracePeriodMs,
+		};
+		const configProvider = createTestConfigProvider();
+		const testContainerConfig: ITestContainerConfig = {
+			runtimeOptions: {
+				summaryOptions: {
+					summaryConfigOverrides: {
+						state: "disabled",
+					},
+				},
+				gcOptions,
+			},
+			loaderProps: { configProvider },
+		};
+
+		let provider: ITestObjectProvider;
+		const summarizerContainerConfig: ITestContainerConfig = {
+			runtimeOptions: { gcOptions },
+			loaderProps: { configProvider },
 		};
 
 		function updateDataStoreReferenceState(
@@ -127,30 +139,14 @@ describeCompat("GC trailing ops tests", "NoCompat", (getTestObjectProvider) => {
 			if (provider.driver.type !== "local") {
 				this.skip();
 			}
-			settings["Fluid.GarbageCollection.TestOverride.TombstoneTimeoutMs"] =
-				sweepTimeoutMs - sweepGracePeriodMs; // sweepGracePeriodMs is 0. In any case, this subtraction represents the correct relationship between these values
-
-			const configProvider = mockConfigProvider(settings);
-			testContainerConfig = {
-				runtimeOptions: {
-					summaryOptions: {
-						summaryConfigOverrides: {
-							state: "disabled",
-						},
-					},
-					gcOptions,
-				},
-				loaderProps: { configProvider },
-			};
-
-			summarizerContainerConfig = {
-				runtimeOptions: { gcOptions },
-				loaderProps: { configProvider },
-			};
+			configProvider.set(
+				"Fluid.GarbageCollection.TestOverride.TombstoneTimeoutMs",
+				sweepTimeoutMs - sweepGracePeriodMs,
+			); // sweepGracePeriodMs is 0. In any case, this subtraction represents the correct relationship between these values
 		});
 
 		afterEach(() => {
-			settings = {};
+			configProvider.clear();
 		});
 
 		it(`Trailing op [${when}] transitions data store from [${transition}] without deleting it`, async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -11,8 +11,8 @@ import { IContainerRuntime } from "@fluidframework/container-runtime-definitions
 import { gcTreeKey } from "@fluidframework/runtime-definitions";
 import {
 	ITestObjectProvider,
+	createTestConfigProvider,
 	createSummarizer,
-	mockConfigProvider,
 	summarizeNow,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils";
@@ -21,7 +21,6 @@ import {
 	ITestDataObject,
 	TestDataObjectType,
 } from "@fluid-private/test-version-utils";
-import { ConfigTypes } from "@fluidframework/core-interfaces";
 // eslint-disable-next-line import/no-internal-modules
 import { detectOutboundRoutesViaDDSKey } from "@fluidframework/container-runtime/test/gc";
 import { defaultGCConfig } from "./gcTestConfigs.js";
@@ -37,11 +36,12 @@ import { getGCStateFromSummary } from "./gcTestSummaryUtils.js";
 describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 
+	const configProvider = createTestConfigProvider();
+
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;
 	let containerRuntime: IContainerRuntime;
 	let dataStoreA: ITestDataObject;
-	let settings: Record<string, ConfigTypes> = {};
 
 	/**
 	 * Submits a summary and returns the unreferenced timestamp for all the nodes in the container. If a node is
@@ -73,15 +73,18 @@ describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider
 			this.skip();
 		}
 
-		settings = {};
 		const testContainerConfig = {
 			...defaultGCConfig,
-			loaderProps: { configProvider: mockConfigProvider(settings) },
+			loaderProps: { configProvider },
 		};
 		mainContainer = await provider.makeTestContainer(testContainerConfig);
 		dataStoreA = (await mainContainer.getEntryPoint()) as ITestDataObject;
 		containerRuntime = dataStoreA._context.containerRuntime as IContainerRuntime;
 		await waitForContainerConnection(mainContainer);
+	});
+
+	afterEach(() => {
+		configProvider.clear();
 	});
 
 	async function createNewDataStore() {
@@ -544,10 +547,10 @@ describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider
 			it(`Scenario 6 - Reference added via new unreferenced nodes and removed`, async () => {
 				// Disable new Reference Detection behavior for now
 				// The re-referencing happens via attach op which we don't detect yet.
-				settings[detectOutboundRoutesViaDDSKey] = true;
+				configProvider.set(detectOutboundRoutesViaDDSKey, true);
 
 				const { summarizer } = await createSummarizer(provider, mainContainer, {
-					loaderProps: { configProvider: mockConfigProvider(settings) },
+					loaderProps: { configProvider },
 				});
 
 				// Create data store C and mark it referenced by storing its handle in data store A.
@@ -609,10 +612,10 @@ describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider
 			it(`Scenario 7 - Reference added transitively via new nodes and removed`, async () => {
 				// Disable new Reference Detection behavior for now
 				// Same reason as Scenario 6 - The re-referencing happens via attach op which we don't detect yet.
-				settings[detectOutboundRoutesViaDDSKey] = true;
+				configProvider.set(detectOutboundRoutesViaDDSKey, true);
 
 				const { summarizer } = await createSummarizer(provider, mainContainer, {
-					loaderProps: { configProvider: mockConfigProvider(settings) },
+					loaderProps: { configProvider },
 				});
 
 				// Create data store D and mark it referenced by storing its handle in data store A.

--- a/packages/test/test-end-to-end-tests/src/test/summarizationEdgeCases.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizationEdgeCases.spec.ts
@@ -14,7 +14,6 @@ import {
 	ITestContainerConfig,
 	ITestObjectProvider,
 	createSummarizer,
-	mockConfigProvider,
 	summarizeNow,
 } from "@fluidframework/test-utils";
 import { ContainerRuntime, ISubmitSummaryOptions } from "@fluidframework/container-runtime";
@@ -24,7 +23,6 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 // These tests intend to ensure that summarization succeeds in edge case scenarios that rarely happen
 describeCompat("Summarization edge cases", "NoCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
-	const settings = {};
 	const testContainerConfig: ITestContainerConfig = {
 		runtimeOptions: {
 			summaryOptions: {
@@ -34,7 +32,6 @@ describeCompat("Summarization edge cases", "NoCompat", (getTestObjectProvider, a
 				gcAllowed: true,
 			},
 		},
-		loaderProps: { configProvider: mockConfigProvider(settings) },
 	};
 
 	let provider: ITestObjectProvider;
@@ -56,9 +53,7 @@ describeCompat("Summarization edge cases", "NoCompat", (getTestObjectProvider, a
 	it("Summarization should still succeed when a datastore and its DDSes are realized between submit and ack", async () => {
 		const container1 = await createContainer();
 		const defaultDataStore1 = (await container1.getEntryPoint()) as ITestDataObject;
-		const { summarizer: summarizer1 } = await createSummarizer(provider, container1, {
-			loaderProps: { configProvider: mockConfigProvider(settings) },
-		});
+		const { summarizer: summarizer1 } = await createSummarizer(provider, container1);
 
 		// create a datastore with a dds as the default one is always realized
 		const containerRuntime1 = defaultDataStore1._context.containerRuntime;
@@ -82,7 +77,7 @@ describeCompat("Summarization edge cases", "NoCompat", (getTestObjectProvider, a
 		const { summarizer: summarizer2 } = await createSummarizer(
 			provider,
 			container1,
-			{ loaderProps: { configProvider: mockConfigProvider(settings) } },
+			undefined /* config */,
 			summaryVersion1,
 		);
 

--- a/packages/test/test-end-to-end-tests/src/test/summarizeRefreshLatestSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeRefreshLatestSummary.spec.ts
@@ -6,26 +6,15 @@
 import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
-import {
-	ITestContainerConfig,
-	mockConfigProvider,
-	ITestObjectProvider,
-	createSummarizer,
-	summarizeNow,
-} from "@fluidframework/test-utils";
+import { ITestObjectProvider, createSummarizer, summarizeNow } from "@fluidframework/test-utils";
 
 describeCompat(
 	"Summarizer can refresh a snapshot from the server",
 	"NoCompat",
 	(getTestObjectProvider) => {
-		const settings = {};
-		const testContainerConfig: ITestContainerConfig = {
-			loaderProps: { configProvider: mockConfigProvider(settings) },
-		};
-
 		let provider: ITestObjectProvider;
 		const createContainer = async (): Promise<IContainer> => {
-			return provider.makeTestContainer(testContainerConfig);
+			return provider.makeTestContainer();
 		};
 
 		beforeEach("getTestObjectProvider", async () => {
@@ -37,9 +26,6 @@ describeCompat(
 			const { container: summarizingContainer, summarizer } = await createSummarizer(
 				provider,
 				container,
-				testContainerConfig,
-				undefined,
-				undefined,
 			);
 
 			await provider.ensureSynchronized();

--- a/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
@@ -10,33 +10,39 @@ import {
 	ITestContainerConfig,
 	ITestFluidObject,
 	ITestObjectProvider,
+	createTestConfigProvider,
 	createSummarizer,
-	mockConfigProvider,
 	summarizeNow,
 } from "@fluidframework/test-utils";
 import { DefaultSummaryConfiguration } from "@fluidframework/container-runtime";
 import { SharedCounter } from "@fluidframework/counter";
 
 describeCompat("Summarizer closes instead of refreshing", "NoCompat", (getTestObjectProvider) => {
-	const settings = {};
+	const configProvider = createTestConfigProvider();
 	const testContainerConfig: ITestContainerConfig = {
 		runtimeOptions: {
 			summaryOptions: {
 				summaryConfigOverrides: { state: "disabled" },
 			},
 		},
-		loaderProps: { configProvider: mockConfigProvider(settings) },
+		loaderProps: { configProvider },
 		registry: [[SharedCounter.getFactory().type, SharedCounter.getFactory()]],
 	};
+	const summarizerContainerConfig: ITestContainerConfig = { loaderProps: { configProvider } };
 
 	let provider: ITestObjectProvider;
+
 	const createContainer = async (): Promise<IContainer> => {
 		return provider.makeTestContainer(testContainerConfig);
 	};
 
 	beforeEach("setup", async () => {
 		provider = getTestObjectProvider({ syncSummarizer: true });
-		settings["Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs"] = 100;
+		configProvider.set("Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs", 100);
+	});
+
+	afterEach(() => {
+		configProvider.clear();
 	});
 
 	itExpects(
@@ -61,7 +67,7 @@ describeCompat("Summarizer closes instead of refreshing", "NoCompat", (getTestOb
 			const { container: summarizingContainer, summarizer } = await createSummarizer(
 				provider,
 				container,
-				{ loaderProps: { configProvider: mockConfigProvider(settings) } },
+				summarizerContainerConfig,
 			);
 
 			const summarizeResults = summarizer.summarizeOnDemand({
@@ -91,13 +97,11 @@ describeCompat("Summarizer closes instead of refreshing", "NoCompat", (getTestOb
 			const { container: summarizingContainer, summarizer } = await createSummarizer(
 				provider,
 				container,
-				{ loaderProps: { configProvider: mockConfigProvider(settings) } },
+				summarizerContainerConfig,
 			);
 
 			const { container: summarizingContainer2, summarizer: summarizer2 } =
-				await createSummarizer(provider, container, {
-					loaderProps: { configProvider: mockConfigProvider(settings) },
-				});
+				await createSummarizer(provider, container, summarizerContainerConfig);
 
 			await summarizeNow(summarizer);
 			await provider.ensureSynchronized();
@@ -126,7 +130,7 @@ describeCompat("Summarizer closes instead of refreshing", "NoCompat", (getTestOb
 			const { container: summarizingContainer, summarizer } = await createSummarizer(
 				provider,
 				container,
-				{ loaderProps: { configProvider: mockConfigProvider(settings) } },
+				summarizerContainerConfig,
 			);
 
 			// summary1
@@ -142,7 +146,7 @@ describeCompat("Summarizer closes instead of refreshing", "NoCompat", (getTestOb
 				await createSummarizer(
 					provider,
 					container,
-					{ loaderProps: { configProvider: mockConfigProvider(settings) } },
+					summarizerContainerConfig,
 					summaryVersion1,
 				);
 

--- a/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
@@ -21,9 +21,9 @@ import {
 	waitForContainerConnection,
 	summarizeNow,
 	createSummarizerFromFactory,
-	mockConfigProvider,
 	timeoutAwait,
 	createSummarizer,
+	createTestConfigProvider,
 } from "@fluidframework/test-utils";
 import { ITestDataObject, describeCompat, itExpects } from "@fluid-private/test-version-utils";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
@@ -173,7 +173,7 @@ const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
 	[dataStoreFactory3.type, Promise.resolve(dataStoreFactory3)],
 ]);
 
-let settings = {};
+const configProvider = createTestConfigProvider();
 
 /** Creates a container with Summary Options overridden to ensure Summarization happens promptly (unless disabled) */
 const createContainer = async (
@@ -208,7 +208,7 @@ const createContainer = async (
 	});
 	return provider.createContainer(runtimeFactory, {
 		logger,
-		configProvider: mockConfigProvider(settings),
+		configProvider,
 	});
 };
 
@@ -232,10 +232,14 @@ describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvid
 		if (provider.driver.type !== "local") {
 			this.skip();
 		}
-		settings = {};
-		settings["Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs"] = 0;
-		settings["Fluid.Summarizer.ValidateSummaryBeforeUpload"] = true;
-		settings["Fluid.Summarizer.PendingOpsRetryDelayMs"] = 5;
+
+		configProvider.set("Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs", 0);
+		configProvider.set("Fluid.Summarizer.ValidateSummaryBeforeUpload", true);
+		configProvider.set("Fluid.Summarizer.PendingOpsRetryDelayMs", 5);
+	});
+
+	afterEach(() => {
+		configProvider.clear();
 	});
 
 	itExpects(
@@ -263,7 +267,7 @@ describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvid
 				undefined /* containerRuntimeFactoryType */,
 				registryStoreEntries,
 				undefined /* logger */,
-				mockConfigProvider(settings),
+				configProvider,
 			);
 			await provider.ensureSynchronized();
 
@@ -295,7 +299,7 @@ describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvid
 			},
 		],
 		async () => {
-			settings["Fluid.Summarizer.ValidateSummaryBeforeUpload"] = false;
+			configProvider.set("Fluid.Summarizer.ValidateSummaryBeforeUpload", false);
 			const container = await createContainer(provider);
 			await waitForContainerConnection(container);
 			const rootDataObject = (await container.getEntryPoint()) as RootTestDataObject;
@@ -311,7 +315,7 @@ describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvid
 				undefined /* containerRuntimeFactoryType */,
 				registryStoreEntries,
 				undefined /* logger */,
-				mockConfigProvider(settings),
+				configProvider,
 			);
 			await provider.ensureSynchronized();
 
@@ -343,13 +347,13 @@ describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvid
 		async () => {
 			// Wait for 100 ms for pending ops to be saved.
 			const pendingOpsTimeoutMs = 100;
-			settings["Fluid.Summarizer.waitForPendingOpsTimeoutMs"] = pendingOpsTimeoutMs;
+			configProvider.set("Fluid.Summarizer.waitForPendingOpsTimeoutMs", pendingOpsTimeoutMs);
 			const mockLogger = new MockLogger();
 			const container1 = await provider.makeTestContainer();
 			const { summarizer, container: summarizerContainer } = await createSummarizer(
 				provider,
 				container1,
-				{ loaderProps: { configProvider: mockConfigProvider(settings) } },
+				{ loaderProps: { configProvider } },
 				undefined /* summaryVersion */,
 				mockLogger,
 			);
@@ -430,7 +434,7 @@ describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvid
 				undefined /* containerRuntimeFactoryType */,
 				registryStoreEntries,
 				mockLogger,
-				mockConfigProvider(settings),
+				configProvider,
 			);
 			await provider.ensureSynchronized();
 
@@ -463,7 +467,7 @@ describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvid
 				},
 			],
 			async () => {
-				settings["Fluid.Summarizer.UseDynamicRetries"] = tryDynamicRetry;
+				configProvider.set("Fluid.Summarizer.UseDynamicRetries", tryDynamicRetry);
 				const logger = new MockLogger();
 				const mainContainer = await createContainer(
 					provider,
@@ -572,7 +576,7 @@ describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvid
 			},
 		],
 		async () => {
-			settings["Fluid.Summarizer.UseDynamicRetries"] = true;
+			configProvider.set("Fluid.Summarizer.UseDynamicRetries", true);
 			const container = await createContainer(provider, false /* disableSummary */);
 			await waitForContainerConnection(container);
 
@@ -654,9 +658,9 @@ describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvid
 			},
 		],
 		async () => {
-			settings["Fluid.Summarizer.UseDynamicRetries"] = true;
-			settings["Fluid.Summarizer.SkipFailingIncorrectSummary"] = true;
-			settings["Fluid.Summarizer.PendingOpsRetryDelayMs"] = 5;
+			configProvider.set("Fluid.Summarizer.UseDynamicRetries", true);
+			configProvider.set("Fluid.Summarizer.SkipFailingIncorrectSummary", true);
+			configProvider.set("Fluid.Summarizer.PendingOpsRetryDelayMs", 5);
 			const container = await createContainer(provider, false /* disableSummary */);
 			await waitForContainerConnection(container);
 
@@ -715,7 +719,7 @@ describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvid
 		],
 		async () => {
 			// The "summarize" event is only emitted when this setting is enabled
-			settings["Fluid.Summarizer.UseDynamicRetries"] = true;
+			configProvider.set("Fluid.Summarizer.UseDynamicRetries", true);
 
 			const container = await createContainer(provider, false /* disableSummary */);
 			await waitForContainerConnection(container);

--- a/packages/test/test-utils/api-report/test-utils.api.md
+++ b/packages/test/test-utils/api-report/test-utils.api.md
@@ -90,6 +90,9 @@ export function createSummarizerFromFactory(provider: ITestObjectProvider, conta
 }>;
 
 // @internal
+export const createTestConfigProvider: () => ITestConfigProvider;
+
+// @internal
 export const createTestContainerRuntimeFactory: (containerRuntimeCtor: typeof ContainerRuntime) => {
     new (type: string, dataStoreFactory: IFluidDataStoreFactory, runtimeOptions?: IContainerRuntimeOptions, requestHandlers?: RuntimeRequestHandler[]): {
         type: string;
@@ -170,6 +173,12 @@ export interface IProvideTestFluidObject {
     readonly ITestFluidObject: ITestFluidObject;
 }
 
+// @internal
+export interface ITestConfigProvider extends IConfigProviderBase {
+    clear: () => void;
+    set: (key: string, value: ConfigTypes) => void;
+}
+
 // @internal (undocumented)
 export interface ITestContainerConfig {
     enableAttribution?: boolean;
@@ -233,9 +242,6 @@ export class LocalCodeLoader implements ICodeDetailsLoader {
     constructor(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, runtimeOptions?: IContainerRuntimeOptions);
     load(source: IFluidCodeDetails): Promise<IFluidModuleWithDetails>;
 }
-
-// @internal (undocumented)
-export const mockConfigProvider: (settings?: Record<string, ConfigTypes>) => IConfigProviderBase;
 
 // @internal
 export const retryWithEventualValue: <T>(callback: () => Promise<T>, check: (value: T) => boolean, defaultValue: T, maxTries?: number, backOffMs?: number) => Promise<T>;

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -125,6 +125,11 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedVariableDeclaration_mockConfigProvider": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/test/test-utils/src/TestConfigs.ts
+++ b/packages/test/test-utils/src/TestConfigs.ts
@@ -19,7 +19,7 @@ export interface ITestConfigProvider extends IConfigProviderBase {
 }
 
 /**
- * Creates a mock config provider with the ability to set configs values and clear all config values.
+ * Creates a test config provider with the ability to set configs values and clear all config values.
  * @internal
  */
 export const createTestConfigProvider = (): ITestConfigProvider => {

--- a/packages/test/test-utils/src/TestConfigs.ts
+++ b/packages/test/test-utils/src/TestConfigs.ts
@@ -6,12 +6,34 @@
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 
 /**
+ * Extension of IConfigProviderBase that supports setting a config value and clearing all
+ * config values for testing.
+ *
  * @internal
  */
-export const mockConfigProvider = (
-	settings: Record<string, ConfigTypes> = {},
-): IConfigProviderBase => {
+export interface ITestConfigProvider extends IConfigProviderBase {
+	/** Set a config value */
+	set: (key: string, value: ConfigTypes) => void;
+	/** Clear all config values */
+	clear: () => void;
+}
+
+/**
+ * Creates a mock config provider with the ability to set configs values and clear all config values.
+ * @internal
+ */
+export const createTestConfigProvider = (): ITestConfigProvider => {
+	const settings: Record<string, ConfigTypes> = {};
 	return {
 		getRawConfig: (name: string): ConfigTypes => settings[name],
+		set: (key: string, value: ConfigTypes) => {
+			settings[key] = value;
+		},
+		clear: () => {
+			Object.keys(settings).forEach((key) => {
+				// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+				delete settings[key];
+			});
+		},
 	};
 };

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -24,7 +24,7 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import { ITestContainerConfig, ITestObjectProvider } from "./testObjectProvider";
-import { mockConfigProvider } from "./TestConfigs";
+import { createTestConfigProvider } from "./TestConfigs";
 import { waitForContainerConnection } from "./containerUtils";
 import { timeoutAwait } from "./timeoutUtils";
 import { createContainerRuntimeFactoryWithDefaultDataStore } from "./testContainerRuntimeFactoryWithDefaultDataStore";
@@ -114,7 +114,7 @@ export async function createSummarizerFromFactory(
 	containerRuntimeFactoryType = ContainerRuntimeFactoryWithDefaultDataStore,
 	registryEntries?: NamedFluidDataStoreRegistryEntries,
 	logger?: ITelemetryBaseLogger,
-	configProvider: IConfigProviderBase = mockConfigProvider(),
+	configProvider: IConfigProviderBase = createTestConfigProvider(),
 ): Promise<{ container: IContainer; summarizer: ISummarizer }> {
 	const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
 		containerRuntimeFactoryType,
@@ -156,7 +156,7 @@ export async function createSummarizer(
 		},
 		loaderProps: {
 			...config?.loaderProps,
-			configProvider: config?.loaderProps?.configProvider ?? mockConfigProvider(),
+			configProvider: config?.loaderProps?.configProvider ?? createTestConfigProvider(),
 			logger,
 		},
 	};

--- a/packages/test/test-utils/src/index.ts
+++ b/packages/test/test-utils/src/index.ts
@@ -13,7 +13,7 @@ export { LoaderContainerTracker } from "./loaderContainerTracker";
 export { fluidEntryPoint, LocalCodeLoader, SupportedExportInterfaces } from "./localCodeLoader";
 export { createAndAttachContainer, createLoader } from "./localLoader";
 export { retryWithEventualValue } from "./retry";
-export { mockConfigProvider } from "./TestConfigs";
+export { createTestConfigProvider, ITestConfigProvider } from "./TestConfigs";
 export {
 	createTestContainerRuntimeFactory,
 	TestContainerRuntimeFactory,

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -768,26 +768,14 @@ use_old_FunctionDeclaration_getUnexpectedLogErrorException(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "VariableDeclaration_mockConfigProvider": {"forwardCompat": false}
+* "RemovedVariableDeclaration_mockConfigProvider": {"forwardCompat": false}
 */
-declare function get_old_VariableDeclaration_mockConfigProvider():
-    TypeOnly<typeof old.mockConfigProvider>;
-declare function use_current_VariableDeclaration_mockConfigProvider(
-    use: TypeOnly<typeof current.mockConfigProvider>): void;
-use_current_VariableDeclaration_mockConfigProvider(
-    get_old_VariableDeclaration_mockConfigProvider());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "VariableDeclaration_mockConfigProvider": {"backCompat": false}
+* "RemovedVariableDeclaration_mockConfigProvider": {"backCompat": false}
 */
-declare function get_current_VariableDeclaration_mockConfigProvider():
-    TypeOnly<typeof current.mockConfigProvider>;
-declare function use_old_VariableDeclaration_mockConfigProvider(
-    use: TypeOnly<typeof old.mockConfigProvider>): void;
-use_old_VariableDeclaration_mockConfigProvider(
-    get_current_VariableDeclaration_mockConfigProvider());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
Some of the GC and summary tests use a mock config provider and a settings object to configure values. However, there is no consistent way of clearing the settings value and as a result, the values may not be cleared and new values may not be correctly set. There were a few instances of this that were fixed recently.

This change adds a `ITestConfigProvider` interface which is an extension of `IConfigProviderBase`. It adds methods `set` and `clear` which can be used to set a configs value and clear all values respectively. Tests can set values at the beginning of each test and reset all values when the test ends. This way every test will start with a clean set of configs and can add them as needed.

[AB#6656](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6656)

