### PR TITLE
converts repo-policy-check pipeline to 1ES template

### DIFF
--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -15,52 +15,82 @@ pr:
 - lts
 - release/*
 
-pool:
-  Small
-
 variables:
 - name: skipComponentGovernanceDetection
   value: true
 - name: pnpmStorePath
   value: $(Pipeline.Workspace)/.pnpm-store
 
-steps:
-- template: templates/include-use-node-version.yml
-
-- template: templates/include-install-pnpm.yml
+# The `resources` specify the location and version of the 1ES PT.
+resources:
+  repositories:
+  - repository: m365Pipelines
+    type: git
+    name: 1ESPipelineTemplates/M365GPT
+    ref: refs/tags/release
+extends:
+  # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
+  template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
   parameters:
-    buildDirectory: .
+    pool:
+      name: Small-1ES # This is one of the Fluid Orgs new 1ES hosted pools.
+      os: linux
+    sdl:
+      arrow:
+        # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
+        # Currently we want to use different names for internal and public builds for Arrow Service Connection
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          serviceConnection: Arrow_FluidFramework_internal
+        ${{ else }}:
+          serviceConnection: Arrow_FluidFramework_public
+      settings:
+        skipBuildTagsForGitHubPullRequests: "true"
+      sourceAnalysisPool:
+        name: Azure-Pipelines-1ESPT-ExDShared
+        image: windows-2022
+        os: windows
+    customBuildTags:
+      - ES365AIMigrationTooling
+    stages:
+    - stage: run_policy_check
+      jobs:
+      - job: run_policy_check
+        steps:
+        - template: /tools/pipelines/templates/include-use-node-version.yml@self
+        - template: /tools/pipelines/templates/include-install-pnpm.yml@self
+          parameters:
+            buildDirectory: .
 
-- task: Bash@3
-  displayName: Install root dependencies
-  inputs:
-    targetType: 'inline'
-    workingDirectory: .
-    script: |
-      # We only need to install the root dependencies
-      pnpm install --workspace-root --frozen-lockfile
+        - task: Bash@3
+          displayName: Install root dependencies
+          inputs:
+            targetType: 'inline'
+            workingDirectory: .
+            script: |
+              # We only need to install the root dependencies
+              pnpm install --workspace-root --frozen-lockfile
 
-- task: Npm@1
-  displayName: Policy Check
-  inputs:
-    command: 'custom'
-    customCommand: 'run policy-check'
+        - task: Npm@1
+          displayName: Policy Check
+          inputs:
+            command: 'custom'
+            customCommand: 'run policy-check'
 
-- task: Npm@1
-  displayName: Layer Check
-  inputs:
-    command: 'custom'
-    customCommand: 'run layer-check'
+        - task: Npm@1
+          displayName: Layer Check
+          inputs:
+            command: 'custom'
+            customCommand: 'run layer-check'
 
-- task: Npm@1
-  displayName: npm run prettier:root
-  inputs:
-    command: 'custom'
-    customCommand: 'run prettier:root'
+        - task: Npm@1
+          displayName: npm run prettier:root
+          inputs:
+            command: 'custom'
+            customCommand: 'run prettier:root'
 
-- task: Bash@3
-  displayName: Prune pnpm store
-  inputs:
-    targetType: 'inline'
-    script: |
-      pnpm store prune
+        - task: Bash@3
+          displayName: Prune pnpm store
+          inputs:
+            targetType: 'inline'
+            script: |
+              pnpm store prune


### PR DESCRIPTION
## Description

This PR converts repo-policy-check.yml to the new 1ES template required by Microsoft with the minimal required set of template changes required. This new template enables security and auditing checks by Microsoft. Read more on how the logic for converting to a 1ES pipeline works on [the official 1ES wiki](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview) 

 There is a *temporary* 1ES folder for converted pipeline templates. Pipeline templates within the 1ES folder are simple the 1ES conversion of the original templates, which are left untouched. This approach minimizes the potential blast radius of pipeline failures after conversion because it allows the newly converted pipeline to use the new 1ES templates while the rest of the pipelines continue to use the original templates.

Once all pipelines have been converted, we can start moving the converted templates back out of the 1ES folder. This will allow us to more clearly see the diff between converted and the original template files. In the mean time, refer to this PR to see a diff: https://github.com/microsoft/FluidFramework/pull/18397

## Breaking Changes

## Reviewer Guidance

- Confirm the newly converted pipelines run successfully. Look at the completed steps and compare with a recent successful run on main to ensure the expected steps run (plus the new SDL and 1ES security checks)
- Make sure all the relevant templates and pipelines for build-client.yml and build-azure.yml have been converted
- Make sure there are no unnecessary changes or 1ES template/pipeline conversions
- Make sure the yml is valid -- a successful pipeline run should suffice for confirming this