### PR TITLE
deprecate inbound and outbound queues on IDeltaManager

### DIFF
--- a/.changeset/cuddly-meals-think.md
+++ b/.changeset/cuddly-meals-think.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/container-definitions": minor
+---
+
+## Overview
+
+-   Deprecated `IDeltaManager.inbound` as it was not very useful to the customer and there are pieces of functionality
+    that can break the core runtime if used improperly. For example, summarization and processing batches.
+-   Deprecated `IDeltaManager.outbound` as it was not very useful to the customer and there are pieces of functionality
+    that can break the core runtime if used improperly. For example, generation of batches and chunking.

--- a/.changeset/cuddly-meals-think.md
+++ b/.changeset/cuddly-meals-think.md
@@ -6,10 +6,17 @@
 
 -   Deprecated `IDeltaManager.inbound` as it was not very useful to the customer and there are pieces of functionality
     that can break the core runtime if used improperly. For example, summarization and processing batches. Do not use
-    the apis on this if possible. For alternatives to `IDeltaManager.inbound.on("op", ...)` are `IDeltaManager.on("op", ...)`
-    Data loss/corruption may occur in these scenarios in which `IDeltaManger.inbound.pause()` or `IDeltaManager.inbound.resume()`
-    get called.
+    the apis on this if possible. Data loss/corruption may occur in these scenarios in which
+    `IDeltaManger.inbound.pause()` or `IDeltaManager.inbound.resume()` get called.
 -   Deprecated `IDeltaManager.outbound` as it was not very useful to the customer and there are pieces of functionality
     that can break the core runtime if used improperly. For example, generation of batches and chunking. Op batching and
     chunking can be broken. Data loss/corruption may occur in these scenarios in which `IDeltaManger.inbound.pause()` or
     `IDeltaManager.inbound.resume()` get called.
+
+## Alternatives
+
+-   Alternatives to `IDeltaManager.inbound.on("op", ...)` are `IDeltaManager.on("op", ...)`
+-   Alternatives to calling `IDeltaManager.inbound.pause`, `IDeltaManager.outbound.pause` for `IContainer` disconnect
+    use `IContainer.disconnect`.
+-   Alternatives to calling `IDeltaManager.inbound.resume`, `IDeltaManager.outbound.resume` for `IContainer` reconnect
+    use `IContainer.connect`.

--- a/.changeset/cuddly-meals-think.md
+++ b/.changeset/cuddly-meals-think.md
@@ -5,6 +5,11 @@
 ## Overview
 
 -   Deprecated `IDeltaManager.inbound` as it was not very useful to the customer and there are pieces of functionality
-    that can break the core runtime if used improperly. For example, summarization and processing batches.
+    that can break the core runtime if used improperly. For example, summarization and processing batches. Do not use
+    the apis on this if possible. For alternatives to `IDeltaManager.inbound.on("op", ...)` are `IDeltaManager.on("op", ...)`
+    Data loss/corruption may occur in these scenarios in which `IDeltaManger.inbound.pause()` or `IDeltaManager.inbound.resume()`
+    get called.
 -   Deprecated `IDeltaManager.outbound` as it was not very useful to the customer and there are pieces of functionality
-    that can break the core runtime if used improperly. For example, generation of batches and chunking.
+    that can break the core runtime if used improperly. For example, generation of batches and chunking. Op batching and
+    chunking can be broken. Data loss/corruption may occur in these scenarios in which `IDeltaManger.inbound.pause()` or
+    `IDeltaManager.inbound.resume()` get called.

--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -228,6 +228,7 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
     readonly active: boolean;
     readonly clientDetails: IClientDetails;
     readonly hasCheckpointSequenceNumber: boolean;
+    // @deprecated
     readonly inbound: IDeltaQueue<T>;
     readonly inboundSignal: IDeltaQueue<ISignalMessage>;
     readonly initialSequenceNumber: number;
@@ -236,6 +237,7 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
     readonly lastSequenceNumber: number;
     readonly maxMessageSize: number;
     readonly minimumSequenceNumber: number;
+    // @deprecated
     readonly outbound: IDeltaQueue<U[]>;
     // (undocumented)
     readonly readOnlyInfo: ReadOnlyInfo;

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -149,11 +149,15 @@ export interface IDeltaManagerEvents extends IEvent {
 export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>, IDeltaSender {
 	/**
 	 * The queue of inbound delta messages
+	 * @deprecated Do not use, for internal use only. There are a lot of complications in core pieces of the runtime
+	 * may break if this is used directly. For example summarization and op processing.
 	 */
 	readonly inbound: IDeltaQueue<T>;
 
 	/**
 	 * The queue of outbound delta messages
+	 * @deprecated Do not use, for internal use only. There are a lot of complications in core pieces of the runtime
+	 * may break if this is used directly. For example op submission
 	 */
 	readonly outbound: IDeltaQueue<U[]>;
 


### PR DESCRIPTION
[AB#7062](https://dev.azure.com/fluidframework/internal/_workitems/edit/7062)

Deprecate inbound and outbound queues on IDeltaManager.

This is done for the Data Virtualization effort as pausing can cause some dangerous state inconsistencies in summarizer and just eventual consistency issues.
