### PR TITLE
Add permissions block to stale-branches action

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -4,6 +4,9 @@
 name: Delete Stale Branches
 on: workflow_dispatch
 
+permissions:
+  contents: write
+
 jobs:
   stale_branches:
     name: Cleanup old branches


### PR DESCRIPTION
## Description

Updates the stale-branches workflow to include a permissions block.

See github permissions doc [here](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#permissions).
