### PR TITLE
fix(docs): Add Pool to linkcheck stage in build-docs

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -265,6 +265,7 @@ stages:
 - stage: link_check
   displayName: 'Website Link Check'
   dependsOn: [] # run in parallel
+  pool: Large
   jobs:
     - job: link_check
       displayName: 'Website Link Check'


### PR DESCRIPTION
The new ado pipeline stage for link checks has an error when it was pushed to prod, setting a pool should be a fix for this.
Error message; https://dev.azure.com/fluidframework/internal/_build/results?buildId=237246&view=logs&j=336c0fe9-169e-5c8f-4859-d4f7d822aab8