### PR TITLE
create shared documentLambda checkpoint resource

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambda.ts
@@ -75,7 +75,8 @@ import {
 	createRoomJoinMessage,
 	createRoomLeaveMessage,
 	CheckpointReason,
-	ICheckpoint,
+	DocumentCheckpointManager,
+	IDocumentCheckpointManager,
 	IServerMetadata,
 } from "../utils";
 import { CheckpointContext } from "./checkpointContext";
@@ -268,12 +269,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 	/**
 	 * Used for controlling checkpoint logic
 	 */
-	private readonly checkpointInfo: ICheckpoint = {
-		lastCheckpointTime: Date.now(),
-		rawMessagesSinceCheckpoint: 0,
-	};
-
-	private noActiveClients: boolean;
+	private readonly documentCheckpointManager: IDocumentCheckpointManager =
+		new DocumentCheckpointManager(true /* createIdleTimer */);
 
 	private globalCheckpointOnly: boolean;
 
@@ -357,8 +354,10 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 		this.successfullyStartedLambdas = lastCheckpoint.successfullyStartedLambdas ?? [];
 
 		const msn = this.clientSeqManager.getMinimumSequenceNumber();
-		this.noActiveClients = msn === -1;
-		this.minimumSequenceNumber = this.noActiveClients ? this.sequenceNumber : msn;
+		this.documentCheckpointManager.noActiveClients = msn === -1;
+		this.minimumSequenceNumber = this.documentCheckpointManager.noActiveClients
+			? this.sequenceNumber
+			: msn;
 
 		if (this.serviceConfiguration.deli.summaryNackMessages.checkOnStartup) {
 			this.checkNackMessagesState();
@@ -449,14 +448,14 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 				databaseLastOffset: this.logOffset,
 			});
 
-			this.updateCheckpointMessages(rawMessage);
+			this.documentCheckpointManager.updateCheckpointMessages(rawMessage);
 			try {
 				if (
-					this.checkpointInfo.currentKafkaCheckpointMessage &&
+					this.documentCheckpointManager.checkpointInfo.currentKafkaCheckpointMessage &&
 					this.serviceConfiguration.deli.kafkaCheckpointOnReprocessingOp
 				) {
 					this.context.checkpoint(
-						this.checkpointInfo.currentKafkaCheckpointMessage,
+						this.documentCheckpointManager.checkpointInfo.currentKafkaCheckpointMessage,
 						this.serviceConfiguration.deli.restartOnCheckpointFailure,
 					);
 				}
@@ -513,7 +512,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 							ticketedMessage.type === MessageType.NoClient ||
 							ticketedMessage.type === MessageType.Control
 						) &&
