### PR TITLE
Add groupId to ISnapshotTree, ISummaryTree, ITree

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -359,7 +359,7 @@ export interface ISnapshotTree {
     blobs: {
         [path: string]: string;
     };
-    groupIdOrName?: string;
+    groupId?: string;
     // (undocumented)
     id?: string;
     // (undocumented)
@@ -446,7 +446,7 @@ export interface ISummaryTokenClaims {
 
 // @public
 export interface ISummaryTree {
-    groupIdOrName?: string;
+    groupId?: string;
     // (undocumented)
     tree: {
         [path: string]: SummaryObject;
@@ -490,7 +490,7 @@ export interface ITrace {
 export interface ITree {
     // (undocumented)
     entries: ITreeEntry[];
-    groupIdOrName?: string;
+    groupId?: string;
     id?: string;
     unreferenced?: true;
 }

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -359,6 +359,7 @@ export interface ISnapshotTree {
     blobs: {
         [path: string]: string;
     };
+    groupIdOrName?: string;
     // (undocumented)
     id?: string;
     // (undocumented)
@@ -445,6 +446,7 @@ export interface ISummaryTokenClaims {
 
 // @public
 export interface ISummaryTree {
+    groupIdOrName?: string;
     // (undocumented)
     tree: {
         [path: string]: SummaryObject;
@@ -488,6 +490,7 @@ export interface ITrace {
 export interface ITree {
     // (undocumented)
     entries: ITreeEntry[];
+    groupIdOrName?: string;
     id?: string;
     unreferenced?: true;
 }

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -123,7 +123,7 @@ export interface ITree {
 	 * the client, and this tree is missing in that snapshot, then this could be used to request the contents
 	 * from the service.
 	 */
-	groupIdOrName?: string;
+	groupId?: string;
 }
 
 /**
@@ -144,7 +144,7 @@ export interface ISnapshotTree {
 	 * the client, and this tree is missing in that snapshot, then this could be used to request the contents
 	 * from the service.
 	 */
-	groupIdOrName?: string;
+	groupId?: string;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -117,6 +117,13 @@ export interface ITree {
 	 * Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
 	 */
 	unreferenced?: true;
+
+	/**
+	 * Represents the group to which the tree belongs to. When the server returns the snapshot to
+	 * the client, and this tree is missing in that snapshot, then this could be used to request the contents
+	 * from the service.
+	 */
+	groupIdOrName?: string;
 }
 
 /**
@@ -131,6 +138,13 @@ export interface ISnapshotTree {
 	 * Indicates that this tree is unreferenced. If this is not present, the tree is considered referenced.
 	 */
 	unreferenced?: true;
+
+	/**
+	 * Represents the group to which the snapshot tree belongs to. When the server returns the snapshot to
+	 * the client, and this tree is missing in that snapshot, then this could be used to request the contents
+	 * from the service.
+	 */
+	groupIdOrName?: string;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/summary.ts
+++ b/common/lib/protocol-definitions/src/summary.ts
@@ -165,4 +165,11 @@ export interface ISummaryTree {
 	 * If this is not present, the tree entry is considered referenced.
 	 */
 	unreferenced?: true;
+
+	/**
+	 * Represents the group to which the summary tree belongs to. The server stores this info and when it returns the
+	 * snapshot to the client, and this tree is missing in that snapshot, then this could be used to request the contents
+	 * from the service.
+	 */
+	groupIdOrName?: string;
 }

--- a/common/lib/protocol-definitions/src/summary.ts
+++ b/common/lib/protocol-definitions/src/summary.ts
@@ -171,5 +171,5 @@ export interface ISummaryTree {
 	 * snapshot to the client, and this tree is missing in that snapshot, then this could be used to request the contents
 	 * from the service.
 	 */
-	groupIdOrName?: string;
+	groupId?: string;
 }


### PR DESCRIPTION
## Description

Add groupId to ISnapshotTree, ISummaryTree, ITree. This groupId will be used to fetch the missing part of the snapsot from the service when they are required.  When the server returns the snapshot to the client, and some tree is missing in that snapshot, then this groupId could be used to request the missing contents from the service.

Base design is present in this doc: [Design Doc](https://microsoft.sharepoint.com/:w:/t/FluidFramework/ESJQvukxffJNiTZzbNCWky4B891mpOpWD7BHhbOznXsMZg?e=UsxB7J)

This concept is talked here but missing in base design where "priority" is used. Will update the base doc with this info:
[Doc Consisting info for the groupIdOrName concept](https://microsoft.sharepoint-df.com/:fl:/g/contentstorage/CSP_e47249b7-d3bf-4f0b-9113-302661c1cf90/EZ0vH8pnufROnyNoUCjZYdUBOXP3t-6wRJvDbRCxcjQh9g?e=3daO3i&nav=cz0lMkZjb250ZW50c3RvcmFnZSUyRkNTUF9lNDcyNDliNy1kM2JmLTRmMGItOTExMy0zMDI2NjFjMWNmOTAmZD1iJTIxdDBseTVMX1RDMC1SRXpBbVljSFBrSTJHYURvUTZnRkh2a0g4SmdoU0lqQ0Y1RnNwZGg5elNMSG5ZMktKaVRhZSZmPTAxNjY0RFNKNDVGNFA0VVo1WjZSSEo2STNJS0FVTlNZT1YmYz0lMkYmYT1Mb29wQXBwJnA9JTQwZmx1aWR4JTJGbG9vcC1wYWdlLWNvbnRhaW5lcg%3D%3D)