### PR TITLE
GC: Properly support running GC only for certain node types

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -39,7 +39,6 @@ import {
 } from "@fluidframework/runtime-definitions";
 
 import { canRetryOnError, runWithRetry } from "@fluidframework/driver-utils";
-import { disableAttachmentBlobSweepKey } from "./gc";
 import { IBlobMetadata } from "./metadata";
 
 /**
@@ -742,11 +741,6 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 	 * @returns The routes of blobs that were deleted.
 	 */
 	public deleteSweepReadyNodes(sweepReadyBlobRoutes: readonly string[]): readonly string[] {
-		// If sweep for attachment blobs is not enabled, return empty list indicating nothing is deleted.
-		if (this.mc.config.getBoolean(disableAttachmentBlobSweepKey) === true) {
-			return [];
-		}
-
 		this.deleteBlobsFromRedirectTable(sweepReadyBlobRoutes);
 		return Array.from(sweepReadyBlobRoutes);
 	}

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -66,7 +66,7 @@ import {
 } from "./dataStoreContext";
 import { StorageServiceWithAttachBlobs } from "./storageServiceWithAttachBlobs";
 import { IDataStoreAliasMessage, channelToDataStore, isDataStoreAliasMessage } from "./dataStore";
-import { GCNodeType, detectOutboundRoutesViaDDSKey, disableDatastoreSweepKey } from "./gc";
+import { GCNodeType, detectOutboundRoutesViaDDSKey } from "./gc";
 import { IContainerRuntimeMetadata, nonDataStorePaths, rootHasIsolatedChannels } from "./summary";
 
 type PendingAliasResolve = (success: boolean) => void;
