### PR TITLE
tools: split Mocha debug into explicitly CJS/ESM tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -326,7 +326,7 @@
 			"skipFiles": ["<node_internals>/**", "**/node_modules/**"],
 			"outFiles": [
 				// This config avoids loading dependent packages' test files, while using the same technique
-				// as the "Debug Current Test (JS)" config to load source maps for test files in the current
+				// as the "Debug Current Mocha Test (*)" config to load source maps for test files in the current
 				// package.
 				// This reduces the number of source files VSCode needs to load to debug the e2e tests
 				// considerably, which decreases the time it takes to start debugging.
@@ -352,7 +352,33 @@
 		{
 			"type": "node",
 			"request": "launch",
-			"name": "Debug Current Test (JS)",
+			"name": "Debug Current Mocha Test (ESM-lib)",
+			"env": {
+				// "fluid__test__driver": "odsp" //values: local, tinylicious, routerlicious, odsp,
+				// "fluid__test__backCompat": "FULL" //values: FULL This tests loader-driver compatibility for describeCompat tests
+				// "FLUID_TEST_VERBOSE": "1"
+			},
+			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"args": [
+				"--no-timeouts",
+				"--exit",
+				"../../lib/test/${fileBasenameNoExtension}.js",
+				"../../../lib/test/**/${fileBasenameNoExtension}.js",
+				"../../../../lib/test/**/${fileBasenameNoExtension}.js",
+			],
+			"cwd": "${fileDirname}",
+			"outFiles": [
+				"${fileDirname}/../../lib/**/*.js",
+				"${fileDirname}/../../../lib/**/*.js",
+				"${fileDirname}/../../../../lib/**/*.js",
+			],
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Debug Current Mocha Test (CommonJS-dist)",
 			"env": {
 				// "fluid__test__driver": "odsp" //values: local, tinylicious, routerlicious, odsp,
 				// "fluid__test__backCompat": "FULL" //values: FULL This tests loader-driver compatibility for describeCompat tests
@@ -367,15 +393,9 @@
 				"../../dist/test/${fileBasenameNoExtension}.js",
 				"../../../dist/test/**/${fileBasenameNoExtension}.js",
 				"../../../../dist/test/**/${fileBasenameNoExtension}.js",
-				"../../lib/test/${fileBasenameNoExtension}.js",
-				"../../../lib/test/**/${fileBasenameNoExtension}.js",
-				"../../../../lib/test/**/${fileBasenameNoExtension}.js",
 			],
 			"cwd": "${fileDirname}",
 			"outFiles": [
-				"${fileDirname}/../../lib/**/*.js",
-				"${fileDirname}/../../../lib/**/*.js",
-				"${fileDirname}/../../../../lib/**/*.js",
 				"${fileDirname}/../../dist/**/*.js",
 				"${fileDirname}/../../../dist/**/*.js",
 				"${fileDirname}/../../../../dist/**/*.js",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -35,8 +35,6 @@
 				"${workspaceRoot}",
 				"--vscode",
 				"-t",
-				"tsc",
-				"-t",
 				"build:test",
 				"${fileDirname}",
 			],


### PR DESCRIPTION
+ remove "tsc" task from "Build Current Tests" ("build:test" should have the proper dependency)