### PR TITLE
Add parsing of omitted prop in ISnapshotTree in odsp driver

### DIFF
--- a/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotWriter.ts
@@ -81,8 +81,12 @@ function writeTreeSectionCore(treesNode: NodeCore, snapshotTree: ISnapshotTree) 
 			const childNode = treeNode.addNode("list");
 			writeTreeSectionCore(childNode, value);
 		}
-		if (snapshotTree.groupId) {
+		if (snapshotTree.groupId !== undefined) {
 			addDictionaryStringProperty(treeNode, "groupId", snapshotTree.groupId);
+		}
+
+		if (snapshotTree.omitted !== undefined) {
+			addBoolProperty(treeNode, "omitted", snapshotTree.omitted);
 		}
 	}
 

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -145,6 +145,7 @@ const snapshotTreeWithGroupId: ISnapshotTree = {
 					},
 					unreferenced: true,
 					groupId: "G2",
+					omitted: false,
 				},
 				".blobs": { blobs: {}, trees: {} },
 			},


### PR DESCRIPTION
## Description

Add parsing of omitted prop in odsp binary snapshot. This property will be used by service to tell whether it omitted the snapshot contents for that tree or not.

This is part of data virtualization effort which is documented here: [Design Doc](https://microsoft.sharepoint.com/:w:/t/FluidFramework/ESJQvukxffJNiTZzbNCWky4B891mpOpWD7BHhbOznXsMZg?e=gAUCrx)