### PR TITLE
fix(container-loader): Add @types/uuid dependency and fix issues that it surfaced

### DIFF
--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -201,6 +201,7 @@
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^7.0.13",
 		"@types/ungap__structured-clone": "^1.2.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/loader/container-loader/src/test/attachment.spec.ts
+++ b/packages/loader/container-loader/src/test/attachment.spec.ts
@@ -461,7 +461,7 @@ describe("runRetriableAttachProcess", () => {
 					createOrGetStorageService: async () =>
 						// only the summary should be left to upload
 						createProxyWithFailDefault<IDocumentStorageService>({
-							uploadSummaryWithContext: async () => Promise.resolve(uuid),
+							uploadSummaryWithContext: async () => Promise.resolve(uuid()),
 						}),
 				}),
 			);

--- a/packages/loader/container-loader/src/test/attachment.spec.ts
+++ b/packages/loader/container-loader/src/test/attachment.spec.ts
@@ -328,7 +328,7 @@ describe("runRetriableAttachProcess", () => {
 					},
 					createOrGetStorageService: async () =>
 						createProxyWithFailDefault<IDocumentStorageService>({
-							createBlob: async () => Promise.resolve(uuid()),
+							createBlob: async () => Promise.resolve({ id: uuid() }),
 						}),
 					detachedBlobStorage,
 				});
@@ -371,7 +371,7 @@ describe("runRetriableAttachProcess", () => {
 						return emptySummary;
 					},
 					createOrGetStorageService: async () => ({
-						createBlob: async () => Promise.resolve(uuid()),
+						createBlob: async () => Promise.resolve({ id: uuid() }),
 						uploadSummaryWithContext: () => {
 							throw error;
 						},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9036,6 +9036,7 @@ importers:
       '@types/node': ^18.19.0
       '@types/sinon': ^7.0.13
       '@types/ungap__structured-clone': ^1.2.0
+      '@types/uuid': ^9.0.2
       '@ungap/structured-clone': ^1.2.0
       c8: ^8.0.1
       copyfiles: ^2.4.1
@@ -9088,6 +9089,7 @@ importers:
       '@types/node': 18.19.1
       '@types/sinon': 7.5.2
       '@types/ungap__structured-clone': 1.2.0
+      '@types/uuid': 9.0.7
       c8: 8.0.1
       copyfiles: 2.4.1
       cross-env: 7.0.3


### PR DESCRIPTION
## Description

Adds @types/uuid as a dev dependency and fixes some typing issues discovered once it is there. We discovered this problem because @alteut ran into it in his local build (still unsure why only him, maybe @types/uuid installed globally?).

Unresolved question: why isn't this caught by tsc before adding @types/uuid ? A function that returns `Promise<any>` shouldn't be valid where we expect one that returns `Promise<string>`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
