### PR TITLE
appendLocatorParam function in odspURLResolverForShareLink

### DIFF
--- a/.changeset/nine-chefs-burn.md
+++ b/.changeset/nine-chefs-burn.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/odsp-driver": minor
+---
+
+Added a new method to odspDriverUrlResolverForShareLink class
+
+Added a new method called appendLocatorParams to odspDriverUrlResolverForShareLink class which aperformas append of locator params to the base URL provided.

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
@@ -252,6 +252,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
     constructor(shareLinkFetcherProps?: ShareLinkFetcherProps | undefined, logger?: ITelemetryBaseLogger, appName?: string | undefined, getContext?: ((resolvedUrl: IOdspResolvedUrl, dataStorePath: string) => Promise<string | undefined>) | undefined);
     appendDataStorePath(requestUrl: URL, pathToAppend: string): string | undefined;
+    appendLocatorParams(baseUrl: string, resolvedUrl: IResolvedUrl, dataStorePath: string, packageInfoSource?: IContainerPackageInfo): Promise<string>;
     static createDocumentUrl(baseUrl: string, driverInfo: OdspFluidDataStoreLocator): string;
     getAbsoluteUrl(resolvedUrl: IResolvedUrl, dataStorePath: string, packageInfoSource?: IContainerPackageInfo): Promise<string>;
     resolve(request: IRequest): Promise<IOdspResolvedUrl>;

--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -129,6 +129,9 @@
 			"InterfaceDeclaration_IPrefetchSnapshotContents": {
 				"backCompat": false,
 				"forwardCompat": false
+			},
+			"ClassDeclaration_OdspDriverUrlResolverForShareLink": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -238,7 +238,9 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
 		const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
 
 		// If the user has passed an empty dataStorePath, then extract it from the resolved url.
-		const actualDataStorePath = dataStorePath || odspResolvedUrl.dataStorePath || "";
+		const actualDataStorePath = dataStorePath
+			? dataStorePath
+			: odspResolvedUrl.dataStorePath ?? "";
 
 		// back-compat: GitHub #9653
 		const isFluidPackage = (pkg: any) =>

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -214,13 +214,13 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
 
 		const shareLink = await this.getShareLinkPromise(odspResolvedUrl);
 
-		return this.appendLocatorParams(shareLink, resolvedUrl, dataStorePath, packageInfoSource)
+		return this.appendLocatorParams(shareLink, resolvedUrl, dataStorePath, packageInfoSource);
 	}
 
 	/**
-	 * Appends the store locator properties to the provided base URL. This function is useful for scenarios where an application 
+	 * Appends the store locator properties to the provided base URL. This function is useful for scenarios where an application
 	 * has a base URL (for example a sharing link) of the Fluid file, but does not have the locator information that would be used by Fluid
-	 * to load the file later. 
+	 * to load the file later.
 	 * @param baseUrl - The input URL on which the locator params will be appended.
 	 * @param resolvedUrl - odsp-driver's resolvedURL object.
 	 * @param dataStorePath - The relative data store path URL.
@@ -228,12 +228,17 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
 	 * will be extracted from the resolved url if present.
 	 * @returns The provided base URL appended with odsp-specific locator information
 	 */
