### PR TITLE
build(example-utils): Add explicit return type to getter

### DIFF
--- a/examples/utils/example-utils/api-report/example-utils.api.md
+++ b/examples/utils/example-utils/api-report/example-utils.api.md
@@ -191,7 +191,7 @@ export class MigrationTool extends DataObject implements IMigrationTool {
     // (undocumented)
     protected initializingFirstTime(): Promise<void>;
     // (undocumented)
-    get migrationState(): "collaborating" | "stopping" | "migrating" | "migrated";
+    get migrationState(): MigrationState;
     // (undocumented)
     get newContainerId(): string | undefined;
     // (undocumented)

--- a/examples/utils/example-utils/src/migrationTool/migrationTool.ts
+++ b/examples/utils/example-utils/src/migrationTool/migrationTool.ts
@@ -12,7 +12,7 @@ import {
 	IConsensusRegisterCollection,
 } from "@fluidframework/register-collection";
 
-import type { IMigrationTool } from "../migrationInterfaces/index.js";
+import type { IMigrationTool, MigrationState } from "../migrationInterfaces/index.js";
 
 const pactMapKey = "pact-map";
 const crcKey = "crc";
@@ -50,7 +50,7 @@ export class MigrationTool extends DataObject implements IMigrationTool {
 		return this._taskManager;
 	}
 
-	public get migrationState() {
+	public get migrationState(): MigrationState {
 		if (this.newContainerId !== undefined) {
 			return "migrated";
 		} else if (this.acceptedVersion !== undefined) {


### PR DESCRIPTION
api-extractor/typescript do not guarantee that the emitted order of an _inferred_ string-literal union type is stable. This can lead to "flip-flopping" where api-extractor sometimes emits `"foo" | "bar"` and sometimes `"bar" | "foo"`.

Adding explicit types instead of relying on inference is the best workaround. In this case there was already an exported type defined so I used that instead of an explicit literal union.
