### PR TITLE
Fix parsing of signals content in odsp

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -238,14 +238,15 @@ export class OdspDelayLoadedDeltaStream {
 			if (signal.clientId === null) {
 				// We could have some issues/irregularities in parsing signals, so put it in try/catch block
 				// and ignore the error as we can have labels update later on through join session response.
+				let envelope: ISignalEnvelope | undefined;
 				try {
-					const envelope = JSON.parse(signal.content as string) as ISignalEnvelope;
-					if (envelope?.contents?.type === policyLabelsUpdatesSignalType) {
-						this.emitMetaDataUpdateEvent({
-							sensitivityLabelsInfo: JSON.stringify(envelope.contents.content),
-						});
-					}
+					envelope = JSON.parse(signal.content as string) as ISignalEnvelope;
 				} catch (err) {}
+				if (envelope?.contents?.type === policyLabelsUpdatesSignalType) {
+					this.emitMetaDataUpdateEvent({
+						sensitivityLabelsInfo: JSON.stringify(envelope.contents.content),
+					});
+				}
 			}
 		});
 	};

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -236,7 +236,7 @@ export class OdspDelayLoadedDeltaStream {
 		signals.forEach((signal: ISignalMessage) => {
 			// Make sure it is not for a specific client as `PolicyLabelsUpdate` is meant for all clients.
 			if (signal.clientId === null) {
-				// We could have some issues.irregularities in parsing signals, so put it in try/catch block
+				// We could have some issues/irregularities in parsing signals, so put it in try/catch block
 				// and ignore the error as we can labels update later on through join session response.
 				try {
 					const envelope = JSON.parse(signal.content as string) as ISignalEnvelope;

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -237,7 +237,7 @@ export class OdspDelayLoadedDeltaStream {
 			// Make sure it is not for a specific client as `PolicyLabelsUpdate` is meant for all clients.
 			if (signal.clientId === null) {
 				// We could have some issues/irregularities in parsing signals, so put it in try/catch block
-				// and ignore the error as we can labels update later on through join session response.
+				// and ignore the error as we can have labels update later on through join session response.
 				try {
 					const envelope = JSON.parse(signal.content as string) as ISignalEnvelope;
 					if (envelope?.contents?.type === policyLabelsUpdatesSignalType) {

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -236,12 +236,16 @@ export class OdspDelayLoadedDeltaStream {
 		signals.forEach((signal: ISignalMessage) => {
 			// Make sure it is not for a specific client as `PolicyLabelsUpdate` is meant for all clients.
 			if (signal.clientId === null) {
-				const envelope = JSON.parse(signal.content as string) as ISignalEnvelope;
-				if (envelope.contents.type === policyLabelsUpdatesSignalType) {
-					this.emitMetaDataUpdateEvent({
-						sensitivityLabelsInfo: JSON.stringify(envelope.contents.content),
-					});
-				}
+				// We could have some issues.irregularities in parsing signals, so put it in try/catch block
+				// and ignore the error as we can labels update later on through join session response.
+				try {
+					const envelope = JSON.parse(signal.content as string) as ISignalEnvelope;
+					if (envelope?.contents?.type === policyLabelsUpdatesSignalType) {
+						this.emitMetaDataUpdateEvent({
+							sensitivityLabelsInfo: JSON.stringify(envelope.contents.content),
+						});
+					}
+				} catch (err) {}
 			}
 		});
 	};


### PR DESCRIPTION
## Description

Fix parsing of signals content in ODSP. We could have some issues/irregularities in parsing signals, so put it in try/catch block and ignore the error as we can labels update later on through join session response.