### PR TITLE
refactor(aqueduct): Upgrade eslint config from "minimal" to "strict" and fix linter violations

### DIFF
--- a/packages/framework/aqueduct/.eslintrc.cjs
+++ b/packages/framework/aqueduct/.eslintrc.cjs
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},

--- a/packages/framework/aqueduct/.eslintrc.cjs
+++ b/packages/framework/aqueduct/.eslintrc.cjs
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},

--- a/packages/framework/aqueduct/api-report/aqueduct.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.api.md
@@ -62,19 +62,18 @@ export interface BaseContainerRuntimeFactoryProps {
 
 // @alpha
 export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRuntimeFactory {
-    constructor(props: {
-        defaultFactory: IFluidDataStoreFactory;
-        registryEntries: NamedFluidDataStoreRegistryEntries;
-        dependencyContainer?: IFluidDependencySynthesizer;
-        requestHandlers?: RuntimeRequestHandler[];
-        runtimeOptions?: IContainerRuntimeOptions;
-        provideEntryPoint?: (runtime: IContainerRuntime) => Promise<FluidObject>;
-    });
+    constructor(props: ContainerRuntimeFactoryWithDefaultDataStoreProps);
     protected containerInitializingFirstTime(runtime: IContainerRuntime): Promise<void>;
     // (undocumented)
     static readonly defaultDataStoreId = "default";
     // (undocumented)
     protected readonly defaultFactory: IFluidDataStoreFactory;
+}
+
+// @alpha
+export interface ContainerRuntimeFactoryWithDefaultDataStoreProps extends BaseContainerRuntimeFactoryProps {
+    // (undocumented)
+    defaultFactory: IFluidDataStoreFactory;
 }
 
 // @alpha

--- a/packages/framework/aqueduct/api-report/aqueduct.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.api.md
@@ -36,13 +36,7 @@ import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
 // @alpha
 export class BaseContainerRuntimeFactory extends RuntimeFactoryHelper implements IProvideFluidDataStoreRegistry {
-    constructor(props: {
-        registryEntries: NamedFluidDataStoreRegistryEntries;
-        dependencyContainer?: IFluidDependencySynthesizer;
-        requestHandlers?: RuntimeRequestHandler[];
-        runtimeOptions?: IContainerRuntimeOptions;
-        provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
-    });
+    constructor(props: BaseContainerRuntimeFactoryProps);
     protected containerHasInitialized(runtime: IContainerRuntime): Promise<void>;
     protected containerInitializingFirstTime(runtime: IContainerRuntime): Promise<void>;
     // (undocumented)
@@ -53,6 +47,17 @@ export class BaseContainerRuntimeFactory extends RuntimeFactoryHelper implements
     instantiateFromExisting(runtime: ContainerRuntime): Promise<void>;
     // (undocumented)
     preInitialize(context: IContainerContext, existing: boolean): Promise<ContainerRuntime>;
+}
+
+// @alpha
+export interface BaseContainerRuntimeFactoryProps {
+    // @deprecated (undocumented)
+    dependencyContainer?: IFluidDependencySynthesizer;
+    provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
+    registryEntries: NamedFluidDataStoreRegistryEntries;
+    // @deprecated
+    requestHandlers?: RuntimeRequestHandler[];
+    runtimeOptions?: IContainerRuntimeOptions;
 }
 
 // @alpha
@@ -109,7 +114,7 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
     protected readonly context: IFluidDataStoreContext;
     finishInitialization(existing: boolean): Promise<void>;
     // (undocumented)
-    static getDataObject(runtime: IFluidDataStoreRuntime): Promise<PureDataObject<DataObjectTypes>>;
+    static getDataObject(runtime: IFluidDataStoreRuntime): Promise<PureDataObject>;
     get handle(): IFluidHandle<this>;
     protected hasInitialized(): Promise<void>;
     // (undocumented)

--- a/packages/framework/aqueduct/api-report/aqueduct.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.api.md
@@ -71,9 +71,16 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
 }
 
 // @alpha
