### PR TITLE
build: increase CI build timeout to 90 min

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -172,11 +172,9 @@ stages:
           # CI builds run more aggressive compat configurations which can take longer.
           # See "FullCompat" under packages\test\test-version-utils\README.md for more details.
           # At the time of adding this comment, the full compat config is on the smaller side and so
-          # CI builds consistently pass with a 60 minutes timeout. However, it will naturally grow
-          # over time and it might be necessary to bump it.
           # AB#6680 is also relevant here, which tracks rethinking how and where we run tests (likely with
           # a focus on e2e tests)
-          timeoutInMinutes: 60
+          timeoutInMinutes: 90
         pool: ${{ parameters.poolBuild }}
         variables:
           testCoverage: ${{ ne(variables['Build.Reason'], 'PullRequest') }}


### PR DESCRIPTION
@scottn12 fixed a bug (see relevant PRs below) where full compat tests were not running with our latest RC versioning changes. However, once fixed, our test pipelines started timing out. This is most likely due to the additional test matrixes added from the latest release (2.0.0-internal.8.0.0 was the latest).

As a stop-gap measure, this PR increases the timeout to 90 minutes so that we can keep getting full CI builds.
 
PRs:
[fix(test-version-utils): Fix full back compat e2e test generation for rc releases by scottn12 · Pull Request #19092 · microsoft/FluidFramework (github.com)](https://github.com/microsoft/FluidFramework/pull/19092)
[fix(test-version-utils): Add check for dev-rc releases by scottn12 · Pull Request #19127 · microsoft/FluidFramework (github.com)](https://github.com/microsoft/FluidFramework/pull/19127)