### PR TITLE
fix(devtools-view): Link styling

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { Body1, Body1Strong, Subtitle1, makeStyles } from "@fluentui/react-components";
+import { Body1, Body1Strong, Link, Subtitle1, makeStyles } from "@fluentui/react-components";
 import {
 	handleIncomingMessage,
 	type InboundHandlers,
@@ -186,13 +186,13 @@ export function OpLatencyView(): React.ReactElement {
 								{`This Graph shows Fluid Op (Operation) Latency metrics.
 					As you make changes in your Fluid-based application, you'll see this graph update in real time with latency data for any ops your client produces.`}
 								&nbsp;
-								<a
+								<Link
 									target="_blank"
 									rel="noreferrer"
 									href="https://fluidframework.com/docs/concepts/tob/"
 								>
 									{`Learn more about ops.`}
-								</a>
+								</Link>
 							</Body1>
 						</div>
 


### PR DESCRIPTION
The link styling in a particular block of text in the "Op Latency View" did not work well in dark mode. Fixed by using FluentUI's `Link` component in place of `<a>`, which better accounts for theme settings.

Before:
![image](https://github.com/microsoft/FluidFramework/assets/54606601/25e28534-78b2-42f4-8968-edcc54e15f4e)

After:
![image](https://github.com/microsoft/FluidFramework/assets/54606601/ebcbed1b-2e12-4f4c-b8b7-456fac3dd647)

[AB#6749](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6749)