### PR TITLE
fix(ci): Fix artifact name so bundle analysis comparison in PRs works again

### DIFF
--- a/tools/pipelines/templates/1ES/build-npm-package.yml
+++ b/tools/pipelines/templates/1ES/build-npm-package.yml
@@ -574,7 +574,7 @@ extends:
                       displayName: Publish Artifacts - bundle-analysis
                       condition: and( succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(${{ parameters.taskPublishBundleSizeArtifacts }}, true) )
                       targetPath: $(Build.ArtifactStagingDirectory)/bundleAnalysis
-                      artifactname: bundleAnalysis
+                      artifactName: bundleAnalysis
                       sbomEnabled: false
                       publishLocation: pipeline
 


### PR DESCRIPTION
## Description

While migrating the pipelines to 1ES templates, we introduced a typo in a yml parameter name that is causing the artifact name for bundle sizes to be `drop` instead of the desired `bundleAnalysis` (e.g. [here](https://dev.azure.com/fluidframework/public/_build/results?buildId=233963&view=artifacts&pathAsName=false&type=publishedArtifacts), compared to [here](https://dev.azure.com/fluidframework/public/_build/results?buildId=233885&view=artifacts&pathAsName=false&type=publishedArtifacts) from a pipeline run from a branch that didn't go through the 1ES migration). That is causing the step that does bundle size comparison and posts the results to PR to fail because [it's still trying to use `bundleAnalysis` as artifact name and not finding anything](https://dev.azure.com/fluidframework/public/_build/results?buildId=233969&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=6404bed1-a7ff-5510-6b6f-9b783bc7f5ae&l=41).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
