### PR TITLE
Remove unused dependency of @fluid-tools/webpack-fluid-loader from property-inspector-table

### DIFF
--- a/experimental/PropertyDDS/packages/property-inspector-table/.storybook/main.js
+++ b/experimental/PropertyDDS/packages/property-inspector-table/.storybook/main.js
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-const customWebpack = require("../webpack.config");
+const customWebpack = require("../webpack.config.cjs");
 const webpackRules = customWebpack({ production: true }).module.rules;
 
 module.exports = {

--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -64,7 +64,6 @@
 		"@fluid-experimental/property-dds": "workspace:~",
 		"@fluid-experimental/property-properties": "workspace:~",
 		"@fluid-experimental/property-proxy": "workspace:~",
-		"@fluid-tools/webpack-fluid-loader": "workspace:~",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.33.0",
 		"@storybook/addon-actions": "^6.4.22",

--- a/experimental/PropertyDDS/packages/property-inspector-table/webpack.config.cjs
+++ b/experimental/PropertyDDS/packages/property-inspector-table/webpack.config.cjs
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const { merge } = require("webpack-merge");
 const webpack = require("webpack");
@@ -82,6 +81,5 @@ module.exports = (env) => {
 			},
 			mode: isProduction ? "production" : "development",
 		},
-		fluidRoute.devServerConfig(__dirname, env),
 	);
 };

--- a/experimental/PropertyDDS/packages/property-inspector-table/webpack.config.cjs
+++ b/experimental/PropertyDDS/packages/property-inspector-table/webpack.config.cjs
@@ -10,76 +10,74 @@ const webpack = require("webpack");
 module.exports = (env) => {
 	const isProduction = env && env.production;
 
-	return merge(
-		{
-			entry: {
-				main: "./src/index.ts",
-			},
-			resolve: {
-				extensions: [".ts", ".tsx", ".js", ".cjs", ".mjs"],
-			},
-			module: {
-				rules: [
-					{
-						test: /\.m?js/,
-						resolve: {
-							// Required until all transitive dependencies are fully ESM.
-							// https://webpack.js.org/configuration/module/#resolvefullyspecified
-							fullySpecified: false,
-						},
-					},
-					{
-						test: /\.tsx?$/,
-						loader: "ts-loader",
-					},
-					{
-						test: /\.s?css$/,
-						use: ["style-loader", "css-loader", "sass-loader"],
-					},
-					{
-						test: /\.svg$/,
-						use: [
-							{
-								loader: "svg-sprite-loader",
-							},
-							{
-								loader: "svgo-loader",
-								options: require("./svgo.plugins.js"),
-							},
-						],
-					},
-				],
-			},
-			output: {
-				filename: "[name].bundle.js",
-				path: path.resolve(__dirname, "dist"),
-				library: "[name]",
-				// https://github.com/webpack/webpack/issues/5767
-				// https://github.com/webpack/webpack/issues/7939
-				devtoolNamespace: "fluid-experimental/inspector-table",
-				// This is required to run webpacked code in webworker/node
-				// https://github.com/webpack/webpack/issues/6522
-				globalObject: "(typeof self !== 'undefined' ? self : this)",
-				libraryTarget: "umd",
-			},
-			devServer: {
-				headers: {
-					"Access-Control-Allow-Origin": "*",
-				},
-			},
-			plugins: [
-				new webpack.ProvidePlugin({
-					process: "process/browser",
-				}),
-			],
-			// This impacts which files are watched by the dev server (and likely by webpack if watch is true).
-			// This should be configurable under devServer.static.watch
-			// (see https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md) but that does not seem to work.
-			// The CLI options for disabling watching don't seem to work either, so this may be a symptom of using webpack4 with the newer webpack-cli and webpack-dev-server.
-			watchOptions: {
-				ignored: "**/node_modules/**",
-			},
-			mode: isProduction ? "production" : "development",
+	return merge({
+		entry: {
+			main: "./src/index.ts",
 		},
-	);
+		resolve: {
+			extensions: [".ts", ".tsx", ".js", ".cjs", ".mjs"],
+		},
+		module: {
+			rules: [
+				{
+					test: /\.m?js/,
+					resolve: {
+						// Required until all transitive dependencies are fully ESM.
+						// https://webpack.js.org/configuration/module/#resolvefullyspecified
+						fullySpecified: false,
+					},
+				},
+				{
+					test: /\.tsx?$/,
+					loader: "ts-loader",
+				},
+				{
+					test: /\.s?css$/,
+					use: ["style-loader", "css-loader", "sass-loader"],
+				},
+				{
+					test: /\.svg$/,
+					use: [
+						{
+							loader: "svg-sprite-loader",
+						},
+						{
+							loader: "svgo-loader",
+							options: require("./svgo.plugins.js"),
+						},
+					],
+				},
+			],
+		},
+		output: {
+			filename: "[name].bundle.js",
+			path: path.resolve(__dirname, "dist"),
+			library: "[name]",
+			// https://github.com/webpack/webpack/issues/5767
+			// https://github.com/webpack/webpack/issues/7939
+			devtoolNamespace: "fluid-experimental/inspector-table",
+			// This is required to run webpacked code in webworker/node
+			// https://github.com/webpack/webpack/issues/6522
+			globalObject: "(typeof self !== 'undefined' ? self : this)",
+			libraryTarget: "umd",
+		},
+		devServer: {
+			headers: {
+				"Access-Control-Allow-Origin": "*",
+			},
+		},
+		plugins: [
+			new webpack.ProvidePlugin({
+				process: "process/browser",
+			}),
+		],
+		// This impacts which files are watched by the dev server (and likely by webpack if watch is true).
+		// This should be configurable under devServer.static.watch
+		// (see https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md) but that does not seem to work.
+		// The CLI options for disabling watching don't seem to work either, so this may be a symptom of using webpack4 with the newer webpack-cli and webpack-dev-server.
+		watchOptions: {
+			ignored: "**/node_modules/**",
+		},
+		mode: isProduction ? "production" : "development",
+	});
 };

--- a/experimental/PropertyDDS/packages/property-inspector-table/webpack.config.cjs
+++ b/experimental/PropertyDDS/packages/property-inspector-table/webpack.config.cjs
@@ -80,6 +80,7 @@ module.exports = (env) => {
 			watchOptions: {
 				ignored: "**/node_modules/**",
 			},
+			mode: isProduction ? "production" : "development",
 		},
 		fluidRoute.devServerConfig(__dirname, env),
 	);

