### PR TITLE
build(docs): Setting skip_api_build to true in docs pipeline

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -324,6 +324,7 @@ stages:
           condition: eq(variables.shouldDeploy, true)
           inputs:
             skip_app_build: true # site was built in previous stage
+            skip_api_build: true # api is written in js, no build needed
             cwd: $(Build.SourcesDirectory)
             app_location: 'docs/public'
             api_location: 'docs/api'


### PR DESCRIPTION
Pipeline was failing on deployment of FF.com after adding the redirects code. Since the azure function is written in js, it does not need a build step like it would if its written in TypeScript, and so node isnt needed. Setting skip_api_build to true resolved this bug