### PR TITLE
Clean Up MergeTree Forgotten Exports

### DIFF
--- a/packages/dds/merge-tree/api-extractor-esm.json
+++ b/packages/dds/merge-tree/api-extractor-esm.json
@@ -1,17 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-base-esm.json",
-	"messages": {
-		"extractorMessageReporting": {
-			// The ESM types complain about missing exports; I don't understand why CJS doesn't. The errors are:
-			//
-			// Error: src/localReference.ts:241:2 - (ae-forgotten-export) The symbol "IRefsAtOffset" needs to be exported by the entry point index.d.mts
-			// Error: src/mergeTreeNodes.ts:402:2 - (ae-forgotten-export) The symbol "ISegmentLeaf" needs to be exported by
-			// the entry point index.d.mts
-			// TODO: AB#6647
-			"ae-forgotten-export": {
-				"logLevel": "none"
-			}
-		}
-	}
+	"extends": "../../../common/build/build-common/api-extractor-base-esm.json"
 }

--- a/packages/dds/merge-tree/api-extractor.json
+++ b/packages/dds/merge-tree/api-extractor.json
@@ -1,12 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-base.json",
-	"messages": {
-		"extractorMessageReporting": {
-			// TODO: Fix violations and remove this rule override
-			"ae-forgotten-export": {
-				"logLevel": "none"
-			}
-		}
-	}
+	"extends": "../../../common/build/build-common/api-extractor-base.json"
 }

--- a/packages/dds/merge-tree/api-report/merge-tree.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { AttributionKey } from '@fluidframework/runtime-definitions';
-import { Heap } from '@fluidframework/core-utils';
 import { IChannelStorageService } from '@fluidframework/datastore-definitions';
 import { IEventThisPlaceHolder } from '@fluidframework/core-interfaces';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
@@ -584,15 +583,13 @@ export interface KeyComparer<TKey> {
     (a: TKey, b: TKey): number;
 }
 
