### PR TITLE
Update fluid-configmap.yaml

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -97,7 +97,6 @@ data:
             "maxMessageSize": "16KB",
             "numberOfMessagesPerTrace": {{ .Values.alfred.numberOfMessagesPerTrace }},
             "sessionStickinessDurationMs": {{ .Values.alfred.sessionStickinessDurationMs }},
-            "enableConnectionCountLogging": {{ .Values.alfred.enableConnectionCountLogging }},
             "ignoreEphemeralFlag": {{ .Values.alfred.ignoreEphemeralFlag }},
             "throttling": {
                 "restCallsPerTenant": {


### PR DESCRIPTION
Connection Count logging has been removed from Alfred this updates the ConfigMap to not have it