### PR TITLE
refactor(tree): decouple tests from format using changeset factories

### DIFF
--- a/packages/dds/tree/src/feature-libraries/optional-field/index.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/index.ts
@@ -4,7 +4,7 @@
  */
 
 export { noChangeCodecFamily, makeOptionalFieldCodecFamily } from "./optionalFieldCodecs.js";
-export { OptionalChangeset, RegisterId } from "./optionalFieldChangeTypes.js";
+export { Move, OptionalChangeset, RegisterId } from "./optionalFieldChangeTypes.js";
 export {
 	optionalChangeHandler,
 	optionalFieldEditor,

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -29,7 +29,7 @@ import {
 	NodeChangePruner,
 } from "../modular-schema/index.js";
 import { nodeIdFromChangeAtom } from "../deltaUtils.js";
-import { RegisterId, OptionalChangeset } from "./optionalFieldChangeTypes.js";
+import { RegisterId, OptionalChangeset, Move } from "./optionalFieldChangeTypes.js";
 import { makeOptionalFieldCodecFamily } from "./optionalFieldCodecs.js";
 
 interface IRegisterMap<T> {
@@ -182,7 +182,7 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 			}
 		}
 
-		const composedMoves: OptionalChangeset["moves"] = [];
+		const composedMoves: Move[] = [];
 		for (const [src, [dst, target]] of srcToDst.entries()) {
 			composedMoves.push([src, dst, target]);
 		}
@@ -237,7 +237,7 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 
 		let changeEmptiesSelf = false;
 		let changeFillsSelf = false;
-		const invertedMoves: typeof change.moves = [];
+		const invertedMoves: Move[] = [];
 		for (const [src, dst] of moves) {
 			changeEmptiesSelf ||= src === "self";
 			changeFillsSelf ||= dst === "self";
@@ -304,7 +304,7 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 
 		const { moves, childChanges } = change;
 		const { change: overChange } = overTagged;
-		const rebasedMoves: typeof moves = [];
+		const rebasedMoves: Move[] = [];
 
 		const overDstToSrc = new RegisterMap<RegisterId>();
 		const overSrcToDst = new RegisterMap<RegisterId>();
@@ -477,14 +477,15 @@ export const optionalFieldEditor: OptionalFieldEditor = {
 			detach: ChangesetLocalId;
 		},
 	): OptionalChangeset => {
+		const moves: Move[] = [[{ localId: ids.fill }, "self", "nodeTargeting"]];
 		const result: OptionalChangeset = {
-			moves: [[{ localId: ids.fill }, "self", "nodeTargeting"]],
+			moves,
 			childChanges: [],
 		};
 		if (wasEmpty) {
 			result.reservedDetachId = { localId: ids.detach };
 		} else {
-			result.moves.push(["self", { localId: ids.detach }, "cellTargeting"]);
+			moves.push(["self", { localId: ids.detach }, "cellTargeting"]);
 		}
 		return result;
 	},

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldChangeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldChangeTypes.ts
@@ -15,6 +15,12 @@ import { NodeChangeset } from "../modular-schema/index.js";
  */
 export type RegisterId = ChangeAtomId | "self";
 
+export type Move = readonly [
+	src: RegisterId,
+	dst: RegisterId,
+	kind: "nodeTargeting" | "cellTargeting",
+];
+
 /**
  * Changes to an optional field.
  *
@@ -37,7 +43,7 @@ export interface OptionalChangeset<TChildChange = NodeChangeset> {
 	 *
 	 * Rebasing logic should only generate moves whose `src` is an occupied register.
 	 */
