### PR TITLE
refactor: Small experiment making an Ext type alpha

### DIFF
--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -21,7 +21,7 @@ import {
 	ISharedObjectEvents,
 	SharedObject,
 } from '@fluidframework/shared-object-base';
-import { ITelemetryProperties } from '@fluidframework/core-interfaces';
+import { ITelemetryProperties, type ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import {
 	ITelemetryLoggerExt,
 	createChildLogger,
@@ -311,7 +311,7 @@ export interface SequencedEditAppliedEventArguments {
 	/** The tree the edit was applied to. */
 	readonly tree: SharedTree;
 	/** The telemetry logger associated with sequenced edit application. */
-	readonly logger: ITelemetryLoggerExt;
+	readonly logger: ITelemetryBaseLogger;
 	/** The reconciliation path for the edit. See {@link ReconciliationPath} for details. */
 	readonly reconciliationPath: ReconciliationPath;
 	/** The outcome of the sequenced edit being applied. */
@@ -484,7 +484,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	/**
 	 * logger for SharedTree events.
 	 */
-	public readonly logger: ITelemetryLoggerExt;
+	public readonly logger: ITelemetryBaseLogger;
 	private readonly sequencedEditAppliedLogger: ITelemetryLoggerExt;
 
 	private readonly encoder_0_0_2: SharedTreeEncoder_0_0_2;

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -31,6 +31,7 @@ import {
 	Client,
 	IJSONSegment,
 } from "@fluidframework/merge-tree";
+import { createChildLogger, type ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
 import { MatrixOp } from "./ops";
 import { PermutationVector, reinsertSegmentIntoVector } from "./permutationvector";
 import { SparseArray2D } from "./sparsearray2d";
@@ -167,6 +168,12 @@ export class SharedMatrix<T = any>
 	private reentrantCount: number = 0;
 
 	/**
+	 * Wrapper over {@link @fluidframework/shared-object-base#SharedObjectCore.logger}, so we can leverage the extended
+	 * interface internally.
+	 */
+	private readonly loggerExt: ITelemetryLoggerExt;
+
+	/**
 	 * Constructor for the Shared Matrix
 	 * @param runtime - DataStore runtime.
 	 * @param id - id of the dds
@@ -181,6 +188,7 @@ export class SharedMatrix<T = any>
 		_isSetCellConflictResolutionPolicyFWW?: boolean,
 	) {
 		super(id, runtime, attributes, "fluid_matrix_");
+		this.loggerExt = createChildLogger({ logger: this.logger });
 
 		this.setCellLwwToFwwPolicySwitchOpSeqNumber =
 			_isSetCellConflictResolutionPolicyFWW === true ? 0 : -1;
@@ -739,7 +747,7 @@ export class SharedMatrix<T = any>
 				this.cellLastWriteTracker = SparseArray2D.load(cellLastWriteTracker);
 			}
 		} catch (error) {
-			this.logger.sendErrorEvent({ eventName: "MatrixLoadFailed" }, error);
+			this.loggerExt.sendErrorEvent({ eventName: "MatrixLoadFailed" }, error);
 		}
 	}
 

--- a/packages/dds/merge-tree/api-report/merge-tree.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.api.md
@@ -12,7 +12,7 @@ import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidSerializer } from '@fluidframework/shared-object-base';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
-import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
+import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
 // @internal @deprecated (undocumented)
@@ -96,7 +96,7 @@ export abstract class BaseSegment extends MergeNode implements ISegment {
 
 // @alpha @deprecated (undocumented)
 export class Client extends TypedEventEmitter<IClientEvents> {
-    constructor(specToSegment: (spec: IJSONSegment) => ISegment, logger: ITelemetryLoggerExt, options?: IMergeTreeOptions & PropertySet, getMinInFlightRefSeq?: () => number | undefined);
+    constructor(specToSegment: (spec: IJSONSegment) => ISegment, logger: ITelemetryBaseLogger, options?: IMergeTreeOptions & PropertySet, getMinInFlightRefSeq?: () => number | undefined);
     // (undocumented)
     addLongClientId(longClientId: string): void;
     annotateMarker(marker: Marker, props: PropertySet): IMergeTreeAnnotateMsg | undefined;
@@ -154,7 +154,7 @@ export class Client extends TypedEventEmitter<IClientEvents> {
     // (undocumented)
     localTransaction(groupOp: IMergeTreeGroupMsg): void;
     // (undocumented)
-    readonly logger: ITelemetryLoggerExt;
+    readonly logger: ITelemetryBaseLogger;
     // (undocumented)
     longClientId: string | undefined;
     obliterateRangeLocal(start: number, end: number): IMergeTreeObliterateMsg;

--- a/packages/dds/merge-tree/src/snapshotV1.ts
+++ b/packages/dds/merge-tree/src/snapshotV1.ts
@@ -4,7 +4,7 @@
  */
 
 import { ITelemetryLoggerExt, createChildLogger } from "@fluidframework/telemetry-utils";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { IFluidHandle, type ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { IFluidSerializer } from "@fluidframework/shared-object-base";
 import { assert } from "@fluidframework/core-utils";
 import { bufferToString } from "@fluid-internal/client-utils";
@@ -45,7 +45,7 @@ export class SnapshotV1 {
 
 	constructor(
 		public mergeTree: MergeTree,
-		logger: ITelemetryLoggerExt,
+		logger: ITelemetryBaseLogger,
 		private readonly getLongClientId: (id: number) => string,
 		public filename?: string,
 		public onCompletion?: () => void,

--- a/packages/dds/merge-tree/src/snapshotlegacy.ts
+++ b/packages/dds/merge-tree/src/snapshotlegacy.ts
@@ -7,7 +7,7 @@
 
 import { ITelemetryLoggerExt, createChildLogger } from "@fluidframework/telemetry-utils";
 import { assert } from "@fluidframework/core-utils";
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { IFluidHandle, type ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { IFluidSerializer } from "@fluidframework/shared-object-base";
 import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -57,7 +57,7 @@ export class SnapshotLegacy {
 
 	constructor(
 		public mergeTree: MergeTree,
-		logger: ITelemetryLoggerExt,
+		logger: ITelemetryBaseLogger,
 		public filename?: string,
 		public onCompletion?: () => void,
 	) {

--- a/packages/dds/ordered-collection/package.json
+++ b/packages/dds/ordered-collection/package.json
@@ -125,6 +125,7 @@
 		"@fluidframework/runtime-definitions": "workspace:~",
 		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/shared-object-base": "workspace:~",
+		"@fluidframework/telemetry-utils": "workspace:~",
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {

--- a/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
+++ b/packages/dds/ordered-collection/src/consensusOrderedCollection.ts
@@ -14,6 +14,7 @@ import {
 import { IFluidSerializer, SharedObject } from "@fluidframework/shared-object-base";
 import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
+import { createChildLogger, type ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
 import { v4 as uuid } from "uuid";
 import {
 	ConsensusCallback,
@@ -101,6 +102,8 @@ export class ConsensusOrderedCollection<T = any>
 	 */
 	private jobTracking: JobTrackingInfo<T> = new Map();
 
+	private readonly loggerExt: ITelemetryLoggerExt;
+
 	/**
 	 * Constructs a new consensus collection. If the object is non-local an id and service interfaces will
 	 * be provided
@@ -112,6 +115,7 @@ export class ConsensusOrderedCollection<T = any>
 		private readonly data: IOrderedCollection<T>,
 	) {
 		super(id, runtime, attributes, "fluid_consensusOrderedCollection_");
+		this.loggerExt = createChildLogger({ logger: this.runtime.logger });
 
 		// We can't simply call this.removeClient(this.runtime.clientId) in on runtime disconnected,
 		// because other clients may disconnect concurrently.
@@ -237,7 +241,7 @@ export class ConsensusOrderedCollection<T = any>
 				opName: "release",
 				acquireId,
 			}).catch((error) => {
-				this.runtime.logger.sendErrorEvent({ eventName: "ConsensusQueue_release" }, error);
+				this.loggerExt.sendErrorEvent({ eventName: "ConsensusQueue_release" }, error);
 			});
 		}
 	}

--- a/packages/dds/shared-object-base/api-report/shared-object-base.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.api.md
@@ -20,8 +20,8 @@ import { IFluidHandleContext } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
+import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
-import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
 
 // @internal
 export function createSingleBlobSummary(key: string, content: string | Uint8Array): ISummaryTreeWithStats;
@@ -117,7 +117,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     isAttached(): boolean;
     load(services: IChannelServices): Promise<void>;
     protected abstract loadCore(services: IChannelStorageService): Promise<void>;
-    protected readonly logger: ITelemetryLoggerExt;
+    protected readonly logger: ITelemetryBaseLogger;
     protected newAckBasedPromise<T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
     protected onConnect(): void;
     protected abstract onDisconnect(): any;

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
@@ -58,7 +58,7 @@ export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocat
 
 // @alpha
 export class EpochTracker implements IPersistedFileCache {
-    constructor(cache: IPersistedCache, fileEntry: IFileEntry, logger: ITelemetryLoggerExt, clientIsSummarizer?: boolean | undefined);
+    constructor(cache: IPersistedCache, fileEntry: IFileEntry, logger: ITelemetryBaseLogger, clientIsSummarizer?: boolean | undefined);
     // (undocumented)
     protected readonly cache: IPersistedCache;
     // (undocumented)
@@ -75,7 +75,7 @@ export class EpochTracker implements IPersistedFileCache {
     // (undocumented)
     get(entry: IEntry): Promise<any>;
     // (undocumented)
-    protected readonly logger: ITelemetryLoggerExt;
+    protected readonly logger: ITelemetryBaseLogger;
     // (undocumented)
     put(entry: IEntry, value: any): Promise<void>;
     // (undocumented)

--- a/packages/framework/agent-scheduler/src/scheduler.ts
+++ b/packages/framework/agent-scheduler/src/scheduler.ts
@@ -21,7 +21,12 @@ import {
 	NamedFluidDataStoreRegistryEntry,
 } from "@fluidframework/runtime-definitions";
 import { v4 as uuid } from "uuid";
-import { tagCodeArtifacts, UsageError } from "@fluidframework/telemetry-utils";
+import {
+	tagCodeArtifacts,
+	UsageError,
+	type ITelemetryLoggerExt,
+	createChildLogger,
+} from "@fluidframework/telemetry-utils";
 import { IAgentScheduler, IAgentSchedulerEvents } from "./agent";
 
 // Note: making sure this ID is unique and does not collide with storage provided clientID
@@ -115,12 +120,15 @@ export class AgentScheduler
 
 	private readonly _handle: IFluidHandle<this>;
 
+	private readonly logger: ITelemetryLoggerExt;
+
 	constructor(
 		private readonly runtime: IFluidDataStoreRuntime,
 		private readonly context: IFluidDataStoreContext,
 		private readonly consensusRegisterCollection: ConsensusRegisterCollection<string | null>,
 	) {
 		super();
+		this.logger = createChildLogger({ logger: this.runtime.logger });
 		// We are expecting this class to have many listeners, so we suppress noisy "MaxListenersExceededWarning" logging.
 		super.setMaxListeners(0);
 		this._handle = new FluidObjectHandle(this, "", this.runtime.objectsRoutingContext);
@@ -423,7 +431,7 @@ export class AgentScheduler
 	}
 
 	private sendErrorEvent(eventName: string, error: any, key?: string) {
-		this.runtime.logger.sendErrorEvent({ eventName, key }, error);
+		this.logger.sendErrorEvent({ eventName, key }, error);
 	}
 }
 

--- a/packages/loader/container-loader/api-report/container-loader.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.api.md
@@ -23,7 +23,6 @@ import { IQuorumSnapshot } from '@fluidframework/protocol-base';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
-import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
 
 // @public (undocumented)
@@ -84,7 +83,7 @@ export interface ILoaderServices {
     readonly options: ILoaderOptions;
     readonly protocolHandlerBuilder?: ProtocolHandlerBuilder;
     readonly scope: FluidObject;
-    readonly subLogger: ITelemetryLoggerExt;
+    readonly subLogger: ITelemetryBaseLogger;
     readonly urlResolver: IUrlResolver;
 }
 

--- a/packages/loader/container-loader/package.json
+++ b/packages/loader/container-loader/package.json
@@ -230,8 +230,14 @@
 	},
 	"typeValidation": {
 		"broken": {
+			"ClassDeclaration_Loader": {
+				"backCompat": false
+			},
 			"InterfaceDeclaration_IContainerExperimental": {
 				"forwardCompat": false
+			},
+			"InterfaceDeclaration_ILoaderServices": {
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -13,6 +13,7 @@ import {
 	FluidObject,
 	LogLevel,
 	IRequest,
+	type ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
 import {
 	AttachState,
@@ -211,7 +212,7 @@ export interface IContainerCreateProps {
 	/**
 	 * The logger downstream consumers should construct their loggers from
 	 */
-	readonly subLogger: ITelemetryLoggerExt;
+	readonly subLogger: ITelemetryBaseLogger;
 
 	/**
 	 * Blobs storage for detached containers.

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -5,7 +5,6 @@
 
 import { v4 as uuid } from "uuid";
 import {
-	ITelemetryLoggerExt,
 	mixinMonitoringContext,
 	MonitoringContext,
 	PerformanceEvent,
@@ -219,7 +218,7 @@ export interface ILoaderServices {
 	/**
 	 * The logger downstream consumers should construct their loggers from
 	 */
-	readonly subLogger: ITelemetryLoggerExt;
+	readonly subLogger: ITelemetryBaseLogger;
 
 	/**
 	 * Blobs storage for detached containers.

--- a/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
+++ b/packages/loader/container-loader/src/test/types/validateContainerLoaderPrevious.generated.ts
@@ -212,6 +212,7 @@ declare function get_current_InterfaceDeclaration_ILoaderServices():
 declare function use_old_InterfaceDeclaration_ILoaderServices(
     use: TypeOnly<old.ILoaderServices>): void;
 use_old_InterfaceDeclaration_ILoaderServices(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ILoaderServices());
 
 /*
@@ -284,6 +285,7 @@ declare function get_current_ClassDeclaration_Loader():
 declare function use_old_ClassDeclaration_Loader(
     use: TypeOnly<old.Loader>): void;
 use_old_ClassDeclaration_Loader(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_Loader());
 
 /*

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -47,6 +47,7 @@ import { ISummaryNack } from '@fluidframework/protocol-definitions';
 import { ISummaryStats } from '@fluidframework/runtime-definitions';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
+import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
 import { MessageType } from '@fluidframework/protocol-definitions';
@@ -97,7 +98,7 @@ export enum ContainerMessageType {
 
 // @alpha
 export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents & ISummarizerEvents> implements IContainerRuntime, IRuntime, ISummarizerRuntime, ISummarizerInternalsProvider, IProvideFluidHandleContext {
-    protected constructor(context: IContainerContext, registry: IFluidDataStoreRegistry, metadata: IContainerRuntimeMetadata | undefined, electedSummarizerData: ISerializedElection | undefined, chunks: [string, string[]][], dataStoreAliasMap: [string, string][], runtimeOptions: Readonly<Required<IContainerRuntimeOptions>>, containerScope: FluidObject, logger: ITelemetryLoggerExt, existing: boolean, blobManagerSnapshot: IBlobManagerLoadInfo, _storage: IDocumentStorageService, idCompressor: (IIdCompressor & IIdCompressorCore) | undefined, provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>, requestHandler?: ((request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>) | undefined, summaryConfiguration?: ISummaryConfiguration);
+    protected constructor(context: IContainerContext, registry: IFluidDataStoreRegistry, metadata: IContainerRuntimeMetadata | undefined, electedSummarizerData: ISerializedElection | undefined, chunks: [string, string[]][], dataStoreAliasMap: [string, string][], runtimeOptions: Readonly<Required<IContainerRuntimeOptions>>, containerScope: FluidObject, logger: ITelemetryBaseLogger, existing: boolean, blobManagerSnapshot: IBlobManagerLoadInfo, _storage: IDocumentStorageService, idCompressor: (IIdCompressor & IIdCompressorCore) | undefined, provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>, requestHandler?: ((request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>) | undefined, summaryConfiguration?: ISummaryConfiguration);
     // (undocumented)
     protected addContainerStateToSummary(summaryTree: ISummaryTreeWithStats, fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext): void;
     addedGCOutboundReference(srcHandle: {
@@ -114,7 +115,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     // (undocumented)
     readonly closeFn: (error?: ICriticalContainerError) => void;
     collectGarbage(options: {
-        logger?: ITelemetryLoggerExt;
+        logger?: ITelemetryBaseLogger;
         runSweep?: boolean;
         fullGC?: boolean;
     }, telemetryContext?: ITelemetryContext): Promise<IGCStats | undefined>;
@@ -179,7 +180,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
         provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>;
     }): Promise<ContainerRuntime>;
     // (undocumented)
-    readonly logger: ITelemetryLoggerExt;
+    readonly logger: ITelemetryBaseLogger;
     // (undocumented)
     notifyOpReplay(message: ISequencedDocumentMessage): Promise<void>;
     // (undocumented)
@@ -210,7 +211,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     summarize(options: {
         fullTree?: boolean;
         trackState?: boolean;
-        summaryLogger?: ITelemetryLoggerExt;
+        summaryLogger?: ITelemetryBaseLogger;
         runGC?: boolean;
         fullGC?: boolean;
         runSweep?: boolean;
@@ -600,7 +601,7 @@ export interface ISummarizerRuntime extends IConnectableRuntime {
     // (undocumented)
     disposeFn(): void;
     // (undocumented)
-    readonly logger: ITelemetryLoggerExt;
+    readonly logger: ITelemetryBaseLogger;
     // (undocumented)
     off(event: "op", listener: (op: ISequencedDocumentMessage, runtimeMessage?: boolean) => void): this;
     // (undocumented)

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -249,6 +249,9 @@
 			},
 			"InterfaceDeclaration_ISubmitSummaryOptions": {
 				"forwardCompat": false
+			},
+			"InterfaceDeclaration_ISummarizerRuntime": {
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -10,6 +10,7 @@ import {
 	IResponse,
 	IFluidHandle,
 	ITelemetryProperties,
+	type ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
 import { IAudience, IDeltaManager, AttachState } from "@fluidframework/container-definitions";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
@@ -55,7 +56,6 @@ import {
 	DataProcessingError,
 	extractSafePropertiesFromMessage,
 	generateStack,
-	ITelemetryLoggerExt,
 	LoggingError,
 	MonitoringContext,
 	tagCodeArtifacts,
@@ -159,7 +159,7 @@ export abstract class FluidDataStoreContext
 		return this._containerRuntime.clientDetails;
 	}
 
-	public get logger(): ITelemetryLoggerExt {
+	public get logger(): ITelemetryBaseLogger {
 		return this._containerRuntime.logger;
 	}
 

--- a/packages/runtime/container-runtime/src/dataStores.ts
+++ b/packages/runtime/container-runtime/src/dataStores.ts
@@ -43,6 +43,7 @@ import {
 	unpackChildNodesUsedRoutes,
 } from "@fluidframework/runtime-utils";
 import {
+	createChildLogger,
 	createChildMonitoringContext,
 	DataCorruptionError,
 	DataProcessingError,
@@ -417,7 +418,13 @@ export class DataStores implements IDisposable {
 			isRootDataStore: isRoot,
 			loadingGroupId,
 			channelToDataStoreFn: (channel: IFluidDataStoreChannel, channelId: string) =>
-				channelToDataStore(channel, channelId, this.runtime, this, this.runtime.logger),
+				channelToDataStore(
+					channel,
+					channelId,
+					this.runtime,
+					this,
+					createChildLogger({ logger: this.runtime.logger }),
+				),
 		});
 		this.contexts.addUnbound(context);
 		return context;

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { IEvent, IEventProvider, ITelemetryProperties } from "@fluidframework/core-interfaces";
+import {
+	IEvent,
+	IEventProvider,
+	ITelemetryProperties,
+	type ITelemetryBaseLogger,
+} from "@fluidframework/core-interfaces";
 import { ITelemetryLoggerExt, ITelemetryLoggerPropertyBag } from "@fluidframework/telemetry-utils";
 import { ContainerWarning, IDeltaManager } from "@fluidframework/container-definitions";
 import {
@@ -85,7 +90,7 @@ export interface IConnectableRuntime {
  * @alpha
  */
 export interface ISummarizerRuntime extends IConnectableRuntime {
-	readonly logger: ITelemetryLoggerExt;
+	readonly logger: ITelemetryBaseLogger;
 	/** clientId of parent (non-summarizing) container that owns summarizer container */
 	readonly summarizerClientId: string | undefined;
 	readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -1059,7 +1059,7 @@ describe("Data Store Context Tests", () => {
 				id,
 				containerRuntime,
 				dataStores,
-				containerRuntime.logger,
+				createChildLogger({ logger: containerRuntime.logger }),
 			);
 		let containerRuntime: ContainerRuntime;
 		let dataStores: DataStores;
@@ -1114,7 +1114,7 @@ describe("Data Store Context Tests", () => {
 			containerRuntime = {
 				IFluidDataStoreRegistry: registry,
 				on: (event, listener) => {},
-				logger: createChildLogger(),
+				logger: createChildLogger() as ITelemetryBaseLogger,
 				clientDetails: {},
 			} as ContainerRuntime;
 

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -4,7 +4,7 @@
  */
 import { strict as assert } from "assert";
 
-import { FluidObject } from "@fluidframework/core-interfaces";
+import { FluidObject, type ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions";
 import {
 	IFluidDataStoreContext,
@@ -110,7 +110,7 @@ describe("Data Store Creation Tests", () => {
 			containerRuntime = {
 				IFluidDataStoreRegistry: globalRegistry,
 				on: (event, listener) => {},
-				logger: createChildLogger(),
+				logger: createChildLogger() as ITelemetryBaseLogger,
 				clientDetails: {},
 			} as ContainerRuntime;
 			const summarizerNode = createRootSummarizerNodeWithGC(

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -1222,6 +1222,7 @@ declare function get_current_InterfaceDeclaration_ISummarizerRuntime():
 declare function use_old_InterfaceDeclaration_ISummarizerRuntime(
     use: TypeOnly<old.ISummarizerRuntime>): void;
 use_old_InterfaceDeclaration_ISummarizerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ISummarizerRuntime());
 
 /*

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -22,8 +22,8 @@ import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
 import { IQuorumClients } from '@fluidframework/protocol-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
+import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
-import { ITelemetryLogger } from '@fluidframework/core-interfaces';
 
 // @public (undocumented)
 export interface IChannel extends IFluidLoadable {
@@ -112,7 +112,7 @@ export interface IFluidDataStoreRuntime extends IEventProvider<IFluidDataStoreRu
     // (undocumented)
     readonly IFluidHandleContext: IFluidHandleContext;
     // (undocumented)
-    readonly logger: ITelemetryLogger;
+    readonly logger: ITelemetryBaseLogger;
     // (undocumented)
     readonly objectsRoutingContext: IFluidHandleContext;
     // (undocumented)

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -93,6 +93,7 @@
 	"typeValidation": {
 		"broken": {
 			"InterfaceDeclaration_IFluidDataStoreRuntime": {
+				"backCompat": false,
 				"forwardCompat": false
 			}
 		}

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -6,11 +6,11 @@
 import {
 	IEvent,
 	IEventProvider,
-	ITelemetryLogger,
 	IDisposable,
 	IFluidHandleContext,
 	IFluidHandle,
 	FluidObject,
+	type ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
 import { IAudience, IDeltaManager, AttachState } from "@fluidframework/container-definitions";
 import {
@@ -57,7 +57,7 @@ export interface IFluidDataStoreRuntime
 
 	readonly connected: boolean;
 
-	readonly logger: ITelemetryLogger;
+	readonly logger: ITelemetryBaseLogger;
 
 	/**
 	 * Indicates the attachment state of the data store to a host service.

--- a/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
@@ -212,6 +212,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreRuntime():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreRuntime(
     use: TypeOnly<old.IFluidDataStoreRuntime>): void;
 use_old_InterfaceDeclaration_IFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/datastore/api-report/datastore.api.md
+++ b/packages/runtime/datastore/api-report/datastore.api.md
@@ -26,8 +26,8 @@ import { IRequest } from '@fluidframework/core-interfaces';
 import { IResponse } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
+import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
-import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 import { VisibilityState } from '@fluidframework/runtime-definitions';
 
@@ -91,7 +91,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     // (undocumented)
     get isAttached(): boolean;
     // (undocumented)
-    get logger(): ITelemetryLoggerExt;
+    get logger(): ITelemetryBaseLogger;
     makeVisibleAndAttachGraph(): void;
     // (undocumented)
     get objectsRoutingContext(): this;

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -174,6 +174,7 @@
 	"typeValidation": {
 		"broken": {
 			"ClassDeclaration_FluidDataStoreRuntime": {
+				"backCompat": false,
 				"forwardCompat": false
 			}
 		}

--- a/packages/runtime/datastore/src/test/localChannelContext.spec.ts
+++ b/packages/runtime/datastore/src/test/localChannelContext.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "@fluidframework/test-runtime-utils";
 import { ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { IChannel } from "@fluidframework/datastore-definitions";
+import { createChildLogger } from "@fluidframework/telemetry-utils";
 import { FluidDataStoreRuntime, ISharedObjectRegistry } from "../dataStoreRuntime";
 import { LocalChannelContext, RehydratedLocalChannelContext } from "../localChannelContext";
 
@@ -45,7 +46,7 @@ describe("LocalChannelContext Tests", () => {
 				dataStoreRuntime,
 				dataStoreContext,
 				dataStoreContext.storage,
-				dataStoreContext.logger,
+				createChildLogger({ logger: dataStoreContext.logger }),
 				() => {},
 				(s: string) => {},
 				(s) => {},
@@ -67,7 +68,7 @@ describe("LocalChannelContext Tests", () => {
 				dataStoreRuntime,
 				dataStoreContext,
 				dataStoreContext.storage,
-				dataStoreContext.logger,
+				createChildLogger({ logger: dataStoreContext.logger }),
 				(content, localOpMetadata) => {},
 				(s: string) => {},
 				(s, o) => {},

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
@@ -68,6 +68,7 @@ declare function get_current_ClassDeclaration_FluidDataStoreRuntime():
 declare function use_old_ClassDeclaration_FluidDataStoreRuntime(
     use: TypeOnly<old.FluidDataStoreRuntime>): void;
 use_old_ClassDeclaration_FluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_FluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/id-compressor/api-report/id-compressor.api.md
+++ b/packages/runtime/id-compressor/api-report/id-compressor.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
-import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
 
 // @internal
 export function assertIsStableId(stableId: string): StableId;
@@ -20,10 +19,10 @@ export function createIdCompressor(sessionId: SessionId, logger?: ITelemetryBase
 export function createSessionId(): SessionId;
 
 // @alpha
-export function deserializeIdCompressor(serialized: SerializedIdCompressorWithOngoingSession, logger?: ITelemetryLoggerExt): IIdCompressor & IIdCompressorCore;
+export function deserializeIdCompressor(serialized: SerializedIdCompressorWithOngoingSession, logger?: ITelemetryBaseLogger): IIdCompressor & IIdCompressorCore;
 
 // @alpha
-export function deserializeIdCompressor(serialized: SerializedIdCompressorWithNoSession, newSessionId: SessionId, logger?: ITelemetryLoggerExt): IIdCompressor & IIdCompressorCore;
+export function deserializeIdCompressor(serialized: SerializedIdCompressorWithNoSession, newSessionId: SessionId, logger?: ITelemetryBaseLogger): IIdCompressor & IIdCompressorCore;
 
 // @internal
 export function generateStableId(): StableId;

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -104,10 +104,13 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 
 	// #endregion
 
+	private readonly logger?: ITelemetryLoggerExt;
+
 	public constructor(
 		localSessionIdOrDeserialized: SessionId | Sessions,
-		private readonly logger?: ITelemetryLoggerExt,
+		logger?: ITelemetryBaseLogger,
 	) {
+		this.logger = createChildLogger({ logger });
 		if (typeof localSessionIdOrDeserialized === "string") {
 			this.localSessionId = localSessionIdOrDeserialized;
 			this.localSession = this.sessions.getOrCreate(localSessionIdOrDeserialized);
@@ -565,19 +568,19 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 
 	public static deserialize(
 		serialized: SerializedIdCompressorWithOngoingSession,
-		logger?: ITelemetryLoggerExt,
+		logger?: ITelemetryBaseLogger,
 	): IdCompressor;
 	public static deserialize(
 		serialized: SerializedIdCompressorWithNoSession,
 		newSessionId: SessionId,
-		logger?: ITelemetryLoggerExt,
+		logger?: ITelemetryBaseLogger,
 	): IdCompressor;
 	public static deserialize(
 		serialized: SerializedIdCompressor,
-		loggerOrSessionId?: ITelemetryLoggerExt | SessionId,
+		loggerOrSessionId?: ITelemetryBaseLogger | SessionId,
 	): IdCompressor {
 		let sessionId: SessionId | undefined;
-		let logger: ITelemetryLoggerExt | undefined;
+		let logger: ITelemetryBaseLogger | undefined;
 		if (typeof loggerOrSessionId === "string") {
 			sessionId = loggerOrSessionId;
 		} else {
@@ -604,7 +607,7 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 	static deserialize2_0(
 		index: Index,
 		sessionId?: SessionId,
-		logger?: ITelemetryLoggerExt,
+		logger?: ITelemetryBaseLogger,
 	): IdCompressor {
 		const hasLocalState = readBoolean(index);
 		const sessionCount = readNumber(index);
@@ -730,7 +733,7 @@ export function createIdCompressor(
  */
 export function deserializeIdCompressor(
 	serialized: SerializedIdCompressorWithOngoingSession,
-	logger?: ITelemetryLoggerExt,
+	logger?: ITelemetryBaseLogger,
 ): IIdCompressor & IIdCompressorCore;
 /**
  * Deserializes the supplied state into an ID compressor.
@@ -739,12 +742,12 @@ export function deserializeIdCompressor(
 export function deserializeIdCompressor(
 	serialized: SerializedIdCompressorWithNoSession,
 	newSessionId: SessionId,
-	logger?: ITelemetryLoggerExt,
+	logger?: ITelemetryBaseLogger,
 ): IIdCompressor & IIdCompressorCore;
 export function deserializeIdCompressor(
 	serialized: SerializedIdCompressor | SerializedIdCompressorWithNoSession,
-	sessionIdOrLogger?: SessionId | ITelemetryLoggerExt,
-	logger?: ITelemetryLoggerExt | undefined,
+	sessionIdOrLogger?: SessionId | ITelemetryBaseLogger,
+	logger?: ITelemetryBaseLogger | undefined,
 ): IIdCompressor & IIdCompressorCore {
 	if (typeof sessionIdOrLogger === "string") {
 		return IdCompressor.deserialize(

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -47,7 +47,7 @@ import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ISnapshotTree } from '@fluidframework/protocol-definitions';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
-import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
+import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { ITokenResponse } from '@fluidframework/routerlicious-driver';
 import { ITree } from '@fluidframework/protocol-definitions';
@@ -313,7 +313,7 @@ export class MockEmptyDeltaConnection implements IDeltaConnection {
 
 // @alpha (undocumented)
 export class MockFluidDataStoreContext implements IFluidDataStoreContext {
-    constructor(id?: string, existing?: boolean, logger?: ITelemetryLoggerExt, interactive?: boolean);
+    constructor(id?: string, existing?: boolean, logger?: ITelemetryBaseLogger, interactive?: boolean);
     attachState: AttachState;
     // (undocumented)
     baseSnapshot: ISnapshotTree | undefined;
@@ -354,7 +354,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // (undocumented)
     isLocalDataStore: boolean;
     // (undocumented)
-    readonly logger: ITelemetryLoggerExt;
+    readonly logger: ITelemetryBaseLogger;
     // (undocumented)
     makeLocallyVisible(): void;
     // (undocumented)
@@ -387,7 +387,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
         clientId?: string;
         entryPoint?: IFluidHandle<FluidObject>;
         id?: string;
-        logger?: ITelemetryLoggerExt;
+        logger?: ITelemetryBaseLogger;
         idCompressor?: IIdCompressor & IIdCompressorCore;
     });
     // (undocumented)
@@ -460,7 +460,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     get local(): boolean;
     set local(local: boolean);
     // (undocumented)
-    readonly logger: ITelemetryLoggerExt;
+    readonly logger: ITelemetryBaseLogger;
     // (undocumented)
     makeVisibleAndAttachGraph(): void;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -141,6 +141,7 @@
 				"forwardCompat": false
 			},
 			"ClassDeclaration_MockFluidDataStoreRuntime": {
+				"backCompat": false,
 				"forwardCompat": false
 			},
 			"ClassDeclaration_MockContainerRuntime": {

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -7,13 +7,14 @@ import { EventEmitter } from "events";
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { IIdCompressor, IIdCompressorCore, IdCreationRange } from "@fluidframework/id-compressor";
 import { assert } from "@fluidframework/core-utils";
-import { ITelemetryLoggerExt, createChildLogger } from "@fluidframework/telemetry-utils";
+import { createChildLogger } from "@fluidframework/telemetry-utils";
 import {
 	FluidObject,
 	IFluidHandle,
 	IFluidHandleContext,
 	IRequest,
 	IResponse,
+	type ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
 import { IAudience, ILoader, AttachState } from "@fluidframework/container-definitions";
 
@@ -681,7 +682,7 @@ export class MockFluidDataStoreRuntime
 		clientId?: string;
 		entryPoint?: IFluidHandle<FluidObject>;
 		id?: string;
-		logger?: ITelemetryLoggerExt;
+		logger?: ITelemetryBaseLogger;
 		idCompressor?: IIdCompressor & IIdCompressorCore;
 	}) {
 		super();
@@ -719,7 +720,7 @@ export class MockFluidDataStoreRuntime
 	public readonly connected = true;
 	public deltaManager = new MockDeltaManager();
 	public readonly loader: ILoader = undefined as any;
-	public readonly logger: ITelemetryLoggerExt;
+	public readonly logger: ITelemetryBaseLogger;
 	public quorum = new MockQuorumClients();
 	public containerRuntime?: MockContainerRuntime;
 	public idCompressor?: IIdCompressor & IIdCompressorCore;

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -3,8 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryLoggerExt, createChildLogger } from "@fluidframework/telemetry-utils";
-import { IFluidHandle, IFluidHandleContext, FluidObject } from "@fluidframework/core-interfaces";
+import { createChildLogger } from "@fluidframework/telemetry-utils";
+import {
+	IFluidHandle,
+	IFluidHandleContext,
+	FluidObject,
+	type ITelemetryBaseLogger,
+} from "@fluidframework/core-interfaces";
 import { IAudience, IDeltaManager, AttachState } from "@fluidframework/container-definitions";
 
 import {
@@ -60,7 +65,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 	constructor(
 		public readonly id: string = uuid(),
 		public readonly existing: boolean = false,
-		public readonly logger: ITelemetryLoggerExt = createChildLogger({
+		public readonly logger: ITelemetryBaseLogger = createChildLogger({
 			namespace: "fluid:MockFluidDataStoreContext",
 		}),
 		private readonly interactive: boolean = true,

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -362,6 +362,7 @@ declare function get_current_ClassDeclaration_MockFluidDataStoreRuntime():
 declare function use_old_ClassDeclaration_MockFluidDataStoreRuntime(
     use: TypeOnly<old.MockFluidDataStoreRuntime>): void;
 use_old_ClassDeclaration_MockFluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_MockFluidDataStoreRuntime());
 
 /*

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -222,7 +222,7 @@ export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
     eventName: string;
 }
 
-// @public
+// @alpha
 export interface ITelemetryLoggerExt extends ITelemetryBaseLogger {
     sendErrorEvent(event: ITelemetryErrorEventExt, error?: unknown): void;
     sendPerformanceEvent(event: ITelemetryPerformanceEventExt, error?: unknown, logLevel?: typeof LogLevel.verbose | typeof LogLevel.default): void;
@@ -348,7 +348,7 @@ export function safeRaiseEvent(emitter: EventEmitter, logger: ITelemetryLoggerEx
 
 // @internal
 export class SampledTelemetryHelper implements IDisposable {
-    constructor(eventBase: ITelemetryGenericEvent, logger: ITelemetryLoggerExt, sampleThreshold: number, includeAggregateMetrics?: boolean, perBucketProperties?: Map<string, ITelemetryProperties>);
+    constructor(eventBase: ITelemetryGenericEvent, logger: ITelemetryBaseLogger, sampleThreshold: number, includeAggregateMetrics?: boolean, perBucketProperties?: Map<string, ITelemetryProperties>);
     // (undocumented)
     dispose(error?: Error | undefined): void;
     // (undocumented)

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -34,7 +34,7 @@ import { TypedEventEmitter } from '@fluid-internal/client-utils';
 // @internal (undocumented)
 export const connectedEventName = "connected";
 
-// @alpha
+// @internal
 export function createChildLogger(props?: {
     logger?: ITelemetryBaseLogger;
     namespace?: string;
@@ -222,7 +222,7 @@ export interface ITelemetryGenericEventExt extends ITelemetryPropertiesExt {
     eventName: string;
 }
 
-// @alpha
+// @internal
 export interface ITelemetryLoggerExt extends ITelemetryBaseLogger {
     sendErrorEvent(event: ITelemetryErrorEventExt, error?: unknown): void;
     sendPerformanceEvent(event: ITelemetryPerformanceEventExt, error?: unknown, logLevel?: typeof LogLevel.verbose | typeof LogLevel.default): void;

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -375,7 +375,7 @@ export class TaggedLoggerAdapter implements ITelemetryBaseLogger {
  *
  * @param props - logger is the base logger the child will log to after it's processing, namespace will be prefixed to all event names, properties are default properties that will be applied events.
  *
- * @alpha
+ * @internal
  */
 export function createChildLogger(props?: {
 	logger?: ITelemetryBaseLogger;

--- a/packages/utils/telemetry-utils/src/sampledTelemetryHelper.ts
+++ b/packages/utils/telemetry-utils/src/sampledTelemetryHelper.ts
@@ -8,9 +8,11 @@ import {
 	ITelemetryPerformanceEvent,
 	ITelemetryProperties,
 	IDisposable,
+	type ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
 import { performance } from "@fluid-internal/client-utils";
 import { ITelemetryLoggerExt } from "./telemetryTypes";
+import { createChildLogger } from "./logger";
 
 /**
  * @privateRemarks
@@ -61,6 +63,7 @@ export class SampledTelemetryHelper implements IDisposable {
 	disposed: boolean = false;
 
 	private readonly measurementsMap = new Map<string, Measurements>();
+	private readonly logger: ITelemetryLoggerExt;
 
 	/**
 	 * @param eventBase -
@@ -82,11 +85,13 @@ export class SampledTelemetryHelper implements IDisposable {
 	 */
 	public constructor(
 		private readonly eventBase: ITelemetryGenericEvent,
-		private readonly logger: ITelemetryLoggerExt,
+		logger: ITelemetryBaseLogger,
 		private readonly sampleThreshold: number,
 		private readonly includeAggregateMetrics: boolean = false,
 		private readonly perBucketProperties = new Map<string, ITelemetryProperties>(),
-	) {}
+	) {
+		this.logger = createChildLogger({ logger });
+	}
 
 	/**
 	 * Executes the specified code and keeps track of execution time statistics.

--- a/packages/utils/telemetry-utils/src/telemetryTypes.ts
+++ b/packages/utils/telemetry-utils/src/telemetryTypes.ts
@@ -104,7 +104,7 @@ export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt
  * @remarks
  * This interface is meant to be used internally within the Fluid Framework,
  * and `ITelemetryBaseLogger` should be used when loggers are passed between layers.
- * @alpha
+ * @internal
  */
 export interface ITelemetryLoggerExt extends ITelemetryBaseLogger {
 	/**

--- a/packages/utils/telemetry-utils/src/telemetryTypes.ts
+++ b/packages/utils/telemetry-utils/src/telemetryTypes.ts
@@ -104,7 +104,7 @@ export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt
  * @remarks
  * This interface is meant to be used internally within the Fluid Framework,
  * and `ITelemetryBaseLogger` should be used when loggers are passed between layers.
- * @public
+ * @alpha
  */
 export interface ITelemetryLoggerExt extends ITelemetryBaseLogger {
 	/**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6613,6 +6613,7 @@ importers:
       '@fluidframework/runtime-definitions': workspace:~
       '@fluidframework/runtime-utils': workspace:~
       '@fluidframework/shared-object-base': workspace:~
+      '@fluidframework/telemetry-utils': workspace:~
       '@fluidframework/test-runtime-utils': workspace:~
       '@microsoft/api-extractor': ^7.39.1
       '@types/mocha': ^9.1.1
@@ -6641,6 +6642,7 @@ importers:
       '@fluidframework/runtime-definitions': link:../../runtime/runtime-definitions
       '@fluidframework/runtime-utils': link:../../runtime/runtime-utils
       '@fluidframework/shared-object-base': link:../shared-object-base
+      '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
       uuid: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3


### PR DESCRIPTION
## Description

Small-scale experiment making one of our `Ext` telemetry types `alpha` (final intention is to make it `internal`, started with `alpha` thinking it would be less complicated to achieve and it's a good stepping stone).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Looking for any and all feedback. Are the patterns to adjust reasonable? Do we expect the technically breaking changes to have a big impact on consumers?