### PR TITLE
tree: Tree event system fixes

### DIFF
--- a/packages/dds/tree/src/events/events.ts
+++ b/packages/dds/tree/src/events/events.ts
@@ -197,6 +197,10 @@ export interface HasListeners<E extends Events<E>> {
  * ```
  */
 export class EventEmitter<E extends Events<E>> implements ISubscribable<E>, HasListeners<E> {
+	// TODO: because the inner data-structure here is a set, adding the same callback twice does not error,
+	// but only calls it once, and unsubscribing will stop calling it all together.
+	// This is surprising since it makes subscribing and unsubscribing not inverses (but instead both idempotent).
+	// This might be desired, but if so the documentation should indicate it.
 	private readonly listeners = new Map<keyof E, Set<(...args: unknown[]) => any>>();
 
 	// Because this is protected and not public, calling this externally (not from a subclass) makes sending events to the constructed instance impossible.
@@ -207,8 +211,12 @@ export class EventEmitter<E extends Events<E>> implements ISubscribable<E>, HasL
 		const listeners = this.listeners.get(eventName);
 		if (listeners !== undefined) {
 			const argArray: unknown[] = args; // TODO: Current TS (4.5.5) cannot spread `args` into `listener()`, but future versions (e.g. 4.8.4) can.
-			for (const listener of listeners.values()) {
-				listener(...argArray);
+			// This explicitly copies listeners so that new listeners added during this call to emit will not receive this event.
+			for (const listener of [...listeners]) {
+				// If listener has been unsubscribed while invoking other listeners, skip it.
+				if (listeners.has(listener)) {
+					listener(...argArray);
+				}
 			}
 		}
 	}
@@ -235,6 +243,10 @@ export class EventEmitter<E extends Events<E>> implements ISubscribable<E>, HasL
 	 * @param listener - the handler to run when the event is fired by the emitter
 	 * @returns a function which will deregister the listener when run.
 	 * This function will error if called more than once.
+	 * @privateRemarks
+	 * TODO:
+	 * invoking the returned callback can error even if its only called once if the same listener was provided to two calls to "on".
+	 * This behavior is not documented and its unclear if its a bug or not: see note on listeners.
 	 */
 	public on<K extends keyof Events<E>>(eventName: K, listener: E[K]): () => void {
 		getOrCreate(this.listeners, eventName, () => new Set()).add(listener);
@@ -244,6 +256,7 @@ export class EventEmitter<E extends Events<E>> implements ISubscribable<E>, HasL
 	private off<K extends keyof Events<E>>(eventName: K, listener: E[K]): void {
 		const listeners =
 			this.listeners.get(eventName) ??
+			// TODO: consider making this (and assert below) a usage error since it can be triggered by users of the public API: maybe separate those use cases somehow?
 			fail(
 				"Event has no listeners. Event deregistration functions may only be invoked once.",
 			);

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/events.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/events.spec.ts
@@ -4,16 +4,13 @@
  */
 import { strict as assert } from "assert";
 
-import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
-import { createIdCompressor } from "@fluidframework/id-compressor";
 import { FieldKinds } from "../../../feature-libraries/index.js";
 import { ForestType, SharedTreeFactory } from "../../../shared-tree/index.js";
 import { typeboxValidator } from "../../../external-utilities/index.js";
 import { SchemaBuilder, leaf } from "../../../domains/index.js";
-import { flexTreeViewWithContent } from "../../utils.js";
+import { flexTreeWithContent } from "../../utils.js";
 // eslint-disable-next-line import/no-internal-modules
 import { onNextChange } from "../../../feature-libraries/flex-tree/flexTreeTypes.js";
-import { AllowedUpdateType } from "../../../core/index.js";
 
 describe("beforeChange/afterChange events", () => {
 	const builder = new SchemaBuilder({
@@ -36,11 +33,7 @@ describe("beforeChange/afterChange events", () => {
 	});
 
 	it("fire the expected number of times", () => {
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -48,8 +41,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 
 		let rootBeforeChangeCount = 0;
 		let rootAfterChangeCount = 0;
@@ -147,11 +139,7 @@ describe("beforeChange/afterChange events", () => {
 	});
 
 	it("fire in the expected order and always together", () => {
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -159,8 +147,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 
 		let beforeCounter = 0;
 		let afterCounter = 0;
@@ -206,11 +193,7 @@ describe("beforeChange/afterChange events", () => {
 	});
 
 	it("event argument contains the expected node", () => {
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -218,8 +201,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 
 		let rootBeforeCounter = 0;
 		let rootAfterCounter = 0;
@@ -282,11 +264,7 @@ describe("beforeChange/afterChange events", () => {
 	});
 
 	it("listeners can be removed successfully", () => {
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -294,8 +272,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 
 		let beforeHasFired = false;
 		let afterHasFired = false;
@@ -334,11 +311,7 @@ describe("beforeChange/afterChange events", () => {
 
 	it("tree is in correct state when events fire - primitive node deletions", () => {
 		const initialNumber = 20;
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: initialNumber,
@@ -346,8 +319,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 
 		let totalListenerCalls = 0;
 
@@ -365,11 +337,7 @@ describe("beforeChange/afterChange events", () => {
 	});
 
 	it("tree is in correct state when events fire - primitive node additions", () => {
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -377,8 +345,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 
 		const newNumber = 20;
 
@@ -398,11 +365,7 @@ describe("beforeChange/afterChange events", () => {
 	});
 
 	it("tree is in correct state when events fire - primitive node replacements", () => {
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -410,8 +373,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 		let totalListenerCalls = 0;
 		const newString = "John";
 
@@ -429,11 +391,7 @@ describe("beforeChange/afterChange events", () => {
 	});
 
 	it("tree is in correct state when events fire - node inserts to sequence fields", () => {
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -441,8 +399,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 
 		let totalListenerCalls = 0;
 
@@ -494,11 +451,7 @@ describe("beforeChange/afterChange events", () => {
 	});
 
 	it("tree is in correct state when events fire - node removals from sequence fields", () => {
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -506,8 +459,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 
 		let totalListenerCalls = 0;
 
@@ -537,11 +489,7 @@ describe("beforeChange/afterChange events", () => {
 	});
 
 	it("tree is in correct state when events fire - node moves in sequence fields", () => {
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -549,8 +497,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 
 		let totalListenerCalls = 0;
 
@@ -612,11 +559,7 @@ describe("beforeChange/afterChange events", () => {
 	});
 
 	it("not emitted by nodes when they are replaced", () => {
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -624,8 +567,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 
 		let beforeCounter = 0;
 		let afterCounter = 0;
@@ -645,11 +587,7 @@ describe("beforeChange/afterChange events", () => {
 	});
 
 	it("bubble up from the affected node to the root", () => {
-		const tree = factory.create(
-			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-			"the tree",
-		);
-		const root = tree.schematizeInternal({
+		const root = flexTreeWithContent({
 			initialTree: {
 				myString: "initial string",
 				myOptionalNumber: undefined,
@@ -657,8 +595,7 @@ describe("beforeChange/afterChange events", () => {
 				child: { myInnerString: "initial string in child" },
 			},
 			schema,
-			allowedSchemaModifications: AllowedUpdateType.None,
-		}).flexTree.content;
+		}).content;
 
 		let rootBeforeCounter = 0;
 		let rootAfterCounter = 0;
@@ -702,8 +639,7 @@ describe("onNextChange event", () => {
 	const initialTree = { content: 3 };
 
 	it("fires exactly once after a change", () => {
-		const view = flexTreeViewWithContent({ schema, initialTree });
-		const editNode = view.flexTree.content;
+		const editNode = flexTreeWithContent({ schema, initialTree }).content;
 		let onNextChangeCount = 0;
 		editNode[onNextChange](() => (onNextChangeCount += 1));
 		assert(editNode.is(object));
@@ -714,16 +650,14 @@ describe("onNextChange event", () => {
 	});
 
 	it("can have at most one listener at a time", () => {
-		const view = flexTreeViewWithContent({ schema, initialTree });
-		const editNode = view.flexTree.content;
+		const editNode = flexTreeWithContent({ schema, initialTree }).content;
 		let onNextChangeEventCount = 0;
 		editNode[onNextChange](() => (onNextChangeEventCount += 1));
 		assert.throws(() => editNode[onNextChange](() => (onNextChangeEventCount += 1)));
 	});
 
 	it("can be subscribed to again after throwing and catching an error", () => {
-		const view = flexTreeViewWithContent({ schema, initialTree });
-		const editNode = view.flexTree.content;
+		const editNode = flexTreeWithContent({ schema, initialTree }).content;
 		assert(editNode.is(object));
 		editNode[onNextChange](() => {
 			throw new Error();
@@ -733,8 +667,7 @@ describe("onNextChange event", () => {
 	});
 
 	it("can be unsubscribed from", () => {
-		const view = flexTreeViewWithContent({ schema, initialTree });
-		const editNode = view.flexTree.content;
+		const editNode = flexTreeWithContent({ schema, initialTree }).content;
 		assert(editNode.is(object));
 		let onNextChangeEventFired = false;
 		const off = editNode[onNextChange](() => {
@@ -746,8 +679,7 @@ describe("onNextChange event", () => {
 	});
 
 	it("unsubscription has no effect if the event has already fired", () => {
-		const view = flexTreeViewWithContent({ schema, initialTree });
-		const editNode = view.flexTree.content;
+		const editNode = flexTreeWithContent({ schema, initialTree }).content;
 		assert(editNode.is(object));
 		const off = editNode[onNextChange](() => {});
 		editNode.content = 7;


### PR DESCRIPTION
## Description

Tidy up flex tree events tests: no need for them to involve SharedTree instances, schematize, fluid etc.

Fix and test adding of new event subscriptions while an event is running.

Document multiple subscription oddness in API.

## Breaking Changes

Any code which subscribed to a tree event inside of a callback for that same event will no longer get invoked for the currently processing event, but will still get invoked if the event is triggered reentrantly.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

