### PR TITLE
refactor(telemetry-utils): Deprecate ILoggingError and isILoggingError, and remove internal usage

### DIFF
--- a/.changeset/eight-mails-play.md
+++ b/.changeset/eight-mails-play.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/telemetry-utils": minor
+---
+
+ILoggingError and isILoggingError are now deprecated
+
+These types are not particularly useful and were not necessary even within FluidFramework, so they are now deprecated
+and will be removed in an upcoming release.

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -285,7 +285,7 @@ export interface IGenericError extends IErrorBase {
     readonly errorType: typeof FluidErrorTypes.genericError;
 }
 
-// @internal
+// @internal @deprecated
 export interface ILoggingError extends Error {
     getTelemetryProperties(): ITelemetryBaseProperties;
 }

--- a/packages/common/core-interfaces/src/logger.ts
+++ b/packages/common/core-interfaces/src/logger.ts
@@ -92,6 +92,10 @@ export interface ITelemetryErrorEvent extends ITelemetryBaseProperties {
 /**
  * An error object that supports exporting its properties to be logged to telemetry
  * @internal
+ *
+ * @deprecated This interface will be removed in a future release, with no replacement.
+ * Its known uses as well as its purpose were internal to FluidFramework.
+ *
  */
 export interface ILoggingError extends Error {
 	/**

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -45,7 +45,7 @@ import {
 	MockLogger,
 	createChildLogger,
 	isFluidError,
-	isILoggingError,
+	LoggingError,
 	mixinMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 import {
@@ -963,7 +963,7 @@ describe("Runtime", () => {
 						error.message,
 						"Runtime detected too many reconnects with no progress syncing local ops.",
 					);
-					assert(isILoggingError(error));
+					assert(LoggingError.isLoggingError(error));
 					assert.strictEqual(error.getTelemetryProperties().attempts, maxReconnects);
 					assert.strictEqual(
 						error.getTelemetryProperties().pendingMessages,
@@ -1126,7 +1126,7 @@ describe("Runtime", () => {
 						error.message,
 						"Runtime detected too many reconnects with no progress syncing local ops.",
 					);
-					assert(isILoggingError(error));
+					assert(LoggingError.isLoggingError(error));
 					assert.strictEqual(error.getTelemetryProperties().attempts, maxReconnects);
 					assert.strictEqual(
 						error.getTelemetryProperties().pendingMessages,

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -8,7 +8,7 @@ import assert from "assert";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import { ContainerErrorTypes } from "@fluidframework/container-definitions/internal";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
-import { isILoggingError } from "@fluidframework/telemetry-utils/internal";
+import { LoggingError } from "@fluidframework/telemetry-utils/internal";
 import Deque from "double-ended-queue";
 
 import type {
@@ -196,7 +196,7 @@ describe("Pending State Manager", () => {
 
 			submitBatch(messages);
 			process(messages);
-			assert(isILoggingError(closeError));
+			assert(LoggingError.isLoggingError(closeError));
 			assert.strictEqual(closeError.errorType, ContainerErrorTypes.dataProcessingError);
 			assert.strictEqual(closeError.getTelemetryProperties().hasBatchStart, true);
 			assert.strictEqual(closeError.getTelemetryProperties().hasBatchEnd, false);
@@ -220,7 +220,7 @@ describe("Pending State Manager", () => {
 						type: "otherType",
 					})),
 				);
-				assert(isILoggingError(closeError));
+				assert(LoggingError.isLoggingError(closeError));
 				assert.strictEqual(closeError.errorType, ContainerErrorTypes.dataProcessingError);
 				assert.strictEqual(
 					closeError.getTelemetryProperties().expectedMessageType,

--- a/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
@@ -5,7 +5,6 @@
 
 import { strict as assert } from "assert";
 
-import { ILoggingError } from "@fluidframework/core-interfaces/internal";
 import {
 	ISequencedDocumentMessage,
 	ISnapshotTree,
@@ -111,7 +110,7 @@ describe("Runtime", () => {
 					throw Error(`${failMsg}: Expected to fail`);
 				} catch (error: unknown) {
 					assert(
-						expectedErrors.some((e) => e === (error as ILoggingError).message),
+						expectedErrors.some((e) => e === (error as Error).message),
 						errMsg,
 					);
 				}
@@ -128,7 +127,7 @@ describe("Runtime", () => {
 					throw Error(`${failMsg}: Expected to reject`);
 				} catch (error: unknown) {
 					assert(
-						expectedErrors.some((e) => e === (error as ILoggingError).message),
+						expectedErrors.some((e) => e === (error as Error).message),
 						errMsg,
 					);
 				}
@@ -492,9 +491,7 @@ describe("Runtime", () => {
 					await rootNode.summarize(false);
 					await assert.rejects(
 						async () => rootNode.refreshLatestSummary(proposalHandle, summaryRefSeq),
-						(
-							error: ILoggingError & { inProgressSummaryRefSeq: number | undefined },
-						) => {
+						(error: Error & { inProgressSummaryRefSeq: number | undefined }) => {
 							const correctErrorMessage =
 								error.message === "UnexpectedRefreshDuringSummarize";
 							const correctInProgressRefSeq =

--- a/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
@@ -23,7 +23,7 @@ import {
 	ISequencedDocumentMessage,
 	ISequencedDocumentSystemMessage,
 } from "@fluidframework/protocol-definitions";
-import { isFluidError, isILoggingError } from "@fluidframework/telemetry-utils/internal";
+import { isFluidError, LoggingError } from "@fluidframework/telemetry-utils/internal";
 import {
 	ITestObjectProvider,
 	TestFluidObject,
@@ -231,7 +231,7 @@ describeCompat("Batching failures", "NoCompat", (getTestObjectProvider) => {
 					await runAndValidateBatch(provider, proxyDsf, this.timeout());
 					assert.fail("expected error");
 				} catch (e) {
-					assert(isILoggingError(e), `${e}`);
+					assert(LoggingError.isLoggingError(e), `${e}`);
 					assert.equal(e.message, "OpBatchIncomplete", e);
 				}
 			},
@@ -274,7 +274,7 @@ describeCompat("Batching failures", "NoCompat", (getTestObjectProvider) => {
 				await runAndValidateBatch(provider, proxyDsf, this.timeout());
 				assert.fail("expected error");
 			} catch (e) {
-				assert(isILoggingError(e), `${e}`);
+				assert(LoggingError.isLoggingError(e), `${e}`);
 				assert.equal(e.message, "OpBatchIncomplete", e);
 			}
 		});
@@ -351,7 +351,7 @@ describeCompat("Batching failures", "NoCompat", (getTestObjectProvider) => {
 					await runAndValidateBatch(provider, proxyDsf, this.timeout());
 					assert.fail("expected error");
 				} catch (e) {
-					assert(isILoggingError(e), `${e}`);
+					assert(LoggingError.isLoggingError(e), `${e}`);
 					assert(isFluidError(e));
 					assert.strictEqual(e.errorType, FluidErrorTypes.dataProcessingError);
 				}
@@ -433,7 +433,7 @@ describeCompat("Batching failures", "NoCompat", (getTestObjectProvider) => {
 					});
 					assert.fail("expected error");
 				} catch (e) {
-					assert(isILoggingError(e), `${e}`);
+					assert(LoggingError.isLoggingError(e), `${e}`);
 					assert(isFluidError(e));
 					assert(e.errorType === FluidErrorTypes.dataProcessingError);
 				}

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -4,13 +4,12 @@
  */
 
 import { strict as assert } from "assert";
-
 import { describeCompat, itExpects } from "@fluid-private/test-version-utils";
 import { ContainerErrorTypes } from "@fluidframework/container-definitions/internal";
 import { ILoaderProps, Loader } from "@fluidframework/container-loader/internal";
 import { IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions/internal";
 import { createOdspNetworkError } from "@fluidframework/odsp-doclib-utils/internal";
-import { isILoggingError, normalizeError } from "@fluidframework/telemetry-utils/internal";
+import { LoggingError, normalizeError } from "@fluidframework/telemetry-utils/internal";
 import {
 	ITestObjectProvider,
 	LoaderContainerTracker,
@@ -145,7 +144,7 @@ describeCompat("Errors Types", "NoCompat", (getTestObjectProvider) => {
 
 	function assertCustomPropertySupport(err: any) {
 		err.asdf = "asdf";
-		assert(isILoggingError(err), "Error should support getTelemetryProperties()");
+		assert(LoggingError.isLoggingError(err), "Error should support getTelemetryProperties()");
 		assert.equal(err.getTelemetryProperties().asdf, "asdf", "Error should have property asdf");
 	}
 

--- a/packages/utils/odsp-doclib-utils/src/test/odspErrorUtils.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/odspErrorUtils.spec.ts
@@ -16,7 +16,7 @@ import {
 	OdspError,
 	OdspErrorTypes,
 } from "@fluidframework/odsp-driver-definitions/internal";
-import { isILoggingError } from "@fluidframework/telemetry-utils/internal";
+import { LoggingError } from "@fluidframework/telemetry-utils/internal";
 
 import { createOdspNetworkError, enrichOdspError } from "../odspErrorUtils.js";
 import { pkgVersion } from "../packageVersion.js";
@@ -24,7 +24,7 @@ import { pkgVersion } from "../packageVersion.js";
 describe("OdspErrorUtils", () => {
 	function assertCustomPropertySupport(err: any) {
 		err.asdf = "asdf";
-		assert(isILoggingError(err), "Error should support getTelemetryProperties()");
+		assert(LoggingError.isLoggingError(err), "Error should support getTelemetryProperties()");
 		assert.equal(err.getTelemetryProperties().asdf, "asdf", "Error should have property asdf");
 	}
 
@@ -159,7 +159,8 @@ describe("OdspErrorUtils", () => {
 			enrichOdspError(error);
 
 			assert(typeof error.online === "string");
-			assert(isILoggingError(error));
+			// The forced typing above causes this line to result in error having type 'never' unless we cast as unknown
+			assert(LoggingError.isLoggingError(error as unknown));
 			assert(typeof error.getTelemetryProperties().online === "string");
 		});
 		it("enriched with facetCodes", () => {
@@ -174,7 +175,7 @@ describe("OdspErrorUtils", () => {
 			);
 
 			assert.deepStrictEqual(error.facetCodes, ["bar", "foo"]);
-			assert(isILoggingError(error));
+			assert(LoggingError.isLoggingError(error));
 			assert.equal(error.getTelemetryProperties().innerMostErrorCode, "bar");
 		});
 		it("error response with redirect location", () => {
@@ -192,7 +193,7 @@ describe("OdspErrorUtils", () => {
 				"Error should be a fileNotFoundOrAccessDeniedError",
 			);
 			assert(error.redirectLocation === "url", "redirect location is wrong");
-			assert(isILoggingError(error));
+			assert(LoggingError.isLoggingError(error));
 			assert(
 				error.getTelemetryProperties().redirectLocation === undefined,
 				"redirect location should not be logged",
@@ -215,7 +216,7 @@ describe("OdspErrorUtils", () => {
 				"non-standard response text",
 			);
 
-			assert(isILoggingError(error));
+			assert(LoggingError.isLoggingError(error));
 			assert.equal(
 				error.getTelemetryProperties().response,
 				undefined,

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -176,7 +176,7 @@ export function isExternalError(error: unknown): boolean;
 // @internal
 export function isFluidError(error: unknown): error is IFluidErrorBase;
 
-// @internal
+// @internal @deprecated
 export const isILoggingError: (x: unknown) => x is ILoggingError;
 
 // @internal
@@ -252,12 +252,14 @@ export interface ITelemetryPropertiesExt {
 export function loggerToMonitoringContext<L extends ITelemetryBaseLogger = ITelemetryLoggerExt>(logger: L): MonitoringContext<L>;
 
 // @internal
-export class LoggingError extends Error implements ILoggingError, Omit<IFluidErrorBase, "errorType"> {
+export class LoggingError extends Error implements Omit<IFluidErrorBase, "errorType"> {
     constructor(message: string, props?: ITelemetryBaseProperties, omitPropsFromLogging?: Set<string>);
     addTelemetryProperties(props: ITelemetryPropertiesExt): void;
     // (undocumented)
     get errorInstanceId(): string;
     getTelemetryProperties(): ITelemetryBaseProperties;
+    // (undocumented)
+    static isLoggingError(input: unknown): input is LoggingError;
     // (undocumented)
     overwriteErrorInstanceId(id: string): void;
     static typeCheck(object: unknown): object is LoggingError;

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -21,8 +21,8 @@ import {
 import {
 	extractLogSafeErrorProperties,
 	generateStack,
-	isILoggingError,
 	isTaggedTelemetryPropertyValue,
+	LoggingError,
 } from "./errorLogging.js";
 import {
 	type ITelemetryErrorEventExt,
@@ -132,7 +132,7 @@ export abstract class TelemetryLogger implements ITelemetryLoggerExt {
 
 	/**
 	 * Take an unknown error object and add the appropriate info from it to the event. Message and stack will be copied
-	 * over from the error object, along with other telemetry properties if it's an ILoggingError.
+	 * over from the error object, along with other telemetry properties if it's a LoggingError.
 	 * @param event - Event being logged
 	 * @param error - Error to extract info from
 	 * @param fetchStack - Whether to fetch the current callstack if error.stack is undefined
@@ -151,7 +151,7 @@ export abstract class TelemetryLogger implements ITelemetryLoggerExt {
 		event.error = message; // Note that the error message goes on the 'error' field
 		event.errorType = errorType;
 
-		if (isILoggingError(error)) {
+		if (LoggingError.isLoggingError(error)) {
 			// Add any other telemetry properties from the LoggingError
 			const telemetryProp = error.getTelemetryProperties();
 			for (const key of Object.keys(telemetryProp)) {

--- a/packages/utils/telemetry-utils/src/test/error.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/error.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "node:assert";
 import { FluidErrorTypes } from "@fluidframework/core-interfaces/internal";
 
 import { DataCorruptionError, DataProcessingError } from "../error.js";
-import { LoggingError, isILoggingError, normalizeError } from "../errorLogging.js";
+import { LoggingError, normalizeError } from "../errorLogging.js";
 
 describe("Errors", () => {
 	describe("DataProcessingError.create", () => {
@@ -222,7 +222,7 @@ describe("Errors", () => {
 				op,
 			);
 
-			assert(isILoggingError(coercedError));
+			assert(LoggingError.isLoggingError(coercedError));
 			assert(
 				coercedError.getTelemetryProperties().messageSequenceNumber === op.sequenceNumber,
 			);
@@ -239,7 +239,7 @@ describe("Errors", () => {
 				op,
 			);
 
-			assert(isILoggingError(coercedError));
+			assert(LoggingError.isLoggingError(coercedError));
 			assert(
 				coercedError.getTelemetryProperties().messageSequenceNumber === op.sequenceNumber,
 			);


### PR DESCRIPTION
## Description

Deprecates `ILoggingError` and `isILoggingError` in telemetry-utils and removes internal uses.

These are both @internal and as far as we can tell not used by our partners, but for safety we're holding on removing them until after 2.0 GA.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
