### PR TITLE
Syncing groupId in attach summary

### DIFF
--- a/packages/test/test-utils/api-report/test-utils.api.md
+++ b/packages/test/test-utils/api-report/test-utils.api.md
@@ -204,7 +204,9 @@ export interface ITestFluidObject extends IProvideTestFluidObject, IFluidLoadabl
 
 // @internal (undocumented)
 export interface ITestObjectProvider {
+    attachDetachedContainer(container: IContainer): Promise<void>;
     createContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps>): Promise<IContainer>;
+    createDetachedContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps>): Promise<IContainer>;
     createFluidEntryPoint: (testContainerConfig?: ITestContainerConfig) => fluidEntryPoint;
     createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, loaderProps?: Partial<ILoaderProps>): IHostLoader;
     defaultCodeDetails: IFluidCodeDetails;
@@ -315,7 +317,9 @@ export class TestObjectProvider implements ITestObjectProvider {
     constructor(LoaderConstructor: typeof Loader,
     driver: ITestDriver,
     createFluidEntryPoint: (testContainerConfig?: ITestContainerConfig) => fluidEntryPoint);
+    attachDetachedContainer(container: IContainer): Promise<void>;
     createContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps>): Promise<IContainer>;
+    createDetachedContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps> | undefined): Promise<IContainer>;
     readonly createFluidEntryPoint: (testContainerConfig?: ITestContainerConfig) => fluidEntryPoint;
     createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, loaderProps?: Partial<ILoaderProps>): Loader;
     get defaultCodeDetails(): IFluidCodeDetails;
