### PR TITLE
Add some telemetry for the (former) 0x162 assert. (#19415)

### DIFF
--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -461,7 +461,23 @@ export class DataStores implements IDisposable {
 			return;
 		}
 
-		assert(!!context, 0x162 /* "There should be a store context for the op" */);
+		if (context === undefined) {
+			// Former assert 0x162
+			throw DataProcessingError.create(
+				"No context for op",
+				"processFluidDataStoreOp",
+				message,
+				{
+					local,
+					messageDetails: JSON.stringify({
+						type: message.type,
+						contentType: typeof message.contents,
+					}),
+					...tagCodeArtifacts({ address: envelope.address }),
+				},
+			);
+		}
+
 		context.process(transformed, local, localMessageMetadata);
 
 		// By default, we use the new behavior of detecting outbound routes here.


### PR DESCRIPTION
## Description

ADO:7045

The assert doesn't tell us much about the context of the error. Converting this into a DataProcessingError.

I am aware that this is likely a data corruption incident, but technically it's a data processing error as the error happens when we process an op. The fact that the error doesn't recover leads to data corruption, but theoretically if a client would load a good summary, it may be able to recover.

Porting https://github.com/microsoft/FluidFramework/pull/19415 from main