### PR TITLE
Fuzz Minimization Improvements

### DIFF
--- a/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
+++ b/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
@@ -73,6 +73,7 @@ export interface DDSFuzzHarnessEvents {
     (event: "clientCreate", listener: (client: Client<IChannelFactory>) => void): any;
     (event: "testStart", listener: (initialState: DDSFuzzTestState<IChannelFactory>) => void): any;
     (event: "testEnd", listener: (finalState: DDSFuzzTestState<IChannelFactory>) => void): any;
+    (event: "operationStart", listener: (operation: BaseOperation) => void): any;
 }
 
 // @internal


### PR DESCRIPTION
This change includes a couple of improvement to minimization that result in more accurate minimized tests. Specifically, in some scenarios if it possible for an error to be hit in multiple ways, and sometimes those errors are uninteresting as they don't capture the reason for the original failure or represent an invalid scenario.  This change adds two improvements that help prevent minimization from going down bad paths.

1. Allow reducers to throw errors if preconditions are not met, and have the minimizer treat them as invalid minimizations.
2. Ensure the same generated op type is failing in the minimized test, not just that the exceptions match. This helps in cases where there are multiple paths to an error, but they can be cause by significantly different reasons.