### PR TITLE
GC: Add GC Option to disable DataStore Sweep

### DIFF
--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -33,6 +33,7 @@ import {
 	gcGenerationOptionName,
 	IGCMetadata_Deprecated,
 	disableDatastoreSweepKey,
+	gcDisableDataStoreSweepOptionName,
 } from "./gcDefinitions";
 import { getGCVersion, shouldAllowGcSweep } from "./gcHelpers";
 
@@ -150,7 +151,9 @@ export function generateGCConfigs(
 			? false
 			: mc.config.getBoolean(runSweepKey) ??
 			  (sweepAllowed && createParams.gcOptions.enableGCSweep === true);
-	const disableDatastoreSweep = mc.config.getBoolean(disableDatastoreSweepKey) === true;
+	const disableDatastoreSweep =
+		mc.config.getBoolean(disableDatastoreSweepKey) === true ||
+		createParams.gcOptions[gcDisableDataStoreSweepOptionName] === true;
 	const shouldRunSweep: IGarbageCollectorConfigs["shouldRunSweep"] = sweepEnabled
 		? disableDatastoreSweep
 			? "ONLY_BLOBS"

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -41,6 +41,12 @@ export const nextGCVersion: GCVersion = 4;
 export const gcDisableThrowOnTombstoneLoadOptionName = "gcDisableThrowOnTombstoneLoad";
 
 /**
+ * This undocumented GC Option (on ContainerRuntime Options) allows an app to enable Sweep for blobs only.
+ * Only applies if enableGCSweep option is set to true.
+ */
+export const gcDisableDataStoreSweepOptionName = "disableDataStoreSweep";
+
+/**
  * This undocumented GC Option (on ContainerRuntime Options) allows configuring which documents can have Sweep enabled.
  * This provides a way to disable both Tombstone Enforcement and Sweep.
  *

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -11,6 +11,7 @@ export {
 	defaultSessionExpiryDurationMs,
 	GCNodeType,
 	gcTestModeKey,
+	gcDisableDataStoreSweepOptionName,
 	gcDisableThrowOnTombstoneLoadOptionName,
 	gcGenerationOptionName,
 	GCFeatureMatrix,

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -42,6 +42,7 @@ import {
 	gcVersionUpgradeToV4Key,
 	gcGenerationOptionName,
 	throwOnTombstoneLoadOverrideKey,
+	gcDisableDataStoreSweepOptionName,
 	gcDisableThrowOnTombstoneLoadOptionName,
 	GCVersion,
 	runSessionExpiryKey,
@@ -783,7 +784,7 @@ describe("Garbage Collection configurations", () => {
 				shouldRunGC: boolean;
 				sweepEnabled_doc: boolean;
 				sweepEnabled_session: boolean;
-				disableDataStoreSweep?: true;
+				disableDataStoreSweep?: "viaGCOption" | "viaConfigProvider";
 				shouldRunSweep?: boolean;
 				expectedShouldRunSweep: IGarbageCollectorConfigs["shouldRunSweep"];
 			}[] = [
@@ -791,7 +792,7 @@ describe("Garbage Collection configurations", () => {
 					shouldRunGC: false, // Veto
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
-					disableDataStoreSweep: true,
+					disableDataStoreSweep: "viaGCOption",
 					shouldRunSweep: true,
 					expectedShouldRunSweep: "NO",
 				},
@@ -799,14 +800,14 @@ describe("Garbage Collection configurations", () => {
 					shouldRunGC: true,
 					sweepEnabled_doc: false, // Veto
 					sweepEnabled_session: true,
-					disableDataStoreSweep: true,
+					disableDataStoreSweep: "viaGCOption",
 					expectedShouldRunSweep: "NO",
 				},
 				{
 					shouldRunGC: true,
 					sweepEnabled_doc: true,
 					sweepEnabled_session: false, // Veto
-					disableDataStoreSweep: true,
+					disableDataStoreSweep: "viaGCOption",
 					expectedShouldRunSweep: "NO",
 				},
 				{
@@ -814,7 +815,7 @@ describe("Garbage Collection configurations", () => {
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
 					shouldRunSweep: false, // Veto
-					disableDataStoreSweep: true,
+					disableDataStoreSweep: "viaGCOption",
 					expectedShouldRunSweep: "NO",
 				},
 				{
@@ -834,7 +835,14 @@ describe("Garbage Collection configurations", () => {
 					shouldRunGC: true,
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
-					disableDataStoreSweep: true,
+					disableDataStoreSweep: "viaGCOption",
+					expectedShouldRunSweep: "ONLY_BLOBS",
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled_doc: true,
+					sweepEnabled_session: true,
+					disableDataStoreSweep: "viaConfigProvider",
 					expectedShouldRunSweep: "ONLY_BLOBS",
 				},
 				{
@@ -842,7 +850,7 @@ describe("Garbage Collection configurations", () => {
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
 					shouldRunSweep: true,
-					disableDataStoreSweep: true, // Applies after shouldRunSweep
+					disableDataStoreSweep: "viaGCOption", // Applies after shouldRunSweep
 					expectedShouldRunSweep: "ONLY_BLOBS",
 				},
 			];
@@ -850,13 +858,18 @@ describe("Garbage Collection configurations", () => {
 				it(`Test Case ${JSON.stringify(testCase)}`, () => {
 					configProvider.set(runGCKey, testCase.shouldRunGC);
 					configProvider.set(runSweepKey, testCase.shouldRunSweep);
-					configProvider.set(disableDatastoreSweepKey, testCase.disableDataStoreSweep);
+					configProvider.set(
+						disableDatastoreSweepKey,
+						testCase.disableDataStoreSweep === "viaConfigProvider",
+					);
 					gc = createGcWithPrivateMembers(
 						{
 							gcFeatureMatrix: { gcGeneration: 1 },
 							sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 						} /* metadata */,
 						{
+							[gcDisableDataStoreSweepOptionName]:
+								testCase.disableDataStoreSweep === "viaGCOption",
 							enableGCSweep: testCase.sweepEnabled_session ? true : undefined,
 							[gcGenerationOptionName]: testCase.sweepEnabled_doc ? 1 : 2,
 						} /* gcOptions */,


### PR DESCRIPTION
## Description

Follow-up to #19524.  Fixes #7086

Enabling Sweep for attachment blobs is lower risk than data stores, and is also ready to ship on version 2.0.0-internal.7.0 (not so for data stores). So add an option for any partners who want to do so.
