### PR TITLE
build(devtools): Update to node16 module resolution

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/tsconfig.json
+++ b/packages/tools/devtools/devtools-browser-extension/tsconfig.json
@@ -1,11 +1,12 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.cjs.json",
+	],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist/tsc",
-		"composite": true,
 		"types": ["chai", "chrome", "mocha", "node"],
-		"jsx": "react-jsx",
 		"target": "es2018",
 		"forceConsistentCasingInFileNames": true,
 		"skipLibCheck": true,

--- a/packages/tools/devtools/devtools-core/package.json
+++ b/packages/tools/devtools/devtools-core/package.json
@@ -11,8 +11,20 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/index.d.mts",
+				"default": "./lib/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			}
+		}
+	},
 	"main": "dist/index.js",
-	"module": "lib/index.js",
+	"module": "lib/index.mjs",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
@@ -22,8 +34,9 @@
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "fluid-build . --task api",
-		"build:esnext": "tsc --project ./tsconfig.esnext.json",
+		"build:esnext": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.esm.json",
 		"build:genver": "gen-version",
+		"check:are-the-types-wrong": "attw --pack",
 		"check:release-tags": "api-extractor run --local --config ./api-extractor-lint.json",
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob _api-extractor-temp nyc dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\"",
@@ -82,6 +95,7 @@
 		"@fluidframework/tree": "workspace:~"
 	},
 	"devDependencies": {
+		"@arethetypeswrong/cli": "^0.13.3",
 		"@fluid-tools/build-cli": "0.29.0-227332",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "0.29.0-227332",
@@ -109,6 +123,7 @@
 		"moment": "^2.21.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
+		"tsc-multi": "^1.1.0",
 		"typescript": "~5.1.6"
 	},
 	"fluidBuild": {

--- a/packages/tools/devtools/devtools-core/tsconfig.esnext.json
+++ b/packages/tools/devtools/devtools-core/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"outDir": "./lib",
-		"module": "esnext",
-	},
-}

--- a/packages/tools/devtools/devtools-core/tsconfig.json
+++ b/packages/tools/devtools/devtools-core/tsconfig.json
@@ -1,11 +1,13 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.cjs.json",
+	],
+	"include": ["src/**/*"],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist",
-		"composite": true,
 		"target": "es6",
 		"types": ["chai", "mocha"],
 	},
-	"include": ["src/**/*"],
 }

--- a/packages/tools/devtools/devtools-example/package.json
+++ b/packages/tools/devtools/devtools-example/package.json
@@ -9,6 +9,7 @@
 		"url": "https://github.com/microsoft/FluidFramework.git",
 		"directory": "packages/tools/devtools/devtools-example"
 	},
+	"type": "module",
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"sideEffects": false,

--- a/packages/tools/devtools/devtools-example/tsconfig.json
+++ b/packages/tools/devtools/devtools-example/tsconfig.json
@@ -1,13 +1,13 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.esm-only.json",
+	],
+	"include": ["src/**/*"],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist",
-		"module": "ESNext",
-		"composite": true,
-		"jsx": "react",
 		"types": ["jest", "node", "puppeteer", "jest-environment-puppeteer"],
 		"skipLibCheck": true,
 	},
-	"include": ["src/**/*"],
 }

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -13,9 +13,12 @@
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
 	"type": "module",
-	"main": "dist/index.js",
-	"module": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
 	"scripts": {
 		"api": "fluid-build . --task api",
 		"api-extractor:commonjs": "api-extractor run --local",
@@ -23,6 +26,7 @@
 		"build-and-test-mocha": "npm run build && npm run test:mocha:verbose",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "fluid-build . --task api",
+		"check:are-the-types-wrong": "attw --pack",
 		"check:release-tags": "api-extractor run --local --config ./api-extractor-lint.json",
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob _api-extractor-temp coverage dist nyc \"**/*.tsbuildinfo\" \"**/*.build.log\"",
@@ -67,6 +71,7 @@
 		"scheduler": "^0.20.0"
 	},
 	"devDependencies": {
+		"@arethetypeswrong/cli": "^0.13.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "0.29.0-227332",
 		"@fluidframework/core-interfaces": "workspace:~",

--- a/packages/tools/devtools/devtools-view/src/test/tsconfig.json
+++ b/packages/tools/devtools/devtools-view/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"types": ["jest"],
 	},

