### PR TITLE
refactor(tinylicious): Remove unused pnpm.overrides

### DIFF
--- a/server/routerlicious/packages/tinylicious/package.json
+++ b/server/routerlicious/packages/tinylicious/package.json
@@ -105,11 +105,5 @@
 	},
 	"engines": {
 		"node": ">=14.0.0"
-	},
-	"pnpm": {
-		"overrides": {
-			"qs": "^6.11.0",
-			"socket.io-parser": "^4.2.1"
-		}
 	}
 }


### PR DESCRIPTION
## Description

Tinylicious became part of the server/routerlicious release group [here](https://github.com/microsoft/FluidFramework/pull/17766). Since then, pnpm overrides for it are controlled by [the package.json at the root of that release group](https://github.com/microsoft/FluidFramework/blob/main/server/routerlicious/package.json#L107-L112), so tinylicious doesn't need its own anymore (they're a remnant from when it was its own release group).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).