### PR TITLE
Disable flaky test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -391,7 +391,11 @@ describeCompat("Message size", "2.0.0-rc.1.0.0", (getTestObjectProvider, apis) =
 					).timeout(chunkingBatchesTimeoutMs);
 				}));
 
-			itExpects(
+			/**
+			 * ADO:6510 to investigate and re-enable.
+			 * The test times out likely due to its nature of creating large payloads.
+			 */
+			itExpects.skip(
 				"Large ops fail when compression chunking is disabled by feature gate",
 				[
 					{


### PR DESCRIPTION
## Description

ADO:6510 - the test often times out
