### PR TITLE
Remove CC from Redis Error logs

### DIFF
--- a/server/routerlicious/packages/services/src/redis.ts
+++ b/server/routerlicious/packages/services/src/redis.ts
@@ -38,7 +38,8 @@ export class RedisCache implements ICache {
 			await this.client.del(this.getKey(key));
 			return true;
 		} catch (error: any) {
-			Lumberjack.error(`Error deleting from cache.`, undefined, error);
+			const newError: Error = { name: error?.name, message: error?.message };
+			Lumberjack.error(`Error deleting from cache.`, undefined, newError);
 			return false;
 		}
 	}
@@ -47,8 +48,12 @@ export class RedisCache implements ICache {
 		try {
 			return this.client.get(this.getKey(key));
 		} catch (error: any) {
-			Lumberjack.error(`Error getting ${key.substring(0, 20)} from cache.`, undefined, error);
 			const newError: Error = { name: error?.name, message: error?.message };
+			Lumberjack.error(
+				`Error getting ${key.substring(0, 20)} from cache.`,
+				undefined,
+				newError,
+			);
 			throw newError;
 		}
 	}
@@ -65,8 +70,12 @@ export class RedisCache implements ICache {
 				throw new Error(result);
 			}
 		} catch (error: any) {
-			Lumberjack.error(`Error setting ${key.substring(0, 20)} in cache.`, undefined, error);
 			const newError: Error = { name: error?.name, message: error?.message };
+			Lumberjack.error(
+				`Error setting ${key.substring(0, 20)} in cache.`,
+				undefined,
+				newError,
+			);
 			throw newError;
 		}
 	}
@@ -75,12 +84,12 @@ export class RedisCache implements ICache {
 		try {
 			return this.client.incr(key);
 		} catch (error: any) {
+			const newError: Error = { name: error?.name, message: error?.message };
 			Lumberjack.error(
 				`Error while incrementing counter for ${key.substring(0, 20)} in redis.`,
 				undefined,
-				error,
+				newError,
 			);
-			const newError: Error = { name: error?.name, message: error?.message };
 			throw newError;
 		}
 	}
@@ -89,12 +98,12 @@ export class RedisCache implements ICache {
 		try {
 			return this.client.decr(key);
 		} catch (error: any) {
+			const newError: Error = { name: error?.name, message: error?.message };
 			Lumberjack.error(
 				`Error while decrementing counter for ${key.substring(0, 20)} in redis.`,
 				undefined,
-				error,
+				newError,
 			);
-			const newError: Error = { name: error?.name, message: error?.message };
 			throw newError;
 		}
 	}


### PR DESCRIPTION
## Description
> Changes how the Redis errors are logged to avoid customer content in logs (key-value pairs in the logs)