### PR TITLE
feat(client examples): bump puppeteer

### DIFF
--- a/common/lib/common-utils/pnpm-lock.yaml
+++ b/common/lib/common-utils/pnpm-lock.yaml
@@ -2512,8 +2512,8 @@ packages:
     resolution: {integrity: sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==}
     dev: true
 
-  /@types/mime-types/2.1.1:
-    resolution: {integrity: sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw==}
+  /@types/mime-types/2.1.4:
+    resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
     dev: true
 
   /@types/minimatch/3.0.5:
@@ -10483,10 +10483,10 @@ packages:
   /puppeteer/2.1.1:
     resolution: {integrity: sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==}
     engines: {node: '>=8.16.0'}
-    deprecated: < 19.4.0 is no longer supported
+    deprecated: < 21.5.0 is no longer supported
     requiresBuild: true
     dependencies:
-      '@types/mime-types': 2.1.1
+      '@types/mime-types': 2.1.4
       debug: 4.3.4
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0

--- a/examples/apps/attributable-map/package.json
+++ b/examples/apps/attributable-map/package.json
@@ -61,7 +61,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/apps/collaborative-textarea/package.json
+++ b/examples/apps/collaborative-textarea/package.json
@@ -71,7 +71,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/apps/contact-collection/package.json
+++ b/examples/apps/contact-collection/package.json
@@ -69,7 +69,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/apps/data-object-grid/package.json
+++ b/examples/apps/data-object-grid/package.json
@@ -89,7 +89,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"sass-loader": "^7.1.0",
 		"source-map-loader": "^2.0.0",

--- a/examples/apps/presence-tracker/package.json
+++ b/examples/apps/presence-tracker/package.json
@@ -67,7 +67,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/apps/task-selection/package.json
+++ b/examples/apps/task-selection/package.json
@@ -69,7 +69,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/apps/tree-comparison/package.json
+++ b/examples/apps/tree-comparison/package.json
@@ -82,7 +82,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"style-loader": "^1.0.0",
 		"ts-jest": "^29.1.1",

--- a/examples/benchmarks/bubblebench/baseline/package.json
+++ b/examples/benchmarks/bubblebench/baseline/package.json
@@ -69,7 +69,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/benchmarks/bubblebench/editable-shared-tree/package.json
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/package.json
@@ -71,7 +71,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/benchmarks/bubblebench/ot/package.json
+++ b/examples/benchmarks/bubblebench/ot/package.json
@@ -71,7 +71,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/benchmarks/bubblebench/sharedtree/package.json
+++ b/examples/benchmarks/bubblebench/sharedtree/package.json
@@ -70,7 +70,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/data-objects/canvas/package.json
+++ b/examples/data-objects/canvas/package.json
@@ -68,7 +68,7 @@
 		"less": "~3.9.0",
 		"less-loader": "^4.1.0",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"style-loader": "^1.0.0",
 		"ts-loader": "^9.3.0",

--- a/examples/data-objects/clicker/package.json
+++ b/examples/data-objects/clicker/package.json
@@ -68,7 +68,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/data-objects/diceroller/package.json
+++ b/examples/data-objects/diceroller/package.json
@@ -64,7 +64,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/data-objects/inventory-app/package.json
+++ b/examples/data-objects/inventory-app/package.json
@@ -66,7 +66,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"source-map-loader": "^2.0.0",
 		"ts-jest": "^29.1.1",

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -62,7 +62,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -65,7 +65,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"style-loader": "^1.0.0",
 		"ts-jest": "^29.1.1",

--- a/examples/data-objects/multiview/container/package.json
+++ b/examples/data-objects/multiview/container/package.json
@@ -78,7 +78,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"style-loader": "^1.0.0",
 		"ts-jest": "^29.1.1",

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -61,7 +61,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -41,7 +41,7 @@
 		"eslint": "~8.50.0",
 		"expect-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-loader": "^9.3.0",
 		"typescript": "~5.1.6",

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -65,7 +65,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"style-loader": "^1.0.0",
 		"ts-jest": "^29.1.1",

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -65,7 +65,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"style-loader": "^1.0.0",
 		"ts-jest": "^29.1.1",

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -65,7 +65,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"style-loader": "^1.0.0",
 		"ts-jest": "^29.1.1",

