### PR TITLE
Exploration prototype to support datastore nesting

### DIFF
--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -179,6 +179,9 @@
 			},
 			"ClassDeclaration_PureDataObjectFactory": {
 				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IDataObjectProps": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -152,6 +152,7 @@ declare function get_old_InterfaceDeclaration_IDataObjectProps():
 declare function use_current_InterfaceDeclaration_IDataObjectProps(
     use: TypeOnly<current.IDataObjectProps>): void;
 use_current_InterfaceDeclaration_IDataObjectProps(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IDataObjectProps());
 
 /*

--- a/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.api.md
+++ b/packages/runtime/container-runtime-definitions/api-report/container-runtime-definitions.api.md
@@ -53,7 +53,7 @@ export type IContainerRuntimeBaseWithCombinedEvents = IContainerRuntimeBase & IE
 // @alpha
 export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
     // (undocumented)
-    (event: "dirty" | "disconnected" | "dispose" | "saved" | "attached", listener: () => void): any;
+    (event: "dirty" | "disconnected" | "saved" | "attached", listener: () => void): any;
     // (undocumented)
     (event: "connected", listener: (clientId: string) => void): any;
 }

--- a/packages/runtime/container-runtime-definitions/package.json
+++ b/packages/runtime/container-runtime-definitions/package.json
@@ -93,10 +93,15 @@
 	"typeValidation": {
 		"broken": {
 			"InterfaceDeclaration_IContainerRuntime": {
-				"backCompat": false
+				"backCompat": false,
+				"forwardCompat": false
 			},
 			"InterfaceDeclaration_IContainerRuntimeWithResolveHandle_Deprecated": {
-				"backCompat": false
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime-definitions/src/containerRuntime.ts
@@ -40,7 +40,7 @@ export interface IContainerRuntimeWithResolveHandle_Deprecated extends IContaine
  * @alpha
  */
 export interface IContainerRuntimeEvents extends IContainerRuntimeBaseEvents {
-	(event: "dirty" | "disconnected" | "dispose" | "saved" | "attached", listener: () => void);
+	(event: "dirty" | "disconnected" | "saved" | "attached", listener: () => void);
 	(event: "connected", listener: (clientId: string) => void);
 }
 

--- a/packages/runtime/container-runtime-definitions/src/test/types/validateContainerRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/container-runtime-definitions/src/test/types/validateContainerRuntimeDefinitionsPrevious.generated.ts
@@ -31,6 +31,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntime():
 declare function use_current_InterfaceDeclaration_IContainerRuntime(
     use: TypeOnly<current.IContainerRuntime>): void;
 use_current_InterfaceDeclaration_IContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntime());
 
 /*
@@ -56,6 +57,7 @@ declare function get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedE
 declare function use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
     use: TypeOnly<current.IContainerRuntimeBaseWithCombinedEvents>): void;
 use_current_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents(
+    // @ts-expect-error compatibility expected to be broken
     get_old_TypeAliasDeclaration_IContainerRuntimeBaseWithCombinedEvents());
 
 /*
@@ -104,6 +106,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntimeWithResolveHandle
 declare function use_current_InterfaceDeclaration_IContainerRuntimeWithResolveHandle_Deprecated(
     use: TypeOnly<current.IContainerRuntimeWithResolveHandle_Deprecated>): void;
 use_current_InterfaceDeclaration_IContainerRuntimeWithResolveHandle_Deprecated(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntimeWithResolveHandle_Deprecated());
 
 /*

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -7,6 +7,7 @@
 import { assertIsStableId } from '@fluidframework/id-compressor';
 import { AttachState } from '@fluidframework/container-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
+import { CreateChildSummarizerNodeParam } from '@fluidframework/runtime-definitions';
 import { FluidDataStoreRegistryEntry } from '@fluidframework/runtime-definitions';
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { FlushMode } from '@fluidframework/runtime-definitions';
@@ -25,7 +26,10 @@ import { IDocumentStorageService } from '@fluidframework/driver-definitions';
 import { IEnvelope } from '@fluidframework/runtime-definitions';
 import { IEvent } from '@fluidframework/core-interfaces';
 import { IEventProvider } from '@fluidframework/core-interfaces';
+import { IFluidDataStoreChannel } from '@fluidframework/runtime-definitions';
+import { IFluidDataStoreContext } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreContextDetached } from '@fluidframework/runtime-definitions';
+import { IFluidDataStoreFactory } from '@fluidframework/runtime-definitions';
 import { IFluidDataStoreRegistry } from '@fluidframework/runtime-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidHandleContext } from '@fluidframework/core-interfaces';
@@ -41,6 +45,7 @@ import { IRuntime } from '@fluidframework/container-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { isStableId } from '@fluidframework/id-compressor';
+import { ISummarizerNodeWithGC } from '@fluidframework/runtime-definitions';
 import { ISummaryAck } from '@fluidframework/protocol-definitions';
 import { ISummaryContent } from '@fluidframework/protocol-definitions';
 import { ISummaryNack } from '@fluidframework/protocol-definitions';
@@ -51,6 +56,7 @@ import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
 import { MessageType } from '@fluidframework/protocol-definitions';
 import { NamedFluidDataStoreRegistryEntries } from '@fluidframework/runtime-definitions';
+import { SummarizeInternalFn } from '@fluidframework/runtime-definitions';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
 // @internal
@@ -131,6 +137,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     // (undocumented)
     createDetachedRootDataStore(pkg: Readonly<string[]>, rootDataStoreId: string): IFluidDataStoreContextDetached;
     createSummary(blobRedirectTable?: Map<string, string>, telemetryContext?: ITelemetryContext): ISummaryTree;
+    // (undocumented)
+    deleteChildSummarizerNode(id: string): void;
     deleteSweepReadyNodes(sweepReadyRoutes: readonly string[]): readonly string[];
     // @deprecated (undocumented)
     deleteUnusedNodes(unusedRoutes: readonly string[]): string[];
@@ -153,6 +161,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     getAliasedDataStoreEntryPoint(alias: string): Promise<IFluidHandle<FluidObject> | undefined>;
     // (undocumented)
     getAudience(): IAudience;
+    // (undocumented)
+    getCreateChildSummarizerNodeFn(id: string, createParam: CreateChildSummarizerNodeParam): (summarizeInternal: SummarizeInternalFn, getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>) => ISummarizerNodeWithGC;
     getCurrentReferenceTimestampMs(): number | undefined;
     // (undocumented)
     getEntryPoint(): Promise<FluidObject>;
@@ -230,6 +240,17 @@ export interface ContainerRuntimeMessage {
     compatDetails?: IContainerRuntimeMessageCompatDetails;
     contents: any;
     type: ContainerMessageType;
+}
+
+// @internal (undocumented)
+export class DataStoresFactory implements IFluidDataStoreFactory {
+    constructor(provideEntryPoint: (runtime: IFluidDataStoreChannel) => Promise<FluidObject>);
+    // (undocumented)
+    get IFluidDataStoreFactory(): this;
+    // (undocumented)
+    instantiateDataStore(context: IFluidDataStoreContext, existing: boolean): Promise<IFluidDataStoreChannel>;
+    // (undocumented)
+    readonly type = "DataStoresChannel";
 }
 
 // @alpha (undocumented)

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -193,6 +193,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     // (undocumented)
     readonly logger: ITelemetryLoggerExt;
     // (undocumented)
+    makeLocallyVisible(): void;
+    // (undocumented)
     notifyOpReplay(message: ISequencedDocumentMessage): Promise<void>;
     // (undocumented)
     readonly options: Record<string | number, any>;
@@ -244,9 +246,11 @@ export interface ContainerRuntimeMessage {
 
 // @internal (undocumented)
 export class DataStoresFactory implements IFluidDataStoreFactory {
-    constructor(provideEntryPoint: (runtime: IFluidDataStoreChannel) => Promise<FluidObject>);
+    constructor(registryEntries: NamedFluidDataStoreRegistryEntries, provideEntryPoint: (runtime: IFluidDataStoreChannel) => Promise<FluidObject>);
     // (undocumented)
     get IFluidDataStoreFactory(): this;
+    // (undocumented)
+    IFluidDataStoreRegistry: IFluidDataStoreRegistry;
     // (undocumented)
     instantiateDataStore(context: IFluidDataStoreContext, existing: boolean): Promise<IFluidDataStoreChannel>;
     // (undocumented)

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -121,6 +121,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     // (undocumented)
     get connected(): boolean;
     // (undocumented)
+    get containerRuntime(): this;
+    // (undocumented)
     createDataStore(pkg: string | string[], loadingGroupId?: string): Promise<IDataStore>;
     // @deprecated (undocumented)
     _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string): Promise<IDataStore>;
@@ -201,10 +203,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     // (undocumented)
     get storage(): IDocumentStorageService;
     // (undocumented)
-    submitDataStoreAliasOp(contents: any, localOpMetadata: unknown): void;
-    // (undocumented)
-    submitDataStoreOp(id: string, contents: any, localOpMetadata?: unknown): void;
-    submitDataStoreSignal(address: string, type: string, content: any, targetClientId?: string): void;
+    submitMessage(type: ContainerMessageType, contents: any, localOpMetadata?: unknown): void;
     submitSignal(type: string, content: any, targetClientId?: string): void;
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
     summarize(options: {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1721,6 +1721,11 @@ export class ContainerRuntime
 		return this.summarizerNode.deleteChild(id);
 	}
 
+	public makeLocallyVisible()
+	{
+		assert(false, "should not be called");
+	}
+
 	/**
 	 * Initializes the state from the base snapshot this container runtime loaded from.
 	 */
