### PR TITLE
build: 'build:docs' should depend on 'compile'

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -71,8 +71,8 @@ module.exports = {
 			dependsOn: ["build:esnext"],
 			script: true,
 		},
-		"build:docs": ["tsc"],
-		"ci:build:docs": ["tsc"],
+		"build:docs": ["compile"],
+		"ci:build:docs": ["compile"],
 		"build:readme": {
 			dependsOn: ["build:manifest"],
 			script: true,

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -71,8 +71,8 @@ module.exports = {
 			dependsOn: ["build:esnext"],
 			script: true,
 		},
-		"build:docs": ["compile"],
-		"ci:build:docs": ["compile"],
+		"build:docs": ["tsc", "build:esnext"],
+		"ci:build:docs": ["tsc", "build:esnext"],
 		"build:readme": {
 			dependsOn: ["build:manifest"],
 			script: true,


### PR DESCRIPTION
Should unblock packages currently encountering the following error:
```
@fluid-experimental/oldest-client-observer: api-extractor 7.39.1  - https://api-extractor.com/
@fluid-experimental/oldest-client-observer: 
@fluid-experimental/oldest-client-observer: Using configuration from ./api-extractor.json
@fluid-experimental/oldest-client-observer: 
@fluid-experimental/oldest-client-observer: 
@fluid-experimental/oldest-client-observer: ERROR: Error parsing /mnt/vss/_work/1/s/packages/framework/oldest-client-observer/api-extractor.json:
@fluid-experimental/oldest-client-observer: The "mainEntryPointFilePath" path does not exist: /mnt/vss/_work/1/s/packages/framework/oldest-client-observer/lib/index.d.ts
```