### PR TITLE
[Data Virtualization] Enable local server to virtualize parts of the snapshot

### DIFF
--- a/packages/drivers/local-driver/api-report/local-driver.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.api.md
@@ -23,6 +23,8 @@ import { ILocalDeltaConnectionServer } from '@fluidframework/server-local-server
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
+import { ISnapshot } from '@fluidframework/driver-definitions';
+import { ISnapshotFetchOptions } from '@fluidframework/driver-definitions';
 import { ISnapshotTreeEx } from '@fluidframework/protocol-definitions';
 import { IStream } from '@fluidframework/driver-definitions';
 import { ISummaryContext } from '@fluidframework/driver-definitions';
@@ -94,6 +96,8 @@ export class LocalDocumentStorageService implements IDocumentStorageService {
     createBlob(file: ArrayBufferLike): Promise<ICreateBlobResponse>;
     // (undocumented)
     downloadSummary(handle: ISummaryHandle): Promise<ISummaryTree>;
+    // (undocumented)
+    getSnapshot(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot>;
     // (undocumented)
     getSnapshotTree(version?: IVersion): Promise<ISnapshotTreeEx | null>;
     // (undocumented)

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -182,7 +182,8 @@
 				"forwardCompat": false
 			},
 			"ClassDeclaration_LocalDocumentStorageService": {
-				"backCompat": false
+				"backCompat": false,
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/drivers/local-driver/src/localDocumentService.ts
+++ b/packages/drivers/local-driver/src/localDocumentService.ts
@@ -44,7 +44,7 @@ export class LocalDocumentService
 		private readonly tenantId: string,
 		private readonly documentId: string,
 		private readonly documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>,
-		public readonly policies: IDocumentServicePolicies = {},
+		public readonly policies: IDocumentServicePolicies = { supportGetSnapshotApi: true },
 		private readonly innerDocumentService?: IDocumentService,
 		private readonly logger?: ITelemetryBaseLogger,
 	) {

--- a/packages/drivers/local-driver/src/localDocumentStorageService.ts
+++ b/packages/drivers/local-driver/src/localDocumentStorageService.ts
@@ -3,12 +3,19 @@
  * Licensed under the MIT License.
  */
 
-import { bufferToString, stringToBuffer, Uint8ArrayToString } from "@fluid-internal/client-utils";
+import {
+	bufferToString,
+	IsoBuffer,
+	stringToBuffer,
+	Uint8ArrayToString,
+} from "@fluid-internal/client-utils";
 import {
 	IDocumentStorageService,
 	IDocumentStorageServicePolicies,
 	IResolvedUrl,
 	ISummaryContext,
+	type ISnapshotFetchOptions,
+	type ISnapshot,
 } from "@fluidframework/driver-definitions";
 import {
 	ICreateBlobResponse,
@@ -24,6 +31,7 @@ import {
 	SummaryTreeUploadManager,
 } from "@fluidframework/server-services-client";
 import { ILocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import { assert } from "@fluidframework/core-utils";
 import { createDocument } from "./localCreateDocument";
 
 const minTTLInSeconds = 24 * 60 * 60; // Same TTL as ODSP
@@ -77,19 +85,173 @@ export class LocalDocumentStorageService implements IDocumentStorageService {
 		return tree;
 	}
 
+	public async getSnapshot(snapshotFetchOptions?: ISnapshotFetchOptions): Promise<ISnapshot> {
+		let versionId = snapshotFetchOptions?.versionId;
+		if (!versionId) {
+			const versions = await this.getVersions(this.id, 1);
+			if (versions.length === 0) {
+				throw new Error("No versions for the document!");
+			}
+
+			versionId = versions[0].treeId;
+		}
+		const rawTree = await this.manager.getTree(versionId);
+		const snapshotTree = buildGitTreeHierarchy(rawTree, this.blobsShaCache, true);
+		if (snapshotFetchOptions?.loadingGroupIds !== undefined) {
+			const groupIds = new Set<string>(snapshotFetchOptions.loadingGroupIds);
+			const hasFoundTree = await this.filterTreeByLoadingGroupIds(
+				snapshotTree,
+				groupIds,
+				false,
+			);
+			assert(hasFoundTree, "No tree found for the given groupIds");
+		} else {
+			await this.stripTreeOfLoadingGroupIds(snapshotTree);
+		}
+
+		const blobContents = new Map<string, ArrayBufferLike>();
+		await this.populateBlobContents(snapshotTree, blobContents);
+
+		const metadataString = IsoBuffer.from(blobContents.get(".metadata")).toString("utf-8");
+		const metadata = JSON.parse(metadataString);
+		const sequenceNumber: number = metadata.message.sequenceNumber;
+		return {
+			snapshotTree,
+			blobContents,
+			ops: [],
+			snapshotFormatV: 1,
+			sequenceNumber,
+			latestSequenceNumber: undefined,
+		};
+	}
+
+	/**
+	 * Strips the tree or any subtree of data if it has a groupId.
+	 *
+	 * @param tree - The tree to strip of loading groupIds
+	 * @returns a tree that has trees with groupIds that are empty
+	 */
+	private async stripTreeOfLoadingGroupIds(tree: ISnapshotTreeEx) {
+		const groupId = await this.readGroupId(tree);
+		if (groupId !== undefined) {
+			// strip
+			this.stripTree(tree, groupId);
+			return;
+		}
+		await Promise.all(
+			Object.values(tree.trees).map(async (childTree) => {
+				await this.stripTreeOfLoadingGroupIds(childTree);
+			}),
+		);
+	}
+
+	/**
+	 * Named differently as the algorithm is a little more involved.
+	 *
+	 * We want to strip the tree if it has a groupId that is not in the loadingGroupIds or if it doesn't have a descendent or ancestor
+	 * that has a groupId that is in the loadingGroupIds.
+	 *
+	 * We keep the tree in the opposite case.
+	 *
+	 * @param tree - the tree to strip of any data that is not in the loadingGroupIds
+	 * @param loadingGroupIds - the set of groupIds that are being loaded
+	 * @param ancestorGroupIdInLoadingGroup - whether the ancestor of the tree has a groupId that is in the loadingGroupIds
+	 * @returns whether or not it or descendant has a groupId that is in the loadingGroupIds
+	 */
+	private async filterTreeByLoadingGroupIds(
+		tree: ISnapshotTreeEx,
+		loadingGroupIds: Set<string>,
+		ancestorGroupIdInLoadingGroup: boolean,
+	): Promise<boolean> {
+		assert(loadingGroupIds.size > 0, "loadingGroupIds should not be empty");
+		const groupId = await this.readGroupId(tree);
+
+		// Strip the tree if it has a groupId and it is not in the loadingGroupIds
+		// This is an optimization here as we have other reasons to keep the tree.
+		const noGroupIdInLoadingGroupIds = groupId !== undefined && !loadingGroupIds.has(groupId);
+		if (noGroupIdInLoadingGroupIds) {
+			this.stripTree(tree, groupId);
+			return false;
+		}
+
+		// Keep tree if it has a groupId and it is in the loadingGroupIds
+		const groupIdInLoadingGroupIds = groupId !== undefined && loadingGroupIds.has(groupId);
+
+		// Keep tree if it has an ancestor that has a groupId that is in loadingGroupIds and it doesn't have groupId
+		const isChildOfAncestorWithGroupId = ancestorGroupIdInLoadingGroup && groupId === undefined;
+
+		// Keep tree if it has a child that has a groupId that is in loadingGroupIds
+		const descendants = await Promise.all<boolean>(
+			Object.values(tree.trees).map(async (childTree) => {
+				return this.filterTreeByLoadingGroupIds(
+					childTree,
+					loadingGroupIds,
+					ancestorGroupIdInLoadingGroup || groupIdInLoadingGroupIds,
+				);
+			}),
+		);
+		const isAncestorOfDescendantsWithGroupId = descendants.some((keep) => keep);
+
+		// We don't want to return prematurely as we still may have children that we want to keep.
+		if (
+			groupIdInLoadingGroupIds ||
+			isChildOfAncestorWithGroupId ||
+			isAncestorOfDescendantsWithGroupId
+		) {
+			// Keep this tree node
+			return true;
+		}
+
+		// This means we have no groupId and none of our ancestors or descendants have a groupId in the loadingGroupIds
+		this.stripTree(tree, groupId);
+		return false;
+	}
+
+	// Takes all the blobs of a tree and puts it into the blobContents
+	private async populateBlobContents(
+		tree: ISnapshotTreeEx,
+		blobContents: Map<string, ArrayBufferLike>,
+	): Promise<void> {
+		await Promise.all(
+			Object.entries(tree.blobs).map(async ([path, blobId]) => {
+				const content = await this.readBlob(blobId);
+				blobContents.set(path, content);
+			}),
+		);
+		await Promise.all(
+			Object.values(tree.trees).map(async (childTree) => {
+				await this.populateBlobContents(childTree, blobContents);
+			}),
+		);
+	}
+
 	private async populateGroupId(tree: ISnapshotTreeEx): Promise<void> {
+		await this.readGroupId(tree);
+		await Promise.all(
+			Object.values(tree.trees).map(async (childTree) => {
+				await this.populateGroupId(childTree);
+			}),
+		);
+	}
+
+	private stripTree(tree: ISnapshotTreeEx, groupId: string | undefined) {
+		tree.blobs = {};
+		tree.groupId = groupId;
+		tree.trees = {};
+		tree.omitted = true;
+	}
+
+	private async readGroupId(tree: ISnapshotTreeEx): Promise<string | undefined> {
 		const groupIdBlobId = tree.blobs[".groupId"];
 		if (groupIdBlobId !== undefined) {
 			const groupIdBuffer = await this.readBlob(groupIdBlobId);
 			const groupId = bufferToString(groupIdBuffer, "utf8");
 			tree.groupId = groupId;
 			delete tree.blobs[".groupId"];
+			return groupId;
 		}
-		await Promise.all(
-			Object.values(tree.trees).map(async (childTree) => {
-				await this.populateGroupId(childTree);
-			}),
-		);
+
+		return tree.groupId;
 	}
 
 	public async readBlob(blobId: string): Promise<ArrayBufferLike> {

--- a/packages/drivers/local-driver/src/test/types/validateLocalDriverPrevious.generated.ts
+++ b/packages/drivers/local-driver/src/test/types/validateLocalDriverPrevious.generated.ts
@@ -128,6 +128,7 @@ declare function get_old_ClassDeclaration_LocalDocumentStorageService():
 declare function use_current_ClassDeclaration_LocalDocumentStorageService(
     use: TypeOnly<current.LocalDocumentStorageService>): void;
 use_current_ClassDeclaration_LocalDocumentStorageService(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_LocalDocumentStorageService());
 
 /*

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -253,7 +253,7 @@ export abstract class FluidDataStoreContext
 	private loaded = false;
 	protected pending: ISequencedDocumentMessage[] | undefined = [];
 	protected channelDeferred: Deferred<IFluidDataStoreChannel> | undefined;
-	private _baseSnapshot: ISnapshotTree | undefined;
+	protected _baseSnapshot: ISnapshotTree | undefined;
 	protected _attachState: AttachState;
 	private _isInMemoryRoot: boolean = false;
 	protected readonly summarizerNode: ISummarizerNodeWithGC;
@@ -1010,7 +1010,6 @@ export abstract class FluidDataStoreContext
 }
 
 export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
-	private initSnapshotValue: ISnapshotTree | undefined;
 	// Tells whether we need to fetch the snapshot before use. This is to support Data Virtualization.
 	private snapshotFetchRequired: boolean;
 	private readonly runtime: ContainerRuntime;
@@ -1020,7 +1019,7 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 			throw new Error("Already attached");
 		});
 
-		this.initSnapshotValue = props.snapshotTree;
+		this._baseSnapshot = props.snapshotTree;
 		this.snapshotFetchRequired = !!props.snapshotTree?.omitted;
 		this.runtime = props.runtime;
 		if (props.snapshotTree !== undefined) {
@@ -1040,11 +1039,11 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 				[this.loadingGroupId],
 				[this.id],
 			);
-			this.initSnapshotValue = snapshot.snapshotTree;
+			this._baseSnapshot = snapshot.snapshotTree;
 			sequenceNumber = snapshot.sequenceNumber;
 			this.snapshotFetchRequired = false;
 		}
-		let tree = this.initSnapshotValue;
+		let tree = this.baseSnapshot;
 		let isRootDataStore = true;
 
 		if (!!tree && tree.blobs[dataStoreAttributesBlobName] !== undefined) {

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -10,14 +10,19 @@ import {
 	DataObject,
 	DataObjectFactory,
 } from "@fluidframework/aqueduct";
-import { type IContainerRuntimeOptions } from "@fluidframework/container-runtime";
+import {
+	type ContainerRuntime,
+	type IContainerRuntimeOptions,
+} from "@fluidframework/container-runtime";
 import {
 	createSummarizerFromFactory,
 	summarizeNow,
 	type ITestObjectProvider,
+	createTestConfigProvider,
 } from "@fluidframework/test-utils";
 import { SummaryType } from "@fluidframework/protocol-definitions";
 import { LoaderHeader } from "@fluidframework/container-definitions";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 // A Test Data Object that exposes some basic functionality.
 class TestDataObject extends DataObject {
@@ -26,7 +31,7 @@ class TestDataObject extends DataObject {
 	}
 
 	public get containerRuntime() {
-		return this.context.containerRuntime;
+		return this.context.containerRuntime as ContainerRuntime;
 	}
 
 	public get loadingGroupId() {
@@ -74,11 +79,10 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			testDataObjectType,
 			loadingGroupId,
 		);
-		const dataObject = (await dataStore.entryPoint.get()) as TestDataObject;
-		const dataObject2 = (await dataStore2.entryPoint.get()) as TestDataObject;
-		mainObject._root.set("dataObject", dataObject.handle);
-		mainObject._root.set("dataObject2", dataObject2.handle);
-		mainObject._root.delete("dataObject2");
+		const dataObjectA = (await dataStore.entryPoint.get()) as TestDataObject;
+		const dataObjectB = (await dataStore2.entryPoint.get()) as TestDataObject;
+		mainObject._root.set("dataObjectA", dataObjectA.handle);
+		mainObject._root.set("dataObjectB", dataObjectB.handle);
 
 		const { summarizer } = await createSummarizerFromFactory(
 			provider,
@@ -89,7 +93,7 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		const { summaryVersion, summaryTree } = await summarizeNow(summarizer);
 		const channelsTree = summaryTree.tree[".channels"];
 		assert(channelsTree.type === SummaryType.Tree, "channels should be a tree");
-		const dataObjectTree = channelsTree.tree[dataObject.id];
+		const dataObjectTree = channelsTree.tree[dataObjectA.id];
 		assert(dataObjectTree !== undefined, "dataObjectTree should exist");
 		assert(dataObjectTree.type === SummaryType.Tree, "dataObjectTree should be a tree");
 		assert(dataObjectTree.groupId === loadingGroupId, "GroupId should be on the summary tree");
@@ -101,10 +105,22 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			});
 
 			const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
-			const handle2 = await mainObject2._root.get("dataObject");
-			assert(handle2 !== undefined, "handle2 should not be undefined");
-			const testObject2 = (await handle2.get()) as TestDataObject;
-			assert.equal(testObject2.loadingGroupId, loadingGroupId, "groupId should be the same");
+			const handleA2 = mainObject2._root.get("dataObjectA");
+			const handleB2 = mainObject2._root.get("dataObjectB");
+			assert(handleA2 !== undefined, "handleA2 should not be undefined");
+			assert(handleB2 !== undefined, "handleB2 should not be undefined");
+			const dataObjectA2 = (await handleA2.get()) as TestDataObject;
+			const dataObjectB2 = (await handleB2.get()) as TestDataObject;
+			assert.equal(
+				dataObjectA2.loadingGroupId,
+				loadingGroupId,
+				"dataObjectA groupId should be set",
+			);
+			assert.equal(
+				dataObjectB2.loadingGroupId,
+				loadingGroupId,
+				"dataObjectB groupId should be set",
+			);
 		}
 	});
 
@@ -135,10 +151,132 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			await provider.ensureSynchronized();
 
 			const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
-			const handle2 = await mainObject2._root.get("dataObject");
-			assert(handle2 !== undefined, "handle2 should not be undefined");
-			const testObject2 = (await handle2.get()) as TestDataObject;
-			assert.equal(testObject2.loadingGroupId, loadingGroupId, "groupId should be the same");
+			const handleA2 = mainObject2._root.get("dataObjectA");
+			const handleB2 = mainObject2._root.get("dataObjectB");
+			assert(handleA2 !== undefined, "handleA2 should not be undefined");
+			assert(handleB2 !== undefined, "handleB2 should not be undefined");
+			const dataObjectA2 = (await handleA2.get()) as TestDataObject;
+			const dataObjectB2 = (await handleB2.get()) as TestDataObject;
+			assert.equal(
+				dataObjectA2.loadingGroupId,
+				loadingGroupId,
+				"dataObjectA groupId should be set",
+			);
+			assert.equal(
+				dataObjectB2.loadingGroupId,
+				loadingGroupId,
+				"dataObjectB groupId should be set",
+			);
 		}
+	});
+
+	it("Excludes dataStores with loadingGroupId from summary", async () => {
+		if (provider.driver.type !== "local") {
+			return;
+		}
+		// Load basic container stuff
+		const container = await provider.createContainer(runtimeFactory);
+		const mainObject = (await container.getEntryPoint()) as TestDataObject;
+		const containerRuntime = mainObject.containerRuntime;
+
+		// Create data stores with loadingGroupIds
+		const dataStoreA = await containerRuntime.createDataStore(
+			testDataObjectType,
+			loadingGroupId,
+		);
+		const dataStoreB = await containerRuntime.createDataStore(
+			testDataObjectType,
+			loadingGroupId,
+		);
+
+		// Attach the data stores
+		const dataObjectA = (await dataStoreA.entryPoint.get()) as TestDataObject;
+		const dataObjectB = (await dataStoreB.entryPoint.get()) as TestDataObject;
+		mainObject._root.set("dataObjectA", dataObjectA.handle);
+		mainObject._root.set("dataObjectB", dataObjectB.handle);
+		dataObjectA._root.set("A", "A");
+		dataObjectB._root.set("B", "B");
+
+		// Summarize
+		await provider.ensureSynchronized();
+		const { summarizer } = await createSummarizerFromFactory(
+			provider,
+			container,
+			dataObjectFactory,
+		);
+		const { summaryVersion } = await summarizeNow(summarizer);
+
+		// Load from the summary
+		const configProvider = createTestConfigProvider();
+		configProvider.set("Fluid.Container.UseLoadingGroupIdForSnapshotFetch", true);
+		const container3 = await provider.loadContainer(
+			runtimeFactory,
+			{ configProvider },
+			{
+				[LoaderHeader.version]: summaryVersion,
+			},
+		);
+
+		// Regular load path should work
+		const mainObject3 = (await container3.getEntryPoint()) as TestDataObject;
+		// Try to load the data stores with groupIds
+		const handleA3 = mainObject3._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
+		const handleB3 = mainObject3._root.get<IFluidHandle<TestDataObject>>("dataObjectB");
+		assert(handleA3 !== undefined, "handleA3 should not be undefined");
+		assert(handleB3 !== undefined, "handleB3 should not be undefined");
+
+		const dataObjectA3 = await handleA3.get();
+		const dataObjectB3 = await handleB3.get();
+		assert.equal(dataObjectA3._root.get("A"), "A", "A should be set");
+		assert.equal(dataObjectB3._root.get("B"), "B", "B should be set");
+
+		// Testing the get snapshot call
+		const runtime3 = mainObject.containerRuntime;
+		assert(runtime3.storage.getSnapshot !== undefined, "getSnapshot should be defined");
+		const snapshot = await runtime3.storage.getSnapshot();
+		const channelsTree = snapshot.snapshotTree.trees[".channels"];
+		const mainObjectTree = channelsTree.trees[mainObject.id];
+		const dataObjectATree = channelsTree.trees[dataObjectA.id];
+		const dataObjectBTree = channelsTree.trees[dataObjectB.id];
+
+		assert(mainObjectTree.omitted === undefined, "mainObject should not be omitted");
+		assert(mainObjectTree.groupId === undefined, "mainObject should not have a groupId");
+		assert(Object.entries(mainObjectTree.trees).length > 0, "mainObject missing trees");
+		assert(Object.entries(mainObjectTree.blobs).length > 0, "mainObject missing blobs");
+
+		assert(dataObjectATree.omitted, "dataObjectA should be omitted");
+		assert(dataObjectATree.groupId === loadingGroupId, "dataObjectA should have a groupId");
+		assert(Object.entries(dataObjectATree.trees).length === 0, "dataObjectA has trees!");
+		assert(Object.entries(dataObjectATree.blobs).length === 0, "dataObjectA has blobs!");
+
+		assert(dataObjectBTree.omitted, "dataObjectB should be omitted");
+		assert(dataObjectBTree.groupId === loadingGroupId, "dataObjectB should have a groupId");
+		assert(Object.entries(dataObjectBTree.trees).length === 0, "dataObjectB has trees!");
+		assert(Object.entries(dataObjectBTree.blobs).length === 0, "dataObjectB has blobs!");
+
+		// Testing the get snapshot call with loadingGroupId
+		const loadingGroupIdSnapshot = await runtime3.storage.getSnapshot({
+			loadingGroupIds: [loadingGroupId],
+			versionId: summaryVersion,
+		});
+		const channelsTree2 = loadingGroupIdSnapshot.snapshotTree.trees[".channels"];
+		const mainObjectTree2 = channelsTree2.trees[mainObject.id];
+		const dataObjectATree2 = channelsTree2.trees[dataObjectA.id];
+		const dataObjectBTree2 = channelsTree2.trees[dataObjectB.id];
+
+		assert(mainObjectTree2.omitted, "mainObject should be omitted");
+		assert(mainObjectTree2.groupId === undefined, "mainObject should not have a groupId");
+		assert(Object.entries(mainObjectTree2.trees).length === 0, "mainObject has trees!");
+		assert(Object.entries(mainObjectTree2.blobs).length === 0, "mainObject has blobs!");
+
+		assert(dataObjectATree2.omitted === undefined, "dataObjectA should not be omitted");
+		assert(dataObjectATree2.groupId === loadingGroupId, "dataObjectA should have a groupId");
+		assert(Object.entries(dataObjectATree2.trees).length > 0, "dataObjectA missing trees");
+		assert(Object.entries(dataObjectATree2.blobs).length > 0, "dataObjectA missing blobs");
+
+		assert(dataObjectBTree2.omitted === undefined, "dataObjectB should not be omitted");
+		assert(dataObjectBTree2.groupId === loadingGroupId, "dataObjectB should have a groupId");
+		assert(Object.entries(dataObjectBTree2.trees).length > 0, "dataObjectB missing trees");
+		assert(Object.entries(dataObjectBTree2.blobs).length > 0, "dataObjectB missing blobs");
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -20,9 +20,28 @@ import {
 	type ITestObjectProvider,
 	createTestConfigProvider,
 } from "@fluidframework/test-utils";
-import { SummaryType } from "@fluidframework/protocol-definitions";
+import { SummaryType, type ISnapshotTree } from "@fluidframework/protocol-definitions";
 import { LoaderHeader } from "@fluidframework/container-definitions";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type { ISnapshot } from "@fluidframework/driver-definitions";
+import { Deferred } from "@fluidframework/core-utils";
+
+import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
+
+const interceptResult = <T>(
+	parent: any,
+	fn: (...args: any[]) => Promise<T>,
+	intercept: (result: T) => void,
+) => {
+	const interceptFn = async (...args: any[]) => {
+		const val = await fn.apply(parent, args);
+		intercept(val);
+		return val as T;
+	};
+	parent[fn.name] = interceptFn;
+	interceptFn.bind(parent);
+	return fn;
+};
 
 // A Test Data Object that exposes some basic functionality.
 class TestDataObject extends DataObject {
@@ -60,6 +79,34 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 	});
 
 	let provider: ITestObjectProvider;
+
+	const assertOmittedGroupIdTree = (snapshotTree: ISnapshotTree, message: string) => {
+		assert(snapshotTree.omitted, message);
+		assert(snapshotTree.groupId === loadingGroupId, message);
+		assert(Object.entries(snapshotTree.trees).length === 0, message);
+		assert(Object.entries(snapshotTree.blobs).length === 0, message);
+	};
+
+	const assertPopulatedRegularTree = (snapshotTree: ISnapshotTree, message: string) => {
+		assert(snapshotTree.omitted === undefined, message);
+		assert(snapshotTree.groupId === undefined, message);
+		assert(Object.entries(snapshotTree.trees).length > 0, message);
+		assert(Object.entries(snapshotTree.blobs).length > 0, message);
+	};
+
+	const assertOmittedRegularTree = (snapshotTree: ISnapshotTree, message: string) => {
+		assert(snapshotTree.omitted, message);
+		assert(snapshotTree.groupId === undefined, message);
+		assert(Object.entries(snapshotTree.trees).length === 0, message);
+		assert(Object.entries(snapshotTree.blobs).length === 0, message);
+	};
+
+	const assertPopulatedGroupIdTree = (snapshotTree: ISnapshotTree, message: string) => {
+		assert(snapshotTree.omitted === undefined, message);
+		assert(snapshotTree.groupId === loadingGroupId, message);
+		assert(Object.entries(snapshotTree.trees).length > 0, message);
+		assert(Object.entries(snapshotTree.blobs).length > 0, message);
+	};
 
 	beforeEach("setup", async () => {
 		provider = getTestObjectProvider();
@@ -206,6 +253,22 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		);
 		const { summaryVersion } = await summarizeNow(summarizer);
 
+		// Intercept the first snapshot call via the creation of the driver
+		const documentServiceFactory = provider.documentServiceFactory;
+		const deferredSnapshot: Deferred<ISnapshot> = new Deferred();
+		interceptResult(
+			documentServiceFactory,
+			documentServiceFactory.createDocumentService,
+			(documentService) => {
+				interceptResult(documentService, documentService.connectToStorage, (storage) => {
+					assert(storage.getSnapshot !== undefined, "Test can't run without getSnapshot");
+					interceptResult(storage, storage.getSnapshot, (snapshot) => {
+						deferredSnapshot.resolve(snapshot);
+					});
+				});
+			},
+		);
+
 		// Load from the summary
 		const configProvider = createTestConfigProvider();
 		configProvider.set("Fluid.Container.UseLoadingGroupIdForSnapshotFetch", true);
@@ -217,66 +280,71 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			},
 		);
 
-		// Regular load path should work
+		// Get the snapshot and runtime we just loaded from
+		const loadingSnapshot3 = await deferredSnapshot.promise;
+
+		// Testing the get snapshot call
 		const mainObject3 = (await container3.getEntryPoint()) as TestDataObject;
+		const runtime3 = mainObject3.containerRuntime;
+		assert(runtime3.storage.getSnapshot !== undefined, "getSnapshot should be defined");
+		const snapshot3 = await runtime3.storage.getSnapshot();
+		assert.deepEqual(snapshot3, loadingSnapshot3, "Mismatched initial snapshots");
+
+		// Snapshot validation (a snapshot call with NO loadingGroupIds)
+		const channelsTree = loadingSnapshot3.snapshotTree.trees[".channels"];
+		const mainObjectTree = channelsTree.trees[mainObject.id];
+		const dataObjectATree = channelsTree.trees[dataObjectA.id];
+		const dataObjectBTree = channelsTree.trees[dataObjectB.id];
+
+		assertPopulatedRegularTree(mainObjectTree, "mainObject should be regular and populated");
+		assertOmittedGroupIdTree(dataObjectATree, "Incorrect tree for A");
+		assertOmittedGroupIdTree(dataObjectBTree, "Incorrect tree for B");
+
+		// intercept loadingGroupId snapshot
+		const groupIdSnapshot: Deferred<ISnapshot> = new Deferred();
+		interceptResult(runtime3.storage, runtime3.storage.getSnapshot, (snapshot) => {
+			groupIdSnapshot.resolve(snapshot);
+		});
+
 		// Try to load the data stores with groupIds
 		const handleA3 = mainObject3._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
 		const handleB3 = mainObject3._root.get<IFluidHandle<TestDataObject>>("dataObjectB");
 		assert(handleA3 !== undefined, "handleA3 should not be undefined");
 		assert(handleB3 !== undefined, "handleB3 should not be undefined");
 
+		// Prep context snapshot intercept
+		// Hack to inspect the runtime's dataStores
+		const stores = (runtime3 as any).dataStores;
+		const contextA = (await stores.getDataStore(dataObjectA.id, {})) as IFluidDataStoreContext;
+		const contextB = (await stores.getDataStore(dataObjectB.id, {})) as IFluidDataStoreContext;
+		assert(contextA.baseSnapshot !== undefined, "contextA should have a baseSnapshot");
+		assert(contextB.baseSnapshot !== undefined, "contextB should have a baseSnapshot");
+		assertOmittedGroupIdTree(contextA.baseSnapshot, "contextA tree should be omitted");
+		assertOmittedGroupIdTree(contextB.baseSnapshot, "contextB tree should be omitted");
+
+		// loading group call
 		const dataObjectA3 = await handleA3.get();
 		const dataObjectB3 = await handleB3.get();
 		assert.equal(dataObjectA3._root.get("A"), "A", "A should be set");
 		assert.equal(dataObjectB3._root.get("B"), "B", "B should be set");
-
-		// Testing the get snapshot call
-		const runtime3 = mainObject.containerRuntime;
-		assert(runtime3.storage.getSnapshot !== undefined, "getSnapshot should be defined");
-		const snapshot = await runtime3.storage.getSnapshot();
-		const channelsTree = snapshot.snapshotTree.trees[".channels"];
-		const mainObjectTree = channelsTree.trees[mainObject.id];
-		const dataObjectATree = channelsTree.trees[dataObjectA.id];
-		const dataObjectBTree = channelsTree.trees[dataObjectB.id];
-
-		assert(mainObjectTree.omitted === undefined, "mainObject should not be omitted");
-		assert(mainObjectTree.groupId === undefined, "mainObject should not have a groupId");
-		assert(Object.entries(mainObjectTree.trees).length > 0, "mainObject missing trees");
-		assert(Object.entries(mainObjectTree.blobs).length > 0, "mainObject missing blobs");
-
-		assert(dataObjectATree.omitted, "dataObjectA should be omitted");
-		assert(dataObjectATree.groupId === loadingGroupId, "dataObjectA should have a groupId");
-		assert(Object.entries(dataObjectATree.trees).length === 0, "dataObjectA has trees!");
-		assert(Object.entries(dataObjectATree.blobs).length === 0, "dataObjectA has blobs!");
-
-		assert(dataObjectBTree.omitted, "dataObjectB should be omitted");
-		assert(dataObjectBTree.groupId === loadingGroupId, "dataObjectB should have a groupId");
-		assert(Object.entries(dataObjectBTree.trees).length === 0, "dataObjectB has trees!");
-		assert(Object.entries(dataObjectBTree.blobs).length === 0, "dataObjectB has blobs!");
 
 		// Testing the get snapshot call with loadingGroupId
 		const loadingGroupIdSnapshot = await runtime3.storage.getSnapshot({
 			loadingGroupIds: [loadingGroupId],
 			versionId: summaryVersion,
 		});
-		const channelsTree2 = loadingGroupIdSnapshot.snapshotTree.trees[".channels"];
+
+		const groupSnapshot = await groupIdSnapshot.promise;
+		assert.deepEqual(groupSnapshot, loadingGroupIdSnapshot, "Should be groupId snapshot");
+
+		// Snapshot validation (a snapshot call for loadingGroupIds = [loadingGroupId])
+		const channelsTree2 = groupSnapshot.snapshotTree.trees[".channels"];
 		const mainObjectTree2 = channelsTree2.trees[mainObject.id];
 		const dataObjectATree2 = channelsTree2.trees[dataObjectA.id];
 		const dataObjectBTree2 = channelsTree2.trees[dataObjectB.id];
 
-		assert(mainObjectTree2.omitted, "mainObject should be omitted");
-		assert(mainObjectTree2.groupId === undefined, "mainObject should not have a groupId");
-		assert(Object.entries(mainObjectTree2.trees).length === 0, "mainObject has trees!");
-		assert(Object.entries(mainObjectTree2.blobs).length === 0, "mainObject has blobs!");
-
-		assert(dataObjectATree2.omitted === undefined, "dataObjectA should not be omitted");
-		assert(dataObjectATree2.groupId === loadingGroupId, "dataObjectA should have a groupId");
-		assert(Object.entries(dataObjectATree2.trees).length > 0, "dataObjectA missing trees");
-		assert(Object.entries(dataObjectATree2.blobs).length > 0, "dataObjectA missing blobs");
-
-		assert(dataObjectBTree2.omitted === undefined, "dataObjectB should not be omitted");
-		assert(dataObjectBTree2.groupId === loadingGroupId, "dataObjectB should have a groupId");
-		assert(Object.entries(dataObjectBTree2.trees).length > 0, "dataObjectB missing trees");
-		assert(Object.entries(dataObjectBTree2.blobs).length > 0, "dataObjectB missing blobs");
+		assertOmittedRegularTree(mainObjectTree2, "mainObject should be regular and omitted");
+		assertPopulatedGroupIdTree(dataObjectATree2, "Incorrect tree for A2");
+		assertPopulatedGroupIdTree(dataObjectBTree2, "Incorrect tree for B2");
 	});
 });


### PR DESCRIPTION
[AB#7197](https://dev.azure.com/fluidframework/internal/_workitems/edit/7197)

## Description

Enables testing of local server to virtualize parts of the snapshot via
loading groupId. This proves that we can virtualize the snapshot and get
less data than what was originally there.

## Details

The changes were made in the local-driver to simulate the service
stripping the relevant data. We could try to do a full implementation,
but that would be more expensive than simply just doing it in one spot.

## Testing
- The snapshot includes the non groupId trees on the regular getSnapshot
call
- The snapshot excludes the groupId trees on the regular getSnapshot
call
- The snapshot includes the groupId trees on the groupId getSnapshot
call
- The snapshot excludes the non groupId trees on the groupId getSnapshot
call
- Can request remote virtualized groupId datastores/dataobjects.
- Remote contexts with groupId contain an empty base snapshot
- Network calls return expected snapshots.