### PR TITLE
Updated opt-out logic to clear localstorage and reset identifiers

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -8,7 +8,7 @@ import { PostChannel, type IChannelConfiguration, type IXHROverride } from "@mic
 import {
 	type ITelemetryBaseLogger,
 	type ITelemetryBaseEvent,
-	TelemetryConfigurationManager,
+	isTelemetryOptInEnabled,
 } from "@fluid-internal/devtools-view";
 import { type ITaggedTelemetryPropertyType } from "@fluidframework/core-interfaces";
 import { v4 as uuidv4 } from "uuid";
@@ -74,11 +74,13 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 	 * requests during local development or other scenarios where a key is not passed in.
 	 */
 	private readonly enabled: boolean = false;
-
+	// We expect the following usage identifiers to be mutated when the user opts in/out.
+	// Identifier that's generated on each session
 	private sessionID?: string;
+	// This identifies a specific browser instance and is reused in subsequent sessions.
 	private continuityID?: string;
+
 	private readonly CONTINUITY_ID_KEY = "Fluid.Devtools.ContinuityId";
-	private readonly telemetryConfig = new TelemetryConfigurationManager();
 
 	public constructor() {
 		const channelConfig: IChannelConfiguration = {
@@ -139,7 +141,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 	 * {@inheritDoc @fluidframework/core-interfaces#ITelemetryBaseLogger.send}
 	 */
 	public send(event: ITelemetryBaseEvent): void {
-		const optIn = this.telemetryConfig.isTelemetryOptedIn();
+		const optIn = isTelemetryOptInEnabled();
 
 		// Clear localStorage and reset identifiers if the user opts out
 		if (!optIn) {

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -74,10 +74,15 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 	 * requests during local development or other scenarios where a key is not passed in.
 	 */
 	private readonly enabled: boolean = false;
-	// We expect the following usage identifiers to be mutated when the user opts in/out.
-	// Identifier that's generated on each session
+	// We expect the following usage identifiers to be mutated when the user opts in/out of reporting telemetry.
+	/**
+	 * Identifier that's generated on each Fluid Devtools session
+	 * @remarks
+	 */
 	private sessionID?: string;
-	// This identifies a specific browser instance and is reused in subsequent sessions.
+	/** 
+	 * This identifies a specific browser instance and is reused in subsequent sessions.
+	 */
 	private continuityID?: string;
 
 	private readonly CONTINUITY_ID_KEY = "Fluid.Devtools.ContinuityId";

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -154,7 +154,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 			return;
 		}
 
-		if ((!this.sessionID || this.continuityID) && optIn) {
+		if ((this.sessionID === undefined || this.continuityID === undefined) && optIn) {
 			this.generateIdentifiers();
 		}
 

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -139,7 +139,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 		const optIn = localStorage.getItem(telemetryOptInKey);
 
 		// Clear localStorage and reset identifiers if the user opts out
-		if (!optIn) {
+		if (optIn !== null && optIn !== "true") {
 			localStorage.removeItem(this.CONTINUITY_ID_KEY);
 			// Reset identifiers, ensuring any subsequent telemetry will have fresh identifiers if the user opts in again.
 			this.continuityID = uuidv4();

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -80,7 +80,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 	 * @remarks
 	 */
 	private sessionID?: string;
-	/** 
+	/**
 	 * This identifies a specific browser instance and is reused in subsequent sessions.
 	 */
 	private continuityID?: string;

--- a/packages/tools/devtools/devtools-view/api-report/devtools-view.api.md
+++ b/packages/tools/devtools/devtools-view/api-report/devtools-view.api.md
@@ -24,18 +24,12 @@ export interface DevtoolsPanelProps {
 
 export { IMessageRelay }
 
+// @internal
+export const isTelemetryOptInEnabled: () => boolean;
+
 export { ITelemetryBaseEvent }
 
 export { ITelemetryBaseLogger }
-
-// @internal
-export class TelemetryConfigurationManager {
-    constructor();
-    // (undocumented)
-    isTelemetryOptedIn(): boolean;
-    // (undocumented)
-    setTelemetryOptIn(optedIn: boolean): void;
-}
 
 // @internal
 export class WindowMessageRelay extends TypedEventEmitter<IMessageRelayEvents> implements IMessageRelay {

--- a/packages/tools/devtools/devtools-view/api-report/devtools-view.api.md
+++ b/packages/tools/devtools/devtools-view/api-report/devtools-view.api.md
@@ -29,6 +29,15 @@ export { ITelemetryBaseEvent }
 export { ITelemetryBaseLogger }
 
 // @internal
+export class TelemetryConfigurationManager {
+    constructor();
+    // (undocumented)
+    isTelemetryOptedIn(): boolean;
+    // (undocumented)
+    setTelemetryOptIn(optedIn: boolean): void;
+}
+
+// @internal
 export class WindowMessageRelay extends TypedEventEmitter<IMessageRelayEvents> implements IMessageRelay {
     constructor(
     messageSource: string);

--- a/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
+++ b/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
@@ -61,14 +61,15 @@ const telemetryOptInKey: string = "fluid:devtools:telemetry:optIn";
  * Hook for getting and setting the usage telemetry opt-in setting, backed by brower's local storage.
  * @returns A tuple (React state) with the current value and a setter for the value.
  */
-export const useTelemetryOptIn = (): [boolean, React.Dispatch<React.SetStateAction<boolean>>] => {
+export const useTelemetryOptIn = (): [boolean, (optedIn: boolean) => void] => {
 	const [value, setValue] = React.useState(() => {
 		return getStorageValue(telemetryOptInKey);
 	});
 
-	React.useEffect(() => {
-		localStorage.setItem(telemetryOptInKey, value.toString());
-	}, [value]);
+	const setOptIn = (optedIn: boolean): void => {
+		setValue(optedIn);
+		localStorage.setItem(telemetryOptInKey, optedIn.toString());
+	};
 
 	const localStorageChangeHandler = (event: StorageEvent): void => {
 		if (event.storageArea === localStorage && event.key === telemetryOptInKey) {
@@ -82,7 +83,7 @@ export const useTelemetryOptIn = (): [boolean, React.Dispatch<React.SetStateActi
 		};
 	});
 
-	return [value, setValue];
+	return [value, setOptIn];
 };
 
 /**
@@ -105,4 +106,22 @@ function getStorageValue(key: string, defaultValue: boolean = false): boolean {
 		return defaultValue;
 	}
 	return saved === "true";
+}
+
+/**
+ * Manages the configuration of telemetry settings for the application.
+ * @internal
+ */
+export class TelemetryConfigurationManager {
+	private telemetryOptInStatus: boolean = getStorageValue(telemetryOptInKey);
+
+	public constructor() {}
+	public isTelemetryOptedIn(): boolean {
+		return this.telemetryOptInStatus;
+	}
+
+	public setTelemetryOptIn(optedIn: boolean): void {
+		this.telemetryOptInStatus = optedIn;
+		localStorage.setItem(telemetryOptInKey, optedIn.toString());
+	}
 }

--- a/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
+++ b/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
@@ -58,18 +58,24 @@ export class ConsoleVerboseLogger implements ITelemetryBaseLogger {
 const telemetryOptInKey: string = "fluid:devtools:telemetry:optIn";
 
 /**
+ * Callback function used to check opt in status
+ * @returns boolean representing whether telemetry collection is enabled
+ * @internal
+ */
+export const isTelemetryOptInEnabled = (): boolean => getStorageValue(telemetryOptInKey);
+
+/**
  * Hook for getting and setting the usage telemetry opt-in setting, backed by brower's local storage.
  * @returns A tuple (React state) with the current value and a setter for the value.
  */
-export const useTelemetryOptIn = (): [boolean, (optedIn: boolean) => void] => {
+export const useTelemetryOptIn = (): [boolean, React.Dispatch<React.SetStateAction<boolean>>] => {
 	const [value, setValue] = React.useState(() => {
 		return getStorageValue(telemetryOptInKey);
 	});
 
-	const setOptIn = (optedIn: boolean): void => {
-		setValue(optedIn);
-		localStorage.setItem(telemetryOptInKey, optedIn.toString());
-	};
+	React.useEffect(() => {
+		localStorage.setItem(telemetryOptInKey, value.toString());
+	}, [value]);
 
 	const localStorageChangeHandler = (event: StorageEvent): void => {
 		if (event.storageArea === localStorage && event.key === telemetryOptInKey) {
@@ -83,7 +89,7 @@ export const useTelemetryOptIn = (): [boolean, (optedIn: boolean) => void] => {
 		};
 	});
 
-	return [value, setOptIn];
+	return [value, setValue];
 };
 
 /**
@@ -106,22 +112,4 @@ function getStorageValue(key: string, defaultValue: boolean = false): boolean {
 		return defaultValue;
 	}
 	return saved === "true";
-}
-
-/**
- * Manages the configuration of telemetry settings for the application.
- * @internal
- */
-export class TelemetryConfigurationManager {
-	private telemetryOptInStatus: boolean = getStorageValue(telemetryOptInKey);
-
-	public constructor() {}
-	public isTelemetryOptedIn(): boolean {
-		return this.telemetryOptInStatus;
-	}
-
-	public setTelemetryOptIn(optedIn: boolean): void {
-		this.telemetryOptInStatus = optedIn;
-		localStorage.setItem(telemetryOptInKey, optedIn.toString());
-	}
 }

--- a/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
+++ b/packages/tools/devtools/devtools-view/src/TelemetryUtils.ts
@@ -58,7 +58,7 @@ export class ConsoleVerboseLogger implements ITelemetryBaseLogger {
 const telemetryOptInKey: string = "fluid:devtools:telemetry:optIn";
 
 /**
- * Callback function used to check opt in status
+ * Callback function that indicates if the user has opted in to report telemetry
  * @returns boolean representing whether telemetry collection is enabled
  * @internal
  */

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -16,7 +16,7 @@ import {
 } from "@fluentui/react-components";
 
 import { ThemeOption, useThemeContext } from "../ThemeHelper";
-import { TelemetryConfigurationManager } from "../TelemetryUtils";
+import { useTelemetryOptIn } from "../TelemetryUtils";
 
 const useStyles = makeStyles({
 	root: {
@@ -62,15 +62,9 @@ const useStyles = makeStyles({
  */
 export function SettingsView(): React.ReactElement {
 	const { themeInfo, setTheme } = useThemeContext();
-	const telemetryConfig = new TelemetryConfigurationManager();
-	const styles = useStyles();
-	const [optedIn, setOptedIn] = React.useState(telemetryConfig.isTelemetryOptedIn());
 
-	function handleTelemetryToggle(ev: React.ChangeEvent<HTMLInputElement>): void {
-		const checked = ev.target.checked;
-		setOptedIn(checked);
-		telemetryConfig.setTelemetryOptIn(checked);
-	}
+	const styles = useStyles();
+	const [optedIn, setOptedIn] = useTelemetryOptIn();
 
 	function handleThemeChange(
 		_event,
@@ -139,7 +133,7 @@ export function SettingsView(): React.ReactElement {
 				<Switch
 					label="Send usage telemetry to Microsoft"
 					checked={optedIn}
-					onChange={handleTelemetryToggle}
+					onChange={(ev, data): void => setOptedIn(data.checked)}
 				/>
 			</div>
 		</div>

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -16,7 +16,7 @@ import {
 } from "@fluentui/react-components";
 
 import { ThemeOption, useThemeContext } from "../ThemeHelper";
-import { useTelemetryOptIn } from "../TelemetryUtils";
+import { TelemetryConfigurationManager } from "../TelemetryUtils";
 
 const useStyles = makeStyles({
 	root: {
@@ -62,9 +62,15 @@ const useStyles = makeStyles({
  */
 export function SettingsView(): React.ReactElement {
 	const { themeInfo, setTheme } = useThemeContext();
-
+	const telemetryConfig = new TelemetryConfigurationManager();
 	const styles = useStyles();
-	const [optedIn, setOptedIn] = useTelemetryOptIn();
+	const [optedIn, setOptedIn] = React.useState(telemetryConfig.isTelemetryOptedIn());
+
+	function handleTelemetryToggle(ev: React.ChangeEvent<HTMLInputElement>): void {
+		const checked = ev.target.checked;
+		setOptedIn(checked);
+		telemetryConfig.setTelemetryOptIn(checked);
+	}
 
 	function handleThemeChange(
 		_event,
@@ -133,7 +139,7 @@ export function SettingsView(): React.ReactElement {
 				<Switch
 					label="Send usage telemetry to Microsoft"
 					checked={optedIn}
-					onChange={(ev, data): void => setOptedIn(data.checked)}
+					onChange={handleTelemetryToggle}
 				/>
 			</div>
 		</div>

--- a/packages/tools/devtools/devtools-view/src/index.ts
+++ b/packages/tools/devtools/devtools-view/src/index.ts
@@ -19,7 +19,7 @@
 export type { DevtoolsPanelProps } from "./DevtoolsPanel";
 export { DevtoolsPanel } from "./DevtoolsPanel";
 export { WindowMessageRelay } from "./WindowMessageRelay";
-export { TelemetryConfigurationManager } from "./TelemetryUtils";
+export { isTelemetryOptInEnabled } from "./TelemetryUtils";
 
 // Convenience re-exports
 export type { IMessageRelay } from "@fluidframework/devtools-core";

--- a/packages/tools/devtools/devtools-view/src/index.ts
+++ b/packages/tools/devtools/devtools-view/src/index.ts
@@ -19,6 +19,7 @@
 export type { DevtoolsPanelProps } from "./DevtoolsPanel";
 export { DevtoolsPanel } from "./DevtoolsPanel";
 export { WindowMessageRelay } from "./WindowMessageRelay";
+export { TelemetryConfigurationManager } from "./TelemetryUtils";
 
 // Convenience re-exports
 export type { IMessageRelay } from "@fluidframework/devtools-core";


### PR DESCRIPTION
[AB#7112](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7112)

## Description

This PR implements logic to clear local storage and reset the sessionID and continuityID identifiers when a user opts out of Devtools usage telemetry collection.