### PR TITLE
converts build-azure.yml pipeline to 1ES template

### DIFF
--- a/tools/pipelines/build-azure.yml
+++ b/tools/pipelines/build-azure.yml
@@ -41,12 +41,12 @@ trigger:
     - .prettierignore
     - azure
     - tools/pipelines/build-azure.yml
-    - tools/pipelines/templates/build-npm-package.yml
+    - tools/pipelines/templates/1ES/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
-    - tools/pipelines/templates/include-publish-npm-package.yml
-    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/1ES/include-publish-npm-package.yml
+    - tools/pipelines/templates/1ES/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
@@ -75,12 +75,12 @@ pr:
     - .prettierignore
     - azure
     - tools/pipelines/build-azure.yml
-    - tools/pipelines/templates/build-npm-package.yml
+    - tools/pipelines/templates/1ES/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
-    - tools/pipelines/templates/include-publish-npm-package.yml
-    - tools/pipelines/templates/include-publish-npm-package-deployment.yml
+    - tools/pipelines/templates/1ES/include-publish-npm-package.yml
+    - tools/pipelines/templates/1ES/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
@@ -93,10 +93,10 @@ pr:
     - packages/framework/loader/container-loader
     - packages/test/test-end-to-end-tests
     - tools/pipelines/test-service-clients.yml
-    - tools/pipelines/templates/include-test-real-service.yml
+    - tools/pipelines/templates/1ES/include-test-real-service.yml
 
 extends:
-  template: templates/build-npm-package.yml
+  template: /tools/pipelines/templates/1ES/build-npm-package.yml@self 
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
@@ -105,6 +105,6 @@ extends:
     packageManager: pnpm
     buildDirectory: azure
     tagName: azure
-    poolBuild: Large
+    poolBuild: NewLarge-linux-1ES
     checkoutSubmodules: true
     taskBundleAnalysis: false

