### PR TITLE
Add optional targetClientId to ISignalMessage

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -350,8 +350,8 @@ export interface ISignalMessageBase {
     clientConnectionNumber?: number;
     content: unknown;
     referenceSequenceNumber?: number;
-    type?: string;
     targetClientId?: string;
+    type?: string;
 }
 
 // @alpha (undocumented)

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -343,7 +343,6 @@ export interface ISignalClient {
 // @public
 export interface ISignalMessage extends ISignalMessageBase {
     clientId: string | null;
-    targetClientId?: string;
 }
 
 // @public
@@ -352,6 +351,7 @@ export interface ISignalMessageBase {
     content: unknown;
     referenceSequenceNumber?: number;
     type?: string;
+    targetClientId?: string;
 }
 
 // @alpha (undocumented)

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -343,7 +343,7 @@ export interface ISignalMessage extends ISignalMessageBase {
     clientId: string | null;
 }
 
-// @internal
+// @public
 export interface ISignalMessageBase {
     clientConnectionNumber?: number;
     content: unknown;

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -274,7 +274,6 @@ export interface IQuorumProposalsEvents {
 
 // @internal
 export interface ISentSignalMessage extends ISignalMessageBase {
-    targetClientId?: string;
 }
 
 // @public
@@ -345,7 +344,7 @@ export interface ISignalMessage extends ISignalMessageBase {
     clientId: string | null;
 }
 
-// @public
+// @internal
 export interface ISignalMessageBase {
     clientConnectionNumber?: number;
     content: unknown;

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -273,8 +273,7 @@ export interface IQuorumProposalsEvents {
 }
 
 // @internal
-export interface ISentSignalMessage extends ISignalMessageBase {
-}
+export type ISentSignalMessage = ISignalMessageBase;
 
 // @public
 export interface ISequencedClient {

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -343,6 +343,7 @@ export interface ISignalClient {
 // @public
 export interface ISignalMessage extends ISignalMessageBase {
     clientId: string | null;
+    targetClientId?: string;
 }
 
 // @public

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -332,7 +332,7 @@ export interface ISequencedDocumentAugmentedMessage extends ISequencedDocumentMe
 
 /**
  * Common interface between incoming and outgoing signals.
- * @internal
+ * @public
  */
 export interface ISignalMessageBase {
 	/**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -332,7 +332,7 @@ export interface ISequencedDocumentAugmentedMessage extends ISequencedDocumentMe
 
 /**
  * Common interface between incoming and outgoing signals.
- * @public
+ * @internal
  */
 export interface ISignalMessageBase {
 	/**
@@ -378,11 +378,8 @@ export interface ISignalMessage extends ISignalMessageBase {
  * Interface for signals sent by clients to the server when submit_signals_v2 is enabled.
  * @internal
  */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ISentSignalMessage extends ISignalMessageBase {
-	/**
-	 * When specified, the signal is only sent to the provided client id
-	 */
-	targetClientId?: string;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -378,9 +378,7 @@ export interface ISignalMessage extends ISignalMessageBase {
  * Interface for signals sent by clients to the server when submit_signals_v2 is enabled.
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ISentSignalMessage extends ISignalMessageBase {
-}
+export type ISentSignalMessage = ISignalMessageBase;
 
 /**
  * @alpha

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -356,7 +356,7 @@ export interface ISignalMessageBase {
 	referenceSequenceNumber?: number;
 
 	/**
-	 * When specified, the signal has been targeted to the recieving client.
+	 * When specified, the signal is being targeted to the recieving client.
 	 */
 	targetClientId?: string;
 }

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -356,7 +356,8 @@ export interface ISignalMessageBase {
 	referenceSequenceNumber?: number;
 
 	/**
-	 * When specified, the signal is being targeted to the recieving client.
+	 * Client ID of the singular client the signal is being (or has been) sent to.
+	 * May only be specified when IConnect.supportedFeatures['submit_signals_v2'] is true, will throw otherwise.
 	 */
 	targetClientId?: string;
 }

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -346,7 +346,7 @@ export interface ISignalMessageBase {
 	type?: string;
 
 	/**
-	 * Counts the number of signals sent by the client that submitted the message.
+	 * Counts the number of signals sent by the sending client.
 	 */
 	clientConnectionNumber?: number;
 
@@ -356,7 +356,7 @@ export interface ISignalMessageBase {
 	referenceSequenceNumber?: number;
 
 	/**
-	 * The client ID of the sole receiver of the signal message, when specified.
+	 * When specified, the signal has been targeted to the recieving client.
 	 */
 	targetClientId?: string;
 }

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -354,6 +354,11 @@ export interface ISignalMessageBase {
 	 * Sequence number that indicates when the signal was created in relation to the delta stream
 	 */
 	referenceSequenceNumber?: number;
+
+	/**
+	 * When specified, the signal has only been sent to the provided client id
+	 */
+	targetClientId?: string;
 }
 
 /**
@@ -367,11 +372,6 @@ export interface ISignalMessage extends ISignalMessageBase {
 	 */
 	// eslint-disable-next-line @rushstack/no-new-null
 	clientId: string | null;
-
-	/**
-	 * When specified, the signal has only been sent to the provided client id
-	 */
-	targetClientId?: string;
 }
 
 /**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -346,7 +346,7 @@ export interface ISignalMessageBase {
 	type?: string;
 
 	/**
-	 * Counts the number of signals sent by the client
+	 * Counts the number of signals sent by the client that submitted the message.
 	 */
 	clientConnectionNumber?: number;
 
@@ -356,7 +356,7 @@ export interface ISignalMessageBase {
 	referenceSequenceNumber?: number;
 
 	/**
-	 * When specified, the signal has only been sent to the provided client id
+	 * The client ID of the sole receiver of the signal message, when specified.
 	 */
 	targetClientId?: string;
 }
@@ -375,7 +375,7 @@ export interface ISignalMessage extends ISignalMessageBase {
 }
 
 /**
- * Interface for signals sent by clients to the server when submit_signals_v2 is enabled.
+ * Interface for signals sent by clients to the server.
  * @internal
  */
 export type ISentSignalMessage = ISignalMessageBase;

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -367,6 +367,11 @@ export interface ISignalMessage extends ISignalMessageBase {
 	 */
 	// eslint-disable-next-line @rushstack/no-new-null
 	clientId: string | null;
+
+	/**
+	 * When specified, the signal has only been sent to the provided client id
+	 */
+	targetClientId?: string;
 }
 
 /**


### PR DESCRIPTION
## Description
Updating ISignalMessage to inlcude optional targetSignalid. 

This can be useful for receiving clients trying to understand the overall approximate load on service and maybe other understanding. If received signal has that property, then we know it wasn't broadcast to everyone. 

### FF API Council Context
I have a minor API change related to ISignalMessage. [ODSP had made changes to allow for targeted signals](https://github.com/microsoft/FluidFramework/pull/17729) and I have been tasked with doing some of the follow-up work related to this. Initially the idea was for the server to strip the targetClientId before sending the signal message to the targeted client, however Jason and Gary came to an agreement that it would be beneficial to leave this information on the message, which would involve adding an optional targetClientId member to ISignalMessage(Base). This could be useful for receiving clients trying to understand the overall approximate load on service and maybe other understanding. If received signal has that property, then we know it wasn't broadcast to everyone. Thanks.
