### PR TITLE
Fix tab->space and indentation in template file for historian chart

### DIFF
--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -34,14 +34,14 @@ data:
             ]
         },
         "requestSizeLimit": "1gb",
-	    "enableResponseCloseLatencyMetric": {{ .Values.gitrest.enableResponseCloseLatencyMetric }},
+        "enableResponseCloseLatencyMetric": {{ .Values.gitrest.enableResponseCloseLatencyMetric }},
         "storageDir": {
             "baseDir": "/home/node/documents",
             "useRepoOwner": true
         },
         "externalStorage": {
-          "enabled": false,
-          "endpoint": "http://externalStorage:3005"
+            "enabled": false,
+            "endpoint": "http://externalStorage:3005"
         },
         "git": {
             "lib": {


### PR DESCRIPTION
## Description

Noticed the deployment of historian to our internal AKS cluster is failing because of a tab on line 37 where it expects spaces. Took the opportunity to standardize the file on 4-space indentation at all levels.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).