### PR TITLE
ci: Use correct dangerfile location

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"build:gendocs:server:routerlicious": "copyfiles \"server/routerlicious/**/*.api.json\" ./_api-extractor-temp/doc-models/ -e \"**/node_modules/**\" -f -V",
 		"build:readme": "markdown-magic --files \"**/*.md\" !docs",
 		"bundle-analysis:collect": "npm run webpack:profile && flub generate bundleStats",
-		"bundle-analysis:run": "flub run bundleStats --dangerfile build-tools/packages/build-cli/lib/lib/dangerfile.js",
+		"bundle-analysis:run": "flub run bundleStats --dangerfile build-tools/packages/build-cli/lib/library/dangerfile.js",
 		"changeset": "flub changeset add --releaseGroup client",
 		"check:are-the-types-wrong": "fluid-build --task check:are-the-types-wrong",
 		"check:versions": "flub check buildVersion -g client --path .",


### PR DESCRIPTION
[#19378](https://github.com/microsoft/FluidFramework/pull/19378) changed the location of the dangerfile we use for bundle size reporting. I forgot to update the reference in the root package.json in that PR.