### PR TITLE
Converts server-gitssh.yml pipeline to new 1ES template

### DIFF
--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -38,11 +38,11 @@ trigger:
     - fluidBuild.config.cjs
     - server/gitssh
     - tools/pipelines/server-gitssh.yml
-    - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/1ES/build-docker-service.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
-    - tools/pipelines/templates/include-publish-docker-service.yml
-    - tools/pipelines/templates/include-publish-docker-service-steps.yml
+    - tools/pipelines/templates/1ES/include-publish-docker-service.yml
+    - tools/pipelines/templates/1ES/include-publish-docker-service-steps.yml
     - tools/pipelines/templates/include-git-tag-steps.yml
     - tools/pipelines/templates/include-use-node-version.yml
 
@@ -59,17 +59,33 @@ pr:
     - fluidBuild.config.cjs
     - server/gitssh
     - tools/pipelines/server-gitssh.yml
-    - tools/pipelines/templates/build-docker-service.yml
+    - tools/pipelines/templates/1ES/build-docker-service.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-use-node-version.yml
 
+variables:
+  - template: /tools/pipelines/templates/include-vars.yml@self
+    parameters:
+      releaseImage: true
+      publishOverride: ${{ parameters.publishOverride }}
+      releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+      buildNumberInPatch: true
+  # Note: we tried to centralize the use of the 'container-registry-info' variable group (i.e. put it inside the shared
+  # build-docker-service.yml template) but ran into issues because if it exists in the stage-level variables of the template
+  # instead of in the root-level variables of a pipeline, then the value for the ACR service connection name (which comes
+  # from the variable group) that gets passed to a Docker@1 task seems to not be available before ADO performs checks for
+  # that task, including that the specified service connection exists and the pipeline is authorized to use it. So ADO ends
+  # uplooking for a service connection named "$(containerRegistryConnection)" instead of the actual value after replacement.
+  - group: container-registry-info
+
 extends:
-  template: templates/build-docker-service.yml
+  template: /tools/pipelines/templates/1ES/build-docker-service.yml@self
   parameters:
-    releaseImage: true
-    publishOverride: ${{ parameters.publishOverride }}
-    releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
+    testBuild: ${{ variables.testBuild }}
+    shouldPushDockerImage: ${{ variables.pushImage }}
+    shouldReleaseDockerImage: ${{ variables.releaseImage }}
+    shouldPublishNpmPackages: ${{ variables.publish }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: server/gitssh
     containerName: fluidframework/routerlicious/gitssh


### PR DESCRIPTION
## Description

This PR converts server-gitssh.yml to the new 1ES template required by Microsoft with the minimal required set of template changes required. This new template enables security and auditing checks by Microsoft. Read more on how the logic for converting to a 1ES pipeline works on [the official 1ES wiki](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview)

A temporary 1ES folder was created for converted pipeline templates. This enables other pipelines to remain unchanged and use the original templates while new PR's are opened for individually converted other pipelines to 1ES as required by Microsoft. 

- Once all pipelines are moved over, we can start moving the files out of the 1ES folder and eventually remove the folder since it will no longer have any files (This is after we convert the rest of the required pipelines). 

## Breaking Changes

## Reviewer Guidance

- Confirm the newly converted pipelines run successfully. Look at the completed steps and compare with a recent successful run on main to ensure the expected steps run (plus the new SDL and 1ES security checks)
- Make sure all the relevant templates and pipelines for server-gitssh.yml have been converted
- Make sure there are no unnecessary changes or 1ES template and/or pipeline conversions
- Make sure the yml is valid -- a successful pipeline run should suffice for confirming this