### PR TITLE
Stress Test: Tweak testConfig for futureOpRatePerMin

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -3,7 +3,7 @@
 		"ci": {
 			"opRatePerMin": 10,
 			"signalsPerMin": 10,
-			"futureOpRatePerMin": 2,
+			"futureOpRatePerMin": 0.5,
 			"progressIntervalMs": 15000,
 			"numClients": 120,
 			"totalSendCount": 10000,
@@ -58,7 +58,7 @@
 		},
 		"ci_frs": {
 			"opRatePerMin": 10,
-			"futureOpRatePerMin": 2,
+			"futureOpRatePerMin": 0.5,
 			"progressIntervalMs": 15000,
 			"numClients": 100,
 			"totalSendCount": 10000,
@@ -85,7 +85,7 @@
 		},
 		"full": {
 			"opRatePerMin": 1920,
-			"futureOpRatePerMin": 6,
+			"futureOpRatePerMin": 1,
 			"progressIntervalMs": 1500000,
 			"numClients": 60,
 			"totalSendCount": 200000,
@@ -97,7 +97,7 @@
 		},
 		"mini": {
 			"opRatePerMin": 60,
-			"futureOpRatePerMin": 6,
+			"futureOpRatePerMin": 1,
 			"progressIntervalMs": 5000,
 			"numClients": 2,
 			"totalSendCount": 30,
@@ -118,7 +118,7 @@
 		},
 		"debug": {
 			"opRatePerMin": 60,
-			"futureOpRatePerMin": 6,
+			"futureOpRatePerMin": 10,
 			"progressIntervalMs": 5000,
 			"numClients": 1,
 			"totalSendCount": 30,
@@ -130,7 +130,7 @@
 		},
 		"ci_nofault": {
 			"opRatePerMin": 10,
-			"futureOpRatePerMin": 6,
+			"futureOpRatePerMin": 0,
 			"progressIntervalMs": 15000,
 			"numClients": 120,
 			"totalSendCount": 10000,
@@ -138,7 +138,7 @@
 		},
 		"scale": {
 			"opRatePerMin": 60,
-			"futureOpRatePerMin": 6,
+			"futureOpRatePerMin": 1,
 			"progressIntervalMs": 20000,
 			"numClients": 10,
 			"totalSendCount": 70000,
@@ -150,7 +150,7 @@
 		},
 		"scale_nofault": {
 			"opRatePerMin": 60,
-			"futureOpRatePerMin": 6,
+			"futureOpRatePerMin": 0,
 			"progressIntervalMs": 20000,
 			"numClients": 10,
 			"totalSendCount": 70000,
@@ -181,7 +181,7 @@
 		},
 		"offline": {
 			"opRatePerMin": 60,
-			"futureOpRatePerMin": 6,
+			"futureOpRatePerMin": 3,
 			"progressIntervalMs": 5000,
 			"numClients": 4,
 			"totalSendCount": 300,


### PR DESCRIPTION
## Description

Follow-up to #19082, to adjust the test config for how many future ops to send per minute.  Remember that every client will follow this config, so total ops _processed_ per minute is scaled up by number of clients.

* CI: reduced to 0.5, which is 5% of the base 10 ops per minute
* Debug: increased to 10
* _NoFault ones: Set to 0, since it's a form of noise/fault injection
* others: Used one as the "default" elsewhere (some don't set it at all which is the same as 0)

## Reviewer Guidance

If you're familiar with a particular config profile, please consider if this is appropriate.  These ops are marked with "compat details" that indicates they should be ignored by clients that don't understand them (which is all the clients here); if some part of the op processing pipeline fails to retain/respect that compat info, then typically it would throw an error (that's the default behavior when compat details is missing).