### PR TITLE
ci(docs): Remove unneeded step in build:docs pipeline

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -202,13 +202,6 @@ stages:
           submodules: false
           clean: true
 
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Copy api-extractor JSON to staging folder'
-          inputs:
-            source: current
-            artifact: api-extractor-combined
-            path: '$(Build.SourcesDirectory)/_api-extractor-temp/doc-models'
-
         - template: templates/include-use-node-version.yml
 
         - template: templates/include-install-pnpm.yml


### PR DESCRIPTION
The npm script `build` (and by extension `ci:build) was previously updated to perform the necessary steps to download and stage the appropriate API model artifacts for API documentation generation. The removed step here is a legacy one that used to serve this purpose, but no longer does. The artifact being downloaded by this step was completely ignored by the website build.