### PR TITLE
Replace non-standard protocol usage in the repo

### DIFF
--- a/.changeset/early-beans-switch.md
+++ b/.changeset/early-beans-switch.md
@@ -1,0 +1,16 @@
+---
+"@fluidframework/driver-utils": major
+"@fluidframework/local-driver": major
+"@fluidframework/odsp-driver": major
+"@fluidframework/odsp-urlresolver": major
+"@fluid-experimental/property-dds": major
+"@fluidframework/routerlicious-driver": major
+"@fluidframework/routerlicious-urlresolver": major
+"@fluid-private/test-end-to-end-tests": major
+"@fluidframework/test-utils": major
+"@fluidframework/tinylicious-driver": major
+---
+
+Resolved URLs no longer use non-standard protocols
+
+Previously, IResolvedUrl.url could use a non-standard protocol like fluid://, fluid-odsp://, or fluid-test://. These have been replaced with https:// to permit standards-compliant URL parsing.

--- a/docs/content/docs/deep/hosts.md
+++ b/docs/content/docs/deep/hosts.md
@@ -81,7 +81,7 @@ const resolvedUrl: IFluidResolvedUrl = {
     },
     tokens: { jwt: "token" },
     type: "fluid",
-    url: "fluid://www.ContosoFluidService.com/ContosoTenant/documentIdentifier",
+    url: "https://www.ContosoFluidService.com/ContosoTenant/documentIdentifier",
 }
 ```
 

--- a/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/propertyTree.spec.ts
@@ -278,7 +278,7 @@ describe("PropertyDDS summarizer", () => {
 
 describe("PropertyTree", () => {
 	const documentId = "localServerTest";
-	const documentLoadUrl = `fluid-test://localhost/${documentId}`;
+	const documentLoadUrl = `https://localhost/${documentId}`;
 	const propertyDdsId = "PropertyTree";
 	const codeDetails: IFluidCodeDetails = {
 		package: "localServerTestPackage",

--- a/experimental/PropertyDDS/packages/property-dds/src/test/rebasing.spec.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/rebasing.spec.ts
@@ -68,7 +68,7 @@ function getFunctionSource(fun: any): string {
 
 describe("PropertyDDS", () => {
 	const documentId = "localServerTest";
-	const documentLoadUrl = `fluid-test://localhost/${documentId}`;
+	const documentLoadUrl = `https://localhost/${documentId}`;
 	const propertyDdsId = "PropertyTree";
 	const codeDetails: IFluidCodeDetails = {
 		package: "localServerTestPackage",

--- a/experimental/PropertyDDS/services/property-query-service/test/unit/rebase.spec.js
+++ b/experimental/PropertyDDS/services/property-query-service/test/unit/rebase.spec.js
@@ -82,7 +82,7 @@ async function processWithMH(queue, mhService) {
 
 describe("Rebasing", () => {
 	const documentId = "localServerTest";
-	const documentLoadUrl = `fluid-test://localhost/${documentId}`;
+	const documentLoadUrl = `https://localhost/${documentId}`;
 	const propertyDdsId = "PropertyTree";
 	const codeDetails = {
 		package: "localServerTestPackage",

--- a/packages/drivers/local-driver/src/localResolver.ts
+++ b/packages/drivers/local-driver/src/localResolver.ts
@@ -55,7 +55,7 @@ export class LocalResolver implements IUrlResolver {
 			id: documentId,
 			tokens: { jwt: generateToken(this.tenantId, documentId, this.tokenKey, scopes) },
 			type: "fluid",
-			url: `fluid-test://localhost:3000/${this.tenantId}/${fullPath}`,
+			url: `https://localhost:3000/${this.tenantId}/${fullPath}`,
 		};
 
 		return resolved;

--- a/packages/drivers/local-driver/src/test/localResolverTest.spec.ts
+++ b/packages/drivers/local-driver/src/test/localResolverTest.spec.ts
@@ -31,7 +31,7 @@ describe("Local Driver Resolver", () => {
 
 		it("should successfully resolve a createNewRequest", async () => {
 			const resolvedUrl = await resolver.resolve(request);
-			const expectedUrl = `fluid-test://localhost:3000/tenantId/${documentId}`;
+			const expectedUrl = `https://localhost:3000/tenantId/${documentId}`;
 			assert.equal(resolvedUrl.url, expectedUrl, "The resolved url should match");
 		});
 
@@ -52,7 +52,7 @@ describe("Local Driver Resolver", () => {
 		it("should successfully resolve request for a container url", async () => {
 			const url = `http://localhost/${documentId}`;
 			const resolvedUrl = await resolver.resolve({ url });
-			const expectedUrl = `fluid-test://localhost:3000/tenantId/${documentId}`;
+			const expectedUrl = `https://localhost:3000/tenantId/${documentId}`;
 			assert.equal(resolvedUrl.url, expectedUrl, "The resolved container url should match");
 		});
 	});

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -127,7 +127,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 				type: "fluid",
 				odspResolvedUrl: true,
 				id: "odspCreateNew",
-				url: `fluid-odsp://${siteURL}?${queryString}&version=null`,
+				url: `https://${siteURL}?${queryString}&version=null`,
 				siteUrl: siteURL,
 				hashedDocumentId: "",
 				driveId: driveID,
@@ -148,7 +148,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 		const hashedDocumentId = await getHashedDocumentId(driveId, itemId);
 		assert(!hashedDocumentId.includes("/"), 0x0a8 /* "Docid should not contain slashes!!" */);
 
-		const documentUrl = `fluid-odsp://placeholder/placeholder/${hashedDocumentId}/${removeBeginningSlash(
+		const documentUrl = `https://placeholder/placeholder/${hashedDocumentId}/${removeBeginningSlash(
 			path,
 		)}`;
 

--- a/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspCreateContainer.spec.ts
@@ -102,7 +102,7 @@ describe("Odsp Create Container Test", () => {
 		assert.strictEqual(finalResolverUrl.siteUrl, siteUrl, "SiteUrl should match");
 		assert.strictEqual(finalResolverUrl.hashedDocumentId, docID, "DocId should match");
 
-		const url = `fluid-odsp://placeholder/placeholder/${docID}/`;
+		const url = `https://placeholder/placeholder/${docID}/`;
 		const snapshotUrl = `${siteUrl}/_api/v2.1/drives/${driveId}/items/${itemId}/opStream/snapshots`;
 		assert.strictEqual(finalResolverUrl.url, url, "Url should match");
 		assert.strictEqual(

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -70,7 +70,7 @@ describe("Odsp Driver Resolver", () => {
 			type: "fluid",
 			odspResolvedUrl: true,
 			id: "odspCreateNew",
-			url: "fluid-odsp://https://localhost?driveId=driveId&path=path&version=null",
+			url: "https://https://localhost?driveId=driveId&path=path&version=null",
 			siteUrl: "https://localhost",
 			hashedDocumentId: "",
 			driveId: "driveId",
@@ -283,7 +283,7 @@ describe("Odsp Driver Resolver", () => {
 		);
 
 		const expectedResolvedUrl =
-			`fluid-odsp://${siteUrl}?driveId=${driveId}&path=${testFilePath}&itemId=${itemId}` +
+			`https://${siteUrl}?driveId=${driveId}&path=${testFilePath}&itemId=${itemId}` +
 			`&version=null`;
 		assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
 	});
@@ -316,8 +316,7 @@ describe("Odsp Driver Resolver", () => {
 		);
 
 		const expectedResolvedUrl =
-			`fluid-odsp://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` +
-			`${testFilePath}`;
+			`https://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` + `${testFilePath}`;
 		assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
 	});
 
@@ -349,8 +348,7 @@ describe("Odsp Driver Resolver", () => {
 		);
 
 		const expectedResolvedUrl =
-			`fluid-odsp://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` +
-			`${testFilePath}`;
+			`https://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` + `${testFilePath}`;
 		assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
 	});
 
@@ -382,8 +380,7 @@ describe("Odsp Driver Resolver", () => {
 		);
 
 		const expectedResolvedUrl =
-			`fluid-odsp://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` +
-			`${testFilePath}`;
+			`https://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` + `${testFilePath}`;
 		assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
 	});
 
@@ -393,7 +390,7 @@ describe("Odsp Driver Resolver", () => {
 
 		assert.strictEqual(
 			resolvedUrl.url,
-			"fluid-odsp://placeholder/placeholder/AV5r7rhbMqs3T5cL8TUpqk6FpWldev0qKsKlnjkC5mg%3D/",
+			"https://placeholder/placeholder/AV5r7rhbMqs3T5cL8TUpqk6FpWldev0qKsKlnjkC5mg%3D/",
 		);
 	});
 
@@ -427,8 +424,7 @@ describe("Odsp Driver Resolver", () => {
 		assert.strictEqual(resolvedUrl.fileVersion, fileVersion, "FileVersion should be equal");
 
 		const expectedResolvedUrl =
-			`fluid-odsp://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` +
-			`${testFilePath}`;
+			`https://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` + `${testFilePath}`;
 		assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
 	});
 });

--- a/packages/drivers/odsp-urlResolver/src/test/spoUrlResolver.spec.ts
+++ b/packages/drivers/odsp-urlResolver/src/test/spoUrlResolver.spec.ts
@@ -23,7 +23,7 @@ describe("Spo Url Resolver", () => {
 		);
 		assert.equal(
 			resolved.url,
-			`fluid-odsp://placeholder/placeholder/${resolved.hashedDocumentId}/`,
+			`https://placeholder/placeholder/${resolved.hashedDocumentId}/`,
 			"fluid url does not match",
 		);
 	});
@@ -43,7 +43,7 @@ describe("Spo Url Resolver", () => {
 		);
 		assert.equal(
 			resolved.url,
-			`fluid-odsp://placeholder/placeholder/${resolved.hashedDocumentId}/`,
+			`https://placeholder/placeholder/${resolved.hashedDocumentId}/`,
 			"fluid url does not match",
 		);
 	});

--- a/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/urlUtils.spec.ts
@@ -10,8 +10,8 @@ import { getDiscoveredFluidResolvedUrl, parseFluidUrl, replaceDocumentIdInPath }
 
 describe("UrlUtils", () => {
 	const exampleFluidUrl1 =
-		"fluid://orderer.examplehost.com/example-tenant/some-document?param1=value1";
-	const exampleFluidUrl2 = "fluid://examplehost.com/other-tenant/";
+		"https://orderer.examplehost.com/example-tenant/some-document?param1=value1";
+	const exampleFluidUrl2 = "https://examplehost.com/other-tenant/";
 	describe("parseFluidUrl()", () => {
 		it("parses Fluid url", () => {
 			const parsedUrl = parseFluidUrl(exampleFluidUrl1);
@@ -33,7 +33,7 @@ describe("UrlUtils", () => {
 		it("updating pathname alters toString of parsedUrl", () => {
 			const parsedUrl = parseFluidUrl(exampleFluidUrl2);
 			parsedUrl.set("pathname", "/not-same");
-			assert.strictEqual(parsedUrl.toString(), "fluid://examplehost.com/not-same");
+			assert.strictEqual(parsedUrl.toString(), "https://examplehost.com/not-same");
 		});
 	});
 

--- a/packages/drivers/routerlicious-driver/src/urlUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/urlUtils.ts
@@ -43,7 +43,7 @@ export const getDiscoveredFluidResolvedUrl = (
 		id: resolvedUrl.id,
 		tokens: resolvedUrl.tokens,
 		type: resolvedUrl.type,
-		url: new URLParse(`fluid://${discoveredOrdererUrl.host}${parsedUrl.pathname}`).toString(),
+		url: new URLParse(`https://${discoveredOrdererUrl.host}${parsedUrl.pathname}`).toString(),
 	};
 	return discoveredResolvedUrl;
 };

--- a/packages/drivers/routerlicious-urlResolver/src/test/routerlicious-urlResolver.spec.ts
+++ b/packages/drivers/routerlicious-urlResolver/src/test/routerlicious-urlResolver.spec.ts
@@ -39,7 +39,7 @@ describe("Routerlicious Url Resolver", () => {
 		);
 		assert.equal(
 			resolved.url,
-			"fluid://wu2.prague.office-int.com/fluid/thinkable-list?chaincode=@fluid-example/shared-text@0.11.14146",
+			"https://wu2.prague.office-int.com/fluid/thinkable-list?chaincode=@fluid-example/shared-text@0.11.14146",
 			"FluidUrl does not match",
 		);
 	});
@@ -71,7 +71,7 @@ describe("Routerlicious Url Resolver", () => {
 		);
 		assert.equal(
 			resolved.url,
-			"fluid://localhost:3003/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0",
+			"https://localhost:3003/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0",
 			"FluidUrl does not match",
 		);
 	});
@@ -119,7 +119,7 @@ describe("Routerlicious Url Resolver", () => {
 		assert.equal(endpoints.ordererUrl, "http://localhost:3003", "Improperly Formed OrdererUrl");
 		assert.equal(
 			url,
-			"fluid://localhost:3003/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0",
+			"https://localhost:3003/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0",
 			"Improperly formed FluidURL",
 		);
 	});
@@ -166,7 +166,7 @@ describe("Routerlicious Url Resolver", () => {
 		assert.equal(endpoints.ordererUrl, "http://alfred:3000", "Improperly Formed OrdererUrl");
 		assert.equal(
 			url,
-			"fluid://localhost:3003/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0",
+			"https://localhost:3003/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0",
 			"Improperly formed FluidURL",
 		);
 	});
@@ -216,7 +216,7 @@ describe("Routerlicious Url Resolver", () => {
 		);
 		assert.equal(
 			url,
-			"fluid://localhost:3003/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0",
+			"https://localhost:3003/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0",
 			"Improperly formed FluidURL",
 		);
 	});
@@ -267,7 +267,7 @@ describe("Routerlicious Url Resolver", () => {
 		);
 		assert.equal(
 			url,
-			"fluid://alfred.wu2-ppe.prague.office-int.com/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0",
+			"https://alfred.wu2-ppe.prague.office-int.com/fluid/damp-competition?chaincode=@fluid-example/shared-text@^0.11.0",
 			"FluidUrl does not match",
 		);
 	});

--- a/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
@@ -77,7 +77,7 @@ export class RouterliciousUrlResolver implements IUrlResolver {
 		const serverSuffix = isLocalHost ? `${server}:3003` : server.substring(4);
 
 		let fluidUrl =
-			"fluid://" +
+			"https://" +
 			`${
 				this.config
 					? parse(this.config.provider.get("worker:serverUrl")).host

--- a/packages/drivers/tinylicious-driver/src/insecureTinyliciousUrlResolver.ts
+++ b/packages/drivers/tinylicious-driver/src/insecureTinyliciousUrlResolver.ts
@@ -30,7 +30,7 @@ export class InsecureTinyliciousUrlResolver implements IUrlResolver {
 	private readonly tinyliciousEndpoint: string;
 	public constructor(port = defaultTinyliciousPort, endpoint = defaultTinyliciousEndpoint) {
 		this.tinyliciousEndpoint = `${endpoint}:${port}`;
-		this.fluidProtocolEndpoint = this.tinyliciousEndpoint.replace(/(^\w+:|^)\/\//, "fluid://");
+		this.fluidProtocolEndpoint = this.tinyliciousEndpoint.replace(/(^\w+:|^)\/\//, "https://");
 	}
 
 	public async resolve(request: IRequest): Promise<IResolvedUrl> {

--- a/packages/drivers/tinylicious-driver/src/test/insecureTinyliciousUrlResolverTest.spec.ts
+++ b/packages/drivers/tinylicious-driver/src/test/insecureTinyliciousUrlResolverTest.spec.ts
@@ -10,7 +10,7 @@ import { InsecureTinyliciousUrlResolver } from "../insecureTinyliciousUrlResolve
 
 describe("Insecure Url Resolver Test", () => {
 	const documentId = "fileName";
-	const hostUrl = "fluid://localhost:7070";
+	const hostUrl = "https://localhost:7070";
 	const tinyliciousEndpoint = "http://localhost:7070";
 	let resolver: InsecureTinyliciousUrlResolver;
 
@@ -32,7 +32,7 @@ describe("Insecure Url Resolver Test", () => {
 
 	it("Should resolve url with custom domain and port", async () => {
 		const customEndpoint = "http://custom-endpoint.io";
-		const customFluidEndpoint = "fluid://custom-endpoint.io";
+		const customFluidEndpoint = "https://custom-endpoint.io";
 		const customPort = 1234;
 		const customResolver = new InsecureTinyliciousUrlResolver(customPort, customEndpoint);
 		const testRequest: IRequest = {

--- a/packages/loader/driver-utils/src/insecureUrlResolver.ts
+++ b/packages/loader/driver-utils/src/insecureUrlResolver.ts
@@ -17,7 +17,7 @@ import Axios from "axios";
  * http://localhost:8080/<documentId>/<path>.
  *
  * We then need to map that to a Fluid based URL. These are of the form
- * fluid://orderingUrl/<tenantId>/<documentId>/<path>.
+ * https://orderingUrl/<tenantId>/<documentId>/<path>.
  *
  * The tenantId/documentId pair defines the 'full' document ID the service makes use of. The path is then an optional
  * part of the URL that the document interprets and maps to a data store. It's exactly similar to how a web service
@@ -106,7 +106,7 @@ export class InsecureUrlResolver implements IUrlResolver {
 				id: "",
 				tokens: {},
 				type: "fluid",
-				url: `fluid://${host}/${encodedTenantId}/new`,
+				url: `https://${host}/${encodedTenantId}/new`,
 			};
 			return createNewResponse;
 		}
@@ -115,7 +115,7 @@ export class InsecureUrlResolver implements IUrlResolver {
 			!documentRelativePath || documentRelativePath.startsWith("/")
 				? documentRelativePath
 				: `/${documentRelativePath}`;
-		const documentUrl = `fluid://${host}/${encodedTenantId}/${encodedDocId}${relativePath}${queryParams}`;
+		const documentUrl = `https://${host}/${encodedTenantId}/${encodedDocId}${relativePath}${queryParams}`;
 
 		const deltaStorageUrl = `${this.ordererUrl}/deltas/${encodedTenantId}/${encodedDocId}`;
 		const storageUrl = `${this.storageUrl}/repos/${encodedTenantId}`;

--- a/packages/loader/driver-utils/src/test/insecureUrlResolverTest.spec.ts
+++ b/packages/loader/driver-utils/src/test/insecureUrlResolverTest.spec.ts
@@ -51,7 +51,7 @@ describe("Insecure Url Resolver Test", () => {
 
 	it("Resolved CreateNew Request", async () => {
 		const resolvedUrl = (await resolver.resolve(request)) as IResolvedUrl;
-		const documentUrl = `fluid://${new URL(ordererUrl).host}/${tenantId}/${fileName}`;
+		const documentUrl = `https://${new URL(ordererUrl).host}/${tenantId}/${fileName}`;
 		assert.strictEqual(
 			resolvedUrl.endpoints.ordererUrl,
 			ordererUrl,
@@ -63,7 +63,7 @@ describe("Insecure Url Resolver Test", () => {
 	it("Test RequestUrl for a data store", async () => {
 		const resolvedUrl = await resolver.resolve(request);
 
-		const expectedResolvedUrl = `fluid://${new URL(ordererUrl).host}/${tenantId}/${fileName}`;
+		const expectedResolvedUrl = `https://${new URL(ordererUrl).host}/${tenantId}/${fileName}`;
 		assert.strictEqual(resolvedUrl?.url, expectedResolvedUrl, "resolved url is wrong");
 
 		const dataStoreId = "dataStore";
@@ -80,7 +80,7 @@ describe("Insecure Url Resolver Test", () => {
 		};
 		const resolvedUrl = await resolver.resolve(testRequest);
 
-		const expectedResolvedUrl = `fluid://${new URL(ordererUrl).host}/${tenantId}/${fileName}`;
+		const expectedResolvedUrl = `https://${new URL(ordererUrl).host}/${tenantId}/${fileName}`;
 		assert.strictEqual(resolvedUrl?.url, expectedResolvedUrl, "resolved url is wrong");
 	});
 
@@ -91,7 +91,7 @@ describe("Insecure Url Resolver Test", () => {
 		};
 		const resolvedUrl = await resolver.resolve(testRequest);
 
-		const expectedResolvedUrl = `fluid://${
+		const expectedResolvedUrl = `https://${
 			new URL(ordererUrl).host
 		}/${tenantId}/${fileName}/dataStore1/dataStore2`;
 		assert.strictEqual(resolvedUrl?.url, expectedResolvedUrl, "resolved url is wrong");
@@ -110,7 +110,7 @@ describe("Insecure Url Resolver Test", () => {
 		};
 		const resolvedUrl = await resolver.resolve(testRequest);
 
-		const expectedResolvedUrl = `fluid://${new URL(ordererUrl).host}/${tenantId}/${fileName}/`;
+		const expectedResolvedUrl = `https://${new URL(ordererUrl).host}/${tenantId}/${fileName}/`;
 		assert.strictEqual(resolvedUrl?.url, expectedResolvedUrl, "resolved url is wrong");
 	});
 
@@ -121,7 +121,7 @@ describe("Insecure Url Resolver Test", () => {
 		};
 		const resolvedUrl = await resolver.resolve(testRequest);
 
-		const expectedResolvedUrl = `fluid://${new URL(ordererUrl).host}/${tenantId}/${fileName}//`;
+		const expectedResolvedUrl = `https://${new URL(ordererUrl).host}/${tenantId}/${fileName}//`;
 		assert.strictEqual(resolvedUrl?.url, expectedResolvedUrl, "resolved url is wrong");
 	});
 
@@ -132,7 +132,7 @@ describe("Insecure Url Resolver Test", () => {
 		};
 		const resolvedUrl = await resolver.resolve(testRequest);
 
-		const expectedResolvedUrl = `fluid://${
+		const expectedResolvedUrl = `https://${
 			new URL(ordererUrl).host
 		}/${tenantId}/${fileName}/!@$123/dataStore!@$`;
 		assert.strictEqual(resolvedUrl?.url, expectedResolvedUrl, "resolved url is wrong");

--- a/packages/test/local-server-tests/src/test/localTestServer.spec.ts
+++ b/packages/test/local-server-tests/src/test/localTestServer.spec.ts
@@ -44,7 +44,7 @@ function createLocalLoader(
 
 describe("LocalTestServer", () => {
 	const documentId = "localServerTest";
-	const documentLoadUrl = `fluid-test://localhost/${documentId}`;
+	const documentLoadUrl = `https://localhost/${documentId}`;
 	const stringId = "stringKey";
 	const codeDetails: IFluidCodeDetails = {
 		package: "localServerTestPackage",

--- a/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
+++ b/packages/test/local-server-tests/src/test/noDeltaStream.spec.ts
@@ -29,7 +29,7 @@ import { ConnectionState } from "@fluidframework/container-loader";
 
 describe("No Delta Stream", () => {
 	const documentId = "localServerTest";
-	const documentLoadUrl = `fluid-test://localhost/${documentId}`;
+	const documentLoadUrl = `https://localhost/${documentId}`;
 	const stringId = "stringKey";
 	const codeDetails: IFluidCodeDetails = {
 		package: "localServerTestPackage",

--- a/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
+++ b/packages/test/local-server-tests/src/test/opsOnReconnect.spec.ts
@@ -30,7 +30,7 @@ import {
 
 describe("Ops on Reconnect", () => {
 	const documentId = "opsOnReconnectTest";
-	const documentLoadUrl = `fluid-test://localhost/${documentId}`;
+	const documentLoadUrl = `https://localhost/${documentId}`;
 	const map1Id = "map1Key";
 	const map2Id = "map2Key";
 	const directoryId = "directoryKey";

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -59,7 +59,7 @@ import {
 } from "@fluidframework/driver-utils";
 import { Deferred } from "@fluidframework/core-utils";
 
-const id = "fluid-test://localhost/containerTest";
+const id = "https://localhost/containerTest";
 const testRequest: IRequest = { url: id };
 const codeDetails: IFluidCodeDetails = { package: "test" };
 const timeoutMs = 500;

--- a/packages/test/test-utils/README.md
+++ b/packages/test/test-utils/README.md
@@ -156,7 +156,7 @@ The typical usage for testing a Fluid object is as follows:
 
 7. To truly test collaboration, create a second `Loader`, `Container`, `fluid object` and `DDS` which will serve as a remote client:
     ```typescript
-    const documentUrl = `fluid-test://localhost/${documentId}`;
+    const documentUrl = `https://localhost/${documentId}`;
     const loader2: ILoader = createLocalLoader(
     	[[codeDetails, entryPoint]],
     	deltaConnectionServer,


### PR DESCRIPTION
A long time ago we used non-standard protocols in resolved urls as a means to distinguish their associated service.  However, these non-standard protocols don't parse properly using standard `URL()` and thus require polyfill usage (url-parse).

Since then I've removed utilities that would use these (#11965) and their notation on the matching DocumentServiceFactories (#14413).

This change converts the non-standard protocol usage (`fluid://`, `fluid-odsp://`, `fluid-test://`) with `https://`.  This generally affects the `IResolvedUrl.url` property which is somewhat less-used anyway.

This change requires a major version since it affects observable url resolver behavior, but after this is done the choice of polyfill vs. `URL()` should have no remaining observable effects and can be done at any time.

[AB#7333](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7333)