### PR TITLE
docs: specify trigger branch name variable in build docs resources

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -100,20 +100,28 @@ resources:
   pipelines:
   - pipeline: common_definitions
     source: Build - common-definitions
+    branch: $(Build.SourceBranchName)
   - pipeline: common_utils
     source: Build - common-utils
+    branch: $(Build.SourceBranchName)
   - pipeline: container_definitions
     source: Build - container-definitions
+    branch: $(Build.SourceBranchName)
   - pipeline: core_interfaces
     source: Build - core-interfaces
+    branch: $(Build.SourceBranchName)
   - pipeline: driver_definitions
     source: Build - driver-definitions
+    branch: $(Build.SourceBranchName)
   - pipeline: protocol_definitions
     source: Build - protocol-definitions
+    branch: $(Build.SourceBranchName)
   - pipeline: azure
     source: Build - azure
+    branch: $(Build.SourceBranchName)
   - pipeline: client
     source: Build - client packages
+    branch: $(Build.SourceBranchName)
     trigger:
       branches:
         include:
@@ -121,6 +129,7 @@ resources:
         - docs/**
   - pipeline: server
     source: server-routerlicious
+    branch: $(Build.SourceBranchName)
 
 stages:
 - stage: build

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -88,9 +88,10 @@ variables:
   - name: pnpmStorePath
     value: $(Pipeline.Workspace)/.pnpm-store
 
-# TODO: include release/* branches as trigger. Currently, the website docs builds and deploys on each commit.
-# However, inconsistencies between the release branches and main is causing the website to change unexpectedly
-# we can re include the release/* branch to the trigger after separating the deploy step to another pipeline
+# TODO: Move trigger to pipeline designated for artifact model generation. Currently, 
+# the website docs builds and deploys on each commit. However, inconsistencies between 
+# the release branches and main is causing the website to change unexpectedly we can 
+# move the release/* trigger after separating the deploy step to another pipeline
 # no PR triggers
 trigger:
   branches:

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -88,14 +88,20 @@ variables:
   - name: pnpmStorePath
     value: $(Pipeline.Workspace)/.pnpm-store
 
+# TODO: include release/* branches as trigger. Currently, the website docs builds and deploys on each commit.
+# However, inconsistencies between the release branches and main is causing the website to change unexpectedly
+# we can re include the release/* branch to the trigger after separating the deploy step to another pipeline
 # no PR triggers
 trigger:
   branches:
     include:
-    - release/*
+    # - release/*
     - main
 pr: none
 
+# TODO: the download artifact step is currently targetting the latest pipeline run from each resource.
+# However, this is causing inconsistencies in the doc in scenarios where the latest runs on each pipeline
+# is not the same (e.g. mix of main and lts). Temporarily setting the branch to main explicitly.
 resources:
   pipelines:
   - pipeline: common_definitions

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -100,28 +100,28 @@ resources:
   pipelines:
   - pipeline: common_definitions
     source: Build - common-definitions
-    branch: $(Build.SourceBranchName)
+    branch: main
   - pipeline: common_utils
     source: Build - common-utils
-    branch: $(Build.SourceBranchName)
+    branch: main
   - pipeline: container_definitions
     source: Build - container-definitions
-    branch: $(Build.SourceBranchName)
+    branch: main
   - pipeline: core_interfaces
     source: Build - core-interfaces
-    branch: $(Build.SourceBranchName)
+    branch: main
   - pipeline: driver_definitions
     source: Build - driver-definitions
-    branch: $(Build.SourceBranchName)
+    branch: main
   - pipeline: protocol_definitions
     source: Build - protocol-definitions
-    branch: $(Build.SourceBranchName)
+    branch: main
   - pipeline: azure
     source: Build - azure
-    branch: $(Build.SourceBranchName)
+    branch: main
   - pipeline: client
     source: Build - client packages
-    branch: $(Build.SourceBranchName)
+    branch: main
     trigger:
       branches:
         include:
@@ -129,7 +129,7 @@ resources:
         - docs/**
   - pipeline: server
     source: server-routerlicious
-    branch: $(Build.SourceBranchName)
+    branch: main
 
 stages:
 - stage: build


### PR DESCRIPTION
Previous build docs was downloading the latest artifact from other resource pipelines such as Build - azure. However, this causes some inconsistencies in the documentation if the latest run on a pipeline resource was from branch different from main (such as lts). Adding branch name to the resource definition to ensure all artifacts are from the same branch runs.