### PR TITLE
fix(docs): remove template expression from parameter default

### DIFF
--- a/tools/pipelines/templates/download-api-extractor-artifact.yml
+++ b/tools/pipelines/templates/download-api-extractor-artifact.yml
@@ -11,7 +11,6 @@ parameters:
 # matches the branch name. By default, the branch triggering this pipeline is used
 - name: branchName
   type: string
-  default: ${{ variables['Build.SourceBranch'] }}
   
 steps:
 # Download the api-extractor outputs

--- a/tools/pipelines/templates/download-api-extractor-artifact.yml
+++ b/tools/pipelines/templates/download-api-extractor-artifact.yml
@@ -8,7 +8,7 @@ parameters:
   type: string
 
 # Branch name to filter specific runs. Takes the most recent completed build which
-# matches the branch name. By default, the branch triggering this pipeline is used
+# matches the branch name.
 - name: branchName
   type: string
   

--- a/tools/pipelines/templates/upload-json-steps.yml
+++ b/tools/pipelines/templates/upload-json-steps.yml
@@ -22,30 +22,39 @@ steps:
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - common-definitions
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - common-utils
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - container-definitions
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - core-interfaces
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - driver-definitions
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - protocol-definitions
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - azure
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: Build - client packages
+    branchName: ${{ variables['Build.SourceBranch'] }}
 - template: download-api-extractor-artifact.yml
   parameters:
     pipelineName: server-routerlicious
+    branchName: ${{ variables['Build.SourceBranch'] }}
 
 # Copy and merge the api-extractor outputs to a central location
 - task: CopyFiles@2


### PR DESCRIPTION
build-docs seems to be failing sice template expressions aren't allowed in parameter defaults. Updated pipeline to pass in branchName on each template call.