### PR TITLE
Remove next branch from the test-stability running

### DIFF
--- a/tools/pipelines/test-stability.yml
+++ b/tools/pipelines/test-stability.yml
@@ -131,7 +131,6 @@ schedules:
     branches:
       include:
       - main
-      - next
     always: true
 
 variables:


### PR DESCRIPTION
As title, the next branch is no longer relevant right now. 
