### PR TITLE
Add more granular summary write metrics

### DIFF
--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -20,6 +20,7 @@ data:
         },
         "lumberjack": {
             "options": {
+                "enableGlobalTelemetryContext": {{ .Values.lumberjack.options.enableGlobalTelemetryContext }},
                 "enableSanitization": {{ .Values.lumberjack.options.enableSanitization }}
             }
         },

--- a/server/charts/historian/templates/historian-configmap.yaml
+++ b/server/charts/historian/templates/historian-configmap.yaml
@@ -20,6 +20,7 @@ data:
         },
         "lumberjack": {
             "options": {
+                "enableGlobalTelemetryContext": {{ .Values.lumberjack.options.enableGlobalTelemetryContext }},
                 "enableSanitization": {{ .Values.lumberjack.options.enableSanitization }}
             }
         },

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -95,4 +95,5 @@ gitssh:
 
 lumberjack:
   options:
+    enableGlobalTelemetryContext: true
     enableSanitization: false

--- a/server/gitrest/packages/gitrest-base/src/utils/gitrestTelemetryDefinitions.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/gitrestTelemetryDefinitions.ts
@@ -11,6 +11,11 @@ export enum GitRestLumberEventName {
 	RetrieveLatestFullSummaryFromStorage = "RetrieveLatestFullSummaryFromStorage",
 	WholeSummaryManagerReadSummary = "ReadSummary",
 	WholeSummaryManagerWriteSummary = "WriteSummary",
+	ComputeSummaryTreeEntries = "ComputeSummaryTreeEntries",
+	WriteSummaryTree = "WriteSummaryTree",
+	CreateSummaryVersion = "CreateSummaryVersion",
+	CreateDocumentRef = "CreateDocumentRef",
+	UpdateDocumentRef = "UpdateDocumentRef",
 
 	// Misc
 	CheckSoftDeleted = "CheckSoftDeleted",

--- a/server/gitrest/packages/gitrest-base/src/utils/wholeSummary/writeWholeSummary.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/wholeSummary/writeWholeSummary.ts
@@ -8,7 +8,10 @@ import {
 	IWholeFlatSummary,
 	IWholeSummaryPayload,
 	IWriteSummaryResponse,
+	WholeSummaryTreeEntry,
 } from "@fluidframework/server-services-client";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import { GitRestLumberEventName } from "../gitrestTelemetryDefinitions";
 import { IFullGitTree, ISummaryVersion, IWholeSummaryOptions } from "./definitions";
 import { convertFullGitTreeToFullSummaryTree } from "./conversions";
 import { computeLowIoSummaryTreeEntries } from "./lowIoWriteUtils";
@@ -83,6 +86,37 @@ async function getDocRef(options: IWholeSummaryOptions): Promise<IRef | undefine
 	return ref;
 }
 
