### PR TITLE
[Port main] Add require in exports for container runtime for node modules in package json (#19161)

### DIFF
--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -13,8 +13,14 @@
 	"sideEffects": false,
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"default": "./dist/index.js"
+			"import": {
+				"types": "./lib/index.d.mts",
+				"default": "./lib/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			}
 		},
 		"./test/containerRuntime": {
 			"import": {

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -310,7 +310,12 @@ export const loadPackage = async (modulePath: string, pkg: string): Promise<any>
 			primaryExport = pkgJson.exports;
 		} else {
 			const exp = pkgJson.exports["."];
-			primaryExport = typeof exp === "string" ? exp : exp.require.default;
+			primaryExport =
+				typeof exp === "string"
+					? exp
+					: exp.require !== undefined
+					? exp.require.default
+					: exp.default;
 			if (primaryExport === undefined) {
 				throw new Error(`Package ${pkg} defined subpath exports but no '.' entry.`);
 			}


### PR DESCRIPTION
Porting PR: https://github.com/microsoft/FluidFramework/pull/19161

This had greatly reduced the bundle size of the RC branch

Add require in exports for container runtime for node modules in package json