-						this.noActiveClients &&
+						this.documentCheckpointManager.noActiveClients &&
 						!this.serviceConfiguration.deli.disableNoClientMessage
 					) {
 						this.lastNoClientP = this.sendToRawDeltas(
@@ -652,8 +651,8 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 			this.produceMessages(this.deltasProducer, produceToDeltas, rawMessage);
 		}
 
-		this.checkpointInfo.rawMessagesSinceCheckpoint++;
-		this.updateCheckpointMessages(rawMessage);
+		this.documentCheckpointManager.checkpointInfo.rawMessagesSinceCheckpoint++;
+		this.documentCheckpointManager.updateCheckpointMessages(rawMessage);
 
 		if (this.lastMessageType === MessageType.ClientJoin) {
 			this.recievedNoClientOp = false;
@@ -672,7 +671,10 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 			// checkpoint the current up to date state
 			this.checkpoint(checkpointReason, this.globalCheckpointOnly);
 		} else {
-			this.updateCheckpointIdleTimer(this.globalCheckpointOnly);
+			this.documentCheckpointManager.updateCheckpointIdleTimer(
+				this.serviceConfiguration.deli.checkpointHeuristics.idleTime,
+				this.idleTimeCheckpoint,
+			);
 		}
 
 		// Start a timer to check inactivity on the document. To trigger idle client leave message,
@@ -726,7 +728,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 		this.clearActivityIdleTimer();
 		this.clearReadClientIdleTimer();
 		this.clearNoopConsolidationTimer();
-		this.clearCheckpointIdleTimer();
+		this.documentCheckpointManager.clearCheckpointIdleTimer();
 		this.clearOpIdleTimer();
 		this.clearOpMaxTimeTimer();
 
@@ -1113,10 +1115,10 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 		const msn = this.clientSeqManager.getMinimumSequenceNumber();
 		if (msn === -1) {
 			this.minimumSequenceNumber = sequenceNumber;
-			this.noActiveClients = true;
+			this.documentCheckpointManager.noActiveClients = true;
 		} else {
 			this.minimumSequenceNumber = msn;
-			this.noActiveClients = false;
+			this.documentCheckpointManager.noActiveClients = false;
 		}
 
 		let sendType = SendType.Immediate;
@@ -1157,7 +1159,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 			 */
 			case MessageType.NoClient: {
 				// Only rev if no clients have shown up since last noClient was sent to alfred.
-				if (this.noActiveClients) {
+				if (this.documentCheckpointManager.noActiveClients) {
 					sequenceNumber = this.revSequenceNumber();
 					message.operation.referenceSequenceNumber = sequenceNumber;
 					this.minimumSequenceNumber = sequenceNumber;
@@ -1192,7 +1194,10 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 						if (dsn >= this.durableSequenceNumber) {
 							// Deli cache is only cleared when no clients have
 							// joined since last noClient was sent to alfred
-							if (controlContents.clearCache && this.noActiveClients) {
+							if (
+								controlContents.clearCache &&
+								this.documentCheckpointManager.noActiveClients
+							) {
 								instruction = InstructionType.ClearCache;
 								const deliCacheMsg = `Deli cache will be cleared`;
 								this.context.log?.info(deliCacheMsg, {
@@ -1703,44 +1708,16 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 	}
 
 	/**
-	 * The deli checkpoint is based on rawMessage
-	 * The kafka checkpoint is based on kafkaCheckpointMessage if clients exist
-	 * This keeps the kafka checkpoint behind by 1 message until there are no active clients
-	 * It ensures that the idle timer and subsequent leave & NoClient messages are created
-	 * If noActiveClients is set, that means we sent a NoClient message. so checkpoint the current offset
-	 */
-	private updateCheckpointMessages(rawMessage: IQueuedMessage) {
-		this.checkpointInfo.currentCheckpointMessage = rawMessage;
-
-		if (this.noActiveClients) {
-			// If noActiveClients is set, that means we sent a NoClient message
-			// so we should checkpoint the current message/offset
-
-			// we need to explicitly set nextKafkaCheckpointMessage to undefined!
-			// because once we checkpoint the current message, DocumentContext.hasPendingWork() will be false
-			// that means that the partition will keep checkpointing since this lambda is up to date
-			// if we don't clear nextKafkaCheckpointMessage,
-			// it will try to checkpoint that old message offset once the next message arrives
-			this.checkpointInfo.nextKafkaCheckpointMessage = undefined;
-
-			this.checkpointInfo.currentKafkaCheckpointMessage = rawMessage;
-		} else {
-			// Keep the kafka checkpoint behind by 1 message until there are no active clients
-			const kafkaCheckpointMessage = this.checkpointInfo.nextKafkaCheckpointMessage;
-			this.checkpointInfo.nextKafkaCheckpointMessage = rawMessage;
-			this.checkpointInfo.currentKafkaCheckpointMessage = kafkaCheckpointMessage;
-		}
-	}
-
-	/**
 	 * Generates a checkpoint for the current state
 	 */
 	private generateCheckpoint(reason: CheckpointReason): ICheckpointParams {
 		return {
 			reason,
 			deliState: this.generateDeliCheckpoint(),
-			deliCheckpointMessage: this.checkpointInfo.currentCheckpointMessage as IQueuedMessage,
-			kafkaCheckpointMessage: this.checkpointInfo.currentKafkaCheckpointMessage,
+			deliCheckpointMessage: this.documentCheckpointManager.checkpointInfo
+				.currentCheckpointMessage as IQueuedMessage,
+			kafkaCheckpointMessage:
+				this.documentCheckpointManager.checkpointInfo.currentKafkaCheckpointMessage,
 		};
 	}
 
@@ -1780,11 +1757,11 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 	}
 
 	private setActivityIdleTimer() {
-		if (this.noActiveClients) {
+		if (this.documentCheckpointManager.noActiveClients) {
 			return;
 		}
 		this.activityIdleTimer = setTimeout(() => {
-			if (!this.noActiveClients) {
+			if (!this.documentCheckpointManager.noActiveClients) {
 				const noOpMessage = this.createOpMessage(MessageType.NoOp);
 				this.sendToRawDeltas(noOpMessage).catch((error) => {
 					const lumberjackProperties = {
@@ -1823,11 +1800,11 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 	}
 
 	private setNoopConsolidationTimer() {
-		if (this.noActiveClients) {
+		if (this.documentCheckpointManager.noActiveClients) {
 			return;
 		}
 		this.noopEvent = setTimeout(() => {
-			if (!this.noActiveClients) {
+			if (!this.documentCheckpointManager.noActiveClients) {
 				const noOpMessage = this.createOpMessage(MessageType.NoOp);
 				this.sendToRawDeltas(noOpMessage).catch((error) => {
 					const lumberjackProperties = {
@@ -1949,12 +1926,18 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 			return CheckpointReason.EveryMessage;
 		}
 
-		if (this.checkpointInfo.rawMessagesSinceCheckpoint >= checkpointHeuristics.maxMessages) {
+		if (
+			this.documentCheckpointManager.checkpointInfo.rawMessagesSinceCheckpoint >=
+			checkpointHeuristics.maxMessages
+		) {
 			// exceeded max messages since last checkpoint
 			return CheckpointReason.MaxMessages;
 		}
 
-		if (Date.now() - this.checkpointInfo.lastCheckpointTime >= checkpointHeuristics.maxTime) {
+		if (
+			Date.now() - this.documentCheckpointManager.checkpointInfo.lastCheckpointTime >=
+			checkpointHeuristics.maxTime
+		) {
 			// exceeded max time since last checkpoint
 			return CheckpointReason.MaxTime;
 		}
@@ -1965,7 +1948,10 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 			return CheckpointReason.ClearCache;
 		}
 
-		if (this.noActiveClients && messageType === MessageType.NoClient) {
+		if (
+			this.documentCheckpointManager.noActiveClients &&
+			messageType === MessageType.NoClient
+		) {
 			return CheckpointReason.NoClients;
 		}
 
@@ -1976,10 +1962,7 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 	 * Checkpoints the current state once the pending kafka messages are produced
 	 */
 	private checkpoint(reason: CheckpointReason, globalCheckpointOnly: boolean) {
-		this.clearCheckpointIdleTimer();
-
-		this.checkpointInfo.lastCheckpointTime = Date.now();
-		this.checkpointInfo.rawMessagesSinceCheckpoint = 0;
+		this.documentCheckpointManager.resetCheckpointTimer();
 
 		Promise.all([this.lastSendP, this.lastNoClientP])
 			.then(() => {
@@ -2035,36 +2018,9 @@ export class DeliLambda extends TypedEventEmitter<IDeliLambdaEvents> implements 
 			});
 	}
 
-	/**
-	 * Updates the time until the state is checkpointed when idle
-	 * @param rawMessage - The current raw message that is initiating the timer
-	 */
-	private updateCheckpointIdleTimer(globalCheckpointOnly: boolean = false) {
-		this.clearCheckpointIdleTimer();
-
-		const initialDeliCheckpointMessage = this.checkpointInfo.currentCheckpointMessage;
-
-		this.checkpointInfo.idleTimer = setTimeout(() => {
-			this.checkpointInfo.idleTimer = undefined;
-
-			// verify that the current deli message matches the raw message that kicked off this timer
-			// if it matches, that means that delis state is for the raw message
-			// this means our checkpoint will result in the correct state
-			if (initialDeliCheckpointMessage === this.checkpointInfo.currentCheckpointMessage) {
-				this.checkpoint(CheckpointReason.IdleTime, globalCheckpointOnly);
-			}
-		}, this.serviceConfiguration.deli.checkpointHeuristics.idleTime);
-	}
-
-	/**
-	 * Clears the timer used for checkpointing when deli is idle
-	 */
-	private clearCheckpointIdleTimer() {
-		if (this.checkpointInfo.idleTimer !== undefined) {
-			clearTimeout(this.checkpointInfo.idleTimer);
-			this.checkpointInfo.idleTimer = undefined;
-		}
-	}
+	private readonly idleTimeCheckpoint = (message: IQueuedMessage) => {
+		this.checkpoint(CheckpointReason.IdleTime, this.globalCheckpointOnly);
+	};
 
 	/**
 	 * Updates the durable sequence number

--- a/server/routerlicious/packages/lambdas/src/index.ts
+++ b/server/routerlicious/packages/lambdas/src/index.ts
@@ -46,4 +46,5 @@ export {
 	IRuntimeSignalEnvelope,
 	logCommonSessionEndMetrics,
 	NoOpLambda,
+	DocumentCheckpointManager,
 } from "./utils";

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -44,8 +44,9 @@ import {
 	createSessionMetric,
 	logCommonSessionEndMetrics,
 	CheckpointReason,
-	ICheckpoint,
 	IServerMetadata,
+	DocumentCheckpointManager,
+	IDocumentCheckpointManager,
 } from "../utils";
 import { ICheckpointManager, IPendingMessageReader, ISummaryWriter } from "./interfaces";
 import { getClientIds, initializeProtocol, sendToDeli } from "./utils";
@@ -89,13 +90,9 @@ export class ScribeLambda implements IPartitionLambda {
 	private closed: boolean = false;
 
 	// Used to control checkpoint logic
-	private readonly checkpointInfo: ICheckpoint = {
-		lastCheckpointTime: Date.now(),
-		rawMessagesSinceCheckpoint: 0,
-	};
+	private readonly documentCheckpointManager: IDocumentCheckpointManager =
+		new DocumentCheckpointManager(true /* createIdleTimer */);
 
-	// Used to checkpoint if no active clients
-	private noActiveClients: boolean = false;
 	private globalCheckpointOnly: boolean;
 
 	constructor(
@@ -136,7 +133,7 @@ export class ScribeLambda implements IPartitionLambda {
 				databaseLastOffset: this.lastOffset,
 			});
 
-			this.updateCheckpointMessages(message);
+			this.documentCheckpointManager.updateCheckpointMessages(message);
 			try {
 				if (this.kafkaCheckpointOnReprocessingOp) {
 					this.context.checkpoint(message, this.restartOnCheckpointFailure);
@@ -351,7 +348,8 @@ export class ScribeLambda implements IPartitionLambda {
 						value.operation.minimumSequenceNumber === value.operation.sequenceNumber,
 						`${value.operation.minimumSequenceNumber} != ${value.operation.sequenceNumber}`,
 					);
-					this.noActiveClients = true;
+
+					this.documentCheckpointManager.noActiveClients = true;
 					this.globalCheckpointOnly = true;
 					const enableServiceSummaryForTenant =
 						this.disableTransientTenantFiltering ||
@@ -450,22 +448,26 @@ export class ScribeLambda implements IPartitionLambda {
 		}
 
 		// Create the checkpoint
-		this.updateCheckpointMessages(message);
-		this.checkpointInfo.rawMessagesSinceCheckpoint++;
+		this.documentCheckpointManager.updateCheckpointMessages(message);
+		this.documentCheckpointManager.checkpointInfo.rawMessagesSinceCheckpoint++;
 
-		if (this.noActiveClients) {
+		if (this.documentCheckpointManager.noActiveClients) {
 			if (this.localCheckpointEnabled) {
 				this.globalCheckpointOnly = true;
 			}
 			this.prepareCheckpoint(message, CheckpointReason.NoClients);
-			this.noActiveClients = false;
+			this.documentCheckpointManager.noActiveClients = false;
 		} else {
 			const checkpointReason = this.getCheckpointReason();
 			if (checkpointReason !== undefined) {
 				// checkpoint the current up-to-date state
 				this.prepareCheckpoint(message, checkpointReason);
 			} else {
-				this.updateCheckpointIdleTimer();
+				this.documentCheckpointManager.updateCheckpointIdleTimer(
+					this.serviceConfiguration.scribe.checkpointHeuristics.idleTime,
+					this.idleTimeCheckpoint,
+					this.isDocumentCorrupt,
+				);
 			}
 		}
 	}
@@ -477,22 +479,23 @@ export class ScribeLambda implements IPartitionLambda {
 	) {
 		// Get checkpoint context
 		const checkpoint = this.generateScribeCheckpoint(message.offset);
-		this.updateCheckpointMessages(message);
+		this.documentCheckpointManager.updateCheckpointMessages(message);
 
 		// write the checkpoint with the current up-to-date state
-		this.checkpoint(checkpointReason);
+		this.documentCheckpointManager.resetCheckpointTimer();
 		this.checkpointCore(checkpoint, message, this.clearCache, skipKafkaCheckpoint);
 		this.lastOffset = message.offset;
 		const reason = CheckpointReason[checkpointReason];
 		const checkpointResult = `Writing checkpoint. Reason: ${reason}`;
+		const checkpointProperties = this.documentCheckpointManager.checkpointInfo;
 		const lumberjackProperties = {
 			...getLumberBaseProperties(this.documentId, this.tenantId),
 			checkpointReason: reason,
 			lastOffset: this.lastOffset,
-			scribeCheckpointOffset: this.checkpointInfo.currentCheckpointMessage?.offset,
-			scribeCheckpointPartition: this.checkpointInfo.currentCheckpointMessage?.partition,
-			kafkaCheckpointOffset: this.checkpointInfo.currentKafkaCheckpointMessage?.offset,
-			kafkaCheckpointPartition: this.checkpointInfo.currentKafkaCheckpointMessage?.partition,
+			scribeCheckpointOffset: checkpointProperties.currentCheckpointMessage?.offset,
+			scribeCheckpointPartition: checkpointProperties.currentCheckpointMessage?.partition,
+			kafkaCheckpointOffset: checkpointProperties.currentKafkaCheckpointMessage?.offset,
+			kafkaCheckpointPartition: checkpointProperties.currentKafkaCheckpointMessage?.partition,
 			clientCount: checkpoint.protocolState.members.length,
 			clients: getClientIds(checkpoint.protocolState, 5),
 			localCheckpointEnabled: this.localCheckpointEnabled,
@@ -682,7 +685,7 @@ export class ScribeLambda implements IPartitionLambda {
 			checkpoint,
 			this.protocolHead,
 			inserts,
-			this.noActiveClients,
+			this.documentCheckpointManager.noActiveClients,
 			this.globalCheckpointOnly,
 			this.isDocumentCorrupt,
 		);
@@ -795,21 +798,6 @@ export class ScribeLambda implements IPartitionLambda {
 		this.isDocumentCorrupt = scribe.isCorrupt;
 	}
 
-	private updateCheckpointMessages(message: IQueuedMessage) {
-		// updates scribe checkpoint message
-		this.checkpointInfo.currentCheckpointMessage = message;
-
-		if (this.noActiveClients) {
-			this.checkpointInfo.nextKafkaCheckpointMessage = undefined;
-			this.checkpointInfo.currentKafkaCheckpointMessage = message;
-		} else {
-			// Keeps Kafka checkpoint behind by 1 message (is this necessary?)
-			const kafkaCheckpointMessage = this.checkpointInfo.nextKafkaCheckpointMessage;
-			this.checkpointInfo.nextKafkaCheckpointMessage = message;
-			this.checkpointInfo.currentKafkaCheckpointMessage = kafkaCheckpointMessage;
-		}
-	}
-
 	// Determines checkpoint reason based on some Heuristics
 
 	private getCheckpointReason(): CheckpointReason | undefined {
@@ -820,12 +808,14 @@ export class ScribeLambda implements IPartitionLambda {
 			return CheckpointReason.EveryMessage;
 		}
 
-		if (this.checkpointInfo.rawMessagesSinceCheckpoint >= checkpointHeuristics.maxMessages) {
+		const checkpointInfo = this.documentCheckpointManager.checkpointInfo;
+
+		if (checkpointInfo.rawMessagesSinceCheckpoint >= checkpointHeuristics.maxMessages) {
 			// exceeded max messages since last checkpoint
 			return CheckpointReason.MaxMessages;
 		}
 
-		if (Date.now() - this.checkpointInfo.lastCheckpointTime >= checkpointHeuristics.maxTime) {
+		if (Date.now() - checkpointInfo.lastCheckpointTime >= checkpointHeuristics.maxTime) {
 			// exceeded max time since last checkpoint
 			return CheckpointReason.MaxTime;
 		}
@@ -833,65 +823,27 @@ export class ScribeLambda implements IPartitionLambda {
 		return undefined;
 	}
 
-	private clearCheckpointIdleTimer() {
-		if (this.checkpointInfo.idleTimer !== undefined) {
-			clearTimeout(this.checkpointInfo.idleTimer);
-			this.checkpointInfo.idleTimer = undefined;
+	private readonly idleTimeCheckpoint = (initialScribeCheckpointMessage: IQueuedMessage) => {
+		if (initialScribeCheckpointMessage) {
+			const checkpoint = this.generateScribeCheckpoint(initialScribeCheckpointMessage.offset);
+			this.checkpointCore(checkpoint, initialScribeCheckpointMessage, this.clearCache);
+			const checkpointResult = `Writing checkpoint. Reason: IdleTime`;
+			const checkpointInfo = this.documentCheckpointManager.checkpointInfo;
+			const lumberjackProperties = {
+				...getLumberBaseProperties(this.documentId, this.tenantId),
+				checkpointReason: "IdleTime",
+				lastOffset: initialScribeCheckpointMessage.offset,
+				scribeCheckpointOffset: checkpointInfo.currentCheckpointMessage?.offset,
+				scribeCheckpointPartition: checkpointInfo.currentCheckpointMessage?.partition,
+				kafkaCheckpointOffset: checkpointInfo.currentKafkaCheckpointMessage?.offset,
+				kafkaCheckpointPartition: checkpointInfo.currentKafkaCheckpointMessage?.partition,
+				clientCount: checkpoint.protocolState.members.length,
+				clients: getClientIds(checkpoint.protocolState, 5),
+				localCheckpointEnabled: this.localCheckpointEnabled,
+				globalCheckpointOnly: this.globalCheckpointOnly,
+				localCheckpoint: this.localCheckpointEnabled && !this.globalCheckpointOnly,
+			};
+			Lumberjack.info(checkpointResult, lumberjackProperties);
 		}
-	}
-
-	private checkpoint(reason: CheckpointReason) {
-		this.clearCheckpointIdleTimer();
-		this.checkpointInfo.lastCheckpointTime = Date.now();
-		this.checkpointInfo.rawMessagesSinceCheckpoint = 0;
-	}
-
-	private updateCheckpointIdleTimer() {
-		this.clearCheckpointIdleTimer();
-
-		const initialScribeCheckpointMessage = this.checkpointInfo.currentCheckpointMessage;
-
-		this.checkpointInfo.idleTimer = setTimeout(() => {
-			this.checkpointInfo.idleTimer = undefined;
-
-			// verify that the current scribe message matches the message that started this timer
-			// same implementation as in Deli
-			if (
-				initialScribeCheckpointMessage === this.checkpointInfo.currentCheckpointMessage &&
-				!this.isDocumentCorrupt
-			) {
-				this.checkpoint(CheckpointReason.IdleTime);
-				if (initialScribeCheckpointMessage) {
-					const checkpoint = this.generateScribeCheckpoint(
-						initialScribeCheckpointMessage.offset,
-					);
-					this.checkpointCore(
-						checkpoint,
-						initialScribeCheckpointMessage,
-						this.clearCache,
-					);
-					const checkpointResult = `Writing checkpoint. Reason: IdleTime`;
-					const lumberjackProperties = {
-						...getLumberBaseProperties(this.documentId, this.tenantId),
-						checkpointReason: "IdleTime",
-						lastOffset: initialScribeCheckpointMessage.offset,
-						scribeCheckpointOffset:
-							this.checkpointInfo.currentCheckpointMessage?.offset,
-						scribeCheckpointPartition:
-							this.checkpointInfo.currentCheckpointMessage?.partition,
-						kafkaCheckpointOffset:
-							this.checkpointInfo.currentKafkaCheckpointMessage?.offset,
-						kafkaCheckpointPartition:
-							this.checkpointInfo.currentKafkaCheckpointMessage?.partition,
-						clientCount: checkpoint.protocolState.members.length,
-						clients: getClientIds(checkpoint.protocolState, 5),
-						localCheckpointEnabled: this.localCheckpointEnabled,
-						globalCheckpointOnly: this.globalCheckpointOnly,
-						localCheckpoint: this.localCheckpointEnabled && !this.globalCheckpointOnly,
-					};
-					Lumberjack.info(checkpointResult, lumberjackProperties);
-				}
-			}
-		}, this.serviceConfiguration.scribe.checkpointHeuristics.idleTime);
-	}
+	};
 }

--- a/server/routerlicious/packages/lambdas/src/utils/checkpointHelper.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/checkpointHelper.ts
@@ -31,4 +31,7 @@ export interface ICheckpoint {
 
 	// time in milliseconds since the last checkpoint
 	lastCheckpointTime: number;
+
+	// last kafka checkpoint offset
+	lastkafkaCheckpointOffset?: number | undefined;
 }

--- a/server/routerlicious/packages/lambdas/src/utils/checkpointHelper.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/checkpointHelper.ts
@@ -31,7 +31,4 @@ export interface ICheckpoint {
 
 	// time in milliseconds since the last checkpoint
 	lastCheckpointTime: number;
-
-	// last kafka checkpoint offset
-	lastkafkaCheckpointOffset?: number | undefined;
 }

--- a/server/routerlicious/packages/lambdas/src/utils/documentLambdaCheckpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/documentLambdaCheckpointManager.ts
@@ -85,6 +85,7 @@ export class DocumentCheckpointManager implements IDocumentCheckpointManager {
 			}
 		}, timeout);
 	}
+
 	public incrementRawMessageCounter() {
 		this.checkpointInfo.rawMessagesSinceCheckpoint++;
 	}

--- a/server/routerlicious/packages/lambdas/src/utils/documentLambdaCheckpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/documentLambdaCheckpointManager.ts
@@ -1,0 +1,89 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { IQueuedMessage } from "@fluidframework/server-services-core";
+import { ICheckpoint } from "./checkpointHelper";
+
+export interface IDocumentCheckpointManager {
+	checkpointInfo: ICheckpoint;
+	noActiveClients: boolean;
+	useCheckpointIdleTimer: boolean;
+
+	updateCheckpointMessages(message: IQueuedMessage);
+	clearCheckpointIdleTimer(): void;
+	resetCheckpointTimer(): void;
+	updateCheckpointIdleTimer(
+		timeout: number,
+		idleTimeCheckpoint: (message: IQueuedMessage) => void,
+		isDocumentCorrupt?: boolean,
+	): void;
+}
+
+export class DocumentCheckpointManager implements IDocumentCheckpointManager {
+	checkpointInfo: ICheckpoint = {
+		lastCheckpointTime: Date.now(),
+		rawMessagesSinceCheckpoint: 0,
+	};
+	noActiveClients: boolean = false;
+	useCheckpointIdleTimer: boolean;
+
+	constructor(createIdleTimer: boolean = true) {
+		this.useCheckpointIdleTimer = createIdleTimer;
+	}
+
+	updateCheckpointMessages(message: IQueuedMessage) {
+		// updates checkpoint message
+		this.checkpointInfo.currentCheckpointMessage = message;
+
+		if (this.noActiveClients) {
+			this.checkpointInfo.nextKafkaCheckpointMessage = undefined;
+			this.checkpointInfo.currentKafkaCheckpointMessage = message;
+		} else {
+			// Keeps Kafka checkpoint behind by 1 message
+			const kafkaCheckpointMessage = this.checkpointInfo.nextKafkaCheckpointMessage;
+			this.checkpointInfo.nextKafkaCheckpointMessage = message;
+			this.checkpointInfo.currentKafkaCheckpointMessage = kafkaCheckpointMessage;
+		}
+	}
+
+	clearCheckpointIdleTimer() {
+		if (this.checkpointInfo.idleTimer !== undefined) {
+			clearTimeout(this.checkpointInfo.idleTimer);
+			this.checkpointInfo.idleTimer = undefined;
+		}
+	}
+
+	public resetCheckpointTimer() {
+		this.clearCheckpointIdleTimer();
+		this.checkpointInfo.lastCheckpointTime = Date.now();
+		this.checkpointInfo.rawMessagesSinceCheckpoint = 0;
+	}
+
+	public updateCheckpointIdleTimer(
+		timeout: number,
+		idleTimeCheckpoint: (message: IQueuedMessage) => void,
+		isDocumentCorrupt: boolean = false,
+	) {
+		this.clearCheckpointIdleTimer();
+
+		const initalCheckpointMessage = this.checkpointInfo.currentCheckpointMessage;
+
+		this.checkpointInfo.idleTimer = setTimeout(() => {
+			this.checkpointInfo.idleTimer = undefined;
+
+			// verify that the current message matches the message that started this timer
+			// original implementation from Deli
+			if (
+				initalCheckpointMessage === this.checkpointInfo.currentCheckpointMessage &&
+				!isDocumentCorrupt
+			) {
+				this.resetCheckpointTimer();
+				if (initalCheckpointMessage) {
+					idleTimeCheckpoint(initalCheckpointMessage);
+				}
+			}
+		}, timeout);
+	}
+}

--- a/server/routerlicious/packages/lambdas/src/utils/index.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/index.ts
@@ -16,7 +16,4 @@ export { isDocumentSessionValid, isDocumentValid } from "./validateDocument";
 export { CheckpointReason, ICheckpoint } from "./checkpointHelper";
 export { ConnectionCountLogger } from "./connectionCountLogger";
 export { IServerMetadata } from "./serverMetadata";
-export {
-	DocumentCheckpointManager,
-	IDocumentCheckpointManager,
-} from "./documentLambdaCheckpointManager";
+export { DocumentCheckpointManager } from "./documentLambdaCheckpointManager";

--- a/server/routerlicious/packages/lambdas/src/utils/index.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/index.ts
@@ -16,3 +16,7 @@ export { isDocumentSessionValid, isDocumentValid } from "./validateDocument";
 export { CheckpointReason, ICheckpoint } from "./checkpointHelper";
 export { ConnectionCountLogger } from "./connectionCountLogger";
 export { IServerMetadata } from "./serverMetadata";
+export {
+	DocumentCheckpointManager,
+	IDocumentCheckpointManager,
+} from "./documentLambdaCheckpointManager";


### PR DESCRIPTION
## Description

> Creates a shared resource for document-lambda specific checkpointing logic.
> This includes keeping the lambda's document partition open if there are clients connected to the document and logic used to control the `checkpointIdleTimer`