### PR TITLE
[Port 2.0.0-rc.1.0] MergeTree: Handle removes and obliterates in getMarkerById (#19192)

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -102,11 +102,11 @@ function markSegmentMoved(seg: ISegment, moveInfo: IMoveInfo): void {
 	seg.wasMovedOnInsert = moveInfo.wasMovedOnInsert;
 }
 
-function isMoved(segment: ISegment): boolean {
+function isMoved(segment: ISegment): segment is ISegment & IMoveInfo {
 	return toMoveInfo(segment) !== undefined;
 }
 
-function isRemoved(segment: ISegment): boolean {
+function isRemoved(segment: ISegment): segment is ISegment & IRemovalInfo {
 	return toRemovalInfo(segment) !== undefined;
 }
 
@@ -115,7 +115,7 @@ function isRemovedAndAcked(segment: ISegment): segment is ISegment & IRemovalInf
 	return removalInfo !== undefined && removalInfo.removedSeq !== UnassignedSequenceNumber;
 }
 
-function isMovedAndAcked(segment: ISegment): boolean {
+function isMovedAndAcked(segment: ISegment): segment is ISegment & IMoveInfo {
 	const moveInfo = toMoveInfo(segment);
 	return moveInfo !== undefined && moveInfo.movedSeq !== UnassignedSequenceNumber;
 }
@@ -1270,7 +1270,12 @@ export class MergeTree {
 
 	// TODO: error checking
 	public getMarkerFromId(id: string): Marker | undefined {
-		return this.idToMarker.get(id);
+		const marker = this.idToMarker.get(id);
+		return marker === undefined ||
+			isRemoved(marker) ||
+			(isMoved(marker) && marker.moveDst === undefined)
+			? undefined
+			: marker;
 	}
 
 	/**

--- a/packages/dds/merge-tree/src/test/client.rollback.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.rollback.spec.ts
@@ -46,7 +46,7 @@ describe("client.rollback", () => {
 
 		assert.equal(client.getText(), "abc");
 		const marker = client.getMarkerFromId("markerId");
-		assert.notEqual(marker?.removedSeq, undefined);
+		assert.equal(marker, undefined);
 	});
 	it("Should rollback insert and validate the partial lengths", () => {
 		client.insertTextLocal(0, "ghi");

--- a/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
+++ b/packages/dds/merge-tree/src/test/client.searchForMarker.spec.ts
@@ -12,6 +12,7 @@ import { reservedTileLabelsKey } from "../referencePositions";
 import { TextSegment } from "../textSegment";
 import { TestClient } from "./testClient";
 import { insertSegments } from "./testUtils";
+import { createClientsAtInitialState } from "./testClientLogger";
 
 describe("TestClient", () => {
 	const localUserLongId = "localUser";
@@ -704,6 +705,128 @@ describe("TestClient", () => {
 
 				assert.equal(marker, undefined, "Returned marker should be undefined.");
 			});
+		});
+	});
+	describe(".getMarkerById", () => {
+		it("removed marker", () => {
+			const clients = createClientsAtInitialState({ initialState: "hello world" }, "A", "B");
+
+			const randomMarkerKey = "randomKey1";
+
+			assert(!clients.A.getMarkerFromId(randomMarkerKey), "local client before insert");
+
+			const ops = [
+				clients.A.makeOpMessage(
+					clients.A.insertMarkerLocal(5, ReferenceType.Simple, {
+						[reservedMarkerIdKey]: randomMarkerKey,
+					}),
+					1,
+				),
+			];
+
+			assert(
+				clients.A.getMarkerFromId(randomMarkerKey),
+				"local client after insert before ack",
+			);
+
+			ops.splice(0).forEach((op) => {
+				clients.all.forEach((c) => c.applyMsg(op));
+			});
+
+			assert(
+				clients.A.getMarkerFromId(randomMarkerKey),
+				"local client after insert after ack",
+			);
+			assert(
+				clients.B.getMarkerFromId(randomMarkerKey),
+				"remote client after insert after ack",
+			);
+
+			ops.push(clients.A.makeOpMessage(clients.A.removeRangeLocal(5, 6), 1));
+
+			assert(
+				!clients.A.getMarkerFromId(randomMarkerKey),
+				"local client after remove before ack",
+			);
+			assert(
+				clients.B.getMarkerFromId(randomMarkerKey),
+				"remote client after remove before ack",
+			);
+
+			ops.splice(0).forEach((op) => {
+				clients.all.forEach((c) => c.applyMsg(op));
+			});
+
+			assert(
+				!clients.A.getMarkerFromId(randomMarkerKey),
+				"local client after remove after ack",
+			);
+			assert(
+				!clients.B.getMarkerFromId(randomMarkerKey),
+				"remote client after remove after ack",
+			);
+		});
+		it("obliterate marker", () => {
+			const clients = createClientsAtInitialState(
+				{ initialState: "hello world", options: { mergeTreeEnableObliterate: true } },
+				"A",
+				"B",
+			);
+
+			const randomMarkerKey = "randomKey1";
+
+			assert(!clients.A.getMarkerFromId(randomMarkerKey), "local client before insert");
+
+			const ops = [
+				clients.A.makeOpMessage(
+					clients.A.insertMarkerLocal(5, ReferenceType.Simple, {
+						[reservedMarkerIdKey]: randomMarkerKey,
+					}),
+					1,
+				),
+			];
+
+			assert(
+				clients.A.getMarkerFromId(randomMarkerKey),
+				"local client after insert before ack",
+			);
+
+			ops.splice(0).forEach((op) => {
+				clients.all.forEach((c) => c.applyMsg(op));
+			});
+
+			assert(
+				clients.A.getMarkerFromId(randomMarkerKey),
+				"local client after insert after ack",
+			);
+			assert(
+				clients.B.getMarkerFromId(randomMarkerKey),
+				"remote client after insert after ack",
+			);
+
+			ops.push(clients.A.makeOpMessage(clients.A.obliterateRangeLocal(5, 6), 1));
+
+			assert(
+				!clients.A.getMarkerFromId(randomMarkerKey),
+				"local client after obliterate before ack",
+			);
+			assert(
+				clients.B.getMarkerFromId(randomMarkerKey),
+				"remote client after obliterate before ack",
+			);
+
+			ops.splice(0).forEach((op) => {
+				clients.all.forEach((c) => c.applyMsg(op));
+			});
+
+			assert(
+				!clients.A.getMarkerFromId(randomMarkerKey),
+				"local client after obliterate after ack",
+			);
+			assert(
+				!clients.B.getMarkerFromId(randomMarkerKey),
+				"remote client after obliterate after ack",
+			);
 		});
 	});
 });


### PR DESCRIPTION
Port #19192 to 2.0.0-rc.1.0.x