### PR TITLE
GC: Remove unreferenced state tracking immediately upon detecting new reference

### DIFF
--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -115,11 +115,13 @@ export class GarbageCollector implements IGarbageCollector {
 	// The GC details generated from the base snapshot.
 	private readonly baseGCDetailsP: Promise<IGarbageCollectionDetailsBase>;
 
-	// Map of node ids to their unreferenced state tracker.
+	/**
+	 * Map of node ids to their unreferenced state tracker
+	 * NOTE: The set of keys in this map is considered as the set of unreferenced nodes
+	 * as of the last GC run. So in between runs, nothing should be added or removed.
+	 */
 	private readonly unreferencedNodesState: UnreferencedStateTrackerMap =
 		new UnreferencedStateTrackerMap();
-	/** Nodes who were unreferenced at the last GC run. Needed to generate GC stats (nodes updated) */
-	private unreferencedNodesAtLastRun: Set<string> = new Set();
 
 	// The Timer responsible for closing the container when the session has expired
 	private sessionExpiryTimer: Timer | undefined;
@@ -303,7 +305,6 @@ export class GarbageCollector implements IGarbageCollector {
 							this.configs.sweepGracePeriodMs,
 						),
 					);
-					this.unreferencedNodesAtLastRun.add(nodeId);
 				}
 				gcNodes[nodeId] = Array.from(nodeData.outboundRoutes);
 			}