@@ -1989,16 +1994,15 @@ export class ContainerRuntime
 		const opContents = this.parseLocalOpContent(serializedOpContent);
 		switch (opContents.type) {
 			case ContainerMessageType.FluidDataStoreOp:
-				return this.dataStores.applyStashedOp(opContents.contents);
 			case ContainerMessageType.Attach:
-				return this.dataStores.applyStashedAttachOp(opContents.contents);
+			case ContainerMessageType.Alias:
+				return this.dataStores.applyStashedOp(opContents);
 			case ContainerMessageType.IdAllocation:
 				assert(
 					this.idCompressor !== undefined,
 					0x67b /* IdCompressor should be defined if enabled */,
 				);
 				return;
-			case ContainerMessageType.Alias:
 			case ContainerMessageType.BlobAttach:
 				return;
 			case ContainerMessageType.ChunkedOp:
@@ -3692,12 +3696,12 @@ export class ContainerRuntime
 		assert(!this.isSummarizerClient, "Summarizer never reconnects so should never resubmit");
 		switch (message.type) {
 			case ContainerMessageType.FluidDataStoreOp:
+			case ContainerMessageType.Attach:
+			case ContainerMessageType.Alias:
 				// For Operations, call resubmitDataStoreOp which will find the right store
 				// and trigger resubmission on it.
 				this.dataStores.reSubmit(message.type, message.contents, localOpMetadata);
 				break;
-			case ContainerMessageType.Attach:
-			case ContainerMessageType.Alias:
 			case ContainerMessageType.IdAllocation: {
 				this.submit(message, localOpMetadata);
 				break;

--- a/packages/runtime/container-runtime/src/dataStore.ts
+++ b/packages/runtime/container-runtime/src/dataStore.ts
@@ -14,6 +14,7 @@ import {
 } from "@fluidframework/runtime-definitions";
 import { ContainerRuntime } from "./containerRuntime";
 import { DataStores } from "./dataStores";
+import { ContainerMessageType } from "./messageTypes";
 
 /**
  * Interface for an op to be used for assigning an
@@ -113,6 +114,7 @@ class DataStore implements IDataStore {
 			internalId: this.internalId,
 			alias,
 		};
+		assert(isDataStoreAliasMessage(message), "validate we can recognize it");
 
 		this.fluidDataStoreChannel.makeVisibleAndAttachGraph();
 
@@ -125,7 +127,7 @@ class DataStore implements IDataStore {
 		}
 
 		const aliased = await this.ackBasedPromise<boolean>((resolve) => {
-			this.runtime.submitDataStoreAliasOp(message, resolve);
+			this.runtime.submitMessage(ContainerMessageType.Alias, message, resolve);
 		})
 			.catch((error) => {
 				this.logger.sendErrorEvent(

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -214,6 +214,7 @@ export abstract class FluidDataStoreContext
 	}
 
 	public get IFluidDataStoreRegistry(): IFluidDataStoreRegistry | undefined {
+		assert(this.channel !== undefined, "registry is populated only when runtime is created");
 		return this.registry;
 	}
 

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -14,9 +14,6 @@ export {
 	RuntimeMessage,
 	agentSchedulerId,
 	ContainerRuntime,
-	RuntimeHeaders,
-	AllowTombstoneRequestHeaderKey,
-	AllowInactiveRequestHeaderKey,
 	TombstoneResponseHeaderKey,
 	InactiveResponseHeaderKey,
 	ISummaryConfiguration,
@@ -34,7 +31,12 @@ export {
 } from "./messageTypes";
 export { IBlobManagerLoadInfo } from "./blobManager";
 export { FluidDataStoreRegistry } from "./dataStoreRegistry";
-export { detectOutboundReferences } from "./dataStores";
+export {
+	detectOutboundReferences,
+	RuntimeHeaders,
+	AllowTombstoneRequestHeaderKey,
+	AllowInactiveRequestHeaderKey,
+} from "./dataStores";
 export {
 	GCNodeType,
 	IGCMetadata,

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -34,6 +34,7 @@ export { FluidDataStoreRegistry } from "./dataStoreRegistry";
 export {
 	detectOutboundReferences,
 	RuntimeHeaders,
+	DataStoresFactory,
 	AllowTombstoneRequestHeaderKey,
 	AllowInactiveRequestHeaderKey,
 } from "./dataStores";

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -32,6 +32,7 @@ import {
 	CreateSummarizerNodeSource,
 	channelsTreeName,
 	IFluidDataStoreChannel,
+	IFluidParentContext,
 } from "@fluidframework/runtime-definitions";
 import { GCDataBuilder, convertSummaryTreeToITree } from "@fluidframework/runtime-utils";
 import {
@@ -140,7 +141,7 @@ describe("Data Store Context Tests", () => {
 					new LocalFluidDataStoreContext({
 						id: invalidId,
 						pkg: ["TestDataStore1"],
-						parent: createRuntimeContext(invalidId, containerRuntime),
+						parentContext: createRuntimeContext(invalidId, containerRuntime),
 						storage,
 						scope,
 						createSummarizerNodeFn,
@@ -159,7 +160,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: fullPackageName, // This will cause an error when calling `realizeCore`
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -201,7 +202,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestDataStore1"],
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -257,7 +258,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestComp", "SubComp"],
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -291,7 +292,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestComp", "SubComp"],
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -345,7 +346,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestDataStore1"],
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -362,7 +363,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestDataStore1"],
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -395,7 +396,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: packageName,
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -428,7 +429,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: packageName,
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -468,7 +469,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: packageName,
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -504,7 +505,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestDataStore1"],
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -525,7 +526,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestComp", "SubComp"],
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -563,7 +564,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestComp", "SubComp"],
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -670,7 +671,7 @@ describe("Data Store Context Tests", () => {
 					remoteDataStoreContext = new RemoteFluidDataStoreContext({
 						id: dataStoreId,
 						snapshotTree,
-						parent: createRuntimeContext(dataStoreId, containerRuntime),
+						parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 						storage: new StorageServiceWithAttachBlobs(
 							storage as IDocumentStorageService,
 							attachBlobs,
@@ -719,7 +720,7 @@ describe("Data Store Context Tests", () => {
 					new RemoteFluidDataStoreContext({
 						id: invalidId,
 						pkg: ["TestDataStore1"],
-						parent: createRuntimeContext(invalidId, containerRuntime),
+						parentContext: createRuntimeContext(invalidId, containerRuntime),
 						storage: storage as IDocumentStorageService,
 						scope,
 						createSummarizerNodeFn,
@@ -798,7 +799,7 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage: new StorageServiceWithAttachBlobs(
 						storage as IDocumentStorageService,
 						attachBlobs,
@@ -850,7 +851,7 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage: new StorageServiceWithAttachBlobs(
 						storage as IDocumentStorageService,
 						attachBlobs,
@@ -902,7 +903,7 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage: new StorageServiceWithAttachBlobs(
 						storage as IDocumentStorageService,
 						attachBlobs,
@@ -956,7 +957,7 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage: new StorageServiceWithAttachBlobs(
 						storage as IDocumentStorageService,
 						attachBlobs,
@@ -1031,7 +1032,7 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					parent: createRuntimeContext(dataStoreId, containerRuntime),
+					parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 					storage: new StorageServiceWithAttachBlobs(
 						storage as IDocumentStorageService,
 						attachBlobs,
@@ -1058,13 +1059,7 @@ describe("Data Store Context Tests", () => {
 		let factory: IFluidDataStoreFactory;
 		const makeLocallyVisibleFn = () => {};
 		const channelToDataStoreFn = (fluidDataStore: IFluidDataStoreChannel, id: string) =>
-			channelToDataStore(
-				fluidDataStore,
-				id,
-				containerRuntime,
-				dataStores,
-				containerRuntime.logger,
-			);
+			channelToDataStore(fluidDataStore, id, dataStores, containerRuntime.logger);
 		let containerRuntime: ContainerRuntime;
 		let dataStores: DataStores;
 		let provideDsRuntimeWithFailingEntrypoint = false;
@@ -1123,7 +1118,9 @@ describe("Data Store Context Tests", () => {
 			} as ContainerRuntime;
 
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-			dataStores = {} as DataStores;
+			dataStores = {
+				parentContext: containerRuntime as IFluidParentContext,
+			} as DataStores;
 		});
 
 		describe("Initialization", () => {
@@ -1133,7 +1130,7 @@ describe("Data Store Context Tests", () => {
 					new LocalDetachedFluidDataStoreContext({
 						id: invalidId,
 						pkg: [factory.type],
-						parent: createRuntimeContext(invalidId, containerRuntime),
+						parentContext: createRuntimeContext(invalidId, containerRuntime),
 						storage,
 						scope,
 						createSummarizerNodeFn,
@@ -1157,7 +1154,7 @@ describe("Data Store Context Tests", () => {
 					localDataStoreContext = new LocalDetachedFluidDataStoreContext({
 						id: dataStoreId,
 						pkg: ["some-datastore-type-not-present-in-registry"],
-						parent: createRuntimeContext(dataStoreId, containerRuntime),
+						parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 						storage,
 						scope,
 						createSummarizerNodeFn,
@@ -1194,7 +1191,7 @@ describe("Data Store Context Tests", () => {
 					localDataStoreContext = new LocalDetachedFluidDataStoreContext({
 						id: dataStoreId,
 						pkg: [factory.type],
-						parent: createRuntimeContext(dataStoreId, containerRuntime),
+						parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 						storage,
 						scope,
 						createSummarizerNodeFn,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -62,7 +62,11 @@ import {
 	summarizerClientType,
 } from "../summary";
 import { channelToDataStore } from "../dataStore";
-import { DataStores } from "../dataStores";
+import { DataStores, createParentContext } from "../dataStores";
+
+function createRuntimeContext(id: string, runtime: ContainerRuntime) {
+	return createParentContext(id, runtime);
+}
 
 describe("Data Store Context Tests", () => {
 	const dataStoreId = "Test1";
@@ -80,7 +84,7 @@ describe("Data Store Context Tests", () => {
 		function createContainerRuntime(
 			logger: ITelemetryBaseLogger = createChildLogger(),
 			clientDetails = {},
-			submitDataStoreOp = (id: string, contents: any, localOpMetadata: unknown) => {},
+			submitMessage = (type: string, contents: any, localOpMetadata: unknown) => {},
 		): ContainerRuntime {
 			const factory: IFluidDataStoreFactory = {
 				type: "store-type",
@@ -102,7 +106,7 @@ describe("Data Store Context Tests", () => {
 				on: (event, listener) => {},
 				logger,
 				clientDetails,
-				submitDataStoreOp,
+				submitMessage,
 			} as ContainerRuntime;
 		}
 
@@ -136,7 +140,7 @@ describe("Data Store Context Tests", () => {
 					new LocalFluidDataStoreContext({
 						id: invalidId,
 						pkg: ["TestDataStore1"],
-						runtime: containerRuntime,
+						parent: createRuntimeContext(invalidId, containerRuntime),
 						storage,
 						scope,
 						createSummarizerNodeFn,
@@ -155,7 +159,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: fullPackageName, // This will cause an error when calling `realizeCore`
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -197,7 +201,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestDataStore1"],
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -253,7 +257,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestComp", "SubComp"],
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -287,7 +291,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestComp", "SubComp"],
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -341,7 +345,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestDataStore1"],
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -358,7 +362,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestDataStore1"],
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -391,7 +395,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: packageName,
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -424,7 +428,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: packageName,
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -464,7 +468,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: packageName,
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -500,7 +504,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestDataStore1"],
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -521,7 +525,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestComp", "SubComp"],
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -559,7 +563,7 @@ describe("Data Store Context Tests", () => {
 				localDataStoreContext = new LocalFluidDataStoreContext({
 					id: dataStoreId,
 					pkg: ["TestComp", "SubComp"],
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage,
 					scope,
 					createSummarizerNodeFn,
@@ -666,7 +670,7 @@ describe("Data Store Context Tests", () => {
 					remoteDataStoreContext = new RemoteFluidDataStoreContext({
 						id: dataStoreId,
 						snapshotTree,
-						runtime: containerRuntime,
+						parent: createRuntimeContext(dataStoreId, containerRuntime),
 						storage: new StorageServiceWithAttachBlobs(
 							storage as IDocumentStorageService,
 							attachBlobs,
@@ -715,7 +719,7 @@ describe("Data Store Context Tests", () => {
 					new RemoteFluidDataStoreContext({
 						id: invalidId,
 						pkg: ["TestDataStore1"],
-						runtime: containerRuntime,
+						parent: createRuntimeContext(invalidId, containerRuntime),
 						storage: storage as IDocumentStorageService,
 						scope,
 						createSummarizerNodeFn,
@@ -794,7 +798,7 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage: new StorageServiceWithAttachBlobs(
 						storage as IDocumentStorageService,
 						attachBlobs,
@@ -846,7 +850,7 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage: new StorageServiceWithAttachBlobs(
 						storage as IDocumentStorageService,
 						attachBlobs,
@@ -898,7 +902,7 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage: new StorageServiceWithAttachBlobs(
 						storage as IDocumentStorageService,
 						attachBlobs,
@@ -952,7 +956,7 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage: new StorageServiceWithAttachBlobs(
 						storage as IDocumentStorageService,
 						attachBlobs,
@@ -1027,7 +1031,7 @@ describe("Data Store Context Tests", () => {
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
 					snapshotTree,
-					runtime: containerRuntime,
+					parent: createRuntimeContext(dataStoreId, containerRuntime),
 					storage: new StorageServiceWithAttachBlobs(
 						storage as IDocumentStorageService,
 						attachBlobs,
@@ -1129,7 +1133,7 @@ describe("Data Store Context Tests", () => {
 					new LocalDetachedFluidDataStoreContext({
 						id: invalidId,
 						pkg: [factory.type],
-						runtime: containerRuntime,
+						parent: createRuntimeContext(invalidId, containerRuntime),
 						storage,
 						scope,
 						createSummarizerNodeFn,
@@ -1153,7 +1157,7 @@ describe("Data Store Context Tests", () => {
 					localDataStoreContext = new LocalDetachedFluidDataStoreContext({
 						id: dataStoreId,
 						pkg: ["some-datastore-type-not-present-in-registry"],
-						runtime: containerRuntime,
+						parent: createRuntimeContext(dataStoreId, containerRuntime),
 						storage,
 						scope,
 						createSummarizerNodeFn,
@@ -1190,7 +1194,7 @@ describe("Data Store Context Tests", () => {
 					localDataStoreContext = new LocalDetachedFluidDataStoreContext({
 						id: dataStoreId,
 						pkg: [factory.type],
-						runtime: containerRuntime,
+						parent: createRuntimeContext(dataStoreId, containerRuntime),
 						storage,
 						scope,
 						createSummarizerNodeFn,

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -135,7 +135,7 @@ describe("Data Store Creation Tests", () => {
 			const context: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName],
-				parent: createRuntimeContext(dataStoreId, containerRuntime),
+				parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -160,7 +160,7 @@ describe("Data Store Creation Tests", () => {
 			const context: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [dataStoreAName],
-				parent: createRuntimeContext(dataStoreId, containerRuntime),
+				parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -185,7 +185,7 @@ describe("Data Store Creation Tests", () => {
 			const contextA: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName, dataStoreAName],
-				parent: createRuntimeContext(dataStoreId, containerRuntime),
+				parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -210,7 +210,7 @@ describe("Data Store Creation Tests", () => {
 			const contextB: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName, dataStoreBName],
-				parent: createRuntimeContext(dataStoreId, containerRuntime),
+				parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -235,7 +235,7 @@ describe("Data Store Creation Tests", () => {
 			const contextB: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreBId,
 				pkg: [defaultName, dataStoreAName, dataStoreBName],
-				parent: createRuntimeContext(dataStoreBId, containerRuntime),
+				parentContext: createRuntimeContext(dataStoreBId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreBId),
@@ -257,7 +257,7 @@ describe("Data Store Creation Tests", () => {
 			const contextC: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreCId,
 				pkg: [defaultName, dataStoreAName, dataStoreCName],
-				parent: createRuntimeContext(dataStoreCId, containerRuntime),
+				parentContext: createRuntimeContext(dataStoreCId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreCId),
@@ -282,7 +282,7 @@ describe("Data Store Creation Tests", () => {
 			const contextFake: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName, dataStoreAName, "fake"],
-				parent: createRuntimeContext(dataStoreId, containerRuntime),
+				parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -307,7 +307,7 @@ describe("Data Store Creation Tests", () => {
 			const contextFake: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName, dataStoreAName, "fake"],
-				parent: createRuntimeContext(dataStoreId, containerRuntime),
+				parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -332,7 +332,7 @@ describe("Data Store Creation Tests", () => {
 			const contextC: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName, dataStoreAName, dataStoreBName, dataStoreCName],
-				parent: createRuntimeContext(dataStoreId, containerRuntime),
+				parentContext: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -20,8 +20,13 @@ import { createChildLogger } from "@fluidframework/telemetry-utils";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils";
 
 import { LocalFluidDataStoreContext } from "../dataStoreContext";
+import { createParentContext } from "../dataStores";
 import { ContainerRuntime } from "../containerRuntime";
 import { createRootSummarizerNodeWithGC } from "../summary";
+
+function createRuntimeContext(id: string, runtime: ContainerRuntime) {
+	return createParentContext(id, runtime);
+}
 
 describe("Data Store Creation Tests", () => {
 	describe("Store creation via local context creation and realize", () => {
@@ -130,7 +135,7 @@ describe("Data Store Creation Tests", () => {
 			const context: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName],
-				runtime: containerRuntime,
+				parent: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -155,7 +160,7 @@ describe("Data Store Creation Tests", () => {
 			const context: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [dataStoreAName],
-				runtime: containerRuntime,
+				parent: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -180,7 +185,7 @@ describe("Data Store Creation Tests", () => {
 			const contextA: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName, dataStoreAName],
-				runtime: containerRuntime,
+				parent: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -205,7 +210,7 @@ describe("Data Store Creation Tests", () => {
 			const contextB: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName, dataStoreBName],
-				runtime: containerRuntime,
+				parent: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -230,7 +235,7 @@ describe("Data Store Creation Tests", () => {
 			const contextB: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreBId,
 				pkg: [defaultName, dataStoreAName, dataStoreBName],
-				runtime: containerRuntime,
+				parent: createRuntimeContext(dataStoreBId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreBId),
@@ -252,7 +257,7 @@ describe("Data Store Creation Tests", () => {
 			const contextC: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreCId,
 				pkg: [defaultName, dataStoreAName, dataStoreCName],
-				runtime: containerRuntime,
+				parent: createRuntimeContext(dataStoreCId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreCId),
@@ -277,7 +282,7 @@ describe("Data Store Creation Tests", () => {
 			const contextFake: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName, dataStoreAName, "fake"],
-				runtime: containerRuntime,
+				parent: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -302,7 +307,7 @@ describe("Data Store Creation Tests", () => {
 			const contextFake: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName, dataStoreAName, "fake"],
-				runtime: containerRuntime,
+				parent: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),
@@ -327,7 +332,7 @@ describe("Data Store Creation Tests", () => {
 			const contextC: LocalFluidDataStoreContext = new LocalFluidDataStoreContext({
 				id: dataStoreId,
 				pkg: [defaultName, dataStoreAName, dataStoreBName, dataStoreCName],
-				runtime: containerRuntime,
+				parent: createRuntimeContext(dataStoreId, containerRuntime),
 				storage,
 				scope,
 				createSummarizerNodeFn: getCreateSummarizerNodeFn(dataStoreId),

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -202,7 +202,6 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     // (undocumented)
     readonly id: string;
     readonly isLocalDataStore: boolean;
-    makeLocallyVisible(): void;
     readonly packagePath: readonly string[];
     setChannelDirty(address: string): void;
 }
@@ -274,6 +273,7 @@ export interface IFluidParentContext extends IProvideFluidHandleContext, Partial
     readonly loadingGroupId?: string;
     // (undocumented)
     readonly logger: ITelemetryBaseLogger;
+    makeLocallyVisible(): void;
     // (undocumented)
     readonly options: Record<string | number, any>;
     readonly scope: FluidObject;

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -170,18 +170,13 @@ export interface IExperimentalIncrementalSummaryContext {
 export interface IFluidDataStoreChannel extends IDisposable {
     // (undocumented)
     applyStashedOp(content: any): Promise<unknown>;
-    // @deprecated
-    attachGraph(): void;
-    readonly attachState: AttachState;
     readonly entryPoint: IFluidHandle<FluidObject>;
     getAttachGCData?(telemetryContext?: ITelemetryContext): IGarbageCollectionData;
     getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
-    // (undocumented)
-    readonly id: string;
     makeVisibleAndAttachGraph(): void;
-    process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
-    processSignal(message: any, local: boolean): void;
+    process(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown, addedOutboundReference?: (fromNodePath: string, toNodePath: string) => void): void;
+    processSignal(message: IInboundSignalMessage, local: boolean): void;
     // (undocumented)
     request(request: IRequest): Promise<IResponse>;
     reSubmit(type: string, content: any, localOpMetadata: unknown): any;
@@ -189,60 +184,27 @@ export interface IFluidDataStoreChannel extends IDisposable {
     setConnectionState(connected: boolean, clientId?: string): any;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
     updateUsedRoutes(usedRoutes: string[]): void;
-    // (undocumented)
-    readonly visibilityState: VisibilityState;
 }
 
 // @alpha
-export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreContextEvents>, Partial<IProvideFluidDataStoreRegistry>, IProvideFluidHandleContext {
-    // @deprecated (undocumented)
-    addedGCOutboundReference?(srcHandle: IFluidHandle, outboundHandle: IFluidHandle): void;
+export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreContextEvents>, IFluidParentContext {
     addedGCOutboundRoute?(fromPath: string, toPath: string): void;
-    readonly attachState: AttachState;
     // (undocumented)
     readonly baseSnapshot: ISnapshotTree | undefined;
-    // (undocumented)
-    readonly clientDetails: IClientDetails;
-    // (undocumented)
-    readonly clientId: string | undefined;
-    // (undocumented)
-    readonly connected: boolean;
-    // (undocumented)
-    readonly containerRuntime: IContainerRuntimeBase;
     // @deprecated (undocumented)
     readonly createProps?: any;
-    // (undocumented)
-    readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-    ensureNoDataModelChanges<T>(callback: () => T): T;
-    getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
-    getAudience(): IAudience;
     // @deprecated (undocumented)
     getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
     // (undocumented)
     getCreateChildSummarizerNodeFn(
     id: string,
     createParam: CreateChildSummarizerNodeParam): CreateChildSummarizerNodeFn;
-    getQuorum(): IQuorumClients;
     // (undocumented)
     readonly id: string;
-    // (undocumented)
-    readonly idCompressor?: IIdCompressor;
     readonly isLocalDataStore: boolean;
-    readonly loadingGroupId?: string;
-    // (undocumented)
-    readonly logger: ITelemetryBaseLogger;
     makeLocallyVisible(): void;
-    // (undocumented)
-    readonly options: Record<string | number, any>;
     readonly packagePath: readonly string[];
-    readonly scope: FluidObject;
     setChannelDirty(address: string): void;
-    // (undocumented)
-    readonly storage: IDocumentStorageService;
-    submitMessage(type: string, content: any, localOpMetadata: unknown): void;
-    submitSignal(type: string, content: any, targetClientId?: string): void;
-    // (undocumented)
-    uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 }
 
 // @alpha (undocumented)
@@ -272,6 +234,49 @@ export const IFluidDataStoreRegistry: keyof IProvideFluidDataStoreRegistry;
 export interface IFluidDataStoreRegistry extends IProvideFluidDataStoreRegistry {
     // (undocumented)
     get(name: string): Promise<FluidDataStoreRegistryEntry | undefined>;
+}
+
+// @alpha
+export interface IFluidParentContext extends IProvideFluidHandleContext, Partial<IProvideFluidDataStoreRegistry> {
+    // @deprecated (undocumented)
+    addedGCOutboundReference?(srcHandle: {
+        absolutePath: string;
+    }, outboundHandle: {
+        absolutePath: string;
+    }): void;
+    readonly attachState: AttachState;
+    // (undocumented)
+    readonly clientDetails: IClientDetails;
+    // (undocumented)
+    readonly clientId: string | undefined;
+    // (undocumented)
+    readonly connected: boolean;
+    // (undocumented)
+    readonly containerRuntime: IContainerRuntimeBase;
+    // (undocumented)
+    readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
+    ensureNoDataModelChanges<T>(callback: () => T): T;
+    // (undocumented)
+    readonly gcThrowOnTombstoneUsage: boolean;
+    // (undocumented)
+    readonly gcTombstoneEnforcementAllowed: boolean;
+    getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
+    getAudience(): IAudience;
+    getQuorum(): IQuorumClients;
+    // (undocumented)
+    readonly idCompressor?: IIdCompressor;
+    readonly loadingGroupId?: string;
+    // (undocumented)
+    readonly logger: ITelemetryBaseLogger;
+    // (undocumented)
+    readonly options: Record<string | number, any>;
+    readonly scope: FluidObject;
+    // (undocumented)
+    readonly storage: IDocumentStorageService;
+    submitMessage(type: string, content: any, localOpMetadata: unknown): void;
+    submitSignal(type: string, content: any, targetClientId?: string): void;
+    // (undocumented)
+    uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 }
 
 // @public

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -124,6 +124,8 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
     // @deprecated (undocumented)
     _createDataStoreWithProps(pkg: string | string[], props?: any, id?: string): Promise<IDataStore>;
     createDetachedDataStore(pkg: Readonly<string[]>, loadingGroupId?: string): IFluidDataStoreContextDetached;
+    // (undocumented)
+    readonly disposed: boolean;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
     getAudience(): IAudience;
     getQuorum(): IQuorumClients;
@@ -145,6 +147,8 @@ export interface IContainerRuntimeBaseEvents extends IEvent {
     (event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void): any;
     // (undocumented)
     (event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): any;
+    // (undocumented)
+    (event: "dispose", listener: () => void): any;
 }
 
 // @alpha
@@ -195,10 +199,6 @@ export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreCo
     readonly createProps?: any;
     // @deprecated (undocumented)
     getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
-    // (undocumented)
-    getCreateChildSummarizerNodeFn(
-    id: string,
-    createParam: CreateChildSummarizerNodeParam): CreateChildSummarizerNodeFn;
     // (undocumented)
     readonly id: string;
     readonly isLocalDataStore: boolean;
@@ -254,6 +254,8 @@ export interface IFluidParentContext extends IProvideFluidHandleContext, Partial
     // (undocumented)
     readonly containerRuntime: IContainerRuntimeBase;
     // (undocumented)
+    deleteChildSummarizerNode?(id: string): void;
+    // (undocumented)
     readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     ensureNoDataModelChanges<T>(callback: () => T): T;
     // (undocumented)
@@ -262,6 +264,10 @@ export interface IFluidParentContext extends IProvideFluidHandleContext, Partial
     readonly gcTombstoneEnforcementAllowed: boolean;
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
     getAudience(): IAudience;
+    // (undocumented)
+    getCreateChildSummarizerNodeFn(
+    id: string,
+    createParam: CreateChildSummarizerNodeParam): CreateChildSummarizerNodeFn;
     getQuorum(): IQuorumClients;
     // (undocumented)
     readonly idCompressor?: IIdCompressor;

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -144,6 +144,9 @@
 			"RemovedTypeAliasDeclaration_StableId": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"InterfaceDeclaration_IFluidDataStoreChannel": {
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -147,6 +147,9 @@
 			},
 			"InterfaceDeclaration_IFluidDataStoreChannel": {
 				"backCompat": false
+			},
+			"InterfaceDeclaration_IContainerRuntimeBase": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -395,13 +395,6 @@ export interface IFluidParentContext
 	readonly gcTombstoneEnforcementAllowed: boolean;
 
 	/**
-	 * Get an absolute url to the container based on the provided relativeUrl.
-	 * Returns undefined if the container or data store isn't attached to storage.
-	 * @param relativeUrl - A relative request within the container
-	 */
-	getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
-
-	/**
 	 * Returns the current quorum.
 	 */
 	getQuorum(): IQuorumClients;
@@ -439,6 +432,35 @@ export interface IFluidParentContext
 	 */
 	submitSignal(type: string, content: any, targetClientId?: string): void;
 
+	/**
+	 * Called to make the data store locally visible in the container. This happens automatically for root data stores
+	 * when they are marked as root. For non-root data stores, this happens when their handle is added to a visible DDS.
+	 */
+	makeLocallyVisible(): void;
+
+	/**
+	 * Get an absolute url to the container based on the provided relativeUrl.
+	 * Returns undefined if the container or data store isn't attached to storage.
+	 * @param relativeUrl - A relative request within the container
+	 */
+	getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
+
+	getCreateChildSummarizerNodeFn(
+		/**
+		 * Initial id or path part of this node
+		 */
+		id: string,
+		/**
+		 * Information needed to create the node.
+		 * If it is from a base summary, it will assert that a summary has been seen.
+		 * Attach information if it is created from an attach op.
+		 * If it is local, it will throw unsupported errors on calls to summarize.
+		 */
+		createParam: CreateChildSummarizerNodeParam,
+	): CreateChildSummarizerNodeFn;
+
+	deleteChildSummarizerNode?(id: string): void;
+
 	uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 
 	/**
@@ -456,22 +478,6 @@ export interface IFluidParentContext
 		srcHandle: { absolutePath: string },
 		outboundHandle: { absolutePath: string },
 	): void;
-
-	getCreateChildSummarizerNodeFn(
-		/**
-		 * Initial id or path part of this node
-		 */
-		id: string,
-		/**
-		 * Information needed to create the node.
-		 * If it is from a base summary, it will assert that a summary has been seen.
-		 * Attach information if it is created from an attach op.
-		 * If it is local, it will throw unsupported errors on calls to summarize.
-		 */
-		createParam: CreateChildSummarizerNodeParam,
-	): CreateChildSummarizerNodeFn;
-
-	deleteChildSummarizerNode?(id: string): void;
 }
 
 /**
@@ -502,12 +508,6 @@ export interface IFluidDataStoreContext
 	 * @deprecated 0.16 Issue #1635, #3631
 	 */
 	readonly createProps?: any;
-
-	/**
-	 * Called to make the data store locally visible in the container. This happens automatically for root data stores
-	 * when they are marked as root. For non-root data stores, this happens when their handle is added to a visible DDS.
-	 */
-	makeLocallyVisible(): void;
 
 	/**
 	 * Call by IFluidDataStoreChannel, indicates that a channel is dirty and needs to be part of the summary.

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -115,6 +115,7 @@ export interface IContainerRuntimeBaseEvents extends IEvent {
 	(event: "op", listener: (op: ISequencedDocumentMessage, runtimeMessage?: boolean) => void);
 	(event: "batchEnd", listener: (error: any, op: ISequencedDocumentMessage) => void);
 	(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void);
+	(event: "dispose", listener: () => void);
 }
 
 /**
@@ -162,6 +163,7 @@ export interface IDataStore {
 export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeBaseEvents> {
 	readonly logger: ITelemetryBaseLogger;
 	readonly clientDetails: IClientDetails;
+	readonly disposed: boolean;
 
 	/**
 	 * Invokes the given callback and guarantees that all operations generated within the callback will be ordered
@@ -454,6 +456,22 @@ export interface IFluidParentContext
 		srcHandle: { absolutePath: string },
 		outboundHandle: { absolutePath: string },
 	): void;
+
+	getCreateChildSummarizerNodeFn(
+		/**
+		 * Initial id or path part of this node
+		 */
+		id: string,
+		/**
+		 * Information needed to create the node.
+		 * If it is from a base summary, it will assert that a summary has been seen.
+		 * Attach information if it is created from an attach op.
+		 * If it is local, it will throw unsupported errors on calls to summarize.
+		 */
+		createParam: CreateChildSummarizerNodeParam,
+	): CreateChildSummarizerNodeFn;
+
+	deleteChildSummarizerNode?(id: string): void;
 }
 
 /**
@@ -496,20 +514,6 @@ export interface IFluidDataStoreContext
 	 * @param address - The address of the channel that is dirty.
 	 */
 	setChannelDirty(address: string): void;
