### PR TITLE
server: Update Gitrest and Historian logger setups

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/logger.ts
+++ b/server/gitrest/packages/gitrest-base/src/logger.ts
@@ -38,7 +38,7 @@ const defaultLumberjackConfig: ILumberjackConfig = {
  * IMPORTANT: call this after `configureLogging` has been called, if calling both, so that Lumberjack is not
  * setup twice, which will throw an error. `configureLogging` does not do a safety check when setting up Lumberjack.
  */
-export function configureLogging(configOrPath: Provider | string) {
+export function configureGitRestLogging(configOrPath: Provider | string) {
 	// If package versions are not mismatched, this check will ensure this function does nothing.
 	if (Lumberjack.isSetupCompleted()) {
 		return;

--- a/server/gitrest/packages/gitrest-base/src/logger.ts
+++ b/server/gitrest/packages/gitrest-base/src/logger.ts
@@ -7,9 +7,29 @@ import nconf, { Provider } from "nconf";
 import { WinstonLumberjackEngine } from "@fluidframework/server-services-utils";
 import {
 	ILumberjackEngine,
+	ILumberjackOptions,
 	ILumberjackSchemaValidator,
 	Lumberjack,
 } from "@fluidframework/server-services-telemetry";
+
+// TODO: this is duplicate code from `@fluidframework/server-services-utils` configureLogging()
+// to avoid adding duplicate transports to the global `winston` instance. This should just call
+// configureLogging() once global winston usage is removed in favor of Lumberjack.
+// Also, once `enableGlobalTelemetryContext` is default to `true` this will be unnecessary.
+
+export interface ILumberjackConfig {
+	engineList: ILumberjackEngine[];
+	schemaValidator?: ILumberjackSchemaValidator[];
+	options?: Partial<ILumberjackOptions>;
+}
+const defaultLumberjackConfig: ILumberjackConfig = {
+	engineList: [new WinstonLumberjackEngine()],
+	schemaValidator: undefined,
+	options: {
+		enableGlobalTelemetryContext: false,
+		enableSanitization: false,
+	},
+};
 
 /**
  * Helps to avoid package version mismatch issues with usage of global Lumberjack instance.
@@ -18,30 +38,31 @@ import {
  * IMPORTANT: call this after `configureLogging` has been called, if calling both, so that Lumberjack is not
  * setup twice, which will throw an error. `configureLogging` does not do a safety check when setting up Lumberjack.
  */
-export function configureGitRestLogging(configOrPath: Provider | string) {
+export function configureLogging(configOrPath: Provider | string) {
 	// If package versions are not mismatched, this check will ensure this function does nothing.
-	if (!Lumberjack.isSetupCompleted()) {
-		// TODO: this is duplicate code from `@fluidframework/server-services-utils` configureLogging()
-		// to avoid adding duplicate transports to the global `winston` instance. This should just call
-		// configureLogging() once global winston usage is removed in favor of Lumberjack.
-		const config =
-			typeof configOrPath === "string"
-				? nconf
-						.argv()
-						.env({ separator: "__", parseValues: true })
-						.file(configOrPath)
-						.use("memory")
-				: configOrPath;
-
-		const lumberjackConfig = config.get("lumberjack");
-		const engineList = (lumberjackConfig?.engineList as ILumberjackEngine[] | undefined) ?? [
-			new WinstonLumberjackEngine(),
-		];
-
-		const schemaValidatorList = lumberjackConfig?.schemaValidator as
-			| ILumberjackSchemaValidator[]
-			| undefined;
-
-		Lumberjack.setup(engineList, schemaValidatorList);
+	if (Lumberjack.isSetupCompleted()) {
+		return;
 	}
+	const config =
+		typeof configOrPath === "string"
+			? nconf
+					.argv()
+					.env({ separator: "__", parseValues: true })
+					.file(configOrPath)
+					.use("memory")
+			: configOrPath;
+
+	const lumberjackConfig: ILumberjackConfig = {
+		...defaultLumberjackConfig,
+		...(config.get("lumberjack") as Partial<ILumberjackConfig>),
+	};
+	lumberjackConfig.options = {
+		...defaultLumberjackConfig.options,
+		...lumberjackConfig.options,
+	};
+	Lumberjack.setup(
+		lumberjackConfig.engineList,
+		lumberjackConfig.schemaValidator,
+		lumberjackConfig.options,
+	);
 }

--- a/server/routerlicious/packages/services-telemetry/src/lumberjack.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberjack.ts
@@ -63,11 +63,11 @@ export class Lumberjack {
 			}
 			return getGlobalLumberjackInstance() as Lumberjack;
 		}
-		if (!Lumberjack._instance) {
-			Lumberjack._instance = new Lumberjack();
+		if (!this._instance) {
+			this._instance = new Lumberjack();
 		}
 
-		return Lumberjack._instance;
+		return this._instance;
 	}
 
 	protected static set options(options: Partial<ILumberjackOptions> | undefined) {

--- a/server/routerlicious/packages/services-telemetry/src/lumberjackCommonTestUtils.ts
+++ b/server/routerlicious/packages/services-telemetry/src/lumberjackCommonTestUtils.ts
@@ -19,7 +19,7 @@ import {
  */
 export class TestLumberjack extends Lumberjack {
 	public static reset() {
-		Lumberjack._instance = undefined;
+		this._instance = undefined;
 	}
 }
 

--- a/server/routerlicious/packages/services-telemetry/src/test/lumberjack.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/lumberjack.spec.ts
@@ -22,7 +22,7 @@ describe("Lumberjack", () => {
 		const engine = new TestEngine1();
 		TestLumberjack.setup([engine]);
 		TestLumberjack.newLumberMetric(LumberEventName.UnitTestEvent);
-		assert.strictEqual(handleErrorStub.notCalled, true);
+		assert.strictEqual(handleErrorStub.notCalled, true, "Handle error should not be called.");
 	});
 
 	it("Sets up a custom Lumberjack instance and creates a Lumber metric.", () => {
@@ -30,7 +30,7 @@ describe("Lumberjack", () => {
 		const engine = new TestEngine1();
 		const customInstance = TestLumberjack.createInstance([engine]);
 		customInstance.newLumberMetric(LumberEventName.UnitTestEvent);
-		assert.strictEqual(handleErrorStub.notCalled, true);
+		assert.strictEqual(handleErrorStub.notCalled, true, "Handle error should not be called.");
 	});
 
 	it("Setting up custom instance of Lumberjack should not interfere with the global instance.", () => {
@@ -39,7 +39,7 @@ describe("Lumberjack", () => {
 		const engine2 = new TestEngine2();
 		TestLumberjack.setup([engine1]);
 		TestLumberjack.createInstance([engine2]);
-		assert.strictEqual(handleErrorStub.notCalled, true);
+		assert.strictEqual(handleErrorStub.notCalled, true, "Handle error should not be called.");
 	});
 
 	it("An error should be logged when trying to setup Lumberjack more than once.", () => {
@@ -47,21 +47,21 @@ describe("Lumberjack", () => {
 		const engine1 = new TestEngine1();
 		const engine2 = new TestEngine2();
 		TestLumberjack.setup([engine1]);
-		assert.strictEqual(handleErrorStub.notCalled, true);
+		assert.strictEqual(handleErrorStub.notCalled, true, "Handle error should not be called.");
 		TestLumberjack.setup([engine2]);
-		assert.strictEqual(handleErrorStub.calledOnce, true);
+		assert.strictEqual(handleErrorStub.calledOnce, true, "Handle error should be called once.");
 	});
 
 	it("Lumberjack should fail when trying to use it with an empty engine list.", () => {
 		const handleErrorStub = Sinon.stub(resources, "handleError");
 		TestLumberjack.setup([]);
-		assert.strictEqual(handleErrorStub.calledOnce, true);
+		assert.strictEqual(handleErrorStub.calledOnce, true, "Handle error should be called once.");
 	});
 
 	it("Lumberjack should fail when trying to create a metric before being properly set up.", () => {
 		const handleErrorStub = Sinon.stub(resources, "handleError");
 		TestLumberjack.newLumberMetric(LumberEventName.UnitTestEvent);
-		assert.strictEqual(handleErrorStub.calledOnce, true);
+		assert.strictEqual(handleErrorStub.calledOnce, true, "Handle error should be called once.");
 	});
 });
 

--- a/server/routerlicious/packages/services-telemetry/src/test/lumberjack.spec.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/lumberjack.spec.ts
@@ -8,7 +8,7 @@ import Sinon from "sinon";
 import { TestEngine1, TestEngine2, TestLumberjack } from "../lumberjackCommonTestUtils";
 import { LumberEventName } from "../lumberEventNames";
 import * as resources from "../resources";
-import { setGlobalLumberjackInstance } from "../lumberjack";
+import { getGlobalLumberjackInstance, setGlobalLumberjackInstance } from "../lumberjack";
 
 describe("Lumberjack", () => {
 	afterEach(() => {
@@ -62,5 +62,32 @@ describe("Lumberjack", () => {
 		const handleErrorStub = Sinon.stub(resources, "handleError");
 		TestLumberjack.newLumberMetric(LumberEventName.UnitTestEvent);
 		assert.strictEqual(handleErrorStub.calledOnce, true);
+	});
+});
+
+describe("Global Lumberjack", () => {
+	afterEach(() => {
+		TestLumberjack.reset();
+		Sinon.restore();
+		setGlobalLumberjackInstance(undefined);
+	});
+
+	it("Sets up Lumberjack's global instance.", () => {
+		const engine = new TestEngine1();
+		const engine2 = new TestEngine2();
+		const handleErrorStub = Sinon.stub(resources, "handleError");
+		assert.strictEqual(
+			undefined,
+			getGlobalLumberjackInstance(),
+			"Global instance should be undefined",
+		);
+		TestLumberjack.setup([engine], undefined, { enableGlobalTelemetryContext: true });
+		assert(getGlobalLumberjackInstance(), "Global instance should be set");
+		assert(TestLumberjack.isSetupCompleted(), "Setup should be completed");
+		assert.strictEqual(handleErrorStub.notCalled, true, "Setup should not have caused errors");
+		getGlobalLumberjackInstance().setup([engine2], undefined, {
+			enableGlobalTelemetryContext: true,
+		});
+		assert.strictEqual(handleErrorStub.calledOnce, true, "setup should have caused an error");
 	});
 });


### PR DESCRIPTION
## Description

#17030 updated the `services-utils` `configureLogging()` method with additional options. However, we didn't update the _duplicate_ code in Gitrest and Historian. This means that in FRS, where we have version mismatches for Historian and Gitrest and Routerlicious, the different Lumberjack imports had different static settings, which results in TelemetryContext being hard-disabled in FRS.
