### PR TITLE
docs(odsp-client): Add `packageDocumentation` and update README

### DIFF
--- a/packages/service-clients/odsp-client/README.md
+++ b/packages/service-clients/odsp-client/README.md
@@ -1,10 +1,10 @@
 # @fluid-experimental/odsp-client
 
-The odsp-client package provides a simple and powerful way to consume collaborative Fluid data with the ODSP as a storage mechanism. Please note that odsp-client is currently an experimental package. We'd love for you to try it out and provide feedback but it is not yet recommended/supported for production scnearios.
+The odsp-client package provides a simple and powerful way to consume collaborative Fluid data with OneDrive/SharePoint (ODSP) storage.. Please note that odsp-client is currently an experimental package. We'd love for you to try it out and provide feedback but it is not yet recommended/supported for production scnearios.
 
 ## Using odsp-client
 
-The odsp-client package has an `OdspClient`` class that allows you to interact with Fluid
+The odsp-client package has an `OdspClient` class that allows you to interact with Fluid.
 
 ```typescript
 import { OdspClient } from "@fluid-experimental/odsp-client";

--- a/packages/service-clients/odsp-client/README.md
+++ b/packages/service-clients/odsp-client/README.md
@@ -1,6 +1,6 @@
 # @fluid-experimental/odsp-client
 
-The odsp-client package provides a simple and powerful way to consume collaborative Fluid data with OneDrive/SharePoint (ODSP) storage.. Please note that odsp-client is currently an experimental package. We'd love for you to try it out and provide feedback but it is not yet recommended or supported for production scenarios.
+The odsp-client package provides a simple and powerful way to consume collaborative Fluid data with OneDrive/SharePoint (ODSP) storage. Please note that odsp-client is currently an experimental package. We'd love for you to try it out and provide feedback but it is not yet recommended or supported for production scenarios.
 
 ## Using odsp-client
 

--- a/packages/service-clients/odsp-client/README.md
+++ b/packages/service-clients/odsp-client/README.md
@@ -1,6 +1,6 @@
 # @fluid-experimental/odsp-client
 
-The odsp-client package provides a simple and powerful way to consume collaborative Fluid data with OneDrive/SharePoint (ODSP) storage.. Please note that odsp-client is currently an experimental package. We'd love for you to try it out and provide feedback but it is not yet recommended/supported for production scnearios.
+The odsp-client package provides a simple and powerful way to consume collaborative Fluid data with OneDrive/SharePoint (ODSP) storage.. Please note that odsp-client is currently an experimental package. We'd love for you to try it out and provide feedback but it is not yet recommended or supported for production scenarios.
 
 ## Using odsp-client
 

--- a/packages/service-clients/odsp-client/api-report/odsp-client.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.api.md
@@ -64,6 +64,4 @@ export interface OdspMember extends IMember {
 
 export { TokenResponse }
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/packages/service-clients/odsp-client/src/index.ts
+++ b/packages/service-clients/odsp-client/src/index.ts
@@ -3,6 +3,16 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * The odsp-client package provides a simple and powerful way to consume collaborative Fluid data with OneDrive/SharePoint (ODSP) storage.
+ *
+ * @remarks
+ * Please note that odsp-client is currently an experimental package.
+ * We'd love for you to try it out and provide feedback but it is not yet recommended/supported for production scnearios.
+ *
+ * @packageDocumentation
+ */
+
 export { type TokenResponse } from "@fluidframework/odsp-driver-definitions";
 export type {
 	OdspConnectionConfig,

--- a/packages/service-clients/odsp-client/src/index.ts
+++ b/packages/service-clients/odsp-client/src/index.ts
@@ -8,7 +8,7 @@
  *
  * @remarks
  * Please note that odsp-client is currently an experimental package.
- * We'd love for you to try it out and provide feedback but it is not yet recommended or supported for production scnearios.
+ * We'd love for you to try it out and provide feedback but it is not yet recommended or supported for production scenarios.
  *
  * @packageDocumentation
  */

--- a/packages/service-clients/odsp-client/src/index.ts
+++ b/packages/service-clients/odsp-client/src/index.ts
@@ -8,7 +8,7 @@
  *
  * @remarks
  * Please note that odsp-client is currently an experimental package.
- * We'd love for you to try it out and provide feedback but it is not yet recommended/supported for production scnearios.
+ * We'd love for you to try it out and provide feedback but it is not yet recommended or supported for production scnearios.
  *
  * @packageDocumentation
  */


### PR DESCRIPTION
The current website entry for `odsp-client` is empty, because the package doesn't have a `@packageDocumentation` comment.
![image](https://github.com/microsoft/FluidFramework/assets/54606601/bc30f5d3-4486-46cb-8341-0185531f2d49)
 
Adds missing `@packageDocumentation` comment to ensure the generated API docs we publish to our website get an entry (derived from overview in the README).

Also makes some quick mechanical fixes to the README and defines the term "ODSP" before use.