### PR TITLE
tools(tree): Simplify eslint config

### DIFF
--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -6,7 +6,7 @@
 module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
 	parserOptions: {
-		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
+		project: ["./tsconfig.json"],
 	},
 	rules: {
 		"@typescript-eslint/no-namespace": "off",
@@ -26,6 +26,9 @@ module.exports = {
 	overrides: [
 		{
 			files: ["src/test/**/*"],
+			parserOptions: {
+				project: ["./src/test/tsconfig.json"],
+			},
 			rules: {
 				"@typescript-eslint/no-unused-vars": ["off"],
 			},


### PR DESCRIPTION
Isolates the `parserOptions` for the test code to the overrides block for the test code.