### PR TITLE
fix(client): use @ungap/structuredClone for structuredClone implementation

### DIFF
--- a/examples/client-logger/app-insights-logger/src/test/components/App.test.tsx
+++ b/examples/client-logger/app-insights-logger/src/test/components/App.test.tsx
@@ -7,9 +7,9 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import { App } from "../../components";
 
-// TODO: update ESM configuration and re-enable test
 describe("App Insights Example App UI test", () => {
-	xit("App renders", async (): Promise<void> => {
+	// TODO: update ESM configuration and re-enable test: ADO 7001
+	it.skip("App renders", async (): Promise<void> => {
 		render(<App />);
 		await screen.findByText("Loading Shared container...");
 	});

--- a/examples/client-logger/app-insights-logger/src/test/components/App.test.tsx
+++ b/examples/client-logger/app-insights-logger/src/test/components/App.test.tsx
@@ -7,8 +7,9 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import { App } from "../../components";
 
+// TODO: update ESM configuration and re-enable test
 describe("App Insights Example App UI test", () => {
-	it("App renders", async (): Promise<void> => {
+	xit("App renders", async (): Promise<void> => {
 		render(<App />);
 		await screen.findByText("Loading Shared container...");
 	});

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -107,7 +107,7 @@
 		"@types/easy-table": "^0.0.32",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",
-		"@types/ungap__structured-clone": "^0.3.0",
+		"@types/ungap__structured-clone": "^1.2.0",
 		"@types/uuid": "^9.0.2",
 		"ajv": "^8.12.0",
 		"ajv-formats": "^2.1.1",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -97,7 +97,6 @@
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@microsoft/applicationinsights-web": "^2.8.11",
-		"@types/ungap__structured-clone": "^1.2.0",
 		"@ungap/structured-clone": "^1.2.0"
 	},
 	"devDependencies": {
@@ -109,6 +108,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^7.0.13",
+		"@types/ungap__structured-clone": "^1.2.0",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -97,6 +97,7 @@
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@microsoft/applicationinsights-web": "^2.8.11",
+		"@types/ungap__structured-clone": "^1.2.0",
 		"@ungap/structured-clone": "^1.2.0"
 	},
 	"devDependencies": {

--- a/packages/framework/client-logger/app-insights-logger/package.json
+++ b/packages/framework/client-logger/app-insights-logger/package.json
@@ -96,7 +96,8 @@
 	"dependencies": {
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"@microsoft/applicationinsights-web": "^2.8.11"
+		"@microsoft/applicationinsights-web": "^2.8.11",
+		"@ungap/structured-clone": "^1.2.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.13.3",

--- a/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
@@ -9,6 +9,7 @@ import {
 	type ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
 import { type TelemetryEventCategory } from "@fluidframework/telemetry-utils";
+import structuredClone from "@ungap/structured-clone";
 
 /**
  * The configuration object for creating the logger via {@link createLogger}.

--- a/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
@@ -134,9 +134,6 @@ class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 	private readonly baseLoggingClient: ApplicationInsights;
 	private readonly config: FluidAppInsightsLoggerConfig;
 
-	private cloneConfig(config: FluidAppInsightsLoggerConfig): FluidAppInsightsLoggerConfig {
-		return structuredClone(config) as FluidAppInsightsLoggerConfig;
-	}
 	public constructor(client: ApplicationInsights, config?: FluidAppInsightsLoggerConfig) {
 		this.baseLoggingClient = client;
 		// Deep copy config to prevent issues if user mutates the object they passed in

--- a/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
@@ -133,11 +133,15 @@ class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 	 */
 	private readonly baseLoggingClient: ApplicationInsights;
 	private readonly config: FluidAppInsightsLoggerConfig;
+
+	private cloneConfig(config: FluidAppInsightsLoggerConfig): FluidAppInsightsLoggerConfig {
+		return structuredClone(config) as FluidAppInsightsLoggerConfig;
+	}
 	public constructor(client: ApplicationInsights, config?: FluidAppInsightsLoggerConfig) {
 		this.baseLoggingClient = client;
 		// Deep copy config to prevent issues if user mutates the object they passed in
 		this.config = config
-			? structuredClone(config) as FluidAppInsightsLoggerConfig
+			? (structuredClone(config) as FluidAppInsightsLoggerConfig)
 			: {
 					filtering: {
 						mode: "exclusive",

--- a/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
@@ -133,12 +133,11 @@ class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 	 */
 	private readonly baseLoggingClient: ApplicationInsights;
 	private readonly config: FluidAppInsightsLoggerConfig;
-
 	public constructor(client: ApplicationInsights, config?: FluidAppInsightsLoggerConfig) {
 		this.baseLoggingClient = client;
 		// Deep copy config to prevent issues if user mutates the object they passed in
 		this.config = config
-			? (structuredClone(config) as FluidAppInsightsLoggerConfig)
+			? structuredClone(config)
 			: {
 					filtering: {
 						mode: "exclusive",

--- a/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
+++ b/packages/framework/client-logger/app-insights-logger/src/fluidAppInsightsLogger.ts
@@ -137,7 +137,7 @@ class FluidAppInsightsLogger implements ITelemetryBaseLogger {
 		this.baseLoggingClient = client;
 		// Deep copy config to prevent issues if user mutates the object they passed in
 		this.config = config
-			? structuredClone(config)
+			? structuredClone(config) as FluidAppInsightsLoggerConfig
 			: {
 					filtering: {
 						mode: "exclusive",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -200,6 +200,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^7.0.13",
+		"@types/ungap__structured-clone": "^1.2.0",
 		"c8": "^8.0.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -177,6 +177,7 @@
 		"@fluidframework/protocol-base": "^3.0.0",
 		"@fluidframework/protocol-definitions": "^3.1.0",
 		"@fluidframework/telemetry-utils": "workspace:~",
+		"@ungap/structured-clone": "^1.2.0",
 		"debug": "^4.3.4",
 		"double-ended-queue": "^2.1.0-0",
 		"events": "^3.1.0",

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -87,6 +87,7 @@ import {
 	GenericError,
 	UsageError,
 } from "@fluidframework/telemetry-utils";
+import structuredClone from "@ungap/structured-clone";
 import { Audience } from "./audience";
 import { ContainerContext } from "./containerContext";
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8376,6 +8376,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
       '@types/sinon': ^7.0.13
+      '@types/ungap__structured-clone': ^1.2.0
       '@ungap/structured-clone': ^1.2.0
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -8395,6 +8396,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@fluidframework/telemetry-utils': link:../../../utils/telemetry-utils
       '@microsoft/applicationinsights-web': 2.8.16_tslib@1.14.1
+      '@types/ungap__structured-clone': 1.2.0
       '@ungap/structured-clone': 1.2.0
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
@@ -22635,6 +22637,10 @@ packages:
   /@types/ungap__structured-clone/0.3.3:
     resolution: {integrity: sha512-RNmhIPwoip6K/zZOv3ypksTAqaqLEXvlNSXKyrC93xMSOAHZCR7PifW6xKZCwkbbnbM9dwB9X56PPoNTlNwEqw==}
     dev: true
+
+  /@types/ungap__structured-clone/1.2.0:
+    resolution: {integrity: sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==}
+    dev: false
 
   /@types/unist/2.0.10:
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
@@ -42067,7 +42073,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.24.0
-      webpack: 5.89.0_webpack-cli@4.10.0
+      webpack: 5.89.0
 
   /terser/4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -44445,7 +44451,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /webpack/5.89.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8396,7 +8396,6 @@ importers:
       '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@fluidframework/telemetry-utils': link:../../../utils/telemetry-utils
       '@microsoft/applicationinsights-web': 2.8.16_tslib@1.14.1
-      '@types/ungap__structured-clone': 1.2.0
       '@ungap/structured-clone': 1.2.0
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
@@ -8407,6 +8406,7 @@ importers:
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
       '@types/sinon': 7.5.2
+      '@types/ungap__structured-clone': 1.2.0
       copyfiles: 2.4.1
       cross-env: 7.0.3
       eslint: 8.50.0
@@ -9081,6 +9081,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
       '@types/sinon': ^7.0.13
+      '@types/ungap__structured-clone': ^1.2.0
       '@ungap/structured-clone': ^1.2.0
       c8: ^8.0.1
       copyfiles: ^2.4.1
@@ -9132,6 +9133,7 @@ importers:
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
       '@types/sinon': 7.5.2
+      '@types/ungap__structured-clone': 1.2.0
       c8: 8.0.1
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -22640,7 +22642,7 @@ packages:
 
   /@types/ungap__structured-clone/1.2.0:
     resolution: {integrity: sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==}
-    dev: false
+    dev: true
 
   /@types/unist/2.0.10:
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
@@ -42073,7 +42075,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.24.0
-      webpack: 5.89.0
+      webpack: 5.89.0_webpack-cli@4.10.0
 
   /terser/4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -44451,6 +44453,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /webpack/5.89.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8376,6 +8376,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
       '@types/sinon': ^7.0.13
+      '@ungap/structured-clone': ^1.2.0
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
       eslint: ~8.50.0
@@ -8394,6 +8395,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../../common/core-interfaces
       '@fluidframework/telemetry-utils': link:../../../utils/telemetry-utils
       '@microsoft/applicationinsights-web': 2.8.16_tslib@1.14.1
+      '@ungap/structured-clone': 1.2.0
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
       '@fluidframework/build-common': 2.0.3
@@ -9077,6 +9079,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
       '@types/sinon': ^7.0.13
+      '@ungap/structured-clone': ^1.2.0
       c8: ^8.0.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -9105,6 +9108,7 @@ importers:
       '@fluidframework/protocol-base': 3.0.0
       '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
+      '@ungap/structured-clone': 1.2.0
       debug: 4.3.4
       double-ended-queue: 2.1.0-0
       events: 3.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7268,7 +7268,7 @@ importers:
       '@types/easy-table': ^0.0.32
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
-      '@types/ungap__structured-clone': ^0.3.0
+      '@types/ungap__structured-clone': ^1.2.0
       '@types/uuid': ^9.0.2
       '@ungap/structured-clone': ^1.2.0
       ajv: ^8.12.0
@@ -7325,7 +7325,7 @@ importers:
       '@types/easy-table': 0.0.32
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
-      '@types/ungap__structured-clone': 0.3.3
+      '@types/ungap__structured-clone': 1.2.0
       '@types/uuid': 9.0.7
       ajv: 8.12.0
       ajv-formats: 2.1.1_ajv@8.12.0
@@ -22634,10 +22634,6 @@ packages:
 
   /@types/underscore/1.11.15:
     resolution: {integrity: sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g==}
-    dev: true
-
-  /@types/ungap__structured-clone/0.3.3:
-    resolution: {integrity: sha512-RNmhIPwoip6K/zZOv3ypksTAqaqLEXvlNSXKyrC93xMSOAHZCR7PifW6xKZCwkbbnbM9dwB9X56PPoNTlNwEqw==}
     dev: true
 
   /@types/ungap__structured-clone/1.2.0:


### PR DESCRIPTION
Updating structuredClone usage to explicit import from @ungap/structuredClone to align with Loop's browser support matrix and to prevent issues with structuredClone not being available in Jest test environment. https://www.npmjs.com/package/@ungap/structured-clone?activeTab=readme

Jest test for app-insights-logger seems to be resulting with a false pass due to some underlying ESM configuration issues:
https://dev.azure.com/fluidframework/internal/_build/results?buildId=230705&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=ca111d9b-56f7-5b3d-b8f6-661164061440&l=1359
skipping test for app-insights-logger example for now. Follow up item to resolve test issues: https://dev.azure.com/fluidframework/internal/_workitems/edit/7001