### PR TITLE
test(e2e): Lint against value-imports of @fluidframework/matrix

### DIFF
--- a/packages/test/test-end-to-end-tests/.eslintrc.cjs
+++ b/packages/test/test-end-to-end-tests/.eslintrc.cjs
@@ -17,7 +17,7 @@ module.exports = {
 		"@typescript-eslint/no-restricted-imports": [
 			"error",
 			{
-				paths: ["@fluidframework/map"].map((importName) => ({
+				paths: ["@fluidframework/map", "@fluidframework/matrix"].map((importName) => ({
 					name: importName,
 					message:
 						"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",

--- a/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { IContainer } from "@fluidframework/container-definitions";
 import {
 	ContainerRuntime,
@@ -22,13 +21,12 @@ import {
 	createSummarizerFromFactory,
 	createContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/test-utils";
-import { describeCompat, getContainerRuntimeApi } from "@fluid-private/test-version-utils";
+import { describeCompat } from "@fluid-private/test-version-utils";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { ISummaryContext } from "@fluidframework/driver-definitions";
-import { SharedMatrix } from "@fluidframework/matrix";
+import type { SharedMatrix } from "@fluidframework/matrix";
 import { ISnapshotTree, ISummaryTree, IVersion } from "@fluidframework/protocol-definitions";
-import { pkgVersion } from "../packageVersion.js";
 
 // Note GC needs to be disabled.
 const runtimeOptions: IContainerRuntimeOptions = {
@@ -39,79 +37,80 @@ const runtimeOptions: IContainerRuntimeOptions = {
 };
 export const TestDataObjectType1 = "@fluid-example/test-dataStore1";
 
-class TestDataObject1 extends DataObject {
-	public get _root() {
-		return this.root;
-	}
-
-	public get _context() {
-		return this.context;
-	}
-
-	private readonly matrixKey = "SharedMatrix";
-	public matrix!: SharedMatrix;
-
-	protected async initializingFirstTime() {
-		const sharedMatrix = SharedMatrix.create(this.runtime, this.matrixKey);
-		this.root.set(this.matrixKey, sharedMatrix.handle);
-		sharedMatrix.insertRows(0, 3);
-		sharedMatrix.insertCols(0, 3);
-	}
-
-	protected async hasInitialized() {
-		const matrixHandle = this.root.get<IFluidHandle<SharedMatrix>>(this.matrixKey);
-		assert(matrixHandle !== undefined, "SharedMatrix not found");
-		this.matrix = await matrixHandle.get();
-	}
-}
-
-const dataStoreFactory1 = new DataObjectFactory(
-	TestDataObjectType1,
-	TestDataObject1,
-	[SharedMatrix.getFactory()],
-	[],
-	[],
-);
-
-const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
-	[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
-]);
-
-const containerRuntimeFactoryWithDefaultDataStore =
-	getContainerRuntimeApi(pkgVersion).ContainerRuntimeFactoryWithDefaultDataStore;
-
-const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
-	containerRuntimeFactoryWithDefaultDataStore,
-	{
-		defaultFactory: dataStoreFactory1,
-		registryEntries: registryStoreEntries,
-		runtimeOptions,
-	},
-);
-
-async function createSummarizer(
-	provider: ITestObjectProvider,
-	container: IContainer,
-	summaryVersion?: string,
-): Promise<ISummarizer> {
-	const createSummarizerResult = await createSummarizerFromFactory(
-		provider,
-		container,
-		dataStoreFactory1,
-		summaryVersion,
-		containerRuntimeFactoryWithDefaultDataStore,
-		registryStoreEntries,
-	);
-	return createSummarizerResult.summarizer;
-}
-
 /**
  * Validates the scenario in which we always retrieve the latest snapshot.
  */
 describeCompat(
 	"Summarizer fetches expected number of times",
 	"2.0.0-rc.1.0.0",
-	(getTestObjectProvider) => {
+	(getTestObjectProvider, apis) => {
+		const { SharedMatrix } = apis.dds;
+		const { DataObject, DataObjectFactory } = apis.dataRuntime;
+		const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+
+		class TestDataObject1 extends DataObject {
+			public get _root() {
+				return this.root;
+			}
+
+			public get _context() {
+				return this.context;
+			}
+
+			private readonly matrixKey = "SharedMatrix";
+			public matrix!: SharedMatrix;
+
+			protected async initializingFirstTime() {
+				const sharedMatrix = SharedMatrix.create(this.runtime, this.matrixKey);
+				this.root.set(this.matrixKey, sharedMatrix.handle);
+				sharedMatrix.insertRows(0, 3);
+				sharedMatrix.insertCols(0, 3);
+			}
+
+			protected async hasInitialized() {
+				const matrixHandle = this.root.get<IFluidHandle<SharedMatrix>>(this.matrixKey);
+				assert(matrixHandle !== undefined, "SharedMatrix not found");
+				this.matrix = await matrixHandle.get();
+			}
+		}
+
+		const dataStoreFactory1 = new DataObjectFactory(
+			TestDataObjectType1,
+			TestDataObject1,
+			[SharedMatrix.getFactory()],
+			[],
+			[],
+		);
+
+		const registryStoreEntries = new Map<string, Promise<IFluidDataStoreFactory>>([
+			[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
+		]);
+
+		const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
+			ContainerRuntimeFactoryWithDefaultDataStore,
+			{
+				defaultFactory: dataStoreFactory1,
+				registryEntries: registryStoreEntries,
+				runtimeOptions,
+			},
+		);
+
+		async function createSummarizer(
+			testObjectProvider: ITestObjectProvider,
+			container: IContainer,
+			summaryVersion?: string,
+		): Promise<ISummarizer> {
+			const createSummarizerResult = await createSummarizerFromFactory(
+				testObjectProvider,
+				container,
+				dataStoreFactory1,
+				summaryVersion,
+				ContainerRuntimeFactoryWithDefaultDataStore,
+				registryStoreEntries,
+			);
+			return createSummarizerResult.summarizer;
+		}
+
 		let provider: ITestObjectProvider;
 		let mainContainer: IContainer;
 		let mainDataStore: TestDataObject1;

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
@@ -4,12 +4,12 @@
  */
 
 import { strict as assert } from "assert";
-import { DataObject, DataObjectFactory, PureDataObject } from "@fluidframework/aqueduct";
+import type { PureDataObject } from "@fluidframework/aqueduct";
 import { IContainer } from "@fluidframework/container-definitions";
 import { IContainerRuntimeOptions, ISummarizer } from "@fluidframework/container-runtime";
 import { FluidObject, IFluidHandle } from "@fluidframework/core-interfaces";
 import { FluidDataStoreRuntime, mixinSummaryHandler } from "@fluidframework/datastore";
-import { SharedMatrix } from "@fluidframework/matrix";
+import type { SharedMatrix } from "@fluidframework/matrix";
 import type { SharedMap } from "@fluidframework/map";
 import {
 	ITestObjectProvider,
@@ -18,9 +18,8 @@ import {
 	createSummarizerFromFactory,
 	createContainerRuntimeFactoryWithDefaultDataStore,
 } from "@fluidframework/test-utils";
-import { describeCompat, getContainerRuntimeApi } from "@fluid-private/test-version-utils";
+import { describeCompat } from "@fluid-private/test-version-utils";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
-import { pkgVersion } from "../packageVersion.js";
 
 interface ProvideSearchContent {
 	SearchContent: SearchContent;
@@ -39,30 +38,6 @@ const runtimeOptions: IContainerRuntimeOptions = {
 export const TestDataObjectType1 = "@fluid-example/test-dataStore1";
 export const TestDataObjectType2 = "@fluid-example/test-dataStore2";
 
-function createDataStoreRuntime(factory: typeof FluidDataStoreRuntime = FluidDataStoreRuntime) {
-	return mixinSummaryHandler(async (runtime: FluidDataStoreRuntime) => {
-		const obj: PureDataObject & FluidObject<SearchContent> =
-			await DataObject.getDataObject(runtime);
-		const searchObj = obj.SearchContent;
-		if (searchObj === undefined) {
-			return undefined;
-		}
-
-		// ODSP parser requires every search blob end with a line-feed character.
-		const searchContent = await searchObj.getSearchContent();
-		if (searchContent === undefined) {
-			return undefined;
-		}
-		const content = searchContent.endsWith("\n") ? searchContent : `${searchContent}\n`;
-		return {
-			// This is the path in snapshot that ODSP expects search blob (in plain text) to be for components
-			// that want to provide search content.
-			path: ["_search", "01"],
-			content,
-		};
-	}, factory);
-}
-
 /**
  * Validates the scenario in which, during summarization, a data store is loaded out of order.
  */
@@ -70,7 +45,35 @@ describeCompat(
 	"Summary where data store is loaded out of order",
 	"2.0.0-rc.1.0.0",
 	(getTestObjectProvider, apis) => {
-		const { SharedMap } = apis.dds;
+		const { SharedMap, SharedMatrix } = apis.dds;
+		const { DataObject, DataObjectFactory } = apis.dataRuntime;
+		const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+
+		function createDataStoreRuntime(
+			factory: typeof FluidDataStoreRuntime = FluidDataStoreRuntime,
+		) {
+			return mixinSummaryHandler(async (runtime: FluidDataStoreRuntime) => {
+				const obj: PureDataObject & FluidObject<SearchContent> =
+					await DataObject.getDataObject(runtime);
+				const searchObj = obj.SearchContent;
+				if (searchObj === undefined) {
+					return undefined;
+				}
+
+				// ODSP parser requires every search blob end with a line-feed character.
+				const searchContent = await searchObj.getSearchContent();
+				if (searchContent === undefined) {
+					return undefined;
+				}
+				const content = searchContent.endsWith("\n") ? searchContent : `${searchContent}\n`;
+				return {
+					// This is the path in snapshot that ODSP expects search blob (in plain text) to be for components
+					// that want to provide search content.
+					path: ["_search", "01"],
+					content,
+				};
+			}, factory);
+		}
 
 		class TestDataObject2 extends DataObject {
 			public get _root() {
@@ -164,10 +167,9 @@ describeCompat(
 			[dataStoreFactory1.type, Promise.resolve(dataStoreFactory1)],
 			[dataStoreFactory2.type, Promise.resolve(dataStoreFactory2)],
 		]);
-		const containerRuntimeFactoryWithDefaultDataStore =
-			getContainerRuntimeApi(pkgVersion).ContainerRuntimeFactoryWithDefaultDataStore;
+
 		const runtimeFactory = createContainerRuntimeFactoryWithDefaultDataStore(
-			containerRuntimeFactoryWithDefaultDataStore,
+			ContainerRuntimeFactoryWithDefaultDataStore,
 			{
 				defaultFactory: dataStoreFactory1,
 				registryEntries: registryStoreEntries,
@@ -185,7 +187,7 @@ describeCompat(
 				container,
 				dataStoreFactory1,
 				summaryVersion,
-				containerRuntimeFactoryWithDefaultDataStore,
+				ContainerRuntimeFactoryWithDefaultDataStore,
 				registryStoreEntries,
 			);
 			return createSummarizerResult.summarizer;

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -4,12 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import {
-	ContainerRuntimeFactoryWithDefaultDataStore,
-	DataObject,
-	DataObjectFactory,
-	PureDataObject,
-} from "@fluidframework/aqueduct";
+import type { PureDataObject } from "@fluidframework/aqueduct";
 import { ITelemetryLoggerExt, createChildLogger } from "@fluidframework/telemetry-utils";
 import { IContainer, IRuntimeFactory, LoaderHeader } from "@fluidframework/container-definitions";
 import { ILoaderProps } from "@fluidframework/container-loader";
@@ -25,7 +20,7 @@ import { FluidObject, IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter";
 import { FluidDataStoreRuntime, mixinSummaryHandler } from "@fluidframework/datastore";
 import { DriverHeader, ISummaryContext } from "@fluidframework/driver-definitions";
-import { SharedMatrix } from "@fluidframework/matrix";
+import type { SharedMatrix } from "@fluidframework/matrix";
 import {
 	ISequencedDocumentMessage,
 	ISummaryTree,
@@ -47,30 +42,6 @@ interface ProvideSearchContent {
 }
 interface SearchContent extends ProvideSearchContent {
 	getSearchContent(): Promise<string | undefined>;
-}
-
-function createDataStoreRuntime(factory: typeof FluidDataStoreRuntime = FluidDataStoreRuntime) {
-	return mixinSummaryHandler(async (runtime: FluidDataStoreRuntime) => {
-		const obj: PureDataObject & FluidObject<SearchContent> =
-			await DataObject.getDataObject(runtime);
-		const searchObj = obj.SearchContent;
-		if (searchObj === undefined) {
-			return undefined;
-		}
-
-		// ODSP parser requires every search blob end with a line-feed character.
-		const searchContent = await searchObj.getSearchContent();
-		if (searchContent === undefined) {
-			return undefined;
-		}
-		const content = searchContent.endsWith("\n") ? searchContent : `${searchContent}\n`;
-		return {
-			// This is the path in snapshot that ODSP expects search blob (in plain text) to be for components
-			// that want to provide search content.
-			path: ["_search", "01"],
-			content,
-		};
-	}, factory);
 }
 
 /**
@@ -169,62 +140,6 @@ async function submitAndAckSummary(
 
 export const TestDataObjectType1 = "@fluid-example/test-dataStore1";
 export const TestDataObjectType2 = "@fluid-example/test-dataStore2";
-class TestDataObject2 extends DataObject {
-	public get _root() {
-		return this.root;
-	}
-	public get _context() {
-		return this.context;
-	}
-}
-class TestDataObject1 extends DataObject implements SearchContent {
-	public async getSearchContent(): Promise<string | undefined> {
-		return Promise.resolve("TestDataObject1 Search Blob");
-	}
-	public get SearchContent() {
-		return this;
-	}
-	public get _root() {
-		return this.root;
-	}
-
-	public get _context() {
-		return this.context;
-	}
-
-	private readonly matrixKey = "SharedMatrix";
-	private readonly counterKey = "Counter";
-	public matrix!: SharedMatrix;
-	public undoRedoStackManager!: UndoRedoStackManager;
-	public counter!: SharedCounter;
-
-	protected async initializingFirstTime() {
-		const sharedMatrix = SharedMatrix.create(this.runtime, this.matrixKey);
-		this.root.set(this.matrixKey, sharedMatrix.handle);
-
-		const dataStore = await this._context.containerRuntime.createDataStore(TestDataObjectType2);
-		const dsFactory2 = (await dataStore.entryPoint.get()) as TestDataObject2;
-		this.root.set("dsFactory2", dsFactory2.handle);
-
-		const counter = SharedCounter.create(this.runtime, this.counterKey);
-		this.root.set(this.counterKey, counter.handle);
-	}
-
-	protected async hasInitialized() {
-		const matrixHandle = this.root.get<IFluidHandle<SharedMatrix>>(this.matrixKey);
-		assert(matrixHandle !== undefined, "SharedMatrix not found");
-		this.matrix = await matrixHandle.get();
-
-		this.undoRedoStackManager = new UndoRedoStackManager();
-		this.matrix.insertRows(0, 3);
-		this.matrix.insertCols(0, 3);
-		this.matrix.openUndo(this.undoRedoStackManager);
-
-		const counterHandle = this.root.get<IFluidHandle<SharedCounter>>(this.counterKey);
-		assert(counterHandle);
-		this.counter = await counterHandle.get();
-	}
-}
 
 /**
  * Validates whether or not a GC Tree Summary Handle should be written to the summary.
@@ -232,7 +147,95 @@ class TestDataObject1 extends DataObject implements SearchContent {
 describeCompat(
 	"Prepare for Summary with Search Blobs",
 	"2.0.0-rc.1.0.0",
-	(getTestObjectProvider) => {
+	(getTestObjectProvider, apis) => {
+		const { SharedMatrix } = apis.dds;
+		const { DataObject, DataObjectFactory } = apis.dataRuntime;
+		const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+
+		class TestDataObject2 extends DataObject {
+			public get _root() {
+				return this.root;
+			}
+			public get _context() {
+				return this.context;
+			}
+		}
+		class TestDataObject1 extends DataObject implements SearchContent {
+			public async getSearchContent(): Promise<string | undefined> {
+				return Promise.resolve("TestDataObject1 Search Blob");
+			}
+			public get SearchContent() {
+				return this;
+			}
+			public get _root() {
+				return this.root;
+			}
+
+			public get _context() {
+				return this.context;
+			}
+
+			private readonly matrixKey = "SharedMatrix";
+			private readonly counterKey = "Counter";
+			public matrix!: SharedMatrix;
+			public undoRedoStackManager!: UndoRedoStackManager;
+			public counter!: SharedCounter;
+
+			protected async initializingFirstTime() {
+				const sharedMatrix = SharedMatrix.create(this.runtime, this.matrixKey);
+				this.root.set(this.matrixKey, sharedMatrix.handle);
+
+				const dataStore =
+					await this._context.containerRuntime.createDataStore(TestDataObjectType2);
+				const dsFactory2 = (await dataStore.entryPoint.get()) as TestDataObject2;
+				this.root.set("dsFactory2", dsFactory2.handle);
+
+				const counter = SharedCounter.create(this.runtime, this.counterKey);
+				this.root.set(this.counterKey, counter.handle);
+			}
+
+			protected async hasInitialized() {
+				const matrixHandle = this.root.get<IFluidHandle<SharedMatrix>>(this.matrixKey);
+				assert(matrixHandle !== undefined, "SharedMatrix not found");
+				this.matrix = await matrixHandle.get();
+
+				this.undoRedoStackManager = new UndoRedoStackManager();
+				this.matrix.insertRows(0, 3);
+				this.matrix.insertCols(0, 3);
+				this.matrix.openUndo(this.undoRedoStackManager);
+
+				const counterHandle = this.root.get<IFluidHandle<SharedCounter>>(this.counterKey);
+				assert(counterHandle);
+				this.counter = await counterHandle.get();
+			}
+		}
+
+		function createDataStoreRuntime(
+			factory: typeof FluidDataStoreRuntime = FluidDataStoreRuntime,
+		) {
+			return mixinSummaryHandler(async (runtime: FluidDataStoreRuntime) => {
+				const obj: PureDataObject & FluidObject<SearchContent> =
+					await DataObject.getDataObject(runtime);
+				const searchObj = obj.SearchContent;
+				if (searchObj === undefined) {
+					return undefined;
+				}
+
+				// ODSP parser requires every search blob end with a line-feed character.
+				const searchContent = await searchObj.getSearchContent();
+				if (searchContent === undefined) {
+					return undefined;
+				}
+				const content = searchContent.endsWith("\n") ? searchContent : `${searchContent}\n`;
+				return {
+					// This is the path in snapshot that ODSP expects search blob (in plain text) to be for components
+					// that want to provide search content.
+					path: ["_search", "01"],
+					content,
+				};
+			}, factory);
+		}
+
 		let provider: ITestObjectProvider;
 		const dataStoreFactory1 = new DataObjectFactory(
 			TestDataObjectType1,

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -28,7 +28,7 @@ import { ConsensusRegisterCollection } from "@fluidframework/register-collection
 import { SequenceInterval, SharedString } from "@fluidframework/sequence";
 import { SharedCell } from "@fluidframework/cell";
 import { Ink } from "@fluidframework/ink";
-import { SharedMatrix } from "@fluidframework/matrix";
+import type { SharedMatrix } from "@fluidframework/matrix";
 import { ConsensusQueue, ConsensusOrderedCollection } from "@fluidframework/ordered-collection";
 import { SharedCounter } from "@fluidframework/counter";
 import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
@@ -121,7 +121,7 @@ describeCompat(
 	`Dehydrate Rehydrate Container Test`,
 	"FullCompat",
 	(getTestObjectProvider, apis) => {
-		const { SharedMap, SharedDirectory } = apis.dds;
+		const { SharedMap, SharedDirectory, SharedMatrix } = apis.dds;
 		function assertSubtree(tree: ISnapshotTree, key: string, msg?: string): ISnapshotTree {
 			const subTree = tree.trees[key];
 			assert(subTree, msg ?? `${key} subtree not present`);

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -15,7 +15,7 @@ import { DataStoreMessageType } from "@fluidframework/datastore";
 import { IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
 import { Ink, IColor } from "@fluidframework/ink";
 import type { SharedMap, SharedDirectory } from "@fluidframework/map";
-import { SharedMatrix } from "@fluidframework/matrix";
+import type { SharedMatrix } from "@fluidframework/matrix";
 import { MergeTreeDeltaType } from "@fluidframework/merge-tree";
 import { ConsensusQueue } from "@fluidframework/ordered-collection";
 import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
@@ -57,7 +57,7 @@ const createFluidObject = async (dataStoreContext: IFluidDataStoreContext, type:
 };
 
 describeCompat("Detached Container", "FullCompat", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory } = apis.dds;
+	const { SharedMap, SharedDirectory, SharedMatrix } = apis.dds;
 
 	const registry: ChannelFactoryRegistry = [
 		[sharedStringId, SharedString.getFactory()],
@@ -890,7 +890,7 @@ describeCompat("Detached Container", "FullCompat", (getTestObjectProvider, apis)
 
 // Review: Run with Full Compat?
 describeCompat("Detached Container", "2.0.0-rc.1.0.0", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory } = apis.dds;
+	const { SharedMap, SharedDirectory, SharedMatrix } = apis.dds;
 
 	const registry: ChannelFactoryRegistry = [
 		[sharedStringId, SharedString.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
@@ -20,13 +20,13 @@ import { FlushMode } from "@fluidframework/runtime-definitions";
 import { SharedCell } from "@fluidframework/cell";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { SharedCounter } from "@fluidframework/counter";
-import { SharedMatrix } from "@fluidframework/matrix";
+import type { SharedMatrix } from "@fluidframework/matrix";
 
 describeCompat(
 	"Op reentry and rebasing during pending batches",
 	"2.0.0-rc.1.0.0",
 	(getTestObjectProvider, apis) => {
-		const { SharedMap, SharedDirectory } = apis.dds;
+		const { SharedMap, SharedDirectory, SharedMatrix } = apis.dds;
 		const registry: ChannelFactoryRegistry = [
 			["map", SharedMap.getFactory()],
 			["sharedString", SharedString.getFactory()],


### PR DESCRIPTION
## Description

Adds a lint rule to prevent value imports of @fluidframework/matrix in e2e tests. This is inline with guidance  [here](https://github.com/microsoft/FluidFramework/tree/main/packages/test/test-end-to-end-tests#how-to).

This PR also adjusted several touched files which construct data objects using the current version of FF packages to use the appropriate version from compat config as well.