### PR TITLE
Azure client must use batching.

### DIFF
--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -227,9 +227,6 @@ class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
 			registryEntries: [rootDataObjectFactory.registryEntry],
 			requestHandlers: [getDefaultObject],
 			runtimeOptions: {
-				// temporary workaround to disable message batching until the message batch size issue is resolved
-				// resolution progress is tracked by the Feature 465 work item in AzDO
-				flushMode: FlushMode.Immediate,
 				// The runtime compressor is required to be on to use @fluidframework/tree.
 				enableRuntimeIdCompressor: true,
 			},

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -14,7 +14,6 @@ import {
 	type IRequest,
 	type IResponse,
 } from "@fluidframework/core-interfaces";
-import { FlushMode } from "@fluidframework/runtime-definitions";
 import { type IRuntimeFactory } from "@fluidframework/container-definitions";
 import { RequestParser } from "@fluidframework/runtime-utils";
 import { type ContainerRuntime } from "@fluidframework/container-runtime";


### PR DESCRIPTION
## Description

`FlushMode.Immediate` will be deprecated soon. This is the only place where it is still being used, mainly due to the 1MB payload size limit which we've since fixed with different other features described at: https://github.com/microsoft/FluidFramework/tree/main/packages/runtime/container-runtime/src/opLifecycle. Right now, azure client does not use batching at all, and [this may cause all sorts of issues such as client observing partial states](https://github.com/microsoft/FluidFramework/issues/18082 

https://github.com/microsoft/FluidFramework/tree/main/packages/runtime/container-runtime/src/opLifecycle#how-batching-works

- Compression and chunking are on by default and will solve more than 90% of the payload size issues
- Op grouping will solve the rest, however it is not enabled by default nor in this PR.

### This is the code change, which is trivial. The rollout is not, so I need some guidance here from the owners:

- Compression is not compatible from 1.0 to 2.0. And with compression enabled by default (since [client_v2.0.0-internal.4.1.0](https://github.com/microsoft/FluidFramework/releases/tag/client_v2.0.0-internal.4.1.0)), a client must turn it off by feature gate, wait for everyone to move to 2.0, then remove the feature gate.
- Op grouping requires all connected clients to be on `2.0.0-internal.7.0.0` or later, hence the reason for not enabling it in this change.