### PR TITLE
server: add more Ephemeral Container optimizations

### DIFF
--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -67,6 +67,7 @@ data:
             "enableSlimGitInit": {{ .Values.gitrest.git.enableSlimGitInit }},
             "enableRedisFsMetrics": {{ .Values.gitrest.git.enableRedisFsMetrics }},
             "enableHashmapRedisFs": {{ .Values.gitrest.git.enableHashmapRedisFs }},
+            "enableRedisFsOptimizedStat": {{ .Values.gitrest.git.enableRedisFsOptimizedStat }},
             "redisApiMetricsSamplingPeriod": {{ .Values.gitrest.git.redisApiMetricsSamplingPeriod }}
         },
         "redis": {

--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -54,6 +54,7 @@ data:
                 "name": "{{ .Values.gitrest.git.ephemeralfilesystem.name }}"
             },
             "persistLatestFullSummary": {{ .Values.gitrest.git.persistLatestFullSummary }},
+            "persistLatestFullEphemeralSummary": {{ .Values.gitrest.git.persistLatestFullEphemeralSummary }},
             "repoPerDocEnabled": {{ .Values.gitrest.git.repoPerDocEnabled }},
             "enableRepositoryManagerMetrics": {{ .Values.gitrest.git.enableRepositoryManagerMetrics }},
             "apiMetricsSamplingPeriod": {{ .Values.gitrest.git.apiMetricsSamplingPeriod }},

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -62,6 +62,7 @@ gitrest:
     ephemeralfilesystem:
       name: redisFs
     persistLatestFullSummary: false
+    persistLatestFullEphemeralSummary: false
     repoPerDocEnabled: false
     enableRepositoryManagerMetrics: false
     apiMetricsSamplingPeriod: 100

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -71,6 +71,7 @@ gitrest:
     enableSlimGitInit: false
     enableRedisFsMetrics: false
     enableHashmapRedisFs: false
+    enableRedisFsOptimizedStat: false
     redisApiMetricsSamplingPeriod: 0
   redis:
     host: redis

