### PR TITLE
docs(markdown-magic): Add missing `README_PACKAGE_SCOPE_NOTICE` transform documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ There are a few different areas in which we generate documentation content as a 
     - We leverage a local tool ([markdown-magic](./tools/markdown-magic/README.md)) to generate / embed contents in our various package-level READMEs.
       This is done as a part of a full build, but it can also be executed in isolation by running `npm run build:readme` from the repo root.
 3. API reports
-    - We leverage [API-Extractor] to generate summaries of our package APIs.
+    - We leverage [API-Extractor](https://api-extractor.com/) to generate summaries of our package APIs.
       This is done as a part of a full build, but it can also be executed in isolation by running `npm run build:api` from the repo root.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ If you've _upgraded_ your Mac to Catalina or higher, you may need to follow [the
 
 -   Ensure that you have enabled running Powershell scripts by setting your environment's [Execution Policy](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.2).
 
+### Other Build Commands
+
+#### Building our docs
+
+There are a few different areas in which we generate documentation content as a part our overall build.
+
+1. [fluidframework.com]()
+    - We build the contents of our public website from the `docs` directory under the root of this repo.
+      See its [README](./docs/README.md) for more details.
+2. Generated README contents
+    - We leverage a local tool ([markdown-magic](./tools/markdown-magic/README.md)) to generate / embed contents in our various package-level READMEs.
+      This is done as a part of a full build, but it can also be executed in isolation by running `npm run build:readme` from the repo root.
+3. API reports
+    - We leverage [API-Extractor] to generate summaries of our package APIs.
+      This is done as a part of a full build, but it can also be executed in isolation by running `npm run build:api` from the repo root.
+
 ## Testing
 
 You can run all of our tests from the root of the repo, or you can run a scoped set of tests by running the `test`

--- a/tools/markdown-magic/README.md
+++ b/tools/markdown-magic/README.md
@@ -224,6 +224,17 @@ Arguments:
 -   `includeHeading`: Whether or not to include a 2nd level heading above the generated contents.
     -   Default: `true`.
 
+#### `README_PACKAGE_SCOPE_NOTICE`
+
+Generates a user-facing notice about target audience and support characteristics of the package based on its scope.
+By default, it generates the appropriate notice based on the package name's scope (if it's one the system recognizes), but this can be overridden by specifying `scopeKind`.
+
+Arguments:
+
+-   `packageJsonPath`: : Relative file path to the library package's `package.json` file.
+    Used to read the package name's scope (when the `scopeKind` argument is not provided).
+-   `scopeKind`: (optional) Override the automatic scope detection behavior with an explicit scope kind: `EXPERIMENTAL`, `INTERNAL`, or `PRIVATE`.
+
 <!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
 
 <!-- prettier-ignore-start -->

--- a/tools/markdown-magic/README.md
+++ b/tools/markdown-magic/README.md
@@ -84,6 +84,7 @@ Arguments:
 
 -   `packageJsonPath`: Relative file path to the library package's `package.json` file.
     Used for generation of package metadata.
+    -   Default: `./package.json`.
 -   `installation`: Whether or not to include the package "Installation" section.
     -   Default: `true`.
     -   See [README_INSTALLATION_SECTION](#readme_installation_section).
@@ -122,6 +123,7 @@ Arguments:
 
 -   `packageJsonPath`: Relative file path to the library package's `package.json` file.
     Used for generation of package metadata.
+    -   Default: `./package.json`.
 -   `gettingStarted`: Whether or not to include a simple "getting started" usage section.
     -   Default: `true`.
     -   See [README_EXAMPLE_GETTING_STARTED_SECTION](#readme_example_getting_started_section).
@@ -149,6 +151,7 @@ Arguments:
 
 -   `packageJsonPath`: Relative file path to the library package's `package.json` file.
     Used for generation of package metadata.
+    -   Default: `./package.json`.
 -   `usesTinylicious`: Whether or not running the example app requires running [Tinylicious][] from another terminal.
     -   Default: `true`.
 -   `includeHeading`: Whether or not to include a 2nd level heading above the generated contents.
@@ -164,6 +167,7 @@ Arguments:
 
 -   `packageJsonPath`: Relative file path to the library package's `package.json` file.
     Used for generation of package metadata.
+    -   Default: `./package.json`.
 -   `includeHeading`: Whether or not to include a 2nd level heading above the generated contents.
     -   Default: `true`.
 
@@ -177,6 +181,7 @@ Arguments:
 
 -   `packageJsonPath`: Relative file path to the library package's `package.json` file.
     Used for generation of package metadata.
+    -   Default: `./package.json`.
 -   `includeHeading`: Whether or not to include a 2nd level heading above the generated contents.
     -   Default: `true`.
 
@@ -221,6 +226,7 @@ Arguments:
 
 -   `packageJsonPath`: Relative file path to the library package's `package.json` file.
     Used for generation of package metadata.
+    -   Default: `./package.json`.
 -   `includeHeading`: Whether or not to include a 2nd level heading above the generated contents.
     -   Default: `true`.
 
@@ -233,6 +239,7 @@ Arguments:
 
 -   `packageJsonPath`: : Relative file path to the library package's `package.json` file.
     Used to read the package name's scope (when the `scopeKind` argument is not provided).
+    -   Default: `./package.json`.
 -   `scopeKind`: (optional) Override the automatic scope detection behavior with an explicit scope kind: `EXPERIMENTAL`, `INTERNAL`, or `PRIVATE`.
 
 <!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->

--- a/tools/markdown-magic/src/md-magic.config.cjs
+++ b/tools/markdown-magic/src/md-magic.config.cjs
@@ -468,7 +468,7 @@ function readmeInstallationSectionTransform(content, options, config) {
 }
 
 /**
- * TODO
+ * Generates simple Markdown contents indicating implications of the specified kind of package scope.
  *
  * @param {object} content - The original document file contents.
  * @param {object} options - Transform options.


### PR DESCRIPTION
Adds notes to the package README, and fills in missing source code comment.