### PR TITLE
docs: Add remarks about Audience behavior when container is disconnected

### DIFF
--- a/packages/common/container-definitions/src/audience.ts
+++ b/packages/common/container-definitions/src/audience.ts
@@ -26,7 +26,10 @@ export interface IAudienceOwner extends IAudience {
 }
 
 /**
- * Audience represents all clients connected to the op stream, both read-only and read/write.
+ * Represents all clients connected to the op stream, both read-only and read/write.
+ *
+ * @remarks Access to the Audience when a container is disconnected is a tricky subject.
+ * See the remarks on specific methods for more details.
  *
  * See {@link https://nodejs.org/api/events.html#class-eventemitter | here} for an overview of the `EventEmitter`
  * class.
@@ -42,13 +45,28 @@ export interface IAudience extends EventEmitter {
 	): this;
 
 	/**
-	 * List all clients connected to the op stream, keyed off their clientId
+	 * List all clients connected to the op stream, keyed off their clientId.
+	 *
+	 * @remarks When the container is disconnected, there are no guarantees about the correctness of what this method returns.
+	 * The default implementation in Fluid Framework continues to return the list of members as it last saw it before the
+	 * container disconnected, but this could change in the future. Other implementations could decide to return an empty
+	 * list, or a list that only includes the local client.
+	 *
+	 * Note that the clientId that a disconnected container might see for itself is an old one. A disconnected container
+	 * does not technically have a clientId tied to an active connection to the service.
 	 */
 	getMembers(): Map<string, IClient>;
 
 	/**
-	 * Get details about the connected client with the specified clientId,
-	 * or undefined if the specified client isn't connected
+	 * Get details about the connected client with the specified clientId, or undefined if the specified client isn't connected.
+	 *
+	 * @remarks When the container is disconnected, there are no guarantees about the correctness of what this method returns.
+	 * The default implementation in Fluid Framework continues to return members that were part of the audience when the
+	 * container disconnected, but this could change in the future. Other implementations could decide to always return
+	 * undefined, or only return an IClient when the local client is requested.
+	 *
+	 * Note that the clientId that a disconnected container might see for itself is an old one. A disconnected container
+	 * does not technically have a clientId tied to an active connection to the service.
 	 */
 	getMember(clientId: string): IClient | undefined;
 }

--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -63,7 +63,7 @@ export class Audience extends EventEmitter implements IAudienceOwner {
 	/**
 	 * Retrieves all the members in the audience.
 	 *
-	 * @remarks When the container is disconnected, this will keep returning the audience as it last seen before the
+	 * @remarks When the container is disconnected, this will keep returning the audience as it was last seen before the
 	 * container disconnected.
 	 */
 	public getMembers(): Map<string, IClient> {

--- a/packages/loader/container-loader/src/audience.ts
+++ b/packages/loader/container-loader/src/audience.ts
@@ -61,14 +61,20 @@ export class Audience extends EventEmitter implements IAudienceOwner {
 	}
 
 	/**
-	 * Retrieves all the members in the audience
+	 * Retrieves all the members in the audience.
+	 *
+	 * @remarks When the container is disconnected, this will keep returning the audience as it last seen before the
+	 * container disconnected.
 	 */
 	public getMembers(): Map<string, IClient> {
 		return new Map(this.members);
 	}
 
 	/**
-	 * Retrieves a specific member of the audience
+	 * Retrieves a specific member of the audience.
+	 *
+	 * @remarks When the container is disconnected, this will keep returning members from the audience as it was last seen
+	 * before the container disconnected.
 	 */
 	public getMember(clientId: string): IClient | undefined {
 		return this.members.get(clientId);


### PR DESCRIPTION
## Description

Updates docs for `IAudience`/`Audience` with remarks about behavior when the container is disconnected.

This came up in a discussion about Devtools and its display of audience "history" (list of events of members joining/leaving).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

This seems correct as far as I can tell but would definitely appreciate feedback with people more familiar with this space. @ChumpChief you come to mind.