### PR TITLE
fix: Do not delete release branches even if they're "stale" (no commits in the past 6 months)

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -19,5 +19,6 @@ jobs:
         with:
           repo_token: ${{ github.token }}
           date: '6 months ago'
-          dry_run: false 
+          dry_run: false
           exclude_open_pr_branches: true
+          extra_protected_branch_regex: ^release/.*


### PR DESCRIPTION
## Description

Adds a regex to explicitly exclude `release/` branches from automated deletion if they don't have activity in 6 months.

The docs for the task say that it won't delete protected branches, but we're in a bit of an unclear state regarding whether branch protection rules are going to remain or not (vs moving to Github's rulesets), so to be safe we're merging this.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
