### PR TITLE
retry local checkpoint write on duplicate key error

### DIFF
--- a/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
+++ b/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
@@ -51,6 +51,15 @@ export class MongoCheckpointRepository implements ICheckpointRepository {
 				"checkpointRepository_writeCheckpoint",
 				3 /* maxRetries */,
 				1000 /* retryAfterMs */,
+				lumberProperties,
+				undefined /* ignoreError */,
+				(error) => {
+					// should retry if duplicate key error
+					return (
+						error.code === 11000 ||
+						error.message?.toString()?.indexOf("E11000 duplicate key") >= 0
+					);
+				},
 			);
 		} catch (error: any) {
 			const err = new Error(`Checkpoint upsert error:  ${error.message?.substring(0, 30)}`);

--- a/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
+++ b/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
@@ -41,6 +41,8 @@ export class MongoCheckpointRepository implements ICheckpointRepository {
 			checkpointType: this.checkpointType,
 		};
 		try {
+			// Duplicate key errors have occurred when 2 upsert() occur at the same time for the same document
+			// retry to allow both checkpoints
 			await runWithRetry(
 				async () =>
 					this.collection.upsert(

--- a/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
+++ b/server/routerlicious/packages/services-core/src/mongoCheckpointRepository.ts
@@ -6,6 +6,7 @@
 import { getLumberBaseProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 import { ICollection, ICheckpointRepository } from "./database";
 import { ICheckpoint, IDeliState, IScribe } from "./document";
+import { requestWithRetry } from "./runWithRetry";
 
 /**
  * @internal
@@ -34,23 +35,33 @@ export class MongoCheckpointRepository implements ICheckpointRepository {
 			return;
 		}
 		const pointReadFilter = this.composePointReadFilter(documentId, tenantId);
+		const lumberProperties = {
+			...getLumberBaseProperties(documentId, tenantId),
+			pointReadFilter,
+			checkpointType: this.checkpointType,
+		};
 		try {
-			await this.collection.upsert(
-				pointReadFilter,
-				{ [this.checkpointType]: JSON.stringify(checkpoint) },
-				null,
+			await requestWithRetry(
+				async () =>
+					this.collection.upsert(
+						pointReadFilter,
+						{ [this.checkpointType]: JSON.stringify(checkpoint) },
+						null,
+					),
+				"checkpointRepository_writeCheckpoint",
+				lumberProperties,
+				(error) => {
+					// should retry if duplicate key error
+					return (
+						error.code === 11000 ||
+						error.message?.toString()?.indexOf("E11000 duplicate key") >= 0
+					);
+				},
+				3 /* maxRetries */,
 			);
 		} catch (error: any) {
 			const err = new Error(`Checkpoint upsert error:  ${error.message?.substring(0, 30)}`);
-			Lumberjack.error(
-				"Unexpected error when writing checkpoint",
-				{
-					...getLumberBaseProperties(documentId, tenantId),
-					pointReadFilter,
-					checkpointType: this.checkpointType,
-				},
-				err,
-			);
+			Lumberjack.error("Unexpected error when writing checkpoint", lumberProperties, err);
 			throw error;
 		}
 	}


### PR DESCRIPTION
When `E11000 Duplicate Key Error` occurs in the localDB we need to retry the checkpoint so it is not skipped