### PR TITLE
New node events proposal

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -397,14 +397,6 @@ export type DetachedRangeUpPath = Brand<Omit<RangeUpPath, "parent">, "DetachedRa
 export const disposeSymbol: unique symbol;
 
 // @internal
-export interface EditableTreeEvents {
-    afterChange(event: TreeEvent): void;
-    beforeChange(event: TreeEvent): void;
-    changing(upPath: UpPath): void;
-    subtreeChanging(upPath: UpPath): PathVisitor | void;
-}
-
-// @internal
 export const EmptyKey: FieldKey;
 
 // @internal
@@ -700,17 +692,26 @@ export interface FlexTreeNode extends FlexTreeEntity<FlexTreeNodeSchema> {
     // (undocumented)
     readonly [flexTreeMarker]: FlexTreeEntityKind.Node;
     [onNextChange](fn: (node: FlexTreeNode) => void): () => void;
+    readonly anchor: AnchorNode;
     // (undocumented)
     boxedIterator(): IterableIterator<FlexTreeField>;
     is<TSchema extends FlexTreeNodeSchema>(schema: TSchema): this is FlexTreeTypedNode<TSchema>;
     // (undocumented)
-    on<K extends keyof EditableTreeEvents>(eventName: K, listener: EditableTreeEvents[K]): () => void;
+    on<K extends keyof FlexTreeNodeEvents>(eventName: K, listener: FlexTreeNodeEvents[K]): () => void;
     readonly parentField: {
         readonly parent: FlexTreeField;
         readonly index: number;
     };
     tryGetField(key: FieldKey): undefined | FlexTreeField;
     readonly value?: TreeValue;
+}
+
+// @internal
+export interface FlexTreeNodeEvents {
+    afterChange(event: TreeEvent): void;
+    beforeChange(event: TreeEvent): void;
+    changing(upPath: UpPath): void;
+    subtreeChanging(upPath: UpPath): PathVisitor | void;
 }
 
 // @internal
