### PR TITLE
fix(client-client-utils): remove Buffer from runtime export

### DIFF
--- a/packages/common/client-utils/src/indexNode.ts
+++ b/packages/common/client-utils/src/indexNode.ts
@@ -4,7 +4,7 @@
  */
 
 export {
-	Buffer,
+	type Buffer,
 	bufferToString,
 	IsoBuffer,
 	stringToBuffer,


### PR DESCRIPTION
Buffer is a declared class only for typing purposes and should not be exported as real class.