### PR TITLE
fix(e2e-test): Fix flaky test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/reconnect.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/reconnect.spec.ts
@@ -39,6 +39,7 @@ import {
 	createSummarizerFromFactory,
 	summarizeNow,
 	type ITestObjectProvider,
+	waitForContainerConnection,
 } from "@fluidframework/test-utils";
 
 const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
@@ -366,6 +367,9 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider) => {
 		const container1 = await provider.loadContainer(runtimeFactory2);
 		const url = await container1.getAbsoluteUrl("");
 		assert(url !== undefined, "Container url should be defined");
+
+		await waitForContainerConnection(container1);
+
 		const testObj1 = (await container1.getEntryPoint()) as TestDataObject;
 		const shim1 = testObj1.getTree<MigrationShim>();
 		const legacyTree1 = shim1.currentTree as LegacySharedTree;
@@ -391,6 +395,8 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider) => {
 				[LoaderHeader.version]: summaryVersion,
 			},
 		);
+		await waitForContainerConnection(container2);
+
 		const testObj2 = (await container2.getEntryPoint()) as TestDataObject;
 		const shim2 = testObj2.getTree<SharedTreeShim>();
 		const newTree2 = shim2.currentTree;

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
@@ -40,6 +40,7 @@ import {
 	createSummarizerFromFactory,
 	summarizeNow,
 	type ITestObjectProvider,
+	waitForContainerConnection,
 } from "@fluidframework/test-utils";
 
 const legacyNodeId: TraitLabel = "inventory" as TraitLabel;
