### PR TITLE
fix(ci): Update CI triggers so they react to changes to common build files

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -65,6 +65,7 @@ trigger:
     - azure
     - examples
     - experimental
+    - common/build/build-common
     - lerna.json
     - package.json
     - pnpm-lock.yaml
@@ -97,6 +98,7 @@ pr:
     - azure
     - examples
     - experimental
+    - common/build/build-common
     - lerna.json
     - package.json
     - pnpm-lock.yaml

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -37,6 +37,7 @@ trigger:
   paths:
     include:
     - .prettierignore
+    - common/build/build-common
     - common/lib/common-definitions
     - tools/pipelines/build-common-definitions.yml
     - tools/pipelines/templates/build-npm-package.yml
@@ -61,6 +62,7 @@ pr:
   paths:
     include:
     - .prettierignore
+    - common/build/build-common
     - common/lib/common-definitions
     - tools/pipelines/build-common-definitions.yml
     - tools/pipelines/templates/build-npm-package.yml

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -37,6 +37,7 @@ trigger:
   paths:
     include:
     - .prettierignore
+    - common/build/build-common
     - common/lib/protocol-definitions
     - tools/pipelines/build-protocol-definitions.yml
     - tools/pipelines/templates/build-npm-package.yml
@@ -61,6 +62,7 @@ pr:
   paths:
     include:
     - .prettierignore
+    - common/build/build-common
     - common/lib/protocol-definitions
     - tools/pipelines/build-protocol-definitions.yml
     - tools/pipelines/templates/build-npm-package.yml


### PR DESCRIPTION
## Description

Recently we updated some packages so they refer to common build config files directly in the repo (by path), instead of through a package dependency. This means that changes to those files should trigger the CI build, but we missed adding them to the pipeline triggers.

Some examples of the file references (non-exhaustive):
- https://github.com/microsoft/FluidFramework/blob/4eb59e40657f12cc20bb2975f7360bffd84d46cd/common/lib/common-definitions/package.json#L30
- https://github.com/microsoft/FluidFramework/blob/4eb59e40657f12cc20bb2975f7360bffd84d46cd/common/lib/protocol-definitions/package.json#L35
- https://github.com/microsoft/FluidFramework/blob/4eb59e40657f12cc20bb2975f7360bffd84d46cd/packages/dds/matrix/package.json#L79

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I explicitly did not try to target the exact files that we depend on today (opting instead for triggering on changes anywhere in the directory) since it is safer. It might lead to some unnecessary CI builds, but I think the risk of that is low and that this side of the trade-off is a better starting point.