### PR TITLE
gitrest: use unlink instead of del

### DIFF
--- a/server/gitrest/packages/gitrest-base/src/utils/filesystems.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/filesystems.ts
@@ -70,6 +70,8 @@ export class RedisFsManagerFactory implements IFileSystemManagerFactory {
 		this.redisParams = {
 			expireAfterSeconds: redisConfig.keyExpireAfterSeconds as number | undefined,
 			enableHashmapRedisFs,
+			enableRedisMetrics: this.redisFsConfig.enableRedisFsMetrics,
+			redisApiMetricsSamplingPeriod: this.redisFsConfig.redisApiMetricsSamplingPeriod,
 		};
 	}
 

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/helpers.ts
@@ -1,0 +1,70 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { getRandomInt } from "@fluidframework/server-services-client";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import sizeof from "object-sizeof";
+import { ISystemError } from "../fileSystemHelper";
+
+export enum RedisFsApis {
+	ReadFile = "ReadFile",
+	WriteFile = "WriteFile",
+	Unlink = "Unlink",
+	Readdir = "Readdir",
+	Removefile = "Removefile",
+	Stat = "Stat",
+	Mkdir = "Mkdir",
+	Rmdir = "Rmdir",
+	KeysByPrefix = "keysByPrefix",
+	HKeysByPrefix = "hkeysByPrefix",
+}
+
+export enum RedisFSConstants {
+	file = "file",
+	directory = "directory",
+	RedisFsApi = "RedisFsApi",
+}
+
+export async function executeRedisFsApiWithMetric<T>(
+	api: () => Promise<T>,
+	apiName: RedisFsApis,
+	metricEnabled: boolean,
+	samplingPeriod: number,
+	telemetryProperties?: Record<string, any>,
+	logResponseSize: boolean = false,
+): Promise<T> {
+	if (!metricEnabled || (samplingPeriod && getRandomInt(samplingPeriod) !== 0)) {
+		return api();
+	}
+
+	const metric = Lumberjack.newLumberMetric(RedisFSConstants.RedisFsApi, telemetryProperties);
+	try {
+		let responseSize;
+		const result = await api();
+		if (logResponseSize) {
+			responseSize = sizeof(result);
+		}
+		metric.setProperty("responseSize", responseSize);
+		metric.success(`${RedisFSConstants.RedisFsApi}: ${apiName} success`);
+		return result;
+	} catch (error: any) {
+		metric.error(`${RedisFSConstants.RedisFsApi}: ${apiName} error`, error);
+		throw error;
+	}
+}
+
+export class RedisFsError extends Error {
+	public get code() {
+		return this.err.code;
+	}
+
+	constructor(
+		public readonly err: ISystemError,
+		message?: string,
+	) {
+		super(message ? `${err.description}: ${message}` : err.description);
+		this.name = "RedisFsError";
+	}
+}

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
@@ -518,7 +518,7 @@ enum RedisFSConstants {
 	RedisFsApi = "RedisFsApi",
 }
 
