### PR TITLE
test: Correct usage of compressor in mock runtime

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -84,7 +84,7 @@ describe("Fuzz - Top-Level", () => {
 				numOpsBeforeAttach: 5,
 				rehydrateDisabled: true,
 			},
-			reconnectProbability: 0,
+			reconnectProbability: 0.1,
 			idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),
 		};
 		createDDSFuzzSuite(model, options);

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -84,7 +84,7 @@ describe("Fuzz - Top-Level", () => {
 				numOpsBeforeAttach: 5,
 				rehydrateDisabled: true,
 			},
-			reconnectProbability: 0.1,
+			reconnectProbability: 0,
 			idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),
 		};
 		createDDSFuzzSuite(model, options);

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -117,8 +117,6 @@ export class MockContainerRuntime {
     finalizeIdRange(range: IdCreationRange): void;
     flush(): void;
     // (undocumented)
-    getGeneratedIdRange(): IdCreationRange | undefined;
-    // (undocumented)
     protected readonly overrides?: {
         minimumSequenceNumber?: number | undefined;
     } | undefined;
@@ -128,7 +126,11 @@ export class MockContainerRuntime {
     process(message: ISequencedDocumentMessage): void;
     rebase(): void;
     protected get referenceSequenceNumber(): number;
-    protected runtimeOptions: Required<IMockContainerRuntimeOptions>;
+    // (undocumented)
+    protected reSubmitMessages(messagesToResubmit: {
+        content: any;
+        localOpMetadata: unknown;
+    }[]): void;
     // (undocumented)
     submit(messageContent: any, localOpMetadata: unknown): number;
 }
@@ -159,8 +161,6 @@ export class MockContainerRuntimeFactory {
     protected readonly runtimes: Set<MockContainerRuntime>;
     // (undocumented)
     sequenceNumber: number;
-    // (undocumented)
-    synchronizeIdCompressors(): void;
 }
 
 // @alpha

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -234,10 +234,7 @@ export class MockContainerRuntime {
 
 			case FlushMode.TurnBased: {
 				// Id allocation messages are directly submitted during the resubmit path
-				if (
-					(message.content as IMockContainerRuntimeSequencedIdAllocationMessage).contents
-						?.type === "idAllocation"
-				) {
+				if (this.isAllocationMessage(message.content)) {
 					this.idAllocationOutbox.push(message);
 				} else {
 					this.outbox.push(message);
@@ -250,6 +247,15 @@ export class MockContainerRuntime {
 		}
 
 		return clientSequenceNumber;
+	}
+
+	private isAllocationMessage(
+		message: any,
+	): message is IMockContainerRuntimeSequencedIdAllocationMessage {
+		return (
+			(message as IMockContainerRuntimeSequencedIdAllocationMessage).contents?.type ===
+			"idAllocation"
+		);
 	}
 
 	public dirty(): void {}
@@ -372,11 +378,8 @@ export class MockContainerRuntime {
 		this.deltaManager.minimumSequenceNumber = message.minimumSequenceNumber;
 		const [local, localOpMetadata] = this.processInternal(message);
 
-		if (
-			(message as IMockContainerRuntimeSequencedIdAllocationMessage).contents.type ===
-			"idAllocation"
-		) {
-			this.finalizeIdRange((message as any).contents.contents as IdCreationRange);
+		if (this.isAllocationMessage(message)) {
+			this.finalizeIdRange(message.contents.contents);
 		} else {
 			this.dataStoreRuntime.process(message, local, localOpMetadata);
 		}


### PR DESCRIPTION
## Description

This corrects the usage of ID compressor in the mocks for the runtime and reconnection. It now emulates the runtime's behavior that batches ID ranges separately and ensures they are sent before ops that depend on them.
