### PR TITLE
[bump] common-utils: 3.0.0 => 3.1.0 (minor)

### DIFF
--- a/common/lib/common-utils/CHANGELOG.md
+++ b/common/lib/common-utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @fluidframework/common-utils Changelog
 
+## [3.1.0](https://github.com/microsoft/FluidFramework/releases/tag/common-utils_v3.1.0)
+
+### Updated @fluidframework/common-definitions
+
+The @fluidframework/common-definitions dependency has been upgraded to v1.1.0.
+[See the full changelog.](https://github.com/microsoft/FluidFramework/blob/main/common/lib/common-definitions/CHANGELOG.md#110)
+
 ## [3.0.0](https://github.com/microsoft/FluidFramework/releases/tag/common-utils_v3.0.0)
 
 ### Updated @fluidframework/common-definitions

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -76,7 +76,7 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"dependencies": {
-		"@fluidframework/common-definitions": "^1.1.0-220319",
+		"@fluidframework/common-definitions": "^1.1.0",
 		"@types/events": "^3.0.0",
 		"base64-js": "^1.5.1",
 		"buffer": "^6.0.3",

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/common-utils",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"description": "Collection of utility functions for Fluid",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/lib/common-utils/pnpm-lock.yaml
+++ b/common/lib/common-utils/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
       '@fluid-tools/build-cli': ^0.26.1
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
-      '@fluidframework/common-definitions': ^1.1.0-220319
+      '@fluidframework/common-definitions': ^1.1.0
       '@fluidframework/common-utils-previous': npm:@fluidframework/common-utils@1.0.0
       '@fluidframework/eslint-config-fluid': ^2.1.0
       '@microsoft/api-extractor': ^7.38.3
@@ -53,7 +53,7 @@ importers:
       ts-node: ^10.9.1
       typescript: ~4.5.5
     dependencies:
-      '@fluidframework/common-definitions': 1.1.0-220319
+      '@fluidframework/common-definitions': 1.1.0
       '@types/events': 3.0.0
       base64-js: 1.5.1
       buffer: 6.0.3
@@ -712,8 +712,8 @@ packages:
     resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
     dev: true
 
-  /@fluidframework/common-definitions/1.1.0-220319:
-    resolution: {integrity: sha512-jNs+MM3EoYBcm1dePQ8r+ybUFVVPfWHKqh/1xvD3+YTJrQMfl2BXWb8gzaT0tFEJk4M761fvNroB6zvvnV3irA==}
+  /@fluidframework/common-definitions/1.1.0:
+    resolution: {integrity: sha512-WQYtG9tkx2j7i1JSXPvwLnQsqCOZAghMj0aGciqjZVNppUly/XBpAjb4V6FEUCEjxCScPKhyE+1rhV1ep52NgA==}
     dev: false
 
   /@fluidframework/common-utils/1.0.0:


### PR DESCRIPTION
Bumped common-utils from 3.0.0 to 3.1.0. A bump wasn't done after the 3.0 release so once this is merged I'll make a second PR that bumps to 3.2.0, then I'll release 3.1.0.

This change also bumps the common-definitions dependency to the release version.