### PR TITLE
Deprecate PureDataObjectFactory.createRootInstance

### DIFF
--- a/packages/framework/aqueduct/api-report/aqueduct.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.api.md
@@ -154,6 +154,7 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
     // (undocumented)
     protected createNonRootInstanceCore(containerRuntime: IContainerRuntimeBase, packagePath: Readonly<string[]>, initialState?: I["InitialState"]): Promise<TObj>;
     createPeerInstance(peerContext: IFluidDataStoreContext, initialState?: I["InitialState"]): Promise<TObj>;
+    // @deprecated
     createRootInstance(rootDataStoreId: string, runtime: IContainerRuntime, initialState?: I["InitialState"]): Promise<TObj>;
     // (undocumented)
     get IFluidDataStoreFactory(): this;

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -301,8 +301,8 @@ export class PureDataObjectFactory<
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
 	 *
-	 * @deprecated - the issue with createRootInstance originally and now is that it does not allow the customer to
-	 * decide the conflict resolution policy when an aliasing conflict occurs. Use createInstanceWithDataStore instead.
+	 * @deprecated - the issue is that it does not allow the customer to decide the conflict resolution policy when an
+	 * aliasing conflict occurs. Use {@link PureDataObjectFactory.createInstanceWithDataStore} instead.
 	 */
 	public async createRootInstance(
 		rootDataStoreId: string,

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -210,6 +210,9 @@ export class PureDataObjectFactory<
 	 * @param initialState - The initial state to provide to the created data store.
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
+	 *
+	 * @deprecated - it's best we don't expose the IFluidDataStoreContext as much as possible. This is a runtime
+	 * concept. Use createInstance or createInstanceWithDataStore instead.
 	 */
 	public async createChildInstance(
 		parentContext: IFluidDataStoreContext,
@@ -231,6 +234,9 @@ export class PureDataObjectFactory<
 	 * @param initialState - The initial state to provide to the created component.
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
+	 *
+	 * @deprecated - it's best we don't expose the IFluidDataStoreContext as much as possible. This is a runtime
+	 * concept. Use createInstance or createInstanceWithDataStore instead.
 	 */
 	public async createPeerInstance(
 		peerContext: IFluidDataStoreContext,
@@ -300,6 +306,9 @@ export class PureDataObjectFactory<
 	 * @param initialState - The initial state to provide to the created component.
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
+	 *
+	 * @deprecated - the issue with createRootInstance originally and now is that it does not allow the customer to
+	 * decide the conflict resolution policy when an aliasing conflict occurs. Use createInstanceWithDataStore instead.
 	 */
 	public async createRootInstance(
 		rootDataStoreId: string,

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -210,9 +210,6 @@ export class PureDataObjectFactory<
 	 * @param initialState - The initial state to provide to the created data store.
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
-	 *
-	 * @deprecated - it's best we don't expose the IFluidDataStoreContext as much as possible. This is a runtime
-	 * concept. Use createInstance or createInstanceWithDataStore instead.
 	 */
 	public async createChildInstance(
 		parentContext: IFluidDataStoreContext,
@@ -234,9 +231,6 @@ export class PureDataObjectFactory<
 	 * @param initialState - The initial state to provide to the created component.
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
-	 *
-	 * @deprecated - it's best we don't expose the IFluidDataStoreContext as much as possible. This is a runtime
-	 * concept. Use createInstance or createInstanceWithDataStore instead.
 	 */
 	public async createPeerInstance(
 		peerContext: IFluidDataStoreContext,


### PR DESCRIPTION
[AB#7082](https://dev.azure.com/fluidframework/internal/_workitems/edit/7082)

## Description
Deprecate `PureDataObjectFactory.createRootInstance` as a follow up to creating `PureDataObject.createInstanceWithDataStore`. Create root instance was updated to use aliasing, but it doesn't give customers the freedom to control what happens when an aliasing conflict occurs. 

For the current `createRootInstance` assumes that when an aliasing conflict occurs, it occurs because the same `DataObject` type was already created with the same alias. If a customer wants a behavior that returns a different type of object, that is not possible with `createRootInstance`. It however is possible with `createInstanceWithDataStore`.

Originally the `createRootInstance` used older deprecated apis and would not properly handle this, and thus we created the aliasing feature.

## Considerations
We can also deprecate `createPeerInstance` and `createChildInstance`, however all this does is fix the package path recorded in the `IFluidDataStoreContext`. There isn't really any "unique" benefits for the customer other than from a debugging standpoint. This same effect can now be achieved with the `createInstanceWithDatastore` api.

`createChildInstance` is used in our examples, so in order to deprecate them we would need to remove `createChildInstance` from our examples.