### PR TITLE
Last configmap fix - remove comma

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -26,7 +26,7 @@ data:
                 {{- range $i, $secret := .Values.config.secretNamesToRedactInConfigDump }}
                 {{ toJson . }}{{- if ne $i $lastIndex -}}, {{ end }}
                 {{- end }}
-            ],
+            ]
         },
         "lumberjack": {
             "options": {


### PR DESCRIPTION
## Description

Follow up to https://github.com/microsoft/FluidFramework/pull/19188 where I missed removing an invalid comma. See also https://github.com/microsoft/FluidFramework/pull/19191 and https://github.com/microsoft/FluidFramework/pull/19195.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
