### PR TITLE
docs(tree): fixes to the tree documentation

### DIFF
--- a/docs/content/docs/data-structures/tree.md
+++ b/docs/content/docs/data-structures/tree.md
@@ -267,7 +267,7 @@ You can now add child items to the `stickyNotesTree` object using the methods de
 
 ### API
 
-The `SharedTree` object provides methods that enable your code to add nodes to the tree, remove nodes, and move nodes within the tree. You can also set and read the values of leaf nodes. The APIs have been designed to match as much as possible the syntax of TypeScript primitives, objects, maps, and arrays; although some editing APIs are different to account for.
+The `SharedTree` object provides methods that enable your code to add nodes to the tree, remove nodes, and move nodes within the tree. You can also set and read the values of leaf nodes. The APIs have been designed to match as much as possible the syntax of TypeScript primitives, objects, maps, and arrays; although some editing APIs are different for the sake of making the merge semantics clearer.
 
 #### Leaf node APIs
 
@@ -315,7 +315,11 @@ We show how to add this note to an array of notes in the tree in [Array node API
 
 ##### Editing Object Properties
 
-To update the property on an object node, you assign a new node to it with the assignment operator (`=`).
+To update the property on an object node, you assign a new node or value to it with the assignment operator (`=`).
+
+```typescript
+rectangle.topLeft = new Point({ x: 0, y: 0 });
+```
 
 ```typescript
 babyShowerNote.author = "The Joneses";
@@ -433,8 +437,8 @@ Inserts the provided value(s) at the end of the array. This is syntactic sugar f
 Array nodes have two methods that remove items from the node. Note the following about these methods:
 
 -   Removed items are saved internally for a time in case they need to be restored as a result of an undo operation.
--   A removed item may be restored as a result of a simultaneous move operation from another client. For example, if one client removes items 3-5, and another client simultaneously moves items 4 and 5, then, if the move operation is ordered last, only item 3 is removed (items 4 and 5 are restored and moved to their destination by the move operation). If the remove operation is ordered last, then all three items will be removed.
--   Removal of items never overrides inserting (or moving in) items. For example, if one client removes items 10-15, and another client simultaneously inserts an item at index 12, the original items 10-15 are removed, but new item is inserted between item 9 and the item that used to be at index 16. This happens regardless of the order of the remove and insert operations.
+-   A removed item may be restored as a result of a simultaneous move operation from another client. For example, if one client removes items 3-5, and another client simultaneously moves items 4 and 5, then, if the move operation is ordered last, only item 3 is removed (items 4 and 5 are restored and moved to their destination by the move operation). If the remove operation is ordered last, then all three items will be removed, no matter where they reside.
+-   Removal of items never overrides inserting (or moving in) items. For example, if one client removes items 10-15, and another client simultaneously inserts an item at index 12, the original items 10-15 are removed, but new item is inserted between item 9 and the item that used to be at index 16. This is true regardless of the order of the remove and insert operations.
 
 For the meaning of "simultaneously", see [Types of distributed data structures]({{< relref "overview.md" >}}).
 
@@ -474,8 +478,8 @@ Moves the items to the specified `index` in the destination array. The item that
 
 Note the following about these methods:
 
--   If multiple clients simultaneously move an item, then that item will be moved to the destination indicated by move of the client whose edit is ordered last.
--   A removed item may be restored as a result of a simultaneous move operation from another client. For example, if one client removes items 3-5, and another client simultaneously moves items 4 and 5, then, if the move operation is ordered last, only item 3 is removed (items 4 and 5 are restored and moved to their destination by the move operation). If the remove operation is ordered last, then all three items will be removed.
+-   If multiple clients simultaneously move an item, then that item will be moved to the destination indicated by the move of the client whose edit is ordered last.
+-   A moved item may be removed as a result of a simultaneous remove operation from another client. For example, if one client moves items 3-5, and another client simultaneously removes items 4 and 5, then, if the remove operation is ordered last, items 4 and 5 are removed from their destination by the remove operation. If the move operation is ordered last, then all three items will be moved to the destination.
 
 For the meaning of "simultaneously", see [Types of distributed data structures]({{< relref "overview.md" >}}).
 

--- a/docs/content/docs/data-structures/tree.md
+++ b/docs/content/docs/data-structures/tree.md
@@ -309,8 +309,8 @@ const babyShowerNote = new Note({
     lastChanged: 19697 // Days since January 1, 1970, the Unix epoch.
     votes: ["0"]
 });
-
 ```
+
 We show how to add this note to an array of notes in the tree in [Array node APIs](#array-node-apis).
 
 ##### Editing Object Properties

--- a/docs/content/docs/data-structures/tree.md
+++ b/docs/content/docs/data-structures/tree.md
@@ -9,11 +9,11 @@ The `SharedTree` distributed data structure (DDS), available in Fluid Framework 
 
 A `SharedTree` object has the following characteristics:
 
--   It has a root and can have several types of interior nodes and several types of leaf nodes.
+-   It has a root and can have several types of internal (i.e., non-leaf) nodes and several types of leaf nodes.
 -   Although there are some exceptions, for the most part, each type of node closely mirrors a familiar JavaScript datatype, such as object, map, array, boolean, number, string, and null.
 -   Again, with exceptions, your code accesses nodes with the syntax of JavaScript and TypeScript, such as dot notation, property assignment, and array indexes.
 -   Besides being of the type `SharedTree`, the object will also conform to a schema that your code creates so it has an application-specific strong typing too.
--   The various types of interior nodes can be nested in one another (subject to the constraints of the schema).
+-   The various types of internal nodes can be nested in one another (subject to the constraints of the schema).
 
 ### Node types
 
@@ -25,11 +25,11 @@ The following leaf node types are available:
 -   **null**: Works identically to a JavaScript null.
 -   **FluidHandle**: A handle to a Fluid DDS or Data Object in the current container. For more information about handles see [Handles]({{< relref "handles.md" >}}).
 
-The following subsections describe the available interior node types.
+The following subsections describe the available internal node types.
 
 #### Object nodes
 
-An object node is a TypeScript-like object with one or more named child properties. The object node's properties can in principle be any of the node types including interior node types; but typically the schema for the `SharedTree` that your code defines will specify for any object node a specific set of properties and node types of each. A `SharedTree` can have many object nodes at various places in the tree and they do not all have to conform to the same schema. Your schema can specify different properties for different object nodes. The schema also specifies whether a child property is required or optional, and it can assign a union datatype to any property. For example, a property could be either number or string.
+An object node is a TypeScript-like object with one or more named child properties. The object node's properties can in principle be any of the node types including internal node types; but typically the schema for the `SharedTree` that your code defines will specify for any object node a specific set of properties and node types of each. A `SharedTree` can have many object nodes at various places in the tree and they do not all have to conform to the same schema. Your schema can specify different properties for different object nodes. The schema also specifies whether a child property is required or optional, and it can assign a union datatype to any property. For example, a property could be either number or string.
 
 For information about creating the schema for an object node, see [Object schema](#object-schema). For information about adding an object node to the the `SharedTree` and about reading and writing to an object node, see [Object node APIs](#object-node-apis).
 
@@ -75,7 +75,7 @@ import { ... SchemaFactory, ... } from '@fluid-experimental/tree2';
 const sf = new SchemaFactory('ec1db2e8-0a00-11ee-be56-0242ac120002');
 ```
 
-The `SchemaFactory` class defines five primitive data types; `boolean`, `string`, `number`, `null`, and `handle` for specifying leaf nodes. It also has three methods for specifying interior nodes; `object()`, `array()`, and `map()`. Use the members of the class to build a schema.
+The `SchemaFactory` class defines five primitive data types; `boolean`, `string`, `number`, `null`, and `handle` for specifying leaf nodes. It also has three methods for specifying internal nodes; `object()`, `array()`, and `map()`. Use the members of the class to build a schema.
 
 As an example, consider an app that provides a digital board with groups of sticky notes as shown in the following screenshot:
 

--- a/docs/content/docs/data-structures/tree.md
+++ b/docs/content/docs/data-structures/tree.md
@@ -309,6 +309,7 @@ const babyShowerNote = new Note({
     lastChanged: 19697 // Days since January 1, 1970, the Unix epoch.
     votes: ["0"]
 });
+
 ```
 We show how to add this note to an array of notes in the tree in [Array node APIs](#array-node-apis).
 
@@ -472,6 +473,7 @@ moveToIndex(index: number, sourceStartIndex: number, sourceEndIndex: number, sou
 Moves the items to the specified `index` in the destination array. The item that is at `index` before the method is called will be at the first index position that follows the moved items after the move. Specify a `source` array if it is different from the destination array. If the items are being moved within the same array, the `index` position is calculated including the items being moved (as if a new copy of the moved items were being inserted, without removing the originals).
 
 Note the following about these methods:
+
 -   If multiple clients simultaneously move an item, then that item will be moved to the destination indicated by move of the client whose edit is ordered last.
 -   A removed item may be restored as a result of a simultaneous move operation from another client. For example, if one client removes items 3-5, and another client simultaneously moves items 4 and 5, then, if the move operation is ordered last, only item 3 is removed (items 4 and 5 are restored and moved to their destination by the move operation). If the remove operation is ordered last, then all three items will be removed.
 

--- a/docs/content/docs/data-structures/tree.md
+++ b/docs/content/docs/data-structures/tree.md
@@ -9,11 +9,11 @@ The `SharedTree` distributed data structure (DDS), available in Fluid Framework 
 
 A `SharedTree` object has the following characteristics:
 
--   It has a root and can have several types of branch nodes and several types of leaf nodes.
+-   It has a root and can have several types of interior nodes and several types of leaf nodes.
 -   Although there are some exceptions, for the most part, each type of node closely mirrors a familiar JavaScript datatype, such as object, map, array, boolean, number, string, and null.
 -   Again, with exceptions, your code accesses nodes with the syntax of JavaScript and TypeScript, such as dot notation, property assignment, and array indexes.
--   Besides being of the type `SharedTree`, the object must also conform to a schema that your code creates so it has an application-specific strong typing too.
--   The various types of branch nodes can be nested in one another (subject to the constraints of the schema).
+-   Besides being of the type `SharedTree`, the object will also conform to a schema that your code creates so it has an application-specific strong typing too.
+-   The various types of interior nodes can be nested in one another (subject to the constraints of the schema).
 
 ### Node types
 
@@ -25,11 +25,11 @@ The following leaf node types are available:
 -   **null**: Works identically to a JavaScript null.
 -   **FluidHandle**: A handle to a Fluid DDS or Data Object in the current container. For more information about handles see [Handles]({{< relref "handles.md" >}}).
 
-The following subsections describe the available branch node types.
+The following subsections describe the available interior node types.
 
 #### Object nodes
 
-An object node it a TypeScript-like object with one or more named child properties. The object node's properties can in principle be any of the node types including branch node types; but typically the schema for the `SharedTree` that your code defines will specify for any object node a specific set of properties and node types of each. A `SharedTree` can have many object nodes at various places in the tree and they do not all have to conform to the same schema. Your schema can specify different properties for different object nodes. The schema also specifies whether a child property is required or optional, and it can assign a union datatype to any property. For example, a property could be either number or string.
+An object node is a TypeScript-like object with one or more named child properties. The object node's properties can in principle be any of the node types including interior node types; but typically the schema for the `SharedTree` that your code defines will specify for any object node a specific set of properties and node types of each. A `SharedTree` can have many object nodes at various places in the tree and they do not all have to conform to the same schema. Your schema can specify different properties for different object nodes. The schema also specifies whether a child property is required or optional, and it can assign a union datatype to any property. For example, a property could be either number or string.
 
 For information about creating the schema for an object node, see [Object schema](#object-schema). For information about adding an object node to the the `SharedTree` and about reading and writing to an object node, see [Object node APIs](#object-node-apis).
 
@@ -45,7 +45,7 @@ For information about creating the schema for a map node, see [Map schema](#map-
 
 An array node is an indexed sequence of zero or more values like a JavaScript array. In principle, values can be any of the node types, but the schema that your code defines will specify what subset of those types can be the values of any given array item.
 
-For information about creating the schema for an array node, see [Array schema](#array-schema). For information about adding an array node to the the `SharedTree` and about reading and writing to an array node, see [Array node APIs](#array-node-apis).
+For information about creating the schema for an array node, see [Array schema](#array-schema). For information about adding an array node to the `SharedTree` and about reading and writing to an array node, see [Array node APIs](#array-node-apis).
 
 ## Installation
 
@@ -75,7 +75,7 @@ import { ... SchemaFactory, ... } from '@fluid-experimental/tree2';
 const sf = new SchemaFactory('ec1db2e8-0a00-11ee-be56-0242ac120002');
 ```
 
-The `SchemaFactory` class defines five primitive data types; `boolean`, `string`, `number`, `null`, and `handle` for specifying leaf nodes. It also has three methods for specifying branch nodes; `object()`, `array()`, and `map()`. Use the members of the class to build a schema.
+The `SchemaFactory` class defines five primitive data types; `boolean`, `string`, `number`, `null`, and `handle` for specifying leaf nodes. It also has three methods for specifying interior nodes; `object()`, `array()`, and `map()`. Use the members of the class to build a schema.
 
 As an example, consider an app that provides a digital board with groups of sticky notes as shown in the following screenshot:
 
@@ -122,7 +122,7 @@ class Note extends sf.object('Note', {
 
 For the remainder of this article, we use the inline style.
 
-You can add fields, properties, and methods like any TypeScript class including methods that wrap one or more methods in the `SharedTree` [APIs](#api). For example, the `Node` class can have the following `updateText` method. Since the method writes to shared properties, the changes are reflected on all clients.
+You can add fields, properties, and methods like any TypeScript class including methods that wrap one or more methods in the `SharedTree` [APIs](#api). For example, the `Note` class can have the following `updateText` method. Since the method writes to shared properties, the changes are reflected on all clients.
 
 ```typescript
 public updateText(text: string) {
@@ -207,7 +207,7 @@ The final step is to create a configuration object that will be used when a `Sha
 
 ```typescript
 export const appTreeConfiguration = new TreeConfiguration(
-    App, // root node
+    App, // root node schema
     () => ({
         // initial tree
         items: [],
@@ -217,7 +217,7 @@ export const appTreeConfiguration = new TreeConfiguration(
 
 #### Map schema
 
-The sticky notes example doesn't have any map branches, but creating a map schema is like creating an array schema, except that you use the `map()` method. Consider a silent auction app. Users view various items up for auction and place bids for items they want. One way to represent the bids for an item is with a map from user names to bids. The following snippet shows how to create the schema. Note that `map()` doesn't need a parameter to specify the type of keys because it is always string.
+The sticky notes example doesn't have any map nodes, but creating a map schema is like creating an array schema, except that you use the `map()` method. Consider a silent auction app. Users view various items up for auction and place bids for items they want. One way to represent the bids for an item is with a map from user names to bids. The following snippet shows how to create the schema. Note that `map()` doesn't need a parameter to specify the type of keys because it is always string.
 
 ```typescript
 class AuctionItem extends sf.map('AuctionItem', sf.number) { ... }
@@ -267,7 +267,7 @@ You can now add child items to the `stickyNotesTree` object using the methods de
 
 ### API
 
-The `SharedTree` object provides methods that enable your code to add nodes to the tree, remove nodes, and move nodes within the tree. You can also set and read the values of leaf nodes. The APIs have been designed to match as much as possible the syntax of TypeScript primitives, objects, maps, and arrays; although it is not possible to match exactly.
+The `SharedTree` object provides methods that enable your code to add nodes to the tree, remove nodes, and move nodes within the tree. You can also set and read the values of leaf nodes. The APIs have been designed to match as much as possible the syntax of TypeScript primitives, objects, maps, and arrays; although some editing APIs are different to account for.
 
 #### Leaf node APIs
 
@@ -285,6 +285,8 @@ const pointsForDetroitTigers: number = seasonTree.tigersTeam.game1.points;
 
 #### Object node APIs
 
+##### Reading Object Properties
+
 Your code reads object nodes and their properties exactly as it would read a JavaScript object. The following are some examples.
 
 ```typescript
@@ -295,7 +297,7 @@ const counterHandle: FluidHandle = myTree.myObjectNode.myHandle;
 const myItems: Array = stickyNotesTree.items;
 ```
 
-To write to an object node, you first create an object and then assign it to the node with the assignment operator (`=`). If the object node is a child of a map or array node, use the write [Map node write APIs](#map-node-write-apis) or [Array node write APIs](#array-node-write-apis).
+##### Creating Objects
 
 You must create the object using the constructor of the class that you derived from the object returned by `SchemaFactory.object()` method. The following shows how to create a note object from the sticky notes example.
 
@@ -308,8 +310,21 @@ const babyShowerNote = new Note({
     votes: ["0"]
 });
 ```
-
 We show how to add this note to an array of notes in the tree in [Array node APIs](#array-node-apis).
+
+##### Editing Object Properties
+
+To update the property on an object node, you assign a new node to it with the assignment operator (`=`).
+
+```typescript
+babyShowerNote.author = "The Joneses";
+```
+
+Optional properties can be cleared by assigning `undefined` to them.
+
+```typescript
+proposal.text = undefined;
+```
 
 #### Map node APIs
 
@@ -351,7 +366,7 @@ Returns an Iterator that contains the key/value pairs in the map node. The pairs
 map(callback: ()=>[]): IterableIterator<[string, T]>
 ```
 
-Returns an array, *not a map node or array node*, that is a result of applying the callback parameter to each member of the original map node. It is just like [Array.map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
+Returns an array, *not a map node or array node*, that is the result of applying the callback parameter to each member of the original map node. It is just like [Array.map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
 
 ##### Map node write APIs
 
@@ -417,8 +432,8 @@ Inserts the provided value(s) at the end of the array. This is syntactic sugar f
 Array nodes have two methods that remove items from the node. Note the following about these methods:
 
 -   Removed items are saved internally for a time in case they need to be restored as a result of an undo operation.
--   A removed item may be restored as a result of a simultaneous move operation from another client. For example, if one client removes items 3-5, and another client simultaneously moves items 4 and 5, then only item 3 is removed. The other two are moved, regardless of the order of the move and remove operations.
--   Removal of items never overrides inserting items. For example, if one client removes items 10-15, and another client simultaneously inserts an item at index 12, the original items 10-15 are removed, but new item is inserted between item 9 and the item that used to be at index 16. This happens regardless of the order of the remove and insert operations.
+-   A removed item may be restored as a result of a simultaneous move operation from another client. For example, if one client removes items 3-5, and another client simultaneously moves items 4 and 5, then, if the move operation is ordered last, only item 3 is removed (items 4 and 5 are restored and moved to their destination by the move operation). If the remove operation is ordered last, then all three items will be removed.
+-   Removal of items never overrides inserting (or moving in) items. For example, if one client removes items 10-15, and another client simultaneously inserts an item at index 12, the original items 10-15 are removed, but new item is inserted between item 9 and the item that used to be at index 16. This happens regardless of the order of the remove and insert operations.
 
 For the meaning of "simultaneously", see [Types of distributed data structures]({{< relref "overview.md" >}}).
 
@@ -454,7 +469,13 @@ Moves the specified items to the end of the array. Specify a `source` array if i
 moveToIndex(index: number, sourceStartIndex: number, sourceEndIndex: number, source?: T)
 ```
 
-Moves the items to the specified `index` in the destination array. The item that is at `index` before the method is called will be at the first index position that follows the moved items after the move. Specify a `source` array if it is different from the destination array. If the items are being moved within the same array, the `index` position is calculated including the items being moved.
+Moves the items to the specified `index` in the destination array. The item that is at `index` before the method is called will be at the first index position that follows the moved items after the move. Specify a `source` array if it is different from the destination array. If the items are being moved within the same array, the `index` position is calculated including the items being moved (as if a new copy of the moved items were being inserted, without removing the originals).
+
+Note the following about these methods:
+-   If multiple clients simultaneously move an item, then that item will be moved to the destination indicated by move of the client whose edit is ordered last.
+-   A removed item may be restored as a result of a simultaneous move operation from another client. For example, if one client removes items 3-5, and another client simultaneously moves items 4 and 5, then, if the move operation is ordered last, only item 3 is removed (items 4 and 5 are restored and moved to their destination by the move operation). If the remove operation is ordered last, then all three items will be removed.
+
+For the meaning of "simultaneously", see [Types of distributed data structures]({{< relref "overview.md" >}}).
 
 ### Events
 


### PR DESCRIPTION
* Change "branch node" to "internal node" ("internal" is the most common term for them. Using "branch" also sets us up for confusion when we start introducing branching).
* Fix typos
* Expanded object docs
* Update description of merge semantics in races between move and remove
* Other nits