### PR TITLE
The Azure client and the T9s client must connect in 'write' mode by default (#19315) - release/client/2.0.0-rc.1.0

### DIFF
--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -108,6 +108,7 @@
 		"@fluidframework/protocol-definitions": "^3.1.0",
 		"@fluidframework/routerlicious-driver": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
+		"@fluidframework/telemetry-utils": "workspace:~",
 		"@fluidframework/tinylicious-driver": "workspace:~",
 		"uuid": "^9.0.0"
 	},

--- a/packages/framework/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/framework/tinylicious-client/src/TinyliciousClient.ts
@@ -24,8 +24,9 @@ import {
 	createServiceAudience,
 } from "@fluidframework/fluid-static";
 import { IClient } from "@fluidframework/protocol-definitions";
-import { FluidObject } from "@fluidframework/core-interfaces";
+import { ConfigTypes, FluidObject } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils";
+import { wrapConfigProviderWithDefaults } from "@fluidframework/telemetry-utils";
 import { TinyliciousClientProps, TinyliciousContainerServices } from "./interfaces";
 import { createTinyliciousAudienceMember } from "./TinyliciousAudience";
 
@@ -158,12 +159,17 @@ export class TinyliciousClient {
 			mode: "write",
 		};
 
+		const featureGates: Record<string, ConfigTypes> = {
+			// T9s client requires a write connection by default
+			"Fluid.Container.ForceWriteConnection": true,
+		};
 		const loader = new Loader({
 			urlResolver: this.urlResolver,
 			documentServiceFactory: this.documentServiceFactory,
 			codeLoader,
 			logger: this.props?.logger,
 			options: { client },
+			configProvider: wrapConfigProviderWithDefaults(/* original */ undefined, featureGates),
 		});
 
 		return loader;

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -6,6 +6,7 @@
 
 /// <reference types="node" />
 
+import { ConfigTypes } from '@fluidframework/core-interfaces';
 import { EventEmitter } from 'events';
 import { EventEmitterEventType } from '@fluid-internal/client-utils';
 import { IConfigProviderBase } from '@fluidframework/core-interfaces';
@@ -432,6 +433,9 @@ export class UsageError extends LoggingError implements IUsageError, IFluidError
 
 // @internal
 export function validatePrecondition(condition: boolean, message: string, props?: ITelemetryBaseProperties): asserts condition;
+
+// @internal
+export const wrapConfigProviderWithDefaults: (original: IConfigProviderBase | undefined, defaults: Record<string, ConfigTypes>) => IConfigProviderBase;
 
 // @internal
 export function wrapError<T extends LoggingError>(innerError: unknown, newErrorFn: (message: string) => T): T;

--- a/packages/utils/telemetry-utils/src/config.ts
+++ b/packages/utils/telemetry-utils/src/config.ts
@@ -167,6 +167,24 @@ const safeSessionStorage = (): Storage | undefined => {
 };
 
 /**
+ * Creates a wrapper on top of an existing config provider which allows for
+ * specifying feature gates if not present in the original provider.
+ *
+ * @param original - the original config provider
+ * @param defaults - default feature gate configs to be used if not specified by the original provider
+ * @returns A config provider that looks for any requested feature gates in the original provider and falls
+ * back to the values specified in the `defaults` feature gates if they're not present in the original.
+ *
+ * @internal
+ */
+export const wrapConfigProviderWithDefaults = (
+	original: IConfigProviderBase | undefined,
+	defaults: Record<string, ConfigTypes>,
+): IConfigProviderBase => ({
+	getRawConfig: (name: string): ConfigTypes => original?.getRawConfig(name) ?? defaults[name],
+});
+
+/**
  * Implementation of {@link IConfigProvider} which contains nested {@link IConfigProviderBase} instances
  */
 export class CachedConfigProvider implements IConfigProvider {

--- a/packages/utils/telemetry-utils/src/index.ts
+++ b/packages/utils/telemetry-utils/src/index.ts
@@ -9,6 +9,7 @@ export {
 	mixinMonitoringContext,
 	IConfigProvider,
 	loggerToMonitoringContext,
+	wrapConfigProviderWithDefaults,
 } from "./config";
 export {
 	DataCorruptionError,

--- a/packages/utils/telemetry-utils/src/test/config.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/config.spec.ts
@@ -5,7 +5,11 @@
 
 import { strict as assert } from "node:assert";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
-import { CachedConfigProvider, inMemoryConfigProvider } from "../config";
+import {
+	CachedConfigProvider,
+	inMemoryConfigProvider,
+	wrapConfigProviderWithDefaults,
+} from "../config";
 import { TelemetryDataTag } from "../logger";
 import { MockLogger } from "../mockLogger";
 
@@ -279,4 +283,30 @@ describe("Config", () => {
 	});
 
 	// #endregion SettingsProvider
+});
+
+describe("wrappedConfigProvider", () => {
+	const configProvider = (featureGates: Record<string, ConfigTypes>): IConfigProviderBase => ({
+		getRawConfig: (name: string): ConfigTypes => featureGates[name],
+	});
+
+	it("When there is no original config provider", () => {
+		const config = wrapConfigProviderWithDefaults(undefined, { "Fluid.Feature.Gate": true });
+		assert.strictEqual(config.getRawConfig("Fluid.Feature.Gate"), true);
+	});
+
+	it("When the original config provider does not specify the required key", () => {
+		const config = wrapConfigProviderWithDefaults(configProvider({}), {
+			"Fluid.Feature.Gate": true,
+		});
+		assert.strictEqual(config.getRawConfig("Fluid.Feature.Gate"), true);
+	});
+
+	it("When the original config provider specifies the required key", () => {
+		const config = wrapConfigProviderWithDefaults(
+			configProvider({ "Fluid.Feature.Gate": false }),
+			{ "Fluid.Feature.Gate": true },
+		);
+		assert.strictEqual(config.getRawConfig("Fluid.Feature.Gate"), false);
+	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8767,6 +8767,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.1.0
       '@fluidframework/routerlicious-driver': workspace:~
       '@fluidframework/runtime-utils': workspace:~
+      '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-utils': workspace:~
       '@fluidframework/tinylicious-client-previous': npm:@fluidframework/tinylicious-client@2.0.0-internal.8.0.0
       '@fluidframework/tinylicious-driver': workspace:~
@@ -8795,6 +8796,7 @@ importers:
       '@fluidframework/protocol-definitions': 3.1.0
       '@fluidframework/routerlicious-driver': link:../../drivers/routerlicious-driver
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
+      '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       '@fluidframework/tinylicious-driver': link:../../drivers/tinylicious-driver
       uuid: 9.0.1
     devDependencies:


### PR DESCRIPTION
## Description

Porting https://github.com/microsoft/FluidFramework/pull/19315 to the release branch.

ADO:7009

The `IClient.mode` property is (was) not driving this behavior at all, so we need to fallback to the feature gate for this requirement to be met.
