### PR TITLE
test(e2e): Lint against value-imports of @fluidframework/counter

### DIFF
--- a/packages/test/test-end-to-end-tests/.eslintrc.cjs
+++ b/packages/test/test-end-to-end-tests/.eslintrc.cjs
@@ -17,7 +17,11 @@ module.exports = {
 		"@typescript-eslint/no-restricted-imports": [
 			"error",
 			{
-				paths: ["@fluidframework/map", "@fluidframework/matrix"].map((importName) => ({
+				paths: [
+					"@fluidframework/map",
+					"@fluidframework/matrix",
+					"@fluidframework/counter",
+				].map((importName) => ({
 					name: importName,
 					message:
 						"Rather than import this Fluid package directly, use the 'apis' argument of describeCompat. See \"How-to\" in the README for more information.",

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -17,7 +17,7 @@ import {
 	SummaryCollection,
 } from "@fluidframework/container-runtime";
 import { FluidObject, IFluidHandle } from "@fluidframework/core-interfaces";
-import { SharedCounter } from "@fluidframework/counter";
+import type { SharedCounter } from "@fluidframework/counter";
 import { FluidDataStoreRuntime, mixinSummaryHandler } from "@fluidframework/datastore";
 import { DriverHeader, ISummaryContext } from "@fluidframework/driver-definitions";
 import type { SharedMatrix } from "@fluidframework/matrix";
@@ -148,7 +148,7 @@ describeCompat(
 	"Prepare for Summary with Search Blobs",
 	"2.0.0-rc.1.0.0",
 	(getTestObjectProvider, apis) => {
-		const { SharedMatrix } = apis.dds;
+		const { SharedMatrix, SharedCounter } = apis.dds;
 		const { DataObject, DataObjectFactory } = apis.dataRuntime;
 		const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { ISharedCounter, SharedCounter } from "@fluidframework/counter";
+import type { ISharedCounter, SharedCounter } from "@fluidframework/counter";
 import {
 	ITestObjectProvider,
 	ITestContainerConfig,
@@ -20,13 +20,16 @@ import { ContainerRuntime } from "@fluidframework/container-runtime";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 
 const counterId = "counterKey";
-const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
-const testContainerConfig: ITestContainerConfig = {
-	fluidDataObjectType: DataObjectFactoryType.Test,
-	registry,
-};
 
-describeCompat("SharedCounter", "FullCompat", (getTestObjectProvider) => {
+describeCompat("SharedCounter", "FullCompat", (getTestObjectProvider, apis) => {
+	const { SharedCounter } = apis.dds;
+
+	const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
+	const testContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry,
+	};
+
 	let provider: ITestObjectProvider;
 	beforeEach("getTestObjectProvider", () => {
 		provider = getTestObjectProvider();
@@ -163,62 +166,74 @@ describeCompat("SharedCounter", "FullCompat", (getTestObjectProvider) => {
 	});
 });
 
-describeCompat("SharedCounter orderSequentially", "2.0.0-rc.1.0.0", (getTestObjectProvider) => {
-	let provider: ITestObjectProvider;
-	beforeEach("getTestObjectProvider", () => {
-		provider = getTestObjectProvider();
-	});
+describeCompat(
+	"SharedCounter orderSequentially",
+	"2.0.0-rc.1.0.0",
+	(getTestObjectProvider, apis) => {
+		const { SharedCounter } = apis.dds;
 
-	let container: IContainer;
-	let dataObject: ITestFluidObject;
-	let dataStore: ITestFluidObject;
-	let sharedCounter: SharedCounter;
-	let containerRuntime: ContainerRuntime;
-
-	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
-		getRawConfig: (name: string): ConfigTypes => settings[name],
-	});
-	const errorMessage = "callback failure";
-
-	beforeEach("setup", async () => {
-		const configWithFeatureGates = {
-			...testContainerConfig,
-			loaderProps: {
-				configProvider: configProvider({
-					"Fluid.ContainerRuntime.EnableRollback": true,
-				}),
-			},
+		const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
+		const testContainerConfig: ITestContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry,
 		};
-		container = await provider.makeTestContainer(configWithFeatureGates);
-		dataObject = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
-		dataStore = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
-		sharedCounter = await dataStore.getSharedObject<SharedCounter>(counterId);
-		containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
-	});
 
-	itExpects(
-		"Closes container when rollback fails",
-		[
-			{
-				eventName: "fluid:telemetry:Container:ContainerClose",
-				error: "RollbackError: rollback not supported",
-				errorType: ContainerErrorTypes.dataProcessingError,
+		let provider: ITestObjectProvider;
+		beforeEach("getTestObjectProvider", () => {
+			provider = getTestObjectProvider();
+		});
+
+		let container: IContainer;
+		let dataObject: ITestFluidObject;
+		let dataStore: ITestFluidObject;
+		let sharedCounter: SharedCounter;
+		let containerRuntime: ContainerRuntime;
+
+		const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+			getRawConfig: (name: string): ConfigTypes => settings[name],
+		});
+		const errorMessage = "callback failure";
+
+		beforeEach("setup", async () => {
+			const configWithFeatureGates = {
+				...testContainerConfig,
+				loaderProps: {
+					configProvider: configProvider({
+						"Fluid.ContainerRuntime.EnableRollback": true,
+					}),
+				},
+			};
+			container = await provider.makeTestContainer(configWithFeatureGates);
+			dataObject = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
+			dataStore = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
+			sharedCounter = await dataStore.getSharedObject<SharedCounter>(counterId);
+			containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
+		});
+
+		itExpects(
+			"Closes container when rollback fails",
+			[
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+					error: "RollbackError: rollback not supported",
+					errorType: ContainerErrorTypes.dataProcessingError,
+				},
+			],
+			async () => {
+				let error: Error | undefined;
+				try {
+					containerRuntime.orderSequentially(() => {
+						sharedCounter.increment(1);
+						throw new Error(errorMessage);
+					});
+				} catch (err) {
+					error = err as Error;
+				}
+
+				assert.notEqual(error, undefined, "No error");
+				assert.ok(error?.message.startsWith("RollbackError:"), "Unexpected error message");
+				assert.equal(container.closed, true);
 			},
-		],
-		async () => {
-			let error: Error | undefined;
-			try {
-				containerRuntime.orderSequentially(() => {
-					sharedCounter.increment(1);
-					throw new Error(errorMessage);
-				});
-			} catch (err) {
-				error = err as Error;
-			}
-
-			assert.notEqual(error, undefined, "No error");
-			assert.ok(error?.message.startsWith("RollbackError:"), "Unexpected error message");
-			assert.equal(container.closed, true);
-		},
-	);
-});
+		);
+	},
+);

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -30,7 +30,7 @@ import { SharedCell } from "@fluidframework/cell";
 import { Ink } from "@fluidframework/ink";
 import type { SharedMatrix } from "@fluidframework/matrix";
 import { ConsensusQueue, ConsensusOrderedCollection } from "@fluidframework/ordered-collection";
-import { SharedCounter } from "@fluidframework/counter";
+import type { SharedCounter } from "@fluidframework/counter";
 import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
@@ -121,7 +121,7 @@ describeCompat(
 	`Dehydrate Rehydrate Container Test`,
 	"FullCompat",
 	(getTestObjectProvider, apis) => {
-		const { SharedMap, SharedDirectory, SharedMatrix } = apis.dds;
+		const { SharedMap, SharedDirectory, SharedMatrix, SharedCounter } = apis.dds;
 		function assertSubtree(tree: ISnapshotTree, key: string, msg?: string): ISnapshotTree {
 			const subTree = tree.trees[key];
 			assert(subTree, msg ?? `${key} subtree not present`);

--- a/packages/test/test-end-to-end-tests/src/test/loadModes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loadModes.spec.ts
@@ -4,15 +4,10 @@
  */
 
 import { strict as assert } from "assert";
-import {
-	ContainerRuntimeFactoryWithDefaultDataStore,
-	DataObject,
-	DataObjectFactory,
-	IDataObjectProps,
-} from "@fluidframework/aqueduct";
+import type { IDataObjectProps } from "@fluidframework/aqueduct";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { IFluidHandle, IRequestHeader } from "@fluidframework/core-interfaces";
-import { SharedCounter } from "@fluidframework/counter";
+import type { SharedCounter } from "@fluidframework/counter";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import {
@@ -32,71 +27,75 @@ import type { SharedMap } from "@fluidframework/map";
 
 const counterKey = "count";
 
-/**
- * Implementation of counter dataObject for testing.
- */
-class TestDataObject extends DataObject {
-	public static readonly type = "@fluid-example/test-dataObject";
+// REVIEW: enable compat testing?
+describeCompat("LoadModes", "2.0.0-rc.1.0.0", (getTestObjectProvider, apis) => {
+	const { SharedCounter } = apis.dds;
+	const { DataObject, DataObjectFactory } = apis.dataRuntime;
+	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 
-	public static getFactory() {
-		return TestDataObject.factory;
+	/**
+	 * Implementation of counter dataObject for testing.
+	 */
+	class TestDataObject extends DataObject {
+		public static readonly type = "@fluid-example/test-dataObject";
+
+		public static getFactory() {
+			return TestDataObject.factory;
+		}
+
+		private static readonly factory = new DataObjectFactory(
+			TestDataObject.type,
+			TestDataObject,
+			[],
+			{},
+		);
+
+		private counter!: SharedCounter;
+
+		/**
+		 * Expose the runtime for testing purposes.
+		 */
+
+		public runtime: IFluidDataStoreRuntime;
+
+		public constructor(props: IDataObjectProps) {
+			super(props);
+			this.runtime = props.runtime;
+		}
+
+		/**
+		 * Gets the current counter value.
+		 */
+		public get value(): number {
+			return this.counter.value;
+		}
+
+		/**
+		 * Increments the counter value by 1.
+		 */
+		public increment() {
+			this.counter.increment(1);
+		}
+
+		protected async initializingFirstTime() {
+			const counter = SharedCounter.create(this.runtime);
+			this.root.set(counterKey, counter.handle);
+		}
+
+		protected async hasInitialized() {
+			const counterHandle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
+			assert(counterHandle);
+			this.counter = await counterHandle.get();
+		}
 	}
 
-	private static readonly factory = new DataObjectFactory(
+	const testDataObjectFactory = new DataObjectFactory(
 		TestDataObject.type,
 		TestDataObject,
-		[],
+		[SharedCounter.getFactory()],
 		{},
 	);
 
-	private counter!: SharedCounter;
-
-	/**
-	 * Expose the runtime for testing purposes.
-	 */
-
-	public runtime: IFluidDataStoreRuntime;
-
-	public constructor(props: IDataObjectProps) {
-		super(props);
-		this.runtime = props.runtime;
-	}
-
-	/**
-	 * Gets the current counter value.
-	 */
-	public get value(): number {
-		return this.counter.value;
-	}
-
-	/**
-	 * Increments the counter value by 1.
-	 */
-	public increment() {
-		this.counter.increment(1);
-	}
-
-	protected async initializingFirstTime() {
-		const counter = SharedCounter.create(this.runtime);
-		this.root.set(counterKey, counter.handle);
-	}
-
-	protected async hasInitialized() {
-		const counterHandle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
-		assert(counterHandle);
-		this.counter = await counterHandle.get();
-	}
-}
-
-const testDataObjectFactory = new DataObjectFactory(
-	TestDataObject.type,
-	TestDataObject,
-	[SharedCounter.getFactory()],
-	{},
-);
-
-// REVIEW: enable compat testing?
-describeCompat("LoadModes", "2.0.0-rc.1.0.0", (getTestObjectProvider, apis) => {
 	let provider: ITestObjectProvider;
 	before(() => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
@@ -4,15 +4,10 @@
  */
 
 import { strict as assert } from "assert";
-import {
-	ContainerRuntimeFactoryWithDefaultDataStore,
-	DataObject,
-	DataObjectFactory,
-	IDataObjectProps,
-} from "@fluidframework/aqueduct";
+import type { IDataObjectProps } from "@fluidframework/aqueduct";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { SharedCounter } from "@fluidframework/counter";
+import type { SharedCounter } from "@fluidframework/counter";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { SharedString } from "@fluidframework/sequence";
@@ -31,71 +26,75 @@ import { IResolvedUrl } from "@fluidframework/driver-definitions";
 
 const counterKey = "count";
 
-/**
- * Implementation of counter dataObject for testing.
- */
-export class TestDataObject extends DataObject {
-	public static readonly type = "@fluid-example/test-dataObject";
+// REVIEW: enable compat testing?
+describeCompat("LocalLoader", "2.0.0-rc.1.0.0", (getTestObjectProvider, apis) => {
+	const { SharedCounter } = apis.dds;
+	const { DataObject, DataObjectFactory } = apis.dataRuntime;
+	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 
-	public static getFactory() {
-		return TestDataObject.factory;
+	/**
+	 * Implementation of counter dataObject for testing.
+	 */
+	class TestDataObject extends DataObject {
+		public static readonly type = "@fluid-example/test-dataObject";
+
+		public static getFactory() {
+			return TestDataObject.factory;
+		}
+
+		private static readonly factory = new DataObjectFactory(
+			TestDataObject.type,
+			TestDataObject,
+			[],
+			{},
+		);
+
+		private counter!: SharedCounter;
+
+		/**
+		 * Expose the runtime for testing purposes.
+		 */
+
+		public runtime: IFluidDataStoreRuntime;
+
+		public constructor(props: IDataObjectProps) {
+			super(props);
+			this.runtime = props.runtime;
+		}
+
+		/**
+		 * Gets the current counter value.
+		 */
+		public get value(): number {
+			return this.counter.value;
+		}
+
+		/**
+		 * Increments the counter value by 1.
+		 */
+		public increment() {
+			this.counter.increment(1);
+		}
+
+		protected async initializingFirstTime() {
+			const counter = SharedCounter.create(this.runtime);
+			this.root.set(counterKey, counter.handle);
+		}
+
+		protected async hasInitialized() {
+			const counterHandle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
+			assert(counterHandle);
+			this.counter = await counterHandle.get();
+		}
 	}
 
-	private static readonly factory = new DataObjectFactory(
+	const testDataObjectFactory = new DataObjectFactory(
 		TestDataObject.type,
 		TestDataObject,
-		[],
+		[SharedCounter.getFactory(), SharedString.getFactory()],
 		{},
 	);
 
-	private counter!: SharedCounter;
-
-	/**
-	 * Expose the runtime for testing purposes.
-	 */
-
-	public runtime: IFluidDataStoreRuntime;
-
-	public constructor(props: IDataObjectProps) {
-		super(props);
-		this.runtime = props.runtime;
-	}
-
-	/**
-	 * Gets the current counter value.
-	 */
-	public get value(): number {
-		return this.counter.value;
-	}
-
-	/**
-	 * Increments the counter value by 1.
-	 */
-	public increment() {
-		this.counter.increment(1);
-	}
-
-	protected async initializingFirstTime() {
-		const counter = SharedCounter.create(this.runtime);
-		this.root.set(counterKey, counter.handle);
-	}
-
-	protected async hasInitialized() {
-		const counterHandle = this.root.get<IFluidHandle<SharedCounter>>(counterKey);
-		assert(counterHandle);
-		this.counter = await counterHandle.get();
-	}
-}
-
-const testDataObjectFactory = new DataObjectFactory(
-	TestDataObject.type,
-	TestDataObject,
-	[SharedCounter.getFactory(), SharedString.getFactory()],
-	{},
-);
-
-// REVIEW: enable compat testing?
-describeCompat("LocalLoader", "2.0.0-rc.1.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	before(() => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
@@ -19,14 +19,14 @@ import { IContainer } from "@fluidframework/container-definitions";
 import { FlushMode } from "@fluidframework/runtime-definitions";
 import { SharedCell } from "@fluidframework/cell";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
-import { SharedCounter } from "@fluidframework/counter";
+import type { SharedCounter } from "@fluidframework/counter";
 import type { SharedMatrix } from "@fluidframework/matrix";
 
 describeCompat(
 	"Op reentry and rebasing during pending batches",
 	"2.0.0-rc.1.0.0",
 	(getTestObjectProvider, apis) => {
-		const { SharedMap, SharedDirectory, SharedMatrix } = apis.dds;
+		const { SharedMap, SharedDirectory, SharedMatrix, SharedCounter } = apis.dds;
 		const registry: ChannelFactoryRegistry = [
 			["map", SharedMap.getFactory()],
 			["sharedString", SharedString.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -7,7 +7,7 @@ import assert from "assert";
 import { IContainer, IHostLoader, LoaderHeader } from "@fluidframework/container-definitions";
 import type { ISharedDirectory, SharedDirectory, SharedMap } from "@fluidframework/map";
 import { SharedCell } from "@fluidframework/cell";
-import { SharedCounter } from "@fluidframework/counter";
+import type { SharedCounter } from "@fluidframework/counter";
 import {
 	ReferenceType,
 	reservedMarkerIdKey,
@@ -77,7 +77,7 @@ type SharedObjCallback = (
 // Introduced in 0.37
 // REVIEW: enable compat testing
 describeCompat("stashed ops", "2.0.0-rc.1.0.0", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory } = apis.dds;
+	const { SharedMap, SharedDirectory, SharedCounter } = apis.dds;
 	const registry: ChannelFactoryRegistry = [
 		[mapId, SharedMap.getFactory()],
 		[stringId, SharedString.getFactory()],
@@ -1729,7 +1729,7 @@ describeCompat("stashed ops", "2.0.0-rc.1.0.0", (getTestObjectProvider, apis) =>
 });
 
 describeCompat("stashed ops", "2.0.0-rc.1.0.0", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory } = apis.dds;
+	const { SharedMap, SharedDirectory, SharedCounter } = apis.dds;
 	const registry: ChannelFactoryRegistry = [
 		[mapId, SharedMap.getFactory()],
 		[stringId, SharedString.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
@@ -15,12 +15,13 @@ import {
 	summarizeNow,
 } from "@fluidframework/test-utils";
 import { DefaultSummaryConfiguration } from "@fluidframework/container-runtime";
-import { SharedCounter } from "@fluidframework/counter";
 
 describeCompat(
 	"Summarizer closes instead of refreshing",
 	"2.0.0-rc.1.0.0",
-	(getTestObjectProvider) => {
+	(getTestObjectProvider, apis) => {
+		const { SharedCounter } = apis.dds;
+
 		const configProvider = createTestConfigProvider();
 		const testContainerConfig: ITestContainerConfig = {
 			runtimeOptions: {


### PR DESCRIPTION
## Description

Adds a lint rule to prevent value imports of @fluidframework/matrix in e2e tests. This is inline with guidance  [here](https://github.com/microsoft/FluidFramework/tree/main/packages/test/test-end-to-end-tests#how-to).

## Reviewer Guidance

Recommended to review with whitespace diffing turned off.