### PR TITLE
[V2int/7.0] GC: Add option to only run Sweep for Attachment Blobs

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2811,8 +2811,13 @@ export class ContainerRuntime
 		const { dataStoreRoutes, blobManagerRoutes } =
 			this.getDataStoreAndBlobManagerRoutes(sweepReadyRoutes);
 
-		const deletedRoutes = this.dataStores.deleteSweepReadyNodes(dataStoreRoutes);
-		return deletedRoutes.concat(this.blobManager.deleteSweepReadyNodes(blobManagerRoutes));
+		// Start with Blob routes, and only add DataStore routes if applicable
+		const deletedRoutes = this.blobManager.deleteSweepReadyNodes(blobManagerRoutes);
+		if (this.garbageCollector.blobOnlySweep) {
+			return deletedRoutes;
+		}
+
+		return deletedRoutes.concat(this.dataStores.deleteSweepReadyNodes(dataStoreRoutes));
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -125,6 +125,10 @@ export class GarbageCollector implements IGarbageCollector {
 	public get throwOnTombstoneUsage(): boolean {
 		return this.configs.throwOnTombstoneUsage;
 	}
+	/** Tells whether we're ONLY sweeping blobs (only applicable if Sweep is enabled). */
+	public get blobOnlySweep(): boolean {
+		return this.configs.shouldRunSweep === "ONLY_BLOBS";
+	}
 
 	/** For a given node path, returns the node's package path. */
 	private readonly getNodePackagePath: (
@@ -373,7 +377,7 @@ export class GarbageCollector implements IGarbageCollector {
 		// tombstones.
 		// If this call is because we are refreshing from a snapshot due to an ack, it is likely that the GC state
 		// in the snapshot is newer than this client's. And so, the deleted / tombstone nodes need to be updated.
-		if (this.configs.shouldRunSweep) {
+		if (this.configs.shouldRunSweep !== false) {
 			const snapshotDeletedNodes = snapshotData?.deletedNodes
 				? new Set(snapshotData.deletedNodes)
 				: undefined;
@@ -699,7 +703,7 @@ export class GarbageCollector implements IGarbageCollector {
 			return [];
 		}
 
-		if (!this.configs.shouldRunSweep) {
+		if (this.configs.shouldRunSweep === false) {
 			return [];
 		}
 

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -140,10 +140,11 @@ export function generateGCConfigs(
 	 * 4. Sweep should be enabled for this container. This can be overridden via runSweep
 	 * feature flag.
 	 */
-	const shouldRunSweep =
+	const shouldRunSweep: IGarbageCollectorConfigs["shouldRunSweep"] =
 		shouldRunGC &&
 		sweepTimeoutMs !== undefined &&
-		(mc.config.getBoolean(runSweepKey) ?? sweepEnabled);
+		(mc.config.getBoolean(runSweepKey) ??
+			(!sweepEnabled ? false : createParams.gcOptions.blobOnlySweep ? "ONLY_BLOBS" : true));
 
 	// Override inactive timeout if test config or gc options to override it is set.
 	const inactiveTimeoutMs =

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -338,7 +338,7 @@ export interface IGarbageCollectorConfigs {
 	 * Tracks if sweep phase should run or not. Even if the sweep phase is enabled for a document (see sweepEnabled), it
 	 * can be explicitly disabled via feature flags. It also won't run if session expiry is not enabled.
 	 */
-	readonly shouldRunSweep: boolean;
+	readonly shouldRunSweep: boolean | "ONLY_BLOBS";
 	/**
 	 * If true, bypass optimizations and generate GC data for all nodes irrespective of whether a node changed or not.
 	 */

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -218,6 +218,8 @@ export interface IGarbageCollector {
 	readonly throwOnTombstoneLoad: boolean;
 	/** Tells whether using a tombstone object should fail or merely log. */
 	readonly throwOnTombstoneUsage: boolean;
+	/** Tells whether we're ONLY sweeping blobs (if Sweep is enabled). */
+	readonly blobOnlySweep: boolean;
 	/** Initialize the state from the base snapshot after its creation. */
 	initializeBaseState(): Promise<void>;
 	/** Run garbage collection and update the reference / used state of the system. */

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -339,6 +339,7 @@ export interface IGarbageCollectorConfigs {
 	/**
 	 * Tracks if sweep phase should run or not. Even if the sweep phase is enabled for a document (see sweepEnabled), it
 	 * can be explicitly disabled via feature flags. It also won't run if session expiry is not enabled.
+	 * There is also an option to only sweep blobs (this respects all other conditions otherwise).
 	 */
 	readonly shouldRunSweep: boolean | "ONLY_BLOBS";
 	/**

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -264,6 +264,29 @@ describe("Garbage Collection configurations", () => {
 				"getMetadata returned different metadata than loaded from",
 			);
 		});
+		it("Metadata Roundtrip with only tombstoneGeneration", () => {
+			const inputMetadata: IGCMetadata = {
+				sweepEnabled: true, // ignored
+				gcFeature: 1,
+				sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
+				sweepTimeoutMs: 123,
+				gcFeatureMatrix: { tombstoneGeneration: 1 },
+			};
+			gc = createGcWithPrivateMembers(inputMetadata, {
+				[gcTombstoneGenerationOptionName]: 2, // 2 should not be persisted
+			});
+			const outputMetadata = gc.getMetadata();
+			const expectedOutputMetadata: IGCMetadata = {
+				...inputMetadata,
+				sweepEnabled: false, // Hardcoded, not used
+				gcFeature: stableGCVersion,
+			};
+			assert.deepEqual(
+				outputMetadata,
+				expectedOutputMetadata,
+				"getMetadata returned different metadata than loaded from",
+			);
+		});
 		it("Metadata Roundtrip with GC version upgrade to v4 enabled", () => {
 			injectedSettings[gcVersionUpgradeToV4Key] = true;
 			const inputMetadata: IGCMetadata = {
@@ -440,16 +463,16 @@ describe("Garbage Collection configurations", () => {
 				"getMetadata returned different metadata than expected",
 			);
 		});
-		it("Metadata Roundtrip with only sweepGeneration", () => {
+		it("Metadata Roundtrip with only tombstoneGeneration", () => {
 			const expectedMetadata: IGCMetadata = {
 				sweepEnabled: false, // hardcoded, not used
 				gcFeature: stableGCVersion,
 				sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 				sweepTimeoutMs: defaultSessionExpiryDurationMs + 6 * oneDayMs,
-				gcFeatureMatrix: { sweepGeneration: 2, tombstoneGeneration: undefined },
+				gcFeatureMatrix: { sweepGeneration: undefined, tombstoneGeneration: 2 },
 			};
 			gc = createGcWithPrivateMembers(undefined /* metadata */, {
-				[gcSweepGenerationOptionName]: 2,
+				[gcTombstoneGenerationOptionName]: 2,
 			});
 			const outputMetadata = gc.getMetadata();
 			assert.deepEqual(

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -738,15 +738,21 @@ describe("Garbage Collection configurations", () => {
 				);
 			});
 		});
-		describe("shouldRunSweep", () => {
+		//* ONLY
+		//* ONLY
+		//* ONLY
+		//* ONLY
+		//* ONLY
+		describe.only("shouldRunSweep", () => {
 			const testCases: {
 				shouldRunGC: boolean;
 				sweepEnabled: boolean;
+				blobOnlySweep?: true;
 				shouldRunSweep?: boolean;
-				expectedShouldRunSweep: boolean;
+				expectedShouldRunSweep: IGarbageCollectorConfigs["shouldRunSweep"];
 			}[] = [
 				{
-					shouldRunGC: false,
+					shouldRunGC: false, // Veto power
 					sweepEnabled: true,
 					shouldRunSweep: true,
 					expectedShouldRunSweep: false,
@@ -760,12 +766,20 @@ describe("Garbage Collection configurations", () => {
 				{
 					shouldRunGC: true,
 					sweepEnabled: true,
-					shouldRunSweep: false,
+					shouldRunSweep: false, // Veto power
 					expectedShouldRunSweep: false,
 				},
 				{
 					shouldRunGC: true,
-					sweepEnabled: false,
+					sweepEnabled: true,
+					blobOnlySweep: true,
+					shouldRunSweep: false, // Veto power
+					expectedShouldRunSweep: false,
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled: false, // Overriden by shouldRunSweep
+					blobOnlySweep: true, // Ignored when shouldRunSweep is set
 					shouldRunSweep: true,
 					expectedShouldRunSweep: true,
 				},
@@ -777,6 +791,18 @@ describe("Garbage Collection configurations", () => {
 				{
 					shouldRunGC: true,
 					sweepEnabled: false,
+					expectedShouldRunSweep: false,
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled: true,
+					blobOnlySweep: true,
+					expectedShouldRunSweep: "ONLY_BLOBS",
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled: false,
+					blobOnlySweep: true,
 					expectedShouldRunSweep: false,
 				},
 			];
@@ -787,6 +813,7 @@ describe("Garbage Collection configurations", () => {
 					gc = createGcWithPrivateMembers(
 						undefined /* metadata */,
 						{
+							blobOnlySweep: testCase.blobOnlySweep, //* Name metadata key
 							[gcSweepGenerationOptionName]: testCase.sweepEnabled ? 1 : undefined,
 						} /* gcOptions */,
 					);

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -738,12 +738,7 @@ describe("Garbage Collection configurations", () => {
 				);
 			});
 		});
-		//* ONLY
-		//* ONLY
-		//* ONLY
-		//* ONLY
-		//* ONLY
-		describe.only("shouldRunSweep", () => {
+		describe("shouldRunSweep", () => {
 			const testCases: {
 				shouldRunGC: boolean;
 				sweepEnabled: boolean;
@@ -760,6 +755,7 @@ describe("Garbage Collection configurations", () => {
 				{
 					shouldRunGC: true,
 					sweepEnabled: true,
+					blobOnlySweep: true, // Ignored when shouldRunSweep is set
 					shouldRunSweep: true,
 					expectedShouldRunSweep: true,
 				},
@@ -779,7 +775,6 @@ describe("Garbage Collection configurations", () => {
 				{
 					shouldRunGC: true,
 					sweepEnabled: false, // Overriden by shouldRunSweep
-					blobOnlySweep: true, // Ignored when shouldRunSweep is set
 					shouldRunSweep: true,
 					expectedShouldRunSweep: true,
 				},
@@ -813,7 +808,7 @@ describe("Garbage Collection configurations", () => {
 					gc = createGcWithPrivateMembers(
 						undefined /* metadata */,
 						{
-							blobOnlySweep: testCase.blobOnlySweep, //* Name metadata key
+							blobOnlySweep: testCase.blobOnlySweep,
 							[gcSweepGenerationOptionName]: testCase.sweepEnabled ? 1 : undefined,
 						} /* gcOptions */,
 					);

--- a/packages/runtime/container-runtime/src/test/gc/gcHelpers.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcHelpers.spec.ts
@@ -86,22 +86,22 @@ describe("Garbage Collection Helpers Tests", () => {
 				expectedShouldAllowValue: false,
 			},
 			{
-				persisted: { sweepGeneration: 0 },
+				persisted: { sweepGeneration: 0, tombstoneGeneration: 0 },
 				current: 0,
 				expectedShouldAllowValue: true,
 			},
 			{
-				persisted: { sweepGeneration: 1 },
+				persisted: { sweepGeneration: 1, tombstoneGeneration: 1 },
 				current: 1,
 				expectedShouldAllowValue: true,
 			},
 			{
-				persisted: { sweepGeneration: 1 },
+				persisted: { sweepGeneration: 1, tombstoneGeneration: 1 },
 				current: 2,
 				expectedShouldAllowValue: false,
 			},
 			{
-				persisted: { sweepGeneration: 2 },
+				persisted: { sweepGeneration: 2, tombstoneGeneration: 2 },
 				current: 1,
 				expectedShouldAllowValue: false,
 			},

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -39,7 +39,12 @@ import {
 describeNoCompat("GC attachment blob sweep tests", (getTestObjectProvider) => {
 	const sweepTimeoutMs = 200;
 	const settings = {};
-	const gcOptions: IGCRuntimeOptions = { inactiveTimeoutMs: 0 };
+	const gcOptions: IGCRuntimeOptions = {
+		inactiveTimeoutMs: 0,
+		//* Eh, some tests should run with it unset...
+		// Ensure that GC for blobs works as expected when this is true
+		blobOnlySweep: true,
+	};
 	const testContainerConfig: ITestContainerConfig = {
 		runtimeOptions: {
 			summaryOptions: {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -1024,38 +1024,40 @@ describeNoCompat("GC attachment blob sweep tests", (getTestObjectProvider) => {
 			}
 		});
 
-		[true, undefined].forEach((blobOnlySweep) => 
-		it(`updates deleted blob state in the summary [blobOnlySweep=${blobOnlySweep}]`, async () => {
-			gcOptions.blobOnlySweep = blobOnlySweep;
+		[true, undefined].forEach((blobOnlySweep) =>
+			it(`updates deleted blob state in the summary [blobOnlySweep=${blobOnlySweep}]`, async () => {
+				gcOptions.blobOnlySweep = blobOnlySweep;
 
-			const { dataStore: mainDataStore, summarizer } = await createDataStoreAndSummarizer();
+				const { dataStore: mainDataStore, summarizer } =
+					await createDataStoreAndSummarizer();
 
-			// Upload an attachment blob.
-			const blob1Contents = "Blob contents 1";
-			const blob1Handle = await mainDataStore._runtime.uploadBlob(
-				stringToBuffer(blob1Contents, "utf-8"),
-			);
-			const blob1NodePath = blob1Handle.absolutePath;
+				// Upload an attachment blob.
+				const blob1Contents = "Blob contents 1";
+				const blob1Handle = await mainDataStore._runtime.uploadBlob(
+					stringToBuffer(blob1Contents, "utf-8"),
+				);
+				const blob1NodePath = blob1Handle.absolutePath;
 
-			// Reference and then unreference the blob so that it's unreferenced in the next summary.
-			mainDataStore._root.set("blob1", blob1Handle);
-			mainDataStore._root.delete("blob1");
+				// Reference and then unreference the blob so that it's unreferenced in the next summary.
+				mainDataStore._root.set("blob1", blob1Handle);
+				mainDataStore._root.delete("blob1");
 
-			// Summarize so that blob is marked unreferenced.
-			await provider.ensureSynchronized();
-			await summarizeNow(summarizer);
+				// Summarize so that blob is marked unreferenced.
+				await provider.ensureSynchronized();
+				await summarizeNow(summarizer);
 
-			// Wait for sweep timeout so that blob is ready to be deleted.
-			await delay(sweepTimeoutMs + 10);
+				// Wait for sweep timeout so that blob is ready to be deleted.
+				await delay(sweepTimeoutMs + 10);
 
-			// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-			mainDataStore._root.set("key", "value");
-			await provider.ensureSynchronized();
+				// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+				mainDataStore._root.set("key", "value");
+				await provider.ensureSynchronized();
 
-			// Summarize so that the sweep ready blob is deleted.
-			const summary2 = await summarizeNow(summarizer);
-			// Validate that the deleted blob's state is correct in the summary.
-			validateBlobStateInSummary(summary2.summaryTree, blob1NodePath);
-		}));
+				// Summarize so that the sweep ready blob is deleted.
+				const summary2 = await summarizeNow(summarizer);
+				// Validate that the deleted blob's state is correct in the summary.
+				validateBlobStateInSummary(summary2.summaryTree, blob1NodePath);
+			}),
+		);
 	});
 });


### PR DESCRIPTION
## Description

Fixes AB#7086

Enabling Sweep for attachment blobs is lower risk than data stores, and is also ready to ship on version 2.0.0-internal.7.0 (not so for data stores).  So add an option for any partners who want to do so.

### Same PR in other release branches:
- https://github.com/microsoft/FluidFramework/pull/19510