### PR TITLE
refactor(azure-client): Improve type-guard in `createAzureAudienceMember`

### DIFF
--- a/packages/service-clients/azure-client/api-report/azure-client.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.api.md
@@ -68,7 +68,7 @@ export interface AzureContainerVersion {
 
 // @internal @deprecated
 export class AzureFunctionTokenProvider implements ITokenProvider {
-    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "userId" | "userName" | "additionalDetails"> | undefined);
+    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "additionalDetails" | "userId" | "userName"> | undefined);
     // (undocumented)
     fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)

--- a/packages/service-clients/azure-client/api-report/azure-client.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.api.md
@@ -68,7 +68,7 @@ export interface AzureContainerVersion {
 
 // @internal @deprecated
 export class AzureFunctionTokenProvider implements ITokenProvider {
-    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "additionalDetails" | "userId" | "userName"> | undefined);
+    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "userId" | "userName" | "additionalDetails"> | undefined);
     // (undocumented)
     fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)

--- a/packages/service-clients/azure-client/src/AzureAudience.ts
+++ b/packages/service-clients/azure-client/src/AzureAudience.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils";
 import { type IClient, type IUser } from "@fluidframework/protocol-definitions";
 import { type AzureMember, type AzureUser } from "./interfaces";
 

--- a/packages/service-clients/azure-client/src/AzureAudience.ts
+++ b/packages/service-clients/azure-client/src/AzureAudience.ts
@@ -2,22 +2,35 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-import { assert } from "@fluidframework/core-utils";
-import { type IClient } from "@fluidframework/protocol-definitions";
 
+import { assert } from "@fluidframework/core-utils";
+import { type IClient, type IUser } from "@fluidframework/protocol-definitions";
 import { type AzureMember, type AzureUser } from "./interfaces";
 
 /**
- * Creates Azure-specific audience member
+ * Creates Azure-specific audience member.
+ *
+ * @remarks
+ * The provided `audienceMember`'s {@link @fluidframework/protocol-definitions#IClient.user} must bean {@link AzureUser}.
  */
 export function createAzureAudienceMember(audienceMember: IClient): AzureMember {
-	const azureUser = audienceMember.user as AzureUser;
-	assert(azureUser?.name !== undefined, 'Provided user was not an "AzureUser".');
+	const user = audienceMember.user;
+	assertIsAzureUser(user);
 
 	return {
-		userId: audienceMember.user.id,
-		userName: azureUser.name,
+		userId: user.id,
+		userName: user.name,
 		connections: [],
-		additionalDetails: azureUser.additionalDetails as unknown,
+		additionalDetails: user.additionalDetails,
 	};
+}
+
+/**
+ * Asserts that the provided {@link @fluidframework/protocol-definitions#IUser} is an {@link AzureUser}.
+ */
+export function assertIsAzureUser(user: IUser): asserts user is AzureUser<unknown> {
+	const maybeAzureUser = user as Partial<AzureUser>;
+	const baseMessage = 'Provided user data was not an "AzureUser".';
+	assert(maybeAzureUser.id !== undefined, `${baseMessage} Missing required "id" property.`);
+	assert(maybeAzureUser.name !== undefined, `${baseMessage} Missing required "name" property.`);
 }

--- a/packages/service-clients/azure-client/src/AzureAudience.ts
+++ b/packages/service-clients/azure-client/src/AzureAudience.ts
@@ -10,7 +10,7 @@ import { type AzureMember, type AzureUser } from "./interfaces";
  * Creates Azure-specific audience member.
  *
  * @remarks
- * The provided `audienceMember`'s {@link @fluidframework/protocol-definitions#IClient.user} must bean {@link AzureUser}.
+ * The provided `audienceMember`'s {@link @fluidframework/protocol-definitions#IClient.user} must be an {@link AzureUser}.
  */
 export function createAzureAudienceMember(audienceMember: IClient): AzureMember {
 	const user = audienceMember.user;

--- a/packages/service-clients/azure-client/src/AzureAudience.ts
+++ b/packages/service-clients/azure-client/src/AzureAudience.ts
@@ -31,6 +31,10 @@ export function createAzureAudienceMember(audienceMember: IClient): AzureMember 
 export function assertIsAzureUser(user: IUser): asserts user is AzureUser<unknown> {
 	const maybeAzureUser = user as Partial<AzureUser>;
 	const baseMessage = 'Provided user data was not an "AzureUser".';
-	assert(maybeAzureUser.id !== undefined, `${baseMessage} Missing required "id" property.`);
-	assert(maybeAzureUser.name !== undefined, `${baseMessage} Missing required "name" property.`);
+	if (maybeAzureUser.id === undefined) {
+		throw new TypeError(`${baseMessage} Missing required "id" property.`);
+	}
+	if (maybeAzureUser.name === undefined) {
+		throw new TypeError(`${baseMessage} Missing required "name" property.`);
+	}
 }

--- a/packages/service-clients/azure-client/src/AzureAudience.ts
+++ b/packages/service-clients/azure-client/src/AzureAudience.ts
@@ -27,7 +27,7 @@ export function createAzureAudienceMember(audienceMember: IClient): AzureMember 
 /**
  * Asserts that the provided {@link @fluidframework/protocol-definitions#IUser} is an {@link AzureUser}.
  */
-export function assertIsAzureUser(user: IUser): asserts user is AzureUser<unknown> {
+function assertIsAzureUser(user: IUser): asserts user is AzureUser<unknown> {
 	const maybeAzureUser = user as Partial<AzureUser>;
 	const baseMessage = 'Provided user data was not an "AzureUser".';
 	if (maybeAzureUser.id === undefined) {


### PR DESCRIPTION
The existing type-guard only checked 1 of the 2 required properties, and did not provide useful context when the check was violated.