### PR TITLE
refactor: Remove ITelemetryProperties and replace with equivalent ITelemetryBaseProperties

### DIFF
--- a/.changeset/deep-plums-call.md
+++ b/.changeset/deep-plums-call.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/core-interfaces": major
+---
+
+Removed ITelemetryProperties interface
+
+The `ITelemetryProperties` interface was deprecated and has been removed.
+Use the identical `ITelemetryBaseProperties` instead.

--- a/experimental/dds/tree/api-report/experimental-tree.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.api.md
@@ -22,9 +22,9 @@ import { IGarbageCollectionData } from '@fluidframework/runtime-definitions';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
+import { ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
-import { ITelemetryProperties } from '@fluidframework/core-interfaces';
 import { ITree } from '@fluidframework/tree';
 import { SharedObject } from '@fluidframework/shared-object-base';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
@@ -920,7 +920,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     internalizeChange(change: Change): ChangeInternal;
     // (undocumented)
     protected loadCore(storage: IChannelStorageService): Promise<void>;
-    loadSerializedSummary(blobData: string): ITelemetryProperties;
+    loadSerializedSummary(blobData: string): ITelemetryBaseProperties;
     loadSummary(summary: SharedTreeSummaryBase): void;
     readonly logger: ITelemetryLoggerExt;
     get logViewer(): LogViewer;

--- a/experimental/dds/tree/src/Checkout.ts
+++ b/experimental/dds/tree/src/Checkout.ts
@@ -5,7 +5,7 @@
 
 import { assert } from '@fluidframework/core-utils';
 import { EventEmitterWithErrorHandling, ITelemetryLoggerExt, createChildLogger } from '@fluidframework/telemetry-utils';
-import { IDisposable, IErrorEvent, ITelemetryProperties } from '@fluidframework/core-interfaces';
+import { IDisposable, IErrorEvent, ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
 import { assertWithMessage, fail, RestOrArray, unwrapRestOrArray } from './Common.js';
 import { EditId } from './Identifiers.js';
 import { CachingLogViewer } from './LogViewer.js';
@@ -197,7 +197,7 @@ export abstract class Checkout extends EventEmitterWithErrorHandling<ICheckoutEv
 		}
 
 		const { failure } = result as { failure: TransactionInternal.Failure };
-		const additionalProps: ITelemetryProperties = {};
+		const additionalProps: ITelemetryBaseProperties = {};
 		switch (failure.kind) {
 			case TransactionInternal.FailureKind.BadPlace:
 				additionalProps.placeFailure = failure.placeFailure;

--- a/experimental/dds/tree/src/Common.ts
+++ b/experimental/dds/tree/src/Common.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryBaseEvent, ITelemetryProperties } from '@fluidframework/core-interfaces';
+import { ITelemetryBaseEvent, ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
 import { BTree } from '@tylerbu/sorted-btree-es6';
 
 const defaultFailMessage = 'Assertion failed';
@@ -21,7 +21,7 @@ export const sharedTreeAssertionErrorType = 'SharedTreeAssertion';
 /**
  * Telemetry properties decorated on all SharedTree events.
  */
-export interface SharedTreeTelemetryProperties extends ITelemetryProperties {
+export interface SharedTreeTelemetryProperties extends ITelemetryBaseProperties {
 	readonly isSharedTreeEvent: true;
 }
 

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -21,7 +21,7 @@ import {
 	ISharedObjectEvents,
 	SharedObject,
 } from '@fluidframework/shared-object-base';
-import { ITelemetryProperties } from '@fluidframework/core-interfaces';
+import { ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
 import {
 	ITelemetryLoggerExt,
 	createChildLogger,
@@ -777,7 +777,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * Initialize shared tree with a serialized summary. This is used for testing.
 	 * @returns Statistics about the loaded summary.
 	 */
-	public loadSerializedSummary(blobData: string): ITelemetryProperties {
+	public loadSerializedSummary(blobData: string): ITelemetryBaseProperties {
 		const summary = deserialize(blobData, this.serializer);
 		this.loadSummary(summary);
 		return getSummaryStatistics(summary);

--- a/experimental/dds/tree/src/SummaryBackCompatibility.ts
+++ b/experimental/dds/tree/src/SummaryBackCompatibility.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { ITelemetryProperties } from '@fluidframework/core-interfaces';
+import type { ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
 import type { IFluidSerializer } from '@fluidframework/shared-object-base';
 import { fail } from './Common.js';
 import { getNumberOfHandlesFromEditLogSummary } from './EditLog.js';
@@ -48,7 +48,7 @@ export function deserialize(jsonSummary: string, serializer: IFluidSerializer): 
 /**
  * General statistics about summaries.
  */
-export interface SummaryStatistics extends ITelemetryProperties {
+export interface SummaryStatistics extends ITelemetryBaseProperties {
 	/** Format version the summary is written in. */
 	readonly formatVersion: string;
 	/** Number of edits. */

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -429,10 +429,7 @@ export interface ITelemetryBaseLogger {
 }
 
 // @public
-export type ITelemetryBaseProperties = ITelemetryProperties;
-
-// @public @deprecated
-export interface ITelemetryProperties {
+export interface ITelemetryBaseProperties {
     // (undocumented)
     [index: string]: TelemetryEventPropertyType | Tagged<TelemetryEventPropertyType>;
 }

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -100,6 +100,10 @@
 			"RemovedInterfaceDeclaration_ITelemetryErrorEvent": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"RemovedInterfaceDeclaration_ITelemetryProperties": {
+				"forwardCompat": false,
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -45,7 +45,6 @@ export type {
 	ITelemetryBaseEvent,
 	ITelemetryBaseLogger,
 	ITelemetryBaseProperties,
-	ITelemetryProperties, // deprecated
 	Tagged,
 	TelemetryEventCategory, // deprecated
 	TelemetryBaseEventPropertyType,

--- a/packages/common/core-interfaces/src/logger.ts
+++ b/packages/common/core-interfaces/src/logger.ts
@@ -57,15 +57,7 @@ export interface ITaggedTelemetryPropertyType {
  * JSON-serializable properties, which will be logged with telemetry.
  * @public
  */
-export type ITelemetryBaseProperties = ITelemetryProperties;
-
-/**
- * {@inheritDoc ITelemetryBaseProperties}
- *
- * @deprecated Renamed to {@link ITelemetryBaseProperties}
- * @public
- */
-export interface ITelemetryProperties {
+export interface ITelemetryBaseProperties {
 	[index: string]: TelemetryEventPropertyType | Tagged<TelemetryEventPropertyType>;
 }
 
@@ -116,7 +108,7 @@ export interface ITelemetryBaseLogger {
  * No replacement intended for FluidFramework consumers.
  * @public
  */
-export interface ITelemetryErrorEvent extends ITelemetryProperties {
+export interface ITelemetryErrorEvent extends ITelemetryBaseProperties {
 	eventName: string;
 }
 

--- a/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
+++ b/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
@@ -1032,26 +1032,26 @@ use_old_InterfaceDeclaration_ITelemetryBaseLogger(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_ITelemetryBaseProperties": {"forwardCompat": false}
+* "RemovedTypeAliasDeclaration_ITelemetryBaseProperties": {"forwardCompat": false}
 */
 declare function get_old_TypeAliasDeclaration_ITelemetryBaseProperties():
     TypeOnly<old.ITelemetryBaseProperties>;
-declare function use_current_TypeAliasDeclaration_ITelemetryBaseProperties(
+declare function use_current_RemovedTypeAliasDeclaration_ITelemetryBaseProperties(
     use: TypeOnly<current.ITelemetryBaseProperties>): void;
-use_current_TypeAliasDeclaration_ITelemetryBaseProperties(
+use_current_RemovedTypeAliasDeclaration_ITelemetryBaseProperties(
     get_old_TypeAliasDeclaration_ITelemetryBaseProperties());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_ITelemetryBaseProperties": {"backCompat": false}
+* "RemovedTypeAliasDeclaration_ITelemetryBaseProperties": {"backCompat": false}
 */
-declare function get_current_TypeAliasDeclaration_ITelemetryBaseProperties():
+declare function get_current_RemovedTypeAliasDeclaration_ITelemetryBaseProperties():
     TypeOnly<current.ITelemetryBaseProperties>;
 declare function use_old_TypeAliasDeclaration_ITelemetryBaseProperties(
     use: TypeOnly<old.ITelemetryBaseProperties>): void;
 use_old_TypeAliasDeclaration_ITelemetryBaseProperties(
-    get_current_TypeAliasDeclaration_ITelemetryBaseProperties());
+    get_current_RemovedTypeAliasDeclaration_ITelemetryBaseProperties());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1104,26 +1104,14 @@ use_old_TypeAliasDeclaration_ITelemetryBaseProperties(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_ITelemetryProperties": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_ITelemetryProperties": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_ITelemetryProperties():
-    TypeOnly<old.ITelemetryProperties>;
-declare function use_current_InterfaceDeclaration_ITelemetryProperties(
-    use: TypeOnly<current.ITelemetryProperties>): void;
-use_current_InterfaceDeclaration_ITelemetryProperties(
-    get_old_InterfaceDeclaration_ITelemetryProperties());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_ITelemetryProperties": {"backCompat": false}
+* "RemovedInterfaceDeclaration_ITelemetryProperties": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_ITelemetryProperties():
-    TypeOnly<current.ITelemetryProperties>;
-declare function use_old_InterfaceDeclaration_ITelemetryProperties(
-    use: TypeOnly<old.ITelemetryProperties>): void;
-use_old_InterfaceDeclaration_ITelemetryProperties(
-    get_current_InterfaceDeclaration_ITelemetryProperties());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -4,7 +4,7 @@
  */
 
 import { v4 as uuid } from "uuid";
-import { IFluidHandle, ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { IFluidHandle, ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import {
 	ITelemetryLoggerExt,
 	createChildLogger,
@@ -143,7 +143,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
 			this.logger,
 			this.mc.config.getNumber("Fluid.SharedObject.OpProcessingTelemetrySampling") ?? 1000,
 			true,
-			new Map<string, ITelemetryProperties>([
+			new Map<string, ITelemetryBaseProperties>([
 				["local", { localOp: true }],
 				["remote", { localOp: false }],
 			]),

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -22,7 +22,7 @@ import {
 	ITokenClaims,
 	ScopeType,
 } from "@fluidframework/protocol-definitions";
-import { IDisposable, ITelemetryProperties, LogLevel } from "@fluidframework/core-interfaces";
+import { IDisposable, ITelemetryBaseProperties, LogLevel } from "@fluidframework/core-interfaces";
 import {
 	ITelemetryLoggerExt,
 	extractLogSafeErrorProperties,
@@ -733,7 +733,7 @@ export class DocumentDeltaConnection
 	private createErrorObjectWithProps(
 		handler: string,
 		error?: any,
-		props?: ITelemetryProperties,
+		props?: ITelemetryBaseProperties,
 		canRetry = true,
 	): IAnyDriverError {
 		return createGenericNetworkError(

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
@@ -26,8 +26,8 @@ import { ISnapshotTree } from '@fluidframework/protocol-definitions';
 import { ISocketStorageDiscovery } from '@fluidframework/odsp-driver-definitions';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
+import { ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
-import { ITelemetryProperties } from '@fluidframework/core-interfaces';
 import { IUrlResolver } from '@fluidframework/driver-definitions';
 import { OdspResourceTokenFetchOptions } from '@fluidframework/odsp-driver-definitions';
 import { PromiseCache } from '@fluidframework/core-utils';
@@ -145,7 +145,7 @@ export interface IOdspResponse<T> {
     // (undocumented)
     headers: Map<string, string>;
     // (undocumented)
-    propsToLog: ITelemetryProperties;
+    propsToLog: ITelemetryBaseProperties;
 }
 
 // @alpha

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -4,7 +4,7 @@
  */
 
 import { v4 as uuid } from "uuid";
-import { ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { validateMessages } from "@fluidframework/driver-base";
 import { ITelemetryLoggerExt, PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { assert } from "@fluidframework/core-utils";
@@ -42,7 +42,7 @@ export class OdspDeltaStorageService {
 	public async get(
 		from: number,
 		to: number,
-		telemetryProps: ITelemetryProperties,
+		telemetryProps: ITelemetryBaseProperties,
 		scenarioName?: string,
 	): Promise<IDeltasFetchResult> {
 		return getWithRetryForTokenRefresh(async (options) => {
@@ -138,7 +138,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 		private readonly getFromStorage: (
 			from: number,
 			to: number,
-			telemetryProps: ITelemetryProperties,
+			telemetryProps: ITelemetryBaseProperties,
 			fetchReason?: string,
 		) => Promise<IDeltasFetchResult>,
 		private readonly getCached: (
@@ -174,7 +174,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 		const requestCallback = async (
 			from: number,
 			to: number,
-			telemetryProps: ITelemetryProperties,
+			telemetryProps: ITelemetryBaseProperties,
 		) => {
 			if (this.snapshotOps !== undefined && this.snapshotOps.length !== 0) {
 				const messages = this.snapshotOps.filter(
@@ -221,7 +221,7 @@ export class OdspDeltaStorageWithCache implements IDocumentDeltaStorageService {
 		};
 
 		const stream = requestOps(
-			async (from: number, to: number, telemetryProps: ITelemetryProperties) => {
+			async (from: number, to: number, telemetryProps: ITelemetryBaseProperties) => {
 				const result = await requestCallback(from, to, telemetryProps);
 				// Catch all case, just in case
 				validateMessages("catch all", result.messages, from, this.logger);

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryProperties, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { IResolvedUrl, ISnapshot } from "@fluidframework/driver-definitions";
 import {
 	isOnline,
@@ -56,7 +56,7 @@ export const getOrigin = (url: string) => new URL(url).origin;
 export interface IOdspResponse<T> {
 	content: T;
 	headers: Map<string, string>;
-	propsToLog: ITelemetryProperties;
+	propsToLog: ITelemetryBaseProperties;
 	duration: number;
 }
 

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -4,7 +4,7 @@
  */
 
 import { v4 as uuid } from "uuid";
-import { ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { ITelemetryLoggerExt, PerformanceEvent } from "@fluidframework/telemetry-utils";
 import {
 	InstrumentedStorageTokenFetcher,
@@ -55,7 +55,7 @@ export async function fetchJoinSession(
 	const tokenRefreshProps = options.refresh
 		? { hasClaims: !!options.claims, hasTenantId: !!options.tenantId }
 		: {};
-	const details: ITelemetryProperties = {
+	const details: ITelemetryBaseProperties = {
 		refreshedToken: options.refresh,
 		requestSocketToken,
 		...tokenRefreshProps,

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { getW3CData, validateMessages } from "@fluidframework/driver-base";
 import {
 	IDeltaStorageService,
@@ -62,7 +62,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 		const requestCallback = async (
 			from: number,
 			to: number,
-			telemetryProps: ITelemetryProperties,
+			telemetryProps: ITelemetryBaseProperties,
 		) => {
 			this.snapshotOps = this.logtailSha
 				? await readAndParse<ISequencedDocumentMessage[]>(
@@ -92,7 +92,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 		};
 
 		const stream = requestOps(
-			async (from: number, to: number, telemetryProps: ITelemetryProperties) => {
+			async (from: number, to: number, telemetryProps: ITelemetryBaseProperties) => {
 				const result = await requestCallback(from, to, telemetryProps);
 				// Catch all case, just in case
 				validateMessages("catch all", result.messages, from, this.logger);

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import {
 	ITelemetryLoggerExt,
 	PerformanceEvent,
@@ -49,7 +49,7 @@ const axiosRequestConfigToFetchRequestConfig = (
 export interface IR11sResponse<T> {
 	content: T;
 	headers: Map<string, string>;
-	propsToLog: ITelemetryProperties;
+	propsToLog: ITelemetryBaseProperties;
 	requestUrl: string;
 }
 
@@ -91,7 +91,7 @@ export function getPropsToLogFromResponse(headers: {
 		{ headerName: "content-encoding", logName: "contentEncoding" },
 		{ headerName: "content-type", logName: "contentType" },
 	];
-	const additionalProps: ITelemetryProperties = {
+	const additionalProps: ITelemetryBaseProperties = {
 		contentsize: numberFromString(headers.get("content-length")),
 	};
 	headersToLog.forEach((header) => {

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable, ITelemetryProperties, LogLevel } from "@fluidframework/core-interfaces";
+import { IDisposable, ITelemetryBaseProperties, LogLevel } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils";
 import { performance, TypedEventEmitter } from "@fluid-internal/client-utils";
 import {
@@ -229,7 +229,7 @@ export class ConnectionManager implements IConnectionManager {
 
 	private _connectionVerboseProps: Record<string, string | number> = {};
 
-	private _connectionProps: ITelemetryProperties = {};
+	private _connectionProps: ITelemetryBaseProperties = {};
 
 	private _disposed = false;
 
@@ -290,7 +290,7 @@ export class ConnectionManager implements IConnectionManager {
 	 * Returns set of props that can be logged in telemetry that provide some insights / statistics
 	 * about current or last connection (if there is no connection at the moment)
 	 */
-	public get connectionProps(): ITelemetryProperties {
+	public get connectionProps(): ITelemetryBaseProperties {
 		return this.connection !== undefined
 			? this._connectionProps
 			: {

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryProperties, TelemetryEventCategory } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties, TelemetryEventCategory } from "@fluidframework/core-interfaces";
 import { assert, Timer } from "@fluidframework/core-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions";
 import { ISequencedClient, IClient } from "@fluidframework/protocol-definitions";
@@ -43,7 +43,7 @@ export interface IConnectionStateHandlerInputs {
 	logConnectionIssue: (
 		eventName: string,
 		category: TelemetryEventCategory,
-		details?: ITelemetryProperties,
+		details?: ITelemetryBaseProperties,
 	) => void;
 	/** Callback to note that an old local client ID is still present in the Quorum that should have left and should now be considered invalid */
 	clientShouldHaveLeft: (clientId: string) => void;
@@ -188,7 +188,7 @@ class ConnectionStateHandlerPassThrough
 	public logConnectionIssue(
 		eventName: string,
 		category: TelemetryEventCategory,
-		details?: ITelemetryProperties,
+		details?: ITelemetryBaseProperties,
 	) {
 		return this.inputs.logConnectionIssue(eventName, category, details);
 	}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -8,7 +8,7 @@ import { assert, unreachableCase } from "@fluidframework/core-utils";
 import { TypedEventEmitter, performance } from "@fluid-internal/client-utils";
 import {
 	IEvent,
-	ITelemetryProperties,
+	ITelemetryBaseProperties,
 	TelemetryEventCategory,
 	FluidObject,
 	LogLevel,
@@ -329,7 +329,7 @@ const getCodeProposal = (quorum: IQuorumProposals) => quorum.get("code") ?? quor
 export async function ReportIfTooLong(
 	logger: ITelemetryLoggerExt,
 	eventName: string,
-	action: () => Promise<ITelemetryProperties>,
+	action: () => Promise<ITelemetryBaseProperties>,
 ) {
 	const event = PerformanceEvent.start(logger, { eventName });
 	const props = await action();
@@ -897,7 +897,7 @@ export class Container
 				logConnectionIssue: (
 					eventName: string,
 					category: TelemetryEventCategory,
-					details?: ITelemetryProperties,
+					details?: ITelemetryBaseProperties,
 				) => {
 					const mode = this.connectionMode;
 					// We get here when socket does not receive any ops on "write" connection, including

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IErrorBase, ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { IErrorBase, ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import {
 	IConnectionDetails,
 	ICriticalContainerError,
@@ -73,12 +73,12 @@ export interface IConnectionManager {
 	// Various connectivity properties for telemetry describing type of current connection
 	// Things like connection mode, service info, etc.
 	// Called when connection state changes (connect / disconnect)
-	readonly connectionProps: ITelemetryProperties;
+	readonly connectionProps: ITelemetryBaseProperties;
 
 	// Verbose information about connection logged to telemetry in case of issues with
 	// maintaining healthy connection, including op gaps, not receiving join op in time, etc.
 	// Contains details information, like sequence numbers at connection time, initial ops info, etc.
-	readonly connectionVerboseProps: ITelemetryProperties;
+	readonly connectionVerboseProps: ITelemetryBaseProperties;
 
 	/**
 	 * Prepares message to be sent. Fills in clientSequenceNumber.

--- a/packages/loader/container-loader/src/debugLogger.ts
+++ b/packages/loader/container-loader/src/debugLogger.ts
@@ -6,7 +6,7 @@
 import {
 	ITelemetryBaseEvent,
 	ITelemetryBaseLogger,
-	ITelemetryProperties,
+	ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces";
 import { performance } from "@fluid-internal/client-utils";
 
@@ -77,7 +77,7 @@ export class DebugLogger implements ITelemetryBaseLogger {
 	 * @param event - the event to send
 	 */
 	public send(event: ITelemetryBaseEvent): void {
-		const newEvent: ITelemetryProperties = { ...event };
+		const newEvent: ITelemetryBaseProperties = { ...event };
 		const isError = newEvent.category === "error";
 		let logger = isError ? this.debugErr : this.debug;
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -7,7 +7,7 @@ import { v4 as uuid } from "uuid";
 import {
 	IThrottlingWarning,
 	IEventProvider,
-	ITelemetryProperties,
+	ITelemetryBaseProperties,
 	type ITelemetryBaseEvent,
 } from "@fluidframework/core-interfaces";
 import {
@@ -361,7 +361,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		assert(this.messageBuffer.length === 0, 0x3cc /* reentrancy */);
 	}
 
-	public get connectionProps(): ITelemetryProperties {
+	public get connectionProps(): ITelemetryBaseProperties {
 		return {
 			sequenceNumber: this.lastSequenceNumber,
 			opsSize: this.opsSize > 0 ? this.opsSize : undefined,

--- a/packages/loader/container-loader/src/error.ts
+++ b/packages/loader/container-loader/src/error.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryProperties, IThrottlingWarning } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties, IThrottlingWarning } from "@fluidframework/core-interfaces";
 import { ContainerErrorTypes } from "@fluidframework/container-definitions";
 import {
 	IFluidErrorBase,
@@ -24,7 +24,7 @@ export class ThrottlingWarning extends LoggingError implements IThrottlingWarnin
 	private constructor(
 		message: string,
 		readonly retryAfterSeconds: number,
-		props?: ITelemetryProperties,
+		props?: ITelemetryBaseProperties,
 	) {
 		super(message, props);
 	}

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -14,7 +14,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { IDeltaManager, IDeltaManagerEvents } from "@fluidframework/container-definitions";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
-import { ITelemetryProperties, TelemetryEventCategory } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties, TelemetryEventCategory } from "@fluidframework/core-interfaces";
 import { createChildLogger } from "@fluidframework/telemetry-utils";
 import { Audience } from "../audience";
 import { ConnectionState } from "../connectionState";
@@ -147,7 +147,7 @@ describe("ConnectionStateHandler Tests", () => {
 			logConnectionIssue: (
 				eventName: string,
 				category: TelemetryEventCategory,
-				details?: ITelemetryProperties,
+				details?: ITelemetryBaseProperties,
 			) => {
 				throw new Error(`logConnectionIssue: ${eventName} ${JSON.stringify(details)}`);
 			},

--- a/packages/loader/driver-utils/api-report/driver-utils.api.md
+++ b/packages/loader/driver-utils/api-report/driver-utils.api.md
@@ -30,9 +30,9 @@ import { IStreamResult } from '@fluidframework/driver-definitions';
 import { ISummaryContext } from '@fluidframework/driver-definitions';
 import { ISummaryHandle } from '@fluidframework/protocol-definitions';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
+import { ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
 import { ITelemetryErrorEventExt } from '@fluidframework/telemetry-utils';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
-import { ITelemetryProperties } from '@fluidframework/core-interfaces';
 import { IThrottlingWarning } from '@fluidframework/driver-definitions';
 import { ITree } from '@fluidframework/protocol-definitions';
 import { ITreeEntry } from '@fluidframework/protocol-definitions';
@@ -159,7 +159,7 @@ export class DocumentStorageServiceProxy implements IDocumentStorageService {
 }
 
 // @internal
-export type DriverErrorTelemetryProps = ITelemetryProperties & {
+export type DriverErrorTelemetryProps = ITelemetryBaseProperties & {
     driverVersion: string | undefined;
 };
 
@@ -283,7 +283,7 @@ export enum OnlineStatus {
 
 // @internal
 export class ParallelRequests<T> {
-    constructor(from: number, to: number | undefined, payloadSize: number, logger: ITelemetryLoggerExt, requestCallback: (request: number, from: number, to: number, strongTo: boolean, props: ITelemetryProperties) => Promise<{
+    constructor(from: number, to: number | undefined, payloadSize: number, logger: ITelemetryLoggerExt, requestCallback: (request: number, from: number, to: number, strongTo: boolean, props: ITelemetryBaseProperties) => Promise<{
         partial: boolean;
         cancel: boolean;
         payload: T[];
@@ -342,7 +342,7 @@ export class RateLimiter {
 export function readAndParse<T>(storage: Pick<IDocumentStorageService, "readBlob">, id: string): Promise<T>;
 
 // @internal
-export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLoggerExt, signal?: AbortSignal, scenarioName?: string): IStream<ISequencedDocumentMessage[]>;
+export function requestOps(get: (from: number, to: number, telemetryProps: ITelemetryBaseProperties) => Promise<IDeltasFetchResult>, concurrency: number, fromTotal: number, toTotal: number | undefined, payloadSize: number, logger: ITelemetryLoggerExt, signal?: AbortSignal, scenarioName?: string): IStream<ISequencedDocumentMessage[]>;
 
 // @internal (undocumented)
 export class RetryableError<T extends string> extends NetworkErrorBasic<T> {

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -11,7 +11,7 @@ import {
 	IResolvedUrl,
 	DriverErrorTypes,
 } from "@fluidframework/driver-definitions";
-import { ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { IFluidErrorBase, LoggingError } from "@fluidframework/telemetry-utils";
 
 /**
@@ -44,7 +44,7 @@ export function isOnline(): OnlineStatus {
  * Telemetry props with driver-specific required properties
  * @internal
  */
-export type DriverErrorTelemetryProps = ITelemetryProperties & {
+export type DriverErrorTelemetryProps = ITelemetryBaseProperties & {
 	driverVersion: string | undefined;
 };
 

--- a/packages/loader/driver-utils/src/parallelRequests.ts
+++ b/packages/loader/driver-utils/src/parallelRequests.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 import { performance } from "@fluid-internal/client-utils";
-import { ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { assert, Deferred } from "@fluidframework/core-utils";
 import { ITelemetryLoggerExt, PerformanceEvent } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -59,7 +59,7 @@ export class ParallelRequests<T> {
 			from: number,
 			to: number,
 			strongTo: boolean,
-			props: ITelemetryProperties,
+			props: ITelemetryBaseProperties,
 		) => Promise<{ partial: boolean; cancel: boolean; payload: T[] }>,
 		private readonly responseCallback: (payload: T[]) => void,
 	) {
@@ -411,8 +411,8 @@ const waitForOnline = async (): Promise<void> => {
  * @returns An object with resulting ops and cancellation / partial result flags
  */
 async function getSingleOpBatch(
-	get: (telemetryProps: ITelemetryProperties) => Promise<IDeltasFetchResult>,
-	props: ITelemetryProperties,
+	get: (telemetryProps: ITelemetryBaseProperties) => Promise<IDeltasFetchResult>,
+	props: ITelemetryBaseProperties,
 	strongTo: boolean,
 	logger: ITelemetryLoggerExt,
 	signal?: AbortSignal,
@@ -539,7 +539,7 @@ export function requestOps(
 	get: (
 		from: number,
 		to: number,
-		telemetryProps: ITelemetryProperties,
+		telemetryProps: ITelemetryBaseProperties,
 	) => Promise<IDeltasFetchResult>,
 	concurrency: number,
 	fromTotal: number,
@@ -554,7 +554,7 @@ export function requestOps(
 	let length = 0;
 	const queue = new Queue<ISequencedDocumentMessage[]>();
 
-	const propsTotal: ITelemetryProperties = {
+	const propsTotal: ITelemetryBaseProperties = {
 		fromTotal,
 		toTotal,
 	};
@@ -575,7 +575,7 @@ export function requestOps(
 			from: number,
 			to: number,
 			strongTo: boolean,
-			propsPerRequest: ITelemetryProperties,
+			propsPerRequest: ITelemetryBaseProperties,
 		) => {
 			requests++;
 			return getSingleOpBatch(

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -9,7 +9,7 @@ import {
 	IRequest,
 	IResponse,
 	IFluidHandle,
-	ITelemetryProperties,
+	ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces";
 import { IAudience, IDeltaManager, AttachState } from "@fluidframework/container-definitions";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
@@ -920,7 +920,7 @@ export abstract class FluidDataStoreContext
 	private verifyNotClosed(
 		callSite: string,
 		checkTombstone = true,
-		safeTelemetryProps: ITelemetryProperties = {},
+		safeTelemetryProps: ITelemetryBaseProperties = {},
 	) {
 		if (this.deleted) {
 			const messageString = `Context is deleted! Call site [${callSite}]`;

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IEvent, IEventProvider, ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { IEvent, IEventProvider, ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { ITelemetryLoggerExt, ITelemetryLoggerPropertyBag } from "@fluidframework/telemetry-utils";
 import { ContainerWarning, IDeltaManager } from "@fluidframework/container-definitions";
 import {
@@ -539,10 +539,10 @@ type ISummarizeTelemetryOptionalProperties =
 	| keyof ISummarizeOptions;
 
 export type ISummarizeTelemetryProperties = Pick<
-	ITelemetryProperties,
+	ITelemetryBaseProperties,
 	ISummarizeTelemetryRequiredProperties
 > &
-	Partial<Pick<ITelemetryProperties, ISummarizeTelemetryOptionalProperties>>;
+	Partial<Pick<ITelemetryBaseProperties, ISummarizeTelemetryOptionalProperties>>;
 
 /** Strategy used to heuristically determine when we should run a summary */
 export interface ISummaryHeuristicStrategy {
@@ -608,10 +608,10 @@ type SummaryGeneratorOptionalTelemetryProperties =
 	| "stage";
 
 export type SummaryGeneratorTelemetry = Pick<
-	ITelemetryProperties,
+	ITelemetryBaseProperties,
 	SummaryGeneratorRequiredTelemetryProperties
 > &
-	Partial<Pick<ITelemetryProperties, SummaryGeneratorOptionalTelemetryProperties>>;
+	Partial<Pick<ITelemetryBaseProperties, SummaryGeneratorOptionalTelemetryProperties>>;
 
 export interface ISummarizeRunnerTelemetry extends ITelemetryLoggerPropertyBag {
 	/** Number of times the summarizer run. */

--- a/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
@@ -8,7 +8,7 @@ import {
 	PerformanceEvent,
 	LoggingError,
 } from "@fluidframework/telemetry-utils";
-import { ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 
 import {
 	assert,
@@ -187,7 +187,7 @@ export class RetriableSummaryError extends LoggingError {
 	constructor(
 		message: string,
 		public readonly retryAfterSeconds?: number,
-		props?: ITelemetryProperties,
+		props?: ITelemetryBaseProperties,
 	) {
 		super(message, props);
 	}

--- a/packages/utils/odsp-doclib-utils/api-report/odsp-doclib-utils.api.md
+++ b/packages/utils/odsp-doclib-utils/api-report/odsp-doclib-utils.api.md
@@ -7,7 +7,7 @@
 import { DriverErrorTelemetryProps } from '@fluidframework/driver-utils';
 import { IFluidErrorBase } from '@fluidframework/telemetry-utils';
 import { IOdspErrorAugmentations } from '@fluidframework/odsp-driver-definitions';
-import { ITelemetryProperties } from '@fluidframework/core-interfaces';
+import { ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
 import { LoggingError } from '@fluidframework/telemetry-utils';
 import { OdspError } from '@fluidframework/odsp-driver-definitions';
 
@@ -15,10 +15,10 @@ import { OdspError } from '@fluidframework/odsp-driver-definitions';
 export function authRequestWithRetry(authRequestInfo: IOdspAuthRequestInfo, requestCallback: (config: RequestInit) => Promise<Response>): Promise<Response>;
 
 // @internal (undocumented)
-export function createOdspNetworkError(errorMessage: string, statusCode: number, retryAfterSeconds?: number, response?: Response, responseText?: string, props?: ITelemetryProperties): IFluidErrorBase & OdspError;
+export function createOdspNetworkError(errorMessage: string, statusCode: number, retryAfterSeconds?: number, response?: Response, responseText?: string, props?: ITelemetryBaseProperties): IFluidErrorBase & OdspError;
 
 // @internal (undocumented)
-export function enrichOdspError(error: IFluidErrorBase & OdspError, response?: Response, facetCodes?: string[], props?: ITelemetryProperties): IFluidErrorBase & OdspError;
+export function enrichOdspError(error: IFluidErrorBase & OdspError, response?: Response, facetCodes?: string[], props?: ITelemetryBaseProperties): IFluidErrorBase & OdspError;
 
 // @internal (undocumented)
 export const fetchIncorrectResponse = 712;
@@ -77,7 +77,7 @@ export function getSiteUrl(server: string): string;
 // @internal (undocumented)
 export function getSPOAndGraphRequestIdsFromResponse(headers: {
     get: (id: string) => string | undefined | null;
-}): ITelemetryProperties;
+}): ITelemetryBaseProperties;
 
 // @internal (undocumented)
 export function hasFacetCodes(x: any): x is Pick<IOdspErrorAugmentations, "facetCodes">;
@@ -172,7 +172,7 @@ export function putAsync(url: string, authRequestInfo: IOdspAuthRequestInfo): Pr
 export function refreshTokens(server: string, scope: string, clientConfig: IClientConfig, tokens: IOdspTokens): Promise<IOdspTokens>;
 
 // @internal
-export function throwOdspNetworkError(errorMessage: string, statusCode: number, response: Response, responseText?: string, props?: ITelemetryProperties): never;
+export function throwOdspNetworkError(errorMessage: string, statusCode: number, response: Response, responseText?: string, props?: ITelemetryBaseProperties): never;
 
 // @internal (undocumented)
 export type TokenRequestCredentials = {

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { DriverErrorTypes } from "@fluidframework/driver-definitions";
 import { IFluidErrorBase, LoggingError, numberFromString } from "@fluidframework/telemetry-utils";
 import {
@@ -60,7 +60,7 @@ export function getSPOAndGraphRequestIdsFromResponse(headers: {
 		{ headerName: "content-encoding", logName: "contentEncoding" },
 		{ headerName: "content-type", logName: "contentType" },
 	];
-	const additionalProps: ITelemetryProperties = {
+	const additionalProps: ITelemetryBaseProperties = {
 		sprequestduration: numberFromString(headers.get("sprequestduration")),
 		contentsize: numberFromString(headers.get("content-length")),
 	};
@@ -193,7 +193,7 @@ export function createOdspNetworkError(
 	retryAfterSeconds?: number,
 	response?: Response,
 	responseText?: string,
-	props: ITelemetryProperties = {},
+	props: ITelemetryBaseProperties = {},
 ): IFluidErrorBase & OdspError {
 	let error: IFluidErrorBase & OdspError;
 	const parseResult = tryParseErrorResponse(responseText);
@@ -377,7 +377,7 @@ export function enrichOdspError(
 	error: IFluidErrorBase & OdspError,
 	response?: Response,
 	facetCodes?: string[],
-	props: ITelemetryProperties = {},
+	props: ITelemetryBaseProperties = {},
 ) {
 	error.online = OnlineStatus[isOnline()];
 	if (facetCodes !== undefined) {
@@ -407,7 +407,7 @@ export function throwOdspNetworkError(
 	statusCode: number,
 	response: Response,
 	responseText?: string,
-	props?: ITelemetryProperties,
+	props?: ITelemetryBaseProperties,
 ): never {
 	const networkError = createOdspNetworkError(
 		errorMessage,

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -19,7 +19,6 @@ import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions'
 import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
-import { ITelemetryProperties } from '@fluidframework/core-interfaces';
 import { IUsageError } from '@fluidframework/core-interfaces';
 import { Lazy } from '@fluidframework/core-utils';
 import { LogLevel } from '@fluidframework/core-interfaces';
@@ -150,10 +149,10 @@ export interface IFluidErrorAnnotations {
 
 // @internal
 export interface IFluidErrorBase extends Error {
-    addTelemetryProperties: (props: ITelemetryProperties) => void;
+    addTelemetryProperties: (props: ITelemetryBaseProperties) => void;
     readonly errorInstanceId: string;
     readonly errorType: string;
-    getTelemetryProperties(): ITelemetryProperties;
+    getTelemetryProperties(): ITelemetryBaseProperties;
     readonly message: string;
     readonly name: string;
     readonly stack?: string;
@@ -345,7 +344,7 @@ export function safeRaiseEvent(emitter: EventEmitter, logger: ITelemetryLoggerEx
 
 // @internal
 export class SampledTelemetryHelper implements IDisposable {
-    constructor(eventBase: ITelemetryGenericEventExt, logger: ITelemetryLoggerExt, sampleThreshold: number, includeAggregateMetrics?: boolean, perBucketProperties?: Map<string, ITelemetryProperties>);
+    constructor(eventBase: ITelemetryGenericEventExt, logger: ITelemetryLoggerExt, sampleThreshold: number, includeAggregateMetrics?: boolean, perBucketProperties?: Map<string, ITelemetryBaseProperties>);
     // (undocumented)
     dispose(error?: Error | undefined): void;
     // (undocumented)

--- a/packages/utils/telemetry-utils/src/fluidErrorBase.ts
+++ b/packages/utils/telemetry-utils/src/fluidErrorBase.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 
 /**
  * An error emitted by the Fluid Framework.
@@ -61,12 +61,12 @@ export interface IFluidErrorBase extends Error {
 	/**
 	 * Get the telemetry properties stashed on this error for logging.
 	 */
-	getTelemetryProperties(): ITelemetryProperties;
+	getTelemetryProperties(): ITelemetryBaseProperties;
 
 	/**
 	 * Add telemetry properties to this error which will be logged with the error
 	 */
-	addTelemetryProperties: (props: ITelemetryProperties) => void;
+	addTelemetryProperties: (props: ITelemetryBaseProperties) => void;
 }
 
 const hasTelemetryPropFunctions = (x: unknown): boolean =>

--- a/packages/utils/telemetry-utils/src/sampledTelemetryHelper.ts
+++ b/packages/utils/telemetry-utils/src/sampledTelemetryHelper.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryProperties, IDisposable } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties, IDisposable } from "@fluidframework/core-interfaces";
 import { performance } from "@fluid-internal/client-utils";
 import {
 	ITelemetryLoggerExt,
@@ -76,7 +76,7 @@ export class SampledTelemetryHelper implements IDisposable {
 	 * properties which should be added to the telemetry event for that bucket. If a bucket being measured does not
 	 * have an entry in this map, no additional properties will be added to its telemetry events. The following keys are
 	 * reserved for use by this class: "duration", "count", "totalDuration", "minDuration", "maxDuration". If any of
-	 * them is specified as a key in one of the ITelemetryProperties objects in this map, that key-value pair will be
+	 * them is specified as a key in one of the ITelemetryBaseProperties objects in this map, that key-value pair will be
 	 * ignored.
 	 */
 	public constructor(
@@ -84,7 +84,7 @@ export class SampledTelemetryHelper implements IDisposable {
 		private readonly logger: ITelemetryLoggerExt,
 		private readonly sampleThreshold: number,
 		private readonly includeAggregateMetrics: boolean = false,
-		private readonly perBucketProperties = new Map<string, ITelemetryProperties>(),
+		private readonly perBucketProperties = new Map<string, ITelemetryBaseProperties>(),
 	) {}
 
 	/**

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -14,7 +14,7 @@
 import { strict as assert } from "node:assert";
 import sinon from "sinon";
 import { v4 as uuid } from "uuid";
-import { ITelemetryBaseEvent, ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseEvent, ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { TelemetryDataTag, TelemetryLogger, TaggedLoggerAdapter } from "../logger.js";
 import {
 	LoggingError,
@@ -39,10 +39,10 @@ describe("Error Logging", () => {
 		function freshEvent(): ITelemetryBaseEvent {
 			return { category: "cat1", eventName: "event1" };
 		}
-		function createILoggingError(props: ITelemetryProperties): {
-			getTelemetryProperties: () => ITelemetryProperties;
+		function createILoggingError(props: ITelemetryBaseProperties): {
+			getTelemetryProperties: () => ITelemetryBaseProperties;
 		} {
-			return { ...props, getTelemetryProperties: (): ITelemetryProperties => props };
+			return { ...props, getTelemetryProperties: (): ITelemetryBaseProperties => props };
 		}
 
 		it("non-object error added to event", () => {
@@ -613,7 +613,7 @@ describe("Error Logging", () => {
 class TestFluidError implements IFluidErrorBase {
 	readonly atpStub: sinon.SinonStub;
 	readonly gtpSpy: sinon.SinonSpy;
-	expectedTelemetryProps: ITelemetryProperties;
+	expectedTelemetryProps: ITelemetryBaseProperties;
 
 	readonly errorType: string;
 	readonly message: string;
@@ -637,12 +637,12 @@ class TestFluidError implements IFluidErrorBase {
 		this.expectedTelemetryProps = { ...errorProps };
 	}
 
-	getTelemetryProperties(): ITelemetryProperties {
+	getTelemetryProperties(): ITelemetryBaseProperties {
 		// Don't actually return any props. We'll use the spy to ensure it was called
 		return {};
 	}
 
-	addTelemetryProperties(props: ITelemetryProperties): void {
+	addTelemetryProperties(props: ITelemetryBaseProperties): void {
 		throw new Error("Not Implemented - Expected to be Stubbed via Sinon");
 	}
 
@@ -653,7 +653,7 @@ class TestFluidError implements IFluidErrorBase {
 		return this;
 	}
 
-	withExpectedTelemetryProps(props: ITelemetryProperties): this {
+	withExpectedTelemetryProps(props: ITelemetryBaseProperties): this {
 		Object.assign(this.expectedTelemetryProps, props);
 		return this;
 	}

--- a/packages/utils/telemetry-utils/src/test/sampledTelemetryHelper.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/sampledTelemetryHelper.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import assert from "node:assert";
-import { ITelemetryBaseEvent, ITelemetryProperties } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseEvent, ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 
 import { SampledTelemetryHelper } from "../sampledTelemetryHelper.js";
 import {
@@ -121,9 +121,9 @@ describe("SampledTelemetryHelper", () => {
 	it("tracks buckets separately and includes per-bucket properties", () => {
 		const bucket1 = "bucket1";
 		const bucket2 = "bucket2";
-		const bucketProperties: Map<string, ITelemetryProperties> = new Map<
+		const bucketProperties: Map<string, ITelemetryBaseProperties> = new Map<
 			string,
-			ITelemetryProperties
+			ITelemetryBaseProperties
 		>([
 			[bucket1, { prop1: "value1" }],
 			[bucket2, { prop2: "value2" }],
@@ -154,9 +154,9 @@ describe("SampledTelemetryHelper", () => {
 		// by the custom properties.
 
 		const bucket1 = "bucket1";
-		const bucketProperties: Map<string, ITelemetryProperties> = new Map<
+		const bucketProperties: Map<string, ITelemetryBaseProperties> = new Map<
 			string,
-			ITelemetryProperties
+			ITelemetryBaseProperties
 		>([
 			// Here just using a duration value that we can be sure will not be the actual value, to make sure the
 			// actuals is different from this one (since it's much harder to guarantee an exact duration
@@ -183,9 +183,9 @@ describe("SampledTelemetryHelper", () => {
 		// custom properties added to the event for each bucket
 		const bucket1 = "bucket1";
 		const bucket2 = "bucket2";
-		const bucketProperties: Map<string, ITelemetryProperties> = new Map<
+		const bucketProperties: Map<string, ITelemetryBaseProperties> = new Map<
 			string,
-			ITelemetryProperties
+			ITelemetryBaseProperties
 		>([
 			[bucket1, { prop1: "value1" }],
 			[bucket2, { prop2: "value2" }],


### PR DESCRIPTION
## Description

Removes the deprecated `ITelemetryProperties` and replaces its internal uses with the equivalent `ITelemetryBaseProperties`.

## Breaking changes

The `ITelemetryProperties` export is removed from `@fluidframework/core-interfaces`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
