### PR TITLE
test(tree): Use describeStress for editManager combinatorial tests

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
@@ -679,7 +679,7 @@ const fieldRebaser: BoundFieldChangeRebaser<TestChangeset> = {
 export function testStateBasedRebaserAxioms() {
 	describe("State-based Rebaser Axioms", () => {
 		describeStress("Lineage Method", function ({ isStress }) {
-			this.timeout(30_000);
+			this.timeout(isStress ? 60_000 : 5000);
 			const allocator = idAllocatorFromMaxId();
 			const startingLength = 2;
 			const startingState: NodeState[] = makeArray(startingLength, () => ({
@@ -705,7 +705,7 @@ export function testStateBasedRebaserAxioms() {
 			);
 		});
 		describeStress("Tombstone Method", function ({ isStress }) {
-			this.timeout(30_000);
+			this.timeout(isStress ? 60_000 : 5000);
 			const allocator = idAllocatorFromMaxId();
 			const startingLength = 2;
 			const startingState: NodeState[] = makeArray(startingLength, () => ({

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
@@ -661,9 +661,12 @@ export function testCorrectness() {
 		 * - They help diagnose issues with the more complicated exhaustive test (e.g., if one of the above tests fails,
 		 * but this one doesn't, then there might be something wrong with this test).
 		 */
-		describeStress("Combinatorial exhaustive", ({ isStress }) => {
+		describeStress("Combinatorial exhaustive", function ({ isStress }) {
 			const NUM_STEPS = isStress ? 5 : 4;
-			const NUM_PEERS = 2;
+			const NUM_PEERS = isStress ? 3 : 2;
+			if (isStress) {
+				this.timeout(60_000);
+			}
 
 			const peers: SessionId[] = makeArray(NUM_PEERS, (i) => String(i + 1) as SessionId);
 			const meta = {

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "assert";
 import { SessionId } from "@fluidframework/id-compressor";
+import { describeStress } from "@fluid-private/stochastic-test-utils";
 import { ChangeFamily, ChangeFamilyEditor, GraphCommit } from "../../../core/index.js";
 import { brand, makeArray } from "../../../util/index.js";
 import { Commit, EditManager } from "../../../shared-tree-core/index.js";
@@ -16,11 +17,6 @@ import { buildScenario, runUnitTestScenario } from "./editManagerScenario.js";
 const localSessionId: SessionId = "0" as SessionId;
 const peer1: SessionId = "1" as SessionId;
 const peer2: SessionId = "2" as SessionId;
-
-// TODO:#4557: Change the number of steps back to 5 once the way these tests are run changes
-const NUM_STEPS = 4;
-const NUM_PEERS = 2;
-const peers: SessionId[] = makeArray(NUM_PEERS, (i) => String(i + 1) as SessionId);
 
 export function testCorrectness() {
 	describe("Correctness", () => {
@@ -665,28 +661,34 @@ export function testCorrectness() {
 		 * - They help diagnose issues with the more complicated exhaustive test (e.g., if one of the above tests fails,
 		 * but this one doesn't, then there might be something wrong with this test).
 		 */
-		it("Combinatorial test", () => {
+		describeStress("Combinatorial exhaustive", ({ isStress }) => {
+			const NUM_STEPS = isStress ? 5 : 4;
+			const NUM_PEERS = 2;
+
+			const peers: SessionId[] = makeArray(NUM_PEERS, (i) => String(i + 1) as SessionId);
 			const meta = {
 				peerRefs: makeArray(NUM_PEERS, () => 0),
 				seq: 0,
 				inFlight: 0,
 			};
-			for (const scenario of buildScenario([], meta, peers, NUM_STEPS)) {
-				// Uncomment the code below to log the titles of generated scenarios.
-				// This is helpful for creating a unit test out of a generated scenario that fails.
-				// const title = scenario
-				// 	.map((s) => {
-				// 		if (s.type === "Pull") {
-				// 			return `Pull(${s.seq}) from:${s.from} ref:${s.ref}`;
-				// 		} else if (s.type === "Ack") {
-				// 			return `Ack(${s.seq})`;
-				// 		}
-				// 		return `Push(${s.seq})`;
-				// 	})
-				// 	.join("|");
-				// console.debug(title);
-				runUnitTestScenario(undefined, scenario);
-			}
+			it(`for ${NUM_PEERS} peers and ${NUM_STEPS} steps`, () => {
+				for (const scenario of buildScenario([], meta, peers, NUM_STEPS)) {
+					// Uncomment the code below to log the titles of generated scenarios.
+					// This is helpful for creating a unit test out of a generated scenario that fails.
+					// const title = scenario
+					// 	.map((s) => {
+					// 		if (s.type === "Pull") {
+					// 			return `Pull(${s.seq}) from:${s.from} ref:${s.ref}`;
+					// 		} else if (s.type === "Ack") {
+					// 			return `Ack(${s.seq})`;
+					// 		}
+					// 		return `Push(${s.seq})`;
+					// 	})
+					// 	.join("|");
+					// console.debug(title);
+					runUnitTestScenario(undefined, scenario);
+				}
+			});
 		});
 	});
 }


### PR DESCRIPTION
## Description

Uses `describeStress` in editManager's combinatorial tests to run longer versions on tree changes as part of the DDS stress pipeline.

This also adjusts the timeout for two other recent additions to that set of longer tests, as they weren't consistently passing on the CI machine pool within 30s.

[AB#4557](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4557)
