### PR TITLE
fix disabled tests

### DIFF
--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -25,7 +25,7 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
-		"test": "mocha --recursive \"dist/test/*.spec.*js\"",
+		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",

--- a/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/checkpointContext.ts
@@ -54,7 +54,7 @@ export class CheckpointContext {
 		} catch (ex) {
 			// TODO flag context as error / use this.context.error() instead?
 			this.context.log?.error(
-				`Error writing checkpoint to the database: ${JSON.stringify(ex)}`,
+				`Error writing checkpoint to the database: ${JSON.stringify(ex)}, ${ex}`,
 				{
 					messageMetaData: {
 						documentId: this.id,

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -138,7 +138,7 @@ export class ScribeLambdaFactory
 				Lumberjack.error(errorMessage, lumberProperties);
 				return new NoOpLambda(context);
 			}
-			if (JSON.parse(document.scribe)?.isCorrupt) {
+			if (document.scribe && JSON.parse(document.scribe)?.isCorrupt) {
 				Lumberjack.info(
 					`Received attempt to connect to a corrupted document.`,
 					lumberProperties,

--- a/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/deli/checkpointContext.spec.ts
@@ -59,6 +59,11 @@ describe("Routerlicious", () => {
 				testCheckpointService = new testUtils.TestNotImplementedCheckpointService();
 				Sinon.replace(testDocumentRepository, "updateOne", Sinon.fake());
 				Sinon.replace(testCheckpointService, "writeCheckpoint", Sinon.fake());
+				Sinon.replace(
+					testCheckpointService,
+					"getLocalCheckpointEnabled",
+					Sinon.fake.returns(false),
+				);
 				const checkpointManager = createDeliCheckpointManagerFromCollection(
 					testTenant,
 					testId,
@@ -80,11 +85,11 @@ describe("Routerlicious", () => {
 				});
 
 				it("Should be able to submit multiple checkpoints", async () => {
-					let i;
-					for (i = 0; i < 10; i++) {
+					const numCheckpoints = 10;
+					for (let i = 0; i < numCheckpoints + 1; i++) {
 						testCheckpointContext.checkpoint(createCheckpoint(i, i));
 					}
-					await testContext.waitForOffset(i - 1);
+					await testContext.waitForOffset(numCheckpoints);
 				});
 			});
 		});

--- a/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
@@ -110,7 +110,11 @@ describe("Routerlicious", () => {
 
 				testCheckpointService = new TestNotImplementedCheckpointService();
 				Sinon.replace(testCheckpointService, "writeCheckpoint", Sinon.fake());
-				Sinon.replace(testCheckpointService, "getLocalCheckpointEnabled", Sinon.fake.returns(false));
+				Sinon.replace(
+					testCheckpointService,
+					"getLocalCheckpointEnabled",
+					Sinon.fake.returns(false),
+				);
 
 				testMessageCollection = new TestCollection([]);
 				testKafka = new TestKafka();

--- a/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
@@ -110,6 +110,7 @@ describe("Routerlicious", () => {
 
 				testCheckpointService = new TestNotImplementedCheckpointService();
 				Sinon.replace(testCheckpointService, "writeCheckpoint", Sinon.fake());
+				Sinon.replace(testCheckpointService, "getLocalCheckpointEnabled", Sinon.fake.returns(false));
 
 				testMessageCollection = new TestCollection([]);
 				testKafka = new TestKafka();

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -30,7 +30,7 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
-		"test": "mocha --recursive \"dist/test/*.spec.*js\"",
+		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -28,7 +28,7 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
-		"test": "mocha --recursive \"dist/test/*.spec.*js\"",
+		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"test:webpack": "webpack --config webpack.config.cjs",
 		"tsc": "tsc",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -31,7 +31,7 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
-		"test": "mocha --recursive \"dist/test/*.spec.*js\"",
+		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"tsc:watch": "tsc --watch",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -32,7 +32,7 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
-		"test": "mocha --recursive \"dist/test/*.spec.*js\"",
+		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -25,7 +25,7 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
-		"test": "mocha --recursive \"dist/test/*.spec.*js\"",
+		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -25,7 +25,7 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
-		"test": "mocha --recursive \"dist/test/*.spec.*js\"",
+		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -25,7 +25,7 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
-		"test": "mocha --recursive \"dist/test/*.spec.*js\"",
+		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"test:debug": "mocha inspect --recursive \"dist/test/*.spec.*js\"",
 		"tsc": "tsc",

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -24,7 +24,7 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
-		"test": "mocha --recursive \"dist/test/*.spec.*js\"",
+		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -24,7 +24,7 @@
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
-		"test": "mocha --recursive \"dist/test/*.spec.*js\"",
+		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",

--- a/server/routerlicious/packages/test-utils/src/testNotImplementedCheckpointRepository.ts
+++ b/server/routerlicious/packages/test-utils/src/testNotImplementedCheckpointRepository.ts
@@ -10,7 +10,8 @@ import {
 	IScribe,
 } from "@fluidframework/server-services-core";
 
-const defaultErrorMsg = "Method not implemented. Provide your own mock.";
+const getDefaultErrorMsg = (methodName: string) =>
+	`TestNotImplementedCheckpointRepository.${methodName}: Method not implemented. Provide your own mock.`;
 
 /**
  * @internal
@@ -21,16 +22,16 @@ export class TestNotImplementedCheckpointRepository implements ICheckpointReposi
 		documentId: string,
 		checkpoint: IDeliState | IScribe,
 	): Promise<void> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("writeCheckpoint"));
 	}
 	async deleteCheckpoint(documentId: string, tenantId: string): Promise<void> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("deleteCheckpoint"));
 	}
 	async getCheckpoint(filter: any): Promise<ICheckpoint> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("getCheckpoint"));
 	}
 
 	async removeServiceCheckpoint(documentId: string, tenantId: string): Promise<void> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("removeServiceCheckpoint"));
 	}
 }

--- a/server/routerlicious/packages/test-utils/src/testNotImplementedCheckpointService.ts
+++ b/server/routerlicious/packages/test-utils/src/testNotImplementedCheckpointService.ts
@@ -10,17 +10,18 @@ import {
 	IScribe,
 } from "@fluidframework/server-services-core";
 
-const defaultErrorMsg = "Method not implemented. Provide your own mock.";
+const getDefaultErrorMsg = (methodName: string) =>
+	`TestNotImplementedCheckpointService.${methodName}: Method not implemented. Provide your own mock.`;
 
 /**
  * @internal
  */
 export class TestNotImplementedCheckpointService implements ICheckpointService {
 	getGlobalCheckpointFailed(): boolean {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("getGlobalCheckpointFailed"));
 	}
 	getLocalCheckpointEnabled(): boolean {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("getLocalCheckpointEnabled"));
 	}
 	async writeCheckpoint(
 		documentId: string,
@@ -29,7 +30,7 @@ export class TestNotImplementedCheckpointService implements ICheckpointService {
 		checkpoint: IScribe | IDeliState,
 		isLocal: boolean,
 	): Promise<void> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("writeCheckpoint"));
 	}
 
 	async clearCheckpoint(
@@ -38,7 +39,7 @@ export class TestNotImplementedCheckpointService implements ICheckpointService {
 		service: string,
 		isLocal: boolean,
 	): Promise<void> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("clearCheckpoint"));
 	}
 
 	async restoreFromCheckpoint(
@@ -47,7 +48,7 @@ export class TestNotImplementedCheckpointService implements ICheckpointService {
 		service: string,
 		document: IDocument,
 	): Promise<IScribe | IDeliState> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("restoreFromCheckpoint"));
 	}
 
 	async getLatestCheckpoint(
@@ -55,6 +56,6 @@ export class TestNotImplementedCheckpointService implements ICheckpointService {
 		documentId: string,
 		activeClients?: boolean,
 	): Promise<any> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("getLatestCheckpoint"));
 	}
 }

--- a/server/routerlicious/packages/test-utils/src/testNotImplementedDocumentRepository.ts
+++ b/server/routerlicious/packages/test-utils/src/testNotImplementedDocumentRepository.ts
@@ -5,25 +5,26 @@
 
 import { IDocument, IDocumentRepository } from "@fluidframework/server-services-core";
 
-const defaultErrorMsg = "Method not implemented. Provide your own mock.";
+const getDefaultErrorMsg = (methodName: string) =>
+	`TestNotImplementedDocumentRepository.${methodName}: Method not implemented. Provide your own mock.`;
 /**
  * @internal
  */
 export class TestNotImplementedDocumentRepository implements IDocumentRepository {
 	async create(document: IDocument): Promise<any> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("create"));
 	}
 
 	async readOne(filter: any): Promise<IDocument> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("readOne"));
 	}
 
 	async updateOne(filter: any, update: any, options?: any): Promise<void> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("updateOne"));
 	}
 
 	async deleteOne(filter: any): Promise<any> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("deleteOne"));
 	}
 
 	async findOneOrCreate(
@@ -31,7 +32,7 @@ export class TestNotImplementedDocumentRepository implements IDocumentRepository
 		value: any,
 		options: any,
 	): Promise<{ value: IDocument; existing: boolean }> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("findOneOrCreate"));
 	}
 
 	async findOneAndUpdate(
@@ -39,10 +40,10 @@ export class TestNotImplementedDocumentRepository implements IDocumentRepository
 		value: any,
 		options: any,
 	): Promise<{ value: IDocument; existing: boolean }> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("findOneAndUpdate"));
 	}
 
 	async exists(filter: any): Promise<boolean> {
-		throw new Error(defaultErrorMsg);
+		throw new Error(getDefaultErrorMsg("exists"));
 	}
 }


### PR DESCRIPTION
## Description

Many tests in R11s were not getting hit by the mocha command (possibly related to changes in #15216). That means recent changes were not hitting Unit tests, and more specifically some "not implemented" mocks were throwing errors when these tests got run. This PR fixes that.