--- a/examples/data-objects/todo/package.json
+++ b/examples/data-objects/todo/package.json
@@ -74,7 +74,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"source-map-loader": "^2.0.0",
 		"style-loader": "^1.0.0",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -109,7 +109,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"start-server-and-test": "^1.11.7",
 		"stream-http": "^3.2.0",

--- a/examples/service-clients/azure-client/external-controller/package.json
+++ b/examples/service-clients/azure-client/external-controller/package.json
@@ -75,7 +75,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"start-server-and-test": "^1.11.7",
 		"tinylicious": "^3.1.0-238497",

--- a/examples/service-clients/odsp-client/shared-tree-demo/package.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/package.json
@@ -57,7 +57,7 @@
 		"html-webpack-plugin": "^5.5.0",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"tailwindcss": "^3.3.2",
 		"ts-loader": "^9.3.0",

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -50,7 +50,7 @@
 		"@types/node": "^18.19.0",
 		"eslint": "~8.50.0",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"string-replace-loader": "^3.1.0",
 		"ts-loader": "^9.3.0",

--- a/examples/version-migration/live-schema-upgrade/package.json
+++ b/examples/version-migration/live-schema-upgrade/package.json
@@ -70,7 +70,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -86,7 +86,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"style-loader": "^1.0.0",
 		"ts-jest": "^29.1.1",

--- a/examples/version-migration/schema-upgrade/package.json
+++ b/examples/version-migration/schema-upgrade/package.json
@@ -86,7 +86,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"style-loader": "^1.0.0",
 		"ts-jest": "^29.1.1",

--- a/examples/version-migration/tree-shim/package.json
+++ b/examples/version-migration/tree-shim/package.json
@@ -81,7 +81,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"start-server-and-test": "^1.11.7",
 		"style-loader": "^1.0.0",

--- a/examples/view-integration/container-views/package.json
+++ b/examples/view-integration/container-views/package.json
@@ -67,7 +67,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/view-integration/external-views/package.json
+++ b/examples/view-integration/external-views/package.json
@@ -64,7 +64,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/view-integration/view-framework-sampler/package.json
+++ b/examples/view-integration/view-framework-sampler/package.json
@@ -69,7 +69,7 @@
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
 		"process": "^0.11.10",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -92,7 +92,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"sass": "^1.42.1",
 		"sass-loader": "^7.1.0",

--- a/experimental/PropertyDDS/examples/property-inspector/package.json
+++ b/experimental/PropertyDDS/examples/property-inspector/package.json
@@ -93,7 +93,7 @@
 		"jest-junit": "^10.0.0",
 		"jest-puppeteer": "^9.0.2",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"sass": "^1.42.1",
 		"sass-loader": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
 		"mocha": "^10.2.0",
 		"prettier": "~3.0.3",
 		"pretty-quick": "^4.0.0",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"run-script-os": "^1.1.6",
 		"syncpack": "^9.8.4",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -126,7 +126,7 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.21.0",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rewire": "^5.0.0",
 		"rimraf": "^4.4.0",
 		"sinon": "^7.4.2",

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -131,7 +131,7 @@
 		"mocha": "^10.2.0",
 		"prettier": "~3.0.3",
 		"proxyquire": "^2.1.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"sinon": "^7.4.2",
 		"sinon-chrome": "^3.0.1",

--- a/packages/tools/devtools/devtools-example/package.json
+++ b/packages/tools/devtools/devtools-example/package.json
@@ -99,7 +99,7 @@
 		"jest-environment-puppeteer": "^9.0.2",
 		"jest-junit": "^10.0.0",
 		"prettier": "~3.0.3",
-		"puppeteer": "^22.0.0",
+		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
       mocha: ^10.2.0
       prettier: ~3.0.3
       pretty-quick: ^4.0.0
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rimraf: ^4.4.0
       run-script-os: ^1.1.6
       syncpack: ^9.8.4
