### PR TITLE
[v2rc/1.0] GC: Add option to run Sweep only for Attachment Blobs

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -39,7 +39,6 @@ import {
 } from "@fluidframework/runtime-definitions";
 
 import { canRetryOnError, runWithRetry } from "@fluidframework/driver-utils";
-import { disableAttachmentBlobSweepKey } from "./gc";
 import { IBlobMetadata } from "./metadata";
 
 /**
@@ -742,11 +741,6 @@ export class BlobManager extends TypedEventEmitter<IBlobManagerEvents> {
 	 * @returns The routes of blobs that were deleted.
 	 */
 	public deleteSweepReadyNodes(sweepReadyBlobRoutes: readonly string[]): readonly string[] {
-		// If sweep for attachment blobs is not enabled, return empty list indicating nothing is deleted.
-		if (this.mc.config.getBoolean(disableAttachmentBlobSweepKey) === true) {
-			return [];
-		}
-
 		this.deleteBlobsFromRedirectTable(sweepReadyBlobRoutes);
 		return Array.from(sweepReadyBlobRoutes);
 	}

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -61,8 +61,8 @@ import {
 	LocalDetachedFluidDataStoreContext,
 } from "./dataStoreContext";
 import { StorageServiceWithAttachBlobs } from "./storageServiceWithAttachBlobs";
-import { GCNodeType, detectOutboundRoutesViaDDSKey, disableDatastoreSweepKey } from "./gc";
-import { IDataStoreAliasMessage, channelToDataStore, isDataStoreAliasMessage } from "./dataStore";
+import { GCNodeType, detectOutboundRoutesViaDDSKey } from "./gc";
+import { IDataStoreAliasMessage, isDataStoreAliasMessage } from "./dataStore";
 import { IContainerRuntimeMetadata, nonDataStorePaths, rootHasIsolatedChannels } from "./summary";
 
 type PendingAliasResolve = (success: boolean) => void;

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -61,8 +61,8 @@ import {
 	LocalDetachedFluidDataStoreContext,
 } from "./dataStoreContext";
 import { StorageServiceWithAttachBlobs } from "./storageServiceWithAttachBlobs";
-import { IDataStoreAliasMessage, isDataStoreAliasMessage } from "./dataStore";
 import { GCNodeType, detectOutboundRoutesViaDDSKey, disableDatastoreSweepKey } from "./gc";
+import { IDataStoreAliasMessage, channelToDataStore, isDataStoreAliasMessage } from "./dataStore";
 import { IContainerRuntimeMetadata, nonDataStorePaths, rootHasIsolatedChannels } from "./summary";
 
 type PendingAliasResolve = (success: boolean) => void;
