### PR TITLE
Finalize ID Range on Attach and Allow ContainerRuntime Deletion

### DIFF
--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -643,7 +643,12 @@ export function mixinAttach<
 			// The production codepath also finalizes ids before attaching. It's difficult for the mocks
 			// to be more direct about this as they don't directly manage any state related to attach
 			// (it's up to the user of the mocks to set them up how they want)
-			state.containerRuntimeFactory.processAllMessages();
+			if (clientA.dataStoreRuntime.idCompressor !== undefined) {
+				const range = clientA.containerRuntime.getGeneratedIdRange();
+				if (range !== undefined) {
+					clientA.dataStoreRuntime.idCompressor?.finalizeCreationRange(range);
+				}
+			}
 
 			const clients = await Promise.all(
 				Array.from({ length: options.numberOfClients }, async (_, index) =>

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -139,8 +139,6 @@ export class MockContainerRuntimeFactory {
     // (undocumented)
     createContainerRuntime(dataStoreRuntime: MockFluidDataStoreRuntime): MockContainerRuntime;
     // (undocumented)
-    removeContainerRuntime(containerRuntime: MockContainerRuntime): void;
-    // (undocumented)
     getMinSeq(): number;
     protected messages: ISequencedDocumentMessage[];
     // (undocumented)
@@ -154,6 +152,8 @@ export class MockContainerRuntimeFactory {
     pushMessage(msg: Partial<ISequencedDocumentMessage>): void;
     // (undocumented)
     readonly quorum: MockQuorumClients;
+    // (undocumented)
+    removeContainerRuntime(containerRuntime: MockContainerRuntime): void;
     protected readonly runtimeOptions: Required<IMockContainerRuntimeOptions>;
     // (undocumented)
     protected readonly runtimes: Set<MockContainerRuntime>;

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -139,6 +139,8 @@ export class MockContainerRuntimeFactory {
     // (undocumented)
     createContainerRuntime(dataStoreRuntime: MockFluidDataStoreRuntime): MockContainerRuntime;
     // (undocumented)
+    deleteContainerRuntime(containerRuntime: MockContainerRuntime): void;
+    // (undocumented)
     getMinSeq(): number;
     protected messages: ISequencedDocumentMessage[];
     // (undocumented)
@@ -154,7 +156,7 @@ export class MockContainerRuntimeFactory {
     readonly quorum: MockQuorumClients;
     protected readonly runtimeOptions: Required<IMockContainerRuntimeOptions>;
     // (undocumented)
-    protected readonly runtimes: MockContainerRuntime[];
+    protected readonly runtimes: Set<MockContainerRuntime>;
     // (undocumented)
     sequenceNumber: number;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -139,7 +139,7 @@ export class MockContainerRuntimeFactory {
     // (undocumented)
     createContainerRuntime(dataStoreRuntime: MockFluidDataStoreRuntime): MockContainerRuntime;
     // (undocumented)
-    deleteContainerRuntime(containerRuntime: MockContainerRuntime): void;
+    removeContainerRuntime(containerRuntime: MockContainerRuntime): void;
     // (undocumented)
     getMinSeq(): number;
     protected messages: ISequencedDocumentMessage[];

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -389,7 +389,7 @@ export class MockContainerRuntimeFactory {
 	 * each of the runtimes.
 	 */
 	protected messages: ISequencedDocumentMessage[] = [];
-	protected readonly runtimes: MockContainerRuntime[] = [];
+	protected readonly runtimes: Set<MockContainerRuntime> = new Set<MockContainerRuntime>();
 
 	/**
 	 * The container runtime options which will be provided to the all runtimes
@@ -439,8 +439,12 @@ export class MockContainerRuntimeFactory {
 			this,
 			this.runtimeOptions,
 		);
-		this.runtimes.push(containerRuntime);
+		this.runtimes.add(containerRuntime);
 		return containerRuntime;
+	}
+
+	public deleteContainerRuntime(containerRuntime: MockContainerRuntime) {
+		this.runtimes.delete(containerRuntime);
 	}
 
 	public synchronizeIdCompressors() {
@@ -475,7 +479,6 @@ export class MockContainerRuntimeFactory {
 		) as ISequencedDocumentMessage;
 
 		// TODO: Determine if this needs to be adapted for handling server-generated messages (which have null clientId and referenceSequenceNumber of -1).
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 		this.minSeq.set(message.clientId as string, message.referenceSequenceNumber);
 		if (
 			this.runtimeOptions.flushMode === FlushMode.Immediate ||
@@ -671,7 +674,6 @@ export class MockFluidDataStoreRuntime
 	public readonly documentId: string = undefined as any;
 	public readonly id: string;
 	public readonly existing: boolean = undefined as any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	public options: Record<string | number, any> = {};
 	public clientId: string;
 	public readonly path = "";
@@ -917,7 +919,6 @@ export class MockEmptyDeltaConnection implements IDeltaConnection {
 
 	public submit(messageContent: any): number {
 		assert(false, "Throw submit error on mock empty delta connection");
-		return 0;
 	}
 
 	public dirty(): void {}

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -443,7 +443,7 @@ export class MockContainerRuntimeFactory {
 		return containerRuntime;
 	}
 
-	public deleteContainerRuntime(containerRuntime: MockContainerRuntime) {
+	public removeContainerRuntime(containerRuntime: MockContainerRuntime) {
 		this.runtimes.delete(containerRuntime);
 	}
 

--- a/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksForReconnection.ts
@@ -118,7 +118,7 @@ export class MockContainerRuntimeFactoryForReconnection extends MockContainerRun
 			this.runtimeOptions,
 			overrides,
 		);
-		this.runtimes.push(containerRuntime);
+		this.runtimes.add(containerRuntime);
 		return containerRuntime;
 	}
 


### PR DESCRIPTION
This PR adds some functionality needed for #19400. We do not currently finalize the id creation ranges on attach, which will prevent the ID compressor from being able to function when rehydrating from a summary is allowed. We also don't have a way to completely remove a container runtime from a factory, which is needed to ensure that any references to the old client are gone once we rehydrate from a summary. 


