### PR TITLE
Summarizer ITelemetryContext: Deprecate "output" functions get/serialize

### DIFF
--- a/.changeset/better-meals-cough.md
+++ b/.changeset/better-meals-cough.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/runtime-definitions": minor
+---
+
+ITelemetryContext: All "read" functions are now deprecated
+
+ITelemetryContext is to be used only for instrumentation, not for attempting to read the values already set by other code.
+This is important because this _public_ interface may soon use FF's _should-be internal_ logging instrumentation types,
+which we reserve the right to expand (to support richer instrumentation).
+In that case, we would not be able to do so in a minor release if they're used as an "out" type
+like the return type for `get`.

--- a/.changeset/better-meals-cough.md
+++ b/.changeset/better-meals-cough.md
@@ -2,10 +2,19 @@
 "@fluidframework/runtime-definitions": minor
 ---
 
-ITelemetryContext: All "read" functions are now deprecated
+ITelemetryContext: Functions `get` and `serialize` are now deprecated
 
 ITelemetryContext is to be used only for instrumentation, not for attempting to read the values already set by other code.
 This is important because this _public_ interface may soon use FF's _should-be internal_ logging instrumentation types,
 which we reserve the right to expand (to support richer instrumentation).
 In that case, we would not be able to do so in a minor release if they're used as an "out" type
 like the return type for `get`.
+
+There is no replacement given in terms of immediate programmatic access to this data.
+The expected use pattern is something like this:
+
+-   Some code creates a concrete implementation of `ITelemetryContext` and passes it around
+-   Callers use the "write" functions on the interface to build up the context
+-   The originator uses a function like `serialize` (on the concrete impl, not exposed on the interface any longer)
+    and passes the result to a logger
+-   The data is inspected along with other logs in whatever telemetry pipeline is used by the application (or Debug Tools, etc)

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -399,7 +399,9 @@ export interface ISummaryTreeWithStats {
 
 // @public
 export interface ITelemetryContext {
+    // @deprecated
     get(prefix: string, property: string): TelemetryEventPropertyType;
+    // @deprecated
     serialize(): string;
     set(prefix: string, property: string, value: TelemetryEventPropertyType): void;
     setMultiple(prefix: string, property: string, values: Record<string, TelemetryEventPropertyType>): void;

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -342,6 +342,9 @@ export interface ITelemetryContext {
 
 	/**
 	 * Get the telemetry data being tracked
+	 *
+	 * @deprecated This interface should only be used for instrumenting, not for attempting to read already-set telemetry data.
+	 *
 	 * @param prefix - unique prefix for this data (ex: "fluid:map:")
 	 * @param property - property name of the telemetry data being tracked (ex: "DirectoryCount")
 	 * @returns undefined if item not found
@@ -351,6 +354,9 @@ export interface ITelemetryContext {
 	/**
 	 * Returns a serialized version of all the telemetry data.
 	 * Should be used when logging in telemetry events.
+	 *
+	 * @deprecated This interface should only be used for instrumenting. A concrete implementation will likely have a serialize function
+	 * but this functionality should not be used by other code being given an ITelemetryContext.
 	 */
 	serialize(): string;
 }


### PR DESCRIPTION
## Description

`ITelemetryContext` is passed all over the place in the runtime to allow layers to jot down info for instrumenting Summarization. It should be a "write-only" interface like the loggers (they only have `send`, not anything about reading what's been logged).

### Why?

Like all our internal instrumentation APIs, we want to use the `Ext` logger types which are richer than the public interfaces.  Unfortunately, `ITelemetryContext` has to be public for now, but at least if we make it "write-only" then the telemetry props will tolerate any change to the `Ext` props type that expands what's allowed (all old callsites will still work). But if we expose getters that _return_ these props, and we want to expand that type, then it's a non-back-compat breaking change and has to wait for the next major release!