+async function computeSummaryTreeEntries(
+	payload: IWholeSummaryPayload,
+	documentRef: IRef | undefined,
+	writeSummaryTreeOptions: IWriteSummaryTreeOptions,
+	options: IWholeSummaryOptions,
+): Promise<WholeSummaryTreeEntry[]> {
+	if (!writeSummaryTreeOptions.enableLowIoWrite) {
+		return payload.entries;
+	}
+
+	const computeSummaryTreeEntriesMetric = Lumberjack.newLumberMetric(
+		GitRestLumberEventName.ComputeSummaryTreeEntries,
+		options.lumberjackProperties,
+	);
+	try {
+		const treeEntries = await computeLowIoSummaryTreeEntries(
+			payload,
+			documentRef,
+			writeSummaryTreeOptions,
+			options,
+		);
+		computeSummaryTreeEntriesMetric.success(
+			"Successfully computed low-io summary tree entries.",
+		);
+		return treeEntries;
+	} catch (error) {
+		Lumberjack.error("Failed to compute low-io summary tree entries.", error);
+		throw error;
+	}
+}
+
 /**
  * Write a summary tree as a Git tree in storage.
  * @returns the written git tree as an {@link IFullGitTree}, which contains all the tree entries, blob entries and their shas.
@@ -103,16 +137,25 @@ async function writeSummaryTree(
 		entryHandleToObjectShaCache: new Map<string, string>(),
 	};
 
-	if (options.useLowIoWrite) {
-		const lowIoWriteSummaryTreeEntries = await computeLowIoSummaryTreeEntries(
-			payload,
-			documentRef,
-			writeSummaryTreeOptions,
-			options,
-		);
-		return writeSummaryTreeCore(lowIoWriteSummaryTreeEntries, writeSummaryTreeOptions);
+	const treeEntries = await computeSummaryTreeEntries(
+		payload,
+		documentRef,
+		writeSummaryTreeOptions,
+		options,
+	);
+
+	const writeSummaryTreeMetric = Lumberjack.newLumberMetric(
+		GitRestLumberEventName.WriteSummaryTree,
+		options.lumberjackProperties,
+	);
+	try {
+		const gitTree = await writeSummaryTreeCore(treeEntries, writeSummaryTreeOptions);
+		writeSummaryTreeMetric.success("Successfully wrote summary tree as Git tree.");
+		return gitTree;
+	} catch (error) {
+		Lumberjack.error("Failed to write summary tree as Git tree.", error);
+		throw error;
 	}
-	return writeSummaryTreeCore(payload.entries, writeSummaryTreeOptions);
 }
 
 /**
@@ -166,11 +209,75 @@ async function createNewSummaryVersion(
 		parents: parentCommitSha ? [parentCommitSha] : [],
 		tree: treeSha,
 	};
-	const commit = await options.repoManager.createCommit(commitParams);
-	return {
-		id: commit.sha,
-		treeId: treeSha,
-	};
+	const writeSummaryVersionMetric = Lumberjack.newLumberMetric(
+		GitRestLumberEventName.CreateSummaryVersion,
+		options.lumberjackProperties,
+	);
+	try {
+		const commit = await options.repoManager.createCommit(commitParams);
+		writeSummaryVersionMetric.success("Successfully created summary version as Git commit.");
+		return {
+			id: commit.sha,
+			treeId: treeSha,
+		};
+	} catch (error) {
+		writeSummaryVersionMetric.error("Failed to create summary version as Git commit.", error);
+		throw error;
+	}
+}
+
+/**
+ * Create or update the document ref to reference the given commit.
+ */
+async function createOrUpdateRef(
+	documentRef: IRef | undefined,
+	commitSha: string,
+	options: IWholeSummaryOptions,
+): Promise<IRef> {
+	if (documentRef) {
+		// Ref already exists, so update it to reference the new commit.
+		const updateDocumenRefMetric = Lumberjack.newLumberMetric(
+			GitRestLumberEventName.UpdateDocumentRef,
+			options.lumberjackProperties,
+		);
+		try {
+			const updatedRef = await options.repoManager.patchRef(
+				`refs/heads/${options.documentId}`,
+				{
+					force: true,
+					sha: commitSha,
+				},
+				{ enabled: options.externalStorageEnabled },
+			);
+			updateDocumenRefMetric.success("Successfully updated document ref.");
+			return updatedRef;
+		} catch (error) {
+			updateDocumenRefMetric.error("Failed to update document ref.", error);
+			throw error;
+		}
+	}
+
+	// Ref does not exist, so create one to reference the new commit.
+	const createDocumenRefMetric = Lumberjack.newLumberMetric(
+		GitRestLumberEventName.CreateDocumentRef,
+		options.lumberjackProperties,
+	);
+	try {
+		const createdRef = await options.repoManager.createRef(
+			{
+				ref: `refs/heads/${options.documentId}`,
+				sha: commitSha,
+				// Bypass internal check for ref existance if possible, because we already know the ref does not exist.
+				force: true,
+			},
+			{ enabled: options.externalStorageEnabled },
+		);
+		createDocumenRefMetric.success("Successfully created document ref.");
+		return createdRef;
+	} catch (error) {
+		createDocumenRefMetric.error("Failed to create document ref.", error);
+		throw error;
+	}
 }
 
 /**
@@ -192,12 +299,15 @@ export async function writeContainerSummary(
 	const useLowIoWrite =
 		featureFlags.enableLowIoWrite === true ||
 		(isNewDocument && featureFlags.enableLowIoWrite === "initial");
+
+	// Write the container summary tree into storage.
 	const fullGitTree = await writeSummaryTree(payload, documentRef, {
 		...options,
 		precomputeFullTree: true,
 		useLowIoWrite,
 	});
 
+	// Create a new commit referencing the container summary tree.
 	const { id: versionId, treeId } = await createNewSummaryVersion(
 		fullGitTree.tree.sha,
 		documentRef?.object.sha,
@@ -206,27 +316,8 @@ export async function writeContainerSummary(
 		options,
 	);
 
-	// eslint-disable-next-line unicorn/prefer-ternary
-	if (documentRef) {
-		await options.repoManager.patchRef(
-			`refs/heads/${options.documentId}`,
-			{
-				force: true,
-				sha: versionId,
-			},
-			{ enabled: options.externalStorageEnabled },
-		);
-	} else {
-		await options.repoManager.createRef(
-			{
-				ref: `refs/heads/${options.documentId}`,
-				sha: versionId,
-				// Bypass internal check for ref existance if possible, because we already know the ref does not exist.
-				force: true,
-			},
-			{ enabled: options.externalStorageEnabled },
-		);
-	}
+	// Create or update the document ref to reference the new commit.
+	await createOrUpdateRef(documentRef, versionId, options);
 
 	const fullSummaryTree = convertFullGitTreeToFullSummaryTree(fullGitTree);
 	const wholeFlatSummary: IWholeFlatSummary = {

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -6,6 +6,12 @@
 		"level": "info",
 		"timestamp": true
 	},
+	"lumberjack": {
+		"options": {
+			"enableGlobalTelemetryContext": true,
+			"enableSanitization": false
+		}
+	},
 	"config": {
 		"configDumpEnabled": false,
 		"secretNamesToRedactInConfigDump": [

--- a/server/historian/packages/historian/config.json
+++ b/server/historian/packages/historian/config.json
@@ -6,6 +6,12 @@
 		"level": "info",
 		"timestamp": true
 	},
+	"lumberjack": {
+		"options": {
+			"enableGlobalTelemetryContext": true,
+			"enableSanitization": false
+		}
+	},
 	"config": {
 		"configDumpEnabled": false,
 		"secretNamesToRedactInConfigDump": [


### PR DESCRIPTION
## Description

When we experience failures in Gitrest, the metrics that we have (WriteSummary and ReadSummary) are not granular enough. We need more granular metrics to help us understand what piece of the Gitrest SummaryWrite process is causing problems.

## Reviewer Guidance

Most of the code changes are just moving some logic into stand-alone functions that better serve the established metric pattern of

```ts
const metric = Lumberjack.newLumberMetric(...);
try {
  const result = await doThing();
  metric.success("Success");
  return result;
} catch (error) {
  metric.error("Failure", error);
  throw error;
}
```