### PR TITLE
fix(tinylicious): Run lint after build

### DIFF
--- a/server/routerlicious/packages/tinylicious/package.json
+++ b/server/routerlicious/packages/tinylicious/package.json
@@ -14,7 +14,7 @@
 	"types": "dist/index.d.ts",
 	"bin": "dist/index.js",
 	"scripts": {
-		"build": "concurrently npm:build:compile npm:lint && npm run build:docs",
+		"build": "npm run build:compile && npm run lint && npm run build:docs",
 		"build:compile": "npm run tsc && npm run build:test",
 		"build:docs": "api-extractor run --local --typescript-compiler-folder ./node_modules/typescript && copyfiles -u 1 \"./_api-extractor-temp/doc-models/*\" ../../_api-extractor-temp/",
 		"build:test": "tsc --project ./src/test/tsconfig.json",
@@ -90,7 +90,6 @@
 		"@types/rimraf": "^3.0.0",
 		"@types/split": "^0.3.28",
 		"@types/uuid": "^9.0.2",
-		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.6.0",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -1380,7 +1380,6 @@ importers:
       body-parser: ^1.17.1
       charwise: ^3.0.1
       compression: ^1.7.2
-      concurrently: ^8.2.1
       cookie-parser: ^1.4.3
       copyfiles: ^2.4.1
       cors: ^2.8.4
@@ -1462,7 +1461,6 @@ importers:
       '@types/rimraf': 3.0.2
       '@types/split': 0.3.28
       '@types/uuid': 9.0.2
-      concurrently: 8.2.1
       copyfiles: 2.4.1
       cross-env: 7.0.3
       eslint: 8.6.0


### PR DESCRIPTION
## Description

Makes the `lint` script run after the `build` one in tinylicious.

The `lint` script runs `check:release-tags` which through the `api-extractor-lint.json` config file expects the type declarations file for the package to be present, so it can fail if it runs concurrently with the build, before the build has output that file.

This is the error today, on a clean build, which disappears on a second build once the type declarations file exists:

![image](https://github.com/microsoft/FluidFramework/assets/716334/19f1a5a5-610d-4e80-ab61-f0443cf8b736)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

In the client release group we use fluid-build which probably takes care of this already, but the server release group doesn't use it yet. In several server packages (where we don't do release tag checks), concurrently running build and lint is fine, but as long as we do release tag checks in tinylicious, it needs this change to build reliably without spurious issues.