### PR TITLE
test(tree): Fix anchor-undo-redo fuzz to reconstruct generator per seed

### DIFF
--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -1098,7 +1098,7 @@ export async function runTestForSeed<
 	let operationCount = 0;
 	const finalState = await performFuzzActionsAsync(
 		model.generatorFactory(),
-		(state, operation) => {
+		async (state, operation) => {
 			operationCount++;
 			return model.reducer(state, operation);
 		},

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -1095,12 +1095,20 @@ export async function runTestForSeed<
 
 	options.emitter.emit("testStart", initialState);
 
+	let operationCount = 0;
 	const finalState = await performFuzzActionsAsync(
 		model.generatorFactory(),
-		model.reducer,
+		(state, operation) => {
+			operationCount++;
+			return model.reducer(state, operation);
+		},
 		initialState,
 		saveInfo,
 	);
+
+	// Sanity-check that the generator produced at least one operation. If it failed to do so,
+	// this usually indicates an error on the part of the test author.
+	assert(operationCount > 0, "Generator should have produced at least one operation.");
 
 	options.emitter.emit("testEnd", finalState);
 

--- a/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
@@ -152,6 +152,17 @@ describe("DDS Fuzz Harness", () => {
 				assert.deepEqual(client.channel.methodCalls, ["loadCore"]);
 			}
 		});
+
+		it("throws a reasonable error if given an exhausted generator", async () => {
+			const model: Model = {
+				...baseModel,
+				generatorFactory: () => takeAsync(0, baseModel.generatorFactory()),
+			};
+			await assert.rejects(
+				runTestForSeed(model, defaultOptions, 0),
+				/Generator should have produced at least one operation/,
+			);
+		});
 	});
 
 	describe("mixinSynchronization", () => {

--- a/packages/dds/tree/src/test/shared-tree/fuzz/anchorStability.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/anchorStability.fuzz.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "assert";
-import { AsyncGenerator, takeAsync } from "@fluid-private/stochastic-test-utils";
+import { takeAsync } from "@fluid-private/stochastic-test-utils";
 import {
 	DDSFuzzModel,
 	DDSFuzzTestState,
@@ -153,7 +153,6 @@ describe("Fuzz - anchor stability", () => {
 		};
 		const generatorFactory = () =>
 			takeAsync(opsPerRun, makeOpGenerator(editGeneratorOpWeights));
-		const generator = generatorFactory() as AsyncGenerator<Operation, AnchorFuzzTestState>;
 		const model: DDSFuzzModel<
 			SharedTreeTestFactory,
 			Operation,
@@ -161,7 +160,7 @@ describe("Fuzz - anchor stability", () => {
 		> = {
 			workloadName: "anchors-undo-redo",
 			factory: new SharedTreeTestFactory(() => undefined),
-			generatorFactory: () => generator,
+			generatorFactory,
 			reducer: fuzzReducer,
 			validateConsistency: () => {},
 		};
@@ -208,7 +207,9 @@ describe("Fuzz - anchor stability", () => {
 				directory: failureDirectory,
 			},
 			idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),
-			skip: [0],
+			// TODO: AB#6664 tracks investigating and resolving.
+			// These seeds encounter issues in delta application (specifically 0x7ce and 0x7cf)
+			skip: [0, 19, 38],
 		});
 	});
 });


### PR DESCRIPTION
## Description

Previous logic constructed a single generator and re-used it across multiple seeds. Thus once it was exhausted, all subsequent tests would no-op.

This PR also adds a sanity-check in the base fuzz harness that at least one operation is run.