### PR TITLE
Enable schema based compression in ops

### DIFF
--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -7,6 +7,7 @@ import { bufferToString, IsoBuffer } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils";
 import type { Static, TAnySchema, TSchema } from "@sinclair/typebox";
 import { fail, JsonCompatibleReadOnly } from "../util/index.js";
+import { ChangeEncodingContext } from "../core/index.js";
 
 /**
  * Translates decoded data to encoded data.
@@ -291,7 +292,7 @@ export function withSchemaValidation<
 	EncodedSchema extends TSchema,
 	TEncodedFormat = JsonCompatibleReadOnly,
 	TValidate = TEncodedFormat,
-	TContext = void,
+	TContext = ChangeEncodingContext,
 >(
 	schema: EncodedSchema,
 	codec: IJsonCodec<TInMemoryFormat, TEncodedFormat, TValidate, TContext>,

--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -7,6 +7,8 @@ import { SessionId } from "@fluidframework/id-compressor";
 import { ICodecFamily, IJsonCodec } from "../../codec/index.js";
 import { ChangeRebaser } from "../rebase/index.js";
 import { JsonCompatibleReadOnly } from "../../util/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { SchemaAndPolicy } from "../../feature-libraries/chunked-forest/codec/codecs.js";
 
 export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
 	buildEditor(changeReceiver: (change: TChange) => void): TEditor;
@@ -17,6 +19,7 @@ export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
 
 export interface ChangeEncodingContext {
 	readonly originatorId: SessionId;
+	readonly schema?: SchemaAndPolicy;
 }
 
 export type ChangeFamilyCodec<TChange> = IJsonCodec<

--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -7,8 +7,7 @@ import { SessionId } from "@fluidframework/id-compressor";
 import { ICodecFamily, IJsonCodec } from "../../codec/index.js";
 import { ChangeRebaser } from "../rebase/index.js";
 import { JsonCompatibleReadOnly } from "../../util/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import { SchemaAndPolicy } from "../../feature-libraries/chunked-forest/codec/codecs.js";
+import { SchemaAndPolicy } from "../../feature-libraries/index.js";
 
 export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
 	buildEditor(changeReceiver: (change: TChange) => void): TEditor;

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/index.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/index.ts
@@ -5,4 +5,9 @@
 
 export { EncodedFieldBatch } from "./format.js";
 export { FieldBatch } from "./fieldBatch.js";
-export { FieldBatchCodec, makeFieldBatchCodec, FieldBatchEncodingContext } from "./codecs.js";
+export {
+	FieldBatchCodec,
+	makeFieldBatchCodec,
+	FieldBatchEncodingContext,
+	SchemaAndPolicy,
+} from "./codecs.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/index.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/index.ts
@@ -20,4 +20,5 @@ export {
 	FieldBatchCodec,
 	makeFieldBatchCodec,
 	FieldBatchEncodingContext,
+	SchemaAndPolicy,
 } from "./codec/index.js";

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -35,6 +35,7 @@ import {
 	EditDescription,
 } from "../modular-schema/index.js";
 import { FieldBatchCodec } from "../chunked-forest/index.js";
+import { TreeCompressionStrategy } from "../treeCompressionUtils.js";
 import { fieldKinds, optional, sequence, required as valueFieldKind } from "./defaultFieldKinds.js";
 
 export type DefaultChangeset = ModularChangeset;
@@ -51,12 +52,14 @@ export class DefaultChangeFamily implements ChangeFamily<DefaultEditBuilder, Def
 		revisionTagCodec: RevisionTagCodec,
 		fieldBatchCodec: FieldBatchCodec,
 		codecOptions: ICodecOptions,
+		chunkCompressionStrategy?: TreeCompressionStrategy,
 	) {
 		this.modularFamily = new ModularChangeFamily(
 			fieldKinds,
 			revisionTagCodec,
 			fieldBatchCodec,
 			codecOptions,
+			chunkCompressionStrategy,
 		);
 	}
 

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -191,6 +191,7 @@ export {
 	makeTreeChunker,
 	makeFieldBatchCodec,
 	FieldBatchEncodingContext,
+	SchemaAndPolicy,
 } from "./chunked-forest/index.js";
 
 export {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -23,7 +23,6 @@ import {
 	SchemaValidationFunction,
 } from "../../codec/index.js";
 import {
-	FieldBatchEncodingContext,
 	FieldBatchCodec,
 	TreeChunk,
 	chunkFieldSingle,
@@ -48,11 +47,6 @@ import {
 	EncodedRevisionInfo,
 } from "./modularChangeFormat.js";
 
-const chunkEncodingContext: FieldBatchEncodingContext = {
-	encodeType: TreeCompressionStrategy.Compressed,
-	// TODO: provide a schema when encoding so schema based compression can actually happen.
-};
-
 export function makeV0Codec(
 	fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor>,
 	revisionTagCodec: IJsonCodec<
@@ -63,6 +57,7 @@ export function makeV0Codec(
 	>,
 	fieldsCodec: FieldBatchCodec,
 	{ jsonValidator: validator }: ICodecOptions,
+	chunkCompressionStrategy: TreeCompressionStrategy = TreeCompressionStrategy.Compressed,
 ): IJsonCodec<
 	ModularChangeset,
 	EncodedModularChangeset,
@@ -236,7 +231,10 @@ export function makeV0Codec(
 			? undefined
 			: {
 					builds: buildsArray,
-					trees: fieldsCodec.encode(treesToEncode, chunkEncodingContext),
+					trees: fieldsCodec.encode(treesToEncode, {
+						encodeType: chunkCompressionStrategy,
+						schema: context.schema,
+					}),
 			  };
 	}
 
@@ -248,7 +246,9 @@ export function makeV0Codec(
 			return undefined;
 		}
 
-		const chunks = fieldsCodec.decode(encoded.trees, chunkEncodingContext);
+		const chunks = fieldsCodec.decode(encoded.trees, {
+			encodeType: chunkCompressionStrategy,
+		});
 		const getChunk = (index: number): TreeChunk => {
 			assert(index < chunks.length, 0x898 /* out of bounds index for build chunk */);
 			return chunkFieldSingle(chunks[index], defaultChunkPolicy);

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -59,6 +59,7 @@ import {
 	chunkTree,
 } from "../chunked-forest/index.js";
 import { cursorForMapTreeNode, mapTreeFromCursor } from "../mapTreeCursor.js";
