### PR TITLE
refactor: Add hostRequirements section to devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,5 +44,12 @@
 		// using this file to develop in a local container.
 		// "azure-cli": "latest",  // DO NOT UNCOMMENT
 		// "github-cli": "latest", // DO NOT UNCOMMENT
+	},
+
+	// Setting this so Codespaces default settings use it. It's not really *required*, but a clean build
+	// can be lengthy enough that it's convenient.
+	"hostRequirements": {
+		"cpus": 16,
+		"memory": "64gb"
 	}
 }


### PR DESCRIPTION
## Description

Add a `hostRequirements` section to our devcontainer.json file, just so Codespaces defaults to those settings when creating a new instance. Per [the docs](https://containers.dev/implementors/json_reference/#min-host-reqs), this won't block different configurations from working, cloud services might just present warnings if spinning up the container with fewer resources.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Curious if anyone has concerns about this. I know some people don't create many new codespaces, they just use git worktrees inside a single one. Not sure how many of us frequently-ish spin up brand new codespaces and how annoyed we are to have to change the default settings when doing it from the Github UI :)