### PR TITLE
feat(merge-tree): add zamboni segment count telemetry

### DIFF
--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -342,10 +342,9 @@ export class SnapshotV1 {
 		// If the last segment in the walk was coalescable, push it now.
 		pushSeg(prev);
 
-		// if there are more than 500 segments removed by snapshot-time zamboni,
-		// log it .5% of the time (1/200). At around 50MM total summary events
-		// per month, this gives us an upper bound of 250,000 events per month
-		if (Math.abs(originalSegments - segmentsAfterCombine) > 500 && Math.random() > 0.005) {
+		// To reduce potential spam from this telemetry, we sample only a small
+		// percentage of summaries
+		if (Math.abs(originalSegments - segmentsAfterCombine) > 500 && Math.random() < 0.005) {
 			this.logger.sendTelemetryEvent({
 				eventName: "MergeTreeV1SummarizeSegmentCount",
 				originalSegments,

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -181,12 +181,16 @@ export class SnapshotV1 {
 		const mergeTree = this.mergeTree;
 		const minSeq = this.header.minSequenceNumber;
 
+		let originalSegments = 0;
+		let segmentsAfterCombine = 0;
+
 		// Helper to add the given `MergeTreeChunkV0SegmentSpec` to the snapshot.
 		const pushSegRaw = (
 			json: JsonSegmentSpecs,
 			length: number,
 			attribution: IAttributionCollection<AttributionKey> | undefined,
 		) => {
+			segmentsAfterCombine += 1;
 			this.segments.push(json);
 			this.segmentLengths.push(length);
 			if (attribution) {
@@ -223,8 +227,13 @@ export class SnapshotV1 {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				segment.movedSeq! <= minSeq
 			) {
+				if (segment.seq !== UnassignedSequenceNumber) {
+					originalSegments += 1;
+				}
 				return true;
 			}
+
+			originalSegments += 1;
 
 			// Next determine if the snapshot needs to preserve information required for merging the segment
 			// (seq, client, etc.)  This information is only needed if the segment is above the MSN (and doesn't
@@ -322,7 +331,7 @@ export class SnapshotV1 {
 					0x066 /* "Corrupted preservation of segment metadata!" */,
 				);
 
-				// Record the segment with it's required metadata.
+				// Record the segment with its required metadata.
 				pushSegRaw(raw, segment.cachedLength, segment.attribution);
 			}
 			return true;
@@ -332,6 +341,18 @@ export class SnapshotV1 {
 
 		// If the last segment in the walk was coalescable, push it now.
 		pushSeg(prev);
+
+		// if there are more than 500 segments removed by snapshot-time zamboni,
+		// log it .5% of the time (1/200). At around 50MM total summary events
+		// per month, this gives us an upper bound of 250,000 events per month
+		if (Math.abs(originalSegments - segmentsAfterCombine) > 500 && Math.random() > 0.005) {
+			this.logger.sendTelemetryEvent({
+				eventName: "MergeTreeV1SummarizeSegmentCount",
+				originalSegments,
+				segmentsAfterCombine,
+				segmentsLen: this.segments.length,
+			});
+		}
 
 		return this.segments;
 	}

--- a/packages/dds/merge-tree/src/snapshotlegacy.ts
+++ b/packages/dds/merge-tree/src/snapshotlegacy.ts
@@ -249,10 +249,9 @@ export class SnapshotLegacy {
 			this.segments!.push(segment);
 		});
 
-		// if there are more than 500 segments removed by snapshot-time zamboni,
-		// log it .5% of the time (1/200). At around 50MM total summary events
-		// per month, this gives us an upper bound of 250,000 events per month
-		if (Math.abs(originalSegments - segs.length) > 500 && Math.random() > 0.005) {
+		// To reduce potential spam from this telemetry, we sample only a small
+		// percentage of summaries
+		if (Math.abs(originalSegments - segs.length) > 500 && Math.random() < 0.005) {
 			this.logger.sendTelemetryEvent({
 				eventName: "MergeTreeLegacySummarizeSegmentCount",
 				originalSegments,


### PR DESCRIPTION
Adds sampled telemetry about segment counts before and after summarization. This is to track the effectiveness of zamboni in production. Currently we think that zamboni is not effective in clearing out merge-tree cruft, but we don't have clear data about this.

AB#7134