### PR TITLE
Make storage network calls non-retriable for throttling errors

### DIFF
--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
@@ -22,6 +22,7 @@ export interface HostStoragePolicy {
     // (undocumented)
     concurrentOpsBatches?: number;
     concurrentSnapshotFetch?: boolean;
+    disableRetriesOnStorageThrottlingError?: boolean;
     // @deprecated (undocumented)
     enableRedeemFallback?: boolean;
     // @deprecated (undocumented)

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -162,4 +162,9 @@ export interface HostStoragePolicy {
 	 * as false. This is if the host wants to do some A/B testing.
 	 */
 	avoidPrefetchSnapshotCache?: boolean;
+
+	/**
+	 * True if host does not want the storage service to perform retries when throttling errors occur in the service.
+	 */
+	disableRetriesOnStorageThrottlingError?: boolean;
 }

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
@@ -57,7 +57,7 @@ export function encodeOdspFluidDataStoreLocator(locator: OdspFluidDataStoreLocat
 
 // @alpha
 export class EpochTracker implements IPersistedFileCache {
-    constructor(cache: IPersistedCache, fileEntry: IFileEntry, logger: ITelemetryLoggerExt, clientIsSummarizer?: boolean | undefined);
+    constructor(cache: IPersistedCache, fileEntry: IFileEntry, logger: ITelemetryLoggerExt, clientIsSummarizer?: boolean | undefined, hostPolicy?: HostStoragePolicy | undefined);
     // (undocumented)
     protected readonly cache: IPersistedCache;
     // (undocumented)
@@ -73,6 +73,8 @@ export class EpochTracker implements IPersistedFileCache {
     get fluidEpoch(): string | undefined;
     // (undocumented)
     get(entry: IEntry): Promise<any>;
+    // (undocumented)
+    protected readonly hostPolicy?: HostStoragePolicy | undefined;
     // (undocumented)
     protected readonly logger: ITelemetryLoggerExt;
     // (undocumented)

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -326,7 +326,7 @@ export class EpochTracker implements IPersistedFileCache {
 						const nonRetriableThrottlingError = new NonRetryableError(
 							error.message,
 							OdspErrorTypes.throttlingError,
-							// retryAfterMs is still provided so that client app can can still use it.
+							// retryAfterMs is still provided in the error so that the value is available for the host app
 							{
 								retryAfterMs:
 									(error as ThrottlingError).retryAfterSeconds === undefined

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -318,7 +318,7 @@ export class EpochTracker implements IPersistedFileCache {
 							throw locationRedirectionError;
 						}
 					} else if (
-						error.errorType == OdspErrorTypes.throttlingError &&
+						error.errorType === OdspErrorTypes.throttlingError &&
 						this.hostPolicy?.disableRetriesOnStorageThrottlingError
 					) {
 						const nonRetriableThrottlingError = new NonRetryableError(

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -296,9 +296,9 @@ export class EpochTracker implements IPersistedFileCache {
 				throw error;
 			})
 			.catch((error) => {
-				// If the error is about location redirection, then we need to generate new resolved url with correct
-				// location info.
 				if (isFluidError(error)) {
+					// If the error is about location redirection, then we need to generate new resolved url with correct
+					// location info.
 					if (error.errorType === OdspErrorTypes.fileNotFoundOrAccessDeniedError) {
 						const redirectLocation = (error as IOdspErrorAugmentations)
 							.redirectLocation;
@@ -317,7 +317,9 @@ export class EpochTracker implements IPersistedFileCache {
 							);
 							throw locationRedirectionError;
 						}
-					} else if (
+					}
+					// If the hostPolicy disallows retries for throttling errors, then we throw a NonRetryableError
+					else if (
 						error.errorType === OdspErrorTypes.throttlingError &&
 						this.hostPolicy?.disableRetriesOnStorageThrottlingError
 					) {

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -327,9 +327,9 @@ export class EpochTracker implements IPersistedFileCache {
 							// retryAfterMs is still provided so that client app can can still use it.
 							{
 								retryAfterMs:
-									(error as ThrottlingError).retryAfterSeconds !== undefined
-										? (error as ThrottlingError).retryAfterSeconds * 1000
-										: undefined,
+									(error as ThrottlingError).retryAfterSeconds === undefined
+										? undefined
+										: (error as ThrottlingError).retryAfterSeconds * 1000,
 								driverVersion,
 							},
 						);

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -326,15 +326,11 @@ export class EpochTracker implements IPersistedFileCache {
 						const nonRetriableThrottlingError = new NonRetryableError(
 							error.message,
 							OdspErrorTypes.throttlingError,
-							// retryAfterMs is still provided in the error so that the value is available for the host app
 							{
-								retryAfterMs:
-									(error as ThrottlingError).retryAfterSeconds === undefined
-										? undefined
-										: (error as ThrottlingError).retryAfterSeconds * 1000,
 								driverVersion,
 							},
 						);
+						// This step ensures all the telemetry props are preserved including the retryAfterSeconds from the original error
 						nonRetriableThrottlingError.addTelemetryProperties(
 							error.getTelemetryProperties(),
 						);

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -30,6 +30,7 @@ import {
 	IOdspErrorAugmentations,
 	IOdspResolvedUrl,
 	maximumCacheDurationMs,
+	type HostStoragePolicy,
 } from "@fluidframework/odsp-driver-definitions";
 import {
 	fetchAndParseAsJSONHelper,
@@ -96,6 +97,7 @@ export class EpochTracker implements IPersistedFileCache {
 		protected readonly fileEntry: IFileEntry,
 		protected readonly logger: ITelemetryLoggerExt,
 		protected readonly clientIsSummarizer?: boolean,
+		protected readonly hostPolicy?: HostStoragePolicy,
 	) {
 		// Limits the max number of concurrent requests to 24.
 		this.rateLimiter = new RateLimiter(24);
@@ -296,27 +298,48 @@ export class EpochTracker implements IPersistedFileCache {
 			.catch((error) => {
 				// If the error is about location redirection, then we need to generate new resolved url with correct
 				// location info.
-				if (
-					isFluidError(error) &&
-					error.errorType === OdspErrorTypes.fileNotFoundOrAccessDeniedError
-				) {
-					const redirectLocation = (error as IOdspErrorAugmentations).redirectLocation;
-					if (redirectLocation !== undefined) {
-						const redirectUrl: IOdspResolvedUrl = patchOdspResolvedUrl(
-							this.fileEntry.resolvedUrl,
-							redirectLocation,
-						);
-						const locationRedirectionError = new LocationRedirectionError(
+				if (isFluidError(error)) {
+					if (error.errorType === OdspErrorTypes.fileNotFoundOrAccessDeniedError) {
+						const redirectLocation = (error as IOdspErrorAugmentations)
+							.redirectLocation;
+						if (redirectLocation !== undefined) {
+							const redirectUrl: IOdspResolvedUrl = patchOdspResolvedUrl(
+								this.fileEntry.resolvedUrl,
+								redirectLocation,
+							);
+							const locationRedirectionError = new LocationRedirectionError(
+								error.message,
+								redirectUrl,
+								{ driverVersion, redirectLocation },
+							);
+							locationRedirectionError.addTelemetryProperties(
+								error.getTelemetryProperties(),
+							);
+							throw locationRedirectionError;
+						}
+					} else if (
+						error.errorType == OdspErrorTypes.throttlingError &&
+						this.hostPolicy?.disableRetriesOnStorageThrottlingError
+					) {
+						const nonRetriableThrottlingError = new NonRetryableError(
 							error.message,
-							redirectUrl,
-							{ driverVersion, redirectLocation },
+							OdspErrorTypes.throttlingError,
+							// retryAfterMs is still provided so that client app can can still use it.
+							{
+								retryAfterMs:
+									(error as ThrottlingError).retryAfterSeconds !== undefined
+										? (error as ThrottlingError).retryAfterSeconds * 1000
+										: undefined,
+								driverVersion,
+							},
 						);
-						locationRedirectionError.addTelemetryProperties(
+						nonRetriableThrottlingError.addTelemetryProperties(
 							error.getTelemetryProperties(),
 						);
-						throw locationRedirectionError;
+						throw nonRetriableThrottlingError;
 					}
 				}
+
 				throw error;
 			})
 			.catch((error) => {
@@ -495,8 +518,9 @@ export class EpochTrackerWithRedemption extends EpochTracker {
 		protected readonly fileEntry: IFileEntry,
 		protected readonly logger: ITelemetryLoggerExt,
 		protected readonly clientIsSummarizer?: boolean,
+		protected readonly hostPolicy?: HostStoragePolicy,
 	) {
-		super(cache, fileEntry, logger, clientIsSummarizer);
+		super(cache, fileEntry, logger, clientIsSummarizer, hostPolicy);
 		// Handles the rejected promise within treesLatestDeferral.
 		this.treesLatestDeferral.promise.catch(() => {});
 	}
@@ -627,12 +651,14 @@ export function createOdspCacheAndTracker(
 	fileEntry: IFileEntry,
 	logger: ITelemetryLoggerExt,
 	clientIsSummarizer?: boolean,
+	hostPolicy?: HostStoragePolicy,
 ): ICacheAndTracker {
 	const epochTracker = new EpochTrackerWithRedemption(
 		persistedCacheArg,
 		fileEntry,
 		logger,
 		clientIsSummarizer,
+		hostPolicy,
 	);
 	return {
 		cache: {

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -151,7 +151,7 @@ export class OdspDocumentServiceFactoryCore
 			fileEntry,
 			odspLogger,
 			clientIsSummarizer,
-			this.hostPolicy
+			this.hostPolicy,
 		);
 
 		return PerformanceEvent.timedExecAsync(
@@ -291,7 +291,7 @@ export class OdspDocumentServiceFactoryCore
 				{ resolvedUrl: odspResolvedUrl, docId: odspResolvedUrl.hashedDocumentId },
 				extLogger,
 				clientIsSummarizer,
-				this.hostPolicy
+				this.hostPolicy,
 			);
 
 		const storageTokenFetcher = toInstrumentedOdspTokenFetcher(

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -151,6 +151,7 @@ export class OdspDocumentServiceFactoryCore
 			fileEntry,
 			odspLogger,
 			clientIsSummarizer,
+			this.hostPolicy
 		);
 
 		return PerformanceEvent.timedExecAsync(
@@ -290,6 +291,7 @@ export class OdspDocumentServiceFactoryCore
 				{ resolvedUrl: odspResolvedUrl, docId: odspResolvedUrl.hashedDocumentId },
 				extLogger,
 				clientIsSummarizer,
+				this.hostPolicy
 			);
 
 		const storageTokenFetcher = toInstrumentedOdspTokenFetcher(

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -12,15 +12,15 @@ import {
 	IEntry,
 	maximumCacheDurationMs,
 } from "@fluidframework/odsp-driver-definitions";
+import { ThrottlingError, type NonRetryableError } from "@fluidframework/driver-utils";
+import { createChildLogger, type IFluidErrorBase } from "@fluidframework/telemetry-utils";
+import { stub } from "sinon";
+import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "../contracts.js";
 import { EpochTracker } from "../epochTracker.js";
 import { LocalPersistentCache } from "../odspCache.js";
 import { getHashedDocumentId } from "../odspPublicUtils.js";
-import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "../contracts.js";
+import * as odspUtilsModule from "../odspUtils.js";
 import { mockFetchOk, mockFetchSingle, createResponse } from "./mockFetch.js";
-import { createChildLogger, type IFluidErrorBase } from "@fluidframework/telemetry-utils";
-import { ThrottlingError, type NonRetryableError } from "@fluidframework/driver-utils";
-import { stub } from "sinon";
-import * as odspUtilsModule from "../odspUtils";
 
 const createUtLocalCache = (): LocalPersistentCache => new LocalPersistentCache();
 

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -395,7 +395,8 @@ describe("Tests for Epoch Tracker", () => {
 		assert.strictEqual(success, false, "Fetching should not succeed!!");
 	});
 
-	it("Checks throttling errors non-retriable when disableRetriesOnStorageThrottlingError=true", async () => {
+	it("Checks throttling errors are non-retriable when disableRetriesOnStorageThrottlingError=true", async () => {
+		const retryAfterSeconds = 1;
 		let fetchStub;
 		const epochTrackerWithHostPolicy = new EpochTracker(
 			localCache,
@@ -412,7 +413,7 @@ describe("Tests for Epoch Tracker", () => {
 			fetchStub = stub(odspUtilsModule, "fetchHelper");
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
 			fetchStub.callsFake(async () => {
-				throw new ThrottlingError("Server is throttled", 1000, {
+				throw new ThrottlingError("Server is throttled", retryAfterSeconds, {
 					testProp: "testProp",
 					driverVersion: "1",
 				});
@@ -425,6 +426,11 @@ describe("Tests for Epoch Tracker", () => {
 			assert(
 				(error as NonRetryableError<string>).canRetry === false,
 				"Error should be marked as non-retriable",
+			);
+			assert(
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+				(error as any).retryAfterMs === retryAfterSeconds * 1000,
+				"retryAfterMs should exist",
 			);
 		}
 	});

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -414,7 +414,7 @@ describe("Tests for Epoch Tracker", () => {
 				Promise.reject(
 					new ThrottlingError("Server is throttled", 1000, {
 						testProp: "testProp",
-						driverVersion: "123",
+						driverVersion: "1",
 					}),
 				),
 			);
@@ -448,7 +448,7 @@ describe("Tests for Epoch Tracker", () => {
 				Promise.reject(
 					new ThrottlingError("Server is throttled", 1000, {
 						testProp: "testProp",
-						driverVersion: "123",
+						driverVersion: "1",
 					}),
 				),
 			);

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -20,7 +20,7 @@ import { mockFetchOk, mockFetchSingle, createResponse } from "./mockFetch.js";
 import { createChildLogger, type IFluidErrorBase } from "@fluidframework/telemetry-utils";
 import { ThrottlingError, type NonRetryableError } from "@fluidframework/driver-utils";
 import { stub } from "sinon";
-import * as odspUtils from "../odspUtils.js";
+import * as odspUtilsModule from "../odspUtils";
 
 const createUtLocalCache = (): LocalPersistentCache => new LocalPersistentCache();
 
@@ -409,18 +409,18 @@ describe("Tests for Epoch Tracker", () => {
 		);
 		try {
 			// fetchHelper is used by epochTracker's fetch method, which we stub here to emulate throttling error
-			fetchStub = stub(odspUtils, "fetchHelper");
-			fetchStub.callsFake(async () =>
-				Promise.reject(
-					new ThrottlingError("Server is throttled", 1000, {
-						testProp: "testProp",
-						driverVersion: "1",
-					}),
-				),
-			);
+			fetchStub = stub(odspUtilsModule, "fetchHelper");
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+			fetchStub.callsFake(async () => {
+				throw new ThrottlingError("Server is throttled", 1000, {
+					testProp: "testProp",
+					driverVersion: "1",
+				});
+			});
 			await epochTrackerWithHostPolicy.fetch("fetchUrl", {}, "test");
 		} catch (error) {
 			// retoring the fetchHelper function to avoid causing errors in other tests
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
 			fetchStub.restore();
 			assert(
 				(error as NonRetryableError<string>).canRetry === false,
@@ -443,18 +443,18 @@ describe("Tests for Epoch Tracker", () => {
 		);
 		try {
 			// fetchHelper is used by epochTracker's fetch method, which we stub here to emulate throttling error
-			fetchStub = stub(odspUtils, "fetchHelper");
-			fetchStub.callsFake(async () =>
-				Promise.reject(
-					new ThrottlingError("Server is throttled", 1000, {
-						testProp: "testProp",
-						driverVersion: "1",
-					}),
-				),
-			);
+			fetchStub = stub(odspUtilsModule, "fetchHelper");
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+			fetchStub.callsFake(async () => {
+				throw new ThrottlingError("Server is throttled", 1000, {
+					testProp: "testProp",
+					driverVersion: "1",
+				});
+			});
 			await epochTrackerWithHostPolicy.fetch("fetchUrl", {}, "test");
 		} catch (error) {
 			// retoring the fetchHelper function to avoid causing errors in other tests
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
 			fetchStub.restore();
 			assert((error as ThrottlingError).canRetry === true, "Error should be retriable");
 		}

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -12,12 +12,15 @@ import {
 	IEntry,
 	maximumCacheDurationMs,
 } from "@fluidframework/odsp-driver-definitions";
-import { IFluidErrorBase, createChildLogger } from "@fluidframework/telemetry-utils";
 import { EpochTracker } from "../epochTracker.js";
 import { LocalPersistentCache } from "../odspCache.js";
 import { getHashedDocumentId } from "../odspPublicUtils.js";
 import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "../contracts.js";
 import { mockFetchOk, mockFetchSingle, createResponse } from "./mockFetch.js";
+import { createChildLogger, type IFluidErrorBase } from "@fluidframework/telemetry-utils";
+import { ThrottlingError, type NonRetryableError } from "@fluidframework/driver-utils";
+import { stub } from "sinon";
+import * as odspUtils from "../odspUtils.js";
 
 const createUtLocalCache = (): LocalPersistentCache => new LocalPersistentCache();
 
@@ -390,5 +393,70 @@ describe("Tests for Epoch Tracker", () => {
 			assert.strictEqual(newResolvedUrl.driveId, driveId, "driveId should remain same");
 		}
 		assert.strictEqual(success, false, "Fetching should not succeed!!");
+	});
+
+	it("Checks throttling errors non-retriable when disableRetriesOnStorageThrottlingError=true", async () => {
+		let fetchStub;
+		const epochTrackerWithHostPolicy = new EpochTracker(
+			localCache,
+			{
+				docId: hashedDocumentId,
+				resolvedUrl,
+			},
+			createChildLogger(),
+			undefined,
+			{ disableRetriesOnStorageThrottlingError: true } /* hostPolicy */,
+		);
+		try {
+			// fetchHelper is used by epochTracker's fetch method, which we stub here to emulate throttling error
+			fetchStub = stub(odspUtils, "fetchHelper");
+			fetchStub.callsFake(async () =>
+				Promise.reject(
+					new ThrottlingError("Server is throttled", 1000, {
+						testProp: "testProp",
+						driverVersion: "123",
+					}),
+				),
+			);
+			await epochTrackerWithHostPolicy.fetch("fetchUrl", {}, "test");
+		} catch (error) {
+			// retoring the fetchHelper function to avoid causing errors in other tests
+			fetchStub.restore();
+			assert(
+				(error as NonRetryableError<string>).canRetry === false,
+				"Error should be marked as non-retriable",
+			);
+		}
+	});
+
+	it("Checks throttling errors retriable when disableRetriesOnStorageThrottlingError=false", async () => {
+		let fetchStub;
+		const epochTrackerWithHostPolicy = new EpochTracker(
+			localCache,
+			{
+				docId: hashedDocumentId,
+				resolvedUrl,
+			},
+			createChildLogger(),
+			undefined,
+			{ disableRetriesOnStorageThrottlingError: false } /* hostPolicy */,
+		);
+		try {
+			// fetchHelper is used by epochTracker's fetch method, which we stub here to emulate throttling error
+			fetchStub = stub(odspUtils, "fetchHelper");
+			fetchStub.callsFake(async () =>
+				Promise.reject(
+					new ThrottlingError("Server is throttled", 1000, {
+						testProp: "testProp",
+						driverVersion: "123",
+					}),
+				),
+			);
+			await epochTrackerWithHostPolicy.fetch("fetchUrl", {}, "test");
+		} catch (error) {
+			// retoring the fetchHelper function to avoid causing errors in other tests
+			fetchStub.restore();
+			assert((error as ThrottlingError).canRetry === true, "Error should be retriable");
+		}
 	});
 });

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -429,8 +429,8 @@ describe("Tests for Epoch Tracker", () => {
 			);
 			assert(
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-				(error as any).retryAfterMs === retryAfterSeconds * 1000,
-				"retryAfterMs should exist",
+				(error as any).retryAfterSeconds === retryAfterSeconds,
+				"retryAfterSeconds should exist",
 			);
 		}
 	});

--- a/packages/test/test-drivers/src/odspDriverApi.ts
+++ b/packages/test/test-drivers/src/odspDriverApi.ts
@@ -76,6 +76,7 @@ export const generateOdspHostStoragePolicy = (seed: number) => {
 		enableShareLinkWithCreate: [false],
 		enableSingleRequestForShareLinkWithCreate: [false],
 		avoidPrefetchSnapshotCache: booleanCases,
+		disableRetriesOnStorageThrottlingError: [false]
 	};
 	return generatePairwiseOptions<HostStoragePolicy>(odspHostPolicyMatrix, seed);
 };

--- a/packages/test/test-drivers/src/odspDriverApi.ts
+++ b/packages/test/test-drivers/src/odspDriverApi.ts
@@ -76,7 +76,7 @@ export const generateOdspHostStoragePolicy = (seed: number) => {
 		enableShareLinkWithCreate: [false],
 		enableSingleRequestForShareLinkWithCreate: [false],
 		avoidPrefetchSnapshotCache: booleanCases,
-		disableRetriesOnStorageThrottlingError: [false],
+		disableRetriesOnStorageThrottlingError: booleanCases,
 	};
 	return generatePairwiseOptions<HostStoragePolicy>(odspHostPolicyMatrix, seed);
 };

--- a/packages/test/test-drivers/src/odspDriverApi.ts
+++ b/packages/test/test-drivers/src/odspDriverApi.ts
@@ -76,7 +76,7 @@ export const generateOdspHostStoragePolicy = (seed: number) => {
 		enableShareLinkWithCreate: [false],
 		enableSingleRequestForShareLinkWithCreate: [false],
 		avoidPrefetchSnapshotCache: booleanCases,
-		disableRetriesOnStorageThrottlingError: [false]
+		disableRetriesOnStorageThrottlingError: [false],
 	};
 	return generatePairwiseOptions<HostStoragePolicy>(odspHostPolicyMatrix, seed);
 };


### PR DESCRIPTION
**Issue:**
When server is throttled, it returns 429 error code along with retryAfter time value. In static workload, if retry-after is respected everything should work smoothly. However the workload is rarely static, i.e. there are always new clients, or clients who are issuing multiple request evert x minutes, which worsens the throttling and could result in clients just staying in an unrecoverable state.

**Solution:**
If a ThrottlingError is thrown when calling any of the ODSP storage services, FF will not perform retries if the host policy object says `disableRetriesOnStorageThrottlingError: true`. The throttling error will eventually be bubbled up to the host app and where the app decide the retry cadence.

The code change is done in `epochTracker `s `fetchCore` method, since that is the one common point where all the storage network calls are made. 

[AB#7056](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7056)