+import { TreeCompressionStrategy } from "../treeCompressionUtils.js";
 import {
 	CrossFieldManager,
 	CrossFieldMap,
@@ -104,8 +105,15 @@ export class ModularChangeFamily
 		revisionTagCodec: RevisionTagCodec,
 		fieldBatchCodec: FieldBatchCodec,
 		codecOptions: ICodecOptions,
+		chunkCompressionStrategy?: TreeCompressionStrategy,
 	) {
-		this.latestCodec = makeV0Codec(fieldKinds, revisionTagCodec, fieldBatchCodec, codecOptions);
+		this.latestCodec = makeV0Codec(
+			fieldKinds,
+			revisionTagCodec,
+			fieldBatchCodec,
+			codecOptions,
+			chunkCompressionStrategy,
+		);
 		this.codecs = makeCodecFamily([[0, this.latestCodec]]);
 	}
 

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -10,6 +10,8 @@ import {
 	makeVersionedValidatedCodec,
 } from "../codec/index.js";
 import { ChangeEncodingContext, EncodedRevisionTag, RevisionTag } from "../core/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { SchemaAndPolicy } from "../feature-libraries/chunked-forest/codec/codecs.js";
 import {
 	JsonCompatibleReadOnly,
 	JsonCompatibleReadOnlySchema,
@@ -23,6 +25,10 @@ import {
 	SequencedCommit,
 	version,
 } from "./editManagerFormat.js";
+
+export interface EditManagerEncodingContext {
+	readonly schema?: SchemaAndPolicy;
+}
 
 export function makeEditManagerCodec<TChangeset>(
 	changeCodec: IMultiFormatCodec<
@@ -38,7 +44,12 @@ export function makeEditManagerCodec<TChangeset>(
 		ChangeEncodingContext
 	>,
 	options: ICodecOptions,
-): IJsonCodec<SummaryData<TChangeset>> {
+): IJsonCodec<
+	SummaryData<TChangeset>,
+	JsonCompatibleReadOnly,
+	JsonCompatibleReadOnly,
+	ChangeEncodingContext
+> {
 	const format = EncodedEditManager(
 		changeCodec.json.encodedSchema ?? JsonCompatibleReadOnlySchema,
 	);
@@ -63,19 +74,29 @@ export function makeEditManagerCodec<TChangeset>(
 
 	const codec: IJsonCodec<
 		SummaryData<TChangeset>,
-		EncodedEditManager<TChangeset>
+		EncodedEditManager<TChangeset>,
+		EncodedEditManager<TChangeset>,
+		EditManagerEncodingContext
 	> = makeVersionedValidatedCodec(options, new Set([version]), format, {
-		encode: (data) => {
+		encode: (data, context: EditManagerEncodingContext) => {
 			const json: EncodedEditManager<TChangeset> = {
 				trunk: data.trunk.map((commit) =>
-					encodeCommit(commit, { originatorId: commit.sessionId }),
+					encodeCommit(commit, {
+						originatorId: commit.sessionId,
+						schema: context.schema,
+					}),
 				),
 				branches: Array.from(data.branches.entries(), ([sessionId, branch]) => [
 					sessionId,
 					{
-						base: revisionTagCodec.encode(branch.base, { originatorId: sessionId }),
+						base: revisionTagCodec.encode(branch.base, {
+							originatorId: sessionId,
+						}),
 						commits: branch.commits.map((commit) =>
-							encodeCommit(commit, { originatorId: commit.sessionId }),
+							encodeCommit(commit, {
+								originatorId: commit.sessionId,
+								schema: context.schema,
+							}),
 						),
 					},
 				]),
@@ -115,5 +136,10 @@ export function makeEditManagerCodec<TChangeset>(
 	// TODO: makeVersionedValidatedCodec and withSchemaValidation should allow the codec to decode JsonCompatibleReadOnly, or Versioned or something like that,
 	// and not leak the internal encoded format in the API surface.
 	// Fixing that would remove the need for this cast.
-	return codec as unknown as IJsonCodec<SummaryData<TChangeset>>;
+	return codec as unknown as IJsonCodec<
+		SummaryData<TChangeset>,
+		JsonCompatibleReadOnly,
+		JsonCompatibleReadOnly,
+		ChangeEncodingContext
+	>;
 }

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -10,8 +10,7 @@ import {
 	makeVersionedValidatedCodec,
 } from "../codec/index.js";
 import { ChangeEncodingContext, EncodedRevisionTag, RevisionTag } from "../core/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import { SchemaAndPolicy } from "../feature-libraries/chunked-forest/codec/codecs.js";
+import { SchemaAndPolicy } from "../feature-libraries/index.js";
 import {
 	JsonCompatibleReadOnly,
 	JsonCompatibleReadOnlySchema,

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -19,10 +19,9 @@ import {
 	ChangeFamilyEditor,
 	EncodedRevisionTag,
 	RevisionTag,
-	TreeStoredSchemaSubscription,
 } from "../core/index.js";
 import { JsonCompatibleReadOnly } from "../util/index.js";
-import { defaultSchemaPolicy } from "../feature-libraries/index.js";
+import { SchemaAndPolicy } from "../feature-libraries/index.js";
 import { Summarizable, SummaryElementParser, SummaryElementStringifier } from "./sharedTreeCore.js";
 import { EditManager, SummaryData } from "./editManager.js";
 import { EditManagerEncodingContext, makeEditManagerCodec } from "./editManagerCodecs.js";
@@ -61,7 +60,7 @@ export class EditManagerSummarizer<TChangeset> implements Summarizable {
 			ChangeEncodingContext
 		>,
 		options: ICodecOptions,
-		private readonly schema?: TreeStoredSchemaSubscription,
+		private readonly schemaAndPolicy?: SchemaAndPolicy,
 	) {
 		const changesetCodec = this.editManager.changeFamily.codecs.resolve(formatVersion);
 		this.codec = makeEditManagerCodec(changesetCodec, revisionTagCodec, options);
@@ -87,9 +86,7 @@ export class EditManagerSummarizer<TChangeset> implements Summarizable {
 
 	private summarizeCore(stringify: SummaryElementStringifier): ISummaryTreeWithStats {
 		const context: EditManagerEncodingContext =
-			this.schema !== undefined
-				? { schema: { policy: defaultSchemaPolicy, schema: this.schema } }
-				: {};
+			this.schemaAndPolicy !== undefined ? { schema: this.schemaAndPolicy } : {};
 		const jsonCompatible = this.codec.encode(this.editManager.getSummaryData(), context);
 		const dataString = stringify(jsonCompatible);
 		return createSingleBlobSummary(stringKey, dataString);

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -12,8 +12,7 @@ import {
 	EncodedRevisionTag,
 	RevisionTag,
 } from "../core/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import { SchemaAndPolicy } from "../feature-libraries/chunked-forest/codec/codecs.js";
+import { SchemaAndPolicy } from "../feature-libraries/index.js";
 import { DecodedMessage } from "./messageTypes.js";
 import { Message } from "./messageFormat.js";
 

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -12,8 +12,14 @@ import {
 	EncodedRevisionTag,
 	RevisionTag,
 } from "../core/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { SchemaAndPolicy } from "../feature-libraries/chunked-forest/codec/codecs.js";
 import { DecodedMessage } from "./messageTypes.js";
 import { Message } from "./messageFormat.js";
+
+export interface MessageEncodingContext {
+	schema?: SchemaAndPolicy;
+}
 
 export function makeMessageCodec<TChangeset>(
 	changeCodec: ChangeFamilyCodec<TChangeset>,
@@ -24,16 +30,33 @@ export function makeMessageCodec<TChangeset>(
 		ChangeEncodingContext
 	>,
 	options: ICodecOptions,
-): IJsonCodec<DecodedMessage<TChangeset>> {
+): IJsonCodec<
+	DecodedMessage<TChangeset>,
+	JsonCompatibleReadOnly,
+	JsonCompatibleReadOnly,
+	MessageEncodingContext
+> {
 	// TODO: consider adding version and using makeVersionedValidatedCodec
-	return withSchemaValidation<DecodedMessage<TChangeset>, TAnySchema>(
+	return withSchemaValidation<
+		DecodedMessage<TChangeset>,
+		TAnySchema,
+		JsonCompatibleReadOnly,
+		JsonCompatibleReadOnly,
+		MessageEncodingContext
+	>(
 		Message(changeCodec.encodedSchema ?? Type.Any()),
 		{
-			encode: ({ commit, sessionId: originatorId }: DecodedMessage<TChangeset>) => {
+			encode: (
+				{ commit, sessionId: originatorId }: DecodedMessage<TChangeset>,
+				context: MessageEncodingContext,
+			) => {
 				const message: Message = {
 					revision: revisionTagCodec.encode(commit.revision, { originatorId }),
 					originatorId,
-					changeset: changeCodec.encode(commit.change, { originatorId }),
+					changeset: changeCodec.encode(commit.change, {
+						originatorId,
+						schema: context.schema,
+					}),
 				};
 				return message as unknown as JsonCompatibleReadOnly;
 			},

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -87,7 +87,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 
 	private readonly idCompressor: IIdCompressor;
 
-	private readonly schema: TreeStoredSchemaSubscription | undefined;
+	private readonly schema: TreeStoredSchemaSubscription;
 
 	/**
 	 * @param summarizables - Summarizers for all indexes used by this tree
@@ -107,7 +107,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		runtime: IFluidDataStoreRuntime,
 		attributes: IChannelAttributes,
 		telemetryContextPrefix: string,
-		schema?: TreeStoredSchemaSubscription,
+		schema: TreeStoredSchemaSubscription,
 	) {
 		super(id, runtime, attributes, telemetryContextPrefix);
 

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -256,6 +256,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		localOpMetadata: unknown,
 	) {
 		const contents: unknown = this.serializer.decode(message.contents);
+		// Empty context object is passed in, as our decode function is schema-agnostic.
 		const { commit, sessionId } = this.messageCodec.decode(contents, {});
 		this.editManager.addSequencedChange(
 			{ ...commit, sessionId },
@@ -282,6 +283,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 	}
 
 	protected override reSubmitCore(content: JsonCompatibleReadOnly, localOpMetadata: unknown) {
+		// Empty context object is passed in, as our decode function is schema-agnostic.
 		const {
 			commit: { revision },
 		} = this.messageCodec.decode(content, {});
@@ -294,6 +296,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 			!this.getLocalBranch().isTransacting(),
 			0x674 /* Unexpected transaction is open while applying stashed ops */,
 		);
+		// Empty context object is passed in, as our decode function is schema-agnostic.
 		const {
 			commit: { revision, change },
 		} = this.messageCodec.decode(content, {});

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -247,7 +247,7 @@ export class SharedTree
 			runtime,
 			attributes,
 			telemetryContextPrefix,
-			schema,
+			{ schema, policy: defaultSchemaPolicy },
 		);
 		this._events = createEmitter<CheckoutEvents>();
 		const localBranch = this.getLocalBranch();

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -259,6 +259,7 @@ export class SharedTree
 			fieldBatchCodec,
 			events: this._events,
 			removedRoots,
+			chunkCompressionStrategy: options.treeEncodeType,
 		});
 	}
 

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -215,6 +215,7 @@ export class SharedTree
 			revisionTagCodec,
 			fieldBatchCodec,
 			options,
+			options.treeEncodeType,
 		);
 		const changeFamily = makeMitigatedChangeFamily(
 			innerChangeFamily,
@@ -246,6 +247,7 @@ export class SharedTree
 			runtime,
 			attributes,
 			telemetryContextPrefix,
+			schema,
 		);
 		this._events = createEmitter<CheckoutEvents>();
 		const localBranch = this.getLocalBranch();

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -19,6 +19,7 @@ import {
 	ModularChangeFamily,
 	ModularChangeset,
 	FieldBatchCodec,
+	TreeCompressionStrategy,
 } from "../feature-libraries/index.js";
 import { Mutable, fail } from "../util/index.js";
 import { makeSharedTreeChangeCodecFamily } from "./sharedTreeChangeCodecs.js";
@@ -46,12 +47,14 @@ export class SharedTreeChangeFamily
 		revisionTagCodec: RevisionTagCodec,
 		fieldBatchCodec: FieldBatchCodec,
 		codecOptions: ICodecOptions,
+		chunkCompressionStrategy?: TreeCompressionStrategy,
 	) {
 		this.modularChangeFamily = new ModularChangeFamily(
 			fieldKinds,
 			revisionTagCodec,
 			fieldBatchCodec,
 			codecOptions,
+			chunkCompressionStrategy,
 		);
 		this.codecs = makeSharedTreeChangeCodecFamily(
 			this.modularChangeFamily.latestCodec,

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -33,6 +33,7 @@ import {
 	FieldBatchCodec,
 	jsonableTreeFromCursor,
 	makeFieldBatchCodec,
+	TreeCompressionStrategy,
 } from "../feature-libraries/index.js";
 import { SharedTreeBranch, getChangeReplaceType } from "../shared-tree-core/index.js";
 import { TransactionResult, fail } from "../util/index.js";
@@ -195,6 +196,7 @@ export function createTreeCheckout(
 			IEmitter<CheckoutEvents> &
 			HasListeners<CheckoutEvents>;
 		removedRoots?: DetachedFieldIndex;
+		chunkCompressionStrategy?: TreeCompressionStrategy;
 	},
 ): TreeCheckout {
 	const forest = args?.forest ?? buildForest();
@@ -206,6 +208,7 @@ export function createTreeCheckout(
 			revisionTagCodec,
 			args?.fieldBatchCodec ?? makeFieldBatchCodec(defaultCodecOptions),
 			{ jsonValidator: noopValidator },
+			args?.chunkCompressionStrategy,
 		);
 	const branch =
 		args?.branch ??

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
@@ -8,7 +8,7 @@ import { makeCodecFamily, withDefaultBinaryEncoding } from "../../../codec/index
 import { typeboxValidator } from "../../../external-utilities/index.js";
 import { TestChange } from "../../testChange.js";
 import { brand } from "../../../util/index.js";
-import { RevisionTagCodec } from "../../../core/index.js";
+import { ChangeEncodingContext, RevisionTagCodec } from "../../../core/index.js";
 import { SummaryData, makeEditManagerCodec } from "../../../shared-tree-core/index.js";
 import {
 	EncodingTestData,
@@ -40,15 +40,18 @@ const trunkCommits: SummaryData<TestChange>["trunk"] = [
 	},
 ];
 
-const testCases: EncodingTestData<SummaryData<TestChange>, unknown> = {
+// Dummy context object created to pass through the codec.
+const dummyContext = { originatorId: "dummySessionID" as SessionId };
+const testCases: EncodingTestData<SummaryData<TestChange>, unknown, ChangeEncodingContext> = {
 	successes: [
-		["empty", { trunk: [], branches: new Map() }],
+		["empty", { trunk: [], branches: new Map() }, dummyContext],
 		[
 			"single commit",
 			{
 				trunk: trunkCommits.slice(0, 1),
 				branches: new Map(),
 			},
+			dummyContext,
 		],
 		[
 			"multiple commits",
@@ -56,6 +59,7 @@ const testCases: EncodingTestData<SummaryData<TestChange>, unknown> = {
 				trunk: trunkCommits,
 				branches: new Map(),
 			},
+			dummyContext,
 		],
 		[
 			"empty branch",
@@ -71,6 +75,7 @@ const testCases: EncodingTestData<SummaryData<TestChange>, unknown> = {
 					],
 				]),
 			},
+			dummyContext,
 		],
 		[
 			"non-empty branch",
@@ -92,6 +97,7 @@ const testCases: EncodingTestData<SummaryData<TestChange>, unknown> = {
 					],
 				]),
 			},
+			dummyContext,
 		],
 		[
 			"multiple branches",
@@ -120,6 +126,7 @@ const testCases: EncodingTestData<SummaryData<TestChange>, unknown> = {
 					],
 				]),
 			},
+			dummyContext,
 		],
 	],
 	failures: {
@@ -130,6 +137,7 @@ const testCases: EncodingTestData<SummaryData<TestChange>, unknown> = {
 					base: tags[0],
 					commits: [{ sessionId: "4", change: TestChange.mint([0], 1) }],
 				},
+				dummyContext,
 			],
 			[
 				"missing sessionId",
@@ -137,14 +145,16 @@ const testCases: EncodingTestData<SummaryData<TestChange>, unknown> = {
 					base: tags[0],
 					commits: [{ change: TestChange.mint([0], 1), revision: mintRevisionTag() }],
 				},
+				dummyContext,
 			],
-			["non-object", ""],
+			["non-object", "", dummyContext],
 			[
 				"commit with parent field",
 				{
 					trunk: trunkCommits.slice(0, 1).map((commit) => ({ ...commit, parent: 0 })),
 					branches: [],
 				},
+				dummyContext,
 			],
 		],
 	},

--- a/packages/dds/tree/src/test/shared-tree-core/message.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/message.spec.ts
@@ -8,7 +8,7 @@ import { typeboxValidator } from "../../external-utilities/index.js";
 import { makeMessageCodec } from "../../shared-tree-core/messageCodecs.js";
 // eslint-disable-next-line import/no-internal-modules
 import { DecodedMessage } from "../../shared-tree-core/messageTypes.js";
-import { RevisionTagCodec } from "../../core/index.js";
+import { ChangeEncodingContext, RevisionTagCodec } from "../../core/index.js";
 import { TestChange } from "../testChange.js";
 import {
 	EncodingTestData,
@@ -41,7 +41,9 @@ const commitInvalid = {
 };
 
 const idCompressor = new MockIdCompressor();
-const testCases: EncodingTestData<DecodedMessage<TestChange>, unknown> = {
+
+const dummyContext = { originatorId: idCompressor.localSessionId };
+const testCases: EncodingTestData<DecodedMessage<TestChange>, unknown, ChangeEncodingContext> = {
 	successes: [
 		[
 			"Message with commit 1",
@@ -49,6 +51,7 @@ const testCases: EncodingTestData<DecodedMessage<TestChange>, unknown> = {
 				sessionId: idCompressor.localSessionId,
 				commit: commit1,
 			},
+			dummyContext,
 		],
 		[
 			"Message with commit 2",
@@ -56,22 +59,25 @@ const testCases: EncodingTestData<DecodedMessage<TestChange>, unknown> = {
 				sessionId: idCompressor.localSessionId,
 				commit: commit2,
 			},
+			dummyContext,
 		],
 	],
 	failures: {
 		0: [
-			["Empty message", {}],
+			["Empty message", {}, dummyContext],
 			[
 				"Missing sessionId",
 				{
 					commit: commit1,
 				},
+				dummyContext,
 			],
 			[
 				"Missing commit",
 				{
 					sessionId: "session1",
 				},
+				dummyContext,
 			],
 			[
 				"Message with invalid sessionId",
@@ -79,6 +85,7 @@ const testCases: EncodingTestData<DecodedMessage<TestChange>, unknown> = {
 					sessionId: 1,
 					commit: commit1,
 				},
+				dummyContext,
 			],
 			[
 				"Message with commit without revision",
@@ -86,6 +93,7 @@ const testCases: EncodingTestData<DecodedMessage<TestChange>, unknown> = {
 					sessionId: "session1",
 					commit: commitWithoutRevision,
 				},
+				dummyContext,
 			],
 			[
 				"Message with invalid commit",
@@ -93,6 +101,7 @@ const testCases: EncodingTestData<DecodedMessage<TestChange>, unknown> = {
 					sessionId: "session1",
 					commit: commitInvalid,
 				},
+				dummyContext,
 			],
 		],
 	},

--- a/packages/dds/tree/src/test/shared-tree-core/utils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/utils.ts
@@ -11,6 +11,7 @@ import {
 	DefaultChangeset,
 	DefaultEditBuilder,
 	TreeCompressionStrategy,
+	defaultSchemaPolicy,
 	makeFieldBatchCodec,
 } from "../../feature-libraries/index.js";
 import { testRevisionTagCodec } from "../utils.js";
@@ -50,7 +51,7 @@ export class TestSharedTreeCore extends SharedTreeCore<DefaultEditBuilder, Defau
 			runtime,
 			TestSharedTreeCore.attributes,
 			id,
-			schema,
+			{ policy: defaultSchemaPolicy, schema },
 		);
 	}
 

--- a/packages/dds/tree/src/test/shared-tree-core/utils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/utils.ts
@@ -10,10 +10,12 @@ import {
 	DefaultChangeFamily,
 	DefaultChangeset,
 	DefaultEditBuilder,
+	TreeCompressionStrategy,
 	makeFieldBatchCodec,
 } from "../../feature-libraries/index.js";
 import { testRevisionTagCodec } from "../utils.js";
 import { ICodecOptions } from "../../codec/index.js";
+import { TreeStoredSchemaRepository, TreeStoredSchemaSubscription } from "../../core/index.js";
 
 /**
  * A `SharedTreeCore` with
@@ -31,6 +33,8 @@ export class TestSharedTreeCore extends SharedTreeCore<DefaultEditBuilder, Defau
 		runtime: IFluidDataStoreRuntime = new MockFluidDataStoreRuntime(),
 		id = "TestSharedTreeCore",
 		summarizables: readonly Summarizable[] = [],
+		schema: TreeStoredSchemaSubscription = new TreeStoredSchemaRepository(),
+		chunkCompressionStrategy: TreeCompressionStrategy = TreeCompressionStrategy.Uncompressed,
 	) {
 		const codecOptions: ICodecOptions = { jsonValidator: typeboxValidator };
 		super(
@@ -39,12 +43,14 @@ export class TestSharedTreeCore extends SharedTreeCore<DefaultEditBuilder, Defau
 				testRevisionTagCodec,
 				makeFieldBatchCodec(codecOptions),
 				codecOptions,
+				chunkCompressionStrategy,
 			),
 			codecOptions,
 			id,
 			runtime,
 			TestSharedTreeCore.attributes,
 			id,
+			schema,
 		);
 	}
 

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -380,7 +380,7 @@ const styles = [
 		extraDescription: `1 transaction`,
 	},
 ];
-// TODO: schemas in this file should be updated/fixed to enable compressed encoding.
+// TODO: ADO#7111 schemas in this file should be updated/fixed to enable compressed encoding.
 const factory = new SharedTreeFactory({
 	jsonValidator: typeboxValidator,
 	treeEncodeType: TreeCompressionStrategy.Uncompressed,

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -12,7 +12,10 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils";
 import { createIdCompressor } from "@fluidframework/id-compressor";
-import { cursorForJsonableTreeNode } from "../../feature-libraries/index.js";
+import {
+	TreeCompressionStrategy,
+	cursorForJsonableTreeNode,
+} from "../../feature-libraries/index.js";
 import { ISharedTree, ITreeCheckout, SharedTreeFactory } from "../../shared-tree/index.js";
 import { JsonCompatibleReadOnly, brand, getOrAddEmptyToMap } from "../../util/index.js";
 import {
@@ -378,7 +381,10 @@ const styles = [
 	},
 ];
 
-const factory = new SharedTreeFactory({ jsonValidator: typeboxValidator });
+const factory = new SharedTreeFactory({
+	jsonValidator: typeboxValidator,
+	treeEncodeType: TreeCompressionStrategy.Uncompressed,
+});
 
 describe("Op Size", () => {
 	const opsByBenchmarkName: Map<string, ISequencedDocumentMessage[]> = new Map();

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -380,7 +380,7 @@ const styles = [
 		extraDescription: `1 transaction`,
 	},
 ];
-
+// TODO: schemas in this file should be updated/fixed to enable compressed encoding.
 const factory = new SharedTreeFactory({
 	jsonValidator: typeboxValidator,
 	treeEncodeType: TreeCompressionStrategy.Uncompressed,

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -13,6 +13,7 @@ import {
 	jsonableTreeFromCursor,
 	cursorForTypedData,
 	cursorForTypedTreeData,
+	TreeCompressionStrategy,
 } from "../../feature-libraries/index.js";
 import { singleJsonCursor } from "../../domains/index.js";
 import {
@@ -22,7 +23,7 @@ import {
 	flexTreeViewWithContent,
 	checkoutWithContent,
 } from "../utils.js";
-import { FlexTreeView } from "../../shared-tree/index.js";
+import { FlexTreeView, SharedTreeFactory } from "../../shared-tree/index.js";
 import { rootFieldKey } from "../../core/index.js";
 import {
 	deepPath,
@@ -43,6 +44,8 @@ import {
 	wideRootSchema,
 	wideSchema,
 } from "../scalableTestTrees.js";
+// eslint-disable-next-line import/no-internal-modules
+import { typeboxValidator } from "../../external-utilities/typeboxValidator.js";
 
 // number of nodes in test for wide trees
 const nodesCountWide = [
@@ -56,6 +59,11 @@ const nodesCountDeep = [
 	[10, BenchmarkType.Perspective],
 	[100, BenchmarkType.Measurement],
 ];
+
+const factory = new SharedTreeFactory({
+	jsonValidator: typeboxValidator,
+	treeEncodeType: TreeCompressionStrategy.Uncompressed,
+});
 
 // TODO: Once the "BatchTooLarge" error is no longer an issue, extend tests for larger trees.
 describe("SharedTree benchmarks", () => {
@@ -340,7 +348,7 @@ describe("SharedTree benchmarks", () => {
 						assert.equal(state.iterationsPerBatch, 1);
 
 						// Setup
-						const provider = new TestTreeProviderLite();
+						const provider = new TestTreeProviderLite(1, factory);
 						// TODO: specify a schema for these trees.
 						const [tree] = provider.trees;
 						for (let i = 0; i < size; i++) {
@@ -378,7 +386,7 @@ describe("SharedTree benchmarks", () => {
 						assert.equal(state.iterationsPerBatch, 1);
 
 						// Setup
-						const provider = new TestTreeProviderLite(nbPeers);
+						const provider = new TestTreeProviderLite(nbPeers, factory);
 						for (let iCommit = 0; iCommit < nbCommits; iCommit++) {
 							for (let iPeer = 0; iPeer < nbPeers; iPeer++) {
 								const peer = provider.trees[iPeer];

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -60,6 +60,7 @@ const nodesCountDeep = [
 	[100, BenchmarkType.Measurement],
 ];
 
+// TODO: ADO#7111 Schema should be fixed to enable schema based encoding.
 const factory = new SharedTreeFactory({
 	jsonValidator: typeboxValidator,
 	treeEncodeType: TreeCompressionStrategy.Uncompressed,

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -258,6 +258,7 @@ describe("SharedTree", () => {
 	});
 
 	it("handle in op", async () => {
+		// TODO: schema should be specified to enable compressed encoding.
 		const provider = await TestTreeProvider.create(
 			2,
 			SummarizeType.disabled,

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1745,7 +1745,7 @@ describe("SharedTree", () => {
 				jsonValidator: typeboxValidator,
 				treeEncodeType: TreeCompressionStrategy.Compressed,
 			});
-			const provider = new TestTreeProviderLite(1, factory);
+			const provider = new TestTreeProviderLite(2, factory);
 			const tree = provider.trees[0].checkout;
 
 			// Initial schema which allows sequence of strings under field "foo".

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -24,6 +24,7 @@ import {
 	intoStoredSchema,
 	SchemaBuilderBase,
 	FlexTreeTypedField,
+	TreeCompressionStrategy,
 } from "../../feature-libraries/index.js";
 import {
 	ChunkedForest,
@@ -59,6 +60,7 @@ import {
 	SharedTree,
 	SharedTreeFactory,
 	CheckoutFlexTreeView,
+	runSynchronous,
 } from "../../shared-tree/index.js";
 import {
 	compareUpPaths,
@@ -71,6 +73,7 @@ import {
 	Revertible,
 	RevertibleKind,
 	RevertibleResult,
+	JsonableTree,
 } from "../../core/index.js";
 import { typeboxValidator } from "../../external-utilities/index.js";
 import { EditManager } from "../../shared-tree-core/index.js";
@@ -255,7 +258,14 @@ describe("SharedTree", () => {
 	});
 
 	it("handle in op", async () => {
-		const provider = await TestTreeProvider.create(2);
+		const provider = await TestTreeProvider.create(
+			2,
+			SummarizeType.disabled,
+			new SharedTreeFactory({
+				jsonValidator: typeboxValidator,
+				treeEncodeType: TreeCompressionStrategy.Uncompressed,
+			}),
+		);
 		assert(provider.trees[0].isAttached());
 		assert(provider.trees[1].isAttached());
 
@@ -1726,6 +1736,130 @@ describe("SharedTree", () => {
 				}),
 			);
 			assert.equal(trees[0].checkout.forest instanceof ChunkedForest, true);
+		});
+	});
+	describe("Schema based op encoding", () => {
+		it("uses the correct schema for subsequent edits after schema change.", async () => {
+			const factory = new SharedTreeFactory({
+				jsonValidator: typeboxValidator,
+				treeEncodeType: TreeCompressionStrategy.Compressed,
+			});
+			const provider = new TestTreeProviderLite(1, factory);
+			const tree = provider.trees[0].checkout;
+
+			// Initial schema which allows sequence of strings under field "foo".
+			const schemaBuilder = new SchemaBuilder({ scope: "op-encoding-test-schema-1" });
+			const nodeSchema = schemaBuilder.object("Node", {
+				foo: SchemaBuilder.sequence(leaf.string),
+			});
+			const rootFieldSchema = SchemaBuilder.required(nodeSchema);
+			const schema = schemaBuilder.intoSchema(rootFieldSchema);
+
+			// Updated schema which allows all primitives under field "foo".
+			const schemaBuilder2 = new SchemaBuilder({ scope: "op-encoding-test-schema-2" });
+			const nodeSchema2 = schemaBuilder2.object("Node", {
+				foo: SchemaBuilder.sequence(leaf.primitives),
+			});
+			const rootFieldSchema2 = SchemaBuilder.required(nodeSchema2);
+			const schema2 = schemaBuilder2.intoSchema(rootFieldSchema2);
+
+			const initialState: JsonableTree = {
+				type: nodeSchema.name,
+				fields: {
+					foo: [{ type: leaf.string.name, value: "a" }],
+				},
+			};
+
+			tree.transaction.start();
+			runSynchronous(tree, () => {
+				tree.updateSchema(intoStoredSchema(schema));
+				const fieldEditor = tree.editor.sequenceField({
+					field: rootFieldKey,
+					parent: undefined,
+				});
+				fieldEditor.insert(0, cursorForJsonableTreeNode(initialState));
+
+				const rootPath = {
+					parent: undefined,
+					parentField: rootFieldKey,
+					parentIndex: 0,
+				};
+
+				const field = tree.editor.sequenceField({ parent: rootPath, field: brand("foo") });
+				field.insert(0, cursorForJsonableTreeNode({ type: leaf.string.name, value: "b" }));
+
+				// Update schema which now allows all primitives under field "foo".
+				tree.updateSchema(intoStoredSchema(schema2));
+				field.insert(0, cursorForJsonableTreeNode({ type: leaf.number.name, value: 1 }));
+			});
+			tree.transaction.commit();
+			provider.processMessages();
+		});
+
+		it("properly encodes ops using specified compression strategy", async () => {
+			// Check that ops are using uncompressed encoding with "Uncompressed" treeEncodeType
+			const factory = new SharedTreeFactory({
+				jsonValidator: typeboxValidator,
+				treeEncodeType: TreeCompressionStrategy.Uncompressed,
+			});
+			const provider = await TestTreeProvider.create(1, SummarizeType.onDemand, factory);
+			provider.trees[0].schematizeInternal({
+				schema: stringSequenceRootSchema,
+				allowedSchemaModifications: AllowedUpdateType.None,
+				initialTree: ["A", "B", "C"],
+			});
+
+			await provider.ensureSynchronized();
+			const summary = (await provider.trees[0].summarize()).summary;
+			const indexesSummary = summary.tree.indexes;
+			assert(indexesSummary.type === SummaryType.Tree);
+			const editManagerSummary = indexesSummary.tree.EditManager;
+			assert(editManagerSummary.type === SummaryType.Tree);
+			const editManagerSummaryBlob = editManagerSummary.tree.String;
+			assert(editManagerSummaryBlob.type === SummaryType.Blob);
+			const changesSummary = JSON.parse(editManagerSummaryBlob.content as string);
+			const encodedTreeData = changesSummary.trunk[0].change[1].data.builds.trees;
+			const expectedUncompressedTreeData = [
+				"com.fluidframework.leaf.string",
+				true,
+				"A",
+				[],
+				"com.fluidframework.leaf.string",
+				true,
+				"B",
+				[],
+				"com.fluidframework.leaf.string",
+				true,
+				"C",
+				[],
+			];
+			assert.deepEqual(encodedTreeData.data[0][1], expectedUncompressedTreeData);
+
+			// Check that ops are encoded using schema based compression with "Compressed" treeEncodeType
+			const factory2 = new SharedTreeFactory({
+				jsonValidator: typeboxValidator,
+				treeEncodeType: TreeCompressionStrategy.Compressed,
+			});
+			const provider2 = await TestTreeProvider.create(1, SummarizeType.onDemand, factory2);
+
+			provider2.trees[0].schematizeInternal({
+				schema: stringSequenceRootSchema,
+				allowedSchemaModifications: AllowedUpdateType.None,
+				initialTree: ["A", "B", "C"],
+			});
+
+			await provider2.ensureSynchronized();
+			const summary2 = (await provider2.trees[0].summarize()).summary;
+			const indexesSummary2 = summary2.tree.indexes;
+			assert(indexesSummary2.type === SummaryType.Tree);
+			const editManagerSummary2 = indexesSummary2.tree.EditManager;
+			assert(editManagerSummary2.type === SummaryType.Tree);
+			const editManagerSummaryBlob2 = editManagerSummary2.tree.String;
+			assert(editManagerSummaryBlob2.type === SummaryType.Blob);
+			const changesSummary2 = JSON.parse(editManagerSummaryBlob2.content as string);
+			const encodedTreeData2 = changesSummary2.trunk[0].change[1].data.builds.trees;
+			const expectedCompressedTreeData = [0, "A", 0, "B", 0, "C"];
+			assert.deepEqual(encodedTreeData2.data[0][1], expectedCompressedTreeData);
 		});
 	});
 });

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -258,7 +258,7 @@ describe("SharedTree", () => {
 	});
 
 	it("handle in op", async () => {
-		// TODO: schema should be specified to enable compressed encoding.
+		// TODO: ADO#7111 schema should be specified to enable compressed encoding.
 		const provider = await TestTreeProvider.create(
 			2,
 			SummarizeType.disabled,

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
@@ -1,0 +1,76 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { SessionId } from "@fluidframework/id-compressor";
+import {
+	FieldBatch,
+	FieldBatchEncodingContext,
+	ModularChangeset,
+	SequenceField,
+	defaultSchemaPolicy,
+	fieldKinds,
+	makeV0Codec,
+} from "../../feature-libraries/index.js";
+import { RevisionTagCodec, TreeStoredSchemaRepository } from "../../core/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { sequence } from "../../feature-libraries/default-schema/defaultFieldKinds.js";
+import { MockIdCompressor } from "../utils.js";
+import { ICodecOptions, noopValidator } from "../../codec/index.js";
+import { ajvValidator } from "../codec/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { makeSharedTreeChangeCodec } from "../../shared-tree/sharedTreeChangeCodecs.js";
+// eslint-disable-next-line import/no-internal-modules
+import { brand } from "../../util/brand.js";
+// eslint-disable-next-line import/no-internal-modules
+import { EncodedFieldBatch } from "../../feature-libraries/chunked-forest/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { uncompressedEncode } from "../../feature-libraries/chunked-forest/codec/uncompressedEncode.js";
+// eslint-disable-next-line import/no-internal-modules
+import { decode } from "../../feature-libraries/chunked-forest/codec/chunkDecoding.js";
+
+const idCompressor = new MockIdCompressor();
+const revisionTagCodec = new RevisionTagCodec(idCompressor);
+const codecOptions: ICodecOptions = { jsonValidator: ajvValidator };
+
+describe("sharedTreeChangeCodec", () => {
+	it("passes down the context's schema to the fieldBatchCodec", () => {
+		const dummyFieldBatchCodec = {
+			encode: (data: FieldBatch, context: FieldBatchEncodingContext): EncodedFieldBatch => {
+				// Checks that the context's schema matches the schema passed into the sharedTreeChangeCodec.
+				assert.equal(context.schema?.schema, dummyTestSchema);
+				return uncompressedEncode(data);
+			},
+			decode: (data: EncodedFieldBatch): FieldBatch => {
+				return decode(data).map((chunk) => chunk.cursor());
+			},
+		};
+		const modularChangeCodec = makeV0Codec(
+			fieldKinds,
+			revisionTagCodec,
+			dummyFieldBatchCodec,
+			codecOptions,
+		);
+		const sharedTreeChangeCodec = makeSharedTreeChangeCodec(modularChangeCodec, {
+			jsonValidator: noopValidator,
+		});
+
+		const dummyTestSchema = new TreeStoredSchemaRepository();
+		const dummyContext = {
+			originatorId: "dummySessionID" as SessionId,
+			schema: { policy: defaultSchemaPolicy, schema: dummyTestSchema },
+		};
+		const changeA: SequenceField.Changeset = [];
+		const dummyModularChangeSet: ModularChangeset = {
+			fieldChanges: new Map([
+				[brand("fA"), { fieldKind: sequence.identifier, change: brand(changeA) }],
+			]),
+		};
+		sharedTreeChangeCodec.encode(
+			{ changes: [{ type: "data", innerChange: dummyModularChangeSet }] },
+			dummyContext,
+		);
+	});
+});

--- a/packages/dds/tree/src/test/snapshots/files/complete-3x3-final-default-compression.json
+++ b/packages/dds/tree/src/test/snapshots/files/complete-3x3-final-default-compression.json
@@ -103,21 +103,22 @@
                                 "shapes": [
                                   {
                                     "c": {
+                                      "type": "test trees.TestInner",
+                                      "value": false,
                                       "extraFields": 1
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "test trees.TestInner",
-                                      false,
-                                      []
-                                    ]
+                                    0,
+                                    []
                                   ]
                                 ]
                               }
@@ -183,22 +184,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "1",
-                                      []
-                                    ]
+                                    0,
+                                    "1"
                                   ]
                                 ]
                               }
@@ -267,22 +261,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "2",
-                                      []
-                                    ]
+                                    0,
+                                    "2"
                                   ]
                                 ]
                               }
@@ -351,22 +338,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "3",
-                                      []
-                                    ]
+                                    0,
+                                    "3"
                                   ]
                                 ]
                               }
@@ -432,22 +412,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "4",
-                                      []
-                                    ]
+                                    0,
+                                    "4"
                                   ]
                                 ]
                               }
@@ -516,22 +489,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "5",
-                                      []
-                                    ]
+                                    0,
+                                    "5"
                                   ]
                                 ]
                               }
@@ -600,22 +566,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "6",
-                                      []
-                                    ]
+                                    0,
+                                    "6"
                                   ]
                                 ]
                               }
@@ -681,22 +640,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "7",
-                                      []
-                                    ]
+                                    0,
+                                    "7"
                                   ]
                                 ]
                               }
@@ -765,22 +717,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "8",
-                                      []
-                                    ]
+                                    0,
+                                    "8"
                                   ]
                                 ]
                               }
@@ -849,22 +794,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "9",
-                                      []
-                                    ]
+                                    0,
+                                    "9"
                                   ]
                                 ]
                               }
@@ -920,21 +858,22 @@
                                 "shapes": [
                                   {
                                     "c": {
+                                      "type": "test trees.TestInner",
+                                      "value": false,
                                       "extraFields": 1
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "test trees.TestInner",
-                                      false,
-                                      []
-                                    ]
+                                    0,
+                                    []
                                   ]
                                 ]
                               }
@@ -1000,22 +939,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "10",
-                                      []
-                                    ]
+                                    0,
+                                    "10"
                                   ]
                                 ]
                               }
@@ -1084,22 +1016,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "11",
-                                      []
-                                    ]
+                                    0,
+                                    "11"
                                   ]
                                 ]
                               }
@@ -1168,22 +1093,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "12",
-                                      []
-                                    ]
+                                    0,
+                                    "12"
                                   ]
                                 ]
                               }
@@ -1249,22 +1167,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "13",
-                                      []
-                                    ]
+                                    0,
+                                    "13"
                                   ]
                                 ]
                               }
@@ -1333,22 +1244,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "14",
-                                      []
-                                    ]
+                                    0,
+                                    "14"
                                   ]
                                 ]
                               }
@@ -1417,22 +1321,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "15",
-                                      []
-                                    ]
+                                    0,
+                                    "15"
                                   ]
                                 ]
                               }
@@ -1498,22 +1395,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "16",
-                                      []
-                                    ]
+                                    0,
+                                    "16"
                                   ]
                                 ]
                               }
@@ -1582,22 +1472,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "17",
-                                      []
-                                    ]
+                                    0,
+                                    "17"
                                   ]
                                 ]
                               }
@@ -1666,22 +1549,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "18",
-                                      []
-                                    ]
+                                    0,
+                                    "18"
                                   ]
                                 ]
                               }
@@ -1737,21 +1613,22 @@
                                 "shapes": [
                                   {
                                     "c": {
+                                      "type": "test trees.TestInner",
+                                      "value": false,
                                       "extraFields": 1
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "test trees.TestInner",
-                                      false,
-                                      []
-                                    ]
+                                    0,
+                                    []
                                   ]
                                 ]
                               }
@@ -1817,22 +1694,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "19",
-                                      []
-                                    ]
+                                    0,
+                                    "19"
                                   ]
                                 ]
                               }
@@ -1901,22 +1771,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "20",
-                                      []
-                                    ]
+                                    0,
+                                    "20"
                                   ]
                                 ]
                               }
@@ -1985,22 +1848,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "21",
-                                      []
-                                    ]
+                                    0,
+                                    "21"
                                   ]
                                 ]
                               }
@@ -2066,22 +1922,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "22",
-                                      []
-                                    ]
+                                    0,
+                                    "22"
                                   ]
                                 ]
                               }
@@ -2150,22 +1999,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "23",
-                                      []
-                                    ]
+                                    0,
+                                    "23"
                                   ]
                                 ]
                               }
@@ -2234,22 +2076,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "24",
-                                      []
-                                    ]
+                                    0,
+                                    "24"
                                   ]
                                 ]
                               }
@@ -2315,22 +2150,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "25",
-                                      []
-                                    ]
+                                    0,
+                                    "25"
                                   ]
                                 ]
                               }
@@ -2399,22 +2227,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "26",
-                                      []
-                                    ]
+                                    0,
+                                    "26"
                                   ]
                                 ]
                               }
@@ -2483,22 +2304,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "27",
-                                      []
-                                    ]
+                                    0,
+                                    "27"
                                   ]
                                 ]
                               }
@@ -2551,21 +2365,22 @@
                                 "shapes": [
                                   {
                                     "c": {
+                                      "type": "test trees.TestInner",
+                                      "value": false,
                                       "extraFields": 1
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "test trees.TestInner",
-                                      false,
-                                      []
-                                    ]
+                                    0,
+                                    []
                                   ]
                                 ]
                               }
@@ -2631,22 +2446,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "28",
-                                      []
-                                    ]
+                                    0,
+                                    "28"
                                   ]
                                 ]
                               }
@@ -2715,22 +2523,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "29",
-                                      []
-                                    ]
+                                    0,
+                                    "29"
                                   ]
                                 ]
                               }
@@ -2799,22 +2600,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "30",
-                                      []
-                                    ]
+                                    0,
+                                    "30"
                                   ]
                                 ]
                               }
@@ -2880,22 +2674,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "31",
-                                      []
-                                    ]
+                                    0,
+                                    "31"
                                   ]
                                 ]
                               }
@@ -2964,22 +2751,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "32",
-                                      []
-                                    ]
+                                    0,
+                                    "32"
                                   ]
                                 ]
                               }
@@ -3048,22 +2828,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "33",
-                                      []
-                                    ]
+                                    0,
+                                    "33"
                                   ]
                                 ]
                               }
@@ -3129,22 +2902,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "34",
-                                      []
-                                    ]
+                                    0,
+                                    "34"
                                   ]
                                 ]
                               }
@@ -3213,22 +2979,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "35",
-                                      []
-                                    ]
+                                    0,
+                                    "35"
                                   ]
                                 ]
                               }
@@ -3297,22 +3056,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "36",
-                                      []
-                                    ]
+                                    0,
+                                    "36"
                                   ]
                                 ]
                               }
@@ -3368,21 +3120,22 @@
                                 "shapes": [
                                   {
                                     "c": {
+                                      "type": "test trees.TestInner",
+                                      "value": false,
                                       "extraFields": 1
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "test trees.TestInner",
-                                      false,
-                                      []
-                                    ]
+                                    0,
+                                    []
                                   ]
                                 ]
                               }
@@ -3448,22 +3201,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "37",
-                                      []
-                                    ]
+                                    0,
+                                    "37"
                                   ]
                                 ]
                               }
@@ -3532,22 +3278,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "38",
-                                      []
-                                    ]
+                                    0,
+                                    "38"
                                   ]
                                 ]
                               }
@@ -3616,22 +3355,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "39",
-                                      []
-                                    ]
+                                    0,
+                                    "39"
                                   ]
                                 ]
                               }
@@ -3697,22 +3429,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "40",
-                                      []
-                                    ]
+                                    0,
+                                    "40"
                                   ]
                                 ]
                               }
@@ -3781,22 +3506,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "41",
-                                      []
-                                    ]
+                                    0,
+                                    "41"
                                   ]
                                 ]
                               }
@@ -3865,22 +3583,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "42",
-                                      []
-                                    ]
+                                    0,
+                                    "42"
                                   ]
                                 ]
                               }
@@ -3946,22 +3657,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "43",
-                                      []
-                                    ]
+                                    0,
+                                    "43"
                                   ]
                                 ]
                               }
@@ -4030,22 +3734,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "44",
-                                      []
-                                    ]
+                                    0,
+                                    "44"
                                   ]
                                 ]
                               }
@@ -4114,22 +3811,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "45",
-                                      []
-                                    ]
+                                    0,
+                                    "45"
                                   ]
                                 ]
                               }
@@ -4185,21 +3875,22 @@
                                 "shapes": [
                                   {
                                     "c": {
+                                      "type": "test trees.TestInner",
+                                      "value": false,
                                       "extraFields": 1
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "test trees.TestInner",
-                                      false,
-                                      []
-                                    ]
+                                    0,
+                                    []
                                   ]
                                 ]
                               }
@@ -4265,22 +3956,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "46",
-                                      []
-                                    ]
+                                    0,
+                                    "46"
                                   ]
                                 ]
                               }
@@ -4349,22 +4033,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "47",
-                                      []
-                                    ]
+                                    0,
+                                    "47"
                                   ]
                                 ]
                               }
@@ -4433,22 +4110,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "48",
-                                      []
-                                    ]
+                                    0,
+                                    "48"
                                   ]
                                 ]
                               }
@@ -4514,22 +4184,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "49",
-                                      []
-                                    ]
+                                    0,
+                                    "49"
                                   ]
                                 ]
                               }
@@ -4598,22 +4261,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "50",
-                                      []
-                                    ]
+                                    0,
+                                    "50"
                                   ]
                                 ]
                               }
@@ -4682,22 +4338,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "51",
-                                      []
-                                    ]
+                                    0,
+                                    "51"
                                   ]
                                 ]
                               }
@@ -4763,22 +4412,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "52",
-                                      []
-                                    ]
+                                    0,
+                                    "52"
                                   ]
                                 ]
                               }
@@ -4847,22 +4489,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "53",
-                                      []
-                                    ]
+                                    0,
+                                    "53"
                                   ]
                                 ]
                               }
@@ -4931,22 +4566,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "54",
-                                      []
-                                    ]
+                                    0,
+                                    "54"
                                   ]
                                 ]
                               }
@@ -4999,21 +4627,22 @@
                                 "shapes": [
                                   {
                                     "c": {
+                                      "type": "test trees.TestInner",
+                                      "value": false,
                                       "extraFields": 1
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "test trees.TestInner",
-                                      false,
-                                      []
-                                    ]
+                                    0,
+                                    []
                                   ]
                                 ]
                               }
@@ -5079,22 +4708,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "55",
-                                      []
-                                    ]
+                                    0,
+                                    "55"
                                   ]
                                 ]
                               }
@@ -5163,22 +4785,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "56",
-                                      []
-                                    ]
+                                    0,
+                                    "56"
                                   ]
                                 ]
                               }
@@ -5247,22 +4862,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "57",
-                                      []
-                                    ]
+                                    0,
+                                    "57"
                                   ]
                                 ]
                               }
@@ -5328,22 +4936,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "58",
-                                      []
-                                    ]
+                                    0,
+                                    "58"
                                   ]
                                 ]
                               }
@@ -5412,22 +5013,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "59",
-                                      []
-                                    ]
+                                    0,
+                                    "59"
                                   ]
                                 ]
                               }
@@ -5496,22 +5090,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "60",
-                                      []
-                                    ]
+                                    0,
+                                    "60"
                                   ]
                                 ]
                               }
@@ -5577,22 +5164,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "61",
-                                      []
-                                    ]
+                                    0,
+                                    "61"
                                   ]
                                 ]
                               }
@@ -5661,22 +5241,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "62",
-                                      []
-                                    ]
+                                    0,
+                                    "62"
                                   ]
                                 ]
                               }
@@ -5745,22 +5318,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "63",
-                                      []
-                                    ]
+                                    0,
+                                    "63"
                                   ]
                                 ]
                               }
@@ -5816,21 +5382,22 @@
                                 "shapes": [
                                   {
                                     "c": {
+                                      "type": "test trees.TestInner",
+                                      "value": false,
                                       "extraFields": 1
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "test trees.TestInner",
-                                      false,
-                                      []
-                                    ]
+                                    0,
+                                    []
                                   ]
                                 ]
                               }
@@ -5896,22 +5463,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "64",
-                                      []
-                                    ]
+                                    0,
+                                    "64"
                                   ]
                                 ]
                               }
@@ -5980,22 +5540,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "65",
-                                      []
-                                    ]
+                                    0,
+                                    "65"
                                   ]
                                 ]
                               }
@@ -6064,22 +5617,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "66",
-                                      []
-                                    ]
+                                    0,
+                                    "66"
                                   ]
                                 ]
                               }
@@ -6145,22 +5691,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "67",
-                                      []
-                                    ]
+                                    0,
+                                    "67"
                                   ]
                                 ]
                               }
@@ -6229,22 +5768,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "68",
-                                      []
-                                    ]
+                                    0,
+                                    "68"
                                   ]
                                 ]
                               }
@@ -6313,22 +5845,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "69",
-                                      []
-                                    ]
+                                    0,
+                                    "69"
                                   ]
                                 ]
                               }
@@ -6394,22 +5919,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "70",
-                                      []
-                                    ]
+                                    0,
+                                    "70"
                                   ]
                                 ]
                               }
@@ -6478,22 +5996,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "71",
-                                      []
-                                    ]
+                                    0,
+                                    "71"
                                   ]
                                 ]
                               }
@@ -6562,22 +6073,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "72",
-                                      []
-                                    ]
+                                    0,
+                                    "72"
                                   ]
                                 ]
                               }
@@ -6633,21 +6137,22 @@
                                 "shapes": [
                                   {
                                     "c": {
+                                      "type": "test trees.TestInner",
+                                      "value": false,
                                       "extraFields": 1
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "test trees.TestInner",
-                                      false,
-                                      []
-                                    ]
+                                    0,
+                                    []
                                   ]
                                 ]
                               }
@@ -6713,22 +6218,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "73",
-                                      []
-                                    ]
+                                    0,
+                                    "73"
                                   ]
                                 ]
                               }
@@ -6797,22 +6295,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "74",
-                                      []
-                                    ]
+                                    0,
+                                    "74"
                                   ]
                                 ]
                               }
@@ -6881,22 +6372,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "75",
-                                      []
-                                    ]
+                                    0,
+                                    "75"
                                   ]
                                 ]
                               }
@@ -6962,22 +6446,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "76",
-                                      []
-                                    ]
+                                    0,
+                                    "76"
                                   ]
                                 ]
                               }
@@ -7046,22 +6523,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "77",
-                                      []
-                                    ]
+                                    0,
+                                    "77"
                                   ]
                                 ]
                               }
@@ -7130,22 +6600,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "78",
-                                      []
-                                    ]
+                                    0,
+                                    "78"
                                   ]
                                 ]
                               }
@@ -7211,22 +6674,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "79",
-                                      []
-                                    ]
+                                    0,
+                                    "79"
                                   ]
                                 ]
                               }
@@ -7295,22 +6751,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "80",
-                                      []
-                                    ]
+                                    0,
+                                    "80"
                                   ]
                                 ]
                               }
@@ -7379,22 +6828,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "81",
-                                      []
-                                    ]
+                                    0,
+                                    "81"
                                   ]
                                 ]
                               }

--- a/packages/dds/tree/src/test/snapshots/files/concurrent-inserts-tree2-default-compression.json
+++ b/packages/dds/tree/src/test/snapshots/files/concurrent-inserts-tree2-default-compression.json
@@ -134,22 +134,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "y",
-                                      []
-                                    ]
+                                    0,
+                                    "y"
                                   ]
                                 ]
                               }
@@ -202,22 +195,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "x",
-                                      []
-                                    ]
+                                    0,
+                                    "x"
                                   ]
                                 ]
                               }
@@ -273,25 +259,25 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
                                     1,
                                     [
-                                      "com.fluidframework.leaf.string",
-                                      true,
+                                      0,
                                       "a",
-                                      [],
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "c",
-                                      []
+                                      0,
+                                      "c"
                                     ]
                                   ]
                                 ]
@@ -348,22 +334,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "b",
-                                      []
-                                    ]
+                                    0,
+                                    "b"
                                   ]
                                 ]
                               }

--- a/packages/dds/tree/src/test/snapshots/files/concurrent-inserts-tree3-default-compression.json
+++ b/packages/dds/tree/src/test/snapshots/files/concurrent-inserts-tree3-default-compression.json
@@ -134,22 +134,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "y",
-                                      []
-                                    ]
+                                    0,
+                                    "y"
                                   ]
                                 ]
                               }
@@ -202,22 +195,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "x",
-                                      []
-                                    ]
+                                    0,
+                                    "x"
                                   ]
                                 ]
                               }
@@ -273,25 +259,25 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
                                     1,
                                     [
-                                      "com.fluidframework.leaf.string",
-                                      true,
+                                      0,
                                       "a",
-                                      [],
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "c",
-                                      []
+                                      0,
+                                      "c"
                                     ]
                                   ]
                                 ]
@@ -348,22 +334,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "b",
-                                      []
-                                    ]
+                                    0,
+                                    "b"
                                   ]
                                 ]
                               }
@@ -416,22 +395,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "z",
-                                      []
-                                    ]
+                                    0,
+                                    "z"
                                   ]
                                 ]
                               }
@@ -487,25 +459,25 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "a": 2
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
                                     1,
                                     [
-                                      "com.fluidframework.leaf.string",
-                                      true,
+                                      0,
                                       "d",
-                                      [],
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "e",
-                                      []
+                                      0,
+                                      "e"
                                     ]
                                   ]
                                 ]
@@ -562,22 +534,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "f",
-                                      []
-                                    ]
+                                    0,
+                                    "f"
                                   ]
                                 ]
                               }

--- a/packages/dds/tree/src/test/snapshots/files/has-handle-final-default-compression.json
+++ b/packages/dds/tree/src/test/snapshots/files/has-handle-final-default-compression.json
@@ -112,25 +112,18 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.handle",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.handle",
-                                      true,
-                                      {
-                                        "type": "__fluid_handle__",
-                                        "url": "/test/test"
-                                      },
-                                      []
-                                    ]
+                                    0,
+                                    {
+                                      "type": "__fluid_handle__",
+                                      "url": "/test/test"
+                                    }
                                   ]
                                 ]
                               }

--- a/packages/dds/tree/src/test/snapshots/files/insert-and-remove-tree-0-after-insert-default-compression.json
+++ b/packages/dds/tree/src/test/snapshots/files/insert-and-remove-tree-0-after-insert-default-compression.json
@@ -56,22 +56,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.string",
-                                      true,
-                                      "42",
-                                      []
-                                    ]
+                                    0,
+                                    "42"
                                   ]
                                 ]
                               }

--- a/packages/dds/tree/src/test/snapshots/files/move-across-fields-tree-0-final-default-compression.json
+++ b/packages/dds/tree/src/test/snapshots/files/move-across-fields-tree-0-final-default-compression.json
@@ -116,52 +116,43 @@
                                 "identifiers": [],
                                 "shapes": [
                                   {
+                                    "a": 2
+                                  },
+                                  {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "move-across-fields.Node",
+                                      "value": false,
+                                      "fields": [
+                                        [
+                                          "foo",
+                                          0
+                                        ],
+                                        [
+                                          "bar",
+                                          0
+                                        ]
+                                      ]
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "c": {
+                                      "type": "com.fluidframework.leaf.string",
+                                      "value": true
+                                    }
                                   }
                                 ],
                                 "data": [
                                   [
                                     1,
                                     [
-                                      "move-across-fields.Node",
-                                      false,
-                                      [
-                                        "foo",
-                                        [
-                                          "com.fluidframework.leaf.string",
-                                          true,
-                                          "a",
-                                          [],
-                                          "com.fluidframework.leaf.string",
-                                          true,
-                                          "b",
-                                          [],
-                                          "com.fluidframework.leaf.string",
-                                          true,
-                                          "c",
-                                          []
-                                        ],
-                                        "bar",
-                                        [
-                                          "com.fluidframework.leaf.string",
-                                          true,
-                                          "d",
-                                          [],
-                                          "com.fluidframework.leaf.string",
-                                          true,
-                                          "e",
-                                          [],
-                                          "com.fluidframework.leaf.string",
-                                          true,
-                                          "f",
-                                          []
-                                        ]
-                                      ]
+                                      "a",
+                                      "b",
+                                      "c"
+                                    ],
+                                    [
+                                      "d",
+                                      "e",
+                                      "f"
                                     ]
                                   ]
                                 ]

--- a/packages/dds/tree/src/test/snapshots/files/nested-sequence-change-final-default-compression.json
+++ b/packages/dds/tree/src/test/snapshots/files/nested-sequence-change-final-default-compression.json
@@ -134,6 +134,8 @@
                                 "shapes": [
                                   {
                                     "c": {
+                                      "type": "has-sequence-map.SeqMap",
+                                      "value": false,
                                       "extraFields": 1
                                     }
                                   },
@@ -143,20 +145,12 @@
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "has-sequence-map.SeqMap",
-                                      false,
-                                      []
-                                    ]
+                                    0,
+                                    []
                                   ],
                                   [
-                                    1,
-                                    [
-                                      "has-sequence-map.SeqMap",
-                                      false,
-                                      []
-                                    ]
+                                    0,
+                                    []
                                   ]
                                 ]
                               }

--- a/packages/dds/tree/src/test/snapshots/files/optional-field-scenarios-final-default-compression.json
+++ b/packages/dds/tree/src/test/snapshots/files/optional-field-scenarios-final-default-compression.json
@@ -66,22 +66,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.number",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.number",
-                                      true,
-                                      40,
-                                      []
-                                    ]
+                                    0,
+                                    40
                                   ]
                                 ]
                               }
@@ -135,27 +128,32 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "optional-field.TestNode",
+                                      "value": false,
+                                      "extraFields": 2
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "c": {
+                                      "type": "com.fluidframework.leaf.number",
+                                      "value": true
+                                    }
+                                  },
+                                  {
+                                    "a": 3
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
+                                    0,
                                     [
-                                      "optional-field.TestNode",
-                                      false,
+                                      "root 2 child",
                                       [
-                                        "root 2 child",
-                                        [
-                                          "com.fluidframework.leaf.number",
-                                          true,
-                                          41,
-                                          []
-                                        ]
+                                        1,
+                                        41
                                       ]
                                     ]
                                   ]
@@ -270,39 +268,36 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.number",
+                                      "value": true
                                     }
                                   },
                                   {
-                                    "a": 0
+                                    "c": {
+                                      "type": "optional-field.TestNode",
+                                      "value": false,
+                                      "extraFields": 2
+                                    }
+                                  },
+                                  {
+                                    "a": 3
+                                  },
+                                  {
+                                    "d": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.number",
-                                      true,
-                                      42,
-                                      []
-                                    ]
+                                    0,
+                                    42
                                   ],
                                   [
                                     1,
-                                    [
-                                      "optional-field.TestNode",
-                                      false,
-                                      []
-                                    ]
+                                    []
                                   ],
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.number",
-                                      true,
-                                      43,
-                                      []
-                                    ]
+                                    0,
+                                    43
                                   ]
                                 ]
                               }
@@ -371,22 +366,15 @@
                                 "shapes": [
                                   {
                                     "c": {
-                                      "extraFields": 1
+                                      "type": "com.fluidframework.leaf.number",
+                                      "value": true
                                     }
-                                  },
-                                  {
-                                    "a": 0
                                   }
                                 ],
                                 "data": [
                                   [
-                                    1,
-                                    [
-                                      "com.fluidframework.leaf.number",
-                                      true,
-                                      44,
-                                      []
-                                    ]
+                                    0,
+                                    44
                                   ]
                                 ]
                               }


### PR DESCRIPTION
## Description

This PR enables schema based compression for SharedTree ops. Some of our tests have been updated to use uncompressed encoding due to failing with incorrect/missing schema, but TODO comments were also added so that they could be updated in a separate PR.

