### PR TITLE
refactor(fluid-framework): Simplify `fluid-framework`'s exports by using re-exporting `tree`'s public API via `export *`

### DIFF
--- a/packages/framework/fluid-framework/api-extractor-cjs.json
+++ b/packages/framework/fluid-framework/api-extractor-cjs.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.cjs.primary.json",
+	"bundledPackages": ["@fluidframework/*"],
 	// CJS is actually secondary; so, no report.
 	"apiReport": {
 		"enabled": false

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -38,60 +38,9 @@ export type {
 export type { ISharedMap, ISharedMapEvents, IValueChanged } from "@fluidframework/map";
 export { SharedMap } from "@fluidframework/map";
 
-export type {
-	AllowedTypes,
-	ApplyKind,
-	ArrayToUnion,
-	Events,
-	ExtractItemType,
-	FlexList,
-	FlexListToUnion,
-	IDisposable,
-	ImplicitAllowedTypes,
-	ImplicitFieldSchema,
-	InsertableObjectFromSchemaRecord,
-	InsertableTreeFieldFromImplicitField,
-	InsertableTreeNodeFromImplicitAllowedTypes,
-	InsertableTypedNode,
-	IsEvent,
-	ISubscribable,
-	ITree,
-	LazyItem,
-	MakeNominal,
-	NodeBuilderData,
-	NodeFromSchema,
-	ObjectFromSchemaRecord,
-	RestrictiveReadonlyRecord,
-	ScopedSchemaName,
-	TreeApi,
-	TreeArrayNodeBase,
-	TreeFieldFromImplicitField,
-	TreeLeafValue,
-	TreeMapNode,
-	TreeNodeEvents,
-	TreeNodeFromImplicitAllowedTypes,
-	TreeNodeSchema,
-	TreeNodeSchemaClass,
-	TreeNodeSchemaCore,
-	TreeNodeSchemaNonClass,
-	TreeView,
-	TreeViewEvents,
-	Unhydrated,
-	WithType,
-	SchemaIncompatible,
-} from "@fluidframework/tree";
-export {
-	disposeSymbol,
-	FieldKind,
-	FieldSchema,
-	IterableTreeArrayContent,
-	NodeKind,
-	SchemaFactory,
-	SharedTree,
-	Tree,
-	TreeArrayNode,
-	TreeConfiguration,
-	TreeNode,
-	TreeStatus,
-	type,
-} from "@fluidframework/tree";
+// Let the tree package manage its own API surface, we will simply reflect it here.
+// Note: this only surfaces the `@public` API items from the tree package. If the `@beta` and `@alpha` items are
+// desired, they can be added by re-exporting from one of the package's aliased export paths instead (e.g. `tree
+// alpha` to surface everything `@alpha` and higher).
+// eslint-disable-next-line no-restricted-syntax
+export * from "@fluidframework/tree";


### PR DESCRIPTION
This will make it infinitely easier to keep `fluid-framework`'s API in sync with `tree`'s.

Also fixes a discrepancy between the package's 2 api-extractor configurations by adding a missing `bundledPackages` entry.