### PR TITLE
fix: URI Root for API docs generation

### DIFF
--- a/docs/api-markdown-documenter/index.js
+++ b/docs/api-markdown-documenter/index.js
@@ -34,7 +34,11 @@ Promise.all(
 			version,
 		);
 
-		const uriRootDirectoryPath = `docs/api/${version}`;
+		// Note: the leading slash in the URI root is important.
+		// It tells Hugo to enterpret the links as relative to the site root, rather than
+		// relative to the document containing the link.
+		// See documentation here: https://gohugo.io/content-management/urls/#relative-urls
+		const uriRootDirectoryPath = `/docs/api/${version}`;
 
 		await renderApiDocumentation(
 			apiReportsDirectoryPath,


### PR DESCRIPTION
At some point recently, the trailing `/` was omitted from the `uriBase` parameter. This leading `/` is important for Hugo's understanding of how to resolve relative links. 

This PR restores the leading slash and adds some documentation to help ensure this mistake doesn't happen again.