### PR TITLE
tree(fix): fix cell ordering in transaction compositions

### DIFF
--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -207,7 +207,16 @@ export function compareCellPositionsUsingTombstones(
 		// If both changesets know of both cells, but we've been asked to compare different cells,
 		// Then either the changesets they originate from do not represent the same context,
 		// or the ordering of their cells in inconsistent.
-		assert(false, 0x8a0 /* Inconsistent cell ordering */);
+		// The only exception to this is when we're composing anonymous changesets in a transaction.
+		assert(
+			oldMarkCell.revision === undefined && newMarkCell.revision === undefined,
+			0x8a0 /* Inconsistent cell ordering */,
+		);
+		// We are composing anonymous changesets in a transaction. The new changeset is creating a cell in a gap
+		// where the old changeset knows of some now empty cell. We order the new cell relative to the old cell in a
+		// way that is consistent with its tie-breaking behavior should the old cell be concurrently re-filled.
+		// Since only tie-break left is supported at the moment, the new cell comes first.
+		return CellOrder.NewThenOld;
 	}
 	if (newChangeKnowsOfOldMarkCellRevision) {
 		// The changeset that contains `newMarkCell` has tombstones for the revision that created `oldMarkCell`,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -79,8 +79,6 @@ describe("Fuzz - Top-Level", () => {
 				maxNumberOfClients: 3,
 			},
 			reconnectProbability: 0,
-			// see AB#7030
-			skip: [37],
 			idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),
 		};
 		createDDSFuzzSuite(model, options);


### PR DESCRIPTION
Fixes a bug where the logic for cell ordering did not account for the case where cells composed in a transaction have the same (undefined) revision but are from different changesets.

Longer term, the changesets in transactions should be given proper revisions.