### PR TITLE
build(docs): Set Node Version On Deployment of docs

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -319,6 +319,8 @@ stages:
           submodules: false
           clean: true
 
+        - template: templates/include-use-node-version.yml
+
         - task: DownloadPipelineArtifact@2
           displayName: 'Copy fluidframework-docs to public folder'
           inputs:


### PR DESCRIPTION
Creating the azure function and deploying it doesnt seem to work in the pipeline, this is one potential fix. Bug this is trying to fix; 
https://dev.azure.com/fluidframework/internal/_build/results?buildId=232022&view=logs&j=25db5cdf-ae19-553c-5168-215eaa605926&t=e66035c1-1522-5593-344e-1cfc550e02cb&l=132