### PR TITLE
Add devtools code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 #
 # Please read and understand all of this documentation before modifying this file.
 #
-# Ownership via this file will block PR until an owner approves. 
+# Ownership via this file will block PR until an owner approves.
 # Taking ownership requires a commitment to review all PRs for the selected files.
 #
 # Lines starting with '#' are comments.
@@ -16,11 +16,15 @@
 # ORDER MATTERS! The last matching pattern has the most precedence.
 # Be careful not to break existing ownership patterns.
 #
-# Do not assign ownership to indviduals. Use a Team: https://github.com/orgs/microsoft/teams/fluid-cr/teams
+# Do not assign ownership to indviduals. Use a Team: https://github.com/orgs/microsoft/teams/fluid-cr/teams .
 # Using individuals can break processing of this file if they are not contributors, or lose contributors status
-# which can and does happen. 
+# which can and does happen. Use "function/area-based" teams rather than "organization-based" teams and add
+# individuals to each one; we use fluid-cr and its child teams (by convention named fluid-cr-<some-specifier>)
+# for this. One reason is that teams in Github cannot have multiple parents, i.e. they cannot be members of more
+# than one other team, so trying to reuse org-based teams to have the same people be reviewers of different areas
+# doesn't work.
 #
-# Team maintainers can control how PRs are assigned to their team members. 
+# Team maintainers can control how PRs are assigned to their team members.
 # This can be modified under the settings for the team which is only visiable to maintainer.
 #
 # If you create a new team its parent should be set to fluid-cr, as teams are microsoft wide,
@@ -38,3 +42,5 @@
 /packages/dds/tree                         @microsoft/fluid-cr-tree
 /experimental/dds/tree                     @microsoft/fluid-cr-tree
 
+# Fluid Devtools
+/packages/tools/devtools                   @microsoft/fluid-cr-devtools


### PR DESCRIPTION
## Description

Adds code owners for Fluid Devtools, and updates docs on the CODEOWNERS file related to using teams to assign ownership.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).