-	public async appendLocatorParams(baseUrl: string, resolvedUrl: IResolvedUrl, dataStorePath: string, packageInfoSource?: IContainerPackageInfo) {
+	public async appendLocatorParams(
+		baseUrl: string,
+		resolvedUrl: IResolvedUrl,
+		dataStorePath: string,
+		packageInfoSource?: IContainerPackageInfo,
+	) {
 		const url = new URL(baseUrl);
 		const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
 
 		// If the user has passed an empty dataStorePath, then extract it from the resolved url.
-		const actualDataStorePath = dataStorePath || odspResolvedUrl.dataStorePath || '';
+		const actualDataStorePath = dataStorePath || odspResolvedUrl.dataStorePath || "";
 
 		// back-compat: GitHub #9653
 		const isFluidPackage = (pkg: any) =>

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -213,13 +213,27 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
 		const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
 
 		const shareLink = await this.getShareLinkPromise(odspResolvedUrl);
-		const shareLinkUrl = new URL(shareLink);
 
-		let actualDataStorePath = dataStorePath;
+		return this.appendLocatorParams(shareLink, resolvedUrl, dataStorePath, packageInfoSource)
+	}
+
+	/**
+	 * Appends the store locator properties to the provided base URL. This function is useful for scenarios where an application 
+	 * has a base URL (for example a sharing link) of the Fluid file, but does not have the locator information that would be used by Fluid
+	 * to load the file later. 
+	 * @param baseUrl - The input URL on which the locator params will be appended.
+	 * @param resolvedUrl - odsp-driver's resolvedURL object.
+	 * @param dataStorePath - The relative data store path URL.
+	 * For requesting a driver URL, this value should always be '/'. If an empty string is passed, then dataStorePath
+	 * will be extracted from the resolved url if present.
+	 * @returns The provided base URL appended with odsp-specific locator information
+	 */
+	public async appendLocatorParams(baseUrl: string, resolvedUrl: IResolvedUrl, dataStorePath: string, packageInfoSource?: IContainerPackageInfo) {
+		const url = new URL(baseUrl);
+		const odspResolvedUrl = getOdspResolvedUrl(resolvedUrl);
+
 		// If the user has passed an empty dataStorePath, then extract it from the resolved url.
-		if (dataStorePath === "" && odspResolvedUrl.dataStorePath !== undefined) {
-			actualDataStorePath = odspResolvedUrl.dataStorePath;
-		}
+		const actualDataStorePath = dataStorePath || odspResolvedUrl.dataStorePath || '';
 
 		// back-compat: GitHub #9653
 		const isFluidPackage = (pkg: any) =>
@@ -240,7 +254,7 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
 
 		const context = await this.getContext?.(odspResolvedUrl, actualDataStorePath);
 
-		storeLocatorInOdspUrl(shareLinkUrl, {
+		storeLocatorInOdspUrl(url, {
 			siteUrl: odspResolvedUrl.siteUrl,
 			driveId: odspResolvedUrl.driveId,
 			itemId: odspResolvedUrl.itemId,
@@ -251,7 +265,7 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
 			context,
 		});
 
-		return shareLinkUrl.href;
+		return url.href;
 	}
 
 	/**

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -13,7 +13,11 @@ import { OdspDriverUrlResolverForShareLink } from "../odspDriverUrlResolverForSh
 import { getHashedDocumentId } from "../odspPublicUtils";
 import { createOdspUrl } from "../createOdspUrl";
 import * as fileLinkImport from "../getFileLink";
-import { getLocatorFromOdspUrl, locatorQueryParamName, storeLocatorInOdspUrl } from "../odspFluidFileLink";
+import {
+	getLocatorFromOdspUrl,
+	locatorQueryParamName,
+	storeLocatorInOdspUrl,
+} from "../odspFluidFileLink";
 import { SharingLinkHeader } from "../contractsPublic";
 import { createOdspCreateContainerRequest } from "../createOdspCreateContainerRequest";
 
@@ -354,40 +358,74 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 	});
 
 	it("appendLocatorParams - Appends the correct nav param", async () => {
-		const testQueryParam = {name: "query1", value: "q1"};
+		const testQueryParam = { name: "query1", value: "q1" };
 		const customShareLink = `${sharelink}?${testQueryParam.name}=${testQueryParam.value}`;
 		const dataStorePath = "/testpath";
-		const appName = "AppName1"
+		const appName = "AppName1";
 		const contextVal = "Context1";
 		const fileVersion = "123";
 		const containerName = "containerA";
-		const urlResolverForShareLink = new OdspDriverUrlResolverForShareLink(undefined /*tokenFetcher*/, undefined /*logger*/, appName /*appName*/, (_resolvedUrl, _dataStorePath) => Promise.resolve(contextVal) /*context*/);
+		const urlResolverForShareLink = new OdspDriverUrlResolverForShareLink(
+			undefined /*tokenFetcher*/,
+			undefined /*logger*/,
+			appName /*appName*/,
+			(_resolvedUrl, _dataStorePath) => Promise.resolve(contextVal) /*context*/,
+		);
 		const resolvedUrl = {
 			siteUrl,
 			driveId,
 			itemId,
 			odspResolvedUrl: true,
 			fileVersion,
-			codeHint: { containerPackageName: containerName }
+			codeHint: { containerPackageName: containerName },
 		} as any as IOdspResolvedUrl;
-		
-		const resultUrl = new URL(await urlResolverForShareLink.appendLocatorParams(customShareLink, resolvedUrl, dataStorePath));
+
+		const resultUrl = new URL(
+			await urlResolverForShareLink.appendLocatorParams(
+				customShareLink,
+				resolvedUrl,
+				dataStorePath,
+			),
+		);
 
 		const testQueryParamValue = resultUrl.searchParams.get(testQueryParam.name);
-		assert.strictEqual(testQueryParamValue, testQueryParam.value , "original url's query params should be preserved");
+		assert.strictEqual(
+			testQueryParamValue,
+			testQueryParam.value,
+			"original url's query params should be preserved",
+		);
 
 		const locatorParamValue = resultUrl.searchParams.get(locatorQueryParamName);
 		assert(locatorParamValue != null, "locator parameter should exist is the resulting url");
-		
+
 		const decodedLocatorParam = getLocatorFromOdspUrl(resultUrl);
 		assert.strictEqual(decodedLocatorParam?.driveId, driveId, "driveId should be equal");
 		assert.strictEqual(decodedLocatorParam?.itemId, itemId, "itemId should be equal");
 		assert.strictEqual(decodedLocatorParam?.siteUrl, siteUrl, "siteUrl should be equal");
-		assert.strictEqual(decodedLocatorParam?.containerPackageName, containerName, "containerPackageName should be equal");
-		assert.strictEqual(decodedLocatorParam?.appName, appName, "appName should be as provided to the OdspDriverUrlResolverForShareLink constructor");
-		assert.strictEqual(decodedLocatorParam?.dataStorePath, dataStorePath, "dataStore path should be as provided to the appendLocatorParams");
-		assert.strictEqual(decodedLocatorParam?.fileVersion, fileVersion, "fileVersion path should be equal");
-		assert.strictEqual(decodedLocatorParam?.context, contextVal, "context value should be as provided to the OdspDriverUrlResolverForShareLink constructor");
+		assert.strictEqual(
+			decodedLocatorParam?.containerPackageName,
+			containerName,
+			"containerPackageName should be equal",
+		);
+		assert.strictEqual(
+			decodedLocatorParam?.appName,
+			appName,
+			"appName should be as provided to the OdspDriverUrlResolverForShareLink constructor",
+		);
+		assert.strictEqual(
+			decodedLocatorParam?.dataStorePath,
+			dataStorePath,
+			"dataStore path should be as provided to the appendLocatorParams",
+		);
+		assert.strictEqual(
+			decodedLocatorParam?.fileVersion,
+			fileVersion,
+			"fileVersion path should be equal",
+		);
+		assert.strictEqual(
+			decodedLocatorParam?.context,
+			contextVal,
+			"context value should be as provided to the OdspDriverUrlResolverForShareLink constructor",
+		);
 	});
