### PR TITLE
build(client-examples): Node16 for multiview-coordinate-interface

### DIFF
--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -11,8 +11,8 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
+	"type": "module",
 	"main": "lib/index.js",
-	"module": "lib/index.js",
 	"types": "lib/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -17,7 +17,7 @@
 	"scripts": {
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
-		"build:esnext": "tsc",
+		"build:esnext": "tsc --project ./tsconfig.json",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\"",
 		"eslint": "eslint --format stylish src",
 		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",

--- a/examples/data-objects/multiview/interface/tsconfig.json
+++ b/examples/data-objects/multiview/interface/tsconfig.json
@@ -3,7 +3,6 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"jsx": "react",
 		"types": ["react", "react-dom", "puppeteer", "expect-puppeteer"],
 	},
 	"include": ["src/**/*"],

--- a/examples/data-objects/multiview/interface/tsconfig.json
+++ b/examples/data-objects/multiview/interface/tsconfig.json
@@ -1,8 +1,8 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
 	"compilerOptions": {
-		"module": "esnext",
-		"outDir": "lib",
+		"rootDir": "./src",
+		"outDir": "./lib",
 		"jsx": "react",
 		"types": ["react", "react-dom", "puppeteer", "expect-puppeteer"],
 	},


### PR DESCRIPTION
Simple switch to Node16 module as already ESM only and no curated API or tests