### PR TITLE
re enable minCompatVersion; test in CI pipeline

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
@@ -98,7 +98,7 @@ function validateDDSStateInSummary(
  */
 describeCompat(
 	"Incremental summaries for data store and DDS",
-	"2.0.0-internal.1.4.9" /** equivalent to FullCompat. Currently used for testing purposes on ADO pipelines */,
+	"1.3.7" /** equivalent to FullCompat. Currently used for testing purposes on ADO pipelines */,
 	(getTestObjectProvider, apis) => {
 		const { SharedDirectory } = apis.dds;
 		let provider: ITestObjectProvider;

--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
@@ -98,7 +98,7 @@ function validateDDSStateInSummary(
  */
 describeCompat(
 	"Incremental summaries for data store and DDS",
-	"FullCompat",
+	"2.0.0-internal.1.4.9" /** equivalent to FullCompat. Currently used for testing purposes on ADO pipelines */,
 	(getTestObjectProvider, apis) => {
 		const { SharedDirectory } = apis.dds;
 		let provider: ITestObjectProvider;

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -255,9 +255,7 @@ function createCompatDescribe(): DescribeCompat {
 			case "NoCompat":
 				return createCompatSuite(tests, [CompatKind.None]);
 			default:
-				throw new Error(`compatVersion ${compatVersion} not supported`);
-			// TODO: https://dev.azure.com/fluidframework/internal/_workitems/edit/7089
-			// return createCompatSuite(tests, undefined, compatVersion);
+				return createCompatSuite(tests, undefined, compatVersion);
 		}
 	};
 	const d: DescribeCompat = (name: string, compatVersion: string, tests) =>

--- a/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
+++ b/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
@@ -23,16 +23,8 @@ function transformVersion(version: string): string {
 }
 
 describe("Minimum Compat Version", () => {
-	// const allVersionsFromNpm = execSync(`npm show fluid-framework versions --json`, {
-	// 	encoding: "utf-8",
-	// });
-	// const allVersions: string[] = JSON.parse(allVersionsFromNpm);
-	// // filter out all versions that don't end with 0 (patches). This is done because N-0 version
-	// // is pkgVersion and this variable only updates in minor releases. So it could be the case that latest
-	// // version is a patch and our N-0 version is behind it.
-	// const noPatchVersions = allVersions.filter((version) => /\.\d*0$/.test(version));
 	const minTestVersion = transformVersion(pkgVersion);
-
+	const numCompatVersions = 9;
 	it("bad min compat string", () => {
 		const invalidString = "invalid string";
 		assert.throws(
@@ -53,7 +45,7 @@ describe("Minimum Compat Version", () => {
 		);
 	});
 
-	for (let i = 1; i < 9; i++) {
+	for (let i = 1; i < numCompatVersions; i++) {
 		it(`compatVersion N-${i} < ${minTestVersion}`, () => {
 			assert.strictEqual(
 				isCompatVersionBelowMinVersion(minTestVersion, {

--- a/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
+++ b/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
@@ -4,20 +4,34 @@
  */
 
 import { strict as assert } from "assert";
-import { execSync } from "child_process";
 import { CompatKind } from "../../compatOptions.cjs";
 import { isCompatVersionBelowMinVersion } from "../compatConfig.js";
+import { pkgVersion } from "../packageVersion.js";
+import { getRequestedVersion } from "../versionUtils.js";
+import { testBaseVersion } from "../baseVersion.js";
 
-describe.skip("Minimum Compat Version", () => {
-	const allVersionsFromNpm = execSync(`npm show fluid-framework versions --json`, {
-		encoding: "utf-8",
-	});
-	const allVersions: string[] = JSON.parse(allVersionsFromNpm);
-	// filter out all versions that don't end with 0 (patches). This is done because N-0 version
-	// is pkgVersion and this variable only updates in minor releases. So it could be the case that latest
-	// version is a patch and our N-0 version is behind it.
-	const noPatchVersions = allVersions.filter((version) => /\.\d*0$/.test(version));
-	const latestVersion = noPatchVersions[noPatchVersions.length - 1];
+function transformVersion(version: string): string {
+	const regex = /(\d+)\.(\d+)\.(\d+)-dev-(\w+)\.(\d+)\.(\d+)\.(\d+)\.\d+/;
+	const matches = version.match(regex);
+
+	if (matches) {
+		const [, major, minor, patch, label, num1, num2, num3] = matches;
+		return `${major}.${minor}.${patch}-${label}.${num1}.${num2}.${num3}`;
+	} else {
+		return version;
+	}
+}
+
+describe("Minimum Compat Version", () => {
+	// const allVersionsFromNpm = execSync(`npm show fluid-framework versions --json`, {
+	// 	encoding: "utf-8",
+	// });
+	// const allVersions: string[] = JSON.parse(allVersionsFromNpm);
+	// // filter out all versions that don't end with 0 (patches). This is done because N-0 version
+	// // is pkgVersion and this variable only updates in minor releases. So it could be the case that latest
+	// // version is a patch and our N-0 version is behind it.
+	// const noPatchVersions = allVersions.filter((version) => /\.\d*0$/.test(version));
+	const minTestVersion = transformVersion(pkgVersion);
 
 	it("bad min compat string", () => {
 		const invalidString = "invalid string";
@@ -40,25 +54,28 @@ describe.skip("Minimum Compat Version", () => {
 	});
 
 	for (let i = 1; i < 9; i++) {
-		it(`compatVersion N-${i} < latest version ${latestVersion}`, () => {
+		it(`compatVersion N-${i} < ${minTestVersion}`, () => {
 			assert.strictEqual(
-				isCompatVersionBelowMinVersion(latestVersion, {
+				isCompatVersionBelowMinVersion(minTestVersion, {
 					name: `test`,
 					kind: CompatKind.None,
 					compatVersion: -i,
 				}),
 				true,
-				`N-${i} is not lower than min version`,
+				`N-${i} version: "${getRequestedVersion(
+					testBaseVersion(-i),
+					-i,
+				)}"  is not lower than min version: ${minTestVersion}`,
 			);
 		});
 	}
 
 	it("cross compat. filters out if loadVersion is lower than minVersion", () => {
 		assert.strictEqual(
-			isCompatVersionBelowMinVersion(latestVersion, {
+			isCompatVersionBelowMinVersion(minTestVersion, {
 				name: "test",
 				kind: CompatKind.CrossVersion,
-				compatVersion: latestVersion,
+				compatVersion: minTestVersion,
 				loadVersion: "1.3.7",
 			}),
 			true,
@@ -67,11 +84,11 @@ describe.skip("Minimum Compat Version", () => {
 
 	it("cross compat. filters out if compatVersion is lower than minVersion", () => {
 		assert.strictEqual(
-			isCompatVersionBelowMinVersion(latestVersion, {
+			isCompatVersionBelowMinVersion(minTestVersion, {
 				name: "test",
 				kind: CompatKind.CrossVersion,
 				compatVersion: "1.3.7",
-				loadVersion: latestVersion,
+				loadVersion: minTestVersion,
 			}),
 			true,
 		);
@@ -82,21 +99,21 @@ describe.skip("Minimum Compat Version", () => {
 			isCompatVersionBelowMinVersion("1.3.7", {
 				name: "test",
 				kind: CompatKind.CrossVersion,
-				compatVersion: latestVersion,
+				compatVersion: minTestVersion,
 				loadVersion: "1.3.7",
 			}),
 			false,
-			`fails with minVersion: 1.3.7 compatversion: ${latestVersion} loadVersion: 1.3.7`,
+			`fails with minVersion: 1.3.7 compatversion: ${minTestVersion} loadVersion: 1.3.7`,
 		);
 		assert.strictEqual(
 			isCompatVersionBelowMinVersion("1.3.7", {
 				name: "test",
 				kind: CompatKind.CrossVersion,
 				compatVersion: "1.3.7",
-				loadVersion: latestVersion,
+				loadVersion: minTestVersion,
 			}),
 			false,
-			`fails with minVersion: 1.3.7 compatversion: 1.3.7 loadVersion: ${latestVersion}`,
+			`fails with minVersion: 1.3.7 compatversion: 1.3.7 loadVersion: ${minTestVersion}`,
 		);
 	});
 });


### PR DESCRIPTION
Testing correct behavior of minCompatVersion parameter in our ADO pipelines using summarizeIncrementally as guinea pig after https://github.com/microsoft/FluidFramework/pull/19436 . 

Expected compat versions were run in PR checks given that during this step, only non compat and N-1 version are expected to run. We still need to verify that full compat (until N-9) is run in CI, therefore not enabling all tests yet. 

It also fixes minVersionCompat tests by transforming dev version into their original internal version. 
While specifying a specific min compat version in a test suite, devs are expected to use the current pkgVersion at the time they are writing the new test. While working locally, our pkgVersion is the normal internal version in the form x.x.x-label.x.x.x, but when running in ADO this version changes to x.x.x-dev-label.x.x.x.x so this change adds a transformation in our tests to correctly use non-dev version as a min test version. 
Even though our N-0 version will be a dev version while running on CI,  N-i calculations are as expected. But semver.compare does not work correctly for dev versions. We don't necessarily need to fix that because in reality neither minCompatVersion is dev nor N-i versions, so after transforming the dev pkgVersion into the original one we are successfully testing the expected behavior which is comparing a non-dev min version with correctly calculated N-i versions. 