-
 });

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -13,7 +13,7 @@ import { OdspDriverUrlResolverForShareLink } from "../odspDriverUrlResolverForSh
 import { getHashedDocumentId } from "../odspPublicUtils";
 import { createOdspUrl } from "../createOdspUrl";
 import * as fileLinkImport from "../getFileLink";
-import { getLocatorFromOdspUrl, storeLocatorInOdspUrl } from "../odspFluidFileLink";
+import { getLocatorFromOdspUrl, locatorQueryParamName, storeLocatorInOdspUrl } from "../odspFluidFileLink";
 import { SharingLinkHeader } from "../contractsPublic";
 import { createOdspCreateContainerRequest } from "../createOdspCreateContainerRequest";
 
@@ -352,4 +352,42 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 			"Nav param should not exist on sharelink",
 		);
 	});
+
+	it("appendLocatorParams - Appends the correct nav param", async () => {
+		const testQueryParam = {name: "query1", value: "q1"};
+		const customShareLink = `${sharelink}?${testQueryParam.name}=${testQueryParam.value}`;
+		const dataStorePath = "/testpath";
+		const appName = "AppName1"
+		const contextVal = "Context1";
+		const fileVersion = "123";
+		const containerName = "containerA";
+		const urlResolverForShareLink = new OdspDriverUrlResolverForShareLink(undefined /*tokenFetcher*/, undefined /*logger*/, appName /*appName*/, (_resolvedUrl, _dataStorePath) => Promise.resolve(contextVal) /*context*/);
+		const resolvedUrl = {
+			siteUrl,
+			driveId,
+			itemId,
+			odspResolvedUrl: true,
+			fileVersion,
+			codeHint: { containerPackageName: containerName }
+		} as any as IOdspResolvedUrl;
+		
+		const resultUrl = new URL(await urlResolverForShareLink.appendLocatorParams(customShareLink, resolvedUrl, dataStorePath));
+
+		const testQueryParamValue = resultUrl.searchParams.get(testQueryParam.name);
+		assert.strictEqual(testQueryParamValue, testQueryParam.value , "original url's query params should be preserved");
+
+		const locatorParamValue = resultUrl.searchParams.get(locatorQueryParamName);
+		assert(locatorParamValue != null, "locator parameter should exist is the resulting url");
+		
+		const decodedLocatorParam = getLocatorFromOdspUrl(resultUrl);
+		assert.strictEqual(decodedLocatorParam?.driveId, driveId, "driveId should be equal");
+		assert.strictEqual(decodedLocatorParam?.itemId, itemId, "itemId should be equal");
+		assert.strictEqual(decodedLocatorParam?.siteUrl, siteUrl, "siteUrl should be equal");
+		assert.strictEqual(decodedLocatorParam?.containerPackageName, containerName, "containerPackageName should be equal");
+		assert.strictEqual(decodedLocatorParam?.appName, appName, "appName should be as provided to the OdspDriverUrlResolverForShareLink constructor");
+		assert.strictEqual(decodedLocatorParam?.dataStorePath, dataStorePath, "dataStore path should be as provided to the appendLocatorParams");
+		assert.strictEqual(decodedLocatorParam?.fileVersion, fileVersion, "fileVersion path should be equal");
+		assert.strictEqual(decodedLocatorParam?.context, contextVal, "context value should be as provided to the OdspDriverUrlResolverForShareLink constructor");
+	});
+
 });

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -360,23 +360,23 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 	it("appendLocatorParams - Appends the correct nav param", async () => {
 		const testQueryParam = { name: "query1", value: "q1" };
 		const customShareLink = `${sharelink}?${testQueryParam.name}=${testQueryParam.value}`;
-		const dataStorePath = "/testpath";
+		const testDataStorePath = "/testpath";
 		const appName = "AppName1";
 		const contextVal = "Context1";
-		const fileVersion = "123";
+		const testFileVersion = "123";
 		const containerName = "containerA";
 		const urlResolverForShareLink = new OdspDriverUrlResolverForShareLink(
-			undefined /*tokenFetcher*/,
-			undefined /*logger*/,
-			appName /*appName*/,
-			(_resolvedUrl, _dataStorePath) => Promise.resolve(contextVal) /*context*/,
+			undefined /* tokenFetcher */,
+			undefined /* logger */,
+			appName /* appName */,
+			async (_resolvedUrl, _dataStorePath) => Promise.resolve(contextVal) /* context */,
 		);
 		const resolvedUrl = {
 			siteUrl,
 			driveId,
 			itemId,
 			odspResolvedUrl: true,
-			fileVersion,
+			testFileVersion,
 			codeHint: { containerPackageName: containerName },
 		} as any as IOdspResolvedUrl;
 
@@ -384,7 +384,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 			await urlResolverForShareLink.appendLocatorParams(
 				customShareLink,
 				resolvedUrl,
-				dataStorePath,
+				testDataStorePath,
 			),
 		);
 
@@ -414,12 +414,12 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 		);
 		assert.strictEqual(
 			decodedLocatorParam?.dataStorePath,
-			dataStorePath,
+			testDataStorePath,
 			"dataStore path should be as provided to the appendLocatorParams",
 		);
 		assert.strictEqual(
 			decodedLocatorParam?.fileVersion,
-			fileVersion,
+			testFileVersion,
 			"fileVersion path should be equal",
 		);
 		assert.strictEqual(

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -376,7 +376,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 			driveId,
 			itemId,
 			odspResolvedUrl: true,
-			testFileVersion,
+			fileVersion: testFileVersion,
 			codeHint: { containerPackageName: containerName },
 		} as any as IOdspResolvedUrl;
 