@@ -839,16 +839,13 @@ export class DataStores implements IDisposable {
 	 * @returns The routes of data stores and its objects that were deleted.
 	 */
 	public deleteSweepReadyNodes(sweepReadyDataStoreRoutes: readonly string[]): readonly string[] {
-		// If sweep for data stores is not enabled, return empty list indicating nothing is deleted.
-		if (this.mc.config.getBoolean(disableDatastoreSweepKey) === true) {
-			return [];
-		}
 		for (const route of sweepReadyDataStoreRoutes) {
 			const pathParts = route.split("/");
 			const dataStoreId = pathParts[1];
 
 			// Ignore sub-data store routes because a data store and its sub-routes are deleted together, so, we only
 			// need to delete the data store.
+			// These routes will still be returned below as among the deleted routes
 			if (pathParts.length > 2) {
 				continue;
 			}

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -555,8 +555,9 @@ export class GarbageCollector implements IGarbageCollector {
 		);
 
 		// 4. Run the Sweep phase.
-		// It will tombstone any tombstone-ready nodes, and initiate the deletion of sweep-ready nodes by sending a
-		// sweep op. All clients, including this one, will delete these nodes once it processes the op.
+		// It will initiate the deletion (sending the GC Sweep op) of any sweep-ready nodes that are
+		// allowed to be deleted per config, and tombstone the rest along with the tombstone-ready nodes.
+		// Note that no nodes will be deleted until the GC Sweep op is processed.
 		this.runSweepPhase(gcResult, tombstoneReadyNodeIds, sweepReadyNodeIds);
 
 		this.gcDataFromLastRun = cloneGCData(gcData);
@@ -667,19 +668,34 @@ export class GarbageCollector implements IGarbageCollector {
 			return;
 		}
 
-		// If sweep is disabled, we'll tombstone both tombstone-ready and sweep-ready nodes.
+		// We'll build up the lists of nodes to be either Tombstoned or Deleted
+		// based on the configuration and the nodes' current state.
+		// We must Tombstone any sweep-ready node that Sweep won't run for.
 		// This is important because a container may never load during a node's Sweep Grace Period,
 		// so that node would directly become sweep-ready skipping over tombstone-ready state,
 		// but should be Tombstoned since Sweep is disabled.
-		const { nodesToTombstone, nodesToDelete } = this.configs.shouldRunSweep
-			? {
-					nodesToTombstone: [...tombstoneReadyNodes],
-					nodesToDelete: [...sweepReadyNodes],
-			  }
-			: {
-					nodesToTombstone: [...tombstoneReadyNodes, ...sweepReadyNodes],
-					nodesToDelete: [],
-			  };
+		const { nodesToTombstone, nodesToDelete } = {
+			nodesToTombstone: [...tombstoneReadyNodes],
+			nodesToDelete: [] as string[],
+		};
+		switch (this.configs.shouldRunSweep) {
+			case "YES":
+				nodesToDelete.push(...sweepReadyNodes);
+				break;
+			case "ONLY_BLOBS":
+				sweepReadyNodes.forEach((nodeId) => {
+					const nodeType = this.runtime.getNodeType(nodeId);
+					if (nodeType === GCNodeType.Blob) {
+						nodesToDelete.push(nodeId);
+					} else {
+						nodesToTombstone.push(nodeId);
+					}
+				});
+				break;
+			default: // case "NO":
+				nodesToTombstone.push(...sweepReadyNodes);
+				break;
+		}
 
 		if (this.configs.tombstoneMode) {
 			this.tombstones = nodesToTombstone;
@@ -687,7 +703,7 @@ export class GarbageCollector implements IGarbageCollector {
 			this.runtime.updateTombstonedRoutes(this.tombstones);
 		}
 
-		if (this.configs.shouldRunSweep && nodesToDelete.length > 0) {
+		if (nodesToDelete.length > 0) {
 			// Do not send DDS node ids in the GC op. This is an optimization to reduce its size. Since GC applies to
 			// to data store only, all its DDSes are deleted along with it. The DDS ids will be retrieved from the
 			// local state when processing the op.
@@ -883,6 +899,10 @@ export class GarbageCollector implements IGarbageCollector {
 	/**
 	 * Delete nodes that are sweep-ready. Call the runtime to delete these nodes and clear the unreferenced state
 	 * tracking for nodes that are actually deleted by the runtime.
+	 *
+	 * Note that this doesn't check any configuration around whether Sweep is enabled.
+	 * That happens before the op is submitted, and from that point, any client should execute the delete.
+	 *
 	 * @param sweepReadyNodeIds - The ids of nodes that are ready to be deleted.
 	 */
 	private deleteSweepReadyNodes(sweepReadyNodeIds: readonly string[]) {
@@ -1113,8 +1133,9 @@ export class GarbageCollector implements IGarbageCollector {
 
 	/**
 	 * Generates the stats of a garbage collection sweep phase run.
-	 * @param deletedNodes - The nodes that have been deleted until this run.
-	 * @param sweepReadyNodes - The nodes that are sweep-ready in this GC run.
+	 * @param deletedNodes - The nodes that have already been deleted even before this run.
+	 * @param sweepReadyNodes - The nodes that are sweep-ready in this GC run. These will be deleted but are not deleted yet,
+	 * due to either sweep not being enabled or the Sweep Op needing to roundtrip before the delete is executed.
 	 * @param markPhaseStats - The stats of the mark phase run.
 	 * @returns the stats of the sweep phase run.
 	 */
@@ -1160,19 +1181,18 @@ export class GarbageCollector implements IGarbageCollector {
 			}
 		}
 
-		// If sweep is enabled, the counts from the mark phase stats do not include nodes that have been
+		// The counts from the mark phase stats do not include nodes that were
 		// deleted in previous runs. So, add the deleted node counts to life time stats.
 		sweepPhaseStats.lifetimeNodeCount += sweepPhaseStats.deletedNodeCount;
 		sweepPhaseStats.lifetimeDataStoreCount += sweepPhaseStats.deletedDataStoreCount;
 		sweepPhaseStats.lifetimeAttachmentBlobCount += sweepPhaseStats.deletedAttachmentBlobCount;
 
-		if (this.configs.shouldRunSweep) {
-			return sweepPhaseStats;
-		}
-
-		// If sweep is not enabled, the current sweep-ready node stats should be added to deleted stats since this
-		// is the final state the node will be in.
-		// If sweep is enabled, this will happen in the run after the GC op round trips back.
+		// These stats are used to estimate the impact of GC in terms of how much garbage is/will be cleaned up.
+		// So we include the current sweep-ready node stats since these nodes will be deleted eventually.
+		// - If sweep is enabled, this will happen in the run after the GC op round trips back
+		//   (they'll be in deletedNodes that time).
+		// - If sweep is not enabled, we still want to include these nodes since they
+		//   _will be_ deleted once it is enabled.
 		for (const nodeId of sweepReadyNodes) {
 			sweepPhaseStats.deletedNodeCount++;
 			const nodeType = this.runtime.getNodeType(nodeId);
@@ -1182,6 +1202,7 @@ export class GarbageCollector implements IGarbageCollector {
 				sweepPhaseStats.deletedAttachmentBlobCount++;
 			}
 		}
+
 		return sweepPhaseStats;
 	}
 }

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -32,6 +32,7 @@ import {
 	defaultSweepGracePeriodMs,
 	gcGenerationOptionName,
 	IGCMetadata_Deprecated,
+	disableDatastoreSweepKey,
 } from "./gcDefinitions";
 import { getGCVersion, shouldAllowGcSweep } from "./gcHelpers";
 
@@ -137,18 +138,24 @@ export function generateGCConfigs(
 	 * Whether sweep should run or not. This refers to whether Tombstones should fail on load and whether
 	 * sweep-ready nodes should be deleted.
 	 *
-	 * Assuming overall GC is enabled and Tombstone timeout is present, the following conditions have to be met to run sweep:
+	 * Assuming overall GC is enabled and tombstoneTimeout is provided, the following conditions have to be met to run sweep:
 	 *
-	 * 1. Sweep should be enabled for this container.
-	 * 2. Sweep should be enabled for this session.
+	 * 1. Sweep should be allowed in this container.
+	 * 2. Sweep should be enabled for this session, optionally restricted to attachment blobs only.
 	 *
 	 * These conditions can be overridden via the RunSweep feature flag.
 	 */
-	const shouldRunSweep =
+	const sweepEnabled: boolean =
 		!shouldRunGC || tombstoneTimeoutMs === undefined
 			? false
 			: mc.config.getBoolean(runSweepKey) ??
 			  (sweepAllowed && createParams.gcOptions.enableGCSweep === true);
+	const disableDatastoreSweep = mc.config.getBoolean(disableDatastoreSweepKey) === true;
+	const shouldRunSweep: IGarbageCollectorConfigs["shouldRunSweep"] = sweepEnabled
+		? disableDatastoreSweep
+			? "ONLY_BLOBS"
+			: "YES"
+		: "NO";
 
 	// Override inactive timeout if test config or gc options to override it is set.
 	const inactiveTimeoutMs =

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -33,6 +33,7 @@ import {
 	gcGenerationOptionName,
 	IGCMetadata_Deprecated,
 	disableDatastoreSweepKey,
+	gcDisableDataStoreSweepOptionName,
 } from "./gcDefinitions";
 import { getGCVersion, shouldAllowGcSweep } from "./gcHelpers";
 
@@ -150,7 +151,9 @@ export function generateGCConfigs(
 			? false
 			: mc.config.getBoolean(runSweepKey) ??
 			  (sweepAllowed && createParams.gcOptions.enableGCSweep === true);
-	const disableDatastoreSweep = mc.config.getBoolean(disableDatastoreSweepKey) === true;
+	const disableDatastoreSweep =
+		mc.config.getBoolean(disableDatastoreSweepKey) === true ||
+		createParams.gcOptions[gcDisableDataStoreSweepOptionName] === true;
 	const shouldRunSweep: IGarbageCollectorConfigs["shouldRunSweep"] = sweepEnabled
 		? disableDatastoreSweep
 			? "ONLY_BLOBS"

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -70,10 +70,8 @@ export const throwOnTombstoneLoadOverrideKey =
 export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombstoneUsage";
 /** Config key to enable GC version upgrade. */
 export const gcVersionUpgradeToV4Key = "Fluid.GarbageCollection.GCVersionUpgradeToV4";
-/** Config key to disable GC sweep for datastores. */
+/** Config key to disable GC sweep for datastores. They'll merely be Tombstoned. */
 export const disableDatastoreSweepKey = "Fluid.GarbageCollection.DisableDataStoreSweep";
-/** Config key to disable GC sweep for attachment blobs. */
-export const disableAttachmentBlobSweepKey = "Fluid.GarbageCollection.DisableAttachmentBlobSweep";
 /** Config key to revert new paradigm of detecting outbound routes in ContainerRuntime layer (use true) */
 export const detectOutboundRoutesViaDDSKey = "Fluid.GarbageCollection.DetectOutboundRoutesViaDDS";
 
@@ -449,7 +447,7 @@ export interface IGarbageCollectorConfigs {
 	 */
 	readonly gcEnabled: boolean;
 	/**
-	 * Tracks if sweep phase is enabled for this document. This is specified during document creation and doesn't change
+	 * Tracks if sweep phase is allowed for this document. This is specified during document creation and doesn't change
 	 * throughout its lifetime.
 	 */
 	readonly sweepEnabled: boolean;
@@ -459,10 +457,11 @@ export interface IGarbageCollectorConfigs {
 	 */
 	readonly shouldRunGC: boolean;
 	/**
-	 * Tracks if sweep phase should run or not. Even if the sweep phase is enabled for a document (see sweepEnabled), it
-	 * can be explicitly disabled via feature flags. It also won't run if session expiry is not enabled.
+	 * Tracks if sweep phase should run or not, or if it should run only for attachment blobs.
+	 * Even if the sweep phase is allowed for a document (see sweepEnabled), it may be disabled or partially enabled
+	 * for the session, depending on a variety of other configurations present.
 	 */
-	readonly shouldRunSweep: boolean;
+	readonly shouldRunSweep: "YES" | "ONLY_BLOBS" | "NO";
 	/**
 	 * If true, bypass optimizations and generate GC data for all nodes irrespective of whether a node changed or not.
 	 */

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -41,6 +41,12 @@ export const nextGCVersion: GCVersion = 4;
 export const gcDisableThrowOnTombstoneLoadOptionName = "gcDisableThrowOnTombstoneLoad";
 
 /**
+ * This undocumented GC Option (on ContainerRuntime Options) allows an app to enable Sweep for blobs only.
+ * Only applies if enableGCSweep option is set to true.
+ */
+export const gcDisableDataStoreSweepOptionName = "disableDataStoreSweep";
+
+/**
  * This undocumented GC Option (on ContainerRuntime Options) allows configuring which documents can have Sweep enabled.
  * This provides a way to disable both Tombstone Enforcement and Sweep.
  *

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -11,6 +11,7 @@ export {
 	defaultSessionExpiryDurationMs,
 	GCNodeType,
 	gcTestModeKey,
+	gcDisableDataStoreSweepOptionName,
 	gcDisableThrowOnTombstoneLoadOptionName,
 	gcGenerationOptionName,
 	GCFeatureMatrix,

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -33,6 +33,7 @@ export {
 	runSweepKey,
 	stableGCVersion,
 	disableAttachmentBlobSweepKey,
+	disableAutoRecoveryKey,
 	disableDatastoreSweepKey,
 	detectOutboundRoutesViaDDSKey,
 	UnreferencedState,

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -33,8 +33,6 @@ export {
 	runSessionExpiryKey,
 	runSweepKey,
 	stableGCVersion,
-	disableAttachmentBlobSweepKey,
-	disableAutoRecoveryKey,
 	disableDatastoreSweepKey,
 	detectOutboundRoutesViaDDSKey,
 	UnreferencedState,

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -34,7 +34,6 @@ import {
 	LoggingError,
 } from "@fluidframework/telemetry-utils";
 import { BlobManager, IBlobManagerLoadInfo, IBlobManagerRuntime } from "../blobManager";
-import { disableAttachmentBlobSweepKey } from "../gc";
 
 const MIN_TTL = 24 * 60 * 60; // same as ODSP
 abstract class BaseMockBlobStorage
@@ -944,47 +943,33 @@ describe("BlobManager", () => {
 			);
 		});
 
-		it("disableAttachmentBlobsSweep true - DOESN'T delete unused blobs ", async () => {
-			injectedSettings[disableAttachmentBlobSweepKey] = true;
+		// Support for this config has been removed.
+		const legacyKey_disableAttachmentBlobSweep =
+			"Fluid.GarbageCollection.DisableAttachmentBlobSweep";
+		[true, undefined].forEach((disableAttachmentBlobsSweep) =>
+			it(`deletes unused blobs regardless of DisableAttachmentBlobsSweep setting [DisableAttachmentBlobsSweep=${disableAttachmentBlobsSweep}]`, async () => {
+				injectedSettings[legacyKey_disableAttachmentBlobSweep] =
+					disableAttachmentBlobsSweep;
 
-			await runtime.attach();
-			await runtime.connect();
+				await runtime.attach();
+				await runtime.connect();
 
-			const blob1 = await createBlobAndGetIds("blob1");
-			const blob2 = await createBlobAndGetIds("blob2");
+				const blob1 = await createBlobAndGetIds("blob1");
+				const blob2 = await createBlobAndGetIds("blob2");
 
-			// Delete blob1's local id. The local id and the storage id should both be deleted from the redirect table
-			// since the blob only had one reference.
-			runtime.blobManager.deleteSweepReadyNodes([blob1.localGCNodeId]);
-			assert(redirectTable.has(blob1.localId));
-			assert(redirectTable.has(blob1.storageId));
+				// Delete blob1's local id. The local id and the storage id should both be deleted from the redirect table
+				// since the blob only had one reference.
+				runtime.blobManager.deleteSweepReadyNodes([blob1.localGCNodeId]);
+				assert(!redirectTable.has(blob1.localId));
+				assert(!redirectTable.has(blob1.storageId));
 
-			// Delete blob2's local id. The local id and the storage id should both be deleted from the redirect table
-			// since the blob only had one reference.
-			runtime.blobManager.deleteSweepReadyNodes([blob2.localGCNodeId]);
-			assert(redirectTable.has(blob2.localId));
-			assert(redirectTable.has(blob2.storageId));
-		});
-
-		it("deletes unused blobs", async () => {
-			await runtime.attach();
-			await runtime.connect();
-
-			const blob1 = await createBlobAndGetIds("blob1");
-			const blob2 = await createBlobAndGetIds("blob2");
-
-			// Delete blob1's local id. The local id and the storage id should both be deleted from the redirect table
-			// since the blob only had one reference.
-			runtime.blobManager.deleteSweepReadyNodes([blob1.localGCNodeId]);
-			assert(!redirectTable.has(blob1.localId));
-			assert(!redirectTable.has(blob1.storageId));
-
-			// Delete blob2's local id. The local id and the storage id should both be deleted from the redirect table
-			// since the blob only had one reference.
-			runtime.blobManager.deleteSweepReadyNodes([blob2.localGCNodeId]);
-			assert(!redirectTable.has(blob2.localId));
-			assert(!redirectTable.has(blob2.storageId));
-		});
+				// Delete blob2's local id. The local id and the storage id should both be deleted from the redirect table
+				// since the blob only had one reference.
+				runtime.blobManager.deleteSweepReadyNodes([blob2.localGCNodeId]);
+				assert(!redirectTable.has(blob2.localId));
+				assert(!redirectTable.has(blob2.storageId));
+			}),
+		);
 
 		it("deletes unused de-duped blobs", async () => {
 			await runtime.attach();

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -42,6 +42,7 @@ import {
 	gcVersionUpgradeToV4Key,
 	gcGenerationOptionName,
 	throwOnTombstoneLoadOverrideKey,
+	gcDisableDataStoreSweepOptionName,
 	gcDisableThrowOnTombstoneLoadOptionName,
 	GCVersion,
 	runSessionExpiryKey,
@@ -783,7 +784,7 @@ describe("Garbage Collection configurations", () => {
 				shouldRunGC: boolean;
 				sweepEnabled_doc: boolean;
 				sweepEnabled_session: boolean;
-				disableDataStoreSweep?: true;
+				disableDataStoreSweep?: "viaGCOption" | "viaConfigProvider";
 				shouldRunSweep?: boolean;
 				expectedShouldRunSweep: IGarbageCollectorConfigs["shouldRunSweep"];
 			}[] = [
@@ -791,7 +792,7 @@ describe("Garbage Collection configurations", () => {
 					shouldRunGC: false, // Veto
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
-					disableDataStoreSweep: true,
+					disableDataStoreSweep: "viaGCOption",
 					shouldRunSweep: true,
 					expectedShouldRunSweep: "NO",
 				},
@@ -799,14 +800,14 @@ describe("Garbage Collection configurations", () => {
 					shouldRunGC: true,
 					sweepEnabled_doc: false, // Veto
 					sweepEnabled_session: true,
-					disableDataStoreSweep: true,
+					disableDataStoreSweep: "viaGCOption",
 					expectedShouldRunSweep: "NO",
 				},
 				{
 					shouldRunGC: true,
 					sweepEnabled_doc: true,
 					sweepEnabled_session: false, // Veto
-					disableDataStoreSweep: true,
+					disableDataStoreSweep: "viaGCOption",
 					expectedShouldRunSweep: "NO",
 				},
 				{
@@ -814,7 +815,7 @@ describe("Garbage Collection configurations", () => {
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
 					shouldRunSweep: false, // Veto
-					disableDataStoreSweep: true,
+					disableDataStoreSweep: "viaGCOption",
 					expectedShouldRunSweep: "NO",
 				},
 				{
@@ -834,7 +835,14 @@ describe("Garbage Collection configurations", () => {
 					shouldRunGC: true,
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
-					disableDataStoreSweep: true,
+					disableDataStoreSweep: "viaGCOption",
+					expectedShouldRunSweep: "ONLY_BLOBS",
+				},
+				{
+					shouldRunGC: true,
+					sweepEnabled_doc: true,
+					sweepEnabled_session: true,
+					disableDataStoreSweep: "viaConfigProvider",
 					expectedShouldRunSweep: "ONLY_BLOBS",
 				},
 				{
@@ -842,7 +850,7 @@ describe("Garbage Collection configurations", () => {
 					sweepEnabled_doc: true,
 					sweepEnabled_session: true,
 					shouldRunSweep: true,
-					disableDataStoreSweep: true, // Applies after shouldRunSweep
+					disableDataStoreSweep: "viaGCOption", // Applies after shouldRunSweep
 					expectedShouldRunSweep: "ONLY_BLOBS",
 				},
 			];
@@ -850,13 +858,16 @@ describe("Garbage Collection configurations", () => {
 				it(`Test Case ${JSON.stringify(testCase)}`, () => {
 					injectedSettings[runGCKey] = testCase.shouldRunGC;
 					injectedSettings[runSweepKey] = testCase.shouldRunSweep;
-					injectedSettings[disableDatastoreSweepKey] = testCase.disableDataStoreSweep;
+					injectedSettings[disableDatastoreSweepKey] =
+						testCase.disableDataStoreSweep === "viaConfigProvider";
 					gc = createGcWithPrivateMembers(
 						{
 							gcFeatureMatrix: { gcGeneration: 1 },
 							sessionExpiryTimeoutMs: defaultSessionExpiryDurationMs,
 						} /* metadata */,
 						{
+							[gcDisableDataStoreSweepOptionName]:
+								testCase.disableDataStoreSweep === "viaGCOption",
 							enableGCSweep: testCase.sweepEnabled_session ? true : undefined,
 							[gcGenerationOptionName]: testCase.sweepEnabled_doc ? 1 : 2,
 						} /* gcOptions */,

--- a/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
@@ -342,9 +342,13 @@ describe("Garbage Collection Stats", () => {
 			clock.tick(sweepTimeoutMs + 1);
 
 			// There shouldn't be any nodes whose reference state updated.
-			// Note that the nodes won't be deleted yet. They will be deleted once the GC op is processed.
 			expectedStats.updatedNodeCount = 0;
 			expectedStats.updatedDataStoreCount = 0;
+
+			// Note that the 2 sweep-ready nodes won't actually be deleted yet (until the GC op is processed)
+			// but we account for them in the deleted stats now.
+			expectedStats.deletedNodeCount += 2;
+			expectedStats.deletedDataStoreCount += 2;
 
 			gcStats = await garbageCollector.collectGarbage({});
 			assert.deepStrictEqual(gcStats, expectedStats, "Incorrect GC stats 1");
@@ -357,10 +361,8 @@ describe("Garbage Collection Stats", () => {
 			// Process the GC message so that the sweep ready nodes are deleted.
 			processLastGCMessage();
 
-			// The 2 sweep ready nodes / data stores should now be deleted.
+			// The 2 sweep ready nodes / data stores should now be truly deleted.
 			// They should be removed from the total node and unreferenced counts.
-			expectedStats.deletedNodeCount += 2;
-			expectedStats.deletedDataStoreCount += 2;
 			expectedStats.nodeCount -= 2;
 			expectedStats.dataStoreCount -= 2;
 			expectedStats.unrefNodeCount -= 2;
@@ -393,9 +395,13 @@ describe("Garbage Collection Stats", () => {
 			clock.tick(sweepTimeoutMs + 1);
 
 			// There shouldn't be any nodes whose reference state updated.
-			// Note that the nodes won't be deleted yet. They will be deleted once the GC op is processed.
 			expectedStats.updatedNodeCount = 0;
 			expectedStats.updatedDataStoreCount = 0;
+
+			// Note that the 2 sweep-ready nodes won't actually be deleted yet (until the GC op is processed)
+			// but we account for them in the deleted stats now.
+			expectedStats.deletedNodeCount += 2;
+			expectedStats.deletedDataStoreCount += 2;
 
 			gcStats = await garbageCollector.collectGarbage({});
 
@@ -407,13 +413,11 @@ describe("Garbage Collection Stats", () => {
 			// Process the GC message so that the sweep ready nodes are deleted.
 			processLastGCMessage();
 
-			// Unreference another data store node.
+			// Unreference one more data store node (nodes[1])
 			defaultGCData.gcNodes[nodes[0]] = [];
 
 			// The 2 sweep ready nodes / data stores should now be deleted.
 			// They should be removed from the total node and unreferenced counts.
-			expectedStats.deletedNodeCount += 2;
-			expectedStats.deletedDataStoreCount += 2;
 			expectedStats.nodeCount -= 2;
 			expectedStats.dataStoreCount -= 2;
 			expectedStats.unrefNodeCount -= 2;
@@ -431,9 +435,13 @@ describe("Garbage Collection Stats", () => {
 			clock.tick(sweepTimeoutMs + 1);
 
 			// No nodes are updated since the last run.
-			// Note that the nodes won't be deleted yet. They will be deleted once the GC op is processed.
 			expectedStats.updatedNodeCount = 0;
 			expectedStats.updatedDataStoreCount = 0;
+
+			// Note that the new sweep-ready node won't actually be deleted yet (until the GC op is processed)
+			// but we account for it in the deleted stats now.
+			expectedStats.deletedNodeCount += 1;
+			expectedStats.deletedDataStoreCount += 1;
 
 			gcStats = await garbageCollector.collectGarbage({});
 			assert.deepStrictEqual(gcStats, expectedStats, "Incorrect GC stats 3");
@@ -446,10 +454,8 @@ describe("Garbage Collection Stats", () => {
 			// Process the GC message so that the sweep ready node is deleted.
 			processLastGCMessage();
 
-			// The sweep ready node / data store should now be deleted.
+			// The sweep ready node / data store should now be truly deleted.
 			// It should be removed from the total node and unreferenced counts.
-			expectedStats.deletedNodeCount++;
-			expectedStats.deletedDataStoreCount++;
 			expectedStats.nodeCount--;
 			expectedStats.dataStoreCount--;
 			expectedStats.unrefNodeCount--;

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -75,7 +75,7 @@ describe("GC Telemetry Tracker", () => {
 			gcEnabled: true,
 			sweepEnabled: false,
 			shouldRunGC: true,
-			shouldRunSweep: false,
+			shouldRunSweep: "NO",
 			runFullGC: false,
 			testMode: false,
 			tombstoneMode: false,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -1099,7 +1099,7 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 
 		[true, undefined].forEach((disableDatastoreSweep) =>
 			it(`updates deleted blob state in the summary [disableDatastoreSweep=${disableDatastoreSweep}]`, async () => {
-				configProvider.set(disableDatastoreSweepKey, disableDatastoreSweep);
+				settings[disableDatastoreSweepKey] = disableDatastoreSweep;
 
 				const { dataStore: mainDataStore, summarizer } =
 					await createDataStoreAndSummarizer();

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
@@ -85,7 +85,6 @@ describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 			this.skip();
 		}
 
-		settings["Fluid.GarbageCollection.DisableAttachmentBlobSweep"] = true; // Only sweep DataStores
 		settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = true;
 		settings["Fluid.GarbageCollection.TestOverride.TombstoneTimeoutMs"] = tombstoneTimeoutMs;
 	});


### PR DESCRIPTION
## Description

Porting 15bce6515457548f99cfe8f439be1f512e96763f and f46c5dc44769ab9815e707665ef1fb3f6c7d6a2a to `release/client/2.0.0-rc.1.0.0`.

Related port PRs:
* #19591
* ..coming soon: port to internal.7.4...
