### PR TITLE
Add parsing of groupId in odsp snapshot

### DIFF
--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -148,20 +148,6 @@ function readTreeSection(node: NodeCore) {
 					}
 
 					// "name": <node name>
-					// "children": <blob id>
-					// groupId: <group name>
-					if (
-						treeNode.getMaybeString(2) === "children" &&
-						treeNode.getMaybeString(4) === "groupId"
-					) {
-						const result = readTreeSection(treeNode.getNode(3));
-						trees[treeNode.getString(1)] = result.snapshotTree;
-						slowTreeStructureCount += result.slowTreeStructureCount;
-						snapshotTree.groupId = treeNode.getMaybeString(5);
-						continue;
-					}
-
-					// "name": <node name>
 					// "unreferenced": true
 					// "children": <blob id>
 					if (
@@ -176,6 +162,20 @@ function readTreeSection(node: NodeCore) {
 							0x3db /* Unreferenced if present should be true */,
 						);
 						snapshotTree.unreferenced = true;
+						continue;
+					}
+
+					// "name": <node name>
+					// "children": <blob id>
+					// groupId: <group name>
+					if (
+						treeNode.getMaybeString(2) === "children" &&
+						treeNode.getMaybeString(4) === "groupId"
+					) {
+						const result = readTreeSection(treeNode.getNode(3));
+						trees[treeNode.getString(1)] = result.snapshotTree;
+						slowTreeStructureCount += result.slowTreeStructureCount;
+						snapshotTree.groupId = treeNode.getMaybeString(5);
 						continue;
 					}
 					break;

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -116,84 +116,92 @@ function readTreeSection(node: NodeCore) {
 		 */
 		const length = treeNode.length;
 		if (length > 0 && treeNode.getMaybeString(0) === "name") {
-			if (length === 4) {
-				const content = treeNode.getMaybeString(2);
-				// "name": <node name>
-				// "children": <blob id>
-				if (content === "children") {
-					const result = readTreeSection(treeNode.getNode(3));
-					trees[treeNode.getString(1)] = result.snapshotTree;
-					slowTreeStructureCount += result.slowTreeStructureCount;
-					continue;
+			switch (length) {
+				case 4: {
+					const content = treeNode.getMaybeString(2);
+					// "name": <node name>
+					// "children": <blob id>
+					if (content === "children") {
+						const result = readTreeSection(treeNode.getNode(3));
+						trees[treeNode.getString(1)] = result.snapshotTree;
+						slowTreeStructureCount += result.slowTreeStructureCount;
+						continue;
+					}
+					// "name": <node name>
+					// "value": <blob id>
+					if (content === "value") {
+						snapshotTree.blobs[treeNode.getString(1)] = treeNode.getString(3);
+						continue;
+					}
+					break;
 				}
-				// "name": <node name>
-				// "value": <blob id>
-				if (content === "value") {
-					snapshotTree.blobs[treeNode.getString(1)] = treeNode.getString(3);
-					continue;
+				case 6: {
+					// "name": <node name>
+					// "nodeType": 3
+					// "value": <blob id>
+					if (
+						treeNode.getMaybeString(2) === "nodeType" &&
+						treeNode.getMaybeString(4) === "value"
+					) {
+						snapshotTree.blobs[treeNode.getString(1)] = treeNode.getString(5);
+						continue;
+					}
+
+					// "name": <node name>
+					// "children": <blob id>
+					// groupId: <group name>
+					if (
+						treeNode.getMaybeString(2) === "children" &&
+						treeNode.getMaybeString(4) === "groupId"
+					) {
+						const result = readTreeSection(treeNode.getNode(3));
+						trees[treeNode.getString(1)] = result.snapshotTree;
+						slowTreeStructureCount += result.slowTreeStructureCount;
+						snapshotTree.groupId = treeNode.getMaybeString(5);
+						continue;
+					}
+
+					// "name": <node name>
+					// "unreferenced": true
+					// "children": <blob id>
+					if (
+						treeNode.getMaybeString(2) === "unreferenced" &&
+						treeNode.getMaybeString(4) === "children"
+					) {
+						const result = readTreeSection(treeNode.getNode(5));
+						trees[treeNode.getString(1)] = result.snapshotTree;
+						slowTreeStructureCount += result.slowTreeStructureCount;
+						assert(
+							treeNode.getBool(3),
+							0x3db /* Unreferenced if present should be true */,
+						);
+						snapshotTree.unreferenced = true;
+						continue;
+					}
+					break;
 				}
-			}
-
-			// "name": <node name>
-			// "nodeType": 3
-			// "value": <blob id>
-			if (
-				length === 6 &&
-				treeNode.getMaybeString(2) === "nodeType" &&
-				treeNode.getMaybeString(4) === "value"
-			) {
-				snapshotTree.blobs[treeNode.getString(1)] = treeNode.getString(5);
-				continue;
-			}
-
-			// "name": <node name>
-			// "children": <blob id>
-			// groupId: <group name>
-			if (
-				length === 6 &&
-				treeNode.getMaybeString(2) === "children" &&
-				treeNode.getMaybeString(4) === "groupId"
-			) {
-				const result = readTreeSection(treeNode.getNode(3));
-				trees[treeNode.getString(1)] = result.snapshotTree;
-				slowTreeStructureCount += result.slowTreeStructureCount;
-				snapshotTree.groupId = treeNode.getMaybeString(5);
-				continue;
-			}
-
-			// "name": <node name>
-			// "unreferenced": true
-			// "children": <blob id>
-			if (
-				length === 6 &&
-				treeNode.getMaybeString(2) === "unreferenced" &&
-				treeNode.getMaybeString(4) === "children"
-			) {
-				const result = readTreeSection(treeNode.getNode(5));
-				trees[treeNode.getString(1)] = result.snapshotTree;
-				slowTreeStructureCount += result.slowTreeStructureCount;
-				assert(treeNode.getBool(3), 0x3db /* Unreferenced if present should be true */);
-				snapshotTree.unreferenced = true;
-				continue;
-			}
-
-			// "name": <node name>
-			// "unreferenced": true
-			// "children": <blob id>
-			// groupId: <group name>
-			if (
-				length === 8 &&
-				treeNode.getMaybeString(2) === "unreferenced" &&
-				treeNode.getMaybeString(4) === "children" &&
-				treeNode.getMaybeString(6) === "groupId"
-			) {
-				const result = readTreeSection(treeNode.getNode(5));
-				trees[treeNode.getString(1)] = result.snapshotTree;
-				slowTreeStructureCount += result.slowTreeStructureCount;
-				assert(treeNode.getBool(3), 0x3db /* Unreferenced if present should be true */);
-				snapshotTree.unreferenced = true;
-				snapshotTree.groupId = treeNode.getMaybeString(7);
-				continue;
+				case 8: {
+					// "name": <node name>
+					// "unreferenced": true
+					// "children": <blob id>
+					// groupId: <group name>
+					if (
+						treeNode.getMaybeString(2) === "unreferenced" &&
+						treeNode.getMaybeString(4) === "children" &&
+						treeNode.getMaybeString(6) === "groupId"
+					) {
+						const result = readTreeSection(treeNode.getNode(5));
+						trees[treeNode.getString(1)] = result.snapshotTree;
+						slowTreeStructureCount += result.slowTreeStructureCount;
+						assert(treeNode.getBool(3), "Unreferenced if present should be true");
+						snapshotTree.unreferenced = true;
+						snapshotTree.groupId = treeNode.getMaybeString(7);
+						continue;
+					}
+					break;
+				}
+				default:
+					break;
 			}
 		}
 

--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -81,6 +81,9 @@ function writeTreeSectionCore(treesNode: NodeCore, snapshotTree: ISnapshotTree) 
 			const childNode = treeNode.addNode("list");
 			writeTreeSectionCore(childNode, value);
 		}
+		if (snapshotTree.groupId) {
+			addDictionaryStringProperty(treeNode, "groupId", snapshotTree.groupId);
+		}
 	}
 
 	if (snapshotTree.blobs) {

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -118,6 +118,49 @@ const ops: ISequencedDocumentMessage[] = [
 	},
 ];
 
+const snapshotTreeWithGroupId: ISnapshotTree = {
+	id: "SnapshotId",
+	blobs: {},
+	trees: {
+		".protocol": {
+			blobs: {},
+			trees: {},
+		},
+		".app": {
+			blobs: { ".metadata": "bARD4RKvW4LL1KmaUKp6hUMSp" },
+			trees: {
+				".channels": {
+					blobs: {},
+					trees: {
+						default: {
+							blobs: {},
+							trees: {
+								dds: {
+									blobs: {},
+									trees: {},
+								},
+							},
+							groupId: "G3",
+						},
+					},
+					unreferenced: true,
+					groupId: "G2",
+				},
+				".blobs": { blobs: {}, trees: {} },
+			},
+			unreferenced: true,
+			groupId: "G4",
+		},
+	},
+};
+
+const blobContents2 = new Map<string, ArrayBuffer>([
+	[
+		"bARD4RKvW4LL1KmaUKp6hUMSp",
+		stringToBuffer(JSON.stringify({ summaryFormatVersion: 1, gcFeature: 0 }), "utf8"),
+	],
+]);
+
 describe("Snapshot Format Conversion Tests", () => {
 	it("Conversion test", async () => {
 		const snapshotContents: ISnapshot = {
@@ -165,6 +208,41 @@ describe("Snapshot Format Conversion Tests", () => {
 		assert.deepStrictEqual(result.snapshotTree, snapshotTree, "Tree structure should match");
 		assert.deepStrictEqual(result.blobContents, blobContents, "Blobs content should match");
 		assert.deepStrictEqual(result.ops, [], "Ops should match");
+		assert(result.sequenceNumber === 0, "Seq number should match");
+		assert(result.latestSequenceNumber === 2, "Latest sequence number should match");
+		assert(
+			(result.snapshotTree.id = snapshotContents.snapshotTree.id),
+			"Snapshot id should match",
+		);
+		// Convert to compact snapshot again and then match to previous one.
+		const compactSnapshot2 = convertToCompactSnapshot(result);
+		assert.deepStrictEqual(
+			compactSnapshot2.buffer,
+			compactSnapshot.buffer,
+			"Compact representation should remain same",
+		);
+		logger.assertMatchNone([{ category: "error" }]);
+	});
+
+	it("Conversion test for snapshot with GroupId", async () => {
+		const snapshotContents: ISnapshot = {
+			snapshotTree: snapshotTreeWithGroupId,
+			blobContents: blobContents2,
+			ops,
+			sequenceNumber: 0,
+			latestSequenceNumber: 2,
+			snapshotFormatV: 1,
+		};
+		const logger = new MockLogger();
+		const compactSnapshot = convertToCompactSnapshot(snapshotContents);
+		const result = parseCompactSnapshotResponse(compactSnapshot, logger.toTelemetryLogger());
+		assert.deepStrictEqual(
+			result.snapshotTree,
+			snapshotTreeWithGroupId,
+			"Tree structure should match",
+		);
+		assert.deepStrictEqual(result.blobContents, blobContents2, "Blobs content should match");
+		assert.deepStrictEqual(result.ops, ops, "Ops should match");
 		assert(result.sequenceNumber === 0, "Seq number should match");
 		assert(result.latestSequenceNumber === 2, "Latest sequence number should match");
 		assert(


### PR DESCRIPTION
## Description

Add parsing of groupId in odsp binary snapshot. ADO link: [AB#7058 ](https://dev.azure.com/fluidframework/internal/_workitems/edit/7058)

This is part of data virtualization effort which is documented here: [Design Doc](https://microsoft.sharepoint.com/:w:/t/FluidFramework/ESJQvukxffJNiTZzbNCWky4B891mpOpWD7BHhbOznXsMZg?e=gAUCrx)