### PR TITLE
Fix processing of array in configmap

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -21,7 +21,12 @@ data:
         },
         "config": {
             "configDumpEnabled": {{ .Values.config.configDumpEnabled }},
-            "secretNamesToRedactInConfigDump": {{ .Values.config.secretNamesToRedactInConfigDump }}
+            "secretNamesToRedactInConfigDump": [
+                {{- $lastIndex := sub (len .Values.config.secretNamesToRedactInConfigDump) 1}}
+                {{- range $i, $secret := .Values.config.secretNamesToRedactInConfigDump }}
+                {{ toJson . }}{{- if ne $i $lastIndex -}}, {{ end }}
+                {{- end }}
+            ],
         },
         "lumberjack": {
             "options": {


### PR DESCRIPTION
## Description

https://github.com/microsoft/FluidFramework/pull/18670 introduced new properties to the config map template but missed that arrays are processed in a way that produces invalid JSON (missing quotes around each array element):

```json
    "config": {
        "configDumpEnabled": false,
        "secretNamesToRedactInConfigDump": [mongo.globalDbEndpoint mongo.operationsDbEndpoint redis.pass redisForTenantCache.pass redis2.pass redisForThrottling.pass]
    },
```

This change copies the same pattern used in other places in the config map template to generate valid JSON arrays for the new property. Validated by running `helm package .` from `server/routerlicious/kubernetes/routerlicious` (which generates a `routerlicious-0.2.0.tgz` file) then `helm install --dry-run=client routerlicious-0.2.0.tgz --generate-name` and looking at the manifest entry for `# Source: routerlicious/templates/fluid-configmap.yaml` in the output, which looks like this:

```json
        "config": {
            "configDumpEnabled": false,
            "secretNamesToRedactInConfigDump": [
                "mongo.globalDbEndpoint", 
                "mongo.operationsDbEndpoint", 
                "redis.pass", 
                "redisForTenantCache.pass", 
                "redis2.pass", 
                "redisForThrottling.pass"
            ],
        },
```

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I looked at this because yesterday the alert we set up in the internal FF AKS cluster for too many pod restarts (usually caused by an invalid JSON configuration) fired yesterday. The offending change went in a while back, so not sure why the alert hadn't triggered.