### PR TITLE
Fix SharedTree article link to FF.com "Introducing DDS"

### DIFF
--- a/docs/content/docs/build/dds.md
+++ b/docs/content/docs/build/dds.md
@@ -233,6 +233,7 @@ These DDSes are used for storing key-value data. They are all optimistic and use
 [SharedMap]: {{< relref "/docs/data-structures/map.md" >}}
 [SharedString]: {{< relref "/docs/data-structures/string.md" >}}
 [Sequences]: {{< relref "/docs/data-structures/sequences.md" >}}
+[SharedTree]: {{ < relref "/docs/data-structures/tree.md" >}}
 
 <!-- API links -->
 

--- a/docs/content/docs/build/dds.md
+++ b/docs/content/docs/build/dds.md
@@ -233,7 +233,7 @@ These DDSes are used for storing key-value data. They are all optimistic and use
 [SharedMap]: {{< relref "/docs/data-structures/map.md" >}}
 [SharedString]: {{< relref "/docs/data-structures/string.md" >}}
 [Sequences]: {{< relref "/docs/data-structures/sequences.md" >}}
-[SharedTree]: {{ < relref "/docs/data-structures/tree.md" >}}
+[SharedTree]: {{< relref "/docs/data-structures/tree.md" >}}
 
 <!-- API links -->
 


### PR DESCRIPTION
## Description

There are missing links to the new SharedTree article on [this page](https://fluidframework.com/docs/build/dds/#array-like-data) of the FF.com website. This PR just adds the proper link. 