### PR TITLE
Sample compressor events, fix passing logger, test finalizing ranges on attach

### DIFF
--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -131,9 +131,10 @@ describe("Runtime", () => {
 
 	describe("Container Runtime", () => {
 		describe("IdCompressor", () => {
-			it("finalizes idRange on attach", async () => {
+			it.only("finalizes idRange on attach", async () => {
+				const logger = new MockLogger();
 				const containerRuntime = await ContainerRuntime.loadRuntime({
-					context: getMockContext() as IContainerContext,
+					context: getMockContext({}, logger) as IContainerContext,
 					registryEntries: [],
 					existing: false,
 					runtimeOptions: {
@@ -143,15 +144,18 @@ describe("Runtime", () => {
 					provideEntryPoint: mockProvideEntryPoint,
 				});
 
+				logger.clear();
+
 				const compressor = containerRuntime.idCompressor;
 				assert(compressor !== undefined);
 				compressor.generateCompressedId();
 				containerRuntime.createSummary();
 
-				// This should return an empty range since we should've
-				// taken the next range and finalized it in the createSummary call above
-				const idRange = compressor.takeNextCreationRange();
-				assert.equal(idRange.ids, undefined);
+				logger.assertMatchAny([
+					{
+						eventName: "RuntimeIdCompressor:FirstCluster",
+					},
+				]);
 			});
 		});
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -151,11 +151,12 @@ describe("Runtime", () => {
 				compressor.generateCompressedId();
 				containerRuntime.createSummary();
 
-				logger.assertMatchAny([
-					{
-						eventName: "RuntimeIdCompressor:FirstCluster",
-					},
-				]);
+				const range = compressor.takeNextCreationRange();
+				assert.equal(
+					range.ids,
+					undefined,
+					"All Ids should have been finalized after calling createSummary()",
+				);
 			});
 		});
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -130,6 +130,31 @@ describe("Runtime", () => {
 	});
 
 	describe("Container Runtime", () => {
+		describe("IdCompressor", () => {
+			it("finalizes idRange on attach", async () => {
+				const containerRuntime = await ContainerRuntime.loadRuntime({
+					context: getMockContext() as IContainerContext,
+					registryEntries: [],
+					existing: false,
+					runtimeOptions: {
+						flushMode: FlushMode.TurnBased,
+						enableRuntimeIdCompressor: true,
+					},
+					provideEntryPoint: mockProvideEntryPoint,
+				});
+
+				const compressor = containerRuntime.idCompressor;
+				assert(compressor !== undefined);
+				compressor.generateCompressedId();
+				containerRuntime.createSummary();
+
+				// This should return an empty range since we should've
+				// taken the next range and finalized it in the createSummary call above
+				const idRange = compressor.takeNextCreationRange();
+				assert.equal(idRange.ids, undefined);
+			});
+		});
+
 		describe("flushMode setting", () => {
 			it("Default flush mode", async () => {
 				const containerRuntime = await ContainerRuntime.loadRuntime({

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -131,7 +131,7 @@ describe("Runtime", () => {
 
 	describe("Container Runtime", () => {
 		describe("IdCompressor", () => {
-			it.only("finalizes idRange on attach", async () => {
+			it("finalizes idRange on attach", async () => {
 				const logger = new MockLogger();
 				const containerRuntime = await ContainerRuntime.loadRuntime({
 					context: getMockContext({}, logger) as IContainerContext,

--- a/packages/runtime/id-compressor/api-report/id-compressor.api.md
+++ b/packages/runtime/id-compressor/api-report/id-compressor.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
+import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
 
 // @internal
 export function assertIsStableId(stableId: string): StableId;
@@ -19,10 +20,10 @@ export function createIdCompressor(sessionId: SessionId, logger?: ITelemetryBase
 export function createSessionId(): SessionId;
 
 // @alpha
-export function deserializeIdCompressor(serialized: SerializedIdCompressorWithOngoingSession): IIdCompressor & IIdCompressorCore;
+export function deserializeIdCompressor(serialized: SerializedIdCompressorWithOngoingSession, logger?: ITelemetryLoggerExt): IIdCompressor & IIdCompressorCore;
 
 // @alpha
-export function deserializeIdCompressor(serialized: SerializedIdCompressorWithNoSession, newSessionId: SessionId): IIdCompressor & IIdCompressorCore;
+export function deserializeIdCompressor(serialized: SerializedIdCompressorWithNoSession, newSessionId: SessionId, logger?: ITelemetryLoggerExt): IIdCompressor & IIdCompressorCore;
 
 // @internal
 export function generateStableId(): StableId;

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -549,14 +549,19 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 		return bufferToString(serializedFloat.buffer, "base64") as SerializedIdCompressor;
 	}
 
-	public static deserialize(serialized: SerializedIdCompressorWithOngoingSession): IdCompressor;
+	public static deserialize(
+		serialized: SerializedIdCompressorWithOngoingSession,
+		loggerOrSessionId?: ITelemetryLoggerExt | SessionId,
+	): IdCompressor;
 	public static deserialize(
 		serialized: SerializedIdCompressorWithNoSession,
 		newSessionId: SessionId,
+		logger?: ITelemetryLoggerExt,
 	): IdCompressor;
 	public static deserialize(
 		serialized: SerializedIdCompressor,
 		sessionId?: SessionId,
+		logger?: ITelemetryLoggerExt,
 	): IdCompressor {
 		const buffer = stringToBuffer(serialized, "base64");
 		const index: Index = {
@@ -569,13 +574,17 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 			case 1.0:
 				throw new Error("IdCompressor version 1.0 is no longer supported.");
 			case 2.0:
-				return IdCompressor.deserialize2_0(index, sessionId);
+				return IdCompressor.deserialize2_0(index, sessionId, logger);
 			default:
 				throw new Error("Unknown IdCompressor serialized version.");
 		}
 	}
 
-	static deserialize2_0(index: Index, sessionId?: SessionId): IdCompressor {
+	static deserialize2_0(
+		index: Index,
+		sessionId?: SessionId,
+		logger?: ITelemetryLoggerExt,
+	): IdCompressor {
 		const hasLocalState = readBoolean(index);
 		const sessionCount = readNumber(index);
 		const clusterCount = readNumber(index);
@@ -601,7 +610,7 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 			sessions.push([numeric, new Session(numeric)]);
 		}
 
-		const compressor = new IdCompressor(new Sessions(sessions));
+		const compressor = new IdCompressor(new Sessions(sessions), logger);
 
 		// Clusters
 		let baseFinalId = 0;
@@ -700,6 +709,7 @@ export function createIdCompressor(
  */
 export function deserializeIdCompressor(
 	serialized: SerializedIdCompressorWithOngoingSession,
+	logger?: ITelemetryLoggerExt,
 ): IIdCompressor & IIdCompressorCore;
 /**
  * Deserializes the supplied state into an ID compressor.
@@ -708,12 +718,20 @@ export function deserializeIdCompressor(
 export function deserializeIdCompressor(
 	serialized: SerializedIdCompressorWithNoSession,
 	newSessionId: SessionId,
+	logger?: ITelemetryLoggerExt,
 ): IIdCompressor & IIdCompressorCore;
 export function deserializeIdCompressor(
 	serialized: SerializedIdCompressor | SerializedIdCompressorWithNoSession,
-	sessionId?: SessionId,
+	sessionIdOrLogger?: SessionId | ITelemetryLoggerExt,
+	logger?: ITelemetryLoggerExt | undefined,
 ): IIdCompressor & IIdCompressorCore {
-	return sessionId === undefined
-		? IdCompressor.deserialize(serialized as SerializedIdCompressorWithOngoingSession)
-		: IdCompressor.deserialize(serialized as SerializedIdCompressorWithNoSession, sessionId);
+	if (typeof sessionIdOrLogger === "string") {
+		return IdCompressor.deserialize(
+			serialized as SerializedIdCompressorWithNoSession,
+			sessionIdOrLogger,
+			logger,
+		);
+	}
+
+	return IdCompressor.deserialize(serialized as SerializedIdCompressorWithOngoingSession, logger);
 }

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -684,7 +684,7 @@ export function createIdCompressor(
 			logger = loggerOrUndefined;
 		} else {
 			localSessionId = createSessionId();
-			logger = loggerOrUndefined;
+			logger = sessionIdOrLogger;
 		}
 	}
 	const compressor = new IdCompressor(

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -551,7 +551,7 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 
 	public static deserialize(
 		serialized: SerializedIdCompressorWithOngoingSession,
-		loggerOrSessionId?: ITelemetryLoggerExt | SessionId,
+		logger?: ITelemetryLoggerExt,
 	): IdCompressor;
 	public static deserialize(
 		serialized: SerializedIdCompressorWithNoSession,
@@ -560,9 +560,16 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 	): IdCompressor;
 	public static deserialize(
 		serialized: SerializedIdCompressor,
-		sessionId?: SessionId,
-		logger?: ITelemetryLoggerExt,
+		loggerOrSessionId?: ITelemetryLoggerExt | SessionId,
 	): IdCompressor {
+		let sessionId: SessionId | undefined;
+		let logger: ITelemetryLoggerExt | undefined;
+		if (typeof loggerOrSessionId === "string") {
+			sessionId = loggerOrSessionId;
+		} else {
+			logger = loggerOrSessionId;
+		}
+
 		const buffer = stringToBuffer(serialized, "base64");
 		const index: Index = {
 			index: 0,

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -14,7 +14,7 @@ import {
 	SessionSpaceCompressedId,
 	StableId,
 } from "../";
-import { IdCompressor, deserializeIdCompressor } from "../idCompressor";
+import { IdCompressor, createIdCompressor, deserializeIdCompressor } from "../idCompressor";
 import { createSessionId } from "../utilities";
 import {
 	performFuzzActions,
@@ -770,6 +770,18 @@ describe("IdCompressor", () => {
 					size: 72,
 					clusterCount: 1,
 					sessionCount: 1,
+				},
+			]);
+		});
+
+		it.only("correctly passes logger when no session specified", () => {
+			const mockLogger = new MockLogger();
+			const compressor = createIdCompressor(mockLogger);
+			compressor.generateCompressedId();
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: "RuntimeIdCompressor:FirstCluster",
 				},
 			]);
 		});

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -774,7 +774,7 @@ describe("IdCompressor", () => {
 			]);
 		});
 
-		it.only("correctly passes logger when no session specified", () => {
+		it("correctly passes logger when no session specified", () => {
 			const mockLogger = new MockLogger();
 			const compressor = createIdCompressor(mockLogger);
 			compressor.generateCompressedId();


### PR DESCRIPTION
## Description

This is a follow-up to fixing the runtime compressor not finalizing any allocated ranges on attach. This adds a test to make sure that this occurs.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

