### PR TITLE
Detecting bundle size regresssions at PR time

### DIFF
--- a/build-tools/packages/build-cli/src/library/dangerfile.ts
+++ b/build-tools/packages/build-cli/src/library/dangerfile.ts
@@ -8,7 +8,7 @@ import {
 	bundlesContainNoChanges,
 	getAzureDevopsApi,
 	BundleComparison,
-	totalSizeMetricName,
+	BundleMetric,
 } from "@fluidframework/bundle-size-tools";
 
 // Handle weirdness with Danger import.  The current module setup prevents us
@@ -68,10 +68,11 @@ export async function dangerfile(): Promise<void> {
 		// Check for bundle size regression
 		const sizeCheck =
 			result.comparison?.some((bundle: BundleComparison) => {
-				const totalMetric = bundle.commonBundleMetrics[totalSizeMetricName];
-				const totalParsedSizeDiff =
-					totalMetric.compare.parsedSize - totalMetric.baseline.parsedSize;
-				return totalParsedSizeDiff > sizeWarningThresholdBytes;
+				return Object.values(bundle.commonBundleMetrics).some(
+					({ baseline, compare }: { baseline: BundleMetric; compare: BundleMetric }) => {
+						return compare.parsedSize - baseline.parsedSize > sizeWarningThresholdBytes;
+					},
+				);
 			}) ?? false;
 
 		// Warn and add label to PR in case of bundle size regression

--- a/build-tools/packages/build-cli/src/library/dangerfile.ts
+++ b/build-tools/packages/build-cli/src/library/dangerfile.ts
@@ -64,7 +64,7 @@ export async function dangerfile(): Promise<void> {
 		?.map((bundle: BundleComparison) => {
 			const totalMetric = bundle.commonBundleMetrics[totalSizeMetricName];
 			const totalParsedSizeDiff = totalMetric.compare.parsedSize - totalMetric.baseline.parsedSize;
-			return totalParsedSizeDiff > 100;
+			return totalParsedSizeDiff > 5120;
 
 		})
 		.reduce((prev: boolean, current: boolean) => {

--- a/build-tools/packages/build-cli/src/library/dangerfile.ts
+++ b/build-tools/packages/build-cli/src/library/dangerfile.ts
@@ -9,6 +9,7 @@ import {
 	getAzureDevopsApi,
 	BundleComparison,
 	BundleMetric,
+	totalSizeMetricName,
 } from "@fluidframework/bundle-size-tools";
 
 // Handle weirdness with Danger import.  The current module setup prevents us
@@ -68,8 +69,14 @@ export async function dangerfile(): Promise<void> {
 		// Check for bundle size regression
 		const sizeRegressionDetected =
 			result.comparison?.some((bundle: BundleComparison) => {
-				return Object.values(bundle.commonBundleMetrics).some(
-					({ baseline, compare }: { baseline: BundleMetric; compare: BundleMetric }) => {
+				return Object.entries(bundle.commonBundleMetrics).some(
+					([metricName, { baseline, compare }]: [
+						string,
+						{ baseline: BundleMetric; compare: BundleMetric },
+					]) => {
+						if (metricName === totalSizeMetricName) {
+							return false;
+						}
 						return compare.parsedSize - baseline.parsedSize > sizeWarningThresholdBytes;
 					},
 				);

--- a/build-tools/packages/build-cli/src/library/dangerfile.ts
+++ b/build-tools/packages/build-cli/src/library/dangerfile.ts
@@ -20,18 +20,6 @@ declare function markdown(message: string, file?: string, line?: number): void;
 
 declare function warn(message: string, file?: string, line?: number): void;
 
-declare const danger: {
-	github: {
-		utils: {
-			createOrAddLabel: (labelConfig: {
-				color: string;
-				description: string;
-				name: string;
-			}) => void;
-		};
-	};
-};
-
 const adoConstants = {
 	orgUrl: "https://dev.azure.com/fluidframework",
 	projectName: "public",
@@ -82,15 +70,9 @@ export async function dangerfile(): Promise<void> {
 				);
 			}) ?? false;
 
-		// Warn and add label to PR in case of bundle size regression
+		// Add warning message in case of bundle size regression
 		if (sizeRegressionDetected) {
 			warn("Bundle size regression detected -- please investigate before merging!");
-			// Add the label to the PR
-			danger.github.utils.createOrAddLabel({
-				color: "ff0000",
-				description: "Significant bundle size regression (>5 KB)",
-				name: "size regression",
-			});
 		}
 
 		markdown(result.message);

--- a/build-tools/packages/build-cli/src/library/dangerfile.ts
+++ b/build-tools/packages/build-cli/src/library/dangerfile.ts
@@ -20,6 +20,16 @@ declare function markdown(message: string, file?: string, line?: number): void;
 
 declare function warn(message: string, file?: string, line?: number): void;
 
+declare const danger: {
+	github: {
+		utils: {
+			createOrAddLabel: (
+				labelConfig: { color: string; description: string; name: string },
+				repoConfig?: { owner: string; repo: string; id: number },
+			) => Promise<void>;
+		};
+	};
+};
 const adoConstants = {
 	orgUrl: "https://dev.azure.com/fluidframework",
 	projectName: "public",
@@ -73,6 +83,16 @@ export async function dangerfile(): Promise<void> {
 		// Add warning message in case of bundle size regression
 		if (sizeRegressionDetected) {
 			warn("Bundle size regression detected -- please investigate before merging!");
+
+			try {
+				await danger.github.utils.createOrAddLabel({
+					color: "ff0000",
+					description: "Significant bundle size regression (>5 KB)",
+					name: "size regression",
+				});
+			} catch (error) {
+				console.error(`Error adding label: ${error}`);
+			}
 		}
 
 		markdown(result.message);

--- a/build-tools/packages/build-cli/src/library/dangerfile.ts
+++ b/build-tools/packages/build-cli/src/library/dangerfile.ts
@@ -66,7 +66,7 @@ export async function dangerfile(): Promise<void> {
 	// message and danger will delete its previous message
 	if (result.comparison === undefined || !bundlesContainNoChanges(result.comparison)) {
 		// Check for bundle size regression
-		const sizeCheck =
+		const sizeRegressionDetected =
 			result.comparison?.some((bundle: BundleComparison) => {
 				return Object.values(bundle.commonBundleMetrics).some(
 					({ baseline, compare }: { baseline: BundleMetric; compare: BundleMetric }) => {
@@ -76,7 +76,7 @@ export async function dangerfile(): Promise<void> {
 			}) ?? false;
 
 		// Warn and add label to PR in case of bundle size regression
-		if (sizeCheck) {
+		if (sizeRegressionDetected) {
 			warn("Bundle size regression detected -- please investigate before merging!");
 			// Add the label to the PR
 			danger.github.utils.createOrAddLabel({

--- a/build-tools/packages/build-cli/src/library/dangerfile.ts
+++ b/build-tools/packages/build-cli/src/library/dangerfile.ts
@@ -7,6 +7,8 @@ import {
 	BundleComparisonResult,
 	bundlesContainNoChanges,
 	getAzureDevopsApi,
+	BundleComparison,
+	totalSizeMetricName,
 } from "@fluidframework/bundle-size-tools";
 
 // Handle weirdness with Danger import.  The current module setup prevents us
@@ -14,6 +16,16 @@ import {
 // import which prevents danger from removing it before evaluation (because it
 // actually puts its exports in the global namespace at that time)
 declare function markdown(message: string, file?: string, line?: number): void;
+
+declare function warn(message: string, file?: string, line?: number): void;
+
+declare const danger: {
+	github: {
+		utils: {
+			createOrAddLabel: (labelConfig: { color: string; description: string; name: string }) => void;
+		};
+	};
+};
 
 const adoConstants = {
 	orgUrl: "https://dev.azure.com/fluidframework",
@@ -47,7 +59,30 @@ export async function dangerfile(): Promise<void> {
 	// there were actual changes to the bundle sizes.  In other cases, we don't post a
 	// message and danger will delete its previous message
 	if (result.comparison === undefined || !bundlesContainNoChanges(result.comparison)) {
-		markdown(result.message);
+		// Check for bundle size regression
+		const sizeCheck = result.comparison
+		?.map((bundle: BundleComparison) => {
+			const totalMetric = bundle.commonBundleMetrics[totalSizeMetricName];
+			const totalParsedSizeDiff = totalMetric.compare.parsedSize - totalMetric.baseline.parsedSize;
+			return totalParsedSizeDiff > 100;
+
+		})
+		.reduce((prev: boolean, current: boolean) => {
+			return prev || current
+		});
+
+	 // Warn and add label to PR in case of bundle size regression
+	 if (sizeCheck) {
+		warn("Bundle size regression detected -- please investigate before merging!");
+		// Add the label to the PR
+		try {
+			await danger.github.utils.createOrAddLabel({color: "ff0000", description: "Significant bundle size regression (>5 KB)", name: "size regression"})
+		} catch (error) {
+			console.error(`Error adding label: ${error}`);
+		}
+	 }
+
+	 markdown(result.message);
 	} else {
 		console.log("No size changes detected, skipping posting PR comment");
 	}


### PR DESCRIPTION
## Description

[ADO Task 6929](https://dev.azure.com/fluidframework/internal/_workitems/edit/6929)

This PR detects significant bundle size regressions for PR's and adds a warning message for the author to investigate as well as a 'size-regression' label to the PR so these PR's can be easily filtered.


## Reviewer Guidance
Decided to add a warning message and label instead of fully blocking the PR completely -- open to opinions about this.