-
-	getCreateChildSummarizerNodeFn(
-		/**
-		 * Initial id or path part of this node
-		 */
-		id: string,
-		/**
-		 * Information needed to create the node.
-		 * If it is from a base summary, it will assert that a summary has been seen.
-		 * Attach information if it is created from an attach op.
-		 * If it is local, it will throw unsupported errors on calls to summarize.
-		 */
-		createParam: CreateChildSummarizerNodeParam,
-	): CreateChildSummarizerNodeFn;
 
 	/**
 	 * @deprecated The functionality to get base GC details has been moved to summarizer node.

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -20,6 +20,7 @@ export {
 	IDataStore,
 	IFluidDataStoreChannel,
 	IFluidDataStoreContext,
+	IFluidParentContext,
 	IFluidDataStoreContextDetached,
 	IFluidDataStoreContextEvents,
 	VisibilityState,

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -427,6 +427,7 @@ declare function get_current_InterfaceDeclaration_IFluidDataStoreChannel():
 declare function use_old_InterfaceDeclaration_IFluidDataStoreChannel(
     use: TypeOnly<old.IFluidDataStoreChannel>): void;
 use_old_InterfaceDeclaration_IFluidDataStoreChannel(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IFluidDataStoreChannel());
 
 /*

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -295,6 +295,7 @@ declare function get_old_InterfaceDeclaration_IContainerRuntimeBase():
 declare function use_current_InterfaceDeclaration_IContainerRuntimeBase(
     use: TypeOnly<current.IContainerRuntimeBase>): void;
 use_current_InterfaceDeclaration_IContainerRuntimeBase(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IContainerRuntimeBase());
 
 /*

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -346,6 +346,10 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // (undocumented)
     readonly existing: boolean;
     // (undocumented)
+    readonly gcThrowOnTombstoneUsage = false;
+    // (undocumented)
+    readonly gcTombstoneEnforcementAllowed = false;
+    // (undocumented)
     getAbsoluteUrl(relativeUrl: string): Promise<string | undefined>;
     // (undocumented)
     getAudience(): IAudience;

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -340,6 +340,8 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // @deprecated (undocumented)
     createProps?: any;
     // (undocumented)
+    deleteChildSummarizerNode(id: string): void;
+    // (undocumented)
     deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
     // (undocumented)
     ensureNoDataModelChanges<T>(callback: () => T): T;

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -125,6 +125,10 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 		throw new Error("Method not implemented.");
 	}
 
+	public deleteChildSummarizerNode(id: string): void {
+		throw new Error("Method not implemented.");
+	}
+
 	public async uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>> {
 		throw new Error("Method not implemented.");
 	}

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -45,6 +45,8 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 	public IFluidDataStoreRegistry: IFluidDataStoreRegistry = undefined as any;
 	public IFluidHandleContext: IFluidHandleContext = undefined as any;
 	public idCompressor: IIdCompressorCore & IIdCompressor = undefined as any;
+	public readonly gcThrowOnTombstoneUsage = false;
+	public readonly gcTombstoneEnforcementAllowed = false;
 
 	/**
 	 * Indicates the attachment state of the data store to a host service.

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="mocha" />
-
 // @internal (undocumented)
 export const mochaHooks: {
     beforeAll(): void;

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="mocha" />
+
 // @internal (undocumented)
 export const mochaHooks: {
     beforeAll(): void;

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -112,6 +112,7 @@
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"@fluidframework/test-driver-definitions": "workspace:~",
+		"@fluid-private/test-drivers": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",
 		"@fluidframework/test-utils": "workspace:~",
 		"@fluidframework/tree": "workspace:~",

--- a/packages/test/test-end-to-end-tests/src/test/dataStoresNested.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/dataStoresNested.spec.ts
@@ -1,0 +1,194 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/core-utils";
+import {
+	ITestObjectProvider,
+	TestContainerRuntimeFactory,
+	TestFluidObjectFactory,
+	TestFluidObject,
+	TestObjectProvider,
+	summarizeNow,
+	createSummarizerCore,
+} from "@fluidframework/test-utils";
+import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct";
+import { IContainer, IHostLoader } from "@fluidframework/container-definitions";
+import {
+	IContainerRuntimeOptions,
+	ISummarizer,
+	ISummaryRuntimeOptions,
+	SummaryCollection,
+	DataStoresFactory,
+} from "@fluidframework/container-runtime";
+import { LocalServerTestDriver } from "@fluid-private/test-drivers";
+import { Loader } from "@fluidframework/container-loader";
+import { createChildLogger } from "@fluidframework/telemetry-utils";
+import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { MapFactory } from "@fluidframework/map";
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+interface IDataStores extends IFluidDataStoreChannel {
+	_createFluidDataStoreContext(
+		pkg: string[],
+		id: string,
+		props?: any,
+		loadingGroupId?: string,
+	): unknown;
+}
+
+describe("Nested DataStores", () => {
+	let provider: ITestObjectProvider;
+	let containers: IContainer[] = [];
+	let summaryCollection: SummaryCollection | undefined;
+	let summarizer: ISummarizer | undefined;
+	let loader: IHostLoader | undefined;
+	let seed: number;
+
+	const summaryOptionsToDisableHeuristics: ISummaryRuntimeOptions = {
+		summaryConfigOverrides: {
+			state: "disableHeuristics",
+			maxAckWaitTime: 20000,
+			maxOpsSinceLastSummary: 7000,
+			initialSummarizerDelayMs: 0,
+		},
+	};
+
+	const runtimeOptions: IContainerRuntimeOptions = {
+		enableGroupedBatching: true,
+		summaryOptions: summaryOptionsToDisableHeuristics, // Force summarizer heuristics to be disabled so we can control when to summarize.
+	};
+
+	const testObjectFactory: TestFluidObjectFactory = new TestFluidObjectFactory(
+		[["test", new MapFactory()]],
+		"testObjectFactoryType",
+	);
+
+	const dataStoreFactory = new DataStoresFactory(
+		[[testObjectFactory.type, Promise.resolve(testObjectFactory)]],
+		async (runtime: IFluidDataStoreChannel) => {
+			return runtime;
+		},
+	);
+
+	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
+		defaultFactory: dataStoreFactory,
+		registryEntries: [[dataStoreFactory.type, Promise.resolve(dataStoreFactory)]],
+		runtimeOptions,
+	});
+
+	async function addContainer(container: IContainer) {
+		containers.push(container);
+		const dataStores = (await container.getEntryPoint()) as IDataStores;
+
+		await provider.ensureSynchronized();
+
+		return { container, dataStores };
+	}
+
+	const createContainer = async () => {
+		const container = await provider.createContainer(runtimeFactory);
+		return addContainer(container);
+	};
+
+	async function addContainerInstance() {
+		const container = await provider.loadContainer(runtimeFactory);
+		return addContainer(container);
+	}
+
+	beforeEach("getTestObjectProvider", async () => {
+		const driver = new LocalServerTestDriver();
+		const registry = [];
+		seed = 1; // Every test is independent from another test!
+
+		provider = new TestObjectProvider(
+			Loader,
+			driver,
+			() =>
+				new TestContainerRuntimeFactory(
+					"@fluid-experimental/test-dataStores",
+					new TestFluidObjectFactory(registry),
+				),
+		);
+		// syncSummarizer: true
+		provider.resetLoaderContainerTracker(true); // syncSummarizerClients
+
+		loader = provider.createLoader([[provider.defaultCodeDetails, runtimeFactory]]);
+	});
+
+	afterEach(() => {
+		provider.reset();
+		for (const container of containers) {
+			container.close();
+		}
+		containers = [];
+		summaryCollection = undefined;
+		summarizer = undefined;
+		loader = undefined;
+	});
+
+	async function waitForSummary(): Promise<string> {
+		// ensure that all changes made it through
+		await provider.ensureSynchronized();
+
+		assert(summaryCollection !== undefined, "summary setup properly");
+		// create promise before we call summarizeNow, as otherwise we might miss summary and will wait
+		// forever for next one to happen
+		const wait = summaryCollection.waitSummaryAck(
+			containers[0].deltaManager.lastSequenceNumber,
+		);
+		const summaryResult = await summarizeNow(summarizer!);
+		assert(summaryResult.summaryVersion !== undefined, "summary result");
+		const ackedSummary = await wait;
+		assert(ackedSummary.summaryAck.contents.handle !== undefined, "summary acked");
+		return summaryResult.summaryVersion;
+	}
+
+	/**
+	 * Creates a pair of containers and initializes them with initial state
+	 * @returns collab space
+	 */
+	async function initialize() {
+		const { container, dataStores } = await createContainer();
+
+		// Create and setup a summary collection that will be used to track and wait for summaries.
+		summaryCollection = new SummaryCollection(container.deltaManager, createChildLogger());
+
+		const summarizerRes = await createSummarizerCore(container, loader!);
+		summarizer = summarizerRes.summarizer;
+		// containers.push(summarizerRes.container);
+
+		// Have a second container that follows passivley the first one
+		await addContainerInstance();
+
+		await provider.ensureSynchronized();
+
+		return dataStores;
+	}
+
+	it("Basic test", async () => {
+		const dataStores = await initialize();
+
+		const res1 = dataStores._createFluidDataStoreContext([testObjectFactory.type], "test");
+		const res2 = await (res1 as any).realize();
+		res2.makeVisibleAndAttachGraph();
+		const testObject1 = (await dataStores.request({ url: "/test" })).value as TestFluidObject;
+		testObject1.root.set("testKey", 100);
+
+		await waitForSummary();
+		const dataStores2 = (await addContainerInstance()).dataStores;
+
+		await provider.ensureSynchronized();
+
+		const testObject2 = (await dataStores2.request({ url: "/test" })).value as TestFluidObject;
+		const value = testObject1.root.get("testKey");
+		assert(value === 100, "same value");
+
+		console.log("Success!");
+	});
+});
+
+/* eslint-enable @typescript-eslint/no-non-null-assertion */

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -7,7 +7,6 @@ import { strict as assert } from "assert";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
 import {
-	ContainerRuntime,
 	IAckedSummary,
 	SummaryCollection,
 	DefaultSummaryConfiguration,
@@ -295,18 +294,6 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 			assert.equal(aliasResult3, "Success");
 
 			assert.ok(await getAliasedDataStoreEntryPoint(dataObject1, alias));
-		});
-
-		it("Sending a bad alias message returns error", async () => {
-			try {
-				(runtimeOf(dataObject1) as ContainerRuntime).submitDataStoreAliasOp(
-					{ id: alias },
-					undefined,
-				);
-				assert.fail("Expected exception from sending invalid alias");
-			} catch (err) {
-				assert.equal((err as Error).message, "malformedDataStoreAliasMessage");
-			}
 		});
 
 		it("Assign multiple data stores to the same alias, first write wins, different containers", async function () {

--- a/packages/test/test-utils/api-report/test-utils.api.md
+++ b/packages/test/test-utils/api-report/test-utils.api.md
@@ -83,6 +83,12 @@ export function createSummarizer(provider: ITestObjectProvider, container: ICont
     summarizer: ISummarizer;
 }>;
 
+// @internal (undocumented)
+export function createSummarizerCore(container: IContainer, loader: IHostLoader, summaryVersion?: string): Promise<{
+    container: IContainer;
+    summarizer: ISummarizer;
+}>;
+
 // @internal
 export function createSummarizerFromFactory(provider: ITestObjectProvider, container: IContainer, dataStoreFactory: IFluidDataStoreFactory, summaryVersion?: string, containerRuntimeFactoryType?: typeof ContainerRuntimeFactoryWithDefaultDataStore, registryEntries?: NamedFluidDataStoreRegistryEntries, logger?: ITelemetryBaseLogger, configProvider?: IConfigProviderBase): Promise<{
     container: IContainer;

--- a/packages/test/test-utils/src/TestSummaryUtils.ts
+++ b/packages/test/test-utils/src/TestSummaryUtils.ts
@@ -53,7 +53,8 @@ async function getSummarizerBackCompat(container: IContainer): Promise<ISummariz
 	return response.value as ISummarizer;
 }
 
-async function createSummarizerCore(
+/** @internal */
+export async function createSummarizerCore(
 	container: IContainer,
 	loader: IHostLoader,
 	summaryVersion?: string,

--- a/packages/test/test-utils/src/index.ts
+++ b/packages/test/test-utils/src/index.ts
@@ -37,6 +37,7 @@ export {
 } from "./testObjectProvider.js";
 export {
 	createSummarizer,
+	createSummarizerCore,
 	createSummarizerFromFactory,
 	summarizeNow,
 	SummaryInfo,

--- a/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
+++ b/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
@@ -48,6 +48,30 @@ use_old_InterfaceDeclaration_ContainerDevtoolsProps(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ContainerKey": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_ContainerKey():
+    TypeOnly<old.ContainerKey>;
+declare function use_current_TypeAliasDeclaration_ContainerKey(
+    use: TypeOnly<current.ContainerKey>): void;
+use_current_TypeAliasDeclaration_ContainerKey(
+    get_old_TypeAliasDeclaration_ContainerKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ContainerKey": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_ContainerKey():
+    TypeOnly<current.ContainerKey>;
+declare function use_old_TypeAliasDeclaration_ContainerKey(
+    use: TypeOnly<old.ContainerKey>): void;
+use_old_TypeAliasDeclaration_ContainerKey(
+    get_current_TypeAliasDeclaration_ContainerKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_DevtoolsProps": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_DevtoolsProps():
@@ -68,6 +92,30 @@ declare function use_old_InterfaceDeclaration_DevtoolsProps(
     use: TypeOnly<old.DevtoolsProps>): void;
 use_old_InterfaceDeclaration_DevtoolsProps(
     get_current_InterfaceDeclaration_DevtoolsProps());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_HasContainerKey": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_HasContainerKey():
+    TypeOnly<old.HasContainerKey>;
+declare function use_current_InterfaceDeclaration_HasContainerKey(
+    use: TypeOnly<current.HasContainerKey>): void;
+use_current_InterfaceDeclaration_HasContainerKey(
+    get_old_InterfaceDeclaration_HasContainerKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_HasContainerKey": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_HasContainerKey():
+    TypeOnly<current.HasContainerKey>;
+declare function use_old_InterfaceDeclaration_HasContainerKey(
+    use: TypeOnly<old.HasContainerKey>): void;
+use_old_InterfaceDeclaration_HasContainerKey(
+    get_current_InterfaceDeclaration_HasContainerKey());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
This is an exploration into how we can support nested data stores.
While it is super important to answer question on "why it's needed", I'd love to discuss it outside of this PR, and focus here on how to get such capability, and best way to accomplish it.

I see two possible ways:
1. Change FluidDataStoreRuntime to support data stores as children.
   - That would require some form of unification of channel interfaces / interaction (IChannel & IFluidDataStoreChannel)
   - This also puts us on the path of reimplementing various container runtime features in the future, like aliasing of channels.
2. Make DataStores class closer to IFluidDataStoreChannel requirements and thus be able to instantiate it as a child of DataStores.
   - This prototype looks into this direction.

I've started poking at # 2, and it turned out not that bad. I was able to refactor enough code in 2-3 days that all existing flows seems to continue to work, and (with some hacks) I can build a minimalistic test case for nested data stores (see DataStoresNested.spec.ts).

Key things that **need to be done** in order to make it real:
1. I introduced **IFluidParentContext** as a subset of IFluidDataStoreContext to incrementally keep moving forward. We need to have just one interface.
2. **API surface** - I have not spent any time defining API surface for nested DataStores - as you can see from UT, I simply hacked things around. More refactoring (moving ContainerRuntime implementations into DataStores and thus exposing same APIs) is likely first step.
   - That said, I totally expect that we will not expose this functionality in a form of generic API first. I can take advantage of that structure by extending DataStores class and exposing custom API for specific goals (DB workstream) only. 
4. Somewhat related to above, but I did not spend much time thinking about visibility change flows / aliasing. This needs to be thought through.

Note that this direction does not allow us to have DDS and DataStore under same parent (yet). Some level of unification of IChannel & IFluidDataStoreChannel is required, but this could be done independently, when needed. I do not think it will be that hard (we migth either change all existing DDSs or build an adapter that wraps IChannel, or both). That said, getting rid of delayed handle / object attachment flow would be a welcome change / simplification on this path.

The most interesting point of discussion (if we go that direction) - **what is the future of FluidDataStoreRuntime class**? Storage layout of FluidDataStoreRuntime is different from how DataStores summarizes (for example - attributes blob), and thus you can't just substitute one for another even if functionality-wise DataStores is superset of FluidDataStoreRuntime  I hope that some cheap adapters could be built here (possibly snapshot transformation adapter) to support back-compat and not need to maintain two different implementations. This could be done later / when needed.

Some note on implementation: Some of the interactions between DataStores and ContainerRuntime become weirder (packing & unpacking of signals / ops). This is due to a fact that interface shapes are different between layers. We can't easily change IFluidDataStoreChannel & context (due to compat concerns), and thus I had to adapt DataStore to those patterns, which causes some weirdness at ContainerRuntime layer. It's not that bad, and comments should help / provide some explanation.

Curious to see what reactions this draft generates! :)