### PR TITLE
Reapply fix(matrix): Expand collab window to include refSeqs of in-flight ops

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -43,6 +43,7 @@ tools/pipelines/
 # Test json
 build-tools/packages/build-tools/src/test/data/
 experimental/dds/tree/src/test/documents/
+packages/dds/matrix/src/test/results/**/*.json
 packages/dds/merge-tree/src/test/literature/*.txt
 packages/dds/merge-tree/src/test/results/*.json
 packages/dds/sequence/src/test/snapshots/**/*.json

--- a/packages/dds/matrix/.eslintrc.cjs
+++ b/packages/dds/matrix/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
 			files: ["*.spec.ts", "src/test/**"],
 			rules: {
 				// Test files are run in node only so additional node libraries can be used.
-				"import/no-nodejs-modules": ["error", { allow: ["assert", "events"] }],
+				"import/no-nodejs-modules": ["error", { allow: ["assert", "events", "path"] }],
 			},
 		},
 	],

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -130,11 +130,13 @@
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@tiny-calc/nano": "0.0.0-alpha.5",
+		"double-ended-queue": "^2.1.0-0",
 		"events": "^3.1.0",
 		"tslib": "^1.10.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.13.3",
+		"@fluid-private/stochastic-test-utils": "workspace:~",
 		"@fluid-private/test-dds-utils": "workspace:~",
 		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.29.0",
@@ -146,6 +148,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.38.3",
 		"@tiny-calc/micro": "0.0.0-alpha.5",
+		"@types/double-ended-queue": "^2.1.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",
 		"best-random": "^1.0.0",

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -142,6 +142,15 @@ export class SharedMatrix<T = any>
 		return new SharedMatrixFactory();
 	}
 
+	/**
+	 * Note: this field only provides a lower-bound on the reference sequence numbers for in-flight ops.
+	 * The exact reason isn't understood, but some e2e tests suggest that the runtime may sometimes process
+	 * incoming leave/join ops before putting an op that this DDS submits over the wire.
+	 *
+	 * E.g. SharedMatrix submits an op while deltaManager has lastSequenceNumber = 10, but before the runtime
+	 * puts this op over the wire, it processes a client join/leave op with sequence number 11, so the referenceSequenceNumber
+	 * on the SharedMatrix op is 11.
+	 */
 	private readonly inFlightRefSeqs = new Deque<number>();
 
 	private readonly rows: PermutationVector; // Map logical row to storage handle (if any)

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import Deque from "double-ended-queue";
 import { assert } from "@fluidframework/core-utils";
 import { IEventThisPlaceHolder } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -141,6 +142,8 @@ export class SharedMatrix<T = any>
 		return new SharedMatrixFactory();
 	}
 
+	private readonly inFlightRefSeqs = new Deque<number>();
+
 	private readonly rows: PermutationVector; // Map logical row to storage handle (if any)
 	private readonly cols: PermutationVector; // Map logical col to storage handle (if any)
 
@@ -172,12 +175,14 @@ export class SharedMatrix<T = any>
 
 		this.setCellLwwToFwwPolicySwitchOpSeqNumber =
 			_isSetCellConflictResolutionPolicyFWW === true ? 0 : -1;
+		const getMinInFlightRefSeq = () => this.inFlightRefSeqs.get(0);
 		this.rows = new PermutationVector(
 			SnapshotPath.rows,
 			this.logger,
 			runtime,
 			this.onRowDelta,
 			this.onRowHandlesRecycled,
+			getMinInFlightRefSeq,
 		);
 
 		this.cols = new PermutationVector(
@@ -186,6 +191,7 @@ export class SharedMatrix<T = any>
 			runtime,
 			this.onColDelta,
 			this.onColHandlesRecycled,
+			getMinInFlightRefSeq,
 		);
 	}
 
@@ -351,9 +357,9 @@ export class SharedMatrix<T = any>
 		rowHandle: Handle,
 		colHandle: Handle,
 		localSeq = this.nextLocalSeq(),
