### PR TITLE
docs: update build-docs artifact download to target trigger branch

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -100,44 +100,6 @@ trigger:
     - main
 pr: none
 
-# TODO: the download artifact step is currently targetting the latest pipeline run from each resource.
-# However, this is causing inconsistencies in the doc in scenarios where the latest runs on each pipeline
-# is not the same (e.g. mix of main and lts). Temporarily setting the branch to main explicitly.
-resources:
-  pipelines:
-  - pipeline: common_definitions
-    source: Build - common-definitions
-    branch: main
-  - pipeline: common_utils
-    source: Build - common-utils
-    branch: main
-  - pipeline: container_definitions
-    source: Build - container-definitions
-    branch: main
-  - pipeline: core_interfaces
-    source: Build - core-interfaces
-    branch: main
-  - pipeline: driver_definitions
-    source: Build - driver-definitions
-    branch: main
-  - pipeline: protocol_definitions
-    source: Build - protocol-definitions
-    branch: main
-  - pipeline: azure
-    source: Build - azure
-    branch: main
-  - pipeline: client
-    source: Build - client packages
-    branch: main
-    trigger:
-      branches:
-        include:
-        - main
-        - docs/**
-  - pipeline: server
-    source: server-routerlicious
-    branch: main
-
 stages:
 - stage: build
   displayName: 'Build website'

--- a/tools/pipelines/templates/download-api-extractor-artifact.yml
+++ b/tools/pipelines/templates/download-api-extractor-artifact.yml
@@ -2,13 +2,13 @@
 # Licensed under the MIT License.
 
 # download-api-extractor-artifact pipeline
-# Downloads the _api-extractor-temp artifact from a specific internal pipeline using
-# branchName and pipelineName as parameters. By default, the branch triggering this
-# pipeline will be used as branchName. 
 parameters:
+# Name of the internal pipeline where the artifact is published
 - name: pipelineName
   type: string
 
+# Branch name to filter specific runs. Takes the most recent completed build which
+# matches the branch name. By default, the branch triggering this pipeline is used
 - name: branchName
   type: string
   default: ${{ variables['Build.SourceBranch'] }}

--- a/tools/pipelines/templates/download-api-extractor-artifact.yml
+++ b/tools/pipelines/templates/download-api-extractor-artifact.yml
@@ -1,14 +1,17 @@
 # Copyright (c) Microsoft Corporation and contributors. All rights reserved.
 # Licensed under the MIT License.
 
-# download-pipeline-artifact pipeline
-
+# download-api-extractor-artifact pipeline
+# Downloads the _api-extractor-temp artifact from a specific internal pipeline using
+# branchName and pipelineName as parameters. By default, the branch triggering this
+# pipeline will be used as branchName. 
 parameters:
-- name: pipelineDefinition
+- name: pipelineName
   type: string
 
 - name: branchName
   type: string
+  default: ${{ variables['Build.SourceBranch'] }}
   
 steps:
 # Download the api-extractor outputs
@@ -19,7 +22,7 @@ steps:
   inputs:
     buildType: specific
     project: internal
-    pipeline: ${{ parameters.pipelineDefinition }}
+    pipeline: ${{ parameters.pipelineName }}
     buildVersionToDownload: latestFromBranch
     branchName: ${{ parameters.branchName }}
     artifact: _api-extractor-temp

--- a/tools/pipelines/templates/download-pipeline-artifact.yml
+++ b/tools/pipelines/templates/download-pipeline-artifact.yml
@@ -11,9 +11,6 @@ parameters:
   type: string
   
 steps:
-- checkout: none
-  clean: true
-  
 # Download the api-extractor outputs
 # Setting allowPartiallySucceededBuilds to true so that builds which complete with 
 # warnings will be included as well. This is especially needed for archived builds

--- a/tools/pipelines/templates/download-pipeline-artifact.yml
+++ b/tools/pipelines/templates/download-pipeline-artifact.yml
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# download-pipeline-artifact pipeline
+
+parameters:
+- name: pipelineDefinition
+  type: string
+
+- name: branchName
+  type: string
+  
+steps:
+- checkout: none
+  clean: true
+  
+# Download the api-extractor outputs
+# Setting allowPartiallySucceededBuilds to true so that builds which complete with 
+# warnings will be included as well. This is especially needed for archived builds
+# with warnings such as driver-definitions and core-interfaces
+- task: DownloadPipelineArtifact@2
+  inputs:
+    buildType: specific
+    project: internal
+    pipeline: ${{ parameters.pipelineDefinition }}
+    buildVersionToDownload: latestFromBranch
+    branchName: ${{ parameters.branchName }}
+    artifact: _api-extractor-temp
+    allowPartiallySucceededBuilds: true

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -19,42 +19,33 @@ steps:
   clean: true
 
 # Download the api-extractor outputs
-- template: download-pipeline-artifact.yml
+- template: download-api-extractor-artifact.yml
   parameters:
-    pipelineDefinition: Build - common-definitions
-    branchName: ${{ variables['Build.SourceBranch'] }}
-- template: download-pipeline-artifact.yml
+    pipelineName: Build - common-definitions
+- template: download-api-extractor-artifact.yml
   parameters:
-    pipelineDefinition: Build - common-utils
-    branchName: ${{ variables['Build.SourceBranch'] }}
-- template: download-pipeline-artifact.yml
+    pipelineName: Build - common-utils
+- template: download-api-extractor-artifact.yml
   parameters:
-    pipelineDefinition: Build - container-definitions
-    branchName: ${{ variables['Build.SourceBranch'] }}
-- template: download-pipeline-artifact.yml
+    pipelineName: Build - container-definitions
+- template: download-api-extractor-artifact.yml
   parameters:
-    pipelineDefinition: Build - core-interfaces
-    branchName: ${{ variables['Build.SourceBranch'] }}
-- template: download-pipeline-artifact.yml
+    pipelineName: Build - core-interfaces
+- template: download-api-extractor-artifact.yml
   parameters:
-    pipelineDefinition: Build - driver-definitions
-    branchName: ${{ variables['Build.SourceBranch'] }}
-- template: download-pipeline-artifact.yml
+    pipelineName: Build - driver-definitions
+- template: download-api-extractor-artifact.yml
   parameters:
-    pipelineDefinition: Build - protocol-definitions
-    branchName: ${{ variables['Build.SourceBranch'] }}
-- template: download-pipeline-artifact.yml
+    pipelineName: Build - protocol-definitions
+- template: download-api-extractor-artifact.yml
   parameters:
-    pipelineDefinition: Build - azure
-    branchName: ${{ variables['Build.SourceBranch'] }}
-- template: download-pipeline-artifact.yml
+    pipelineName: Build - azure
+- template: download-api-extractor-artifact.yml
   parameters:
-    pipelineDefinition: Build - client packages
-    branchName: ${{ variables['Build.SourceBranch'] }}
-- template: download-pipeline-artifact.yml
+    pipelineName: Build - client packages
+- template: download-api-extractor-artifact.yml
   parameters:
-    pipelineDefinition: server-routerlicious
-    branchName: ${{ variables['Build.SourceBranch'] }}
+    pipelineName: server-routerlicious
 
 # Copy and merge the api-extractor outputs to a central location
 - task: CopyFiles@2

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -15,6 +15,9 @@ parameters:
   default: false
 
 steps:
+- checkout: none
+  clean: true
+
 # Download the api-extractor outputs
 - template: download-pipeline-artifact.yml
   parameters:

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -19,39 +19,39 @@ steps:
   clean: true
 
 # Download the api-extractor outputs
-- template: templates/download-pipeline-artifact.yml
+- template: download-pipeline-artifact.yml
   parameters:
     pipelineDefinition: Build - common-definitions
     branchName: ${{ variables['Build.SourceBranch'] }}
-- template: templates/download-pipeline-artifact.yml
+- template: download-pipeline-artifact.yml
   parameters:
     pipelineDefinition: Build - common-utils
     branchName: ${{ variables['Build.SourceBranch'] }}
-- template: templates/download-pipeline-artifact.yml
+- template: download-pipeline-artifact.yml
   parameters:
     pipelineDefinition: Build - container-definitions
     branchName: ${{ variables['Build.SourceBranch'] }}
-- template: templates/download-pipeline-artifact.yml
+- template: download-pipeline-artifact.yml
   parameters:
     pipelineDefinition: Build - core-interfaces
     branchName: ${{ variables['Build.SourceBranch'] }}
-- template: templates/download-pipeline-artifact.yml
+- template: download-pipeline-artifact.yml
   parameters:
     pipelineDefinition: Build - driver-definitions
     branchName: ${{ variables['Build.SourceBranch'] }}
-- template: templates/download-pipeline-artifact.yml
+- template: download-pipeline-artifact.yml
   parameters:
     pipelineDefinition: Build - protocol-definitions
     branchName: ${{ variables['Build.SourceBranch'] }}
-- template: templates/download-pipeline-artifact.yml
+- template: download-pipeline-artifact.yml
   parameters:
     pipelineDefinition: Build - azure
     branchName: ${{ variables['Build.SourceBranch'] }}
-- template: templates/download-pipeline-artifact.yml
+- template: download-pipeline-artifact.yml
   parameters:
     pipelineDefinition: Build - client packages
     branchName: ${{ variables['Build.SourceBranch'] }}
-- template: templates/download-pipeline-artifact.yml
+- template: download-pipeline-artifact.yml
   parameters:
     pipelineDefinition: server-routerlicious
     branchName: ${{ variables['Build.SourceBranch'] }}

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -15,9 +15,6 @@ parameters:
   default: false
 
 steps:
-- checkout: none
-  clean: true
-
 # Download the api-extractor outputs
 - template: download-pipeline-artifact.yml
   parameters:

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -19,87 +19,42 @@ steps:
   clean: true
 
 # Download the api-extractor outputs
-- task: DownloadPipelineArtifact@2
-  inputs:
-    buildType: specific
-    project: internal
-    pipeline: Build - common-definitions
-    buildVersionToDownload: latestFromBranch
+- template: templates/download-pipeline-artifact.yml
+  parameters:
+    pipelineDefinition: Build - common-definitions
     branchName: ${{ variables['Build.SourceBranch'] }}
-    artifact: _api-extractor-temp
-    allowPartiallySucceededBuilds: true
-- task: DownloadPipelineArtifact@2
-  inputs:
-    buildType: specific
-    project: internal
-    pipeline: Build - common-utils
-    buildVersionToDownload: latestFromBranch
+- template: templates/download-pipeline-artifact.yml
+  parameters:
+    pipelineDefinition: Build - common-utils
     branchName: ${{ variables['Build.SourceBranch'] }}
-    artifact: _api-extractor-temp
-    allowPartiallySucceededBuilds: true
-- task: DownloadPipelineArtifact@2
-  inputs:
-    buildType: specific
-    project: internal
-    pipeline: Build - container-definitions
-    buildVersionToDownload: latestFromBranch
+- template: templates/download-pipeline-artifact.yml
+  parameters:
+    pipelineDefinition: Build - container-definitions
     branchName: ${{ variables['Build.SourceBranch'] }}
-    artifact: _api-extractor-temp
-    allowPartiallySucceededBuilds: true
-- task: DownloadPipelineArtifact@2
-  inputs:
-    buildType: specific
-    project: internal
-    pipeline: Build - core-interfaces
-    buildVersionToDownload: latestFromBranch
+- template: templates/download-pipeline-artifact.yml
+  parameters:
+    pipelineDefinition: Build - core-interfaces
     branchName: ${{ variables['Build.SourceBranch'] }}
-    artifact: _api-extractor-temp
-    allowPartiallySucceededBuilds: true
-- task: DownloadPipelineArtifact@2
-  inputs:
-    buildType: specific
-    project: internal
-    pipeline: Build - driver-definitions
-    buildVersionToDownload: latestFromBranch
+- template: templates/download-pipeline-artifact.yml
+  parameters:
+    pipelineDefinition: Build - driver-definitions
     branchName: ${{ variables['Build.SourceBranch'] }}
-    artifact: _api-extractor-temp
-    allowPartiallySucceededBuilds: true
-- task: DownloadPipelineArtifact@2
-  inputs:
-    buildType: specific
-    project: internal
-    pipeline: Build - protocol-definitions
-    buildVersionToDownload: latestFromBranch
+- template: templates/download-pipeline-artifact.yml
+  parameters:
+    pipelineDefinition: Build - protocol-definitions
     branchName: ${{ variables['Build.SourceBranch'] }}
-    artifact: _api-extractor-temp
-    allowPartiallySucceededBuilds: true
-- task: DownloadPipelineArtifact@2
-  inputs:
-    buildType: specific
-    project: internal
-    pipeline: Build - azure
-    buildVersionToDownload: latestFromBranch
+- template: templates/download-pipeline-artifact.yml
+  parameters:
+    pipelineDefinition: Build - azure
     branchName: ${{ variables['Build.SourceBranch'] }}
-    artifact: _api-extractor-temp
-    allowPartiallySucceededBuilds: true
-- task: DownloadPipelineArtifact@2
-  inputs:
-    buildType: specific
-    project: internal
-    pipeline: Build - client packages
-    buildVersionToDownload: latestFromBranch
+- template: templates/download-pipeline-artifact.yml
+  parameters:
+    pipelineDefinition: Build - client packages
     branchName: ${{ variables['Build.SourceBranch'] }}
-    artifact: _api-extractor-temp
-    allowPartiallySucceededBuilds: true   
-- task: DownloadPipelineArtifact@2
-  inputs:
-    buildType: specific
-    project: internal
-    pipeline: server-routerlicious
-    buildVersionToDownload: latestFromBranch
+- template: templates/download-pipeline-artifact.yml
+  parameters:
+    pipelineDefinition: server-routerlicious
     branchName: ${{ variables['Build.SourceBranch'] }}
-    artifact: _api-extractor-temp
-    allowPartiallySucceededBuilds: true
 
 # Copy and merge the api-extractor outputs to a central location
 - task: CopyFiles@2

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -19,24 +19,87 @@ steps:
   clean: true
 
 # Download the api-extractor outputs
-- download: common_definitions
-  artifact: _api-extractor-temp
-- download: common_utils
-  artifact: _api-extractor-temp
-- download: container_definitions
-  artifact: _api-extractor-temp
-- download: core_interfaces
-  artifact: _api-extractor-temp
-- download: driver_definitions
-  artifact: _api-extractor-temp
-- download: protocol_definitions
-  artifact: _api-extractor-temp
-- download: azure
-  artifact: _api-extractor-temp
-- download: client
-  artifact: _api-extractor-temp
-- download: server
-  artifact: _api-extractor-temp
+- task: DownloadPipelineArtifact@2
+  inputs:
+    buildType: specific
+    project: internal
+    pipeline: Build - common-definitions
+    buildVersionToDownload: latestFromBranch
+    branchName: ${{ variables['Build.SourceBranch'] }}
+    artifact: _api-extractor-temp
+    allowPartiallySucceededBuilds: true
+- task: DownloadPipelineArtifact@2
+  inputs:
+    buildType: specific
+    project: internal
+    pipeline: Build - common-utils
+    buildVersionToDownload: latestFromBranch
+    branchName: ${{ variables['Build.SourceBranch'] }}
+    artifact: _api-extractor-temp
+    allowPartiallySucceededBuilds: true
+- task: DownloadPipelineArtifact@2
+  inputs:
+    buildType: specific
+    project: internal
+    pipeline: Build - container-definitions
+    buildVersionToDownload: latestFromBranch
+    branchName: ${{ variables['Build.SourceBranch'] }}
+    artifact: _api-extractor-temp
+    allowPartiallySucceededBuilds: true
+- task: DownloadPipelineArtifact@2
+  inputs:
+    buildType: specific
+    project: internal
+    pipeline: Build - core-interfaces
+    buildVersionToDownload: latestFromBranch
+    branchName: ${{ variables['Build.SourceBranch'] }}
+    artifact: _api-extractor-temp
+    allowPartiallySucceededBuilds: true
+- task: DownloadPipelineArtifact@2
+  inputs:
+    buildType: specific
+    project: internal
+    pipeline: Build - driver-definitions
+    buildVersionToDownload: latestFromBranch
+    branchName: ${{ variables['Build.SourceBranch'] }}
+    artifact: _api-extractor-temp
+    allowPartiallySucceededBuilds: true
+- task: DownloadPipelineArtifact@2
+  inputs:
+    buildType: specific
+    project: internal
+    pipeline: Build - protocol-definitions
+    buildVersionToDownload: latestFromBranch
+    branchName: ${{ variables['Build.SourceBranch'] }}
+    artifact: _api-extractor-temp
+    allowPartiallySucceededBuilds: true
+- task: DownloadPipelineArtifact@2
+  inputs:
+    buildType: specific
+    project: internal
+    pipeline: Build - azure
+    buildVersionToDownload: latestFromBranch
+    branchName: ${{ variables['Build.SourceBranch'] }}
+    artifact: _api-extractor-temp
+    allowPartiallySucceededBuilds: true
+- task: DownloadPipelineArtifact@2
+  inputs:
+    buildType: specific
+    project: internal
+    pipeline: Build - client packages
+    buildVersionToDownload: latestFromBranch
+    branchName: ${{ variables['Build.SourceBranch'] }}
+    artifact: _api-extractor-temp
+    allowPartiallySucceededBuilds: true   
+- task: DownloadPipelineArtifact@2
+  inputs:
+    buildType: specific
+    project: internal
+    pipeline: server-routerlicious
+    buildVersionToDownload: latestFromBranch
+    branchName: ${{ variables['Build.SourceBranch'] }}
+    artifact: _api-extractor-temp
+    allowPartiallySucceededBuilds: true
 
 # Copy and merge the api-extractor outputs to a central location
 - task: CopyFiles@2


### PR DESCRIPTION
Previously, a temporary fix was made to prevent build-docs from generating docs using content from various branches: https://github.com/microsoft/FluidFramework/pull/19190

Updated the download step to target a specific branch and removed unused pipeline resource definitions in build-docs.