### PR TITLE
Make mongo retry throw error upon E11000

### DIFF
--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -395,9 +395,11 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
 				MaxRetryAttempts, // maxRetries
 				InitialRetryIntervalInMs, // retryAfterMs
 				telemetryProperties,
+				undefined, // shouldIgnoreError
 				(e) =>
-					e.code === 11000 || e.message?.toString()?.indexOf("E11000 duplicate key") >= 0, // shouldIgnoreError
-				(e) => this.retryEnabled && this.mongoErrorRetryAnalyzer.shouldRetry(e), // ShouldRetry
+					(this.retryEnabled && this.mongoErrorRetryAnalyzer.shouldRetry(e)) ||
+					e.code === 11000 ||
+					e.message?.toString()?.indexOf("E11000 duplicate key") >= 0, // ShouldRetry
 				(error: any, numRetries: number, retryAfterInterval: number) =>
 					numRetries * retryAfterInterval, // calculateIntervalMs
 				(error) => {


### PR DESCRIPTION
## Description
Fix the bug that mongo api retry layer swallowing error E11000.
This fix will bubble up this error to caller.