-async function executeRedisFsApi<T>(
+export async function executeRedisFsApi<T>(
 	api: () => Promise<T>,
 	apiName: string,
 	metricName: string,

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
@@ -21,12 +21,16 @@ import { FileHandle } from "fs/promises";
 import { Stream } from "stream";
 import { Abortable } from "events";
 import { Redis as IoRedis, RedisOptions as IoRedisOptions } from "ioredis";
-import sizeof from "object-sizeof";
-import { getRandomInt } from "@fluidframework/server-services-client";
 import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { IFileSystemManager, IFileSystemManagerParams, IFileSystemPromises } from "../definitions";
-import { getStats, ISystemError, packedRefsFileName, SystemErrors } from "../fileSystemHelper";
+import { getStats, packedRefsFileName, SystemErrors } from "../fileSystemHelper";
 import { HashMapRedis, IRedis, Redis, RedisParams } from "./redis";
+import {
+	executeRedisFsApiWithMetric,
+	RedisFsApis,
+	RedisFSConstants,
+	RedisFsError,
+} from "./helpers";
 
 export interface RedisFsConfig {
 	enableRedisFsMetrics: boolean;
@@ -126,10 +130,9 @@ export class RedisFs implements IFileSystemPromises {
 			return undefined;
 		}
 
-		const data = await executeRedisFsApi(
+		const data = await executeRedisFsApiWithMetric(
 			async () => this.redisFsClient.get<string | Buffer>(filepathString),
 			RedisFsApis.ReadFile,
-			RedisFSConstants.RedisFsApi,
 			this.redisFsConfig.enableRedisFsMetrics,
 			this.redisFsConfig.redisApiMetricsSamplingPeriod,
 			{
@@ -168,10 +171,9 @@ export class RedisFs implements IFileSystemPromises {
 			return;
 		}
 
-		const result = await executeRedisFsApi(
+		const result = await executeRedisFsApiWithMetric(
 			async () => this.redisFsClient.set(filepathString, data),
 			RedisFsApis.WriteFile,
-			RedisFSConstants.RedisFsApi,
 			this.redisFsConfig.enableRedisFsMetrics,
 			this.redisFsConfig.redisApiMetricsSamplingPeriod,
 			{
@@ -193,10 +195,9 @@ export class RedisFs implements IFileSystemPromises {
 	public async unlink(filepath: PathLike): Promise<void> {
 		const filepathString = filepath.toString();
 
-		await executeRedisFsApi(
+		await executeRedisFsApiWithMetric(
 			async () => this.redisFsClient.del(filepathString),
 			RedisFsApis.Unlink,
-			RedisFSConstants.RedisFsApi,
 			this.redisFsConfig.enableRedisFsMetrics,
 			this.redisFsConfig.redisApiMetricsSamplingPeriod,
 			{
@@ -242,10 +243,9 @@ export class RedisFs implements IFileSystemPromises {
 	): Promise<string[] | Buffer[] | Dirent[]> {
 		const folderpathString = folderpath.toString();
 
-		const result = await executeRedisFsApi(
+		const result = await executeRedisFsApiWithMetric(
 			async () => this.redisFsClient.keysByPrefix(folderpathString),
 			RedisFsApis.Readdir,
-			RedisFSConstants.RedisFsApi,
 			this.redisFsConfig.enableRedisFsMetrics,
 			this.redisFsConfig.redisApiMetricsSamplingPeriod,
 			{
@@ -302,11 +302,10 @@ export class RedisFs implements IFileSystemPromises {
 			redisFsClient: IRedis,
 			redisFsConfig: RedisFsConfig,
 		): Promise<void> {
-			await executeRedisFsApi(
+			await executeRedisFsApiWithMetric(
 				async (): Promise<void> =>
 					redisFsClient.setMany(paths.map((path) => ({ key: path, value: "" }))),
 				RedisFsApis.Mkdir,
-				RedisFSConstants.RedisFsApi,
 				redisFsConfig.enableRedisFsMetrics,
 				redisFsConfig.redisApiMetricsSamplingPeriod,
 				{ folderpathString: paths.length > 1 ? paths.join(", ") : paths[0] },
@@ -327,10 +326,9 @@ export class RedisFs implements IFileSystemPromises {
 		// this method is used by `rm(..., {recursive: true}).
 		// If implementing this as an actual FS, this should fail if directory is not empty, and
 		// `delAll` usage should be moved to `rm` instead.
-		await executeRedisFsApi(
+		await executeRedisFsApiWithMetric(
 			async () => this.redisFsClient.delAll(folderpathString),
 			RedisFsApis.Rmdir,
-			RedisFSConstants.RedisFsApi,
 			this.redisFsConfig.enableRedisFsMetrics,
 			this.redisFsConfig.redisApiMetricsSamplingPeriod,
 			{
@@ -364,10 +362,9 @@ export class RedisFs implements IFileSystemPromises {
 	public async stat(filepath: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
 	public async stat(filepath: PathLike, options?: any): Promise<Stats | BigIntStats> {
 		const filepathString = filepath.toString();
-		const data = await executeRedisFsApi(
+		const data = await executeRedisFsApiWithMetric(
 			async () => this.redisFsClient.get<string | Buffer>(filepathString),
 			RedisFsApis.Stat,
-			RedisFSConstants.RedisFsApi,
 			this.redisFsConfig.enableRedisFsMetrics,
 			this.redisFsConfig.redisApiMetricsSamplingPeriod,
 			{
@@ -401,10 +398,9 @@ export class RedisFs implements IFileSystemPromises {
 			return this.rmdir(filepath);
 		}
 
-		await executeRedisFsApi(
+		await executeRedisFsApiWithMetric(
 			async () => this.redisFsClient.del(filepathString),
 			RedisFsApis.Removefile,
-			RedisFSConstants.RedisFsApi,
 			this.redisFsConfig.enableRedisFsMetrics,
 			this.redisFsConfig.redisApiMetricsSamplingPeriod,
 			{
@@ -483,66 +479,5 @@ export class RedisFs implements IFileSystemPromises {
 	 */
 	public async chmod(filepath: PathLike, mode: Mode): Promise<void> {
 		throw Error("Not implemented");
-	}
-}
-
-class RedisFsError extends Error {
-	public get code() {
-		return this.err.code;
-	}
-
-	constructor(
-		public readonly err: ISystemError,
-		message?: string,
-	) {
-		super(message ? `${err.description}: ${message}` : err.description);
-		this.name = "RedisFsError";
-	}
-}
-
-enum RedisFsApis {
-	ReadFile = "ReadFile",
-	WriteFile = "WriteFile",
-	Unlink = "Unlink",
-	Readdir = "Readdir",
-	Removefile = "Removefile",
-	Stat = "Stat",
-	Mkdir = "Mkdir",
-	Rmdir = "Rmdir",
-	KeysByPrefix = "keysByPrefix",
-}
-
-enum RedisFSConstants {
-	file = "file",
-	directory = "directory",
-	RedisFsApi = "RedisFsApi",
-}
-
-export async function executeRedisFsApi<T>(
-	api: () => Promise<T>,
-	apiName: string,
-	metricName: string,
-	metricEnabled: boolean,
-	samplingPeriod: number,
-	telemetryProperties?: Record<string, any>,
-	logResponseSize: boolean = false,
-): Promise<T> {
-	if (!metricEnabled || (samplingPeriod && getRandomInt(samplingPeriod) !== 0)) {
-		return api();
-	}
-
-	const metric = Lumberjack.newLumberMetric(metricName, telemetryProperties);
-	try {
-		let responseSize;
-		const result = await api();
-		if (logResponseSize) {
-			responseSize = sizeof(result);
-		}
-		metric.setProperty("responseSize", responseSize);
-		metric.success(`${metricName}: ${apiName} success`);
-		return result;
-	} catch (error: any) {
-		metric.error(`${metricName}: ${apiName} error`, error);
-		throw error;
 	}
 }


### PR DESCRIPTION
## Description

The Redis API for `unlink` is better than `del` because it is non-blocking. We should use it where possible.

This PR also adds back metrics for `keysByPrefix` which were accidentally removed when keysByPrefix became an internal implementation detail of `delAll`.