--- a/packages/tools/devtools/devtools-view/tsconfig.json
+++ b/packages/tools/devtools/devtools-view/tsconfig.json
@@ -1,13 +1,12 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.esm-only.json",
+	],
+	"include": ["src/**/*"],
 	"compilerOptions": {
-		"module": "esnext",
-		"lib": ["ESNext", "DOM"],
 		"rootDir": "src",
 		"outDir": "dist",
-		"composite": true,
-		"jsx": "react",
 		"skipLibCheck": true,
 	},
-	"include": ["src/**/*"],
 }

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -11,8 +11,20 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/index.d.mts",
+				"default": "./lib/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			}
+		}
+	},
 	"main": "dist/index.js",
-	"module": "lib/index.js",
+	"module": "lib/index.mjs",
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
@@ -22,7 +34,8 @@
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "fluid-build . --task api",
-		"build:esnext": "tsc --project ./tsconfig.esnext.json",
+		"build:esnext": "tsc-multi --config ../../../../common/build/build-common/tsc-multi.esm.json",
+		"check:are-the-types-wrong": "attw --pack",
 		"check:release-tags": "api-extractor run --local --config ./api-extractor-lint.json",
 		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob _api-extractor-temp nyc dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\"",
@@ -69,6 +82,7 @@
 		"@fluidframework/fluid-static": "workspace:~"
 	},
 	"devDependencies": {
+		"@arethetypeswrong/cli": "^0.13.3",
 		"@fluid-tools/build-cli": "0.29.0-227332",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "0.29.0-227332",
@@ -92,6 +106,7 @@
 		"moment": "^2.21.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
+		"tsc-multi": "^1.1.0",
 		"typescript": "~5.1.6"
 	},
 	"fluidBuild": {

--- a/packages/tools/devtools/devtools/tsconfig.esnext.json
+++ b/packages/tools/devtools/devtools/tsconfig.esnext.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"outDir": "./lib",
-		"module": "esnext",
-	},
-}

--- a/packages/tools/devtools/devtools/tsconfig.json
+++ b/packages/tools/devtools/devtools/tsconfig.json
@@ -1,10 +1,12 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.base.json",
+		"../../../../common/build/build-common/tsconfig.cjs.json",
+	],
+	"include": ["src/**/*"],
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist",
-		"composite": true,
 		"types": ["chai", "mocha"],
 	},
-	"include": ["src/**/*"],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10841,6 +10841,7 @@ importers:
 
   packages/tools/devtools/devtools:
     specifiers:
+      '@arethetypeswrong/cli': ^0.13.3
       '@fluid-tools/build-cli': 0.29.0-227332
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': 0.29.0-227332
@@ -10868,6 +10869,7 @@ importers:
       moment: ^2.21.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
+      tsc-multi: ^1.1.0
       typescript: ~5.1.6
     dependencies:
       '@fluidframework/container-definitions': link:../../../common/container-definitions
@@ -10875,6 +10877,7 @@ importers:
       '@fluidframework/devtools-core': link:../devtools-core
       '@fluidframework/fluid-static': link:../../../framework/fluid-static
     devDependencies:
+      '@arethetypeswrong/cli': 0.13.3
       '@fluid-tools/build-cli': 0.29.0-227332_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.29.0-227332
@@ -10898,6 +10901,7 @@ importers:
       moment: 2.29.4
       prettier: 3.0.3
       rimraf: 4.4.1
+      tsc-multi: 1.1.0_bwju7gmfuwum2ryv7w6vqpkpiy_typescript@5.1.6
       typescript: 5.1.6
 
   packages/tools/devtools/devtools-browser-extension:
@@ -11049,6 +11053,7 @@ importers:
 
   packages/tools/devtools/devtools-core:
     specifiers:
+      '@arethetypeswrong/cli': ^0.13.3
       '@fluid-internal/client-utils': workspace:~
       '@fluid-tools/build-cli': 0.29.0-227332
       '@fluidframework/build-common': ^2.0.3
@@ -11090,6 +11095,7 @@ importers:
       moment: ^2.21.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