@@ -517,7 +518,6 @@ export class GarbageCollector implements IGarbageCollector {
 				// Update the state of summary state tracker from this run's stats.
 				this.summaryStateTracker.updateStateFromGCRunStats(gcStats);
 				this.newReferencesSinceLastRun.clear();
-				this.unreferencedNodesAtLastRun = new Set(this.unreferencedNodesState.keys());
 				this.completedRuns++;
 
 				return gcStats;
@@ -928,6 +928,8 @@ export class GarbageCollector implements IGarbageCollector {
 
 		// Clear unreferenced state tracking for deleted nodes.
 		for (const nodeId of deletedNodeIds) {
+			// Usually we avoid modifying the set of unreferencedNodesState keys in between GC runs,
+			// but this is ok since this node won't exist at all in the next GC run.
 			this.unreferencedNodesState.delete(nodeId);
 			this.deletedNodes.add(nodeId);
 		}
@@ -1083,7 +1085,10 @@ export class GarbageCollector implements IGarbageCollector {
 		});
 
 		// This node is referenced - Clear its unreferenced state
-		this.unreferencedNodesState.delete(toNodePath);
+		// But don't delete the node id from the map yet.
+		// When generating GC stats, the set of nodes in here is used as the baseline for
+		// what was unreferenced in the last GC run.
+		this.unreferencedNodesState.get(toNodePath)?.stopTracking();
 	}
 
 	/**
@@ -1121,7 +1126,7 @@ export class GarbageCollector implements IGarbageCollector {
 			markPhaseStats.nodeCount++;
 			// If there is no previous GC data, every node's state is generated and is considered as updated.
 			// Otherwise, find out if any node went from referenced to unreferenced or vice-versa.
-			const wasNotReferenced = this.unreferencedNodesAtLastRun.has(nodeId);
+			const wasNotReferenced = this.unreferencedNodesState.has(nodeId);
 			const stateUpdated =
 				this.gcDataFromLastRun === undefined || wasNotReferenced === isReferenced;
 			if (stateUpdated) {

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -189,6 +189,8 @@ export class GCTelemetryTracker {
 		};
 
 		// If the node that is used is tombstoned, log a tombstone telemetry.
+		//* TODO: If we're feeling brave we could assert here that nodeStateTracker !== undefined, or just move the early return back to the top
+		//* I am not feeling that brave - and there's no harm to leave it as-is.
 		if (nodeUsageProps.isTombstoned) {
 			this.logTombstoneUsageTelemetry(nodeUsageProps, unrefEventProps, nodeType, usageType);
 		}

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -189,8 +189,6 @@ export class GCTelemetryTracker {
 		};
 
 		// If the node that is used is tombstoned, log a tombstone telemetry.
-		//* TODO: If we're feeling brave we could assert here that nodeStateTracker !== undefined, or just move the early return back to the top
-		//* I am not feeling that brave - and there's no harm to leave it as-is.
 		if (nodeUsageProps.isTombstoned) {
 			this.logTombstoneUsageTelemetry(nodeUsageProps, unrefEventProps, nodeType, usageType);
 		}

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -189,8 +189,6 @@ export class GCTelemetryTracker {
 		};
 
 		// If the node that is used is tombstoned, log a tombstone telemetry.
-		// Note that this is done before checking if "nodeStateTracker" is undefined below because unreferenced
-		// tracking may not have yet been enabled. That happens only after the client transitions to write mode.
 		if (nodeUsageProps.isTombstoned) {
 			this.logTombstoneUsageTelemetry(nodeUsageProps, unrefEventProps, nodeType, usageType);
 		}

--- a/packages/runtime/container-runtime/src/gc/gcUnreferencedStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcUnreferencedStateTracker.ts
@@ -5,7 +5,7 @@
 
 import { assert, Timer } from "@fluidframework/core-utils";
 import { validatePrecondition } from "@fluidframework/telemetry-utils";
-import { UnreferencedState } from "./gcDefinitions";
+import { IGarbageCollectorConfigs, UnreferencedState } from "./gcDefinitions";
 
 /** A wrapper around common-utils Timer that requires the timeout when calling start/restart */
 class TimerWithNoDefaultTimeout extends Timer {
@@ -22,6 +22,54 @@ class TimerWithNoDefaultTimeout extends Timer {
 
 	restart(timeoutMs: number): void {
 		super.restart(timeoutMs, this.callback);
+	}
+}
+
+/** The collection of UnreferencedStateTrackers for all unreferenced nodes */
+export class UnreferencedNodeTrackers extends Map<string, UnreferencedStateTracker> {
+	constructor(private readonly configs: IGarbageCollectorConfigs) {
+		super();
+	}
+
+	/** Update tracking for all nodes, using the given timestamp as the current time */
+	updateAllTracking(currentReferenceTimestampMs: number) {
+		for (const nodeStateTracker of this.values()) {
+			nodeStateTracker.updateTracking(currentReferenceTimestampMs);
+		}
+	}
+
+	/**
+	 * Start or Update tracking for the given node, using the given timestamp as the current time
+	 * @returns the current state of the given node, after updating tracking info. Will be "Active" for newly tracked nodes.
+	 */
+	startOrUpdateTracking(nodeId: string, currentReferenceTimestampMs: number) {
+		const nodeStateTracker = this.get(nodeId);
+		if (nodeStateTracker === undefined) {
+			this.set(
+				nodeId,
+				new UnreferencedStateTracker(
+					currentReferenceTimestampMs,
+					this.configs.inactiveTimeoutMs,
+					currentReferenceTimestampMs,
+					this.configs.tombstoneTimeoutMs,
+					this.configs.sweepGracePeriodMs,
+				),
+			);
+			return UnreferencedState.Active;
+		}
+
+		// If a node was already unreferenced, update its tracking information. Since the current reference time
+		// is from the ops seen, this will ensure that we keep updating unreferenced state as time moves forward.
+		nodeStateTracker.updateTracking(currentReferenceTimestampMs);
+		return nodeStateTracker.state;
+	}
+
+	/** Delete the given key, and stop tracking if that node was actually unreferenced */
+	delete(key: string): boolean {
+		// Stop tracking so as to clear out any running timers.
+		this.get(key)?.stopTracking();
+		// Delete the node as we don't need to track it any more.
+		return super.delete(key);
 	}
 }
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -85,13 +85,13 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 	}
 
 	async function loadContainer(
-		config: ITestContainerConfig,
+		configNoLoaderProps: ITestContainerConfig, // loaderProps gets overwritten
 		summaryVersion: string,
 		logger?: MockLogger,
 	) {
 		return provider.loadTestContainer(
 			{
-				...config,
+				...configNoLoaderProps,
 				loaderProps: { logger },
 			},
 			{

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -29,6 +29,7 @@ import {
 	itExpects,
 	TestDataObjectType,
 } from "@fluid-private/test-version-utils";
+import { delay } from "@fluidframework/core-utils";
 import {
 	manufactureHandle,
 	waitForContainerWriteModeConnectionWrite,
@@ -80,6 +81,22 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 				{ eventName: loadedEvent },
 			]),
 			"inactive object events should not have been logged",
+		);
+	}
+
+	async function loadContainer(
+		config: ITestContainerConfig,
+		summaryVersion: string,
+		logger?: MockLogger,
+	) {
+		return provider.loadTestContainer(
+			{
+				...config,
+				loaderProps: { logger },
+			},
+			{
+				[LoaderHeader.version]: summaryVersion,
+			},
 		);
 	}
 
@@ -414,12 +431,10 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 
 					// Load a non-summarizer container from the above summary that uses the mock logger. This container has to
 					// be in "write" mode for GC to initialize unreferenced nodes from summary.
