### PR TITLE
Increase timeout for OpCompressor test

### DIFF
--- a/packages/runtime/container-runtime/src/test/opLifecycle/opCompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opCompressor.spec.ts
@@ -59,7 +59,7 @@ describe("OpCompressor", () => {
 					assert.strictEqual(compressedBatch.content[1].compression, undefined);
 					assert.strictEqual(compressedBatch.content[1].contents, undefined);
 				}
-			});
+			}).timeout(3000);
 		}));
 
 	describe("Unsupported batches", () =>


### PR DESCRIPTION
There were some recent changes to how the files are compiled and tested, and these changes caused an OpCompressor test to consistently timeout on the build pipeline.

This test was technically already running over the default 2 seconds before these changes, it's just now being failed in CI.