### PR TITLE
tree: Deduplicate hydrate and getRoot test utilities

### DIFF
--- a/packages/dds/tree/src/test/simple-tree/list.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/list.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { SchemaFactory } from "../../simple-tree/index.js";
-import { getRoot, pretty } from "./utils.js";
+import { hydrate, pretty } from "./utils.js";
 
 const schemaFactory = new SchemaFactory("test");
 
@@ -44,14 +44,14 @@ describe("List", () => {
 
 	/** Helper that creates a new List<number> proxy */
 	function createNumberList(items: readonly number[]) {
-		const list = getRoot(schemaFactory.array(schemaFactory.number), () => items);
+		const list = hydrate(schemaFactory.array(schemaFactory.number), items);
 		assert.deepEqual(list, items);
 		return list;
 	}
 
 	/** Helper that creates a new List<string> proxy */
 	function createStringList(items: readonly string[]) {
-		const list = getRoot(schemaFactory.array(schemaFactory.string), () => items);
+		const list = hydrate(schemaFactory.array(schemaFactory.string), items);
 		assert.deepEqual(list, items);
 		return list;
 	}

--- a/packages/dds/tree/src/test/simple-tree/node.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 import { TreeNode, NodeFromSchema, SchemaFactory, Tree } from "../../simple-tree/index.js";
-import { getRoot } from "./utils.js";
+import { hydrate } from "./utils.js";
 
 // TODO: migrate remaining tests to src/test/class-tree/treeApi.spec.ts
 describe("node API", () => {
@@ -16,15 +16,13 @@ describe("node API", () => {
 	const list = sb.array(object);
 	const treeSchema = sb.object("parent", { object, list });
 
-	const initialTree = () => ({
-		object: { content: 42 },
-		list: [{ content: 42 }, { content: 42 }, { content: 42 }],
-	});
-
 	describe("events", () => {
 		function check(mutate: (root: NodeFromSchema<typeof treeSchema>) => void) {
 			it(".on(..) must subscribe to change event", () => {
-				const root = getRoot(treeSchema, initialTree);
+				const root = hydrate(treeSchema, {
+					object: { content: 1 },
+					list: [{ content: 2 }, { content: 3 }],
+				});
 				const log: any[][] = [];
 
 				Tree.on(root as TreeNode, "afterChange", (...args: any[]) => {
@@ -41,7 +39,10 @@ describe("node API", () => {
 			});
 
 			it(".on(..) must return unsubscribe function", () => {
-				const root = getRoot(treeSchema, initialTree);
+				const root = hydrate(treeSchema, {
+					object: { content: 1 },
+					list: [{ content: 2 }, { content: 3 }],
+				});
 				const log: any[][] = [];
 
 				const unsubscribe = Tree.on(root as TreeNode, "afterChange", (...args: any[]) => {

--- a/packages/dds/tree/src/test/simple-tree/object.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/object.spec.ts
@@ -11,7 +11,7 @@ import {
 	TreeFieldFromImplicitField,
 	TreeNodeSchema,
 } from "../../simple-tree/index.js";
-import { getRoot, pretty } from "./utils.js";
+import { hydrate, pretty } from "./utils.js";
 
 const schemaFactory = new SchemaFactory("Test");
 
@@ -44,7 +44,7 @@ function testObjectLike(testCases: TestCase[]) {
 	describe("Object-like", () => {
 		describe("satisfies 'deepEqual'", () => {
 			for (const { schema, initialTree } of testCases) {
-				const proxy = getRoot(schema, () => initialTree);
+				const proxy = hydrate(schema, initialTree);
 				const real = initialTree;
 
 				it(`deepEqual(${pretty(proxy)}, ${pretty(real)})`, () => {
@@ -65,7 +65,7 @@ function testObjectLike(testCases: TestCase[]) {
 			for (const { schema, initialTree } of testCases) {
 				describe("instanceof Object", () => {
 					it(`${pretty(initialTree)} -> true`, () => {
-						const root = getRoot(schema, () => initialTree);
+						const root = hydrate(schema, initialTree);
 						assert(root instanceof Object, "object must be instanceof Object");
 					});
 				});
@@ -77,7 +77,7 @@ function testObjectLike(testCases: TestCase[]) {
 						it(`Object.getOwnPropertyDescriptor(${pretty(
 							initialTree,
 						)}, ${key}) -> ${pretty(descriptor)}`, () => {
-							const root = getRoot(schema, () => initialTree);
+							const root = hydrate(schema, initialTree);
 							assert.deepEqual(
 								Object.getOwnPropertyDescriptor(findObjectPrototype(root), key),
 								descriptor,
@@ -89,14 +89,14 @@ function testObjectLike(testCases: TestCase[]) {
 
 				describe("methods inherited from Object.prototype", () => {
 					it(`${pretty(initialTree)}.isPrototypeOf(Object.create(root)) -> true`, () => {
-						const root = getRoot(schema, () => initialTree);
+						const root = hydrate(schema, initialTree);
 						const asObject = root as object;
 						// eslint-disable-next-line no-prototype-builtins -- compatibility test
 						assert.equal(asObject.isPrototypeOf(Object.create(asObject)), true);
 					});
 
 					it(`${pretty(initialTree)}.isPrototypeOf(root) -> false`, () => {
-						const root = getRoot(schema, () => initialTree);
+						const root = hydrate(schema, initialTree);
 						const asObject = root as object;
 						// eslint-disable-next-line no-prototype-builtins -- compatibility test
 						assert.equal(asObject.isPrototypeOf(asObject), false);
@@ -111,7 +111,7 @@ function testObjectLike(testCases: TestCase[]) {
 						);
 
 						it(`${key} -> ${expected}`, () => {
-							const root = getRoot(schema, () => initialTree);
+							const root = hydrate(schema, initialTree);
 							const asObject = root as object;
 							// eslint-disable-next-line no-prototype-builtins -- compatibility test
 							assert.equal(asObject.propertyIsEnumerable(key), expected);
@@ -127,7 +127,7 @@ function testObjectLike(testCases: TestCase[]) {
 				const expected = fn(real);
 
 				it(`${pretty(real)} -> ${pretty(expected)}`, () => {
-					const proxy = getRoot(schema, () => initialTree);
+					const proxy = hydrate(schema, initialTree);
 					const actual = fn(proxy as object);
 					assert.deepEqual(actual, expected);
 				});
@@ -312,7 +312,7 @@ const factory = new SchemaFactory("test");
 describe("Object-like", () => {
 	describe("setting an local field", () => {
 		it("throws TypeError in POJO emulation mode", () => {
-			const root = getRoot(schemaFactory.object("no fields", {}), () => ({}));
+			const root = hydrate(schemaFactory.object("no fields", {}), {});
 			assert.throws(() => {
 				// The actual error "'TypeError: 'set' on proxy: trap returned falsish for property 'foo'"
 				(root as unknown as any).foo = 3;
@@ -323,15 +323,15 @@ describe("Object-like", () => {
 			class Custom extends schemaFactory.object("no fields", {}) {
 				public foo?: number;
 			}
-			const root = getRoot(Custom, () => ({}));
+			const root = hydrate(Custom, {});
 			root.foo = 3;
 		});
 	});
 
 	describe("deep equality and types", () => {
 		it("types are ignored in POJO emulation mode", () => {
-			const a = getRoot(schemaFactory.object("a", {}), () => ({}));
-			const b = getRoot(schemaFactory.object("b", {}), () => ({}));
+			const a = hydrate(schemaFactory.object("a", {}), {});
+			const b = hydrate(schemaFactory.object("b", {}), {});
 			assert.deepEqual(a, {});
 			assert.deepEqual(a, b);
 		});
@@ -339,11 +339,11 @@ describe("Object-like", () => {
 		it("types are compared in Customizable mode", () => {
 			class A extends schemaFactory.object("a", {}) {}
 			class B extends schemaFactory.object("b", {}) {}
-			const a = getRoot(A, () => ({}));
-			const b = getRoot(B, () => ({}));
+			const a = hydrate(A, {});
+			const b = hydrate(B, {});
 			assert.notDeepEqual(a, {});
 			assert.notDeepEqual(a, b);
-			const a2 = getRoot(A, () => ({}));
+			const a2 = hydrate(A, {});
 			assert.deepEqual(a, a2);
 		});
 	});
@@ -358,7 +358,7 @@ describe("Object-like", () => {
 				describe(`required ${typeof before} `, () => {
 					it(`(${pretty(before)} -> ${pretty(after)})`, () => {
 						const Root = factory.object("", { value: schema });
-						const root = getRoot(Root, () => ({ value: before }));
+						const root = hydrate(Root, { value: before });
 						assert.equal(root.value, before);
 						root.value = after;
 						assert.equal(root.value, after);
@@ -367,9 +367,9 @@ describe("Object-like", () => {
 
 				describe(`optional ${typeof before}`, () => {
 					it(`(undefined -> ${pretty(before)} -> ${pretty(after)})`, () => {
-						const root = getRoot(
+						const root = hydrate(
 							schemaFactory.object("", { value: schemaFactory.optional(schema) }),
-							() => ({ value: undefined }),
+							{ value: undefined },
 						);
 						assert.equal(root.value, undefined);
 						root.value = before;
@@ -397,7 +397,7 @@ describe("Object-like", () => {
 			const after = { objId: 1 };
 
 			it(`(${pretty(before)} -> ${pretty(after)})`, () => {
-				const root = getRoot(Schema, () => ({ child: before }));
+				const root = hydrate(Schema, { child: before });
 				assert.equal(root.child.objId, 0);
 				root.child = new Child(after);
 				assert.equal(root.child.objId, 1);
@@ -416,7 +416,7 @@ describe("Object-like", () => {
 			const after = { objId: 1 };
 
 			it(`(undefined -> ${pretty(before)} -> ${pretty(after)})`, () => {
-				const root = getRoot(Schema, () => ({ child: undefined }));
+				const root = hydrate(Schema, { child: undefined });
 				assert.equal(root.child, undefined);
 				root.child = new Child(before);
 				assert.equal(root.child.objId, 0);

--- a/packages/dds/tree/src/test/simple-tree/primitives.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/primitives.spec.ts
@@ -9,7 +9,7 @@ import {
 	InsertableTreeFieldFromImplicitField,
 	SchemaFactory,
 } from "../../simple-tree/index.js";
-import { getRoot, pretty } from "./utils.js";
+import { hydrate, pretty } from "./utils.js";
 
 const schemaFactory = new SchemaFactory("Test");
 
@@ -38,7 +38,7 @@ describe("Primitives", () => {
 				`Expected ${pretty(value)} to be preserved by JSON.`,
 			);
 
-			const actual = getRoot(schema, () => value);
+			const actual = hydrate(schema, value);
 			assert.deepEqual(actual, value, "Readback of initialTree must match expected value.");
 		});
 
@@ -82,7 +82,7 @@ describe("Primitives", () => {
 		it(`initialTree(${pretty(
 			value,
 		)}) is coerced to ${typeof coercedValue} ${coercedValue}`, () => {
-			const actual = getRoot(schema, () => value);
+			const actual = hydrate(schema, value);
 			assert.deepEqual(
 				actual,
 				coercedValue,
@@ -114,7 +114,7 @@ describe("Primitives", () => {
 			value,
 		)}) throws when coercion to ${typeof value}' ${coercedValue}' violates schema.`, () => {
 			assert.throws(
-				() => getRoot(schema, () => value),
+				() => hydrate(schema, value),
 				`initialTree(${pretty(
 					value,
 				)}) must throw when coercion to '${coercedValue}' violates schema.`,

--- a/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
@@ -9,7 +9,7 @@ import { TreeArrayNode, NodeFromSchema, SchemaFactory } from "../../simple-tree/
 // TODO: test other things from "proxies" file.
 // eslint-disable-next-line import/no-internal-modules
 import { isTreeNode } from "../../simple-tree/proxies.js";
-import { getRoot, pretty } from "./utils.js";
+import { hydrate, pretty } from "./utils.js";
 
 describe("simple-tree proxies", () => {
 	const sb = new SchemaFactory("test");
@@ -24,31 +24,31 @@ describe("simple-tree proxies", () => {
 		map: sb.map("map", sb.string),
 	});
 
-	const initialTree = () => ({
+	const initialTree = {
 		object: { content: 42 },
 		list: [42, 42, 42],
 		map: new Map([
 			["foo", "Hello"],
 			["bar", "World"],
 		]),
-	});
+	};
 
 	it("cache and reuse objects", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree);
 		const objectProxy = root.object;
 		const objectProxyAgain = root.object;
 		assert.equal(objectProxyAgain, objectProxy);
 	});
 
 	it("cache and reuse lists", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree);
 		const listProxy = root.list;
 		const listProxyAgain = root.list;
 		assert.equal(listProxyAgain, listProxy);
 	});
 
 	it("cache and reuse maps", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree);
 		const mapProxy = root.map;
 		const mapProxyAgain = root.map;
 		assert.equal(mapProxyAgain, mapProxy);
@@ -62,7 +62,7 @@ describe("simple-tree proxies", () => {
 		// Unhydrated node:
 		assert(isTreeNode(new childSchema({ content: 5 })));
 		// Hydrated node:
-		assert(isTreeNode(getRoot(schema, initialTree)));
+		assert(isTreeNode(hydrate(schema, initialTree)));
 	});
 });
 
@@ -106,13 +106,13 @@ describe("SharedTreeObject", () => {
 	});
 
 	it("can read required fields", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree());
 		assert.equal(root.content, 42);
 		assert.equal(root.child.content, 42);
 	});
 
 	it("can read lists", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree());
 		assert.equal(root.list.length, 2);
 		for (const x of root.list) {
 			assert.equal(x.content, 42);
@@ -120,7 +120,7 @@ describe("SharedTreeObject", () => {
 	});
 
 	it("can read maps", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree());
 		assert.equal(root.map.size, 2);
 		assert.equal(root.map.get("foo"), "Hello");
 		assert.equal(root.map.get("bar"), "World");
@@ -128,20 +128,20 @@ describe("SharedTreeObject", () => {
 	});
 
 	it("can read fields common to all polymorphic types", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree());
 		assert.equal(root.polyChild.content, "42");
 	});
 
 	// TODO:#6133: Make this properly async and check that the value of the handle is correct
 	it("can read and write handles", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree());
 		assert.notEqual(root.handle, undefined);
 		root.handle = new MockHandle(43);
 		assert.notEqual(root.handle, undefined);
 	});
 
 	it("can set fields", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree());
 		assert.equal(root.child.content, 42);
 		assert.equal(root.optional?.content, 42);
 		const newChild = new numberChild({ content: 43 });
@@ -153,7 +153,7 @@ describe("SharedTreeObject", () => {
 	});
 
 	it("can unset fields", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree());
 		assert.equal(root.optional?.content, 42);
 		root.optional = undefined;
 		assert.equal(root.optional, undefined);
@@ -167,7 +167,7 @@ describe("SharedTreeList", () => {
 		const schema = _.array(obj);
 
 		it("insertAtStart()", () => {
-			const root = getRoot(schema, () => [{ id: "B" }]);
+			const root = hydrate(schema, [{ id: "B" }]);
 			assert.deepEqual(root, [{ id: "B" }]);
 			const newItem = new obj({ id: "A" });
 			root.insertAtStart(newItem);
@@ -177,7 +177,7 @@ describe("SharedTreeList", () => {
 		});
 
 		it("insertAtEnd()", () => {
-			const root = getRoot(schema, () => [{ id: "A" }]);
+			const root = hydrate(schema, [{ id: "A" }]);
 			assert.deepEqual(root, [{ id: "A" }]);
 			const newItem = new obj({ id: "B" });
 			root.insertAtEnd(newItem);
@@ -187,7 +187,7 @@ describe("SharedTreeList", () => {
 		});
 
 		it("insertAt()", () => {
-			const root = getRoot(schema, () => [{ id: "A" }, { id: "C" }]);
+			const root = hydrate(schema, [{ id: "A" }, { id: "C" }]);
 			assert.deepEqual(root, [{ id: "A" }, { id: "C" }]);
 			const newItem = new obj({ id: "B" });
 			root.insertAt(1, newItem);
@@ -197,14 +197,14 @@ describe("SharedTreeList", () => {
 		});
 
 		it("at()", () => {
-			const root = getRoot(schema, () => [{ id: "B" }]);
+			const root = hydrate(schema, [{ id: "B" }]);
 			assert.equal(root.at(0), root[0]);
 			assert.deepEqual(root, [{ id: "B" }]);
 			assert.deepEqual(root.at(0), { id: "B" });
 		});
 
 		it("at() with negative", () => {
-			const root = getRoot(schema, () => [{ id: "B" }]);
+			const root = hydrate(schema, [{ id: "B" }]);
 			assert.equal(root.at(-1), root[0]);
 			const newItem = new obj({ id: "C" });
 			root.insertAt(1, newItem);
@@ -219,7 +219,7 @@ describe("SharedTreeList", () => {
 		const schema = _.array(_.number);
 
 		it("insertAtStart()", () => {
-			const list = getRoot(schema, () => []);
+			const list = hydrate(schema, []);
 			list.insertAtStart(TreeArrayNode.spread([0, 1]));
 			assert.deepEqual(list, [0, 1]);
 			list.removeRange();
@@ -231,7 +231,7 @@ describe("SharedTreeList", () => {
 		});
 
 		it("insertAtEnd()", () => {
-			const list = getRoot(schema, () => []);
+			const list = hydrate(schema, []);
 			list.insertAtEnd(TreeArrayNode.spread([0, 1]));
 			assert.deepEqual(list, [0, 1]);
 			list.removeRange();
@@ -243,7 +243,7 @@ describe("SharedTreeList", () => {
 		});
 
 		it("insertAt()", () => {
-			const list = getRoot(schema, () => []);
+			const list = hydrate(schema, []);
 			list.insertAt(0, TreeArrayNode.spread([0, 1]));
 			assert.deepEqual(list, [0, 1]);
 			list.removeRange();
@@ -264,15 +264,15 @@ describe("SharedTreeList", () => {
 			handles: _.array(_.handle),
 			poly: _.array([_.number, _.string, _.boolean, _.handle]),
 		});
-		const initialTree = () => ({
+		const initialTree = {
 			numbers: [],
 			strings: [],
 			booleans: [],
 			handles: [],
 			poly: [],
-		});
+		};
 		it("numbers", () => {
-			const root = getRoot(schema, initialTree);
+			const root = hydrate(schema, initialTree);
 			root.numbers.insertAtStart(0);
 			root.numbers.insertAt(1, 1);
 			root.numbers.insertAtEnd(2);
@@ -280,7 +280,7 @@ describe("SharedTreeList", () => {
 		});
 
 		it("booleans", () => {
-			const root = getRoot(schema, initialTree);
+			const root = hydrate(schema, initialTree);
 			root.booleans.insertAtStart(true);
 			root.booleans.insertAt(1, false);
 			root.booleans.insertAtEnd(true);
@@ -288,7 +288,7 @@ describe("SharedTreeList", () => {
 		});
 
 		it("handles", () => {
-			const root = getRoot(schema, initialTree);
+			const root = hydrate(schema, initialTree);
 			const handles = [new MockHandle(5), new MockHandle(6), new MockHandle(7)];
 			root.handles.insertAtStart(handles[0]);
 			root.handles.insertAt(1, handles[1]);
@@ -297,7 +297,7 @@ describe("SharedTreeList", () => {
 		});
 
 		it("of multiple possible types", () => {
-			const root = getRoot(schema, initialTree);
+			const root = hydrate(schema, initialTree);
 			const allowsStrings: typeof root.numbers | typeof root.poly = root.poly;
 			allowsStrings.insertAtStart(42);
 			const allowsStsrings: typeof root.strings | typeof root.poly = root.poly;
@@ -316,21 +316,21 @@ describe("SharedTreeList", () => {
 		const schema = _.array(_.number);
 
 		it("removeAt()", () => {
-			const list = getRoot(schema, () => [0, 1, 2]);
+			const list = hydrate(schema, [0, 1, 2]);
 			assert.deepEqual(list, [0, 1, 2]);
 			list.removeAt(1);
 			assert.deepEqual(list, [0, 2]);
 		});
 
 		it("removeRange()", () => {
-			const list = getRoot(schema, () => [0, 1, 2, 3]);
+			const list = hydrate(schema, [0, 1, 2, 3]);
 			assert.deepEqual(list, [0, 1, 2, 3]);
 			list.removeRange(/* start: */ 1, /* end: */ 3);
 			assert.deepEqual(list, [0, 3]);
 		});
 
 		it("removeRange() - all", () => {
-			const list = getRoot(schema, () => [0, 1, 2, 3]);
+			const list = hydrate(schema, [0, 1, 2, 3]);
 			assert.deepEqual(list, [0, 1, 2, 3]);
 			list.removeRange(/* start: */ 1, /* end: */ 3);
 			assert.deepEqual(list, [0, 3]);
@@ -339,7 +339,7 @@ describe("SharedTreeList", () => {
 		});
 
 		it("removeRange() - past end", () => {
-			const list = getRoot(schema, () => [0, 1, 2, 3]);
+			const list = hydrate(schema, [0, 1, 2, 3]);
 			assert.deepEqual(list, [0, 1, 2, 3]);
 			list.removeRange(/* start: */ 1, /* end: */ 3);
 			assert.deepEqual(list, [0, 3]);
@@ -348,14 +348,14 @@ describe("SharedTreeList", () => {
 		});
 
 		it("removeRange() - empty range", () => {
-			const list = getRoot(schema, () => [0, 1, 2, 3]);
+			const list = hydrate(schema, [0, 1, 2, 3]);
 			assert.deepEqual(list, [0, 1, 2, 3]);
 			list.removeRange(2, 2);
 			assert.deepEqual(list, [0, 1, 2, 3]);
 		});
 
 		it("removeRange() - empty list", () => {
-			const list = getRoot(schema, () => []);
+			const list = hydrate(schema, []);
 			assert.deepEqual(list, []);
 			assert.throws(() => list.removeRange());
 		});
@@ -365,24 +365,24 @@ describe("SharedTreeList", () => {
 		describe("within the same list", () => {
 			const _ = new SchemaFactory("test");
 			const schema = _.array(_.number);
-			const initialTree = () => [0, 1, 2, 3];
+			const initialTree = [0, 1, 2, 3];
 
 			it("moveToStart()", () => {
-				const list = getRoot(schema, initialTree);
+				const list = hydrate(schema, initialTree);
 				assert.deepEqual(list, [0, 1, 2, 3]);
 				list.moveToStart(1);
 				assert.deepEqual(list, [1, 0, 2, 3]);
 			});
 
 			it("moveToEnd()", () => {
-				const list = getRoot(schema, initialTree);
+				const list = hydrate(schema, initialTree);
 				assert.deepEqual(list, [0, 1, 2, 3]);
 				list.moveToEnd(1);
 				assert.deepEqual(list, [0, 2, 3, 1]);
 			});
 
 			it("moveToIndex()", () => {
-				const list = getRoot(schema, initialTree);
+				const list = hydrate(schema, initialTree);
 				assert.deepEqual(list, [0, 1, 2, 3]);
 				list.moveToIndex(1, 2);
 				assert.deepEqual(list, [0, 2, 1, 3]);
@@ -393,14 +393,14 @@ describe("SharedTreeList", () => {
 			});
 
 			it("moveRangeToStart()", () => {
-				const list = getRoot(schema, initialTree);
+				const list = hydrate(schema, initialTree);
 				assert.deepEqual(list, [0, 1, 2, 3]);
 				list.moveRangeToStart(/* sourceStart: */ 1, /* sourceEnd: */ 3);
 				assert.deepEqual(list, [1, 2, 0, 3]);
 			});
 
 			it("moveRangeToEnd()", () => {
-				const list = getRoot(schema, initialTree);
+				const list = hydrate(schema, initialTree);
 				assert.deepEqual(list, [0, 1, 2, 3]);
 				list.moveRangeToEnd(/* sourceStart: */ 1, /* sourceEnd: */ 3);
 				assert.deepEqual(list, [0, 3, 1, 2]);
@@ -408,7 +408,7 @@ describe("SharedTreeList", () => {
 
 			describe("moveRangeToIndex()", () => {
 				function check(index: number, start: number, end: number) {
-					const expected = initialTree().slice(0);
+					const expected = initialTree.slice(0);
 					// Remove the moved items from [start..end).
 					const moved = expected.splice(start, /* deleteCount: */ end - start);
 					// Re-insert the moved items, adjusting index as necessary.
@@ -427,7 +427,7 @@ describe("SharedTreeList", () => {
 					)}.moveToStart(dest: ${index}, start: ${start}, end: ${end}) -> ${pretty(
 						expected,
 					)}`, () => {
-						const list = getRoot(schema, initialTree);
+						const list = hydrate(schema, initialTree);
 						assert.deepEqual(list, initialTree);
 						list.moveRangeToIndex(index, start, end);
 						assert.deepEqual(list, expected);
@@ -453,13 +453,13 @@ describe("SharedTreeList", () => {
 				listB: _.array(_.string),
 			});
 
-			const initialTree = () => ({
+			const initialTree = {
 				listA: ["a0", "a1"],
 				listB: ["b0", "b1"],
-			});
+			};
 
 			it("moveToStart()", () => {
-				const { listA, listB } = getRoot(schema, initialTree);
+				const { listA, listB } = hydrate(schema, initialTree);
 				assert.deepEqual(listA, ["a0", "a1"]);
 				assert.deepEqual(listB, ["b0", "b1"]);
 				listB.moveToStart(0, listA);
@@ -468,7 +468,7 @@ describe("SharedTreeList", () => {
 			});
 
 			it("moveToEnd()", () => {
-				const { listA, listB } = getRoot(schema, initialTree);
+				const { listA, listB } = hydrate(schema, initialTree);
 				assert.deepEqual(listA, ["a0", "a1"]);
 				assert.deepEqual(listB, ["b0", "b1"]);
 				listB.moveToEnd(0, listA);
@@ -477,7 +477,7 @@ describe("SharedTreeList", () => {
 			});
 
 			it("moveToIndex()", () => {
-				const { listA, listB } = getRoot(schema, initialTree);
+				const { listA, listB } = hydrate(schema, initialTree);
 				assert.deepEqual(listA, ["a0", "a1"]);
 				assert.deepEqual(listB, ["b0", "b1"]);
 				listB.moveToIndex(/* index: */ 1, /* sourceStart: */ 0, listA);
@@ -486,7 +486,7 @@ describe("SharedTreeList", () => {
 			});
 
 			it("moveRangeToStart()", () => {
-				const { listA, listB } = getRoot(schema, initialTree);
+				const { listA, listB } = hydrate(schema, initialTree);
 				assert.deepEqual(listA, ["a0", "a1"]);
 				assert.deepEqual(listB, ["b0", "b1"]);
 				listB.moveRangeToStart(/* sourceStart: */ 0, /* sourceEnd: */ 1, listA);
@@ -495,7 +495,7 @@ describe("SharedTreeList", () => {
 			});
 
 			it("moveRangeToEnd()", () => {
-				const { listA, listB } = getRoot(schema, initialTree);
+				const { listA, listB } = hydrate(schema, initialTree);
 				assert.deepEqual(listA, ["a0", "a1"]);
 				assert.deepEqual(listB, ["b0", "b1"]);
 				listB.moveRangeToEnd(/* sourceStart: */ 0, /* sourceEnd: */ 1, listA);
@@ -504,7 +504,7 @@ describe("SharedTreeList", () => {
 			});
 
 			it("moveRangeToIndex()", () => {
-				const { listA, listB } = getRoot(schema, initialTree);
+				const { listA, listB } = hydrate(schema, initialTree);
 				assert.deepEqual(listA, ["a0", "a1"]);
 				assert.deepEqual(listB, ["b0", "b1"]);
 				listB.moveRangeToIndex(
@@ -529,10 +529,10 @@ describe("SharedTreeList", () => {
 				listB,
 			});
 
-			const initialTree = () => ({
+			const initialTree = {
 				listA: ["a", 1],
 				listB: [2, true],
-			});
+			};
 
 			/** This function returns a union of both listA and listB, which exercises more interesting compile type-checking cases */
 			function getEitherList(
@@ -543,7 +543,7 @@ describe("SharedTreeList", () => {
 			}
 
 			it("move to start", () => {
-				const root = getRoot(schema, initialTree);
+				const root = hydrate(schema, initialTree);
 				const list1 = getEitherList(root, "a");
 				const list2 = getEitherList(root, "b");
 				list2.moveToStart(1, list1);
@@ -555,7 +555,7 @@ describe("SharedTreeList", () => {
 			});
 
 			it("move to end", () => {
-				const root = getRoot(schema, initialTree);
+				const root = hydrate(schema, initialTree);
 				const list1 = getEitherList(root, "a");
 				const list2 = getEitherList(root, "b");
 				list2.moveToEnd(1, list1);
@@ -567,7 +567,7 @@ describe("SharedTreeList", () => {
 			});
 
 			it("move to index", () => {
-				const root = getRoot(schema, initialTree);
+				const root = hydrate(schema, initialTree);
 				const list1 = getEitherList(root, "a");
 				const list2 = getEitherList(root, "b");
 				list2.moveToIndex(/* index: */ 1, /* sourceIndex */ 1, list1);
@@ -584,7 +584,7 @@ describe("SharedTreeList", () => {
 			});
 
 			it("fails if incompatible type", () => {
-				const root = getRoot(schema, initialTree);
+				const root = hydrate(schema, initialTree);
 				const list1 = getEitherList(root, "a");
 				const list2 = getEitherList(root, "b");
 				assert.throws(() =>
@@ -610,16 +610,16 @@ describe("SharedTreeMap", () => {
 		objectMap: sb.map(object),
 	});
 
-	const initialTree = () => ({
+	const initialTree = {
 		map: new Map([
 			["foo", "Hello"],
 			["bar", "World"],
 		]),
 		objectMap: new Map(),
-	});
+	};
 
 	it("entries", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree);
 		assert.deepEqual(Array.from(root.map.entries()), [
 			["foo", "Hello"],
 			["bar", "World"],
@@ -627,17 +627,17 @@ describe("SharedTreeMap", () => {
 	});
 
 	it("keys", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree);
 		assert.deepEqual(Array.from(root.map.keys()), ["foo", "bar"]);
 	});
 
 	it("values", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree);
 		assert.deepEqual(Array.from(root.map.values()), ["Hello", "World"]);
 	});
 
 	it("iteration", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree);
 		const result = [];
 		for (const entry of root.map) {
 			result.push(entry);
@@ -650,14 +650,14 @@ describe("SharedTreeMap", () => {
 	});
 
 	it("has", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree);
 		assert.equal(root.map.has("foo"), true);
 		assert.equal(root.map.has("bar"), true);
 		assert.equal(root.map.has("baz"), false);
 	});
 
 	it("set", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree);
 		// Insert new value
 		root.map.set("baz", "42");
 		assert.equal(root.map.size, 3);
@@ -678,7 +678,7 @@ describe("SharedTreeMap", () => {
 	});
 
 	it("set object", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree);
 		const o = new object({ content: 42 });
 		root.objectMap.set("foo", o);
 		assert.equal(root.objectMap.get("foo"), o); // Check that the inserted and read proxies are the same object
@@ -686,7 +686,7 @@ describe("SharedTreeMap", () => {
 	});
 
 	it("delete", () => {
-		const root = getRoot(schema, initialTree);
+		const root = hydrate(schema, initialTree);
 		// Delete existing value
 		root.map.delete("bar");
 		assert.equal(root.map.size, 1);

--- a/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
@@ -10,8 +10,6 @@ import { unreachableCase } from "@fluidframework/core-utils";
 import { MockFluidDataStoreRuntime, MockHandle } from "@fluidframework/test-runtime-utils";
 import { Tree, TreeConfiguration, TreeView } from "../../simple-tree/index.js";
 import {
-	ImplicitFieldSchema,
-	InsertableTreeFieldFromImplicitField,
 	NodeFromSchema,
 	TreeFieldFromImplicitField,
 	TreeNodeFromImplicitAllowedTypes,
@@ -27,6 +25,7 @@ import { areSafelyAssignable, requireAssignableTo, requireTrue } from "../../uti
 import { TreeFactory } from "../../treeFactory.js";
 // eslint-disable-next-line import/no-internal-modules
 import { isTreeNode } from "../../simple-tree/proxies.js";
+import { hydrate } from "./utils.js";
 
 {
 	const schema = new SchemaFactory("Blah");
@@ -645,20 +644,3 @@ describe("schemaFactory", () => {
 		assert.equal(schemaFromValue(false), f.boolean);
 	});
 });
-
-/**
- * Create a tree and use it to hydrate the input.
- */
-function hydrate<TSchema extends ImplicitFieldSchema>(
-	schema: TSchema,
-	data: InsertableTreeFieldFromImplicitField<TSchema>,
-): TreeFieldFromImplicitField<TSchema> {
-	const config = new TreeConfiguration(schema, () => data);
-	const factory = new TreeFactory({});
-	const tree = factory.create(
-		new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-		"tree",
-	);
-	const root = tree.schematize(config).root;
-	return root;
-}

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -22,11 +22,11 @@ import { flexTreeViewWithContent, flexTreeWithContent } from "../utils.js";
  *
  * For minimal/concise targeted unit testing of specific simple-tree content.
  */
-export function getRoot<TSchema extends ImplicitFieldSchema>(
+export function hydrate<TSchema extends ImplicitFieldSchema>(
 	schema: TSchema,
-	initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>,
+	initialTree: InsertableTreeFieldFromImplicitField<TSchema>,
 ): TreeFieldFromImplicitField<TSchema> {
-	const config = new TreeConfiguration(schema, initialTree);
+	const config = new TreeConfiguration(schema, () => initialTree);
 	const flexConfig = toFlexConfig(config);
 	const tree = flexTreeWithContent(flexConfig);
 	return getProxyForField(tree) as TreeFieldFromImplicitField<TSchema>;
@@ -49,7 +49,6 @@ export function getView<TSchema extends ImplicitFieldSchema>(
 /**
  * Similar to JSON stringify, but allows `undefined` at the root and returns numbers as-is at the root.
  */
-
 export function pretty(arg: unknown): number | string {
 	if (arg === undefined) {
 		return "undefined";


### PR DESCRIPTION
## Description

Both `hydrate` and `getRoot` constructed and hydrated a tree, so they have been unified.

`hydrate` seemed like the better name so it was used.
The lower dependency implementation from `getRoot` was used, but with the simpler signature from `hydrate`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

