### PR TITLE
Copy src/test to test directory for test artifacts

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -278,6 +278,7 @@ jobs:
               mkdir ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/dist/test
               tar -xvf $(Pipeline.Workspace)/test-files/${{ parameters.testFileTarName }}.test-files.tar -C $(Pipeline.Workspace)/test-files
               mv $(Pipeline.Workspace)/test-files/dist/test/* ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/dist/test
+              mv $(Pipeline.Workspace)/test-files/src/test/* ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/src/test
 
         - task: Bash@3
           displayName: Copy devDependencies


### PR DESCRIPTION
## Description

I noticed that tree's DDS fuzz tests are failing at test resolution time, since its snapshot tests assert that the snapshot directory exists and it does not. This should resolve that issue by copying the package's source files alongside its JS / source maps. Since we're already packaging the source folder, I went with this solution over e.g. something like changing the expectation that this folder exists.

For some prior context, see #12778 and #12951