-					const container2 = await provider.loadTestContainer(
-						{
-							...testContainerConfigWithThrowOption,
-							loaderProps: { logger: mockLogger },
-						},
-						{ [LoaderHeader.version]: summaryVersion1 },
+					const container2 = await loadContainer(
+						testContainerConfigWithThrowOption,
+						summaryVersion1,
+						mockLogger,
 					);
 					const defaultDataStoreContainer2 =
 						(await container2.getEntryPoint()) as ITestDataObject;
@@ -502,12 +517,10 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 
 					// Load a non-summarizer container from the above summary that uses the mock logger. This container has to
 					// be in "write" mode for GC to initialize unreferenced nodes from summary.
-					const container2 = await provider.loadTestContainer(
-						{
-							...testContainerConfigWithThrowOption,
-							loaderProps: { logger: mockLogger },
-						},
-						{ [LoaderHeader.version]: summaryVersion1 },
+					const container2 = await loadContainer(
+						testContainerConfigWithThrowOption,
+						summaryVersion1,
+						mockLogger,
 					);
 					const defaultDataStoreContainer2 =
 						(await container2.getEntryPoint()) as ITestDataObject;
@@ -579,12 +592,10 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 
 					// Load a non-summarizer container from the above summary that uses the mock logger. This container has to
 					// be in "write" mode for GC to initialize unreferenced nodes from summary.
-					const container2 = await provider.loadTestContainer(
-						{
-							...testContainerConfigWithThrowOption,
-							loaderProps: { logger: mockLogger },
-						},
-						{ [LoaderHeader.version]: summaryVersion1 },
+					const container2 = await loadContainer(
+						testContainerConfigWithThrowOption,
+						summaryVersion1,
+						mockLogger,
 					);
 					const defaultDataStoreContainer2 =
 						(await container2.getEntryPoint()) as ITestDataObject;
@@ -649,12 +660,10 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 
 					// Load a non-summarizer container from the above summary that uses the mock logger. This container has to
 					// be in "write" mode for GC to initialize unreferenced nodes from summary.
-					const container2 = await provider.loadTestContainer(
-						{
-							...testContainerConfig, // NOT including the throwOnInactiveLoad flag
-							loaderProps: { logger: mockLogger },
-						},
-						{ [LoaderHeader.version]: summaryVersion1 },
+					const container2 = await loadContainer(
+						testContainerConfig, // NOT including the throwOnInactiveLoad flag
+						summaryVersion1,
+						mockLogger,
 					);
 					const defaultDataStoreContainer2 =
 						(await container2.getEntryPoint()) as ITestDataObject;
@@ -749,5 +758,89 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 				);
 			},
 		);
+
+		it("Reviving an InactiveObject clears Inactive state immediately in interactive client (but not for its subtree)", async () => {
+			const container1 = mainContainer;
+			const { summarizer: summarizer1 } = await createSummarizer(
+				provider,
+				container1,
+				testContainerConfig,
+			);
+			const defaultDataObject1 = (await container1.getEntryPoint()) as ITestDataObject;
+			await waitForContainerConnection(container1);
+
+			const dataObjectA_1 = await createNewDataObject();
+			const dataObjectB_1 = await createNewDataObject();
+			const idA = dataObjectA_1._context.id;
+			const idB = dataObjectB_1._context.id;
+
+			// Reference A from the container entrypoint, and B from A
+			defaultDataObject1._root.set("A", dataObjectA_1.handle);
+			dataObjectA_1._root.set("B", dataObjectB_1.handle);
+
+			// Then unreference the A-B chain (but leave it intact), and Summarize to start unreferenced tracking
+			defaultDataObject1._root.delete("A");
+			await provider.ensureSynchronized();
+			const { summaryVersion: summaryVersion1 } = await summarizeNow(summarizer1);
+
+			// A and B are unreferenced in container2/container3. Timers will be set
+			// We need two containers because each event type is only logged once per container
+			const mockLogger2 = new MockLogger();
+			const container2 = await loadContainer(
+				testContainerConfig,
+				summaryVersion1,
+				mockLogger2,
+			);
+			const defaultDataObject2 = (await container2.getEntryPoint()) as ITestDataObject;
+			const mockLogger3 = new MockLogger();
+			const container3 = await loadContainer(
+				testContainerConfig,
+				summaryVersion1,
+				mockLogger3,
+			);
+			const defaultDataObject3 = (await container3.getEntryPoint()) as ITestDataObject;
+
+			// Wait the Inactive Timeout. Timers will fire
+			await delay(inactiveTimeoutMs);
+
+			// Load A in container2 and ensure InactiveObject_Loaded is logged
+			const handleA_2 = manufactureHandle<ITestDataObject>(
+				defaultDataObject2._context.IFluidHandleContext, // yields the ContaineRuntime's handleContext
+				idA,
+			);
+			await handleA_2?.get();
+			mockLogger2.assertMatch([
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded",
+					id: { value: `/${idA}`, tag: "CodeArtifact" },
+				},
+			]);
+
+			// Reference A again in container1. Should be revived on container3
+			defaultDataObject1._root.set("A", dataObjectA_1.handle);
+			await provider.ensureSynchronized();
+
+			// Since A was directly revived, its unreferenced state was cleared immediately so we shouldn't see InactiveObject logs for it
+			const handleA_3 = defaultDataObject3._root.get<IFluidHandle<ITestDataObject>>("A");
+			const dataObjectA_3 = await handleA_3?.get();
+			mockLogger3.assertMatchNone([
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded",
+				},
+			]);
+
+			// Since B wasn't directly revived, it wrongly still thinks it's Inactive. Next GC will clear it up.
+			const handleB_3 = dataObjectA_3?._root.get<IFluidHandle<ITestDataObject>>("B");
+			await handleB_3?.get();
+			mockLogger3.assertMatch([
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded",
+					id: { value: `/${idB}`, tag: "CodeArtifact" },
+				},
+			]);
+		});
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -402,7 +402,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 
 		// Nothing should be unreferenced.
 		let gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+		assert.deepStrictEqual(gcStats, expectedGCStats, "1. GC stats is not as expected");
 
 		// Remove both data store handles to mark them unreferenced.
 		mainDataObject._root.delete("dataStore1");
