### PR TITLE
Fix describeCompat.noCompat

### DIFF
--- a/packages/test/test-version-utils/README.md
+++ b/packages/test/test-version-utils/README.md
@@ -78,11 +78,6 @@ Therefore, we would test the following combinations:
 -   Use for tests that targets the loader layer, and don't care about compat combinations of other layers.
 -   Test combination generated: [CompatKind.None, CompatKind.Loader]
 
-`NoCompat` - generate one test variant that doesn't varies version of any layers.
-
--   Use for tests that doesn't benefit or require any compat testing.
--   Test combination generated: [CompatKind.None]
-
 This compat `describe*` function will also load the APIs with appropriate version and provide the test with a
 `TestObjectProvider` object, where the test can use to access Fluid functionality. Even when compat testing
 is not necessary, `TestObjectProvider` provide functionalities that help writing Fluid tests, and it allows the test

--- a/packages/test/test-version-utils/api-report/test-version-utils.api.md
+++ b/packages/test/test-version-utils/api-report/test-version-utils.api.md
@@ -91,7 +91,11 @@ export const DataRuntimeApi: {
 };
 
 // @internal (undocumented)
-export type DescribeCompat = DescribeCompatSuite & Record<"skip" | "only" | "noCompat", DescribeCompatSuite>;
+export type DescribeCompat = DescribeCompatSuite & {
+    skip: DescribeCompatSuite;
+    only: DescribeCompatSuite;
+    noCompat: DescribeCompatSuite;
+};
 
 // @internal
 export const describeCompat: DescribeCompat;

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -221,8 +221,26 @@ export type DescribeCompatSuite = (
 /**
  * @internal
  */
-export type DescribeCompat = DescribeCompatSuite &
-	Record<"skip" | "only" | "noCompat", DescribeCompatSuite>;
+export type DescribeCompat = DescribeCompatSuite & {
+	/**
+	 * Like Mocha's `describe.skip`, but for compat tests.
+	 */
+	skip: DescribeCompatSuite;
+
+	/**
+	 * Like Mocha's `describe.only`, but for compat tests.
+	 */
+	only: DescribeCompatSuite;
+
+	/**
+	 * Run the test suite ignoring the compatibility matrix. In other words, all Fluid layers will
+	 * reference the current code version.
+	 *
+	 * This is meant as a debug utility for e2e tests: do not check in tests that use it as they won't have any
+	 * compat coverage (attempting to do so will fail the PR gate anyway).
+	 */
+	noCompat: DescribeCompatSuite;
+};
 
 function createCompatDescribe(): DescribeCompat {
 	const createCompatSuiteWithDefault = (
@@ -259,7 +277,6 @@ function createCompatDescribe(): DescribeCompat {
  * `LoaderCompat`: generate test variants with compat combinations that only varies the loader version.
  * Specific version (String) : specify a minimum compat version (e.g. "2.0.0-rc.1.0.0") which will be the minimum version a
  * test suite will test against. This should be equal to the value of pkgVersion at the time you're writing the new test suite.
- *
  *
  * @internal
  */

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -25,6 +25,7 @@ import {
 	CompatApis,
 	getDriverApi,
 } from "./testApi.js";
+import { pkgVersion } from "./packageVersion.js";
 
 // See doc comment on mochaGlobalSetup.
 await mochaGlobalSetup();
@@ -245,8 +246,8 @@ function createCompatDescribe(): DescribeCompat {
 	d.only = (name, compatVersion, tests) =>
 		describe.only(name, createCompatSuiteWithDefault(tests, compatVersion));
 
-	d.noCompat = (name, compatVersion, tests) =>
-		describe(name, createCompatSuiteWithDefault(tests, "NoCompat"));
+	d.noCompat = (name, _, tests) =>
+		describe(name, createCompatSuiteWithDefault(tests, pkgVersion));
 
 	return d;
 }


### PR DESCRIPTION
## Description

"NoCompat" is no longer a supported argument to `createCompatSuiteWithDefault`. This restores support for `describeCompat.noCompat` by passing the current package version as the min supported version.