### PR TITLE
refactor: Cleanup uuid deps throughout the repo

### DIFF
--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -106,6 +106,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.3.0",
 		"@microsoft/api-extractor": "^7.39.1",
 		"@types/jsrsasign": "^10.5.12",
+		"@types/uuid": "^9.0.2",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"eslint-config-prettier": "~9.0.0",

--- a/azure/packages/azure-service-utils/src/generateToken.ts
+++ b/azure/packages/azure-service-utils/src/generateToken.ts
@@ -77,7 +77,6 @@ export function generateToken(
 		iat: now,
 		exp: now + lifetime,
 		ver,
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 		jti: uuid(),
 	};
 
@@ -99,9 +98,7 @@ export function generateToken(
  */
 export function generateUser(): IUser {
 	const randomUser = {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 		id: uuid(),
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
 		name: uuid(),
 	};
 

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -59,6 +59,7 @@
 		"@types/jest-environment-puppeteer": "2.2.0",
 		"@types/node": "^18.19.0",
 		"@types/puppeteer": "1.3.0",
+		"@types/uuid": "^9.0.2",
 		"clean-webpack-plugin": "^4.0.0",
 		"cross-env": "^7.0.3",
 		"eslint": "~8.50.0",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -68,6 +68,7 @@
 		"@types/puppeteer": "1.3.0",
 		"@types/react": "^17.0.44",
 		"@types/react-dom": "^17.0.18",
+		"@types/uuid": "^9.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^1.0.0",
 		"eslint": "~8.50.0",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -78,7 +78,6 @@
 		"react": "^17.0.1",
 		"react-dom": "^17.0.1",
 		"style-loader": "^1.0.0",
-		"uuid": "^9.0.0",
 		"valid-url": "^1.0.9"
 	},
 	"devDependencies": {

--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -76,6 +76,7 @@
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"chai": "^4.2.0",
 		"cross-env": "^7.0.3",
 		"easy-table": "^1.1.1",

--- a/packages/dds/ink/package.json
+++ b/packages/dds/ink/package.json
@@ -136,6 +136,7 @@
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@microsoft/api-extractor": "^7.39.1",
 		"@types/mocha": "^9.1.1",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -166,8 +166,7 @@
 		"rimraf": "^4.4.0",
 		"ts-node": "^10.9.1",
 		"tsc-multi": "^1.1.0",
-		"typescript": "~5.1.6",
-		"uuid": "^9.0.0"
+		"typescript": "~5.1.6"
 	},
 	"fluidBuild": {
 		"tasks": {

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -140,6 +140,7 @@
 		"@microsoft/api-extractor": "^7.39.1",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/dds/shared-object-base/package.json
+++ b/packages/dds/shared-object-base/package.json
@@ -144,6 +144,7 @@
 		"@types/benchmark": "^2.1.0",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"benchmark": "^2.1.4",
 		"c8": "^8.0.1",
 		"copyfiles": "^2.4.1",

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -93,6 +93,7 @@
 		"@types/node": "^18.19.0",
 		"@types/node-fetch": "^2.5.10",
 		"@types/sinon": "^7.0.13",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -114,6 +114,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.3.0",
 		"@microsoft/api-extractor": "^7.39.1",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -134,8 +134,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/synthesize": "workspace:~",
-		"@fluidframework/view-interfaces": "workspace:~",
-		"uuid": "^9.0.0"
+		"@fluidframework/view-interfaces": "workspace:~"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.13.3",

--- a/packages/framework/tinylicious-client/package.json
+++ b/packages/framework/tinylicious-client/package.json
@@ -109,8 +109,7 @@
 		"@fluidframework/routerlicious-driver": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
-		"@fluidframework/tinylicious-driver": "workspace:~",
-		"uuid": "^9.0.0"
+		"@fluidframework/tinylicious-driver": "workspace:~"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.13.3",

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -90,6 +90,7 @@
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.19.0",
 		"@types/sinon": "^7.0.13",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"copyfiles": "^2.4.1",
 		"cross-env": "^7.0.3",

--- a/packages/test/test-driver-definitions/package.json
+++ b/packages/test/test-driver-definitions/package.json
@@ -43,8 +43,7 @@
 	"dependencies": {
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",
-		"@fluidframework/protocol-definitions": "^3.2.0-231454",
-		"uuid": "^9.0.0"
+		"@fluidframework/protocol-definitions": "^3.2.0-231454"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.13.3",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -88,6 +88,7 @@
 		"@fluidframework/eslint-config-fluid": "^3.3.0",
 		"@microsoft/api-extractor": "^7.39.1",
 		"@types/node": "^18.19.0",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"copyfiles": "^2.4.1",
 		"eslint": "~8.50.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.2.0-231454
       '@microsoft/api-extractor': ^7.39.1
       '@types/jsrsasign': ^10.5.12
+      '@types/uuid': ^9.0.2
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       eslint-config-prettier: ~9.0.0
@@ -229,6 +230,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 3.3.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.39.1_5jttfhtxwdhxb7mhu7m3cyak6i
       '@types/jsrsasign': 10.5.12
+      '@types/uuid': 9.0.7
       copyfiles: 2.4.1
       eslint: 8.50.0
       eslint-config-prettier: 9.0.0_eslint@8.50.0
@@ -585,6 +587,7 @@ importers:
       '@types/jest-environment-puppeteer': 2.2.0
       '@types/node': ^18.19.0
       '@types/puppeteer': 1.3.0
+      '@types/uuid': ^9.0.2
       clean-webpack-plugin: ^4.0.0
       cross-env: ^7.0.3
       css-loader: ^1.0.0
@@ -631,6 +634,7 @@ importers:
       '@types/jest-environment-puppeteer': 2.2.0
       '@types/node': 18.19.1
       '@types/puppeteer': 1.3.0
+      '@types/uuid': 9.0.7
       clean-webpack-plugin: 4.0.0_webpack@5.89.0
       cross-env: 7.0.3
       eslint: 8.50.0
@@ -3004,6 +3008,7 @@ importers:
       '@types/puppeteer': 1.3.0
       '@types/react': ^17.0.44
       '@types/react-dom': ^17.0.18
+      '@types/uuid': ^9.0.2
       cross-env: ^7.0.3
       css-loader: ^1.0.0
       eslint: ~8.50.0
@@ -3052,6 +3057,7 @@ importers:
       '@types/puppeteer': 1.3.0
       '@types/react': 17.0.71
       '@types/react-dom': 17.0.25
+      '@types/uuid': 9.0.7
       cross-env: 7.0.3
       css-loader: 1.0.1_webpack@5.89.0
       eslint: 8.50.0
@@ -3253,7 +3259,6 @@ importers:
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
       typescript: ~5.1.6
-      uuid: ^9.0.0
       valid-url: ^1.0.9
       webpack: ^5.82.0
       webpack-cli: ^4.9.2
@@ -3289,7 +3294,6 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       style-loader: 1.3.0_webpack@5.89.0
-      uuid: 9.0.1
       valid-url: 1.0.9
     devDependencies:
       '@fluidframework/build-common': 2.0.3
@@ -4879,6 +4883,7 @@ importers:
       '@types/lodash': ^4.14.118
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
+      '@types/uuid': ^9.0.2
       axios: ^1.6.2
       buffer: ^6.0.3
       chai: ^4.2.0
@@ -4937,6 +4942,7 @@ importers:
       '@types/lodash': 4.14.202
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
+      '@types/uuid': 9.0.7
       chai: 4.3.10
       cross-env: 7.0.3
       easy-table: 1.2.0
@@ -6317,6 +6323,7 @@ importers:
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.39.1
       '@types/mocha': ^9.1.1
+      '@types/uuid': ^9.0.2
       c8: ^8.0.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -6350,6 +6357,7 @@ importers:
       '@fluidframework/test-runtime-utils': link:../../runtime/test-runtime-utils
       '@microsoft/api-extractor': 7.39.1_5jttfhtxwdhxb7mhu7m3cyak6i
       '@types/mocha': 9.1.1
+      '@types/uuid': 9.0.7
       c8: 8.0.1
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -6498,7 +6506,6 @@ importers:
       tsc-multi: ^1.1.0
       tslib: ^1.10.0
       typescript: ~5.1.6
-      uuid: ^9.0.0
     dependencies:
       '@fluid-internal/client-utils': link:../../common/client-utils
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
@@ -6548,7 +6555,6 @@ importers:
       ts-node: 10.9.1_ggysxzqxruqvydtrq6zb2nxvwm
       tsc-multi: 1.1.0_bwju7gmfuwum2ryv7w6vqpkpiy_typescript@5.1.6
       typescript: 5.1.6
-      uuid: 9.0.1
 
   packages/dds/merge-tree:
     specifiers:
@@ -6655,6 +6661,7 @@ importers:
       '@microsoft/api-extractor': ^7.39.1
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
+      '@types/uuid': ^9.0.2
       c8: ^8.0.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -6692,6 +6699,7 @@ importers:
       '@microsoft/api-extractor': 7.39.1_5jttfhtxwdhxb7mhu7m3cyak6i_@types+node@18.19.1
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
+      '@types/uuid': 9.0.7
       c8: 8.0.1
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -6966,6 +6974,7 @@ importers:
       '@types/benchmark': ^2.1.0
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
+      '@types/uuid': ^9.0.2
       benchmark: ^2.1.4
       c8: ^8.0.1
       copyfiles: ^2.4.1
@@ -7008,6 +7017,7 @@ importers:
       '@types/benchmark': 2.1.5
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
+      '@types/uuid': 9.0.7
       benchmark: 2.1.4
       c8: 8.0.1
       copyfiles: 2.4.1
@@ -7668,6 +7678,7 @@ importers:
       '@types/node': ^18.19.0
       '@types/node-fetch': ^2.5.10
       '@types/sinon': ^7.0.13
+      '@types/uuid': ^9.0.2
       c8: ^8.0.1
       copyfiles: ^2.4.1
       cross-env: ^7.0.3
@@ -7712,6 +7723,7 @@ importers:
       '@types/node': 18.19.1
       '@types/node-fetch': 2.6.9
       '@types/sinon': 7.5.2
+      '@types/uuid': 9.0.7
       c8: 8.0.1
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -8113,6 +8125,7 @@ importers:
       '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.39.1
       '@types/node': ^18.19.0
+      '@types/uuid': ^9.0.2
       copyfiles: ^2.4.1
       eslint: ~8.50.0
       prettier: ~3.0.3
@@ -8142,6 +8155,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 3.3.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.39.1_5jttfhtxwdhxb7mhu7m3cyak6i_@types+node@18.19.1
       '@types/node': 18.19.1
+      '@types/uuid': 9.0.7
       copyfiles: 2.4.1
       eslint: 8.50.0
       prettier: 3.0.3
@@ -8188,7 +8202,6 @@ importers:
       rimraf: ^4.4.0
       tsc-multi: ^1.1.0
       typescript: ~5.1.6
-      uuid: ^9.0.0
     dependencies:
       '@fluid-internal/client-utils': link:../../common/client-utils
       '@fluidframework/container-definitions': link:../../common/container-definitions
@@ -8204,7 +8217,6 @@ importers:
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
       '@fluidframework/synthesize': link:../synthesize
       '@fluidframework/view-interfaces': link:../view-interfaces
-      uuid: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
       '@fluid-tools/build-cli': 0.29.0_mhw3tufvtaceew37hrkkevjcli
@@ -8822,7 +8834,6 @@ importers:
       tinylicious: ^3.1.0-231702
       tsc-multi: ^1.1.0
       typescript: ~5.1.6
-      uuid: ^9.0.0
     dependencies:
       '@fluidframework/container-definitions': link:../../common/container-definitions
       '@fluidframework/container-loader': link:../../loader/container-loader
@@ -8837,7 +8848,6 @@ importers:
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
       '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       '@fluidframework/tinylicious-driver': link:../../drivers/tinylicious-driver
-      uuid: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
       '@fluid-tools/build-cli': 0.29.0_mhw3tufvtaceew37hrkkevjcli
@@ -9123,6 +9133,7 @@ importers:
       '@types/mocha': ^9.1.1
       '@types/node': ^18.19.0
       '@types/sinon': ^7.0.13
+      '@types/uuid': ^9.0.2
       axios: ^1.6.2
       c8: ^8.0.1
       copyfiles: ^2.4.1
@@ -9165,6 +9176,7 @@ importers:
       '@types/mocha': 9.1.1
       '@types/node': 18.19.1
       '@types/sinon': 7.5.2
+      '@types/uuid': 9.0.7
       c8: 8.0.1
       copyfiles: 2.4.1
       cross-env: 7.0.3
@@ -10306,12 +10318,10 @@ importers:
       prettier: ~3.0.3
       rimraf: ^4.4.0
       typescript: ~5.1.6
-      uuid: ^9.0.0
     dependencies:
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
       '@fluidframework/protocol-definitions': 3.2.0-231454
-      uuid: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
       '@fluid-tools/build-cli': 0.29.0_loebgezstcsvd2poh2d55fifke
@@ -10352,6 +10362,7 @@ importers:
       '@fluidframework/tool-utils': workspace:~
       '@microsoft/api-extractor': ^7.39.1
       '@types/node': ^18.19.0
+      '@types/uuid': ^9.0.2
       agentkeepalive: ^4.5.0
       axios: ^1.6.2
       c8: ^8.0.1
@@ -10392,6 +10403,7 @@ importers:
       '@fluidframework/eslint-config-fluid': 3.3.0_loebgezstcsvd2poh2d55fifke
       '@microsoft/api-extractor': 7.39.1_5jttfhtxwdhxb7mhu7m3cyak6i_@types+node@18.19.1
       '@types/node': 18.19.1
+      '@types/uuid': 9.0.7
       c8: 8.0.1
       copyfiles: 2.4.1
       eslint: 8.50.0

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -82,6 +82,7 @@
 		"@types/nock": "^9.3.0",
 		"@types/node": "^18.17.1",
 		"@types/sinon": "^9.0.9",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -84,6 +84,7 @@
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.17.1",
+		"@types/uuid": "^9.0.2",
 		"axios-mock-adapter": "^1.19.0",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -90,6 +90,7 @@
 		"@types/nconf": "^0.10.2",
 		"@types/node": "^18.17.1",
 		"@types/supertest": "^2.0.5",
+		"@types/uuid": "^9.0.2",
 		"axios": "^1.6.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -76,6 +76,7 @@
 		"@types/node": "^18.17.1",
 		"@types/sinon": "^9.0.9",
 		"@types/string-hash": "^1.1.1",
+		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.27.0",

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -289,6 +289,7 @@ importers:
       '@types/nock': ^9.3.0
       '@types/node': ^18.17.1
       '@types/sinon': ^9.0.9
+      '@types/uuid': ^9.0.2
       c8: ^8.0.1
       concurrently: ^8.2.1
       copyfiles: ^2.4.1
@@ -331,6 +332,7 @@ importers:
       '@types/nock': 9.3.1
       '@types/node': 18.17.6
       '@types/sinon': 9.0.11
+      '@types/uuid': 9.0.2
       c8: 8.0.1
       concurrently: 8.2.1
       copyfiles: 2.4.1
@@ -792,6 +794,7 @@ importers:
       '@types/jsrsasign': ^10.5.12
       '@types/mocha': ^10.0.1
       '@types/node': ^18.17.1
+      '@types/uuid': ^9.0.2
       axios: ^1.6.2
       axios-mock-adapter: ^1.19.0
       c8: ^8.0.1
@@ -835,6 +838,7 @@ importers:
       '@types/jsrsasign': 10.5.12
       '@types/mocha': 10.0.1
       '@types/node': 18.17.6
+      '@types/uuid': 9.0.2
       axios-mock-adapter: 1.21.5_axios@1.6.2
       c8: 8.0.1
       concurrently: 8.2.1
@@ -1062,6 +1066,7 @@ importers:
       '@types/nconf': ^0.10.2
       '@types/node': ^18.17.1
       '@types/supertest': ^2.0.5
+      '@types/uuid': ^9.0.2
       axios: ^1.6.2
       body-parser: ^1.17.1
       c8: ^8.0.1
@@ -1125,6 +1130,7 @@ importers:
       '@types/nconf': 0.10.3
       '@types/node': 18.17.6
       '@types/supertest': 2.0.12
+      '@types/uuid': 9.0.2
       axios: 1.6.2_debug@4.3.4
       c8: 8.0.1
       concurrently: 8.2.1
@@ -1293,6 +1299,7 @@ importers:
       '@types/node': ^18.17.1
       '@types/sinon': ^9.0.9
       '@types/string-hash': ^1.1.1
+      '@types/uuid': ^9.0.2
       assert: ^2.0.0
       c8: ^8.0.1
       concurrently: ^8.2.1
@@ -1332,6 +1339,7 @@ importers:
       '@types/node': 18.17.6
       '@types/sinon': 9.0.11
       '@types/string-hash': 1.1.1
+      '@types/uuid': 9.0.2
       c8: 8.0.1
       concurrently: 8.2.1
       eslint: 8.27.0


### PR DESCRIPTION
## Description

Adds `@types/uuid` as a devDependency on packages that use `uuid` (this also helped clean up a few eslint-disable lines). Removes `uuid` from a few packages that declared a dependency on it but didn't use it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