@@ -417,7 +417,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		expectedGCStats.updatedDataStoreCount = 2;
 
 		gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+		assert.deepStrictEqual(gcStats, expectedGCStats, "2. GC stats is not as expected");
 
 		// Add their handle back to re-reference them.
 		mainDataObject._root.set("dataStore1", dataStore1.handle);
@@ -430,6 +430,6 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		expectedGCStats.unrefDataStoreCount -= 2;
 
 		gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+		assert.deepStrictEqual(gcStats, expectedGCStats, "3. GC stats is not as expected");
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -40,7 +40,11 @@ import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { FluidSerializer, parseHandles } from "@fluidframework/shared-object-base";
 import type { SharedMap } from "@fluidframework/map";
-import { getGCStateFromSummary, getGCTombstoneStateFromSummary } from "./gcTestSummaryUtils.js";
+import {
+	getGCStateFromSummary,
+	getGCTombstoneStateFromSummary,
+	manufactureHandle,
+} from "./gcTestSummaryUtils.js";
 
 /**
  * These tests validate that TombstoneReady data stores are correctly marked as tombstones. Tombstones should be added
@@ -48,8 +52,10 @@ import { getGCStateFromSummary, getGCTombstoneStateFromSummary } from "./gcTestS
  */
 describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
-	const remainingTimeUntilSweepMs = 100;
-	const tombstoneTimeoutMs = 200;
+	//* Revert all changes to this file after moving the new test out
+	const remainingTimeUntilSweepMs = 1000;
+	const tombstoneTimeoutMs = 2000;
+	const inactiveTimeoutMs = 100;
 	assert(
 		remainingTimeUntilSweepMs < tombstoneTimeoutMs,
 		"remainingTimeUntilSweepMs should be < tombstoneTimeoutMs",
@@ -58,7 +64,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 
 	const testContainerConfig: ITestContainerConfig = {
 		runtimeOptions: {
-			gcOptions: { enableGCSweep: true, inactiveTimeoutMs: 0 },
+			gcOptions: { enableGCSweep: true, inactiveTimeoutMs },
 		},
 		loaderProps: { configProvider: mockConfigProvider(settings) },
 	};
@@ -260,41 +266,82 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
 		});
 