+      tsc-multi: ^1.1.0
       typescript: ~5.1.6
     dependencies:
       '@fluid-internal/client-utils': link:../../../common/client-utils
@@ -11107,6 +11113,7 @@ importers:
       '@fluidframework/telemetry-utils': link:../../../utils/telemetry-utils
       '@fluidframework/tree': link:../../../dds/tree
     devDependencies:
+      '@arethetypeswrong/cli': 0.13.3
       '@fluid-tools/build-cli': 0.29.0-227332_loebgezstcsvd2poh2d55fifke
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.29.0-227332
@@ -11134,6 +11141,7 @@ importers:
       moment: 2.29.4
       prettier: 3.0.3
       rimraf: 4.4.1
+      tsc-multi: 1.1.0_bwju7gmfuwum2ryv7w6vqpkpiy_typescript@5.1.6
       typescript: 5.1.6
 
   packages/tools/devtools/devtools-example:
@@ -11275,6 +11283,7 @@ importers:
 
   packages/tools/devtools/devtools-view:
     specifiers:
+      '@arethetypeswrong/cli': ^0.13.3
       '@fluentui/react': ^8.109.4
       '@fluentui/react-components': ~9.19.1
       '@fluentui/react-hooks': ^8.6.24
@@ -11361,6 +11370,7 @@ importers:
       recharts: 2.10.1_oxfzelaz5ynxsop2v2nu2h2m64
       scheduler: 0.20.2
     devDependencies:
+      '@arethetypeswrong/cli': 0.13.3
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.29.0-227332_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 3.3.0_loebgezstcsvd2poh2d55fifke
@@ -17037,7 +17047,7 @@ packages:
     dependencies:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/protocol-definitions': 3.1.0
       events: 3.3.0
 
   /@fluidframework/protocol-base/3.0.0-223236:
@@ -17055,7 +17065,6 @@ packages:
 
   /@fluidframework/protocol-definitions/3.1.0:
     resolution: {integrity: sha512-BgGF82z4sk5M4torMR38NGjHjFG9t6Y653UcGOlXiIaGQMDZpRfrxiIuq53Gb12OTfUgbNtvBJL1W46JfLvzQw==}
-    dev: true
 
   /@fluidframework/protocol-definitions/3.1.0-223007:
     resolution: {integrity: sha512-5Y1pdROt00bTVkdjYuQ/5lQW/ajJjb0KlRcsvcCYVOQK+qDb1E3i+6K6XMY5Fv9ufPXT4mrQzKkdOMDMJXynMA==}
@@ -17288,7 +17297,7 @@ packages:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/server-lambdas-driver': 2.0.2
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-core': 2.0.2
@@ -17317,7 +17326,7 @@ packages:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/server-lambdas-driver': 2.0.2
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-core': 2.0.2
@@ -17346,7 +17355,7 @@ packages:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/gitresources': 3.0.0-223236
       '@fluidframework/protocol-base': 3.0.0-223236
-      '@fluidframework/protocol-definitions': 3.1.0-223007
+      '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/server-lambdas-driver': 3.0.0-223236
       '@fluidframework/server-services-client': 3.0.0-223236
       '@fluidframework/server-services-core': 3.0.0-223236
@@ -17372,7 +17381,7 @@ packages:
     resolution: {integrity: sha512-aKSvb13M5lsoUXN0vKadc6yVcBjJ2RZrtQr/vr0E7qJHlAQ+CZVaRIcFWavS5fZEMNi4+h4U2ohxtl+h4uu5NA==}
     dependencies:
       '@fluidframework/common-utils': 3.0.0
-      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/server-lambdas': 2.0.2_debug@4.3.4
       '@fluidframework/server-memory-orderer': 2.0.2
       '@fluidframework/server-services-client': 2.0.2
@@ -17413,7 +17422,7 @@ packages:
     dependencies:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/server-lambdas': 2.0.2_debug@4.3.4
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-core': 2.0.2
@@ -17441,7 +17450,7 @@ packages:
     dependencies:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/protocol-base': 3.0.0-223236
-      '@fluidframework/protocol-definitions': 3.1.0-223007
+      '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/server-lambdas': 3.0.0-223236_debug@4.3.4
       '@fluidframework/server-services-client': 3.0.0-223236
       '@fluidframework/server-services-core': 3.0.0-223236
