### PR TITLE
Fix Rebase with Inflight Ops on Merge Tree (#19080) - RELEASE 8.0

### DIFF
--- a/packages/dds/merge-tree/api-report/merge-tree.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.api.md
@@ -164,7 +164,9 @@ export class Client extends TypedEventEmitter<IClientEvents> {
     // (undocumented)
     longClientId: string | undefined;
     obliterateRangeLocal(start: number, end: number): IMergeTreeObliterateMsg;
-    peekPendingSegmentGroups(count?: number): SegmentGroup | SegmentGroup[] | undefined;
+    peekPendingSegmentGroups(): SegmentGroup | undefined;
+    // (undocumented)
+    peekPendingSegmentGroups(count: number): SegmentGroup | SegmentGroup[] | undefined;
     posFromRelativePos(relativePos: IRelativePosition): number;
     regeneratePendingOp(resetOp: IMergeTreeOp, segmentGroup: SegmentGroup | SegmentGroup[]): IMergeTreeOp;
     removeLocalReferencePosition(lref: LocalReferencePosition): LocalReferencePosition | undefined;
@@ -946,6 +948,8 @@ export class SegmentGroupCollection {
     enqueue(segmentGroup: SegmentGroup): void;
     // (undocumented)
     pop?(): SegmentGroup | undefined;
+    // (undocumented)
+    remove?(segmentGroup: SegmentGroup): boolean;
     // (undocumented)
     get size(): number;
 }

--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -164,6 +164,10 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 	 * @param count - The number segment groups to get peek from the tail of the queue. Default 1.
 	 */
 	// eslint-disable-next-line import/no-deprecated
+	public peekPendingSegmentGroups(): SegmentGroup | undefined;
+	// eslint-disable-next-line import/no-deprecated
+	public peekPendingSegmentGroups(count: number): SegmentGroup | SegmentGroup[] | undefined;
+	// eslint-disable-next-line import/no-deprecated
 	public peekPendingSegmentGroups(count: number = 1): SegmentGroup | SegmentGroup[] | undefined {
 		const pending = this._mergeTree.pendingSegments;
 		let node = pending?.last;
@@ -746,10 +750,9 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 		for (const segment of segmentGroup.segments.sort((a, b) =>
 			a.ordinal < b.ordinal ? -1 : 1,
 		)) {
-			const segmentSegGroup = segment.segmentGroups.dequeue();
 			assert(
-				segmentGroup === segmentSegGroup,
-				0x035 /* "Segment group not at head of segment pending queue" */,
+				segment.segmentGroups.remove?.(segmentGroup) === true,
+				0x035 /* "Segment group not in segment pending queue" */,
 			);
 			assert(
 				segmentGroup.localSeq !== undefined,

--- a/packages/dds/merge-tree/src/segmentGroupCollection.ts
+++ b/packages/dds/merge-tree/src/segmentGroupCollection.ts
@@ -39,6 +39,16 @@ export class SegmentGroupCollection {
 	}
 
 	// eslint-disable-next-line import/no-deprecated
+	public remove?(segmentGroup: SegmentGroup): boolean {
+		const found = this.segmentGroups.find((v) => v.data === segmentGroup);
+		if (found === undefined) {
+			return false;
+		}
+		this.segmentGroups.remove(found);
+		return true;
+	}
+
+	// eslint-disable-next-line import/no-deprecated
 	public pop?(): SegmentGroup | undefined {
 		return this.segmentGroups.pop ? this.segmentGroups.pop()?.data : undefined;
 	}

--- a/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
+++ b/packages/dds/merge-tree/src/test/resetPendingSegmentsToOp.spec.ts
@@ -5,11 +5,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { strict as assert } from "assert";
-import { Marker, reservedMarkerIdKey } from "../mergeTreeNodes";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { Marker, SegmentGroup, reservedMarkerIdKey } from "../mergeTreeNodes";
 import { IMergeTreeOp, ReferenceType } from "../ops";
 import { clone } from "../properties";
 import { TextSegment } from "../textSegment";
 import { TestClient } from "./testClient";
+import { TestClientLogger, createClientsAtInitialState } from "./testClientLogger";
 
 describe("resetPendingSegmentsToOp", () => {
 	let client: TestClient;
@@ -262,5 +264,37 @@ describe("resetPendingSegmentsToOp", () => {
 			assert(otherSegment !== undefined && TextSegment.is(otherSegment));
 			assert.deepStrictEqual(otherSegment.properties, clone({ prop1: "foo" }));
 		});
+	});
+});
+
+describe("resetPendingSegmentsToOp.rebase", () => {
+	it("rebase with oustanding ops", () => {
+		const clients = createClientsAtInitialState({ initialState: "0123456789" }, "A", "B");
+
+		const logger = new TestClientLogger(clients.all);
+		const ops: [ISequencedDocumentMessage, SegmentGroup][] = Array.from({ length: 10 }).map(
+			(_, i) => [
+				clients.A.makeOpMessage(
+					clients.A.annotateRangeLocal(0, clients.A.getLength(), { prop: i }),
+					i + 1,
+				),
+				clients.A.peekPendingSegmentGroups()!,
+			],
+		);
+
+		ops.push(
+			...ops
+				.splice(Math.floor(ops.length / 2))
+				.map<[ISequencedDocumentMessage, SegmentGroup]>(([op, sg]) => [
+					clients.A.makeOpMessage(
+						clients.A.regeneratePendingOp(op.contents as IMergeTreeOp, sg),
+						op.sequenceNumber,
+					),
+					clients.A.peekPendingSegmentGroups()!,
+				]),
+		);
+
+		ops.forEach(([op]) => clients.all.forEach((c) => c.applyMsg(op)));
+		logger.validate();
 	});
 });

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -56,7 +56,7 @@ export const shortCodeMap = {
 	"0x032": "localSeq greater than collab window",
 	"0x033": "Segment group undefined",
 	"0x034": "Segment group not at head of pending rebase queue",
-	"0x035": "Segment group not at head of segment pending queue",
+	"0x035": "Segment group not in segment pending queue",
 	"0x036": "Segment has no pending properties",
 	"0x037": "Segment already has assigned sequence number",
 	"0x038": "Incoming op sequence# < local collabWindow's currentSequence#",


### PR DESCRIPTION
Porting https://github.com/microsoft/FluidFramework/pull/19080 to the release branch.

Fix a bug in the rebase logic of merge tree where we weren't handling out of order ops at the segment level. Specifically, the head of the segment queue may not match the rebase op, as we allow there to be outstanding ops before the rebase. The fix for this is fairly straightforward, rather than dequeue we attempt to remove the segment group, regardless of positions, but still validate it exists. ordering will still be validated in the acknowledgement phase once the ops round trip.

---------

