### PR TITLE
Enable min compat tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
@@ -25,7 +25,7 @@ import { MockDetachedBlobStorage, driverSupportsBlobs } from "./mockDetachedBlob
 const mapId = "map";
 const directoryId = "directoryKey";
 
-describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("blob handle isAttached", "2.0.0-internal.8.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap, SharedDirectory } = apis.dds;
 	const registry: ChannelFactoryRegistry = [
 		[mapId, SharedMap.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -71,7 +71,7 @@ type SharedObjCallback = (
 
 // Introduced in 0.37
 // REVIEW: enable compat testing
-describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("stashed ops", "2.0.0-internal.8.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap, SharedDirectory, SharedCounter, SharedString, SharedCell } = apis.dds;
 	const { getTextAndMarkers } = apis.dataRuntime.packages.sequence;
 

--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -253,7 +253,7 @@ export function isCompatVersionBelowMinVersion(minVersion: string, config: Compa
 				: config.compatVersion;
 	}
 	const compatVersion = getRequestedVersion(testBaseVersion(lowerVersion), lowerVersion);
-	const minReqVersion = getRequestedVersion(testBaseVersion(minVersion), minVersion);
+	const minReqVersion = getRequestedVersion(minVersion, minVersion);
 	return semver.compare(compatVersion, minReqVersion) < 0;
 }
 

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -255,7 +255,7 @@ function createCompatDescribe(): DescribeCompat {
 			case "NoCompat":
 				return createCompatSuite(tests, [CompatKind.None]);
 			default:
-			    return createCompatSuite(tests, undefined, compatVersion);
+				return createCompatSuite(tests, undefined, compatVersion);
 		}
 	};
 	const d: DescribeCompat = (name: string, compatVersion: string, tests) =>

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -255,9 +255,7 @@ function createCompatDescribe(): DescribeCompat {
 			case "NoCompat":
 				return createCompatSuite(tests, [CompatKind.None]);
 			default:
-				throw new Error(`compatVersion ${compatVersion} not supported`);
-			// TODO: https://dev.azure.com/fluidframework/internal/_workitems/edit/7089
-			// return createCompatSuite(tests, undefined, compatVersion);
+			    return createCompatSuite(tests, undefined, compatVersion);
 		}
 	};
 	const d: DescribeCompat = (name: string, compatVersion: string, tests) =>

--- a/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
+++ b/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
@@ -4,21 +4,17 @@
  */
 
 import { strict as assert } from "assert";
+import { execSync } from "child_process";
 import { CompatKind } from "../../compatOptions.cjs";
 import { isCompatVersionBelowMinVersion } from "../compatConfig.js";
-import { pkgVersion } from "../packageVersion.js";
 
 describe("Minimum Compat Version", () => {
-	// const allVersionsFromNpm = execSync(`npm show fluid-framework versions --json`, {
-	// 	encoding: "utf-8",
-	// });
-	// const allVersions: string[] = JSON.parse(allVersionsFromNpm);
-	// // filter out all versions that don't end with 0 (patches). This is done because N-0 version
-	// // is pkgVersion and this variable only updates in minor releases. So it could be the case that latest
-	// // version is a patch and our N-0 version is behind it.
-	// const noPatchVersions = allVersions.filter((version) => /\.\d*0$/.test(version));
-	// const latestVersion = noPatchVersions[noPatchVersions.length - 1];
-	const latestVersion = pkgVersion;
+	const versionFromPackageJson = JSON.parse(
+		execSync(`pnpm flub info --json`, {
+			encoding: "utf-8",
+		}),
+	);
+	const latestVersion = versionFromPackageJson["@fluidframework/container-loader"];
 
 	it("bad min compat string", () => {
 		const invalidString = "invalid string";

--- a/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
+++ b/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
@@ -8,6 +8,7 @@ import { CompatKind } from "../../compatOptions.cjs";
 import { isCompatVersionBelowMinVersion } from "../compatConfig.js";
 import { pkgVersion } from "../packageVersion.js";
 import { getRequestedVersion } from "../versionUtils.js";
+import { testBaseVersion } from "../baseVersion.js";
 
 describe("Minimum Compat Version", () => {
 	const latestVersion = pkgVersion;
@@ -41,9 +42,9 @@ describe("Minimum Compat Version", () => {
 					compatVersion: -i,
 				}),
 				true,
-				`N-${i} is not lower than min version: ${getRequestedVersion(
-					latestVersion,
-					latestVersion,
+				`N-${i} is not lower than min version. ${getRequestedVersion(
+					testBaseVersion(-i),
+					-i,
 				)}`,
 			);
 		});

--- a/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
+++ b/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
@@ -4,20 +4,21 @@
  */
 
 import { strict as assert } from "assert";
-import { execSync } from "child_process";
 import { CompatKind } from "../../compatOptions.cjs";
 import { isCompatVersionBelowMinVersion } from "../compatConfig.js";
+import { pkgVersion } from "../packageVersion.js";
 
 describe("Minimum Compat Version", () => {
-	const allVersionsFromNpm = execSync(`npm show fluid-framework versions --json`, {
-		encoding: "utf-8",
-	});
-	const allVersions: string[] = JSON.parse(allVersionsFromNpm);
-	// filter out all versions that don't end with 0 (patches). This is done because N-0 version
-	// is pkgVersion and this variable only updates in minor releases. So it could be the case that latest
-	// version is a patch and our N-0 version is behind it.
-	const noPatchVersions = allVersions.filter((version) => /\.\d*0$/.test(version));
-	const latestVersion = noPatchVersions[noPatchVersions.length - 1];
+	// const allVersionsFromNpm = execSync(`npm show fluid-framework versions --json`, {
+	// 	encoding: "utf-8",
+	// });
+	// const allVersions: string[] = JSON.parse(allVersionsFromNpm);
+	// // filter out all versions that don't end with 0 (patches). This is done because N-0 version
+	// // is pkgVersion and this variable only updates in minor releases. So it could be the case that latest
+	// // version is a patch and our N-0 version is behind it.
+	// const noPatchVersions = allVersions.filter((version) => /\.\d*0$/.test(version));
+	// const latestVersion = noPatchVersions[noPatchVersions.length - 1];
+	const latestVersion = pkgVersion;
 
 	it("bad min compat string", () => {
 		const invalidString = "invalid string";

--- a/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
+++ b/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
@@ -4,17 +4,13 @@
  */
 
 import { strict as assert } from "assert";
-import { execSync } from "child_process";
 import { CompatKind } from "../../compatOptions.cjs";
 import { isCompatVersionBelowMinVersion } from "../compatConfig.js";
+import { pkgVersion } from "../packageVersion.js";
+import { getRequestedVersion } from "../versionUtils.js";
 
 describe("Minimum Compat Version", () => {
-	const versionFromPackageJson = JSON.parse(
-		execSync(`pnpm flub info --json`, {
-			encoding: "utf-8",
-		}),
-	);
-	const latestVersion = versionFromPackageJson["@fluidframework/container-loader"];
+	const latestVersion = pkgVersion;
 
 	it("bad min compat string", () => {
 		const invalidString = "invalid string";
@@ -45,7 +41,10 @@ describe("Minimum Compat Version", () => {
 					compatVersion: -i,
 				}),
 				true,
-				`N-${i} is not lower than min version`,
+				`N-${i} is not lower than min version: ${getRequestedVersion(
+					latestVersion,
+					latestVersion,
+				)}`,
 			);
 		});
 	}

--- a/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
+++ b/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
@@ -8,7 +8,7 @@ import { execSync } from "child_process";
 import { CompatKind } from "../../compatOptions.cjs";
 import { isCompatVersionBelowMinVersion } from "../compatConfig.js";
 
-describe.skip("Minimum Compat Version", () => {
+describe("Minimum Compat Version", () => {
 	const allVersionsFromNpm = execSync(`npm show fluid-framework versions --json`, {
 		encoding: "utf-8",
 	});


### PR DESCRIPTION
Currently just for testing purposes. Checking whether or not, after recent bug fixes for dev version calculations, min compat tests are run in ADO