### PR TITLE
fix(e2e tests): Add build:test->^build:esnext dependency

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -162,6 +162,7 @@
 			},
 			"build:test": [
 				"...",
+				"^build:esnext",
 				"@fluidframework/container-runtime#build:test"
 			]
 		}


### PR DESCRIPTION
## Description

An FF team member observed this error log from a clean state:

![image](https://github.com/microsoft/FluidFramework/assets/5222607/c6ce082f-cd67-4661-812d-4ac16ddce453)

They confirmed that experimental tree's /lib folder wasn't present on the resulting output. L2 of that error log is test-end-to-end-test's `build:test` script, so flub appears to not realize the `build:test` script is dependent on all of test-end-to-end-test's dependencies' ESM builds.

This adds an explicit dependency for that script.