@@ -17470,7 +17479,7 @@ packages:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/protocol-definitions': 3.1.0
       axios: 0.26.1_debug@4.3.4
       crc-32: 1.2.0
       debug: 4.3.4
@@ -17507,7 +17516,7 @@ packages:
     dependencies:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-telemetry': 2.0.2
       '@types/nconf': 0.10.6
@@ -17540,7 +17549,7 @@ packages:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-core': 2.0.2
       '@fluidframework/server-services-telemetry': 2.0.2
@@ -17585,7 +17594,7 @@ packages:
   /@fluidframework/server-services-utils/2.0.2:
     resolution: {integrity: sha512-0oADQbRJl/5TtrinRh7N1ttFtn+E6NouB0TZceuC90sJVnGBDiyzffZyDdiFTDfOGi3EcEpMiyUP1cOJsPZGvg==}
     dependencies:
-      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-core': 2.0.2
       '@fluidframework/server-services-telemetry': 2.0.2
@@ -17611,7 +17620,7 @@ packages:
       '@fluidframework/common-utils': 3.0.0
       '@fluidframework/gitresources': 2.0.2
       '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.0.0
+      '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/server-services-client': 2.0.2
       '@fluidframework/server-services-core': 2.0.2
       '@fluidframework/server-services-telemetry': 2.0.2
@@ -18226,7 +18235,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -18407,7 +18416,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.20
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -21892,7 +21901,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       '@types/responselike': 1.0.3
     dev: true
 
@@ -21916,7 +21925,7 @@ packages:
   /@types/cli-progress/3.11.5:
     resolution: {integrity: sha512-D4PbNRbviKyppS5ivBGyFO29POlySLmA2HyUFE4p5QGazAMM3CwkKWcvTl8gvElSuxRh6FPKL8XmidX873ou4g==}
     dependencies:
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
 
   /@types/codemirror/5.60.7:
     resolution: {integrity: sha512-QXIC+RPzt/1BGSuD6iFn6UMC9TDp+9hkOANYNPVsjjrDdzKphfRkwQDKGp2YaC54Yhz0g6P5uYTCCibZZEiMAA==}
@@ -22099,7 +22108,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
     dev: true
 
   /@types/glob/8.1.0:
@@ -22112,7 +22121,7 @@ packages:
   /@types/graceful-fs/4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
     dev: true
 
   /@types/handlebars/4.1.0:
@@ -22253,7 +22262,7 @@ packages:
   /@types/keyv/3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
     dev: true
 
   /@types/lodash.isequal/4.5.8:
@@ -22339,6 +22348,7 @@ packages:
     resolution: {integrity: sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==}
     dependencies:
       undici-types: 5.26.5
+    dev: true
 
   /@types/normalize-package-data/2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -22442,7 +22452,7 @@ packages:
   /@types/responselike/1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
     dev: true
 
   /@types/retry/0.12.0:
@@ -22568,7 +22578,7 @@ packages:
     resolution: {integrity: sha512-vPXzCLmRp74e9LsP8oltnWKTH+jBwt86WgRUb4Pc9Lf3pkMVGyvIo2gm9bODeGfCay2DBB/hAWDuvf07JcK4rw==}
     dependencies:
       '@types/expect': 1.20.4
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
     dev: true
 
   /@types/webpack-env/1.18.4:
@@ -29279,7 +29289,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.11
       '@types/lodash': 4.14.202
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       '@types/sinon': 7.5.2
       lodash: 4.17.21
       mock-stdin: 1.0.0
@@ -32582,7 +32592,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -32916,7 +32926,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -32989,7 +32999,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -33157,7 +33167,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -33188,7 +33198,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       chalk: 4.1.2
       cjs-module-lexer: 1.2.3
       collect-v8-coverage: 1.0.2
@@ -33313,7 +33323,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -33334,7 +33344,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -33342,7 +33352,7 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.10.5
+      '@types/node': 18.19.1
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1


### PR DESCRIPTION
Updates the packages in packages/tools/devtools to build ESM using tsc-multi, create valid ESM types, and adds an exports field and testing using arethetypeswrong.