### PR TITLE
Remove deprecated method: createNavParam 

### DIFF
--- a/.changeset/sixty-words-stick.md
+++ b/.changeset/sixty-words-stick.md
@@ -1,0 +1,5 @@
+---
+"@fluidframework/odsp-driver": minor
+---
+
+Remove deprecated method: createNavParam from odsp-driver's odspDriverUrlResolverForShareLink.

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
@@ -253,8 +253,6 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
     constructor(shareLinkFetcherProps?: ShareLinkFetcherProps | undefined, logger?: ITelemetryBaseLogger, appName?: string | undefined, getContext?: ((resolvedUrl: IOdspResolvedUrl, dataStorePath: string) => Promise<string | undefined>) | undefined);
     appendDataStorePath(requestUrl: URL, pathToAppend: string): string | undefined;
     static createDocumentUrl(baseUrl: string, driverInfo: OdspFluidDataStoreLocator): string;
-    // @deprecated
-    static createNavParam(locator: OdspFluidDataStoreLocator): string;
     getAbsoluteUrl(resolvedUrl: IResolvedUrl, dataStorePath: string, packageInfoSource?: IContainerPackageInfo): Promise<string>;
     resolve(request: IRequest): Promise<IOdspResolvedUrl>;
 }

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -19,7 +19,6 @@ import {
 import {
 	getLocatorFromOdspUrl,
 	storeLocatorInOdspUrl,
-	encodeOdspFluidDataStoreLocator,
 	locatorQueryParamName,
 } from "./odspFluidFileLink";
 import { OdspFluidDataStoreLocator, SharingLinkHeader } from "./contractsPublic";
@@ -264,13 +263,5 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
 		storeLocatorInOdspUrl(url, driverInfo);
 
 		return url.href;
-	}
-
-	/**
-	 * Crafts a supported data store nav param
-	 * @deprecated encodeOdspFluidDataStoreLocator should be used instead
-	 */
-	public static createNavParam(locator: OdspFluidDataStoreLocator) {
-		return encodeOdspFluidDataStoreLocator(locator);
 	}
 }


### PR DESCRIPTION
Remove deprecated method: `createNavParam` from odsp-driver's `odspDriverUrlResolverForShareLink`. There is an alternative utility function already available that can be used to achieve the same purpose. (createNavParam method was marked as deprecated in [this PR](https://github.com/microsoft/FluidFramework/pull/10411))