### PR TITLE
[Data Virtualization] Add capability to load omitted snaphot in RemoteFluidDataStore

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -275,7 +275,8 @@ export abstract class OdspDocumentStorageServiceBase implements IDocumentStorage
 			}
 		}
 
-		if (blobContents !== undefined && cacheSnapshot) {
+		// Currently always cache blobs as container runtime is not caching them.
+		if (blobContents !== undefined) {
 			this.initBlobsCache(blobContents);
 		}
 

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -318,7 +318,7 @@ describe("Tests1 for snapshot fetch", () => {
 			assert.fail("the getSnapshot request should succeed");
 		}
 		assert(success, "should have asked for g1 group id");
-		assert(service["blobCache"].value.size === 0, "no blobs should be cached locally");
+		assert(service["blobCache"].value.size !== 0, "blobs should still be cached locally");
 		assert(service["commitCache"].size === 0, "no trees should be cached");
 		assert(
 			mockLogger.matchEvents([
@@ -381,7 +381,7 @@ describe("Tests1 for snapshot fetch", () => {
 		}
 		const cachedValue = (await epochTracker.get(createCacheSnapshotKey(resolved))) as ISnapshot;
 		assert(cachedValue.snapshotTree.id === "SnapshotId", "snapshot should have been cached");
-		assert(service["blobCache"].value.size === 0, "no blobs should be cached locally");
+		assert(service["blobCache"].value.size !== 0, "blobs should still be cached locally");
 		assert(service["commitCache"].size === 0, "no trees should be cached");
 	});
 

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -40,6 +40,7 @@ import { IResponse } from '@fluidframework/core-interfaces';
 import { IRuntime } from '@fluidframework/container-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
+import { ISnapshotTree } from '@fluidframework/protocol-definitions';
 import { isStableId } from '@fluidframework/id-compressor';
 import { ISummaryAck } from '@fluidframework/protocol-definitions';
 import { ISummaryContent } from '@fluidframework/protocol-definitions';
@@ -161,6 +162,10 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     getPendingLocalState(props?: IGetPendingLocalStateProps): unknown;
     // (undocumented)
     getQuorum(): IQuorumClients;
+    getSnapshotForLoadingGroupId(loadingGroupIds: string[], pathParts: string[]): Promise<{
+        snapshotTree: ISnapshotTree;
+        sequenceNumber: number;
+    }>;
     // (undocumented)
     idCompressor: (IIdCompressor & IIdCompressorCore) | undefined;
     // (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -29,7 +29,7 @@ import {
 	IContainerRuntime,
 	IContainerRuntimeEvents,
 } from "@fluidframework/container-runtime-definitions";
-import { assert, delay, LazyPromise } from "@fluidframework/core-utils";
+import { assert, Deferred, delay, LazyPromise, PromiseCache } from "@fluidframework/core-utils";
 import { Trace, TypedEventEmitter } from "@fluid-internal/client-utils";
 import {
 	createChildLogger,
@@ -53,6 +53,7 @@ import {
 	DriverHeader,
 	FetchSource,
 	IDocumentStorageService,
+	type ISnapshot,
 } from "@fluidframework/driver-definitions";
 import { readAndParse } from "@fluidframework/driver-utils";
 import {
@@ -159,6 +160,7 @@ import {
 	ISummarizerEvents,
 	IBaseSummarizeResult,
 	ISummarizer,
+	rootHasIsolatedChannels,
 } from "./summary";
 import { formExponentialFn, Throttler } from "./throttler";
 import {
@@ -1185,11 +1187,16 @@ export class ContainerRuntime
 	 */
 	private readonly loadedFromVersionId: string | undefined;
 
+	/**
+	 * It a cache for holding mapping for groupIds with its snapshot from the service.
+	 */
+	private readonly snapshotCacheForLoadingGroupIds = new PromiseCache<string, ISnapshot>();
+
 	/***/
 	protected constructor(
-		context: IContainerContext,
+		private readonly context: IContainerContext,
 		private readonly registry: IFluidDataStoreRegistry,
-		metadata: IContainerRuntimeMetadata | undefined,
+		private readonly metadata: IContainerRuntimeMetadata | undefined,
 		electedSummarizerData: ISerializedElection | undefined,
 		chunks: [string, string[]][],
 		dataStoreAliasMap: [string, string][],
@@ -1739,6 +1746,96 @@ export class ContainerRuntime
 		this.pendingStateManager.dispose();
 		this.emit("dispose");
 		this.removeAllListeners();
+	}
+
+	/**
+	 * Api to fetch the snapshot from the service for a loadingGroupIds.
+	 * @param loadingGroupIds - LoadingGroupId for which the snapshot is asked for.
+	 * @param pathParts - Parts of the path, which we want to extract from the snapshot tree.
+	 * @returns - snapshotTree and the sequence number of the snapshot.
+	 */
+	public async getSnapshotForLoadingGroupId(
+		loadingGroupIds: string[],
+		pathParts: string[],
+	): Promise<{ snapshotTree: ISnapshotTree; sequenceNumber: number }> {
+		const sortedLoadingGroupIds = loadingGroupIds.sort();
+		assert(this.storage.getSnapshot !== undefined, "getSnapshot api should be defined if used");
+		// Lookup up in the cache, if not present then make the network call as multiple datastores could
+		// be in same loading group. So, once we have fetched the snapshot for that loading group on
+		// any request, then cache that as same group could be requested in future too.
+		const snapshot = await this.snapshotCacheForLoadingGroupIds.addOrGet(
+			sortedLoadingGroupIds.join(),
+			async () => {
+				assert(
+					this.storage.getSnapshot !== undefined,
+					"getSnapshot api should be defined if used",
+				);
+				return this.storage.getSnapshot({
+					cacheSnapshot: false,
+					scenarioName: "snapshotForLoadingGroupId",
+					loadingGroupIds: sortedLoadingGroupIds,
+				});
+			},
+		);
+
+		// Find the snapshotTree inside the returned snapshot based on the path as given in the request.
+		const hasIsolatedChannels = rootHasIsolatedChannels(this.metadata);
+		const snapshotTreeForPath = this.getSnapshotTreeForPath(
+			snapshot.snapshotTree,
+			pathParts,
+			hasIsolatedChannels,
+		);
+		assert(snapshotTreeForPath !== undefined, "no snapshotTree for the path");
+		const snapshotSeqNumber = snapshot.sequenceNumber;
+		assert(snapshotSeqNumber !== undefined, "snapshotSeqNumber should be present");
+
+		// If the snapshot is ahead of the last seq number of the delta manager, then catch up before
+		// returning the snapshot.
+		if (snapshotSeqNumber > this.context.deltaManager.lastSequenceNumber) {
+			// If this is a summarizer client, which is trying to load a group and it finds that there is
+			// another snapshot from which the summarizer loaded and it is behind, then just give up as
+			// the summarizer state is not up to date.
+			if (this.isSummarizerClient) {
+				throw new Error(
+					"Summarizer client behind when loading snapshot with loadingGroupId",
+				);
+			}
+			// If the inbound deltas queue is paused, then unpause it for now as we need
+			// to catch up to the snapshot sequence number.
+			if (this.context.deltaManager.inbound.paused) {
+				this.context.deltaManager.inbound.resume();
+			}
+			const defP = new Deferred<boolean>();
+			this.context.deltaManager.on("op", (message: ISequencedDocumentMessage) => {
+				if (message.sequenceNumber >= snapshotSeqNumber) {
+					defP.resolve(true);
+				}
+			});
+			await defP.promise;
+		}
+		return { snapshotTree: snapshotTreeForPath, sequenceNumber: snapshotSeqNumber };
+	}
+
+	/**
+	 * Api to find a snapshot tree inside a bigger snapshot tree based on the path in the pathParts array.
+	 * @param snapshotTree - snapshot tree to look into.
+	 * @param pathParts - Part of the path, which we want to extract from the snapshot tree.
+	 * @param hasIsolatedChannels - whether the channels are present inside ".channels" subtree.
+	 * @returns - requested snapshot tree based on the path parts.
+	 */
+	private getSnapshotTreeForPath(
+		snapshotTree: ISnapshotTree,
+		pathParts: string[],
+		hasIsolatedChannels: boolean,
+	): ISnapshotTree | undefined {
+		let childTree = snapshotTree;
+		for (const part of pathParts) {
+			if (hasIsolatedChannels) {
+				childTree = childTree?.trees[channelsTreeName];
+			}
+			childTree = childTree?.trees[part];
+		}
+		return childTree;
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1194,7 +1194,7 @@ export class ContainerRuntime
 
 	/***/
 	protected constructor(
-		private readonly context: IContainerContext,
+		context: IContainerContext,
 		private readonly registry: IFluidDataStoreRegistry,
 		private readonly metadata: IContainerRuntimeMetadata | undefined,
 		electedSummarizerData: ISerializedElection | undefined,
@@ -1791,7 +1791,7 @@ export class ContainerRuntime
 
 		// If the snapshot is ahead of the last seq number of the delta manager, then catch up before
 		// returning the snapshot.
-		if (snapshotSeqNumber > this.context.deltaManager.lastSequenceNumber) {
+		if (snapshotSeqNumber > this.deltaManager.lastSequenceNumber) {
 			// If this is a summarizer client, which is trying to load a group and it finds that there is
 			// another snapshot from which the summarizer loaded and it is behind, then just give up as
 			// the summarizer state is not up to date.
@@ -1802,11 +1802,11 @@ export class ContainerRuntime
 			}
 			// If the inbound deltas queue is paused, then unpause it for now as we need
 			// to catch up to the snapshot sequence number.
-			if (this.context.deltaManager.inbound.paused) {
+			if (this.deltaManager.inbound.paused) {
 				throw new Error("Could not catch up as inbound queue is paused");
 			}
 			const defP = new Deferred<boolean>();
-			this.context.deltaManager.on("op", (message: ISequencedDocumentMessage) => {
+			this.deltaManager.on("op", (message: ISequencedDocumentMessage) => {
 				if (message.sequenceNumber >= snapshotSeqNumber) {
 					defP.resolve(true);
 				}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1829,7 +1829,8 @@ export class ContainerRuntime
 	 * Api to find a snapshot tree inside a bigger snapshot tree based on the path in the pathParts array.
 	 * @param snapshotTree - snapshot tree to look into.
 	 * @param pathParts - Part of the path, which we want to extract from the snapshot tree.
-	 * @param hasIsolatedChannels - whether the channels are present inside ".channels" subtree.
+	 * @param hasIsolatedChannels - whether the channels are present inside ".channels" subtree. Older
+	 * snapshots will not have trees inside ".channels", so check that.
 	 * @returns - requested snapshot tree based on the path parts.
 	 */
 	private getSnapshotTreeForPath(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1188,7 +1188,7 @@ export class ContainerRuntime
 	private readonly loadedFromVersionId: string | undefined;
 
 	/**
-	 * It a cache for holding mapping for groupIds with its snapshot from the service.
+	 * It a cache for holding mapping for loading groupIds with its snapshot from the service.
 	 */
 	private readonly snapshotCacheForLoadingGroupIds = new PromiseCache<string, ISnapshot>();
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1803,7 +1803,7 @@ export class ContainerRuntime
 			// If the inbound deltas queue is paused, then unpause it for now as we need
 			// to catch up to the snapshot sequence number.
 			if (this.context.deltaManager.inbound.paused) {
-				this.context.deltaManager.inbound.resume();
+				throw new Error("Could not catch up as inbound queue is paused");
 			}
 			const defP = new Deferred<boolean>();
 			this.context.deltaManager.on("op", (message: ISequencedDocumentMessage) => {

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -1012,7 +1012,7 @@ export abstract class FluidDataStoreContext
 export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 	private initSnapshotValue: ISnapshotTree | undefined;
 	// Tells whether we need to fetch the snapshot before use. This is to support Data Virtualization.
-	private readonly snapshotFetchRequired: boolean;
+	private snapshotFetchRequired: boolean;
 	private readonly runtime: ContainerRuntime;
 
 	constructor(props: IRemoteFluidDataStoreContextProps) {
@@ -1042,6 +1042,7 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 			);
 			this.initSnapshotValue = snapshot.snapshotTree;
 			sequenceNumber = snapshot.sequenceNumber;
+			this.snapshotFetchRequired = false;
 		}
 		let tree = this.initSnapshotValue;
 		let isRootDataStore = true;

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -95,6 +95,7 @@ interface ISnapshotDetails {
 	pkg: readonly string[];
 	isRootDataStore: boolean;
 	snapshot?: ISnapshotTree;
+	sequenceNumber?: number;
 }
 
 interface FluidDataStoreMessage {
@@ -221,6 +222,8 @@ export abstract class FluidDataStoreContext
 	public get IFluidDataStoreRegistry(): IFluidDataStoreRegistry | undefined {
 		return this.registry;
 	}
+
+	private baseSnapshotSequenceNumber: number | undefined;
 
 	/**
 	 * A datastore is considered as root if it
@@ -445,6 +448,7 @@ export abstract class FluidDataStoreContext
 		// It is important that this be in sync with the pending ops, and also
 		// that it is set here, before bindRuntime is called.
 		this._baseSnapshot = details.snapshot;
+		this.baseSnapshotSequenceNumber = details.sequenceNumber;
 		const packages = details.pkg;
 
 		const { factory, registry } = await this.factoryFromPackagePath(packages);
@@ -808,7 +812,11 @@ export abstract class FluidDataStoreContext
 
 			// Apply all pending ops
 			for (const op of pending) {
-				channel.process(op, false, undefined /* localOpMetadata */);
+				// Only process ops whose seq number is greater than snapshot sequence number from which it loaded.
+				const seqNumber = this.baseSnapshotSequenceNumber ?? -1;
+				if (op.sequenceNumber > seqNumber) {
+					channel.process(op, false, undefined /* localOpMetadata */);
+				}
 			}
 
 			this.thresholdOpsCounter.send("ProcessPendingOps", pending.length);
@@ -1002,7 +1010,10 @@ export abstract class FluidDataStoreContext
 }
 
 export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
-	private readonly initSnapshotValue: ISnapshotTree | undefined;
+	private initSnapshotValue: ISnapshotTree | undefined;
+	// Tells whether we need to fetch the snapshot before use. This is to support Data Virtualization.
+	private readonly snapshotFetchRequired: boolean;
+	private readonly runtime: ContainerRuntime;
 
 	constructor(props: IRemoteFluidDataStoreContextProps) {
 		super(props, true /* existing */, false /* isLocalDataStore */, () => {
@@ -1010,13 +1021,28 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 		});
 
 		this.initSnapshotValue = props.snapshotTree;
-
+		this.snapshotFetchRequired = !!props.snapshotTree?.omitted;
+		this.runtime = props.runtime;
 		if (props.snapshotTree !== undefined) {
 			this.summarizerNode.updateBaseSummaryState(props.snapshotTree);
 		}
 	}
 
 	private readonly initialSnapshotDetailsP = new LazyPromise<ISnapshotDetails>(async () => {
+		// Sequence number of the snapshot.
+		let sequenceNumber: number | undefined;
+		if (this.snapshotFetchRequired) {
+			assert(
+				this.loadingGroupId !== undefined,
+				"groupId should be present to fetch snapshot",
+			);
+			const snapshot = await this.runtime.getSnapshotForLoadingGroupId(
+				[this.loadingGroupId],
+				[this.id],
+			);
+			this.initSnapshotValue = snapshot.snapshotTree;
+			sequenceNumber = snapshot.sequenceNumber;
+		}
 		let tree = this.initSnapshotValue;
 		let isRootDataStore = true;
 
@@ -1062,6 +1088,7 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 			pkg: this.pkg!,
 			isRootDataStore,
 			snapshot: tree,
+			sequenceNumber,
 		};
 	});
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -2309,7 +2309,7 @@ describe("Runtime", () => {
 					["G1"],
 					["missingDataStore"],
 				);
-				assert.deepEqual(
+				assert.deepStrictEqual(
 					snapshotTree.trees[".channels"].trees.missingDataStore,
 					snapshot.snapshotTree,
 					"snapshot should be equal",

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -13,7 +13,6 @@ import {
 } from "@fluidframework/container-definitions";
 import {
 	ISequencedDocumentMessage,
-	// ISnapshotTree,
 	ISummaryTree,
 	MessageType,
 	type ISnapshotTree,


### PR DESCRIPTION
## Description

This adds capability to load individual datastores with a loadingGroupId if the snapshot content is omitted.
1.) Add function in container Runtime to fetch the snapshot based on loadingGroupid and return the part of that snapshot for the path requested. The group snapshot is cached so that it can used by used by other requests. We use PromiseCache so that we can get the same promise if it is not yet completed.
2.) The above API returns the snapshot when the container has caught up to the snapshot seq number of the snapshot of a loading group. If it is summarizer, then it throws an error as that means summarizer is not up to date.
3.) In datastoreContext, when the snapshot is returned, we only process the ops which are after the snapshot seq number.
4.) Also added various unit tests to cover different scenarios.

This is part of data virtualization effort which is documented here: [Design Doc](https://microsoft.sharepoint.com/:w:/t/FluidFramework/ESJQvukxffJNiTZzbNCWky4B891mpOpWD7BHhbOznXsMZg?e=gAUCrx)