### PR TITLE
fix(matrix): Rebase positions by scanning MergeTree for handles

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -631,13 +631,13 @@ export class SharedMatrix<T = any>
 		this.cols.startOrUpdateCollaboration(this.runtime.clientId as string);
 	}
 
-	private rebasePosition( 
+	private rebasePosition(
 		client: PermutationVector,
 		localSeq: number,
-		handle: number
+		handle: number,
 	): number | undefined {
 		const { segment, offset } = client.handleToSegment(handle);
-		
+
 		if (segment.removedSeq !== undefined) {
 			return undefined;
 		}

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -12,7 +12,7 @@ import {
 import {
 	BaseSegment,
 	ISegment,
-	 
+	// eslint-disable-next-line import/no-deprecated
 	Client,
 	IMergeTreeDeltaOpArgs,
 	IMergeTreeDeltaCallbackArgs,
@@ -119,7 +119,7 @@ export class PermutationSegment extends BaseSegment {
 	}
 }
 
- 
+// eslint-disable-next-line import/no-deprecated
 export class PermutationVector extends Client {
 	private handleTable = new HandleTable<never>(); // Tracks available storage handles for rows.
 	public readonly handleCache = new HandleCache(this);

--- a/packages/dds/matrix/src/test/matrix.reconnect.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.reconnect.spec.ts
@@ -14,7 +14,7 @@ import { extract } from "./utils";
 
 describe("SharedMatrix reconnect", () => {
 	// https://dev.azure.com/fluidframework/internal/_workitems/edit/7217
-	it.skip("rebase setCell in inserted column with overlapping remove", () => {
+	it("rebase setCell in inserted column with overlapping remove", () => {
 		const factory = SharedMatrix.getFactory();
 		const containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 		const dataRuntime1 = new MockFluidDataStoreRuntime();
@@ -68,7 +68,7 @@ describe("SharedMatrix reconnect", () => {
 	});
 
 	// https://dev.azure.com/fluidframework/internal/_workitems/edit/7217
-	it.skip("discards setCell in removed column", () => {
+	it("discards setCell in removed column", () => {
 		const factory = SharedMatrix.getFactory();
 		const containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 		const dataRuntime1 = new MockFluidDataStoreRuntime();


### PR DESCRIPTION
A POC fix/workaround for [AB#7217](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7217)

During reconnection, SharedMatrix attempts to reuse MergeTree's 'getContainingSegment()' to resolve past row/col positions to the current MergeTree segment + offset containing the row/col handle.

In practice, what I observed is that 'getContainingSegment(..)' may not resolve to the segment that contains the row/col handle, but to an adjacent removed segment.  I believe this happens because removed segments have a length of zero, and therefore there are multiple segments occupying the same index.

For insertion semantics, this is not an issue: any of the segments at the desired index will serve as a usable reference point for 'findReconnectionPosition()'.

For replace semantics, this _is_ a problem: we need to find the specific MergeTree segment that contains the row/col handle to determine if it has been removed.

This draft PR presents a low-confidence, quadratic-time work around that locates the segment + offset containing the row/col handle by linearly scanning the MergeTree.  (See GH comments in 'Files changed' tab.)