### PR TITLE
[Data Virtualization]: Create datastores with groupId via aqueduct

### DIFF
--- a/packages/framework/aqueduct/api-report/aqueduct.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.api.md
@@ -148,14 +148,14 @@ export abstract class PureDataObject<I extends DataObjectTypes = DataObjectTypes
 export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends DataObjectTypes = DataObjectTypes> implements IFluidDataStoreFactory, Partial<IProvideFluidDataStoreRegistry> {
     constructor(
     type: string, ctor: new (props: IDataObjectProps<I>) => TObj, sharedObjects: readonly IChannelFactory[], optionalProviders: FluidObjectSymbolProvider<I["OptionalProviders"]>, registryEntries?: NamedFluidDataStoreRegistryEntries, runtimeClass?: typeof FluidDataStoreRuntime);
-    createChildInstance(parentContext: IFluidDataStoreContext, initialState?: I["InitialState"]): Promise<TObj>;
-    createInstance(runtime: IContainerRuntimeBase, initialState?: I["InitialState"]): Promise<TObj>;
+    createChildInstance(parentContext: IFluidDataStoreContext, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
+    createInstance(runtime: IContainerRuntimeBase, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
     // (undocumented)
     protected createInstanceCore(context: IFluidDataStoreContextDetached, initialState?: I["InitialState"]): Promise<TObj>;
-    createInstanceWithDataStore(containerRuntime: IContainerRuntimeBase, initialState?: I["InitialState"], packagePath?: Readonly<string[]>): Promise<[TObj, IDataStore]>;
+    createInstanceWithDataStore(containerRuntime: IContainerRuntimeBase, initialState?: I["InitialState"], packagePath?: Readonly<string[]>, loadingGroupId?: string): Promise<[TObj, IDataStore]>;
     // (undocumented)
-    protected createNonRootInstanceCore(containerRuntime: IContainerRuntimeBase, packagePath: Readonly<string[]>, initialState?: I["InitialState"]): Promise<TObj>;
-    createPeerInstance(peerContext: IFluidDataStoreContext, initialState?: I["InitialState"]): Promise<TObj>;
+    protected createNonRootInstanceCore(containerRuntime: IContainerRuntimeBase, packagePath: Readonly<string[]>, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
+    createPeerInstance(peerContext: IFluidDataStoreContext, initialState?: I["InitialState"], loadingGroupId?: string): Promise<TObj>;
     // @deprecated
     createRootInstance(rootDataStoreId: string, runtime: IContainerRuntime, initialState?: I["InitialState"]): Promise<TObj>;
     // (undocumented)

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -214,7 +214,7 @@ export class PureDataObjectFactory<
 	 * @param context - The context being used to create the runtime
 	 * (the created object will have its own new context created as well)
 	 * @param initialState - The initial state to provide to the created data store.
-	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README} tries to delay load a data store. The service needs to support this feature, does not work for most services
+	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL, please read {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README}. The service needs to support this feature, does not work for most services
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
 	 */
@@ -238,7 +238,7 @@ export class PureDataObjectFactory<
 	 * @param context - The component context being used to create the object
 	 * (the created object will have its own new context created as well)
 	 * @param initialState - The initial state to provide to the created component.
-	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README} tries to delay load a data store. The service needs to support this feature, does not work for most services
+	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL, please read {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README}. The service needs to support this feature, does not work for most services
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
 	 */
@@ -262,7 +262,7 @@ export class PureDataObjectFactory<
 	 * The name in this registry for such record should match type of this factory.
 	 * @param runtime - container runtime. It's registry is used to create an object.
 	 * @param initialState - The initial state to provide to the created component.
-	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README} tries to delay load a data store. The service needs to support this feature, does not work for most services
+	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL, please read {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README}. The service needs to support this feature, does not work for most services
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
 	 */
@@ -280,7 +280,7 @@ export class PureDataObjectFactory<
 	 * the underlying infrastructure to get the data object to operate.
 	 * @param initialState - The initial state to provide to the created component.
 	 * @param packagePath - The path to the data store factory to use to create the data object.
-	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README} tries to delay load a data store. The service needs to support this feature, does not work for most services
+	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL, please read {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README}. The service needs to support this feature, does not work for most services
 	 * @returns an array containing the object created by this factory and an IDataStore object that enables users to
 	 * alias the data object.
 	 * The data object is attached only when it is attached to the handle graph that connects to an aliased object or

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -214,17 +214,20 @@ export class PureDataObjectFactory<
 	 * @param context - The context being used to create the runtime
 	 * (the created object will have its own new context created as well)
 	 * @param initialState - The initial state to provide to the created data store.
