### PR TITLE
fix(ci): Add missing variable so pipeline run telemetry reporting works again

### DIFF
--- a/tools/pipelines/templates/1ES/build-npm-package.yml
+++ b/tools/pipelines/templates/1ES/build-npm-package.yml
@@ -162,7 +162,7 @@ extends:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022
         os: windows
-    # Skip tagging if Github PR coming from a fork;  This skips Microsoft security checks that won't work on forks. 
+    # Skip tagging if Github PR coming from a fork;  This skips Microsoft security checks that won't work on forks.
     settings:
       skipBuildTagsForGitHubPullRequests: true
     customBuildTags:
@@ -194,7 +194,7 @@ extends:
               # over time and it might be necessary to bump it.
               # AB#6680 is also relevant here, which tracks rethinking how and where we run tests (likely with
               # a focus on e2e tests)
-              # Note, This was recently updated to 90 minutes to account for the additional build time added from extending 
+              # Note, This was recently updated to 90 minutes to account for the additional build time added from extending
               # the Microsoft 1ES template required for corporate security compliance
               timeoutInMinutes: 90
             variables:
@@ -636,9 +636,13 @@ extends:
               displayName: Upload pipeline run telemetry to Kusto
               pool: Small-1ES
               variables:
+              - group: ado-feeds
               - name: pipelineTelemetryWorkdir
                 value: $(Pipeline.Workspace)/pipelineTelemetryWorkdir
-              - group: ado-feeds
+                readonly: true
+              - name: absolutePathToTelemetryGenerator
+                value: $(Build.SourcesDirectory)/tools/telemetry-generator
+                readonly: true
               steps:
               - template: /tools/pipelines/templates/include-telemetry-setup.yml@self
                 parameters:


### PR DESCRIPTION
## Description

Readding a variable to a pipeline stage that needs it. Before the migration to 1ES pipeline templates it used to inherit it from the variables defined in a higher scope, but now it needs to have it specified explicitly. (Alternatively we could hoist the variable to `include-vars` and make it available to _everything_, but for now I decided to go for a more explicit approach).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).