-export interface ContainerRuntimeFactoryWithDefaultDataStoreProps extends BaseContainerRuntimeFactoryProps {
+export interface ContainerRuntimeFactoryWithDefaultDataStoreProps {
     // (undocumented)
     defaultFactory: IFluidDataStoreFactory;
+    // @deprecated (undocumented)
+    dependencyContainer?: IFluidDependencySynthesizer;
+    provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
+    registryEntries: NamedFluidDataStoreRegistryEntries;
+    // @deprecated
+    requestHandlers?: RuntimeRequestHandler[];
+    runtimeOptions?: IContainerRuntimeOptions;
 }
 
 // @alpha

--- a/packages/framework/aqueduct/api-report/aqueduct.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.api.md
@@ -76,7 +76,7 @@ export interface ContainerRuntimeFactoryWithDefaultDataStoreProps {
     defaultFactory: IFluidDataStoreFactory;
     // @deprecated (undocumented)
     dependencyContainer?: IFluidDependencySynthesizer;
-    provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
+    provideEntryPoint?: (runtime: IContainerRuntime) => Promise<FluidObject>;
     registryEntries: NamedFluidDataStoreRegistryEntries;
     // @deprecated
     requestHandlers?: RuntimeRequestHandler[];

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -60,7 +60,7 @@ export class BaseContainerRuntimeFactory
 	 * @param provideEntryPoint - Function that will initialize the entryPoint of the ContainerRuntime instances
 	 * created with this factory
 	 */
-	constructor(props: {
+	public constructor(props: {
 		registryEntries: NamedFluidDataStoreRegistryEntries;
 		dependencyContainer?: IFluidDependencySynthesizer;
 		/**

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -35,7 +35,10 @@ export class BaseContainerRuntimeFactory
 	extends RuntimeFactoryHelper
 	implements IProvideFluidDataStoreRegistry
 {
-	public get IFluidDataStoreRegistry() {
+	/**
+	 * {@inheritDoc @fluidframework/runtime-definitions#IProvideFluidDataStoreRegistry.IFluidDataStoreRegistry}
+	 */
+	public get IFluidDataStoreRegistry(): IFluidDataStoreRegistry {
 		return this.registry;
 	}
 	private readonly registry: IFluidDataStoreRegistry;
@@ -113,12 +116,12 @@ export class BaseContainerRuntimeFactory
 	 * is created. This likely includes creating any initial data stores that are expected to be there at the outset.
 	 * @param runtime - The container runtime for the container being initialized
 	 */
-	protected async containerInitializingFirstTime(runtime: IContainerRuntime) {}
+	protected async containerInitializingFirstTime(runtime: IContainerRuntime): Promise<void> {}
 
 	/**
 	 * Subclasses may override containerHasInitialized to perform any steps after the container has initialized.
 	 * This likely includes loading any data stores that are expected to be there at the outset.
 	 * @param runtime - The container runtime for the container being initialized
 	 */
-	protected async containerHasInitialized(runtime: IContainerRuntime) {}
+	protected async containerHasInitialized(runtime: IContainerRuntime): Promise<void> {}
 }

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -3,27 +3,30 @@
  * Licensed under the MIT License.
  */
 
-import { IContainerContext } from "@fluidframework/container-definitions";
+import { type IContainerContext } from "@fluidframework/container-definitions";
 import {
-	IContainerRuntimeOptions,
+	type IContainerRuntimeOptions,
 	FluidDataStoreRegistry,
 	ContainerRuntime,
 } from "@fluidframework/container-runtime";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import { type IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 // eslint-disable-next-line import/no-deprecated
-import { RuntimeRequestHandler, buildRuntimeRequestHandler } from "@fluidframework/request-handler";
 import {
-	IFluidDataStoreRegistry,
-	IProvideFluidDataStoreRegistry,
-	NamedFluidDataStoreRegistryEntries,
+	type RuntimeRequestHandler,
+	buildRuntimeRequestHandler,
+} from "@fluidframework/request-handler";
+import {
+	type IFluidDataStoreRegistry,
+	type IProvideFluidDataStoreRegistry,
+	type NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
 import {
 	DependencyContainer,
-	IFluidDependencySynthesizer,
-	IProvideFluidDependencySynthesizer,
+	type IFluidDependencySynthesizer,
+	type IProvideFluidDependencySynthesizer,
 } from "@fluidframework/synthesize";
 import { RuntimeFactoryHelper } from "@fluidframework/runtime-utils";
-import { FluidObject } from "@fluidframework/core-interfaces";
+import { type FluidObject } from "@fluidframework/core-interfaces";
 
 /**
  * BaseContainerRuntimeFactory produces container runtimes with the specified data store and service registries,

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -57,7 +57,9 @@ export class BaseContainerRuntimeFactory
 	constructor(props: {
 		registryEntries: NamedFluidDataStoreRegistryEntries;
 		dependencyContainer?: IFluidDependencySynthesizer;
-		/** @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md */
+		/**
+		 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
+		 */
 		requestHandlers?: RuntimeRequestHandler[];
 		runtimeOptions?: IContainerRuntimeOptions;
 		provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -29,6 +29,35 @@ import { RuntimeFactoryHelper } from "@fluidframework/runtime-utils";
 import { type FluidObject } from "@fluidframework/core-interfaces";
 
 /**
+ * {@link BaseContainerRuntimeFactory} construction properties.
+ * @alpha
+ */
+export interface BaseContainerRuntimeFactoryProps {
+	/**
+	 * The data store registry for containers produced.
+	 */
+	registryEntries: NamedFluidDataStoreRegistryEntries;
+	/**
+	 * @deprecated Will be removed in a future release.
+	 */
+	dependencyContainer?: IFluidDependencySynthesizer;
+	/**
+	 * Request handlers for containers produced.
+	 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
+	 */
+	requestHandlers?: RuntimeRequestHandler[];
+	/**
+	 * The runtime options passed to the ContainerRuntime when instantiating it
+	 */
+	runtimeOptions?: IContainerRuntimeOptions;
+	/**
+	 * Function that will initialize the entryPoint of the ContainerRuntime instances
+	 * created with this factory
+	 */
+	provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
+}
+
+/**
  * BaseContainerRuntimeFactory produces container runtimes with the specified data store and service registries,
  * request handlers, runtimeOptions, and entryPoint initialization function.
  * It can be subclassed to implement a first-time initialization procedure for the containers it creates.
@@ -52,24 +81,7 @@ export class BaseContainerRuntimeFactory
 	private readonly requestHandlers: RuntimeRequestHandler[];
 	private readonly provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
 
-	/**
-	 * @param registryEntries - The data store registry for containers produced
-	 * @param dependencyContainer - deprecated, will be removed in a future release
-	 * @param requestHandlers - Request handlers for containers produced
-	 * @param runtimeOptions - The runtime options passed to the ContainerRuntime when instantiating it
-	 * @param provideEntryPoint - Function that will initialize the entryPoint of the ContainerRuntime instances
-	 * created with this factory
-	 */
-	public constructor(props: {
-		registryEntries: NamedFluidDataStoreRegistryEntries;
-		dependencyContainer?: IFluidDependencySynthesizer;
-		/**
-		 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
-		 */
-		requestHandlers?: RuntimeRequestHandler[];
-		runtimeOptions?: IContainerRuntimeOptions;
-		provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
-	}) {
+	public constructor(props: BaseContainerRuntimeFactoryProps) {
 		super();
 
 		this.registryEntries = props.registryEntries;

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -3,15 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import { ContainerRuntime, IContainerRuntimeOptions } from "@fluidframework/container-runtime";
 import {
-	IFluidDataStoreFactory,
-	NamedFluidDataStoreRegistryEntries,
+	type ContainerRuntime,
+	type IContainerRuntimeOptions,
+} from "@fluidframework/container-runtime";
+import {
+	type IFluidDataStoreFactory,
+	type NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { IFluidDependencySynthesizer } from "@fluidframework/synthesize";
-import { RuntimeRequestHandler } from "@fluidframework/request-handler";
-import { FluidObject, type IRequest, type IResponse } from "@fluidframework/core-interfaces";
+import { type IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import { type IFluidDependencySynthesizer } from "@fluidframework/synthesize";
+import { type RuntimeRequestHandler } from "@fluidframework/request-handler";
+import { type FluidObject, type IRequest, type IResponse } from "@fluidframework/core-interfaces";
 import { RequestParser } from "@fluidframework/runtime-utils";
 import { BaseContainerRuntimeFactory } from "./baseContainerRuntimeFactory";
 

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -55,7 +55,7 @@ export interface ContainerRuntimeFactoryWithDefaultDataStoreProps {
 	 * Function that will initialize the entryPoint of the ContainerRuntime instances
 	 * created with this factory
 	 */
-	provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
+	provideEntryPoint?: (runtime: IContainerRuntime) => Promise<FluidObject>;
 }
 
 /**

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -3,15 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import { type ContainerRuntime } from "@fluidframework/container-runtime";
-import { type IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
+import {
+	type IContainerRuntimeOptions,
+	type ContainerRuntime,
+} from "@fluidframework/container-runtime";
+import {
+	type NamedFluidDataStoreRegistryEntries,
+	type IFluidDataStoreFactory,
+} from "@fluidframework/runtime-definitions";
 import { type IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import { type FluidObject, type IRequest, type IResponse } from "@fluidframework/core-interfaces";
 import { RequestParser } from "@fluidframework/runtime-utils";
-import {
-	BaseContainerRuntimeFactory,
-	type BaseContainerRuntimeFactoryProps,
-} from "./baseContainerRuntimeFactory";
+import { type IFluidDependencySynthesizer } from "@fluidframework/synthesize";
+import { type RuntimeRequestHandler } from "@fluidframework/request-handler";
+import { BaseContainerRuntimeFactory } from "./baseContainerRuntimeFactory";
 
 const defaultDataStoreId = "default";
 
@@ -27,9 +32,30 @@ async function getDefaultFluidObject(runtime: IContainerRuntime): Promise<FluidO
  * {@link ContainerRuntimeFactoryWithDefaultDataStore} construction properties.
  * @alpha
  */
-export interface ContainerRuntimeFactoryWithDefaultDataStoreProps
-	extends BaseContainerRuntimeFactoryProps {
+export interface ContainerRuntimeFactoryWithDefaultDataStoreProps {
 	defaultFactory: IFluidDataStoreFactory;
+	/**
+	 * The data store registry for containers produced.
+	 */
+	registryEntries: NamedFluidDataStoreRegistryEntries;
+	/**
+	 * @deprecated Will be removed in a future release.
+	 */
+	dependencyContainer?: IFluidDependencySynthesizer;
+	/**
+	 * Request handlers for containers produced.
+	 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
+	 */
+	requestHandlers?: RuntimeRequestHandler[];
+	/**
+	 * The runtime options passed to the ContainerRuntime when instantiating it
+	 */
+	runtimeOptions?: IContainerRuntimeOptions;
+	/**
+	 * Function that will initialize the entryPoint of the ContainerRuntime instances
+	 * created with this factory
+	 */
+	provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
 }
 
 /**

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -50,7 +50,9 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
 		defaultFactory: IFluidDataStoreFactory;
 		registryEntries: NamedFluidDataStoreRegistryEntries;
 		dependencyContainer?: IFluidDependencySynthesizer;
-		/** @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md */
+		/**
+		 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
+		 */
 		requestHandlers?: RuntimeRequestHandler[];
 		runtimeOptions?: IContainerRuntimeOptions;
 		provideEntryPoint?: (runtime: IContainerRuntime) => Promise<FluidObject>;

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -40,7 +40,7 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
 
 	protected readonly defaultFactory: IFluidDataStoreFactory;
 
-	constructor(props: {
+	public constructor(props: {
 		defaultFactory: IFluidDataStoreFactory;
 		registryEntries: NamedFluidDataStoreRegistryEntries;
 		dependencyContainer?: IFluidDependencySynthesizer;

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -3,20 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import {
-	type ContainerRuntime,
-	type IContainerRuntimeOptions,
-} from "@fluidframework/container-runtime";
-import {
-	type IFluidDataStoreFactory,
-	type NamedFluidDataStoreRegistryEntries,
-} from "@fluidframework/runtime-definitions";
+import { type ContainerRuntime } from "@fluidframework/container-runtime";
+import { type IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { type IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { type IFluidDependencySynthesizer } from "@fluidframework/synthesize";
-import { type RuntimeRequestHandler } from "@fluidframework/request-handler";
 import { type FluidObject, type IRequest, type IResponse } from "@fluidframework/core-interfaces";
 import { RequestParser } from "@fluidframework/runtime-utils";
-import { BaseContainerRuntimeFactory } from "./baseContainerRuntimeFactory";
+import {
+	BaseContainerRuntimeFactory,
+	type BaseContainerRuntimeFactoryProps,
+} from "./baseContainerRuntimeFactory";
 
 const defaultDataStoreId = "default";
 
@@ -26,6 +21,15 @@ async function getDefaultFluidObject(runtime: IContainerRuntime): Promise<FluidO
 		throw new Error("default dataStore must exist");
 	}
 	return entryPoint.get();
+}
+
+/**
+ * {@link ContainerRuntimeFactoryWithDefaultDataStore} construction properties.
+ * @alpha
+ */
+export interface ContainerRuntimeFactoryWithDefaultDataStoreProps
+	extends BaseContainerRuntimeFactoryProps {
+	defaultFactory: IFluidDataStoreFactory;
 }
 
 /**
@@ -40,17 +44,7 @@ export class ContainerRuntimeFactoryWithDefaultDataStore extends BaseContainerRu
 
 	protected readonly defaultFactory: IFluidDataStoreFactory;
 
-	public constructor(props: {
-		defaultFactory: IFluidDataStoreFactory;
-		registryEntries: NamedFluidDataStoreRegistryEntries;
-		dependencyContainer?: IFluidDependencySynthesizer;
-		/**
-		 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
-		 */
-		requestHandlers?: RuntimeRequestHandler[];
-		runtimeOptions?: IContainerRuntimeOptions;
-		provideEntryPoint?: (runtime: IContainerRuntime) => Promise<FluidObject>;
-	}) {
+	public constructor(props: ContainerRuntimeFactoryWithDefaultDataStoreProps) {
 		const requestHandlers = props.requestHandlers ?? [];
 		const provideEntryPoint = props.provideEntryPoint ?? getDefaultFluidObject;
 

--- a/packages/framework/aqueduct/src/container-runtime-factories/index.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/index.ts
@@ -3,5 +3,8 @@
  * Licensed under the MIT License.
  */
 
-export { BaseContainerRuntimeFactory } from "./baseContainerRuntimeFactory";
+export {
+	BaseContainerRuntimeFactory,
+	type BaseContainerRuntimeFactoryProps,
+} from "./baseContainerRuntimeFactory";
 export { ContainerRuntimeFactoryWithDefaultDataStore } from "./containerRuntimeFactoryWithDefaultDataStore";

--- a/packages/framework/aqueduct/src/container-runtime-factories/index.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/index.ts
@@ -7,4 +7,7 @@ export {
 	BaseContainerRuntimeFactory,
 	type BaseContainerRuntimeFactoryProps,
 } from "./baseContainerRuntimeFactory";
-export { ContainerRuntimeFactoryWithDefaultDataStore } from "./containerRuntimeFactoryWithDefaultDataStore";
+export {
+	ContainerRuntimeFactoryWithDefaultDataStore,
+	type ContainerRuntimeFactoryWithDefaultDataStoreProps,
+} from "./containerRuntimeFactoryWithDefaultDataStore";

--- a/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
@@ -4,12 +4,12 @@
  */
 
 import { DirectoryFactory, MapFactory, SharedDirectory, SharedMap } from "@fluidframework/map";
-import { NamedFluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions";
-import { IChannelFactory } from "@fluidframework/datastore-definitions";
-import { FluidObjectSymbolProvider } from "@fluidframework/synthesize";
+import { type NamedFluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions";
+import { type IChannelFactory } from "@fluidframework/datastore-definitions";
+import { type FluidObjectSymbolProvider } from "@fluidframework/synthesize";
 import { FluidDataStoreRuntime } from "@fluidframework/datastore";
 
-import { DataObject, DataObjectTypes, IDataObjectProps } from "../data-objects";
+import { type DataObject, type DataObjectTypes, type IDataObjectProps } from "../data-objects";
 import { PureDataObjectFactory } from "./pureDataObjectFactory";
 
 /**

--- a/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
@@ -35,13 +35,13 @@ export class DataObjectFactory<
 	) {
 		const mergedObjects = [...sharedObjects];
 
-		if (!sharedObjects.find((factory) => factory.type === DirectoryFactory.Type)) {
+		if (!sharedObjects.some((factory) => factory.type === DirectoryFactory.Type)) {
 			// User did not register for directory
 			mergedObjects.push(SharedDirectory.getFactory());
 		}
 
 		// TODO: Remove SharedMap factory when compatibility with SharedMap DataObject is no longer needed in 0.10
-		if (!sharedObjects.find((factory) => factory.type === MapFactory.Type)) {
+		if (!sharedObjects.some((factory) => factory.type === MapFactory.Type)) {
 			// User did not register for map
 			mergedObjects.push(SharedMap.getFactory());
 		}

--- a/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
@@ -25,7 +25,7 @@ export class DataObjectFactory<
 	TObj extends DataObject<I>,
 	I extends DataObjectTypes = DataObjectTypes,
 > extends PureDataObjectFactory<TObj, I> {
-	constructor(
+	public constructor(
 		type: string,
 		ctor: new (props: IDataObjectProps<I>) => TObj,
 		sharedObjects: readonly IChannelFactory[] = [],

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -3,33 +3,36 @@
  * Licensed under the MIT License.
  */
 
-import { IRequest, FluidObject } from "@fluidframework/core-interfaces";
+import { type IRequest, type FluidObject } from "@fluidframework/core-interfaces";
 import {
 	FluidDataStoreRuntime,
-	ISharedObjectRegistry,
+	type ISharedObjectRegistry,
 	mixinRequestHandler,
 } from "@fluidframework/datastore";
 import { FluidDataStoreRegistry } from "@fluidframework/container-runtime";
 import {
-	IFluidDataStoreContext,
-	IContainerRuntimeBase,
-	IFluidDataStoreFactory,
-	IFluidDataStoreRegistry,
-	IProvideFluidDataStoreRegistry,
-	NamedFluidDataStoreRegistryEntries,
-	NamedFluidDataStoreRegistryEntry,
-	IFluidDataStoreContextDetached,
+	type IFluidDataStoreContext,
+	type IContainerRuntimeBase,
+	type IFluidDataStoreFactory,
+	type IFluidDataStoreRegistry,
+	type IProvideFluidDataStoreRegistry,
+	type NamedFluidDataStoreRegistryEntries,
+	type NamedFluidDataStoreRegistryEntry,
+	type IFluidDataStoreContextDetached,
 } from "@fluidframework/runtime-definitions";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { IChannelFactory, IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
+import { type IContainerRuntime } from "@fluidframework/container-runtime-definitions";
 import {
-	AsyncFluidObjectProvider,
-	FluidObjectSymbolProvider,
-	IFluidDependencySynthesizer,
+	type IChannelFactory,
+	type IFluidDataStoreRuntime,
+} from "@fluidframework/datastore-definitions";
+import {
+	type AsyncFluidObjectProvider,
+	type FluidObjectSymbolProvider,
+	type IFluidDependencySynthesizer,
 } from "@fluidframework/synthesize";
 
 import { assert } from "@fluidframework/core-utils";
-import { IDataObjectProps, PureDataObject, DataObjectTypes } from "../data-objects";
+import { type IDataObjectProps, type PureDataObject, type DataObjectTypes } from "../data-objects";
 
 /**
  * Proxy over PureDataObject

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -137,7 +137,7 @@ export class PureDataObjectFactory<
 	private readonly sharedObjectRegistry: ISharedObjectRegistry;
 	private readonly registry: IFluidDataStoreRegistry | undefined;
 
-	constructor(
+	public constructor(
 		public readonly type: string,
 		private readonly ctor: new (props: IDataObjectProps<I>) => TObj,
 		sharedObjects: readonly IChannelFactory[],

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -46,7 +46,10 @@ async function createDataObject<
 	runtimeClassArg: typeof FluidDataStoreRuntime,
 	existing: boolean,
 	initProps?: I["InitialState"],
-) {
+): Promise<{
+	instance: TObj;
+	runtime: FluidDataStoreRuntime;
+}> {
 	// base
 	let runtimeClass = runtimeClassArg;
 
@@ -148,11 +151,17 @@ export class PureDataObjectFactory<
 		this.sharedObjectRegistry = new Map(sharedObjects.map((ext) => [ext.type, ext]));
 	}
 
-	public get IFluidDataStoreFactory() {
+	/**
+	 * {@inheritDoc @fluidframework/runtime-definitions#IProvideFluidDataStoreFactory.IFluidDataStoreFactory}
+	 */
+	public get IFluidDataStoreFactory(): IFluidDataStoreFactory {
 		return this;
 	}
 
-	public get IFluidDataStoreRegistry() {
+	/**
+	 * {@inheritDoc @fluidframework/runtime-definitions#IProvideFluidDataStoreRegistry.IFluidDataStoreRegistry}
+	 */
+	public get IFluidDataStoreRegistry(): IFluidDataStoreRegistry | undefined {
 		return this.registry;
 	}
 
@@ -171,7 +180,10 @@ export class PureDataObjectFactory<
 	 *
 	 * @param context - data store context used to load a data store runtime
 	 */
-	public async instantiateDataStore(context: IFluidDataStoreContext, existing: boolean) {
+	public async instantiateDataStore(
+		context: IFluidDataStoreContext,
+		existing: boolean,
+	): Promise<FluidDataStoreRuntime> {
 		const { runtime } = await createDataObject(
 			this.ctor,
 			context,

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -157,7 +157,7 @@ export class PureDataObjectFactory<
 	/**
 	 * {@inheritDoc @fluidframework/runtime-definitions#IProvideFluidDataStoreFactory.IFluidDataStoreFactory}
 	 */
-	public get IFluidDataStoreFactory(): IFluidDataStoreFactory {
+	public get IFluidDataStoreFactory(): this {
 		return this;
 	}
 

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { ISharedDirectory, MapFactory, SharedDirectory } from "@fluidframework/map";
+import { type ISharedDirectory, MapFactory, SharedDirectory } from "@fluidframework/map";
 import { PureDataObject } from "./pureDataObject";
-import { DataObjectTypes } from "./types";
+import { type DataObjectTypes } from "./types";
 
 /**
  * DataObject is a base data store that is primed with a root directory. It

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -41,11 +41,7 @@ export abstract class DataObject<
 	 * Caller is responsible for ensuring this is only invoked once.
 	 */
 	public async initializeInternal(existing: boolean): Promise<void> {
-		if (!existing) {
-			// Create a root directory and register it before calling initializingFirstTime
-			this.internalRoot = SharedDirectory.create(this.runtime, this.rootDirectoryId);
-			this.internalRoot.bindToContext();
-		} else {
+		if (existing) {
 			// data store has a root directory so we just need to set it before calling initializingFromExisting
 			this.internalRoot = (await this.runtime.getChannel(
 				this.rootDirectoryId,
@@ -62,6 +58,10 @@ export abstract class DataObject<
 						"Legacy document, SharedMap is masquerading as SharedDirectory in DataObject",
 				});
 			}
+		} else {
+			// Create a root directory and register it before calling initializingFirstTime
+			this.internalRoot = SharedDirectory.create(this.runtime, this.rootDirectoryId);
+			this.internalRoot.bindToContext();
 		}
 
 		await super.initializeInternal(existing);

--- a/packages/framework/aqueduct/src/data-objects/index.ts
+++ b/packages/framework/aqueduct/src/data-objects/index.ts
@@ -5,4 +5,4 @@
 
 export { DataObject } from "./dataObject";
 export { PureDataObject } from "./pureDataObject";
-export { DataObjectTypes, IDataObjectProps } from "./types";
+export type { DataObjectTypes, IDataObjectProps } from "./types";

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -54,13 +54,21 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 
 	protected initializeP: Promise<void> | undefined;
 
-	public get id() {
+	public get id(): string {
 		return this.runtime.id;
 	}
-	public get IFluidLoadable() {
+
+	/**
+	 * {@inheritDoc @fluidframework/core-interfaces#IProvideFluidLoadable.IFluidLoadable}
+	 */
+	public get IFluidLoadable(): IFluidLoadable {
 		return this;
 	}
-	public get IFluidHandle() {
+
+	/**
+	 * {@inheritDoc @fluidframework/core-interfaces#IProvideFluidHandle.IFluidHandle}
+	 */
+	public get IFluidHandle(): IFluidHandle {
 		return this.handle;
 	}
 
@@ -75,7 +83,7 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 		return this.runtime.entryPoint as IFluidHandle<this>;
 	}
 
-	public static async getDataObject(runtime: IFluidDataStoreRuntime) {
+	public static async getDataObject(runtime: IFluidDataStoreRuntime): Promise<PureDataObject> {
 		const obj = await runtime.entryPoint.get();
 		return obj as PureDataObject;
 	}
@@ -87,11 +95,15 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 		this.providers = props.providers;
 		this.initProps = props.initProps;
 
+		/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+		/* eslint-disable @typescript-eslint/no-explicit-any */
 		assert(
 			(this.runtime as any)._dataObject === undefined,
 			0x0bd /* "Object runtime already has DataObject!" */,
 		);
 		(this.runtime as any)._dataObject = this;
+		/* eslint-enable @typescript-eslint/no-explicit-any */
+		/* eslint-enable @typescript-eslint/no-unsafe-member-access */
 	}
 
 	/**

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -61,14 +61,14 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 	/**
 	 * {@inheritDoc @fluidframework/core-interfaces#IProvideFluidLoadable.IFluidLoadable}
 	 */
-	public get IFluidLoadable(): IFluidLoadable {
+	public get IFluidLoadable(): this {
 		return this;
 	}
 
 	/**
 	 * {@inheritDoc @fluidframework/core-interfaces#IProvideFluidHandle.IFluidHandle}
 	 */
-	public get IFluidHandle(): IFluidHandle {
+	public get IFluidHandle(): IFluidHandle<this> {
 		return this.handle;
 	}
 

--- a/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/pureDataObject.ts
@@ -6,18 +6,18 @@
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils";
 import {
-	IEvent,
-	IFluidHandle,
-	IFluidLoadable,
-	IProvideFluidHandle,
-	IRequest,
-	IResponse,
+	type IEvent,
+	type IFluidHandle,
+	type IFluidLoadable,
+	type IProvideFluidHandle,
+	type IRequest,
+	type IResponse,
 } from "@fluidframework/core-interfaces";
-import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
-import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
-import { AsyncFluidObjectProvider } from "@fluidframework/synthesize";
+import { type IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
+import { type IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
+import { type AsyncFluidObjectProvider } from "@fluidframework/synthesize";
 import { create404Response } from "@fluidframework/runtime-utils";
-import { DataObjectTypes, IDataObjectProps } from "./types";
+import { type DataObjectTypes, type IDataObjectProps } from "./types";
 
 /**
  * This is a bare-bones base class that does basic setup and enables for factory on an initialize call.

--- a/packages/framework/aqueduct/src/data-objects/types.ts
+++ b/packages/framework/aqueduct/src/data-objects/types.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { IEvent, FluidObject } from "@fluidframework/core-interfaces";
-import { AsyncFluidObjectProvider } from "@fluidframework/synthesize";
-import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
-import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
+import { type IEvent, type FluidObject } from "@fluidframework/core-interfaces";
+import { type AsyncFluidObjectProvider } from "@fluidframework/synthesize";
+import { type IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
+import { type IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 
 /**
  * This type is used as the base generic input to DataObject and PureDataObject.

--- a/packages/framework/aqueduct/src/data-objects/types.ts
+++ b/packages/framework/aqueduct/src/data-objects/types.ts
@@ -14,15 +14,17 @@ import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
  */
 export interface DataObjectTypes {
 	/**
-	 * represents a type that will define optional providers that will be injected
+	 * Represents a type that will define optional providers that will be injected.
 	 */
 	OptionalProviders?: FluidObject;
 	/**
-	 * the initial state type that the produced data object may take during creation
+	 * The initial state type that the produced data object may take during creation.
 	 */
+	// TODO: Use a real type here.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	InitialState?: any;
 	/**
-	 * represents events that will be available in the EventForwarder
+	 * Represents events that will be available in the EventForwarder.
 	 */
 	Events?: IEvent;
 }

--- a/packages/framework/aqueduct/src/index.ts
+++ b/packages/framework/aqueduct/src/index.ts
@@ -19,7 +19,8 @@
  */
 
 export { DataObjectFactory, PureDataObjectFactory } from "./data-object-factories";
-export { DataObject, DataObjectTypes, IDataObjectProps, PureDataObject } from "./data-objects";
+export type { DataObjectTypes, IDataObjectProps } from "./data-objects";
+export { DataObject, PureDataObject } from "./data-objects";
 export {
 	BaseContainerRuntimeFactory,
 	ContainerRuntimeFactoryWithDefaultDataStore,

--- a/packages/framework/aqueduct/src/index.ts
+++ b/packages/framework/aqueduct/src/index.ts
@@ -29,4 +29,5 @@ export {
 	BaseContainerRuntimeFactory,
 	type BaseContainerRuntimeFactoryProps,
 	ContainerRuntimeFactoryWithDefaultDataStore,
+	type ContainerRuntimeFactoryWithDefaultDataStoreProps,
 } from "./container-runtime-factories";

--- a/packages/framework/aqueduct/src/index.ts
+++ b/packages/framework/aqueduct/src/index.ts
@@ -19,9 +19,14 @@
  */
 
 export { DataObjectFactory, PureDataObjectFactory } from "./data-object-factories";
-export type { DataObjectTypes, IDataObjectProps } from "./data-objects";
-export { DataObject, PureDataObject } from "./data-objects";
+export {
+	DataObject,
+	type DataObjectTypes,
+	type IDataObjectProps,
+	PureDataObject,
+} from "./data-objects";
 export {
 	BaseContainerRuntimeFactory,
+	type BaseContainerRuntimeFactoryProps,
 	ContainerRuntimeFactoryWithDefaultDataStore,
 } from "./container-runtime-factories";


### PR DESCRIPTION
Public packages should not be using our minimal config. This PR updates the package's eslint config to our "strict" base and fixes violations.

Also extracts a couple of inline "props" constructor parameter types into their own explicit types to better encapsulate documentation.