### PR TITLE
refactor(tree): move sequence utils that are only used for tests into test area

### DIFF
--- a/packages/dds/tree/.dependency-cruiser-known-violations.json
+++ b/packages/dds/tree/.dependency-cruiser-known-violations.json
@@ -84,19 +84,6 @@
   },
   {
     "type": "cycle",
-    "from": "src/feature-libraries/sequence-field/markListFactory.ts",
-    "to": "src/feature-libraries/sequence-field/utils.ts",
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      "src/feature-libraries/sequence-field/utils.ts",
-      "src/feature-libraries/sequence-field/markListFactory.ts"
-    ]
-  },
-  {
-    "type": "cycle",
     "from": "src/feature-libraries/sequence-field/moveEffectTable.ts",
     "to": "src/feature-libraries/sequence-field/utils.ts",
     "rule": {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/index.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/index.ts
@@ -42,11 +42,8 @@ export { NodeChangeRebaser, rebase } from "./rebase.js";
 export { invert, NodeChangeInverter } from "./invert.js";
 export { amendCompose, compose, NodeChangeComposer } from "./compose.js";
 export {
-	areComposable,
-	areRebasable,
 	getInputLength,
 	isDetach,
-	DetachedNodeTracker,
 	newCrossFieldTable,
 	newMoveEffectTable,
 	CrossFieldTable,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -9,17 +9,9 @@ import {
 	ChangesetLocalId,
 	RevisionMetadataSource,
 	RevisionTag,
-	TaggedChange,
 	areEqualChangeAtomIds,
 } from "../../core/index.js";
-import {
-	brand,
-	fail,
-	getFromRangeMap,
-	getOrAddEmptyToMap,
-	Mutable,
-	RangeMap,
-} from "../../util/index.js";
+import { brand, fail, getFromRangeMap, Mutable, RangeMap } from "../../util/index.js";
 import {
 	addCrossFieldQuery,
 	CrossFieldManager,
@@ -42,7 +34,6 @@ import {
 	MoveId,
 	Remove,
 	NoopMarkType,
-	HasMarkFields,
 	CellId,
 	CellMark,
 	AttachAndDetach,
@@ -50,11 +41,9 @@ import {
 	DetachFields,
 	IdRange,
 } from "./types.js";
-import { MarkListFactory } from "./markListFactory.js";
 import { isMoveMark, MoveEffectTable } from "./moveEffectTable.js";
 import {
 	EmptyInputCellMark,
-	DetachedCellMark,
 	MoveMarkEffect,
 	DetachOfRemovedNodes,
 	CellRename,
@@ -818,268 +807,6 @@ function tryMergeEffects(
 	}
 
 	return undefined;
-}
-
-/**
- * Keeps track of the different ways detached nodes may be referred to.
- * Allows updating changesets so they refer to a detached node by the details
- * of the last detach that affected them.
- *
- * WARNING: this code consumes O(N) space and time for marks that affect N nodes.
- * This is code is currently meant for usage in tests.
- * It should be tested and made more efficient before production use.
- */
-export class DetachedNodeTracker {
-	// Maps the index for a node to its last characterization as a reattached node.
-	private nodes: Map<number, CellId> = new Map();
-	private readonly equivalences: { old: CellId; new: CellId }[] = [];
-
-	public constructor() {}
-
-	/**
-	 * Updates the internals of this instance to account for `change` having been applied.
-	 * @param change - The change that is being applied. Not mutated.
-	 * Must be applicable (i.e., `isApplicable(change)` must be true).
-	 */
-	public apply(change: TaggedChange<Changeset<unknown>>): void {
-		let index = 0;
-		for (const mark of change.change) {
-			const inputLength: number = getInputLength(mark);
-			if (markEmptiesCells(mark)) {
-				assert(isDetach(mark), 0x70d /* Only detach marks should empty cells */);
-				const newNodes: Map<number, CellId> = new Map();
-				const after = index + inputLength;
-				for (const [k, v] of this.nodes) {
-					if (k >= index) {
-						if (k >= after) {
-							newNodes.set(k - inputLength, v);
-						} else {
-							// The node is removed
-							this.equivalences.push({
-								old: v,
-								new: {
-									revision:
-										change.rollbackOf ??
-										mark.revision ??
-										change.revision ??
-										fail("Unable to track detached nodes"),
-									localId: brand((mark.id as number) + (k - index)),
-								},
-							});
-						}
-					} else {
-						newNodes.set(k, v);
-					}
-				}
-				this.nodes = newNodes;
-			}
-			index += inputLength;
-		}
-		index = 0;
-		for (const mark of change.change) {
-			const inputLength: number = getInputLength(mark);
-			if (isActiveReattach(mark)) {
-				const newNodes: Map<number, CellId> = new Map();
-				for (const [k, v] of this.nodes) {
-					if (k >= index) {
-						newNodes.set(k + inputLength, v);
-					} else {
-						newNodes.set(k, v);
-					}
-				}
-				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
-				for (let i = 0; i < mark.count; ++i) {
-					newNodes.set(index + i, {
-						revision: detachEvent.revision,
-						localId: brand((detachEvent.localId as number) + i),
-					});
-				}
-				this.nodes = newNodes;
-			}
-			if (!markEmptiesCells(mark)) {
-				index += inputLength;
-			}
-		}
-	}
-
-	/**
-	 * Checks whether the given `change` is applicable based on previous changes.
-	 * @param change - The change to verify the applicability of. Not mutated.
-	 * @returns false iff `change`'s description of detached nodes is inconsistent with that of changes applied
-	 * earlier. Returns true otherwise.
-	 */
-	public isApplicable(change: Changeset<unknown>): boolean {
-		for (const mark of change) {
-			if (isActiveReattach(mark)) {
-				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
-				const revision = detachEvent.revision;
-				for (let i = 0; i < mark.count; ++i) {
-					const localId = brand<ChangesetLocalId>((detachEvent.localId as number) + i);
-					const original: CellId = { revision, localId };
-					const updated = this.getUpdatedDetach(original);
-					for (const detached of this.nodes.values()) {
-						if (
-							updated.revision === detached.revision &&
-							updated.localId === detached.localId
-						) {
-							// The new change is attempting to reattach nodes in a location that has already been
-							// filled by a prior reattach.
-							return false;
-						}
-					}
-				}
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * Creates an updated representation of the given `change` so that it refers to detached nodes using the revision
-	 * that last detached them.
-	 * @param change - The change to update. Not mutated.
-	 * Must be applicable (i.e., `isApplicable(change)` must be true).
-	 * @param genId - An ID allocator that produces ID unique within this changeset.
-	 * @returns A change equivalent to `change` that refers to detached nodes using the revision that last detached
-	 * them. May reuse parts of the input `change` structure.
-	 */
-	public update<T>(change: TaggedChange<Changeset<T>>): TaggedChange<Changeset<T>> {
-		const factory = new MarkListFactory<T>();
-		for (const mark of change.change) {
-			const cloned = cloneMark(mark);
-			if (areInputCellsEmpty(cloned) && !isNewAttach(cloned)) {
-				let remainder = cloned;
-				while (remainder.count > 1) {
-					const [head, tail] = splitMark(remainder, 1);
-					this.updateMark(head);
-					factory.push(head);
-					remainder = tail;
-				}
-				this.updateMark(remainder);
-				factory.push(remainder);
-			} else {
-				factory.push(cloned);
-			}
-		}
-
-		return {
-			...change,
-			change: factory.list,
-		};
-	}
-
-	private updateMark(mark: HasMarkFields & DetachedCellMark): void {
-		const detachEvent = mark.cellId;
-		const original = { revision: detachEvent.revision, localId: detachEvent.localId };
-		const updated = this.getUpdatedDetach(original);
-		if (updated.revision !== original.revision || updated.localId !== original.localId) {
-			mark.cellId = { ...updated };
-		}
-	}
-
-	private getUpdatedDetach(detach: CellId): CellId {
-		let curr = detach;
-		for (const eq of this.equivalences) {
-			if (curr.revision === eq.old.revision && curr.localId === eq.old.localId) {
-				curr = eq.new;
-			}
-		}
-		return curr;
-	}
-}
-
-/**
- * Checks whether `branch` changeset is consistent with a `target` changeset that is may be rebased over.
- *
- * WARNING: this code consumes O(N) space and time for marks that affect N nodes.
- * This is code is currently meant for usage in tests.
- * It should be tested and made more efficient before production use.
- *
- * @param branch - The changeset that would be rebased over `target`.
- * @param target - The changeset that `branch` would be rebased over.
- * @returns false iff `branch`'s description of detached nodes is inconsistent with that of `target`.
- * Returns true otherwise.
- */
-export function areRebasable(branch: Changeset<unknown>, target: Changeset<unknown>): boolean {
-	const indexToReattach: Map<number, string[]> = new Map();
-	const reattachToIndex: Map<string, number> = new Map();
-	let index = 0;
-	for (const mark of branch) {
-		if (isActiveReattach(mark)) {
-			const list = getOrAddEmptyToMap(indexToReattach, index);
-			for (let i = 0; i < mark.count; ++i) {
-				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
-				const entry: CellId = {
-					...detachEvent,
-					localId: brand((detachEvent.localId as number) + i),
-				};
-				const key = `${entry.revision}|${entry.localId}`;
-				assert(
-					!reattachToIndex.has(key),
-					0x506 /* First changeset as inconsistent characterization of detached nodes */,
-				);
-				list.push(key);
-				reattachToIndex.set(key, index);
-			}
-		}
-		index += getInputLength(mark);
-	}
-	index = 0;
-	let listIndex = 0;
-	for (const mark of target) {
-		if (isActiveReattach(mark)) {
-			const list = getOrAddEmptyToMap(indexToReattach, index);
-			for (let i = 0; i < mark.count; ++i) {
-				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
-				const entry: CellId = {
-					...detachEvent,
-					localId: brand((detachEvent.localId as number) + i),
-				};
-				const key = `${entry.revision}|${entry.localId}`;
-				const indexInA = reattachToIndex.get(key);
-				if (indexInA !== undefined && indexInA !== index) {
-					// change b tries to reattach the same content as change a but in a different location
-					return false;
-				}
-				if (list.includes(key)) {
-					while (list[listIndex] !== undefined && list[listIndex] !== key) {
-						++listIndex;
-					}
-					if (list.slice(0, listIndex).includes(key)) {
-						// change b tries to reattach the same content as change a but in a different order
-						return false;
-					}
-				}
-			}
-		}
-		const inputLength = getInputLength(mark);
-		if (inputLength > 0) {
-			listIndex = 0;
-		}
-		index += inputLength;
-	}
-	return true;
-}
-
-/**
- * Checks whether sequential changesets are consistent.
- *
- * WARNING: this code consumes O(N) space and time for marks that affect N nodes.
- * This is code is currently meant for usage in tests.
- * It should be tested and made more efficient before production use.
- *
- * @param changes - The changesets that would be composed together.
- * @returns false iff the changesets in `changes` are inconsistent/incompatible in their description of detached nodes.
- * Returns true otherwise.
- */
-export function areComposable(changes: TaggedChange<Changeset<unknown>>[]): boolean {
-	const tracker = new DetachedNodeTracker();
-	for (const change of changes) {
-		if (!tracker.isApplicable(change.change)) {
-			return false;
-		}
-		tracker.apply(change);
-	}
-	return true;
 }
 
 /**

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.test.ts
@@ -21,6 +21,7 @@ import { brand } from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 import { cases, ChangeMaker as Change, MarkMaker as Mark, TestChangeset } from "./testEdits.js";
 import {
+	areComposable,
 	assertChangesetsEqual,
 	compose,
 	composeNoVerify,
@@ -63,7 +64,7 @@ export function testCompose() {
 						if (
 							title.startsWith("((remove, insert), revive)") ||
 							title.startsWith("((move, insert), revive)") ||
-							!SF.areComposable([taggedA, taggedB, taggedC])
+							!areComposable([taggedA, taggedB, taggedC])
 						) {
 							// These changes do not form a valid sequence of composable changes
 						} else if (

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
@@ -39,6 +39,8 @@ import {
 	assertChangesetsEqual,
 	withoutTombstones,
 	skipOnLineageMethod,
+	areRebasable,
+	DetachedNodeTracker,
 } from "./utils.js";
 import { ChangeMaker as Change, MarkMaker as Mark, TestChangeset } from "./testEdits.js";
 
@@ -215,7 +217,7 @@ export function testRebaserAxioms() {
 										makeChange2(offset2, maxOffset),
 										tag5,
 									);
-									if (!SF.areRebasable(change1.change, change2.change)) {
+									if (!areRebasable(change1.change, change2.change)) {
 										continue;
 									}
 									const inv = tagRollbackInverse(invert(change2), tag6, tag5);
@@ -273,7 +275,7 @@ export function testRebaserAxioms() {
 										makeChange2(offset2, maxOffset),
 										tag5,
 									);
-									if (!SF.areRebasable(change1.change, change2.change)) {
+									if (!areRebasable(change1.change, change2.change)) {
 										continue;
 									}
 									const inv = tagChange(invert(change2), tag6);
@@ -331,7 +333,7 @@ export function testRebaserAxioms() {
 										makeChange2(offset2, maxOffset),
 										tag5,
 									);
-									if (!SF.areRebasable(change1.change, change2.change)) {
+									if (!areRebasable(change1.change, change2.change)) {
 										continue;
 									}
 									const inverse2 = tagRollbackInverse(
@@ -377,7 +379,7 @@ export function testRebaserAxioms() {
 			for (const [name, makeChange] of testChanges) {
 				it(`${name}⁻¹ ○ ${name} === ε`, () =>
 					withConfig(() => {
-						const tracker = new SF.DetachedNodeTracker();
+						const tracker = new DetachedNodeTracker();
 						const change = makeChange(0, 0);
 						const taggedChange = tagChange(change, tag5);
 						const inv = tagRollbackInverse(

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -26,7 +26,9 @@ import {
 } from "../../utils.js";
 import {
 	brand,
+	fail,
 	fakeIdAllocator,
+	getOrAddEmptyToMap,
 	IdAllocator,
 	idAllocatorFromMaxId,
 	Mutable,
@@ -34,9 +36,16 @@ import {
 // eslint-disable-next-line import/no-internal-modules
 import { RebaseRevisionMetadata } from "../../../feature-libraries/modular-schema/index.js";
 import {
+	areInputCellsEmpty,
+	cloneMark,
+	getInputLength,
+	isActiveReattach,
 	isAttachAndDetachEffect,
 	isDetach,
+	isNewAttach,
 	isTombstone,
+	markEmptiesCells,
+	splitMark,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/sequence-field/utils.js";
 import {
@@ -45,6 +54,15 @@ import {
 	sequenceConfig,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/sequence-field/config.js";
+import {
+	CellId,
+	Changeset,
+	HasMarkFields,
+	MarkListFactory,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../../feature-libraries/sequence-field/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { DetachedCellMark } from "../../../feature-libraries/sequence-field/helperTypes.js";
 // eslint-disable-next-line import/no-internal-modules
 import { rebaseRevisionMetadataFromInfo } from "../../../feature-libraries/modular-schema/modularChangeFamily.js";
 import { TestChangeset } from "./testEdits.js";
@@ -423,4 +441,266 @@ function cmp(a: any, b: any): number {
 	}
 
 	return a > b ? 1 : -1;
+}
+
+/**
+ * Keeps track of the different ways detached nodes may be referred to.
+ * Allows updating changesets so they refer to a detached node by the details
+ * of the last detach that affected them.
+ *
+ * WARNING: this code consumes O(N) space and time for marks that affect N nodes.
+ * This is code is currently meant for usage in tests.
+ * It should be tested and made more efficient before production use.
+ */
+export class DetachedNodeTracker {
+	// Maps the index for a node to its last characterization as a reattached node.
+	private nodes: Map<number, CellId> = new Map();
+	private readonly equivalences: { old: CellId; new: CellId }[] = [];
+
+	public constructor() {}
+
+	/**
+	 * Updates the internals of this instance to account for `change` having been applied.
+	 * @param change - The change that is being applied. Not mutated.
+	 * Must be applicable (i.e., `isApplicable(change)` must be true).
+	 */
+	public apply(change: TaggedChange<Changeset<unknown>>): void {
+		let index = 0;
+		for (const mark of change.change) {
+			const inputLength: number = getInputLength(mark);
+			if (markEmptiesCells(mark)) {
+				assert(isDetach(mark), 0x70d /* Only detach marks should empty cells */);
+				const newNodes: Map<number, CellId> = new Map();
+				const after = index + inputLength;
+				for (const [k, v] of this.nodes) {
+					if (k >= index) {
+						if (k >= after) {
+							newNodes.set(k - inputLength, v);
+						} else {
+							// The node is removed
+							this.equivalences.push({
+								old: v,
+								new: {
+									revision:
+										change.rollbackOf ??
+										mark.revision ??
+										change.revision ??
+										fail("Unable to track detached nodes"),
+									localId: brand((mark.id as number) + (k - index)),
+								},
+							});
+						}
+					} else {
+						newNodes.set(k, v);
+					}
+				}
+				this.nodes = newNodes;
+			}
+			index += inputLength;
+		}
+		index = 0;
+		for (const mark of change.change) {
+			const inputLength: number = getInputLength(mark);
+			if (isActiveReattach(mark)) {
+				const newNodes: Map<number, CellId> = new Map();
+				for (const [k, v] of this.nodes) {
+					if (k >= index) {
+						newNodes.set(k + inputLength, v);
+					} else {
+						newNodes.set(k, v);
+					}
+				}
+				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
+				for (let i = 0; i < mark.count; ++i) {
+					newNodes.set(index + i, {
+						revision: detachEvent.revision,
+						localId: brand((detachEvent.localId as number) + i),
+					});
+				}
+				this.nodes = newNodes;
+			}
+			if (!markEmptiesCells(mark)) {
+				index += inputLength;
+			}
+		}
+	}
+
+	/**
+	 * Checks whether the given `change` is applicable based on previous changes.
+	 * @param change - The change to verify the applicability of. Not mutated.
+	 * @returns false iff `change`'s description of detached nodes is inconsistent with that of changes applied
+	 * earlier. Returns true otherwise.
+	 */
+	public isApplicable(change: Changeset<unknown>): boolean {
+		for (const mark of change) {
+			if (isActiveReattach(mark)) {
+				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
+				const revision = detachEvent.revision;
+				for (let i = 0; i < mark.count; ++i) {
+					const localId = brand<ChangesetLocalId>((detachEvent.localId as number) + i);
+					const original: CellId = { revision, localId };
+					const updated = this.getUpdatedDetach(original);
+					for (const detached of this.nodes.values()) {
+						if (
+							updated.revision === detached.revision &&
+							updated.localId === detached.localId
+						) {
+							// The new change is attempting to reattach nodes in a location that has already been
+							// filled by a prior reattach.
+							return false;
+						}
+					}
+				}
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Creates an updated representation of the given `change` so that it refers to detached nodes using the revision
+	 * that last detached them.
+	 * @param change - The change to update. Not mutated.
+	 * Must be applicable (i.e., `isApplicable(change)` must be true).
+	 * @param genId - An ID allocator that produces ID unique within this changeset.
+	 * @returns A change equivalent to `change` that refers to detached nodes using the revision that last detached
+	 * them. May reuse parts of the input `change` structure.
+	 */
+	public update<T>(change: TaggedChange<Changeset<T>>): TaggedChange<Changeset<T>> {
+		const factory = new MarkListFactory<T>();
+		for (const mark of change.change) {
+			const cloned = cloneMark(mark);
+			if (areInputCellsEmpty(cloned) && !isNewAttach(cloned)) {
+				let remainder = cloned;
+				while (remainder.count > 1) {
+					const [head, tail] = splitMark(remainder, 1);
+					this.updateMark(head);
+					factory.push(head);
+					remainder = tail;
+				}
+				this.updateMark(remainder);
+				factory.push(remainder);
+			} else {
+				factory.push(cloned);
+			}
+		}
+
+		return {
+			...change,
+			change: factory.list,
+		};
+	}
+
+	private updateMark(mark: HasMarkFields & DetachedCellMark): void {
+		const detachEvent = mark.cellId;
+		const original = { revision: detachEvent.revision, localId: detachEvent.localId };
+		const updated = this.getUpdatedDetach(original);
+		if (updated.revision !== original.revision || updated.localId !== original.localId) {
+			mark.cellId = { ...updated };
+		}
+	}
+
+	private getUpdatedDetach(detach: CellId): CellId {
+		let curr = detach;
+		for (const eq of this.equivalences) {
+			if (curr.revision === eq.old.revision && curr.localId === eq.old.localId) {
+				curr = eq.new;
+			}
+		}
+		return curr;
+	}
+}
+
+/**
+ * Checks whether `branch` changeset is consistent with a `target` changeset that is may be rebased over.
+ *
+ * WARNING: this code consumes O(N) space and time for marks that affect N nodes.
+ * This is code is currently meant for usage in tests.
+ * It should be tested and made more efficient before production use.
+ *
+ * @param branch - The changeset that would be rebased over `target`.
+ * @param target - The changeset that `branch` would be rebased over.
+ * @returns false iff `branch`'s description of detached nodes is inconsistent with that of `target`.
+ * Returns true otherwise.
+ */
+export function areRebasable(branch: Changeset<unknown>, target: Changeset<unknown>): boolean {
+	const indexToReattach: Map<number, string[]> = new Map();
+	const reattachToIndex: Map<string, number> = new Map();
+	let index = 0;
+	for (const mark of branch) {
+		if (isActiveReattach(mark)) {
+			const list = getOrAddEmptyToMap(indexToReattach, index);
+			for (let i = 0; i < mark.count; ++i) {
+				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
+				const entry: CellId = {
+					...detachEvent,
+					localId: brand((detachEvent.localId as number) + i),
+				};
+				const key = `${entry.revision}|${entry.localId}`;
+				assert(
+					!reattachToIndex.has(key),
+					0x506 /* First changeset as inconsistent characterization of detached nodes */,
+				);
+				list.push(key);
+				reattachToIndex.set(key, index);
+			}
+		}
+		index += getInputLength(mark);
+	}
+	index = 0;
+	let listIndex = 0;
+	for (const mark of target) {
+		if (isActiveReattach(mark)) {
+			const list = getOrAddEmptyToMap(indexToReattach, index);
+			for (let i = 0; i < mark.count; ++i) {
+				const detachEvent = mark.cellId ?? fail("Unable to track detached nodes");
+				const entry: CellId = {
+					...detachEvent,
+					localId: brand((detachEvent.localId as number) + i),
+				};
+				const key = `${entry.revision}|${entry.localId}`;
+				const indexInA = reattachToIndex.get(key);
+				if (indexInA !== undefined && indexInA !== index) {
+					// change b tries to reattach the same content as change a but in a different location
+					return false;
+				}
+				if (list.includes(key)) {
+					while (list[listIndex] !== undefined && list[listIndex] !== key) {
+						++listIndex;
+					}
+					if (list.slice(0, listIndex).includes(key)) {
+						// change b tries to reattach the same content as change a but in a different order
+						return false;
+					}
+				}
+			}
+		}
+		const inputLength = getInputLength(mark);
+		if (inputLength > 0) {
+			listIndex = 0;
+		}
+		index += inputLength;
+	}
+	return true;
+}
+
+/**
+ * Checks whether sequential changesets are consistent.
+ *
+ * WARNING: this code consumes O(N) space and time for marks that affect N nodes.
+ * This is code is currently meant for usage in tests.
+ * It should be tested and made more efficient before production use.
+ *
+ * @param changes - The changesets that would be composed together.
+ * @returns false iff the changesets in `changes` are inconsistent/incompatible in their description of detached nodes.
+ * Returns true otherwise.
+ */
+export function areComposable(changes: TaggedChange<Changeset<unknown>>[]): boolean {
+	const tracker = new DetachedNodeTracker();
+	for (const change of changes) {
+		if (!tracker.isApplicable(change.change)) {
+			return false;
+		}
+		tracker.apply(change);
+	}
+	return true;
 }


### PR DESCRIPTION
Resolves an import cycle by moving some sequence utils that are only used for tests into the test utils for sequence