### PR TITLE
Configurable no op lambda checkpoint

### DIFF
--- a/server/routerlicious/packages/lambdas/src/index.ts
+++ b/server/routerlicious/packages/lambdas/src/index.ts
@@ -46,5 +46,6 @@ export {
 	IRuntimeSignalEnvelope,
 	logCommonSessionEndMetrics,
 	NoOpLambda,
+	NoOpLambdaCheckpointConfiguration,
 	DocumentCheckpointManager,
 } from "./utils";

--- a/server/routerlicious/packages/lambdas/src/utils/index.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/index.ts
@@ -10,7 +10,7 @@ export {
 	createRuntimeMessage,
 	IRuntimeSignalEnvelope,
 } from "./messageGenerator";
-export { NoOpLambda } from "./noOpLambda";
+export { NoOpLambda, NoOpLambdaCheckpointConfiguration } from "./noOpLambda";
 export { createSessionMetric, logCommonSessionEndMetrics } from "./telemetryHelper";
 export { isDocumentSessionValid, isDocumentValid } from "./validateDocument";
 export { CheckpointReason, ICheckpoint } from "./checkpointHelper";

--- a/server/routerlicious/packages/lambdas/src/utils/noOpLambda.ts
+++ b/server/routerlicious/packages/lambdas/src/utils/noOpLambda.ts
@@ -9,12 +9,62 @@ import { IContext, IQueuedMessage, IPartitionLambda } from "@fluidframework/serv
  * @internal
  */
 export class NoOpLambda implements IPartitionLambda {
-	constructor(private readonly context: IContext) {}
+	private opsCount = 0;
+	private lastCheckpointOffset = 0;
+	private timer: NodeJS.Timer | undefined;
+
+	constructor(
+		private readonly context: IContext,
+		private readonly checkpointConfiguration?: NoOpLambdaCheckpointConfiguration,
+	) {
+		this.timer = undefined;
+	}
 
 	public handler(message: IQueuedMessage) {
-		this.context.checkpoint(message);
+		// default
+		if (!this.checkpointConfiguration || !this.checkpointConfiguration?.enabled) {
+			this.context.checkpoint(message);
+			return undefined;
+		}
+
+		this.opsCount++;
+		if (this.opsCount >= this.checkpointConfiguration.maxMessages) {
+			this.configurableCheckpoint(message);
+		}
+
+		if (this.checkpointConfiguration?.enabled) {
+			this.resetTimer(message, this.checkpointConfiguration.maxTime);
+		}
+
 		return undefined;
 	}
 
 	public close(): void {}
+
+	private configurableCheckpoint(message: IQueuedMessage) {
+		if (message.offset > this.lastCheckpointOffset) {
+			this.context.checkpoint(message);
+			if (this.timer) {
+				clearTimeout(this.timer);
+				this.timer = undefined;
+			}
+			this.opsCount = 0;
+			this.lastCheckpointOffset = message.offset;
+		}
+	}
+
+	private resetTimer(message: IQueuedMessage, timeout: number) {
+		if (this.timer) {
+			clearTimeout(this.timer);
+		}
+		this.timer = setInterval(() => {
+			this.configurableCheckpoint(message);
+		}, timeout);
+	}
+}
+
+export interface NoOpLambdaCheckpointConfiguration {
+	enabled: boolean;
+	maxMessages: number;
+	maxTime: number;
 }


### PR DESCRIPTION
## Description
Creates the option to pass a set of configuration values to the NoOpLambda to reduce the frequency of checkpoints from each document lambda.

The default value will still be `context.checkpoint()` with every message.