### PR TITLE
Re-enable migration shim tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/migrationShim.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/migrationShim.spec.ts
@@ -146,7 +146,7 @@ describeCompat("MigrationShim", "NoCompat", (getTestObjectProvider) => {
 		provider = getTestObjectProvider();
 	});
 
-	it.skip("Can create and retrieve tree without migration", async () => {
+	it("Can create and retrieve tree without migration", async () => {
 		// Setup containers and get Migration Shims instead of LegacySharedTrees
 		const container1 = await provider.createContainer(runtimeFactory);
 		const testObj1 = (await container1.getEntryPoint()) as TestDataObject;
@@ -157,6 +157,7 @@ describeCompat("MigrationShim", "NoCompat", (getTestObjectProvider) => {
 
 		const container2 = await provider.loadContainer(runtimeFactory);
 		const testObj2 = (await container2.getEntryPoint()) as TestDataObject;
+		await provider.ensureSynchronized();
 		// This is a silent check that we can get the tree after storing the handle
 		const shim2 = (await testObj2.getShim()) as MigrationShim;
 
@@ -201,6 +202,7 @@ describeCompat("MigrationShim", "NoCompat", (getTestObjectProvider) => {
 		});
 
 		const testObj3 = (await container3.getEntryPoint()) as TestDataObject;
+		await provider.ensureSynchronized();
 		const shim3 = await testObj3.getShim();
 		const tree3 = shim3.currentTree as LegacySharedTree;
 
@@ -217,7 +219,7 @@ describeCompat("MigrationShim", "NoCompat", (getTestObjectProvider) => {
 		assert(getQuantity(tree1) === getQuantity(tree3), `Failed to sync new shared trees`);
 	});
 
-	it.skip("Can create and retrieve tree with migration", async () => {
+	it("Can create and retrieve tree with migration", async () => {
 		// Setup containers and get Migration Shims instead of LegacySharedTrees
 		const container1 = await provider.createContainer(runtimeFactory);
 		const testObj1 = (await container1.getEntryPoint()) as TestDataObject;
@@ -228,6 +230,7 @@ describeCompat("MigrationShim", "NoCompat", (getTestObjectProvider) => {
 
 		const container2 = await provider.loadContainer(runtimeFactory);
 		const testObj2 = (await container2.getEntryPoint()) as TestDataObject;
+		await provider.ensureSynchronized();
 		// This is a silent check that we can get the tree after storing the handle
 		const shim2 = await testObj2.getShim();
 
@@ -281,6 +284,7 @@ describeCompat("MigrationShim", "NoCompat", (getTestObjectProvider) => {
 		});
 
 		const testObj3 = (await container3.getEntryPoint()) as TestDataObject;
+		await provider.ensureSynchronized();
 		const shim3 = await testObj3.getShim();
 		const tree3 = shim3.currentTree as ITree;
 		const view3 = getNewTreeView(tree3);

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/sharedTreeShim.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/sharedTreeShim.spec.ts
@@ -94,7 +94,7 @@ describeCompat("SharedTreeShim", "NoCompat", (getTestObjectProvider) => {
 		provider = getTestObjectProvider();
 	});
 
-	it.skip("Can create and retrieve tree", async () => {
+	it("Can create and retrieve tree", async () => {
 		// Setup containers and get Migration Shims instead of LegacySharedTrees
 		const container1 = await provider.createContainer(runtimeFactory);
 		const testObj1 = (await container1.getEntryPoint()) as TestDataObject;
@@ -106,6 +106,7 @@ describeCompat("SharedTreeShim", "NoCompat", (getTestObjectProvider) => {
 
 		const container2 = await provider.loadContainer(runtimeFactory);
 		const testObj2 = (await container2.getEntryPoint()) as TestDataObject;
+		await provider.ensureSynchronized();
 		// This is a silent check that we can get the tree after storing the handle
 		const shim2 = await testObj2.getTree();
 
@@ -115,8 +116,8 @@ describeCompat("SharedTreeShim", "NoCompat", (getTestObjectProvider) => {
 
 		// Schematize our tree, this sends an op since we are a live container
 		const view1 = getNewTreeView(tree1);
-		const view2 = getNewTreeView(tree2);
 		await provider.ensureSynchronized();
+		const view2 = getNewTreeView(tree2);
 
 		// This does some typing and gives us the root node.
 		const rootNode1: RootType = view1.root;
@@ -143,6 +144,7 @@ describeCompat("SharedTreeShim", "NoCompat", (getTestObjectProvider) => {
 
 		// Get the root node loaded from the new summary
 		const testObj3 = (await container3.getEntryPoint()) as TestDataObject;
+		await provider.ensureSynchronized();
 		const shim3 = await testObj3.getTree();
 		const tree3 = shim3.currentTree;
 		const view3 = getNewTreeView(tree3);

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
@@ -214,7 +214,7 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider) => {
 		container.close();
 	});
 
-	it.skip("MigrationShim can drop v1 ops and migrate ops", async () => {
+	it("MigrationShim can drop v1 ops and migrate ops", async () => {
 		// Setup containers and get Migration Shims instead of LegacySharedTrees
 		const container1 = await provider.loadContainer(runtimeFactory2);
 		const testObj1 = (await container1.getEntryPoint()) as TestDataObject;
@@ -223,6 +223,7 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider) => {
 
 		const container2 = await provider.loadContainer(runtimeFactory2);
 		const testObj2 = (await container2.getEntryPoint()) as TestDataObject;
+		await provider.ensureSynchronized();
 		const shim2 = testObj2.getTree<MigrationShim>();
 		const legacyTree2 = shim2.currentTree as LegacySharedTree;
 
@@ -250,6 +251,7 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider) => {
 		const newTree1 = shim1.currentTree as ITree;
 		const newTree2 = shim2.currentTree as ITree;
 		const view1 = getNewTreeView(newTree1);
+		await provider.ensureSynchronized();
 		const view2 = getNewTreeView(newTree2);
 		const node1 = view1.root;
 		const node2 = view2.root;
@@ -317,6 +319,7 @@ describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider) => {
 		const newTree1 = shim1.currentTree as ITree;
 		const newTree2 = shim2.currentTree;
 		const view1 = getNewTreeView(newTree1);
+		await provider.ensureSynchronized();
 		const view2 = getNewTreeView(newTree2);
 		const node1 = view1.root;
 		const node2 = view2.root;

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandlesDetached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandlesDetached.spec.ts
@@ -121,7 +121,7 @@ describeCompat("Storing handles detached", "NoCompat", (getTestObjectProvider) =
 		provider = getTestObjectProvider();
 	});
 
-	it.skip("Detached handles", async () => {
+	it("Detached handles", async () => {
 		const loader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory2]]);
 
 		const container1 = await loader.createDetachedContainer(provider.defaultCodeDetails);
@@ -135,12 +135,14 @@ describeCompat("Storing handles detached", "NoCompat", (getTestObjectProvider) =
 
 		const request = provider.driver.createCreateNewRequest(provider.documentId);
 		await container1.attach(request);
+		provider.updateDocumentId(container1.resolvedUrl);
 		await waitForContainerConnection(container1);
 
 		await provider.ensureSynchronized();
 
 		const container2 = await provider.loadContainer(runtimeFactory2);
 		const testObj2 = (await container2.getEntryPoint()) as TestDataObject;
+		await provider.ensureSynchronized();
 		const shim2 = testObj2.getTree<SharedTreeShim>();
 		const tree2 = shim2.currentTree;
 		const node2 = getNewTreeView(tree2).root;


### PR DESCRIPTION
[AB#6416](https://dev.azure.com/fluidframework/internal/_workitems/edit/6416)

Re-enables these data migration shim tests.

- `migrationShim.spec.ts`: added a `provider.ensureSynchronized` that would send the handle and attach ops for the second container to load from.
- `sharedTreeShim.spec.ts`: added a `provider.ensureSynchronized` that would send the handle and attach ops for the second container to load from. It also added a `provider.ensureSynchronized` to ensure that `tree.schematize` would work as expected. 
- `stampedV2Ops.spec.ts`: similar to `sharedTreeShim.spec.ts` above
- `storingHandlesDetached.spec.ts`: added a `provider.ensureSynchronized` that would send the handle and attach ops for the second container to load from. Also added a `provider.updateDocumentId` call so the second load container would successfully load the container.