@@ -420,7 +420,7 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 		assert.strictEqual(
 			decodedLocatorParam?.fileVersion,
 			testFileVersion,
-			"fileVersion path should be equal",
+			"fileVersion should be equal",
 		);
 		assert.strictEqual(
 			decodedLocatorParam?.context,

--- a/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
+++ b/packages/drivers/odsp-driver/src/test/types/validateOdspDriverPrevious.generated.ts
@@ -515,6 +515,7 @@ declare function get_old_ClassDeclaration_OdspDriverUrlResolverForShareLink():
 declare function use_current_ClassDeclaration_OdspDriverUrlResolverForShareLink(
     use: TypeOnly<current.OdspDriverUrlResolverForShareLink>): void;
 use_current_ClassDeclaration_OdspDriverUrlResolverForShareLink(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_OdspDriverUrlResolverForShareLink());
 
 /*


### PR DESCRIPTION
- New utility function in `odspUrlResolverForShareLink` class of odsp-driver which can add locator parameter (`nav` param) to the base url provided as an input to the function.
- One of the immediate use-cases for this utility is that when the host application has a sharing link (say generated from using the [`SingleRT`](https://github.com/microsoft/FluidFramework/pull/11177) feature), the host application can create a re-loadable link to the fluid component by calling this utility. Up until now, the host apps had to rely on the `getAbsoluteUrl` method, which was not ideal as it made a network call to odsp to get the absolute url for the resource.
- Added tests as well to test the complete resolvedUrl information is preserved in the `nav` param, and to test that no other params are disturbed in the original url provided.