### PR TITLE
GC: Bump up timeout to alleviate flakey test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
@@ -35,7 +35,7 @@ describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 	// Since these tests depend on these timing windows, they should not be run against drivers talking over the network
 	// (see this.skip() call below)
 	const tombstoneTimeoutMs = 200; // Tombstone at 200ms
-	const sweepGracePeriodMs = 100; // Sweep at 300ms
+	const sweepGracePeriodMs = 200; // Sweep at 400ms
 
 	const configProvider = createTestConfigProvider();
 	const gcOptions: IGCRuntimeOptions = {


### PR DESCRIPTION
## Description

Fixes AB#6521

I repro'd this test failure today, incidentally. It's a slightly different manifestation/error, but the bug was opened 2 months ago and this code has changed a bit so seems plausible it's the same situation.

## Reviewer Guidance

It's a sad fix, just expanding a 100ms timeout to 200ms.  I am in parallel looking into using Sinon Fake Timers in e2e tests, I was able to run this test with them, using the `shouldAdvanceTime` option to avoid interference with the rest of the system.

This test would be among those switched to fake timers if/when that change is made.