### PR TITLE
[Data Migration] Make unreachable parts asserts

### DIFF
--- a/experimental/dds/tree/src/migration-shim/migrationDeltaHandler.ts
+++ b/experimental/dds/tree/src/migration-shim/migrationDeltaHandler.ts
@@ -82,10 +82,7 @@ export class MigrationShimDeltaHandler implements IShimDeltaHandler {
 	public process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void {
 		// This allows us to process the migrate op and prevent the shared object from processing the wrong ops
 		assert(!this.isPreAttachState(), 0x82c /* Can't process ops before attaching tree handler */);
-		if (
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-			message.type !== MessageType.Operation
-		) {
+		if (message.type !== MessageType.Operation) {
 			return;
 		}
 
@@ -126,10 +123,10 @@ export class MigrationShimDeltaHandler implements IShimDeltaHandler {
 			return;
 		}
 
-		if (this.shouldDropOp(opContents)) {
-			this.submitLocalMessage(opContents);
-			return;
-		}
+		assert(
+			!this.shouldDropOp(opContents),
+			"MigrationShim should not be able to apply v1 ops as they shouldn't have been created locally."
+		);
 		this.treeDeltaHandler.applyStashedOp(contents);
 	}
 

--- a/experimental/dds/tree/src/migration-shim/sharedTreeDeltaHandler.ts
+++ b/experimental/dds/tree/src/migration-shim/sharedTreeDeltaHandler.ts
@@ -50,7 +50,7 @@ export class SharedTreeShimDeltaHandler implements IShimDeltaHandler {
 		// This allows us to process the migrate op and prevent the shared object from processing the wrong ops
 		// Drop v1 ops
 		assert(this.hasTreeDeltaHandler(), 0x831 /* Can't process ops before attaching tree handler */);
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+
 		if (message.type !== MessageType.Operation) {
 			return;
 		}
@@ -79,7 +79,7 @@ export class SharedTreeShimDeltaHandler implements IShimDeltaHandler {
 	public applyStashedOp(contents: unknown): void {
 		assert(
 			!this.shouldDropOp(contents as IOpContents),
-			"Should not be able to apply v1 ops as they shouldn't have been created locally."
+			"SharedTreeShim should not be able to apply v1 ops as they shouldn't have been created locally."
 		);
 		this.handler.applyStashedOp(contents);
 	}


### PR DESCRIPTION
[AB#7163](https://dev.azure.com/fluidframework/internal/_workitems/edit/7163)

These places should be asserts as they should not happen. We should not generate v1 ops when we are in a v2 state.