-	moves: (readonly [src: RegisterId, dst: RegisterId, kind: "nodeTargeting" | "cellTargeting"])[];
+	moves: readonly Move[];
 
 	/**
 	 * Nested changes to nodes that occupy registers.

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
@@ -16,14 +16,14 @@ import {
 	// Allow import from file being tested.
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/default-schema/defaultFieldKinds.js";
-import { makeAnonChange, TaggedChange, tagChange } from "../../../core/index.js";
+import { makeAnonChange, tagChange } from "../../../core/index.js";
 import { brand, fakeIdAllocator, idAllocatorFromMaxId } from "../../../util/index.js";
 import { defaultRevisionMetadataFromChanges, mintRevisionTag } from "../../utils.js";
 // eslint-disable-next-line import/no-internal-modules
 import { OptionalChangeset } from "../../../feature-libraries/optional-field/index.js";
 import { changesetForChild } from "../fieldKindTestUtils.js";
 // eslint-disable-next-line import/no-internal-modules
-import { assertEqual } from "../optional-field/optionalFieldUtils.js";
+import { Change, assertEqual, assertTaggedEqual } from "../optional-field/optionalFieldUtils.js";
 // eslint-disable-next-line import/no-internal-modules
 import { rebaseRevisionMetadataFromInfo } from "../../../feature-libraries/modular-schema/index.js";
 
@@ -54,14 +54,11 @@ const childComposer1_2 = (
 describe("defaultFieldKinds", () => {
 	describe("valueFieldEditor.set", () => {
 		it("valueFieldEditor.set", () => {
-			const expected: OptionalChangeset = {
-				moves: [
-					[{ localId: brand(41) }, "self", "nodeTargeting"],
-					["self", { localId: brand(1) }, "cellTargeting"],
-				],
-				childChanges: [],
-			};
-			assert.deepEqual(
+			const expected = Change.atOnce(
+				Change.clear("self", brand(1)),
+				Change.move(brand(41), "self"),
+			);
+			assertEqual(
 				valueFieldEditor.set({
 					detach: brand(1),
 					fill: brand(41),
@@ -78,18 +75,9 @@ describe("defaultFieldKinds", () => {
 		const fieldHandler: FieldChangeHandler<OptionalChangeset, ValueFieldEditor> =
 			valueChangeHandler;
 
-		const childChange1: OptionalChangeset = {
-			moves: [],
-			childChanges: [["self", nodeChange1]],
-		};
-		const childChange2: OptionalChangeset = {
-			moves: [],
-			childChanges: [["self", nodeChange2]],
-		};
-		const childChange3: OptionalChangeset = {
-			moves: [],
-			childChanges: [["self", arbitraryChildChange]],
-		};
+		const childChange1 = Change.child(nodeChange1);
+		const childChange2 = Change.child(nodeChange2);
+		const childChange3 = Change.child(arbitraryChildChange);
 
 		const change1 = tagChange(
 			fieldHandler.editor.set({ detach: brand(1), fill: brand(41) }),
@@ -100,29 +88,25 @@ describe("defaultFieldKinds", () => {
 			mintRevisionTag(),
 		);
 
-		const change1WithChildChange: OptionalChangeset = {
-			moves: [
-				[{ localId: brand(41) }, "self", "nodeTargeting"],
-				["self", { localId: brand(1) }, "cellTargeting"],
-			],
-			childChanges: [[{ localId: brand(41) }, nodeChange1]],
-		};
+		const change1WithChildChange = Change.atOnce(
+			Change.clear("self", brand(1)),
+			Change.move(brand(41), "self"),
+			Change.childAt(brand(41), nodeChange1),
+		);
 
 		/**
 		 * Represents the outcome of composing change1 and change2.
 		 */
