### PR TITLE
eslint: allow imports from '/beta'

### DIFF
--- a/common/build/eslint-config-fluid/minimal.js
+++ b/common/build/eslint-config-fluid/minimal.js
@@ -370,7 +370,10 @@ module.exports = {
 			"error",
 			{
 				allow: [
+					// Within Fluid Framework, allow import of '/internal' and '/beta' exports.
+					"@fluidframework/*/beta",
 					"@fluidframework/*/internal",
+
 					// Allow imports from sibling and ancestral sibling directories,
 					// but not from cousin directories. Parent is allowed but only
 					// because there isn't a known way to deny it.

--- a/common/build/eslint-config-fluid/package.json
+++ b/common/build/eslint-config-fluid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/eslint-config-fluid",
-	"version": "3.3.0",
+	"version": "3.4.0",
 	"description": "Shareable ESLint config for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -598,6 +598,7 @@
             "error",
             {
                 "allow": [
+                    "@fluidframework/*/beta",
                     "@fluidframework/*/internal",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -591,6 +591,7 @@
             "error",
             {
                 "allow": [
+                    "@fluidframework/*/beta",
                     "@fluidframework/*/internal",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -600,6 +600,7 @@
             "error",
             {
                 "allow": [
+                    "@fluidframework/*/beta",
                     "@fluidframework/*/internal",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -598,6 +598,7 @@
             "error",
             {
                 "allow": [
+                    "@fluidframework/*/beta",
                     "@fluidframework/*/internal",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -611,6 +611,7 @@
             "error",
             {
                 "allow": [
+                    "@fluidframework/*/beta",
                     "@fluidframework/*/internal",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -598,6 +598,7 @@
             "error",
             {
                 "allow": [
+                    "@fluidframework/*/beta",
                     "@fluidframework/*/internal",
                     "*/index.js"
                 ]


### PR DESCRIPTION
Avoids the need to suppress 'import/no-internal-modules' when testing beta APIs.

Ran into this with 'odsp-client' tests because 'odsp-client' is shipping as beta in FF 2.0.
I could have imported '/internal' instead, but that seamed against the spirit of the end-to-end test & demo.