### PR TITLE
ci: Try alternative way of uploading tinylicious logs

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -361,15 +361,14 @@ extends:
                     # Source is wherever the tinylicious log ends up in, after executing tests above.
                     # CopyFiles@2 failed with OOM for some reason so doing it "by hand".
                     - task: Bash@3
-                      displayName: Copy tinylicious.log to artifact staging directory
+                      displayName: Upload tinylicious log to pipeline run logs
                       condition: succeededOrFailed()
                       continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
                       inputs:
                         targetType: inline
                         workingDirectory: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests'
                         script: |
-                          mkdir -p $(Build.ArtifactStagingDirectory)/tinyliciousLog
-                          cp tinylicious.log $(Build.ArtifactStagingDirectory)/tinyliciousLog/tinylicious.log
+                          ##vso[task.uploadfile]tinylicious.log
 
                     # At this point we want to publish the tinylicious.log artifact, but as part of 1ES migration
                     # that is now part of templateContext.outputs below.
@@ -549,16 +548,6 @@ extends:
             templateContext:
               outputParentDirectory: $(Build.ArtifactStagingDirectory)
               outputs:
-                - ${{ if and(ne(convertToJson(parameters.taskTest), '[]'), contains(convertToJson(parameters.taskTest), 'tinylicious')) }}:
-                    - output: pipelineArtifact
-                      displayName: Publish Artifact - Tinylicious Log
-                      condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
-                      targetPath: '$(Build.ArtifactStagingDirectory)/tinyliciousLog/tinylicious.log'
-                      artifactName: tinyliciousLog_attempt-$(System.JobAttempt)
-                      sbomEnabled: false
-                      publishLocation: pipeline
-                      continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
-
                 - ${{ if ne(parameters.taskPack, false) }}:
                     - output: pipelineArtifact
                       displayName: Publish Artifact - pack

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -358,7 +358,7 @@ extends:
 
                   - ${{ if contains(convertToJson(parameters.taskTest), 'tinylicious') }}:
                     - task: Bash@3
-                      displayName: Upload tinylicious log to pipeline run logs
+                      displayName: Upload tinylicious log
                       condition: succeededOrFailed()
                       continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
                       inputs:
@@ -368,7 +368,6 @@ extends:
                           if [ -f $PATH_TO_TINYLICIOUS_LOG ] ; then
                             echo "Found file at '$PATH_TO_TINYLICIOUS_LOG'. Uploading.";
                             echo "##vso[task.uploadfile]$PATH_TO_TINYLICIOUS_LOG";
-                            echo "##vso[build.uploadLog]$PATH_TO_TINYLICIOUS_LOG";
                           else
                             echo "##vso[task.logissue type=warning]Failed to upload tinylicious log file ('$PATH_TO_TINYLICIOUS_LOG' not found).";
                           fi

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -367,7 +367,7 @@ extends:
                       inputs:
                         targetType: inline
                         script: |
-                          PATH_TO_TINYLICIOUS_LOG=${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log;
+                          PATH_TO_TINYLICIOUS_LOG=$(Build.SourcesDirectory)/packages/test/test-end-to-end-tests/tinylicious.log;
                           if [ -f $PATH_TO_TINYLICIOUS_LOG ] ; then
                             echo "Found file at '$PATH_TO_TINYLICIOUS_LOG'. Uploading.";
                             echo "##vso[task.uploadfile]$PATH_TO_TINYLICIOUS_LOG";

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -368,7 +368,7 @@ extends:
                         targetType: inline
                         script: |
                           PATH_TO_TINYLICIOUS_LOG=${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log;
-                          if [ -f $PATH_TO_TINYLICIOUS_LOG]; then
+                          if [ -f $PATH_TO_TINYLICIOUS_LOG ] ; then
                             echo "Found file at '$PATH_TO_TINYLICIOUS_LOG'. Uploading.";
                             echo "##vso[task.uploadfile]$PATH_TO_TINYLICIOUS_LOG";
                           else

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -366,9 +366,14 @@ extends:
                       continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
                       inputs:
                         targetType: inline
-                        workingDirectory: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests'
                         script: |
-                          echo "##vso[task.uploadfile]tinylicious.log"
+                          PATH_TO_TINYLICIOUS_LOG=${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests/tinylicious.log;
+                          if [ -f $PATH_TO_TINYLICIOUS_LOG]; then
+                            echo "Found file at '$PATH_TO_TINYLICIOUS_LOG'. Uploading.";
+                            echo "##vso[task.uploadfile]$PATH_TO_TINYLICIOUS_LOG";
+                          else
+                            echo "##vso[task.logissue type=warning]Failed to upload tinylicious log file ('$PATH_TO_TINYLICIOUS_LOG' not found).";
+                          fi
 
                     # At this point we want to publish the tinylicious.log artifact, but as part of 1ES migration
                     # that is now part of templateContext.outputs below.

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -357,9 +357,6 @@ extends:
                           testCoverage: ${{ parameters.testCoverage }}
 
                   - ${{ if contains(convertToJson(parameters.taskTest), 'tinylicious') }}:
-                    # Copy files so all artifacts we publish end up under the same parent folder.
-                    # Source is wherever the tinylicious log ends up in, after executing tests above.
-                    # CopyFiles@2 failed with OOM for some reason so doing it "by hand".
                     - task: Bash@3
                       displayName: Upload tinylicious log to pipeline run logs
                       condition: succeededOrFailed()
@@ -371,6 +368,7 @@ extends:
                           if [ -f $PATH_TO_TINYLICIOUS_LOG ] ; then
                             echo "Found file at '$PATH_TO_TINYLICIOUS_LOG'. Uploading.";
                             echo "##vso[task.uploadfile]$PATH_TO_TINYLICIOUS_LOG";
+                            echo "##vso[build.uploadLog]$PATH_TO_TINYLICIOUS_LOG";
                           else
                             echo "##vso[task.logissue type=warning]Failed to upload tinylicious log file ('$PATH_TO_TINYLICIOUS_LOG' not found).";
                           fi

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -368,7 +368,7 @@ extends:
                         targetType: inline
                         workingDirectory: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests'
                         script: |
-                          ##vso[task.uploadfile]tinylicious.log
+                          echo "##vso[task.uploadfile]tinylicious.log"
 
                     # At this point we want to publish the tinylicious.log artifact, but as part of 1ES migration
                     # that is now part of templateContext.outputs below.


### PR DESCRIPTION
## Description

Since the tinylicious logs are just for internal troubleshooting, try native ADO ways to upload them for a pipeline run so we don't have to go through additional security/auditing steps for them. Hoping this will reduce the pipeline execution time a bit.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