-		const change1And2: TaggedChange<OptionalChangeset> = makeAnonChange({
-			moves: [
-				[
+		const change1And2 = makeAnonChange(
+			Change.atOnce(
+				Change.move(
 					{ localId: brand(41), revision: change1.revision },
 					{ localId: brand(2), revision: change2.revision },
-					"nodeTargeting",
-				],
-				["self", { localId: brand(1), revision: change1.revision }, "cellTargeting"],
-				[{ localId: brand(42), revision: change2.revision }, "self", "nodeTargeting"],
-			],
-			childChanges: [],
-		});
+				),
+				Change.clear("self", { localId: brand(1), revision: change1.revision }),
+				Change.move({ localId: brand(42), revision: change2.revision }, "self"),
+			),
+		);
 
 		const simpleChildComposer = (
 			a: NodeChangeset | undefined,
@@ -143,28 +127,16 @@ describe("defaultFieldKinds", () => {
 					defaultRevisionMetadataFromChanges([change1, change2]),
 				);
 
-				assertEqual(makeAnonChange(composed), change1And2);
+				assertTaggedEqual(makeAnonChange(composed), change1And2);
 			});
 
 			it("a field change and a child change", () => {
 				const taggedChildChange1 = tagChange(childChange1, mintRevisionTag());
-				const expected: OptionalChangeset = {
-					moves: [
-						[
-							{ localId: brand(41), revision: change1.revision },
-							"self",
-							"nodeTargeting",
-						],
-						[
-							"self",
-							{ localId: brand(1), revision: change1.revision },
-							"cellTargeting",
-						],
-					],
-					childChanges: [
-						[{ localId: brand(41), revision: change1.revision }, nodeChange1],
-					],
-				};
+				const expected = Change.atOnce(
+					Change.move({ localId: brand(41), revision: change1.revision }, "self"),
+					Change.clear("self", { localId: brand(1), revision: change1.revision }),
+					Change.childAt({ localId: brand(41), revision: change1.revision }, nodeChange1),
+				);
 				const actual = fieldHandler.rebaser.compose(
 					change1,
 					taggedChildChange1,
@@ -173,7 +145,7 @@ describe("defaultFieldKinds", () => {
 					failCrossFieldManager,
 					defaultRevisionMetadataFromChanges([change1, taggedChildChange1]),
 				);
-				assertEqual(makeAnonChange(actual), makeAnonChange(expected));
+				assertEqual(actual, expected);
 			});
 
 			it("a child change and a field change", () => {
@@ -185,37 +157,25 @@ describe("defaultFieldKinds", () => {
 					failCrossFieldManager,
 					defaultRevisionMetadataFromChanges([change1]),
 				);
-				const expected2: OptionalChangeset = {
-					moves: [
-						[
-							{ localId: brand(41), revision: change1.revision },
-							"self",
-							"nodeTargeting",
-						],
-						[
-							"self",
-							{ localId: brand(1), revision: change1.revision },
-							"cellTargeting",
-						],
-					],
-					childChanges: [["self", nodeChange1]],
-				};
-				assertEqual(makeAnonChange(actual), makeAnonChange(expected2));
+				const expected2 = Change.atOnce(
+					Change.move({ localId: brand(41), revision: change1.revision }, "self"),
+					Change.clear("self", { localId: brand(1), revision: change1.revision }),
+					Change.child(nodeChange1),
+				);
+				assertEqual(actual, expected2);
 			});
 
 			it("two child changes", () => {
 				assertEqual(
-					makeAnonChange(
-						fieldHandler.rebaser.compose(
-							makeAnonChange(childChange1),
-							makeAnonChange(childChange2),
-							childComposer1_2,
-							fakeIdAllocator,
-							failCrossFieldManager,
-							defaultRevisionMetadataFromChanges([]),
-						),
+					fieldHandler.rebaser.compose(
+						makeAnonChange(childChange1),
+						makeAnonChange(childChange2),
+						childComposer1_2,
+						fakeIdAllocator,
+						failCrossFieldManager,
+						defaultRevisionMetadataFromChanges([]),
 					),
-					makeAnonChange(childChange3),
+					childChange3,
 				);
 			});
 		});
@@ -235,24 +195,12 @@ describe("defaultFieldKinds", () => {
 				defaultRevisionMetadataFromChanges([taggedChange]),
 			);
 
-			assertEqual(
-				makeAnonChange(inverted),
-				makeAnonChange({
-					moves: [
-						[
-							{ localId: brand(1), revision: taggedChange.revision },
-							"self",
-							"nodeTargeting",
-						],
-						[
-							"self",
-							{ localId: brand(41), revision: taggedChange.revision },
-							"cellTargeting",
-						],
-					],
-					childChanges: [["self", nodeChange2]],
-				}),
+			const expected = Change.atOnce(
+				Change.clear("self", { localId: brand(41), revision: taggedChange.revision }),
+				Change.move({ localId: brand(1), revision: taggedChange.revision }, "self"),
+				Change.child(nodeChange2),
 			);
+			assertEqual(inverted, expected);
 		});
 
 		it("can be rebased", () => {

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
@@ -49,7 +49,7 @@ import {
 	rebaseRevisionMetadataFromInfo,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/modular-schema/index.js";
-import { assertEqual } from "./optionalFieldUtils.js";
+import { Change, assertTaggedEqual } from "./optionalFieldUtils.js";
 
 type RevisionTagMinter = () => RevisionTag;
 
@@ -201,7 +201,7 @@ function composeList(
 ): OptionalChangeset {
 	const moveEffects = failCrossFieldManager;
 	const idAllocator = idAllocatorFromMaxId(getMaxId(...changes.map((c) => c.change)));
-	let composed: OptionalChangeset = createEmpty();
+	let composed: OptionalChangeset = Change.empty();
 	const metadataOrDefault = metadata ?? defaultRevisionMetadataFromChanges(changes);
 
 	for (const change of changes) {
@@ -232,10 +232,6 @@ function compose(
 		moveEffects,
 		metadata ?? defaultRevisionMetadataFromChanges([change1, change2]),
 	);
-}
-
-function createEmpty(): OptionalChangeset {
-	return { moves: [], childChanges: [] };
 }
 
 type OptionalFieldTestState = FieldStateTree<string | undefined, OptionalChangeset>;
@@ -494,7 +490,14 @@ export function testRebaserAxioms() {
 			runExhaustiveComposeRebaseSuite(
 				[{ content: undefined }, { content: "A" }],
 				generateChildStates,
-				{ rebase, rebaseComposed, compose, invert, assertEqual, createEmpty },
+				{
+					rebase,
+					rebaseComposed,
+					compose,
+					invert,
+					assertEqual: assertTaggedEqual,
+					createEmpty: Change.empty,
+				},
 				{
 					numberOfEditsToRebase: 3,
 					numberOfEditsToRebaseOver: isStress ? 5 : 3,

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -506,7 +506,7 @@ describe("optionalField", () => {
 			it("a tree that remains untouched", () => {
 				const actual = Array.from(
 					optionalChangeHandler.relevantRemovedRoots(
-						makeAnonChange({ moves: [], childChanges: [] }),
+						makeAnonChange(Change.empty()),
 						noTreesDelegate,
 					),
 				);

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -37,7 +37,7 @@ import {
 import { changesetForChild, fooKey } from "../fieldKindTestUtils.js";
 // eslint-disable-next-line import/no-internal-modules
 import { rebaseRevisionMetadataFromInfo } from "../../../feature-libraries/modular-schema/modularChangeFamily.js";
-import { assertEqual } from "./optionalFieldUtils.js";
+import { Change, assertEqual } from "./optionalFieldUtils.js";
 import { testSnapshots } from "./optionalFieldSnapshots.test.js";
 import { testRebaserAxioms } from "./optionalChangeRebaser.test.js";
 import { testCodecs } from "./optionalFieldChangeCodecs.test.js";
@@ -95,12 +95,12 @@ const deltaFromChild2 = ({ change, revision }: TaggedChange<NodeChangeset>): Del
 };
 
 const tag = mintRevisionTag();
-const change1: TaggedChange<OptionalChangeset> = tagChange(
-	{
-		moves: [[{ localId: brand(41) }, "self", "nodeTargeting"]],
-		childChanges: [[{ localId: brand(41) }, nodeChange1]],
-		reservedDetachId: { localId: brand(1) },
-	},
+const change1 = tagChange(
+	Change.atOnce(
+		Change.reserve("self", brand(1)),
+		Change.move(brand(41), "self"),
+		Change.childAt(brand(41), nodeChange1),
+	),
 	tag,
 );
 
@@ -110,14 +110,7 @@ const change2: TaggedChange<OptionalChangeset> = tagChange(
 );
 
 const revertChange2: TaggedChange<OptionalChangeset> = tagChange(
-	{
-		moves: [
-			[{ localId: brand(2) }, "self", "nodeTargeting"],
-			["self", { localId: brand(42) }, "cellTargeting"],
-		],
-		childChanges: [],
-		build: [],
-	},
+	Change.atOnce(Change.clear("self", brand(42)), Change.move(brand(2), "self")),
 	mintRevisionTag(),
 );
 
@@ -147,12 +140,11 @@ describe("optionalField", () => {
 				fill: brand(42),
 				detach: brand(43),
 			});
-			const expected: OptionalChangeset = {
-				moves: [[{ localId: brand(42) }, "self", "nodeTargeting"]],
-				childChanges: [],
-				reservedDetachId: { localId: brand(43) },
-			};
-			assert.deepEqual(actual, expected);
+			const expected = Change.atOnce(
+				Change.reserve("self", brand(43)),
+				Change.move(brand(42), "self"),
+			);
+			assertEqual(actual, expected);
 		});
 	});
 
@@ -174,32 +166,28 @@ describe("optionalField", () => {
 				defaultRevisionMetadataFromChanges([change1, change2]),
 			);
 
-			const change1And2: OptionalChangeset = {
-				moves: [
-					[
-						{ localId: brand(41), revision: change1.revision },
-						{ localId: brand(2), revision: change2.revision },
-						"nodeTargeting",
-					],
-					[{ localId: brand(42), revision: change2.revision }, "self", "nodeTargeting"],
-				],
-				childChanges: [[{ localId: brand(41), revision: change1.revision }, nodeChange1]],
-				reservedDetachId: { localId: brand(1), revision: change1.revision },
-			};
+			const change1And2 = Change.atOnce(
+				Change.move(
+					{ localId: brand(41), revision: change1.revision },
+					{ localId: brand(2), revision: change2.revision },
+				),
+				Change.move({ localId: brand(42), revision: change2.revision }, "self"),
+				Change.reserve("self", { localId: brand(1), revision: change1.revision }),
+				Change.childAt({ localId: brand(41), revision: change1.revision }, nodeChange1),
+			);
 
-			assertEqual(makeAnonChange(composed), makeAnonChange(change1And2));
+			assertEqual(composed, change1And2);
 		});
 
 		it("can compose child changes", () => {
-			const expected: OptionalChangeset = {
-				moves: [
-					[{ localId: brand(41), revision: change1.revision }, "self", "nodeTargeting"],
-				],
-				childChanges: [
-					[{ localId: brand(41), revision: change1.revision }, arbitraryChildChange],
-				],
-				reservedDetachId: { localId: brand(1), revision: change1.revision },
-			};
+			const expected = Change.atOnce(
+				Change.move({ localId: brand(41), revision: change1.revision }, "self"),
+				Change.reserve("self", { localId: brand(1), revision: change1.revision }),
+				Change.childAt(
+					{ localId: brand(41), revision: change1.revision },
+					arbitraryChildChange,
+				),
+			);
 
 			assert.deepEqual(
 				optionalChangeRebaser.compose(
@@ -227,12 +215,10 @@ describe("optionalField", () => {
 				return nodeChange2;
 			};
 
-			const expected: OptionalChangeset = {
-				moves: [
-					["self", { localId: brand(41), revision: change1.revision }, "cellTargeting"],
-				],
-				childChanges: [["self", nodeChange2]],
-			};
+			const expected = Change.atOnce(
+				Change.clear("self", { localId: brand(41), revision: change1.revision }),
+				Change.child(nodeChange2),
+			);
 
 			assert.deepEqual(
 				optionalChangeRebaser.invert(
@@ -268,14 +254,8 @@ describe("optionalField", () => {
 			});
 
 			it("can rebase child change", () => {
-				const baseChange: OptionalChangeset = {
-					moves: [],
-					childChanges: [["self", nodeChange1]],
-				};
-				const changeToRebase: OptionalChangeset = {
-					moves: [],
-					childChanges: [["self", nodeChange2]],
-				};
+				const baseChange = Change.child(nodeChange1);
+				const changeToRebase = Change.child(nodeChange2);
 
 				const childRebaser = (
 					change: NodeChangeset | undefined,
@@ -286,10 +266,7 @@ describe("optionalField", () => {
 					return arbitraryChildChange;
 				};
 
-				const expected: OptionalChangeset = {
-					moves: [],
-					childChanges: [["self", arbitraryChildChange]],
-				};
+				const expected = Change.child(arbitraryChildChange);
 
 				assert.deepEqual(
 					optionalChangeRebaser.rebase(
@@ -356,21 +333,19 @@ describe("optionalField", () => {
 			});
 
 			it("can rebase child change (field change ↷ field change)", () => {
-				const baseChange: OptionalChangeset = {
-					moves: [["self", { localId: brand(0) }, "cellTargeting"]],
-					childChanges: [["self", nodeChange1]],
-				};
+				const baseChange = Change.atOnce(
+					Change.clear("self", brand(0)),
+					Change.child(nodeChange1),
+				);
 				const taggedBaseChange = tagChange(baseChange, mintRevisionTag());
 
 				// Note: this sort of change (has field changes as well as nested child changes)
 				// can only be created for production codepaths using transactions.
-				const changeToRebase: OptionalChangeset = {
-					moves: [
-						[{ localId: brand(41) }, "self", "nodeTargeting"],
-						["self", { localId: brand(1) }, "cellTargeting"],
-					],
-					childChanges: [["self", nodeChange2]],
-				};
+				const changeToRebase = Change.atOnce(
+					Change.clear("self", brand(1)),
+					Change.move(brand(41), "self"),
+					Change.child(nodeChange2),
+				);
 
 				const childRebaser = (
 					change: NodeChangeset | undefined,
@@ -381,16 +356,14 @@ describe("optionalField", () => {
 					return arbitraryChildChange;
 				};
 
-				const expected: OptionalChangeset = {
-					moves: [[{ localId: brand(41) }, "self", "nodeTargeting"]],
-					childChanges: [
-						[
-							{ localId: brand(0), revision: taggedBaseChange.revision },
-							arbitraryChildChange,
-						],
-					],
-					reservedDetachId: { localId: brand(1) },
-				};
+				const expected = Change.atOnce(
+					Change.reserve("self", brand(1)),
+					Change.move(brand(41), "self"),
+					Change.childAt(
+						{ localId: brand(0), revision: taggedBaseChange.revision },
+						arbitraryChildChange,
+					),
+				);
 
 				const actual = optionalChangeRebaser.rebase(
 					changeToRebase,
@@ -688,13 +661,7 @@ describe("optionalField", () => {
 			});
 		});
 		it("uses passed down revision", () => {
-			const restore = tagChange<OptionalChangeset>(
-				{
-					moves: [[{ localId: brand(42) }, "self", "nodeTargeting"]],
-					childChanges: [],
-				},
-				tag,
-			);
+			const restore = tagChange(Change.move(brand(42), "self"), tag);
 			const actual = Array.from(
 				optionalChangeHandler.relevantRemovedRoots(restore, failingDelegate),
 			);
@@ -704,35 +671,25 @@ describe("optionalField", () => {
 
 	describe("isEmpty", () => {
 		it("is true for an empty change", () => {
-			const change: OptionalChangeset = {
-				moves: [],
-				childChanges: [],
-			};
+			const change = Change.empty();
 			const actual = optionalChangeHandler.isEmpty(change);
 			assert.equal(actual, true);
 		});
 		it("is false for a change with moves", () => {
-			const change: OptionalChangeset = {
-				moves: [[{ localId: brand(42) }, "self", "nodeTargeting"]],
-				childChanges: [],
-			};
+			const change = Change.move(brand(42), "self");
 			const actual = optionalChangeHandler.isEmpty(change);
 			assert.equal(actual, false);
 		});
 		it("is false for a change with child changes", () => {
-			const change: OptionalChangeset = {
-				moves: [],
-				childChanges: [[{ localId: brand(0), revision: tag }, arbitraryChildChange]],
-			};
+			const change = Change.childAt(
+				{ localId: brand(0), revision: tag },
+				arbitraryChildChange,
+			);
 			const actual = optionalChangeHandler.isEmpty(change);
 			assert.equal(actual, false);
 		});
 		it("is false for a change with a reserved detach ID", () => {
-			const change: OptionalChangeset = {
-				moves: [],
-				childChanges: [],
-				reservedDetachId: { localId: brand(0) },
-			};
+			const change = Change.reserve("self", brand(0));
 			const actual = optionalChangeHandler.isEmpty(change);
 			assert.equal(actual, false);
 		});

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
@@ -17,6 +17,7 @@ import {
 import { IJsonCodec } from "../../../codec/index.js";
 import { ChangeEncodingContext, RevisionTagCodec } from "../../../core/index.js";
 import { changesetForChild } from "../fieldKindTestUtils.js";
+import { Change } from "./optionalFieldUtils.js";
 
 const nodeChange1 = changesetForChild("nodeChange1");
 
@@ -38,34 +39,25 @@ const childCodec1: IJsonCodec<
 	},
 };
 
-const change1: OptionalChangeset = {
-	moves: [[{ localId: brand(41) }, "self", "nodeTargeting"]],
-	childChanges: [],
-	reservedDetachId: { localId: brand(1) },
-};
+const change1 = Change.atOnce(Change.reserve("self", brand(1)), Change.move(brand(41), "self"));
 
 const change2: OptionalChangeset = optionalFieldEditor.set(false, {
 	fill: brand(42),
 	detach: brand(2),
 });
 
-const change2Inverted: OptionalChangeset = {
-	moves: [
-		[{ localId: brand(2) }, "self", "nodeTargeting"],
-		["self", { localId: brand(42) }, "cellTargeting"],
-	],
-	childChanges: [],
-};
+const change2Inverted = Change.atOnce(
+	Change.clear("self", brand(42)),
+	Change.move(brand(2), "self"),
+);
 
 const changeWithChildChange = optionalFieldEditor.buildChildChange(0, nodeChange1);
 
-const change1WithChildChange: OptionalChangeset = {
-	moves: [
-		[{ localId: brand(41) }, "self", "nodeTargeting"],
-		["self", { localId: brand(1) }, "cellTargeting"],
-	],
-	childChanges: [["self", nodeChange1]],
-};
+const change1WithChildChange = Change.atOnce(
+	Change.clear("self", brand(1)),
+	Change.move(brand(41), "self"),
+	Change.child(nodeChange1),
+);
 
 export function testCodecs() {
 	describe("Codecs", () => {

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldSnapshots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldSnapshots.test.ts
@@ -15,6 +15,7 @@ import { TestChange } from "../../testChange.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "../../snapshots/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { sessionId } from "../../snapshots/testTrees.js";
+import { Change } from "./optionalFieldUtils.js";
 
 function generateTestChangesets(
 	idCompressor: IIdCompressor,
@@ -25,48 +26,31 @@ function generateTestChangesets(
 	return [
 		{
 			name: "empty",
-			change: {
-				moves: [],
-				childChanges: [],
-			},
+			change: Change.empty(),
 		},
 		{
 			name: "change with moves",
-			change: {
-				moves: [
-					[{ revision, localId }, "self", "nodeTargeting"],
-					["self", { revision, localId }, "cellTargeting"],
-					[{ localId }, { localId }, "nodeTargeting"],
-				],
-				childChanges: [],
-			},
+			change: Change.atOnce(
+				Change.move({ revision, localId }, "self"),
+				Change.clear("self", { revision, localId }),
+				Change.move(localId, localId),
+			),
 		},
 		{
 			name: "with child change",
-			change: {
-				moves: [],
-				childChanges: [
-					[{ revision, localId }, childChange],
-					[{ localId }, childChange],
-					["self", childChange],
-				],
-			},
+			change: Change.atOnce(
+				Change.childAt({ revision, localId }, childChange),
+				Change.childAt(localId, childChange),
+				Change.child(childChange),
+			),
 		},
 		{
 			name: "with reserved detach on self",
-			change: {
-				moves: [],
-				childChanges: [],
-				reservedDetachId: "self",
-			},
+			change: Change.reserve("self", "self"),
 		},
 		{
 			name: "with reserved detach not on self",
-			change: {
-				moves: [],
-				childChanges: [],
-				reservedDetachId: { revision, localId },
-			},
+			change: Change.reserve("self", { revision, localId }),
 		},
 	];
 }

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldUtils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldUtils.ts
@@ -4,17 +4,82 @@
  */
 
 import { strict as assert } from "assert";
-import { TaggedChange } from "../../../core/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import { RegisterId, OptionalChangeset } from "../../../feature-libraries/optional-field/index.js";
+import { ChangesetLocalId, TaggedChange, makeAnonChange } from "../../../core/index.js";
+import {
+	RegisterId,
+	OptionalChangeset,
+	Move,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../../feature-libraries/optional-field/index.js";
+import { Mutable } from "../../../util/index.js";
+
+function asRegister(input: RegisterId | ChangesetLocalId): RegisterId {
+	if (typeof input === "string" || typeof input === "object") {
+		return input;
+	}
+	return { localId: input };
+}
+
+export const Change = {
+	empty: (): OptionalChangeset<never> => ({ moves: [], childChanges: [] }),
+	move: (
+		src: RegisterId | ChangesetLocalId,
+		dst: RegisterId | ChangesetLocalId,
+	): OptionalChangeset<never> => ({
+		moves: [[asRegister(src), asRegister(dst), "nodeTargeting"]],
+		childChanges: [],
+	}),
+	clear: (
+		src: RegisterId | ChangesetLocalId,
+		dst: RegisterId | ChangesetLocalId,
+	): OptionalChangeset<never> => ({
+		moves: [[asRegister(src), asRegister(dst), "cellTargeting"]],
+		childChanges: [],
+	}),
+	reserve: (
+		src: RegisterId | ChangesetLocalId,
+		dst: RegisterId | ChangesetLocalId,
+	): OptionalChangeset<never> => {
+		assert(src === "self", "Reserve cell only supports self as source");
+		return { moves: [], childChanges: [], reservedDetachId: asRegister(dst) };
+	},
+	childAt: <TChild>(
+		at: RegisterId | ChangesetLocalId,
+		change: TChild,
+	): OptionalChangeset<TChild> => ({
+		moves: [],
+		childChanges: [[asRegister(at), change]],
+	}),
+	child: <TChild>(change: TChild): OptionalChangeset<TChild> => Change.childAt("self", change),
+	atOnce: <TChild>(...changes: OptionalChangeset<TChild>[]): OptionalChangeset<TChild> => {
+		const moves: Move[] = [];
+		const childChanges: [RegisterId, TChild][] = [];
+		let reservedDetachId: RegisterId | undefined;
+		const changeset: Mutable<OptionalChangeset<TChild>> = { moves, childChanges };
+		for (const change of changes) {
+			// Note: this will stack overflow if there are too many moves.
+			moves.push(...change.moves);
+			// Note: this will stack overflow if there are too many child changes.
+			childChanges.push(...change.childChanges);
+			if (change.reservedDetachId !== undefined) {
+				assert(reservedDetachId === undefined, "Multiple reserved detach ids");
+				reservedDetachId = change.reservedDetachId;
+			}
+		}
+		if (reservedDetachId !== undefined) {
+			changeset.reservedDetachId = reservedDetachId;
+		}
+		return changeset;
+	},
+};
 
 // Optional changesets may be equivalent but not evaluate to be deep-equal, as some ordering is irrelevant.
-export function assertEqual(
+export function assertTaggedEqual(
 	a: TaggedChange<OptionalChangeset> | undefined,
 	b: TaggedChange<OptionalChangeset> | undefined,
 ): void {
 	if (a === undefined || b === undefined) {
-		assert.deepEqual(a, b);
+		assert.equal(a, b);
 		return;
 	}
 	const normalizeRegisterId = (registerId: RegisterId): string => {
@@ -38,4 +103,15 @@ export function assertEqual(
 	delete aCopy.change.reservedDetachId;
 	delete bCopy.change.reservedDetachId;
 	assert.deepEqual(aCopy, bCopy);
+}
+
+export function assertEqual(
+	a: OptionalChangeset | undefined,
+	b: OptionalChangeset | undefined,
+): void {
+	if (a === undefined || b === undefined) {
+		assert.equal(a, b);
+		return;
+	}
+	assertTaggedEqual(makeAnonChange(a), makeAnonChange(b));
 }


### PR DESCRIPTION
This paves the way for changes to the format, and makes the tests somewhat more readable.