### PR TITLE
[Port 2.0.0-rc.1.0] Fix the directory loadCore on detached scenario (#19351)

### DIFF
--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -781,10 +781,7 @@ export class SharedDirectory
 						// guaranteed during the serialization process. As a result, it is only essential to utilize the
 						// "fake" client sequence number to signify the loading order, and there is no need to retain
 						// the actual client sequence number at this point.
-						if (createInfo !== undefined && createInfo.csn > -1) {
-							// If csn is -1, then initialize it with 0, otherwise we will never process ops for this
-							// sub directory. This could be done at serialization time too, but we need to maintain
-							// back compat too and also we will actually know the state when it was serialized.
+						if (createInfo !== undefined && createInfo.csn > 0) {
 							if (!tempSeqNums.has(createInfo.csn)) {
 								tempSeqNums.set(createInfo.csn, 0);
 							}
@@ -792,6 +789,13 @@ export class SharedDirectory
 							seqData = { seq: createInfo.csn, clientSeq: fakeClientSeq };
 							tempSeqNums.set(createInfo.csn, ++fakeClientSeq);
 						} else {
+							/**
+							 * 1. If csn is -1, then initialize it with 0, otherwise we will never process ops for this
+							 * sub directory. This could be done at serialization time too, but we need to maintain
+							 * back compat too and also we will actually know the state when it was serialized.
+							 * 2. We need to make the csn = -1 and csn = 0 share the same counter, there are cases
+							 * where both -1 and 0 coexist within a single document.
+							 */
 							seqData = {
 								seq: 0,
 								clientSeq: ++currentSubDir.localCreationSeq,

--- a/packages/dds/map/src/test/mocha/directory.order.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.order.spec.ts
@@ -12,6 +12,7 @@ import {
 	MockSharedObjectServices,
 	MockStorage,
 } from "@fluidframework/test-runtime-utils";
+import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import {
 	DirectoryFactory,
 	DirectoryLocalOpMetadata,
@@ -391,6 +392,39 @@ describe("Directory Iteration Order", () => {
 			await directory2.load(services);
 
 			assertDirectoryIterationOrder(directory2, ["c", "b", "a"]);
+		});
+
+		it("can be compatible with the detached scenario", async () => {
+			// It is to reproduce the regression bug causing the corruption of the summarization, indicated by 0x85c
+			// https://dev.azure.com/fluidframework/internal/_workitems/edit/7013
+			const runtimeFactory = new MockContainerRuntimeFactory();
+			const dataStoreRuntime = new MockFluidDataStoreRuntime();
+			runtimeFactory.createContainerRuntime(dataStoreRuntime);
+			const factory = SharedDirectory.getFactory();
+
+			const summaryContent =
+				'{"blobs":[],"content":{"ci":{"csn":0,"ccIds":[]},"subdirectories":{"detached1":{"ci":{"csn":0,"ccIds":["97cd0b77-34b1-46a8-bbe2-5fbefb3e014b"]}},"detached2":{"ci":{"csn":0,"ccIds":["97cd0b77-34b1-46a8-bbe2-5fbefb3e014b"]}},"detached3":{"ci":{"csn":-1,"ccIds":["97cd0b77-34b1-46a8-bbe2-5fbefb3e014b"]}}}}}';
+			const summary: ISummaryTree = {
+				type: 1,
+				tree: {
+					header: {
+						type: 2,
+						content: summaryContent,
+					},
+				},
+			};
+
+			const directory = await factory.load(
+				dataStoreRuntime,
+				"A",
+				{
+					deltaConnection: dataStoreRuntime.createDeltaConnection(),
+					objectStorage: MockStorage.createFromSummary(summary),
+				},
+				factory.attributes,
+			);
+
+			await directory.summarize();
 		});
 	});
 


### PR DESCRIPTION
[AB#7013](https://dev.azure.com/fluidframework/internal/_workitems/edit/7013), [AB#7022](https://dev.azure.com/fluidframework/internal/_workitems/edit/7022)

Reproduced 0x85c based on
https://github.com/microsoft/FluidFramework/compare/main...Abe27342:FluidFramework:0x85c

Resolved the corner case in the directory `loadCore` function where the coexistence of `csn = 0` and `csn = -1` in a detached scenario occurred.
