### PR TITLE
tree: better errors for json snapshots diffs

### DIFF
--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -12,10 +12,29 @@ const regenerateSnapshots = process.argv.includes("--snapshot");
 
 export function takeJsonSnapshot(data: JsonCompatibleReadOnly, suffix: string = ""): void {
 	const dataStr = JSON.stringify(data, undefined, 2);
-	return takeSnapshot(dataStr, `${suffix}.json`);
+	return takeSnapshot(dataStr, `${suffix}.json`, jsonCompare);
 }
 
-export function takeSnapshot(data: string, suffix: string): void {
+function jsonCompare(actual: string, expected: string, message: string): void {
+	const parsedA = JSON.parse(actual);
+	const parsedB = JSON.parse(expected);
+	assert.deepEqual(parsedA, parsedB, message);
+}
+
+/**
+ * @param data - content to save and compare. Must be deterministic.
+ * @param suffix - appended to file name. For example ".txt" or ".json"
+ * @param compare - given the before and after strings and throws an error if they differ.
+ * This cannot be used to suppress errors for non-deterministic input: it can only be used to provide nicer error messages.
+ *
+ * Non-deterministic data is forbidden (and will error after compare is run) to prevent unneeded changes/churn of snapshot files when regenerating,
+ * as well as to ensure that buggy compare functions can't falsy pass tests.
+ */
+export function takeSnapshot(
+	data: string,
+	suffix: string,
+	compare?: (actual: string, expected: string, message: string) => void,
+): void {
 	assert(
 		currentTestName !== undefined,
 		"use `useSnapshotDirectory` to configure the tests containing describe block to take snapshots",
@@ -33,11 +52,15 @@ export function takeSnapshot(data: string, suffix: string): void {
 	const exists = existsSync(fullFile);
 	if (regenerateSnapshots) {
 		assert(exists === false, "snapshot should not already exist: possible name collision.");
+		// Ensure compare function does not error with this output.
+		compare?.(data, data, "invalid compare function");
 		writeFileSync(fullFile, data);
 	} else {
 		assert(exists, `test snapshot file does not exist: "${fullFile}"`);
 		const pastData = readFileSync(fullFile, "utf-8");
-		assert.equal(data, pastData, `snapshot different for "${currentTestName}"`);
+		const message = `snapshot different for "${currentTestName}"`;
+		compare?.(data, pastData, message);
+		assert.equal(data, pastData, message);
 	}
 }
 


### PR DESCRIPTION
## Description

Make json snapshot test errors show nicer diff messages, instead of a giant escaped string in one line.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