-		rowsRefSeq = this.rows.getCollabWindow().currentSeq,
-		colsRefSeq = this.cols.getCollabWindow().currentSeq,
 	) {
+		const rowsRefSeq = this.rows.getCollabWindow().currentSeq;
+		const colsRefSeq = this.cols.getCollabWindow().currentSeq;
 		assert(
 			this.isAttached(),
 			0x1e2 /* "Caller must ensure 'isAttached()' before calling 'sendSetCellOp'." */,
@@ -574,6 +580,7 @@ export class SharedMatrix<T = any>
 			0x01d /* "Trying to submit message to runtime while detached!" */,
 		);
 
+		this.inFlightRefSeqs.push(this.runtime.deltaManager.lastSequenceNumber);
 		super.submitLocalMessage(
 			makeHandlesSerializable(message, this.serializer, this.handle),
 			localOpMetadata,
@@ -627,6 +634,7 @@ export class SharedMatrix<T = any>
 	}
 
 	protected reSubmitCore(content: any, localOpMetadata: unknown) {
+		this.inFlightRefSeqs.shift();
 		switch (content.target) {
 			case SnapshotPath.cols:
 				this.submitColMessage(
@@ -679,16 +687,7 @@ export class SharedMatrix<T = any>
 						lastCellModificationDetails === undefined ||
 						referenceSeqNumber >= lastCellModificationDetails.seqNum
 					) {
-						this.sendSetCellOp(
-							row,
-							col,
-							setOp.value,
-							rowHandle,
-							colHandle,
-							localSeq,
-							rowsRefSeq,
-							colsRefSeq,
-						);
+						this.sendSetCellOp(row, col, setOp.value, rowHandle, colHandle, localSeq);
 					} else if (this.pending.getCell(rowHandle, colHandle) !== undefined) {
 						// Clear the pending changes if any as we are not sending the op.
 						this.pending.setCell(rowHandle, colHandle, undefined);
@@ -763,6 +762,12 @@ export class SharedMatrix<T = any>
 		local: boolean,
 		localOpMetadata: unknown,
 	) {
+		if (local) {
+			assert(
+				this.inFlightRefSeqs.shift() === rawMessage.referenceSequenceNumber,
+				"RefSeq mismatch",
+			);
+		}
 		const msg = parseHandles(rawMessage, this.serializer);
 
 		const contents = msg.contents;

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -135,15 +135,17 @@ export class PermutationVector extends Client {
 			numInserted: number,
 		) => void,
 		private readonly handlesRecycledCallback: (handles: Handle[]) => void,
+		getMinInFlightRefSeq: () => number | undefined,
 	) {
 		super(
 			PermutationSegment.fromJSONObject,
 			createChildLogger({ logger, namespace: `Matrix.${path}.MergeTreeClient` }),
 			{
 				...runtime.options,
-				newMergeTreeSnapshotFormat: true, // Temporarily force new snapshot format until it is the default.
+				newMergeTreeSnapshotFormat: true, // Force new snapshot format as it's generally more efficient for matrices.
 			},
-		); // (See https://github.com/microsoft/FluidFramework/issues/84)
+			getMinInFlightRefSeq,
+		);
 
 		this.on("delta", this.onDelta);
 		this.on("maintenance", this.onMaintenance);

--- a/packages/dds/matrix/src/test/matrix.applyStashedOp.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.applyStashedOp.spec.ts
@@ -1,0 +1,127 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+	MockFluidDataStoreRuntime,
+	MockContainerRuntimeFactoryForReconnection,
+	MockContainerRuntimeForReconnection,
+	MockStorage,
+	MockDeltaConnection,
+} from "@fluidframework/test-runtime-utils";
+import { ISequencedDocumentMessage, ISummaryTree } from "@fluidframework/protocol-definitions";
+import { SharedMatrix, SharedMatrixFactory } from "../index";
+import { extract } from "./utils";
+
+async function createMatrixForReconnection(
+	id: string,
+	runtimeFactory: MockContainerRuntimeFactoryForReconnection,
+	summary?: ISummaryTree,
+	overrides?: { minimumSequenceNumber?: number },
+): Promise<{
+	matrix: SharedMatrix;
+	containerRuntime: MockContainerRuntimeForReconnection;
+	deltaConnection: MockDeltaConnection;
+}> {
+	const dataStoreRuntime = new MockFluidDataStoreRuntime();
+	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime, overrides);
+	const services = {
+		deltaConnection: dataStoreRuntime.createDeltaConnection(),
+		objectStorage:
+			summary !== undefined ? MockStorage.createFromSummary(summary) : new MockStorage(),
+	};
+
+	const matrix = new SharedMatrix(dataStoreRuntime, id, SharedMatrixFactory.Attributes);
+	if (summary !== undefined) {
+		await matrix.load(services);
+	} else {
+		matrix.connect(services);
+	}
+	return { matrix, containerRuntime, deltaConnection: services.deltaConnection };
+}
+
+function spyOnContainerRuntimeMessages(runtime: MockContainerRuntimeForReconnection): {
+	submittedContent: any[];
+	processedMessages: ISequencedDocumentMessage[];
+} {
+	const submittedContent: any[] = [];
+	const originalSubmit = runtime.submit.bind(runtime);
+	runtime.submit = (content: any, localMetadata) => {
+		submittedContent.push(content);
+		return originalSubmit(content, localMetadata);
+	};
+
+	const processedMessages: ISequencedDocumentMessage[] = [];
+	const originalProcess = runtime.process.bind(runtime);
+	runtime.process = (message: ISequencedDocumentMessage) => {
+		processedMessages.push(message);
+		return originalProcess(message);
+	};
+
+	return { submittedContent, processedMessages };
+}
+
+/**
+ * Note: be careful when writing tests in this suite. The mocks don't have much safety around use of applyStashedOp,
+ * since they're mostly built for scenarios where clients aren't joining/leaving.
+ *
+ * In particular, the author of a test needs to make sure that a container applying stashed ops has reasonable values
+ * for referenceSequenceNumber for any resubmitted ops.
+ */
+describe("Matrix applyStashedOp", () => {
+	it("Can rehydrate a session with stashed ops", async () => {
+		const containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
+		const { matrix: matrix1, containerRuntime: containerRuntime1 } =
+			await createMatrixForReconnection("A", containerRuntimeFactory);
+		const { matrix: matrix2, containerRuntime: containerRuntime2 } =
+			await createMatrixForReconnection("B", containerRuntimeFactory);
+
+		matrix1.insertRows(0, 2);
+		matrix2.insertCols(0, 2);
+		containerRuntimeFactory.processAllMessages();
+		const { summary } = await matrix2.summarize();
+		const minimumSequenceNumber = containerRuntimeFactory.sequenceNumber;
+
+		const { submittedContent } = spyOnContainerRuntimeMessages(containerRuntime1);
+		const { processedMessages } = spyOnContainerRuntimeMessages(containerRuntime2);
+
+		containerRuntime1.connected = false;
+		matrix1.setCell(0, 0, "Originally submitted by matrix1, applied via matrix3");
+
+		matrix2.setCell(1, 0, "Applied via matrix2");
+		containerRuntimeFactory.processAllMessages();
+
+		const { matrix: matrix3, deltaConnection } = await createMatrixForReconnection(
+			"C",
+			containerRuntimeFactory,
+			summary,
+			{
+				minimumSequenceNumber,
+			},
+		);
+
+		assert.equal(submittedContent.length, 1);
+		assert.equal(processedMessages.length, 1);
+
+		const matrix1OpContent = submittedContent[0];
+		// Simulate applyStashedOp flow
+		const localOpMetadata = deltaConnection.handler?.applyStashedOp(matrix1OpContent);
+		deltaConnection.process(processedMessages[0], false, undefined);
+		deltaConnection.reSubmit(matrix1OpContent, localOpMetadata);
+
+		matrix3.setCell(0, 1, "Originally submitted by matrix3, applied via matrix3");
+		containerRuntimeFactory.processAllMessages();
+
+		const expected = [
+			[
+				"Originally submitted by matrix1, applied via matrix3",
+				"Originally submitted by matrix3, applied via matrix3",
+			],
+			["Applied via matrix2", undefined],
+		];
+		assert.deepEqual(extract(matrix2), expected);
+		assert.deepEqual(extract(matrix3), expected);
+	});
+});

--- a/packages/dds/matrix/src/test/matrix.fuzz.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.fuzz.spec.ts
@@ -1,0 +1,206 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as path from "path";
+import { strict as assert } from "assert";
+import {
+	DDSFuzzModel,
+	DDSFuzzSuiteOptions,
+	DDSFuzzTestState,
+	createDDSFuzzSuite,
+} from "@fluid-private/test-dds-utils";
+import {
+	IChannelAttributes,
+	IChannelServices,
+	IFluidDataStoreRuntime,
+} from "@fluidframework/datastore-definitions";
+import {
+	combineReducers,
+	createWeightedGenerator,
+	AsyncGenerator,
+	Generator,
+	takeAsync,
+} from "@fluid-private/stochastic-test-utils";
+import { FlushMode } from "@fluidframework/runtime-definitions";
+import { MatrixItem, SharedMatrix } from "../matrix";
+import { SharedMatrixFactory } from "../runtime";
+/**
+ * Supported cell values used within the fuzz model.
+ */
+type Value = string | number | undefined;
+
+interface InsertRows {
+	type: "insertRows";
+	start: number;
+	count: number;
+}
+
+interface InsertColumns {
+	type: "insertCols";
+	start: number;
+	count: number;
+}
+
+interface SetCell {
+	type: "set";
+	row: number;
+	col: number;
+	value: MatrixItem<Value>;
+}
+
+type Operation = InsertRows | InsertColumns | SetCell;
+
+/**
+ * @remarks - This makes the DDS fuzz harness typecheck state fields as SharedMatrix<Value> instead of IChannel,
+ * which avoids the need to cast elsewhere.
+ */
+class TypedMatrixFactory extends SharedMatrixFactory {
+	public async load(
+		runtime: IFluidDataStoreRuntime,
+		id: string,
+		services: IChannelServices,
+		attributes: IChannelAttributes,
+	): Promise<SharedMatrix<Value>> {
+		return (await super.load(runtime, id, services, attributes)) as SharedMatrix<Value>;
+	}
+
+	public create(document: IFluidDataStoreRuntime, id: string): SharedMatrix<Value> {
+		return super.create(document, id) as SharedMatrix<Value>;
+	}
+}
+
+// This type gets used a lot as the state object of the suite; shorthand it here.
+type State = DDSFuzzTestState<TypedMatrixFactory>;
+
+function assertMatricesAreEquivalent<T>(a: SharedMatrix<T>, b: SharedMatrix<T>) {
+	assert.equal(a.colCount, b.colCount, `${a.id} and ${b.id} have different number of columns.`);
+	assert.equal(a.rowCount, b.rowCount, `${a.id} and ${b.id} have different number of rows.`);
+	for (let row = 0; row < a.rowCount; row++) {
+		for (let col = 0; col < a.colCount; col++) {
+			const aVal = a.getCell(row, col);
+			const bVal = b.getCell(row, col);
+			assert.equal(
+				aVal,
+				bVal,
+				`${a.id} and ${b.id} differ at (${row}, ${col}): ${aVal} vs ${bVal}`,
+			);
+		}
+	}
+}
+
+const reducer = combineReducers<Operation, State>({
+	insertRows: ({ client }, { start, count }) => client.channel.insertRows(start, count),
+	insertCols: ({ client }, { start, count }) => {
+		client.channel.insertCols(start, count);
+	},
+	set: ({ client }, { row, col, value }) => {
+		client.channel.setCell(row, col, value);
+	},
+});
+
+interface GeneratorOptions {
+	insertRowWeight: number;
+	insertColWeight: number;
+	setWeight: number;
+}
+
+const defaultOptions: GeneratorOptions = {
+	insertRowWeight: 1,
+	insertColWeight: 1,
+	setWeight: 20,
+};
+
+function makeGenerator(optionsParam?: Partial<GeneratorOptions>): AsyncGenerator<Operation, State> {
+	const { setWeight, insertColWeight, insertRowWeight } = {
+		...defaultOptions,
+		...optionsParam,
+	};
+
+	const insertRows: Generator<InsertRows, State> = ({ random, client }) => ({
+		type: "insertRows",
+		start: random.integer(0, client.channel.rowCount),
+		count: random.integer(1, 3),
+	});
+
+	const insertCols: Generator<InsertColumns, State> = ({ random, client }) => ({
+		type: "insertCols",
+		start: random.integer(0, client.channel.colCount),
+		count: random.integer(1, 3),
+	});
+
+	const setKey: Generator<SetCell, State> = ({ random, client }) => ({
+		type: "set",
+		row: random.integer(0, client.channel.rowCount - 1),
+		col: random.integer(0, client.channel.colCount - 1),
+		value: random.bool() ? random.integer(1, 50) : random.string(random.integer(1, 2)),
+	});
+
+	const syncGenerator = createWeightedGenerator<Operation, State>([
+		[
+			setKey,
+			setWeight,
+			(state) => state.client.channel.rowCount > 0 && state.client.channel.colCount > 0,
+		],
+		[insertRows, insertRowWeight],
+		[insertCols, insertColWeight],
+	]);
+
+	return async (state) => syncGenerator(state);
+}
+
+describe("Matrix fuzz tests", () => {
+	const model: Omit<DDSFuzzModel<TypedMatrixFactory, Operation>, "workloadName"> = {
+		factory: new TypedMatrixFactory(),
+		generatorFactory: () => takeAsync(100, makeGenerator()),
+		reducer: async (state, operation) => reducer(state, operation),
+		validateConsistency: assertMatricesAreEquivalent,
+	};
+
+	const baseOptions: Partial<DDSFuzzSuiteOptions> = {
+		defaultTestCount: 100,
+		numberOfClients: 3,
+		clientJoinOptions: {
+			maxNumberOfClients: 6,
+			clientAddProbability: 0.1,
+		},
+		reconnectProbability: 0,
+		saveFailures: { directory: path.join(__dirname, "../../src/test/results") },
+	};
+
+	const nameModel = (workloadName: string): DDSFuzzModel<TypedMatrixFactory, Operation> => ({
+		...model,
+		workloadName,
+	});
+
+	createDDSFuzzSuite(nameModel("default"), {
+		...baseOptions,
+		reconnectProbability: 0,
+		// Uncomment to replay a particular seed.
+		// replay: 0,
+	});
+
+	createDDSFuzzSuite(nameModel("with reconnect"), {
+		...baseOptions,
+		defaultTestCount: 100,
+		clientJoinOptions: {
+			maxNumberOfClients: 3,
+			clientAddProbability: 0,
+		},
+		reconnectProbability: 0.1,
+		// Uncomment to replay a particular seed.
+		// replay: 0,
+	});
+
+	createDDSFuzzSuite(nameModel("with batches and rebasing"), {
+		...baseOptions,
+		rebaseProbability: 0.2,
+		containerRuntimeOptions: {
+			flushMode: FlushMode.TurnBased,
+			enableGroupedBatching: true,
+		},
+		// Uncomment to replay a particular seed.
+		// replay: 0,
+	});
+});

--- a/packages/dds/matrix/src/test/matrix.reconnect.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.reconnect.spec.ts
@@ -1,0 +1,120 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+	MockContainerRuntimeFactoryForReconnection,
+	MockFluidDataStoreRuntime,
+	MockStorage,
+} from "@fluidframework/test-runtime-utils";
+import { SharedMatrix } from "../matrix";
+import { extract } from "./utils";
+
+describe("SharedMatrix reconnect", () => {
+	// This test demonstrates the need to use the `currentSeq` on the collab window at resubmission time
+	// rather than the refSeq of the original op. Since that information is only used in local op metadata
+	// and only used for resubmitting ops, disconnecting twice is necessary to reproduce the issue.
+	it("resolves insert+set against concurrent insert after disconnecting twice", () => {
+		const factory = SharedMatrix.getFactory();
+		const containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
+		const dataRuntime1 = new MockFluidDataStoreRuntime();
+		const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataRuntime1);
+		const dataRuntime2 = new MockFluidDataStoreRuntime();
+		const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataRuntime2);
+		const matrix1 = factory.create(dataRuntime1, "A") as SharedMatrix<number>;
+		matrix1.connect({
+			deltaConnection: dataRuntime1.createDeltaConnection(),
+			objectStorage: new MockStorage(),
+		});
+		const matrix2 = factory.create(dataRuntime2, "B") as SharedMatrix<number>;
+		matrix2.connect({
+			deltaConnection: dataRuntime2.createDeltaConnection(),
+			objectStorage: new MockStorage(),
+		});
+
+		matrix1.insertCols(0, 1);
+		containerRuntimeFactory.processAllMessages();
+
+		containerRuntime1.connected = false;
+		matrix1.insertRows(0, 1);
+		matrix2.insertRows(0, 1);
+
+		containerRuntimeFactory.processAllMessages();
+		containerRuntime1.connected = true;
+		containerRuntime2.connected = false;
+
+		// Matrix2 hasn't yet seen the row inserted by matrix1, so this set should refer to the row that matrix2 inserted.
+		matrix2.setCell(0, 0, 42);
+		containerRuntimeFactory.processAllMessages();
+		containerRuntime2.connected = true;
+		containerRuntime2.connected = false;
+		containerRuntime2.connected = true;
+		containerRuntimeFactory.processAllMessages();
+
+		const expected = [[undefined], [42]];
+		assert.deepEqual(extract(matrix1), expected);
+		assert.deepEqual(extract(matrix2), expected);
+	});
+
+	// This is a fuzz test minimization of a scenario where resubmit requires information outside of the collab
+	// window dictated by incoming messages. It motivates the need for Client's minSeq updating logic to take into
+	// account in-flight ops.
+	// See "client.applyMsg updates minSeq" in merge-tree's test suite for a lower-level unit test of some relevant behavior.
+	it("avoids zamboni of information required to resubmit", async () => {
+		const factory = SharedMatrix.getFactory();
+		const containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
+		const dataRuntime1 = new MockFluidDataStoreRuntime();
+		const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataRuntime1);
+		const dataRuntime2 = new MockFluidDataStoreRuntime();
+		const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataRuntime2);
+		const dataRuntime3 = new MockFluidDataStoreRuntime();
+		const containerRuntime3 = containerRuntimeFactory.createContainerRuntime(dataRuntime3);
+		const matrix1 = factory.create(dataRuntime1, "A") as SharedMatrix<number>;
+
+		matrix1.insertCols(0, 2);
+		const { summary } = matrix1.getAttachSummary();
+		matrix1.connect({
+			deltaConnection: dataRuntime1.createDeltaConnection(),
+			objectStorage: new MockStorage(),
+		});
+
+		const matrix2 = (await factory.load(
+			dataRuntime2,
+			"B",
+			{
+				deltaConnection: dataRuntime2.createDeltaConnection(),
+				objectStorage: MockStorage.createFromSummary(summary),
+			},
+			factory.attributes,
+		)) as SharedMatrix<number>;
+		const matrix3 = (await factory.load(
+			dataRuntime3,
+			"C",
+			{
+				deltaConnection: dataRuntime3.createDeltaConnection(),
+				objectStorage: MockStorage.createFromSummary(summary),
+			},
+			factory.attributes,
+		)) as SharedMatrix<number>;
+
+		containerRuntime3.connected = false;
+		containerRuntime1.connected = false;
+
+		matrix2.insertCols(0, 1);
+		matrix1.insertCols(0, 1);
+		matrix3.insertRows(0, 1);
+		matrix3.setCell(0, 1, 42);
+
+		containerRuntimeFactory.processAllMessages();
+		containerRuntime2.connected = false;
+		containerRuntime1.connected = true;
+		containerRuntimeFactory.processAllMessages();
+		containerRuntime3.connected = true;
+		containerRuntimeFactory.processAllMessages();
+		const expected = [[undefined, undefined, undefined, 42]];
+		assert.deepEqual(extract(matrix1), expected);
+		assert.deepEqual(extract(matrix3), expected);
+	});
+});