--- a/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
+++ b/server/gitrest/packages/gitrest-base/src/routes/summaries.ts
@@ -50,6 +50,7 @@ async function getSummary(
 	repoManagerParams: IRepoManagerParams,
 	externalWriterConfig?: IExternalWriterConfig,
 	persistLatestFullSummary = false,
+	persistLatestFullEphemeralSummary = false,
 	enforceStrictPersistedFullSummaryReads = false,
 ): Promise<IWholeFlatSummary> {
 	const lumberjackProperties = {
@@ -57,7 +58,10 @@ async function getSummary(
 		[BaseGitRestTelemetryProperties.sha]: sha,
 	};
 
-	if (persistLatestFullSummary && sha === latestSummarySha) {
+	const enablePersistLatestFullSummary = repoManagerParams.isEphemeralContainer
+		? persistLatestFullEphemeralSummary
+		: persistLatestFullSummary;
+	if (enablePersistLatestFullSummary && sha === latestSummarySha) {
 		try {
 			const latestFullSummaryFromStorage = await retrieveLatestFullSummaryFromStorage(
 				fileSystemManager,
@@ -104,7 +108,7 @@ async function getSummary(
 
 	// Now that we computed the summary from scratch, we can persist it to storage if
 	// the following conditions are met.
-	if (persistLatestFullSummary && sha === latestSummarySha && fullSummary) {
+	if (enablePersistLatestFullSummary && sha === latestSummarySha && fullSummary) {
 		// We persist the full summary in a fire-and-forget way because we don't want it
 		// to impact getSummary latency. So upon computing the full summary above, we should
 		// return as soon as possible. Also, we don't care about failures much, since the
@@ -134,6 +138,7 @@ async function createSummary(
 	externalWriterConfig?: IExternalWriterConfig,
 	isInitialSummary?: boolean,
 	persistLatestFullSummary = false,
+	persistLatestFullEphemeralSummary = false,
 	enableLowIoWrite: "initial" | boolean = false,
 	optimizeForInitialSummary: boolean = false,
 ): Promise<IWriteSummaryResponse | IWholeFlatSummary> {
@@ -177,7 +182,10 @@ async function createSummary(
 					return undefined;
 			  });
 		if (latestFullSummary) {
-			if (persistLatestFullSummary) {
+			const enablePersistLatestFullSummary = repoManagerParams.isEphemeralContainer
+				? persistLatestFullEphemeralSummary
+				: persistLatestFullSummary;
+			if (enablePersistLatestFullSummary) {
 				// Send latest full summary to storage for faster read access.
 				const persistP = persistLatestFullSummaryInStorage(
 					fileSystemManager,
@@ -271,6 +279,8 @@ export function create(
 ): Router {
 	const router: Router = Router();
 	const persistLatestFullSummary: boolean = store.get("git:persistLatestFullSummary") ?? false;
+	const persistLatestFullEphemeralSummary: boolean =
+		store.get("git:persistLatestFullEphemeralSummary") ?? false;
 	const enableLowIoWrite: "initial" | boolean = store.get("git:enableLowIoWrite") ?? false;
 	const enableOptimizedInitialSummary: boolean =
 		store.get("git:enableOptimizedInitialSummary") ?? false;
@@ -321,6 +331,7 @@ export function create(
 						repoManagerParams,
 						getExternalWriterParams(request.query?.config as string | undefined),
 						persistLatestFullSummary,
+						persistLatestFullEphemeralSummary,
 						enforceStrictPersistedFullSummaryReads,
 					);
 				})
@@ -401,6 +412,7 @@ export function create(
 					getExternalWriterParams(request.query?.config as string | undefined),
 					isInitialSummary,
 					persistLatestFullSummary,
+					persistLatestFullEphemeralSummary,
 					enableLowIoWrite,
 					optimizeForInitialSummary,
 				);

--- a/server/gitrest/packages/gitrest-base/src/test/utils.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/utils.ts
@@ -48,6 +48,7 @@ export const defaultProvider = new nconf.Provider({}).use("memory").defaults({
 			name: "redisFs",
 		},
 		persistLatestFullSummary: false,
+		persistLatestFullEphemeralSummary: false,
 		repoPerDocEnabled: false,
 		enableRepositoryManagerMetrics: false,
 		apiMetricsSamplingPeriod: 100,

--- a/server/gitrest/packages/gitrest-base/src/utils/filesystems.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/filesystems.ts
@@ -40,6 +40,7 @@ export class RedisFsManagerFactory implements IFileSystemManagerFactory {
 			enableRedisFsMetrics: (config.get("git:enableRedisFsMetrics") as boolean) ?? true,
 			redisApiMetricsSamplingPeriod:
 				(config.get("git:redisApiMetricsSamplingPeriod") as number) ?? 0,
+			enableOptimizedStat: (config.get("git:enableRedisFsOptimizedStat") as boolean) ?? false,
 		};
 		const redisConfig = config.get("redis");
 		this.redisOptions = {

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/helpers.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/helpers.ts
@@ -19,6 +19,7 @@ export enum RedisFsApis {
 	Rmdir = "Rmdir",
 	KeysByPrefix = "keysByPrefix",
 	HKeysByPrefix = "hkeysByPrefix",
+	InitHashmapFs = "initHashmapFs",
 }
 
 export enum RedisFSConstants {

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
@@ -183,7 +183,7 @@ export class HashMapRedis implements IRedis {
 	public async get<T>(field: string): Promise<T> {
 		if (this.isFieldRootDirectory(field)) {
 			// Field is part of the root hashmap key, so return empty string.
-			return "" as T;
+			return "" as unknown as T;
 		}
 		const stringValue = await this.client.hget(this.getMapKey(), this.getMapField(field));
 		return JSON.parse(stringValue) as T;

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
@@ -295,9 +295,16 @@ export class HashMapRedis implements IRedis {
 		const initializeHashMapIfNotExists = async (): Promise<void> => {
 			const exists = await this.client.exists(this.getMapKey());
 			if (!exists) {
-				// Set a blank field/value pair to initialize the hashmap.
-				await this.client.hset(this.getMapKey(), "", "");
-				await this.client.expire(this.getMapKey(), this.expireAfterSeconds);
+				await executeRedisFsApiWithMetric(
+					async () => {
+						// Set a blank field/value pair to initialize the hashmap.
+						await this.client.hset(this.getMapKey(), "", "");
+						await this.client.expire(this.getMapKey(), this.expireAfterSeconds);
+					},
+					RedisFsApis.InitHashmapFs,
+					this.parameters?.enableRedisMetrics,
+					this.parameters?.redisApiMetricsSamplingPeriod,
+				);
 			}
 		};
 		// Setting expiration on the hashmap key is vital, so we should retry it on failure

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redis.ts
@@ -104,11 +104,10 @@ export class Redis implements IRedis {
 	}
 
 	public async peek(key: string): Promise<number> {
-		const [exists, strlen] = await Promise.all([
-			this.client.exists(this.getKey(key)),
-			this.client.strlen(this.getKey(key)),
-		]);
-		return exists ? strlen : -1;
+		const strlen = await this.client.strlen(this.getKey(key));
+		// If the key does not exist, strlen will return 0.
+		// Otherwise, we are stringifying everything we store in Redis, so strlen will always be at least 2 from the stringified quotes.
+		return strlen === 0 ? -1 : strlen - 2;
 	}
 
 	public async del(key: string, appendPrefixToKey = true): Promise<boolean> {
@@ -227,11 +226,10 @@ export class HashMapRedis implements IRedis {
 			// Field is part of the root hashmap key, so it exists but is empty.
 			return 0;
 		}
-		const [exists, strlen] = await Promise.all([
-			this.client.hexists(this.getMapKey(), this.getMapField(field)),
-			this.client.hstrlen(this.getMapKey(), this.getMapField(field)),
-		]);
-		return exists ? strlen : -1;
+		const strlen = await this.client.hstrlen(this.getMapKey(), this.getMapField(field));
+		// If the key does not exist, strlen will return 0.
+		// Otherwise, we are stringifying everything we store in Redis, so strlen will always be at least 2 from the stringified quotes.
+		return strlen === 0 ? -1 : strlen - 2;
 	}
 
 	public async del(field: string): Promise<boolean> {

--- a/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
+++ b/server/gitrest/packages/gitrest-base/src/utils/redisFs/redisFsManager.ts
@@ -362,8 +362,8 @@ export class RedisFs implements IFileSystemPromises {
 	public async stat(filepath: PathLike, options?: StatOptions): Promise<Stats | BigIntStats>;
 	public async stat(filepath: PathLike, options?: any): Promise<Stats | BigIntStats> {
 		const filepathString = filepath.toString();
-		const data = await executeRedisFsApiWithMetric(
-			async () => this.redisFsClient.get<string | Buffer>(filepathString),
+		const dataLength = await executeRedisFsApiWithMetric(
+			async () => this.redisFsClient.peek(filepathString),
 			RedisFsApis.Stat,
 			this.redisFsConfig.enableRedisFsMetrics,
 			this.redisFsConfig.redisApiMetricsSamplingPeriod,
@@ -373,11 +373,11 @@ export class RedisFs implements IFileSystemPromises {
 			true,
 		);
 
-		if (data === null) {
+		if (dataLength === null) {
 			throw new RedisFsError(SystemErrors.ENOENT, filepath.toString());
 		}
 
-		const fsEntityType = data === "" ? RedisFSConstants.directory : RedisFSConstants.file;
+		const fsEntityType = dataLength === 0 ? RedisFSConstants.directory : RedisFSConstants.file;
 
 		return getStats(fsEntityType);
 	}

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -44,6 +44,7 @@
 			"name": "redisFs"
 		},
 		"persistLatestFullSummary": false,
+		"persistLatestFullEphemeralSummary": false,
 		"repoPerDocEnabled": false,
 		"enableRepositoryManagerMetrics": false,
 		"apiMetricsSamplingPeriod": 100,

--- a/server/gitrest/packages/gitrest/config.json
+++ b/server/gitrest/packages/gitrest/config.json
@@ -53,6 +53,7 @@
 		"enableSlimGitInit": false,
 		"enableRedisFsMetrics": true,
 		"enableHashmapRedisFs": false,
+		"enableRedisFsOptimizedStat": false,
 		"redisApiMetricsSamplingPeriod": 0,
 		"enforceStrictPersistedFullSummaryReads": false
 	},

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -156,7 +156,8 @@ data:
             "groupId": "{{ template "deli.fullname" . }}",
             "checkpointBatchSize": 10,
             "checkpointTimeIntervalMsec": 1000,
-            "restartOnCheckpointFailure": {{ .Values.deli.restartOnCheckpointFailure }}
+            "restartOnCheckpointFailure": {{ .Values.deli.restartOnCheckpointFailure }},
+            "enableEphemeralContainerSummaryCleanup": {{ .Values.deli.enableEphemeralContainerSummaryCleanup }}
         },
         "scribe": {
             "kafkaClientId": "{{ template "scribe.fullname" . }}",

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -69,6 +69,7 @@ deli:
     maxTime: 60000
     maxMessages: 500
   restartOnCheckpointFailure: true
+  enableEphemeralContainerSummaryCleanup: true
 
 scriptorium:
   name: scriptorium

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -235,14 +235,19 @@ export class DeliLambdaFactory
 					closeType === LambdaCloseType.Error
 				) {
 					if (document?.isEphemeralContainer) {
-						// Call to historian to delete summaries
-						await requestWithRetry(
-							async () => gitManager.deleteSummary(false),
-							"deliLambda_onClose" /* callName */,
-							getLumberBaseProperties(documentId, tenantId) /* telemetryProperties */,
-							(error) => true /* shouldRetry */,
-							3 /* maxRetries */,
-						);
+						if (this.serviceConfiguration.deli.enableEphemeralContainerSummaryCleanup) {
+							// Call to historian to delete summaries
+							await requestWithRetry(
+								async () => gitManager.deleteSummary(false),
+								"deliLambda_onClose" /* callName */,
+								getLumberBaseProperties(
+									documentId,
+									tenantId,
+								) /* telemetryProperties */,
+								(error) => true /* shouldRetry */,
+								3 /* maxRetries */,
+							);
+						}
 
 						// Delete the document metadata
 						await runWithRetry(

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -205,7 +205,8 @@
 			"maxTime": 60000,
 			"maxMessages": 500
 		},
-		"restartOnCheckpointFailure": true
+		"restartOnCheckpointFailure": true,
+		"enableEphemeralContainerSummaryCleanup": true
 	},
 	"scribe": {
 		"kafkaClientId": "scribe",

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -63,6 +63,11 @@ export async function deliCreate(
 		core.DefaultServiceConfiguration.deli.checkpointHeuristics = checkpointHeuristics;
 	}
 
+	const enableEphemeralContainerSummaryCleanup =
+		(config.get("deli:enableEphemeralContainerSummaryCleanup") as boolean | undefined) ?? true;
+	core.DefaultServiceConfiguration.deli.enableEphemeralContainerSummaryCleanup =
+		enableEphemeralContainerSummaryCleanup;
+
 	let globalDb: core.IDb;
 	if (globalDbEnabled) {
 		const globalDbReconnect = (config.get("mongo:globalDbReconnect") as boolean) ?? false;

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -26,6 +26,9 @@ export interface IDeliServerConfiguration {
 	// Enables creating join/leave signals for write clients
 	enableWriteClientSignals: boolean;
 
+	// Enables ephemeral container summary deletion on deli close
+	enableEphemeralContainerSummaryCleanup: boolean;
+
 	// Enables deli to maintain batches as it produces them to the next lambdas
 	maintainBatches: boolean;
 
@@ -220,6 +223,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
 		enableNackMessages: true,
 		enableOpHashing: true,
 		enableAutoDSNUpdate: false,
+		enableEphemeralContainerSummaryCleanup: true,
 		checkForIdleClientsOnStartup: false,
 		maintainBatches: false,
 		enableWriteClientSignals: false,


### PR DESCRIPTION
## Description

We need to trim down as many unnecessary Redis API calls as possible in the Ephemeral Container scenario. This PR adds the following optimizations:

1. **Stat Optimization** (behind flag): Uses `strlen` instead of `get` to check if a path exists and if it's a directory or file. Empty files are assumed to be directories.
2. **Disable Persist Latest Full Summary** (behind flag): Disables storing the latest full summary as its own blob in RedisFs, because it's redundant to Historian's Redis cache.
3. **Disable Delete Summary on Deli Close** (behind flag): Disables Deli's call to Historian/Gitrest to proactively delete an ephemeral container's summaries on session end because they will be cleaned up by TTL eventually.
4. **HashMap "rootDir" optimizations**: Don't bother getting/setting fields that are included in the hashmap's key, because those are always directories with an empty value.
5. **HashMap "expire" optmization**: Update expire once on hashmap creation and never again so that we don't keep calling `expire` everytime a recursive mkdir is called.