### PR TITLE
Remove the 'experimental' notes from the grouped batching docs.

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/README.md
+++ b/packages/runtime/container-runtime/src/opLifecycle/README.md
@@ -73,7 +73,7 @@ See [below](#how-grouped-batching-works) for an example.
 
 ### Risks
 
-This option should **ONLY** be enabled after observing that 99.9% of your application sessions contains these changes (runtime version "2.0.0-internal.4.1.0" or later). Containers created with this option may not open in future versions of the framework.
+This option should **ONLY** be enabled after observing that 99.9% of your application sessions contains these changes (runtime version "2.0.0-internal.7.0.0" or later). Containers created with this option may not open in future versions of the framework.
 
 This option will change a couple of expectations around message structure and runtime layer expectations. Only enable this option after testing
 and verifying that the following expectation changes won't have any effects:

--- a/packages/runtime/container-runtime/src/opLifecycle/README.md
+++ b/packages/runtime/container-runtime/src/opLifecycle/README.md
@@ -65,8 +65,6 @@ Compression is relevant for both `FlushMode.TurnBased` and `FlushMode.Immediate`
 
 ## Grouped batching
 
-**Note: This feature is currently considered experimental and is not ready for production usage.**
-
 The `IContainerRuntimeOptions.enableGroupedBatching` option has been added to the container runtime layer and is **off by default**. This option will group all batch messages under a new "grouped" message to be sent to the service. Upon receiving this new "grouped" message, the batch messages will be extracted and given the sequence number of the parent "grouped" message.
 
 The purpose for enabling grouped batching on top of compression is that regular compression won't include the empty messages in the chunks. Thus, if we have batches with many messages (i.e. more than 4k), we will go over the batch size limit just on empty op envelopes alone.
@@ -75,7 +73,7 @@ See [below](#how-grouped-batching-works) for an example.
 
 ### Risks
 
-This option is experimental and should not be enabled yet in production. This option should **ONLY** be enabled after observing that 99.9% of your application sessions contains these changes (runtime version "2.0.0-internal.4.1.0" or later). Containers created with this option may not open in future versions of the framework.
+This option should **ONLY** be enabled after observing that 99.9% of your application sessions contains these changes (runtime version "2.0.0-internal.4.1.0" or later). Containers created with this option may not open in future versions of the framework.
 
 This option will change a couple of expectations around message structure and runtime layer expectations. Only enable this option after testing
 and verifying that the following expectation changes won't have any effects:
@@ -91,7 +89,7 @@ Therefore, when grouped batching is enabled, all batches with reentrant ops are 
 
 ### How to enable
 
-**This feature is disabled by default, currently considered experimental and not ready for production usage.**
+**This feature is disabled by default**
 
 If all prerequisites in the previous section are met, enabling the feature can be done via the `IContainerRuntimeOptions` as following:
 


### PR DESCRIPTION
## Description

This has been enabled for a while and running in Production for more than a month.