### PR TITLE
test(client): rename end-to-end outDir

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -45,7 +45,7 @@
 		"test:realsvc:r11s:docker": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=docker --timeout=20s",
 		"test:realsvc:routerlicious": "npm run test:realsvc:r11s",
 		"test:realsvc:routerlicious:report": "npm run test:realsvc:r11s --",
-		"test:realsvc:run": "mocha dist/test --config src/test/.mocharc.cjs --exclude \"dist/test/benchmark/**/*\" --verbose",
+		"test:realsvc:run": "mocha lib/test --config src/test/.mocharc.cjs --exclude \"lib/test/benchmark/**/*\" --verbose",
 		"test:realsvc:tinylicious": "start-server-and-test start:tinylicious:test 7070 test:realsvc:tinylicious:run",
 		"test:realsvc:tinylicious:report": "npm run test:realsvc:tinylicious",
 		"test:realsvc:tinylicious:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:tinylicious",
@@ -57,12 +57,12 @@
 		"cache-dir": "nyc/.cache",
 		"exclude": [
 			"src/test/**/*.*ts",
-			"dist/test/**/*.*js"
+			"lib/test/**/*.*js"
 		],
 		"exclude-after-remap": false,
 		"include": [
 			"src/**/*.*ts",
-			"dist/**/*.*js"
+			"lib/**/*.*js"
 		],
 		"report-dir": "nyc/report",
 		"reporter": [

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.memory.cjs
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.memory.cjs
@@ -20,8 +20,8 @@ const newConfig = {
 	"reporterOptions": ["reportDir=.memoryTestsOutput/"],
 	"require": [...config.require, "node_modules/@fluidframework/mocha-test-setup"],
 	"spec": [
-		"dist/test/benchmark/**/*.memory.spec.*js",
-		"dist/test/benchmark/**/*.all.spec.*js",
+		"lib/test/benchmark/**/*.memory.spec.*js",
+		"lib/test/benchmark/**/*.all.spec.*js",
 		"--perfMode",
 	],
 	"timeout": "360000", // depending on the test and the size of the E2E document, the timeout might not be enough. To address it, let's first try to decrease the number of iterations (minSampleCount).

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.time.cjs
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/.mocharc.time.cjs
@@ -20,8 +20,8 @@ const newConfig = {
 	"reporterOptions": ["reportDir=.timeTestsOutput/"],
 	"require": [...config.require, "node_modules/@fluidframework/mocha-test-setup"],
 	"spec": [
-		"dist/test/benchmark/**/*.time.spec.*js",
-		"dist/test/benchmark/**/*.all.spec.*js",
+		"lib/test/benchmark/**/*.time.spec.*js",
+		"lib/test/benchmark/**/*.all.spec.*js",
 		"--perfMode",
 	],
 	"timeout": "360000", // depending on the test and the size of the E2E document, the timeout might not be enough. To address it, let's first try to decrease the number of iterations (minSampleCount).

--- a/packages/test/test-end-to-end-tests/src/test/tsconfig.json
+++ b/packages/test/test-end-to-end-tests/src/test/tsconfig.json
@@ -3,7 +3,7 @@
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"rootDir": "../",
-		"outDir": "../../dist",
+		"outDir": "../../lib",
 		"types": ["mocha", "@fluidframework/test-driver-definitions"],
 		"noUnusedLocals": false, // Need it so memory tests can declare local variables just for the sake of keeping things in memory,
 		"module": "ESNext",


### PR DESCRIPTION
to match its ESM build