### PR TITLE
feat(build-tools): `fluid-tsc`

### DIFF
--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -15,6 +15,7 @@
 	"bin": {
 		"fluid-build": "bin/fluid-build",
 		"fluid-doc-stats": "bin/fluid-doc-stats",
+		"fluid-tsc": "dist/fluidTsc/fluidTsc.js",
 		"fluid-type-test-generator": "bin/fluid-type-test-generator"
 	},
 	"scripts": {

--- a/build-tools/packages/build-tools/src/common/tsCompile.ts
+++ b/build-tools/packages/build-tools/src/common/tsCompile.ts
@@ -1,0 +1,122 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type * as tsTypes from "typescript";
+import path from "path";
+import { getTscUtils } from "./tscUtils.js";
+
+// Any paths given by typescript will be normalized to forward slashes.
+// Local paths should be normalized to make any comparisons.
+const directorySeparator = "/";
+const backslashRegExp = /\\/g;
+function normalizeSlashes(path: string): string {
+	return path.includes("\\") ? path.replace(backslashRegExp, directorySeparator) : path;
+}
+
+export function tsCompile({
+	command,
+	cwd,
+	packageJsonTypeOverride,
+}: {
+	command: string;
+	cwd: string;
+	packageJsonTypeOverride?: "commonjs" | "module";
+}): number {
+	// Load the typescript version that is in the cwd scope
+	const tscUtils = getTscUtils(cwd);
+
+	const ts = tscUtils.tsLib;
+	let commandLine = tscUtils.parseCommandLine(command);
+	const diagnostics: tsTypes.Diagnostic[] = [];
+	if (commandLine) {
+		const configFileName = tscUtils.findConfigFile(cwd, commandLine);
+		if (configFileName) {
+			commandLine = ts.getParsedCommandLineOfConfigFile(configFileName, commandLine.options, {
+				...ts.sys,
+				getCurrentDirectory: () => cwd,
+				onUnRecoverableConfigFileDiagnostic: (diagnostic: tsTypes.Diagnostic) => {
+					diagnostics.push(diagnostic);
+				},
+			});
+		} else {
+			throw new Error("Unknown config file in command line");
+		}
+	}
+
+	let code = ts.ExitStatus.DiagnosticsPresent_OutputsSkipped;
+	if (commandLine && diagnostics.length === 0) {
+		const incremental = !!(commandLine.options.incremental || commandLine.options.composite);
+
+		const host = incremental
+			? ts.createIncrementalCompilerHost(commandLine.options)
+			: ts.createCompilerHost(commandLine.options);
+		// When specified overrides current directory's package.json type field so tsc may cleanly
+		// transpile .ts files to CommonJS or ESM using compilerOptions.module Node16 or NodeNext.
+		if (packageJsonTypeOverride) {
+			const origReadFile = host.readFile;
+			const packageJsonPath = normalizeSlashes(path.join(cwd, "package.json"));
+			host.readFile = (fileName: string) => {
+				const rawFile = origReadFile(fileName);
+				if (fileName === packageJsonPath && rawFile !== undefined) {
+					// Reading local package.json: override type field
+					const packageJson = JSON.parse(rawFile);
+					return JSON.stringify({ ...packageJson, type: packageJsonTypeOverride });
+				}
+				return rawFile;
+			};
+		}
+
+		const param = {
+			rootNames: commandLine.fileNames,
+			options: tscUtils.convertOptionPaths(commandLine.options, cwd, path.resolve),
+			host,
+			projectReferences: commandLine.projectReferences,
+		};
+		const program = incremental ? ts.createIncrementalProgram(param) : ts.createProgram(param);
+
+		diagnostics.push(...program.getConfigFileParsingDiagnostics());
+		diagnostics.push(...program.getSyntacticDiagnostics());
+		diagnostics.push(...program.getOptionsDiagnostics());
+		diagnostics.push(...program.getGlobalDiagnostics());
+		diagnostics.push(...program.getSemanticDiagnostics());
+
+		const emitResult = program.emit();
+		diagnostics.push(...emitResult.diagnostics);
+
+		if (emitResult.emitSkipped && diagnostics.length > 0) {
+			code = ts.ExitStatus.DiagnosticsPresent_OutputsSkipped;
+		} else {
+			code =
+				diagnostics.length !== 0
+					? ts.ExitStatus.DiagnosticsPresent_OutputsGenerated
+					: ts.ExitStatus.Success;
+		}
+	}
+
+	if (diagnostics.length > 0) {
+		const sortedDiagnostics = ts.sortAndDeduplicateDiagnostics(diagnostics);
+
+		const formatDiagnosticsHost: tsTypes.FormatDiagnosticsHost = {
+			getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
+			getCanonicalFileName: tscUtils.getCanonicalFileName,
+			getNewLine: () => ts.sys.newLine,
+		};
+
+		// TODO: tsc has more complicated summary than this
+		if (commandLine?.options?.pretty !== false) {
+			console.log(
+				ts.formatDiagnosticsWithColorAndContext(sortedDiagnostics, formatDiagnosticsHost),
+			);
+			console.log(
+				`${ts.sys.newLine}Found ${sortedDiagnostics.length} error${
+					sortedDiagnostics.length > 1 ? "s" : ""
+				}.`,
+			);
+		} else {
+			console.log(ts.formatDiagnostics(sortedDiagnostics, formatDiagnosticsHost));
+		}
+	}
+	return code;
+}

--- a/build-tools/packages/build-tools/src/common/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/common/tscUtils.ts
@@ -11,6 +11,13 @@ export const parseCommandLine = defaultTscUtil.parseCommandLine;
 export const findConfigFile = defaultTscUtil.findConfigFile;
 export const readConfigFile = defaultTscUtil.readConfigFile;
 
+/**
+ * Matches fluid-tsc command start.
+ * Upon match index 1 and group.type will be "commonjs"|"module".
+ * Remaining string will be tsc arguments.
+ */
+export const fluidTscRegEx = /^fluid-tsc\s+(?<type>commonjs|module)/;
+
 // See convertToProgramBuildInfoCompilerOptions in typescript src/compiler/builder.ts
 const incrementalOptions = [
 	// affectsEmit === true
@@ -182,7 +189,8 @@ function createTscUtil(tsLib: typeof ts) {
 		tsLib,
 		parseCommandLine: (command: string) => {
 			// TODO: parse the command line for real, split space for now.
-			const args = command.split(" ");
+			// In case of fluid-tsc, replace those parts with 'tsc' before split.
+			const args = command.replace(fluidTscRegEx, "tsc").split(" ");
 			if (command.includes("&&")) {
 				console.warn("Warning: '&&' is not supported in tsc command.");
 			}

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
@@ -31,6 +31,7 @@ const executableToLeafTask: {
 } = {
 	"ts2esm": Ts2EsmTask,
 	"tsc": TscTask,
+	"fluid-tsc": TscTask,
 	"tsc-multi": TscMultiTask,
 	"tslint": TsLintTask,
 	"eslint": EsLintTask,

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
@@ -2,85 +2,21 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import type * as tsTypes from "typescript";
-import path from "path";
-import { getTscUtils } from "../../../common/tscUtils";
-import type { WorkerExecResult, WorkerMessage } from "./worker";
+
+import { tsCompile } from "../../../common/tsCompile.js";
+import { fluidTscRegEx } from "../../../common/tscUtils.js";
+import type { WorkerExecResult, WorkerMessage } from "./worker.js";
 
 export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
-	const { command, cwd } = msg;
-	// Load the typescript version that is in the cwd scope
-	const tscUtils = getTscUtils(cwd);
+	return { code: tsCompile(msg) };
+}
 
-	const ts = tscUtils.tsLib;
-	let commandLine = tscUtils.parseCommandLine(command);
-	const diagnostics: tsTypes.Diagnostic[] = [];
-	if (commandLine) {
-		const configFileName = tscUtils.findConfigFile(cwd, commandLine);
-		if (configFileName) {
-			commandLine = ts.getParsedCommandLineOfConfigFile(configFileName, commandLine.options, {
-				...ts.sys,
-				getCurrentDirectory: () => cwd,
-				onUnRecoverableConfigFileDiagnostic: (diagnostic: tsTypes.Diagnostic) => {
-					diagnostics.push(diagnostic);
-				},
-			});
-		} else {
-			throw new Error("Unknown config file in command line");
-		}
+export async function fluidCompile(msg: WorkerMessage): Promise<WorkerExecResult> {
+	const commandMatch = fluidTscRegEx.exec(msg.command);
+	if (!commandMatch) {
+		throw new Error(`worker command not recognized: ${msg.command}`);
 	}
-
-	let code = ts.ExitStatus.DiagnosticsPresent_OutputsSkipped;
-	if (commandLine && diagnostics.length === 0) {
-		const incremental = !!(commandLine.options.incremental || commandLine.options.composite);
-		const param = {
-			rootNames: commandLine.fileNames,
-			options: tscUtils.convertOptionPaths(commandLine.options, cwd, path.resolve),
-			projectReferences: commandLine.projectReferences,
-		};
-		const program = incremental ? ts.createIncrementalProgram(param) : ts.createProgram(param);
-
-		diagnostics.push(...program.getConfigFileParsingDiagnostics());
-		diagnostics.push(...program.getSyntacticDiagnostics());
-		diagnostics.push(...program.getOptionsDiagnostics());
-		diagnostics.push(...program.getGlobalDiagnostics());
-		diagnostics.push(...program.getSemanticDiagnostics());
-
-		const emitResult = program.emit();
-		diagnostics.push(...emitResult.diagnostics);
-
-		if (emitResult.emitSkipped && diagnostics.length > 0) {
-			code = ts.ExitStatus.DiagnosticsPresent_OutputsSkipped;
-		} else {
-			code =
-				diagnostics.length !== 0
-					? ts.ExitStatus.DiagnosticsPresent_OutputsGenerated
-					: ts.ExitStatus.Success;
-		}
-	}
-
-	if (diagnostics.length > 0) {
-		const sortedDiagnostics = ts.sortAndDeduplicateDiagnostics(diagnostics);
-
-		const formatDiagnosticsHost: tsTypes.FormatDiagnosticsHost = {
-			getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
-			getCanonicalFileName: tscUtils.getCanonicalFileName,
-			getNewLine: () => ts.sys.newLine,
-		};
-
-		// TODO: tsc has more complicated summary than this
-		if (commandLine?.options?.pretty !== false) {
-			console.log(
-				ts.formatDiagnosticsWithColorAndContext(sortedDiagnostics, formatDiagnosticsHost),
-			);
-			console.log(
-				`${ts.sys.newLine}Found ${sortedDiagnostics.length} error${
-					sortedDiagnostics.length > 1 ? "s" : ""
-				}.`,
-			);
-		} else {
-			console.log(ts.formatDiagnostics(sortedDiagnostics, formatDiagnosticsHost));
-		}
-	}
-	return { code };
+	const command = `tsc${msg.command.slice(fluidTscRegEx.lastIndex)}`;
+	const packageJsonTypeOverride = commandMatch[1] as "commonjs" | "module";
+	return { code: tsCompile({ command, cwd: msg.cwd, packageJsonTypeOverride }) };
 }

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/tscWorker.ts
@@ -12,11 +12,11 @@ export async function compile(msg: WorkerMessage): Promise<WorkerExecResult> {
 }
 
 export async function fluidCompile(msg: WorkerMessage): Promise<WorkerExecResult> {
-	const commandMatch = fluidTscRegEx.exec(msg.command);
+	const commandMatch = msg.command.match(fluidTscRegEx);
 	if (!commandMatch) {
 		throw new Error(`worker command not recognized: ${msg.command}`);
 	}
-	const command = `tsc${msg.command.slice(fluidTscRegEx.lastIndex)}`;
+	const command = msg.command.replace(commandMatch[0], "tsc");
 	const packageJsonTypeOverride = commandMatch[1] as "commonjs" | "module";
 	return { code: tsCompile({ command, cwd: msg.cwd, packageJsonTypeOverride }) };
 }

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/worker.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/workers/worker.ts
@@ -5,7 +5,7 @@
 import { parentPort } from "worker_threads";
 
 import { lint } from "./eslintWorker";
-import { compile } from "./tscWorker";
+import { compile, fluidCompile } from "./tscWorker";
 
 export interface WorkerMessage {
 	workerName: string;
@@ -20,8 +20,9 @@ export interface WorkerExecResult {
 }
 
 const workers: { [key: string]: (message: WorkerMessage) => Promise<WorkerExecResult> } = {
-	tsc: compile,
-	eslint: lint,
+	"tsc": compile,
+	"fluid-tsc": fluidCompile,
+	"eslint": lint,
 };
 
 let collectMemoryUsage = false;

--- a/build-tools/packages/build-tools/src/fluidTsc/fluidTsc.ts
+++ b/build-tools/packages/build-tools/src/fluidTsc/fluidTsc.ts
@@ -11,9 +11,15 @@ const { log, errorLog: error } = defaultLogger;
 function printUsage() {
 	log(
 		`
+Runs tsc using arguments given in an environment where local package.json "type" property is overridden. This enables single package to support both CommonJS and ESM.
+
+Warning: Use this dual build approach carefully as consumers must be careful not to depend on both CommonJS and ESM versions of the same package.
+
 Usage: fluid-tsc [commonjs|module] [<tsc args>...]
     [commonjs|module] value for package.json "type" property
     [<tsc args>...] arguments passed to Typescript compiler (see tsc -?)
+
+Example: fluid-tsc commonjs --project tsconfig.cjs.json
 `,
 	);
 }

--- a/build-tools/packages/build-tools/src/fluidTsc/fluidTsc.ts
+++ b/build-tools/packages/build-tools/src/fluidTsc/fluidTsc.ts
@@ -1,0 +1,42 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { defaultLogger } from "../common/logging";
+import { tsCompile } from "../common/tsCompile";
+
+const { log, errorLog: error } = defaultLogger;
+
+function printUsage() {
+	log(
+		`
+Usage: fluid-tsc [commonjs|module] [<tsc args>...]
+    [commonjs|module] value for package.json "type" property
+    [<tsc args>...] arguments passed to Typescript compiler (see tsc -?)
+`,
+	);
+}
+
+async function main() {
+	const firstArg = process.argv[2];
+
+	if (firstArg === "-?" || firstArg === "--help") {
+		printUsage();
+		process.exit(0);
+	}
+
+	if (firstArg !== "commonjs" && firstArg !== "module") {
+		throw new Error(
+			`fluid-tsc's first argument must be 'commonjs' or 'module'. Was: ${firstArg}`,
+		);
+	}
+
+	const command = `tsc ${process.argv.slice(3).join(" ")}`;
+	process.exit(tsCompile({ command, cwd: process.cwd(), packageJsonTypeOverride: firstArg }));
+}
+
+main().catch((e) => {
+	error(`Unexpected error. ${e.message}`);
+	error(e.stack);
+});

--- a/build-tools/packages/build-tools/src/fluidTsc/fluidTsc.ts
+++ b/build-tools/packages/build-tools/src/fluidTsc/fluidTsc.ts
@@ -45,4 +45,5 @@ async function main() {
 main().catch((e) => {
 	error(`Unexpected error. ${e.message}`);
 	error(e.stack);
+	process.exit(1);
 });


### PR DESCRIPTION
replaces `tsc-multi` with package overrides

`tsCompile.ts` refactored from `tscWorker.ts` leaving `Worker` interface behind and adding custom host with readFile that may override the "type"field of current directories package.json.

- Add `fluid-tsc` command to run tsc with package.json override in effect.
- Add task recognition of `fluid-tsc` as a `tsc` task with handling of command line difference.
- Fix `getTscCommandDependencies` detection of directory or file reference specification.