--- a/tools/pipelines/templates/1ES/include-test-real-service.yml
+++ b/tools/pipelines/templates/1ES/include-test-real-service.yml
@@ -1,0 +1,364 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# include-test-real-service
+
+parameters:
+- name: poolBuild
+  type: object
+  default: Small-1ES
+
+- name: testPackage
+  type: string
+  default: "@fluid-private/test-end-to-end-tests"
+
+- name: testWorkspace
+  type: string
+
+- name: timeoutInMinutes
+  type: number
+  default: 60
+
+- name: env
+  type: object
+  default:
+
+- name: splitTestVariants
+  type: object
+  default:
+  - name: ""
+    flags: ""
+
+- name: testCommand
+  type: string
+
+- name: continueOnError
+  type: boolean
+  default: false
+
+- name: testFileTarName
+  type: string
+  default: null
+
+# Id of the pipeline run that contains the artifacts to download.
+# Needed to workaround a bug in the DownloadPipelineArtifact task that might cause artifacts to be downloaded from the
+# incorrect pipeline run (see https://github.com/microsoft/azure-pipelines-tasks/issues/13518).
+- name: artifactBuildId
+  type: string
+
+# Name of the Secure File that contains the self-signed cert for the R11s deployment.
+# If not blank, the pipeline will try to install it to the local cert store.
+- name: r11sSelfSignedCertSecureFile
+  type: string
+  default: ""
+
+- name: condition
+  type: string
+  default: true
+
+- name: loggerPackage
+  type: string
+  default: '@ff-internal/aria-logger'
+
+# Custom steps specified by the "caller" of this template, for any additional things that need to be done
+# after the steps in this template complete.
+- name: additionalSteps
+  type: stepList
+  default: []
+
+jobs:
+  - ${{ each variant in parameters.splitTestVariants }}:
+    - job:
+      displayName: Run ${{ variant.name }}
+      pool: ${{ parameters.poolBuild }}
+      condition: ${{ parameters.condition }}
+      timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+      variables:
+      - group: ado-feeds
+      - name: isTestBranch
+        value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/test/') }}
+        readonly: true
+      # We use 'chalk' to colorize output, which auto-detects color support in the
+      # running terminal.  The log output shown in Azure DevOps job runs only has
+      # basic ANSI color support though, so force that in the pipeline
+      - name: FORCE_COLOR
+        value: 1
+      - name: testPackageDir
+        value: '${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}'
+      - name: testPackageFilePattern
+        value: ${{ replace(replace(parameters.testPackage, '@', '' ), '/', '-') }}-[0-9]*.tgz
+      - name: testPackagePathPattern
+        value: $(Pipeline.Workspace)/client/pack/scoped/${{ variables.testPackageFilePattern }}
+      - name: skipComponentGovernanceDetection
+        value: true
+      - name: artifactPipeline
+        value: Build - client packages
+      - name: feed
+        ${{ if eq(variables.isTestBranch, 'true') }}:
+          value: $(ado-feeds-internal) # Comes from the ado-feeds variable group
+        ${{ else }}:
+          value: $(ado-feeds-build) # Comes from the ado-feeds variable group
+      - name: devFeed
+        ${{ if eq(variables.isTestBranch, 'true') }}:
+          value: $(ado-feeds-internal) # Comes from the ado-feeds variable group
+        ${{ else }}:
+          value: $(ado-feeds-dev) # Comes from the ado-feeds variable group
+
+      steps:
+      # Setup
+      - checkout: none
+        clean: true
+
+      # Install self-signed cert for R11s deployment in local cert store
+      - ${{ if ne(parameters.r11sSelfSignedCertSecureFile, '') }}:
+        - task: DownloadSecureFile@1
+          displayName: 'Download r11s self-signed cert'
+          name: downloadCertTask
+          inputs:
+            secureFile: ${{ parameters.r11sSelfSignedCertSecureFile }}
+            retryCount: '2'
+
+        - task: Bash@3
+          displayName: 'Install r11s self-signed cert in local cert store'
+          inputs:
+            targetType: 'inline'
+            script: |
+
+              # Extract public part from cert
+              openssl x509 -in $(downloadCertTask.secureFilePath) -out cert.crt
+              # Install cert
+              sudo cp cert.crt /usr/local/share/ca-certificates/
+              sudo update-ca-certificates
+
+      # Print parameters/Vars
+      # Variables declared outside this template will only work with "macro syntax": $(name).
+      # Variables declared inside this template also work with "template expression syntax": ${{ variables.name }}.
+      - task: Bash@3
+        displayName: Print Parameters and Variables
+        inputs:
+          targetType: 'inline'
+          script: |
+            # Show all task group conditions
+
+            echo "
+            Pipeline Parameters:
+              poolBuild=${{ parameters.poolBuild }}
+              testPackage=${{ parameters.testPackage }}
+
+            Pipeline Variables:
+              isTestBranch=${{ variables.isTestBranch }}
+              testWorkspace=${{ parameters.testWorkspace }}
+              testPackageFilePattern=${{ variables.testPackageFilePattern }}
+              feed=${{ variables.feed }}
+              devFeed=${{ variables.devFeed }}
+              testCommand=${{ parameters.testCommand }}
+              continueOnError=${{ parameters.continueOnError }}
+              variant.flag=${{ variant.flags }}
+              testFileTarName=${{ parameters.testFileTarName }}
+              artifactPipeline=${{ variables.artifactPipeline }}
+              artifactBuildId=${{ parameters.artifactBuildId }}
+            "
+
+      - template: include-use-node-version.yml
+
+      # Download artifact
+      - task: DownloadPipelineArtifact@2
+        displayName: Download test package
+        inputs:
+          source: specific
+          project: internal
+          pipeline: ${{ variables.artifactPipeline }}
+          buildVersionToDownload: specific
+          buildId: ${{ parameters.artifactBuildId }}
+          artifact: pack
+          patterns: "**/${{ variables.testPackageFilePattern }}"
+          path: $(Pipeline.Workspace)/client/pack
+          # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
+          # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
+          # It seems there's a bug and preferTriggeringPipeline is not respected.
+          # We force the behavior by explicitly specifying:
+          # - buildVersionToDownload: specific
+          # - buildId: <the id of the triggering build>
+          # preferTriggeringPipeline: true
+
+
+      - task: Bash@3
+        displayName: Create test directory
+        inputs:
+          targetType: 'inline'
+          script: |
+            mkdir ${{ parameters.testWorkspace }}
+
+      - task: Bash@3
+        name: Initialize
+        displayName: Initialize
+        inputs:
+          targetType: 'inline'
+          workingDirectory: ${{ parameters.testWorkspace }}
+          # Note: $(ado-feeds-build) and $(ado-feeds-office) come from the ado-feeds variable group
+          script: |
+            echo Initialize package
+            npm init --yes
+
+            echo Generating .npmrc
+            echo "registry=https://registry.npmjs.org" >> ./.npmrc
+            echo "always-auth=false" >> ./.npmrc
+
+            echo "@fluidframework:registry=${{ variables.feed }}" >> ./.npmrc
+            echo "@fluid-experimental:registry=${{ variables.feed }}" >> ./.npmrc
+
+            # This is confusing, but we are using the .npmrc here to load dependencies from different feeds. These
+            # scopes must be loaded from the "dev" feed because that is the only place they are published. Ideally this
+            # logic will be centralized outside of CI in the future.
+            echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
+            echo "@fluid-private:registry=${{ variables.devFeed }}" >> ./.npmrc
+
+            # This scope must be loaded from the "build" feed
+            echo "@ff-internal:registry=$(ado-feeds-build)" >> ./.npmrc
+
+            # This scope must be loaded from the internal Office feed
+            echo "@microsoft:registry=$(ado-feeds-office)" >> ./.npmrc
+
+            echo "always-auth=true" >> ./.npmrc
+            cat .npmrc
+
+            if [[ `ls -1 ${{ variables.testPackagePathPattern }} | wc -l` -eq 1 ]]; then
+              echo "##vso[task.setvariable variable=testPackageTgz;isOutput=true]`ls ${{ variables.testPackagePathPattern }}`"
+            else
+              ls -1 ${{ variables.testPackagePathPattern }}
+              echo "##vso[task.logissue type=error]Test package '${{ parameters.testPackage }}' not found, or there are more than one found"
+              exit -1
+            fi
+
+      # Auth to internal feed
+      - task: npmAuthenticate@0
+        displayName: 'npm authenticate (internal feed)'
+        inputs:
+          workingFile: ${{ parameters.testWorkspace }}/.npmrc
+
+      # Install test and logger package
+      - task: Npm@1
+        displayName: 'npm install'
+        inputs:
+          command: 'custom'
+          workingDir: ${{ parameters.testWorkspace }}
+          customCommand: 'install $(Initialize.testPackageTgz) ${{ parameters.loggerPackage }}'
+          customRegistry: 'useNpmrc'
+
+      # Download Test Files & Install Extra Dependencies
+      # These steps are intended to include extra dependencies that are not available as
+      # part of the normal package .tgz installed previously in the pipeline.
+      - ${{ if ne(parameters.testFileTarName, 'null') }}:
+        # Download Artifact - Test Files
+        - task: DownloadPipelineArtifact@2
+          displayName: Download test files
+          inputs:
+            source: specific
+            project: internal
+            pipeline: ${{ variables.artifactPipeline }}
+            buildVersionToDownload: specific
+            buildId: ${{ parameters.artifactBuildId }}
+            artifact: test-files
+            path: $(Pipeline.Workspace)/test-files
+            # allowPartiallySucceededBuilds: true # No effect as long as we have buildVersionToDownload: specific
+            # branchName: $(Build.SourceBranch)   # No effect as long as we have buildVersionToDownload: specific
+            # It seems there's a bug and preferTriggeringPipeline is not respected.
+            # We force the behavior by explicitly specifying:
+            # - buildVersionToDownload: specific
+            # - buildId: <the id of the triggering build>
+            # preferTriggeringPipeline: true
+
+        # Unpack test files
+        - task: Bash@3
+          displayName: Unpack test files
+          inputs:
+            workingDir: ${{ parameters.testWorkspace }}
+            targetType: 'inline'
+            script: |
+              mkdir ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/dist/test
+              tar -xvf $(Pipeline.Workspace)/test-files/${{ parameters.testFileTarName }}.test-files.tar -C $(Pipeline.Workspace)/test-files
+              mv $(Pipeline.Workspace)/test-files/dist/test/* ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/dist/test
+
+        - task: Bash@3
+          displayName: Copy devDependencies
+          inputs:
+            workingDir: ${{ parameters.testWorkspace }}
+            targetType: 'inline'
+            script: |
+              testPkgJsonPath=${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/package.json
+              pkgJsonPath=${{ parameters.testWorkspace }}/package.json
+              node -e "
+                const { devDependencies } = require('$testPkgJsonPath');
+                const pkg = require('$pkgJsonPath');
+                pkg.devDependencies=devDependencies;
+                require('fs').writeFileSync('$pkgJsonPath', JSON.stringify(pkg));
+              "
+
+        - task: Npm@1
+          displayName: 'npm install - extra dependencies for test files'
+          inputs:
+            command: 'custom'
+            workingDir: ${{ parameters.testWorkspace }}
+            customCommand: 'install'
+            customRegistry: 'useNpmrc'
+
+      # run the test
+      - task: Npm@1
+        displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'
+        continueOnError: ${{ parameters.continueOnError }}
+        env:
+          ${{ parameters.env }}
+        inputs:
+          command: 'custom'
+          workingDir: ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}
+          customCommand: 'run ${{ parameters.testCommand }} -- ${{ variant.flags }}'
+
+      # filter report
+      - task: Bash@3
+        displayName: Filter skipped test from report
+        condition: succeededOrFailed()
+        inputs:
+          workingDir: ${{ variables.testPackageDir }}/nyc
+          targetType: 'inline'
+          script: |
+            if [[ -d ${{ variables.testPackageDir }}/nyc ]]; then
+              echo "directory '${{ variables.testPackageDir }}/nyc' exists."
+              cd ${{ variables.testPackageDir }}/nyc
+              if ! [[ -z "$(ls -A .)" ]]; then
+                curdirfiles=`ls`
+                echo "report file(s) ${curdirfiles} found. Filtering skipped tests..."
+                for i in `ls`; do sed -i '/<skipped/d' $i; done
+              else
+                echo "No report files found in '${{ variables.testPackageDir }}/nyc'"
+              fi
+            else
+              echo "Directory '${{ variables.testPackageDir }}/nyc' not found"
+            fi
+
+      # Upload results
+      - task: PublishTestResults@2
+        displayName: Publish Test Results
+        inputs:
+          testResultsFormat: 'JUnit'
+          testResultsFiles: '**/*junit-report.xml'
+          searchFolder: ${{ variables.testPackageDir }}/nyc
+          mergeTestResults: false
+        condition: succeededOrFailed()
+
+      # Publish tinylicious log for troubleshooting
+      - ${{ if or(contains(convertToJson(parameters.testCommand), 'tinylicious'), contains(convertToJson(parameters.testCommand), 't9s')) }}:
+        - task: PublishPipelineArtifact@1
+          displayName: Publish Artifact - Tinylicious Log
+          inputs:
+            targetPath: '${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/tinylicious.log'
+            artifactName: 'tinyliciousLog_attempt-$(System.JobAttempt)'
+            publishLocation: 'pipeline'
+          condition: succeededOrFailed()
+          continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
+
+      # Log Test Failures
+      # - template: include-process-test-results.yml
+      #   parameters:
+      #     buildDirectory: ${{ variables.testPackageDir }}
+
+      - ${{ parameters.additionalSteps }}


