### PR TITLE
test(e2e): Lint against value-imports to @fluidframework/sequence

### DIFF
--- a/packages/test/test-end-to-end-tests/.eslintrc.cjs
+++ b/packages/test/test-end-to-end-tests/.eslintrc.cjs
@@ -21,6 +21,7 @@ module.exports = {
 					"@fluidframework/map",
 					"@fluidframework/matrix",
 					"@fluidframework/counter",
+					"@fluidframework/sequence",
 				].map((importName) => ({
 					name: importName,
 					message:

--- a/packages/test/test-end-to-end-tests/README.md
+++ b/packages/test/test-end-to-end-tests/README.md
@@ -33,6 +33,7 @@ The APIs are organized roughly by layer, i.e. `apis.dds` exports the various DDS
 
 Less common APIs can be found on `apis.<layer-name>.packages.<package-name>` (package names are unscoped and camelCased).
 Keep in mind that if these APIs change over time, tests depending on them will either need to have a reduced compat matrix or include back-compat logic.
+See "Change contents of dds, then rehydrate and then check summary" for an example of such a test.
 
 ### ❌ Incorrect
 

--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -10,7 +10,7 @@ import {
 	enableOnNewFileKey,
 	IRuntimeAttributor,
 } from "@fluid-experimental/attributor";
-import { SharedString } from "@fluidframework/sequence";
+import type { SharedString } from "@fluidframework/sequence";
 import {
 	ITestObjectProvider,
 	ITestContainerConfig,
@@ -25,11 +25,6 @@ import { createInsertOnlyAttributionPolicy } from "@fluidframework/merge-tree";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 
 const stringId = "sharedStringKey";
-const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
-const testContainerConfig: ITestContainerConfig = {
-	fluidDataObjectType: DataObjectFactoryType.Test,
-	registry,
-};
 
 function assertAttributionMatches(
 	sharedString: SharedString,
@@ -90,7 +85,14 @@ function assertAttributionMatches(
 
 // TODO: Expand the e2e tests in this suite to cover interesting combinations of configuration and versioning that aren't covered by mixinAttributor
 // unit tests.
-describeCompat("Attributor", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Attributor", "NoCompat", (getTestObjectProvider, apis) => {
+	const { SharedString } = apis.dds;
+	const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
+	const testContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry,
+	};
+
 	let provider: ITestObjectProvider;
 	beforeEach("getTestObjectProvider", () => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -25,7 +25,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { IContainerRuntimeBase } from "@fluidframework/runtime-definitions";
 import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
-import { SequenceInterval, SharedString } from "@fluidframework/sequence";
+import type { SequenceInterval, SharedString } from "@fluidframework/sequence";
 import { SharedCell } from "@fluidframework/cell";
 import { Ink } from "@fluidframework/ink";
 import type { SharedMatrix } from "@fluidframework/matrix";
@@ -121,7 +121,7 @@ describeCompat(
 	`Dehydrate Rehydrate Container Test`,
 	"FullCompat",
 	(getTestObjectProvider, apis) => {
-		const { SharedMap, SharedDirectory, SharedMatrix, SharedCounter } = apis.dds;
+		const { SharedMap, SharedDirectory, SharedMatrix, SharedCounter, SharedString } = apis.dds;
 		function assertSubtree(tree: ISnapshotTree, key: string, msg?: string): ISnapshotTree {
 			const subTree = tree.trees[key];
 			assert(subTree, msg ?? `${key} subtree not present`);

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -594,7 +594,13 @@ describeCompat(
 					change(id: string, start: number, end: number): SequenceInterval | undefined;
 				}
 
-				if (semver.lt(apis.dataRuntime.version, "2.0.0-internal.8.0.0")) {
+				// Note: "dev" prereleases have to be special-cased since semver orders prerelease tags alphabetically,
+				// so dev builds (i.e. -dev or -dev-rc) sort as before official internal releases.
+				const isCurrentApi =
+					apis.dataRuntime.version.includes("dev") ||
+					semver.gte(apis.dataRuntime.version, "2.0.0-internal.8.0.0");
+
+				if (!isCurrentApi) {
 					// Versions of @fluidframework/sequence before this version had a different `add` API.
 					// See https://github.com/microsoft/FluidFramework/commit/e5b463cc8b24a411581c3e48f62ce1eea68dd639
 					// for the removal of that API.
@@ -627,7 +633,7 @@ describeCompat(
 					id1 = interval1.getIntervalId();
 					assert.strictEqual(typeof id0, "string");
 					assert.strictEqual(typeof id1, "string");
-					if (semver.lt(apis.dataRuntime.version, "2.0.0-internal.8.0.0")) {
+					if (!isCurrentApi) {
 						// Versions of @fluidframework/sequence before this version had a different `change` API.
 						// See https://github.com/microsoft/FluidFramework/commit/12c83d26962a1d76db6eb0ccad31fd6a7976a1af
 						(intervalsBefore as unknown as OldIntervalCollection).change(id0, 2, 3);

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -24,7 +24,7 @@ import { MergeTreeDeltaType } from "@fluidframework/merge-tree";
 import { ConsensusQueue } from "@fluidframework/ordered-collection";
 import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
 import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
-import { SharedString } from "@fluidframework/sequence";
+import type { SharedString } from "@fluidframework/sequence";
 import { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
 import { createChildLogger, isFluidError } from "@fluidframework/telemetry-utils";
 import {
@@ -61,7 +61,7 @@ const createFluidObject = async (dataStoreContext: IFluidDataStoreContext, type:
 };
 
 describeCompat("Detached Container", "FullCompat", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory, SharedMatrix } = apis.dds;
+	const { SharedMap, SharedDirectory, SharedMatrix, SharedString } = apis.dds;
 
 	const registry: ChannelFactoryRegistry = [
 		[sharedStringId, SharedString.getFactory()],
@@ -894,7 +894,7 @@ describeCompat("Detached Container", "FullCompat", (getTestObjectProvider, apis)
 
 // Review: Run with Full Compat?
 describeCompat("Detached Container", "NoCompat", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory, SharedMatrix } = apis.dds;
+	const { SharedMap, SharedDirectory, SharedMatrix, SharedString } = apis.dds;
 
 	const registry: ChannelFactoryRegistry = [
 		[sharedStringId, SharedString.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/intervalCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/intervalCollectionEndToEndTests.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { SharedString, IIntervalCollection, SequenceInterval } from "@fluidframework/sequence";
+import type { SharedString, IIntervalCollection, SequenceInterval } from "@fluidframework/sequence";
 import {
 	ITestObjectProvider,
 	ITestContainerConfig,
@@ -22,35 +22,6 @@ import { IHostLoader } from "@fluidframework/container-definitions";
 
 const stringId = "sharedStringKey";
 const collectionId = "collectionKey";
-
-const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
-const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
-	getRawConfig: (name: string): ConfigTypes => settings[name],
-});
-
-const testContainerConfig: ITestContainerConfig = {
-	fluidDataObjectType: DataObjectFactoryType.Test,
-	registry,
-	runtimeOptions: {
-		summaryOptions: {
-			summaryConfigOverrides: {
-				...DefaultSummaryConfiguration,
-				...{
-					maxTime: 5000 * 12,
-					maxAckWaitTime: 120000,
-					maxOps: 1,
-					initialSummarizerDelayMs: 20,
-				},
-			},
-		},
-		enableRuntimeIdCompressor: true,
-	},
-	loaderProps: {
-		configProvider: configProvider({
-			"Fluid.Container.enableOfflineLoad": true,
-		}),
-	},
-};
 
 const assertIntervals = (
 	sharedString: SharedString,
@@ -81,7 +52,38 @@ const assertIntervals = (
 	assert.deepEqual(actualPos, expected, "intervals are not as expected");
 };
 
-describeCompat("IntervalCollection with stashed ops", "NoCompat", (getTestObjectProvider) => {
+describeCompat("IntervalCollection with stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
+	const { SharedString } = apis.dds;
+
+	const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
+	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+		getRawConfig: (name: string): ConfigTypes => settings[name],
+	});
+
+	const testContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry,
+		runtimeOptions: {
+			summaryOptions: {
+				summaryConfigOverrides: {
+					...DefaultSummaryConfiguration,
+					...{
+						maxTime: 5000 * 12,
+						maxAckWaitTime: 120000,
+						maxOps: 1,
+						initialSummarizerDelayMs: 20,
+					},
+				},
+			},
+			enableRuntimeIdCompressor: true,
+		},
+		loaderProps: {
+			configProvider: configProvider({
+				"Fluid.Container.enableOfflineLoad": true,
+			}),
+		},
+	};
+
 	let provider: ITestObjectProvider;
 	let container1: IContainerExperimental;
 	let sharedString1: SharedString;

--- a/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
@@ -10,7 +10,7 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { SharedCounter } from "@fluidframework/counter";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
-import { SharedString } from "@fluidframework/sequence";
+import type { SharedString } from "@fluidframework/sequence";
 import {
 	createAndAttachContainer,
 	ITestFluidObject,
@@ -28,7 +28,7 @@ const counterKey = "count";
 
 // REVIEW: enable compat testing?
 describeCompat("LocalLoader", "NoCompat", (getTestObjectProvider, apis) => {
-	const { SharedCounter } = apis.dds;
+	const { SharedCounter, SharedString } = apis.dds;
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
@@ -15,7 +15,7 @@ import {
 	getContainerEntryPointBackCompat,
 } from "@fluidframework/test-utils";
 import { describeCompat, itExpects } from "@fluid-private/test-version-utils";
-import { SharedString } from "@fluidframework/sequence";
+import type { SharedString } from "@fluidframework/sequence";
 import { IContainer } from "@fluidframework/container-definitions";
 import { IMergeTreeInsertMsg } from "@fluidframework/merge-tree";
 import { FlushMode } from "@fluidframework/runtime-definitions";
@@ -25,7 +25,7 @@ describeCompat(
 	"Concurrent op processing via DDS event handlers",
 	"NoCompat",
 	(getTestObjectProvider, apis) => {
-		const { SharedMap, SharedDirectory } = apis.dds;
+		const { SharedMap, SharedDirectory, SharedString } = apis.dds;
 		const mapId = "mapKey";
 		const sharedStringId = "sharedStringKey";
 		const sharedDirectoryId = "sharedDirectoryKey";

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 
-import { SequenceDeltaEvent, SharedString } from "@fluidframework/sequence";
+import type { SharedString } from "@fluidframework/sequence";
 import {
 	ITestObjectProvider,
 	ITestContainerConfig,
@@ -28,7 +28,9 @@ const cellId = "cellKey";
 const mapId = "mapKey";
 
 describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory } = apis.dds;
+	const { SharedMap, SharedDirectory, SharedString } = apis.dds;
+	const { SequenceDeltaEvent } = apis.dataRuntime.packages.sequence;
+
 	const registry: ChannelFactoryRegistry = [
 		[stringId, SharedString.getFactory()],
 		[string2Id, SharedString.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
@@ -14,7 +14,7 @@ import {
 	ITestObjectProvider,
 } from "@fluidframework/test-utils";
 import { describeCompat } from "@fluid-private/test-version-utils";
-import { SharedString } from "@fluidframework/sequence";
+import type { SharedString } from "@fluidframework/sequence";
 import { IContainer } from "@fluidframework/container-definitions";
 import { FlushMode } from "@fluidframework/runtime-definitions";
 import { SharedCell } from "@fluidframework/cell";
@@ -26,7 +26,7 @@ describeCompat(
 	"Op reentry and rebasing during pending batches",
 	"NoCompat",
 	(getTestObjectProvider, apis) => {
-		const { SharedMap, SharedDirectory, SharedMatrix, SharedCounter } = apis.dds;
+		const { SharedMap, SharedDirectory, SharedMatrix, SharedCounter, SharedString } = apis.dds;
 		const registry: ChannelFactoryRegistry = [
 			["map", SharedMap.getFactory()],
 			["sharedString", SharedString.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -8,12 +8,11 @@ import { IFluidHandle, IFluidLoadable } from "@fluidframework/core-interfaces";
 import type { ISharedMap, SharedMap } from "@fluidframework/map";
 import { DetachedReferencePosition, PropertySet } from "@fluidframework/merge-tree";
 import { ISummaryBlob } from "@fluidframework/protocol-definitions";
-import {
+import type {
 	IIntervalCollection,
 	IOverlappingIntervalsIndex,
 	SequenceInterval,
 	SharedString,
-	createOverlappingIntervalsIndex,
 } from "@fluidframework/sequence";
 // This is not in sequence's public API, but an e2e test in this file sniffs the summary.
 // eslint-disable-next-line import/no-internal-modules
@@ -248,7 +247,8 @@ function testIntervalOperations(intervalCollection: IIntervalCollection<Sequence
 	}
 }
 describeCompat("SharedInterval", "NoCompat", (getTestObjectProvider, apis) => {
-	const { SharedMap } = apis.dds;
+	const { SharedMap, SharedString } = apis.dds;
+	const { createOverlappingIntervalsIndex } = apis.dataRuntime.packages.sequence;
 	let provider: ITestObjectProvider;
 	beforeEach("getTestObjectProvider", () => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 
 import { Marker, ReferenceType, reservedMarkerIdKey } from "@fluidframework/merge-tree";
-import { SharedString } from "@fluidframework/sequence";
+import type { SharedString } from "@fluidframework/sequence";
 import {
 	ITestObjectProvider,
 	ITestContainerConfig,
@@ -20,17 +20,16 @@ import {
 import { describeCompat } from "@fluid-private/test-version-utils";
 
 const stringId = "sharedStringKey";
-const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
-const testContainerConfig: ITestContainerConfig = {
-	fluidDataObjectType: DataObjectFactoryType.Test,
-	registry,
-};
-const groupedBatchingContainerConfig: ITestContainerConfig = {
-	...testContainerConfig,
-	runtimeOptions: { enableGroupedBatching: true },
-};
 
-describeCompat("SharedString", "FullCompat", (getTestObjectProvider) => {
+describeCompat("SharedString", "FullCompat", (getTestObjectProvider, apis) => {
+	const { SharedString } = apis.dds;
+
+	const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
+	const testContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry,
+	};
+
 	let provider: ITestObjectProvider;
 	beforeEach("getTestObjectProvider", () => {
 		provider = getTestObjectProvider();
@@ -125,7 +124,19 @@ describeCompat("SharedString", "FullCompat", (getTestObjectProvider) => {
 	});
 });
 
-describeCompat("SharedString grouped batching", "NoCompat", (getTestObjectProvider) => {
+describeCompat("SharedString grouped batching", "NoCompat", (getTestObjectProvider, apis) => {
+	const { SharedString } = apis.dds;
+
+	const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
+	const testContainerConfig: ITestContainerConfig = {
+		fluidDataObjectType: DataObjectFactoryType.Test,
+		registry,
+	};
+	const groupedBatchingContainerConfig: ITestContainerConfig = {
+		...testContainerConfig,
+		runtimeOptions: { enableGroupedBatching: true },
+	};
+
 	let provider: ITestObjectProvider;
 	beforeEach("getTestObjectProvider", () => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { Loader } from "@fluidframework/container-loader";
-import { SharedString } from "@fluidframework/sequence";
+import type { SharedString } from "@fluidframework/sequence";
 import {
 	ChannelFactoryRegistry,
 	createDocumentId,
@@ -27,7 +27,9 @@ import { describeCompat, itExpects } from "@fluid-private/test-version-utils";
 import { pkgVersion } from "../packageVersion.js";
 
 // REVIEW: enable compat testing?
-describeCompat("SharedString", "NoCompat", (getTestObjectProvider) => {
+describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
+	const { SharedString } = apis.dds;
+
 	itExpects(
 		"Failure to Load in Shared String",
 		[

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -14,12 +14,7 @@ import {
 	reservedMarkerSimpleTypeKey,
 	reservedTileLabelsKey,
 } from "@fluidframework/merge-tree";
-import {
-	getTextAndMarkers,
-	SharedString,
-	IIntervalCollection,
-	SequenceInterval,
-} from "@fluidframework/sequence";
+import type { SharedString, IIntervalCollection, SequenceInterval } from "@fluidframework/sequence";
 import { SharedObject } from "@fluidframework/shared-object-base";
 import {
 	ChannelFactoryRegistry,
@@ -77,7 +72,9 @@ type SharedObjCallback = (
 // Introduced in 0.37
 // REVIEW: enable compat testing
 describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory, SharedCounter } = apis.dds;
+	const { SharedMap, SharedDirectory, SharedCounter, SharedString } = apis.dds;
+	const { getTextAndMarkers } = apis.dataRuntime.packages.sequence;
+
 	const registry: ChannelFactoryRegistry = [
 		[mapId, SharedMap.getFactory()],
 		[stringId, SharedString.getFactory()],
@@ -1729,7 +1726,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 });
 
 describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory, SharedCounter } = apis.dds;
+	const { SharedMap, SharedDirectory, SharedCounter, SharedString } = apis.dds;
 	const registry: ChannelFactoryRegistry = [
 		[mapId, SharedMap.getFactory()],
 		[stringId, SharedString.getFactory()],

--- a/packages/test/test-version-utils/api-report/test-version-utils.api.md
+++ b/packages/test/test-version-utils/api-report/test-version-utils.api.md
@@ -4,10 +4,10 @@
 
 ```ts
 
-import { ConsensusQueue } from '@fluidframework/ordered-collection';
-import { ConsensusRegisterCollection } from '@fluidframework/register-collection';
+import * as cell from '@fluidframework/cell';
 import { ContainerRuntime } from '@fluidframework/container-runtime';
 import { ContainerRuntimeFactoryWithDefaultDataStore } from '@fluidframework/aqueduct';
+import * as counter from '@fluidframework/counter';
 import { DataObject } from '@fluidframework/aqueduct';
 import { DataObjectFactory } from '@fluidframework/aqueduct';
 import { DriverApi } from '@fluid-private/test-drivers';
@@ -16,19 +16,18 @@ import { IFluidDataStoreContext } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreFactory } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
-import { Ink } from '@fluidframework/ink';
+import * as ink from '@fluidframework/ink';
 import { ISharedDirectory } from '@fluidframework/map';
 import { ITelemetryGenericEvent } from '@fluidframework/core-interfaces';
 import { ITestContainerConfig } from '@fluidframework/test-utils';
 import { ITestObjectProvider } from '@fluidframework/test-utils';
 import { Loader } from '@fluidframework/container-loader';
-import { SharedCell } from '@fluidframework/cell';
-import { SharedCounter } from '@fluidframework/counter';
-import { SharedDirectory } from '@fluidframework/map';
-import { SharedMap } from '@fluidframework/map';
-import { SharedMatrix } from '@fluidframework/matrix';
-import { SharedString } from '@fluidframework/sequence';
-import { SparseMatrix } from '@fluid-experimental/sequence-deprecated';
+import * as map from '@fluidframework/map';
+import * as matrix from '@fluidframework/matrix';
+import * as orderedCollection from '@fluidframework/ordered-collection';
+import * as registerCollection from '@fluidframework/register-collection';
+import * as sequence from '@fluidframework/sequence';
+import * as sequenceDeprecated from '@fluid-experimental/sequence-deprecated';
 import { TestDriverTypes } from '@fluidframework/test-driver-definitions';
 import { TestFluidObjectFactory } from '@fluidframework/test-utils';
 import { TestObjectProvider } from '@fluidframework/test-utils';
@@ -77,16 +76,27 @@ export const DataRuntimeApi: {
     DataObjectFactory: typeof DataObjectFactory;
     TestFluidObjectFactory: typeof TestFluidObjectFactory;
     dds: {
-        SharedCell: typeof SharedCell;
-        SharedCounter: typeof SharedCounter;
-        Ink: typeof Ink;
-        SharedDirectory: typeof SharedDirectory;
-        SharedMap: typeof SharedMap;
-        SharedMatrix: typeof SharedMatrix;
-        ConsensusQueue: typeof ConsensusQueue;
-        ConsensusRegisterCollection: typeof ConsensusRegisterCollection;
-        SharedString: typeof SharedString;
-        SparseMatrix: typeof SparseMatrix;
+        SharedCell: typeof cell.SharedCell;
+        SharedCounter: typeof counter.SharedCounter;
+        Ink: typeof ink.Ink;
+        SharedDirectory: typeof map.SharedDirectory;
+        SharedMap: typeof map.SharedMap;
+        SharedMatrix: typeof matrix.SharedMatrix;
+        ConsensusQueue: typeof orderedCollection.ConsensusQueue;
+        ConsensusRegisterCollection: typeof registerCollection.ConsensusRegisterCollection;
+        SharedString: typeof sequence.SharedString;
+        SparseMatrix: typeof sequenceDeprecated.SparseMatrix;
+    };
+    packages: {
+        cell: typeof cell;
+        counter: typeof counter;
+        ink: typeof ink;
+        map: typeof map;
+        matrix: typeof matrix;
+        orderedCollection: typeof orderedCollection;
+        registerCollection: typeof registerCollection;
+        sequence: typeof sequence;
+        sequenceDeprecated: typeof sequenceDeprecated;
     };
 };
 

--- a/packages/test/test-version-utils/src/testApi.ts
+++ b/packages/test/test-version-utils/src/testApi.ts
@@ -13,16 +13,22 @@ import { Loader } from "@fluidframework/container-loader";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 // Data Runtime API
-import cell, { SharedCell } from "@fluidframework/cell";
-import counter, { SharedCounter } from "@fluidframework/counter";
-import ink, { Ink } from "@fluidframework/ink";
-import map, { SharedDirectory, SharedMap } from "@fluidframework/map";
-import matrix, { SharedMatrix } from "@fluidframework/matrix";
-import orderedCollection, { ConsensusQueue } from "@fluidframework/ordered-collection";
-import registerCollection, {
-	ConsensusRegisterCollection,
-} from "@fluidframework/register-collection";
-import sequence, { SharedString } from "@fluidframework/sequence";
+import * as cell from "@fluidframework/cell";
+import { SharedCell } from "@fluidframework/cell";
+import * as counter from "@fluidframework/counter";
+import { SharedCounter } from "@fluidframework/counter";
+import * as ink from "@fluidframework/ink";
+import { Ink } from "@fluidframework/ink";
+import * as map from "@fluidframework/map";
+import { SharedDirectory, SharedMap } from "@fluidframework/map";
+import * as matrix from "@fluidframework/matrix";
+import { SharedMatrix } from "@fluidframework/matrix";
+import * as orderedCollection from "@fluidframework/ordered-collection";
+import { ConsensusQueue } from "@fluidframework/ordered-collection";
+import * as registerCollection from "@fluidframework/register-collection";
+import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
+import * as sequence from "@fluidframework/sequence";
+import { SharedString } from "@fluidframework/sequence";
 import { TestFluidObjectFactory } from "@fluidframework/test-utils";
 
 // ContainerRuntime and Data Runtime API
@@ -31,7 +37,8 @@ import {
 	DataObject,
 	DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import sequenceDeprecated, { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
+import * as sequenceDeprecated from "@fluid-experimental/sequence-deprecated";
+import { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
 
 import * as semver from "semver";
 import { pkgVersion } from "./packageVersion.js";

--- a/packages/test/test-version-utils/src/testApi.ts
+++ b/packages/test/test-version-utils/src/testApi.ts
@@ -13,14 +13,16 @@ import { Loader } from "@fluidframework/container-loader";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
 
 // Data Runtime API
-import { SharedCell } from "@fluidframework/cell";
-import { SharedCounter } from "@fluidframework/counter";
-import { Ink } from "@fluidframework/ink";
-import { SharedDirectory, SharedMap } from "@fluidframework/map";
-import { SharedMatrix } from "@fluidframework/matrix";
-import { ConsensusQueue } from "@fluidframework/ordered-collection";
-import { ConsensusRegisterCollection } from "@fluidframework/register-collection";
-import { SharedString } from "@fluidframework/sequence";
+import cell, { SharedCell } from "@fluidframework/cell";
+import counter, { SharedCounter } from "@fluidframework/counter";
+import ink, { Ink } from "@fluidframework/ink";
+import map, { SharedDirectory, SharedMap } from "@fluidframework/map";
+import matrix, { SharedMatrix } from "@fluidframework/matrix";
+import orderedCollection, { ConsensusQueue } from "@fluidframework/ordered-collection";
+import registerCollection, {
+	ConsensusRegisterCollection,
+} from "@fluidframework/register-collection";
+import sequence, { SharedString } from "@fluidframework/sequence";
 import { TestFluidObjectFactory } from "@fluidframework/test-utils";
 
 // ContainerRuntime and Data Runtime API
@@ -29,7 +31,7 @@ import {
 	DataObject,
 	DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
+import sequenceDeprecated, { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
 
 import * as semver from "semver";
 import { pkgVersion } from "./packageVersion.js";
@@ -136,6 +138,26 @@ export const DataRuntimeApi = {
 		SharedString,
 		SparseMatrix,
 	},
+	/**
+	 * Contains all APIs from imported DDS packages.
+	 * Keep in mind that regardless of the DataRuntime version,
+	 * the APIs will be typechecked as if they were from the latest version.
+	 *
+	 * @remarks - Using these APIs in an e2e test puts additional burden on the test author and anyone making
+	 * changes to those APIs in the future, since this will necessitate back-compat logic in the tests.
+	 * Using non-stable APIs in e2e tests for that reason is discouraged.
+	 */
+	packages: {
+		cell,
+		counter,
+		ink,
+		map,
+		matrix,
+		orderedCollection,
+		registerCollection,
+		sequence,
+		sequenceDeprecated,
+	},
 };
 
 // #endregion
@@ -190,15 +212,15 @@ async function loadDataRuntime(baseVersion: string, requested?: number | string)
 		const [
 			{ DataObject, DataObjectFactory },
 			{ TestFluidObjectFactory },
-			{ SharedMap, SharedDirectory },
-			{ SharedString },
-			{ SharedCell },
-			{ SharedCounter },
-			{ SharedMatrix },
-			{ Ink },
-			{ ConsensusQueue },
-			{ ConsensusRegisterCollection },
-			{ SparseMatrix },
+			map,
+			sequence,
+			cell,
+			counter,
+			matrix,
+			ink,
+			orderedCollection,
+			registerCollection,
+			sequenceDeprecated,
 		] = await Promise.all([
 			loadPackage(modulePath, "@fluidframework/aqueduct"),
 			loadPackage(modulePath, "@fluidframework/test-utils"),
@@ -217,6 +239,15 @@ async function loadDataRuntime(baseVersion: string, requested?: number | string)
 					: "@fluidframework/sequence",
 			),
 		]);
+		const { SharedCell } = cell;
+		const { SharedCounter } = counter;
+		const { Ink } = ink;
+		const { SharedDirectory, SharedMap } = map;
+		const { SharedMatrix } = matrix;
+		const { ConsensusQueue } = orderedCollection;
+		const { ConsensusRegisterCollection } = registerCollection;
+		const { SharedString } = sequence;
+		const { SparseMatrix } = sequenceDeprecated;
 		/* eslint-enable @typescript-eslint/no-shadow */
 
 		const dataRuntime = {
@@ -235,6 +266,17 @@ async function loadDataRuntime(baseVersion: string, requested?: number | string)
 				ConsensusRegisterCollection,
 				SharedString,
 				SparseMatrix,
+			},
+			packages: {
+				map,
+				sequence,
+				cell,
+				counter,
+				matrix,
+				ink,
+				orderedCollection,
+				registerCollection,
+				sequenceDeprecated,
 			},
 		};
 		dataRuntimeCache.set(version, dataRuntime);


### PR DESCRIPTION
## Description

Adds a lint rule to prevent value imports of @fluidframework/sequence in e2e tests. This is inline with guidance  [here](https://github.com/microsoft/FluidFramework/tree/main/packages/test/test-end-to-end-tests#how-to).

Some e2e tests rely on relatively reasonable APIs provided by sequence (`SequenceDeltaEvent`, `createOverlappingIntervalsIndex`). I didn't want to clutter the 'simplified' API surface we provide, so I added some logic to test-version-utils to provide full package APIs with corresponding disclaimers that test authors should use discretion before doing so. README on guidance has been updated accordingly.

## Reviewer Guidance

Recommended to review with whitespace diffing turned off.