### PR TITLE
Move task manager to new stashing model

### DIFF
--- a/packages/dds/task-manager/api-report/task-manager.api.md
+++ b/packages/dds/task-manager/api-report/task-manager.api.md
@@ -45,7 +45,7 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
     abandon(taskId: string): void;
     // (undocumented)
-    applyStashedOp(): void;
+    protected applyStashedOp(content: any): void;
     assigned(taskId: string): boolean;
     canVolunteer(): boolean;
     complete(taskId: string): void;

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -170,6 +170,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_TaskManager": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from "events";
 
-import { assert } from "@fluidframework/core-utils";
+import { assert, unreachableCase } from "@fluidframework/core-utils";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import {
 	IChannelAttributes,
@@ -770,7 +770,23 @@ export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITa
 		}
 	}
 
-	public applyStashedOp() {
-		// do nothing...
+	protected applyStashedOp(content: any): void {
+		const taskOp: ITaskManagerOperation = content;
+		switch (taskOp.type) {
+			case "abandon": {
+				this.abandon(taskOp.taskId);
+				break;
+			}
+			case "complete": {
+				this.complete(taskOp.taskId);
+				break;
+			}
+			case "volunteer": {
+				this.subscribeToTask(taskOp.taskId);
+				break;
+			}
+			default:
+				unreachableCase(taskOp);
+		}
 	}
 }

--- a/packages/dds/task-manager/src/test/taskManager.fuzz.spec.ts
+++ b/packages/dds/task-manager/src/test/taskManager.fuzz.spec.ts
@@ -240,7 +240,11 @@ describe("TaskManager fuzz testing", () => {
 		// Leaving the tests enabled without reconnect on mimics previous behavior (and provides more coverage
 		// than skipping them)
 		reconnectProbability: 0,
-		clientJoinOptions: { maxNumberOfClients: 6, clientAddProbability: 0.05 },
+		clientJoinOptions: {
+			maxNumberOfClients: 6,
+			clientAddProbability: 0.05,
+			stashableClientProbability: 0.2,
+		},
 		defaultTestCount: defaultOptions.testCount,
 		saveFailures: { directory: path.join(__dirname, "../../src/test/results") },
 		// Uncomment this line to replay a specific seed:
@@ -264,13 +268,17 @@ describe("TaskManager fuzz testing with rebasing", () => {
 	createDDSFuzzSuite(model, {
 		validationStrategy: { type: "fixedInterval", interval: defaultOptions.validateInterval },
 		// AB#5185: enabling rebasing indicates some unknown eventual consistency issue
-		skip: [0, 2, 6],
+		skip: [5, 7],
 		rebaseProbability: 0.15,
 		containerRuntimeOptions: {
 			flushMode: FlushMode.TurnBased,
 			enableGroupedBatching: true,
 		},
-		clientJoinOptions: { maxNumberOfClients: 6, clientAddProbability: 0.05 },
+		clientJoinOptions: {
+			maxNumberOfClients: 6,
+			clientAddProbability: 0.05,
+			stashableClientProbability: 0.2,
+		},
 		defaultTestCount: defaultOptions.testCount,
 		saveFailures: { directory: path.join(__dirname, "../../src/test/results") },
 		// AB#5341: enabling 'start from detached' within the fuzz harness demonstrates eventual consistency failures.

--- a/packages/dds/task-manager/src/test/types/validateTaskManagerPrevious.generated.ts
+++ b/packages/dds/task-manager/src/test/types/validateTaskManagerPrevious.generated.ts
@@ -115,4 +115,5 @@ declare function get_current_ClassDeclaration_TaskManager():
 declare function use_old_ClassDeclaration_TaskManager(
     use: TypeOnly<old.TaskManager>): void;
 use_old_ClassDeclaration_TaskManager(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_TaskManager());


### PR DESCRIPTION
### Background
This change is related to https://github.com/microsoft/FluidFramework/pull/19518. That change introduced a new and simpler mechanism for applying stash ops. Specifically, it allows dds to reuse their existing flows for creating local changes, rather than needing custom flows to apply the change and get the local op metadata. This reduces complexity, bundle size, and bug potential by having fewer code paths to do the same thing; apply changes locally.

## Overview
This change moves task manager to the new applyStashedOps model. The current model for stashing for task manager was incorrect, as ops could have already been sent, and must be handles appropriately. For unsent ops, they will go through the reconnet flow before being resent, this is where any ops that can be ignored should be ignored. Based on bugs called out it looks like reconenct is also broken for task manger in some scenarios, this should be fixed and incorperate any changes around stashing as well in a follow up pr.

[AB#3985](https://dev.azure.com/fluidframework/internal/_workitems/edit/3985)
[AB#7264](https://dev.azure.com/fluidframework/internal/_workitems/edit/7264)