### PR TITLE
feat(devtools): Renamed usage telemetry event name

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -177,7 +177,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 				["Event.Name"]: eventType, // Same as 'name' but is an actual column in Kusto; useful for cross-table queries
 				["Data.extensionVersion"]: extensionVersion,
 				["Data.sessionID"]: this.sessionID,
-				["Data.continuityID"]: this.continuityID
+				["Data.continuityID"]: this.continuityID,
 			},
 		};
 

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -171,7 +171,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 			: "Generic";
 		// Note: "Office.Fluid" here has a connection to the Aria tenant(s) we're targetting, and the full string
 		// impacts the way the data is structured once ingested. Don't change this without proper consideration.
-		const eventType = `Office.Fluid.Devtools.${category}`;
+		const eventType = `Fluid.Framework.Devtools.Usage`;
 
 		const telemetryEvent = {
 			name: eventType, // Dictates which table the event goes to
@@ -181,6 +181,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 				["Data.extensionVersion"]: extensionVersion,
 				["Data.sessionID"]: this.sessionID,
 				["Data.continuityID"]: this.continuityID,
+				["Data.category"]: category,
 			},
 		};
 

--- a/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
+++ b/packages/tools/devtools/devtools-browser-extension/src/devtools/TelemetryLogging.ts
@@ -166,10 +166,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 		}
 
 		// Note: the calls that the 1DS SDK makes to external endpoints might fail if the last part of the eventName is not uppercase
-		const category = event.category
-			? `${event.category.charAt(0).toUpperCase()}${event.category.slice(1)}`
-			: "Generic";
-		// Note: "Office.Fluid" here has a connection to the Aria tenant(s) we're targetting, and the full string
+		// Note: "Fluid.Framework" here has a connection to the Aria tenant(s) we're targetting, and the full string
 		// impacts the way the data is structured once ingested. Don't change this without proper consideration.
 		const eventType = `Fluid.Framework.Devtools.Usage`;
 
@@ -180,8 +177,7 @@ export class OneDSLogger implements ITelemetryBaseLogger {
 				["Event.Name"]: eventType, // Same as 'name' but is an actual column in Kusto; useful for cross-table queries
 				["Data.extensionVersion"]: extensionVersion,
 				["Data.sessionID"]: this.sessionID,
-				["Data.continuityID"]: this.continuityID,
-				["Data.category"]: category,
+				["Data.continuityID"]: this.continuityID
 			},
 		};
 


### PR DESCRIPTION
## Description

This PR changes the event name of the usage telemetry events being collected so that it's appropriately routed to the right table.