### PR TITLE
Update the category for performance-related event logging

### DIFF
--- a/tools/telemetry-generator/src/handlers/bundleSizeHandler.ts
+++ b/tools/telemetry-generator/src/handlers/bundleSizeHandler.ts
@@ -19,6 +19,7 @@ module.exports = function handler(fileData, logger) {
 			asset.name.toLowerCase().endsWith(".js") === true
 		) {
 			logger.send({
+				namespace: "FFEngineering", // Transfer the telemetry associated with bundle size measurement to namespace "FFEngineering"
 				category: "performance",
 				eventName: "Benchmark",
 				benchmarkType: "BundleSize",

--- a/tools/telemetry-generator/src/handlers/executionTimeTestHandler.ts
+++ b/tools/telemetry-generator/src/handlers/executionTimeTestHandler.ts
@@ -12,6 +12,7 @@ module.exports = function handler(fileData, logger) {
 
 	fileData.benchmarks.forEach((testData) => {
 		logger.send({
+			namespace: "FFEngineering", // Transfer the telemetry associated with tests performance measurement to namespace "FFEngineering"
 			category: "performance",
 			eventName: "Benchmark",
 			benchmarkType: "ExecutionTime",

--- a/tools/telemetry-generator/src/handlers/memoryUsageTestHandler.ts
+++ b/tools/telemetry-generator/src/handlers/memoryUsageTestHandler.ts
@@ -12,6 +12,7 @@ module.exports = function handler(fileData, logger) {
 
 	fileData.tests.forEach((testData) => {
 		logger.send({
+			namespace: "FFEngineering", // Transfer the telemetry associated with tests performance measurement to namespace "FFEngineering"
 			category: "performance",
 			eventName: "Benchmark",
 			benchmarkType: "MemoryUsage",

--- a/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
+++ b/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
@@ -55,16 +55,10 @@ module.exports = function handler(fileData, logger) {
 			continue;
 		}
 
-		// Transfer the event StageTiming (associated with the stress, e2e and tests performance) to the
-		// table suffixed with performance_tests. For telemetry related to the build or other events, retain
-		// them in the original table.
-		const category =
-			job.stageName.includes("tests") || job.stageName.includes("e2e")
-				? "performance_tests"
-				: "performance";
-
+		// Transfer the telemetry associated with pipeline status to namespace "FFEngineering".
 		logger.send({
-			category,
+			namespace: "FFEngineering",
+			category: "performance",
 			eventName: "StageTiming",
 			benchmarkType: "PipelineInfo",
 			stageName: job.stageName,

--- a/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
+++ b/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
@@ -55,9 +55,8 @@ module.exports = function handler(fileData, logger) {
 			continue;
 		}
 
-		// Transfer the telemetry associated with pipeline status to namespace "FFEngineering".
 		logger.send({
-			namespace: "FFEngineering",
+			namespace: "FFEngineering", // Transfer the telemetry associated with pipeline status to namespace "FFEngineering".
 			category: "performance",
 			eventName: "StageTiming",
 			benchmarkType: "PipelineInfo",

--- a/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
+++ b/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
@@ -54,8 +54,17 @@ module.exports = function handler(fileData, logger) {
 		if (job.stageName === "runAfterAll") {
 			continue;
 		}
+
+		// Transfer the event StageTiming (associated with the stress, e2e and tests performance) to the
+		// table suffixed with performance_tests. For telemetry related to the build or other events, retain
+		// them in the original table.
+		const category =
+			job.stageName.includes("tests") || job.stageName.includes("e2e")
+				? "performance_tests"
+				: "performance";
+
 		logger.send({
-			category: "performance",
+			category,
 			eventName: "StageTiming",
 			benchmarkType: "PipelineInfo",
 			stageName: job.stageName,

--- a/tools/telemetry-generator/src/handlers/testPassRate.ts
+++ b/tools/telemetry-generator/src/handlers/testPassRate.ts
@@ -28,8 +28,9 @@ module.exports = function handler(fileData, logger) {
 	const totalTests = passedTests + failedTests;
 	const passRate = totalTests !== 0 ? passedTests / totalTests : 0;
 	console.log(passRate);
+	// Transfer the event testPassRate to the table suffixed with performance_tests
 	logger.send({
-		category: "performance",
+		category: "performance_tests",
 		eventName: "TestPassRate",
 		benchmarkType: "PipelineInfo",
 		stageName: fileData.currentContext.stageReference.stageName,

--- a/tools/telemetry-generator/src/handlers/testPassRate.ts
+++ b/tools/telemetry-generator/src/handlers/testPassRate.ts
@@ -28,9 +28,10 @@ module.exports = function handler(fileData, logger) {
 	const totalTests = passedTests + failedTests;
 	const passRate = totalTests !== 0 ? passedTests / totalTests : 0;
 	console.log(passRate);
-	// Transfer the event testPassRate to the table suffixed with performance_tests
+	// Transfer the telemetry associated with performance test measurements to namespace "FFEngineering"
 	logger.send({
-		category: "performance_tests",
+		namespace: "FFEngineering",
+		category: "performance",
 		eventName: "TestPassRate",
 		benchmarkType: "PipelineInfo",
 		stageName: fileData.currentContext.stageReference.stageName,

--- a/tools/telemetry-generator/src/handlers/testPassRate.ts
+++ b/tools/telemetry-generator/src/handlers/testPassRate.ts
@@ -28,9 +28,9 @@ module.exports = function handler(fileData, logger) {
 	const totalTests = passedTests + failedTests;
 	const passRate = totalTests !== 0 ? passedTests / totalTests : 0;
 	console.log(passRate);
-	// Transfer the telemetry associated with test passsing rate to namespace "FFEngineering"
+
 	logger.send({
-		namespace: "FFEngineering",
+		namespace: "FFEngineering", // Transfer the telemetry associated with test passing rate to namespace "FFEngineering"
 		category: "performance",
 		eventName: "TestPassRate",
 		benchmarkType: "PipelineInfo",

--- a/tools/telemetry-generator/src/handlers/testPassRate.ts
+++ b/tools/telemetry-generator/src/handlers/testPassRate.ts
@@ -28,7 +28,7 @@ module.exports = function handler(fileData, logger) {
 	const totalTests = passedTests + failedTests;
 	const passRate = totalTests !== 0 ? passedTests / totalTests : 0;
 	console.log(passRate);
-	// Transfer the telemetry associated with performance test measurements to namespace "FFEngineering"
+	// Transfer the telemetry associated with test passsing rate to namespace "FFEngineering"
 	logger.send({
 		namespace: "FFEngineering",
 		category: "performance",


### PR DESCRIPTION
[AB#6533](https://dev.azure.com/fluidframework/internal/_workitems/edit/6533)

Currently, both the build performance data and real fluid telemetry from tests are stored in the same table. Updating the event category will facilitate the storage of tests telemetry in a new table.
