### PR TITLE
[bump] common-utils: 3.1.0 => 3.2.0 (minor)

### DIFF
--- a/common/lib/common-utils/CHANGELOG.md
+++ b/common/lib/common-utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluidframework/common-utils Changelog
 
+## [3.2.0](https://github.com/microsoft/FluidFramework/releases/tag/common-utils_v3.2.0)
+
 ## [3.1.0](https://github.com/microsoft/FluidFramework/releases/tag/common-utils_v3.1.0)
 
 ### Updated @fluidframework/common-definitions

--- a/common/lib/common-utils/package.json
+++ b/common/lib/common-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/common-utils",
-	"version": "3.1.0",
+	"version": "3.2.0",
 	"description": "Collection of utility functions for Fluid",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bumped common-utils from 3.1.0 to 3.2.0.