### PR TITLE
Additional tests for "future" ops with compatDetails (stress tests, e2e tests)

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -857,6 +857,12 @@ export type SummaryStage = SubmitSummaryResult["stage"] | "unknown";
 export const TombstoneResponseHeaderKey = "isTombstoned";
 
 // @internal
+export interface UnknownContainerRuntimeMessage extends Partial<RecentlyAddedContainerRuntimeMessageDetails> {
+    contents: unknown;
+    type: "__unknown_container_message_type__never_use_as_value__";
+}
+
+// @internal
 export function unpackRuntimeMessage(message: ISequencedDocumentMessage): boolean;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2050,6 +2050,8 @@ export class ContainerRuntime
 					this.closeFn(error);
 					throw error;
 				}
+				// Note: Even if its compat behavior allows it, we don't know how to apply this stashed op.
+				// All we can do is ignore it (similar to on process).
 			}
 		}
 	}
@@ -3691,9 +3693,10 @@ export class ContainerRuntime
 				throw new LoggingError("GC op not expected to be resubmitted in summarizer");
 			default: {
 				// This case should be very rare - it would imply an op was stashed from a
-				// future version of runtime code and now is being applied on an older version
+				// future version of runtime code and now is being applied on an older version.
 				const compatBehavior = message.compatDetails?.behavior;
 				if (compatBehaviorAllowsMessageType(message.type, compatBehavior)) {
+					// We do not ultimately resubmit it, to be consistent with this version of the code.
 					this.logger.sendTelemetryEvent({
 						eventName: "resubmitUnrecognizedMessageTypeAllowed",
 						messageDetails: { type: message.type, compatBehavior },

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -30,6 +30,7 @@ export {
 	IContainerRuntimeMessageCompatDetails,
 	CompatModeBehavior,
 	RecentlyAddedContainerRuntimeMessageDetails,
+	UnknownContainerRuntimeMessage,
 } from "./messageTypes";
 export { IBlobManagerLoadInfo } from "./blobManager";
 export { FluidDataStoreRegistry } from "./dataStoreRegistry";

--- a/packages/runtime/container-runtime/src/messageTypes.ts
+++ b/packages/runtime/container-runtime/src/messageTypes.ts
@@ -133,7 +133,7 @@ export type ContainerRuntimeGCMessage = TypedContainerRuntimeMessage<
 >;
 
 /**
- * Represents an unrecognized {@link TypedContainerRuntimeMessage}, e.g. a message from a future version of the container runtime.
+ * Represents an unrecognized TypedContainerRuntimeMessage, e.g. a message from a future version of the container runtime.
  * @internal
  */
 export interface UnknownContainerRuntimeMessage

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -157,6 +157,9 @@ describeCompat("Flushing ops", "NoCompat", (getTestObjectProvider, apis) => {
 			enableGroupedBatching: true,
 			chunkSizeInBytes: 100,
 		});
+		const futureOpSubmitter2 = dataObject2.context.containerRuntime as unknown as {
+			submit: (containerRuntimeMessage: UnknownContainerRuntimeMessage) => void;
+		};
 		const dataObject1BatchMessages: ISequencedDocumentMessage[] = [];
 		const dataObject2BatchMessages: ISequencedDocumentMessage[] = [];
 		setupBatchMessageListener(dataObject1, dataObject1BatchMessages);
@@ -164,11 +167,7 @@ describeCompat("Flushing ops", "NoCompat", (getTestObjectProvider, apis) => {
 
 		// Submit two ops, one of which is unrecognized
 		dataObject2map1.set("key1", "value1");
-		(
-			dataObject2.context.containerRuntime as unknown as {
-				submit: (containerRuntimeMessage: UnknownContainerRuntimeMessage) => void;
-			}
-		).submit({
+		futureOpSubmitter2.submit({
 			type: "FUTURE_TYPE" as any,
 			contents: "Hello",
 			compatDetails: { behavior: "Ignore" }, // This op should be ignored when processed

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -559,9 +559,10 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 		const opsPerCycle = (config.testConfig.opRatePerMin * cycleMs) / 60000;
 		const opsGapMs = cycleMs / opsPerCycle;
 		const futureOpPeriod =
-			config.testConfig.futureOpRate !== undefined && config.testConfig.futureOpRate > 0
-				? 1 / config.testConfig.futureOpRate
-				: undefined;
+			config.testConfig.futureOpRatePerMin === undefined ||
+			config.testConfig.futureOpRatePerMin <= 0
+				? undefined
+				: Math.floor(config.testConfig.opRatePerMin / config.testConfig.futureOpRatePerMin);
 		const opSizeinBytes =
 			typeof config.testConfig.content?.opSizeinBytes === "undefined"
 				? 0

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -22,6 +22,7 @@ export interface ILoadTestConfig {
 	totalSignalsSendCount?: number;
 	readWriteCycleMs: number;
 	signalsPerMin?: number;
+	futureOpRate?: number;
 	faultInjectionMs?: {
 		min: number;
 		max: number;

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -22,7 +22,7 @@ export interface ILoadTestConfig {
 	totalSignalsSendCount?: number;
 	readWriteCycleMs: number;
 	signalsPerMin?: number;
-	futureOpRate?: number;
+	futureOpRatePerMin?: number;
 	faultInjectionMs?: {
 		min: number;
 		max: number;

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -3,6 +3,7 @@
 		"ci": {
 			"opRatePerMin": 10,
 			"signalsPerMin": 10,
+			"futureOpRate": 0.1,
 			"progressIntervalMs": 15000,
 			"numClients": 120,
 			"totalSendCount": 10000,
@@ -57,6 +58,7 @@
 		},
 		"ci_frs": {
 			"opRatePerMin": 10,
+			"futureOpRate": 0.1,
 			"progressIntervalMs": 15000,
 			"numClients": 100,
 			"totalSendCount": 10000,
@@ -83,6 +85,7 @@
 		},
 		"full": {
 			"opRatePerMin": 1920,
+			"futureOpRate": 0.1,
 			"progressIntervalMs": 1500000,
 			"numClients": 60,
 			"totalSendCount": 200000,
@@ -94,6 +97,7 @@
 		},
 		"mini": {
 			"opRatePerMin": 60,
+			"futureOpRate": 0.1,
 			"progressIntervalMs": 5000,
 			"numClients": 2,
 			"totalSendCount": 30,
@@ -114,6 +118,7 @@
 		},
 		"debug": {
 			"opRatePerMin": 60,
+			"futureOpRate": 0.5,
 			"progressIntervalMs": 5000,
 			"numClients": 1,
 			"totalSendCount": 30,
@@ -125,6 +130,7 @@
 		},
 		"ci_nofault": {
 			"opRatePerMin": 10,
+			"futureOpRate": 0.1,
 			"progressIntervalMs": 15000,
 			"numClients": 120,
 			"totalSendCount": 10000,
@@ -132,6 +138,7 @@
 		},
 		"scale": {
 			"opRatePerMin": 60,
+			"futureOpRate": 0.1,
 			"progressIntervalMs": 20000,
 			"numClients": 10,
 			"totalSendCount": 70000,
@@ -143,6 +150,7 @@
 		},
 		"scale_nofault": {
 			"opRatePerMin": 60,
+			"futureOpRate": 0.1,
 			"progressIntervalMs": 20000,
 			"numClients": 10,
 			"totalSendCount": 70000,
@@ -150,6 +158,7 @@
 		},
 		"blobs": {
 			"opRatePerMin": 60,
+			"futureOpRate": 0.1,
 			"progressIntervalMs": 5000,
 			"numClients": 4,
 			"totalSendCount": 150,
@@ -173,6 +182,7 @@
 		},
 		"offline": {
 			"opRatePerMin": 60,
+			"futureOpRate": 0.1,
 			"progressIntervalMs": 5000,
 			"numClients": 4,
 			"totalSendCount": 300,
@@ -196,6 +206,7 @@
 		},
 		"binarySnapshotFormat": {
 			"opRatePerMin": 60,
+			"futureOpRate": 0.1,
 			"progressIntervalMs": 5000,
 			"numClients": 4,
 			"totalSendCount": 150,

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -3,7 +3,7 @@
 		"ci": {
 			"opRatePerMin": 10,
 			"signalsPerMin": 10,
-			"futureOpRatePerMin": 6,
+			"futureOpRatePerMin": 2,
 			"progressIntervalMs": 15000,
 			"numClients": 120,
 			"totalSendCount": 10000,
@@ -58,7 +58,7 @@
 		},
 		"ci_frs": {
 			"opRatePerMin": 10,
-			"futureOpRatePerMin": 6,
+			"futureOpRatePerMin": 2,
 			"progressIntervalMs": 15000,
 			"numClients": 100,
 			"totalSendCount": 10000,

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -3,7 +3,7 @@
 		"ci": {
 			"opRatePerMin": 10,
 			"signalsPerMin": 10,
-			"futureOpRate": 0.1,
+			"futureOpRatePerMin": 6,
 			"progressIntervalMs": 15000,
 			"numClients": 120,
 			"totalSendCount": 10000,
@@ -58,7 +58,7 @@
 		},
 		"ci_frs": {
 			"opRatePerMin": 10,
-			"futureOpRate": 0.1,
+			"futureOpRatePerMin": 6,
 			"progressIntervalMs": 15000,
 			"numClients": 100,
 			"totalSendCount": 10000,
@@ -85,7 +85,7 @@
 		},
 		"full": {
 			"opRatePerMin": 1920,
-			"futureOpRate": 0.1,
+			"futureOpRatePerMin": 6,
 			"progressIntervalMs": 1500000,
 			"numClients": 60,
 			"totalSendCount": 200000,
@@ -97,7 +97,7 @@
 		},
 		"mini": {
 			"opRatePerMin": 60,
-			"futureOpRate": 0.1,
+			"futureOpRatePerMin": 6,
 			"progressIntervalMs": 5000,
 			"numClients": 2,
 			"totalSendCount": 30,
@@ -118,7 +118,7 @@
 		},
 		"debug": {
 			"opRatePerMin": 60,
-			"futureOpRate": 0.5,
+			"futureOpRatePerMin": 6,
 			"progressIntervalMs": 5000,
 			"numClients": 1,
 			"totalSendCount": 30,
@@ -130,7 +130,7 @@
 		},
 		"ci_nofault": {
 			"opRatePerMin": 10,
-			"futureOpRate": 0.1,
+			"futureOpRatePerMin": 6,
 			"progressIntervalMs": 15000,
 			"numClients": 120,
 			"totalSendCount": 10000,
@@ -138,7 +138,7 @@
 		},
 		"scale": {
 			"opRatePerMin": 60,
-			"futureOpRate": 0.1,
+			"futureOpRatePerMin": 6,
 			"progressIntervalMs": 20000,
 			"numClients": 10,
 			"totalSendCount": 70000,
@@ -150,7 +150,7 @@
 		},
 		"scale_nofault": {
 			"opRatePerMin": 60,
-			"futureOpRate": 0.1,
+			"futureOpRatePerMin": 6,
 			"progressIntervalMs": 20000,
 			"numClients": 10,
 			"totalSendCount": 70000,
@@ -158,7 +158,6 @@
 		},
 		"blobs": {
 			"opRatePerMin": 60,
-			"futureOpRate": 0.1,
 			"progressIntervalMs": 5000,
 			"numClients": 4,
 			"totalSendCount": 150,
@@ -182,7 +181,7 @@
 		},
 		"offline": {
 			"opRatePerMin": 60,
-			"futureOpRate": 0.1,
+			"futureOpRatePerMin": 6,
 			"progressIntervalMs": 5000,
 			"numClients": 4,
 			"totalSendCount": 300,
@@ -206,7 +205,6 @@
 		},
 		"binarySnapshotFormat": {
 			"opRatePerMin": 60,
-			"futureOpRate": 0.1,
 			"progressIntervalMs": 5000,
 			"numClients": 4,
 			"totalSendCount": 150,


### PR DESCRIPTION
## Description

Additional test coverage for #16364.  Fixes AB#5316

- Add periodic future ops (with compat behavior set to "ignore") to Stress Test to get coverage of them being processed under the various configurations and conditions the stress test covers.
- e2e test to round-trip a future op through compression/chunking/grouping
- unit test to cover future op going through resubmit (should not actually be resubmitted)

## Reviewer Guidance

For the stress tests, I followed the lead of the "large ops" addition, where periodically an additional op is sent on top of the typical counter increment.  I ran a pipeline with these changes and it operated as expected based on the logs.