### PR TITLE
tree: Split files to fix cycle

### DIFF
--- a/packages/dds/tree/.dependency-cruiser-known-violations.json
+++ b/packages/dds/tree/.dependency-cruiser-known-violations.json
@@ -37,18 +37,5 @@
       "src/feature-libraries/flex-tree/unboxed.ts",
       "src/feature-libraries/flex-tree/lazyNode.ts"
     ]
-  },
-  {
-    "type": "cycle",
-    "from": "src/feature-libraries/modular-schema/comparison.ts",
-    "to": "src/feature-libraries/modular-schema/fieldKind.ts",
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      "src/feature-libraries/modular-schema/fieldKind.ts",
-      "src/feature-libraries/modular-schema/comparison.ts"
-    ]
   }
 ]

--- a/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
@@ -16,8 +16,9 @@ import {
 	MapNodeStoredSchema,
 	ObjectNodeStoredSchema,
 } from "../../core/index.js";
-import { Multiplicity } from "../multiplicity.js";
-import { FullSchemaPolicy, withEditor } from "./fieldKind.js";
+import { FullSchemaPolicy } from "./fieldKind.js";
+import { withEditor } from "./fieldKindWithEditor.js";
+import { isNeverTree } from "./isNeverTree.js";
 
 /**
  * @returns true iff `superset` is a superset of `original`.
@@ -198,108 +199,6 @@ export function allowsRepoSuperset(
 		}
 	}
 	return true;
-}
-
-/**
- * @internal
- */
-export function isNeverField(
-	policy: FullSchemaPolicy,
-	originalData: TreeStoredSchema,
-	field: TreeFieldStoredSchema,
-): boolean {
-	return isNeverFieldRecursive(policy, originalData, field, new Set());
-}
-
-export function isNeverFieldRecursive(
-	policy: FullSchemaPolicy,
-	originalData: TreeStoredSchema,
-	field: TreeFieldStoredSchema,
-	parentTypeStack: Set<TreeNodeStoredSchema>,
-): boolean {
-	if (
-		(policy.fieldKinds.get(field.kind.identifier) ?? fail("missing field kind"))
-			.multiplicity === Multiplicity.Single &&
-		field.types !== undefined
-	) {
-		for (const type of field.types) {
-			if (
-				!isNeverTreeRecursive(
-					policy,
-					originalData,
-					originalData.nodeSchema.get(type),
-					parentTypeStack,
-				)
-			) {
-				return false;
-			}
-		}
-		// This field requires at least one child, and there are no types permitted in it that can exist,
-		// so this is a never field (field which no sequence of children content could ever be in schema for)
-		return true;
-	}
-	return false;
-}
-
-/**
- * Returns true iff there are no possible trees that could meet this schema.
- * Trees which are infinite (like endless linked lists) are considered impossible.
- *
- * `undefined` means the schema is not present and thus a NeverTree.
- */
-export function isNeverTree(
-	policy: FullSchemaPolicy,
-	originalData: TreeStoredSchema,
-	treeNode: TreeNodeStoredSchema | undefined,
-): boolean {
-	return isNeverTreeRecursive(policy, originalData, treeNode, new Set());
-}
-
-/**
- * Returns true iff there are no possible trees that could meet this schema.
- * Trees which are infinite (like endless linked lists) are considered impossible.
- *
- * `undefined` means the schema is not present and thus a NeverTree.
- */
-export function isNeverTreeRecursive(
-	policy: FullSchemaPolicy,
-	originalData: TreeStoredSchema,
-	treeNode: TreeNodeStoredSchema | undefined,
-	parentTypeStack: Set<TreeNodeStoredSchema>,
-): boolean {
-	if (treeNode === undefined) {
-		return true;
-	}
-	if (parentTypeStack.has(treeNode)) {
-		return true;
-	}
-	try {
-		parentTypeStack.add(treeNode);
-		if (treeNode instanceof MapNodeStoredSchema) {
-			return (
-				(
-					policy.fieldKinds.get(treeNode.mapFields.kind.identifier) ??
-					fail("missing field kind")
-				).multiplicity === Multiplicity.Single
-			);
-		} else if (treeNode instanceof ObjectNodeStoredSchema) {
-			for (const field of treeNode.objectNodeFields.values()) {
-				// TODO: this can recurse infinitely for schema that include themselves in a value field.
-				// This breaks even if there are other allowed types.
-				// Such schema should either be rejected (as an error here) or considered never (and thus detected by this).
-				// This can be done by passing a set/stack of current types recursively here.
-				if (isNeverFieldRecursive(policy, originalData, field, parentTypeStack)) {
-					return true;
-				}
-			}
-			return false;
-		} else {
-			assert(treeNode instanceof LeafNodeStoredSchema, 0x897 /* unsupported node kind */);
-			return false;
-		}
-	} finally {
-		parentTypeStack.delete(treeNode);
-	}
 }
 
 export function normalizeField(schema: TreeFieldStoredSchema | undefined): TreeFieldStoredSchema {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldKind.ts
@@ -3,17 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils";
-import {
-	TreeFieldStoredSchema,
-	FieldKindIdentifier,
-	TreeStoredSchema,
-	FieldKindSpecifier,
-	TreeTypeSet,
-} from "../../core/index.js";
+import { FieldKindIdentifier, FieldKindSpecifier } from "../../core/index.js";
 import { Multiplicity } from "../multiplicity.js";
-import { isNeverField } from "./comparison.js";
-import { FieldChangeHandler, FieldEditor } from "./fieldChangeHandler.js";
 
 /**
  * Functionality for FieldKinds that is stable,
@@ -50,88 +41,6 @@ export abstract class FieldKind<
 	) {}
 }
 
-/**
- * Functionality for FieldKinds that is stable,
- * meaning that it can not change in any measurable way without providing a new identifier.
- *
- * It is assumed that this information and policy is available on all clients interacting with a document
- * using the identifier.
- *
- * This must contain enough information to process remote edits to this FieldKind consistently with all clients.
- * All behavior must be deterministic, and not change across versions of the app/library.
- *
- * These policies include the data encoding, change encoding, change rebase and change application.
- */
-export class FieldKindWithEditor<
-	TEditor extends FieldEditor<any> = FieldEditor<any>,
-	TMultiplicity extends Multiplicity = Multiplicity,
-	TName extends string = string,
-> extends FieldKind<TName, TMultiplicity> {
-	/**
-	 * @param identifier - Globally scoped identifier.
-	 * @param multiplicity - bound on the number of children that fields of this kind may have.
-	 * TODO: replace with numeric upper and lower bounds.
-	 * @param changeHandler - Change handling policy.
-	 * @param allowsTreeSupersetOf - returns true iff `superset` supports all that this does
-	 * and `superset` is an allowed upgrade. Does not have to handle the `never` cases.
-	 * See {@link isNeverField}.
-	 * TODO: when used as a method (instead of a free function like the other superset related functions),
-	 * this name is/signature is confusing and seems backwards.
-	 * @param handlesEditsFrom - Kinds (in addition to this) whose edits can be processed by changeHandler.
-	 * If the kind of a field changes, and edits are rebased across that kind change,
-	 * listing the other old kind here can prevent those edits from being conflicted and
-	 * provide a chance to handle them.
-	 */
-	public constructor(
-		identifier: TName,
-		multiplicity: TMultiplicity,
-		public readonly changeHandler: FieldChangeHandler<any, TEditor>,
-		private readonly allowsTreeSupersetOf: (
-			originalTypes: TreeTypeSet,
-			superset: TreeFieldStoredSchema,
-		) => boolean,
-		public readonly handlesEditsFrom: ReadonlySet<FieldKindIdentifier>,
-	) {
-		super(identifier as TName & FieldKindIdentifier, multiplicity);
-	}
-
-	/**
-	 * @returns true iff `superset` permits a (non-strict) superset of the subtrees
-	 * allowed by field made from `this` and `originalTypes`.
-	 */
-	public allowsFieldSuperset(
-		policy: FullSchemaPolicy,
-		originalData: TreeStoredSchema,
-		originalTypes: TreeTypeSet,
-		superset: TreeFieldStoredSchema,
-	): boolean {
-		if (
-			isNeverField(policy, originalData, {
-				kind: this,
-				types: originalTypes,
-			})
-		) {
-			return true;
-		}
-		if (isNeverField(policy, originalData, superset)) {
-			return false;
-		}
-		return this.allowsTreeSupersetOf(originalTypes, superset);
-	}
-}
-
-/**
- * Downcasts to FieldKindWithEditor.
- */
-export function withEditor<
-	TName extends string = string,
-	TMultiplicity extends Multiplicity = Multiplicity,
->(
-	kind: FieldKind<TName, TMultiplicity>,
-): FieldKindWithEditor<FieldEditor<any>, TMultiplicity, TName> {
-	assert(kind instanceof FieldKindWithEditor, 0x7b5 /* kind must be FieldKindWithEditor */);
-	return kind as FieldKindWithEditor<FieldEditor<any>, TMultiplicity, TName>;
-}
 /**
  * Policy from the app for interpreting the stored schema.
  * The app must ensure consistency for all users of the document.

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldKindWithEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldKindWithEditor.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { assert } from "@fluidframework/core-utils";
 import {
 	TreeFieldStoredSchema,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldKindWithEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldKindWithEditor.ts
@@ -1,0 +1,95 @@
+import { assert } from "@fluidframework/core-utils";
+import {
+	TreeFieldStoredSchema,
+	FieldKindIdentifier,
+	TreeStoredSchema,
+	TreeTypeSet,
+} from "../../core/index.js";
+import { Multiplicity } from "../multiplicity.js";
+import { isNeverField } from "./isNeverTree.js";
+import { FieldChangeHandler, FieldEditor } from "./fieldChangeHandler.js";
+import { FieldKind, FullSchemaPolicy } from "./fieldKind.js";
+
+/**
+ * Functionality for FieldKinds that is stable,
+ * meaning that it can not change in any measurable way without providing a new identifier.
+ *
+ * It is assumed that this information and policy is available on all clients interacting with a document
+ * using the identifier.
+ *
+ * This must contain enough information to process remote edits to this FieldKind consistently with all clients.
+ * All behavior must be deterministic, and not change across versions of the app/library.
+ *
+ * These policies include the data encoding, change encoding, change rebase and change application.
+ */
+
+export class FieldKindWithEditor<
+	TEditor extends FieldEditor<any> = FieldEditor<any>,
+	TMultiplicity extends Multiplicity = Multiplicity,
+	TName extends string = string,
+> extends FieldKind<TName, TMultiplicity> {
+	/**
+	 * @param identifier - Globally scoped identifier.
+	 * @param multiplicity - bound on the number of children that fields of this kind may have.
+	 * TODO: replace with numeric upper and lower bounds.
+	 * @param changeHandler - Change handling policy.
+	 * @param allowsTreeSupersetOf - returns true iff `superset` supports all that this does
+	 * and `superset` is an allowed upgrade. Does not have to handle the `never` cases.
+	 * See {@link isNeverField}.
+	 * TODO: when used as a method (instead of a free function like the other superset related functions),
+	 * this name is/signature is confusing and seems backwards.
+	 * @param handlesEditsFrom - Kinds (in addition to this) whose edits can be processed by changeHandler.
+	 * If the kind of a field changes, and edits are rebased across that kind change,
+	 * listing the other old kind here can prevent those edits from being conflicted and
+	 * provide a chance to handle them.
+	 */
+	public constructor(
+		identifier: TName,
+		multiplicity: TMultiplicity,
+		public readonly changeHandler: FieldChangeHandler<any, TEditor>,
+		private readonly allowsTreeSupersetOf: (
+			originalTypes: TreeTypeSet,
+			superset: TreeFieldStoredSchema,
+		) => boolean,
+		public readonly handlesEditsFrom: ReadonlySet<FieldKindIdentifier>,
+	) {
+		super(identifier as TName & FieldKindIdentifier, multiplicity);
+	}
+
+	/**
+	 * @returns true iff `superset` permits a (non-strict) superset of the subtrees
+	 * allowed by field made from `this` and `originalTypes`.
+	 */
+	public allowsFieldSuperset(
+		policy: FullSchemaPolicy,
+		originalData: TreeStoredSchema,
+		originalTypes: TreeTypeSet,
+		superset: TreeFieldStoredSchema,
+	): boolean {
+		if (
+			isNeverField(policy, originalData, {
+				kind: this,
+				types: originalTypes,
+			})
+		) {
+			return true;
+		}
+		if (isNeverField(policy, originalData, superset)) {
+			return false;
+		}
+		return this.allowsTreeSupersetOf(originalTypes, superset);
+	}
+}
+
+/**
+ * Downcasts to FieldKindWithEditor.
+ */
+export function withEditor<
+	TName extends string = string,
+	TMultiplicity extends Multiplicity = Multiplicity,
+>(
+	kind: FieldKind<TName, TMultiplicity>,
+): FieldKindWithEditor<FieldEditor<any>, TMultiplicity, TName> {
+	assert(kind instanceof FieldKindWithEditor, 0x7b5 /* kind must be FieldKindWithEditor */);
+	return kind as FieldKindWithEditor<FieldEditor<any>, TMultiplicity, TName>;
+}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -24,7 +24,7 @@ import {
 	RelevantRemovedRootsFromChild,
 	NodeChangePruner,
 } from "./fieldChangeHandler.js";
-import { FieldKindWithEditor } from "./fieldKind.js";
+import { FieldKindWithEditor } from "./fieldKindWithEditor.js";
 import { makeGenericChangeCodec } from "./genericFieldKindCodecs.js";
 import { GenericChange, GenericChangeset } from "./genericFieldKindTypes.js";
 import { NodeChangeset } from "./modularChangeTypes.js";

--- a/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
@@ -4,13 +4,12 @@
  */
 
 export {
-	isNeverField,
-	isNeverTree,
 	allowsRepoSuperset,
 	allowsTreeSchemaIdentifierSuperset,
 	allowsFieldSuperset,
 	allowsTreeSuperset,
 } from "./comparison.js";
+export { isNeverField, isNeverTree } from "./isNeverTree.js";
 export {
 	addCrossFieldQuery,
 	CrossFieldManager,
@@ -25,7 +24,8 @@ export {
 	EncodedRevisionInfo,
 	EncodedModularChangeset,
 } from "./modularChangeFormat.js";
-export { FieldKind, FullSchemaPolicy, FieldKindWithEditor } from "./fieldKind.js";
+export { FieldKind, FullSchemaPolicy } from "./fieldKind.js";
+export { FieldKindWithEditor } from "./fieldKindWithEditor.js";
 export {
 	FieldChangeHandler,
 	FieldChangeRebaser,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/isNeverTree.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/isNeverTree.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { assert } from "@fluidframework/core-utils";
 import { fail } from "../../util/index.js";
 import {
@@ -106,7 +111,7 @@ export function isNeverTreeRecursive(
 			}
 			return false;
 		} else {
-			assert(treeNode instanceof LeafNodeStoredSchema, 2199 /* unsupported node kind */);
+			assert(treeNode instanceof LeafNodeStoredSchema, 0x897 /* unsupported node kind */);
 			return false;
 		}
 	} finally {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/isNeverTree.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/isNeverTree.ts
@@ -1,0 +1,115 @@
+import { assert } from "@fluidframework/core-utils";
+import { fail } from "../../util/index.js";
+import {
+	TreeNodeStoredSchema,
+	TreeFieldStoredSchema,
+	TreeStoredSchema,
+	LeafNodeStoredSchema,
+	MapNodeStoredSchema,
+	ObjectNodeStoredSchema,
+} from "../../core/index.js";
+import { Multiplicity } from "../multiplicity.js";
+import { FullSchemaPolicy } from "./fieldKind.js";
+
+/**
+ * @internal
+ */
+
+export function isNeverField(
+	policy: FullSchemaPolicy,
+	originalData: TreeStoredSchema,
+	field: TreeFieldStoredSchema,
+): boolean {
+	return isNeverFieldRecursive(policy, originalData, field, new Set());
+}
+
+export function isNeverFieldRecursive(
+	policy: FullSchemaPolicy,
+	originalData: TreeStoredSchema,
+	field: TreeFieldStoredSchema,
+	parentTypeStack: Set<TreeNodeStoredSchema>,
+): boolean {
+	if (
+		(policy.fieldKinds.get(field.kind.identifier) ?? fail("missing field kind"))
+			.multiplicity === Multiplicity.Single &&
+		field.types !== undefined
+	) {
+		for (const type of field.types) {
+			if (
+				!isNeverTreeRecursive(
+					policy,
+					originalData,
+					originalData.nodeSchema.get(type),
+					parentTypeStack,
+				)
+			) {
+				return false;
+			}
+		}
+		// This field requires at least one child, and there are no types permitted in it that can exist,
+		// so this is a never field (field which no sequence of children content could ever be in schema for)
+		return true;
+	}
+	return false;
+}
+/**
+ * Returns true iff there are no possible trees that could meet this schema.
+ * Trees which are infinite (like endless linked lists) are considered impossible.
+ *
+ * `undefined` means the schema is not present and thus a NeverTree.
+ */
+
+export function isNeverTree(
+	policy: FullSchemaPolicy,
+	originalData: TreeStoredSchema,
+	treeNode: TreeNodeStoredSchema | undefined,
+): boolean {
+	return isNeverTreeRecursive(policy, originalData, treeNode, new Set());
+}
+/**
+ * Returns true iff there are no possible trees that could meet this schema.
+ * Trees which are infinite (like endless linked lists) are considered impossible.
+ *
+ * `undefined` means the schema is not present and thus a NeverTree.
+ */
+
+export function isNeverTreeRecursive(
+	policy: FullSchemaPolicy,
+	originalData: TreeStoredSchema,
+	treeNode: TreeNodeStoredSchema | undefined,
+	parentTypeStack: Set<TreeNodeStoredSchema>,
+): boolean {
+	if (treeNode === undefined) {
+		return true;
+	}
+	if (parentTypeStack.has(treeNode)) {
+		return true;
+	}
+	try {
+		parentTypeStack.add(treeNode);
+		if (treeNode instanceof MapNodeStoredSchema) {
+			return (
+				(
+					policy.fieldKinds.get(treeNode.mapFields.kind.identifier) ??
+					fail("missing field kind")
+				).multiplicity === Multiplicity.Single
+			);
+		} else if (treeNode instanceof ObjectNodeStoredSchema) {
+			for (const field of treeNode.objectNodeFields.values()) {
+				// TODO: this can recurse infinitely for schema that include themselves in a value field.
+				// This breaks even if there are other allowed types.
+				// Such schema should either be rejected (as an error here) or considered never (and thus detected by this).
+				// This can be done by passing a set/stack of current types recursively here.
+				if (isNeverFieldRecursive(policy, originalData, field, parentTypeStack)) {
+					return true;
+				}
+			}
+			return false;
+		} else {
+			assert(treeNode instanceof LeafNodeStoredSchema, 2199 /* unsupported node kind */);
+			return false;
+		}
+	} finally {
+		parentTypeStack.delete(treeNode);
+	}
+}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -36,7 +36,7 @@ import {
 	ModularChangeset,
 	NodeChangeset,
 } from "./modularChangeTypes.js";
-import { FieldKindWithEditor } from "./fieldKind.js";
+import { FieldKindWithEditor } from "./fieldKindWithEditor.js";
 import { genericFieldKind } from "./genericFieldKind.js";
 import {
 	EncodedBuilds,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -74,7 +74,8 @@ import {
 	NodeExistenceState,
 	RebaseRevisionMetadata,
 } from "./fieldChangeHandler.js";
-import { FieldKind, FieldKindWithEditor, withEditor } from "./fieldKind.js";
+import { FieldKind } from "./fieldKind.js";
+import { FieldKindWithEditor, withEditor } from "./fieldKindWithEditor.js";
 import { convertGenericChange, genericFieldKind, newGenericChangeset } from "./genericFieldKind.js";
 import { GenericChangeset } from "./genericFieldKindTypes.js";
 import {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -10,8 +10,6 @@ import {
 	allowsTreeSuperset,
 	allowsTreeSchemaIdentifierSuperset,
 	allowsValueSuperset,
-	isNeverField,
-	isNeverTree,
 	// Allow importing from this specific file which is being tested:
 	/* eslint-disable-next-line import/no-internal-modules */
 } from "../../../feature-libraries/modular-schema/comparison.js";
@@ -33,18 +31,6 @@ import { brand } from "../../../util/index.js";
 import { defaultSchemaPolicy, FieldKinds } from "../../../feature-libraries/index.js";
 
 /**
- * APIs to help build schema.
- *
- * See typedSchema.ts for a wrapper for these APIs that captures the types as TypeScript types
- * in addition to runtime data.
- */
-
-/**
- * Empty readonly map.
- */
-const emptyMap: ReadonlyMap<never, never> = new Map<never, never>();
-
-/**
  * Helper for building {@link TreeFieldStoredSchema}.
  * @internal
  */
@@ -56,15 +42,6 @@ function fieldSchema(
 		kind,
 		types: types === undefined ? undefined : new Set(types),
 	};
-}
-
-/**
- * See {@link TreeNodeStoredSchema} for details.
- */
-interface TreeNodeStoredSchemaBuilder {
-	readonly objectNodeFields?: { [key: string]: TreeFieldStoredSchema };
-	readonly mapFields?: TreeFieldStoredSchema;
-	readonly leafValue?: ValueSchema;
 }
 
 describe("Schema Comparison", () => {
@@ -133,79 +110,6 @@ describe("Schema Comparison", () => {
 			nodeSchema: new Map([...repo.nodeSchema, [identifier, schema]]),
 		});
 	}
-
-	it("isNeverField", () => {
-		const repo = new TreeStoredSchemaRepository();
-		assert(isNeverField(defaultSchemaPolicy, repo, neverField));
-		updateTreeSchema(repo, brand("never"), neverTree);
-		const neverField2: TreeFieldStoredSchema = fieldSchema(FieldKinds.required, [
-			brand("never"),
-		]);
-		assert(isNeverField(defaultSchemaPolicy, repo, neverField2));
-		assert.equal(isNeverField(defaultSchemaPolicy, repo, storedEmptyFieldSchema), false);
-		assert.equal(isNeverField(defaultSchemaPolicy, repo, anyField), false);
-		assert.equal(isNeverField(defaultSchemaPolicy, repo, valueEmptyTreeField), true);
-		updateTreeSchema(repo, brand("empty"), emptyTree.schema);
-		assert.equal(
-			isNeverField(
-				defaultSchemaPolicy,
-				repo,
-				fieldSchema(FieldKinds.required, [brand("empty")]),
-			),
-			false,
-		);
-		assert.equal(isNeverField(defaultSchemaPolicy, repo, valueAnyField), false);
-		assert.equal(isNeverField(defaultSchemaPolicy, repo, valueEmptyTreeField), false);
-		assert.equal(isNeverField(defaultSchemaPolicy, repo, optionalAnyField), false);
-		assert.equal(isNeverField(defaultSchemaPolicy, repo, optionalEmptyTreeField), false);
-	});
-
-	it("isNeverTree", () => {
-		const repo = new TreeStoredSchemaRepository();
-		assert(isNeverTree(defaultSchemaPolicy, repo, neverTree));
-		assert(isNeverTree(defaultSchemaPolicy, repo, new MapNodeStoredSchema(neverField)));
-		assert(isNeverTree(defaultSchemaPolicy, repo, neverTree2));
-		assert(isNeverTree(defaultSchemaPolicy, repo, undefined));
-		assert.equal(
-			isNeverTree(defaultSchemaPolicy, repo, new ObjectNodeStoredSchema(emptyMap)),
-			false,
-		);
-		assert.equal(isNeverTree(defaultSchemaPolicy, repo, anyTreeWithoutValue), false);
-
-		assert(
-			allowsTreeSuperset(
-				defaultSchemaPolicy,
-				repo,
-				repo.nodeSchema.get(emptyTree.name),
-				emptyTree.schema,
-			),
-		);
-		updateTreeSchema(repo, emptyTree.name, emptyTree.schema);
-
-		assert.equal(isNeverTree(defaultSchemaPolicy, repo, emptyLocalFieldTree.schema), false);
-		assert.equal(isNeverTree(defaultSchemaPolicy, repo, valueLocalFieldTree.schema), false);
-		assert.equal(isNeverTree(defaultSchemaPolicy, repo, optionalLocalFieldTree.schema), false);
-	});
-
-	it("isNeverTreeRecursive", () => {
-		const repo = new TreeStoredSchemaRepository();
-		const recursiveField = fieldSchema(FieldKinds.required, [brand("recursive")]);
-		const recursiveType = new MapNodeStoredSchema(recursiveField);
-		updateTreeSchema(repo, brand("recursive"), recursiveType);
-		assert(isNeverTree(defaultSchemaPolicy, repo, recursiveType));
-	});
-
-	it("isNeverTreeRecursive non-never", () => {
-		const repo = new TreeStoredSchemaRepository();
-		const recursiveField = fieldSchema(FieldKinds.required, [
-			brand("recursive"),
-			emptyTree.name,
-		]);
-		const recursiveType = new MapNodeStoredSchema(recursiveField);
-		updateTreeSchema(repo, emptyTree.name, emptyTree.schema);
-		updateTreeSchema(repo, brand("recursive"), recursiveType);
-		assert(isNeverTree(defaultSchemaPolicy, repo, recursiveType));
-	});
 
 	it("allowsValueSuperset", () => {
 		assert.equal(

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/isNeverTree.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/isNeverTree.spec.ts
@@ -1,0 +1,186 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import {
+	isNeverField,
+	isNeverTree,
+	// Allow importing from this specific file which is being tested:
+	/* eslint-disable-next-line import/no-internal-modules */
+} from "../../../feature-libraries/modular-schema/isNeverTree.js";
+import {
+	TreeFieldStoredSchema,
+	TreeNodeStoredSchema,
+	TreeNodeSchemaIdentifier,
+	storedEmptyFieldSchema,
+	FieldKindIdentifier,
+	MapNodeStoredSchema,
+	ObjectNodeStoredSchema,
+	MutableTreeStoredSchema,
+	TreeStoredSchemaRepository,
+} from "../../../core/index.js";
+import { brand } from "../../../util/index.js";
+import { defaultSchemaPolicy, FieldKinds } from "../../../feature-libraries/index.js";
+/* eslint-disable-next-line import/no-internal-modules */
+import { allowsTreeSuperset } from "../../../feature-libraries/modular-schema/index.js";
+
+/**
+ * Empty readonly map.
+ */
+const emptyMap: ReadonlyMap<never, never> = new Map<never, never>();
+
+/**
+ * Helper for building {@link TreeFieldStoredSchema}.
+ * @internal
+ */
+function fieldSchema(
+	kind: { identifier: FieldKindIdentifier },
+	types?: Iterable<TreeNodeSchemaIdentifier>,
+): TreeFieldStoredSchema {
+	return {
+		kind,
+		types: types === undefined ? undefined : new Set(types),
+	};
+}
+
+describe("Schema Comparison", () => {
+	/**
+	 * TreeFieldStoredSchema permits anything.
+	 * Note that children inside the field still have to be in schema.
+	 */
+	const anyField = fieldSchema(FieldKinds.sequence);
+
+	/**
+	 * TreeNodeStoredSchema that permits anything without a value.
+	 * Note that children under the fields still have to be in schema.
+	 */
+	const anyTreeWithoutValue: TreeNodeStoredSchema = new MapNodeStoredSchema(anyField);
+
+	/**
+	 * TreeFieldStoredSchema which is impossible for any data to be in schema with.
+	 */
+	const neverField = fieldSchema(FieldKinds.required, []);
+
+	/**
+	 * TreeNodeStoredSchema which is impossible for any data to be in schema with.
+	 */
+	const neverTree: TreeNodeStoredSchema = new MapNodeStoredSchema(neverField);
+
+	const neverTree2: TreeNodeStoredSchema = new ObjectNodeStoredSchema(
+		new Map([[brand("x"), neverField]]),
+	);
+
+	const emptyTree = {
+		name: brand<TreeNodeSchemaIdentifier>("empty"),
+		schema: new ObjectNodeStoredSchema(new Map()),
+	};
+
+	const emptyLocalFieldTree = {
+		name: brand<TreeNodeSchemaIdentifier>("emptyLocalFieldTree"),
+		schema: new ObjectNodeStoredSchema(new Map([[brand("x"), storedEmptyFieldSchema]])),
+	};
+
+	const optionalLocalFieldTree = {
+		name: brand<TreeNodeSchemaIdentifier>("optionalLocalFieldTree"),
+		schema: new ObjectNodeStoredSchema(
+			new Map([[brand("x"), fieldSchema(FieldKinds.optional, [emptyTree.name])]]),
+		),
+	};
+	const valueLocalFieldTree = {
+		name: brand<TreeNodeSchemaIdentifier>("valueLocalFieldTree"),
+		schema: new ObjectNodeStoredSchema(
+			new Map([[brand("x"), fieldSchema(FieldKinds.required, [emptyTree.name])]]),
+		),
+	};
+	const valueAnyField = fieldSchema(FieldKinds.required);
+	const valueEmptyTreeField = fieldSchema(FieldKinds.required, [emptyTree.name]);
+	const optionalAnyField = fieldSchema(FieldKinds.optional);
+	const optionalEmptyTreeField = fieldSchema(FieldKinds.optional, [emptyTree.name]);
+
+	function updateTreeSchema(
+		repo: MutableTreeStoredSchema,
+		identifier: TreeNodeSchemaIdentifier,
+		schema: TreeNodeStoredSchema,
+	) {
+		repo.apply({
+			rootFieldSchema: repo.rootFieldSchema,
+			nodeSchema: new Map([...repo.nodeSchema, [identifier, schema]]),
+		});
+	}
+
+	it("isNeverField", () => {
+		const repo = new TreeStoredSchemaRepository();
+		assert(isNeverField(defaultSchemaPolicy, repo, neverField));
+		updateTreeSchema(repo, brand("never"), neverTree);
+		const neverField2: TreeFieldStoredSchema = fieldSchema(FieldKinds.required, [
+			brand("never"),
+		]);
+		assert(isNeverField(defaultSchemaPolicy, repo, neverField2));
+		assert.equal(isNeverField(defaultSchemaPolicy, repo, storedEmptyFieldSchema), false);
+		assert.equal(isNeverField(defaultSchemaPolicy, repo, anyField), false);
+		assert.equal(isNeverField(defaultSchemaPolicy, repo, valueEmptyTreeField), true);
+		updateTreeSchema(repo, brand("empty"), emptyTree.schema);
+		assert.equal(
+			isNeverField(
+				defaultSchemaPolicy,
+				repo,
+				fieldSchema(FieldKinds.required, [brand("empty")]),
+			),
+			false,
+		);
+		assert.equal(isNeverField(defaultSchemaPolicy, repo, valueAnyField), false);
+		assert.equal(isNeverField(defaultSchemaPolicy, repo, valueEmptyTreeField), false);
+		assert.equal(isNeverField(defaultSchemaPolicy, repo, optionalAnyField), false);
+		assert.equal(isNeverField(defaultSchemaPolicy, repo, optionalEmptyTreeField), false);
+	});
+
+	it("isNeverTree", () => {
+		const repo = new TreeStoredSchemaRepository();
+		assert(isNeverTree(defaultSchemaPolicy, repo, neverTree));
+		assert(isNeverTree(defaultSchemaPolicy, repo, new MapNodeStoredSchema(neverField)));
+		assert(isNeverTree(defaultSchemaPolicy, repo, neverTree2));
+		assert(isNeverTree(defaultSchemaPolicy, repo, undefined));
+		assert.equal(
+			isNeverTree(defaultSchemaPolicy, repo, new ObjectNodeStoredSchema(emptyMap)),
+			false,
+		);
+		assert.equal(isNeverTree(defaultSchemaPolicy, repo, anyTreeWithoutValue), false);
+
+		assert(
+			allowsTreeSuperset(
+				defaultSchemaPolicy,
+				repo,
+				repo.nodeSchema.get(emptyTree.name),
+				emptyTree.schema,
+			),
+		);
+		updateTreeSchema(repo, emptyTree.name, emptyTree.schema);
+
+		assert.equal(isNeverTree(defaultSchemaPolicy, repo, emptyLocalFieldTree.schema), false);
+		assert.equal(isNeverTree(defaultSchemaPolicy, repo, valueLocalFieldTree.schema), false);
+		assert.equal(isNeverTree(defaultSchemaPolicy, repo, optionalLocalFieldTree.schema), false);
+	});
+
+	it("isNeverTreeRecursive", () => {
+		const repo = new TreeStoredSchemaRepository();
+		const recursiveField = fieldSchema(FieldKinds.required, [brand("recursive")]);
+		const recursiveType = new MapNodeStoredSchema(recursiveField);
+		updateTreeSchema(repo, brand("recursive"), recursiveType);
+		assert(isNeverTree(defaultSchemaPolicy, repo, recursiveType));
+	});
+
+	it("isNeverTreeRecursive non-never", () => {
+		const repo = new TreeStoredSchemaRepository();
+		const recursiveField = fieldSchema(FieldKinds.required, [
+			brand("recursive"),
+			emptyTree.name,
+		]);
+		const recursiveType = new MapNodeStoredSchema(recursiveField);
+		updateTreeSchema(repo, emptyTree.name, emptyTree.schema);
+		updateTreeSchema(repo, brand("recursive"), recursiveType);
+		assert(isNeverTree(defaultSchemaPolicy, repo, recursiveType));
+	});
+});


### PR DESCRIPTION
## Description

Split up some files so that isNeverTree can be used by FieldKindWithEditor and by schema comparisons without cycles.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).