+	 * @param loadingGroupId - experimental feature, that tries to delay load a data store. The service needs to support this feature, does not work for most services
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
 	 */
 	public async createChildInstance(
 		parentContext: IFluidDataStoreContext,
 		initialState?: I["InitialState"],
+		loadingGroupId?: string,
 	): Promise<TObj> {
 		return this.createNonRootInstanceCore(
 			parentContext.containerRuntime,
 			[...parentContext.packagePath, this.type],
 			initialState,
+			loadingGroupId,
 		);
 	}
 
@@ -235,17 +238,20 @@ export class PureDataObjectFactory<
 	 * @param context - The component context being used to create the object
 	 * (the created object will have its own new context created as well)
 	 * @param initialState - The initial state to provide to the created component.
+	 * @param loadingGroupId - experimental feature, that tries to delay load a data store. The service needs to support this feature, does not work for most services
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
 	 */
 	public async createPeerInstance(
 		peerContext: IFluidDataStoreContext,
 		initialState?: I["InitialState"],
+		loadingGroupId?: string,
 	): Promise<TObj> {
 		return this.createNonRootInstanceCore(
 			peerContext.containerRuntime,
 			peerContext.packagePath,
 			initialState,
+			loadingGroupId,
 		);
 	}
 
@@ -256,14 +262,16 @@ export class PureDataObjectFactory<
 	 * The name in this registry for such record should match type of this factory.
 	 * @param runtime - container runtime. It's registry is used to create an object.
 	 * @param initialState - The initial state to provide to the created component.
+	 * @param loadingGroupId - experimental feature, that tries to delay load a data store. The service needs to support this feature, does not work for most services
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
 	 */
 	public async createInstance(
 		runtime: IContainerRuntimeBase,
 		initialState?: I["InitialState"],
+		loadingGroupId?: string,
 	): Promise<TObj> {
-		return this.createNonRootInstanceCore(runtime, [this.type], initialState);
+		return this.createNonRootInstanceCore(runtime, [this.type], initialState, loadingGroupId);
 	}
 
 	/**
@@ -272,6 +280,7 @@ export class PureDataObjectFactory<
 	 * the underlying infrastructure to get the data object to operate.
 	 * @param initialState - The initial state to provide to the created component.
 	 * @param packagePath - The path to the data store factory to use to create the data object.
+	 * @param loadingGroupId - experimental feature, that tries to delay load a data store. The service needs to support this feature, does not work for most services
 	 * @returns an array containing the object created by this factory and an IDataStore object that enables users to
 	 * alias the data object.
 	 * The data object is attached only when it is attached to the handle graph that connects to an aliased object or
@@ -281,8 +290,12 @@ export class PureDataObjectFactory<
 		containerRuntime: IContainerRuntimeBase,
 		initialState?: I["InitialState"],
 		packagePath?: Readonly<string[]>,
+		loadingGroupId?: string,
 	): Promise<[TObj, IDataStore]> {
-		const context = containerRuntime.createDetachedDataStore(packagePath ?? [this.type]);
+		const context = containerRuntime.createDetachedDataStore(
+			packagePath ?? [this.type],
+			loadingGroupId,
+		);
 		const { instance, runtime } = await createDataObject(
 			this.ctor,
 			context,
@@ -339,8 +352,9 @@ export class PureDataObjectFactory<
 		containerRuntime: IContainerRuntimeBase,
 		packagePath: Readonly<string[]>,
 		initialState?: I["InitialState"],
+		loadingGroupId?: string,
 	): Promise<TObj> {
-		const context = containerRuntime.createDetachedDataStore(packagePath);
+		const context = containerRuntime.createDetachedDataStore(packagePath, loadingGroupId);
 		return this.createInstanceCore(context, initialState);
 	}
 

--- a/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/pureDataObjectFactory.ts
@@ -214,7 +214,7 @@ export class PureDataObjectFactory<
 	 * @param context - The context being used to create the runtime
 	 * (the created object will have its own new context created as well)
 	 * @param initialState - The initial state to provide to the created data store.
-	 * @param loadingGroupId - experimental feature, that tries to delay load a data store. The service needs to support this feature, does not work for most services
+	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README} tries to delay load a data store. The service needs to support this feature, does not work for most services
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
 	 */