-// @alpha
+// @alpha @sealed
 export class LocalReferenceCollection {
     // (undocumented)
     [Symbol.iterator](): {
         next(): IteratorResult<LocalReferencePosition>;
         [Symbol.iterator](): any;
     };
-    constructor(
-    segment: ISegment, initialRefsByfOffset?: (IRefsAtOffset | undefined)[]);
     // (undocumented)
     addAfterTombstones(...refs: Iterable<LocalReferencePosition>[]): void;
     // (undocumented)
@@ -611,6 +608,8 @@ export class LocalReferenceCollection {
     isAfterTombstone(lref: LocalReferencePosition): boolean;
     // (undocumented)
     removeLocalRef(lref: LocalReferencePosition): LocalReferencePosition | undefined;
+    // (undocumented)
+    static setOrGet(segment: ISegment): LocalReferenceCollection;
     split(offset: number, splitSeg: ISegment): void;
     // (undocumented)
     walkReferences(visitor: (lref: LocalReferencePosition) => boolean | void | undefined, start?: LocalReferencePosition, forward?: boolean): boolean;
@@ -925,7 +924,7 @@ export interface SegmentGroup {
     // (undocumented)
     refSeq: number;
     // (undocumented)
-    segments: ISegmentLeaf[];
+    segments: ISegment[];
 }
 
 // @alpha (undocumented)

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -24,7 +24,7 @@ import {
 	CollaborationWindow,
 	compareStrings,
 	IMoveInfo,
-	IMergeLeaf,
+	ISegmentLeaf,
 	ISegment,
 	ISegmentAction,
 	Marker,
@@ -360,7 +360,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	 * @param segment - The segment to get the position of
 	 */
 	public getPosition(segment: ISegment | undefined, localSeq?: number): number {
-		const mergeSegment: IMergeLeaf | undefined = segment;
+		const mergeSegment: ISegmentLeaf | undefined = segment;
 		if (mergeSegment?.parent === undefined) {
 			return -1;
 		}

--- a/packages/dds/merge-tree/src/endOfTreeSegment.ts
+++ b/packages/dds/merge-tree/src/endOfTreeSegment.ts
@@ -6,8 +6,8 @@
 import { assert } from "@fluidframework/core-utils";
 import { LocalClientId } from "./constants";
 import { LocalReferenceCollection } from "./localReference";
-import { ISegmentLeaf, MergeTree } from "./mergeTree";
-import { IMergeBlock, IRemovalInfo, ISegment } from "./mergeTreeNodes";
+import { MergeTree } from "./mergeTree";
+import { IMergeBlock, IRemovalInfo, ISegment, ISegmentLeaf } from "./mergeTreeNodes";
 import { depthFirstNodeWalk, NodeAction } from "./mergeTreeNodeWalk";
 
 /**

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -212,6 +212,8 @@ export function setValidateRefCount(cb?: (collection?: LocalReferenceCollection)
  * Represents a collection of {@link LocalReferencePosition}s associated with
  * one segment in a merge-tree.
  * Represents a collection of {@link LocalReferencePosition}s associated with one segment in a merge-tree.
+ * @sealed
+ *
  * @alpha
  */
 export class LocalReferenceCollection {
@@ -234,11 +236,15 @@ export class LocalReferenceCollection {
 		validateRefCount?.(seg2.localRefs);
 	}
 
+	public static setOrGet(segment: ISegment) {
+		return (segment.localRefs ??= new LocalReferenceCollection(segment));
+	}
+
 	private readonly refsByOffset: (IRefsAtOffset | undefined)[];
 	private refCount: number = 0;
 
 	/***/
-	constructor(
+	private constructor(
 		/** Segment this `LocalReferenceCollection` is associated to. */
 		private readonly segment: ISegment,
 		initialRefsByfOffset = new Array<IRefsAtOffset | undefined>(segment.cachedLength),

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -29,7 +29,7 @@ import {
 	CollaborationWindow,
 	IHierBlock,
 	IMergeBlock,
-	IMergeLeaf,
+	ISegmentLeaf,
 	IMergeNode,
 	IMoveInfo,
 	InsertContext,
@@ -79,12 +79,6 @@ import { zamboniSegments } from "./zamboni";
 // eslint-disable-next-line import/no-deprecated
 import { Client } from "./client";
 import { EndOfTreeSegment, StartOfTreeSegment } from "./endOfTreeSegment";
-
-/**
- * someday we may split tree leaves from segments, but for now they are the same
- * this is just a convenience type that makes it clear that we need something that is both a segment and a leaf node
- */
-export type ISegmentLeaf = ISegment & IMergeLeaf;
 
 function wasRemovedAfter(seg: ISegment, seq: number): boolean {
 	return (
@@ -643,7 +637,7 @@ export class MergeTree {
 		this.nodeUpdateLengthNewStructure(this.root, true);
 	}
 
-	private addToLRUSet(leaf: IMergeLeaf, seq: number) {
+	private addToLRUSet(leaf: ISegmentLeaf, seq: number) {
 		// If the parent node has not yet been marked for scour (i.e., needsScour is not false or undefined),
 		// add the segment and mark the mark the node now.
 
@@ -786,7 +780,7 @@ export class MergeTree {
 
 			if (maybeEndpoint) {
 				const endpoint = maybeEndpoint === "start" ? this.startOfTree : this.endOfTree;
-				const localRefs = (endpoint.localRefs ??= new LocalReferenceCollection(endpoint));
+				const localRefs = LocalReferenceCollection.setOrGet(endpoint);
 				if (currentSlideIsForward) {
 					localRefs.addBeforeTombstones(...endpointRefsToAdd);
 				} else {
@@ -795,8 +789,7 @@ export class MergeTree {
 			}
 
 			if (currentSlideDestination !== undefined) {
-				const localRefs = (currentSlideDestination.localRefs ??=
-					new LocalReferenceCollection(currentSlideDestination));
+				const localRefs = LocalReferenceCollection.setOrGet(currentSlideDestination);
 				if (currentSlideIsForward) {
 					localRefs.addBeforeTombstones(...nonEndpointRefsToAdd);
 				} else {
@@ -1099,7 +1092,7 @@ export class MergeTree {
 		let foundMarker: Marker | undefined;
 
 		const { segment } = this.getContainingSegment(startPos, UniversalSequenceNumber, clientId);
-		const segWithParent: IMergeLeaf | undefined = segment;
+		const segWithParent: ISegmentLeaf | undefined = segment;
 		if (segWithParent?.parent === undefined) {
 			return undefined;
 		}
@@ -1169,7 +1162,7 @@ export class MergeTree {
 					const locallyMovedSegments = this.locallyMovedSegments.get(localMovedSeq);
 
 					if (locallyMovedSegments) {
-						for (const segment of locallyMovedSegments.segments) {
+						locallyMovedSegments.segments.forEach((segment: ISegmentLeaf) => {
 							segment.localMovedSeq = undefined;
 
 							if (!nodesToUpdate.includes(segment.parent!)) {
@@ -1179,7 +1172,7 @@ export class MergeTree {
 							if (segment.movedSeq === UnassignedSequenceNumber) {
 								segment.movedSeq = seq;
 							}
-						}
+						});
 
 						this.locallyMovedSegments.delete(localMovedSeq);
 					}
@@ -2293,8 +2286,7 @@ export class MergeTree {
 			segment = _segment;
 		}
 
-		const localRefs = segment.localRefs ?? new LocalReferenceCollection(segment);
-		segment.localRefs = localRefs;
+		const localRefs = LocalReferenceCollection.setOrGet(segment);
 
 		const segRef = localRefs.createLocalRef(
 			offset,

--- a/packages/dds/merge-tree/src/revertibles.ts
+++ b/packages/dds/merge-tree/src/revertibles.ts
@@ -9,7 +9,7 @@ import { DoublyLinkedList } from "./collections";
 import { EndOfTreeSegment } from "./endOfTreeSegment";
 import { LocalReferenceCollection, LocalReferencePosition } from "./localReference";
 import { IMergeTreeDeltaCallbackArgs } from "./mergeTreeDeltaCallback";
-import { IMergeLeaf, ISegment, toRemovalInfo } from "./mergeTreeNodes";
+import { ISegmentLeaf, ISegment, toRemovalInfo } from "./mergeTreeNodes";
 import { depthFirstNodeWalk } from "./mergeTreeNodeWalk";
 import { ITrackingGroup, Trackable, UnorderedTrackingGroup } from "./mergeTreeTracking";
 import { IJSONSegment, MergeTreeDeltaType, ReferenceType } from "./ops";
@@ -94,9 +94,7 @@ function findMergeTreeWithRevert(trackable: Trackable): MergeTreeWithRevert {
 		const refCallbacks: MergeTreeWithRevert["__mergeTreeRevertible"]["refCallbacks"] = {
 			afterSlide: (r: LocalReferencePosition) => {
 				if (mergeTree.referencePositionToLocalPosition(r) === DetachedReferencePosition) {
-					const refs = (detachedReferences.localRefs ??= new LocalReferenceCollection(
-						detachedReferences,
-					));
+					const refs = LocalReferenceCollection.setOrGet(detachedReferences);
 					refs.addAfterTombstones([r]);
 				}
 			},
@@ -284,7 +282,7 @@ function revertLocalRemove(
 
 		const props = tracked.properties as RemoveSegmentRefProperties;
 		driver.insertFromSpec(realPos, props.segSpec);
-		const insertSegment: IMergeLeaf | undefined = mergeTreeWithRevert.getContainingSegment(
+		const insertSegment: ISegmentLeaf | undefined = mergeTreeWithRevert.getContainingSegment(
 			realPos,
 			mergeTreeWithRevert.collabWindow.currentSeq,
 			mergeTreeWithRevert.collabWindow.clientId,
@@ -339,9 +337,7 @@ function revertLocalRemove(
 		}
 
 		if (insertRef !== undefined) {
-			const localRefs = (insertSegment.localRefs ??= new LocalReferenceCollection(
-				insertSegment,
-			));
+			const localRefs = LocalReferenceCollection.setOrGet(insertSegment);
 			if (insertRef.before?.empty === false) {
 				localRefs.addBeforeTombstones(insertRef.before.map((n) => n.data));
 			}

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -6,7 +6,7 @@
 
 import { strict as assert } from "assert";
 import { UniversalSequenceNumber } from "../constants";
-import { IMergeLeaf, Marker, reservedMarkerIdKey, SegmentGroup } from "../mergeTreeNodes";
+import { ISegmentLeaf, Marker, reservedMarkerIdKey, SegmentGroup } from "../mergeTreeNodes";
 import { MergeTreeDeltaType, ReferenceType } from "../ops";
 import { TextSegment } from "../textSegment";
 import { TestClient } from "./testClient";
@@ -77,7 +77,7 @@ describe("client.rollback", () => {
 		client.insertTextLocal(0, "aefg");
 		client.insertTextLocal(1, "bcd");
 		const segmentGroup = client.peekPendingSegmentGroups() as SegmentGroup;
-		const segment: IMergeLeaf = segmentGroup.segments[0];
+		const segment: ISegmentLeaf = segmentGroup.segments[0];
 		client.rollback?.({ type: MergeTreeDeltaType.INSERT }, segmentGroup);
 
 		// do some work and move the client's min seq forward, so zamboni runs
@@ -257,7 +257,7 @@ describe("client.rollback", () => {
 		);
 		client.annotateRangeLocal(2, 3, { foo: "bar" });
 		const segmentGroup = client.peekPendingSegmentGroups() as SegmentGroup;
-		const segment: IMergeLeaf = segmentGroup.segments[0];
+		const segment: ISegmentLeaf = segmentGroup.segments[0];
 		client.rollback?.({ type: MergeTreeDeltaType.ANNOTATE }, segmentGroup);
 
 		// do some work and move the client's min seq forward, so zamboni runs
@@ -368,7 +368,7 @@ describe("client.rollback", () => {
 		);
 		client.removeRangeLocal(1, 4);
 		const segmentGroup = client.peekPendingSegmentGroups() as SegmentGroup;
-		const segment: IMergeLeaf = segmentGroup.segments[0];
+		const segment: ISegmentLeaf = segmentGroup.segments[0];
 		client.rollback?.({ type: MergeTreeDeltaType.REMOVE }, segmentGroup);
 
 		// do some work and move the client's min seq forward, so zamboni runs

--- a/packages/dds/merge-tree/src/test/mergeTree.walk.spec.ts
+++ b/packages/dds/merge-tree/src/test/mergeTree.walk.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { IMergeBlock, IMergeLeaf, MaxNodesInBlock } from "../mergeTreeNodes";
+import { IMergeBlock, ISegmentLeaf, MaxNodesInBlock } from "../mergeTreeNodes";
 import { TextSegment } from "../textSegment";
 import { LocalClientId, UniversalSequenceNumber } from "../constants";
 import { MergeTree } from "../mergeTree";
@@ -56,7 +56,7 @@ describe("MergeTree walks", () => {
 		it("visits only descendants", () => {
 			for (const block of getAllDescendantBlocks(mergeTree.root)) {
 				let walkedAnySegments = false;
-				walkAllChildSegments(block, (seg: IMergeLeaf) => {
+				walkAllChildSegments(block, (seg: ISegmentLeaf) => {
 					walkedAnySegments = true;
 					let current = seg.parent;
 					while (current !== block && current !== undefined) {

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -19,7 +19,7 @@ import { AttributionKey } from "@fluidframework/runtime-definitions";
 import { Client } from "../client";
 import { DoublyLinkedList } from "../collections";
 import { UnassignedSequenceNumber } from "../constants";
-import { IMergeBlock, IMergeLeaf, ISegment, Marker, MaxNodesInBlock } from "../mergeTreeNodes";
+import { IMergeBlock, ISegmentLeaf, ISegment, Marker, MaxNodesInBlock } from "../mergeTreeNodes";
 import { createAnnotateRangeOp, createInsertSegmentOp, createRemoveRangeOp } from "../opBuilder";
 import { IJSONSegment, IMarkerDef, IMergeTreeOp, MergeTreeDeltaType, ReferenceType } from "../ops";
 import { PropertySet } from "../properties";
@@ -149,7 +149,7 @@ export class TestClient extends Client {
 			// assert.notEqual(d.deltaSegments.length, 0);
 			d.deltaSegments.forEach((s) => {
 				if (d.operation === MergeTreeDeltaType.INSERT) {
-					const seg: IMergeLeaf = s.segment;
+					const seg: ISegmentLeaf = s.segment;
 					assert.notEqual(seg.parent, undefined);
 				}
 			});
@@ -519,7 +519,8 @@ export class TestClient extends Client {
 		let foundMarker: Marker | undefined;
 
 		const { segment } = this.getContainingSegment(startPos);
-		const segWithParent: IMergeLeaf = segment as IMergeLeaf;
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const segWithParent: ISegmentLeaf = segment!;
 
 		if (Marker.is(segWithParent)) {
 			if (refHasTileLabel(segWithParent, markerLabel)) {

--- a/packages/dds/merge-tree/src/zamboni.ts
+++ b/packages/dds/merge-tree/src/zamboni.ts
@@ -40,8 +40,8 @@ export function zamboniSegments(
 		}
 		segmentToScour = mergeTree.segmentsToScour.get()!;
 		// Only skip scouring if needs scour is explicitly false, not true or undefined
-		if (segmentToScour.segment!.parent && segmentToScour.segment!.parent.needsScour !== false) {
-			const block = segmentToScour.segment!.parent;
+		if (segmentToScour?.segment?.parent && segmentToScour.segment.parent.needsScour !== false) {
+			const block = segmentToScour.segment.parent;
 			const childrenCopy: IMergeNode[] = [];
 			scourNode(block, childrenCopy, mergeTree);
 			// This will avoid the cost of re-scouring nodes

--- a/packages/dds/sequence/src/test/reentrancy.spec.ts
+++ b/packages/dds/sequence/src/test/reentrancy.spec.ts
@@ -122,12 +122,8 @@ describe("SharedString op-reentrancy", () => {
 			sharedString.insertText(0, "abcX");
 			const { segment } = sharedString.getContainingSegment(0);
 			assert(segment);
-			segment.localRefs ??= new LocalReferenceCollection(segment);
-			const localRef = segment.localRefs.createLocalRef(
-				0,
-				ReferenceType.SlideOnRemove,
-				undefined,
-			);
+			const localRefs = LocalReferenceCollection.setOrGet(segment);
+			const localRef = localRefs.createLocalRef(0, ReferenceType.SlideOnRemove, undefined);
 
 			assert.notEqual(localRef.getSegment(), undefined);
 
@@ -163,8 +159,8 @@ describe("SharedString op-reentrancy", () => {
 			sharedString.insertText(0, "abcX");
 			const { segment } = sharedString.getContainingSegment(0);
 			assert(segment);
-			segment.localRefs ??= new LocalReferenceCollection(segment);
-			const localRef = segment.localRefs.createLocalRef(0, ReferenceType.Simple, undefined);
+			const localRefs = LocalReferenceCollection.setOrGet(segment);
+			const localRef = localRefs.createLocalRef(0, ReferenceType.Simple, undefined);
 
 			assert.notEqual(localRef.getSegment(), undefined);
 


### PR DESCRIPTION
Neither ISegmentLeaf or IRefsAtOffset should be exported, however they were unnecessarily part of exposed the api and this was not caught by tooling. This exposure was not usable, as the types themselves were not available. This change cleans up those exposures. 