### PR TITLE
fix(ci): Do not fail build if test results folder doesn't exist

### DIFF
--- a/tools/pipelines/templates/include-process-test-results.yml
+++ b/tools/pipelines/templates/include-process-test-results.yml
@@ -26,11 +26,19 @@ steps:
       condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
 
   # Console Log Failed Tests
-  - ${{ each testResultDir in parameters.testResultDirs }}:    
+  # The task above this one doesn't cause a build failure if the testResultDir doesn't exist, it just logs a warning.
+  # This one should behave the same way in that case.
+  - ${{ each testResultDir in parameters.testResultDirs }}:
     - task: Bash@3
       displayName: Log Failed Tests in ${{ testResultDir }}
       inputs:
         targetType: inline
-        script: node $(Build.SourcesDirectory)/scripts/report-parser.js ${{ testResultDir }}
+        script: |
+          TEST_RESULTS_PATH=$(pwd)/${{ testResultDir }}
+          if [ -d $TEST_RESULTS_PATH ]; then
+            node $(Build.SourcesDirectory)/scripts/report-parser.js ${{ testResultDir }} ;
+          else
+            echo "##vso[task.logissue type=warning]'$TEST_RESULTS_PATH' doesn't exist." ;
+          fi
         workingDirectory: ${{ parameters.buildDirectory }}
       condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))


### PR DESCRIPTION
## Description

Update task so that it doesn't cause the build to fail if the test results directory doesn't exist. This allows packages that have a test script but don't produce output to build successfully in CI. Also note that the ADO-native task right above the one being updated uses the same path and already just logs a warning if it can't find it, instead of causing the whole build to fail. [Example](https://dev.azure.com/fluidframework/public/_build/results?buildId=237767&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=8ee6b0c5-48a4-51bb-d1f6-a7ad1e52f3d2).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