@@ -238,14 +238,14 @@ export class PureDataObjectFactory<
 	 * @param context - The component context being used to create the object
 	 * (the created object will have its own new context created as well)
 	 * @param initialState - The initial state to provide to the created component.
-	 * @param loadingGroupId - experimental feature, that tries to delay load a data store. The service needs to support this feature, does not work for most services
+	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README} tries to delay load a data store. The service needs to support this feature, does not work for most services
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
 	 */
 	public async createPeerInstance(
 		peerContext: IFluidDataStoreContext,
 		initialState?: I["InitialState"],
-		loadingGroupId?: string,
+		loadingGroupId?: string, // DO NOT USE, this is an experimental feature
 	): Promise<TObj> {
 		return this.createNonRootInstanceCore(
 			peerContext.containerRuntime,
@@ -262,7 +262,7 @@ export class PureDataObjectFactory<
 	 * The name in this registry for such record should match type of this factory.
 	 * @param runtime - container runtime. It's registry is used to create an object.
 	 * @param initialState - The initial state to provide to the created component.
-	 * @param loadingGroupId - experimental feature, that tries to delay load a data store. The service needs to support this feature, does not work for most services
+	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README} tries to delay load a data store. The service needs to support this feature, does not work for most services
 	 * @returns an object created by this factory. Data store and objects created are not attached to container.
 	 * They get attached only when a handle to one of them is attached to already attached objects.
 	 */
@@ -280,7 +280,7 @@ export class PureDataObjectFactory<
 	 * the underlying infrastructure to get the data object to operate.
 	 * @param initialState - The initial state to provide to the created component.
 	 * @param packagePath - The path to the data store factory to use to create the data object.
-	 * @param loadingGroupId - experimental feature, that tries to delay load a data store. The service needs to support this feature, does not work for most services
+	 * @param loadingGroupId - NOT production ready, EXPERIMENTAL {@link https://github.com/microsoft/FluidFramework/blob/main/packages/runtime/container-runtime/README.md | README} tries to delay load a data store. The service needs to support this feature, does not work for most services
 	 * @returns an array containing the object created by this factory and an IDataStore object that enables users to
 	 * alias the data object.
 	 * The data object is attached only when it is attached to the handle graph that connects to an aliased object or

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -24,7 +24,6 @@ import { SummaryType, type ISnapshotTree } from "@fluidframework/protocol-defini
 import { LoaderHeader } from "@fluidframework/container-definitions";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
 import type { ISnapshot } from "@fluidframework/driver-definitions";
-import { Deferred } from "@fluidframework/core-utils";
 
 import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions";
 
@@ -80,47 +79,48 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 
 	let provider: ITestObjectProvider;
 
-	const assertOmittedGroupIdTree = (snapshotTree: ISnapshotTree, message: string) => {
+	const assertOmittedTree = (
+		snapshotTree: ISnapshotTree,
+		groupId: string | undefined,
+		message: string,
+	) => {
 		assert(snapshotTree.omitted, message);
-		assert(snapshotTree.groupId === loadingGroupId, message);
+		assert(snapshotTree.groupId === groupId, message);
 		assert(Object.entries(snapshotTree.trees).length === 0, message);
 		assert(Object.entries(snapshotTree.blobs).length === 0, message);
 	};
 
-	const assertPopulatedRegularTree = (snapshotTree: ISnapshotTree, message: string) => {
+	const assertPopulatedTree = (
+		snapshotTree: ISnapshotTree,
+		groupId: string | undefined,
+		message: string,
+	) => {
 		assert(snapshotTree.omitted === undefined, message);
-		assert(snapshotTree.groupId === undefined, message);
+		assert(snapshotTree.groupId === groupId, message);
 		assert(Object.entries(snapshotTree.trees).length > 0, message);
 		assert(Object.entries(snapshotTree.blobs).length > 0, message);
 	};
 
-	const assertOmittedRegularTree = (snapshotTree: ISnapshotTree, message: string) => {
-		assert(snapshotTree.omitted, message);
-		assert(snapshotTree.groupId === undefined, message);
-		assert(Object.entries(snapshotTree.trees).length === 0, message);
-		assert(Object.entries(snapshotTree.blobs).length === 0, message);
-	};
-
-	const assertPopulatedGroupIdTree = (snapshotTree: ISnapshotTree, message: string) => {
-		assert(snapshotTree.omitted === undefined, message);
-		assert(snapshotTree.groupId === loadingGroupId, message);
-		assert(Object.entries(snapshotTree.trees).length > 0, message);
-		assert(Object.entries(snapshotTree.blobs).length > 0, message);
-	};
-
+	let dataObjectA = {} as unknown as TestDataObject;
+	let dataObjectB = {} as unknown as TestDataObject;
+	let dataObjectC = {} as unknown as TestDataObject;
+	let dataObjectD = {} as unknown as TestDataObject;
 	beforeEach("setup", async () => {
 		provider = getTestObjectProvider();
+		dataObjectA = {} as unknown as TestDataObject;
+		dataObjectB = {} as unknown as TestDataObject;
+		dataObjectC = {} as unknown as TestDataObject;
+		dataObjectD = {} as unknown as TestDataObject;
 	});
 
+	const noId = undefined;
 	const loadingGroupId = "loadingGroupId";
 	const loadingGroupId2 = "loadingGroupId2";
-	it("Can create loadingGroupId", async () => {
-		const container = await provider.createContainer(runtimeFactory);
-		const mainObject = (await container.getEntryPoint()) as TestDataObject;
-		const containerRuntime = mainObject.containerRuntime;
-
-		// Testing all apis for creating a data store with a loadingGroupId
-		const dataObjectA = await dataObjectFactory.createInstance(
+	const createDataObjectsWithGroupIds = async (
+		mainObject: TestDataObject,
+		containerRuntime: ContainerRuntime,
+	) => {
+		dataObjectA = await dataObjectFactory.createInstance(
 			containerRuntime,
 			undefined,
 			loadingGroupId,
@@ -129,26 +129,36 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			testDataObjectType,
 			loadingGroupId,
 		);
-		const dataObjectB = (await dataStoreB.entryPoint.get()) as TestDataObject;
+		dataObjectB = (await dataStoreB.entryPoint.get()) as TestDataObject;
 
-		const [dataObjectC] = await dataObjectFactory.createInstanceWithDataStore(
+		[dataObjectC] = await dataObjectFactory.createInstanceWithDataStore(
 			containerRuntime,
 			undefined,
 			undefined,
 			loadingGroupId2,
 		);
-		const [_, dataStoreD] = await dataObjectFactory.createInstanceWithDataStore(
+		const [objD, dataStoreD] = await dataObjectFactory.createInstanceWithDataStore(
 			containerRuntime,
 			undefined,
 			undefined,
 			loadingGroupId2,
 		);
+		dataObjectD = objD;
 
 		mainObject._root.set("dataObjectA", dataObjectA.handle);
 		mainObject._root.set("dataObjectB", dataObjectB.handle);
 		mainObject._root.set("dataObjectC", dataObjectC.handle);
 		const result = await dataStoreD.trySetAlias("dataObjectD");
 		assert(result === "Success", "Alias should be set");
+	};
+
+	it("Can create loadingGroupId", async () => {
+		const container = await provider.createContainer(runtimeFactory);
+		const mainObject = (await container.getEntryPoint()) as TestDataObject;
+		const containerRuntime = mainObject.containerRuntime;
+
+		// Testing all apis for creating a data store with a loadingGroupId
+		await createDataObjectsWithGroupIds(mainObject, containerRuntime);
 
 		const { summarizer } = await createSummarizerFromFactory(
 			provider,
@@ -207,24 +217,12 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		}
 	});
 
-	// TODO: enable this test, because it fails for local server.
 	it("Can create loadingGroupId via detached flow", async () => {
 		const container = await provider.createDetachedContainer(runtimeFactory);
 		const mainObject = (await container.getEntryPoint()) as TestDataObject;
 		const containerRuntime = mainObject.containerRuntime;
 
-		const dataStore = await containerRuntime.createDataStore(
-			testDataObjectType,
-			loadingGroupId,
-		);
-		const dataStore2 = await containerRuntime.createDataStore(
-			testDataObjectType,
-			loadingGroupId,
-		);
-		const dataObjectA = (await dataStore.entryPoint.get()) as TestDataObject;
-		const dataObjectB = (await dataStore2.entryPoint.get()) as TestDataObject;
-		mainObject._root.set("dataObjectA", dataObjectA.handle);
-		mainObject._root.set("dataObjectB", dataObjectB.handle);
+		await createDataObjectsWithGroupIds(mainObject, containerRuntime);
 
 		await provider.attachDetachedContainer(container);
 		// TODO: Enable this portion in tinylicious
@@ -261,23 +259,9 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		const mainObject = (await container.getEntryPoint()) as TestDataObject;
 		const containerRuntime = mainObject.containerRuntime;
 
-		// Create data stores with loadingGroupIds
-		const [dataObjectA] = await dataObjectFactory.createInstanceWithDataStore(
-			containerRuntime,
-			undefined,
-			undefined,
-			loadingGroupId,
-		);
-		const dataStoreB = await containerRuntime.createDataStore(
-			testDataObjectType,
-			loadingGroupId,
-		);
-		const dataObjectB = (await dataStoreB.entryPoint.get()) as TestDataObject;
-
-		// Attach the data stores
-		mainObject._root.set("dataObjectA", dataObjectA.handle);
-		mainObject._root.set("dataObjectB", dataObjectB.handle);
+		await createDataObjectsWithGroupIds(mainObject, containerRuntime);
 		dataObjectA._root.set("A", "A");
+		mainObject._root.set("doubleHandleA", dataObjectA.handle);
 		dataObjectB._root.set("B", "B");
 
 		// Summarize
@@ -287,11 +271,12 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			container,
 			dataObjectFactory,
 		);
-		const { summaryVersion } = await summarizeNow(summarizer);
+		const { summaryVersion, summaryRefSeq } = await summarizeNow(summarizer);
 
 		// Intercept the first snapshot call via the creation of the driver
 		const documentServiceFactory = provider.documentServiceFactory;
-		const deferredSnapshot: Deferred<ISnapshot> = new Deferred();
+		let snapshotCaptured: ISnapshot | undefined;
+		let callCount = 0;
 		interceptResult(
 			documentServiceFactory,
 			documentServiceFactory.createDocumentService,
@@ -299,7 +284,8 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 				interceptResult(documentService, documentService.connectToStorage, (storage) => {
 					assert(storage.getSnapshot !== undefined, "Test can't run without getSnapshot");
 					interceptResult(storage, storage.getSnapshot, (snapshot) => {
-						deferredSnapshot.resolve(snapshot);
+						snapshotCaptured = snapshot;
+						callCount++;
 					});
 				});
 			},
@@ -308,7 +294,7 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		// Load from the summary
 		const configProvider = createTestConfigProvider();
 		configProvider.set("Fluid.Container.UseLoadingGroupIdForSnapshotFetch", true);
-		const container3 = await provider.loadContainer(
+		const container2 = await provider.loadContainer(
 			runtimeFactory,
 			{ configProvider },
 			{
@@ -317,70 +303,118 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		);
 
 		// Get the snapshot and runtime we just loaded from
-		const loadingSnapshot3 = await deferredSnapshot.promise;
+		const loadingSnapshot = snapshotCaptured;
+		assert(loadingSnapshot !== undefined, "should have captured loading snapshot!");
 
 		// Testing the get snapshot call
-		const mainObject3 = (await container3.getEntryPoint()) as TestDataObject;
-		const runtime3 = mainObject3.containerRuntime;
-		assert(runtime3.storage.getSnapshot !== undefined, "getSnapshot should be defined");
-		const snapshot3 = await runtime3.storage.getSnapshot();
-		assert.deepEqual(snapshot3, loadingSnapshot3, "Mismatched initial snapshots");
+		const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
+		const runtime2 = mainObject2.containerRuntime;
+		assert(runtime2.storage.getSnapshot !== undefined, "getSnapshot should be defined");
+		assert(callCount === 1, "Should have only called getSnapshot once");
+		assert(loadingSnapshot.sequenceNumber === summaryRefSeq, "Loaded from wrong snapshot");
 
 		// Snapshot validation (a snapshot call with NO loadingGroupIds)
-		const channelsTree = loadingSnapshot3.snapshotTree.trees[".channels"];
+		const channelsTree = loadingSnapshot.snapshotTree.trees[".channels"];
 		const mainObjectTree = channelsTree.trees[mainObject.id];
 		const dataObjectATree = channelsTree.trees[dataObjectA.id];
 		const dataObjectBTree = channelsTree.trees[dataObjectB.id];
+		const dataObjectCTree = channelsTree.trees[dataObjectC.id];
+		const dataObjectDTree = channelsTree.trees[dataObjectD.id];
 
-		assertPopulatedRegularTree(mainObjectTree, "mainObject should be regular and populated");
-		assertOmittedGroupIdTree(dataObjectATree, "Incorrect tree for A");
-		assertOmittedGroupIdTree(dataObjectBTree, "Incorrect tree for B");
+		assertPopulatedTree(mainObjectTree, noId, "mainObject tree not right");
+		assertOmittedTree(dataObjectATree, loadingGroupId, "Wrong tree for A");
+		assertOmittedTree(dataObjectBTree, loadingGroupId, "Wrong tree for B");
+		assertOmittedTree(dataObjectCTree, loadingGroupId2, "Wrong tree for C");
+		assertOmittedTree(dataObjectDTree, loadingGroupId2, "Wrong tree for D");
 
-		// intercept loadingGroupId snapshot
-		const groupIdSnapshot: Deferred<ISnapshot> = new Deferred();
-		interceptResult(runtime3.storage, runtime3.storage.getSnapshot, (snapshot) => {
-			groupIdSnapshot.resolve(snapshot);
-		});
+		callCount = 0;
 
 		// Try to load the data stores with groupIds
-		const handleA3 = mainObject3._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
-		const handleB3 = mainObject3._root.get<IFluidHandle<TestDataObject>>("dataObjectB");
-		assert(handleA3 !== undefined, "handleA3 should not be undefined");
-		assert(handleB3 !== undefined, "handleB3 should not be undefined");
+		const doubleHandleA2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("doubleHandleA");
+		const handleA2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
+		const handleB2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectB");
+		assert(doubleHandleA2 !== undefined, "doubleHandleA2 should not be undefined");
+		assert(handleA2 !== undefined, "handleA2 should not be undefined");
+		assert(handleB2 !== undefined, "handleB2 should not be undefined");
 
 		// Prep context snapshot intercept
 		// Hack to inspect the runtime's dataStores
-		const stores = (runtime3 as any).dataStores;
+		const stores = (runtime2 as any).dataStores;
 		const contextA = (await stores.getDataStore(dataObjectA.id, {})) as IFluidDataStoreContext;
 		const contextB = (await stores.getDataStore(dataObjectB.id, {})) as IFluidDataStoreContext;
+		const contextC = (await stores.getDataStore(dataObjectC.id, {})) as IFluidDataStoreContext;
+		const contextD = (await stores.getDataStore(dataObjectD.id, {})) as IFluidDataStoreContext;
 		assert(contextA.baseSnapshot !== undefined, "contextA should have a baseSnapshot");
 		assert(contextB.baseSnapshot !== undefined, "contextB should have a baseSnapshot");
-		assertOmittedGroupIdTree(contextA.baseSnapshot, "contextA tree should be omitted");
-		assertOmittedGroupIdTree(contextB.baseSnapshot, "contextB tree should be omitted");
+		assert(contextC.baseSnapshot !== undefined, "contextC should have a baseSnapshot");
+		assert(contextD.baseSnapshot !== undefined, "contextD should have a baseSnapshot");
+
+		assert.equal(callCount, 0, "Should not have made any network calls");
+		assertOmittedTree(contextA.baseSnapshot, loadingGroupId, "contextA tree not omitted");
+		assertOmittedTree(contextB.baseSnapshot, loadingGroupId, "contextB tree not omitted");
+		assertOmittedTree(contextC.baseSnapshot, loadingGroupId2, "contextC tree not omitted");
+		assertOmittedTree(contextD.baseSnapshot, loadingGroupId2, "contextD tree not omitted");
 
 		// loading group call
-		const dataObjectA3 = await handleA3.get();
-		const dataObjectB3 = await handleB3.get();
-		assert.equal(dataObjectA3._root.get("A"), "A", "A should be set");
-		assert.equal(dataObjectB3._root.get("B"), "B", "B should be set");
+		assert.equal(callCount, 0, "Should not have made any network calls");
+		const [dataObjectA2, dataObjectB2] = await Promise.all([handleA2.get(), handleB2.get()]);
+		assert.equal(callCount, 1, "Should have only called getSnapshot once!");
+		assert.equal(dataObjectA2._root.get("A"), "A", "A should be set");
+		assert.equal(dataObjectB2._root.get("B"), "B", "B should be set");
+		assert.equal(callCount, 1, "retrieving data should not have made any network calls");
+
+		callCount = 0;
+		const aDataObjectA2 = await doubleHandleA2.get();
+		assert.equal(callCount, 0, "Network call made on same object!");
+		assert.equal(aDataObjectA2, dataObjectA2, "Should be the same object");
 
 		// Testing the get snapshot call with loadingGroupId
-		const loadingGroupIdSnapshot = await runtime3.storage.getSnapshot({
-			loadingGroupIds: [loadingGroupId],
-			versionId: summaryVersion,
-		});
-
-		const groupSnapshot = await groupIdSnapshot.promise;
-		assert.deepEqual(groupSnapshot, loadingGroupIdSnapshot, "Should be groupId snapshot");
+		const groupSnapshot = snapshotCaptured;
+		assert(groupSnapshot !== undefined, "should have captured group snapshot!");
+		assert.deepEqual(groupSnapshot.sequenceNumber, summaryRefSeq, "Should be groupId snapshot");
 
 		// Snapshot validation (a snapshot call for loadingGroupIds = [loadingGroupId])
 		const channelsTree2 = groupSnapshot.snapshotTree.trees[".channels"];
 		const mainObjectTree2 = channelsTree2.trees[mainObject.id];
 		const dataObjectATree2 = channelsTree2.trees[dataObjectA.id];
 		const dataObjectBTree2 = channelsTree2.trees[dataObjectB.id];
+		const dataObjectCTree2 = channelsTree2.trees[dataObjectC.id];
+		const dataObjectDTree2 = channelsTree2.trees[dataObjectD.id];
 
-		assertOmittedRegularTree(mainObjectTree2, "mainObject should be regular and omitted");
-		assertPopulatedGroupIdTree(dataObjectATree2, "Incorrect tree for A2");
-		assertPopulatedGroupIdTree(dataObjectBTree2, "Incorrect tree for B2");
+		assertOmittedTree(mainObjectTree2, noId, "mainObject tree incorrect");
+		assertPopulatedTree(dataObjectATree2, loadingGroupId, "Incorrect tree for A2");
+		assertPopulatedTree(dataObjectBTree2, loadingGroupId, "Incorrect tree for B2");
+		assertOmittedTree(dataObjectCTree2, loadingGroupId2, "Incorrect tree for C2");
+		assertOmittedTree(dataObjectDTree2, loadingGroupId2, "Incorrect tree for D2");
+
+		const handleC2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectC");
+		assert.equal(callCount, 0, "call count should be reset");
+		// This call realizes the data object
+		const handleD2 = await runtime2.getAliasedDataStoreEntryPoint("dataObjectD");
+		assert.equal(callCount, 1, "Extra calls made");
+		assert(handleC2 !== undefined, "handleC2 should not be undefined");
+		assert(handleD2 !== undefined, "handleD2 should not be undefined");
+
+		callCount = 0;
+		await handleC2.get();
+		await handleD2.get();
+		assert.equal(callCount, 0, "Some extra calls were made");
+
+		// Snapshot validation (a snapshot call for loadingGroupIds = [loadingGroupId])
+		const group2Snapshot = snapshotCaptured;
+		assert(group2Snapshot !== undefined, "should have captured group2 snapshot!");
+		assert.deepEqual(group2Snapshot.sequenceNumber, summaryRefSeq, "Unexpected snapshot");
+		const channels2Tree2 = group2Snapshot.snapshotTree.trees[".channels"];
+		const mainObject2Tree2 = channels2Tree2.trees[mainObject.id];
+		const dataObjectA2Tree2 = channels2Tree2.trees[dataObjectA.id];
+		const dataObjectB2Tree2 = channels2Tree2.trees[dataObjectB.id];
+		const dataObjectC2Tree2 = channels2Tree2.trees[dataObjectC.id];
+		const dataObjectD2Tree2 = channels2Tree2.trees[dataObjectD.id];
+
+		assertOmittedTree(mainObject2Tree2, noId, "Not omitted tree for mainObject");
+		assertOmittedTree(dataObjectA2Tree2, loadingGroupId, "Not omitted tree for A2");
+		assertOmittedTree(dataObjectB2Tree2, loadingGroupId, "Not omitted tree for B2");
+		assertPopulatedTree(dataObjectC2Tree2, loadingGroupId2, "Not populated tree for C2");
+		assertPopulatedTree(dataObjectD2Tree2, loadingGroupId2, "Not populated tree for D2");
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -194,26 +194,10 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			const dataObjectB2 = (await handleB2.get()) as TestDataObject;
 			const dataObjectC2 = (await handleC2.get()) as TestDataObject;
 			const dataObjectD2 = (await handleD2.get()) as TestDataObject;
-			assert.equal(
-				dataObjectA2.loadingGroupId,
-				loadingGroupId,
-				"dataObjectA groupId should be set",
-			);
-			assert.equal(
-				dataObjectB2.loadingGroupId,
-				loadingGroupId,
-				"dataObjectB groupId should be set",
-			);
-			assert.equal(
-				dataObjectC2.loadingGroupId,
-				loadingGroupId2,
-				"dataObjectB groupId should be set",
-			);
-			assert.equal(
-				dataObjectD2.loadingGroupId,
-				loadingGroupId2,
-				"dataObjectB groupId should be set",
-			);
+			assert.equal(dataObjectA2.loadingGroupId, loadingGroupId, "A groupId not set");
+			assert.equal(dataObjectB2.loadingGroupId, loadingGroupId, "B groupId not set");
+			assert.equal(dataObjectC2.loadingGroupId, loadingGroupId2, "B groupId not set");
+			assert.equal(dataObjectD2.loadingGroupId, loadingGroupId2, "B groupId not set");
 		}
 	});
 


### PR DESCRIPTION
[AB#7382](https://dev.azure.com/fluidframework/internal/_workitems/edit/7382)

Enable `PureDataObjectFactory` to create `PureDataObject`s with loadingGroupId