### PR DESCRIPTION
## Description

This PR converts build-azure.yml to the new 1ES template required by Microsoft with the minimal required set of template changes required. This new template enables security and auditing checks by Microsoft. Read more on how the logic for converting to a 1ES pipeline works on [the official 1ES wiki](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview)

A temporary 1ES folder was created for converted pipeline templates. This enables other pipelines to remain unchanged and use the original templates while new PR's are opened for individually converted other pipelines to 1ES as required by Microsoft.
**You can easily view what the template changes are by looking at the diff in [the following PR](https://github.com/microsoft/FluidFramework/pull/19326) which is a fork of this branch and simply moves the template changes from the 1ES folder to the original so there is a clear diff present on github**

- Once all pipelines are moved over, we can start moving the files out of the 1ES folder and eventually remove the folder since it will no longer have any files (This is after we convert the rest of the required pipelines). 

## Breaking Changes

## Reviewer Guidance

- Confirm the newly converted pipelines run successfully. Look at the completed steps and compare with a recent successful run on main to ensure the expected steps run (plus the new SDL and 1ES security checks)
- Make sure all the relevant templates and pipelines for build-azure.yml have been converted
- Make sure there are no unnecessary changes or 1ES template and/or pipeline conversions
- Make sure the yml is valid -- a successful pipeline run should suffice for confirming this