### PR TITLE
fix(tree): Fix incremental build

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -162,6 +162,10 @@
 				],
 				"script": false
 			},
+			"build:test": [
+				"...",
+				"@fluidframework/id-compressor#build:test"
+			],
 			"check:release-tags": [
 				"build:esnext"
 			],


### PR DESCRIPTION
## Description

#19630 added test-only imports from tree->id-compressor. This fixes tree's incremental build by making that dependency explicit from fluid-build's perspective.