### PR TITLE
Add permissions block to push-tag-create-release.yml

### DIFF
--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -13,6 +13,9 @@ on:
     tags:
       - "*_v*"
 
+permissions:
+  contents: write
+
 jobs:
   create-release:
     name: Create GitHub release


### PR DESCRIPTION
## Description

Updates the push-tag-create-release workflow to include a permissions block.

See github permissions doc [here](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#permissions).
