### PR TITLE
Enable groupId in local server base changes

### DIFF
--- a/packages/drivers/local-driver/src/localDocumentStorageService.ts
+++ b/packages/drivers/local-driver/src/localDocumentStorageService.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { stringToBuffer, Uint8ArrayToString } from "@fluid-internal/client-utils";
+import { bufferToString, stringToBuffer, Uint8ArrayToString } from "@fluid-internal/client-utils";
 import {
 	IDocumentStorageService,
 	IDocumentStorageServicePolicies,
@@ -73,7 +73,21 @@ export class LocalDocumentStorageService implements IDocumentStorageService {
 
 		const rawTree = await this.manager.getTree(requestVersion.treeId);
 		const tree = buildGitTreeHierarchy(rawTree, this.blobsShaCache, true);
+		await this.populateGroupId(tree);
 		return tree;
+	}
+
+	private async populateGroupId(tree: ISnapshotTreeEx): Promise<void> {
+		const groupIdBlobId = tree.blobs[".groupId"];
+		const groupIdBuffer = await this.readBlob(groupIdBlobId);
+		const groupId = bufferToString(groupIdBuffer, "utf8");
+		tree.groupId = groupId;
+		delete tree.blobs[".groupId"];
+		await Promise.all(
+			Object.values(tree.trees).map(async (childTree) => {
+				await this.populateGroupId(childTree);
+			}),
+		);
 	}
 
 	public async readBlob(blobId: string): Promise<ArrayBufferLike> {

--- a/packages/drivers/local-driver/src/localDocumentStorageService.ts
+++ b/packages/drivers/local-driver/src/localDocumentStorageService.ts
@@ -79,10 +79,12 @@ export class LocalDocumentStorageService implements IDocumentStorageService {
 
 	private async populateGroupId(tree: ISnapshotTreeEx): Promise<void> {
 		const groupIdBlobId = tree.blobs[".groupId"];
-		const groupIdBuffer = await this.readBlob(groupIdBlobId);
-		const groupId = bufferToString(groupIdBuffer, "utf8");
-		tree.groupId = groupId;
-		delete tree.blobs[".groupId"];
+		if (groupIdBlobId !== undefined) {
+			const groupIdBuffer = await this.readBlob(groupIdBlobId);
+			const groupId = bufferToString(groupIdBuffer, "utf8");
+			tree.groupId = groupId;
+			delete tree.blobs[".groupId"];
+		}
 		await Promise.all(
 			Object.values(tree.trees).map(async (childTree) => {
 				await this.populateGroupId(childTree);

--- a/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
+++ b/server/routerlicious/packages/services-client/src/summaryTreeUploadManager.ts
@@ -13,6 +13,7 @@ import {
 import { ICreateTreeEntry } from "@fluidframework/gitresources";
 import { getGitMode, getGitType } from "@fluidframework/protocol-base";
 import {
+	FileMode,
 	ISnapshotTreeEx,
 	ISummaryTree,
 	SummaryObject,
@@ -62,6 +63,17 @@ export class SummaryTreeUploadManager implements ISummaryUploadManager {
 				return treeEntry;
 			}),
 		);
+
+		if (summaryTree.groupId !== undefined) {
+			const groupId = summaryTree.groupId;
+			const groupIdBlobHandle = await this.writeSummaryBlob(groupId);
+			entries.push({
+				mode: FileMode.File,
+				path: encodeURIComponent(".groupId"),
+				sha: groupIdBlobHandle,
+				type: "blob",
+			});
+		}
 
 		const treeHandle = await this.manager.createGitTree({ tree: entries });
 		return treeHandle.sha;


### PR DESCRIPTION
[AB#7196](https://dev.azure.com/fluidframework/internal/_workitems/edit/7196)

## Description
Enable local-driver and local-server to round trip `loadableGroupId`. The gist is that we create a blob and store `groupId` in the upload manager. (maybe we need to do it also on attach). On load we take that blob and convert it to `groupId` on the snapshot. Not sure what the best way to do this as this is more a POC currently than a final implementation.

## GroupId
The `loadableGroupId` effort is intended to make it so data stores can be virtualized. This is part of the data virtualization effort.

## Alternatives
Looked into enabling `WholeSummaryUpload`, which is not supported by `TestHistorian` currently. Thus, we would need to build it out.