### PR TITLE
recognize empty values for point read filter

### DIFF
--- a/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
+++ b/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
@@ -70,8 +70,6 @@ export class MongoCheckpointRepository implements ICheckpointRepository {
 				"Missing parameter when writing checkpoint.",
 				{
 					...getLumberBaseProperties(documentId, tenantId),
-					documentIdInput: documentId,
-					tenantIdInput: tenantId,
 				},
 				error,
 			);

--- a/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
+++ b/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
@@ -75,7 +75,6 @@ export class MongoCheckpointRepository implements ICheckpointRepository {
 				},
 				error,
 			);
-			throw error;
 		}
 
 		return { _id: documentId + tenantId, documentId };

--- a/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
+++ b/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
@@ -62,7 +62,7 @@ export class MongoCheckpointRepository implements ICheckpointRepository {
 		documentId: string,
 		tenantId: string,
 	): { _id: string; documentId: string } & any {
-		const isError = !documentId || !tenantId ? true : false;
+		const isError = !documentId || !tenantId;
 
 		if (isError) {
 			const error = new Error(`Cannot create filter due to missing parameter`);

--- a/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
+++ b/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
@@ -62,6 +62,22 @@ export class MongoCheckpointRepository implements ICheckpointRepository {
 		documentId: string,
 		tenantId: string,
 	): { _id: string; documentId: string } & any {
+		const isError = !documentId || !tenantId ? true : false;
+
+		if (isError) {
+			const error = new Error(`Cannot create filter due to missing parameter`);
+			Lumberjack.error(
+				"Missing parameter when writing checkpoint.",
+				{
+					...getLumberBaseProperties(documentId, tenantId),
+					documentIdInput: documentId,
+					tenantIdInput: tenantId,
+				},
+				error,
+			);
+			throw error;
+		}
+
 		return { _id: documentId + tenantId, documentId };
 	}
 }


### PR DESCRIPTION
This change is to find and throw an error when the `documentId` or `tenantId` values are empty on attempts to write to the local database.