### PR TITLE
examples: enable app-insights-logger example test

### DIFF
--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -32,8 +32,8 @@
 		"start:tinylicious": "tinylicious",
 		"test": "npm run test:jest",
 		"test:coverage": "npm run test:jest:coverage",
-		"test:jest": "jest --detectOpenHandles",
-		"test:jest:coverage": "jest --detectOpenHandles --coverage --ci",
+		"test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --detectOpenHandles",
+		"test:jest:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --detectOpenHandles --coverage --ci",
 		"tsc": "tsc",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"

--- a/examples/client-logger/app-insights-logger/src/components/App.tsx
+++ b/examples/client-logger/app-insights-logger/src/components/App.tsx
@@ -95,7 +95,7 @@ export function App(): React.ReactElement {
 				setContainerInfo(data);
 			},
 			(error) => {
-				console.error(error);
+				throw error;
 			},
 		);
 	}, []);

--- a/examples/client-logger/app-insights-logger/src/test/components/App.test.tsx
+++ b/examples/client-logger/app-insights-logger/src/test/components/App.test.tsx
@@ -8,8 +8,7 @@ import React from "react";
 import { App } from "../../components";
 
 describe("App Insights Example App UI test", () => {
-	// TODO: update ESM configuration and re-enable test: ADO 7001
-	it.skip("App renders", async (): Promise<void> => {
+	it("App renders", async (): Promise<void> => {
 		render(<App />);
 		await screen.findByText("Loading Shared container...");
 	});


### PR DESCRIPTION
re-enable test which was previously disbaled due to issue with non explicit package imports of structuredClone.