### PR TITLE
[Port] Tree: Fix bug where move endpoints were not correctly updated during composition

### DIFF
--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -249,6 +249,27 @@ function composeMarks<TNodeChange>(
 		if (isImpactfulCellRename(baseMark, undefined, revisionMetadata)) {
 			const baseAttachAndDetach = asAttachAndDetach(baseMark);
 			const newOutputId = getOutputCellId(newAttachAndDetach, newRev, revisionMetadata);
+
+			if (isMoveIn(baseAttachAndDetach.attach) && isMoveOut(newAttachAndDetach.detach)) {
+				const moveStartId = getEndpoint(baseAttachAndDetach.attach, undefined);
+				const moveEndId = getEndpoint(newAttachAndDetach.detach, newRev);
+				setEndpoint(
+					moveEffects,
+					CrossFieldTarget.Source,
+					moveStartId,
+					baseMark.count,
+					moveEndId,
+				);
+
+				setEndpoint(
+					moveEffects,
+					CrossFieldTarget.Destination,
+					moveEndId,
+					baseMark.count,
+					moveStartId,
+				);
+			}
+
 			if (areEqualCellIds(newOutputId, baseAttachAndDetach.cellId)) {
 				return withNodeChange(
 					{ count: baseAttachAndDetach.count, cellId: baseAttachAndDetach.cellId },


### PR DESCRIPTION
## Description

Cherry-picks https://github.com/microsoft/FluidFramework/pull/19216 which fixes a bug with composition of sequence changesets. This bug could cause the state of different clients to diverge in some cases.