### PR TITLE
test(client-devtools-browser-extension): correct jest config

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/e2e-tests/chromebrowserdevtool.test.ts
+++ b/packages/tools/devtools/devtools-browser-extension/e2e-tests/chromebrowserdevtool.test.ts
@@ -3,10 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/// <reference types="jest-environment-puppeteer" />
-/// <reference types="puppeteer" />
-/// <reference types="jest" />
-
 import { globals } from "../jest.config.cjs";
 import { retryWithEventualValue } from "@fluidframework/test-utils";
 

--- a/packages/tools/devtools/devtools-browser-extension/jest.config.cjs
+++ b/packages/tools/devtools/devtools-browser-extension/jest.config.cjs
@@ -18,7 +18,12 @@ module.exports = {
 	testMatch: ["**/e2e-tests/?(*.)+(spec|test).[t]s"],
 	testPathIgnorePatterns: ["/node_modules/", "dist"],
 	transform: {
-		"^.+\\.test.ts?$": "ts-jest",
+		"^.+\\.test.ts?$": [
+			"ts-jest",
+			{
+				tsconfig: "e2e-tests/tsconfig.json",
+			},
+		],
 	},
 	// While we still have transitive dependencies on 'uuid<9.0.0', force the CJS entry point:
 	// See: https://stackoverflow.com/questions/73203367/jest-syntaxerror-unexpected-token-export-with-uuid-library


### PR DESCRIPTION
to reference proper tsconfig.json.
Then remove type directives from .ts file.
(Those can be coded in a .d.ts but should never be in a .ts directly.)