-		itExpects(
-			"Send ops fails for tombstoned datastores in summarizing container loaded after tombstone timeout",
-			[
+		//* ONLY
+		//* ONLY
+		//* ONLY
+		//* ONLY
+		//* ONLY
+		//* ONLY
+		it.only("Send ops fails for tombstoned datastores in summarizing container loaded after tombstone timeout", async () => {
+			const container1 = await makeContainer();
+			const { summarizer: summarizer1 } = await loadSummarizer(container1);
+			const defaultDataObject1 = (await container1.getEntryPoint()) as ITestDataObject;
+			await waitForContainerConnection(container1);
+
+			const dataObjectA_1 = await createDataStore(defaultDataObject1);
+			const dataObjectB_1 = await createDataStore(defaultDataObject1);
+			const idA = dataObjectA_1._context.id;
+			const idB = dataObjectB_1._context.id;
+
+			// Reference A from the container entrypoint, and B from A
+			defaultDataObject1._root.set("A", dataObjectA_1.handle);
+			dataObjectA_1._root.set("B", dataObjectB_1.handle);
+
+			// Then unreference the A-B chain (but leave it intact), and Summarize to start unreferenced tracking
+			defaultDataObject1._root.delete("A");
+			const { summaryVersion } = await summarize(summarizer1);
+
+			// A and B are unreferenced in container2/container3. Timers will be set
+			// We need two containers because each event type is only logged once per container
+			const mockLogger2 = new MockLogger();
+			const container2 = await loadContainer(summaryVersion, false, mockLogger2);
+			const defaultDataObject2 = (await container2.getEntryPoint()) as ITestDataObject;
+			const mockLogger3 = new MockLogger();
+			const container3 = await loadContainer(summaryVersion, false, mockLogger3);
+			const defaultDataObject3 = (await container3.getEntryPoint()) as ITestDataObject;
+
+			// Wait the Inactive Timeout. Timers will fire
+			await delay(inactiveTimeoutMs);
+
+			// Load A in container2 and ensure InactiveObject_Loaded is logged
+			const handleA_2 = manufactureHandle<ITestDataObject>(
+				defaultDataObject2._context.IFluidHandleContext, // yields the ContaineRuntime's handleContext
+				idA,
+			);
+			await handleA_2?.get();
+			mockLogger2.assertMatch([
 				{
 					eventName:
-						"fluid:telemetry:FluidDataStoreContext:GC_Tombstone_DataStore_Changed",
-					callSite: "submitMessage",
-					clientType: "interactive",
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded",
+					id: { value: `/${idA}`, tag: "CodeArtifact" },
 				},
-			],
-			async () => {
-				const { unreferencedId, summarizer } =
-					await summarizationWithUnreferencedDataStoreAfterTime(tombstoneTimeoutMs);
+			]);
 
-				// The datastore should be tombstoned now
-				const { summaryVersion } = await summarize(summarizer);
+			// Reference A again in container1. Should be revived on container3
+			defaultDataObject1._root.set("A", dataObjectA_1.handle);
+			await provider.ensureSynchronized();
 
-				const dataObject = await getTombstonedDataObjectFromSummary(
-					summaryVersion,
-					unreferencedId,
-				);
+			// Since A was directly revived, its unreferenced state was cleared immediately so we shouldn't see InactiveObject logs for it
+			const handleA_3 = defaultDataObject3._root.get<IFluidHandle<ITestDataObject>>("A");
+			const dataObjectA_3 = await handleA_3?.get();
+			mockLogger3.assertMatchNone([
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded",
+				},
+			]);
 
-				// Modifying a testDataObject substantiated from the request pattern should fail!
-				assert.throws(
-					() => dataObject._root.set("send", "op"),
-					(error: IErrorBase) => {
-						const correctErrorType = error.errorType === "dataCorruptionError";
-						const correctErrorMessage =
-							error.message?.startsWith(`Context is tombstoned`) === true;
-						return correctErrorType && correctErrorMessage;
-					},
-					`Should not be able to send ops for a tombstoned datastore.`,
-				);
-			},
-		);
+			// Since B wasn't directly revived, it wrongly still thinks it's Inactive. Next GC will clear it up.
+			const handleB_3 = dataObjectA_3?._root.get<IFluidHandle<ITestDataObject>>("B");
+			await handleB_3?.get();
+			mockLogger3.assertMatch([
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded",
+					id: { value: `/${idB}`, tag: "CodeArtifact" },
+				},
+			]);
+		});
 
 		itExpects(
 			"Receive ops fails for tombstoned datastores in summarizing container loaded after sweep time",


### PR DESCRIPTION
## Description

Fixes AB#6655

The goal here is that when a reference is added (via addedOutboundReference), we should immediately clear unreferenced state tracking.

We can do this effectively and reliably from it because we detect added references "inline"/immediately as the ContainerRuntime processes the op stream.  The benefit of removing unreferenced state tracking immediately is that subsequent usages (changed/loaded) will not be wrongly logged anymore.

This fact is covered by the new test added.
