### PR TITLE
refactor(map): Upgrade eslint config from "minimal" to "recommended"

### DIFF
--- a/packages/dds/map/.eslintrc.cjs
+++ b/packages/dds/map/.eslintrc.cjs
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},

--- a/packages/dds/map/.eslintrc.cjs
+++ b/packages/dds/map/.eslintrc.cjs
@@ -15,4 +15,13 @@ module.exports = {
 		// TODO: consider re-enabling once we have addressed how this rule conflicts with our error codes.
 		"unicorn/numeric-separators-style": "off",
 	},
+	overrides: [
+		{
+			files: ["src/test/**"],
+			rules: {
+				// Allow tests (which only run in Node.js) use `__dirname`
+				"unicorn/prefer-module": "off",
+			},
+		},
+	],
 };

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -36,9 +36,9 @@ export interface IValueChanged {
  * @remarks When used as a Map, operates on its keys.
  * @alpha
  */
-// TODO: Use `unknown` instead (breaking change).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface IDirectory
+	// TODO: Use `unknown` instead (breaking change).
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	extends Map<string, any>,
 		IEventProvider<IDirectoryEvents>,
 		Partial<IDisposable> {

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -746,10 +746,10 @@ export class MapKernel {
 	private getMapKeyMessageId(op: IMapKeyOperation): number {
 		const pendingMessageId = ++this.pendingMessageId;
 		const pendingMessageIds = this.pendingKeys.get(op.key);
-		if (pendingMessageIds !== undefined) {
-			pendingMessageIds.push(pendingMessageId);
-		} else {
+		if (pendingMessageIds === undefined) {
 			this.pendingKeys.set(op.key, [pendingMessageId]);
+		} else {
+			pendingMessageIds.push(pendingMessageId);
 		}
 		return pendingMessageId;
 	}
@@ -785,7 +785,7 @@ export class MapKernel {
 			return;
 		}
 
-		const index = pendingMessageIds.findIndex((id) => id === localOpMetadata.pendingMessageId);
+		const index = pendingMessageIds.indexOf(localOpMetadata.pendingMessageId);
 		if (index === -1) {
 			return;
 		}

--- a/packages/dds/map/src/test/mocha/directory.order.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.order.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import {
 	MockContainerRuntimeFactory,
 	MockContainerRuntimeFactoryForReconnection,

--- a/packages/dds/map/src/test/mocha/directory.order.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.order.spec.ts
@@ -48,7 +48,10 @@ async function populate(directory: SharedDirectory, content: unknown): Promise<v
 	return directory.load(storage);
 }
 
-function assertDirectoryIterationOrder(directory: ISharedDirectory, expectedDirNames: string[]) {
+function assertDirectoryIterationOrder(
+	directory: ISharedDirectory,
+	expectedDirNames: string[],
+): void {
 	const actualDirNames: string[] = [];
 	for (const [subdirName, subdirObject] of directory.subdirectories()) {
 		actualDirNames.push(subdirName);

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
+import { type IFluidHandle } from "@fluidframework/core-interfaces";
 import { UsageError } from "@fluidframework/telemetry-utils";
 import { ISummaryBlob, SummaryType } from "@fluidframework/protocol-definitions";
 import { IGCTestProvider, runGCTests } from "@fluid-private/test-dds-utils";
@@ -176,7 +177,9 @@ describe("Directory", () => {
 					);
 					containedValueChangedExpected = false;
 
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 					assert.equal(changed.key, "dwayne");
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 					assert.equal(changed.previousValue, previousValue);
 
 					assert.equal(
@@ -392,6 +395,7 @@ describe("Directory", () => {
 					directory.set(undefined as unknown as string, "testValue");
 				}, "Should throw for key of undefined");
 				assert.throws(() => {
+					// eslint-disable-next-line unicorn/no-null
 					directory.set(null as unknown as string, "testValue");
 				}, "Should throw for key of null");
 			});
@@ -401,6 +405,7 @@ describe("Directory", () => {
 					directory.createSubDirectory(undefined as unknown as string);
 				}, "Should throw for undefined subDirectory name");
 				assert.throws(() => {
+					// eslint-disable-next-line unicorn/no-null
 					directory.createSubDirectory(null as unknown as string);
 				}, "Should throw for null subDirectory name");
 			});
@@ -1800,11 +1805,15 @@ describe("Directory", () => {
 				assert(fooSubDir);
 				const fooSubDirIterator = fooSubDir.entries();
 				const fooSubDirResult1 = fooSubDirIterator.next();
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 				assert.equal(fooSubDirResult1.value[0], "testKey");
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 				assert.equal(fooSubDirResult1.value[1], "testValue");
 				assert.equal(fooSubDirResult1.done, false);
 				const fooSubDirResult2 = fooSubDirIterator.next();
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 				assert.equal(fooSubDirResult2.value[0], "testKey2");
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 				assert.equal(fooSubDirResult2.value[1], "testValue2");
 				assert.equal(fooSubDirResult2.done, false);
 				const fooSubDirResult3 = fooSubDirIterator.next();
@@ -1826,11 +1835,15 @@ describe("Directory", () => {
 				assert(fooSubDir2);
 				const fooSubDir2Iterator = fooSubDir2.entries();
 				const fooSubDir2Result1 = fooSubDir2Iterator.next();
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 				assert.equal(fooSubDir2Result1.value[0], "testKey");
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 				assert.equal(fooSubDir2Result1.value[1], "testValue");
 				assert.equal(fooSubDir2Result1.done, false);
 				const fooSubDir2Result2 = fooSubDir2Iterator.next();
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 				assert.equal(fooSubDir2Result2.value[0], "testKey2");
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 				assert.equal(fooSubDir2Result2.value[1], "testValue2");
 				assert.equal(fooSubDir2Result2.done, false);
 				const fooSubDir2Result3 = fooSubDir2Iterator.next();
@@ -1963,7 +1976,7 @@ describe("Directory", () => {
 
 				const subMapId = `subMap-${this.subMapCount}`;
 
-				const deletedHandle = fooDirectory.get(subMapId);
+				const deletedHandle = fooDirectory.get(subMapId) as IFluidHandle;
 				assert(deletedHandle, "Route must be added before deleting");
 
 				fooDirectory.delete(subMapId);

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 
 import { UsageError } from "@fluidframework/telemetry-utils";
 import { ISummaryBlob, SummaryType } from "@fluidframework/protocol-definitions";

--- a/packages/dds/map/src/test/mocha/directoryEquivalenceUtils.ts
+++ b/packages/dds/map/src/test/mocha/directoryEquivalenceUtils.ts
@@ -13,7 +13,7 @@ export function assertEquivalentDirectories(first: IDirectory, second: IDirector
 function assertEventualConsistencyCore(
 	first: IDirectory | undefined,
 	second: IDirectory | undefined,
-) {
+): void {
 	assert(first !== undefined, "first root dir should be present");
 	assert(second !== undefined, "second root dir should be present");
 

--- a/packages/dds/map/src/test/mocha/directoryEquivalenceUtils.ts
+++ b/packages/dds/map/src/test/mocha/directoryEquivalenceUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import { IDirectory } from "../../interfaces";
 
 export function assertEquivalentDirectories(first: IDirectory, second: IDirectory): void {
@@ -58,7 +58,7 @@ function assertEventualConsistencyCore(
 	}
 
 	// Check for consistency of subdirectories ordering of both directories
-	const firstSubdirNames = Array.from(first.subdirectories()).map(([dirName, _]) => dirName);
-	const secondSubdirNames = Array.from(second.subdirectories()).map(([dirName, _]) => dirName);
+	const firstSubdirNames = [...first.subdirectories()].map(([dirName, _]) => dirName);
+	const secondSubdirNames = [...second.subdirectories()].map(([dirName, _]) => dirName);
 	assert.deepStrictEqual(firstSubdirNames, secondSubdirNames);
 }

--- a/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import * as path from "path";
-import { strict as assert } from "assert";
+import * as path from "node:path";
+import { strict as assert } from "node:assert";
 import { DDSFuzzModel, DDSFuzzTestState, createDDSFuzzSuite } from "@fluid-private/test-dds-utils";
 import { Jsonable } from "@fluidframework/datastore-definitions";
 import {

--- a/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
@@ -38,11 +38,11 @@ type Operation = SetKey | DeleteKey | Clear;
 // This type gets used a lot as the state object of the suite; shorthand it here.
 type State = DDSFuzzTestState<MapFactory>;
 
-function assertMapsAreEquivalent(a: ISharedMap, b: ISharedMap) {
+function assertMapsAreEquivalent(a: ISharedMap, b: ISharedMap): void {
 	assert.equal(a.size, b.size, `${a.id} and ${b.id} have different number of keys.`);
 	for (const key of a.keys()) {
-		const aVal = a.get(key);
-		const bVal = b.get(key);
+		const aVal: unknown = a.get(key);
+		const bVal: unknown = b.get(key);
 		assert.equal(aVal, bVal, `${a.id} and ${b.id} differ at ${key}: ${aVal} vs ${bVal}`);
 	}
 }

--- a/packages/dds/map/src/test/mocha/map.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISummaryBlob } from "@fluidframework/protocol-definitions";
 import { IGCTestProvider, runGCTests } from "@fluid-private/test-dds-utils";

--- a/packages/dds/map/src/test/mocha/map.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.spec.ts
@@ -141,6 +141,7 @@ describe("Map", () => {
 					map.set(undefined as unknown as string, "one");
 				}, "Should throw for key of undefined");
 				assert.throws(() => {
+					// eslint-disable-next-line unicorn/no-null
 					map.set(null as unknown as string, "two");
 				}, "Should throw for key of null");
 			});
@@ -545,7 +546,7 @@ describe("Map", () => {
 
 					containerRuntimeFactory.processAllMessages();
 
-					const retrieved = map1.get("object");
+					const retrieved = map1.get("object") as typeof containingObject;
 					const retrievedSubMap: unknown = await retrieved.subMapHandle.get();
 					assert.equal(retrievedSubMap, subMap, "could not get nested map 1");
 					const retrievedSubMap2: unknown = await retrieved.nestedObj.subMap2Handle.get();

--- a/packages/dds/map/src/test/mocha/rebasing.spec.ts
+++ b/packages/dds/map/src/test/mocha/rebasing.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import {
 	MockFluidDataStoreRuntime,
 	MockContainerRuntimeFactory,
@@ -20,7 +20,7 @@ describe("Rebasing", () => {
 	let containerRuntime1: MockContainerRuntime;
 	let containerRuntime2: MockContainerRuntime;
 
-	[
+	for (const testConfig of [
 		{
 			options: {
 				flushMode: FlushMode.Immediate,
@@ -34,7 +34,7 @@ describe("Rebasing", () => {
 			},
 			name: "FlushMode TurnBased with grouped batching",
 		},
-	].forEach((testConfig) => {
+	]) {
 		describe(`SharedMap - ${testConfig.name}`, () => {
 			let map1: SharedMap;
 			let map2: SharedMap;
@@ -139,28 +139,27 @@ describe("Rebasing", () => {
 					return;
 				}
 
-				const leftKeys = Array.from(a.keys());
-				const rightKeys = Array.from(b.keys());
+				const leftKeys = [...a.keys()];
+				const rightKeys = [...b.keys()];
 				assert.strictEqual(
 					leftKeys.length,
 					rightKeys.length,
 					"Number of keys should be the same",
 				);
-				leftKeys.forEach((key) => {
+				for (const key of leftKeys) {
 					assert.strictEqual(a.get(key), b.get(key), "Key values should be the same");
-				});
+				}
 
-				const leftSubdirectories = Array.from(a.subdirectories());
-				const rightSubdirectories = Array.from(b.subdirectories());
+				const leftSubdirectories = [...a.subdirectories()];
+				const rightSubdirectories = [...b.subdirectories()];
 				assert.strictEqual(
 					leftSubdirectories.length,
 					rightSubdirectories.length,
 					"Number of subdirectories should be the same",
 				);
 
-				leftSubdirectories.forEach(([name]) =>
-					areDirectoriesEqual(a.getSubDirectory(name), b.getSubDirectory(name)),
-				);
+				for (const [name] of leftSubdirectories)
+					areDirectoriesEqual(a.getSubDirectory(name), b.getSubDirectory(name));
 			};
 
 			it("Rebasing ops maintains eventual consistency", () => {
@@ -203,5 +202,5 @@ describe("Rebasing", () => {
 				areDirectoriesEqual(dir1, dir2);
 			});
 		});
-	});
+	}
 });

--- a/packages/dds/map/src/test/mocha/rebasing.spec.ts
+++ b/packages/dds/map/src/test/mocha/rebasing.spec.ts
@@ -133,7 +133,10 @@ describe("Rebasing", () => {
 				dir2.connect(services2);
 			});
 
-			const areDirectoriesEqual = (a: IDirectory | undefined, b: IDirectory | undefined) => {
+			const areDirectoriesEqual = (
+				a: IDirectory | undefined,
+				b: IDirectory | undefined,
+			): void => {
 				if (a === undefined || b === undefined) {
 					assert.strictEqual(a, b, "Both directories should be undefined");
 					return;

--- a/packages/dds/map/src/test/mocha/reconnection.spec.ts
+++ b/packages/dds/map/src/test/mocha/reconnection.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import {
 	MockFluidDataStoreRuntime,
 	MockContainerRuntimeFactoryForReconnection,


### PR DESCRIPTION
The "minimal" config is intended for prototype packages and repo-local infra, it is not intended for use in production libraries.

This package was migrated to the "recommended" config in the past, but at some point it was apparently downgraded back to "minimal", and a number of new linter violations were introduced. This PR fixes those violations and restores the config to the "recommended" level.