### PR TITLE
[Port 2.0.0-rc.1.0] Enable all getAttachSummary paths in Legacy Shared Tree (#19365)

### DIFF
--- a/experimental/dds/tree/api-report/experimental-tree.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.api.md
@@ -908,6 +908,8 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     get edits(): OrderedEditSet<InternalizedChange>;
     equals(sharedTree: SharedTree): boolean;
     generateNodeId(override?: string): NodeId;
+    // (undocumented)
+    getAttachSummary(fullTree?: boolean | undefined, trackState?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined): ISummaryTreeWithStats;
     static getFactory(...args: SharedTreeArgs<WriteFormat.v0_0_2>): SharedTreeFactory;
     // (undocumented)
     static getFactory(...args: SharedTreeArgs<WriteFormat.v0_1_1>): SharedTreeFactory;

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -30,7 +30,7 @@ import {
 	createSampledLogger,
 	IEventSampler,
 } from '@fluidframework/telemetry-utils';
-import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
+import { ISummaryTreeWithStats, ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { fail, copyPropertyIfDefined, RestOrArray, unwrapRestOrArray } from './Common';
 import { EditHandle, EditLog, OrderedEditSet } from './EditLog';
 import {
@@ -738,6 +738,32 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	}
 
 	/**
+	 * {@inheritDoc @fluidframework/datastore-definitions#(IChannel:interface).getAttachSummary}
+	 */
+	public override getAttachSummary(
+		fullTree?: boolean | undefined,
+		trackState?: boolean | undefined,
+		telemetryContext?: ITelemetryContext | undefined
+	): ISummaryTreeWithStats {
+		// If local changes exist, emulate the sequencing of those changes.
+		// Doing so is necessary so edits created during DataObject.initializingFirstTime are included.
+		// Doing so is safe because it is guaranteed that the DDS has not yet been attached. This is because summary creation is only
+		// ever invoked on a DataObject containing local changes when it is attached for the first time. In post-attach flows, an extra
+		// instance of the DataObject is created for generating summaries and will never have local edits.
+		if (this.editLog.numberOfLocalEdits > 0) {
+			if (this.writeFormat === WriteFormat.v0_1_1) {
+				// Since we're the first client to attach, we can safely finalize ourselves since we're the only ones who have made IDs.
+				this.idCompressor.finalizeCreationRange(this.idCompressor.takeNextCreationRange());
+				for (const edit of this.editLog.getLocalEdits()) {
+					this.internStringsFromEdit(edit);
+				}
+			}
+			this.editLog.sequenceLocalEdits();
+		}
+		return super.getAttachSummary(fullTree, trackState, telemetryContext);
+	}
+
+	/**
 	 * Saves this SharedTree into a serialized summary. This is used for testing.
 	 *
 	 * @param summarizer - Optional summarizer to use. If not passed in, SharedTree's summarizer is used.
@@ -761,26 +787,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * Saves this SharedTree into a deserialized summary.
 	 */
 	public saveSummary(): SharedTreeSummaryBase {
-		// If local changes exist, emulate the sequencing of those changes.
-		// Doing so is necessary so edits created during DataObject.initializingFirstTime are included.
-		// Doing so is safe because it is guaranteed that the DDS has not yet been attached. This is because summary creation is only
-		// ever invoked on a DataObject containing local changes when it is attached for the first time. In post-attach flows, an extra
-		// instance of the DataObject is created for generating summaries and will never have local edits.
-		if (this.editLog.numberOfLocalEdits > 0) {
-			assert(
-				!this.isAttached(),
-				0x62e /* Summarizing should not occur with local edits except on first attach. */
-			);
-			if (this.writeFormat === WriteFormat.v0_1_1) {
-				// Since we're the first client to attach, we can safely finalize ourselves since we're the only ones who have made IDs.
-				this.idCompressor.finalizeCreationRange(this.idCompressor.takeNextCreationRange());
-				for (const edit of this.editLog.getLocalEdits()) {
-					this.internStringsFromEdit(edit);
-				}
-			}
-			this.editLog.sequenceLocalEdits();
-		}
-
 		assert(this.editLog.numberOfLocalEdits === 0, 0x62f /* generateSummary must not be called with local edits */);
 		return this.generateSummary();
 	}

--- a/experimental/dds/tree/src/test/Summary.tests.ts
+++ b/experimental/dds/tree/src/test/Summary.tests.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 import { join } from 'path';
 import { expect, assert } from 'chai';
 import { v5 } from 'uuid';
+import { ISummaryBlob, SummaryType } from '@fluidframework/protocol-definitions';
 import { Change, StablePlace, StableRange } from '../ChangeTypes';
 import { fail, RecursiveMutable } from '../Common';
 import { areRevisionViewsSemanticallyEqual } from '../EditUtilities';
@@ -196,7 +197,13 @@ export function runSummaryTests(title: string): void {
 
 			it('writes 0.0.2 files without history', async () => {
 				const tree = await setUp002SummaryTestTree(false);
-				const summary: RecursiveMutable<SharedTreeSummary_0_0_2> = JSON.parse(tree.saveSerializedSummary());
+
+				const { summary: attachSummary } = tree.getAttachSummary();
+				expect(attachSummary.type).to.equal(SummaryType.Tree, 'Summary type should be Tree');
+				expect(attachSummary.tree.header.type).to.equal(SummaryType.Blob, 'Summary should contain header blob');
+				const serializedSummary = (attachSummary.tree.header as ISummaryBlob).content as string;
+
+				const summary: RecursiveMutable<SharedTreeSummary_0_0_2> = JSON.parse(serializedSummary);
 				const expectedSummary: SharedTreeSummary_0_0_2 = JSON.parse(summaryFileNoHistory_0_0_2);
 				// The edit ID of the single "no history edit" is generated randomly. Replace it with the baseline edit for the sake of this test.
 				summary.sequencedEdits[0].id = expectedSummary.sequencedEdits[0].id;

--- a/packages/test/test-end-to-end-tests/src/test/attachLegacyTree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachLegacyTree.spec.ts
@@ -36,7 +36,7 @@ const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 	registryEntries: [["test", Promise.resolve(dataObjectFactory)]],
 });
 
-describeCompat("Can attach Legacy Shared Tree", "2.0.0-rc.1.0.0", (getTestObjectProvider, apis) => {
+describeCompat("Can attach Legacy Shared Tree", "NoCompat", (getTestObjectProvider, apis) => {
 	let provider: ITestObjectProvider;
 	beforeEach("getTestObjectProvider", () => {
 		provider = getTestObjectProvider();

--- a/packages/test/test-end-to-end-tests/src/test/attachLegacyTree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachLegacyTree.spec.ts
@@ -1,0 +1,110 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { ITestObjectProvider } from "@fluidframework/test-utils";
+import { BuildNode, Change, SharedTree, StablePlace, TraitLabel } from "@fluid-experimental/tree";
+import { ITestDataObject, describeCompat } from "@fluid-private/test-version-utils";
+import {
+	ContainerRuntimeFactoryWithDefaultDataStore,
+	DataObject,
+	DataObjectFactory,
+} from "@fluidframework/aqueduct";
+
+class TestDataObject extends DataObject {
+	public get _context() {
+		return this.context;
+	}
+	public get _runtime() {
+		return this.runtime;
+	}
+	public get _root() {
+		return this.root;
+	}
+}
+
+const dataObjectFactory = new DataObjectFactory(
+	"test",
+	TestDataObject,
+	[SharedTree.getFactory()],
+	undefined,
+);
+const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
+	defaultFactory: dataObjectFactory,
+	registryEntries: [["test", Promise.resolve(dataObjectFactory)]],
+});
+
+describeCompat("Can attach Legacy Shared Tree", "2.0.0-rc.1.0.0", (getTestObjectProvider, apis) => {
+	let provider: ITestObjectProvider;
+	beforeEach("getTestObjectProvider", () => {
+		provider = getTestObjectProvider();
+	});
+
+	it("attached container, detached data store, tree attached to data store", async () => {
+		const container = await provider.createContainer(runtimeFactory);
+		const rootObject = (await container.getEntryPoint()) as ITestDataObject;
+		const containerRuntime = rootObject._context.containerRuntime;
+
+		const dataStore = await containerRuntime.createDataStore("test");
+		const testDataObject = (await dataStore.entryPoint.get()) as TestDataObject;
+
+		const tree = testDataObject._runtime.createChannel(
+			"tree",
+			SharedTree.getFactory().type,
+		) as SharedTree;
+		const inventoryNode: BuildNode = {
+			definition: "abc",
+			traits: {
+				quantity: {
+					definition: "quantity",
+					payload: 0,
+				},
+			},
+		};
+		tree.applyEdit(
+			Change.insertTree(
+				inventoryNode,
+				StablePlace.atStartOf({
+					parent: tree.currentView.root,
+					label: "inventory" as TraitLabel,
+				}),
+			),
+		);
+
+		testDataObject._root.set("tree", tree.handle);
+		rootObject._root.set("tree", testDataObject.handle);
+		await provider.ensureSynchronized();
+	});
+
+	it("Attached container, attached data store, detached tree", async () => {
+		const container = await provider.createContainer(runtimeFactory);
+		const testObj = (await container.getEntryPoint()) as ITestDataObject;
+		const someNodeId = "someNodeId" as TraitLabel;
+		const tree = testObj._runtime.createChannel(
+			"abc",
+			SharedTree.getFactory().type,
+		) as SharedTree;
+		const inventoryNode: BuildNode = {
+			definition: someNodeId,
+			traits: {
+				quantity: {
+					definition: "quantity",
+					payload: 5,
+				},
+			},
+		};
+		tree.applyEdit(
+			Change.insertTree(
+				inventoryNode,
+				StablePlace.atStartOf({
+					parent: tree.currentView.root,
+					label: someNodeId,
+				}),
+			),
+		);
+		assert.doesNotThrow(() => testObj._root.set("any", tree.handle), "Can't attach tree");
+		await provider.ensureSynchronized();
+	});
+});


### PR DESCRIPTION
Back port fix to 2.0.0-rc.1.0

[AB#7049](https://dev.azure.com/fluidframework/internal/_workitems/edit/7049)

Original change causing the regression:
https://github.com/microsoft/FluidFramework/pull/18088

A customer was seeing `0x62e` errors appear in telemetry after `2.0.0-internal.7.4.3` was consumed. After an investigation, a regression was detected. It was determined that the original fix did not properly check if an attach summary was being generated in all cases, and would fail in some cases when an attach summary was generated.

When a datastore was attached, customers could not create new legacy shared tree DDSes with local edits as assert `0x62e` would be hit as the check would check to see if the datastore was attached, and not if the DDS was "attached".

When a datastore was detached, while attaching the datastore, the assert `0x62e` would be hit as the datastore runtime would be put into an `attaching` state thus the legacy SharedTree DDS would consider itself `attached` when the attach summary was generated.

Instead of putting the local edit logic when generating both attach summaries and regular summaries, we put the local edit logic only when generating the attach summary. This way, we already know that the legacy SharedTree DDS is being attached. When generating a regular summary, the assert `0x62f` should fire off if there are any local edits to a summary when it's being generated.