### PR TITLE
Simplify the Session Log in updateExistingSession

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -193,7 +193,9 @@ async function updateExistingSession(
 			},
 		);
 		Lumberjack.info(
-			`The original document in updateExistingSession: ${JSON.stringify(result)}`,
+			`The original document session in updateExistingSession: ${JSON.stringify(
+				result?.value?.session,
+			)}`,
 			lumberjackProperties,
 		);
 		// There is no document with isSessionAlive as false. It means this session has been discovered by


### PR DESCRIPTION
This fix is used to simplify the log by reducing its length to only include information from each session with a smaller string length.