### PR TITLE
Log savedOpsCount in scriptorium every 1 minute

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -214,7 +214,8 @@ data:
             "groupId": "{{ template "scriptorium.fullname" . }}",
             "checkpointBatchSize": 1,
             "checkpointTimeIntervalMsec": 1000,
-            "restartOnCheckpointFailure": {{ .Values.scriptorium.restartOnCheckpointFailure }}
+            "restartOnCheckpointFailure": {{ .Values.scriptorium.restartOnCheckpointFailure }},
+            "logSavedOpsTimeIntervalMs": {{ .Values.scriptorium.logSavedOpsTimeIntervalMs }}
         },
         "riddler": {
             "port": 5000

--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -215,7 +215,8 @@ data:
             "checkpointBatchSize": 1,
             "checkpointTimeIntervalMsec": 1000,
             "restartOnCheckpointFailure": {{ .Values.scriptorium.restartOnCheckpointFailure }},
-            "logSavedOpsTimeIntervalMs": {{ .Values.scriptorium.logSavedOpsTimeIntervalMs }}
+            "logSavedOpsTimeIntervalMs": {{ .Values.scriptorium.logSavedOpsTimeIntervalMs }},
+            "opsCountTelemetryEnabled": {{ .Values.scriptorium.opsCountTelemetryEnabled }}
         },
         "riddler": {
             "port": 5000

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -76,6 +76,7 @@ scriptorium:
   replicas: 8
   restartOnCheckpointFailure: true
   logSavedOpsTimeIntervalMs: 60000
+  opsCountTelemetryEnabled: false
 
 scribe:
   name: scribe

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -75,6 +75,7 @@ scriptorium:
   name: scriptorium
   replicas: 8
   restartOnCheckpointFailure: true
+  logSavedOpsTimeIntervalMs: 60000
 
 scribe:
   name: scribe

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -275,7 +275,8 @@
 		"shouldLogInitialSuccessVerbose": false,
 		"maxDbBatchSize": 1000,
 		"restartOnCheckpointFailure": true,
-		"logSavedOpsTimeIntervalMs": 60000
+		"logSavedOpsTimeIntervalMs": 60000,
+		"opsCountTelemetryEnabled": true
 	},
 	"copier": {
 		"topic": "rawdeltas",

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -274,7 +274,8 @@
 		"enableTelemetry": true,
 		"shouldLogInitialSuccessVerbose": false,
 		"maxDbBatchSize": 1000,
-		"restartOnCheckpointFailure": true
+		"restartOnCheckpointFailure": true,
+		"logSavedOpsTimeIntervalMs": 60000
 	},
 	"copier": {
 		"topic": "rawdeltas",

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -44,6 +44,8 @@ export async function create(
 	const maxDbBatchSize = config.get("scriptorium:maxDbBatchSize") as number;
 	const restartOnCheckpointFailure =
 		(config.get("scriptorium:restartOnCheckpointFailure") as boolean) ?? true;
+	const logSavedOpsTimeIntervalMs =
+		(config.get("scriptorium:logSavedOpsTimeIntervalMs") as number) ?? 60000;
 
 	// Database connection for global db if enabled
 	const factory = await services.getDbFactory(config);
@@ -124,5 +126,6 @@ export async function create(
 		maxDbBatchSize,
 		restartOnCheckpointFailure,
 		shouldLogInitialSuccessVerbose,
+		logSavedOpsTimeIntervalMs,
 	});
 }

--- a/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scriptorium/index.ts
@@ -46,6 +46,8 @@ export async function create(
 		(config.get("scriptorium:restartOnCheckpointFailure") as boolean) ?? true;
 	const logSavedOpsTimeIntervalMs =
 		(config.get("scriptorium:logSavedOpsTimeIntervalMs") as number) ?? 60000;
+	const opsCountTelemetryEnabled =
+		(config.get("scriptorium:opsCountTelemetryEnabled") as boolean) ?? false;
 
 	// Database connection for global db if enabled
 	const factory = await services.getDbFactory(config);
@@ -127,5 +129,6 @@ export async function create(
 		restartOnCheckpointFailure,
 		shouldLogInitialSuccessVerbose,
 		logSavedOpsTimeIntervalMs,
+		opsCountTelemetryEnabled,
 	});
 }


### PR DESCRIPTION

## Description

Adding a log in scriptorium to write savedOpsCount every 1 minute (configurable), which can be used to monitor data loss situations by comparing with seqOpLogger.

