### PR TITLE
refactor(telemetry-utlis): Add support for Ext types in LoggingError

### DIFF
--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -148,7 +148,7 @@ export interface IFluidErrorAnnotations {
 
 // @internal
 export interface IFluidErrorBase extends Error {
-    addTelemetryProperties: (props: ITelemetryBaseProperties) => void;
+    addTelemetryProperties: (props: ITelemetryPropertiesExt) => void;
     readonly errorInstanceId: string;
     readonly errorType: string;
     getTelemetryProperties(): ITelemetryBaseProperties;
@@ -256,7 +256,7 @@ export function loggerToMonitoringContext<L extends ITelemetryBaseLogger = ITele
 // @internal
 export class LoggingError extends Error implements ILoggingError, Omit<IFluidErrorBase, "errorType"> {
     constructor(message: string, props?: ITelemetryBaseProperties, omitPropsFromLogging?: Set<string>);
-    addTelemetryProperties(props: ITelemetryBaseProperties): void;
+    addTelemetryProperties(props: ITelemetryPropertiesExt): void;
     // (undocumented)
     get errorInstanceId(): string;
     getTelemetryProperties(): ITelemetryBaseProperties;

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -14,7 +14,7 @@ import type { IDisposable } from '@fluidframework/core-interfaces';
 import { IErrorBase } from '@fluidframework/core-interfaces';
 import { IEvent } from '@fluidframework/core-interfaces';
 import { IGenericError } from '@fluidframework/core-interfaces';
-import { ILoggingError } from '@fluidframework/core-interfaces';
+import type { ILoggingError } from '@fluidframework/core-interfaces';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { ILoggingError, ITelemetryBaseProperties, Tagged } from "@fluidframework/core-interfaces";
+import type {
+	ILoggingError,
+	ITelemetryBaseProperties,
+	Tagged,
+} from "@fluidframework/core-interfaces";
 import { v4 as uuid } from "uuid";
 import {
 	hasErrorInstanceId,
@@ -11,10 +15,10 @@ import {
 	isFluidError,
 	isValidLegacyError,
 } from "./fluidErrorBase.js";
-import {
+import type {
 	ITelemetryLoggerExt,
 	TelemetryEventPropertyTypeExt,
-	type ITelemetryPropertiesExt,
+	ITelemetryPropertiesExt,
 } from "./telemetryTypes.js";
 import { convertToBasePropertyType } from "./logger.js";
 

--- a/packages/utils/telemetry-utils/src/fluidErrorBase.ts
+++ b/packages/utils/telemetry-utils/src/fluidErrorBase.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
+import type { ITelemetryPropertiesExt } from "./telemetryTypes.js";
 
 /**
  * An error emitted by the Fluid Framework.
@@ -66,7 +67,7 @@ export interface IFluidErrorBase extends Error {
 	/**
 	 * Add telemetry properties to this error which will be logged with the error
 	 */
-	addTelemetryProperties: (props: ITelemetryBaseProperties) => void;
+	addTelemetryProperties: (props: ITelemetryPropertiesExt) => void;
 }
 
 const hasTelemetryPropFunctions = (x: unknown): boolean =>

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -351,6 +351,7 @@ describe("Error Logging", () => {
 				p9: [true, true, false],
 				p10: { one: "1" },
 				p11: undefined,
+				p12: { value: ["1", 2, true], tag: "CodeArtifact" },
 			});
 			const props = loggingError.getTelemetryProperties();
 			assert.strictEqual(props.p1, "should not be overwritten");
@@ -362,6 +363,7 @@ describe("Error Logging", () => {
 			assert.strictEqual(props.p9, "[true,true,false]");
 			assert.strictEqual(props.p10, `{"one":"1"}`);
 			assert.strictEqual(props.p11, undefined);
+			assert.deepStrictEqual(props.p12, { value: `["1",2,true]`, tag: "CodeArtifact" });
 			const errorAsAny = loggingError as any;
 			assert.strictEqual(errorAsAny.p1, "should not be overwritten");
 			assert.strictEqual(errorAsAny.p4, 4);
@@ -372,6 +374,7 @@ describe("Error Logging", () => {
 			assert.deepStrictEqual(errorAsAny.p9, [true, true, false]);
 			assert.deepStrictEqual(errorAsAny.p10, { one: "1" });
 			assert.strictEqual(errorAsAny.p11, undefined);
+			assert.deepStrictEqual(errorAsAny.p12, { value: ["1", 2, true], tag: "CodeArtifact" });
 		});
 		it("Set valid props via 'as any' - returned from getTelemetryProperties, overwrites", () => {
 			const loggingError = new LoggingError("myMessage", { p1: 1, p2: "two", p3: true });
@@ -388,10 +391,11 @@ describe("Error Logging", () => {
 			errorAsAny.p9 = [true, true, false];
 			errorAsAny.p10 = { one: "1" };
 			errorAsAny.p11 = undefined;
+			errorAsAny.p12 = { value: ["1", 2, true], tag: "CodeArtifact" };
 			// Things that can't be set with addTelemetryProperties
-			errorAsAny.p12 = null; // Null
-			errorAsAny.p13 = ["a", "b", "c", null]; // Array with nulls
-			errorAsAny.p14 = [[1, 2]]; // Nested array
+			errorAsAny.p13 = null; // Null
+			errorAsAny.p14 = ["a", "b", "c", null]; // Array with nulls
+			errorAsAny.p15 = [[1, 2]]; // Nested array
 			const props = loggingError.getTelemetryProperties();
 			assert.strictEqual(props.p1, "one");
 			assert.strictEqual(props.p4, 4);
@@ -403,9 +407,10 @@ describe("Error Logging", () => {
 			assert.strictEqual(props.p9, `[true,true,false]`);
 			assert.strictEqual(props.p10, `{"one":"1"}`);
 			assert.strictEqual(props.p11, undefined);
-			assert.strictEqual(props.p12, "null");
-			assert.strictEqual(props.p13, `["a","b","c",null]`);
-			assert.strictEqual(props.p14, "[[1,2]]");
+			assert.deepStrictEqual(props.p12, { value: `["1",2,true]`, tag: "CodeArtifact" });
+			assert.strictEqual(props.p13, "null");
+			assert.strictEqual(props.p14, `["a","b","c",null]`);
+			assert.strictEqual(props.p15, "[[1,2]]");
 		});
 		it("addTelemetryProperties - Does not overwrite base class Error fields (untagged)", () => {
 			const loggingError = new LoggingError("myMessage");

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -36,6 +36,7 @@ import {
 	isValidLegacyError,
 } from "../fluidErrorBase.js";
 import { MockLogger } from "../mockLogger.js";
+import type { ITelemetryPropertiesExt } from "../telemetryTypes.js";
 
 describe("Error Logging", () => {
 	describe("TelemetryLogger.prepareErrorObject", () => {
@@ -337,53 +338,74 @@ describe("Error Logging", () => {
 			assert.strictEqual(props.foo, undefined, "foo should have been omitted");
 			assert.strictEqual(props.bar, "normal", "bar should not be omitted");
 		});
-		it("addTelemetryProperties - adds to object, returned from getTelemetryProperties, overwrites", () => {
+		it("addTelemetryProperties - adds to object, returned from getTelemetryProperties, doesn't overwrite", () => {
 			const loggingError = new LoggingError("myMessage", { p1: 1, p2: "two", p3: true });
 			(loggingError as any).p1 = "should not be overwritten";
 			loggingError.addTelemetryProperties({
 				p1: "ignored",
 				p4: 4,
-				p5: { value: 5, tag: "CodeArtifact" },
+				p5: true,
+				p6: { value: 5, tag: "CodeArtifact" },
+				p7: ["a", "b", "c"],
+				p8: [1, 2, 3],
+				p9: [true, true, false],
+				p10: { one: "1" },
+				p11: undefined,
 			});
 			const props = loggingError.getTelemetryProperties();
 			assert.strictEqual(props.p1, "should not be overwritten");
 			assert.strictEqual(props.p4, 4);
-			assert.deepStrictEqual(props.p5, { value: 5, tag: "CodeArtifact" });
+			assert.strictEqual(props.p5, true);
+			assert.deepStrictEqual(props.p6, { value: 5, tag: "CodeArtifact" });
+			assert.strictEqual(props.p7, '["a","b","c"]');
+			assert.strictEqual(props.p8, "[1,2,3]");
+			assert.strictEqual(props.p9, "[true,true,false]");
+			assert.strictEqual(props.p10, `{"one":"1"}`);
+			assert.strictEqual(props.p11, undefined);
 			const errorAsAny = loggingError as any;
 			assert.strictEqual(errorAsAny.p1, "should not be overwritten");
 			assert.strictEqual(errorAsAny.p4, 4);
-			assert.deepStrictEqual(errorAsAny.p5, { value: 5, tag: "CodeArtifact" });
+			assert.strictEqual(errorAsAny.p5, true);
+			assert.deepStrictEqual(errorAsAny.p6, { value: 5, tag: "CodeArtifact" });
+			assert.deepStrictEqual(errorAsAny.p7, ["a", "b", "c"]);
+			assert.deepStrictEqual(errorAsAny.p8, [1, 2, 3]);
+			assert.deepStrictEqual(errorAsAny.p9, [true, true, false]);
+			assert.deepStrictEqual(errorAsAny.p10, { one: "1" });
+			assert.strictEqual(errorAsAny.p11, undefined);
 		});
 		it("Set valid props via 'as any' - returned from getTelemetryProperties, overwrites", () => {
 			const loggingError = new LoggingError("myMessage", { p1: 1, p2: "two", p3: true });
 			loggingError.addTelemetryProperties({ p1: "should be overwritten" });
 			const errorAsAny = loggingError as any;
+			// Things that could be set with addTelemetryProperties
 			errorAsAny.p1 = "one";
 			errorAsAny.p4 = 4;
-			errorAsAny.p5 = { value: 5, tag: "CodeArtifact" };
+			errorAsAny.p5 = true;
+			errorAsAny.p6 = { value: 5, tag: "CodeArtifact" };
 			errorAsAny.userData6 = { value: 5, tag: "UserData" };
+			errorAsAny.p7 = ["a", "b", "c"];
+			errorAsAny.p8 = [1, 2, 3];
+			errorAsAny.p9 = [true, true, false];
+			errorAsAny.p10 = { one: "1" };
+			errorAsAny.p11 = undefined;
+			// Things that can't be set with addTelemetryProperties
+			errorAsAny.p12 = null; // Null
+			errorAsAny.p13 = ["a", "b", "c", null]; // Array with nulls
+			errorAsAny.p14 = [[1, 2]]; // Nested array
 			const props = loggingError.getTelemetryProperties();
 			assert.strictEqual(props.p1, "one");
 			assert.strictEqual(props.p4, 4);
-			assert.deepStrictEqual(props.p5, { value: 5, tag: "CodeArtifact" });
+			assert.strictEqual(props.p5, true);
+			assert.deepStrictEqual(props.p6, { value: 5, tag: "CodeArtifact" });
 			assert.deepStrictEqual(props.userData6, { value: 5, tag: "UserData" });
-		});
-		it("Set invalid props via 'as any' - excluded from getTelemetryProperties, overwrites", () => {
-			const loggingError = new LoggingError("myMessage", { p1: 1, p2: "two", p3: true });
-			const errorAsAny = loggingError as any;
-			errorAsAny.p1 = { one: 1 };
-			errorAsAny.p4 = null;
-			errorAsAny.p5 = ["a", "b", "c", 1, true, undefined];
-			errorAsAny.p6 = ["a", "b", "c", null];
-			errorAsAny.p7 = { value: null, tag: "tag" };
-			errorAsAny.p8 = { value: errorAsAny.p5, tag: "tag" };
-			const props = loggingError.getTelemetryProperties();
-			assert.strictEqual(props.p1, "REDACTED (arbitrary object)");
-			assert.strictEqual(props.p4, "REDACTED (arbitrary object)");
-			assert.strictEqual(props.p5, `["a","b","c",1,true,null]`);
-			assert.strictEqual(props.p6, "REDACTED (arbitrary object)");
-			assert.deepStrictEqual(props.p7, { value: "REDACTED (arbitrary object)", tag: "tag" });
-			assert.deepStrictEqual(props.p8, { value: props.p5, tag: "tag" });
+			assert.strictEqual(props.p7, `["a","b","c"]`);
+			assert.strictEqual(props.p8, `[1,2,3]`);
+			assert.strictEqual(props.p9, `[true,true,false]`);
+			assert.strictEqual(props.p10, `{"one":"1"}`);
+			assert.strictEqual(props.p11, undefined);
+			assert.strictEqual(props.p12, "null");
+			assert.strictEqual(props.p13, `["a","b","c",null]`);
+			assert.strictEqual(props.p14, "[[1,2]]");
 		});
 		it("addTelemetryProperties - Does not overwrite base class Error fields (untagged)", () => {
 			const loggingError = new LoggingError("myMessage");
@@ -645,7 +667,7 @@ class TestFluidError implements IFluidErrorBase {
 		return {};
 	}
 
-	addTelemetryProperties(props: ITelemetryBaseProperties): void {
+	addTelemetryProperties(props: ITelemetryPropertiesExt): void {
 		throw new Error("Not Implemented - Expected to be Stubbed via Sinon");
 	}
 


### PR DESCRIPTION
## Description

Updates the `LoggingError` class so we can add "extended telemetry properties" (internal `*Ext` types) to errors with it, instead of just "base properties".

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

`IFluidErrorBase` and `LoggingError` are @internal APIs so the signature change in `addTelemetryProperties()` shouldn't be an issue.

[AB#2802](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2802)