### PR TITLE
docs(fluid-framework): Update package README and `@packageDocumentation` comment for 2.0

### DIFF
--- a/docs/build-redirects.js
+++ b/docs/build-redirects.js
@@ -17,8 +17,13 @@ const {
 const configFileName = "staticwebapp.config.json";
 const config = require(`./static/${configFileName}`);
 
+// TODO: Remove these hard-coded redirects once we have dynamic redirects working
 const routes = {
 	"/docs/apis": `/docs/api/${currentVersion}`,
+	"/docs/apis/azure-client": `/docs/api/${currentVersion}/azure-client`,
+	"/docs/apis/azure-service-utils": `/docs/api/${currentVersion}/azure-service-utils`,
+	"/docs/apis/fluid-framework": `/docs/api/${currentVersion}/fluid-framework`,
+	"/docs/apis/odsp-client": `/docs/api/${currentVersion}/odsp-client`,
 	// "/docs/api/current/*": `/docs/api/${currentVersion}/*`,
 	// "/docs/api/lts/*": `/docs/api/${ltsVersion}/*`,
 };

--- a/packages/framework/fluid-framework/README.md
+++ b/packages/framework/fluid-framework/README.md
@@ -8,7 +8,7 @@ The `fluid-framework` package consists primarily of two portions: the `IFluidCon
 
 ### IFluidContainer
 
-The **[IFluidContainer][]** interface is the one of the types returned by calls to `createContainer()` and `getContainer()` on the service clients such as `AzureClient`.
+The **[IFluidContainer][]** interface is one of the types returned by calls to `createContainer()` and `getContainer()` on the service clients such as `AzureClient`.
 It includes functionality to retrieve the Fluid data contained within, as well as to inspect the state of the collaboration session connection.
 
 ### DDS packages

--- a/packages/framework/fluid-framework/README.md
+++ b/packages/framework/fluid-framework/README.md
@@ -1,8 +1,29 @@
 # fluid-framework
 
-The `fluid-framework` package bundles a collection of Fluid Framework client packages for easy use when paired with a corresponding service client package (ex. `@fluidframework/azure-client` & `@fluidframework/tinylicious-client`).
+The `fluid-framework` package bundles a collection of Fluid Framework client libraries for easy use when paired with a corresponding service client package (e.g. `@fluidframework/azure-client`, `@fluidframework/tinylicious-client`, or `@fluid-experimental/osdp-client (BETA)`).
 
-<!-- AUTO-GENERATED-CONTENT:START (README_DEPENDENCY_GUIDELINES_SECTION:includeHeading=TRUE) -->
+## Contents
+
+The `fluid-framework` package consists primarily of two portions: the `IFluidContainer` and a selection of distributed data structures (DDSes).
+
+### IFluidContainer
+
+The **[IFluidContainer][]** interface is the one of the types returned by calls to `createContainer()` and `getContainer()` on the service clients such as `AzureClient`.
+It includes functionality to retrieve the Fluid data contained within, as well as to inspect the state of the collaboration session connection.
+
+### DDS packages
+
+You'll use one or more DDS data structures in your container to model your collaborative data. The `fluid-framework` package comes with three data structures that cover a broad range of scenarios:
+
+1. **[SharedTree][]**
+1. **[SharedMap][]**, a map-like data structure for storing key/value pair data
+    - Note: as of version 2.0, `SharedMap` is deprecated. Please use `SharedTree` instead.
+
+## Tutorial
+
+Check out the Hello World tutorial using the `fluid-framework` package [here](https://fluidframework.com/docs/start/tutorial/).
+
+<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README:scripts=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
@@ -13,34 +34,45 @@ When taking a dependency on a Fluid Framework library, we recommend using a `^` 
 While Fluid Framework libraries may use different ranges with interdependencies between other Fluid Framework libraries,
 library consumers should always prefer `^`.
 
-<!-- prettier-ignore-end -->
+## Installation
 
-<!-- AUTO-GENERATED-CONTENT:END -->
+To get started, install the package by running the following command:
 
-## Contents
+```bash
+npm i fluid-framework
+```
 
-The `fluid-framework` package consists primarily of two portions: the `IFluidContainer` and a selection of distributed data structures (DDSes).
+## API Documentation
 
-### IFluidContainer
+API documentation for **fluid-framework** is available at <https://fluidframework.com/docs/apis/fluid-framework>.
 
-The **[IFluidContainer][]** interface is the one of the types returned by calls to `createContainer()` and `getContainer()` on the service clients such as `AzureClient`. It includes functionality to retrieve the Fluid data contained within, as well as to inspect the state of the collaboration session connection.
+## Contribution Guidelines
 
-### DDS packages
+There are many ways to [contribute](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md) to Fluid.
 
-You'll use one or more DDS data structures in your container to model your collaborative data. The `fluid-framework` package comes with three data structures that cover a broad range of scenarios:
+-   Participate in Q&A in our [GitHub Discussions](https://github.com/microsoft/FluidFramework/discussions).
+-   [Submit bugs](https://github.com/microsoft/FluidFramework/issues) and help us verify fixes as they are checked in.
+-   Review the [source code changes](https://github.com/microsoft/FluidFramework/pulls).
+-   [Contribute bug fixes](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).
 
-1. **[SharedMap][]**, a map-like data structure for storing key/value pair data
-2. **[SharedDirectory][]**, a map-like data structure with ability to organize keys into subdirectories
-3. **[SharedString][]**, a data structure for string data
+Detailed instructions for working in the repo can be found in the [Wiki](https://github.com/microsoft/FluidFramework/wiki).
 
-## Tutorial
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-Check out the Hello World tutorial using the `fluid-framework` package [here](https://fluidframework.com/docs/start/tutorial/).
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services.
+Use of these trademarks or logos must follow Microsoft’s [Trademark & Brand Guidelines](https://www.microsoft.com/trademarks).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 
-<!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->
+## Help
 
-<!-- prettier-ignore-start -->
-<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
+Not finding what you're looking for in this README? Check out our [GitHub
+Wiki](https://github.com/microsoft/FluidFramework/wiki) or [fluidframework.com](https://fluidframework.com/docs/).
+
+Still not finding what you're looking for? Please [file an
+issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
+
+Thank you!
 
 ## Trademark
 
@@ -56,7 +88,6 @@ Use of Microsoft trademarks or logos in modified versions of this project must n
 
 <!-- Links -->
 
-[ifluidcontainer]: https://fluidframework.com/docs/apis/fluid-static/ifluidcontainer/
-[sharedmap]: https://fluidframework.com/docs/apis/map/sharedmap/
-[shareddirectory]: https://fluidframework.com/docs/apis/map/shareddirectory/
-[sharedstring]: https://fluidframework.com/docs/apis/sequence/sharedstring/
+[ifluidcontainer]: https://fluidframework.com/docs/api/v2/fluid-framework/ifluidcontainer-interface
+[sharedmap]: https://fluidframework.com/docs/data-structures/map/
+[sharedtree]: https://fluidframework.com/docs/data-structures/tree/

--- a/packages/framework/fluid-framework/README.md
+++ b/packages/framework/fluid-framework/README.md
@@ -13,7 +13,8 @@ It includes functionality to retrieve the Fluid data contained within, as well a
 
 ### DDS packages
 
-You'll use one or more DDS data structures in your container to model your collaborative data. The `fluid-framework` package comes with three data structures that cover a broad range of scenarios:
+You'll use one or more DDS data structures in your container to model your collaborative data.
+The `fluid-framework` package offers the following data structures:
 
 1. **[SharedTree][]**
 1. **[SharedMap][]**, a map-like data structure for storing key/value pair data

--- a/packages/framework/fluid-framework/README.md
+++ b/packages/framework/fluid-framework/README.md
@@ -22,7 +22,7 @@ The `fluid-framework` package offers the following data structures:
 
 ## Tutorial
 
-Check out the Hello World tutorial using the `fluid-framework` package [here](https://fluidframework.com/docs/start/tutorial/).
+Check out the [Hello World tutorial](https://fluidframework.com/docs/start/tutorial/) using `fluid-framework`.
 
 <!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README:scripts=FALSE) -->
 

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -4,9 +4,8 @@
  */
 
 /**
- * The **fluid-framework** package bundles a collection of Fluid Framework client libraries for easy use
- * when paired with a corresponding service client library (for example,
- * `\@fluidframework/azure-client` or `\@fluidframework/tinylicious-client`).
+ * Bundles a collection of Fluid Framework client libraries for easy use when paired with a corresponding service client
+ * package (e.g. `@fluidframework/azure-client`, `@fluidframework/tinylicious-client`, or `@fluid-experimental/osdp-client (BETA)`).
  *
  * @packageDocumentation
  */


### PR DESCRIPTION
Updates include:
* Add missing template-generated sections for contribution guidelines and help directions
* Update terminology to not mention other client "packages", since we don't want our SDK users digging into our lower-level libraries
* Mention the beta `@fluid-experimental/odsp-client`
* Remove mentions of `SharedDirectory` and `SharedString`, and add references to `SharedTree`

Also updates website redirects to include links to SDK packages' API docs.