### PR TITLE
[Port v2int8.0] Fix wait time in calculateMaxWaitTime

### DIFF
--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -157,7 +157,7 @@ export function calculateMaxWaitTime(delayMs: number, error: unknown): number {
 	const retryDelayFromError = getRetryDelayFromError(error);
 	let newDelayMs = Math.max(retryDelayFromError ?? 0, delayMs * 2);
 	newDelayMs = Math.min(
-		delayMs,
+		newDelayMs,
 		isFluidError(error) && error.getTelemetryProperties().endpointReached === true
 			? MaxReconnectDelayInMsWhenEndpointIsReachable
 			: MaxReconnectDelayInMsWhenEndpointIsNotReachable,


### PR DESCRIPTION
The logic in `calculateMaxWaitTime` is using the wrong value when calculating the min

See https://github.com/microsoft/FluidFramework/pull/18973