### PR TITLE
Demonstrate the issue with CreateDataStore()

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -461,7 +461,7 @@ export abstract class FluidDataStoreContext
 
 		const channel = await factory.instantiateDataStore(this, existing);
 		assert(channel !== undefined, 0x140 /* "undefined channel on datastore context" */);
-		this.bindRuntime(channel);
+		await this.bindRuntime(channel, existing);
 		// This data store may have been disposed before the channel is created during realization. If so,
 		// dispose the channel now.
 		if (this.disposed) {
@@ -794,7 +794,7 @@ export abstract class FluidDataStoreContext
 		this.makeLocallyVisibleFn();
 	}
 
-	protected bindRuntime(channel: IFluidDataStoreChannel) {
+	protected async bindRuntime(channel: IFluidDataStoreChannel, existing: boolean) {
 		if (this.channel) {
 			throw new Error("Runtime already bound");
 		}
@@ -807,19 +807,32 @@ export abstract class FluidDataStoreContext
 			assert(this.channelDeferred !== undefined, 0x149 /* "Undefined channel deferral" */);
 			assert(this.pkg !== undefined, 0x14a /* "Undefined package path" */);
 
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const pending = this.pending!;
+			if (existing) {
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+				const pending = this.pending!;
 
-			// Apply all pending ops
-			for (const op of pending) {
-				// Only process ops whose seq number is greater than snapshot sequence number from which it loaded.
-				const seqNumber = this.baseSnapshotSequenceNumber ?? -1;
-				if (op.sequenceNumber > seqNumber) {
-					channel.process(op, false, undefined /* localOpMetadata */);
+				// Apply all pending ops
+				for (const op of pending) {
+					// Only process ops whose seq number is greater than snapshot sequence number from which it loaded.
+					const seqNumber = this.baseSnapshotSequenceNumber ?? -1;
+					if (op.sequenceNumber > seqNumber) {
+						channel.process(op, false, undefined /* localOpMetadata */);
+					}
 				}
-			}
 
-			this.thresholdOpsCounter.send("ProcessPendingOps", pending.length);
+				this.thresholdOpsCounter.send("ProcessPendingOps", pending.length);
+			} else {
+				assert(this.pending?.length === 0, "no pending ops");
+
+				// Load the handle to the data store's entryPoint to make sure that for a detached data store, the entryPoint
+				// initialization function is called before the data store gets attached and potentially connected to the
+				// delta stream, so it gets a chance to do things while the data store is still "purely local".
+				// This preserves the behavior from before we introduced entryPoints, where the instantiateDataStore method
+				// of data store factories tends to construct the data object (at least kick off an async method that returns
+				// it); that code moved to the entryPoint initialization function, so we want to ensure it still executes
+				// before the data store is attached.
+				await channel.entryPoint.get();
+			}
 			this.pending = undefined;
 
 			// And now mark the runtime active
@@ -1307,16 +1320,7 @@ export class LocalDetachedFluidDataStoreContext
 		assert(this.registry === undefined, 0x157 /* "datastore registry already attached" */);
 		this.registry = entry.registry;
 
-		super.bindRuntime(dataStoreChannel);
-
-		// Load the handle to the data store's entryPoint to make sure that for a detached data store, the entryPoint
-		// initialization function is called before the data store gets attached and potentially connected to the
-		// delta stream, so it gets a chance to do things while the data store is still "purely local".
-		// This preserves the behavior from before we introduced entryPoints, where the instantiateDataStore method
-		// of data store factories tends to construct the data object (at least kick off an async method that returns
-		// it); that code moved to the entryPoint initialization function, so we want to ensure it still executes
-		// before the data store is attached.
-		await dataStoreChannel.entryPoint.get();
+		await super.bindRuntime(dataStoreChannel, false /* existing */);
 
 		if (await this.isRoot()) {
 			dataStoreChannel.makeVisibleAndAttachGraph();

--- a/packages/test/test-utils/src/testContainerRuntimeFactory.ts
+++ b/packages/test/test-utils/src/testContainerRuntimeFactory.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/core-utils";
 import { IContainerContext, IRuntime } from "@fluidframework/container-definitions";
 import {
 	ContainerRuntime,
@@ -83,12 +84,9 @@ export const createTestContainerRuntimeFactory = (
 		}
 
 		public async instantiateFirstTime(runtime: ContainerRuntime): Promise<void> {
-			const rootContext = runtime.createDetachedRootDataStore([this.type], "default");
-			const rootRuntime = await this.dataStoreFactory.instantiateDataStore(
-				rootContext,
-				/* existing */ false,
-			);
-			await rootContext.attachRuntime(this.dataStoreFactory, rootRuntime);
+			const dataStore = await runtime.createDataStore([this.type]);
+			const result = await dataStore.trySetAlias("default");
+			assert(result === "Success", "success");
 		}
 
 		public async instantiateFromExisting(runtime: ContainerRuntime): Promise<void> {


### PR DESCRIPTION
This PR is for demonstration purposes.

@agarwal-navin , you have had this suggestion in my other PR: https://github.com/microsoft/FluidFramework/pull/19859/files#r1511449809

This PR demonstrates (tests would fail) that it's not possible to follow your advice, as it actually uncovers somewhat serious bug in our code. Detached runtime creation (through createDetachedRootDataStore() or equivalent, followed by attachRuntime()) would result in executing dataStoreChannel.entryPoint.get() which ensures that DataObject (based on data store) had a chance to initialize (create DDS) before it gets attached to file.

To my surprise, createDataStore() is missing that, as realizeCore() does not attempt to follow same pattern!
This breaks AgentScheduler.

Fixing it (as demonstrated by this PR) fixes all non-compat tests, but leaves broken some cross-version tests, as same fix is not present in 1.3!
There are other failures (as fix is not complete - full fix to the issue discovered is tracked in https://github.com/microsoft/FluidFramework/pull/19956).

We will need to submit changes in dataStoreContext.ts (to fix it for future - see above mentioned PR), but test changes would need to wait until 1.3 is dropped from support (and test matrix).

