### PR TITLE
ci: Run CODEOWNERS validation on release branches

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
       - next
-      - release/*
+      - release/**/*
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
The CODEOWNERS PR validation should run on release branches, but the branch trigger was incorrectly specified.