@@ -904,10 +904,6 @@ export class DataStores implements IDisposable {
 	 * @returns The routes of data stores and its objects that were deleted.
 	 */
 	public deleteSweepReadyNodes(sweepReadyDataStoreRoutes: readonly string[]): readonly string[] {
-		// If sweep for data stores is not enabled, return empty list indicating nothing is deleted.
-		if (this.mc.config.getBoolean(disableDatastoreSweepKey) === true) {
-			return [];
-		}
 		for (const route of sweepReadyDataStoreRoutes) {
 			const pathParts = route.split("/");
 			const dataStoreId = pathParts[1];

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -914,6 +914,7 @@ export class DataStores implements IDisposable {
 
 			// Ignore sub-data store routes because a data store and its sub-routes are deleted together, so, we only
 			// need to delete the data store.
+			// These routes will still be returned below as among the deleted routes
 			if (pathParts.length > 2) {
 				continue;
 			}

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -936,6 +936,10 @@ export class GarbageCollector implements IGarbageCollector {
 	/**
 	 * Delete nodes that are sweep-ready. Call the runtime to delete these nodes and clear the unreferenced state
 	 * tracking for nodes that are actually deleted by the runtime.
+	 *
+	 * Note that this doesn't check any configuration around whether Sweep is enabled.
+	 * That happens before the op is submitted, and from that point, any client should execute the delete.
+	 *
 	 * @param sweepReadyNodeIds - The ids of nodes that are ready to be deleted.
 	 */
 	private deleteSweepReadyNodes(sweepReadyNodeIds: readonly string[]) {

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -32,6 +32,7 @@ import {
 	defaultSweepGracePeriodMs,
 	gcGenerationOptionName,
 	IGCMetadata_Deprecated,
+	disableDatastoreSweepKey,
 } from "./gcDefinitions";
 import { getGCVersion, shouldAllowGcSweep } from "./gcHelpers";
 
@@ -137,18 +138,24 @@ export function generateGCConfigs(
 	 * Whether sweep should run or not. This refers to whether Tombstones should fail on load and whether
 	 * sweep-ready nodes should be deleted.
 	 *
-	 * Assuming overall GC is enabled and Tombstone timeout is present, the following conditions have to be met to run sweep:
+	 * Assuming overall GC is enabled and tombstoneTimeout is provided, the following conditions have to be met to run sweep:
 	 *
-	 * 1. Sweep should be enabled for this container.
-	 * 2. Sweep should be enabled for this session.
+	 * 1. Sweep should be allowed in this container.
+	 * 2. Sweep should be enabled for this session, optionally restricted to attachment blobs only.
 	 *
 	 * These conditions can be overridden via the RunSweep feature flag.
 	 */
-	const shouldRunSweep =
+	const sweepEnabled: boolean =
 		!shouldRunGC || tombstoneTimeoutMs === undefined
 			? false
 			: mc.config.getBoolean(runSweepKey) ??
 			  (sweepAllowed && createParams.gcOptions.enableGCSweep === true);
+	const disableDatastoreSweep = mc.config.getBoolean(disableDatastoreSweepKey) === true;
+	const shouldRunSweep: IGarbageCollectorConfigs["shouldRunSweep"] = sweepEnabled
+		? disableDatastoreSweep
+			? "ONLY_BLOBS"
+			: "YES"
+		: "NO";
 
 	// Override inactive timeout if test config or gc options to override it is set.
 	const inactiveTimeoutMs =

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -72,8 +72,6 @@ export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombston
 export const gcVersionUpgradeToV4Key = "Fluid.GarbageCollection.GCVersionUpgradeToV4";
 /** Config key to disable GC sweep for datastores. They'll merely be Tombstoned. */
 export const disableDatastoreSweepKey = "Fluid.GarbageCollection.DisableDataStoreSweep";
-/** Config key to disable GC sweep for attachment blobs. They'll merely be Tombstoned. */
-export const disableAttachmentBlobSweepKey = "Fluid.GarbageCollection.DisableAttachmentBlobSweep";
 /** Config key to revert new paradigm of detecting outbound routes in ContainerRuntime layer (use true) */
 export const detectOutboundRoutesViaDDSKey = "Fluid.GarbageCollection.DetectOutboundRoutesViaDDS";
 /** Config key to disable auto-recovery mechanism that protects Tombstones that are loaded from being swept (use true) */
@@ -472,7 +470,7 @@ export interface IGarbageCollectorConfigs {
 	 */
 	readonly gcEnabled: boolean;
 	/**
-	 * Tracks if sweep phase is enabled for this document. This is specified during document creation and doesn't change
+	 * Tracks if sweep phase is allowed for this document. This is specified during document creation and doesn't change
 	 * throughout its lifetime.
 	 */
 	readonly sweepEnabled: boolean;
@@ -482,10 +480,11 @@ export interface IGarbageCollectorConfigs {
 	 */
 	readonly shouldRunGC: boolean;
 	/**
-	 * Tracks if sweep phase should run or not. Even if the sweep phase is enabled for a document (see sweepEnabled), it
-	 * can be explicitly disabled via feature flags. It also won't run if session expiry is not enabled.
+	 * Tracks if sweep phase should run or not, and if it should run only for attachment blobs.
+	 * Even if the sweep phase is allowed for a document (see sweepEnabled), it may be disabled or partially enabled
+	 * for the session, depending on a variety of other configurations present.
 	 */
-	readonly shouldRunSweep: boolean;
+	readonly shouldRunSweep: "YES" | "ONLY_BLOBS" | "NO";
 	/**
 	 * If true, bypass optimizations and generate GC data for all nodes irrespective of whether a node changed or not.
 	 */

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -70,9 +70,9 @@ export const throwOnTombstoneLoadOverrideKey =
 export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
 /** Config key to enable GC version upgrade. */
 export const gcVersionUpgradeToV4Key = "Fluid.GarbageCollection.GCVersionUpgradeToV4";
-/** Config key to disable GC sweep for datastores. */
+/** Config key to disable GC sweep for datastores. They'll merely be Tombstoned. */
 export const disableDatastoreSweepKey = "Fluid.GarbageCollection.DisableDataStoreSweep";
-/** Config key to disable GC sweep for attachment blobs. */
+/** Config key to disable GC sweep for attachment blobs. They'll merely be Tombstoned. */
 export const disableAttachmentBlobSweepKey = "Fluid.GarbageCollection.DisableAttachmentBlobSweep";
 /** Config key to revert new paradigm of detecting outbound routes in ContainerRuntime layer (use true) */
 export const detectOutboundRoutesViaDDSKey = "Fluid.GarbageCollection.DetectOutboundRoutesViaDDS";

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -480,7 +480,7 @@ export interface IGarbageCollectorConfigs {
 	 */
 	readonly shouldRunGC: boolean;
 	/**
-	 * Tracks if sweep phase should run or not, and if it should run only for attachment blobs.
+	 * Tracks if sweep phase should run or not, or if it should run only for attachment blobs.
 	 * Even if the sweep phase is allowed for a document (see sweepEnabled), it may be disabled or partially enabled
 	 * for the session, depending on a variety of other configurations present.
 	 */

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -32,7 +32,6 @@ export {
 	runSessionExpiryKey,
 	runSweepKey,
 	stableGCVersion,
-	disableAttachmentBlobSweepKey,
 	disableAutoRecoveryKey,
 	disableDatastoreSweepKey,
 	detectOutboundRoutesViaDDSKey,

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -34,7 +34,6 @@ import {
 	LoggingError,
 } from "@fluidframework/telemetry-utils";
 import { BlobManager, IBlobManagerLoadInfo, IBlobManagerRuntime } from "../blobManager";
-import { disableAttachmentBlobSweepKey } from "../gc";
 
 const MIN_TTL = 24 * 60 * 60; // same as ODSP
 abstract class BaseMockBlobStorage
@@ -944,10 +943,13 @@ describe("BlobManager", () => {
 			);
 		});
 
-		// DisableAttachmentBlobsSweep setting is checked in GC code _before_ calling BlobManager.
+		// Support for this config has been removed.
+		const legacyKey_disableAttachmentBlobSweep =
+			"Fluid.GarbageCollection.DisableAttachmentBlobSweep";
 		[true, false, undefined].forEach((disableAttachmentBlobsSweep) =>
 			it(`deletes unused blobs regardless of DisableAttachmentBlobsSweep setting [DisableAttachmentBlobsSweep=${disableAttachmentBlobsSweep}]`, async () => {
-				injectedSettings[disableAttachmentBlobSweepKey] = disableAttachmentBlobsSweep;
+				injectedSettings[legacyKey_disableAttachmentBlobSweep] =
+					disableAttachmentBlobsSweep;
 
 				await runtime.attach();
 				await runtime.connect();

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -944,47 +944,30 @@ describe("BlobManager", () => {
 			);
 		});
 
-		it("disableAttachmentBlobsSweep true - DOESN'T delete unused blobs ", async () => {
-			injectedSettings[disableAttachmentBlobSweepKey] = true;
+		// DisableAttachmentBlobsSweep setting is checked in GC code _before_ calling BlobManager.
+		[true, false, undefined].forEach((disableAttachmentBlobsSweep) =>
+			it(`deletes unused blobs regardless of DisableAttachmentBlobsSweep setting [DisableAttachmentBlobsSweep=${disableAttachmentBlobsSweep}]`, async () => {
+				injectedSettings[disableAttachmentBlobSweepKey] = disableAttachmentBlobsSweep;
 
-			await runtime.attach();
-			await runtime.connect();
+				await runtime.attach();
+				await runtime.connect();
 
-			const blob1 = await createBlobAndGetIds("blob1");
-			const blob2 = await createBlobAndGetIds("blob2");
+				const blob1 = await createBlobAndGetIds("blob1");
+				const blob2 = await createBlobAndGetIds("blob2");
 
-			// Delete blob1's local id. The local id and the storage id should both be deleted from the redirect table
-			// since the blob only had one reference.
-			runtime.blobManager.deleteSweepReadyNodes([blob1.localGCNodeId]);
-			assert(redirectTable.has(blob1.localId));
-			assert(redirectTable.has(blob1.storageId));
+				// Delete blob1's local id. The local id and the storage id should both be deleted from the redirect table
+				// since the blob only had one reference.
+				runtime.blobManager.deleteSweepReadyNodes([blob1.localGCNodeId]);
+				assert(!redirectTable.has(blob1.localId));
+				assert(!redirectTable.has(blob1.storageId));
 
-			// Delete blob2's local id. The local id and the storage id should both be deleted from the redirect table
-			// since the blob only had one reference.
-			runtime.blobManager.deleteSweepReadyNodes([blob2.localGCNodeId]);
-			assert(redirectTable.has(blob2.localId));
-			assert(redirectTable.has(blob2.storageId));
-		});
-
-		it("deletes unused blobs", async () => {
-			await runtime.attach();
-			await runtime.connect();
-
-			const blob1 = await createBlobAndGetIds("blob1");
-			const blob2 = await createBlobAndGetIds("blob2");
-
-			// Delete blob1's local id. The local id and the storage id should both be deleted from the redirect table
-			// since the blob only had one reference.
-			runtime.blobManager.deleteSweepReadyNodes([blob1.localGCNodeId]);
-			assert(!redirectTable.has(blob1.localId));
-			assert(!redirectTable.has(blob1.storageId));
-
-			// Delete blob2's local id. The local id and the storage id should both be deleted from the redirect table
-			// since the blob only had one reference.
-			runtime.blobManager.deleteSweepReadyNodes([blob2.localGCNodeId]);
-			assert(!redirectTable.has(blob2.localId));
-			assert(!redirectTable.has(blob2.storageId));
-		});
+				// Delete blob2's local id. The local id and the storage id should both be deleted from the redirect table
+				// since the blob only had one reference.
+				runtime.blobManager.deleteSweepReadyNodes([blob2.localGCNodeId]);
+				assert(!redirectTable.has(blob2.localId));
+				assert(!redirectTable.has(blob2.storageId));
+			}),
+		);
 
 		it("deletes unused de-duped blobs", async () => {
 			await runtime.attach();

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -946,7 +946,7 @@ describe("BlobManager", () => {
 		// Support for this config has been removed.
 		const legacyKey_disableAttachmentBlobSweep =
 			"Fluid.GarbageCollection.DisableAttachmentBlobSweep";
-		[true, false, undefined].forEach((disableAttachmentBlobsSweep) =>
+		[true, undefined].forEach((disableAttachmentBlobsSweep) =>
 			it(`deletes unused blobs regardless of DisableAttachmentBlobsSweep setting [DisableAttachmentBlobsSweep=${disableAttachmentBlobsSweep}]`, async () => {
 				injectedSettings[legacyKey_disableAttachmentBlobSweep] =
 					disableAttachmentBlobsSweep;

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -45,6 +45,7 @@ import {
 	gcDisableThrowOnTombstoneLoadOptionName,
 	GCVersion,
 	runSessionExpiryKey,
+	disableDatastoreSweepKey,
 } from "../../gc";
 import { ContainerRuntimeGCMessage } from "../../messageTypes";
 import { IContainerRuntimeMetadata } from "../../summary";
@@ -177,7 +178,7 @@ describe("Garbage Collection configurations", () => {
 			assert(!gc.configs.gcEnabled, "gcEnabled incorrect");
 			assert(!gc.configs.shouldRunGC, "shouldRunGC incorrect");
 			assert(gc.configs.sweepEnabled, "sweepEnabled incorrect");
-			assert(!gc.configs.shouldRunSweep, "shouldRunSweep incorrect");
+			assert.equal(gc.configs.shouldRunSweep, "NO", "shouldRunSweep incorrect");
 			assert(
 				gc.configs.sessionExpiryTimeoutMs === undefined,
 				"sessionExpiryTimeoutMs incorrect",
@@ -370,7 +371,7 @@ describe("Garbage Collection configurations", () => {
 			assert(gc.configs.gcEnabled, "gcEnabled incorrect");
 			assert(gc.configs.shouldRunGC, "shouldRunGC incorrect");
 			assert(gc.configs.sweepEnabled, "sweepEnabled incorrect"); // Sweep is always allowed for a new container
-			assert(!gc.configs.shouldRunSweep, "shouldRunSweep incorrect");
+			assert.equal(gc.configs.shouldRunSweep, "NO", "shouldRunSweep incorrect");
 			assert(
 				gc.configs.sessionExpiryTimeoutMs !== undefined,
 				"sessionExpiryTimeoutMs incorrect",
@@ -782,60 +783,74 @@ describe("Garbage Collection configurations", () => {
 				shouldRunGC: boolean;
 				sweepEnabled_doc: boolean;
 				sweepEnabled_session: boolean;
+				disableDataStoreSweep?: true;
 				shouldRunSweep?: boolean;
-				expectedShouldRunSweep: boolean;
+				expectedShouldRunSweep: IGarbageCollectorConfigs["shouldRunSweep"];
 			}[] = [
 				{
-					shouldRunGC: false, // Veto power
+					shouldRunGC: false, // Veto
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
+					disableDataStoreSweep: true,
 					shouldRunSweep: true,
-					expectedShouldRunSweep: false,
-				},
-				{
-					shouldRunGC: true,
-					sweepEnabled_doc: true,
-					sweepEnabled_session: true,
-					shouldRunSweep: true,
-					expectedShouldRunSweep: true,
-				},
-				{
-					shouldRunGC: true,
-					sweepEnabled_doc: true,
-					sweepEnabled_session: true,
-					shouldRunSweep: false, // Veto power
-					expectedShouldRunSweep: false,
-				},
-				{
-					shouldRunGC: true,
-					sweepEnabled_doc: true,
-					sweepEnabled_session: false,
-					shouldRunSweep: true, // Overrides sweepEnabled_session
-					expectedShouldRunSweep: true,
-				},
-				{
-					shouldRunGC: true,
-					sweepEnabled_doc: true,
-					sweepEnabled_session: true,
-					expectedShouldRunSweep: true,
-				},
-				{
-					shouldRunGC: true,
-					sweepEnabled_doc: true,
-					sweepEnabled_session: false, // Veto
-					expectedShouldRunSweep: false,
+					expectedShouldRunSweep: "NO",
 				},
 				{
 					shouldRunGC: true,
 					sweepEnabled_doc: false, // Veto
 					sweepEnabled_session: true,
-					expectedShouldRunSweep: false,
+					disableDataStoreSweep: true,
+					expectedShouldRunSweep: "NO",
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled_doc: true,
+					sweepEnabled_session: false, // Veto
+					disableDataStoreSweep: true,
+					expectedShouldRunSweep: "NO",
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled_doc: true,
+					sweepEnabled_session: true,
+					shouldRunSweep: false, // Veto
+					disableDataStoreSweep: true,
+					expectedShouldRunSweep: "NO",
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled_doc: true,
+					sweepEnabled_session: false, // Overriden by shouldRunSweep
+					shouldRunSweep: true,
+					expectedShouldRunSweep: "YES",
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled_doc: true,
+					sweepEnabled_session: true,
+					expectedShouldRunSweep: "YES",
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled_doc: true,
+					sweepEnabled_session: true,
+					disableDataStoreSweep: true,
+					expectedShouldRunSweep: "ONLY_BLOBS",
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled_doc: true,
+					sweepEnabled_session: true,
+					shouldRunSweep: true,
+					disableDataStoreSweep: true, // Applies after shouldRunSweep
+					expectedShouldRunSweep: "ONLY_BLOBS",
 				},
 			];
 			testCases.forEach((testCase, index) => {
 				it(`Test Case ${JSON.stringify(testCase)}`, () => {
 					configProvider.set(runGCKey, testCase.shouldRunGC);
 					configProvider.set(runSweepKey, testCase.shouldRunSweep);
+					configProvider.set(disableDatastoreSweepKey, testCase.disableDataStoreSweep);
 					gc = createGcWithPrivateMembers(
 						{
 							gcFeatureMatrix: { gcGeneration: 1 },

--- a/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
@@ -338,9 +338,13 @@ describe("Garbage Collection Stats", () => {
 			clock.tick(sweepTimeoutMs + 1);
 
 			// There shouldn't be any nodes whose reference state updated.
-			// Note that the nodes won't be deleted yet. They will be deleted once the GC op is processed.
 			expectedStats.updatedNodeCount = 0;
 			expectedStats.updatedDataStoreCount = 0;
+
+			// Note that the 2 sweep-ready nodes won't actually be deleted yet (until the GC op is processed)
+			// but we account for them in the deleted stats now.
+			expectedStats.deletedNodeCount += 2;
+			expectedStats.deletedDataStoreCount += 2;
 
 			gcStats = await garbageCollector.collectGarbage({});
 			assert.deepStrictEqual(gcStats, expectedStats, "Incorrect GC stats 1");
@@ -353,10 +357,8 @@ describe("Garbage Collection Stats", () => {
 			// Process the GC message so that the sweep ready nodes are deleted.
 			processLastGCMessage();
 
-			// The 2 sweep ready nodes / data stores should now be deleted.
+			// The 2 sweep ready nodes / data stores should now be truly deleted.
 			// They should be removed from the total node and unreferenced counts.
-			expectedStats.deletedNodeCount += 2;
-			expectedStats.deletedDataStoreCount += 2;
 			expectedStats.nodeCount -= 2;
 			expectedStats.dataStoreCount -= 2;
 			expectedStats.unrefNodeCount -= 2;
@@ -389,9 +391,13 @@ describe("Garbage Collection Stats", () => {
 			clock.tick(sweepTimeoutMs + 1);
 
 			// There shouldn't be any nodes whose reference state updated.
-			// Note that the nodes won't be deleted yet. They will be deleted once the GC op is processed.
 			expectedStats.updatedNodeCount = 0;
 			expectedStats.updatedDataStoreCount = 0;
+
+			// Note that the 2 sweep-ready nodes won't actually be deleted yet (until the GC op is processed)
+			// but we account for them in the deleted stats now.
+			expectedStats.deletedNodeCount += 2;
+			expectedStats.deletedDataStoreCount += 2;
 
 			gcStats = await garbageCollector.collectGarbage({});
 
@@ -403,13 +409,11 @@ describe("Garbage Collection Stats", () => {
 			// Process the GC message so that the sweep ready nodes are deleted.
 			processLastGCMessage();
 
-			// Unreference another data store node.
+			// Unreference one more data store node (nodes[1])
 			defaultGCData.gcNodes[nodes[0]] = [];
 
 			// The 2 sweep ready nodes / data stores should now be deleted.
 			// They should be removed from the total node and unreferenced counts.
-			expectedStats.deletedNodeCount += 2;
-			expectedStats.deletedDataStoreCount += 2;
 			expectedStats.nodeCount -= 2;
 			expectedStats.dataStoreCount -= 2;
 			expectedStats.unrefNodeCount -= 2;
@@ -427,9 +431,13 @@ describe("Garbage Collection Stats", () => {
 			clock.tick(sweepTimeoutMs + 1);
 
 			// No nodes are updated since the last run.
-			// Note that the nodes won't be deleted yet. They will be deleted once the GC op is processed.
 			expectedStats.updatedNodeCount = 0;
 			expectedStats.updatedDataStoreCount = 0;
+
+			// Note that the new sweep-ready node won't actually be deleted yet (until the GC op is processed)
+			// but we account for it in the deleted stats now.
+			expectedStats.deletedNodeCount += 1;
+			expectedStats.deletedDataStoreCount += 1;
 
 			gcStats = await garbageCollector.collectGarbage({});
 			assert.deepStrictEqual(gcStats, expectedStats, "Incorrect GC stats 3");
@@ -442,10 +450,8 @@ describe("Garbage Collection Stats", () => {
 			// Process the GC message so that the sweep ready node is deleted.
 			processLastGCMessage();
 
-			// The sweep ready node / data store should now be deleted.
+			// The sweep ready node / data store should now be truly deleted.
 			// It should be removed from the total node and unreferenced counts.
-			expectedStats.deletedNodeCount++;
-			expectedStats.deletedDataStoreCount++;
 			expectedStats.nodeCount--;
 			expectedStats.dataStoreCount--;
 			expectedStats.unrefNodeCount--;

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -73,7 +73,7 @@ describe("GC Telemetry Tracker", () => {
 			gcEnabled: true,
 			sweepEnabled: false,
 			shouldRunGC: true,
-			shouldRunSweep: false,
+			shouldRunSweep: "NO",
 			runFullGC: false,
 			testMode: false,
 			tombstoneMode: false,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -32,7 +32,7 @@ import {
 	// eslint-disable-next-line import/no-internal-modules
 } from "@fluidframework/container-runtime/test/summary";
 // eslint-disable-next-line import/no-internal-modules
-import { ISweepMessage } from "@fluidframework/container-runtime/test/gc";
+import { disableDatastoreSweepKey, ISweepMessage } from "@fluidframework/container-runtime/test/gc";
 import {
 	driverSupportsBlobs,
 	getUrlFromDetachedBlobStorage,
@@ -128,8 +128,11 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 		loaderProps: { configProvider },
 	};
 
-	async function loadContainer(summaryVersion: string) {
-		return provider.loadTestContainer(testContainerConfig, {
+	async function loadContainer(
+		summaryVersion: string,
+		config: ITestContainerConfig = testContainerConfig,
+	) {
+		return provider.loadTestContainer(config, {
 			[LoaderHeader.version]: summaryVersion,
 		});
 	}
@@ -1090,45 +1093,50 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 			}
 		});
 
-		it("updates deleted blob state in the summary", async () => {
-			const { dataStore: mainDataStore, summarizer } = await createDataStoreAndSummarizer();
+		[true, undefined].forEach((disableDatastoreSweep) =>
+			it(`updates deleted blob state in the summary [disableDatastoreSweep=${disableDatastoreSweep}]`, async () => {
+				configProvider.set(disableDatastoreSweepKey, disableDatastoreSweep);
 
-			// Upload an attachment blob.
-			const blob1Contents = "Blob contents 1";
-			const blob1Handle = await mainDataStore._runtime.uploadBlob(
-				stringToBuffer(blob1Contents, "utf-8"),
-			);
-			const blob1NodePath = blob1Handle.absolutePath;
+				const { dataStore: mainDataStore, summarizer } =
+					await createDataStoreAndSummarizer();
 
-			// Reference and then unreference the blob so that it's unreferenced in the next summary.
-			mainDataStore._root.set("blob1", blob1Handle);
-			mainDataStore._root.delete("blob1");
+				// Upload an attachment blob.
+				const blob1Contents = "Blob contents 1";
+				const blob1Handle = await mainDataStore._runtime.uploadBlob(
+					stringToBuffer(blob1Contents, "utf-8"),
+				);
+				const blob1NodePath = blob1Handle.absolutePath;
 
-			// Summarize so that blob is marked unreferenced.
-			await provider.ensureSynchronized();
-			await summarizeNow(summarizer);
+				// Reference and then unreference the blob so that it's unreferenced in the next summary.
+				mainDataStore._root.set("blob1", blob1Handle);
+				mainDataStore._root.delete("blob1");
 
-			// Wait for sweep full timeout so that blob is ready to be deleted.
-			await delay(sweepTimeoutMs + 10);
+				// Summarize so that blob is marked unreferenced.
+				await provider.ensureSynchronized();
+				await summarizeNow(summarizer);
 
-			// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
-			mainDataStore._root.set("key", "value");
-			await provider.ensureSynchronized();
+				// Wait for sweep full timeout so that blob is ready to be deleted.
+				await delay(sweepTimeoutMs + 10);
 
-			// Summarize. In this summary, the gc op will be sent with the deleted blob ids. The blobs will be
-			// removed in the subsequent summary.
-			await summarizeNow(summarizer);
+				// Send an op to update the current reference timestamp that GC uses to make sweep ready objects.
+				mainDataStore._root.set("key", "value");
+				await provider.ensureSynchronized();
 
-			// Summarize again so that the sweep ready blobs are now deleted from the GC data.
-			const summary3 = await summarizeNow(summarizer);
-			// Validate that the deleted blob's state is correct in the summary.
-			validateBlobStateInSummary(
-				summary3.summaryTree,
-				blob1NodePath,
-				true /* expectDelete */,
-				false /* expectGCStateHandle */,
-			);
-		});
+				// Summarize. In this summary, the gc op will be sent with the deleted blob ids. The blobs will be
+				// removed in the subsequent summary.
+				await summarizeNow(summarizer);
+
+				// Summarize again so that the sweep ready blobs are now deleted from the GC data.
+				const summary3 = await summarizeNow(summarizer);
+				// Validate that the deleted blob's state is correct in the summary.
+				validateBlobStateInSummary(
+					summary3.summaryTree,
+					blob1NodePath,
+					true /* expectDelete */,
+					false /* expectGCStateHandle */,
+				);
+			}),
+		);
 	});
 
 	describe("Sweep with summarize failures and retries", () => {
@@ -1341,7 +1349,16 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 
 					// Load a container from the above summary, process all ops (including any GC ops) and validate that
 					// the deleted blob cannot be retrieved.
-					const container2 = await loadContainer(summary.summaryVersion);
+					// We load with GC Disabled to confirm that the GC Op is processed regardless of such settings
+					const config_gcSweepDisabled = JSON.parse(
+						JSON.stringify(testContainerConfig),
+					) as ITestContainerConfig;
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					config_gcSweepDisabled.runtimeOptions!.gcOptions!.enableGCSweep = undefined;
+					const container2 = await loadContainer(
+						summary.summaryVersion,
+						config_gcSweepDisabled,
+					);
 					await waitForContainerConnection(container2);
 
 					await provider.ensureSynchronized();

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -157,8 +157,11 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 		configProvider.clear();
 	});
 
-	async function loadContainer(summaryVersion: string) {
-		return provider.loadTestContainer(testContainerConfig, {
+	async function loadContainer(
+		summaryVersion: string,
+		config: ITestContainerConfig = testContainerConfig,
+	) {
+		return provider.loadTestContainer(config, {
 			[LoaderHeader.version]: summaryVersion,
 		});
 	}
@@ -782,7 +785,16 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 
 					// Load a container from the above summary, process all ops (including any GC ops) and validate that
 					// the deleted data store cannot be retrieved.
-					const container2 = await loadContainer(summary.summaryVersion);
+					// We load with GC Disabled to confirm that the GC Op is processed regardless of such settings
+					const config_gcSweepDisabled = JSON.parse(
+						JSON.stringify(testContainerConfig),
+					) as ITestContainerConfig;
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					config_gcSweepDisabled.runtimeOptions!.gcOptions!.enableGCSweep = undefined;
+					const container2 = await loadContainer(
+						summary.summaryVersion,
+						config_gcSweepDisabled,
+					);
 					await waitForContainerConnection(container2);
 
 					await provider.ensureSynchronized();

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -546,16 +546,6 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 			// will be removed in the subsequent summary.
 			await ensureSynchronizedAndSummarize(summarizer);
 
-			//* Maybe remove this since we can check at the end below
-			// const garbageCollector = (
-			// 	summarizingContainer as unknown as { garbageCollector: { tombstones: string[] } }
-			// ).garbageCollector;
-			// assert.deepEqual(
-			// 	garbageCollector.tombstones,
-			// 	[sweepReadyDataStoreNodePath],
-			// 	"Expected sweepReady node to be merely Tombstoned",
-			// );
-
 			// The datastore should NOT be swept here. If sweep was enabled, it would be deleted in this summary.
 			// We need to do fullTree because the GC data won't change (since it's not swept).
 			// But the validation depends on the GC subtree being present (not a handle).

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
@@ -85,7 +85,6 @@ describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 			this.skip();
 		}
 
-		configProvider.set("Fluid.GarbageCollection.DisableAttachmentBlobSweep", true); // Only sweep DataStores
 		configProvider.set("Fluid.GarbageCollection.ThrowOnTombstoneUsage", true);
 		configProvider.set(
 			"Fluid.GarbageCollection.TestOverride.TombstoneTimeoutMs",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
@@ -35,7 +35,7 @@ describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 	// Since these tests depend on these timing windows, they should not be run against drivers talking over the network
 	// (see this.skip() call below)
 	const tombstoneTimeoutMs = 200; // Tombstone at 200ms
-	const sweepGracePeriodMs = 100; // Sweep at 300ms
+	const sweepGracePeriodMs = 200; // Sweep at 400ms
 
 	const configProvider = createTestConfigProvider();
 	const gcOptions: IGCRuntimeOptions = {


### PR DESCRIPTION
## Description

Fixes AB#7141

When implementing two-stage sweep (including follow-up bug fix #18734), we missed the case where config flags are set to disable GC Sweep for either blobs or datastores.  In those cases, the excluded nodes should be tombstoned, but as it is they will not be.

The fix involves:

* Removing the option to disable blob GC.  It's the simpler case, and I don't anticipate needing this ability. It reduces the support matrix for incoming configs, which outweighs the loss of functionality.
* Consolidating the logic for deciding what nodes to run sweep for into the GC classes, rather than out in other parts of the runtime.
* Adding a new `ONLY_BLOBS` case to the `shouldRunSweep` internal config

## Reviewer Guidance

I intend to port this back to internal.7.4 and rebase #19510 onto it - that diff will become much simpler. We are accelerating delivery of this feature for the benefit of some 1P partners building on Fluid.
