### PR TITLE
build(client-dds-test-utils): fix build dependencies

### DIFF
--- a/packages/dds/test-dds-utils/.eslintrc.cjs
+++ b/packages/dds/test-dds-utils/.eslintrc.cjs
@@ -5,9 +5,12 @@
 
 module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
+	parserOptions: {
+		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
+	},
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off",
+		// This package implements test utils to be run under Node.JS.
 		"import/no-nodejs-modules": "off",
-		"unicorn/prefer-module": "off",
 	},
 };

--- a/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
+++ b/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
@@ -4,19 +4,19 @@
 
 ```ts
 
-import { AsyncGenerator as AsyncGenerator_2 } from '@fluid-private/stochastic-test-utils';
-import { AsyncReducer } from '@fluid-private/stochastic-test-utils';
-import { BaseFuzzTestState } from '@fluid-private/stochastic-test-utils';
-import { IChannelFactory } from '@fluidframework/datastore-definitions';
-import { IIdCompressor } from '@fluidframework/id-compressor';
-import { IIdCompressorCore } from '@fluidframework/id-compressor';
-import { IMockContainerRuntimeOptions } from '@fluidframework/test-runtime-utils';
-import { ISharedObject } from '@fluidframework/shared-object-base';
+import type { AsyncGenerator as AsyncGenerator_2 } from '@fluid-private/stochastic-test-utils';
+import type { AsyncReducer } from '@fluid-private/stochastic-test-utils';
+import type { BaseFuzzTestState } from '@fluid-private/stochastic-test-utils';
+import type { IChannelFactory } from '@fluidframework/datastore-definitions';
+import type { IIdCompressor } from '@fluidframework/id-compressor';
+import type { IIdCompressorCore } from '@fluidframework/id-compressor';
+import type { IMockContainerRuntimeOptions } from '@fluidframework/test-runtime-utils';
+import type { ISharedObject } from '@fluidframework/shared-object-base';
 import { MockContainerRuntimeFactoryForReconnection } from '@fluidframework/test-runtime-utils';
-import { MockContainerRuntimeForReconnection } from '@fluidframework/test-runtime-utils';
-import { MockFluidDataStoreRuntime } from '@fluidframework/test-runtime-utils';
-import { SaveInfo } from '@fluid-private/stochastic-test-utils';
-import { SerializedIdCompressorWithNoSession } from '@fluidframework/id-compressor';
+import type { MockContainerRuntimeForReconnection } from '@fluidframework/test-runtime-utils';
+import type { MockFluidDataStoreRuntime } from '@fluidframework/test-runtime-utils';
+import type { SaveInfo } from '@fluid-private/stochastic-test-utils';
+import type { SerializedIdCompressorWithNoSession } from '@fluidframework/id-compressor';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
 // @internal (undocumented)

--- a/packages/dds/test-dds-utils/package.json
+++ b/packages/dds/test-dds-utils/package.json
@@ -54,6 +54,9 @@
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "fluid-build . --task api",
 		"build:esnext": "tsc --project ./tsconfig.json",
+		"build:test": "npm run build:test:esm && npm run build:test:cjs",
+		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack . --entrypoints .",
 		"check:release-tags": "api-extractor run --local --config ./api-extractor-lint.json",
 		"ci:build:docs": "api-extractor run",
@@ -67,11 +70,11 @@
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../../.prettierignore",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
-		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
-		"test:mocha:base": "mocha --ignore \"dist/test/types/*\" -r node_modules/@fluid-internal/mocha-test-setup",
-		"test:mocha:cjs": "mocha --recursive \"dist/test/**/*.spec.*js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
-		"test:mocha:esm": "mocha --recursive \"lib/test/**/*.spec.*js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
-		"test:mocha:suite": "npm run test:mocha:base -- \"dist/test/ddsSuiteCases/*js\"",
+		"test:mocha": "npm run test:mocha:esm && npm run test:mocha:cjs",
+		"test:mocha:base": "mocha --ignore \"dist/test/types/*\" --ignore \"lib/test/types/*\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
+		"test:mocha:cjs": "pnpm test:mocha:base --recursive \"dist/test/**/*.spec.*js\"",
+		"test:mocha:esm": "pnpm test:mocha:base --recursive \"lib/test/**/*.spec.*js\"",
+		"test:mocha:suite": "pnpm test:mocha:base \"lib/test/ddsSuiteCases/*js\"",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"tsc": "fluid-tsc commonjs --project ./tsconfig.cjs.json && copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist"
 	},
@@ -139,7 +142,15 @@
 					"api-extractor:esnext"
 				],
 				"script": false
-			}
+			},
+			"build:test:cjs": [
+				"...",
+				"@fluid-private/stochastic-test-utils#build:test"
+			],
+			"build:test:esm": [
+				"...",
+				"@fluid-private/stochastic-test-utils#build:test"
+			]
 		}
 	},
 	"typeValidation": {

--- a/packages/dds/test-dds-utils/src/clientLoading.ts
+++ b/packages/dds/test-dds-utils/src/clientLoading.ts
@@ -3,16 +3,16 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type {
 	IIdCompressorCore,
 	SerializedIdCompressorWithNoSession,
 } from "@fluidframework/id-compressor";
-import {
+import type {
 	MockFluidDataStoreRuntime,
 	MockContainerRuntimeForReconnection,
 } from "@fluidframework/test-runtime-utils";
-import { IChannelFactory } from "@fluidframework/datastore-definitions";
-import { ISummaryTree } from "@fluidframework/protocol-definitions";
+import type { IChannelFactory } from "@fluidframework/datastore-definitions";
+import type { ISummaryTree } from "@fluidframework/protocol-definitions";
 
 /**
  * @internal

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -7,41 +7,44 @@ import { strict as assert } from "node:assert";
 import { mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
-import {
+import type {
 	IIdCompressor,
 	IIdCompressorCore,
 	SerializedIdCompressorWithNoSession,
 } from "@fluidframework/id-compressor";
-import {
+import type {
 	BaseFuzzTestState,
+	AsyncGenerator,
+	IRandom,
+	AsyncReducer,
+	SaveInfo,
+} from "@fluid-private/stochastic-test-utils";
+import {
 	chainAsync,
 	createFuzzDescribe,
 	defaultOptions,
 	done,
 	ExitBehavior,
-	AsyncGenerator,
 	asyncGeneratorFromArray,
 	interleaveAsync,
-	IRandom,
 	makeRandom,
 	performFuzzActionsAsync,
-	AsyncReducer,
-	SaveInfo,
 	saveOpsToFile,
 	takeAsync,
 	createWeightedAsyncGenerator,
 } from "@fluid-private/stochastic-test-utils";
+import type { IMockContainerRuntimeOptions } from "@fluidframework/test-runtime-utils";
 import {
 	MockFluidDataStoreRuntime,
 	MockStorage,
 	MockContainerRuntimeFactoryForReconnection,
-	IMockContainerRuntimeOptions,
 } from "@fluidframework/test-runtime-utils";
-import { IChannelFactory, IChannelServices } from "@fluidframework/datastore-definitions";
+import type { IChannelFactory, IChannelServices } from "@fluidframework/datastore-definitions";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { unreachableCase } from "@fluidframework/core-utils";
 import { AttachState } from "@fluidframework/container-definitions";
-import { FuzzTestMinimizer, MinimizationTransform } from "./minification.js";
+import type { MinimizationTransform } from "./minification.js";
+import { FuzzTestMinimizer } from "./minification.js";
 import {
 	hasStashData,
 	type Client,

--- a/packages/dds/test-dds-utils/src/gcTestRunner.ts
+++ b/packages/dds/test-dds-utils/src/gcTestRunner.ts
@@ -4,7 +4,7 @@
  */
 
 import { strict as assert } from "node:assert";
-import { ISharedObject } from "@fluidframework/shared-object-base";
+import type { ISharedObject } from "@fluidframework/shared-object-base";
 
 /**
  * Defines a set of functions to be passed to the GC test runner.

--- a/packages/dds/test-dds-utils/src/index.ts
+++ b/packages/dds/test-dds-utils/src/index.ts
@@ -3,21 +3,21 @@
  * Licensed under the MIT License.
  */
 
-export { IGCTestProvider, runGCTests } from "./gcTestRunner.js";
-export {
+export type { IGCTestProvider } from "./gcTestRunner.js";
+export { runGCTests } from "./gcTestRunner.js";
+export type {
 	AddClient,
 	BaseOperation,
 	ChangeConnectionState,
 	ClientSpec,
-	createDDSFuzzSuite,
 	DDSFuzzModel,
 	DDSFuzzSuiteOptions,
 	DDSFuzzTestState,
-	defaultDDSFuzzSuiteOptions,
 	DDSFuzzHarnessEvents,
 	Synchronize,
-	replayTest,
 } from "./ddsFuzzHarness.js";
-export { createSnapshotSuite, ISnapshotSuite } from "./ddsSnapshotHarness.js";
-export { MinimizationTransform } from "./minification.js";
-export { Client } from "./clientLoading.js";
+export { createDDSFuzzSuite, defaultDDSFuzzSuiteOptions, replayTest } from "./ddsFuzzHarness.js";
+export type { ISnapshotSuite } from "./ddsSnapshotHarness.js";
+export { createSnapshotSuite } from "./ddsSnapshotHarness.js";
+export type { MinimizationTransform } from "./minification.js";
+export type { Client } from "./clientLoading.js";

--- a/packages/dds/test-dds-utils/src/minification.ts
+++ b/packages/dds/test-dds-utils/src/minification.ts
@@ -3,17 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { SaveInfo, makeRandom } from "@fluid-private/stochastic-test-utils";
-import { IChannelFactory } from "@fluidframework/datastore-definitions";
+import type { SaveInfo } from "@fluid-private/stochastic-test-utils";
+import { makeRandom } from "@fluid-private/stochastic-test-utils";
+import type { IChannelFactory } from "@fluidframework/datastore-definitions";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import {
+import type {
 	BaseOperation,
 	DDSFuzzHarnessEvents,
 	DDSFuzzModel,
 	DDSFuzzSuiteOptions,
-	ReducerPreconditionError,
-	replayTest,
 } from "./ddsFuzzHarness.js";
+import { ReducerPreconditionError, replayTest } from "./ddsFuzzHarness.js";
 
 /**
  * A function which takes in an operation and modifies it by reference to be more

--- a/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "node:assert";
-import fs from "node:fs";
-import path from "node:path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 import execa from "execa";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
@@ -12,32 +12,36 @@ import {
 	MockContainerRuntimeFactoryForReconnection,
 	MockFluidDataStoreRuntime,
 } from "@fluidframework/test-runtime-utils";
-import { IChannelFactory } from "@fluidframework/datastore-definitions";
-import { AsyncGenerator, chainAsync, done, takeAsync } from "@fluid-private/stochastic-test-utils";
+import type { IChannelFactory } from "@fluidframework/datastore-definitions";
+import type { AsyncGenerator } from "@fluid-private/stochastic-test-utils";
+import { chainAsync, done, takeAsync } from "@fluid-private/stochastic-test-utils";
 // eslint-disable-next-line import/no-internal-modules
 import { Counter } from "@fluid-private/stochastic-test-utils/test/utils";
-import {
+import type {
 	BaseOperation,
 	ChangeConnectionState,
 	ClientSpec,
-	defaultDDSFuzzSuiteOptions,
 	DDSFuzzTestState,
 	DDSFuzzSuiteOptions,
 	DDSFuzzModel,
+	Synchronize,
+	DDSFuzzHarnessEvents,
+	TriggerRebase,
+} from "../ddsFuzzHarness.js";
+import {
+	defaultDDSFuzzSuiteOptions,
 	mixinClientSelection,
 	mixinNewClient,
 	mixinReconnect,
 	mixinSynchronization,
 	runTestForSeed,
-	Synchronize,
-	DDSFuzzHarnessEvents,
 	mixinRebase,
-	TriggerRebase,
 	mixinAttach,
 	mixinStashedClient,
 } from "../ddsFuzzHarness.js";
 import { hasStashData, type Client } from "../clientLoading.js";
-import { Operation, SharedNothingFactory, baseModel, isNoopOp } from "./sharedNothing.js";
+import type { Operation, SharedNothingFactory } from "./sharedNothing.js";
+import { baseModel, isNoopOp } from "./sharedNothing.js";
 import { _dirname } from "./dirname.cjs";
 
 type Model = DDSFuzzModel<SharedNothingFactory, Operation | ChangeConnectionState>;

--- a/packages/dds/test-dds-utils/src/test/ddsSuiteCases/dirname.cts
+++ b/packages/dds/test-dds-utils/src/test/ddsSuiteCases/dirname.cts
@@ -10,4 +10,5 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
+// eslint-disable-next-line unicorn/prefer-module
 export const _dirname = __dirname;

--- a/packages/dds/test-dds-utils/src/test/ddsSuiteCases/dotOnly.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsSuiteCases/dotOnly.ts
@@ -4,8 +4,10 @@
  */
 
 import { takeAsync } from "@fluid-private/stochastic-test-utils";
-import { Operation, SharedNothingFactory, baseModel } from "../sharedNothing.js";
-import { ChangeConnectionState, DDSFuzzModel, createDDSFuzzSuite } from "../../ddsFuzzHarness.js";
+import type { Operation, SharedNothingFactory } from "../sharedNothing.js";
+import { baseModel } from "../sharedNothing.js";
+import type { ChangeConnectionState, DDSFuzzModel } from "../../ddsFuzzHarness.js";
+import { createDDSFuzzSuite } from "../../ddsFuzzHarness.js";
 
 const shortModel: DDSFuzzModel<SharedNothingFactory, Operation | ChangeConnectionState> = {
 	...baseModel,

--- a/packages/dds/test-dds-utils/src/test/ddsSuiteCases/dotSkip.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsSuiteCases/dotSkip.ts
@@ -4,8 +4,10 @@
  */
 
 import { takeAsync } from "@fluid-private/stochastic-test-utils";
-import { Operation, SharedNothingFactory, baseModel } from "../sharedNothing.js";
-import { ChangeConnectionState, DDSFuzzModel, createDDSFuzzSuite } from "../../ddsFuzzHarness.js";
+import type { Operation, SharedNothingFactory } from "../sharedNothing.js";
+import { baseModel } from "../sharedNothing.js";
+import type { ChangeConnectionState, DDSFuzzModel } from "../../ddsFuzzHarness.js";
+import { createDDSFuzzSuite } from "../../ddsFuzzHarness.js";
 
 const shortModel: DDSFuzzModel<SharedNothingFactory, Operation | ChangeConnectionState> = {
 	...baseModel,

--- a/packages/dds/test-dds-utils/src/test/ddsSuiteCases/failure.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsSuiteCases/failure.ts
@@ -3,8 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { Operation, SharedNothingFactory, baseModel } from "../sharedNothing.js";
-import { ChangeConnectionState, DDSFuzzModel, createDDSFuzzSuite } from "../../ddsFuzzHarness.js";
+import type { Operation, SharedNothingFactory } from "../sharedNothing.js";
+import { baseModel } from "../sharedNothing.js";
+import type { ChangeConnectionState, DDSFuzzModel } from "../../ddsFuzzHarness.js";
+import { createDDSFuzzSuite } from "../../ddsFuzzHarness.js";
 import { _dirname } from "./dirname.cjs";
 
 const model: DDSFuzzModel<SharedNothingFactory, Operation | ChangeConnectionState> = {

--- a/packages/dds/test-dds-utils/src/test/ddsSuiteCases/failure.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsSuiteCases/failure.ts
@@ -19,6 +19,6 @@ const model: DDSFuzzModel<SharedNothingFactory, Operation | ChangeConnectionStat
 
 createDDSFuzzSuite(model, {
 	defaultTestCount: 2,
-	// Note: this should place files in dist/test-dds-utils/ddsSuiteCases/failing-configuration
+	// Note: this should place files in (dist|lib)/test-dds-utils/ddsSuiteCases/failing-configuration
 	saveFailures: { directory: _dirname },
 });

--- a/packages/dds/test-dds-utils/src/test/ddsSuiteCases/replay.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsSuiteCases/replay.ts
@@ -3,10 +3,12 @@
  * Licensed under the MIT License.
  */
 import { strict as assert } from "node:assert";
-import path from "node:path";
+import * as path from "node:path";
 
-import { Operation, SharedNothingFactory, baseModel } from "../sharedNothing.js";
-import { DDSFuzzModel, createDDSFuzzSuite } from "../../ddsFuzzHarness.js";
+import type { Operation, SharedNothingFactory } from "../sharedNothing.js";
+import { baseModel } from "../sharedNothing.js";
+import type { DDSFuzzModel } from "../../ddsFuzzHarness.js";
+import { createDDSFuzzSuite } from "../../ddsFuzzHarness.js";
 import { _dirname } from "./dirname.cjs";
 
 let currentIndex = 0;

--- a/packages/dds/test-dds-utils/src/test/dirname.cts
+++ b/packages/dds/test-dds-utils/src/test/dirname.cts
@@ -10,4 +10,5 @@
 //   - Export '__dirname' from a .cjs file in the same directory.
 //
 // Note that *.cjs files are always CommonJS, but can be imported from ESM.
+// eslint-disable-next-line unicorn/prefer-module
 export const _dirname = __dirname;

--- a/packages/dds/test-dds-utils/src/test/sharedNothing.ts
+++ b/packages/dds/test-dds-utils/src/test/sharedNothing.ts
@@ -4,14 +4,14 @@
  */
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils";
 import { SharedObject } from "@fluidframework/shared-object-base";
-import {
+import type {
 	IChannelAttributes,
 	IChannelFactory,
 	IChannelServices,
 	IChannelStorageService,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
-import { ChangeConnectionState, DDSFuzzModel, type BaseOperation } from "../ddsFuzzHarness.js";
+import type { ChangeConnectionState, DDSFuzzModel, BaseOperation } from "../ddsFuzzHarness.js";
 
 /**
  * Mock DDS which holds no data.
@@ -31,7 +31,7 @@ class SharedNothing extends SharedObject {
 	public noopCalls = 0;
 	public methodCalls: string[] = [];
 
-	constructor(
+	public constructor(
 		public readonly id: string,
 		public readonly runtime: IFluidDataStoreRuntime,
 		public readonly attributes: IChannelAttributes,

--- a/packages/dds/test-dds-utils/src/test/tsconfig.cjs.json
+++ b/packages/dds/test-dds-utils/src/test/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use fluid-tsc commonjs.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/test",
+	},
+	"references": [
+		{
+			"path": "../../tsconfig.cjs.json",
+		},
+	],
+}

--- a/packages/dds/test-dds-utils/src/test/tsconfig.json
+++ b/packages/dds/test-dds-utils/src/test/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../../lib/test",
+		"types": ["mocha", "node"],
+	},
+	"include": ["./**/*"],
+	"references": [
+		{
+			"path": "../..",
+		},
+	],
+}

--- a/packages/dds/test-dds-utils/tsconfig.json
+++ b/packages/dds/test-dds-utils/tsconfig.json
@@ -1,9 +1,11 @@
 {
 	"extends": "../../../common/build/build-common/tsconfig.node16.json",
 	"include": ["src/**/*"],
-	"exclude": ["dist", "node_modules"],
+	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
+		// This package implements test utils to be run under Node.JS.
+		"types": ["node"],
 	},
 }


### PR DESCRIPTION
Test build requires stochastic-test-utils test build.
- Create an actual internal test build separate from "product" build. Have that depend on stochastic-test-utils test build (always CJS)
- Clean up test scripts and focus on ESM
  - Do test CJS as this is test utility library and CJS is still commonplace
- Move unicorn/prefer-module disables to specific locations

### bonus lint cleanup while here
(see second commit)
- apply stricter rules and use --fix for type imports/exports
- manually correct some property accessors and node import statements