### PR TITLE
Add permissions block to changeset workflows

### DIFF
--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   load_report:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
         with:

--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
 
+permissions:
+  pull-requests: read
+
 jobs:
   # When a PR has the changeset-required label, check if it has a changeset.
   changeset-required:


### PR DESCRIPTION
## Description

Updates the workflows related to changeset management to include a permissions block.

See github permissions doc [here](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#permissions).
