### PR TITLE
Tree: Fix bug where move endpoints were not correctly updated during composition

### DIFF
--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -249,6 +249,27 @@ function composeMarks<TNodeChange>(
 		if (isImpactfulCellRename(baseMark, undefined, revisionMetadata)) {
 			const baseAttachAndDetach = asAttachAndDetach(baseMark);
 			const newOutputId = getOutputCellId(newAttachAndDetach, newRev, revisionMetadata);
+
+			if (isMoveIn(baseAttachAndDetach.attach) && isMoveOut(newAttachAndDetach.detach)) {
+				const moveStartId = getEndpoint(baseAttachAndDetach.attach, undefined);
+				const moveEndId = getEndpoint(newAttachAndDetach.detach, newRev);
+				setEndpoint(
+					moveEffects,
+					CrossFieldTarget.Source,
+					moveStartId,
+					baseMark.count,
+					moveEndId,
+				);
+
+				setEndpoint(
+					moveEffects,
+					CrossFieldTarget.Destination,
+					moveEndId,
+					baseMark.count,
+					moveStartId,
+				);
+			}
+
 			if (areEqualCellIds(newOutputId, baseAttachAndDetach.cellId)) {
 				return withNodeChange(
 					{ count: baseAttachAndDetach.count, cellId: baseAttachAndDetach.cellId },

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
@@ -973,7 +973,7 @@ export function testSandwichComposing() {
 				assertChangesetsEqual(sandwichParts1to6, []);
 			}),
 		);
-		it.skip("[move, move, modify, move] ↷ [del]", () =>
+		it("[move, move, modify, move] ↷ [del]", () =>
 			withConfig(() => {
 				const [mo1, mi1] = Mark.move(1, brand(1));
 				const move1 = tagChange([mi1, mo1], tag1);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
@@ -999,21 +999,7 @@ export function testSandwichComposing() {
 					mod,
 					move3,
 				];
-				// Ret3: RF3 -> RT3
-				// -Mod:        Mod
-				// Ret2:        RF2 -> RT2
-				// Ret1:               RF1 -> RT1
-				//  Del:                      Del
-				// Mov1:               MI1 <- MO1
-				// Mov2:        MI2 <- MO2        // MO2 is made to point to RT3, which causes RT3 to be made to point to RF2
-				// +Mod:        Mod
-				// Mov3: MI3 -> MO3
-				// When +Mod is composed, its effect is sent to RF2 instead of RF3.
-				// This happens because, during the composition of RT2 and MO2,
-				// we send effects endpoint updating effects to bridge the temporary location, but MO2 has a finalEndpoint set to RT3,
-				// so we send to RT3 a new finalEndpoint that points to RF2.
-				// This happens because, during the composition of (RT3 + RF2) and MI2,
-				// MO2 gets sent a new finalEndpoint that points to RT3.
+
 				const sandwich = compose(changes);
 				const pruned = prune(sandwich);
 				const noTombstones = withoutTombstones(pruned);


### PR DESCRIPTION
## Description

Fixed a bug where the `finalEndpoint` field was not correctly updated in some cases when composing moves of the same nodes.