### PR TITLE
Allow rehydrate op generation to be disabled

### DIFF
--- a/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
+++ b/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
@@ -93,6 +93,7 @@ export interface DDSFuzzSuiteOptions {
     defaultTestCount: number;
     detachedStartOptions: {
         numOpsBeforeAttach: number;
+        numRehydrateOps?: 0 | 1;
     };
     emitter: TypedEventEmitter<DDSFuzzHarnessEvents>;
     idCompressorFactory?: (summary?: SerializedIdCompressorWithNoSession) => IIdCompressor & IIdCompressorCore;

--- a/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
+++ b/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
@@ -93,7 +93,7 @@ export interface DDSFuzzSuiteOptions {
     defaultTestCount: number;
     detachedStartOptions: {
         numOpsBeforeAttach: number;
-        numRehydrateOps?: 0 | 1;
+        rehydrateDisabled?: true;
     };
     emitter: TypedEventEmitter<DDSFuzzHarnessEvents>;
     idCompressorFactory?: (summary?: SerializedIdCompressorWithNoSession) => IIdCompressor & IIdCompressorCore;

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -35,7 +35,7 @@ const baseOptions: Partial<DDSFuzzSuiteOptions> = {
  * The fuzz tests should validate that the clients do not crash and that their document states do not diverge.
  * See the "Fuzz - Targeted" test suite for tests that validate more specific code paths or invariants.
  */
-describe.only("Fuzz - Top-Level", () => {
+describe("Fuzz - Top-Level", () => {
 	const runsPerBatch = 50;
 	const opsPerRun = 20;
 	// TODO: Enable other types of ops.

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -35,7 +35,7 @@ const baseOptions: Partial<DDSFuzzSuiteOptions> = {
  * The fuzz tests should validate that the clients do not crash and that their document states do not diverge.
  * See the "Fuzz - Targeted" test suite for tests that validate more specific code paths or invariants.
  */
-describe("Fuzz - Top-Level", () => {
+describe.only("Fuzz - Top-Level", () => {
 	const runsPerBatch = 50;
 	const opsPerRun = 20;
 	// TODO: Enable other types of ops.
@@ -78,9 +78,13 @@ describe("Fuzz - Top-Level", () => {
 				clientAddProbability: 0,
 				maxNumberOfClients: 3,
 			},
+			// AB#7162: enabling rehydrate in these tests hits 0x744 and 0x79d. Disabling rehydrate for now
+			// and using the default number of ops before attach.
+			detachedStartOptions: {
+				numOpsBeforeAttach: 5,
+				rehydrateDisabled: true,
+			},
 			reconnectProbability: 0,
-			// AB#7162
-			skip: [2, 9, 18, 21, 26, 35, 38, 39, 42],
 			idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),
 		};
 		createDDSFuzzSuite(model, options);
@@ -107,8 +111,11 @@ describe("Fuzz - Top-Level", () => {
 				flushMode: FlushMode.TurnBased,
 				enableGroupedBatching: true,
 			},
-			// AB#7162
-			skip: [9, 12, 26, 27, 29],
+			// AB#7162: see comment above.
+			detachedStartOptions: {
+				numOpsBeforeAttach: 5,
+				rehydrateDisabled: true,
+			},
 			saveFailures: {
 				directory: failureDirectory,
 			},


### PR DESCRIPTION
With the new change to the DDS Fuzz Harness that rehydrates a client from a summary before attaching, add support for not generating a rehydrate op before the attach. This allows each DDS test suite to determine whether or not they want rehydrate enabled in their tests, either for debugging or permanent use. 