### PR TITLE
Fix groupedBatch being ungrouped multiple times

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -95,25 +95,13 @@ export class OpGroupingManager {
 		return groupedBatch;
 	}
 
-	private lastSeenSeqNum = -1;
 	public ungroupOp(op: ISequencedDocumentMessage): ISequencedDocumentMessage[] {
-		let fakeCsn = 1;
 		if (!isGroupContents(op.contents)) {
-			// Align the worlds of what clientSequenceNumber represents when grouped batching is enabled
-			// If lastSeenSeqNum is a match, we know we already processed this op
-			if (this.config.groupedBatchingEnabled && op.sequenceNumber !== this.lastSeenSeqNum) {
-				this.lastSeenSeqNum = op.sequenceNumber;
-				return [
-					{
-						...op,
-						clientSequenceNumber: fakeCsn,
-					},
-				];
-			}
 			return [op];
 		}
 
 		const messages = op.contents.contents;
+		let fakeCsn = 1;
 		return messages.map((subMessage) => ({
 			...op,
 			clientSequenceNumber: fakeCsn++,

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -95,11 +95,14 @@ export class OpGroupingManager {
 		return groupedBatch;
 	}
 
+	private lastSeenSeqNum = -1;
 	public ungroupOp(op: ISequencedDocumentMessage): ISequencedDocumentMessage[] {
 		let fakeCsn = 1;
 		if (!isGroupContents(op.contents)) {
 			// Align the worlds of what clientSequenceNumber represents when grouped batching is enabled
-			if (this.config.groupedBatchingEnabled) {
+			if (this.config.groupedBatchingEnabled && op.sequenceNumber !== this.lastSeenSeqNum) {
+				// If lastSeenSeqNum is a match, we know we already processed this op
+				this.lastSeenSeqNum = op.sequenceNumber;
 				return [
 					{
 						...op,

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -100,8 +100,8 @@ export class OpGroupingManager {
 		let fakeCsn = 1;
 		if (!isGroupContents(op.contents)) {
 			// Align the worlds of what clientSequenceNumber represents when grouped batching is enabled
+			// If lastSeenSeqNum is a match, we know we already processed this op
 			if (this.config.groupedBatchingEnabled && op.sequenceNumber !== this.lastSeenSeqNum) {
-				// If lastSeenSeqNum is a match, we know we already processed this op
 				this.lastSeenSeqNum = op.sequenceNumber;
 				return [
 					{

--- a/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
@@ -176,7 +176,7 @@ describe("OpGroupingManager", () => {
 
 			assert.deepStrictEqual(result, [
 				{
-					clientSequenceNumber: 1,
+					clientSequenceNumber: 10,
 					contents: "1",
 				},
 			]);

--- a/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
@@ -5,6 +5,7 @@
 
 import { strict as assert } from "assert";
 import { MockLogger } from "@fluidframework/telemetry-utils";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ContainerMessageType } from "../..";
 import { BatchMessage, IBatch, OpGroupingManager } from "../../opLifecycle";
 
@@ -205,5 +206,85 @@ describe("OpGroupingManager", () => {
 				},
 			]);
 		});
+	});
+
+	it("Ungrouping multiple times does not mess up groupedBatch messages", () => {
+		const groupedBatch = {
+			type: "op",
+			sequenceNumber: 10,
+			clientSequenceNumber: 12,
+			contents: {
+				type: OpGroupingManager.groupedBatchOp,
+				contents: [
+					{
+						contents: {
+							type: ContainerMessageType.FluidDataStoreOp,
+							contents: {
+								contents: "a",
+							},
+						},
+					},
+					{
+						contents: {
+							type: ContainerMessageType.FluidDataStoreOp,
+							contents: {
+								contents: "b",
+							},
+						},
+					},
+				],
+			},
+		} as any;
+		const opGroupingManager = new OpGroupingManager(
+			{
+				groupedBatchingEnabled: false,
+				opCountThreshold: 2,
+				reentrantBatchGroupingEnabled: true,
+			},
+			mockLogger,
+		);
+
+		// Run the groupedBatch through a couple times to ensure it cannot get messed up
+		let messagesToUngroup: ISequencedDocumentMessage[] = [groupedBatch];
+		let result: ISequencedDocumentMessage[] = [];
+		for (let i = 0; i < 4; i++) {
+			result = [];
+			for (const message of messagesToUngroup) {
+				for (const ungroupedOp of opGroupingManager.ungroupOp(message)) {
+					result.push(ungroupedOp);
+				}
+			}
+			messagesToUngroup = [...result];
+		}
+
+		const expected = [
+			{
+				type: "op",
+				sequenceNumber: 10,
+				clientSequenceNumber: 1,
+				metadata: undefined,
+				compression: undefined,
+				contents: {
+					type: ContainerMessageType.FluidDataStoreOp,
+					contents: {
+						contents: "a",
+					},
+				},
+			},
+			{
+				type: "op",
+				sequenceNumber: 10,
+				clientSequenceNumber: 2,
+				metadata: undefined,
+				compression: undefined,
+				contents: {
+					type: ContainerMessageType.FluidDataStoreOp,
+					contents: {
+						contents: "b",
+					},
+				},
+			},
+		];
+		assert.deepStrictEqual(result, expected, "unexpected processing of groupedBatch");
 	});
 });

--- a/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/OpGroupingManager.spec.ts
@@ -285,6 +285,6 @@ describe("OpGroupingManager", () => {
 				},
 			},
 		];
-		assert.deepStrictEqual(result, expected, "unexpected processing of groupedBatch");
+		assert.deepStrictEqual(result, expected, "ungrouping should work as expected");
 	});
 });


### PR DESCRIPTION
The `RemoteMessageProcessor` is repeatedly putting the ungrouped batch back through the `ungroupOp` method. Because of the change in https://github.com/microsoft/FluidFramework/pull/17959, this causes every op in a groupedBatch to have `clientSequenceNumber` 1.

[AB#7174](https://dev.azure.com/fluidframework/internal/_workitems/edit/7174)