### PR TITLE
A11y(docs): fix contrast on images for Aquatic and Desert themes

### DIFF
--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -70,52 +70,43 @@ footer {
 }
 
 .cta-icon {
-	background-repeat: no-repeat;
-	background-position: center;
-	background-size: 48px 48px;
-	width: 15rem;
-	height: 10rem;
-	margin-left: auto;
-	margin-right: auto;
-	margin-bottom: 1rem;
+    background-repeat: no-repeat;
+    background-position: center;
+    width: 15rem;
+    height: 10rem;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 1rem;
 }
 
-.cta-icon.get-started {
-	background-image: url("/codicons/play-circle.svg");
-	background-size: 64px 64px;
-	filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(80%);
-}
-
-.cta-icon.learn-more {
-	background-image: url("/codicons/book.svg");
-	background-size: 64px 64px;
-	filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(80%);
-}
-
-.cta-icon.play {
-	background-image: url("/codicons/beaker.svg");
-	background-size: 64px 64px;
-	filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(80%);
-}
-
-.cta-icon.issue {
-	background-image: url("/codicons/bug.svg");
-	background-size: 64px 64px;
-	filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(80%);
-}
-
-.cta-icon.github {
-	background-image: url("/codicons/github.svg");
-	background-size: 64px 64px;
-	filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(80%);
-}
-
+.cta-icon.get-started,
+.cta-icon.learn-more,
+.cta-icon.play,
+.cta-icon.issue,
+.cta-icon.github,
 .cta-icon.gh-discussions {
-	background-image: url("/codicons/comment-discussion.svg");
-	background-size: 64px 64px;
-	/* helpful codepen for recoloring SVGs: https://codepen.io/sosuke/pen/Pjoqqp */
-	filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(80%);
+    background-size: 64px 64px;
+    filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(80%);
 }
+
+.cta-icon.get-started { background-image: url("/codicons/play-circle.svg"); }
+.cta-icon.learn-more { background-image: url("/codicons/book.svg"); }
+.cta-icon.play { background-image: url("/codicons/beaker.svg"); }
+.cta-icon.issue { background-image: url("/codicons/bug.svg"); }
+.cta-icon.github { background-image: url("/codicons/github.svg"); }
+.cta-icon.gh-discussions { background-image: url("/codicons/comment-discussion.svg"); }
+
+@media screen and (-ms-high-contrast: black-on-white) {
+    .cta-icon.get-started,
+    .cta-icon.learn-more,
+    .cta-icon.play,
+    .cta-icon.issue,
+    .cta-icon.github,
+    .cta-icon.gh-discussions {
+        filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(0%);
+    }
+}
+
 
 .omt {
 	font-size: 16px;

--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -70,13 +70,13 @@ footer {
 }
 
 .cta-icon {
-    background-repeat: no-repeat;
-    background-position: center;
-    width: 15rem;
-    height: 10rem;
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: 1rem;
+	background-repeat: no-repeat;
+	background-position: center;
+	width: 15rem;
+	height: 10rem;
+	margin-left: auto;
+	margin-right: auto;
+	margin-bottom: 1rem;
 }
 
 .cta-icon.get-started,
@@ -85,26 +85,39 @@ footer {
 .cta-icon.issue,
 .cta-icon.github,
 .cta-icon.gh-discussions {
-    background-size: 64px 64px;
-    filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(80%);
+	background-size: 64px 64px;
+	filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(80%);
 }
 
-.cta-icon.get-started { background-image: url("/codicons/play-circle.svg"); }
-.cta-icon.learn-more { background-image: url("/codicons/book.svg"); }
-.cta-icon.play { background-image: url("/codicons/beaker.svg"); }
-.cta-icon.issue { background-image: url("/codicons/bug.svg"); }
-.cta-icon.github { background-image: url("/codicons/github.svg"); }
-.cta-icon.gh-discussions { background-image: url("/codicons/comment-discussion.svg"); }
+.cta-icon.get-started {
+	background-image: url("/codicons/play-circle.svg");
+}
+.cta-icon.learn-more {
+	background-image: url("/codicons/book.svg");
+}
+.cta-icon.play {
+	background-image: url("/codicons/beaker.svg");
+}
+.cta-icon.issue {
+	background-image: url("/codicons/bug.svg");
+}
+.cta-icon.github {
+	background-image: url("/codicons/github.svg");
+}
+.cta-icon.gh-discussions {
+	background-image: url("/codicons/comment-discussion.svg");
+}
 
 @media screen and (-ms-high-contrast: black-on-white) {
-    .cta-icon.get-started,
-    .cta-icon.learn-more,
-    .cta-icon.play,
-    .cta-icon.issue,
-    .cta-icon.github,
-    .cta-icon.gh-discussions {
-        filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(0%);
-    }
+	.cta-icon.get-started,
+	.cta-icon.learn-more,
+	.cta-icon.play,
+	.cta-icon.issue,
+	.cta-icon.github,
+	.cta-icon.gh-discussions {
+		filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%)
+			contrast(0%);
+	}
 }
 
 .omt {

--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -107,7 +107,6 @@ footer {
     }
 }
 
-
 .omt {
 	font-size: 16px;
 	padding: 8em 4em;

--- a/docs/themes/thxvscode/assets/scss/includes/_sidebar_connect.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_sidebar_connect.scss
@@ -22,6 +22,7 @@
 		
 	}
 }
+
 @media screen and (-ms-high-contrast: white-on-black) {
 	.connect-links a img {
 		filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(80%);

--- a/docs/themes/thxvscode/assets/scss/includes/_sidebar_connect.scss
+++ b/docs/themes/thxvscode/assets/scss/includes/_sidebar_connect.scss
@@ -19,5 +19,11 @@
 		width: 15px;
 		height: 15px;
 		margin-right: 1rem;
+		
+	}
+}
+@media screen and (-ms-high-contrast: white-on-black) {
+	.connect-links a img {
+		filter: invert(99%) sepia(4%) saturate(1700%) hue-rotate(269deg) brightness(114%) contrast(80%);
 	}
 }


### PR DESCRIPTION
Fixed contrast on Aquatic and Desert themes

Previously it was hard to see
![5779_Deset theme](https://github.com/microsoft/FluidFramework/assets/107130183/38b44c98-3ca0-4fe0-80ee-803451da018a)


![5790_Aquatic theme](https://github.com/microsoft/FluidFramework/assets/107130183/19175dfb-e8b0-44a9-9458-4286b50512ce)

[AB#5779](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5779)
[AB#5790](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5790)