### PR TITLE
tree: Add explicit use after free/delete check in simple-tree

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
@@ -62,3 +62,5 @@ export {
 } from "./flexTreeTypes.js";
 
 export { NodeKeys } from "./nodeKeys.js";
+
+export { assertFlexTreeEntityNotFreed } from "./lazyEntity.js";

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
@@ -35,6 +35,17 @@ export const cursorSymbol = Symbol("cursor");
 export const anchorSymbol = Symbol("anchor");
 
 /**
+ * Assert `entity` is not deleted.
+ * @privateRemarks
+ * This can be faster than getting the tree status and checking that since that can require computing removed vs deleted.
+ * TODO: provide a non implementation dependent way to leverage this optimization.
+ */
+export function assertFlexTreeEntityNotFreed(entity: FlexTreeEntity): void {
+	assert(entity instanceof LazyEntity, "unexpected implementation");
+	assert(!entity[isFreedSymbol](), "Use after free");
+}
+
+/**
  * This is a base class for lazy (cursor based) UntypedEntity implementations, which uniformly handles cursors and anchors.
  */
 export abstract class LazyEntity<TSchema = unknown, TAnchor = unknown>

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -274,6 +274,7 @@ export {
 	reservedObjectNodeFieldPropertyNames,
 	reservedObjectNodeFieldPropertyNamePrefixes,
 	FlexTreeObjectNodeFieldsInner,
+	assertFlexTreeEntityNotFreed,
 } from "./flex-tree/index.js";
 
 export { treeSchemaFromStoredSchema } from "./storedToViewSchema.js";

--- a/packages/dds/tree/src/simple-tree/flexNode.ts
+++ b/packages/dds/tree/src/simple-tree/flexNode.ts
@@ -49,7 +49,7 @@ export function getFlexNode(
 export function getFlexNode(target: TreeMapNode, allowFreed?: true): FlexTreeMapNode<MapNodeSchema>;
 export function getFlexNode(target: TreeNode, allowFreed?: true): FlexTreeNode;
 export function getFlexNode(target: TreeNode, allowFreed = false): FlexTreeNode {
-	const node = flexNodeMap.get(target) ?? fail("Target is not associated with an flex node");
+	const node = flexNodeMap.get(target) ?? fail("Target is not associated with a flex node");
 	if (!(node instanceof RawTreeNode) && !allowFreed) {
 		assertFlexTreeEntityNotFreed(node);
 	}

--- a/packages/dds/tree/src/simple-tree/flexNode.ts
+++ b/packages/dds/tree/src/simple-tree/flexNode.ts
@@ -13,10 +13,12 @@ import {
 	FlexTreeObjectNode,
 	FlexTreeFieldNode,
 	FlexTreeMapNode,
+	assertFlexTreeEntityNotFreed,
 } from "../feature-libraries/index.js";
 import { TreeNode, TypedNode } from "./types.js";
 import { TreeArrayNode } from "./treeArrayNode.js";
 import { TreeMapNode } from "./schemaTypes.js";
+import { RawTreeNode } from "./rawNode.js";
 
 /** Associates an FlexTreeNode with a target object  */
 const targetSymbol = Symbol("FlexNodeTarget");
@@ -36,12 +38,22 @@ const flexNodeMap = new WeakMap<TreeNode, FlexTreeNode>();
  * Retrieves the flex node associated with the given target via {@link setFlexNode}.
  * @remarks Fails if the flex node has not been set.
  */
-export function getFlexNode(target: TypedNode<ObjectNodeSchema>): FlexTreeObjectNode;
-export function getFlexNode(target: TreeArrayNode): FlexTreeFieldNode<FieldNodeSchema>;
-export function getFlexNode(target: TreeMapNode): FlexTreeMapNode<MapNodeSchema>;
-export function getFlexNode(target: TreeNode): FlexTreeNode;
-export function getFlexNode(target: TreeNode): FlexTreeNode {
-	return flexNodeMap.get(target) ?? fail("Target is not associated with an flex node");
+export function getFlexNode(
+	target: TypedNode<ObjectNodeSchema>,
+	allowFreed?: true,
+): FlexTreeObjectNode;
+export function getFlexNode(
+	target: TreeArrayNode,
+	allowFreed?: true,
+): FlexTreeFieldNode<FieldNodeSchema>;
+export function getFlexNode(target: TreeMapNode, allowFreed?: true): FlexTreeMapNode<MapNodeSchema>;
+export function getFlexNode(target: TreeNode, allowFreed?: true): FlexTreeNode;
+export function getFlexNode(target: TreeNode, allowFreed = false): FlexTreeNode {
+	const node = flexNodeMap.get(target) ?? fail("Target is not associated with an flex node");
+	if (!(node instanceof RawTreeNode) && !allowFreed) {
+		assertFlexTreeEntityNotFreed(node);
+	}
+	return node;
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/treeApi.ts
+++ b/packages/dds/tree/src/simple-tree/treeApi.ts
@@ -112,7 +112,7 @@ export const nodeApi: TreeApi = {
 		return getFlexNode(node).on(eventName, listener);
 	},
 	status: (node: TreeNode) => {
-		return getFlexNode(node).treeStatus();
+		return getFlexNode(node, true).treeStatus();
 	},
 	is: <TSchema extends TreeNodeSchema>(
 		value: unknown,


### PR DESCRIPTION
## Description

Most places using simple-tree nodes should only handle nodes before they are deleted.
This adds some explicit checking for use of deleted nodes.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
