### PR TITLE
Avoid including config in query string if undefined

### DIFF
--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -151,18 +151,17 @@ export class RestGitService {
 	}
 
 	public async getCommits(sha: string, count: number): Promise<git.ICommitDetails[]> {
-		let config;
+		const queryParams: { count: string; sha: string; config?: string } = {
+			count: count.toString(),
+			sha,
+		};
 		if (this.writeToExternalStorage) {
 			const getRefParams: IGetRefParamsExternal = {
 				config: { enabled: true },
 			};
-			config = encodeURIComponent(JSON.stringify(getRefParams));
+			queryParams.config = encodeURIComponent(JSON.stringify(getRefParams));
 		}
-		const query = new URLSearchParams({
-			count: count.toString(),
-			sha,
-			config,
-		}).toString();
+		const query = new URLSearchParams(queryParams).toString();
 		return this.get(`/repos/${this.getRepoPath()}/commits?${query}`);
 	}
 


### PR DESCRIPTION
In my recent #19624 I regressed historian, as the behavior for serializing `undefined` differed.  This change omits the config if undefined, which is probably the right thing to do regardless of using `querystring` vs `URLSearchParams`.

Thanks to @znewton for discovering, debugging, and coming up with this fix :)