### PR TITLE
Load mjs source maps in webpack configs

### DIFF
--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/webpack.config.js
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
 				exclude: /node_modules/,
 			},
 			{
-				test: /\.js$/,
+				test: /\.m?js$/,
 				use: [require.resolve("source-map-loader")],
 				enforce: "pre",
 			},

--- a/examples/data-objects/monaco/webpack.config.cjs
+++ b/examples/data-objects/monaco/webpack.config.cjs
@@ -36,7 +36,7 @@ module.exports = (env) => {
 					// This example currently has missing sourcemap issues.
 					// Disabling source mapping allows it to be runnable with these issues.
 					// {
-					//     test: /\.js$/,
+					//     test: /\.m?js$/,
 					//     use: [require.resolve("source-map-loader")],
 					//     enforce: "pre"
 					// },

--- a/examples/data-objects/table-view/webpack.config.js
+++ b/examples/data-objects/table-view/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = (env) => {
 						exclude: /node_modules/,
 					},
 					{
-						test: /\.js$/,
+						test: /\.m?js$/,
 						use: [require.resolve("source-map-loader")],
 						enforce: "pre",
 					},

--- a/examples/data-objects/todo/webpack.config.js
+++ b/examples/data-objects/todo/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = (env) => {
 						],
 					},
 					{
-						test: /\.js$/,
+						test: /\.m?js$/,
 						use: [require.resolve("source-map-loader")],
 						enforce: "pre",
 					},

--- a/examples/utils/bundle-size-tests/webpack.config.js
+++ b/examples/utils/bundle-size-tests/webpack.config.js
@@ -60,7 +60,7 @@ webpackModuleRules.push(
 		exclude: /node_modules/,
 	},
 	{
-		test: /\.js$/,
+		test: /\.m?js$/,
 		use: [require.resolve("source-map-loader")],
 		enforce: "pre",
 	},

--- a/experimental/PropertyDDS/examples/property-inspector/webpack.config.js
+++ b/experimental/PropertyDDS/examples/property-inspector/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = (env) => {
 					loader: "ts-loader",
 				},
 				{
-					test: /\.js$/,
+					test: /\.m?js$/,
 					use: ["source-map-loader"],
 				},
 			],

--- a/packages/tools/webpack-fluid-loader/webpack.config.js
+++ b/packages/tools/webpack-fluid-loader/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
 				exclude: /node_modules/,
 			},
 			{
-				test: /\.js$/,
+				test: /\.m?js$/,
 				use: [require.resolve("source-map-loader")],
 				enforce: "pre",
 			},

--- a/server/routerlicious/packages/lambdas/src/test/webpack.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/webpack.spec.ts
@@ -25,7 +25,7 @@ const config: webpack.Configuration = {
 				exclude: /node_modules/,
 			},
 			{
-				test: /\.js$/,
+				test: /\.m?js$/,
 				use: [require.resolve("source-map-loader")],
 				enforce: "pre",
 			},


### PR DESCRIPTION
## Description

Adjusts the rule for `source-map-loader` to include `.mjs` files as well as `.js` files. This should fix some issues with source-mapping dependent packages while debugging our examples or setups running webpacked versions of our examples.

Before:

![image](https://github.com/microsoft/FluidFramework/assets/5222607/c0fb8386-05bf-4dce-aed5-786beb408a33)


After:

![image](https://github.com/microsoft/FluidFramework/assets/5222607/33d5c045-250f-44bb-9709-c3eca8899ef2)