--- a/experimental/PropertyDDS/packages/property-inspector-table/webpack.svgs.cjs
+++ b/experimental/PropertyDDS/packages/property-inspector-table/webpack.svgs.cjs
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-const fluidRoute = require("@fluid-tools/webpack-fluid-loader");
 const path = require("path");
 const { merge } = require("webpack-merge");
 const webpack = require("webpack");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4912,7 +4912,6 @@ importers:
       '@fluid-experimental/property-dds': workspace:~
       '@fluid-experimental/property-properties': workspace:~
       '@fluid-experimental/property-proxy': workspace:~
-      '@fluid-tools/webpack-fluid-loader': workspace:~
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.33.0
       '@hig/fonts': ^1.0.2
@@ -4997,7 +4996,6 @@ importers:
       '@fluid-experimental/property-dds': link:../property-dds
       '@fluid-experimental/property-properties': link:../property-properties
       '@fluid-experimental/property-proxy': link:../property-proxy
-      '@fluid-tools/webpack-fluid-loader': link:../../../../packages/tools/webpack-fluid-loader
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.33.0_h467wi3sy6j67ifywrn7x7qf4m
       '@storybook/addon-actions': 6.5.16_sfoxds7t5ydpegc3knd667wn6m


### PR DESCRIPTION
The property-inspector-table doesn't really use webpack-fluid-loader, so cleaning up the references and removing the dependency.

While attempting to verify it didn't have some weird interaction with storybook, I noticed it's pretty broken in main right now for a few reasons.  This PR fixes a couple of the obvious errors/warnings, but even after these it still doesn't webpack correctly.

My primary goal is to remove the dependency though, so leaving those remaining errors as-is.

[AB#7215](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7215)