--- a/packages/dds/merge-tree/api-report/merge-tree.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.api.md
@@ -96,7 +96,7 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
 
 // @alpha @deprecated (undocumented)
 export class Client extends TypedEventEmitter<IClientEvents> {
-    constructor(specToSegment: (spec: IJSONSegment) => ISegment, logger: ITelemetryLoggerExt, options?: IMergeTreeOptions & PropertySet);
+    constructor(specToSegment: (spec: IJSONSegment) => ISegment, logger: ITelemetryLoggerExt, options?: IMergeTreeOptions & PropertySet, getMinInFlightRefSeq?: () => number | undefined);
     // (undocumented)
     addLongClientId(longClientId: string): void;
     annotateMarker(marker: Marker, props: PropertySet): IMergeTreeAnnotateMsg | undefined;

--- a/packages/dds/merge-tree/src/test/testClient.ts
+++ b/packages/dds/merge-tree/src/test/testClient.ts
@@ -139,8 +139,17 @@ export class TestClient extends Client {
 		new DoublyLinkedList<ISequencedDocumentMessage>();
 
 	private readonly textHelper: MergeTreeTextHelper;
-	constructor(options?: IMergeTreeOptions & PropertySet, specToSeg = specToSegment) {
-		super(specToSeg, createChildLogger({ namespace: "fluid:testClient" }), options);
+	constructor(
+		options?: IMergeTreeOptions & PropertySet,
+		specToSeg = specToSegment,
+		getMinInFlightRefSeq: () => number | undefined = () => undefined,
+	) {
+		super(
+			specToSeg,
+			createChildLogger({ namespace: "fluid:testClient" }),
+			options,
+			getMinInFlightRefSeq,
+		);
 		this.mergeTree = (this as Record<"_mergeTree", MergeTree>)._mergeTree;
 		this.textHelper = new MergeTreeTextHelper(this.mergeTree);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6454,6 +6454,7 @@ importers:
     specifiers:
       '@arethetypeswrong/cli': ^0.13.3
       '@fluid-internal/client-utils': workspace:~
+      '@fluid-private/stochastic-test-utils': workspace:~
       '@fluid-private/test-dds-utils': workspace:~
       '@fluid-tools/benchmark': ^0.48.0
       '@fluid-tools/build-cli': ^0.29.0
@@ -6476,12 +6477,14 @@ importers:
       '@microsoft/api-extractor': ^7.38.3
       '@tiny-calc/micro': 0.0.0-alpha.5
       '@tiny-calc/nano': 0.0.0-alpha.5
+      '@types/double-ended-queue': ^2.1.0
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
       best-random: ^1.0.0
       c8: ^8.0.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
+      double-ended-queue: ^2.1.0-0
       eslint: ~8.50.0
       events: ^3.1.0
       hotloop: ^1.2.0
@@ -6510,10 +6513,12 @@ importers:
       '@fluidframework/shared-object-base': link:../shared-object-base
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       '@tiny-calc/nano': 0.0.0-alpha.5
+      double-ended-queue: 2.1.0-0
       events: 3.3.0
       tslib: 1.14.1
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
+      '@fluid-private/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-private/test-dds-utils': link:../test-dds-utils
       '@fluid-tools/benchmark': 0.48.0
       '@fluid-tools/build-cli': 0.29.0_mhw3tufvtaceew37hrkkevjcli
@@ -6525,6 +6530,7 @@ importers:
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.38.3_t5dutvxrlkz26qgmievy2jdkpi_@types+node@18.19.1
       '@tiny-calc/micro': 0.0.0-alpha.5
+      '@types/double-ended-queue': 2.1.7
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
       best-random: 1.0.3


### PR DESCRIPTION
## Description

Reapplies the fix in #19211 with some changes to how strict we are with the queue of in-flight ops. Notably, it appears that `this.runtime.deltaManager.lastSequenceNumber` at op submit time sometimes trails behind the reference sequence number that actually gets submitted for that op, as evidenced by some e2e tests. This had something to do with client leave/join messages. Rather than assert equality on round-trip, I've converted the mismatch assert to verify `<=`, since that's all that's required for correctness of the scheme.

The applyStashedOp codepath also happened to work before but in an unexpected way: `reSubmit` was calling `.shift()` on an empty queue. This PR adds enforcement to the reSubmit codepath and a corresponding unit test for that flow.

The changes here are split naturally into commits for reviewers familiar with that PR.