### PR TITLE
Remove provider.ensureSynchronized to remove flakiness of test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
@@ -158,8 +158,6 @@ describeCompat(
 						summaryVersion1,
 					);
 
-				await provider.ensureSynchronized();
-
 				// This tells the summarizer to process the latest summary ack
 				// This is because the second summarizer is not the elected summarizer and thus the summaryManager does not
 				// tell the summarizer to process acks.


### PR DESCRIPTION
[AB#6706](https://dev.azure.com/fluidframework/internal/_workitems/edit/6706)

## Description
Reduce flakiness of test.

What was happening was we were expecting to process a summary ack that would close the container. The test would hang because sometimes we would process both acks before the summarizer would get to it and the container would close, but we would run the summarizer again, which wouldn't close the container. If we run the summarizer before we process the ack, which was what the test originally intended, then we will hit our failure scenario.