### PR TITLE
Missing condition setting offlineLoadEnabled

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -962,7 +962,7 @@ export class Container
 		const offlineLoadEnabled =
 			(this.isInteractiveClient &&
 				this.mc.config.getBoolean("Fluid.Container.enableOfflineLoad")) ??
-			false;
+			options.enableOfflineLoad === true;
 		this.serializedStateManager = new SerializedStateManager(
 			pendingLocalState,
 			this.subLogger,


### PR DESCRIPTION
Recent PR https://github.com/microsoft/FluidFramework/pull/19697 does not rewrite offlineLoadEnabled flag correctly. There is a change in which now we include this.isInteractiveClient into the equation but the reason why our stress tests were triggered are more likely due to the omission of options.enableOfflineLoad.