### PR TITLE
fix(docs): redirect fix using pathname instead of header

### DIFF
--- a/docs/api/fallback/index.js
+++ b/docs/api/fallback/index.js
@@ -16,10 +16,11 @@ const routes = new Map([
  * If a matching route is found, it constructs and returns the redirect URL. Otherwise, it returns a 404 response.
  */
 module.exports = async (context, { headers }) => {
-	const route = [...routes].find(([path, _]) => headers["x-ms-original-url"].includes(path));
+	const { pathname, search } = new URL(headers["x-ms-original-url"]);
+	const route = [...routes].find(([path, _]) => pathname.startsWith(path));
 
 	context.res = {
 		status: route ? 302 : 404,
-		headers: { location: route ? headers["x-ms-original-url"].replace(...route) : "/404" },
+		headers: { location: route ? `${pathname.replace(...route)}${search}` : "/404" },
 	};
 };

--- a/docs/build-redirects.js
+++ b/docs/build-redirects.js
@@ -33,11 +33,12 @@ const routes = new Map([
  * If a matching route is found, it constructs and returns the redirect URL. Otherwise, it returns a 404 response.
  */
 module.exports = async (context, { headers }) => {
-	const route = [...routes].find(([path, _]) => headers["x-ms-original-url"].includes(path));
+	const { pathname, search } = new URL(headers["x-ms-original-url"]);
+	const route = [...routes].find(([path, _]) => pathname.startsWith(path));
 
 	context.res = {
 		status: route ? 302 : 404,
-		headers: { location: route ? headers["x-ms-original-url"].replace(...route) : "/404" },
+		headers: { location: route ? \`\${pathname.replace(...route)}\${search}\` : "/404" },
 	};
 };
 `;


### PR DESCRIPTION
https://salmon-sand-0b7fa7c1e.1.azurestaticapps.net/docs/api/v2/fluid-framework contains a bug from the last release. where it switches back from FF.com to the one swa assigned. hoping this is a fix
AB#7096