@@ -339,7 +343,9 @@ export class TestObjectProvider implements ITestObjectProvider {
 // @internal
 export class TestObjectProviderWithVersionedLoad implements ITestObjectProvider {
     constructor(LoaderConstructorForCreating: typeof Loader, LoaderConstructorForLoading: typeof Loader, driverForCreating: ITestDriver, driverForLoading: ITestDriver, createFluidEntryPointForCreating: (testContainerConfig?: ITestContainerConfig) => fluidEntryPoint, createFluidEntryPointForLoading: (testContainerConfig?: ITestContainerConfig) => fluidEntryPoint);
+    attachDetachedContainer(container: IContainer): Promise<void>;
     createContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps>): Promise<IContainer>;
+    createDetachedContainer(entryPoint: fluidEntryPoint, loaderProps?: Partial<ILoaderProps> | undefined): Promise<IContainer>;
     get createFluidEntryPoint(): (testContainerConfig?: ITestContainerConfig) => fluidEntryPoint;
     createLoader(packageEntries: Iterable<[IFluidCodeDetails, fluidEntryPoint]>, loaderProps?: Partial<ILoaderProps>): Loader;
     get defaultCodeDetails(): IFluidCodeDetails;

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -152,6 +152,15 @@
 			"RemovedVariableDeclaration_mockConfigProvider": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"ClassDeclaration_TestObjectProvider": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_TestObjectProviderWithVersionedLoad": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_ITestObjectProvider": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -223,6 +223,7 @@ declare function get_old_InterfaceDeclaration_ITestObjectProvider():
 declare function use_current_InterfaceDeclaration_ITestObjectProvider(
     use: TypeOnly<current.ITestObjectProvider>): void;
 use_current_InterfaceDeclaration_ITestObjectProvider(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ITestObjectProvider());
 
 /*
@@ -391,6 +392,7 @@ declare function get_old_ClassDeclaration_TestObjectProvider():
 declare function use_current_ClassDeclaration_TestObjectProvider(
     use: TypeOnly<current.TestObjectProvider>): void;
 use_current_ClassDeclaration_TestObjectProvider(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TestObjectProvider());
 
 /*
@@ -415,6 +417,7 @@ declare function get_old_ClassDeclaration_TestObjectProviderWithVersionedLoad():
 declare function use_current_ClassDeclaration_TestObjectProviderWithVersionedLoad(
     use: TypeOnly<current.TestObjectProviderWithVersionedLoad>): void;
 use_current_ClassDeclaration_TestObjectProviderWithVersionedLoad(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TestObjectProviderWithVersionedLoad());
 
 /*

--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -127,6 +127,19 @@ export interface ITestObjectProvider {
 	): Promise<IContainer>;
 
 	/**
+	 * Create a detached container much like createContainer, but without attaching it to the document service.
+	 */
+	createDetachedContainer(
+		entryPoint: fluidEntryPoint,
+		loaderProps?: Partial<ILoaderProps>,
+	): Promise<IContainer>;
+
+	/**
+	 * Attaches a detached container to the document service.
+	 */
+	attachDetachedContainer(container: IContainer): Promise<void>;
+
+	/**
 	 * Loads a container using the default document id
 	 */
 	loadContainer(
@@ -506,6 +519,36 @@ export class TestObjectProvider implements ITestObjectProvider {
 	}
 
 	/**
+	 * {@inheritdoc ITestObjectProvider.createDetachedContainer}
+	 */
+	public async createDetachedContainer(
+		entryPoint: fluidEntryPoint,
+		loaderProps?: Partial<ILoaderProps> | undefined,
+	): Promise<IContainer> {
+		if (this._documentCreated) {
+			throw new Error(
+				"Only one container/document can be created. To load the container/document use loadContainer",
+			);
+		}
+		const loader = this.createLoader([[defaultCodeDetails, entryPoint]], loaderProps);
+		return loader.createDetachedContainer(defaultCodeDetails);
+	}
+
+	/**
+	 * {@inheritdoc ITestObjectProvider.attachDetachedContainer}
+	 */
+	public async attachDetachedContainer(container: IContainer): Promise<void> {
+		if (this._documentCreated) {
+			throw new Error(
+				"Only one container/document can be created. To load the container/document use loadContainer",
+			);
+		}
+		await container.attach(this.driver.createCreateNewRequest(this.documentId));
+		this._documentCreated = true;
+		this._documentIdStrategy.update(container.resolvedUrl);
+	}
+
+	/**
 	 * {@inheritDoc ITestObjectProvider.loadContainer}
 	 */
 	public async loadContainer(
@@ -815,6 +858,36 @@ export class TestObjectProviderWithVersionedLoad implements ITestObjectProvider 
 		// update the document ID with the actual ID of the attached container.
 		this._documentIdStrategy.update(container.resolvedUrl);
 		return container;
+	}
+
+	/**
+	 * {@inheritdoc ITestObjectProvider.createDetachedContainer}
+	 */
+	public async createDetachedContainer(
+		entryPoint: fluidEntryPoint,
+		loaderProps?: Partial<ILoaderProps> | undefined,
+	): Promise<IContainer> {
+		if (this._documentCreated) {
+			throw new Error(
+				"Only one container/document can be created. To load the container/document use loadContainer",
+			);
+		}
+		const loader = this.createLoader([[defaultCodeDetails, entryPoint]], loaderProps);
+		return loader.createDetachedContainer(defaultCodeDetails);
+	}
+
+	/**
+	 * {@inheritdoc ITestObjectProvider.attachDetachedContainer}
+	 */
+	public async attachDetachedContainer(container: IContainer): Promise<void> {
+		if (this._documentCreated) {
+			throw new Error(
+				"Only one container/document can be created. To load the container/document use loadContainer",
+			);
+		}
+		await container.attach(this.driver.createCreateNewRequest(this.documentId));
+		this._documentCreated = true;
+		this._documentIdStrategy.update(container.resolvedUrl);
 	}
 
 	/**

--- a/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
+++ b/server/routerlicious/packages/test-utils/src/testDocumentStorage.ts
@@ -32,6 +32,7 @@ import {
 	SummaryType,
 	ISnapshotTreeEx,
 	SummaryObject,
+	FileMode,
 } from "@fluidframework/protocol-definitions";
 import { IQuorumSnapshot, getGitMode, getGitType } from "@fluidframework/protocol-base";
 import { gitHashFile, IsoBuffer, Uint8ArrayToString } from "@fluidframework/common-utils";
@@ -273,6 +274,17 @@ export async function writeSummaryTree(
 			return treeEntry;
 		}),
 	);
+
+	if (summaryTree.groupId !== undefined) {
+		const groupId = summaryTree.groupId;
+		const groupIdBlobHandle = await writeSummaryBlob(groupId, blobsShaCache, manager);
+		entries.push({
+			mode: FileMode.File,
+			path: encodeURIComponent(".groupId"),
+			sha: groupIdBlobHandle,
+			type: "blob",
+		});
+	}
 
 	const treeHandle = await manager.createGitTree({ tree: entries });
 	return treeHandle.sha;


### PR DESCRIPTION
[AB#7196](https://dev.azure.com/fluidframework/internal/_workitems/edit/7196)

Previous PR with first change enabling summary upload: https://github.com/microsoft/FluidFramework/pull/19662

Document creation and document summaries go through slightly different flows. 

When attaching we use the `TestDocumentStorage` to create a document and when summarizing we use the `SummaryTreeUploadManager` to upload a new summary.

The test added passes when you sync the tests locally, I'll consume the next set of packages after I get the delay loading of groupId in snapshots for local server.