@@ -73,7 +73,7 @@ importers:
       mocha: 10.2.0
       prettier: 3.0.3
       pretty-quick: 4.0.0_prettier@3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       run-script-os: 1.1.6
       syncpack: 9.8.6
@@ -341,7 +341,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rimraf: ^4.4.0
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
@@ -376,10 +376,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -421,7 +421,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -465,10 +465,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -507,7 +507,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -550,10 +550,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -607,7 +607,7 @@ importers:
       prettier: ~3.0.3
       process: ^0.11.10
       prop-types: ^15.8.1
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-collapsible: ^2.7.0
       react-dom: ^17.0.1
@@ -672,10 +672,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       sass-loader: 7.3.1_webpack@5.89.0
       source-map-loader: 2.0.2_webpack@5.89.0
@@ -719,7 +719,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rimraf: ^4.4.0
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
@@ -757,9 +757,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -801,7 +801,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rimraf: ^4.4.0
       style-loader: ^1.0.0
       ts-jest: ^29.1.1
@@ -841,10 +841,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -896,7 +896,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -953,10 +953,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.89.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
@@ -994,7 +994,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       ts-jest: ^29.1.1
@@ -1030,9 +1030,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -1134,7 +1134,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       ts-jest: ^29.1.1
@@ -1173,9 +1173,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -1215,7 +1215,7 @@ importers:
       jest-puppeteer: ^9.0.2
       ot-json1: ^1.0.1
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       ts-jest: ^29.1.1
@@ -1253,9 +1253,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -1293,7 +1293,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       ts-jest: ^29.1.1
@@ -1330,9 +1330,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -1604,7 +1604,7 @@ importers:
       less: ~3.9.0
       less-loader: ^4.1.0
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       style-loader: ^1.0.0
@@ -1639,11 +1639,11 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       less: 3.9.0
       less-loader: 4.1.0_less@3.9.0+webpack@5.89.0
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.89.0
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -1681,7 +1681,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       ts-jest: ^29.1.1
@@ -1717,9 +1717,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -1827,7 +1827,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       ts-jest: ^29.1.1
@@ -1859,9 +1859,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -1896,7 +1896,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       source-map-loader: ^2.0.0
@@ -1931,9 +1931,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       source-map-loader: 2.0.2_webpack@5.89.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
@@ -2033,7 +2033,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rimraf: ^4.4.0
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
@@ -2062,9 +2062,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -2097,7 +2097,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       style-loader: ^1.0.0
@@ -2130,9 +2130,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.89.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
@@ -2179,7 +2179,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       style-loader: ^1.0.0
@@ -2225,9 +2225,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.89.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
@@ -2259,7 +2259,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rimraf: ^4.4.0
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
@@ -2287,9 +2287,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -2311,7 +2311,7 @@ importers:
       eslint: ~8.50.0
       expect-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rimraf: ^4.4.0
       ts-loader: ^9.3.0
       typescript: ~5.1.6
@@ -2330,7 +2330,7 @@ importers:
       eslint: 8.50.0
       expect-puppeteer: 9.0.2
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
       typescript: 5.1.6
@@ -2362,7 +2362,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       style-loader: ^1.0.0
@@ -2395,9 +2395,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.89.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
@@ -2431,7 +2431,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       style-loader: ^1.0.0
@@ -2464,9 +2464,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.89.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
@@ -2500,7 +2500,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       rimraf: ^4.4.0
       style-loader: ^1.0.0
@@ -2533,9 +2533,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.89.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
@@ -2891,7 +2891,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -2936,9 +2936,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       source-map-loader: 2.0.2_webpack@5.89.0
       style-loader: 1.3.0_webpack@5.89.0
@@ -3116,7 +3116,7 @@ importers:
       node-fetch: ^2.6.9
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -3190,10 +3190,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       start-server-and-test: 1.15.5
       stream-http: 3.2.0
