### PR TITLE
converts build-build-tools.yml pipeline to 1ES template

### DIFF
--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -49,12 +49,12 @@ trigger:
     - .prettierignore
     - build-tools
     - tools/pipelines/build-build-tools.yml
-    - tools/pipelines/templates/build-npm-package.yml
+    - tools/pipelines/templates/1ES/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
-    - tools/pipelines/templates/include-publish-npm-package.yml
-    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/1ES/include-publish-npm-package.yml
+    - tools/pipelines/templates/1ES/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
@@ -72,7 +72,7 @@ pr:
     - .prettierignore
     - build-tools
     - tools/pipelines/build-build-tools.yml
-    - tools/pipelines/templates/build-npm-package.yml
+    - tools/pipelines/templates/1ES/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
@@ -80,9 +80,17 @@ pr:
     - tools/pipelines/templates/include-process-test-results.yml
     - scripts/*
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+    parameters:
+      publishOverride: '${{ parameters.publishOverride }}'
+      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+      buildNumberInPatch: ''
+
 extends:
-  template: templates/build-npm-package.yml
+  template: /tools/pipelines/templates/1ES/build-npm-package.yml@self
   parameters:
+    publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
@@ -99,6 +107,7 @@ extends:
     - test:copyresults
     taskLint: true
     taskLintName: ci:eslint
+    poolBuild: NewLarge-linux-1ES
     poolBuild: Large
     checkoutSubmodules: true
     taskBundleAnalysis: false

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -108,7 +108,6 @@ extends:
     taskLint: true
     taskLintName: ci:eslint
     poolBuild: NewLarge-linux-1ES
-    poolBuild: Large
     checkoutSubmodules: true
     taskBundleAnalysis: false
     checks:


### PR DESCRIPTION
## Description

This PR converts  build-build-tools.yml to the new 1ES template required by Microsoft with the minimal required set of template changes required. This new template enables security and auditing checks by Microsoft. Read more on how the logic for converting to a 1ES pipeline works on [the official 1ES wiki](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview)

A temporary 1ES folder was created for converted pipeline templates. This enables other pipelines to remain unchanged and use the original templates while new PR's are opened for individually converted other pipelines to 1ES as required by Microsoft.

- Once all pipelines are moved over, we can start moving the files out of the 1ES folder and eventually remove the folder since it will no longer have any files (This is after we convert the rest of the required pipelines). 

## Breaking Changes

## Reviewer Guidance

- Confirm the newly converted pipelines run successfully. Look at the completed steps and compare with a recent successful run on main to ensure the expected steps run (plus the new SDL and 1ES security checks)
- Make sure all the relevant templates and pipelines for build-build-tools.yml have been converted
- Make sure there are no unnecessary changes or 1ES template and/or pipeline conversions
- Make sure the yml is valid -- a successful pipeline run should suffice for confirming this