### PR TITLE
fix(ci): Add attempt number to name of Fluid Devtools Extension artifact

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -186,5 +186,5 @@ extends:
       displayName: Publish Artifact - Devtools Browser Extension
       inputs:
         targetPath: './packages/tools/devtools/devtools-browser-extension/dist/bundle/'
-        artifactName: 'devtools-extension-bundle'
+        artifactName: 'devtools-extension-bundle_attempt-$(System.JobAttempt)'
         publishLocation: 'pipeline'


### PR DESCRIPTION
## Description

Adds the attempt (ADO job (re)run) number to the name of the artifact that contains the Fluid Devtools Extension. So that when we have to re-run the job but it had succeeded in publishing the artifact on a previous run, it doesn't fail complaining that the artifact already exists.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