@@ -3242,7 +3242,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rimraf: ^4.4.0
       start-server-and-test: ^1.11.7
       tinylicious: ^3.1.0-238497
@@ -3287,10 +3287,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       start-server-and-test: 1.15.5
       tinylicious: 3.1.0-238497
@@ -3323,7 +3323,7 @@ importers:
       html-webpack-plugin: ^5.5.0
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -3359,7 +3359,7 @@ importers:
       html-webpack-plugin: 5.5.3_webpack@5.89.0
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       tailwindcss: 3.3.6
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -3390,7 +3390,7 @@ importers:
       '@types/node': ^18.19.0
       eslint: ~8.50.0
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rimraf: ^4.4.0
       source-map-loader: ^2.0.0
       string-replace-loader: ^3.1.0
@@ -3421,7 +3421,7 @@ importers:
       '@types/node': 18.19.1
       eslint: 8.50.0
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       string-replace-loader: 3.1.0_webpack@5.89.0
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -3655,7 +3655,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rimraf: ^4.4.0
       style-loader: ^1.0.0
       ts-jest: ^29.1.1
@@ -3696,10 +3696,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -3756,7 +3756,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -3816,10 +3816,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.89.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
@@ -3877,7 +3877,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -3937,10 +3937,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       style-loader: 1.3.0_webpack@5.89.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
@@ -3993,7 +3993,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -4052,10 +4052,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       start-server-and-test: 1.15.5
       style-loader: 1.3.0_webpack@5.89.0
@@ -4098,7 +4098,7 @@ importers:
       jest-junit: ^10.0.0
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -4139,9 +4139,9 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -4178,7 +4178,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rimraf: ^4.4.0
       style-loader: ^1.0.0
       ts-jest: ^29.1.1
@@ -4213,10 +4213,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -4255,7 +4255,7 @@ importers:
       jest-puppeteer: ^9.0.2
       prettier: ~3.0.3
       process: ^0.11.10
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -4298,10 +4298,10 @@ importers:
       jest: 29.7.0_@types+node@18.19.1
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
       process: 0.11.10
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -4363,7 +4363,7 @@ importers:
       jsonwebtoken: ^8.4.0
       lodash: ^4.17.21
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -4427,9 +4427,9 @@ importers:
       jest: 29.7.0
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       sass: 1.69.5
       sass-loader: 7.3.1_webpack@5.89.0
@@ -4493,7 +4493,7 @@ importers:
       jsonwebtoken: ^8.4.0
       lodash: ^4.17.21
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       react-virtualized-auto-sizer: ^1.0.6
@@ -4561,9 +4561,9 @@ importers:
       jest: 29.7.0
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       sass: 1.69.5
       sass-loader: 7.3.1_webpack@5.89.0
@@ -5924,7 +5924,7 @@ importers:
       mocha-multi-reporters: ^1.5.1
       moment: ^2.21.0
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       rewire: ^5.0.0
       rimraf: ^4.4.0
       sha.js: ^2.4.11
@@ -5968,13 +5968,13 @@ importers:
       jest: 29.7.0_5hr63yjncn3tlo6qh7e6tsd2me
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       mocha: 10.2.0
       mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
       moment: 2.29.4
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rewire: 5.0.0
       rimraf: 4.4.1
       sinon: 7.5.0
@@ -10996,7 +10996,7 @@ importers:
       mocha: ^10.2.0
       prettier: ~3.0.3
       proxyquire: ^2.1.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
@@ -11068,13 +11068,13 @@ importers:
       jest-dev-server: 9.0.2
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
-      jest-puppeteer: 9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma
+      jest-puppeteer: 9.0.2_45yw4b353ouaepujuapfecneom
       jsdom: 16.7.0
       jsdom-global: 3.0.2_jsdom@16.7.0
       mocha: 10.2.0
       prettier: 3.0.3
       proxyquire: 2.1.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       sinon: 7.5.0
       sinon-chrome: 3.0.1
@@ -11233,7 +11233,7 @@ importers:
       jest-environment-puppeteer: ^9.0.2
       jest-junit: ^10.0.0
       prettier: ~3.0.3
