### PR TITLE
Disable minCompatVersion tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/aliasWithProps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/aliasWithProps.spec.ts
@@ -77,7 +77,7 @@ class RuntimeFactoryWithProps extends BaseContainerRuntimeFactory {
 	}
 }
 
-describeCompat("HotSwap", "2.0.0-rc.1.0.0", (getTestObjectProvider) => {
+describeCompat("HotSwap", "NoCompat", (getTestObjectProvider) => {
 	// Registry -----------------------------------------
 	const childDataObjectFactory = new DataObjectFactory("Child", TestDataObject, [], {});
 	const dataObjectFactory = new DataObjectFactory("Test", TestDataObject, [], {}, [

--- a/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachRegisterLocalApiTests.spec.ts
@@ -24,7 +24,7 @@ import { describeCompat } from "@fluid-private/test-version-utils";
 // REVIEW: enable compat testing?
 describeCompat(
 	`Attach/Reference Api Tests For Attached Container`,
-	"2.0.0-internal.8.0.0",
+	"NoCompat" /* 2.0.0-internal.8.0.0 */,
 	(getTestObjectProvider, apis) => {
 		const { SharedMap } = apis.dds;
 		const codeDetails: IFluidCodeDetails = {

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -255,7 +255,9 @@ function createCompatDescribe(): DescribeCompat {
 			case "NoCompat":
 				return createCompatSuite(tests, [CompatKind.None]);
 			default:
-				return createCompatSuite(tests, undefined, compatVersion);
+				throw new Error(`compatVersion ${compatVersion} not supported`);
+				// TODO: https://dev.azure.com/fluidframework/internal/_workitems/edit/7089
+				// return createCompatSuite(tests, undefined, compatVersion);
 		}
 	};
 	const d: DescribeCompat = (name: string, compatVersion: string, tests) =>

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -256,8 +256,8 @@ function createCompatDescribe(): DescribeCompat {
 				return createCompatSuite(tests, [CompatKind.None]);
 			default:
 				throw new Error(`compatVersion ${compatVersion} not supported`);
-				// TODO: https://dev.azure.com/fluidframework/internal/_workitems/edit/7089
-				// return createCompatSuite(tests, undefined, compatVersion);
+			// TODO: https://dev.azure.com/fluidframework/internal/_workitems/edit/7089
+			// return createCompatSuite(tests, undefined, compatVersion);
 		}
 	};
 	const d: DescribeCompat = (name: string, compatVersion: string, tests) =>

--- a/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
+++ b/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
@@ -8,7 +8,7 @@ import { execSync } from "child_process";
 import { CompatKind } from "../../compatOptions.cjs";
 import { isCompatVersionBelowMinVersion } from "../compatConfig.js";
 
-describe("Minimum Compat Version", () => {
+describe.skip("Minimum Compat Version", () => {
 	const allVersionsFromNpm = execSync(`npm show fluid-framework versions --json`, {
 		encoding: "utf-8",
 	});


### PR DESCRIPTION
Related https://dev.azure.com/fluidframework/internal/_workitems/edit/7089
No reason to have these tests enabled given that we disabled specifying minVersion in tests suites. Will bring them back once the issue is fixed
It also prevents people to use minVersion in our test suites