### PR TITLE
docs: Fix various API links in the repo

### DIFF
--- a/azure/packages/azure-client/src/interfaces.ts
+++ b/azure/packages/azure-client/src/interfaces.ts
@@ -161,7 +161,7 @@ export interface AzureUser<T = any> extends IUser {
 
 /**
  * Since Azure provides user names for all of its members, we extend the
- * {@link @fluidframework/protocol-definitions#IMember} interface to include this service-specific value.
+ * {@link @fluidframework/fluid-static#IMember} interface to include this service-specific value.
  * It will be returned for all audience members connected to Azure.
  *
  * @typeParam T - See {@link AzureMember.additionalDetails}.

--- a/common/lib/protocol-definitions/src/config.ts
+++ b/common/lib/protocol-definitions/src/config.ts
@@ -31,7 +31,7 @@ export interface IClientConfiguration {
 
 	/**
 	 * Set min op frequency with which noops would be sent in case of an active connection which is not sending any op.
-	 * See {@link IClientConfiguration#noopTimeFrequency} for more details.
+	 * See {@link IClientConfiguration.noopTimeFrequency} for more details.
 	 * 'Infinity' will disable this feature and if no value is provided, the client choses some reasonable value.
 	 */
 	noopCountFrequency?: number;

--- a/packages/dds/tree/src/domains/leafDomain.ts
+++ b/packages/dds/tree/src/domains/leafDomain.ts
@@ -64,7 +64,7 @@ export const leaf = {
 	string,
 
 	/**
-	 * {@link LeafNodeSchema} for holding an {@link @fluidframework/core-interfaces#IFluidHandle}.
+	 * {@link LeafNodeSchema} for holding an {@link @fluidframework/core-interfaces#(IFluidHandle:interface)}.
 	 */
 	handle,
 

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -300,7 +300,7 @@ export interface Summarizable {
 
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#(IChannel:interface).getAttachSummary}
-	 * @param stringify - Serializes the contents of the component (including {@link IFluidHandle}s) for storage.
+	 * @param stringify - Serializes the contents of the component (including {@link (IFluidHandle:interface)}s) for storage.
 	 */
 	getAttachSummary(
 		stringify: SummaryElementStringifier,
@@ -312,7 +312,7 @@ export interface Summarizable {
 
 	/**
 	 * {@inheritDoc @fluidframework/datastore-definitions#(IChannel:interface).summarize}
-	 * @param stringify - Serializes the contents of the component (including {@link IFluidHandle}s) for storage.
+	 * @param stringify - Serializes the contents of the component (including {@link (IFluidHandle:interface)}s) for storage.
 	 */
 	summarize(
 		stringify: SummaryElementStringifier,

--- a/packages/dds/tree/src/simple-tree/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/schemaFactory.ts
@@ -191,7 +191,7 @@ export class SchemaFactory<TScope extends string = string, TName extends number 
 	public readonly null = nullSchema;
 
 	/**
-	 * {@link TreeNodeSchema} for holding an {@link @fluidframework/core-interfaces#IFluidHandle}.
+	 * {@link TreeNodeSchema} for holding an {@link @fluidframework/core-interfaces#(IFluidHandle:interface)}.
 	 */
 	public readonly handle = handleSchema;
 

--- a/packages/dds/tree/src/simple-tree/schemaTypes.ts
+++ b/packages/dds/tree/src/simple-tree/schemaTypes.ts
@@ -35,7 +35,7 @@ export type TreeObjectNode<T extends RestrictiveReadonlyRecord<string, ImplicitF
  * 3. Union of 1 and 2.
  *
  * @privateRemarks TODO: consider separating these cases into different types.
- * 
+ *
  * @public
  */
 export type InsertableObjectFromSchemaRecord<

--- a/packages/dds/tree/src/simple-tree/schemaTypes.ts
+++ b/packages/dds/tree/src/simple-tree/schemaTypes.ts
@@ -34,7 +34,8 @@ export type TreeObjectNode<T extends RestrictiveReadonlyRecord<string, ImplicitF
  *
  * 3. Union of 1 and 2.
  *
- * TODO: consider separating these cases into different types.
+ * @privateRemarks TODO: consider separating these cases into different types.
+ * 
  * @public
  */
 export type InsertableObjectFromSchemaRecord<

--- a/packages/drivers/routerlicious-driver/src/tokens.ts
+++ b/packages/drivers/routerlicious-driver/src/tokens.ts
@@ -87,8 +87,7 @@ export interface ITokenProvider {
 	 *
 	 * * Using the callback may have performance impact on the document creation process.
 	 *
-	 * * Any exceptions thrown in the callback would fail the creation workflow
-	 * (see {@link RouterliciousDocumentServiceFactory.createContainer} for more details).
+	 * * Any exceptions thrown in the callback would fail the creation workflow.
 	 *
 	 * @param documentId - Document ID.
 	 * @param creationToken - A special token that doesn't provide any kind of access, but it has the user's payload

--- a/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
@@ -117,7 +117,7 @@ export interface NamespaceFilter {
 export type TelemetryFilter = CategoryFilter | NamespaceFilter | (CategoryFilter & NamespaceFilter);
 
 /**
- * An implementation of {@link @fluidframework/core-interfaces#ITelemetryBaseLogger | ITelemetryBaseLogger}
+ * An implementation of {@link @fluidframework/core-interfaces#ITelemetryBaseLogger}
  * that routes Fluid telemetry events to Azure App Insights using the App Insights trackEvent API.
  * The provided ApplicationInsights instance MUST be initialized with client.loadAppInsights()
  * or else logging will not occur.
@@ -304,7 +304,7 @@ class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 }
 
 /**
- * Creates an {@link @fluidframework/core-interfaces#ITelemetryBaseLogger | ITelemetryBaseLogger}
+ * Creates an {@link @fluidframework/core-interfaces#ITelemetryBaseLogger}
  * that routes Fluid telemetry events to Azure App Insights using the App Insights trackEvent API.
  *
  * The provided ApplicationInsights instance MUST be initialized with client.loadAppInsights(),

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -176,7 +176,7 @@ export interface IFluidContainer<TContainerSchema extends ContainerSchema = Cont
 	 * @remarks
 	 *
 	 * This should only be called when the container is in the
-	 * {@link @fluidframework/container-definitions#ConnectionState.Disconnected} state.
+	 * {@link @fluidframework/container-definitions#(ConnectionState:namespace).Disconnected} state.
 	 *
 	 * This can be determined by observing {@link IFluidContainer.connectionState}.
 	 */
@@ -188,7 +188,7 @@ export interface IFluidContainer<TContainerSchema extends ContainerSchema = Cont
 	 * @remarks
 	 *
 	 * This should only be called when the container is in the
-	 * {@link @fluidframework/container-definitions#ConnectionState.Connected} state.
+	 * {@link @fluidframework/container-definitions#(ConnectionState:namespace).Connected} state.
 	 *
 	 * This can be determined by observing {@link IFluidContainer.connectionState}.
 	 */

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -108,7 +108,7 @@ export interface IFluidModuleWithDetails {
 }
 
 /**
- * @deprecated ICodeDetailsLoader interface is moved to {@link @fluidframework/container-definition#ICodeDetailsLoader}
+ * @deprecated ICodeDetailsLoader interface is moved to {@link @fluidframework/container-definitions#ICodeDetailsLoader}
  * to have code loading modules in one package. #8193
  * Fluid code loader resolves a code module matching the document schema, i.e. code details, such as
  * a package name and package version range.

--- a/packages/service-clients/odsp-client/src/interfaces.ts
+++ b/packages/service-clients/odsp-client/src/interfaces.ts
@@ -71,7 +71,7 @@ export interface OdspContainerServices {
 
 /**
  * Since ODSP provides user names and email for all of its members, we extend the
- * {@link @fluidframework/protocol-definitions#IMember} interface to include this service-specific value.
+ * {@link @fluidframework/fluid-static#IMember} interface to include this service-specific value.
  * It will be returned for all audience members connected.
  * @beta
  */

--- a/packages/service-clients/odsp-client/src/odspAudience.ts
+++ b/packages/service-clients/odsp-client/src/odspAudience.ts
@@ -9,7 +9,7 @@ import { type OdspMember } from "./interfaces";
 
 /**
  * Since ODSP provides user names, email and oids for all of its members, we extend the
- * {@link @fluidframework/protocol-definitions#IMember} interface to include this service-specific value.
+ * {@link @fluidframework/fluid-static#IMember} interface to include this service-specific value.
  * @internal
  */
 interface OdspUser {

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
@@ -282,7 +282,7 @@ export class DataVisualizerGraph
 	}
 
 	/**
-	 * Adds a visualizer node to the collection for the specified {@link @fluidframework/core-interfaces#IFluidHandle}
+	 * Adds a visualizer node to the collection for the specified {@link @fluidframework/core-interfaces#(IFluidHandle:interface)}
 	 * if one does not already exist.
 	 *
 	 * @returns
@@ -470,8 +470,8 @@ export class VisualizerNode extends TypedEventEmitter<DataVisualizerEvents> impl
  * See {@link VisualizeChildData}.
  *
  * @param data - The child data to (recursively) render.
- * @param resolveHandle - Function which accepts an {@link @fluidframework/core-interfaces#IFluidHandle} and
- * returns its resolved object ID.
+ * @param resolveHandle - Function which accepts an {@link @fluidframework/core-interfaces#(IFluidHandle:interface)}
+ * and returns its resolved object ID.
  *
  * @privateRemarks Exported from this module for testing purposes. This is not intended to be exported by the package.
  */

--- a/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
@@ -6,7 +6,7 @@ import {
 	ApiItemKind,
 	type ApiItem,
 	type IResolveDeclarationReferenceResult,
-	ApiPackage,
+	type ApiPackage,
 } from "@microsoft/api-extractor-model";
 import { type DocDeclarationReference } from "@microsoft/tsdoc";
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
@@ -111,8 +111,10 @@ function resolveSymbolicLink(
 		const linkSource =
 			contextApiItem.kind === ApiItemKind.Package
 				? (contextApiItem as ApiPackage).displayName
-				: `${contextApiItem.getAssociatedPackage()
-						?.displayName}/${contextApiItem.getScopedNameWithinPackage()}`;
+				: `${
+						contextApiItem.getAssociatedPackage()?.displayName ?? "<NO-PACKAGE>"
+				  }#${contextApiItem.getScopedNameWithinPackage()}`;
+
 		logger.warning(
 			`Unable to resolve reference "${codeDestination.emitAsTsdoc()}" from "${linkSource}":`,
 			resolvedReference.errorMessage,

--- a/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/Utilities.ts
@@ -3,8 +3,10 @@
  * Licensed under the MIT License.
  */
 import {
+	ApiItemKind,
 	type ApiItem,
 	type IResolveDeclarationReferenceResult,
+	ApiPackage,
 } from "@microsoft/api-extractor-model";
 import { type DocDeclarationReference } from "@microsoft/tsdoc";
 
@@ -106,8 +108,13 @@ function resolveSymbolicLink(
 		apiModel.resolveDeclarationReference(codeDestination, contextApiItem);
 
 	if (resolvedReference.resolvedApiItem === undefined) {
+		const linkSource =
+			contextApiItem.kind === ApiItemKind.Package
+				? (contextApiItem as ApiPackage).displayName
+				: `${contextApiItem.getAssociatedPackage()
+						?.displayName}/${contextApiItem.getScopedNameWithinPackage()}`;
 		logger.warning(
-			`Unable to resolve reference "${codeDestination.emitAsTsdoc()}" from "${contextApiItem.getScopedNameWithinPackage()}":`,
+			`Unable to resolve reference "${codeDestination.emitAsTsdoc()}" from "${linkSource}":`,
 			resolvedReference.errorMessage,
 		);
 


### PR DESCRIPTION
Also updates the warnings logged by `api-markdown-documenter` to give a bit more context in terms of the location of the bad links.