### PR TITLE
tree: Fix bugs with visit delta

### DIFF
--- a/packages/dds/tree/src/core/tree/visitDelta.ts
+++ b/packages/dds/tree/src/core/tree/visitDelta.ts
@@ -442,6 +442,7 @@ function attachPass(delta: Delta.FieldChanges, visitor: DeltaVisitor, config: Pa
 					const offsetAttachId = offsetDetachId(mark.attach!, i);
 					const sourceRoot = config.detachedFieldIndex.getEntry(offsetAttachId);
 					const sourceField = config.detachedFieldIndex.toFieldKey(sourceRoot);
+					const offsetIndex = index + i;
 					if (isReplaceMark(mark)) {
 						const rootDestination = config.detachedFieldIndex.createEntry(
 							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -451,8 +452,7 @@ function attachPass(delta: Delta.FieldChanges, visitor: DeltaVisitor, config: Pa
 							config.detachedFieldIndex.toFieldKey(rootDestination);
 						visitor.replace(
 							sourceField,
-							// BUG: These indices should be offset
-							{ start: index, end: index + 1 },
+							{ start: offsetIndex, end: offsetIndex + 1 },
 							destinationField,
 						);
 						// We may need to do a second pass on the detached nodes
@@ -461,13 +461,13 @@ function attachPass(delta: Delta.FieldChanges, visitor: DeltaVisitor, config: Pa
 						}
 					} else {
 						// This a simple attach
-						visitor.attach(sourceField, 1, index + i);
+						visitor.attach(sourceField, 1, offsetIndex);
 					}
 					config.detachedFieldIndex.deleteEntry(offsetAttachId);
 					const fields = config.attachPassRoots.get(sourceRoot);
 					if (fields !== undefined) {
 						config.attachPassRoots.delete(sourceRoot);
-						visitNode(index + i, fields, visitor, config);
+						visitNode(offsetIndex, fields, visitor, config);
 					}
 				}
 			} else if (!isDetachMark(mark) && mark.fields !== undefined) {

--- a/packages/dds/tree/src/core/tree/visitDelta.ts
+++ b/packages/dds/tree/src/core/tree/visitDelta.ts
@@ -451,6 +451,7 @@ function attachPass(delta: Delta.FieldChanges, visitor: DeltaVisitor, config: Pa
 							config.detachedFieldIndex.toFieldKey(rootDestination);
 						visitor.replace(
 							sourceField,
+							// BUG: These indices should be offset
 							{ start: index, end: index + 1 },
 							destinationField,
 						);
@@ -466,7 +467,7 @@ function attachPass(delta: Delta.FieldChanges, visitor: DeltaVisitor, config: Pa
 					const fields = config.attachPassRoots.get(sourceRoot);
 					if (fields !== undefined) {
 						config.attachPassRoots.delete(sourceRoot);
-						visitNode(index, fields, visitor, config);
+						visitNode(index + i, fields, visitor, config);
 					}
 				}
 			} else if (!isDetachMark(mark) && mark.fields !== undefined) {

--- a/packages/dds/tree/src/test/tree/visitDelta.spec.ts
+++ b/packages/dds/tree/src/test/tree/visitDelta.spec.ts
@@ -605,6 +605,36 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 
+	it("replace nodes", () => {
+		const buildId = { minor: 0 };
+
+		const replace: DeltaMark = {
+			count: 2,
+			detach: { minor: 2 },
+			attach: buildId,
+		};
+
+		const rootChanges: DeltaFieldChanges = { local: [replace] };
+		const delta: DeltaRoot = {
+			build: [{ id: buildId, trees: [content, content] }],
+			fields: new Map([[rootKey, rootChanges]]),
+		};
+
+		const expected: VisitScript = [
+			["create", [content], field0],
+			["create", [content], field1],
+			["enterField", rootKey],
+			["exitField", rootKey],
+			["enterField", rootKey],
+			["replace", field0, { start: 0, end: 1 }, field2],
+			["replace", field1, { start: 1, end: 2 }, field3],
+			["exitField", rootKey],
+		];
+
+		const index = makeDetachedFieldIndex("", testRevisionTagCodec);
+		testVisit(delta, expected, index);
+	});
+
 	it("changes under replaced node", () => {
 		const index = makeDetachedFieldIndex("", testRevisionTagCodec);
 		const moveId1 = { minor: 1 };
@@ -651,6 +681,7 @@ describe("visitDelta", () => {
 		testTreeVisit(delta, expected, index);
 		assert.deepEqual(Array.from(index.entries()), [{ id: { minor: 42 }, root: 2 }]);
 	});
+
 	it("changes under replacement node", () => {
 		const index = makeDetachedFieldIndex("", testRevisionTagCodec);
 		const moveId1 = { minor: 1 };


### PR DESCRIPTION
## Description

The utility for visiting a delta could pass incorrect an incorrect index when replacing a node or entering a newly attached node. This PR fixes these issues.