### PR TITLE
Convert ephemeral container to be specified on attach rather than as driver policy

### DIFF
--- a/azure/packages/azure-client/src/AzureClient.ts
+++ b/azure/packages/azure-client/src/AzureClient.ts
@@ -288,21 +288,25 @@ export class AzureClient {
 	private async createFluidContainer<TContainerSchema extends ContainerSchema>(
 		container: IContainer,
 		connection: AzureConnectionConfig,
+		// Option 1, add param to createFluidContainer:
+		// createAsEphemeral?: boolean,
 	): Promise<IFluidContainer<TContainerSchema>> {
-		const createNewRequest = createAzureCreateNewRequest(
-			connection.endpoint,
-			getTenantId(connection),
-		);
-
 		const rootDataObject = await this.getContainerEntryPoint(container);
 
 		/**
 		 * See {@link FluidContainer.attach}
+		 * Option 2, add param to attach:
+		 * createAsEphemeral?: boolean
 		 */
 		const attach = async (): Promise<string> => {
 			if (container.attachState !== AttachState.Detached) {
 				throw new Error("Cannot attach container. Container is not in detached state");
 			}
+			const createNewRequest = createAzureCreateNewRequest(
+				connection.endpoint,
+				getTenantId(connection),
+				// createAsEphemeral,
+			);
 			await container.attach(createNewRequest);
 			if (container.resolvedUrl === undefined) {
 				throw new Error("Resolved Url not available on attached container");

--- a/packages/drivers/routerlicious-driver/api-report/routerlicious-driver.api.md
+++ b/packages/drivers/routerlicious-driver/api-report/routerlicious-driver.api.md
@@ -31,6 +31,12 @@ export class DocumentPostCreateError extends Error {
     get stack(): string | undefined;
 }
 
+// @alpha
+export interface IAzureResolvedUrl extends IResolvedUrl {
+    azureResolvedUrl: true;
+    createAsEphemeral?: boolean;
+}
+
 // @internal (undocumented)
 export interface IRouterliciousDriverPolicies {
     enableDiscovery: boolean;
@@ -39,7 +45,6 @@ export interface IRouterliciousDriverPolicies {
     enablePrefetch: boolean;
     enableRestLess: boolean;
     enableWholeSummaryUpload: boolean;
-    isEphemeralContainer: boolean;
     maxConcurrentOrdererRequests: number;
     maxConcurrentStorageRequests: number;
 }

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -182,6 +182,9 @@
 			"RemovedEnumDeclaration_RouterliciousErrorType": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"InterfaceDeclaration_IRouterliciousDriverPolicies": {
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/drivers/routerlicious-driver/src/azureResolvedUrl.ts
+++ b/packages/drivers/routerlicious-driver/src/azureResolvedUrl.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { IResolvedUrl } from "@fluidframework/driver-definitions";
+
+/**
+ * Azure extends the resolved url with additional properties to control Azure-specific behaviors.
+ * @alpha
+ */
+export interface IAzureResolvedUrl extends IResolvedUrl {
+	/**
+	 * A flag to facilitate type narrowing from IResolvedUrl to IAzureResolvedUrl.
+	 */
+	azureResolvedUrl: true;
+	/**
+	 * Controls whether a newly created container will be ephemeral. Only affects createContainer requests.
+	 */
+	createAsEphemeral?: boolean;
+}
+
+/**
+ * Type guard to detect if an IResolvedUrl is an IAzureResolvedUrl.
+ * @alpha
+ */
+export const isAzureResolvedUrl = (resolvedUrl: IResolvedUrl): resolvedUrl is IAzureResolvedUrl =>
+	(resolvedUrl as IAzureResolvedUrl).azureResolvedUrl === true;

--- a/packages/drivers/routerlicious-driver/src/index.ts
+++ b/packages/drivers/routerlicious-driver/src/index.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+export { IAzureResolvedUrl } from "./azureResolvedUrl";
+
 // Tokens
 export { DefaultTokenProvider } from "./defaultTokenProvider";
 export { ITokenProvider, ITokenResponse, ITokenService } from "./tokens";

--- a/packages/drivers/routerlicious-driver/src/policies.ts
+++ b/packages/drivers/routerlicious-driver/src/policies.ts
@@ -49,10 +49,4 @@ export interface IRouterliciousDriverPolicies {
 	 * Default: true
 	 */
 	enableLongPollingDowngrade: boolean;
-	/**
-	 * Indicates that the container is ephemeral.
-	 * Artifacts relates to the container are limited to container lifetime.
-	 * Default: false
-	 */
-	isEphemeralContainer: boolean;
 }

--- a/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.generated.ts
+++ b/packages/drivers/routerlicious-driver/src/test/types/validateRouterliciousDriverPrevious.generated.ts
@@ -91,6 +91,7 @@ declare function get_current_InterfaceDeclaration_IRouterliciousDriverPolicies()
 declare function use_old_InterfaceDeclaration_IRouterliciousDriverPolicies(
     use: TypeOnly<old.IRouterliciousDriverPolicies>): void;
 use_old_InterfaceDeclaration_IRouterliciousDriverPolicies(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IRouterliciousDriverPolicies());
 
 /*

--- a/packages/tools/webpack-fluid-loader/README.md
+++ b/packages/tools/webpack-fluid-loader/README.md
@@ -18,7 +18,6 @@ See the [Azure Fluid Relay](#azure-fluid-relay) and [SharePoint](#sharepoint) se
 | `tenantSecret`             | Secret for your tenant                                                                                   |
 | `bearerSecret`             | Secret for your bearer                                                                                   |
 | `enableWholeSummaryUpload` | Enables whole summary upload functionality (required for Azure Fluid Relay)                              |
-| `isEphemeralContainer`     | Indicates that the container is ephemeral (required for Azure Fluid Relay)                               |
 
 | modes         | description                                                                                          |
 | ------------- | ---------------------------------------------------------------------------------------------------- |
@@ -59,7 +58,6 @@ npm run start -- --env fluidHost=https://fluidhost.com --env tenantId=my_tenant 
 -   `fluid__webpack__bearerSecret`
 -   `fluid__webpack__npm`
 -   `fluid__webpack__enableWholeSummaryUpload`
--   `fluid__webpack__isEphemeralContainer`
 
 ### config file:
 
@@ -75,8 +73,7 @@ or in an optional `config.json` file in the `baseDir` passed into `webpack-fluid
 			"tenantSecret": "my_secret",
 			"bearerSecret": "bear_secret",
 			"npm": "npm.com",
-			"enableWholeSummaryUpload": false,
-			"isEphemeralContainer": false
+			"enableWholeSummaryUpload": false
 		}
 	}
 }
@@ -97,8 +94,7 @@ npm run start:r11s --env mode=r11s \
                    --env enableWholeSummaryUpload=true \
                    --env tenantId=$TenantId \
                    --env tenantSecret=$PrimaryKey \
-                   --env discoveryEndpoint=$ServiceEndpoint \
-				   --env isEphemeralContainer=$isEphemeralContainer
+                   --env discoveryEndpoint=$ServiceEndpoint
 ```
 
 ## SharePoint

--- a/packages/tools/webpack-fluid-loader/src/getDocumentServiceFactory.ts
+++ b/packages/tools/webpack-fluid-loader/src/getDocumentServiceFactory.ts
@@ -63,10 +63,6 @@ export function getDocumentServiceFactory(
 						? options.enableWholeSummaryUpload
 						: undefined,
 				enableDiscovery: options.mode === "r11s" && options.discoveryEndpoint !== undefined,
-				isEphemeralContainer:
-					options.mode === "r11s" || options.mode === "docker"
-						? options.isEphemeralContainer
-						: false,
 			});
 
 		case "spo":

--- a/packages/tools/webpack-fluid-loader/src/loader.ts
+++ b/packages/tools/webpack-fluid-loader/src/loader.ts
@@ -60,7 +60,6 @@ export interface IDockerRouteOptions extends IBaseRouteOptions {
 	tenantSecret?: string;
 	bearerSecret?: string;
 	enableWholeSummaryUpload?: boolean;
-	isEphemeralContainer?: boolean;
 }
 
 export interface IRouterliciousRouteOptions extends IBaseRouteOptions {
@@ -71,7 +70,6 @@ export interface IRouterliciousRouteOptions extends IBaseRouteOptions {
 	tenantSecret?: string;
 	bearerSecret?: string;
 	enableWholeSummaryUpload?: boolean;
-	isEphemeralContainer?: boolean;
 }
 
 export interface ITinyliciousRouteOptions extends IBaseRouteOptions {

--- a/packages/tools/webpack-fluid-loader/src/routes.ts
+++ b/packages/tools/webpack-fluid-loader/src/routes.ts
@@ -120,14 +120,6 @@ export const after = (
 				options.enableWholeSummaryUpload = options.enableWholeSummaryUpload === "true";
 			}
 
-			options.isEphemeralContainer =
-				options.isEphemeralContainer ??
-				config.get("fluid:webpack:isEphemeralContainer") ??
-				false;
-			if (typeof options.isEphemeralContainer === "string") {
-				options.isEphemeralContainer = options.isEphemeralContainer === "true";
-			}
-
 			options.tenantSecret =
 				options.mode === "docker"
 					? options.tenantSecret ??


### PR DESCRIPTION
A container is either created as ephemeral/persisted depending on how the createContainer network request is issued.  This happens during the `attach()` flow, and can vary from container to container.

The current implementation in repo sets a flag at driver creation, which is both sooner than needed and more global than desirable (affects all containers created from that driver).  By doing this, we can then avoid exposing a new property on AzureClient as in #18928.

This draft PR explores what it might look like to move that to the attach by mimicking the pattern used in ODSP driver to smuggle additional creation params through to the createContainer call (see odspDocumentServiceFactoryCore.ts).

I'm particularly interested in feedback on:
1. Preferences on the options 1/2 I call out in AzureClient.
2. Any objections to putting Azure-specific behaviors in routerlicious-driver (versus the overhead of standing up a new package similar to what the ODSP equivalents do).  Note that the ephemeral container behavior is already Azure-specific and is already in routerlicious-driver, but this becomes more obvious and apparent with the addition of AzureResolvedUrl.
3. Any concerns about current customers trying out the ephemeral functionality and their ability to adapt to this (breaking) change.  There is no change to the client/server protocol, they would just need to adapt when picking up the new FF version.