### PR TITLE
refactor(tree): remove unnecessary type params from delta

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -304,9 +304,9 @@ export interface DeltaDetachedNodeBuild<TTree = DeltaProtoNode> {
 }
 
 // @internal
-export interface DeltaDetachedNodeChanges<TTree = DeltaProtoNode> {
+export interface DeltaDetachedNodeChanges {
     // (undocumented)
-    readonly fields: DeltaFieldMap<TTree>;
+    readonly fields: DeltaFieldMap;
     // (undocumented)
     readonly id: DeltaDetachedNodeId;
 }
@@ -338,21 +338,21 @@ export interface DeltaDetachedNodeRename {
 }
 
 // @internal
-export interface DeltaFieldChanges<TTree = DeltaProtoNode> {
-    readonly global?: readonly DeltaDetachedNodeChanges<TTree>[];
-    readonly local?: readonly DeltaMark<TTree>[];
+export interface DeltaFieldChanges {
+    readonly global?: readonly DeltaDetachedNodeChanges[];
+    readonly local?: readonly DeltaMark[];
     readonly rename?: readonly DeltaDetachedNodeRename[];
 }
 
 // @internal (undocumented)
-export type DeltaFieldMap<TTree = DeltaProtoNode> = ReadonlyMap<FieldKey, DeltaFieldChanges<TTree>>;
+export type DeltaFieldMap = ReadonlyMap<FieldKey, DeltaFieldChanges>;
 
 // @internal
-export interface DeltaMark<TTree = DeltaProtoNode> {
+export interface DeltaMark {
     readonly attach?: DeltaDetachedNodeId;
     readonly count: number;
     readonly detach?: DeltaDetachedNodeId;
-    readonly fields?: DeltaFieldMap<TTree>;
+    readonly fields?: DeltaFieldMap;
 }
 
 // @internal
@@ -362,7 +362,7 @@ export type DeltaProtoNode = ITreeCursorSynchronous;
 export interface DeltaRoot<TTree = DeltaProtoNode> {
     readonly build?: readonly DeltaDetachedNodeBuild<TTree>[];
     readonly destroy?: readonly DeltaDetachedNodeDestruction[];
-    readonly fields?: DeltaFieldMap<TTree>;
+    readonly fields?: DeltaFieldMap;
 }
 
 // @internal

--- a/packages/dds/tree/src/core/tree/delta.ts
+++ b/packages/dds/tree/src/core/tree/delta.ts
@@ -74,7 +74,7 @@ export interface Root<TTree = ProtoNode> {
 	/**
 	 * Changes to apply to the root fields.
 	 */
-	readonly fields?: FieldMap<TTree>;
+	readonly fields?: FieldMap;
 	/**
 	 * New detached nodes to be constructed.
 	 * The ordering has no significance.
@@ -94,6 +94,7 @@ export interface Root<TTree = ProtoNode> {
 	 */
 	readonly destroy?: readonly DetachedNodeDestruction[];
 }
+
 /**
  * The default representation for inserted content.
  *
@@ -121,7 +122,7 @@ export type ProtoNodes = readonly ProtoNode[];
  * Represents a change being made to a part of the document tree.
  * @internal
  */
-export interface Mark<TTree = ProtoNode> {
+export interface Mark {
 	/**
 	 * The number of nodes affected.
 	 * When `isAttachMark(mark)` is true, this is the number of new nodes being attached.
@@ -134,7 +135,7 @@ export interface Mark<TTree = ProtoNode> {
 	 * Modifications to the pre-existing content.
 	 * Must be undefined when `attach` is set but `detach` is not.
 	 */
-	readonly fields?: FieldMap<TTree>;
+	readonly fields?: FieldMap;
 
 	/**
 	 * When set, indicates that some pre-existing content is being detached and sent to the given detached field.
@@ -159,15 +160,15 @@ export interface DetachedNodeId {
 /**
  * @internal
  */
-export type FieldMap<TTree = ProtoNode> = ReadonlyMap<FieldKey, FieldChanges<TTree>>;
+export type FieldMap = ReadonlyMap<FieldKey, FieldChanges>;
 
 /**
  * Represents changes made to a detached node
  * @internal
  */
-export interface DetachedNodeChanges<TTree = ProtoNode> {
+export interface DetachedNodeChanges {
 	readonly id: DetachedNodeId;
-	readonly fields: FieldMap<TTree>;
+	readonly fields: FieldMap;
 }
 
 /**
@@ -205,14 +206,14 @@ export interface DetachedNodeRename {
  * Represents the changes to perform on a given field.
  * @internal
  */
-export interface FieldChanges<TTree = ProtoNode> {
+export interface FieldChanges {
 	/**
 	 * Represents a list of changes to the nodes in the field.
 	 * The index of each mark within the range of nodes, before
 	 * applying any of the changes, is not represented explicitly.
 	 * It corresponds to the sum of `mark.count` values for all previous marks for which `isAttachMark(mark)` is false.
 	 */
-	readonly local?: readonly Mark<TTree>[];
+	readonly local?: readonly Mark[];
 	/**
 	 * Changes to apply to detached nodes.
 	 * The ordering has no significance.
@@ -221,7 +222,7 @@ export interface FieldChanges<TTree = ProtoNode> {
 	 * For example, if one wishes to change a tree which is being renamed from ID A to ID B,
 	 * then the changes should be listed under ID A.
 	 */
-	readonly global?: readonly DetachedNodeChanges<TTree>[];
+	readonly global?: readonly DetachedNodeChanges[];
 	/**
 	 * Detached whose associated ID needs to be updated.
 	 * The ordering has no significance.

--- a/packages/dds/tree/src/core/tree/deltaUtil.ts
+++ b/packages/dds/tree/src/core/tree/deltaUtil.ts
@@ -11,7 +11,7 @@ import { rootFieldKey } from "./types.js";
 
 export const emptyDelta: Root<never> = {};
 
-export const emptyFieldChanges: FieldChanges<never> = {};
+export const emptyFieldChanges: FieldChanges = {};
 
 export function isAttachMark(mark: Mark): boolean {
 	return mark.attach !== undefined && mark.detach === undefined;

--- a/packages/dds/tree/src/feature-libraries/deltaUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/deltaUtils.ts
@@ -6,11 +6,7 @@
 import {
 	ChangeAtomId,
 	DeltaDetachedNodeId,
-	DeltaFieldChanges,
-	DeltaFieldMap,
-	DeltaMark,
 	DeltaRoot,
-	FieldKey,
 	RevisionTag,
 	makeDetachedNodeId,
 } from "../core/index.js";
@@ -39,108 +35,13 @@ export function mapRootChanges<TIn, TOut>(
 ): DeltaRoot<TOut> {
 	const out: Mutable<DeltaRoot<TOut>> = {};
 	if (root.fields !== undefined) {
-		out.fields = mapFieldsChanges(root.fields, func);
+		out.fields = root.fields;
 	}
 	if (root.build !== undefined) {
 		out.build = root.build.map(({ id, trees }) => ({
 			id,
 			trees: trees.map(func),
 		}));
-	}
-	return out;
-}
-
-/**
- * Converts a `Delta.FieldMarks` whose tree content is represented with by `TIn` instances
- * into a `Delta.FieldMarks`whose tree content is represented with by `TOut` instances.
- *
- * This function is useful for converting `Delta`s that represent tree content with cursors
- * into `Delta`s that represent tree content with a deep-comparable representation of the content.
- * See {@link assertDeltaEqual}.
- * @param fields - The Map of fields to convert. Not mutated.
- * @param func - The functions used to map tree content.
- */
-export function mapFieldsChanges<TIn, TOut>(
-	fields: DeltaFieldMap<TIn>,
-	func: (tree: TIn) => TOut,
-): DeltaFieldMap<TOut> {
-	const out: Map<FieldKey, DeltaFieldChanges<TOut>> = new Map();
-	for (const [k, v] of fields) {
-		out.set(k, mapFieldChanges(v, func));
-	}
-	return out;
-}
-
-/**
- * Converts a `Delta.FieldChanges` whose tree content is represented with by `TIn` instances
- * into a `Delta.FieldChanges`whose tree content is represented with by `TOut` instances.
- *
- * This function is useful for converting `Delta`s that represent tree content with cursors
- * into `Delta`s that represent tree content with a deep-comparable representation of the content.
- * See {@link assertMarkListEqual}.
- * @param fieldChanges - The instance to convert. Not mutated.
- * @param func - The functions used to map tree content.
- */
-export function mapFieldChanges<TIn, TOut>(
-	fieldChanges: DeltaFieldChanges<TIn>,
-	func: (tree: TIn) => TOut,
-): DeltaFieldChanges<TOut> {
-	const out: Mutable<DeltaFieldChanges<TOut>> = {};
-	if (fieldChanges.local !== undefined) {
-		out.local = mapMarkList(fieldChanges.local, func);
-	}
-	if (fieldChanges.global !== undefined) {
-		out.global = fieldChanges.global.map(({ id, fields }) => ({
-			id,
-			fields: mapFieldsChanges(fields, func),
-		}));
-	}
-	if (fieldChanges.rename !== undefined) {
-		out.rename = fieldChanges.rename;
-	}
-	return out;
-}
-
-/**
- * Converts a list of `Delta.Mark`s whose tree content is represented by `TIn` instances
- * into a list of `Delta.Mark`s whose tree content is represented by `TOut` instances.
- *
- * This function is useful for converting `Delta`s that represent tree content with cursors
- * into `Delta`s that represent tree content with a deep-comparable representation of the content.
- * See {@link assertMarkListEqual}.
- * @param list - The list of marks to convert. Not mutated.
- * @param func - The functions used to map tree content.
- */
-export function mapMarkList<TIn, TOut>(
-	list: readonly DeltaMark<TIn>[],
-	func: (tree: TIn) => TOut,
-): DeltaMark<TOut>[] {
-	return list.map((mark: DeltaMark<TIn>) => mapMark(mark, func));
-}
-
-/**
- * Converts a `Delta.Mark` whose tree content is represented with by `TIn` instances
- * into a `Delta.Mark`whose tree content is represented with by `TOut` instances.
- *
- * This function is useful for converting `Delta`s that represent tree content with cursors
- * into `Delta`s that represent tree content with a deep-comparable representation of the content.
- * See {@link assertMarkListEqual}.
- * @param mark - The mark to convert. Not mutated.
- * @param func - The functions used to map tree content.
- */
-export function mapMark<TIn, TOut>(
-	mark: DeltaMark<TIn>,
-	func: (tree: TIn) => TOut,
-): DeltaMark<TOut> {
-	const out: Mutable<DeltaMark<TOut>> = { count: mark.count };
-	if (mark.fields !== undefined) {
-		out.fields = mapFieldsChanges(mark.fields, func);
-	}
-	if (mark.detach !== undefined) {
-		out.detach = mark.detach;
-	}
-	if (mark.attach !== undefined) {
-		out.attach = mark.attach;
 	}
 	return out;
 }

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -181,13 +181,7 @@ export {
 } from "./schemaBuilderBase.js";
 export { SchemaBuilderInternal } from "./schemaBuilder.js";
 
-export {
-	mapRootChanges,
-	mapFieldChanges,
-	mapFieldsChanges,
-	mapMark,
-	mapMarkList,
-} from "./deltaUtils.js";
+export { mapRootChanges } from "./deltaUtils.js";
 
 export {
 	TreeChunk,

--- a/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/deltaUtils.spec.ts
@@ -63,7 +63,7 @@ describe("DeltaUtils", () => {
 			};
 			deepFreeze(input);
 			const actual = mapRootChanges(input, mapTreeFromCursor);
-			const nestedMapTreeInsert = new Map<FieldKey, DeltaFieldChanges<MapTree>>([
+			const nestedMapTreeInsert = new Map<FieldKey, DeltaFieldChanges>([
 				[
 					fooField,
 					{
@@ -79,7 +79,7 @@ describe("DeltaUtils", () => {
 			]);
 			const expected: DeltaRoot<MapTree> = {
 				build: [{ id: detachId, trees: [nodeX] }],
-				fields: new Map<FieldKey, DeltaFieldChanges<MapTree>>([
+				fields: new Map<FieldKey, DeltaFieldChanges>([
 					[
 						fooField,
 						{

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -62,9 +62,6 @@ import {
 	createMockNodeKeyManager,
 	TreeFieldSchema,
 	jsonableTreeFromFieldCursor,
-	mapFieldChanges,
-	mapFieldsChanges,
-	mapMarkList,
 	mapTreeFromCursor,
 	nodeKeyFieldKey as nodeKeyFieldKeyDefault,
 	NodeKeyManager,
@@ -488,27 +485,21 @@ export function isDeltaVisible(delta: DeltaFieldChanges): boolean {
  * Assert two MarkList are equal, handling cursors.
  */
 export function assertFieldChangesEqual(a: DeltaFieldChanges, b: DeltaFieldChanges): void {
-	const aTree = mapFieldChanges(a, mapTreeFromCursor);
-	const bTree = mapFieldChanges(b, mapTreeFromCursor);
-	assert.deepStrictEqual(aTree, bTree);
+	assert.deepStrictEqual(a, b);
 }
 
 /**
  * Assert two MarkList are equal, handling cursors.
  */
 export function assertMarkListEqual(a: readonly DeltaMark[], b: readonly DeltaMark[]): void {
-	const aTree = mapMarkList(a, mapTreeFromCursor);
-	const bTree = mapMarkList(b, mapTreeFromCursor);
-	assert.deepStrictEqual(aTree, bTree);
+	assert.deepStrictEqual(a, b);
 }
 
 /**
  * Assert two Delta are equal, handling cursors.
  */
 export function assertDeltaFieldMapEqual(a: DeltaFieldMap, b: DeltaFieldMap): void {
-	const aTree = mapFieldsChanges(a, mapTreeFromCursor);
-	const bTree = mapFieldsChanges(b, mapTreeFromCursor);
-	assert.deepStrictEqual(aTree, bTree);
+	assert.deepStrictEqual(a, b);
 }
 
 /**


### PR DESCRIPTION
Removes unnecessary type params from delta types now that builds can only occur on delta Root

## Breaking Changes

This PR changes the following internal types:
* DeltaDetachedNodeChanges
* DeltaFieldChanges
* DeltaFieldMap
* DeltaMark
In all cases, they just lose their one type parameter. Users of these type can just delete the type parameter passed in if they were not using the default.