### PR TITLE
[Data Virtualization] Add omitted prop on ISnapshotTree

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -361,6 +361,7 @@ export interface ISnapshotTree {
     groupId?: string;
     // (undocumented)
     id?: string;
+    omitted?: boolean;
     // (undocumented)
     trees: {
         [path: string]: ISnapshotTree;

--- a/common/lib/protocol-definitions/src/storage.ts
+++ b/common/lib/protocol-definitions/src/storage.ts
@@ -147,6 +147,12 @@ export interface ISnapshotTree {
 	 * intentional to minimize snapshot/summary size.
 	 */
 	groupId?: string;
+
+	/**
+	 * If true, then the service did not include the blobs content for the blobs in this snapshot tree. The service would
+	 * specify the groupId in that case, so that we can use that to fetch the latest content.
+	 */
+	omitted?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Description

This is part of the data virtualization effort. Add omitted prop on ISnapshotTree. This will be used by service to communicate that they omitted the blobs contents in the snapshot.