### PR TITLE
refactor(data-object-base): Upgrade eslint config from "minimal" to "strict" and fix linter violations

### DIFF
--- a/packages/framework/data-object-base/.eslintrc.cjs
+++ b/packages/framework/data-object-base/.eslintrc.cjs
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-	extends: [require.resolve("@fluidframework/eslint-config-fluid/minimal"), "prettier"],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},

--- a/packages/framework/data-object-base/.eslintrc.cjs
+++ b/packages/framework/data-object-base/.eslintrc.cjs
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid/strict"), "prettier"],
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},

--- a/packages/framework/data-object-base/api-report/data-object-base.api.md
+++ b/packages/framework/data-object-base/api-report/data-object-base.api.md
@@ -72,16 +72,23 @@ export class LazyLoadedDataObjectFactory<T extends LazyLoadedDataObject> impleme
 
 // @internal (undocumented)
 export class RuntimeFactory extends RuntimeFactoryHelper {
-    constructor(props: {
-        defaultStoreFactory: IFluidDataStoreFactory;
-        storeFactories: IFluidDataStoreFactory[];
-        requestHandlers?: RuntimeRequestHandler[];
-        provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
-    });
+    constructor(props: RuntimeFactoryProps);
     // (undocumented)
     instantiateFirstTime(runtime: ContainerRuntime): Promise<void>;
     // (undocumented)
     preInitialize(context: IContainerContext, existing: boolean): Promise<ContainerRuntime>;
+}
+
+// @internal
+export interface RuntimeFactoryProps {
+    // (undocumented)
+    defaultStoreFactory: IFluidDataStoreFactory;
+    // (undocumented)
+    provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
+    // @deprecated (undocumented)
+    requestHandlers?: RuntimeRequestHandler[];
+    // (undocumented)
+    storeFactories: IFluidDataStoreFactory[];
 }
 
 ```

--- a/packages/framework/data-object-base/src/index.ts
+++ b/packages/framework/data-object-base/src/index.ts
@@ -12,4 +12,4 @@
 
 export { LazyLoadedDataObject } from "./lazyLoadedDataObject";
 export { LazyLoadedDataObjectFactory } from "./lazyLoadedDataObjectFactory";
-export { RuntimeFactory } from "./runtimeFactory";
+export { RuntimeFactory, type RuntimeFactoryProps } from "./runtimeFactory";

--- a/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
@@ -30,13 +30,21 @@ export abstract class LazyLoadedDataObject<
 {
 	private _handle?: IFluidHandle<this>;
 
-	public get IFluidLoadable() {
+	/**
+	 * {@inheritDoc @fluidframework/core-interfaces#IProvideFluidLoadable.IFluidLoadable}
+	 */
+	public get IFluidLoadable(): this {
 		return this;
 	}
-	public get IFluidHandle() {
+
+	/**
+	 * {@inheritDoc @fluidframework/core-interfaces#IProvideFluidHandle.IFluidHandle}
+	 */
+	public get IFluidHandle(): IFluidHandle<this> {
 		return this.handle;
 	}
-	public get IProvideFluidHandle() {
+
+	public get IProvideFluidHandle(): this {
 		return this;
 	}
 
@@ -70,6 +78,8 @@ export abstract class LazyLoadedDataObject<
 
 	// #endregion IFluidLoadable
 
+	// TODO: Use unknown (or a stronger type) instead of any. Breaking change.
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 	public abstract create(props?: any);
 	public abstract load(
 		context: IFluidDataStoreContext,

--- a/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
@@ -4,17 +4,17 @@
  */
 
 import {
-	IEvent,
-	IFluidHandle,
-	IFluidLoadable,
-	IRequest,
-	IResponse,
-	IProvideFluidHandle,
+	type IEvent,
+	type IFluidHandle,
+	type IFluidLoadable,
+	type IRequest,
+	type IResponse,
+	type IProvideFluidHandle,
 } from "@fluidframework/core-interfaces";
-import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
-import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
+import { type IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
+import { type IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { FluidObjectHandle } from "@fluidframework/datastore";
-import { ISharedObject } from "@fluidframework/shared-object-base";
+import { type ISharedObject } from "@fluidframework/shared-object-base";
 import { EventForwarder } from "@fluid-internal/client-utils";
 import { create404Response } from "@fluidframework/runtime-utils";
 

--- a/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
@@ -3,23 +3,26 @@
  * Licensed under the MIT License.
  */
 
-import { FluidObject, IRequest } from "@fluidframework/core-interfaces";
+import { type FluidObject, type IRequest } from "@fluidframework/core-interfaces";
 import {
-	FluidDataStoreRuntime,
-	ISharedObjectRegistry,
+	type FluidDataStoreRuntime,
+	type ISharedObjectRegistry,
 	mixinRequestHandler,
 } from "@fluidframework/datastore";
 import { FluidDataStoreRegistry } from "@fluidframework/container-runtime";
 import { assert, LazyPromise } from "@fluidframework/core-utils";
 import {
-	IFluidDataStoreContext,
-	IFluidDataStoreFactory,
-	IFluidDataStoreRegistry,
-	NamedFluidDataStoreRegistryEntries,
+	type IFluidDataStoreContext,
+	type IFluidDataStoreFactory,
+	type IFluidDataStoreRegistry,
+	type NamedFluidDataStoreRegistryEntries,
 } from "@fluidframework/runtime-definitions";
-import { IFluidDataStoreRuntime, IChannelFactory } from "@fluidframework/datastore-definitions";
-import { ISharedObject } from "@fluidframework/shared-object-base";
-import { LazyLoadedDataObject } from "./lazyLoadedDataObject";
+import {
+	type IFluidDataStoreRuntime,
+	type IChannelFactory,
+} from "@fluidframework/datastore-definitions";
+import { type ISharedObject } from "@fluidframework/shared-object-base";
+import { type LazyLoadedDataObject } from "./lazyLoadedDataObject";
 
 /**
  * @internal

--- a/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
@@ -33,7 +33,7 @@ export class LazyLoadedDataObjectFactory<T extends LazyLoadedDataObject>
 	public readonly ISharedObjectRegistry: ISharedObjectRegistry;
 	public readonly IFluidDataStoreRegistry: IFluidDataStoreRegistry | undefined;
 
-	constructor(
+	public constructor(
 		public readonly type: string,
 		private readonly ctor: new (
 			context: IFluidDataStoreContext,

--- a/packages/framework/data-object-base/src/runtimeFactory.ts
+++ b/packages/framework/data-object-base/src/runtimeFactory.ts
@@ -44,7 +44,7 @@ export class RuntimeFactory extends RuntimeFactoryHelper {
 	private readonly requestHandlers: RuntimeRequestHandler[];
 	private readonly provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
 
-	constructor(props: RuntimeFactoryProps) {
+	public constructor(props: RuntimeFactoryProps) {
 		super();
 
 		this.defaultStoreFactory = props.defaultStoreFactory;

--- a/packages/framework/data-object-base/src/runtimeFactory.ts
+++ b/packages/framework/data-object-base/src/runtimeFactory.ts
@@ -3,15 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import { IContainerContext } from "@fluidframework/container-definitions";
+import { type IContainerContext } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
-import { IContainerRuntime } from "@fluidframework/container-runtime-definitions";
-import { FluidObject } from "@fluidframework/core-interfaces";
+import { type IContainerRuntime } from "@fluidframework/container-runtime-definitions";
+import { type FluidObject } from "@fluidframework/core-interfaces";
 // eslint-disable-next-line import/no-deprecated
-import { RuntimeRequestHandler, buildRuntimeRequestHandler } from "@fluidframework/request-handler";
 import {
-	NamedFluidDataStoreRegistryEntries,
-	IFluidDataStoreFactory,
+	type RuntimeRequestHandler,
+	buildRuntimeRequestHandler,
+} from "@fluidframework/request-handler";
+import {
+	type NamedFluidDataStoreRegistryEntries,
+	type IFluidDataStoreFactory,
 } from "@fluidframework/runtime-definitions";
 import { RuntimeFactoryHelper } from "@fluidframework/runtime-utils";
 

--- a/packages/framework/data-object-base/src/runtimeFactory.ts
+++ b/packages/framework/data-object-base/src/runtimeFactory.ts
@@ -18,6 +18,20 @@ import { RuntimeFactoryHelper } from "@fluidframework/runtime-utils";
 const defaultStoreId = "" as const;
 
 /**
+ * {@link RuntimeFactory} construction properties.
+ * @internal
+ */
+export interface RuntimeFactoryProps {
+	defaultStoreFactory: IFluidDataStoreFactory;
+	storeFactories: IFluidDataStoreFactory[];
+	/**
+	 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
+	 */
+	requestHandlers?: RuntimeRequestHandler[];
+	provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
+}
+
+/**
  * @internal
  */
 export class RuntimeFactory extends RuntimeFactoryHelper {
@@ -27,15 +41,7 @@ export class RuntimeFactory extends RuntimeFactoryHelper {
 	private readonly requestHandlers: RuntimeRequestHandler[];
 	private readonly provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
 
-	constructor(props: {
-		defaultStoreFactory: IFluidDataStoreFactory;
-		storeFactories: IFluidDataStoreFactory[];
-		/**
-		 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
-		 */
-		requestHandlers?: RuntimeRequestHandler[];
-		provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
-	}) {
+	constructor(props: RuntimeFactoryProps) {
 		super();
 
 		this.defaultStoreFactory = props.defaultStoreFactory;

--- a/packages/framework/data-object-base/src/runtimeFactory.ts
+++ b/packages/framework/data-object-base/src/runtimeFactory.ts
@@ -30,7 +30,9 @@ export class RuntimeFactory extends RuntimeFactoryHelper {
 	constructor(props: {
 		defaultStoreFactory: IFluidDataStoreFactory;
 		storeFactories: IFluidDataStoreFactory[];
-		/** @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md */
+		/**
+		 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
+		 */
 		requestHandlers?: RuntimeRequestHandler[];
 		provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
 	}) {

--- a/packages/framework/data-object-base/src/runtimeFactory.ts
+++ b/packages/framework/data-object-base/src/runtimeFactory.ts
@@ -52,7 +52,7 @@ export class RuntimeFactory extends RuntimeFactoryHelper {
 		this.registry = (
 			storeFactories.includes(this.defaultStoreFactory)
 				? storeFactories
-				: storeFactories.concat(this.defaultStoreFactory)
+				: [...storeFactories, this.defaultStoreFactory]
 		).map((factory) => [factory.type, factory]) as NamedFluidDataStoreRegistryEntries;
 	}
 


### PR DESCRIPTION
Public packages should not be using our minimal config. This PR updates the package's eslint config to our "strict" base and fixes violations.

Also extracts the type of a constructor's props parameter into an interface for better documentation encapsulation.