### PR TITLE
tree: Fix bug with composing changes to moved nodes

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -255,6 +255,11 @@ export class ModularChangeFamily
 					node1: NodeChangeset | undefined,
 					node2: NodeChangeset | undefined,
 				): NodeChangeset => {
+					// Note that it is important that the key is `node ?? node1` and not `node1 ?? node2`.
+					// If the first changeset moves this node, the change handler may not have seen the second changeset's
+					// changes for this node on its first pass.
+					// In that case we will have cached an entry the call to `compose(node1, undefined)`, and we must make sure
+					// not to reuse the cached entry if a subsequent pass calls `compose(node1, node2)`.
 					const key = node2 ?? node1 ?? fail("Should not have two undefined nodes");
 					const cachedResult = crossFieldTable.nodeCache.get(key);
 					if (cachedResult !== undefined) {

--- a/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -253,6 +253,7 @@ describe("ModularChangeFamily integration", () => {
 			const expectedDelta = intoDelta(makeAnonChange(expected), fieldKinds);
 			assertDeltaEqual(composedDelta, expectedDelta);
 		});
+
 		it("cross-field move and nested changes", () => {
 			const [changeReceiver, getChanges] = testChangeReceiver(family);
 			const editor = new DefaultEditBuilder(family, changeReceiver);


### PR DESCRIPTION
## Description

This fixes an issue where, when composing `ModularChanget`s, changesets for a moved node would not get an additional pass if they were invalidated by cross-field updates.

The previous implementation also assumed that each field would only need to be invalidated once, but this assumption turned out to be incorrect. This PR enables as many compose passes to be made as necessary.