### PR TITLE
refactor(api-markdown-documenter): Add needed utility functions locally, and remove dependency on `@microsoft/api-documenter`

### DIFF
--- a/tools/api-markdown-documenter/.eslintrc.cjs
+++ b/tools/api-markdown-documenter/.eslintrc.cjs
@@ -16,18 +16,6 @@ module.exports = {
 		// extensibility.
 		"@typescript-eslint/no-unsafe-enum-comparison": "off",
 
-		/**
-		 * This package utilizes internals of api-documenter that are not exported by the package root.
-		 *
-		 * TODO: remove once we have completely migrated off of this library.
-		 */
-		"import/no-internal-modules": [
-			"error",
-			{
-				allow: ["@microsoft/api-documenter/**"],
-			},
-		],
-
 		// Useful for developer accessibility
 		"unicorn/prevent-abbreviations": [
 			"error",

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -63,7 +63,6 @@
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"dependencies": {
-		"@microsoft/api-documenter": "7.23.9",
 		"@microsoft/api-extractor-model": "~7.28.2",
 		"@microsoft/tsdoc": "^0.14.2",
 		"@rushstack/node-core-library": "^3.55.2",

--- a/tools/api-markdown-documenter/pnpm-lock.yaml
+++ b/tools/api-markdown-documenter/pnpm-lock.yaml
@@ -12,7 +12,6 @@ importers:
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/eslint-config-fluid': file:../../common/build/eslint-config-fluid
       '@fluidframework/mocha-test-setup': ~2.0.0-internal.6.2.0
-      '@microsoft/api-documenter': 7.23.9
       '@microsoft/api-extractor': ^7.39.1
       '@microsoft/api-extractor-model': ~7.28.2
       '@microsoft/tsdoc': ^0.14.2
@@ -40,7 +39,6 @@ importers:
       rimraf: ^5.0.0
       typescript: ~5.1.6
     dependencies:
-      '@microsoft/api-documenter': 7.23.9_@types+node@18.15.11
       '@microsoft/api-extractor-model': 7.28.2_@types+node@18.15.11
       '@microsoft/tsdoc': 0.14.2
       '@rushstack/node-core-library': 3.55.2_@types+node@18.15.11
@@ -403,21 +401,6 @@ packages:
       jju: 1.4.0
       read-yaml-file: 1.1.0
     dev: true
-
-  /@microsoft/api-documenter/7.23.9_@types+node@18.15.11:
-    resolution: {integrity: sha512-CvOy3JF0oCDm3GDqce3uFS9QGO72lfOEgVbvpje32O+ug/WoL8ITOg2jZszMtowuClasPbpEcEoVsHJJLePirg==}
-    hasBin: true
-    dependencies:
-      '@microsoft/api-extractor-model': 7.28.2_@types+node@18.15.11
-      '@microsoft/tsdoc': 0.14.2
-      '@rushstack/node-core-library': 3.61.0_@types+node@18.15.11
-      '@rushstack/ts-command-line': 4.16.1
-      colors: 1.2.5
-      js-yaml: 3.13.1
-      resolve: 1.22.2
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: false
 
   /@microsoft/api-extractor-model/7.28.2_@types+node@18.15.11:
     resolution: {integrity: sha512-vkojrM2fo3q4n4oPh4uUZdjJ2DxQ2+RnDQL/xhTWSRUNPF6P4QyrvY357HBxbnltKcYu+nNNolVqc6TIGQ73Ig==}
@@ -900,15 +883,6 @@ packages:
     resolution: {integrity: sha512-2yn4qTkXZTByQffL3ymS6viYuyZk3YnJT49bopGBlm9Thtyfa7iuFUV6tt+09YIRO1sjmSWILf4dPj6+Dr5YVA==}
     dev: true
 
-  /@rushstack/ts-command-line/4.16.1:
-    resolution: {integrity: sha512-+OCsD553GYVLEmz12yiFjMOzuPeCiZ3f8wTiFHL30ZVXexTyPmgjwXEhg2K2P0a2lVf+8YBy7WtPoflB2Fp8/A==}
-    dependencies:
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      colors: 1.2.5
-      string-argv: 0.3.1
-    dev: false
-
   /@rushstack/ts-command-line/4.17.1:
     resolution: {integrity: sha512-2jweO1O57BYP5qdBGl6apJLB+aRIn5ccIRTPDyULh0KMwVzFqWtw6IZWt1qtUoZD/pD2RNkIOosH6Cq45rIYeg==}
     dependencies:
@@ -1007,6 +981,7 @@ packages:
 
   /@types/argparse/1.0.38:
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+    dev: true
 
   /@types/chai/4.3.4:
     resolution: {integrity: sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==}
@@ -1564,6 +1539,7 @@ packages:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
       sprintf-js: 1.0.3
+    dev: true
 
   /argparse/2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2849,6 +2825,7 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /esquery/1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
@@ -3905,14 +3882,6 @@ packages:
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
     dev: true
-
-  /js-yaml/3.13.1:
-    resolution: {integrity: sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==}
-    hasBin: true
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-    dev: false
 
   /js-yaml/3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -5639,6 +5608,7 @@ packages:
 
   /sprintf-js/1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: true
 
   /strict-uri-encode/2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
@@ -5648,6 +5618,7 @@ packages:
   /string-argv/0.3.1:
     resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
     engines: {node: '>=0.6.19'}
+    dev: true
 
   /string-width/4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -6539,7 +6510,7 @@ packages:
     resolution: {directory: ../../common/build/eslint-config-fluid, type: directory}
     id: file:../../common/build/eslint-config-fluid
     name: '@fluidframework/eslint-config-fluid'
-    version: 3.3.0
+    version: 4.0.0
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@rushstack/eslint-patch': 1.4.0
@@ -6574,7 +6545,7 @@ packages:
     version: 0.1.0
     hasBin: true
     dependencies:
-      '@rushstack/node-core-library': 3.61.0_@types+node@18.15.11
+      '@rushstack/node-core-library': 3.63.0_@types+node@18.15.11
       '@tylerbu/markdown-magic': 2.4.0-tylerbu-1
       chalk: 4.1.2
       markdown-magic-package-scripts: 1.2.2

--- a/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuiteOptions.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/configuration/DocumentationSuiteOptions.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Utilities } from "@microsoft/api-documenter/lib/utils/Utilities";
 import {
 	type ApiDeclaredItem,
 	type ApiItem,
@@ -18,6 +17,8 @@ import {
 	getReleaseTag,
 	getUnscopedPackageName,
 	releaseTagToString,
+	getSafeFilenameForName,
+	getConciseSignature,
 } from "../../utilities";
 
 /**
@@ -282,9 +283,7 @@ export namespace DefaultDocumentationSuiteOptions {
 				return "index";
 			}
 			case ApiItemKind.Package: {
-				return Utilities.getSafeFilenameForName(
-					getUnscopedPackageName(apiItem as ApiPackage),
-				);
+				return getSafeFilenameForName(getUnscopedPackageName(apiItem as ApiPackage));
 			}
 			default: {
 				return getQualifiedApiItemName(apiItem);
@@ -352,7 +351,7 @@ export namespace DefaultDocumentationSuiteOptions {
 				return getSingleLineExcerptText((apiItem as ApiDeclaredItem).excerpt);
 			}
 			default: {
-				return Utilities.getConciseSignature(apiItem);
+				return getConciseSignature(apiItem);
 			}
 		}
 	}

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { Utilities } from "@microsoft/api-documenter/lib/utils/Utilities";
 import {
 	type ApiCallSignature,
 	type ApiConstructSignature,
@@ -123,7 +122,7 @@ export enum ApiModifier {
  * @public
  */
 export function getQualifiedApiItemName(apiItem: ApiItem): string {
-	let qualifiedName: string = Utilities.getSafeFilenameForName(apiItem.displayName);
+	let qualifiedName: string = getSafeFilenameForName(apiItem.displayName);
 	if (ApiParameterListMixin.isBaseClassOf(apiItem) && apiItem.overloadIndex > 1) {
 		// Subtract one for compatibility with earlier releases of API Documenter.
 		// (This will get revamped when we fix GitHub issue #1308)
@@ -442,4 +441,26 @@ export function getModifiers(apiItem: ApiItem, modifiersToOmit?: ApiModifier[]):
 	}
 
 	return modifiers;
+}
+
+/**
+ * Generates a concise signature for a function.  Example: "getArea(width, height)"
+ */
+export function getConciseSignature(apiItem: ApiItem): string {
+	if (ApiParameterListMixin.isBaseClassOf(apiItem)) {
+		return `${apiItem.displayName}(${apiItem.parameters.map((x) => x.name).join(", ")})`;
+	}
+	return apiItem.displayName;
+}
+
+/**
+ * Converts bad filename characters to underscores.
+ */
+export function getSafeFilenameForName(apiItemName: string): string {
+	// eslint-disable-next-line unicorn/better-regex, no-useless-escape
+	const badFilenameCharsRegExp: RegExp = /[^a-z0-9_\-\.]/gi;
+
+	// TODO: This can introduce naming collisions.
+	// Will be fixed as part of https://github.com/microsoft/rushstack/issues/1308
+	return apiItemName.replace(badFilenameCharsRegExp, "_").toLowerCase();
 }

--- a/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
+++ b/tools/api-markdown-documenter/src/utilities/ApiItemUtilities.ts
@@ -460,7 +460,8 @@ export function getSafeFilenameForName(apiItemName: string): string {
 	// eslint-disable-next-line unicorn/better-regex, no-useless-escape
 	const badFilenameCharsRegExp: RegExp = /[^a-z0-9_\-\.]/gi;
 
-	// TODO: This can introduce naming collisions.
-	// Will be fixed as part of https://github.com/microsoft/rushstack/issues/1308
+	// Note: This can introduce naming collisions.
+	// TODO: once the following issue has been resolved in api-extractor, we may be able to clean this up:
+	// https://github.com/microsoft/rushstack/issues/1308
 	return apiItemName.replace(badFilenameCharsRegExp, "_").toLowerCase();
 }


### PR DESCRIPTION
This library was originally derived from api-documenter. Later, it was refactored to stand on its own, but retained a few references to api-documenter internals for misc. utilities. This PR inlines the 2 simple, remaining utility functions needed by this library and removes the dependency.