### PR TITLE
id-compressor: Add generation method for document-unique IDs

### DIFF
--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1125,6 +1125,11 @@ export class MockIdCompressor implements IIdCompressor, IIdCompressorCore {
 	public generateCompressedId(): SessionSpaceCompressedId {
 		return this.count++ as SessionSpaceCompressedId;
 	}
+
+	public generateDocumentUniqueId(): (SessionSpaceCompressedId & OpSpaceCompressedId) | StableId {
+		throw new Error("Method not implemented.");
+	}
+
 	public normalizeToOpSpace(id: SessionSpaceCompressedId): OpSpaceCompressedId {
 		return id as unknown as OpSpaceCompressedId;
 	}

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -91,6 +91,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"InterfaceDeclaration_IFluidDataStoreRuntime": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
@@ -199,6 +199,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreRuntime():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreRuntime(
     use: TypeOnly<current.IFluidDataStoreRuntime>): void;
 use_current_InterfaceDeclaration_IFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/id-compressor/api-report/id-compressor.api.md
+++ b/packages/runtime/id-compressor/api-report/id-compressor.api.md
@@ -44,6 +44,7 @@ export interface IdCreationRange {
 export interface IIdCompressor {
     decompress(id: SessionSpaceCompressedId): StableId;
     generateCompressedId(): SessionSpaceCompressedId;
+    generateDocumentUniqueId(): (SessionSpaceCompressedId & OpSpaceCompressedId) | StableId;
     localSessionId: SessionId;
     normalizeToOpSpace(id: SessionSpaceCompressedId): OpSpaceCompressedId;
     normalizeToSessionSpace(id: OpSpaceCompressedId, originSessionId: SessionId): SessionSpaceCompressedId;

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -166,6 +166,11 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 		}
 	}
 
+	public generateDocumentUniqueId(): (SessionSpaceCompressedId & OpSpaceCompressedId) | StableId {
+		const id = this.generateCompressedId();
+		return isFinalId(id) ? id : this.decompress(id);
+	}
+
 	/**
 	 * {@inheritdoc IIdCompressorCore.beginGhostSession}
 	 */

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -45,6 +45,19 @@ describe("IdCompressor", () => {
 			assert.equal(id, compressor.recompress(uuid));
 		});
 
+		it("can generate document unique IDs", () => {
+			const compressor = CompressorFactory.createCompressor(Client.Client1, 2);
+			let id = compressor.generateDocumentUniqueId();
+			assert(typeof id === "string");
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			id = compressor.generateDocumentUniqueId();
+			assert(typeof id === "number" && isFinalId(id));
+			id = compressor.generateDocumentUniqueId();
+			assert(typeof id === "number" && isFinalId(id));
+			id = compressor.generateDocumentUniqueId();
+			assert(typeof id === "string");
+		});
+
 		describe("Eager final ID allocation", () => {
 			it("eagerly allocates final IDs when cluster creation has been finalized", () => {
 				const compressor = CompressorFactory.createCompressor(Client.Client1, 3);

--- a/packages/runtime/id-compressor/src/types/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/types/idCompressor.ts
@@ -189,6 +189,18 @@ export interface IIdCompressor {
 	generateCompressedId(): SessionSpaceCompressedId;
 
 	/**
+	 * Generates a new ID that is guaranteed to be unique across all sessions known to this compressor without the need for any
+	 * normalization. The returned ID is not guaranteed to be a compressed ID (small number); it may be a stable ID (UUID string).
+	 * In Fluid, the likelihood of generating the bulkier stable ID is dictated by network conditions and is highly probably in
+	 * scenarios such as offline. This is still useful for use cases where simplicity is more important than performance and
+	 * this approach will often be superior to generating a UUID.
+	 * If small numbers are a requirement, `generateCompressedId` and normalization should be used instead.
+	 * See `IIdCompressor` for more details.
+	 * @returns A new local ID in session space.
+	 */
+	generateDocumentUniqueId(): (SessionSpaceCompressedId & OpSpaceCompressedId) | StableId;
+
+	/**
 	 * Normalizes a session space ID into op space.
 	 * The returned ID is in op space and can be safely serialized. However, it should be normalized back to session space before use.
 	 * See `IIdCompressor` for more details.

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -93,6 +93,12 @@
 	},
 	"typeValidation": {
 		"broken": {
+			"InterfaceDeclaration_IFluidDataStoreContext": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IFluidDataStoreContextDetached": {
+				"forwardCompat": false
+			},
 			"RemovedInterfaceDeclaration_IIdCompressorCore": {
 				"forwardCompat": false,
 				"backCompat": false

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -439,6 +439,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContext():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContext(
     use: TypeOnly<current.IFluidDataStoreContext>): void;
 use_current_InterfaceDeclaration_IFluidDataStoreContext(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContext());
 
 /*
@@ -463,6 +464,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreContextDetached():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
     use: TypeOnly<current.IFluidDataStoreContextDetached>): void;
 use_current_InterfaceDeclaration_IFluidDataStoreContextDetached(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreContextDetached());
 
 /*


### PR DESCRIPTION
## Description

This adds a new method to the ID compressor to create document-unique IDs that do not require normalization at a perf penalty.

## Breaking Changes

This adds a new method to IIDCompressor and is thus forwards-compat breaking.
