### PR TITLE
build(client): revised node16 support

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -498,6 +498,9 @@ function configKeyForPackageOverrides(overrides: Record<string, unknown> | undef
  *
  * Source files are also considered for incremental purposes. However, config files outside the package (e.g. shared
  * config files) are not considered. Thus, changes to those files will not trigger a rebuild of downstream packages.
+ *
+ * Jason-Ha observes that caching is only effective after the second build. But since tsc-multi is just orchestrating
+ * tsc, this should be able to derive from {@link TscTask} and override to get to the right config and tsbuildinfo.
  */
 export class TscMultiTask extends LeafWithDoneFileTask {
 	protected async getToolVersion() {
@@ -517,15 +520,31 @@ export class TscMultiTask extends LeafWithDoneFileTask {
 				this.package.directory,
 				commandArgs[configArg + 1],
 			);
+			commandArgs.splice(configArg, 2);
+			commandArgs.shift(); // Remove "tsc-multi" from the command
+			// Assume that the remaining arguments are project paths
+			const tscMultiProjects = commandArgs.filter((arg) => !arg.startsWith("-"));
 			const tscMultiConfig = JSON.parse(
 				await readFileAsync(tscMultiConfigFile, "utf-8"),
 			) as TscMultiConfig;
 
-			if (tscMultiConfig.targets.length !== 1 || tscMultiConfig.projects.length !== 1) {
+			// Command line projects replace any in config projects
+			if (tscMultiProjects.length > 0) {
+				tscMultiConfig.projects = tscMultiProjects;
+			}
+
+			if (tscMultiConfig.projects.length !== 1) {
 				throw new Error(
-					`TscMultiTask does not support ${tscMultiConfigFile} that does not have exactly one target and project.`,
+					`TscMultiTask does not support ${command} that does not have exactly one project.`,
 				);
 			}
+
+			if (tscMultiConfig.targets.length !== 1) {
+				throw new Error(
+					`TscMultiTask does not support ${tscMultiConfigFile} that does not have exactly one target.`,
+				);
+			}
+
 			const project = tscMultiConfig.projects[0];
 			const projectExt = path.extname(project);
 			const target = tscMultiConfig.targets[0];

--- a/common/build/build-common/README.md
+++ b/common/build/build-common/README.md
@@ -13,6 +13,18 @@ It can be extended in your package's local configuration file like the following
 "extends": "@fluidframework/build-common/api-extractor-base.json",
 ```
 
+### Dual Build Considerations
+
+A variety of configuration files were build and named while dual build pattern was being developed and have not been rationalized for what is believed to be the final state. The import aspect is to select a set of files that generate the report once. With the current dual build pattern this means using both of the `api-extractor-base.(cjs|esm).primary.json` files and then configuration override of:
+
+```json
+	"apiReport": {
+		"enabled": false
+	}
+```
+
+preferrably for the CommonJS case.
+
 ### Legacy Configurations
 
 This package previously exported a series of configurations with differing levels of validation.
@@ -20,26 +32,35 @@ These configurations are now deprecated and have been replaced with the configur
 
 ## TypeScript Configurations (`tsconfig.json`)
 
-This package includes several TypeScript config (tsconfig) files that are contain the common configurations used within
+This package includes several TypeScript project (tsconfig) files that are contain the common configurations used within
 the Fluid Framework repo. These configs are designed to be used together using [TypeScript's support for extending
 multiple config
 files](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#supporting-multiple-configuration-files-in-extends).
 
 -   tsconfig.base.json - This base config contains defaults that all packages within the repo should use as a baseline.
--   tsconfig.cjs.json - This config sets `module: Node16` and `moduleResolution: Node16` and is intended for CommonJS
-    builds. This config is intended to be layered on top of the base config.
--   tsconfig.esm.json - This config sets `module: ESNext` and `moduleResolution: Node10` and is intended for ESM builds
-    in packages that build both CJS and ESM. This config is intended to be layered on top of the base config. This config
-    uses `Node10` module resolution because `Node16` cannot be used to build both CJS and ESM from a common source.
--   tsconfig.esm-only.json - This config sets `module: Node16` and `moduleResolution: Node16` and is intended for
-    packages that build _only_ ESM. It should only be used in ESM-only packages, and it assumes the `type` field in
-    package.json is set to `"module"`. This config is intended to be layered on top of the base config. Note that while
-    this config is currently the same as tsconfig.cjs.json, that may not always be true, and having "tsm-only" in the
-    name means it won't confuse people why an ESM-only package would be inheriting from the CJS base config.
--   tsconfig.test.json - This config disables some settings that we don't want to use in test code, like `declaration` and
+-   tsconfig.node16.json - This config extends base and sets `module: Node16` and `moduleResolution: Node16`. It is intended for all
+    builds.
+-   tsconfig.test.node16.json - This config disables some settings that we don't want to use in test code, like `declaration` and
     `decarationMap`. It also enables the `node` types by default.
 
 ### Legacy tsconfig
 
 This package also contains a legacy base tsconfig, `ts-common-config.json`. This config is still used in some places
 within the repo but is considered deprecated.
+
+And there are a handful of tsconfigs that we thought we'd want but no longer think they have common purpose:
+`tsconfig.cjs.json`, `tsconfig.esm.json`, `tsconfig.esm-only.json`, and `tsconfig.test.json`
+
+## Tsc-Multi Configurations (`tsc-multi.*.json`)
+
+This package includes several Tsc-Multi config files that are contain the common configurations used within
+the Fluid Framework repo. These configs are designed to be used to dual build packages for CommonJS and ESM.
+
+-   tsc-multi.type-commonjs.json - basic specification that overrides tsc view of current directory package.json "type" to be "commonjs". To be used in conjunction with a tsc project file, which specifies `"module": "Nodes16"`, on command line.
+-   tsc-multi.type-module.json - basic specification that overrides tsc view of current directory package.json "type" to be "module". To be used in conjunction with a tsc project file, which specifies `"module": "Nodes16"`, on command line.
+-   tsc-multi.node16.cjs.json - complete specification with package `"type": "commonjs"` override, tsc `"outDir": "dist"` override, and reference to `tsconfig.json` project, which is expected to specify `"module": "Nodes16"`. If also testing both CommonJs and ESM, prefer using `tsc-multi.type-commonjs.json` and a local tsconfig.cjs.json with `outDir` override for both product and test builds. (The test tsconfig.cjs.json will need `references` to the product tsconfig.cjs.json.)
+
+### Legacy tsc-multi.\*.json
+
+Several Tsc-Multi config files remain that use a deprecated style of dual build that emit modified .js extensions. As extension modification means rewriting files the likelihood of error is signficant and this has been superceded by package type override pattern. Configurations that should be replaced:
+`tsc-multi.cjs.json`, `tsc-multi.esm.json`

--- a/common/build/build-common/tsc-multi.type-commonjs.json
+++ b/common/build/build-common/tsc-multi.type-commonjs.json
@@ -1,0 +1,3 @@
+{
+	"targets": [{ "packageOverrides": { "package.json": { "type": "commonjs" } } }]
+}

--- a/common/build/build-common/tsc-multi.type-module.json
+++ b/common/build/build-common/tsc-multi.type-module.json
@@ -1,0 +1,3 @@
+{
+	"targets": [{ "packageOverrides": { "package.json": { "type": "module" } } }]
+}

--- a/common/build/build-common/tsconfig.node16.json
+++ b/common/build/build-common/tsconfig.node16.json
@@ -1,0 +1,7 @@
+{
+	"extends": ["./tsconfig.base.json"],
+	"compilerOptions": {
+		"module": "Node16",
+		"moduleResolution": "Node16",
+	},
+}

--- a/common/build/build-common/tsconfig.test.node16.json
+++ b/common/build/build-common/tsconfig.test.node16.json
@@ -1,0 +1,10 @@
+{
+	"extends": ["./tsconfig.base.json", "./tsconfig.node16.json"],
+	"compilerOptions": {
+		"composite": false,
+		"types": ["node"],
+		"declaration": false,
+		"declarationMap": false,
+		"skipLibCheck": true,
+	},
+}

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -167,6 +167,8 @@ module.exports = {
 				"tools/telemetry-generator/package-lock.json", // Workaround to allow version 2 while we move it to pnpm
 			],
 			"fluid-build-tasks-eslint": [
+				// eslint doesn't really depend on build. Doing so just slows down a package build.
+				"^packages/test/test-utils/package.json",
 				// Can be removed once the policy handler is updated to support tsc-multi as equivalent to tsc.
 				"^azure/packages/azure-client/package.json",
 				"^azure/packages/azure-service-utils/package.json",

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -36,7 +36,9 @@
 		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json && copyfiles -f ../../../common/build/build-common/src/esm/package.json ./lib",
 		"build:genver": "gen-version",
-		"build:test": "tsc --project ./src/test/tsconfig.json && tsc --project ./src/test/tsconfig.cjs.json",
+		"build:test": "npm run build:test:cjs && npm run build:test:esm",
+		"build:test:cjs": "tsc-multi --config ../../../common/build/build-common/tsc-multi.type-commonjs.json ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack",
 		"check:release-tags": "api-extractor run --local --config ./api-extractor-lint.json",
 		"ci:build:docs": "api-extractor run",
@@ -53,7 +55,7 @@
 		"test:mocha:cjs": "mocha  --recursive \"dist/test/*.spec.*js\" --exit --project src/test/tsconfig.cjs.json -r node_modules/@fluidframework/mocha-test-setup",
 		"test:mocha:esm": "mocha  --recursive \"lib/test/*.spec.*js\" --exit --project src/test/tsconfig.json -r node_modules/@fluidframework/mocha-test-setup",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
-		"tsc": "tsc-multi --config ../../../common/build/build-common/tsc-multi.node16.cjs.json && copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist",
+		"tsc": "tsc-multi --config ../../../common/build/build-common/tsc-multi.type-commonjs.json tsconfig.cjs.json && copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist",
 		"typetests:gen": "fluid-type-test-generator",
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
@@ -100,6 +102,7 @@
 		"@fluidframework/test-driver-definitions": "workspace:~",
 		"best-random": "^1.0.0",
 		"debug": "^4.3.4",
+		"mocha": "^10.2.0",
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
@@ -121,7 +124,6 @@
 		"cross-env": "^7.0.3",
 		"diff": "^3.5.0",
 		"eslint": "~8.50.0",
-		"mocha": "^10.2.0",
 		"mocha-json-output-reporter": "^2.0.1",
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.21.0",
@@ -138,6 +140,9 @@
 				],
 				"script": false
 			},
+			"build:test:esm": [
+				"build:esnext"
+			],
 			"check:release-tags": [
 				"build:esnext"
 			],

--- a/packages/test/test-utils/src/test/tsconfig.json
+++ b/packages/test/test-utils/src/test/tsconfig.json
@@ -1,14 +1,9 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",
-		"module": "Node16",
-		"moduleResolution": "Node16",
 		"types": ["mocha", "node"],
-		"declaration": false,
-		"declarationMap": false,
-		"skipLibCheck": true,
 	},
 	"include": ["./**/*"],
 	"references": [

--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import { assert, Deferred } from "@fluidframework/core-utils";
+import type * as Mocha from "mocha";
 
 // @deprecated this value is no longer used
 /**

--- a/packages/test/test-utils/tsconfig.cjs.json
+++ b/packages/test/test-utils/tsconfig.cjs.json
@@ -2,11 +2,6 @@
 	// This config must be used in a "type": "commonjs" environment. (Use tsc-mult.)
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"outDir": "../../dist/test",
+		"outDir": "./dist",
 	},
-	"references": [
-		{
-			"path": "../../tsconfig.cjs.json",
-		},
-	],
 }

--- a/packages/test/test-utils/tsconfig.json
+++ b/packages/test/test-utils/tsconfig.json
@@ -1,13 +1,10 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": "../../../common/build/build-common/tsconfig.node16.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"module": "Node16",
-		"moduleResolution": "Node16",
-		"composite": true,
-		"types": ["mocha", "node"],
+		"types": ["node"],
 	},
 	"include": ["src/**/*"],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10661,6 +10661,7 @@ importers:
       '@fluidframework/test-driver-definitions': link:../test-driver-definitions
       best-random: 1.0.3
       debug: 4.3.4
+      mocha: 10.2.0
       uuid: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
@@ -10681,7 +10682,6 @@ importers:
       cross-env: 7.0.3
       diff: 3.5.0
       eslint: 8.50.0
-      mocha: 10.2.0
       mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
       moment: 2.29.4


### PR DESCRIPTION
- establish new tsc-multi config pattern supporting test builds
   - build-tools changes to support incremental build
   - document in build-common readme
- use pattern with test-utils
   - clean up tsconfig_s
   - correct mocha dependency and make obvious where used via import