### PR TITLE
bubble up the duplicate key error

### DIFF
--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -40,6 +40,21 @@ class InternalBulkWriteErrorRule extends BaseMongoExceptionRetryRule {
 	}
 }
 
+class DuplicateKeyErrorRule extends BaseMongoExceptionRetryRule {
+	private static readonly errorMsg = "E11000 duplicate key";
+	protected defaultRetryDecision: boolean = false;
+
+	constructor(retryRuleOverride: Map<string, boolean>) {
+		super("DuplicateKeyErrorRule", retryRuleOverride);
+	}
+
+	public match(error: any): boolean {
+		return (
+			error.code === 11000 || error.message?.toString()?.indexOf(DuplicateKeyErrorRule.errorMsg) >= 0
+		);
+	}
+}
+
 // This handles the requested queued on client side buffer overflow. Should relies on reconnect instead of retry?
 class NoConnectionAvailableRule extends BaseMongoExceptionRetryRule {
 	private static readonly messagePrefix =
@@ -383,6 +398,7 @@ export function createMongoErrorRetryRuleset(
 
 		// The rules are using multiple compare
 		new PoolDestroyedRule(retryRuleOverride),
+		new DuplicateKeyErrorRule(retryRuleOverride),
 
 		// The rules are using string startWith
 		new NoConnectionAvailableRule(retryRuleOverride, connectionNotAvailableMode),

--- a/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
+++ b/server/routerlicious/packages/services/src/mongoExceptionRetryRules/mongoError/index.ts
@@ -50,7 +50,8 @@ class DuplicateKeyErrorRule extends BaseMongoExceptionRetryRule {
 
 	public match(error: any): boolean {
 		return (
-			error.code === 11000 || error.message?.toString()?.indexOf(DuplicateKeyErrorRule.errorMsg) >= 0
+			error.code === 11000 ||
+			error.message?.toString()?.indexOf(DuplicateKeyErrorRule.errorMsg) >= 0
 		);
 	}
 }

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -395,8 +395,7 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
 				MaxRetryAttempts, // maxRetries
 				InitialRetryIntervalInMs, // retryAfterMs
 				telemetryProperties,
-				(e) =>
-					e.code === 11000 || e.message?.toString()?.indexOf("E11000 duplicate key") >= 0, // shouldIgnoreError
+				undefined, // shouldIgnoreError
 				(e) => this.retryEnabled && this.mongoErrorRetryAnalyzer.shouldRetry(e), // ShouldRetry
 				(error: any, numRetries: number, retryAfterInterval: number) =>
 					numRetries * retryAfterInterval, // calculateIntervalMs


### PR DESCRIPTION
E11000 was added to not retry long ago, because from DB perspective retry won't help at all.

However, it was added in shouldIgnoreError property, meaning we will not retry and mute the exception. This seems wrong, the error should bubble up and let the caller to handle.