### PR TITLE
Only do back compat to loader v2 int 3

### DIFF
--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -220,7 +220,7 @@ const genFullBackCompatConfig = (driverVersionsAboveV2Int1: number = 0): CompatC
 	// not working with new rc version
 	const _configList: CompatConfig[] = [];
 
-	const loaderVersionBackCompatCount = getNumberOfVersionsToGoBack(0);
+	const loaderVersionBackCompatCount = getNumberOfVersionsToGoBack(driverVersionsAboveV2Int1);
 
 	// This makes the assumption N and N-1 scenarios are already fully tested thus skipping 0 and -1.
 	// This loop goes as far back as 2.0.0.internal.1.y.z.
@@ -336,7 +336,7 @@ export const configList = new Lazy<readonly CompatConfig[]>(() => {
 		if (process.env.fluid__test__backCompat === "FULL") {
 			_configList.push(...genFullBackCompatConfig());
 		}
-		if (process.env.fluid__test__backCompat === "V2_INT_1_Loader_V2_INT_3_Driver") {
+		if (process.env.fluid__test__backCompat === "V2_INT_3") {
 			_configList.push(...genFullBackCompatConfig(defaultNumOfDriverVersionsAboveV2Int1));
 		}
 	} else {
@@ -352,7 +352,7 @@ export const configList = new Lazy<readonly CompatConfig[]>(() => {
 					_configList.push(...genFullBackCompatConfig());
 					break;
 				}
-				case "V2_INT_1_Loader_V2_INT_3_Driver": {
+				case "V2_INT_3": {
 					_configList.push(
 						...genFullBackCompatConfig(defaultNumOfDriverVersionsAboveV2Int1),
 					);

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -160,7 +160,7 @@ stages:
           # Tests N-2 to LTS+1 back compat for loader
           # Tests N-2 to LTS+3 back compat for loader + driver
           - name: N-2ToLTS+1-back-compat
-            flags: --compatVersion=V2_INT_1_Loader_V2_INT_3_Driver --tenantIndex=3
+            flags: --compatVersion=V2_INT_3 --tenantIndex=3
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)
           login__microsoft__secret: $(login-microsoft-secret)


### PR DESCRIPTION
[AB#6724](https://dev.azure.com/fluidframework/internal/_workitems/edit/6724)

Previous change: https://github.com/microsoft/FluidFramework/pull/19167

We were still getting summary nacks from ODSP for tests that odsp loader compat. Did not realize that it was the loader that was causing the issue. This also makes it so for ODSP full back compat loader + driver tests we run only from the current version to version `2.0.0-internal.3.x.y`