### PR TITLE
Revert "[Port v2int 7.4] Follow up changes to GC sweep op that are needed to enable sweep (#19204)

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1449,6 +1449,9 @@ export class ContainerRuntime
 			getNodePackagePath: async (nodePath: string) => this.getGCNodePackagePath(nodePath),
 			getLastSummaryTimestampMs: () => this.messageAtLastSummary?.timestamp,
 			readAndParseBlob: async <T>(id: string) => readAndParse<T>(this.storage, id),
+			// GC runs in summarizer client and needs access to the real (non-proxy) active information. The proxy
+			// delta manager would always return false for summarizer client.
+			activeConnection: () => this.innerDeltaManager.active,
 			submitMessage: (message: ContainerRuntimeGCMessage) => this.submit(message),
 		});
 

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, LazyPromise, Timer } from "@fluidframework/core-utils";
+import { LazyPromise, Timer } from "@fluidframework/core-utils";
 import { IRequest } from "@fluidframework/core-interfaces";
 import {
 	gcTreeKey,
@@ -21,7 +21,6 @@ import {
 	MonitoringContext,
 	PerformanceEvent,
 } from "@fluidframework/telemetry-utils";
-import { BlobManager } from "../blobManager";
 import {
 	InactiveResponseHeaderKey,
 	RuntimeHeaderData,
@@ -142,6 +141,8 @@ export class GarbageCollector implements IGarbageCollector {
 	) => Promise<readonly string[] | undefined>;
 	/** Returns the timestamp of the last summary generated for this container. */
 	private readonly getLastSummaryTimestampMs: () => number | undefined;
+	/** Returns true if connection is active, i.e. it's "write" connection and the runtime is connected. */
+	private readonly activeConnection: () => boolean;
 
 	private readonly submitMessage: (message: ContainerRuntimeGCMessage) => void;
 
@@ -159,6 +160,7 @@ export class GarbageCollector implements IGarbageCollector {
 		this.isSummarizerClient = createParams.isSummarizerClient;
 		this.getNodePackagePath = createParams.getNodePackagePath;
 		this.getLastSummaryTimestampMs = createParams.getLastSummaryTimestampMs;
+		this.activeConnection = createParams.activeConnection;
 		this.submitMessage = createParams.submitMessage;
 
 		const baseSnapshot = createParams.baseSnapshot;
@@ -253,18 +255,28 @@ export class GarbageCollector implements IGarbageCollector {
 		);
 
 		/**
-		 * Set up the initializer which initializes the GC state from the data in base snapshot. It sets up GC data
-		 * from the base GC state and starts tracking the state of unreferenced nodes.
-		 *
-		 * Must only be called if there is a current reference timestamp.
+		 * Set up the initializer which initializes the GC state from the data in base snapshot. This is done when
+		 * connected in write mode or when GC runs the first time. It sets up all unreferenced nodes from the base
+		 * GC state and updates their inactive or sweep-ready state.
 		 */
 		this.initializeGCStateFromBaseSnapshotP = new LazyPromise<void>(async () => {
+			/**
+			 * If there is no current reference timestamp, skip initialization. We need the current timestamp to track
+			 * how long objects have been unreferenced and if they can be deleted.
+			 *
+			 * Note that the only scenario where there is no reference timestamp is when no ops have ever been processed
+			 * for this container and it is in read mode. In this scenario, there is no point in running GC anyway
+			 * because references in the container do not change without any ops, i.e., there is nothing to collect.
+			 */
 			const currentReferenceTimestampMs = this.runtime.getCurrentReferenceTimestampMs();
-			assert(
-				currentReferenceTimestampMs !== undefined,
-				"Trying to initialize GC state without current timestamp",
-			);
-
+			if (currentReferenceTimestampMs === undefined) {
+				// Log an event so we can evaluate how often we run into this scenario.
+				this.mc.logger.sendErrorEvent({
+					eventName: "GarbageCollectorInitializedWithoutTimestamp",
+					gcConfigs: JSON.stringify(this.configs),
+				});
+				return;
+			}
 			/**
 			 * The base snapshot data will not be present if the container is loaded from:
 			 * 1. The first summary created by the detached container.
@@ -272,31 +284,11 @@ export class GarbageCollector implements IGarbageCollector {
 			 * 3. A summary that was generated before GC even existed.
 			 */
 			const baseSnapshotData = await this.baseSnapshotDataP;
-			this.summaryStateTracker.initializeBaseState(baseSnapshotData);
-
-			if (baseSnapshotData?.gcState === undefined) {
+			if (baseSnapshotData === undefined) {
 				return;
 			}
-
-			// Update unreferenced state tracking as per the GC state in the snapshot data and update gcDataFromLastRun
-			// to the GC data from the snapshot data.
-			const gcNodes: { [id: string]: string[] } = {};
-			for (const [nodeId, nodeData] of Object.entries(baseSnapshotData.gcState.gcNodes)) {
-				if (nodeData.unreferencedTimestampMs !== undefined) {
-					this.unreferencedNodesState.set(
-						nodeId,
-						new UnreferencedStateTracker(
-							nodeData.unreferencedTimestampMs,
-							this.configs.inactiveTimeoutMs,
-							currentReferenceTimestampMs,
-							this.configs.sweepTimeoutMs,
-							this.configs.sweepGracePeriodMs,
-						),
-					);
-				}
-				gcNodes[nodeId] = Array.from(nodeData.outboundRoutes);
-			}
-			this.gcDataFromLastRun = { gcNodes };
+			this.updateStateFromSnapshotData(baseSnapshotData, currentReferenceTimestampMs);
+			this.summaryStateTracker.initializeBaseState(baseSnapshotData);
 		});
 
 		// Get the GC details from the GC state in the base summary. This is returned in getBaseGCDetails which is
@@ -330,10 +322,8 @@ export class GarbageCollector implements IGarbageCollector {
 	}
 
 	/**
-	 * Called during container initialization. Initializes the tombstone and deleted nodes state from the base snapshot.
-	 * Also, initializes the GC state including unreferenced nodes tracking if a current reference timestamp exists.
-	 * Note that if there is any GC state in the base snapshot, then there will definitely be a reference timestamp
-	 * to work with - The GC state would have been generated using a timestamp which is part of the snapshot.
+	 * Called during container initialization. Initialize from the tombstone state in the base snapshot. This is done
+	 * during initialization so that deleted or tombstoned objects are marked as such before they are loaded or used.
 	 */
 	public async initializeBaseState(): Promise<void> {
 		const baseSnapshotData = await this.baseSnapshotDataP;
@@ -360,59 +350,115 @@ export class GarbageCollector implements IGarbageCollector {
 			this.tombstones = Array.from(baseSnapshotData.tombstones);
 			this.runtime.updateTombstonedRoutes(this.tombstones);
 		}
-
-		await this.initializeOrUpdateGCState();
 	}
 
 	/**
-	 * Initialize the GC state if not already initialized. If GC state is already initialized, update the unreferenced
-	 * state tracking as per the current reference timestamp.
+	 * Update state from the given snapshot data. This is done during load and during refreshing state from a snapshot.
+	 * All current tracking is reset and updated from the data in the snapshot.
+	 * @param snapshotData - The snapshot data to update state from. If this is undefined, all GC state and tracking
+	 * is reset.
+	 * @param currentReferenceTimestampMs - The current reference timestamp for marking unreferenced nodes' unreferenced
+	 * timestamp.
 	 */
-	private async initializeOrUpdateGCState() {
-		const currentReferenceTimestampMs = this.runtime.getCurrentReferenceTimestampMs();
-		if (currentReferenceTimestampMs === undefined) {
-			return;
-		}
+	private updateStateFromSnapshotData(
+		snapshotData: IGarbageCollectionSnapshotData | undefined,
+		currentReferenceTimestampMs: number,
+	) {
+		/**
+		 * Note: "newReferencesSinceLastRun" is not reset here. This is done because there may be references since the
+		 * snapshot that we are updating state from. For example, this client may have processed ops till seq#1000 and
+		 * its refreshing state from a summary that happened at seq#900. In this case, there may be references between
+		 * seq#901 and seq#1000 that we don't want to reset.
+		 * Unfortunately, there is no way to track the seq# of ops that add references, so we choose to not reset any
+		 * references here. This should be fine because, in the worst case, we may end up updating the unreferenced
+		 * timestamp of a node which will delay its deletion. Although not ideal, this will only happen in rare
+		 * scenarios, so it should be okay.
+		 */
 
-		// If the GC state hasn't been initialized yet, initialize it and return.
-		if (this.gcDataFromLastRun === undefined) {
-			await this.initializeGCStateFromBaseSnapshotP;
-			return;
-		}
-
-		// If the GC state has been initialized, update the tracking of unreferenced nodes as per the current
-		// reference timestamp.
+		// Clear all existing unreferenced state tracking.
 		for (const [, nodeStateTracker] of this.unreferencedNodesState) {
-			nodeStateTracker.updateTracking(currentReferenceTimestampMs);
+			nodeStateTracker.stopTracking();
 		}
+		this.unreferencedNodesState.clear();
+
+		// If running sweep, the tombstone state represents the list of nodes that have been deleted during sweep.
+		// If running in tombstone mode, the tombstone state represents the list of nodes that have been marked as
+		// tombstones.
+		// If this call is because we are refreshing from a snapshot due to an ack, it is likely that the GC state
+		// in the snapshot is newer than this client's. And so, the deleted / tombstone nodes need to be updated.
+		if (this.configs.shouldRunSweep) {
+			const snapshotDeletedNodes = snapshotData?.deletedNodes
+				? new Set(snapshotData.deletedNodes)
+				: undefined;
+			// If the snapshot contains deleted nodes that are not yet deleted by this client, ask the runtime to
+			// delete them.
+			if (snapshotDeletedNodes !== undefined) {
+				const newDeletedNodes: string[] = [];
+				for (const nodeId of snapshotDeletedNodes) {
+					if (!this.deletedNodes.has(nodeId)) {
+						newDeletedNodes.push(nodeId);
+					}
+				}
+				if (newDeletedNodes.length > 0) {
+					// Call container runtime to delete these nodes and add deleted nodes to this.deletedNodes.
+				}
+			}
+		} else if (this.configs.tombstoneMode) {
+			// The snapshot may contain more or fewer tombstone nodes than this client. Update tombstone state and
+			// notify the runtime to update its state as well.
+			this.tombstones = snapshotData?.tombstones ? Array.from(snapshotData.tombstones) : [];
+			this.runtime.updateTombstonedRoutes(this.tombstones);
+		}
+
+		// If there is no snapshot data, it means this snapshot was generated with GC disabled. Unset all GC state.
+		if (snapshotData?.gcState === undefined) {
+			this.gcDataFromLastRun = undefined;
+			return;
+		}
+
+		// Update unreferenced state tracking as per the GC state in the snapshot data and update gcDataFromLastRun
+		// to the GC data from the snapshot data.
+		const gcNodes: { [id: string]: string[] } = {};
+		for (const [nodeId, nodeData] of Object.entries(snapshotData.gcState.gcNodes)) {
+			if (nodeData.unreferencedTimestampMs !== undefined) {
+				this.unreferencedNodesState.set(
+					nodeId,
+					new UnreferencedStateTracker(
+						nodeData.unreferencedTimestampMs,
+						this.configs.inactiveTimeoutMs,
+						currentReferenceTimestampMs,
+						this.configs.sweepTimeoutMs,
+						this.configs.sweepGracePeriodMs,
+					),
+				);
+			}
+			gcNodes[nodeId] = Array.from(nodeData.outboundRoutes);
+		}
+		this.gcDataFromLastRun = { gcNodes };
 	}
 
 	/**
 	 * Called when the connection state of the runtime changes, i.e., it connects or disconnects. GC subscribes to this
-	 * to initialize or update the unreference state tracking.
+	 * to initialize the base state for non-summarizer clients so that they can track inactive / sweep-ready nodes.
 	 * @param connected - Whether the runtime connected / disconnected.
 	 * @param clientId - The clientId of this runtime.
 	 */
 	public setConnectionState(connected: boolean, clientId?: string | undefined): void {
 		/**
-		 * When the client connects (or reconnects), attempt to initialize or update the GC state. This will keep
-		 * the unreferenced state tracking updated as per the reference timestamp at the time of connection.
+		 * For all clients, initialize the base state when the container becomes active, i.e., it transitions
+		 * to "write" mode. This will ensure that the container's own join op is processed and there is a recent
+		 * reference timestamp that will be used to update the state of unreferenced nodes. Also, all trailing ops which
+		 * could affect the GC state will have been processed.
 		 *
-		 * During GC initialization and during connections in read mode, it is possible that either no ops are
-		 * processed or only trailing ops are processed. This means that the GC state is not initialized or initialized
-		 * with an older reference timestamp. So, doing this on every connection will keep the unreferenced state
-		 * tracking up-to-date.
+		 * If GC is up-to-date for the client and the summarizing client, there will be an doubling of both
+		 * InactiveObject_Loaded and SweepReady_Loaded errors, as there will be one from the sending client and one from
+		 * the receiving summarizer client.
+		 *
+		 * Ideally, this initialization should only be done for summarizer client. However, we are currently rolling out
+		 * sweep in phases and we want to track when inactive and sweep-ready objects are used in any client.
 		 */
-		if (connected && this.configs.shouldRunGC) {
-			this.initializeOrUpdateGCState().catch((error) => {
-				this.mc.logger.sendErrorEvent(
-					{
-						eventName: "GCInitializationOrUpdateFailed",
-						gcConfigs: JSON.stringify(this.configs),
-					},
-					error,
-				);
-			});
+		if (this.activeConnection() && this.configs.shouldRunGC) {
+			this.initializeGCStateFromBaseSnapshotP.catch((error) => {});
 		}
 	}
 
@@ -490,11 +536,8 @@ export class GarbageCollector implements IGarbageCollector {
 				const gcStats = await this.runGC(fullGC, currentReferenceTimestampMs, logger);
 				event.end({
 					...gcStats,
-					details: {
-						timestamp: currentReferenceTimestampMs,
-						sweep: this.configs.shouldRunSweep,
-						tombstone: this.configs.throwOnTombstoneLoad,
-					},
+					timestamp: currentReferenceTimestampMs,
+					sweep: this.configs.shouldRunSweep,
 				});
 
 				/** Post-GC steps */
@@ -1120,25 +1163,9 @@ export class GarbageCollector implements IGarbageCollector {
 			deletedAttachmentBlobCount: 0,
 		};
 
-		// The runtime can't reliably identify the type of deleted nodes. So, get the type here. This should
-		// be good enough because the only types that participate in GC today are data stores, DDSes and blobs.
-		const getDeletedNodeType = (nodeId: string): GCNodeType => {
-			const pathParts = nodeId.split("/");
-			if (pathParts[1] === BlobManager.basePath) {
-				return GCNodeType.Blob;
-			}
-			if (pathParts.length === 2) {
-				return GCNodeType.DataStore;
-			}
-			if (pathParts.length === 3) {
-				return GCNodeType.SubDataStore;
-			}
-			return GCNodeType.Other;
-		};
-
 		for (const nodeId of deletedNodes) {
 			sweepPhaseStats.deletedNodeCount++;
-			const nodeType = getDeletedNodeType(nodeId);
+			const nodeType = this.runtime.getNodeType(nodeId);
 			if (nodeType === GCNodeType.DataStore) {
 				sweepPhaseStats.deletedDataStoreCount++;
 			} else if (nodeType === GCNodeType.Blob) {

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -353,6 +353,7 @@ export interface IGarbageCollectorCreateParams {
 	readonly getNodePackagePath: (nodePath: string) => Promise<readonly string[] | undefined>;
 	readonly getLastSummaryTimestampMs: () => number | undefined;
 	readonly readAndParseBlob: ReadAndParseBlob;
+	readonly activeConnection: () => boolean;
 	readonly submitMessage: (message: ContainerRuntimeGCMessage) => void;
 }
 

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -111,11 +111,7 @@ export class GCSummaryStateTracker {
 	/**
 	 * Called during GC initialization. Initialize the latest summary data from the base snapshot data.
 	 */
-	public initializeBaseState(baseSnapshotData: IGarbageCollectionSnapshotData | undefined) {
-		if (baseSnapshotData === undefined) {
-			return;
-		}
-
+	public initializeBaseState(baseSnapshotData: IGarbageCollectionSnapshotData) {
 		// If tracking state across summaries, update latest summary data from the snapshot's GC data.
 		this.latestSummaryData = {
 			serializedGCState: baseSnapshotData.gcState

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -240,9 +240,13 @@ export class GCTelemetryTracker {
 					gcConfigs,
 				};
 
-				// These are logged as generic events and not errors because there can be false positives. The Tombstone
-				// and Delete errors are separately logged and are reliable.
-				this.mc.logger.sendTelemetryEvent(event);
+				// Do not log the inactive object x events as error events as they are not the best signal for
+				// detecting something wrong with GC either from the partner or from the runtime itself.
+				if (state === UnreferencedState.Inactive) {
+					this.mc.logger.sendTelemetryEvent(event);
+				} else {
+					this.mc.logger.sendErrorEvent(event);
+				}
 			}
 		}
 	}
@@ -389,7 +393,12 @@ export class GCTelemetryTracker {
 						fromPkg: fromPkg?.join("/"),
 					}),
 				};
-				logger.sendTelemetryEvent(event);
+
+				if (state === UnreferencedState.Inactive) {
+					logger.sendTelemetryEvent(event);
+				} else {
+					logger.sendErrorEvent(event);
+				}
 			}
 		}
 		this.pendingEventsQueue = [];

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -177,6 +177,7 @@ describe("Garbage Collection Tests", () => {
 			readAndParseBlob: async <T>(id: string) => gcBlobsMap.get(id) as T,
 			getNodePackagePath: async (nodeId: string) => testPkgPath,
 			getLastSummaryTimestampMs: () => Date.now(),
+			activeConnection: () => true,
 			submitMessage: (message: ContainerRuntimeGCMessage) => {},
 		}) as GcWithPrivates;
 	}

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -143,6 +143,7 @@ describe("Garbage Collection configurations", () => {
 			readAndParseBlob: async <T>(id: string) => gcBlobsMap.get(id) as T,
 			getNodePackagePath: async (nodeId: string) => testPkgPath,
 			getLastSummaryTimestampMs: () => Date.now(),
+			activeConnection: () => true,
 			submitMessage: (message: ContainerRuntimeGCMessage) => {},
 		});
 	}

--- a/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
@@ -120,6 +120,7 @@ describe("Garbage Collection Stats", () => {
 			readAndParseBlob: async <T>(id: string) => gcBlobsMap.get(id) as T,
 			getNodePackagePath: async (nodeId: string) => testPkgPath,
 			getLastSummaryTimestampMs: () => Date.now(),
+			activeConnection: () => true,
 			submitMessage: (message: ContainerRuntimeGCMessage) => {
 				gcMessagesCount++;
 				lastGCMessage = message;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -5,23 +5,20 @@
 
 import { strict as assert } from "assert";
 import { stringToBuffer } from "@fluid-internal/client-utils";
-import { delay } from "@fluidframework/core-utils";
-import { ContainerRuntime, IGCRuntimeOptions, IGCStats } from "@fluidframework/container-runtime";
+
+import { ContainerRuntime, IGCStats } from "@fluidframework/container-runtime";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { ISummaryStats } from "@fluidframework/runtime-definitions";
 import { calculateStats, mergeStats } from "@fluidframework/runtime-utils";
-import {
-	ITestContainerConfig,
-	ITestObjectProvider,
-	mockConfigProvider,
-	waitForContainerConnection,
-} from "@fluidframework/test-utils";
+import { ITestObjectProvider, waitForContainerConnection } from "@fluidframework/test-utils";
 import {
 	describeCompat,
 	ITestDataObject,
+	itExpects,
 	TestDataObjectType,
 } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
+import { defaultGCConfig } from "./gcTestConfigs.js";
 import { waitForContainerWriteModeConnectionWrite } from "./gcTestSummaryUtils.js";
 
 /**
@@ -30,20 +27,9 @@ import { waitForContainerWriteModeConnectionWrite } from "./gcTestSummaryUtils.j
  */
 describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
-	let mainContainer: IContainer;
-	let mainDataObject: ITestDataObject;
-	let summarizerRuntime: ContainerRuntime;
-	const tombstoneTimeoutMs = 200;
-	const sweepGracePeriodMs = 0;
-
-	let settings = {};
-
-	// GC options with sweep enabled.
-	const gcOptions: IGCRuntimeOptions = {
-		inactiveTimeoutMs: 0,
-		enableGCSweep: true,
-		sweepGracePeriodMs,
-	};
+	let container: IContainer;
+	let containerRuntime: ContainerRuntime;
+	let mainDataStore: ITestDataObject;
 
 	/**
 	 * Returns the summary stats in the summary for the data stores with the gives ids.
@@ -75,43 +61,19 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 
 	beforeEach(async function () {
 		provider = getTestObjectProvider({ syncSummarizer: true });
-		// These tests validate the GC stats in summary. It disables heuristics and summarizes explicitly on a separate
-		// container. They do not submits these summaries so it doesn't need to run against real services.
+		// These tests validate the GC stats in summary by calling summarize directly on the container runtime.
+		// They do not post these summaries or download them. So, it doesn't need to run against real services.
 		if (provider.driver.type !== "local") {
 			this.skip();
 		}
-		settings = {};
-		settings["Fluid.GarbageCollection.TestOverride.SweepTimeoutMs"] = tombstoneTimeoutMs;
-		const testContainerConfig: ITestContainerConfig = {
-			runtimeOptions: {
-				summaryOptions: {
-					summaryConfigOverrides: {
-						state: "disabled",
-					},
-				},
-				gcOptions,
-			},
-			loaderProps: { configProvider: mockConfigProvider(settings) },
-		};
-		mainContainer = await provider.makeTestContainer(testContainerConfig);
-		mainDataObject = (await mainContainer.getEntryPoint()) as ITestDataObject;
-		await waitForContainerConnection(mainContainer);
-
-		// Create a second summarizer for running GC and summarizing so that it doesn't summarize local changes.
-		const summarizerContainer = await provider.loadTestContainer(testContainerConfig);
-		const summarizerDataObject = (await summarizerContainer.getEntryPoint()) as ITestDataObject;
-		summarizerRuntime = summarizerDataObject._context.containerRuntime as ContainerRuntime;
-
-		// Ensure the container used to summarize is in write mode. This is necessary because this container may
-		// submit a GC op when GC runs. If it's in read mode, it would attempt to resubmit the op and that would
-		// result in closing the container (GC op can't be resubmitted).
-		summarizerDataObject._root.set("write", "mode");
-		await waitForContainerWriteModeConnectionWrite(summarizerContainer);
+		container = await provider.makeTestContainer(defaultGCConfig);
+		mainDataStore = (await container.getEntryPoint()) as ITestDataObject;
+		containerRuntime = mainDataStore._context.containerRuntime as ContainerRuntime;
+		await waitForContainerConnection(container);
 	});
 
 	async function createNewDataStore() {
-		const newDataStore =
-			await mainDataObject._context.containerRuntime.createDataStore(TestDataObjectType);
+		const newDataStore = await containerRuntime.createDataStore(TestDataObjectType);
 		return (await newDataStore.entryPoint.get()) as ITestDataObject;
 	}
 
@@ -144,30 +106,30 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		};
 
 		// Add both data store handles in default data store to mark them referenced.
-		mainDataObject._root.set("dataStore1", dataStore1.handle);
-		mainDataObject._root.set("dataStore2", dataStore2.handle);
+		mainDataStore._root.set("dataStore1", dataStore1.handle);
+		mainDataStore._root.set("dataStore2", dataStore2.handle);
 
 		// Upload 2 attachment blobs and store their handles to mark them referenced.
 		const blob1Contents = "Blob contents 1";
 		const blob2Contents = "Blob contents 2";
 		// Blob stats will be different if we upload while not connected
-		await waitForContainerWriteModeConnectionWrite(mainContainer);
-		const blob1Handle = await mainDataObject._context.uploadBlob(
+		await waitForContainerWriteModeConnectionWrite(container);
+		const blob1Handle = await mainDataStore._context.uploadBlob(
 			stringToBuffer(blob1Contents, "utf-8"),
 		);
-		const blob2Handle = await mainDataObject._context.uploadBlob(
+		const blob2Handle = await mainDataStore._context.uploadBlob(
 			stringToBuffer(blob2Contents, "utf-8"),
 		);
-		mainDataObject._root.set("blob1", blob1Handle);
-		mainDataObject._root.set("blob2", blob2Handle);
+		mainDataStore._root.set("blob1", blob1Handle);
+		mainDataStore._root.set("blob2", blob2Handle);
 
 		await provider.ensureSynchronized();
 
 		// Nothing should be unreferenced.
-		const gcStats = await summarizerRuntime.collectGarbage({});
+		const gcStats = await containerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		const summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		const summarizeResult = await containerRuntime.summarize({ trackState: false });
 		assert.strictEqual(
 			summarizeResult.stats.unreferencedBlobSize,
 			0,
@@ -197,46 +159,46 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		};
 
 		// Add both data store handles in default data store to mark them referenced.
-		mainDataObject._root.set("dataStore1", dataStore1.handle);
-		mainDataObject._root.set("dataStore2", dataStore2.handle);
+		mainDataStore._root.set("dataStore1", dataStore1.handle);
+		mainDataStore._root.set("dataStore2", dataStore2.handle);
 
 		// Upload 2 attachment blobs and store their handles to mark them referenced.
 		const blob1Contents = "Blob contents 1";
 		const blob2Contents = "Blob contents 2";
 		// Blob stats will be different if we upload while not connected
-		await waitForContainerWriteModeConnectionWrite(mainContainer);
-		const blob1Handle = await mainDataObject._context.uploadBlob(
+		await waitForContainerWriteModeConnectionWrite(container);
+		const blob1Handle = await mainDataStore._context.uploadBlob(
 			stringToBuffer(blob1Contents, "utf-8"),
 		);
-		const blob2Handle = await mainDataObject._context.uploadBlob(
+		const blob2Handle = await mainDataStore._context.uploadBlob(
 			stringToBuffer(blob2Contents, "utf-8"),
 		);
-		mainDataObject._root.set("blob1", blob1Handle);
-		mainDataObject._root.set("blob2", blob2Handle);
+		mainDataStore._root.set("blob1", blob1Handle);
+		mainDataStore._root.set("blob2", blob2Handle);
 
 		await provider.ensureSynchronized();
 
-		let gcStats = await summarizerRuntime.collectGarbage({});
+		let gcStats = await containerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
 		// Remove dataStore1 and blob1's handles to mark them unreferenced.
-		mainDataObject._root.delete("dataStore1");
-		mainDataObject._root.delete("blob1");
+		mainDataStore._root.delete("dataStore1");
+		mainDataStore._root.delete("blob1");
 		await provider.ensureSynchronized();
 
 		// dataStore1, its DDS and blob1 should be now unreferenced. Also, their reference state updated from referenced
 		// to unreferenced.
-		expectedGCStats.unrefNodeCount += 3;
+		expectedGCStats.unrefNodeCount = 3;
 		expectedGCStats.updatedNodeCount = 3;
-		expectedGCStats.unrefDataStoreCount += 1;
+		expectedGCStats.unrefDataStoreCount = 1;
 		expectedGCStats.updatedDataStoreCount = 1;
-		expectedGCStats.unrefAttachmentBlobCount += 1;
+		expectedGCStats.unrefAttachmentBlobCount = 1;
 		expectedGCStats.updatedAttachmentBlobCount = 1;
 
-		gcStats = await summarizerRuntime.collectGarbage({});
+		gcStats = await containerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		let summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		let summarizeResult = await containerRuntime.summarize({ trackState: false });
 		let unrefDataStoreStats = getDataStoreSummaryStats(summarizeResult.summary, [
 			dataStore1._context.id,
 		]);
@@ -247,23 +209,23 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		);
 
 		// Remove dataStore2 and blob2's handles to mark them unreferenced.
-		mainDataObject._root.delete("dataStore2");
-		mainDataObject._root.delete("blob2");
+		mainDataStore._root.delete("dataStore2");
+		mainDataStore._root.delete("blob2");
 		await provider.ensureSynchronized();
 
-		// dataStore2, its DDS, and blob2 should be now unreferenced. Also, their reference state updated from referenced
-		// to unreferenced.
-		expectedGCStats.unrefNodeCount += 3;
+		// dataStore1, dataStore2, their DDS, blob1 and blob2 should be now unreferenced. Also, dataStore2, its DDS
+		// and blob2's reference state updated from referenced to unreferenced.
+		expectedGCStats.unrefNodeCount = 6;
 		expectedGCStats.updatedNodeCount = 3;
-		expectedGCStats.unrefDataStoreCount += 1;
+		expectedGCStats.unrefDataStoreCount = 2;
 		expectedGCStats.updatedDataStoreCount = 1;
-		expectedGCStats.unrefAttachmentBlobCount += 1;
+		expectedGCStats.unrefAttachmentBlobCount = 2;
 		expectedGCStats.updatedAttachmentBlobCount = 1;
 
-		gcStats = await summarizerRuntime.collectGarbage({});
+		gcStats = await containerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		summarizeResult = await containerRuntime.summarize({ trackState: false });
 		unrefDataStoreStats = getDataStoreSummaryStats(summarizeResult.summary, [
 			dataStore1._context.id,
 			dataStore2._context.id,
@@ -273,39 +235,6 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 			unrefDataStoreStats.totalBlobSize,
 			"dataStore1 and dataStore2's blobs should be in unreferenced blob size",
 		);
-
-		// Deleted stats. Wait for sweep timeout and send an op to update the current reference timestamp. Usually,
-		// GC wouldn't run without ops so this step is not needed for heuristics based summaries. It's needed here
-		// because we are explicitly running GC in absence of ops.
-		await delay(tombstoneTimeoutMs + sweepGracePeriodMs);
-		mainDataObject._root.set("update", "timestamp");
-		await provider.ensureSynchronized();
-
-		// Close the main container before running GC which generates a GC op. Otherwise, it will hit this error
-		// "GC_Deleted_DataStore_Unexpected_Delete". We don't expect local data stores to be deleted because
-		// their session expires before deletion. This mimics that behavior.
-		mainContainer.close();
-
-		// Run GC. This will generate a GC sweep op with the sweep ready node ids and wait for the op to be processed.
-		await summarizerRuntime.collectGarbage({});
-		await provider.ensureSynchronized();
-
-		expectedGCStats.nodeCount -= 6;
-		expectedGCStats.unrefNodeCount -= 6;
-		expectedGCStats.deletedNodeCount += 6;
-		expectedGCStats.updatedNodeCount = 0;
-		expectedGCStats.dataStoreCount -= 2;
-		expectedGCStats.unrefDataStoreCount -= 2;
-		expectedGCStats.deletedDataStoreCount += 2;
-		expectedGCStats.updatedDataStoreCount = 0;
-		expectedGCStats.attachmentBlobCount -= 2;
-		expectedGCStats.unrefAttachmentBlobCount -= 2;
-		expectedGCStats.deletedAttachmentBlobCount += 2;
-		expectedGCStats.updatedAttachmentBlobCount = 0;
-
-		// Run GC again. This will have the nodes deleted and update the delete stats.
-		gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 	});
 
 	it("can correctly generate GC stats when nodes are re-referenced", async () => {
@@ -330,43 +259,43 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		};
 
 		// Add both data store handles in default data store to mark them referenced.
-		mainDataObject._root.set("dataStore1", dataStore1.handle);
-		mainDataObject._root.set("dataStore2", dataStore2.handle);
+		mainDataStore._root.set("dataStore1", dataStore1.handle);
+		mainDataStore._root.set("dataStore2", dataStore2.handle);
 
 		// Upload 2 attachment blobs and store their handles to mark them referenced.
 		const blob1Contents = "Blob contents 1";
 		const blob2Contents = "Blob contents 2";
 		// Blob stats will be different if we upload while not connected
-		await waitForContainerWriteModeConnectionWrite(mainContainer);
-		const blob1Handle = await mainDataObject._context.uploadBlob(
+		await waitForContainerWriteModeConnectionWrite(container);
+		const blob1Handle = await mainDataStore._context.uploadBlob(
 			stringToBuffer(blob1Contents, "utf-8"),
 		);
-		const blob2Handle = await mainDataObject._context.uploadBlob(
+		const blob2Handle = await mainDataStore._context.uploadBlob(
 			stringToBuffer(blob2Contents, "utf-8"),
 		);
-		mainDataObject._root.set("blob1", blob1Handle);
-		mainDataObject._root.set("blob2", blob2Handle);
+		mainDataStore._root.set("blob1", blob1Handle);
+		mainDataStore._root.set("blob2", blob2Handle);
 		await provider.ensureSynchronized();
 
 		// Remove both data store and both blob handles to mark them unreferenced.
-		mainDataObject._root.delete("dataStore1");
-		mainDataObject._root.delete("dataStore2");
-		mainDataObject._root.delete("blob1");
-		mainDataObject._root.delete("blob2");
+		mainDataStore._root.delete("dataStore1");
+		mainDataStore._root.delete("dataStore2");
+		mainDataStore._root.delete("blob1");
+		mainDataStore._root.delete("blob2");
 		await provider.ensureSynchronized();
 
 		// Add all handles back to re-reference them.
-		mainDataObject._root.set("dataStore1", dataStore1.handle);
-		mainDataObject._root.set("dataStore2", dataStore2.handle);
-		mainDataObject._root.set("blob1", blob1Handle);
-		mainDataObject._root.set("blob2", blob2Handle);
+		mainDataStore._root.set("dataStore1", dataStore1.handle);
+		mainDataStore._root.set("dataStore2", dataStore2.handle);
+		mainDataStore._root.set("blob1", blob1Handle);
+		mainDataStore._root.set("blob2", blob2Handle);
 		await provider.ensureSynchronized();
 
 		// Nothing should be unreferenced.
-		const gcStats = await summarizerRuntime.collectGarbage({});
+		const gcStats = await containerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		const summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		const summarizeResult = await containerRuntime.summarize({ trackState: false });
 		assert.strictEqual(
 			summarizeResult.stats.unreferencedBlobSize,
 			0,
@@ -374,62 +303,73 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		);
 	});
 
-	it("can correctly generate GC stats when reference state changes between GC runs", async () => {
-		const dataStore1 = await createNewDataStore();
-		const dataStore2 = await createNewDataStore();
-		const expectedGCStats: IGCStats = {
-			nodeCount: 7,
-			unrefNodeCount: 0,
-			updatedNodeCount: 7,
-			dataStoreCount: 3,
-			unrefDataStoreCount: 0,
-			updatedDataStoreCount: 3,
-			attachmentBlobCount: 0,
-			unrefAttachmentBlobCount: 0,
-			updatedAttachmentBlobCount: 0,
-			lifetimeNodeCount: 7,
-			lifetimeDataStoreCount: 3,
-			lifetimeAttachmentBlobCount: 0,
-			deletedNodeCount: 0,
-			deletedDataStoreCount: 0,
-			deletedAttachmentBlobCount: 0,
-		};
+	itExpects(
+		"can correctly generate GC stats when reference state changes between GC runs",
+		[
+			{
+				eventName:
+					"fluid:telemetry:ContainerRuntime:GarbageCollector:gcUnknownOutboundReferences",
+			},
+		],
+		async () => {
+			const dataStore1 = await createNewDataStore();
+			const dataStore2 = await createNewDataStore();
+			const expectedGCStats: IGCStats = {
+				nodeCount: 7,
+				unrefNodeCount: 0,
+				updatedNodeCount: 7,
+				dataStoreCount: 3,
+				unrefDataStoreCount: 0,
+				updatedDataStoreCount: 3,
+				attachmentBlobCount: 0,
+				unrefAttachmentBlobCount: 0,
+				updatedAttachmentBlobCount: 0,
+				lifetimeNodeCount: 7,
+				lifetimeDataStoreCount: 3,
+				lifetimeAttachmentBlobCount: 0,
+				deletedNodeCount: 0,
+				deletedDataStoreCount: 0,
+				deletedAttachmentBlobCount: 0,
+			};
 
-		// Add both data store handles in default data store to mark them referenced.
-		mainDataObject._root.set("dataStore1", dataStore1.handle);
-		mainDataObject._root.set("dataStore2", dataStore2.handle);
-		await provider.ensureSynchronized();
+			// Add both data store handles in default data store to mark them referenced.
+			mainDataStore._root.set("dataStore1", dataStore1.handle);
+			mainDataStore._root.set("dataStore2", dataStore2.handle);
+			await provider.ensureSynchronized();
 
-		// Nothing should be unreferenced.
-		let gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+			// Nothing should be unreferenced.
+			let gcStats = await containerRuntime.collectGarbage({});
+			assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		// Remove both data store handles to mark them unreferenced.
-		mainDataObject._root.delete("dataStore1");
-		mainDataObject._root.delete("dataStore2");
-		await provider.ensureSynchronized();
+			// Remove both data store handles to mark them unreferenced.
+			mainDataStore._root.delete("dataStore1");
+			mainDataStore._root.delete("dataStore2");
+			await provider.ensureSynchronized();
 
-		// dataStore1, dataStore2 and their DDS should be now unreferenced. Also, their reference state updated
-		// from referenced to unreferenced.
-		expectedGCStats.unrefNodeCount += 4;
-		expectedGCStats.updatedNodeCount = 4;
-		expectedGCStats.unrefDataStoreCount += 2;
-		expectedGCStats.updatedDataStoreCount = 2;
+			// dataStore1, dataStore2 and their DDS should be now unreferenced. Also, their reference state updated
+			// from referenced to unreferenced.
+			expectedGCStats.unrefNodeCount = 4;
+			expectedGCStats.updatedNodeCount = 4;
+			expectedGCStats.unrefDataStoreCount = 2;
+			expectedGCStats.updatedDataStoreCount = 2;
 
-		gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+			gcStats = await containerRuntime.collectGarbage({});
+			assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		// Add their handle back to re-reference them.
-		mainDataObject._root.set("dataStore1", dataStore1.handle);
-		mainDataObject._root.set("dataStore2", dataStore2.handle);
-		await provider.ensureSynchronized();
+			// Add their handle back to re-reference them.
+			mainDataStore._root.set("dataStore1", dataStore1.handle);
+			mainDataStore._root.set("dataStore2", dataStore2.handle);
+			await provider.ensureSynchronized();
 
-		// dataStore1, dataStore2 and their DDS should be now referenced. Also, their reference state updated
-		// from unreferenced to referenced.
-		expectedGCStats.unrefNodeCount -= 4;
-		expectedGCStats.unrefDataStoreCount -= 2;
+			// dataStore1, dataStore2 and their DDS should be now referenced. Also, their reference state updated
+			// from unreferenced to referenced.
+			expectedGCStats.unrefNodeCount = 0;
+			expectedGCStats.unrefDataStoreCount = 0;
 
-		gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
-	});
+			// Note that this will result in a "gcUnknownOutboundReferences" error. Since the same client is creating and
+			// adding the handle, the handle is not decoded and it will not result in GC detecting the referenced.
+			gcStats = await containerRuntime.collectGarbage({});
+			assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+		},
+	);
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -174,6 +174,10 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 			"Send ops fails for swept datastores in summarizing container loaded before sweep timeout",
 			[
 				{
+					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
+					clientType: "noninteractive/summarizer",
+				},
+				{
 					eventName: "fluid:telemetry:FluidDataStoreContext:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
 					callSite: "submitMessage",
@@ -206,6 +210,10 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 			"Send signals fails for swept datastores in summarizing container loaded before sweep timeout",
 			[
 				{
+					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
+					clientType: "noninteractive/summarizer",
+				},
+				{
 					eventName: "fluid:telemetry:FluidDataStoreContext:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
 					callSite: "submitSignal",
@@ -237,6 +245,10 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 		itExpects(
 			"Requesting swept datastores not allowed",
 			[
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
+					clientType: "noninteractive/summarizer",
+				},
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
 					clientType: "interactive",
@@ -307,6 +319,10 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 			"Ops for swept data stores is ignored but logs an error",
 			[
 				{
+					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
+					clientType: "noninteractive/summarizer",
+				},
+				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
 					callSite: "processFluidDataStoreOp",
@@ -374,6 +390,10 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 		itExpects(
 			"Signals for swept datastores are ignored but logs an error",
 			[
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
+					clientType: "noninteractive/summarizer",
+				},
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
@@ -489,50 +509,69 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 			);
 		}
 
-		it("updates deleted data store state in the summary", async () => {
-			const { unreferencedId, summarizer } =
-				await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-			const sweepReadyDataStoreNodePath = `/${unreferencedId}`;
-			await sendOpToUpdateSummaryTimestampToNow(summarizer);
+		itExpects(
+			"updates deleted data store state in the summary",
+			[
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
+					clientType: "noninteractive/summarizer",
+				},
+			],
+			async () => {
+				const { unreferencedId, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+				const sweepReadyDataStoreNodePath = `/${unreferencedId}`;
+				await sendOpToUpdateSummaryTimestampToNow(summarizer);
 
-			// Summarize. In this summary, the gc op will be sent with the deleted data store id. The data store
-			// will be removed in the subsequent summary.
-			await summarizeNow(summarizer);
+				// Summarize. In this summary, the gc op will be sent with the deleted data store id. The data store
+				// will be removed in the subsequent summary.
+				await summarizeNow(summarizer);
 
-			// Summarize again so that the sweep ready blobs are now deleted from the GC data.
-			const summary3 = await summarizeNow(summarizer);
+				// Summarize again so that the sweep ready blobs are now deleted from the GC data.
+				const summary3 = await summarizeNow(summarizer);
 
-			// Validate that the deleted data store's state is correct in the summary.
-			validateDataStoreStateInSummary(summary3.summaryTree, sweepReadyDataStoreNodePath);
-		});
+				// Validate that the deleted data store's state is correct in the summary.
+				validateDataStoreStateInSummary(summary3.summaryTree, sweepReadyDataStoreNodePath);
+			},
+		);
 
-		it("disableDatastoreSweep true - DOES NOT update deleted data store state in the summary", async () => {
-			settings["Fluid.GarbageCollection.DisableDataStoreSweep"] = true;
+		itExpects(
+			"disableDatastoreSweep true - DOES NOT update deleted data store state in the summary",
+			[
+				{
+					// Since we do full tree summary, everything is loaded including the sweepReady node
+					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
+					clientType: "noninteractive/summarizer",
+				},
+			],
+			async () => {
+				settings["Fluid.GarbageCollection.DisableDataStoreSweep"] = true;
 
-			const { unreferencedId, summarizer } =
-				await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-			const sweepReadyDataStoreNodePath = `/${unreferencedId}`;
-			await sendOpToUpdateSummaryTimestampToNow(summarizer);
+				const { unreferencedId, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+				const sweepReadyDataStoreNodePath = `/${unreferencedId}`;
+				await sendOpToUpdateSummaryTimestampToNow(summarizer);
 
-			// Summarize. If sweep was enabled, the gc op will be sent with the deleted data store id. The data store
-			// will be removed in the subsequent summary.
-			await summarizeNow(summarizer);
+				// Summarize. If sweep was enabled, the gc op will be sent with the deleted data store id. The data store
+				// will be removed in the subsequent summary.
+				await summarizeNow(summarizer);
 
-			// The datastore should NOT be swept here. If sweep was enabled, it would be deleted in this summary.
-			// We need to do fullTree because the GC data won't change (since it's not swept).
-			// But the validation depends on the GC subtree being present (not a handle).
-			const summary3 = await summarize(summarizer, {
-				reason: "end-to-end test",
-				fullTree: true,
-			});
+				// The datastore should NOT be swept here. If sweep was enabled, it would be deleted in this summary.
+				// We need to do fullTree because the GC data won't change (since it's not swept).
+				// But the validation depends on the GC subtree being present (not a handle).
+				const summary3 = await summarize(summarizer, {
+					reason: "end-to-end test",
+					fullTree: true,
+				});
 
-			// Validate that the data store's state is correct in the summary - it shouldn't have been deleted.
-			validateDataStoreStateInSummary(
-				summary3.summaryTree,
-				sweepReadyDataStoreNodePath,
-				false /* expectDelete */,
-			);
-		});
+				// Validate that the data store's state is correct in the summary - it shouldn't have been deleted.
+				validateDataStoreStateInSummary(
+					summary3.summaryTree,
+					sweepReadyDataStoreNodePath,
+					false /* expectDelete */,
+				);
+			},
+		);
 	});
 
 	describe("Sweep with ValidateSummaryBeforeUpload enabled", () => {
@@ -540,24 +579,33 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 			settings["Fluid.Summarizer.ValidateSummaryBeforeUpload"] = true;
 		});
 
