### PR TITLE
test(matrix): add repo for set x row/col removal rebase bug

### DIFF
--- a/packages/dds/matrix/src/test/matrix.reconnect.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.reconnect.spec.ts
@@ -13,6 +13,60 @@ import { SharedMatrix } from "../matrix";
 import { extract } from "./utils";
 
 describe("SharedMatrix reconnect", () => {
+	// https://dev.azure.com/fluidframework/internal/_workitems/edit/7217
+	it.skip("discards setCell in removed column", () => {
+		const factory = SharedMatrix.getFactory();
+		const containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
+		const dataRuntime1 = new MockFluidDataStoreRuntime();
+		containerRuntimeFactory.createContainerRuntime(dataRuntime1);
+		const dataRuntime2 = new MockFluidDataStoreRuntime();
+		const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataRuntime2);
+
+		const matrix1 = factory.create(dataRuntime1, "A") as SharedMatrix<number>;
+		matrix1.connect({
+			deltaConnection: dataRuntime1.createDeltaConnection(),
+			objectStorage: new MockStorage(),
+		});
+
+		const matrix2 = factory.create(dataRuntime2, "B") as SharedMatrix<number>;
+		matrix2.connect({
+			deltaConnection: dataRuntime2.createDeltaConnection(),
+			objectStorage: new MockStorage(),
+		});
+
+		// Create a 1x2 matrix
+		matrix1.insertCols(0, 2);
+		matrix1.insertRows(0, 1);
+		containerRuntimeFactory.processAllMessages();
+
+		// Concurrently:
+		//
+		//   A) Remove the first column (of matrix1)
+		//   B) Set a cell in the first column (of matrix2)
+		//
+		// We do this while matrix2 is disconnected so can force a resubmission that rebases
+		// over the removal of the set cell.
+		containerRuntime2.connected = false;
+		matrix1.removeCols(0, 1);
+		matrix2.setCell(0, 0, 42);
+		containerRuntimeFactory.processAllMessages();
+
+		// Because matrix2 is disconnected, our local states will have temporarily diverged.
+		assert.deepEqual(extract(matrix1), [[undefined]]);
+		assert.deepEqual(extract(matrix2), [[42, undefined]]);
+
+		// Reconnect matrix2 and process all messages.  This will cause the 'setCell(0,0)' to
+		// be rebased over the removal of the first column.
+		containerRuntime2.connected = true;
+		containerRuntimeFactory.processAllMessages();
+
+		// Because the cell the user intended to set has been removed, the remaining cell should
+		// continue to be empty (undefined).
+		const expected = [[undefined]];
+		assert.deepEqual(extract(matrix1), expected);
+		assert.deepEqual(extract(matrix2), expected);
+	});
+
 	// This test demonstrates the need to use the `currentSeq` on the collab window at resubmission time
 	// rather than the refSeq of the original op. Since that information is only used in local op metadata
 	// and only used for resubmitting ops, disconnecting twice is necessary to reproduce the issue.


### PR DESCRIPTION
Adds a (disabled) test case for the recently discovered 'setCell' x 'row/col removal' reconneciton bug.