### PR TITLE
[bump] common-definitions: 1.1.0 => 1.2.0 (minor)

### DIFF
--- a/common/lib/common-definitions/CHANGELOG.md
+++ b/common/lib/common-definitions/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @fluidframework/common-definitions Changelog
 
+## [1.1.0](https://github.com/microsoft/FluidFramework/releases/tag/common-definitions_v1.1.0)
+
+### Package now declares explicit exports
+
+This package now uses the [package.json exports field](https://nodejs.org/api/packages.html#exports) to declare package
+entrypoints. The package only provides a CommonJS entrypoint.
+
 ## [1.0.0](https://github.com/microsoft/FluidFramework/releases/tag/common-definitions_v1.0.0)
 
 ### Deprecated interfaces and types

--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/common-definitions",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Fluid common definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bumped common-definitions from 1.1.0 to 1.2.0.