### PR TITLE
fix(id-compressor): Increase specificity of npmignore

### DIFF
--- a/packages/runtime/id-compressor/.npmignore
+++ b/packages/runtime/id-compressor/.npmignore
@@ -1,6 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
-src/test
-dist/test
+src/test/**/*.spec.ts
+dist/test/**/*.spec.js
 **/_api-extractor-temp/**


### PR DESCRIPTION
## Description

#19630 adds a test dep on these test utils. Since we have some pipelines (ex: perf) which run tree tests from an installed package, the test utilities need to be published. This adjusts .npmignore to enable that (but still excludes id-compressor tests)
