### PR TITLE
converts build-bundle-size-artifacts.yml pipeline to 1ES template

### DIFF
--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -15,8 +15,9 @@ trigger:
     - release/*
 
 extends:
-  template: templates/build-npm-package.yml
+  template: /tools/pipelines/templates/1ES/build-npm-package.yml@self
   parameters:
+    publish: false
     taskLint: false
     taskTest: [] # no tests
     taskPack: false
@@ -26,7 +27,10 @@ extends:
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
     buildDirectory: .
-    tagName: bundle-artifacts
+    tagName: bundle-artifact
+    # This pipeline doesn't generate production artifacts but the build-npm-package template is too intertwined with
+    # that scenario, which requires that the pipeline runs in the 1ES pool.
+    poolBuild: NewLarge-linux-1ES
     poolBuild: Large
     checkoutSubmodules: true
     releaseBuildOverride: none

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -27,7 +27,7 @@ extends:
     packageManagerInstallCommand: 'pnpm i --frozen-lockfile'
     packageManager: pnpm
     buildDirectory: .
-    tagName: bundle-artifact
+    tagName: bundle-artifacts
     # This pipeline doesn't generate production artifacts but the build-npm-package template is too intertwined with
     # that scenario, which requires that the pipeline runs in the 1ES pool.
     poolBuild: NewLarge-linux-1ES

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -31,7 +31,6 @@ extends:
     # This pipeline doesn't generate production artifacts but the build-npm-package template is too intertwined with
     # that scenario, which requires that the pipeline runs in the 1ES pool.
     poolBuild: NewLarge-linux-1ES
-    poolBuild: Large
     checkoutSubmodules: true
     releaseBuildOverride: none
     publishOverride: default


### PR DESCRIPTION
## Description

This PR converts build-bundle-size-artifacts.yml to the new 1ES template required by Microsoft with the minimal required set of template changes required. This new template enables security and auditing checks by Microsoft. Read more on how the logic for converting to a 1ES pipeline works on [the official 1ES wiki](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview)

A temporary 1ES folder was created for converted pipeline templates. This enables other pipelines to remain unchanged and use the original templates while new PR's are opened for individually converted other pipelines to 1ES as required by Microsoft.

- Once all pipelines are moved over, we can start moving the files out of the 1ES folder and eventually remove the folder since it will no longer have any files (This is after we convert the rest of the required pipelines). 

## Breaking Changes

## Reviewer Guidance

- Confirm the newly converted pipelines run successfully. Look at the completed steps and compare with a recent successful run on main to ensure the expected steps run (plus the new SDL and 1ES security checks)
- Make sure all the relevant templates and pipelines for build-bundle-size-artifacts.yml have been converted
- Make sure there are no unnecessary changes or 1ES template and/or pipeline conversions
- Make sure the yml is valid -- a successful pipeline run should suffice for confirming this