### PR TITLE
fix(PropertyDDS): Update msgpackr to 1.10.1 to address security vulnerability

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/package.json
+++ b/experimental/PropertyDDS/packages/property-dds/package.json
@@ -53,7 +53,7 @@
 		"fastest-json-copy": "^1.0.1",
 		"lodash": "^4.17.21",
 		"lz4js": "^0.2.0",
-		"msgpackr": "^1.4.7",
+		"msgpackr": "^1.10.1",
 		"pako": "^2.0.4",
 		"uuid": "^9.0.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4895,7 +4895,7 @@ importers:
       mocha-json-output-reporter: ^2.0.1
       mocha-multi-reporters: ^1.5.1
       moment: ^2.21.0
-      msgpackr: ^1.4.7
+      msgpackr: ^1.10.1
       pako: ^2.0.4
       prettier: ~3.0.3
       rimraf: ^4.4.0
@@ -4917,7 +4917,7 @@ importers:
       fastest-json-copy: 1.0.1
       lodash: 4.17.21
       lz4js: 0.2.0
-      msgpackr: 1.10.0
+      msgpackr: 1.10.1
       pako: 2.1.0
       uuid: 9.0.1
     devDependencies:
@@ -36088,8 +36088,8 @@ packages:
     dev: false
     optional: true
 
-  /msgpackr/1.10.0:
-    resolution: {integrity: sha512-rVQ5YAQDoZKZLX+h8tNq7FiHrPJoeGHViz3U4wIcykhAEpwF/nH2Vbk8dQxmpX5JavkI8C7pt4bnkJ02ZmRoUw==}
+  /msgpackr/1.10.1:
+    resolution: {integrity: sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==}
     optionalDependencies:
       msgpackr-extract: 3.0.2
     dev: false


### PR DESCRIPTION
## Description

Updates dependency to address [CVE-2023-52079](https://nvd.nist.gov/vuln/detail/CVE-2023-52079).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Component detection [flagged version 1.10.0](https://dev.azure.com/fluidframework/internal/_build/results?buildId=233730&view=logs&j=189bf95d-4688-543c-ef32-29eb64497bc0&t=6f877908-1312-595c-5922-0456f1e657b1&l=43318) (msft internal). Resolution [came with version 1.10.1](https://nvd.nist.gov/vuln/detail/CVE-2023-52079).