@@ -1394,7 +1395,7 @@ export const reservedObjectNodeFieldPropertyNamePrefixes: readonly ["set", "boxe
 export type ReservedObjectNodeFieldPropertyNames = (typeof reservedObjectNodeFieldPropertyNames)[number];
 
 // @internal
-export const reservedObjectNodeFieldPropertyNames: readonly ["constructor", "context", "is", "on", "parentField", "schema", "treeStatus", "tryGetField", "type", "value", "localNodeKey", "boxedIterator", "iterator"];
+export const reservedObjectNodeFieldPropertyNames: readonly ["constructor", "context", "is", "on", "parentField", "schema", "treeStatus", "tryGetField", "type", "value", "localNodeKey", "boxedIterator", "iterator", "anchor"];
 
 // @public
 export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
@@ -1807,7 +1808,8 @@ export abstract class TreeNode implements WithType {
 
 // @public
 export interface TreeNodeEvents {
-    afterChange(): void;
+    afterDeepChange(): void;
+    afterShallowChange(): void;
 }
 
 // @public

--- a/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
@@ -47,7 +47,7 @@ export {
 
 export { getTreeContext, FlexTreeContext, Context } from "./context.js";
 
-export { TreeEvent, EditableTreeEvents } from "./treeEvents.js";
+export { TreeEvent, FlexTreeNodeEvents } from "./treeEvents.js";
 
 // Below here are things that are used by the above, but not part of the desired API surface.
 export {

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
@@ -32,7 +32,6 @@ export const isFreedSymbol = Symbol("isFreed");
 export const tryMoveCursorToAnchorSymbol = Symbol("tryMoveCursorToAnchor");
 export const forgetAnchorSymbol = Symbol("forgetAnchor");
 export const cursorSymbol = Symbol("cursor");
-export const anchorSymbol = Symbol("anchor");
 
 /**
  * Assert `entity` is not deleted.
@@ -52,15 +51,13 @@ export abstract class LazyEntity<TSchema = unknown, TAnchor = unknown>
 	implements FlexTreeEntity<TSchema>, IDisposable
 {
 	readonly #lazyCursor: ITreeSubscriptionCursor;
-	public readonly [anchorSymbol]: TAnchor;
 
 	protected constructor(
 		public readonly context: Context,
 		public readonly schema: TSchema,
 		cursor: ITreeSubscriptionCursor,
-		anchor: TAnchor,
+		public readonly anchor: TAnchor,
 	) {
-		this[anchorSymbol] = anchor;
 		this.#lazyCursor = cursor.fork();
 		context.withCursors.add(this);
 		this.context.withAnchors.add(this);
@@ -74,7 +71,7 @@ export abstract class LazyEntity<TSchema = unknown, TAnchor = unknown>
 	public [disposeSymbol](): void {
 		this.#lazyCursor.free();
 		this.context.withCursors.delete(this);
-		this[forgetAnchorSymbol](this[anchorSymbol]);
+		this[forgetAnchorSymbol]();
 		this.context.withAnchors.delete(this);
 	}
 
@@ -94,10 +91,10 @@ export abstract class LazyEntity<TSchema = unknown, TAnchor = unknown>
 				0x778 /* Unset cursor should be in cleared state */,
 			);
 			assert(
-				this[anchorSymbol] !== undefined,
+				this.anchor !== undefined,
 				0x779 /* EditableTree should have an anchor if it does not have a cursor */,
 			);
-			const result = this[tryMoveCursorToAnchorSymbol](this[anchorSymbol], this.#lazyCursor);
+			const result = this[tryMoveCursorToAnchorSymbol](this.#lazyCursor);
 			assert(
 				result === TreeNavigationResult.Ok,
 				0x77a /* It is invalid to access an EditableTree node which no longer exists */,
@@ -108,14 +105,13 @@ export abstract class LazyEntity<TSchema = unknown, TAnchor = unknown>
 	}
 
 	protected abstract [tryMoveCursorToAnchorSymbol](
-		anchor: TAnchor,
 		cursor: ITreeSubscriptionCursor,
 	): TreeNavigationResult;
 
 	/**
 	 * Called when disposing of this target, iff it has an anchor.
 	 */
-	protected abstract [forgetAnchorSymbol](anchor: TAnchor): void;
+	protected abstract [forgetAnchorSymbol](): void;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -57,7 +57,6 @@ import {
 import { makeTree } from "./lazyNode.js";
 import {
 	LazyEntity,
-	anchorSymbol,
 	cursorSymbol,
 	forgetAnchorSymbol,
 	isFreedSymbol,
@@ -161,7 +160,7 @@ export abstract class LazyField<TKind extends FlexFieldKind, TTypes extends Flex
 	}
 
 	public get parent(): FlexTreeNode | undefined {
-		if (this[anchorSymbol].parent === undefined) {
+		if (this.anchor.parent === undefined) {
 			return undefined;
 		}
 
@@ -173,15 +172,14 @@ export abstract class LazyField<TKind extends FlexFieldKind, TTypes extends Flex
 	}
 
 	protected override [tryMoveCursorToAnchorSymbol](
-		anchor: FieldAnchor,
 		cursor: ITreeSubscriptionCursor,
 	): TreeNavigationResult {
-		return this.context.forest.tryMoveCursorToField(anchor, cursor);
+		return this.context.forest.tryMoveCursorToField(this.anchor, cursor);
 	}
 
-	protected override [forgetAnchorSymbol](anchor: FieldAnchor): void {
-		if (anchor.parent === undefined) return;
-		this.context.forest.anchors.forget(anchor.parent);
+	protected override [forgetAnchorSymbol](): void {
+		if (this.anchor.parent === undefined) return;
+		this.context.forest.anchors.forget(this.anchor.parent);
 	}
 
 	public get length(): number {
@@ -233,7 +231,7 @@ export abstract class LazyField<TKind extends FlexFieldKind, TTypes extends Flex
 		if (this[isFreedSymbol]()) {
 			return TreeStatus.Deleted;
 		}
-		const fieldAnchor = this[anchorSymbol];
+		const fieldAnchor = this.anchor;
 		const parentAnchor = fieldAnchor.parent;
 		// If the parentAnchor is undefined it is a detached field.
 		if (parentAnchor === undefined) {

--- a/packages/dds/tree/src/feature-libraries/flex-tree/treeEvents.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/treeEvents.ts
@@ -10,12 +10,12 @@ import { FlexTreeNode } from "./flexTreeTypes.js";
  * This file provides an API for working with trees which is type safe even when schema is not known.
  * This means no editing is allowed.
  *
- * Schema aware APIs for working with trees should superset this, while sub-setting EditableTree.
+ * Schema aware APIs for working with trees should superset this, while sub-setting FlexTree.
  *
  * TODO:
- * This API should replace EditableTree as the default public API for tree access.
+ * This API should replace FlexTree as the default public API for tree access.
  * SchemaAware builds on this, adding editing and type safe APIs which can be accessed via SchematizeView.
- * Once this is finished, the unsafe EditableTree types can be removed (or converted to package internal documentation for the proxies).
+ * Once this is finished, the unsafe FlexTree types can be removed (or converted to package internal documentation for the proxies).
  */
 
 /**
@@ -40,12 +40,13 @@ export interface TreeEvent {
  * - Include sub-deltas in events.
  * - Add more events.
  * - Have some events (or a way to defer events) until the tree can be read.
+ * - Consider removing this and just using AnchorEvents and simple-tree's events (and extending them as needed).
  *
  * @internal
  */
-export interface EditableTreeEvents {
+export interface FlexTreeNodeEvents {
 	/**
-	 * Raised when a specific EditableTree node is changing.
+	 * Raised when a specific FlexTree node is changing.
 	 * This includes its fields.
 	 * @param upPath - the path corresponding to the location of the node being changed, upward.
 	 */
@@ -67,20 +68,20 @@ export interface EditableTreeEvents {
 	 * @param event - The event object. See {@link TreeEvent} for details.
 	 *
 	 * @remarks
-	 * What exactly qualifies as a change that triggers this event (or {@link EditableTreeEvents.afterChange}) is dependent
+	 * What exactly qualifies as a change that triggers this event (or {@link FlexTreeNodeEvents.afterChange}) is dependent
 	 * on the implementation of SharedTree. In general, these events will fire once for every atomic editing operation
-	 * supported by SharedTree; {@link EditableTreeEvents.beforeChange} before the change is applied, and
-	 * {@link EditableTreeEvents.afterChange} after it is.
+	 * supported by SharedTree; {@link FlexTreeNodeEvents.beforeChange} before the change is applied, and
+	 * {@link FlexTreeNodeEvents.afterChange} after it is.
 	 *
 	 * {@link FieldKinds.sequence} fields present two exceptions:
 	 *
 	 * The first one is that events will fire separately for each node involved in the operation (when inserting, removing,
 	 * or moving more than one node at a time). This means that, for example, when inserting two nodes into a {@link FieldKinds.sequence}
 	 * field the following will happen:
-	 * - {@link EditableTreeEvents.beforeChange} will fire once before either new node is present in the tree.
-	 * - {@link EditableTreeEvents.afterChange} will fire once after the first node is present in the tree, but the second one isn't.
-	 * - {@link EditableTreeEvents.beforeChange} will fire once before the second node is present in the tree, but the first one already is.
-	 * - {@link EditableTreeEvents.afterChange} will fire once after the second node is present in the tree (so at this point both nodes are).
+	 * - {@link FlexTreeNodeEvents.beforeChange} will fire once before either new node is present in the tree.
+	 * - {@link FlexTreeNodeEvents.afterChange} will fire once after the first node is present in the tree, but the second one isn't.
+	 * - {@link FlexTreeNodeEvents.beforeChange} will fire once before the second node is present in the tree, but the first one already is.
+	 * - {@link FlexTreeNodeEvents.afterChange} will fire once after the second node is present in the tree (so at this point both nodes are).
 	 * Something similar applies to removing nodes from a sequence, and moving them to another sequence.
 	 *
 	 * The second one is that for an operation to move nodes, events will fire *twice* for each node being moved; once
@@ -94,20 +95,20 @@ export interface EditableTreeEvents {
 	 * @param event - The event object. See {@link TreeEvent} for details.
 	 *
 	 * @remarks
-	 * What exactly qualifies as a change that triggers this event (or {@link EditableTreeEvents.beforeChange}) is dependent
+	 * What exactly qualifies as a change that triggers this event (or {@link FlexTreeNodeEvents.beforeChange}) is dependent
 	 * on the implementation of SharedTree. In general, these events will fire once for every atomic editing operation supported
-	 * by SharedTree; {@link EditableTreeEvents.beforeChange} before the change is applied, and
-	 * {@link EditableTreeEvents.afterChange} after it is.
+	 * by SharedTree; {@link FlexTreeNodeEvents.beforeChange} before the change is applied, and
+	 * {@link FlexTreeNodeEvents.afterChange} after it is.
 	 *
 	 * {@link FieldKinds.sequence} present two exceptions:
 	 *
 	 * The first one is that events will fire separately for each node involved in the operation (when inserting, removing,
 	 * or moving more than one node at a time). This means that, for example, when inserting two nodes into a {@link FieldKinds.sequence}
 	 * field the following will happen:
-	 * - {@link EditableTreeEvents.beforeChange} will fire once before either new node is present in the tree.
-	 * - {@link EditableTreeEvents.afterChange} will fire once after the first node is present in the tree, but the second one isn't.
-	 * - {@link EditableTreeEvents.beforeChange} will fire once before the second node is present in the tree, but the first one already is.
-	 * - {@link EditableTreeEvents.afterChange} will fire once after the second node is present in the tree (so at this point both nodes are).
+	 * - {@link FlexTreeNodeEvents.beforeChange} will fire once before either new node is present in the tree.
+	 * - {@link FlexTreeNodeEvents.afterChange} will fire once after the first node is present in the tree, but the second one isn't.
+	 * - {@link FlexTreeNodeEvents.beforeChange} will fire once before the second node is present in the tree, but the first one already is.
+	 * - {@link FlexTreeNodeEvents.afterChange} will fire once after the second node is present in the tree (so at this point both nodes are).
 	 * Something similar applies to removing nodes from a sequence, and moving them to another sequence.
 	 *
 	 * The second one is that for an operation to move nodes, events will fire *twice* for each node being moved; once

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -251,7 +251,7 @@ export {
 	TreeStatus,
 	Context,
 	TreeEvent,
-	EditableTreeEvents,
+	FlexTreeNodeEvents,
 	FlexTreeUnknownUnboxed,
 	onNextChange,
 	isFlexTreeNode,

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -152,7 +152,7 @@ export {
 	stackTreeNodeCursor,
 	CursorAdapter,
 	CursorWithNode,
-	EditableTreeEvents,
+	FlexTreeNodeEvents,
 	ArrayLikeMut,
 	FieldKinds,
 	ContextuallyTypedFieldData,

--- a/packages/dds/tree/src/simple-tree/rawNode.ts
+++ b/packages/dds/tree/src/simple-tree/rawNode.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { FieldKey, TreeNodeSchemaIdentifier } from "../core/index.js";
+import { AnchorNode, FieldKey, TreeNodeSchemaIdentifier } from "../core/index.js";
 import {
-	EditableTreeEvents,
+	FlexTreeNodeEvents,
 	FlexFieldNodeSchema,
 	FlexTreeContext,
 	FlexTreeField,
@@ -122,9 +122,13 @@ export abstract class RawTreeNode<TSchema extends FlexTreeNodeSchema, TContent>
 
 	public value: undefined;
 
-	public on<K extends keyof EditableTreeEvents>(
+	public get anchor(): AnchorNode {
+		throw rawError("Getting anchor");
+	}
+
+	public on<K extends keyof FlexTreeNodeEvents>(
 		eventName: K,
-		listener: EditableTreeEvents[K],
+		listener: FlexTreeNodeEvents[K],
 	): () => void {
 		throw rawError("Event registration");
 	}

--- a/packages/dds/tree/src/test/simple-tree/node.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "assert";
-import { TreeNode, NodeFromSchema, SchemaFactory, Tree } from "../../simple-tree/index.js";
+import { NodeFromSchema, SchemaFactory, Tree } from "../../simple-tree/index.js";
 import { getRoot } from "./utils.js";
 
 // TODO: migrate remaining tests to src/test/class-tree/treeApi.spec.ts
@@ -25,46 +25,39 @@ describe("node API", () => {
 		function check(mutate: (root: NodeFromSchema<typeof treeSchema>) => void) {
 			it(".on(..) must subscribe to change event", () => {
 				const root = getRoot(treeSchema, initialTree);
-				const log: any[][] = [];
+				const log: string[] = [];
 
-				Tree.on(root as TreeNode, "afterChange", (...args: any[]) => {
-					log.push(args);
+				Tree.on(root, "afterDeepChange", () => {
+					log.push("deep");
 				});
 
 				mutate(root);
-
-				const numChanges = log.length;
-				assert(
-					numChanges > 0,
-					"Must receive change notifications after subscribing to event.",
-				);
+				assert.deepEqual(log, ["deep"]);
 			});
 
 			it(".on(..) must return unsubscribe function", () => {
 				const root = getRoot(treeSchema, initialTree);
-				const log: any[][] = [];
+				const log: string[] = [];
 
-				const unsubscribe = Tree.on(root as TreeNode, "afterChange", (...args: any[]) => {
-					log.push(args);
+				const unsubscribe = Tree.on(root, "afterDeepChange", () => {
+					log.push("deep");
 				});
 
 				mutate(root);
 
-				const numChanges = log.length;
-				assert(
-					numChanges > 0,
-					"Must receive change notifications after subscribing to event.",
-				);
+				assert.deepEqual(log, ["deep"]);
+				log.length = 0;
+
+				// Confirm events stay registered after changes
+				mutate(root);
+				assert.deepEqual(log, ["deep"]);
+				log.length = 0;
 
 				unsubscribe();
 
 				mutate(root);
 
-				assert.equal(
-					log.length,
-					numChanges,
-					"Mutation after unsubscribe must not emit change events.",
-				);
+				assert.deepEqual(log, []);
 			});
 		}
 

--- a/packages/dds/tree/src/test/simple-tree/objectFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/objectFactory.spec.ts
@@ -219,7 +219,12 @@ describe("SharedTreeObject factories", () => {
 		getFlexNode(root).on("beforeChange", () => {
 			readData();
 		});
-		Tree.on(root, "afterChange", () => {
+		Tree.on(root, "afterDeepChange", () => {
+			readData();
+		});
+		// TODO: Fix that this causes `root.child = ` to crash. Issue is likely that afterShallowChange can run before onNextChange causing issues.
+		// TODO: Add more targeted tests for this kind of thing, and/or improved validation that detects this kind of issue better, and/or make the hydration more robust.
+		Tree.on(root, "afterShallowChange", () => {
 			readData();
 		});
 

--- a/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
@@ -167,7 +167,7 @@ describe("schemaFactory", () => {
 			assert.equal(root.y, 2);
 
 			const values: number[] = [];
-			Tree.on(root, "afterChange", () => {
+			Tree.on(root, "afterDeepChange", () => {
 				values.push(root.x);
 			});
 			root.x = 5;
@@ -203,7 +203,7 @@ describe("schemaFactory", () => {
 			assert.equal(root.x, 1);
 
 			const values: number[] = [];
-			Tree.on(root, "afterChange", () => {
+			Tree.on(root, "afterDeepChange", () => {
 				values.push(root.x);
 			});
 
@@ -625,7 +625,7 @@ describe("schemaFactory", () => {
 					}
 
 					// Ensure that the proxies can be read during the change, as well as after
-					Tree.on(view.root, "afterChange", () => validate());
+					Tree.on(view.root, "afterDeepChange", () => validate());
 					view.events.on("afterBatch", () => validate());
 					view.root.root = parent;
 					validate();

--- a/packages/dds/tree/src/test/simple-tree/treeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeApi.spec.ts
@@ -105,4 +105,6 @@ describe("treeApi", () => {
 		assert.equal(nodeApi.status(newChild), TreeStatus.InDocument);
 		// TODO: test Deleted status.
 	});
+
+	// TODO: event tests to replace ones in src/test/simple-tree/node.spec.ts, and provide better coverage.
 });


### PR DESCRIPTION
## Description

Add explicit shallow and deep change events for nodes.

## Breaking Changes

All use of `Tree.on` events are broken.

## Reviewer Guidance

The public API needs review/approval. The implementation is current draft level since it has one know bug (does not work with hydration and shallow events together correctly)