-      puppeteer: ^22.0.0
+      puppeteer: ^22.2.0
       re-resizable: ^6.9.9
       react: ^17.0.1
       react-dom: ^17.0.1
@@ -11305,7 +11305,7 @@ importers:
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
       jest-junit: 10.0.0
       prettier: 3.0.3
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -17164,7 +17164,7 @@ packages:
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
       nconf: 0.12.1
-      semver: 7.5.4
+      semver: 7.6.0
       sha.js: 2.4.11
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -19082,7 +19082,7 @@ packages:
       read-package-json-fast: 2.0.3
       readdir-scoped-modules: 1.1.0
       rimraf: 3.0.2
-      semver: 7.5.4
+      semver: 7.6.0
       ssri: 8.0.1
       treeverse: 1.0.4
       walk-up-path: 1.0.0
@@ -19095,7 +19095,7 @@ packages:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /@npmcli/fs/2.1.2:
@@ -19103,14 +19103,14 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /@npmcli/fs/3.1.0:
     resolution: {integrity: sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /@npmcli/git/2.1.0:
@@ -19122,7 +19122,7 @@ packages:
       npm-pick-manifest: 6.1.1
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.4
+      semver: 7.6.0
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -19138,7 +19138,7 @@ packages:
       proc-log: 3.0.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.5.4
+      semver: 7.6.0
       which: 3.0.1
     transitivePeerDependencies:
       - bluebird
@@ -19179,7 +19179,7 @@ packages:
       cacache: 15.3.0
       json-parse-even-better-errors: 2.3.1
       pacote: 12.0.3
-      semver: 7.5.4
+      semver: 7.6.0
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -19621,7 +19621,7 @@ packages:
       '@types/shimmer': 1.0.5
       import-in-the-middle: 1.4.2
       require-in-the-middle: 7.2.0
-      semver: 7.5.4
+      semver: 7.6.0
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -19966,16 +19966,17 @@ packages:
       fs-extra: 11.1.1
     dev: true
 
-  /@puppeteer/browsers/2.0.0:
-    resolution: {integrity: sha512-3PS82/5+tnpEaUWonjAFFvlf35QHF15xqyGd34GBa5oP5EPVfFXRsbSxIGYf1M+vZlqBZ3oxT1kRg9OYhtt8ng==}
+  /@puppeteer/browsers/2.1.0:
+    resolution: {integrity: sha512-xloWvocjvryHdUjDam/ZuGMh7zn4Sn3ZAaV4Ah2e2EwEt90N3XphZlSsU3n0VDc1F7kggCjMuH0UuxfPQ5mD9w==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
       debug: 4.3.4
       extract-zip: 2.0.1
       progress: 2.0.3
-      proxy-agent: 6.3.1
-      tar-fs: 3.0.4
+      proxy-agent: 6.4.0
+      semver: 7.6.0
+      tar-fs: 3.0.5
       unbzip2-stream: 1.4.3
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -22700,7 +22701,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
+      semver: 7.6.0
       tsutils: 3.21.0_typescript@5.1.6
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -22721,7 +22722,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
+      semver: 7.6.0
       tsutils: 3.21.0_typescript@5.1.6
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -22742,7 +22743,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
+      semver: 7.6.0
       ts-api-utils: 1.0.3_typescript@5.1.6
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -22763,7 +22764,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.4
+      semver: 7.6.0
       ts-api-utils: 1.0.3_typescript@5.1.6
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -22784,7 +22785,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.59.11_typescript@5.1.6
       eslint: 8.50.0
       eslint-scope: 5.1.1
-      semver: 7.5.4
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -22842,7 +22843,7 @@ packages:
       '@typescript-eslint/types': 6.7.5
       '@typescript-eslint/typescript-estree': 6.7.5_typescript@5.1.6
       eslint: 8.50.0
-      semver: 7.5.4
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -24477,6 +24478,34 @@ packages:
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  /bare-events/2.2.0:
+    resolution: {integrity: sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==}
+    dev: true
+    optional: true
+
+  /bare-fs/2.1.5:
+    resolution: {integrity: sha512-5t0nlecX+N2uJqdxe9d18A98cp2u9BETelbjKpiVgQqzzmVNFYWEAjQHqS+2Khgto1vcwhik9cXucaj5ve2WWA==}
+    requiresBuild: true
+    dependencies:
+      bare-events: 2.2.0
+      bare-os: 2.2.0
+      bare-path: 2.1.0
+      streamx: 2.15.7
+    dev: true
+    optional: true
+
+  /bare-os/2.2.0:
+    resolution: {integrity: sha512-hD0rOPfYWOMpVirTACt4/nK8mC55La12K5fY1ij8HAdfQakD62M+H4o4tpfKzVGLgRDTuk3vjA4GqGXXCeFbag==}
+    dev: true
+    optional: true
+
+  /bare-path/2.1.0:
+    resolution: {integrity: sha512-DIIg7ts8bdRKwJRJrUMy/PICEaQZaPGZ26lsSx9MJSwIhSrcdHn7/C8W+XmnG/rKi6BaRcz+JO00CjZteybDtw==}
+    dependencies:
+      bare-os: 2.2.0
+    dev: true
+    optional: true
+
   /base/0.11.2:
     resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
     engines: {node: '>=0.10.0'}
@@ -24567,7 +24596,7 @@ packages:
     dependencies:
       arg-parser: 1.2.0
       commander: 9.5.0
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /bfj/7.1.0:
@@ -24963,7 +24992,7 @@ packages:
   /builtins/5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.0
 
   /bytes/3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -25523,12 +25552,12 @@ packages:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
     engines: {node: '>=6.0'}
 
-  /chromium-bidi/0.5.8_ncn5kdxe6rasr54dhc2fl42uoa:
-    resolution: {integrity: sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==}
+  /chromium-bidi/0.5.9_74t7hwmhzgczi6zz4gvli4zmpa:
+    resolution: {integrity: sha512-wOTX3m2zuHX0zRX4h7Ol1DAGz0cqHzo2IrAPvOqBxdd4ZR32vxg4FKNjmBihi1oP9b1QGSBBG5VNUUXUCsxDfg==}
     peerDependencies:
       devtools-protocol: '*'
     dependencies:
-      devtools-protocol: 0.0.1232444
+      devtools-protocol: 0.0.1249869
       mitt: 3.0.1
       urlpattern-polyfill: 10.0.0
     dev: true
@@ -26629,7 +26658,7 @@ packages:
       postcss-modules-values: 4.0.0_postcss@8.4.31
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
-      semver: 7.5.4
+      semver: 7.6.0
       webpack: 5.89.0_webpack-cli@4.10.0
     dev: true
 
@@ -27403,8 +27432,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /devtools-protocol/0.0.1232444:
-    resolution: {integrity: sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==}
+  /devtools-protocol/0.0.1249869:
+    resolution: {integrity: sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==}
     dev: true
 
   /dezalgo/1.0.4:
@@ -28385,7 +28414,7 @@ packages:
       is-glob: 4.0.3
       minimatch: 3.1.2
       resolve: 1.22.8
-      semver: 7.5.4
+      semver: 7.6.0
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-typescript
@@ -29675,7 +29704,7 @@ packages:
       memfs: 3.5.3
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.5.4
+      semver: 7.6.0
       tapable: 1.1.3
       typescript: 5.1.6
       webpack: 4.47.0_webpack-cli@4.10.0
@@ -29707,7 +29736,7 @@ packages:
       memfs: 3.5.3
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.5.4
+      semver: 7.6.0
       tapable: 1.1.3
       typescript: 5.1.6
       webpack: 5.89.0_webpack-cli@4.10.0
@@ -31057,6 +31086,16 @@ packages:
       - supports-color
     dev: true
 
+  /http-proxy-agent/7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /http-proxy-middleware/2.0.6:
     resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
     engines: {node: '>=12.0.0'}
@@ -31196,6 +31235,16 @@ packages:
 
   /https-proxy-agent/7.0.2:
     resolution: {integrity: sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /https-proxy-agent/7.0.4:
+    resolution: {integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==}
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
@@ -32302,7 +32351,7 @@ packages:
       '@babel/parser': 7.23.4
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.5.4
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -32843,7 +32892,7 @@ packages:
       jest-resolve: 29.7.0
     dev: true
 
-  /jest-puppeteer/9.0.2_fwvjoj5ale4jdvhe6tcl5zcnma:
+  /jest-puppeteer/9.0.2_45yw4b353ouaepujuapfecneom:
     resolution: {integrity: sha512-ZB0K/tH+0e7foRRn+VpKIufvkW1by8l7ifh62VOdOh5ijEf7yt8W2/PcBNNwP0RLm46AytiBkrIEenvWhxcBRQ==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -32851,7 +32900,7 @@ packages:
     dependencies:
       expect-puppeteer: 9.0.2
       jest-environment-puppeteer: 9.0.2_typescript@5.1.6
-      puppeteer: 22.0.0_typescript@5.1.6
+      puppeteer: 22.2.0_typescript@5.1.6
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -32983,7 +33032,7 @@ packages:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.5.4
+      semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -33583,7 +33632,7 @@ packages:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.5.4
+      semver: 7.6.0
 
   /jsprim/1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
@@ -34427,7 +34476,7 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /make-error/1.3.6:
@@ -35389,10 +35438,6 @@ packages:
     engines: {node: '>= 8.0.0'}
     dev: true
 
-  /mkdirp-classic/0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-    dev: true
-
   /mkdirp-infer-owner/2.0.0:
     resolution: {integrity: sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==}
     engines: {node: '>=10'}
@@ -35887,7 +35932,7 @@ packages:
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.5.4
+      semver: 7.6.0
       tar: 6.2.0
       which: 2.0.2
     transitivePeerDependencies:
@@ -35908,7 +35953,7 @@ packages:
       nopt: 6.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.5.4
+      semver: 7.6.0
       tar: 6.2.0
       which: 2.0.2
     transitivePeerDependencies:
@@ -35989,7 +36034,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.13.1
-      semver: 7.5.4
+      semver: 7.6.0
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -35999,7 +36044,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       is-core-module: 2.13.1
-      semver: 7.5.4
+      semver: 7.6.0
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -36099,14 +36144,14 @@ packages:
     resolution: {integrity: sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /npm-install-checks/6.3.0:
     resolution: {integrity: sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /npm-normalize-package-bin/1.0.1:
@@ -36129,7 +36174,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       proc-log: 3.0.0
-      semver: 7.5.4
+      semver: 7.6.0
       validate-npm-package-name: 5.0.0
     dev: true
 
@@ -36138,7 +36183,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.5.4
+      semver: 7.6.0
       validate-npm-package-name: 3.0.0
     dev: true
 
@@ -36166,7 +36211,7 @@ packages:
       npm-install-checks: 4.0.0
       npm-normalize-package-bin: 1.0.1
       npm-package-arg: 8.1.5
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /npm-pick-manifest/8.0.2:
@@ -36176,7 +36221,7 @@ packages:
       npm-install-checks: 6.3.0
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 10.1.0
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /npm-registry-fetch/12.0.2:
@@ -36857,8 +36902,8 @@ packages:
       agent-base: 7.1.0
       debug: 4.3.4
       get-uri: 6.0.2
-      http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
       pac-resolver: 7.0.0
       socks-proxy-agent: 8.0.2
     transitivePeerDependencies:
@@ -36901,7 +36946,7 @@ packages:
       got: 12.6.1
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /pacote/12.0.3:
@@ -37591,7 +37636,7 @@ packages:
       loader-utils: 2.0.4
       postcss: 7.0.39
       schema-utils: 3.3.0
-      semver: 7.5.4
+      semver: 7.6.0
       webpack: 4.47.0_webpack-cli@4.10.0
     dev: true
 
@@ -38203,6 +38248,22 @@ packages:
       - supports-color
     dev: true
 
+  /proxy-agent/6.4.0:
+    resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.0.1
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /proxy-from-env/1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -38322,15 +38383,15 @@ packages:
       escape-goat: 4.0.0
     dev: true
 
-  /puppeteer-core/22.0.0:
-    resolution: {integrity: sha512-S3s91rLde0A86PWVeNY82h+P0fdS7CTiNWAicCVH/bIspRP4nS2PnO5j+VTFqCah0ZJizGzpVPAmxVYbLxTc9w==}
+  /puppeteer-core/22.2.0:
+    resolution: {integrity: sha512-rxLM860FP05CxCPAn6dwY0KnVhbnogsXu4XORb+2hb/va69v7R1VdJWLMGHd7EE5wfpT8oFZ7Q6NN85OhOtV9Q==}
     engines: {node: '>=18'}
     dependencies:
-      '@puppeteer/browsers': 2.0.0
-      chromium-bidi: 0.5.8_ncn5kdxe6rasr54dhc2fl42uoa
+      '@puppeteer/browsers': 2.1.0
+      chromium-bidi: 0.5.9_74t7hwmhzgczi6zz4gvli4zmpa
       cross-fetch: 4.0.0
       debug: 4.3.4
-      devtools-protocol: 0.0.1232444
+      devtools-protocol: 0.0.1249869
       ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
@@ -38339,15 +38400,15 @@ packages:
       - utf-8-validate
     dev: true
 
-  /puppeteer/22.0.0_typescript@5.1.6:
-    resolution: {integrity: sha512-zYVnjwJngnSB4dbkWp7DHFSIc3nqHvZzrdHyo9+ugV1nq1Lm8obOMcmCFaGfR3PJs0EmYNz+/skBeO45yvASCQ==}
+  /puppeteer/22.2.0_typescript@5.1.6:
+    resolution: {integrity: sha512-0Ax7zeqqbQL6Zcpo1WAvrqWQAnGsLB4tmQUUwsb5Cfo05XaQ78LWUUjaO4um7qaddKpZfk0vXlGcRVwtedpWfg==}
     engines: {node: '>=18'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@puppeteer/browsers': 2.0.0
+      '@puppeteer/browsers': 2.1.0
       cosmiconfig: 9.0.0_typescript@5.1.6
-      puppeteer-core: 22.0.0
+      puppeteer-core: 22.2.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -40074,7 +40135,7 @@ packages:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /semver-try-require/6.2.3:
@@ -40107,6 +40168,13 @@ packages:
 
   /semver/7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+
+  /semver/7.6.0:
+    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -41653,12 +41721,14 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  /tar-fs/3.0.4:
-    resolution: {integrity: sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==}
+  /tar-fs/3.0.5:
+    resolution: {integrity: sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==}
     dependencies:
-      mkdirp-classic: 0.5.3
       pump: 3.0.0
       tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 2.1.5
+      bare-path: 2.1.0
     dev: true
 
   /tar-stream/3.1.7:
@@ -43026,7 +43096,7 @@ packages:
       is-yarn-global: 0.4.1
       latest-version: 7.0.0
       pupa: 3.1.0
-      semver: 7.5.4
+      semver: 7.6.0
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: true
@@ -44834,7 +44904,7 @@ packages:
       preferred-pm: 3.1.2
       pretty-bytes: 5.6.0
       readable-stream: 4.4.2
-      semver: 7.5.4
+      semver: 7.6.0
       slash: 3.0.0
       strip-ansi: 6.0.1
       text-table: 0.2.0
@@ -44865,7 +44935,7 @@ packages:
       pacote: 15.2.0
       read-pkg-up: 7.0.1
       run-async: 2.4.1
-      semver: 7.5.4
+      semver: 7.6.0
       shelljs: 0.8.5
       sort-keys: 4.2.0
       text-table: 0.2.0


### PR DESCRIPTION
Bump puppeteer to 22.2.0 to workaround https://github.com/puppeteer/puppeteer/issues/11967. This causes the policy-check stage to fail, as puppeteer is unable to download the chromium version it needs. 