### PR TITLE
refactor(devtools-browser-extension): Update BackgroundConnection to take in the tabId

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/src/BackgroundConnection.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/BackgroundConnection.ts
@@ -4,7 +4,6 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { type IDisposable } from "@fluidframework/core-interfaces";
 import {
 	type IDevtoolsMessage,
 	type ISourcedDevtoolsMessage,
@@ -67,7 +66,7 @@ export interface BackgroundConnectionParameters {
  */
 export class BackgroundConnection
 	extends TypedEventEmitter<IMessageRelayEvents>
-	implements IMessageRelay, IDisposable
+	implements IMessageRelay
 {
 	/**
 	 * {@inheritDoc BackgroundConnectionParameters.messageSource}
@@ -83,18 +82,6 @@ export class BackgroundConnection
 	 * Port connection to the Background Script
 	 */
 	private backgroundServiceConnection!: TypedPortConnection;
-
-	/**
-	 * Whether or not the connection has been disposed.
-	 */
-	private _disposed: boolean = false;
-
-	/**
-	 * {@inheritDoc @fluidframework/core-interfaces#IDisposable.disposed}
-	 */
-	public get disposed(): boolean {
-		return this._disposed;
-	}
 
 	/**
 	 * Creates a new {@link BackgroundConnection}.
@@ -135,13 +122,6 @@ export class BackgroundConnection
 
 		this.logDebugMessage(`Posting message to background service:`, sourcedMessage);
 		this.backgroundServiceConnection.postMessage(sourcedMessage);
-	}
-
-	/**
-	 * {@inheritDoc @fluidframework/core-interfaces#IDisposable.dispose}
-	 */
-	public dispose(): void {
-		this._disposed = true;
 	}
 
 	/**

--- a/packages/tools/devtools/devtools-browser-extension/src/BackgroundConnection.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/BackgroundConnection.ts
@@ -96,6 +96,9 @@ export class BackgroundConnection
 		return this._disposed;
 	}
 
+	/**
+	 * Creates a new {@link BackgroundConnection}.
+	 */
 	public static async Initialize(
 		props: BackgroundConnectionParameters,
 	): Promise<BackgroundConnection> {
@@ -169,6 +172,9 @@ export class BackgroundConnection
 		return this.emitMessage(message);
 	};
 
+	/**
+	 * Emits the provided message to subscribers of the `message` event.
+	 */
 	private emitMessage(message: ISourcedDevtoolsMessage): boolean {
 		this.logDebugMessage(`Relaying message from Background Service:`, message);
 		return this.emit("message", message);

--- a/packages/tools/devtools/devtools-browser-extension/src/BackgroundConnection.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/BackgroundConnection.ts
@@ -27,8 +27,11 @@ import {
  */
 export interface BackgroundConnectionParameters {
 	/**
-	 * All messages sent through the returned instance's {@link BackgroundConnection.postMessage}
-	 * method will get this value written to their 'source' property.
+	 * This value will get written to the {@link @fluidframework/devtools-core#ISourcedDevtoolsMessage.source} property
+	 * of all messages sent via {@link BackgroundConnection.postMessage}.
+	 *
+	 * It will also be used as context metadata for console debug logging.
+	 *
 	 * @see {@link @fluidframework/devtools-core#ISourcedDevtoolsMessage}
 	 */
 	messageSource: string;

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/InitializeView.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/InitializeView.ts
@@ -8,9 +8,9 @@ import ReactDOM from "react-dom";
 
 import { DevtoolsPanel } from "@fluid-internal/devtools-view";
 
+import { BackgroundConnection } from "../BackgroundConnection";
 import { browser } from "../Globals";
 import { extensionMessageSource } from "../messaging";
-import { BackgroundConnection } from "./BackgroundConnection";
 import { formatDevtoolsScriptMessageForLogging } from "./Logging";
 import { OneDSLogger } from "./TelemetryLogging";
 

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/InitializeView.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/InitializeView.ts
@@ -8,6 +8,8 @@ import ReactDOM from "react-dom";
 
 import { DevtoolsPanel } from "@fluid-internal/devtools-view";
 
+import { browser } from "../Globals";
+import { extensionMessageSource } from "../messaging";
 import { BackgroundConnection } from "./BackgroundConnection";
 import { formatDevtoolsScriptMessageForLogging } from "./Logging";
 import { OneDSLogger } from "./TelemetryLogging";
@@ -18,7 +20,12 @@ import { OneDSLogger } from "./TelemetryLogging";
  * @param target - The element into which the devtools view will be rendered.
  */
 export async function initializeDevtoolsView(target: HTMLElement): Promise<void> {
-	const connection = await BackgroundConnection.Initialize();
+	const connection = await BackgroundConnection.Initialize({
+		// TODO: devtools-panel-specific source
+		messageSource: extensionMessageSource,
+		// The devtools panel will always be associated with this fixed tabID
+		tabId: browser.devtools.inspectedWindow.tabId,
+	});
 
 	const logger = new OneDSLogger();
 	ReactDOM.render(


### PR DESCRIPTION
Takes in the tabId, rather than always using the tabID from devtools panel context. This is in preparation for using BackgroundConnection from the context of a popup view.

Tested manually 🙂