### PR TITLE
GC: Clear Tombstone state immediately when a Tombstone is revived

### DIFF
--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -1084,11 +1084,15 @@ export class GarbageCollector implements IGarbageCollector {
 			autorecovery,
 		});
 
-		// This node is referenced - Clear its unreferenced state
+		// This node is referenced - Clear its unreferenced state immediately
 		// But don't delete the node id from the map yet.
 		// When generating GC stats, the set of nodes in here is used as the baseline for
 		// what was unreferenced in the last GC run.
 		this.unreferencedNodesState.get(toNodePath)?.stopTracking();
+
+		// Also clear the tombstone state immediately
+		this.tombstones.splice(this.tombstones.indexOf(toNodePath), 1);
+		this.runtime.updateTombstonedRoutes(this.tombstones);
 	}
 
 	/**

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -848,13 +848,6 @@ describeCompat("GC data store tombstone tests", "2.0.0-rc.1.0.0", (getTestObject
 					clientType: "interactive",
 					category: "error",
 				},
-				// 1A again
-				{
-					eventName:
-						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
-					clientType: "interactive",
-					category: "error",
-				},
 				// 3A
 				{
 					eventName:
@@ -949,16 +942,17 @@ describeCompat("GC data store tombstone tests", "2.0.0-rc.1.0.0", (getTestObject
 					),
 				);
 
-				// This request still fails because Auto-Recovery only affects the next summary (via next GC run)
-				const tombstoneErrorResponse_Interactive = await (
+				// This succeeds even though this Interactive session already loaded.
+				// Because we cleared the Tombstone state when the reference was "added" back by Auto-Recovery
+				const successResponse_Interactive = await (
 					entryPoint1._context.containerRuntime as ContainerRuntime
 				).resolveHandle({
 					url: dataStoreAId,
 				});
 				assert.equal(
-					tombstoneErrorResponse_Interactive.status,
-					404,
-					"Expected tombstone error - Auto-Recovery shouldn't affect in-progress Interactive sessions (1A again)",
+					successResponse_Interactive.status,
+					200,
+					"Auto-Recovery should clear the Tombstone state (1A again)",
 				);
 
 				// Auto-Recovery: This summary will have the unref timestamp reset due to the GC TombstoneLoaded op


### PR DESCRIPTION
## Description

_Is this a good idea?_

Since we changed things to get revival events "in order" in the op stream, we can update state immediately, even in interactive clients.  This was already done for unreferenced state tracking, but not for the Tombstone state.

Before this PR, we would see extra "Tombstone Requested" logs, even when the object was destined to become un-tombstoned in the next GC Run

## Reviewer Guidance

I'm not actually sure we should do this!  Tombstone state has always been static for the life of a session.  And until GC runs again, the object "really is" still a Tombstone.  Curious for input.