### PR TITLE
Fix the directory loadCore on detached scenario

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -782,9 +782,6 @@ export class SharedDirectory
 						// "fake" client sequence number to signify the loading order, and there is no need to retain
 						// the actual client sequence number at this point.
 						if (createInfo !== undefined && createInfo.csn > 0) {
-							// If csn is -1, then initialize it with 0, otherwise we will never process ops for this
-							// sub directory. This could be done at serialization time too, but we need to maintain
-							// back compat too and also we will actually know the state when it was serialized.
 							if (!tempSeqNums.has(createInfo.csn)) {
 								tempSeqNums.set(createInfo.csn, 0);
 							}

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -781,7 +781,7 @@ export class SharedDirectory
 						// guaranteed during the serialization process. As a result, it is only essential to utilize the
 						// "fake" client sequence number to signify the loading order, and there is no need to retain
 						// the actual client sequence number at this point.
-						if (createInfo !== undefined && createInfo.csn > -1) {
+						if (createInfo !== undefined && createInfo.csn > 0) {
 							// If csn is -1, then initialize it with 0, otherwise we will never process ops for this
 							// sub directory. This could be done at serialization time too, but we need to maintain
 							// back compat too and also we will actually know the state when it was serialized.
@@ -792,6 +792,13 @@ export class SharedDirectory
 							seqData = { seq: createInfo.csn, clientSeq: fakeClientSeq };
 							tempSeqNums.set(createInfo.csn, ++fakeClientSeq);
 						} else {
+							/**
+							 * 1. If csn is -1, then initialize it with 0, otherwise we will never process ops for this
+							 * sub directory. This could be done at serialization time too, but we need to maintain
+							 * back compat too and also we will actually know the state when it was serialized.
+							 * 2. We need to make the csn = -1 and csn = 0 share the same counter, there are cases
+							 * where both -1 and 0 coexist within a single document.
+							 */
 							seqData = {
 								seq: 0,
 								clientSeq: ++currentSubDir.localCreationSeq,


### PR DESCRIPTION
[AB#7013](https://dev.azure.com/fluidframework/internal/_workitems/edit/7013), [AB#7022](https://dev.azure.com/fluidframework/internal/_workitems/edit/7022)

Reproduced 0x85c based on https://github.com/microsoft/FluidFramework/compare/main...Abe27342:FluidFramework:0x85c

Resolved the corner case in the directory `loadCore` function where the coexistence of `csn = 0` and `csn = -1` in a detached scenario occurred.
