### PR TITLE
fix(ci): Update test file spec so running memory perf tests succeeds again

### DIFF
--- a/packages/dds/map/src/test/memory/.mocharc.cjs
+++ b/packages/dds/map/src/test/memory/.mocharc.cjs
@@ -15,6 +15,6 @@ module.exports = {
 	"reporter": "@fluid-tools/benchmark/dist/MochaMemoryTestReporter.js",
 	"reporterOptions": ["reportDir=.memoryTestsOutput/"],
 	"require": ["node_modules/@fluidframework/mocha-test-setup"],
-	"spec": ["dist/test/memory/**/*.spec.cjs", "--perfMode"],
+	"spec": ["dist/test/memory/**/*.spec.*js", "--perfMode"],
 	"timeout": "60000",
 };

--- a/packages/dds/matrix/src/test/memory/.mocharc.cjs
+++ b/packages/dds/matrix/src/test/memory/.mocharc.cjs
@@ -15,6 +15,6 @@ module.exports = {
 	"reporter": "@fluid-tools/benchmark/dist/MochaMemoryTestReporter.js",
 	"reporterOptions": ["reportDir=.memoryTestsOutput/"],
 	"require": ["node_modules/@fluidframework/mocha-test-setup"],
-	"spec": ["dist/test/memory/**/*.spec.cjs", "--perfMode"],
+	"spec": ["dist/test/memory/**/*.spec.*js", "--perfMode"],
 	"timeout": "90000",
 };


### PR DESCRIPTION
## Description

In https://github.com/microsoft/FluidFramework/pull/18939 we made it so several packages went back to emitting `.js` files instead of `.cjs` files, but we missed the corresponding update in the mocha config file for memory perf tests in map and matrix. This PR applies those updates so memory perf tests run again in CI ([sample failed pipeline run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=225568&view=logs&j=12bb9097-5cdf-5833-9679-3c0d8d960191&t=aa1364aa-cafa-5827-7682-d3d7a207c906), msft internal). Went with a wildcard to support both worlds as the safer option.

@tylerbutler @jason-ha FYI, for consideration as we keep working in this space.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