-		it("can run sweep without failing summaries due to local changes", async () => {
-			const { summarizer } =
-				await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
-			await sendOpToUpdateSummaryTimestampToNow(summarizer);
+		itExpects(
+			"can run sweep without failing summaries due to local changes",
+			[
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Loaded",
+					clientType: "noninteractive/summarizer",
+				},
+			],
+			async () => {
+				const { summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
+				await sendOpToUpdateSummaryTimestampToNow(summarizer);
 
-			// Summarize. In this summary, the gc op will be sent with the deleted data store id. Validate that
-			// the GC op does not fail summary due to local changes.
-			await assert.doesNotReject(
-				async () => summarizeNow(summarizer),
-				"Summary and GC should succeed in presence of GC op",
-			);
+				// Summarize. In this summary, the gc op will be sent with the deleted data store id. Validate that
+				// the GC op does not fail summary due to local changes.
+				await assert.doesNotReject(
+					async () => summarizeNow(summarizer),
+					"Summary and GC should succeed in presence of GC op",
+				);
 
-			// Summarize again so that the sweep ready blobs are now deleted from the GC data. Validate that
-			// summarize and GC succeed.
-			await assert.doesNotReject(
-				async () => summarizeNow(summarizer),
-				"Summary and GC should succeed with deleted data store",
-			);
-		});
+				// Summarize again so that the sweep ready blobs are now deleted from the GC data. Validate that
+				// summarize and GC succeed.
+				await assert.doesNotReject(
+					async () => summarizeNow(summarizer),
+					"Summary and GC should succeed with deleted data store",
+				);
+			},
+		);
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -262,6 +262,10 @@ describeCompat("GC attachment blob tombstone tests", "NoCompat", (getTestObjectP
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Requested",
 					clientType: "interactive",
 				},
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:TombstoneReadyObject_Revived",
+					clientType: "noninteractive/summarizer",
+				},
 			],
 			async () => {
 				const { dataStore: mainDataStore, summarizer } =
@@ -311,7 +315,7 @@ describeCompat("GC attachment blob tombstone tests", "NoCompat", (getTestObjectP
 				container2.close();
 
 				// Reference the blob in the main container where it's not a tombstone yet. This should un-tombstone the
-				// blob.
+				// blob. It will result in a SweepReadyObject_Revived error log.
 				mainDataStore._root.set("blob1", blobHandle1);
 
 				// Summarize so that the blob is not a tombstone in the summary.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -766,6 +766,10 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Revived",
 					clientType: "noninteractive/summarizer",
 				},
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:TombstoneReadyObject_Revived",
+					clientType: "noninteractive/summarizer",
+				},
 			],
 			async () => {
 				const { unreferencedId, summarizingContainer, summarizer } =
@@ -1036,6 +1040,14 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 				{
 					eventName:
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_Blob_Revived",
+					clientType: "noninteractive/summarizer",
+				},
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:TombstoneReadyObject_Revived",
+					clientType: "noninteractive/summarizer",
+				},
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:TombstoneReadyObject_Revived",
 					clientType: "noninteractive/summarizer",
 				},
 			],
