### PR TITLE
fix(merge-tree): Tolerate local references without segments in SortedSegmentSet

### DIFF
--- a/packages/dds/merge-tree/src/sortedSegmentSet.ts
+++ b/packages/dds/merge-tree/src/sortedSegmentSet.ts
@@ -39,9 +39,11 @@ export class SortedSegmentSet<T extends SortedSegmentSetItem = ISegment> extends
 		const maybeRef = item as Partial<LocalReferencePosition>;
 		if (maybeRef.getSegment !== undefined && maybeRef.isLeaf?.() === false) {
 			const lref = maybeRef as LocalReferencePosition;
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const segment = lref.getSegment()!;
-			return segment.ordinal;
+			// If the reference position has no associated segment, assign it a sentinel value.
+			// The particular value for comparison doesn't matter because `findItemPosition` tolerates
+			// elements with duplicate keys (as it must, since local references use the same key as their segment).
+			// All that matters is that it's consistent.
+			return lref.getSegment()?.ordinal ?? "";
 		}
 		const maybeObject = item as { readonly segment: ISegment };
 		if (maybeObject?.segment) {


### PR DESCRIPTION
## Description

Removes a bad assumption in `SortedSegmentSet` that local references' segments are defined. This code does not actually require the segment, just that any local reference with an undefined segment reports a consistent ordering key.

Cherry-pick of #19847