### PR TITLE
docs: Give Types their own pages + nav entries in the API docs on the website

### DIFF
--- a/docs/api-markdown-documenter/build-api-nav.js
+++ b/docs/api-markdown-documenter/build-api-nav.js
@@ -19,6 +19,7 @@ async function buildNavBar(documents, version) {
 		ApiItemKind.Interface,
 		ApiItemKind.Enum,
 		ApiItemKind.Namespace,
+		ApiItemKind.TypeAlias,
 	]);
 	const apiItems = documents
 		.map((document) => document.apiItem)

--- a/docs/api-markdown-documenter/render-api-documentation.js
+++ b/docs/api-markdown-documenter/render-api-documentation.js
@@ -72,6 +72,7 @@ async function renderApiDocumentation(inputDir, outputDir, uriRootDir, apiVersio
 			ApiItemKind.Enum,
 			ApiItemKind.Interface,
 			ApiItemKind.Namespace,
+			ApiItemKind.TypeAlias,
 		],
 		newlineKind: "lf",
 		uriRoot: uriRootDir,

--- a/docs/themes/thxvscode/layouts/partials/apiNav.html
+++ b/docs/themes/thxvscode/layouts/partials/apiNav.html
@@ -137,7 +137,7 @@
 
                                 {{ $isCurrentPage := in (trim $current.RelPermalink " ") (trim $targetPage.RelPermalink " ") }}
                                 {{ $hasActiveLeaf := false }}
-                                {{ range $category := slice "Interface" "Class" "Enum" }}
+                                {{ range $category := slice "Interface" "Class" "Enum" "TypeAlias" }}
                                     {{ if isset $apiDetails $category }}
                                         {{ $currentTrimmedLink := trim $current.RelPermalink " " }}
                                         {{ $categoryLower := lower $category }}
@@ -157,9 +157,9 @@
                                         {{ (path.Base $targetPage.RelPermalink) | humanize | title }}
                                     </a>
                                     <ul id="leaf-docs-nav-{{ $isCurrentPage }}" class="leaf-docs-nav collapse {{ if $isCurrentPage }}in{{ end }}">
-                                        {{ $plurals := dict "Interface" "Interfaces" "Class" "Classes" "Enum" "Enums" }}
+                                        {{ $plurals := dict "Interface" "Interfaces" "Class" "Classes" "Enum" "Enums" "TypeAlias" "Types" }}
     
-                                        {{ range $category := slice "Interface" "Class" "Enum" }}
+                                        {{ range $category := slice "Interface" "Class" "Enum" "TypeAlias" }}
                                             {{ if isset $apiDetails $category }}
                                                 {{ $currentTrimmedLink := trim $current.RelPermalink " " }}
                                                 {{ $categoryLower := lower $category }}
@@ -263,4 +263,3 @@
         {{ end }}
     </select>
 </nav>
-


### PR DESCRIPTION
Updates the API docs config to produce separate pages for `Types`, rather than appending their information to the page of the parent item (packages or namespaces). Also adds navigation entries for them.

![image](https://github.com/microsoft/FluidFramework/assets/54606601/07a541ed-2202-4158-8fea-94fc546a69d6)