### PR TITLE
tree: Document impossible identity reuse cases

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -102,6 +102,18 @@ export function relevantRemovedRoots(
 
 /**
  * Default editor for transactional tree data changes.
+ * @privateRemarks
+ * When taking into account not just the content of the tree,
+ * but also how the merge identities (and thus anchors, flex-tree and simple-tree nodes) of nodes before and after the edits correspond,
+ * some edits are currently impossible to express.
+ * Examples of these non-expressible edits include:
+ * - Changing the type of a node while keeping its merge identity.
+ * - Changing the value of a leaf while keeping its merge identity.
+ * - Swapping subtrees between two value fields.
+ * - Replacing a node in the middle of a tree while reusing some of the old nodes decedents that were under value fields.
+ * At some point it will likely be worth supporting at least some of these, possibly using a mechanism could support all of them if desired.
+ * If/when such a mechanism becomes available, it should be evaluated if any existing editing operations should be changed to leverage it (Possibly by adding opt ins at the view schema layer).
+ *
  * @internal
  */
 export interface IDefaultEditBuilder {

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -107,12 +107,15 @@ export function relevantRemovedRoots(
  * but also how the merge identities (and thus anchors, flex-tree and simple-tree nodes) of nodes before and after the edits correspond,
  * some edits are currently impossible to express.
  * Examples of these non-expressible edits include:
+ *
  * - Changing the type of a node while keeping its merge identity.
  * - Changing the value of a leaf while keeping its merge identity.
  * - Swapping subtrees between two value fields.
  * - Replacing a node in the middle of a tree while reusing some of the old nodes decedents that were under value fields.
- * At some point it will likely be worth supporting at least some of these, possibly using a mechanism could support all of them if desired.
- * If/when such a mechanism becomes available, it should be evaluated if any existing editing operations should be changed to leverage it (Possibly by adding opt ins at the view schema layer).
+ *
+ * At some point it will likely be worth supporting at least some of these, possibly using a mechanism that could support all of them if desired.
+ * If/when such a mechanism becomes available, an evaluation should be done to determine if any existing editing operations should be changed to leverage it
+ * (Possibly by adding opt ins at the view schema layer).
  *
  * @internal
  */


### PR DESCRIPTION
## Description

Add internal document comment covering gaps in editing expressiveness with respect to reuse of node merge identity.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
