### PR TITLE
build(fluid-framework): Bundle `container-loader`

### DIFF
--- a/packages/framework/fluid-framework/api-extractor.json
+++ b/packages/framework/fluid-framework/api-extractor.json
@@ -3,6 +3,7 @@
 	"extends": "../../../common/build/build-common/api-extractor-base.json",
 	"bundledPackages": [
 		"@fluidframework/container-definitions",
+		"@fluidframework/container-loader",
 		"@fluidframework/driver-definitions",
 		"@fluidframework/fluid-static",
 		"@fluidframework/map",

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { ConnectionState } from '@fluidframework/container-loader';
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { IChannel } from '@fluidframework/datastore-definitions';
 import { IChannelAttributes } from '@fluidframework/datastore-definitions';
@@ -44,7 +43,13 @@ export enum AttachState {
     Detached = "Detached"
 }
 
-export { ConnectionState }
+// @public (undocumented)
+export enum ConnectionState {
+    CatchingUp = 1,
+    Connected = 2,
+    Disconnected = 0,
+    EstablishingConnection = 3
+}
 
 // @public
 export namespace ConnectionStateType {


### PR DESCRIPTION
Adds `@fluidframework/container-definitions` to the list of packages bundled by API-Extractor in `fluid-framework`. Ensures that API documentation for API members re-exported by fluid-framework appears in generated docs suite. Also enforces API completeness for re-exported members.