### PR TITLE
fix(id-compressor): Fix corrupting resubmit bug

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -14,6 +14,7 @@ import { IBatchMessage, ICriticalContainerError } from "@fluidframework/containe
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { ICompressionRuntimeOptions } from "../containerRuntime";
 import { IPendingBatchMessage, PendingStateManager } from "../pendingStateManager";
+import { ContainerMessageType } from "../messageTypes";
 import {
 	BatchManager,
 	BatchSequenceNumbers,
@@ -136,10 +137,12 @@ export class Outbox {
 		const mainBatchSeqNums = this.mainBatch.sequenceNumbers;
 		const attachFlowBatchSeqNums = this.attachFlowBatch.sequenceNumbers;
 		const blobAttachSeqNums = this.blobAttachBatch.sequenceNumbers;
+		const idAllocSeqNums = this.idAllocationBatch.sequenceNumbers;
 		assert(
 			this.params.config.disablePartialFlush ||
 				(sequenceNumbersMatch(mainBatchSeqNums, attachFlowBatchSeqNums) &&
-					sequenceNumbersMatch(mainBatchSeqNums, blobAttachSeqNums)),
+					sequenceNumbersMatch(mainBatchSeqNums, blobAttachSeqNums) &&
+					sequenceNumbersMatch(mainBatchSeqNums, idAllocSeqNums)),
 			0x58d /* Reference sequence numbers from both batches must be in sync */,
 		);
 
@@ -148,7 +151,8 @@ export class Outbox {
 		if (
 			sequenceNumbersMatch(mainBatchSeqNums, currentSequenceNumbers) &&
 			sequenceNumbersMatch(attachFlowBatchSeqNums, currentSequenceNumbers) &&
-			sequenceNumbersMatch(blobAttachSeqNums, currentSequenceNumbers)
+			sequenceNumbersMatch(blobAttachSeqNums, currentSequenceNumbers) &&
+			sequenceNumbersMatch(idAllocSeqNums, currentSequenceNumbers)
 		) {
 			// The reference sequence numbers are stable, there is nothing to do
 			return;
@@ -178,12 +182,20 @@ export class Outbox {
 	}
 
 	public submit(message: BatchMessage) {
+		assert(
+			message.type !== ContainerMessageType.IdAllocation,
+			"Allocation message submitted to mainBatch.",
+		);
 		this.maybeFlushPartialBatch();
 
 		this.addMessageToBatchManager(this.mainBatch, message);
 	}
 
 	public submitAttach(message: BatchMessage) {
+		assert(
+			message.type === ContainerMessageType.Attach,
+			"Non attach message submitted to attachFlowBatch.",
+		);
 		this.maybeFlushPartialBatch();
 
 		if (
@@ -215,6 +227,10 @@ export class Outbox {
 	}
 
 	public submitBlobAttach(message: BatchMessage) {
+		assert(
+			message.type === ContainerMessageType.BlobAttach,
+			"Non blobAttach message submitted to blobAttachBatch.",
+		);
 		this.maybeFlushPartialBatch();
 
 		this.addMessageToBatchManager(this.blobAttachBatch, message);
@@ -233,6 +249,10 @@ export class Outbox {
 	}
 
 	public submitIdAllocation(message: BatchMessage) {
+		assert(
+			message.type === ContainerMessageType.IdAllocation,
+			"Non allocation message submitted to idAllocationBatch.",
+		);
 		this.maybeFlushPartialBatch();
 
 		if (

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -520,6 +520,17 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		// Trigger Id submission
 		sharedMapContainer1.set("key", "value");
 
+		const superResubmit = (sharedMapContainer1 as any).reSubmitCore.bind(sharedMapContainer1);
+		(sharedMapContainer1 as any).reSubmitCore = (
+			content: unknown,
+			localOpMetadata: unknown,
+		) => {
+			// Simulate a DDS that generates IDs as part of the resubmit path (e.g. SharedTree)
+			// This will test that ID allocation ops are correctly sorted into a separate batch in the outbox
+			getIdCompressor(sharedMapContainer1).generateCompressedId();
+			superResubmit(content, localOpMetadata);
+		};
+
 		// Generate ids in a connected container but don't send them yet
 		const id2 = getIdCompressor(sharedMapContainer2).generateCompressedId();
 		const id3 = getIdCompressor(sharedMapContainer2).generateCompressedId();


### PR DESCRIPTION
## Description

This change fixes a bug where resubmission of an ID allocation op was incorrectly routed to the main batch manager. A DDS that generates IDs during resubmit will result in allocation ops in both the allocation batch manager and the main batch manager, causing ranges to be finalized out of order and permanently corrupting the document. This change adds asserts to prevent incorrect op types in specific batch managers.