### PR TITLE
converts build-benchmark-tool.yml pipeline to 1ES template

### DIFF
--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -38,12 +38,12 @@ trigger:
     - .prettierignore
     - tools/benchmark
     - tools/pipelines/build-benchmark-tool.yml
-    - tools/pipelines/templates/build-npm-package.yml
+    - tools/pipelines/templates/1ES/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
-    - tools/pipelines/templates/include-publish-npm-package.yml
-    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/1ES/include-publish-npm-package.yml
+    - tools/pipelines/templates/1ES/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
@@ -61,7 +61,7 @@ pr:
     - .prettierignore
     - tools/benchmark
     - tools/pipelines/build-benchmark-tool.yml
-    - tools/pipelines/templates/build-npm-package.yml
+    - tools/pipelines/templates/1ES/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
@@ -69,9 +69,17 @@ pr:
     - tools/pipelines/templates/include-process-test-results.yml
     - scripts/*
 
+variables:
+  - template: /tools/pipelines/templates/1ES/include-vars.yml@self
+    parameters:
+      publishOverride: '${{ parameters.publishOverride }}'
+      releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'
+      buildNumberInPatch: ''
+
 extends:
-  template: templates/build-npm-package.yml
+  template: /tools/pipelines/templates/1ES/build-npm-package.yml@self
   parameters:
+    publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -70,7 +70,7 @@ pr:
     - scripts/*
 
 variables:
-  - template: /tools/pipelines/templates/1ES/include-vars.yml@self
+  - template: /tools/pipelines/templates/include-vars.yml@self
     parameters:
       publishOverride: '${{ parameters.publishOverride }}'
       releaseBuildOverride: '${{ parameters.releaseBuildOverride }}'


### PR DESCRIPTION
## Description

This PR converts build-benchmark-tool.yml to the new 1ES template required by Microsoft with the minimal required set of template changes required. This new template enables security and auditing checks by Microsoft. Read more on how the logic for converting to a 1ES pipeline works on [the official 1ES wiki](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview)

A temporary 1ES folder was created for converted pipeline templates. This enables other pipelines to remain unchanged and use the original templates while new PR's are opened for individually converted other pipelines to 1ES as required by Microsoft.

- Once all pipelines are moved over, we can start moving the files out of the 1ES folder and eventually remove the folder since it will no longer have any files (This is after we convert the rest of the required pipelines). 

## Breaking Changes

## Reviewer Guidance

- Confirm the newly converted pipelines run successfully. Look at the completed steps and compare with a recent successful run on main to ensure the expected steps run (plus the new SDL and 1ES security checks)
- Make sure all the relevant templates and pipelines for build-benchmark-tool.yml have been converted
- Make sure there are no unnecessary changes or 1ES template and/or pipeline conversions
- Make sure the yml is valid -- a successful pipeline run should suffice for confirming this