### PR TITLE
[main > release/7.4]: Only emit throttling time in case it was from error (#19526)

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -656,8 +656,12 @@ export class ConnectionManager implements IConnectionManager {
 				if (retryDelayFromError !== undefined || globalThis.navigator?.onLine !== false) {
 					delayMs = calculateMaxWaitTime(delayMs, origError);
 				}
-				// Raise event in case the delay was there.
-				this.props.reconnectionDelayHandler(delayMs, origError);
+
+				// Raise event in case the delay was there from the error.
+				if (retryDelayFromError !== undefined) {
+					this.props.reconnectionDelayHandler(delayMs, origError);
+				}
+
 				await new Promise<void>((resolve) => {
 					setTimeout(resolve, delayMs);
 				});


### PR DESCRIPTION
## Description

Only emit throttling time in case it was from error. This was a change in behavior from before, so reverting it back to previous logic.

