### PR TITLE
Unify eventing for interval endpoint and property changes 

### DIFF
--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -178,7 +178,7 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
     (event: "changeInterval", listener: (interval: TInterval, previousInterval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): void;
     (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
     (event: "propertyChanged", listener: (interval: TInterval, propertyDeltas: PropertySet, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
-    (event: "endpointOrPropertyChanged", listener: (interval: TInterval, propertyDeltas: PropertySet, previousInterval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): void;
+    (event: "changed", listener: (interval: TInterval, propertyDeltas: PropertySet, previousInterval: TInterval, local: boolean, slide: boolean) => void): void;
 }
 
 // @internal @sealed @deprecated (undocumented)

--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -178,7 +178,7 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
     (event: "changeInterval", listener: (interval: TInterval, previousInterval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): void;
     (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
     (event: "propertyChanged", listener: (interval: TInterval, propertyDeltas: PropertySet, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
-    (event: "changed", listener: (interval: TInterval, propertyDeltas: PropertySet, previousInterval: TInterval, local: boolean, slide: boolean) => void): void;
+    (event: "changed", listener: (interval: TInterval, propertyDeltas: PropertySet, previousInterval: TInterval | undefined, local: boolean, slide: boolean) => void): void;
 }
 
 // @internal @sealed @deprecated (undocumented)

--- a/packages/dds/sequence/api-report/sequence.api.md
+++ b/packages/dds/sequence/api-report/sequence.api.md
@@ -178,6 +178,7 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
     (event: "changeInterval", listener: (interval: TInterval, previousInterval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): void;
     (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
     (event: "propertyChanged", listener: (interval: TInterval, propertyDeltas: PropertySet, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
+    (event: "endpointOrPropertyChanged", listener: (interval: TInterval, propertyDeltas: PropertySet, previousInterval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): void;
 }
 
 // @internal @sealed @deprecated (undocumented)

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -742,7 +742,7 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
 	 * This object can be used directly in a call to `changeProperties` to revert the property change if desired.
 	 * 'previousInterval' contains transient `ReferencePosition`s at the same location as the interval's original
 	 * endpoints. These references should be used for position information only. In the case of a property change
-	 * only, this argument should be equal to `interval`.
+	 * only, this argument should be undefined.
 	 * `local` reflects whether the change originated locally.
 	 * `slide` is true if the change is due to sliding on removal of position.
 	 */

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -748,13 +748,12 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
 	 * `slide` is true if the change is due to sliding on removal of position.
 	 */
 	(
-		event: "endpointOrPropertyChanged",
+		event: "changed",
 		listener: (
 			interval: TInterval,
 			propertyDeltas: PropertySet,
 			previousInterval: TInterval,
 			local: boolean,
-			op: ISequencedDocumentMessage | undefined,
 			slide: boolean,
 		) => void,
 	): void;
@@ -1223,28 +1222,12 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			previousInterval.start.refType = ReferenceType.Transient;
 			previousInterval.end.refType = ReferenceType.Transient;
 			this.emit("changeInterval", interval, previousInterval, local, op, slide);
-			this.emit(
-				"endpointOrPropertyChanged",
-				interval,
-				undefined,
-				previousInterval ?? interval,
-				local,
-				op,
-				slide,
-			);
+			this.emit("changed", interval, undefined, previousInterval ?? interval, local, slide);
 			previousInterval.start.refType = startRefType;
 			previousInterval.end.refType = endRefType;
 		} else {
 			this.emit("changeInterval", interval, previousInterval, local, op, slide);
-			this.emit(
-				"endpointOrPropertyChanged",
-				interval,
-				undefined,
-				previousInterval ?? interval,
-				local,
-				op,
-				slide,
-			);
+			this.emit("changed", interval, undefined, previousInterval ?? interval, local, slide);
 		}
 	}
 
@@ -1439,15 +1422,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			this.emitter.emit("change", undefined, serializedInterval, { localSeq });
 			if (deltaProps !== undefined) {
 				this.emit("propertyChanged", interval, deltaProps, true, undefined);
-				this.emit(
-					"endpointOrPropertyChanged",
-					newInterval ?? interval,
-					deltaProps,
-					interval,
-					true,
-					undefined,
-					false,
-				);
+				this.emit("changed", newInterval ?? interval, deltaProps, interval, true, false);
 			}
 			if (newInterval) {
 				this.addPendingChange(id, serializedInterval);
@@ -1606,15 +1581,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			const changedProperties = Object.keys(newProps).length > 0;
 			if (changedProperties) {
 				this.emit("propertyChanged", interval, deltaProps, local, op);
-				this.emit(
-					"endpointOrPropertyChanged",
-					newInterval ?? interval,
-					deltaProps,
-					interval,
-					local,
-					op,
-					false,
-				);
+				this.emit("changed", newInterval ?? interval, deltaProps, interval, local, false);
 			}
 		}
 	}

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -752,7 +752,7 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
 		listener: (
 			interval: TInterval,
 			propertyDeltas: PropertySet,
-			previousInterval: TInterval,
+			previousInterval: TInterval | undefined,
 			local: boolean,
 			slide: boolean,
 		) => void,
@@ -1222,12 +1222,12 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			previousInterval.start.refType = ReferenceType.Transient;
 			previousInterval.end.refType = ReferenceType.Transient;
 			this.emit("changeInterval", interval, previousInterval, local, op, slide);
-			this.emit("changed", interval, undefined, previousInterval ?? interval, local, slide);
+			this.emit("changed", interval, undefined, previousInterval ?? undefined, local, slide);
 			previousInterval.start.refType = startRefType;
 			previousInterval.end.refType = endRefType;
 		} else {
 			this.emit("changeInterval", interval, previousInterval, local, op, slide);
-			this.emit("changed", interval, undefined, previousInterval ?? interval, local, slide);
+			this.emit("changed", interval, undefined, previousInterval ?? undefined, local, slide);
 		}
 	}
 
@@ -1422,7 +1422,14 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			this.emitter.emit("change", undefined, serializedInterval, { localSeq });
 			if (deltaProps !== undefined) {
 				this.emit("propertyChanged", interval, deltaProps, true, undefined);
-				this.emit("changed", newInterval ?? interval, deltaProps, interval, true, false);
+				this.emit(
+					"changed",
+					newInterval ?? interval,
+					deltaProps,
+					newInterval ? interval : undefined,
+					true,
+					false,
+				);
 			}
 			if (newInterval) {
 				this.addPendingChange(id, serializedInterval);
@@ -1581,7 +1588,7 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			const changedProperties = Object.keys(newProps).length > 0;
 			if (changedProperties) {
 				this.emit("propertyChanged", interval, deltaProps, local, op);
-				this.emit("changed", newInterval ?? interval, deltaProps, interval, local, false);
+				this.emit("changed", interval, deltaProps, undefined, local, false);
 			}
 		}
 	}

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -734,6 +734,30 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
 			op: ISequencedDocumentMessage | undefined,
 		) => void,
 	): void;
+	/**
+	 * This event is invoked whenever an interval's endpoints or properties (or both) have changed.
+	 * `interval` reflects the state of the updated endpoints or properties.
+	 * `propertyDeltas` is a map-like whose keys contain all values that were changed, and whose
+	 * values contain all previous values of the property set.
+	 * This object can be used directly in a call to `changeProperties` to revert the property change if desired.
+	 * 'previousInterval' contains transient `ReferencePosition`s at the same location as the interval's original
+	 * endpoints. These references should be used for position information only. In the case of a property change
+	 * only, this argument should be equal to `interval`.
+	 * `local` reflects whether the change originated locally.
+	 * `op` is defined if and only if the server has acked this change.
+	 * `slide` is true if the change is due to sliding on removal of position.
+	 */
+	(
+		event: "endpointOrPropertyChanged",
+		listener: (
+			interval: TInterval,
+			propertyDeltas: PropertySet,
+			previousInterval: TInterval,
+			local: boolean,
+			op: ISequencedDocumentMessage | undefined,
+			slide: boolean,
+		) => void,
+	): void;
 }
 
 /**
@@ -1199,10 +1223,28 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			previousInterval.start.refType = ReferenceType.Transient;
 			previousInterval.end.refType = ReferenceType.Transient;
 			this.emit("changeInterval", interval, previousInterval, local, op, slide);
+			this.emit(
+				"endpointOrPropertyChanged",
+				interval,
+				undefined,
+				previousInterval ?? interval,
+				local,
+				op,
+				slide,
+			);
 			previousInterval.start.refType = startRefType;
 			previousInterval.end.refType = endRefType;
 		} else {
 			this.emit("changeInterval", interval, previousInterval, local, op, slide);
+			this.emit(
+				"endpointOrPropertyChanged",
+				interval,
+				undefined,
+				previousInterval ?? interval,
+				local,
+				op,
+				slide,
+			);
 		}
 	}
 
@@ -1397,6 +1439,15 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			this.emitter.emit("change", undefined, serializedInterval, { localSeq });
 			if (deltaProps !== undefined) {
 				this.emit("propertyChanged", interval, deltaProps, true, undefined);
+				this.emit(
+					"endpointOrPropertyChanged",
+					newInterval ?? interval,
+					deltaProps,
+					interval,
+					true,
+					undefined,
+					false,
+				);
 			}
 			if (newInterval) {
 				this.addPendingChange(id, serializedInterval);
@@ -1555,6 +1606,15 @@ export class IntervalCollection<TInterval extends ISerializableInterval>
 			const changedProperties = Object.keys(newProps).length > 0;
 			if (changedProperties) {
 				this.emit("propertyChanged", interval, deltaProps, local, op);
+				this.emit(
+					"endpointOrPropertyChanged",
+					newInterval ?? interval,
+					deltaProps,
+					interval,
+					local,
+					op,
+					false,
+				);
 			}
 		}
 	}

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -744,7 +744,6 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
 	 * endpoints. These references should be used for position information only. In the case of a property change
 	 * only, this argument should be equal to `interval`.
 	 * `local` reflects whether the change originated locally.
-	 * `op` is defined if and only if the server has acked this change.
 	 * `slide` is true if the change is due to sliding on removal of position.
 	 */
 	(

--- a/packages/dds/sequence/src/test/intervalCollection.events.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.events.spec.ts
@@ -388,4 +388,197 @@ describe("SharedString interval collection event spec", () => {
 			assert.equal(eventLog.length, 1);
 		});
 	});
+
+	describe("endpointOrPropertyChanged", () => {
+		const eventLog: (IntervalEventInfo & {
+			id: string;
+			deltas: PropertySet;
+			previousEndpoints: { start: number; end: number };
+			previousInterval: SequenceInterval;
+			slide: boolean;
+		})[] = [];
+		let intervalId: string;
+		beforeEach(() => {
+			collection.on(
+				"endpointOrPropertyChanged",
+				(interval, deltas, previousInterval, local, op, slide) =>
+					eventLog.push({
+						id: interval.getIntervalId() ?? assert.fail("Expected interval to have id"),
+						deltas,
+						previousEndpoints: {
+							start: sharedString.localReferencePositionToPosition(
+								previousInterval.start ?? interval.start,
+							),
+							end: sharedString.localReferencePositionToPosition(
+								previousInterval.end ?? interval.end,
+							),
+						},
+						previousInterval: previousInterval ?? interval,
+						interval: {
+							start: sharedString.localReferencePositionToPosition(interval.start),
+							end: sharedString.localReferencePositionToPosition(interval.end),
+						},
+						local,
+						op,
+						slide,
+					}),
+			);
+			intervalId =
+				collection
+					.add({ start: 0, end: 1, props: { initialProp: "baz" } })
+					.getIntervalId() ?? fail("Expected interval to have id");
+			containerRuntimeFactory.processAllMessages();
+			eventLog.length = 0;
+		});
+
+		it("is emitted on initial local change but not ack of that change", () => {
+			collection.change(intervalId, { start: 2, end: 3 });
+			assert.equal(eventLog.length, 1);
+			{
+				const [{ interval, previousEndpoints, local, op, slide }] = eventLog;
+				assert.deepEqual(interval, { start: 2, end: 3 });
+				assert.deepEqual(previousEndpoints, { start: 0, end: 1 });
+				assert.equal(local, true);
+				assert.equal(op, undefined);
+				assert.equal(slide, false);
+			}
+			containerRuntimeFactory.processAllMessages();
+			assert.equal(eventLog.length, 1);
+		});
+
+		it("is emitted on a remote change", () => {
+			const collection2 = sharedString2.getIntervalCollection("test");
+			collection2.change(intervalId, { start: 2, end: 3 });
+			assert.equal(eventLog.length, 0);
+			containerRuntimeFactory.processAllMessages();
+			assert.equal(eventLog.length, 1);
+			{
+				const [{ interval, previousEndpoints, local, op, slide }] = eventLog;
+				assert.deepEqual(interval, { start: 2, end: 3 });
+				assert.deepEqual(previousEndpoints, { start: 0, end: 1 });
+				assert.equal(local, false);
+				assert.equal((op?.contents as { type?: unknown }).type, "act");
+				assert.equal(slide, false);
+			}
+		});
+
+		it("is emitted on change of properties and endpoints", () => {
+			collection.change(intervalId, { start: 2, end: 3, props: { foo: "bar" } });
+			// for now: allow both events to be logged (in endpoint path and props path)
+			assert.equal(eventLog.length, 2);
+			{
+				const [{ interval, previousEndpoints, local, op, slide }] = eventLog;
+				assert.deepEqual(interval, { start: 2, end: 3 });
+				assert.deepEqual(previousEndpoints, { start: 0, end: 1 });
+				assert.equal(local, true);
+				assert.equal(op, undefined);
+				assert.equal(slide, false);
+			}
+			containerRuntimeFactory.processAllMessages();
+			assert.equal(eventLog.length, 2);
+		});
+
+		describe("is emitted on a change due to an endpoint sliding", () => {
+			it("on ack of a segment remove containing a ref", () => {
+				sharedString.removeRange(1, 3);
+				assert.equal(eventLog.length, 0);
+				containerRuntimeFactory.processAllMessages();
+				assert.equal(eventLog.length, 1);
+				{
+					const [{ interval, previousInterval, previousEndpoints, local, op, slide }] =
+						eventLog;
+					assert.deepEqual(interval, { start: 0, end: 1 });
+					assert(toRemovalInfo(previousInterval.end.getSegment()) !== undefined);
+					assert.deepEqual(previousEndpoints, { start: 0, end: 1 });
+					assert.equal(local, true);
+					assert.equal(op, undefined);
+					assert.equal(slide, true);
+				}
+			});
+
+			it("on ack of an add to a concurrently removed segment", () => {
+				sharedString2.removeRange(3, sharedString2.getLength());
+				collection.add({ start: 4, end: 4 });
+				assert.equal(eventLog.length, 0);
+				containerRuntimeFactory.processAllMessages();
+				assert.equal(eventLog.length, 1);
+				{
+					const [{ interval, previousInterval, previousEndpoints, local, op, slide }] =
+						eventLog;
+					assert.deepEqual(interval, { start: 2, end: 2 });
+					assert(toRemovalInfo(previousInterval.start.getSegment()) !== undefined);
+					// Note: this isn't 4 because we're interpreting the segment+offset from the current view.
+					assert.deepEqual(previousEndpoints, { start: 3, end: 3 });
+					assert.equal(local, true);
+					assert.equal((op?.contents as { type?: unknown }).type, "act");
+					assert.equal(slide, true);
+				}
+			});
+
+			it("on ack of a change to a concurrently removed segment", () => {
+				sharedString2.removeRange(3, sharedString2.getLength());
+				collection.change(intervalId, { start: 4, end: 4 });
+				assert.equal(eventLog.length, 1);
+				containerRuntimeFactory.processAllMessages();
+				assert.equal(eventLog.length, 2);
+				{
+					const { interval, previousInterval, previousEndpoints, local, op, slide } =
+						eventLog[1];
+					assert.deepEqual(interval, { start: 2, end: 2 });
+					assert(toRemovalInfo(previousInterval.start.getSegment()) !== undefined);
+					// Note: this isn't 4 because we're interpreting the segment+offset from the current view.
+					assert.deepEqual(previousEndpoints, { start: 3, end: 3 });
+					assert.equal(local, true);
+					assert.equal((op?.contents as { type?: unknown }).type, "act");
+					assert.equal(slide, true);
+				}
+			});
+		});
+
+		it("is emitted on initial local property change but not ack of that change", () => {
+			collection.change(intervalId, { props: { foo: "bar" } });
+			assert.equal(eventLog.length, 1);
+			{
+				const [{ id, deltas, local, op }] = eventLog;
+				assert.equal(id, intervalId);
+				assert.equal(local, true);
+				assert.equal(op, undefined);
+				assert.deepEqual(deltas, { foo: null });
+			}
+			containerRuntimeFactory.processAllMessages();
+			assert.equal(eventLog.length, 1);
+		});
+
+		it("is emitted on ack of remote property change", () => {
+			const collection2 = sharedString2.getIntervalCollection("test");
+			collection2.change(intervalId, { props: { foo: "bar" } });
+			assert.equal(eventLog.length, 0);
+			containerRuntimeFactory.processAllMessages();
+			assert.equal(eventLog.length, 1);
+			{
+				const [{ id, deltas, local, op }] = eventLog;
+				assert.equal(id, intervalId);
+				assert.equal(local, false);
+				assert.equal((op?.contents as { type?: unknown }).type, "act");
+				assert.deepEqual(deltas, { foo: null });
+			}
+		});
+
+		it("only includes deltas for values that actually changed", () => {
+			const collection2 = sharedString2.getIntervalCollection("test");
+			collection2.change(intervalId, { props: { applies: true, conflictedDoesNotApply: 5 } });
+			assert.equal(eventLog.length, 0);
+			collection.change(intervalId, { props: { conflictedDoesNotApply: 2 } });
+			assert.equal(eventLog.length, 1);
+			containerRuntimeFactory.processAllMessages();
+			assert.equal(eventLog.length, 2);
+			{
+				const { id, deltas, local, op } = eventLog[1];
+				assert.equal(id, intervalId);
+				assert.equal(local, false);
+				assert.equal((op?.contents as { type?: unknown }).type, "act");
+				assert.deepEqual(deltas, { applies: null });
+			}
+		});
+	});
 });


### PR DESCRIPTION
Creates a new event to emit whenever the endpoints, properties, or both on an interval are changed. This is to better align with the changes made in #18676 that combine the changing of endpoints and properties into a single method. To avoid a breaking change, the new event is emitted along with the existing changeInterval and propertyChanged events. 

AB#6556