@@ -278,6 +279,8 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider) => {
 		const shim1 = testObj1.getTree<MigrationShim>();
 		const legacyTree1 = shim1.currentTree as LegacySharedTree;
 
+		await waitForContainerConnection(container1);
+
 		await provider.opProcessingController.pauseProcessing();
 		shim1.submitMigrateOp();
 
@@ -303,6 +306,7 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider) => {
 		const container2 = await provider.loadContainer(runtimeFactory2, undefined, {
 			[LoaderHeader.version]: summaryVersion,
 		});
+		await waitForContainerConnection(container2);
 		const testObj2 = (await container2.getEntryPoint()) as TestDataObject;
 		const shim2 = testObj2.getTree<SharedTreeShim>();
 		assert(

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -105,11 +105,6 @@ export interface ITestObjectProvider {
 	 * containerRuntime/dataRuntime used in fluidEntryPoint will be used as is from what is passed in.
 	 *
 	 * @param packageEntries - list of code details and fluidEntryPoint pairs.
-	 *
-	 * @remarks
-	 *
-	 * The containers returned by the loader are not guaranteed to be in Connected state.
-	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
 	 */
 	createLoader(
 		packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>,
@@ -126,26 +121,13 @@ export interface ITestObjectProvider {
 	 * @param packageEntries - list of code details and fluidEntryPoint pairs.
 	 */
 
-	/**
-	 * Creates a container using the default document id.
-	 *
-	 * @remarks
-	 *
-	 * The container is not guaranteed to be in Connected state.
-	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
-	 */
 	createContainer(
 		entryPoint: fluidEntryPoint,
 		loaderProps?: Partial<ILoaderProps>,
 	): Promise<IContainer>;
 
 	/**
-	 * Loads a container using the default document id.
-	 *
-	 * @remarks
-	 *
-	 * The container is not guaranteed to be in Connected state.
-	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
+	 * Loads a container using the default document id
 	 */
 	loadContainer(
 		entryPoint: fluidEntryPoint,
@@ -157,11 +139,6 @@ export interface ITestObjectProvider {
 	 * Make a test loader. Containers created/loaded through this loader will be added to the OpProcessingController.
 	 * The version of the loader/containerRuntime/dataRuntime may vary based on compat config of the current run
 	 * @param testContainerConfig - optional configuring the test Container
-	 *
-	 * @remarks
-	 *
-	 * The containers returned by the loader are not guaranteed to be in Connected state.
-	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
 	 */
 	makeTestLoader(testContainerConfig?: ITestContainerConfig): IHostLoader;
 
@@ -169,11 +146,6 @@ export interface ITestObjectProvider {
 	 * Make a container using a default document id and code details
 	 * Container loaded is automatically added to the OpProcessingController to manage op flow
 	 * @param testContainerConfig - optional configuring the test Container
-	 *
-	 * @remarks
-	 *
-	 * The container is not guaranteed to be in Connected state.
-	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
 	 */
 	makeTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer>;
 
@@ -182,11 +154,6 @@ export interface ITestObjectProvider {
 	 * IContainer loaded is automatically added to the OpProcessingController to manage op flow
 	 * @param testContainerConfig - optional configuring the test Container
 	 * @param requestHeader - optional headers to be supplied to the loader
-	 *
-	 * @remarks
-	 *
-	 * The container is not guaranteed to be in Connected state.
-	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
 	 */
 	loadTestContainer(
 		testContainerConfig?: ITestContainerConfig,

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -105,6 +105,11 @@ export interface ITestObjectProvider {
 	 * containerRuntime/dataRuntime used in fluidEntryPoint will be used as is from what is passed in.
 	 *
 	 * @param packageEntries - list of code details and fluidEntryPoint pairs.
+	 *
+	 * @remarks
+	 *
+	 * The containers returned by the loader are not guaranteed to be in Connected state.
+	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
 	 */
 	createLoader(
 		packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>,
@@ -121,13 +126,26 @@ export interface ITestObjectProvider {
 	 * @param packageEntries - list of code details and fluidEntryPoint pairs.
 	 */
 
+	/**
+	 * Creates a container using the default document id.
+	 *
+	 * @remarks
+	 *
+	 * The container is not guaranteed to be in Connected state.
+	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
+	 */
 	createContainer(
 		entryPoint: fluidEntryPoint,
 		loaderProps?: Partial<ILoaderProps>,
 	): Promise<IContainer>;
 
 	/**
-	 * Loads a container using the default document id
+	 * Loads a container using the default document id.
+	 *
+	 * @remarks
+	 *
+	 * The container is not guaranteed to be in Connected state.
+	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
 	 */
 	loadContainer(
 		entryPoint: fluidEntryPoint,
@@ -139,6 +157,11 @@ export interface ITestObjectProvider {
 	 * Make a test loader. Containers created/loaded through this loader will be added to the OpProcessingController.
 	 * The version of the loader/containerRuntime/dataRuntime may vary based on compat config of the current run
 	 * @param testContainerConfig - optional configuring the test Container
+	 *
+	 * @remarks
+	 *
+	 * The containers returned by the loader are not guaranteed to be in Connected state.
+	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
 	 */
 	makeTestLoader(testContainerConfig?: ITestContainerConfig): IHostLoader;
 
@@ -146,6 +169,11 @@ export interface ITestObjectProvider {
 	 * Make a container using a default document id and code details
 	 * Container loaded is automatically added to the OpProcessingController to manage op flow
 	 * @param testContainerConfig - optional configuring the test Container
+	 *
+	 * @remarks
+	 *
+	 * The container is not guaranteed to be in Connected state.
+	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
 	 */
 	makeTestContainer(testContainerConfig?: ITestContainerConfig): Promise<IContainer>;
 
@@ -154,6 +182,11 @@ export interface ITestObjectProvider {
 	 * IContainer loaded is automatically added to the OpProcessingController to manage op flow
 	 * @param testContainerConfig - optional configuring the test Container
 	 * @param requestHeader - optional headers to be supplied to the loader
+	 *
+	 * @remarks
+	 *
+	 * The container is not guaranteed to be in Connected state.
+	 * If your test requires it, make sure to do that explicitly (e.g. by using {@link waitForContainerConnection}).
 	 */
 	loadTestContainer(
 		testContainerConfig?: ITestContainerConfig,


### PR DESCRIPTION
## Description

Fixes a couple of flaky tests (errors seen in the e2e tests pipeline and when running e2e tests locally against frs) which expect containers to be in Connected state so they can run successfully. The containers returned by the TestObjectProvider (or loaders created from it) are not guaranteed to be in the connected state if no explicit options are passed to the loaders so they guarantee it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I confirmed the fix through many manual runs of the tests, which very frequently failed with the error below before the fix, and very consistently pass after.

```console
1) Stamped v2 ops
       Non-Compat
         SharedTreeShim can drop v1 ops and migrate ops:
     Error: Container should not be paused yet (outbound queue)
      at assert (/workspaces/FluidFramework/packages/common/core-utils/src/assert.ts:19:9)
      at LoaderContainerTracker.pauseContainer (/workspaces/FluidFramework/packages/test/test-utils/src/loaderContainerTracker.ts:527:9)
      at LoaderContainerTracker.pauseProcessing (/workspaces/FluidFramework/packages/test/test-utils/src/loaderContainerTracker.ts:508:27)
      at Context.<anonymous> (file:///workspaces/FluidFramework/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts:281:41)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```