### PR TITLE
Don't check message contents in ghost session unit test

### DIFF
--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -378,24 +378,9 @@ describe("IdCompressor", () => {
 			const compressor = CompressorFactory.createCompressor(Client.Client1);
 			const range = compressor.takeNextCreationRange();
 			compressor.beginGhostSession(createSessionId(), () => {
-				assert.throws(
-					() => compressor.takeNextCreationRange(),
-					(e: Error) =>
-						e.message ===
-						"IdCompressor should not be operated normally when in a ghost session",
-				);
-				assert.throws(
-					() => compressor.finalizeCreationRange(range),
-					(e: Error) =>
-						e.message ===
-						"IdCompressor should not be operated normally when in a ghost session",
-				);
-				assert.throws(
-					() => compressor.serialize(false),
-					(e: Error) =>
-						e.message ===
-						"IdCompressor should not be operated normally when in a ghost session",
-				);
+				assert.throws(() => compressor.takeNextCreationRange());
+				assert.throws(() => compressor.finalizeCreationRange(range));
+				assert.throws(() => compressor.serialize(false));
 			});
 		});
 


### PR DESCRIPTION
## Description

This test breaks after we tag asserts

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

