### PR TITLE
rc1 > ci: Update dist-tags for RC

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package-steps.yml
+++ b/tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -44,13 +44,13 @@ steps:
     workingDirectory: $(Pipeline.Workspace)/pack/${{ parameters.artifactPath }}
     script: |
       echo "Artifact path: ${{ parameters.artifactPath }}"
-      tag="--tag canary"
+      tag="--tag rc"
       if [[ "$(release)" == "release" ]]; then
         if [ "$(isLatest)" = "true" ]; then
           tag="--tag latest"
         fi
       elif [[ "$(Build.SourceBranch)" = refs/heads/main ]]; then
-        tag="--tag next"
+        tag="--tag dev"
       fi
       echo Tag: $tag
       cp .npmrc ~/.npmrc


### PR DESCRIPTION
_Cherry-pick of https://github.com/microsoft/FluidFramework/pull/18955 to the RC1 release branch._

Per our RC plans, we're changing the [dist-tags](https://docs.npmjs.com/cli/v10/commands/npm-dist-tag) we use for RC and dev builds.

canary --> rc

next --> dev