### PR TITLE
Repro: summarizeIncrementally.spec.ts test failures

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
@@ -96,7 +96,7 @@ function validateDDSStateInSummary(
  * These tests validate that data stores and DDSes do incremental summaries correctly, i.e., if the data
  * in it does not change, it summaries using a SummaryHandle and not a SummaryTree.
  */
-describeCompat(
+describeCompat.only(
 	"Incremental summaries for data store and DDS",
 	"1.3.7" /** equivalent to FullCompat. Currently used for testing purposes on ADO pipelines */,
 	(getTestObjectProvider, apis) => {
@@ -126,7 +126,15 @@ describeCompat(
 				this.skip();
 			}
 			const dataStore2 = await containerRuntime.createDataStore(TestDataObjectType);
-			const dataObject2 = (await dataStore2.entryPoint.get()) as ITestDataObject;
+			const dataObject2 =
+				((await dataStore2.entryPoint?.get()) as ITestDataObject) ??
+				// Added to support back compat where entryPoint is not available.
+				// Can be removed when we no longer support `^2.0.0-internal.7.0.0`
+				((
+					await (containerRuntime as any).request({
+						url: "/",
+					})
+				).value as ITestDataObject);
 			dataObject1._root.set("dataObject2", dataStore2.entryPoint);
 
 			await provider.ensureSynchronized();

--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
@@ -122,9 +122,9 @@ describeCompat.only(
 
 		it("can do incremental data store summary", async function () {
 			// TODO: Re-enable after cross version compat bugs are fixed - ADO:6978
-			if (provider.type === "TestObjectProviderWithVersionedLoad") {
-				this.skip();
-			}
+			// if (provider.type === "TestObjectProviderWithVersionedLoad") {
+			// 	this.skip();
+			// }
 			const dataStore2 = await containerRuntime.createDataStore(TestDataObjectType);
 			const dataObject2 =
 				((await dataStore2.entryPoint?.get()) as ITestDataObject) ??


### PR DESCRIPTION
## Description

This PR will **not** be merged and is only to reproduce a test failure.

### Steps to repro:
1. `pnpm i && pnpm build:fast`
2. `cd packages/test/test-end-to-end-tests`
3. `pnpm test`

### Expected test failure:
```
  1) data store retrieval during creation / initialization tests
       compat cross version - create with 1.3.7 + load with 2.0.0-rc.2.0.0
         Requesting data store before outer data store completes initialization:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/workspaces/FluidFramework/packages/test/test-end-to-end-tests/dist/test/dataStoreRetrieval.spec.js)
      at listOnTimeout (node:internal/timers:569:17)
      at processTimers (node:internal/timers:512:7)

  2) data store retrieval during creation / initialization tests
       compat cross version - create with 1.3.7 + load with 2.0.0-rc.2.0.0
         Requesting data store before outer data store (non-root) completes initialization:
     Error: 0x13d
      at assert (/workspaces/FluidFramework/packages/test/test-version-utils/node_modules/.legacy/1.3.7/node_modules/@fluidframework/common-utils/src/assert.ts:15:16)
      at LocalDetachedFluidDataStoreContext.realize (/workspaces/FluidFramework/packages/test/test-version-utils/node_modules/.legacy/1.3.7/node_modules/@fluidframework/container-runtime/src/dataStoreContext.ts:326:15)
      at LocalDetachedFluidDataStoreContext.request (/workspaces/FluidFramework/packages/test/test-version-utils/node_modules/.legacy/1.3.7/node_modules/@fluidframework/container-runtime/src/dataStoreContext.ts:594:36)
      at OuterDataObject.initializingFirstTime (file:///workspaces/FluidFramework/packages/test/test-end-to-end-tests/src/test/dataStoreRetrieval.spec.ts:74:38)
      at OuterDataObject.initializeInternal (/workspaces/FluidFramework/packages/test/test-version-utils/node_modules/.legacy/1.3.7/node_modules/@fluidframework/aqueduct/src/data-objects/pureDataObject.ts:151:13)
      at OuterDataObject.initializeInternal (/workspaces/FluidFramework/packages/test/test-version-utils/node_modules/.legacy/1.3.7/node_modules/@fluidframework/aqueduct/src/data-objects/dataObject.ts:83:9)
      at createDataObject (/workspaces/FluidFramework/packages/test/test-version-utils/node_modules/.legacy/1.3.7/node_modules/@fluidframework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts:94:9)
      at DataObjectFactory.createInstanceCore (/workspaces/FluidFramework/packages/test/test-version-utils/node_modules/.legacy/1.3.7/node_modules/@fluidframework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts:256:39)
      at Context.<anonymous> (file:///workspaces/FluidFramework/packages/test/test-end-to-end-tests/src/test/dataStoreRetrieval.spec.ts:153:23)
```