### PR TITLE
Optimize summary writer

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -24,7 +24,7 @@ import {
 	getQuorumTreeEntries,
 	generateServiceProtocolEntries,
 	mergeAppAndProtocolTree,
-	mergeArrays,
+	mergeSortedArrays,
 	dedupeSortedArray,
 	mergeKArrays,
 	convertSortedNumberArrayToRanges,
@@ -647,7 +647,11 @@ export class SummaryWriter implements ISummaryWriter {
 				.map((op) => op.operation);
 
 			logtailFromMemory = dedupeSortedArray(
-				mergeArrays(logTailFromLastSummary, logTailFromPending, (op) => op.sequenceNumber),
+				mergeSortedArrays(
+					logTailFromLastSummary,
+					logTailFromPending,
+					(opS, opP) => opS.sequenceNumber - opP.sequenceNumber,
+				),
 				(op) => op.sequenceNumber,
 			);
 
@@ -658,8 +662,8 @@ export class SummaryWriter implements ISummaryWriter {
 			}
 
 			retrievedGaps = await Promise.all(
-				logtailGaps.map(async (gap) => {
-					return this.retrieveOps(gap[0] - 1, gap[1] + 1);
+				logtailGaps.map(async ([gapBeginInclusive, gapEndInclusive]) => {
+					return this.retrieveOps(gapBeginInclusive - 1, gapEndInclusive + 1);
 				}),
 			);
 

--- a/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/summaryWriter.ts
@@ -653,7 +653,8 @@ export class SummaryWriter implements ISummaryWriter {
 
 			logtailGaps = this.findMissingGapsInLogtail(logtailFromMemory, gt + 1, lt - 1);
 			if (logtailGaps.length === 0) {
-				return logtailFromMemory;
+				finalLogTail = logtailFromMemory;
+				return finalLogTail;
 			}
 
 			retrievedGaps = await Promise.all(
@@ -665,7 +666,8 @@ export class SummaryWriter implements ISummaryWriter {
 			const nonEmptyRetrievedGaps = retrievedGaps.filter((gap) => gap.length > 0);
 
 			if (nonEmptyRetrievedGaps.length === 0) {
-				return logtailFromMemory;
+				finalLogTail = logtailFromMemory;
+				return finalLogTail;
 			}
 
 			const minHeapComparator = (
@@ -680,6 +682,7 @@ export class SummaryWriter implements ISummaryWriter {
 				}
 				return 0;
 			};
+
 			finalLogTail = dedupeSortedArray(
 				mergeKArrays<ISequencedDocumentMessage>(
 					[...nonEmptyRetrievedGaps, logtailFromMemory],

--- a/server/routerlicious/packages/lambdas/src/test/broadcaster/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/broadcaster/lambda.spec.ts
@@ -66,7 +66,6 @@ describe("Routerlicious", () => {
 						kafkaMessageFactory.getHeadOffset(testDocumentId),
 					);
 
-					console.log(kafkaMessageFactory.getHeadOffset(testDocumentId));
 					assert.equal(
 						numMessages,
 						countOps(

--- a/server/routerlicious/packages/lambdas/src/test/scribe/summaryWriter.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/scribe/summaryWriter.spec.ts
@@ -1,0 +1,308 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { MessageType } from "@fluidframework/protocol-definitions";
+import { SummaryWriter } from "../..";
+import { TestDeltaManager, TestTenantManager } from "@fluidframework/server-test-utils";
+import Sinon from "sinon";
+import { strict as assert } from "assert";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
+import {
+	ISequencedOperationMessage,
+	SequencedOperationType,
+} from "@fluidframework/server-services-core";
+
+describe("Routerlicious", () => {
+	describe("Scribe", () => {
+		describe("SummaryWriter", () => {
+			const testTenantId = "test";
+			const testDocumentId = "test";
+			describe("getLogTail", () => {
+				let sandbox: Sinon.SinonSandbox;
+				let testTenantManager: TestTenantManager;
+				let testDeltaManager: TestDeltaManager;
+				let testGitManager: any;
+				const opStorage = undefined;
+				const enableWholeSummaryUpload = true;
+				const getDeltasViaAlfred = true;
+				beforeEach(async () => {
+					sandbox = Sinon.createSandbox();
+					testTenantManager = new TestTenantManager();
+					testDeltaManager = new TestDeltaManager();
+					testGitManager = await testTenantManager.getTenantGitManager(
+						testTenantId,
+						testDocumentId,
+					);
+				});
+
+				afterEach(async () => {
+					sandbox.restore();
+				});
+				it("Should not try fetch remote if current summary fill the range", async () => {
+					const lastSummaryMessages = generateOps(1, 10, 1).map((op) => op.operation);
+					const testingSummaryWriter = new SummaryWriter(
+						testTenantId,
+						testDocumentId,
+						testGitManager,
+						testDeltaManager,
+						opStorage,
+						enableWholeSummaryUpload,
+						lastSummaryMessages,
+						getDeltasViaAlfred,
+					);
+					const lumberJackSpy = sandbox.spy(Lumberjack, "info");
+					const deltaServiceSpy = sandbox.spy(testDeltaManager, "getDeltas");
+					const result = await testingSummaryWriter["getLogTail"](0, 11, []);
+					assert.strictEqual(
+						JSON.stringify(result.map((op) => op.sequenceNumber)),
+						JSON.stringify([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+					);
+					assert.strictEqual(false, deltaServiceSpy.called);
+					const logMessage = lumberJackSpy.getCalls()[0].args[0];
+					assert.strictEqual(
+						"LogTail of length 10 fetched from seq no 0 to 11",
+						logMessage,
+					);
+					const logProperties = lumberJackSpy.getCalls()[0].args[1];
+					verifyLogResult(
+						logMessage,
+						logProperties,
+						"LogTail of length 10 fetched from seq no 0 to 11",
+						[[1, 10]],
+						[],
+						[[1, 10]],
+						[],
+						[],
+						[[1, 10]],
+					);
+				});
+
+				it("Should not try fetch remote if pending ops fill the range", async () => {
+					const pendingOps = generateOps(1, 10, 1);
+					const testingSummaryWriter = new SummaryWriter(
+						testTenantId,
+						testDocumentId,
+						testGitManager,
+						testDeltaManager,
+						opStorage,
+						enableWholeSummaryUpload,
+						[],
+						getDeltasViaAlfred,
+					);
+					const lumberJackSpy = sandbox.spy(Lumberjack, "info");
+					const deltaServiceSpy = sandbox.spy(testDeltaManager, "getDeltas");
+					const result = await testingSummaryWriter["getLogTail"](0, 11, pendingOps);
+					assert.strictEqual(
+						JSON.stringify(result.map((op) => op.sequenceNumber)),
+						JSON.stringify([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+					);
+					assert.strictEqual(false, deltaServiceSpy.called);
+					const logMessage = lumberJackSpy.getCalls()[0].args[0];
+					const logProperties = lumberJackSpy.getCalls()[0].args[1];
+					verifyLogResult(
+						logMessage,
+						logProperties,
+						"LogTail of length 10 fetched from seq no 0 to 11",
+						[],
+						[[1, 10]],
+						[[1, 10]],
+						[],
+						[],
+						[[1, 10]],
+					);
+				});
+
+				it("Should not try fetch remote if current summary and pending ops work together fill the range", async () => {
+					const lastSummaryMessages = generateOps(1, 6, 1).map((op) => op.operation);
+					const pendingOps = generateOps(4, 10, 1);
+					const testingSummaryWriter = new SummaryWriter(
+						testTenantId,
+						testDocumentId,
+						testGitManager,
+						testDeltaManager,
+						opStorage,
+						enableWholeSummaryUpload,
+						lastSummaryMessages,
+						getDeltasViaAlfred,
+					);
+					const lumberJackSpy = sandbox.spy(Lumberjack, "info");
+					const deltaServiceSpy = sandbox.spy(testDeltaManager, "getDeltas");
+					const result = await testingSummaryWriter["getLogTail"](0, 11, pendingOps);
+					assert.strictEqual(
+						JSON.stringify(result.map((op) => op.sequenceNumber)),
+						JSON.stringify([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+					);
+					assert.strictEqual(false, deltaServiceSpy.called);
+					const logMessage = lumberJackSpy.getCalls()[0].args[0];
+					const logProperties = lumberJackSpy.getCalls()[0].args[1];
+					verifyLogResult(
+						logMessage,
+						logProperties,
+						"LogTail of length 10 fetched from seq no 0 to 11",
+						[[1, 6]],
+						[[4, 10]],
+						[[1, 10]],
+						[],
+						[],
+						[[1, 10]],
+					);
+				});
+
+				it("Should try fetch remote if current summary and pending ops work together not able to fill the range", async () => {
+					const lastSummaryMessages = generateOps(1, 3, 1).map((op) => op.operation);
+					const pendingOps = generateOps(7, 10, 1);
+					const testingSummaryWriter = new SummaryWriter(
+						testTenantId,
+						testDocumentId,
+						testGitManager,
+						testDeltaManager,
+						opStorage,
+						enableWholeSummaryUpload,
+						lastSummaryMessages,
+						getDeltasViaAlfred,
+					);
+					const lumberJackSpy = sandbox.spy(Lumberjack, "info");
+					const mockDeltas = generateOps(4, 4, 1).concat(generateOps(6, 6, 1));
+					const deltaManagerStub = sandbox
+						.stub(testDeltaManager, "getDeltas")
+						.resolves(mockDeltas.map((op) => op.operation));
+					const result = await testingSummaryWriter["getLogTail"](0, 11, pendingOps);
+					assert.strictEqual(
+						JSON.stringify(result.map((op) => op.sequenceNumber)),
+						JSON.stringify([1, 2, 3, 4, 6, 7, 8, 9, 10]),
+					);
+					assert.strictEqual(true, deltaManagerStub.calledOnce);
+					const logMessage = lumberJackSpy.getCalls()[0].args[0];
+					const logProperties = lumberJackSpy.getCalls()[0].args[1];
+					verifyLogResult(
+						logMessage,
+						logProperties,
+						"LogTail of length 9 fetched from seq no 0 to 11",
+						[[1, 3]],
+						[[7, 10]],
+						[
+							[1, 3],
+							[7, 10],
+						],
+						[[4, 6]],
+						[
+							[
+								[4, 4],
+								[6, 6],
+							],
+						],
+						[
+							[1, 4],
+							[6, 10],
+						],
+					);
+				});
+
+				it("Should try fetch remote if current summary and pending ops work together not able to fill the range, dedupe and preserve the order", async () => {
+					const lastSummaryMessages = generateOps(1, 1, 1)
+						.concat(generateOps(3, 4, 1))
+						.map((op) => op.operation);
+					const pendingOps = generateOps(7, 10, 1);
+					const testingSummaryWriter = new SummaryWriter(
+						testTenantId,
+						testDocumentId,
+						testGitManager,
+						testDeltaManager,
+						opStorage,
+						enableWholeSummaryUpload,
+						lastSummaryMessages,
+						getDeltasViaAlfred,
+					);
+					const lumberJackSpy = sandbox.spy(Lumberjack, "info");
+					const mockDeltas = generateOps(2, 8, 1);
+					const deltaManagerStub = sandbox
+						.stub(testDeltaManager, "getDeltas")
+						.resolves(mockDeltas.map((op) => op.operation));
+					const result = await testingSummaryWriter["getLogTail"](0, 11, pendingOps);
+					assert.strictEqual(
+						JSON.stringify(result.map((op) => op.sequenceNumber)),
+						JSON.stringify([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+					);
+					assert.strictEqual(true, deltaManagerStub.calledTwice);
+					const logMessage = lumberJackSpy.getCalls()[0].args[0];
+					const logProperties = lumberJackSpy.getCalls()[0].args[1];
+					verifyLogResult(
+						logMessage,
+						logProperties,
+						"LogTail of length 10 fetched from seq no 0 to 11",
+						[
+							[1, 1],
+							[3, 4],
+						],
+						[[7, 10]],
+						[
+							[1, 1],
+							[3, 4],
+							[7, 10],
+						],
+						[
+							[2, 2],
+							[5, 6],
+						],
+						[[[2, 8]], [[2, 8]]],
+						[[1, 10]],
+					);
+				});
+			});
+		});
+	});
+});
+
+function generateOps(
+	fromInclusive: number,
+	toInclusive: number,
+	step: number,
+): ISequencedOperationMessage[] {
+	return Array.from(
+		{ length: (toInclusive - fromInclusive) / step + 1 },
+		(_, i) => fromInclusive + i * step,
+	).map(
+		(sequenceNumber) =>
+			({
+				type: SequencedOperationType,
+				operation: {
+					clientId: "Some client ID",
+					clientSequenceNumber: sequenceNumber,
+					minimumSequenceNumber: 0,
+					sequenceNumber: sequenceNumber,
+					type: MessageType.Operation,
+				},
+			}) as ISequencedOperationMessage,
+	);
+}
+
+function verifyLogResult(
+	actualLogMessage: string,
+	actualLogProperties: any,
+	expectedLogMessage: string,
+	expectedLogtailRangeFromLastSummary: number[][],
+	expectedLogtailRangeFromPending: number[][],
+	expectedLogtailRangeFromMemory: number[][],
+	expectedLogtailGaps: number[][],
+	expectedRetrievedGapsRange: number[][][],
+	expectedFinalLogtailRange: number[][],
+) {
+	assert.strictEqual(actualLogMessage, expectedLogMessage);
+	assert.deepStrictEqual(
+		actualLogProperties["logtailRangeFromLastSummary"],
+		expectedLogtailRangeFromLastSummary,
+	);
+	assert.deepStrictEqual(
+		actualLogProperties["logtailRangeFromPending"],
+		expectedLogtailRangeFromPending,
+	);
+	assert.deepStrictEqual(
+		actualLogProperties["logtailRangeFromMemory"],
+		expectedLogtailRangeFromMemory,
+	);
+	assert.deepStrictEqual(actualLogProperties["logtailGaps"], expectedLogtailGaps);
+	assert.deepStrictEqual(actualLogProperties["retrievedGapsRange"], expectedRetrievedGapsRange);
+	assert.deepStrictEqual(actualLogProperties["finalLogtailRange"], expectedFinalLogtailRange);
+}

--- a/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
+++ b/server/routerlicious/packages/services-client/api-report/server-services-client.api.md
@@ -69,6 +69,9 @@ export const CorrelationIdHeaderName = "x-correlation-id";
 // @internal
 export function createFluidServiceNetworkError(statusCode: number, errorData?: INetworkErrorDetails | string): NetworkError;
 
+// @internal
+export function dedupeSortedArray<T, TSelector>(array: T[], selector: (item: T) => TSelector): T[];
+
 // @internal (undocumented)
 export const defaultHash = "00000000";
 
@@ -156,6 +159,19 @@ export class GitManager implements IGitManager {
     // (undocumented)
     upsertRef(branch: string, commitSha: string): Promise<resources.IRef>;
     write(branch: string, inputTree: api.ITree, parents: string[], message: string): Promise<resources.ICommit>;
+}
+
+// @internal
+export class Heap<T> {
+    constructor(comparator: IHeapComparator<T>);
+    // (undocumented)
+    peek(): T | undefined;
+    // (undocumented)
+    pop(): T | undefined;
+    // (undocumented)
+    push(value: T): void;
+    // (undocumented)
+    get size(): number;
 }
 
 // @internal
@@ -339,6 +355,12 @@ export interface IGitService {
     getTree(sha: string, recursive: boolean): Promise<resources.ITree>;
     // (undocumented)
     updateRef(ref: string, params: resources.IPatchRefParams): Promise<resources.IRef>;
+}
+
+// @internal
+export interface IHeapComparator<T> {
+    // (undocumented)
+    compareFn(a: T, b: T): number;
 }
 
 // @internal
@@ -530,6 +552,12 @@ export const LatestSummaryId = "latest";
 
 // @internal (undocumented)
 export function mergeAppAndProtocolTree(appSummaryTree: ITree, protocolTree: ITree): ICreateTreeEntry[];
+
+// @internal
+export function mergeKArrays<T>(arrays: T[][], comparator: (a: T, b: T) => number): T[];
+
+// @internal
+export function mergeSortedArrays<T>(arr1: T[], arr2: T[], comparator: (item1: T, item2: T) => number): T[];
 
 // @internal
 export class NetworkError extends Error {

--- a/server/routerlicious/packages/services-client/src/array.ts
+++ b/server/routerlicious/packages/services-client/src/array.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { Heap } from "./heap";
+
 /**
  * Converts the given number array into an array of ranges
  * Example: [1, 2, 3, 4, 5, 6] to [[1, 6]]
@@ -29,4 +31,73 @@ export function convertSortedNumberArrayToRanges(numberArray: number[]): number[
 	// Last range
 	ranges.push([begin, end]);
 	return ranges;
+}
+
+export function mergeArrays<T, TComp>(arr1: T[], arr2: T[], selector: (item: T) => TComp): T[] {
+	const mergedResult: T[] = [];
+	let index1 = 0;
+	let index2 = 0;
+	while (index1 < arr1.length && index2 < arr2.length) {
+		const value1 = selector(arr1[index1]);
+		const value2 = selector(arr2[index2]);
+		if (value1 <= value2) {
+			mergedResult.push(arr1[index1]);
+			index1++;
+		} else if (value1 > value2) {
+			mergedResult.push(arr2[index2]);
+			index2++;
+		}
+	}
+	while (index1 < arr1.length) {
+		mergedResult.push(arr1[index1]);
+		index1++;
+	}
+	while (index2 < arr2.length) {
+		mergedResult.push(arr2[index2]);
+		index2++;
+	}
+	return mergedResult;
+}
+
+class HeapNode<T> {
+	constructor(
+		public readonly index: number,
+		public readonly row: number,
+		public readonly value: T,
+	) {}
+}
+
+export function mergeKArrays<T>(arrays: T[][], comparator: (a: T, b: T) => number): T[] {
+	const heapComparator = {
+		compareFn: (a: HeapNode<T>, b: HeapNode<T>) => comparator(a.value, b.value),
+	};
+	const heap: Heap<HeapNode<T>> = new Heap<HeapNode<T>>(heapComparator);
+	for (let i = 0; i < arrays.length; i++) {
+		if (arrays[i].length > 0) {
+			heap.push(new HeapNode<T>(0, i, arrays[i][0]));
+		}
+	}
+	const mergedResult: T[] = [];
+	while (heap.size > 0) {
+		const node = heap.pop();
+		mergedResult.push(node.value);
+		const nextIndex = node.index + 1;
+		if (nextIndex < arrays[node.row].length) {
+			heap.push(new HeapNode<T>(nextIndex, node.row, arrays[node.row][nextIndex]));
+		}
+	}
+	return mergedResult;
+}
+
+export function dedupeSortedArray<T, TSelector>(array: T[], selector: (item: T) => TSelector): T[] {
+	const result: T[] = [];
+	let pre: any;
+	for (const item of array) {
+		const key = selector(item);
+		if (pre !== key) {
+			result.push(item);
+			pre = key;
+		}
+	}
+	return result;
 }

--- a/server/routerlicious/packages/services-client/src/array.ts
+++ b/server/routerlicious/packages/services-client/src/array.ts
@@ -33,17 +33,30 @@ export function convertSortedNumberArrayToRanges(numberArray: number[]): number[
 	return ranges;
 }
 
-export function mergeArrays<T, TComp>(arr1: T[], arr2: T[], selector: (item: T) => TComp): T[] {
+/**
+ * Merge two already sorted array into one sorted array. Please make sure the comparator is consistent with the array sorting order.
+ * Which means if the arrays were sorted in ascending order, the comparator should return a negative number if a &gt; b, 0 if a === b, and a positive number if a &lt; b.
+ * While if the arrays were sorted in descending order, the comparator should return a positive number if a &lt; b, 0 if a === b, and a negative number if a &gt b.
+ * @param arr1 - Sorted array 1
+ * @param arr2 - Sorted array 2
+ * @param comparator - comparator function, need to be consistent with the arrays sorting order
+ * @returns merged sorted array based on the sorting order
+ * @internal
+ */
+export function mergeSortedArrays<T>(
+	arr1: T[],
+	arr2: T[],
+	comparator: (item1: T, item2: T) => number,
+): T[] {
 	const mergedResult: T[] = [];
 	let index1 = 0;
 	let index2 = 0;
 	while (index1 < arr1.length && index2 < arr2.length) {
-		const value1 = selector(arr1[index1]);
-		const value2 = selector(arr2[index2]);
-		if (value1 <= value2) {
+		const compareResult = comparator(arr1[index1], arr2[index2]);
+		if (compareResult <= 0) {
 			mergedResult.push(arr1[index1]);
 			index1++;
-		} else if (value1 > value2) {
+		} else {
 			mergedResult.push(arr2[index2]);
 			index2++;
 		}
@@ -67,6 +80,13 @@ class HeapNode<T> {
 	) {}
 }
 
+/**
+ * Merge K sorted arrays into one sorted array. Please make sure the comparator is consistent with the array sorting order.
+ * @param arrays - array of sorted arrays
+ * @param comparator - comparator function, need to be consistent with the arrays sorting order
+ * @returns merged sorted array based on the sorting order
+ * @internal
+ */
 export function mergeKArrays<T>(arrays: T[][], comparator: (a: T, b: T) => number): T[] {
 	const heapComparator = {
 		compareFn: (a: HeapNode<T>, b: HeapNode<T>) => comparator(a.value, b.value),
@@ -89,6 +109,13 @@ export function mergeKArrays<T>(arrays: T[][], comparator: (a: T, b: T) => numbe
 	return mergedResult;
 }
 
+/**
+ * Dedupe the sorted array based on the selector. The array should be sorted based on the selector.
+ * @param array - array to dedupe
+ * @param selector - selector function
+ * @returns deduped sorted array based on the selector
+ * @internal
+ */
 export function dedupeSortedArray<T, TSelector>(array: T[], selector: (item: T) => TSelector): T[] {
 	const result: T[] = [];
 	let pre: any;

--- a/server/routerlicious/packages/services-client/src/heap.ts
+++ b/server/routerlicious/packages/services-client/src/heap.ts
@@ -1,0 +1,84 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export interface IHeapComparator<T> {
+	compareFn(a: T, b: T): number;
+}
+
+export class Heap<T> {
+	private readonly heap: T[] = [];
+	constructor(private readonly comparator: IHeapComparator<T>) {}
+
+	public get size(): number {
+		return this.heap.length;
+	}
+
+	public peek(): T | undefined {
+		return this.heap[0];
+	}
+
+	public push(value: T): void {
+		this.heap.push(value);
+		this.bubbleUp(this.size - 1);
+	}
+
+	public pop(): T | undefined {
+		if (this.size === 0) {
+			return undefined;
+		}
+		const result = this.heap[0];
+		const last = this.heap.pop();
+		if (this.size > 0 && last !== undefined) {
+			this.heap[0] = last;
+			this.bubbleDown(0);
+		}
+		return result;
+	}
+
+	private bubbleUp(index: number): void {
+		let current = index;
+		while (current > 0) {
+			const parent = Math.floor((current - 1) / 2);
+			if (this.comparator.compareFn(this.heap[current], this.heap[parent]) >= 0) {
+				break;
+			}
+			this.swap(current, parent);
+			current = parent;
+		}
+	}
+
+	private bubbleDown(index: number): void {
+		let currentIndex = index;
+		// eslint-disable-next-line no-constant-condition
+		while (true) {
+			const left = currentIndex * 2 + 1;
+			const right = currentIndex * 2 + 2;
+			let smallestIndex = currentIndex;
+			if (
+				left < this.size &&
+				this.comparator.compareFn(this.heap[left], this.heap[smallestIndex]) < 0
+			) {
+				smallestIndex = left;
+			}
+			if (
+				right < this.size &&
+				this.comparator.compareFn(this.heap[right], this.heap[smallestIndex]) < 0
+			) {
+				smallestIndex = right;
+			}
+			if (smallestIndex === currentIndex) {
+				break;
+			}
+			this.swap(currentIndex, smallestIndex);
+			currentIndex = smallestIndex;
+		}
+	}
+
+	private swap(a: number, b: number): void {
+		const temp = this.heap[a];
+		this.heap[a] = this.heap[b];
+		this.heap[b] = temp;
+	}
+}

--- a/server/routerlicious/packages/services-client/src/heap.ts
+++ b/server/routerlicious/packages/services-client/src/heap.ts
@@ -3,10 +3,18 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * compareFn for the heap.
+ * @internal
+ */
 export interface IHeapComparator<T> {
 	compareFn(a: T, b: T): number;
 }
 
+/**
+ * Ordered {@link https://en.wikipedia.org/wiki/Heap_(data_structure) | Heap} data structure implementation.
+ * @internal
+ */
 export class Heap<T> {
 	private readonly heap: T[] = [];
 	constructor(private readonly comparator: IHeapComparator<T>) {}

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -9,7 +9,12 @@ export {
 	validateTokenClaims,
 	validateTokenClaimsExpiration,
 } from "./auth";
-export { convertSortedNumberArrayToRanges } from "./array";
+export {
+	convertSortedNumberArrayToRanges,
+	dedupeSortedArray,
+	mergeArrays,
+	mergeKArrays,
+} from "./array";
 export { CorrelationIdHeaderName, DriverVersionHeaderName, LatestSummaryId } from "./constants";
 export {
 	createFluidServiceNetworkError,
@@ -20,6 +25,7 @@ export {
 } from "./error";
 export { choose, getRandomName } from "./generateNames";
 export { GitManager } from "./gitManager";
+export { Heap, IHeapComparator } from "./heap";
 export { getAuthorizationTokenFromCredentials, Historian, ICredentials } from "./historian";
 export { IAlfredTenant, ISession } from "./interfaces";
 export { promiseTimeout } from "./promiseTimeout";

--- a/server/routerlicious/packages/services-client/src/index.ts
+++ b/server/routerlicious/packages/services-client/src/index.ts
@@ -12,8 +12,8 @@ export {
 export {
 	convertSortedNumberArrayToRanges,
 	dedupeSortedArray,
-	mergeArrays,
 	mergeKArrays,
+	mergeSortedArrays,
 } from "./array";
 export { CorrelationIdHeaderName, DriverVersionHeaderName, LatestSummaryId } from "./constants";
 export {

--- a/server/routerlicious/packages/services-client/src/test/array.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/array.spec.ts
@@ -7,8 +7,8 @@ import { strict as assert } from "assert";
 import {
 	convertSortedNumberArrayToRanges,
 	dedupeSortedArray,
-	mergeArrays,
 	mergeKArrays,
+	mergeSortedArrays,
 } from "../array";
 
 describe("convertToRanges", () => {
@@ -75,18 +75,32 @@ describe("convertToRanges", () => {
 });
 
 describe("mergeArrays", () => {
-	it("Should return an merged sorted array from two sorted arrays", () => {
+	it("Should return an merged sorted ascending array from two ascending sorted arrays", () => {
 		const arr1 = [1, 3, 5, 7, 9];
 		const arr2 = [2, 4, 6, 8, 10];
-		const result = mergeArrays(arr1, arr2, (a) => a);
+		const result = mergeSortedArrays(arr1, arr2, (a, b) => a - b);
 		assert.strictEqual(JSON.stringify(result), JSON.stringify([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
 	});
 
-	it("Should return an merged sorted array from two sorted arrays based on selector", () => {
-		const arr1 = [1, 3, 5, 7, 9];
-		const arr2 = [2, 4, 6, 8, 10];
-		const result = mergeArrays(arr1, arr2, (_) => 1);
-		assert.strictEqual(JSON.stringify(result), JSON.stringify([1, 3, 5, 7, 9, 2, 4, 6, 8, 10]));
+	it("Should return an merged sorted ascending array from two ascending sorted arrays with duplicates", () => {
+		const arr1 = [1, 1, 7, 7, 9];
+		const arr2 = [4, 4, 8, 8, 10];
+		const result = mergeSortedArrays(arr1, arr2, (a, b) => a - b);
+		assert.strictEqual(JSON.stringify(result), JSON.stringify([1, 1, 4, 4, 7, 7, 8, 8, 9, 10]));
+	});
+
+	it("Should return an merged sorted descending array from two descending sorted arrays based on selector", () => {
+		const arr1 = [9, 7, 5, 3, 1];
+		const arr2 = [10, 8, 6, 4, 2];
+		const result = mergeSortedArrays(arr1, arr2, (a, b) => b - a);
+		assert.strictEqual(JSON.stringify(result), JSON.stringify([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]));
+	});
+
+	it("Should return an merged sorted descending array from two descending sorted arrays based on selector with duplicates", () => {
+		const arr1 = [9, 9, 5, 5, 1];
+		const arr2 = [8, 8, 4, 4, 2];
+		const result = mergeSortedArrays(arr1, arr2, (a, b) => b - a);
+		assert.strictEqual(JSON.stringify(result), JSON.stringify([9, 9, 8, 8, 5, 5, 4, 4, 2, 1]));
 	});
 });
 
@@ -98,11 +112,31 @@ describe("mergeKArray", () => {
 		assert.strictEqual(JSON.stringify(result), JSON.stringify([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
 	});
 
+	it("Should return an merged sorted array from sorted arrays asc with duplicates", () => {
+		const input = [
+			[1, 1, 3, 3],
+			[2, 2, 4, 4, 6, 6],
+		];
+		const ascComparator = (a: number, b: number) => (a - b < 0 ? -1 : a === b ? 0 : 1);
+		const result = mergeKArrays(input, ascComparator);
+		assert.strictEqual(JSON.stringify(result), JSON.stringify([1, 1, 2, 2, 3, 3, 4, 4, 6, 6]));
+	});
+
 	it("Should return an merged sorted array from sorted arrays desc", () => {
 		const input = [[3, 1], [6, 4, 2], [9, 0], [8, 7], [5], []];
 		const descComparator = (a: number, b: number) => (a - b > 0 ? -1 : a === b ? 0 : 1);
 		const result = mergeKArrays(input, descComparator);
 		assert.strictEqual(JSON.stringify(result), JSON.stringify([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]));
+	});
+
+	it("Should return an merged sorted array from sorted arrays desc with duplicates", () => {
+		const input = [
+			[3, 3, 1, 1],
+			[6, 6, 4, 4, 2, 2],
+		];
+		const descComparator = (a: number, b: number) => (a - b > 0 ? -1 : a === b ? 0 : 1);
+		const result = mergeKArrays(input, descComparator);
+		assert.strictEqual(JSON.stringify(result), JSON.stringify([6, 6, 4, 4, 3, 3, 2, 2, 1, 1]));
 	});
 });
 

--- a/server/routerlicious/packages/services-client/src/test/array.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/array.spec.ts
@@ -4,7 +4,12 @@
  */
 
 import { strict as assert } from "assert";
-import { convertSortedNumberArrayToRanges, dedupeSortedArray, mergeArrays, mergeKArrays } from "../array";
+import {
+	convertSortedNumberArrayToRanges,
+	dedupeSortedArray,
+	mergeArrays,
+	mergeKArrays,
+} from "../array";
 
 describe("convertToRanges", () => {
 	it("Should return empty array if input is empty", () => {
@@ -69,47 +74,33 @@ describe("convertToRanges", () => {
 	});
 });
 
-describe("mergeArrays", ()=>{
+describe("mergeArrays", () => {
 	it("Should return an merged sorted array from two sorted arrays", () => {
 		const arr1 = [1, 3, 5, 7, 9];
 		const arr2 = [2, 4, 6, 8, 10];
-		const result = mergeArrays(arr1, arr2, a=>a);
+		const result = mergeArrays(arr1, arr2, (a) => a);
 		assert.strictEqual(JSON.stringify(result), JSON.stringify([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
 	});
 
 	it("Should return an merged sorted array from two sorted arrays based on selector", () => {
 		const arr1 = [1, 3, 5, 7, 9];
 		const arr2 = [2, 4, 6, 8, 10];
-		const result = mergeArrays(arr1, arr2, _=>1);
+		const result = mergeArrays(arr1, arr2, (_) => 1);
 		assert.strictEqual(JSON.stringify(result), JSON.stringify([1, 3, 5, 7, 9, 2, 4, 6, 8, 10]));
 	});
 });
 
 describe("mergeKArray", () => {
 	it("Should return an merged sorted array from sorted arrays asc", () => {
-		const input = [
-			[1, 3],
-			[2, 4, 6],
-			[0, 9],
-			[7, 8],
-			[5],
-			[],
-		];
-		const ascComparator = (a: number, b: number) => a - b < 0 ? -1 : a === b ? 0 : 1;
+		const input = [[1, 3], [2, 4, 6], [0, 9], [7, 8], [5], []];
+		const ascComparator = (a: number, b: number) => (a - b < 0 ? -1 : a === b ? 0 : 1);
 		const result = mergeKArrays(input, ascComparator);
 		assert.strictEqual(JSON.stringify(result), JSON.stringify([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
 	});
 
 	it("Should return an merged sorted array from sorted arrays desc", () => {
-		const input = [
-			[3, 1],
-			[6, 4, 2],
-			[9, 0],
-			[8, 7],
-			[5],
-			[],
-		];
-		const descComparator = (a: number, b: number) => a - b > 0 ? -1 : a === b ? 0 : 1;
+		const input = [[3, 1], [6, 4, 2], [9, 0], [8, 7], [5], []];
+		const descComparator = (a: number, b: number) => (a - b > 0 ? -1 : a === b ? 0 : 1);
 		const result = mergeKArrays(input, descComparator);
 		assert.strictEqual(JSON.stringify(result), JSON.stringify([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]));
 	});
@@ -118,13 +109,13 @@ describe("mergeKArray", () => {
 describe("dedupeSortedArray", () => {
 	it("Should return an deduped sorted array", () => {
 		const input = [1, 2, 2, 3, 3, 3, 4, 5, 5, 6];
-		const result = dedupeSortedArray(input, a=>a);
+		const result = dedupeSortedArray(input, (a) => a);
 		assert.strictEqual(JSON.stringify(result), JSON.stringify([1, 2, 3, 4, 5, 6]));
 	});
 
 	it("Should return an deduped sorted array based on selector", () => {
 		const input = [1, 2, 2, 3, 3, 3, 4, 5, 5, 6];
-		const result = dedupeSortedArray(input, _=>6);
+		const result = dedupeSortedArray(input, (_) => 6);
 		assert.strictEqual(JSON.stringify(result), JSON.stringify([1]));
 	});
-})
+});

--- a/server/routerlicious/packages/services-client/src/test/array.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/array.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { convertSortedNumberArrayToRanges } from "../array";
+import { convertSortedNumberArrayToRanges, dedupeSortedArray, mergeArrays, mergeKArrays } from "../array";
 
 describe("convertToRanges", () => {
 	it("Should return empty array if input is empty", () => {
@@ -68,3 +68,49 @@ describe("convertToRanges", () => {
 		assert.strictEqual(JSON.stringify(ranges), JSON.stringify([[0, 999]]));
 	});
 });
+
+describe("mergeArrays", ()=>{
+	it("Should return an merged sorted array from two sorted arrays", () => {
+		const arr1 = [1, 3, 5, 7, 9];
+		const arr2 = [2, 4, 6, 8, 10];
+		const result = mergeArrays(arr1, arr2, a=>a);
+		assert.strictEqual(JSON.stringify(result), JSON.stringify([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
+	});
+
+	it("Should return an merged sorted array from two sorted arrays based on selector", () => {
+		const arr1 = [1, 3, 5, 7, 9];
+		const arr2 = [2, 4, 6, 8, 10];
+		const result = mergeArrays(arr1, arr2, _=>1);
+		assert.strictEqual(JSON.stringify(result), JSON.stringify([1, 3, 5, 7, 9, 2, 4, 6, 8, 10]));
+	});
+});
+
+describe("mergeKArray", () => {
+	it("Should return an merged sorted array from sorted arrays", () => {
+		const input = [
+			[1, 3],
+			[2, 4, 6],
+			[0, 9],
+			[7, 8],
+			[5],
+			[],
+		];
+		const ascComparator = (a: number, b: number) => a - b < 0 ? -1 : a === b ? 0 : 1;
+		const result = mergeKArrays(input, ascComparator);
+		assert.strictEqual(JSON.stringify(result), JSON.stringify([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+	});
+});
+
+describe("dedupeSortedArray", () => {
+	it("Should return an deduped sorted array", () => {
+		const input = [1, 2, 2, 3, 3, 3, 4, 5, 5, 6];
+		const result = dedupeSortedArray(input, a=>a);
+		assert.strictEqual(JSON.stringify(result), JSON.stringify([1, 2, 3, 4, 5, 6]));
+	});
+
+	it("Should return an deduped sorted array based on selector", () => {
+		const input = [1, 2, 2, 3, 3, 3, 4, 5, 5, 6];
+		const result = dedupeSortedArray(input, _=>6);
+		assert.strictEqual(JSON.stringify(result), JSON.stringify([1]));
+	});
+})

--- a/server/routerlicious/packages/services-client/src/test/array.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/array.spec.ts
@@ -86,7 +86,7 @@ describe("mergeArrays", ()=>{
 });
 
 describe("mergeKArray", () => {
-	it("Should return an merged sorted array from sorted arrays", () => {
+	it("Should return an merged sorted array from sorted arrays asc", () => {
 		const input = [
 			[1, 3],
 			[2, 4, 6],
@@ -98,6 +98,20 @@ describe("mergeKArray", () => {
 		const ascComparator = (a: number, b: number) => a - b < 0 ? -1 : a === b ? 0 : 1;
 		const result = mergeKArrays(input, ascComparator);
 		assert.strictEqual(JSON.stringify(result), JSON.stringify([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+	});
+
+	it("Should return an merged sorted array from sorted arrays desc", () => {
+		const input = [
+			[3, 1],
+			[6, 4, 2],
+			[9, 0],
+			[8, 7],
+			[5],
+			[],
+		];
+		const descComparator = (a: number, b: number) => a - b > 0 ? -1 : a === b ? 0 : 1;
+		const result = mergeKArrays(input, descComparator);
+		assert.strictEqual(JSON.stringify(result), JSON.stringify([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]));
 	});
 });
 

--- a/server/routerlicious/packages/services-client/src/test/heap.spec.ts
+++ b/server/routerlicious/packages/services-client/src/test/heap.spec.ts
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { strict as assert } from "assert";
+import { Heap } from "../heap";
+
+interface TestObject {
+	value: number;
+	key: string;
+}
+
+describe("Heap", () => {
+	it("should return undefined if heap is empty", () => {
+		const heap = new Heap<number>({
+			compareFn: (a, b) => a - b,
+		});
+		assert.strictEqual(heap.pop(), undefined);
+	});
+
+	it("should return the smallest element for a min heap", () => {
+		const heap = new Heap<number>({
+			compareFn: (a, b) => a - b,
+		});
+		heap.push(3);
+		heap.push(1);
+		heap.push(2);
+		assert.strictEqual(heap.pop(), 1);
+		assert.strictEqual(heap.pop(), 2);
+		assert.strictEqual(heap.pop(), 3);
+	});
+
+	it("should return the largest element for a max heap", () => {
+		const heap = new Heap<number>({
+			compareFn: (a, b) => b - a,
+		});
+		heap.push(3);
+		heap.push(1);
+		heap.push(2);
+		assert.strictEqual(heap.pop(), 3);
+		assert.strictEqual(heap.pop(), 2);
+		assert.strictEqual(heap.pop(), 1);
+	});
+
+	it("should return the smallest element for a min heap with custom comparator for a complex object", () => {
+		const heap = new Heap<TestObject>({
+			compareFn: (a, b) => a.value - b.value,
+		});
+		heap.push({ value: 3, key: "3" });
+		heap.push({ value: 1, key: "1" });
+		heap.push({ value: 1, key: "2" });
+		heap.push({ value: 2, key: "2" });
+		assert.strictEqual(heap.pop().value, 1);
+		assert.strictEqual(heap.pop().value, 1);
+		assert.strictEqual(heap.pop().value, 2);
+		assert.strictEqual(heap.pop().value, 3);
+	});
+});


### PR DESCRIPTION
## Description

Older versions will try to create a logtail from the pending from Kafka first, then from db/alfred, lastly from the latest summaries. The second step doesn't consume very wisely because it added a lot of networkIO, and older logtail in latest summaries + the pending ones, should consist most of the tail already. We only need to make network IO calls when needed. So changed the logic to use the logtail from latest summary + pending from kafak, and determine any gaps, and then send networkIO request to fill these gaps.

Also, older version detects the gap is way too expensive, changes to use a simpler and easy version.

## Breaking Changes

None

## Reviewer Guidance

