### PR TITLE
Deprecate LazyLoadedDataObject and convert remaining use to DataObject, fixing demos

### DIFF
--- a/.changeset/wicked-views-remain.md
+++ b/.changeset/wicked-views-remain.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/data-object-base": minor
+---
+
+LazyLoadedDataObject and LazyLoadedDataObjectFactory deprecated
+
+LazyLoadedDataObject and LazyLoadedDataObjectFactory have been deprecated and are not recommended for use. For lazy loading of data objects, prefer to defer dereferencing their handles.

--- a/examples/data-objects/webflow/src/document/index.ts
+++ b/examples/data-objects/webflow/src/document/index.ts
@@ -3,22 +3,15 @@
  * Licensed under the MIT License.
  */
 
+import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/core-utils";
 import { IEvent, IFluidHandle } from "@fluidframework/core-interfaces";
-import {
-	LazyLoadedDataObject,
-	LazyLoadedDataObjectFactory,
-} from "@fluidframework/data-object-base";
 import {
 	createDetachedLocalReferencePosition,
 	createRemoveRangeOp,
 	IMergeTreeRemoveMsg,
 	refGetTileLabels,
 } from "@fluidframework/merge-tree";
-import {
-	IFluidDataStoreContext,
-	IFluidDataStoreFactory,
-} from "@fluidframework/runtime-definitions";
 import {
 	SharedString,
 	SharedStringSegment,
@@ -34,7 +27,6 @@ import {
 	reservedTileLabelsKey,
 	TextSegment,
 } from "@fluidframework/sequence";
-import { ISharedDirectory, SharedDirectory } from "@fluidframework/map";
 import { clamp, TagName, TokenList } from "../util/index.js";
 import { IHTMLAttributes } from "../util/attr.js";
 import { documentType } from "../package.js";
@@ -142,20 +134,16 @@ const textId = "text";
 /**
  * @internal
  */
-export class FlowDocument extends LazyLoadedDataObject<ISharedDirectory, IFlowDocumentEvents> {
-	private static readonly factory = new LazyLoadedDataObjectFactory<FlowDocument>(
+export class FlowDocument extends DataObject {
+	private static readonly factory = new DataObjectFactory<FlowDocument>(
 		documentType,
 		FlowDocument,
-		/* root: */ SharedDirectory.getFactory(),
 		[SharedString.getFactory()],
+		{},
 	);
 
-	public static getFactory(): IFluidDataStoreFactory {
+	public static getFactory() {
 		return FlowDocument.factory;
-	}
-
-	public static async create(parentContext: IFluidDataStoreContext, props?: any) {
-		return FlowDocument.factory.create(parentContext, props);
 	}
 
 	public get length() {
@@ -172,16 +160,21 @@ export class FlowDocument extends LazyLoadedDataObject<ISharedDirectory, IFlowDo
 
 	private sharedString: SharedString;
 
-	public create() {
+	protected async initializingFirstTime(props?: any): Promise<void> {
 		// For 'findTile(..)', we must enable tracking of left/rightmost tiles:
 		Object.assign(this.runtime, { options: { ...(this.runtime.options || {}) } });
 
 		this.sharedString = SharedString.create(this.runtime);
 		this.root.set(textId, this.sharedString.handle);
-		this.forwardEvent(this.sharedString, "sequenceDelta", "maintenance");
+		this.sharedString.on("sequenceDelta", (event, target) => {
+			this.emit("sequenceDelta", event, target);
+		});
+		this.sharedString.on("maintenance", (event, target) => {
+			this.emit("maintenance", event, target);
+		});
 	}
 
-	public async load() {
+	protected async initializingFromExisting(): Promise<void> {
 		// For 'findTile(..)', we must enable tracking of left/rightmost tiles:
 		Object.assign(this.runtime, { options: { ...(this.runtime.options || {}) } });
 
@@ -190,7 +183,12 @@ export class FlowDocument extends LazyLoadedDataObject<ISharedDirectory, IFlowDo
 			throw new Error("String not initialized properly");
 		}
 		this.sharedString = await handle.get();
-		this.forwardEvent(this.sharedString, "sequenceDelta", "maintenance");
+		this.sharedString.on("sequenceDelta", (event, target) => {
+			this.emit("sequenceDelta", event, target);
+		});
+		this.sharedString.on("maintenance", (event, target) => {
+			this.emit("maintenance", event, target);
+		});
 	}
 
 	public async getComponentFromMarker(marker: Marker) {

--- a/experimental/PropertyDDS/examples/partial-checkout/src/dataObject.ts
+++ b/experimental/PropertyDDS/examples/partial-checkout/src/dataObject.ts
@@ -4,20 +4,16 @@
  */
 
 import { EventEmitter } from "events";
+import { SharedPropertyTree, PropertyTreeFactory } from "@fluid-experimental/property-dds";
+import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { IDirectory, IValueChanged } from "@fluidframework/map";
 import {
 	IFluidDataStoreContext,
 	IFluidDataStoreFactory,
 } from "@fluidframework/runtime-definitions";
-import { IFluidHandle, IRequest, IResponse } from "@fluidframework/core-interfaces";
-import { SharedPropertyTree, PropertyTreeFactory } from "@fluid-experimental/property-dds";
-import { IDirectory, ISharedDirectory, IValueChanged, SharedDirectory } from "@fluidframework/map";
 
-import {
-	LazyLoadedDataObject,
-	LazyLoadedDataObjectFactory,
-} from "@fluidframework/data-object-base";
 import { BaseProperty, NodeProperty } from "@fluid-experimental/property-properties";
-import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 
 export interface IPropertyTree extends EventEmitter {
 	pset: NodeProperty;
@@ -57,10 +53,8 @@ const directoryWait = async <T = any>(directory: IDirectory, key: string): Promi
 /**
  * The DiceRoller is our data object that implements the IDiceRoller interface.
  */
-export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> implements IPropertyTree {
+export class PropertyTree extends DataObject implements IPropertyTree {
 	private _tree?: SharedPropertyTree;
-	private _queryString: string | undefined;
-	private _existing: boolean = false;
 
 	stopTransmission(stopped: boolean): void {
 		this._tree?.stopTransmission(stopped);
@@ -77,18 +71,10 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
 				this.root,
 				propertyKey,
 			);
-			if (this._queryString !== undefined) {
-				// The absolutePath of the DDS should not be updated. Instead, a new handle can be created with the new
-				// path. To be fixed with this issue - https://github.com/microsoft/FluidFramework/issues/6036
-				(treeHandle as any).absolutePath += `?${this._queryString}`;
-			}
 			this._tree = await treeHandle.get();
 		} else {
 			if (this._tree === undefined) {
-				this.root.set(
-					propertyKey,
-					SharedPropertyTree.create(this.runtime, undefined, this._queryString).handle,
-				);
+				this.root.set(propertyKey, SharedPropertyTree.create(this.runtime).handle);
 				this._tree = await this.root
 					.get<IFluidHandle<SharedPropertyTree>>(propertyKey)
 					?.get();
@@ -98,6 +84,14 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
 		this.tree.on("localModification", (changeSet: any) => {
 			this.emit("changeSetModified", changeSet);
 		});
+	}
+
+	protected async initializingFirstTime(props?: any): Promise<void> {
+		return this.initialize(false);
+	}
+
+	protected async initializingFromExisting(): Promise<void> {
+		return this.initialize(true);
 	}
 
 	public get tree() {
@@ -123,38 +117,15 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
 		// return PropertyTreeRoot.factory.create(parentContext, props);
 		throw new Error("Not yet implemented");
 	}
-
-	public create() {
-		/* this.initialize(false); */
-		console.log("A");
-	}
-	public async load(
-		_context: IFluidDataStoreContext,
-		_runtime: IFluidDataStoreRuntime,
-		existing: boolean,
-	) {
-		this._existing = existing;
-		/* this.initialize(true); */
-		console.log("B");
-	}
-
-	public async request(request: IRequest): Promise<IResponse> {
-		const url = request.url;
-		console.log(url);
-		this._queryString = url.split("?")[1];
-		await this.initialize(this._existing);
-		return super.request(request);
-	}
 }
 
 /**
  * The DataObjectFactory is used by Fluid Framework to instantiate our DataObject.  We provide it with a unique name
  * and the constructor it will call.  In this scenario, the third and fourth arguments are not used.
  */
-export const PropertyTreeInstantiationFactory = new LazyLoadedDataObjectFactory<PropertyTree>(
+export const PropertyTreeInstantiationFactory = new DataObjectFactory<PropertyTree>(
 	"property-tree",
 	PropertyTree,
-	SharedDirectory.getFactory(),
 	[new PropertyTreeFactory()],
-	[],
+	{},
 );

--- a/experimental/PropertyDDS/examples/property-inspector/src/dataObject.ts
+++ b/experimental/PropertyDDS/examples/property-inspector/src/dataObject.ts
@@ -4,20 +4,12 @@
  */
 
 import { EventEmitter } from "events";
-import {
-	IFluidDataStoreContext,
-	IFluidDataStoreFactory,
-} from "@fluidframework/runtime-definitions";
-import { IFluidHandle, IRequest, IResponse } from "@fluidframework/core-interfaces";
-import { SharedPropertyTree, PropertyTreeFactory } from "@fluid-experimental/property-dds";
-import { IDirectory, ISharedDirectory, IValueChanged, SharedDirectory } from "@fluidframework/map";
-
-import {
-	LazyLoadedDataObject,
-	LazyLoadedDataObjectFactory,
-} from "@fluidframework/data-object-base";
 import { BaseProperty } from "@fluid-experimental/property-properties";
-import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
+import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { IDirectory, IValueChanged } from "@fluidframework/map";
+import { SharedPropertyTree, PropertyTreeFactory } from "@fluid-experimental/property-dds";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 
 export interface IPropertyTree extends EventEmitter {
 	pset: any;
@@ -57,10 +49,8 @@ const directoryWait = async <T = any>(directory: IDirectory, key: string): Promi
 /**
  * The DiceRoller is our data object that implements the IDiceRoller interface.
  */
-export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> implements IPropertyTree {
+export class PropertyTree extends DataObject implements IPropertyTree {
 	private _tree?: SharedPropertyTree;
-	private _queryString: string | undefined;
-	private _existing: boolean = false;
 
 	stopTransmission(stopped: boolean): void {
 		this._tree?.stopTransmission(stopped);
@@ -77,18 +67,10 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
 				this.root,
 				propertyKey,
 			);
-			if (this._queryString !== undefined) {
-				// The absolutePath of the DDS should not be updated. Instead, a new handle can be created with the new
-				// path. To be fixed with this issue - https://github.com/microsoft/FluidFramework/issues/6036
-				(treeHandle as any).absolutePath += `?${this._queryString}`;
-			}
 			this._tree = await treeHandle.get();
 		} else {
 			if (this._tree === undefined) {
-				this.root.set(
-					propertyKey,
-					SharedPropertyTree.create(this.runtime, undefined, this._queryString).handle,
-				);
+				this.root.set(propertyKey, SharedPropertyTree.create(this.runtime).handle);
 				this._tree = await this.root
 					.get<IFluidHandle<SharedPropertyTree>>(propertyKey)
 					?.get();
@@ -98,6 +80,14 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
 		this.tree.on("localModification", (changeSet: any) => {
 			this.emit("changeSetModified", changeSet);
 		});
+	}
+
+	protected async initializingFirstTime(props?: any): Promise<void> {
+		return this.initialize(false);
+	}
+
+	protected async initializingFromExisting(): Promise<void> {
+		return this.initialize(true);
 	}
 
 	public get tree() {
@@ -116,35 +106,10 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
 	resolvePath(path: string, options: any): BaseProperty | undefined {
 		return this.tree.root.resolvePath(path, options);
 	}
-	public static getFactory(): IFluidDataStoreFactory {
-		return PropertyTreeInstantiationFactory;
-	}
 
 	public static async create(parentContext: IFluidDataStoreContext, props?: any) {
 		// return PropertyTreeRoot.factory.create(parentContext, props);
 		throw new Error("Not yet implemented");
-	}
-
-	public create() {
-		/* this.initialize(false); */
-		console.log("A");
-	}
-	public async load(
-		_context: IFluidDataStoreContext,
-		_runtime: IFluidDataStoreRuntime,
-		existing: boolean,
-	) {
-		this._existing = existing;
-		/* this.initialize(true); */
-		console.log("B");
-	}
-
-	public async request(request: IRequest): Promise<IResponse> {
-		const url = request.url;
-		console.log(url);
-		this._queryString = url.split("?")[1];
-		await this.initialize(this._existing);
-		return super.request(request);
 	}
 }
 
@@ -152,10 +117,9 @@ export class PropertyTree extends LazyLoadedDataObject<ISharedDirectory> impleme
  * The DataObjectFactory is used by Fluid Framework to instantiate our DataObject.  We provide it with a unique name
  * and the constructor it will call.  In this scenario, the third and fourth arguments are not used.
  */
-export const PropertyTreeInstantiationFactory = new LazyLoadedDataObjectFactory<PropertyTree>(
+export const PropertyTreeInstantiationFactory = new DataObjectFactory<PropertyTree>(
 	"property-tree",
 	PropertyTree,
-	SharedDirectory.getFactory(),
 	[new PropertyTreeFactory()],
-	[],
+	{},
 );

--- a/packages/framework/data-object-base/api-report/data-object-base.api.md
+++ b/packages/framework/data-object-base/api-report/data-object-base.api.md
@@ -26,7 +26,7 @@ import { ISharedObjectRegistry } from '@fluidframework/datastore';
 import { RuntimeFactoryHelper } from '@fluidframework/runtime-utils';
 import { RuntimeRequestHandler } from '@fluidframework/request-handler';
 
-// @internal (undocumented)
+// @internal @deprecated (undocumented)
 export abstract class LazyLoadedDataObject<TRoot extends ISharedObject = ISharedObject, TEvents extends IEvent = IEvent> extends EventForwarder<TEvents> implements IFluidLoadable, IProvideFluidHandle {
     constructor(context: IFluidDataStoreContext, runtime: IFluidDataStoreRuntime, root: ISharedObject);
     // (undocumented)
@@ -51,7 +51,7 @@ export abstract class LazyLoadedDataObject<TRoot extends ISharedObject = IShared
     protected readonly runtime: IFluidDataStoreRuntime;
 }
 
-// @internal (undocumented)
+// @internal @deprecated (undocumented)
 export class LazyLoadedDataObjectFactory<T extends LazyLoadedDataObject> implements IFluidDataStoreFactory {
     constructor(type: string, ctor: new (context: IFluidDataStoreContext, runtime: IFluidDataStoreRuntime, root: ISharedObject) => T, root: IChannelFactory, sharedObjects?: readonly IChannelFactory[], storeFactories?: readonly IFluidDataStoreFactory[]);
     // (undocumented)

--- a/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObject.ts
@@ -20,6 +20,7 @@ import { create404Response } from "@fluidframework/runtime-utils";
 
 /**
  * @internal
+ * @deprecated Not recommended for use.  For lazy loading of data objects, prefer to defer dereferencing their handles.
  */
 export abstract class LazyLoadedDataObject<
 		TRoot extends ISharedObject = ISharedObject,

--- a/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
+++ b/packages/framework/data-object-base/src/lazyLoadedDataObjectFactory.ts
@@ -22,11 +22,14 @@ import {
 	type IChannelFactory,
 } from "@fluidframework/datastore-definitions";
 import { type ISharedObject } from "@fluidframework/shared-object-base";
+// eslint-disable-next-line import/no-deprecated
 import { type LazyLoadedDataObject } from "./lazyLoadedDataObject";
 
 /**
  * @internal
+ * @deprecated Not recommended for use.  For lazy loading of data objects, prefer to defer dereferencing their handles.
  */
+// eslint-disable-next-line import/no-deprecated
 export class LazyLoadedDataObjectFactory<T extends LazyLoadedDataObject>
 	implements IFluidDataStoreFactory
 {


### PR DESCRIPTION
The three demos that use LazyLoadedDataObject are broken in main currently (I believe at least the PropertyDDS ones were probably broken as part of the entrypoint work, since they rely on request() to complete initialization).  Additionally, the LazyLoadedDataObject class doesn't seem particularly useful since a similar effect can probably be achieved by deferring handle access.  Because of the broken behavior, alternate option, usage of deprecated request() pattern, and usage of EventForwarder which we also want to remove, I think it's best to deprecate and remove it.

This change converts the three broken demos to use DataObject which fixes them, and deprecates LazyLoadedDataObject.

AB#4863