### PR TITLE
build(docs): Don't generate API docs for `@alpha` members

### DIFF
--- a/docs/api-markdown-documenter/render-api-documentation.js
+++ b/docs/api-markdown-documenter/render-api-documentation.js
@@ -9,6 +9,7 @@ const {
 	getApiItemTransformationConfigurationWithDefaults,
 	loadModel,
 	MarkdownRenderer,
+	ReleaseTag,
 	transformApiModel,
 } = require("@fluid-tools/api-markdown-documenter");
 const { PackageName } = require("@rushstack/node-core-library");
@@ -89,8 +90,7 @@ async function renderApiDocumentation(inputDir, outputDir, uriRootDir, apiVersio
 		},
 		frontMatter: (apiItem) =>
 			createHugoFrontMatter(apiItem, config, customRenderers, apiVersionNum),
-		// TODO: enable the following once we have finished gettings the repo's release tags sorted out for 2.0.
-		// minimumReleaseLevel: ReleaseTag.Beta, // Don't include `@alpha` or `@internal` items in docs published to the public website.
+		minimumReleaseLevel: ReleaseTag.Beta, // Don't include `@alpha` or `@internal` items in docs published to the public website.
 	});
 
 	logProgress("Generating API documentation...");


### PR DESCRIPTION
We reserve `@alpha` for use by existing partners, they are not intended for public use. This PR updates the API docs generation to not emit documentation entries for `@alpha` APIs.

This was previously blocked on ensuring our tagging was in the correct shape across the repo, and ensuring that our manually written docs didn't reference any such APIs. That work has now been completed, and this change can be made safely.

AB#6469