### PR TITLE
Add permissions block to pr-labeler and pr-validation workflows

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,6 +4,9 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main, next, release/*]
 
+permissions:
+  pull-requests: write
+
 jobs:
   areas_label:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -11,6 +11,9 @@ on:
       - next
       - release/*
 
+permissions:
+  pull-requests: write
+
 jobs:
   validate-codeowners:
     name: Validate CODEOWNERS


### PR DESCRIPTION
## Description

Updates pr-labeler and pr-validation to include a permissions block.

See github permissions doc [here](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#permissions).