### PR TITLE
[v2int/7.4] GC: Add option to only run Sweep for Attachment Blobs

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2948,8 +2948,13 @@ export class ContainerRuntime
 		const { dataStoreRoutes, blobManagerRoutes } =
 			this.getDataStoreAndBlobManagerRoutes(sweepReadyRoutes);
 
-		const deletedRoutes = this.dataStores.deleteSweepReadyNodes(dataStoreRoutes);
-		return deletedRoutes.concat(this.blobManager.deleteSweepReadyNodes(blobManagerRoutes));
+		// Start with Blob routes, and only add DataStore routes if applicable
+		const deletedRoutes = this.blobManager.deleteSweepReadyNodes(blobManagerRoutes);
+		if (this.garbageCollector.blobOnlySweep) {
+			return deletedRoutes;
+		}
+
+		return deletedRoutes.concat(this.dataStores.deleteSweepReadyNodes(dataStoreRoutes));
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2950,7 +2950,7 @@ export class ContainerRuntime
 
 		// Start with Blob routes, and only add DataStore routes if applicable
 		const deletedRoutes = this.blobManager.deleteSweepReadyNodes(blobManagerRoutes);
-		if (this.garbageCollector.blobOnlySweep) {
+		if (this.garbageCollector.sweepOnlyBlobs) {
 			return deletedRoutes;
 		}
 

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -134,7 +134,7 @@ export class GarbageCollector implements IGarbageCollector {
 	public get throwOnTombstoneUsage(): boolean {
 		return this.configs.throwOnTombstoneUsage;
 	}
-	/** Tells whether we're ONLY sweeping blobs (only applicable if Sweep is enabled). */
+	/** Tells whether we're ONLY sweeping blobs (only applicable if Sweep is allowed). */
 	public get blobOnlySweep(): boolean {
 		return this.configs.shouldRunSweep === "ONLY_BLOBS";
 	}

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -135,7 +135,7 @@ export class GarbageCollector implements IGarbageCollector {
 		return this.configs.throwOnTombstoneUsage;
 	}
 	/** Tells whether we're ONLY sweeping blobs (only applicable if Sweep is allowed). */
-	public get blobOnlySweep(): boolean {
+	public get sweepOnlyBlobs(): boolean {
 		return this.configs.shouldRunSweep === "ONLY_BLOBS";
 	}
 

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -134,6 +134,10 @@ export class GarbageCollector implements IGarbageCollector {
 	public get throwOnTombstoneUsage(): boolean {
 		return this.configs.throwOnTombstoneUsage;
 	}
+	/** Tells whether we're ONLY sweeping blobs (only applicable if Sweep is enabled). */
+	public get blobOnlySweep(): boolean {
+		return this.configs.shouldRunSweep === "ONLY_BLOBS";
+	}
 
 	/** For a given node path, returns the node's package path. */
 	private readonly getNodePackagePath: (
@@ -386,7 +390,7 @@ export class GarbageCollector implements IGarbageCollector {
 		// tombstones.
 		// If this call is because we are refreshing from a snapshot due to an ack, it is likely that the GC state
 		// in the snapshot is newer than this client's. And so, the deleted / tombstone nodes need to be updated.
-		if (this.configs.shouldRunSweep) {
+		if (this.configs.shouldRunSweep !== false) {
 			const snapshotDeletedNodes = snapshotData?.deletedNodes
 				? new Set(snapshotData.deletedNodes)
 				: undefined;
@@ -728,7 +732,7 @@ export class GarbageCollector implements IGarbageCollector {
 			this.runtime.updateTombstonedRoutes(this.tombstones);
 		}
 
-		if (this.configs.shouldRunSweep && nodesToDelete.length > 0) {
+		if (this.configs.shouldRunSweep !== false && nodesToDelete.length > 0) {
 			// Do not send DDS node ids in the GC op. This is an optimization to reduce its size. Since GC applies to
 			// to data store only, all its DDSes are deleted along with it. The DDS ids will be retrieved from the
 			// local state when processing the op.

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -144,12 +144,9 @@ export function generateGCConfigs(
 			: mc.config.getBoolean(runSweepKey) ??
 			  (!sweepAllowed
 					? false
-					: !createParams.gcOptions.enableGCSweep
-					? false
-					: createParams.gcOptions.blobOnlySweep
+					: createParams.gcOptions.enableGCSweep_BlobsOnly // If this and enableGCSweep are both set, ONLY_BLOBS wins
 					? "ONLY_BLOBS"
-					: true);
-	//* (!sweepAllowed ? false : createParams.gcOptions.blobOnlySweep ? "ONLY_BLOBS" : createParams.gcOptions.enableGCSweep);
+					: createParams.gcOptions.enableGCSweep === true);
 
 	// Override inactive timeout if test config or gc options to override it is set.
 	const inactiveTimeoutMs =

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -142,7 +142,8 @@ export function generateGCConfigs(
 		!shouldRunGC || sweepTimeoutMs === undefined
 			? false
 			: mc.config.getBoolean(runSweepKey) ??
-			  (sweepAllowed && createParams.gcOptions.enableGCSweep === true);
+				(!sweepAllowed ? false : !createParams.gcOptions.enableGCSweep ? false : createParams.gcOptions.blobOnlySweep ? "ONLY_BLOBS" : true);
+				//* (!sweepAllowed ? false : createParams.gcOptions.blobOnlySweep ? "ONLY_BLOBS" : createParams.gcOptions.enableGCSweep);
 
 	// Override inactive timeout if test config or gc options to override it is set.
 	const inactiveTimeoutMs =

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -133,8 +133,8 @@ export function generateGCConfigs(
 	 *
 	 * Assuming overall GC is enabled and sweepTimeout is provided, the following conditions have to be met to run sweep:
 	 *
-	 * 1. Sweep should be enabled for this container.
-	 * 2. Sweep should be enabled for this session.
+	 * 1. Sweep should be allowed in this container.
+	 * 2. Sweep should be enabled for this session, optionally restricted to attachment blobs only.
 	 *
 	 * These conditions can be overridden via the RunSweep feature flag.
 	 */
@@ -142,8 +142,14 @@ export function generateGCConfigs(
 		!shouldRunGC || sweepTimeoutMs === undefined
 			? false
 			: mc.config.getBoolean(runSweepKey) ??
-				(!sweepAllowed ? false : !createParams.gcOptions.enableGCSweep ? false : createParams.gcOptions.blobOnlySweep ? "ONLY_BLOBS" : true);
-				//* (!sweepAllowed ? false : createParams.gcOptions.blobOnlySweep ? "ONLY_BLOBS" : createParams.gcOptions.enableGCSweep);
+			  (!sweepAllowed
+					? false
+					: !createParams.gcOptions.enableGCSweep
+					? false
+					: createParams.gcOptions.blobOnlySweep
+					? "ONLY_BLOBS"
+					: true);
+	//* (!sweepAllowed ? false : createParams.gcOptions.blobOnlySweep ? "ONLY_BLOBS" : createParams.gcOptions.enableGCSweep);
 
 	// Override inactive timeout if test config or gc options to override it is set.
 	const inactiveTimeoutMs =

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -295,7 +295,7 @@ export interface IGarbageCollector {
 	readonly throwOnTombstoneLoad: boolean;
 	/** Tells whether using a tombstone object should fail or merely log. */
 	readonly throwOnTombstoneUsage: boolean;
-	/** Tells whether we're ONLY sweeping blobs (if Sweep is enabled). */
+	/** Tells whether we're ONLY sweeping blobs (if Sweep is allowed). */
 	readonly blobOnlySweep: boolean;
 	/** Initialize the state from the base snapshot after its creation. */
 	initializeBaseState(): Promise<void>;
@@ -428,7 +428,7 @@ export interface IGarbageCollectorConfigs {
 	 */
 	readonly gcEnabled: boolean;
 	/**
-	 * Tracks if sweep phase is enabled for this document. This is specified during document creation and doesn't change
+	 * Tracks if sweep phase is allowed for this document. This is specified during document creation and doesn't change
 	 * throughout its lifetime.
 	 */
 	readonly sweepEnabled: boolean;
@@ -438,9 +438,9 @@ export interface IGarbageCollectorConfigs {
 	 */
 	readonly shouldRunGC: boolean;
 	/**
-	 * Tracks if sweep phase should run or not. Even if the sweep phase is enabled for a document (see sweepEnabled), it
+	 * Tracks if sweep phase should run or not. Even if the sweep phase is allowed for a document (see sweepEnabled), it
 	 * can be explicitly disabled via feature flags. It also won't run if session expiry is not enabled.
-	 * There is also an option to only sweep blobs (this respects all other conditions otherwise).
+	 * There is also an option to only sweep blobs.
 	 */
 	readonly shouldRunSweep: boolean | "ONLY_BLOBS";
 	/**

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -296,7 +296,7 @@ export interface IGarbageCollector {
 	/** Tells whether using a tombstone object should fail or merely log. */
 	readonly throwOnTombstoneUsage: boolean;
 	/** Tells whether we're ONLY sweeping blobs (if Sweep is allowed). */
-	readonly blobOnlySweep: boolean;
+	readonly sweepOnlyBlobs: boolean;
 	/** Initialize the state from the base snapshot after its creation. */
 	initializeBaseState(): Promise<void>;
 	/** Run garbage collection and update the reference / used state of the system. */

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -295,6 +295,8 @@ export interface IGarbageCollector {
 	readonly throwOnTombstoneLoad: boolean;
 	/** Tells whether using a tombstone object should fail or merely log. */
 	readonly throwOnTombstoneUsage: boolean;
+	/** Tells whether we're ONLY sweeping blobs (if Sweep is enabled). */
+	readonly blobOnlySweep: boolean;
 	/** Initialize the state from the base snapshot after its creation. */
 	initializeBaseState(): Promise<void>;
 	/** Run garbage collection and update the reference / used state of the system. */
@@ -438,8 +440,9 @@ export interface IGarbageCollectorConfigs {
 	/**
 	 * Tracks if sweep phase should run or not. Even if the sweep phase is enabled for a document (see sweepEnabled), it
 	 * can be explicitly disabled via feature flags. It also won't run if session expiry is not enabled.
+	 * There is also an option to only sweep blobs (this respects all other conditions otherwise).
 	 */
-	readonly shouldRunSweep: boolean;
+	readonly shouldRunSweep: boolean | "ONLY_BLOBS";
 	/**
 	 * If true, bypass optimizations and generate GC data for all nodes irrespective of whether a node changed or not.
 	 */

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -759,7 +759,7 @@ describe("Garbage Collection configurations", () => {
 				shouldRunGC: boolean;
 				sweepEnabled_doc: boolean;
 				sweepEnabled_session: boolean;
-				blobOnlySweep?: true;
+				sweepEnabled_onlyBlobs?: true;
 				shouldRunSweep?: boolean;
 				expectedShouldRunSweep: IGarbageCollectorConfigs["shouldRunSweep"];
 			}[] = [
@@ -774,7 +774,7 @@ describe("Garbage Collection configurations", () => {
 					shouldRunGC: true,
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
-					blobOnlySweep: true, // Ignored when shouldRunSweep is set
+					sweepEnabled_onlyBlobs: true, // Ignored when shouldRunSweep is set
 					shouldRunSweep: true,
 					expectedShouldRunSweep: true,
 				},
@@ -782,7 +782,7 @@ describe("Garbage Collection configurations", () => {
 					shouldRunGC: true,
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
-					blobOnlySweep: true,
+					sweepEnabled_onlyBlobs: true,
 					shouldRunSweep: false, // Veto power
 					expectedShouldRunSweep: false,
 				},
@@ -803,21 +803,21 @@ describe("Garbage Collection configurations", () => {
 					shouldRunGC: true,
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
-					blobOnlySweep: true,
+					sweepEnabled_onlyBlobs: true,
 					expectedShouldRunSweep: "ONLY_BLOBS",
 				},
 				{
 					shouldRunGC: true,
 					sweepEnabled_doc: true,
-					sweepEnabled_session: false, // Veto
-					blobOnlySweep: true, //* This should probably actually win here (makes sense with sweepEnabled_session being undefined not false)
-					expectedShouldRunSweep: false,
+					sweepEnabled_session: false,
+					sweepEnabled_onlyBlobs: true,
+					expectedShouldRunSweep: "ONLY_BLOBS",
 				},
 				{
 					shouldRunGC: true,
 					sweepEnabled_doc: false, // Veto
 					sweepEnabled_session: true,
-					blobOnlySweep: true,
+					sweepEnabled_onlyBlobs: true,
 					expectedShouldRunSweep: false,
 				},
 			];
@@ -832,7 +832,7 @@ describe("Garbage Collection configurations", () => {
 						} /* metadata */,
 						{
 							enableGCSweep: testCase.sweepEnabled_session ? true : undefined,
-							blobOnlySweep: testCase.blobOnlySweep,
+							enableGCSweep_BlobsOnly: testCase.sweepEnabled_onlyBlobs,
 							[gcGenerationOptionName]: testCase.sweepEnabled_doc ? 1 : 2,
 						} /* gcOptions */,
 					);

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -318,29 +318,6 @@ describe("Garbage Collection configurations", () => {
 				"getMetadata returned different metadata than loaded from",
 			);
 		});
-		it("Metadata Roundtrip with only tombstoneGeneration", () => {
-			const inputMetadata: IGCMetadata = {
-				sweepEnabled: true, // ignored
-				gcFeature: 1,
-				sessionExpiryTimeoutMs: customSessionExpiryDurationMs,
-				sweepTimeoutMs: 123,
-				gcFeatureMatrix: { tombstoneGeneration: 1 },
-			};
-			gc = createGcWithPrivateMembers(inputMetadata, {
-				[gcTombstoneGenerationOptionName]: 2, // 2 should not be persisted
-			});
-			const outputMetadata = gc.getMetadata();
-			const expectedOutputMetadata: IGCMetadata = {
-				...inputMetadata,
-				sweepEnabled: false, // Hardcoded, not used
-				gcFeature: stableGCVersion,
-			};
-			assert.deepEqual(
-				outputMetadata,
-				expectedOutputMetadata,
-				"getMetadata returned different metadata than loaded from",
-			);
-		});
 		it("Metadata Roundtrip with GC version upgrade to v4 enabled", () => {
 			injectedSettings[gcVersionUpgradeToV4Key] = true;
 			const inputMetadata: IGCMetadata = {

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -802,6 +802,13 @@ describe("Garbage Collection configurations", () => {
 				{
 					shouldRunGC: true,
 					sweepEnabled_doc: true,
+					sweepEnabled_session: true,
+					blobOnlySweep: true,
+					expectedShouldRunSweep: "ONLY_BLOBS",
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled_doc: true,
 					sweepEnabled_session: false, // Veto
 					blobOnlySweep: true, //* This should probably actually win here (makes sense with sweepEnabled_session being undefined not false)
 					expectedShouldRunSweep: false,
@@ -812,13 +819,6 @@ describe("Garbage Collection configurations", () => {
 					sweepEnabled_session: true,
 					blobOnlySweep: true,
 					expectedShouldRunSweep: false,
-				},
-				{
-					shouldRunGC: true,
-					sweepEnabled_doc: true,
-					sweepEnabled_session: true,
-					blobOnlySweep: true,
-					expectedShouldRunSweep: "ONLY_BLOBS",
 				},
 			];
 			testCases.forEach((testCase, index) => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -40,7 +40,7 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 	const settings = {};
 	const defaultGCOptions: IGCRuntimeOptions = {
 		inactiveTimeoutMs: 0,
-		enableGCSweep: true, //* blobOnlySweep needs to override this, or change the tests
+		enableGCSweep: true,
 		sweepGracePeriodMs: 0, // Skip Tombstone, these tests focus on Sweep
 	};
 	let gcOptions: IGCRuntimeOptions = defaultGCOptions;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -1053,9 +1053,9 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 			}
 		});
 
-		[true, undefined].forEach((blobOnlySweep) =>
-			it(`updates deleted blob state in the summary [blobOnlySweep=${blobOnlySweep}]`, async () => {
-				gcOptions.blobOnlySweep = blobOnlySweep;
+		[true, undefined].forEach((enableGCSweep_BlobsOnly) =>
+			it(`updates deleted blob state in the summary [enableGCSweep_BlobsOnly=${enableGCSweep_BlobsOnly}]`, async () => {
+				gcOptions.enableGCSweep_BlobsOnly = enableGCSweep_BlobsOnly;
 
 				const { dataStore: mainDataStore, summarizer } =
 					await createDataStoreAndSummarizer();

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -1090,6 +1090,7 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 				const summary3 = await summarizeNow(summarizer);
 				// Validate that the deleted blob's state is correct in the summary.
 				validateBlobStateInSummary(summary3.summaryTree, blob1NodePath);
-			});
+			}),
+		);
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -590,7 +590,7 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 				const { unreferencedId, summarizingContainer, summarizer } =
 					await summarizationWithUnreferencedDataStoreAfterTime(sweepTimeoutMs);
 				const sweepReadyDataStoreNodePath = `/${unreferencedId}`;
-				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer);
+				await sendOpToUpdateSummaryTimestampToNow(summarizer);
 
 				// The datastore should NOT be swept here.
 				// We need to do fullTree because the GC data won't change (since it's not swept).

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -578,7 +578,7 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 				},
 			);
 			itExpects(
-				"via blobOnlySweep GC option",
+				"via enableGCSweep_BlobsOnly GC option",
 				[
 					{
 						// Since we do full tree summary, everything is loaded including the sweepReady node
@@ -587,7 +587,7 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 					},
 				],
 				async () => {
-					gcOptions.blobOnlySweep = true;
+					gcOptions.enableGCSweep_BlobsOnly = true;
 					await ensureDataStoreSweepDisabled();
 				},
 			);


### PR DESCRIPTION
## Description

Fixes AB#7086

Enabling Sweep for attachment blobs is lower risk than data stores, and is also ready to ship on version 2.0.0-internal.7.0 (not so for data stores).  So add an option for any partners who want to do so.

## Reviewer Guidance

I will not merge this without approval of Rohan and other folks driving the current patch release(s) on this minor. I don't want this to interfere with that effort, but I do want it to come in ASAP to unblock our 1P partner trying to ship GC.

### Same PR in other release branches:
- https://github.com/microsoft/FluidFramework/pull/19495
