### PR TITLE
Fix another tab->space issue in template file for historian chart

### DIFF
--- a/server/charts/historian/templates/historian-configmap.yaml
+++ b/server/charts/historian/templates/historian-configmap.yaml
@@ -34,7 +34,7 @@ data:
             ]
         },
         "requestSizeLimit": "1gb",
-	    "enableResponseCloseLatencyMetric": {{ .Values.historian.enableResponseCloseLatencyMetric }},
+        "enableResponseCloseLatencyMetric": {{ .Values.historian.enableResponseCloseLatencyMetric }},
         "riddler": "{{ .Values.historian.riddler }}",
         "ignoreEphemeralFlag": {{ .Values.historian.ignoreEphemeralFlag }},
         "redis": {


### PR DESCRIPTION
## Description

Follow up to https://github.com/microsoft/FluidFramework/pull/19250; same error in different file, wasn't showing up before because of the failure hitting the previous tab issue.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
