### PR TITLE
feat(azure-service-utils): Promote generateToken from @internal to @alpha to ensure API docs are generated for it.

### DIFF
--- a/azure/packages/azure-service-utils/api-report/azure-service-utils.api.md
+++ b/azure/packages/azure-service-utils/api-report/azure-service-utils.api.md
@@ -7,7 +7,7 @@
 import { IUser } from '@fluidframework/protocol-definitions';
 import { ScopeType } from '@fluidframework/protocol-definitions';
 
-// @internal
+// @alpha
 export function generateToken(tenantId: string, key: string, scopes: ScopeType[], documentId?: string, user?: IUser, lifetime?: number, ver?: string): string;
 
 export { IUser }

--- a/azure/packages/azure-service-utils/src/generateToken.ts
+++ b/azure/packages/azure-service-utils/src/generateToken.ts
@@ -47,7 +47,8 @@ import type { ITokenClaims, IUser, ScopeType } from "@fluidframework/protocol-de
  * Default: 3600 (1 hour).
  * @param ver - See {@link @fluidframework/protocol-definitions#ITokenClaims.ver}.
  * Default: `1.0`.
- * @internal
+ *
+ * @alpha
  */
 export function generateToken(
 	tenantId: string,


### PR DESCRIPTION
The API as tagged would not generate API docs, but we _do_ expect our SDK users to at least reference it.

Changes merged into 2.0 release candidate branch in #19132