### PR TITLE
Add changeset for deprecating FlushMode.Immediate

### DIFF
--- a/.changeset/odd-facts-wonder.md
+++ b/.changeset/odd-facts-wonder.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/runtime-definitions": minor
+---
+
+FlushMode.Immediate is deprecated
+
+FlushMode.Immediate is deprecated, it will be removed in the next major version and should not be used. Use FlushMode.TurnBased instead, which is the default. See https://github.com/microsoft/FluidFramework/tree/main/packages/runtime/container-runtime/src/opLifecycle#how-batching-works


### PR DESCRIPTION
## Description

It was brought to my attention that https://github.com/microsoft/FluidFramework/pull/19753 is missing a changset file.