@@ -1381,6 +1393,14 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 					clientType: "interactive",
 				},
 				{
+					eventName: "fluid:telemetry:Summarizer:Running:TombstoneReadyObject_Changed",
+					clientType: "noninteractive/summarizer",
+				},
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:TombstoneReadyObject_Loaded",
+					clientType: "noninteractive/summarizer",
+				},
+				{
 					eventName:
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
 					clientType: "interactive",
@@ -1507,6 +1527,14 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 					eventName:
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
 					clientType: "interactive",
+				},
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:TombstoneReadyObject_Changed",
+					clientType: "noninteractive/summarizer",
+				},
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:TombstoneReadyObject_Loaded",
+					clientType: "noninteractive/summarizer",
 				},
 			],
 			async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
@@ -15,6 +15,7 @@ import {
 import {
 	describeCompat,
 	ITestDataObject,
+	itExpects,
 	TestDataObjectType,
 } from "@fluid-private/test-version-utils";
 import { stringToBuffer } from "@fluid-internal/client-utils";
@@ -138,77 +139,100 @@ describeCompat("GC trailing ops tests", "NoCompat", (getTestObjectProvider) => {
 			assert(blobTimestamp2 !== undefined, `Should have unreferenced blob`);
 		});
 
-		it(`A summary has a datastore and blob unreferenced, but trailing ops referenced them ${
-			tombstoneEnabled ? "after sweep timeout" : "before sweep timeout"
-		}`, async () => {
-			const mainContainer = await provider.makeTestContainer(testContainerConfig);
-			const mainDefaultDataStore = (await mainContainer.getEntryPoint()) as ITestDataObject;
-			await waitForContainerConnection(mainContainer);
+		itExpects(
+			`A summary has a datastore and blob unreferenced, but trailing ops referenced them ${
+				tombstoneEnabled ? "after sweep timeout" : "before sweep timeout"
+			}`,
+			tombstoneEnabled
+				? [
+						{
+							eventName:
+								"fluid:telemetry:Summarizer:Running:TombstoneReadyObject_Revived",
+						},
+						{
+							eventName:
+								"fluid:telemetry:Summarizer:Running:TombstoneReadyObject_Revived",
+						},
+				  ]
+				: [],
+			async () => {
+				const mainContainer = await provider.makeTestContainer(testContainerConfig);
+				const mainDefaultDataStore =
+					(await mainContainer.getEntryPoint()) as ITestDataObject;
+				await waitForContainerConnection(mainContainer);
 
-			// Create a data store and blob.
-			const newDataStore =
-				await mainDefaultDataStore._context.containerRuntime.createDataStore(
-					TestDataObjectType,
+				// Create a data store and blob.
+				const newDataStore =
+					await mainDefaultDataStore._context.containerRuntime.createDataStore(
+						TestDataObjectType,
+					);
+				assert(newDataStore.entryPoint !== undefined, `Should have a handle`);
+				const blobContents = "Blob contents";
+				const blobHandle = await mainDefaultDataStore._runtime.uploadBlob(
+					stringToBuffer(blobContents, "utf-8"),
 				);
-			assert(newDataStore.entryPoint !== undefined, `Should have a handle`);
-			const blobContents = "Blob contents";
-			const blobHandle = await mainDefaultDataStore._runtime.uploadBlob(
-				stringToBuffer(blobContents, "utf-8"),
-			);
 
-			// Create a summarizer
-			const { summarizer: mainSummarizer } = await createSummarizer(provider, mainContainer, {
-				runtimeOptions: { gcOptions },
-				loaderProps: { configProvider },
-			});
+				// Create a summarizer
+				const { summarizer: mainSummarizer } = await createSummarizer(
+					provider,
+					mainContainer,
+					{ runtimeOptions: { gcOptions }, loaderProps: { configProvider } },
+				);
 
-			// Make the datastore and blob live and unreferenced
-			// Note: Technically the blob is live once the blob is uploaded and the attach op is sequenced, view the BlobManager for more details.
-			mainDefaultDataStore._root.set("datastore", newDataStore.entryPoint);
-			mainDefaultDataStore._root.set("blob", blobHandle);
-			mainDefaultDataStore._root.delete("datastore");
-			mainDefaultDataStore._root.delete("blob");
+				// Make the datastore and blob live and unreferenced
+				// Note: Technically the blob is live once the blob is uploaded and the attach op is sequenced, view the BlobManager for more details.
+				mainDefaultDataStore._root.set("datastore", newDataStore.entryPoint);
+				mainDefaultDataStore._root.set("blob", blobHandle);
+				mainDefaultDataStore._root.delete("datastore");
+				mainDefaultDataStore._root.delete("blob");
 
-			// Summarize and verify that the datastore and blob are unreferenced
-			await provider.ensureSynchronized();
-			const summary1 = await summarizeNow(mainSummarizer);
-			const unreferencedTimestamps1 = await getUnreferencedTimestamps(summary1.summaryTree);
-			const dataStoreTimestamp1 = unreferencedTimestamps1.get(
-				newDataStore.entryPoint.absolutePath.slice(1),
-			);
-			const blobTimestamp1 = unreferencedTimestamps1.get(blobHandle.absolutePath.slice(1));
-			assert(dataStoreTimestamp1 !== undefined, `Should have unreferenced datastore`);
-			assert(blobTimestamp1 !== undefined, `Should have unreferenced blob`);
+				// Summarize and verify that the datastore and blob are unreferenced
+				await provider.ensureSynchronized();
+				const summary1 = await summarizeNow(mainSummarizer);
+				const unreferencedTimestamps1 = await getUnreferencedTimestamps(
+					summary1.summaryTree,
+				);
+				const dataStoreTimestamp1 = unreferencedTimestamps1.get(
+					newDataStore.entryPoint.absolutePath.slice(1),
+				);
+				const blobTimestamp1 = unreferencedTimestamps1.get(
+					blobHandle.absolutePath.slice(1),
+				);
+				assert(dataStoreTimestamp1 !== undefined, `Should have unreferenced datastore`);
+				assert(blobTimestamp1 !== undefined, `Should have unreferenced blob`);
 
-			// Create trailing ops where the datastore and blob are referenced
-			mainDefaultDataStore._root.set("datastore", newDataStore.entryPoint);
-			mainDefaultDataStore._root.set("blob", blobHandle);
-			await provider.ensureSynchronized();
+				// Create trailing ops where the datastore and blob are referenced
+				mainDefaultDataStore._root.set("datastore", newDataStore.entryPoint);
+				mainDefaultDataStore._root.set("blob", blobHandle);
+				await provider.ensureSynchronized();
 
-			mainContainer.close();
-			mainSummarizer.close();
+				mainContainer.close();
+				mainSummarizer.close();
 
-			// Load a new container/summarizer from the summary and trailing ops
-			const { summarizer } = await createSummarizer(
-				provider,
-				mainContainer,
-				{ runtimeOptions: { gcOptions }, loaderProps: { configProvider } },
-				summary1.summaryVersion,
-			);
+				// Load a new container/summarizer from the summary and trailing ops
+				const { summarizer } = await createSummarizer(
+					provider,
+					mainContainer,
+					{ runtimeOptions: { gcOptions }, loaderProps: { configProvider } },
+					summary1.summaryVersion,
+				);
 
-			// Ensure trailing ops are processed, summarize, and verify that the datastore and blob are referenced
-			await provider.ensureSynchronized();
-			const summary2 = await summarizeNow(summarizer);
-			const unreferencedTimestamps2 = await getUnreferencedTimestamps(summary2.summaryTree);
-			const dataStoreId = newDataStore.entryPoint.absolutePath.slice(1);
-			const blobId = blobHandle.absolutePath.slice(1);
-			assert(unreferencedTimestamps2.has(dataStoreId), `GC should detect the datastore`);
-			assert(unreferencedTimestamps2.has(blobId), `GC should detect the blob`);
-			const dataStoreTimestamp2 = unreferencedTimestamps2.get(dataStoreId);
-			const blobTimestamp2 = unreferencedTimestamps2.get(blobId);
-			assert(dataStoreTimestamp2 === undefined, `Should have a referenced datastore`);
-			assert(blobTimestamp2 === undefined, `Should have a referenced blob`);
-		});
+				// Ensure trailing ops are processed, summarize, and verify that the datastore and blob are referenced
+				await provider.ensureSynchronized();
+				const summary2 = await summarizeNow(summarizer);
+				const unreferencedTimestamps2 = await getUnreferencedTimestamps(
+					summary2.summaryTree,
+				);
+				const dataStoreId = newDataStore.entryPoint.absolutePath.slice(1);
+				const blobId = blobHandle.absolutePath.slice(1);
+				assert(unreferencedTimestamps2.has(dataStoreId), `GC should detect the datastore`);
+				assert(unreferencedTimestamps2.has(blobId), `GC should detect the blob`);
+				const dataStoreTimestamp2 = unreferencedTimestamps2.get(dataStoreId);
+				const blobTimestamp2 = unreferencedTimestamps2.get(blobId);
+				assert(dataStoreTimestamp2 === undefined, `Should have a referenced datastore`);
+				assert(blobTimestamp2 === undefined, `Should have a referenced blob`);
+			},
+		);
 	};
 
 	tests();

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -336,19 +336,19 @@ export function overwriteStack(error: IFluidErrorBase | LoggingError, stack: str
 
 // @internal
 export class PerformanceEvent {
-    protected constructor(logger: ITelemetryLoggerExt, event: ITelemetryGenericEventExt, markers?: IPerformanceEventMarkers, recordHeapSize?: boolean, emitLogs?: boolean);
+    protected constructor(logger: ITelemetryLoggerExt, event: ITelemetryGenericEvent, markers?: IPerformanceEventMarkers, recordHeapSize?: boolean, emitLogs?: boolean);
     // (undocumented)
-    cancel(props?: ITelemetryPropertiesExt, error?: unknown): void;
+    cancel(props?: ITelemetryProperties, error?: unknown): void;
     // (undocumented)
     get duration(): number;
     // (undocumented)
-    end(props?: ITelemetryPropertiesExt): void;
-    reportEvent(eventNameSuffix: string, props?: ITelemetryPropertiesExt, error?: unknown): void;
+    end(props?: ITelemetryProperties): void;
+    reportEvent(eventNameSuffix: string, props?: ITelemetryProperties, error?: unknown): void;
     // (undocumented)
-    reportProgress(props?: ITelemetryPropertiesExt, eventNameSuffix?: string): void;
-    static start(logger: ITelemetryLoggerExt, event: ITelemetryGenericEventExt, markers?: IPerformanceEventMarkers, recordHeapSize?: boolean, emitLogs?: boolean): PerformanceEvent;
-    static timedExec<T>(logger: ITelemetryLoggerExt, event: ITelemetryGenericEventExt, callback: (event: PerformanceEvent) => T, markers?: IPerformanceEventMarkers, sampleThreshold?: number): T;
-    static timedExecAsync<T>(logger: ITelemetryLoggerExt, event: ITelemetryGenericEventExt, callback: (event: PerformanceEvent) => Promise<T>, markers?: IPerformanceEventMarkers, recordHeapSize?: boolean, sampleThreshold?: number): Promise<T>;
+    reportProgress(props?: ITelemetryProperties, eventNameSuffix?: string): void;
+    static start(logger: ITelemetryLoggerExt, event: ITelemetryGenericEvent, markers?: IPerformanceEventMarkers, recordHeapSize?: boolean, emitLogs?: boolean): PerformanceEvent;
+    static timedExec<T>(logger: ITelemetryLoggerExt, event: ITelemetryGenericEvent, callback: (event: PerformanceEvent) => T, markers?: IPerformanceEventMarkers, sampleThreshold?: number): T;
+    static timedExecAsync<T>(logger: ITelemetryLoggerExt, event: ITelemetryGenericEvent, callback: (event: PerformanceEvent) => Promise<T>, markers?: IPerformanceEventMarkers, recordHeapSize?: boolean, sampleThreshold?: number): Promise<T>;
 }
 
 // @internal

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -9,6 +9,7 @@ import {
 	ITelemetryErrorEvent,
 	ITelemetryGenericEvent,
 	ITelemetryPerformanceEvent,
+	ITelemetryProperties,
 	TelemetryBaseEventPropertyType as TelemetryEventPropertyType,
 	LogLevel,
 	Tagged,
@@ -30,7 +31,6 @@ import {
 	ITelemetryPerformanceEventExt,
 	TelemetryEventPropertyTypeExt,
 	TelemetryEventCategory,
-	ITelemetryPropertiesExt,
 } from "./telemetryTypes";
 
 export interface Memory {
@@ -642,7 +642,7 @@ export class PerformanceEvent {
 	 */
 	public static start(
 		logger: ITelemetryLoggerExt,
-		event: ITelemetryGenericEventExt,
+		event: ITelemetryGenericEvent,
 		markers?: IPerformanceEventMarkers,
 		recordHeapSize: boolean = false,
 		emitLogs: boolean = true,
@@ -667,7 +667,7 @@ export class PerformanceEvent {
 	 */
 	public static timedExec<T>(
 		logger: ITelemetryLoggerExt,
-		event: ITelemetryGenericEventExt,
+		event: ITelemetryGenericEvent,
 		callback: (event: PerformanceEvent) => T,
 		markers?: IPerformanceEventMarkers,
 		sampleThreshold: number = 1,
@@ -707,7 +707,7 @@ export class PerformanceEvent {
 	 */
 	public static async timedExecAsync<T>(
 		logger: ITelemetryLoggerExt,
-		event: ITelemetryGenericEventExt,
+		event: ITelemetryGenericEvent,
 		callback: (event: PerformanceEvent) => Promise<T>,
 		markers?: IPerformanceEventMarkers,
 		recordHeapSize?: boolean,
@@ -734,14 +734,14 @@ export class PerformanceEvent {
 		return performance.now() - this.startTime;
 	}
 
-	private event?: ITelemetryGenericEventExt;
+	private event?: ITelemetryGenericEvent;
 	private readonly startTime = performance.now();
 	private startMark?: string;
 	private startMemoryCollection: number | undefined = 0;
 
 	protected constructor(
 		private readonly logger: ITelemetryLoggerExt,
-		event: ITelemetryGenericEventExt,
+		event: ITelemetryGenericEvent,
 		private readonly markers: IPerformanceEventMarkers = { end: true, cancel: "generic" },
 		private readonly recordHeapSize: boolean = false,
 		private readonly emitLogs: boolean = true,
@@ -757,10 +757,7 @@ export class PerformanceEvent {
 		}
 	}
 
-	public reportProgress(
-		props?: ITelemetryPropertiesExt,
-		eventNameSuffix: string = "update",
-	): void {
+	public reportProgress(props?: ITelemetryProperties, eventNameSuffix: string = "update"): void {
 		this.reportEvent(eventNameSuffix, props);
 	}
 
@@ -773,7 +770,7 @@ export class PerformanceEvent {
 		this.event = undefined;
 	}
 
-	public end(props?: ITelemetryPropertiesExt): void {
+	public end(props?: ITelemetryProperties): void {
 		this.reportEvent("end", props);
 		this.performanceEndMark();
 		this.event = undefined;
@@ -788,7 +785,7 @@ export class PerformanceEvent {
 		}
 	}
 
-	public cancel(props?: ITelemetryPropertiesExt, error?: unknown): void {
+	public cancel(props?: ITelemetryProperties, error?: unknown): void {
 		if (this.markers.cancel !== undefined) {
 			this.reportEvent("cancel", { category: this.markers.cancel, ...props }, error);
 		}
@@ -800,7 +797,7 @@ export class PerformanceEvent {
 	 */
 	public reportEvent(
 		eventNameSuffix: string,
-		props?: ITelemetryPropertiesExt,
+		props?: ITelemetryProperties,
 		error?: unknown,
 	): void {
 		// There are strange sequences involving multiple Promise chains
@@ -814,7 +811,7 @@ export class PerformanceEvent {
 			return;
 		}
 
-		const event: ITelemetryPerformanceEventExt = { ...this.event, ...props };
+		const event: ITelemetryPerformanceEvent = { ...this.event, ...props };
 		event.eventName = `${event.eventName}_${eventNameSuffix}`;
 		if (eventNameSuffix !== "start") {
 			event.duration = this.duration;
@@ -837,10 +834,7 @@ export class PerformanceEvent {
 	}
 
 	private static readonly eventHits = new Map<string, number>();
-	private static shouldReport(
-		event: ITelemetryGenericEventExt,
-		sampleThreshold: number,
-	): boolean {
+	private static shouldReport(event: ITelemetryGenericEvent, sampleThreshold: number): boolean {
 		const eventKey = `.${event.category}.${event.eventName}`;
 		const hitCount = PerformanceEvent.eventHits.get(eventKey) ?? 0;
 		PerformanceEvent.eventHits.set(eventKey, hitCount >= sampleThreshold ? 1 : hitCount + 1);


### PR DESCRIPTION
Reverting https://github.com/microsoft/FluidFramework/pull/19204.
There are some issues in 7.4 that needs to be addressed and it would require a patch. Although this change is safe, don't want this change to interfere with that and cause any issues. Will re-apply this once 7.4 is stable.