### PR TITLE
fluid-build: conservative dependencies on tasks without config

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -18,9 +18,10 @@ import * as assert from "assert";
 import {
 	TaskDefinitions,
 	TaskDefinitionsOnDisk,
-	TaskConfig,
+	TaskDefinition,
 	getTaskDefinitions,
 	normalizeGlobalTaskDefinitions,
+	getDefaultTaskDefinition,
 } from "../common/fluidTaskDefinitions";
 import registerDebug from "debug";
 
@@ -120,29 +121,35 @@ export class BuildPackage {
 		return tasks.length !== 0;
 	}
 
-	private getTaskDefinition(taskName: string): TaskConfig | undefined {
-		let taskDefinition = this._taskDefinitions[taskName];
-		if (taskDefinition === undefined && this.pkg.isReleaseGroupRoot) {
-			const isReleaseGroupRootScriptEnabled =
-				this.pkg.packageJson.fluidBuild?.tasks !== undefined;
-			const script = this.pkg.getScript(taskName);
-			if (
-				// Only enable release group root script if it is explicitly defined, for places that don't use it yet
-				!isReleaseGroupRootScriptEnabled ||
-				// if there is no script or the script starts with "fluid-build", then use the default
-				script === undefined ||
-				script.startsWith("fluid-build ")
-			) {
-				// default for release group root is to depend on the task of all packages in the release group
-				taskDefinition = {
-					dependsOn: [`^${taskName}`],
-					script: false,
-					before: [],
-					after: [],
-				};
-			}
+	private getTaskDefinition(taskName: string): TaskDefinition | undefined {
+		const taskDefinition = this._taskDefinitions[taskName];
+		if (taskDefinition !== undefined) {
+			return taskDefinition;
 		}
-		return taskDefinition;
+		if (!this.pkg.isReleaseGroupRoot) {
+			return this.pkg.getScript(taskName) !== undefined
+				? getDefaultTaskDefinition(taskName)
+				: undefined;
+		}
+		const isReleaseGroupRootScriptEnabled =
+			this.pkg.packageJson.fluidBuild?.tasks !== undefined;
+		const script = this.pkg.getScript(taskName);
+		if (
+			// Only enable release group root script if it is explicitly defined, for places that don't use it yet
+			!isReleaseGroupRootScriptEnabled ||
+			// if there is no script or the script starts with "fluid-build", then use the default
+			script === undefined ||
+			script.startsWith("fluid-build ")
+		) {
+			// default for release group root is to depend on the task of all packages in the release group
+			return {
+				dependsOn: [`^${taskName}`],
+				script: false,
+				before: [],
+				after: [],
+			};
+		}
+		return undefined;
 	}
 
 	private createTask(taskName: string, pendingInitDep: Task[]) {
@@ -212,7 +219,7 @@ export class BuildPackage {
 		}
 
 		if (pendingInitDep === undefined) {
-			// when pendingInitDep is undefined, it means we don't expect to instantiate the reference task
+			// when pendingInitDep is undefined, it is a weak dependency, so don't instantiate the referenced task
 			return undefined;
 		}
 
@@ -250,11 +257,7 @@ export class BuildPackage {
 		traceTaskDepTask(
 			`Expanding dependsOn: ${task.nameColored} -> ${JSON.stringify(taskConfig.dependsOn)}`,
 		);
-		const matchedTasks = this.getMatchedTasks(taskConfig.dependsOn, pendingInitDep);
-		matchedTasks.forEach((matchedTask) => {
-			traceTaskDepTask(`${task.nameColored} -> ${matchedTask.nameColored}`);
-		});
-		return matchedTasks;
+		return this.getMatchedTasks(taskConfig.dependsOn, pendingInitDep);
 	}
 
 	// Create or get the task with names in the `deps` array
@@ -266,12 +269,20 @@ export class BuildPackage {
 			let found = pendingInitDep === undefined;
 			// should have be replaced already.
 			assert.notStrictEqual(dep, "...");
+			assert.notStrictEqual(dep, "*");
 			if (dep.startsWith("^")) {
 				found = true; // Don't worry if we can't find any
+				const taskName = dep.substring(1);
+
 				for (const depPackage of this.dependentPackages) {
-					const depTask = depPackage.getTask(dep.substring(1), pendingInitDep);
-					if (depTask !== undefined) {
-						matchedTasks.push(depTask);
+					if (taskName === "*") {
+						assert.strictEqual(pendingInitDep, undefined);
+						matchedTasks.push(...depPackage.tasks.values());
+					} else {
+						const depTask = depPackage.getTask(taskName, pendingInitDep);
+						if (depTask !== undefined) {
+							matchedTasks.push(depTask);
+						}
 					}
 				}
 			} else if (dep.includes("#")) {
@@ -301,69 +312,85 @@ export class BuildPackage {
 	}
 
 	public finalizeDependentTasks() {
-		// Set up the dependencies for "before"
-		this.tasks.forEach((task) => {
-			if (task.taskName === undefined) {
-				return;
+		// Set up the dependencies for "before" and "after"
+
+		// Get the beforeStar and afterStar tasks name on demand
+		let beforeStarTaskNames: string[] | undefined;
+		const getBeforeStarTaskNames = () => {
+			if (beforeStarTaskNames !== undefined) {
+				return beforeStarTaskNames;
 			}
-			const taskConfig = this.getTaskDefinition(task.taskName);
+			// avoid circular dependency. ignore mutual before "*" */
+			beforeStarTaskNames = Array.from(this.tasks.keys()).filter(
+				(depTaskName) => !this.getTaskDefinition(depTaskName)?.before.includes("*"),
+			);
+			return beforeStarTaskNames;
+		};
+
+		let afterStarTaskNames: string[] | undefined;
+		const getAfterStarTaskNames = () => {
+			if (afterStarTaskNames !== undefined) {
+				return afterStarTaskNames;
+			}
+			// avoid circular dependency. ignore mutual after "*" */
+			afterStarTaskNames = Array.from(this.tasks.keys()).filter(
+				(depTaskName) => !this.getTaskDefinition(depTaskName)?.after.includes("*"),
+			);
+			return afterStarTaskNames;
+		};
+
+		// Expand the star entry to all scheduled tasks
+		const expandStar = (deps: string[], getTaskNames: () => string[]) => {
+			const newDeps = deps.filter((dep) => dep !== "*");
+			if (newDeps.length === deps.length) {
+				return newDeps;
+			}
+			return newDeps.concat(getTaskNames());
+		};
+		const finalizeTask = (task: Task) => {
+			assert.notStrictEqual(task.taskName, undefined);
+
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			const taskConfig = this.getTaskDefinition(task.taskName!);
 			if (taskConfig === undefined) {
 				return;
 			}
 
-			// Expand the star entry to all scheduled tasks
-			const expandStar = (
-				deps: string[],
-				additionalFilter: (depTaskName: string) => boolean,
-			) => {
-				const newDeps = deps.filter((dep) => dep !== "*");
-				if (newDeps.length === deps.length) {
-					return newDeps;
-				}
-				const taskNames = Array.from(this.tasks.keys());
-				// avoid circular dependency
-				const filteredTaskNames = taskNames.filter(
-					(depTaskName) => depTaskName !== task.taskName && additionalFilter(depTaskName),
-				);
-				return newDeps.concat(filteredTaskNames);
-			};
-
 			if (taskConfig.before.length !== 0) {
 				// We don't want parent packages to inject dependencies to the child packages,
 				// so ^ and # are not supported for 'before'
-				const before = expandStar(
-					taskConfig.before,
-					/* ignore mutual before "*" */
-					(depTaskName) => !this.getTaskDefinition(depTaskName)?.before.includes("*"),
-				);
+				const before = expandStar(taskConfig.before, getBeforeStarTaskNames);
 				traceTaskDepTask(
-					`Expanding before: ${task.nameColored} -> ${JSON.stringify(before)}`,
+					`Expanding ${taskConfig.isDefault ? "default " : ""}before: ${JSON.stringify(
+						before,
+					)} -> ${task.nameColored}`,
 				);
 				const matchedTasks = this.getMatchedTasks(before);
+				const dependentTask = [task];
 				for (const matchedTask of matchedTasks) {
-					traceTaskDepTask(`${matchedTask.nameColored} -> ${task.nameColored}`);
-					// initializeDependentTask should have been called on all the task already
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					matchedTask.dependentTasks!.push(task);
+					matchedTask.addDependentTasks(dependentTask, taskConfig.isDefault);
 				}
 			}
 
 			if (taskConfig.after.length !== 0) {
-				const after = expandStar(
-					taskConfig.after,
-					/* ignore mutual after "*" */
-					(depTaskName) => !this.getTaskDefinition(depTaskName)?.after.includes("*"),
-				);
+				const after = expandStar(taskConfig.after, getAfterStarTaskNames);
 				traceTaskDepTask(
-					`Expanding after: ${task.nameColored} -> ${JSON.stringify(after)}`,
+					`Expanding ${taskConfig.isDefault ? "default " : ""}after: ${
+						task.nameColored
+					} -> ${JSON.stringify(after)}`,
 				);
-				const matchedTasks = this.getMatchedTasks(taskConfig.after);
-				matchedTasks.forEach((matchedTask) => {
-					traceTaskDepTask(`${task.nameColored} -> ${matchedTask.nameColored}`);
-				});
-				// initializeDependentTask should have been called on all the task already
+				const matchedTasks = this.getMatchedTasks(after);
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				task.dependentTasks!.push(...matchedTasks);
+				task.addDependentTasks(matchedTasks, taskConfig.isDefault);
+			}
+		};
+
+		this.tasks.forEach(finalizeTask);
+		this.scriptTasks.forEach((task: Task, name: string) => {
+			// Process named script task that hasn't been processed yet.
+			if (this.tasks.get(name) !== task) {
+				finalizeTask(task);
 			}
 		});
 	}

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidBuild.ts
@@ -20,7 +20,7 @@ async function main() {
 	const timer = new Timer(commonOptions.timer);
 	const resolvedRoot = await getResolvedFluidRoot();
 
-	log(`Fluid Repo Root: ${resolvedRoot}`);
+	log(`Build Root: ${resolvedRoot}`);
 
 	// Load the package
 	const repo = new FluidRepoBuild(resolvedRoot);

--- a/build-tools/packages/build-tools/src/fluidBuild/options.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/options.ts
@@ -10,6 +10,7 @@ import { defaultLogger } from "../common/logging";
 import { existsSync } from "../common/utils";
 import { IPackageMatchedOptions } from "./fluidRepoBuild";
 import { ISymlinkOptions } from "./symlinkUtils";
+import { defaultBuildTaskName, defaultCleanTaskName } from "../common/fluidTaskDefinitions";
 
 const { log, warning, errorLog } = defaultLogger;
 
@@ -323,11 +324,11 @@ export function parseOptions(argv: string[]) {
 
 	// If we are building, and don't have a task name, default to "build"
 	if (options.build !== false && options.buildTaskNames.length === 0) {
-		options.buildTaskNames.push("build");
+		options.buildTaskNames.push(defaultBuildTaskName);
 	}
 
 	// Add the "clean" task if --clean is specified
 	if (options.clean) {
-		options.buildTaskNames.push("clean");
+		options.buildTaskNames.push(defaultCleanTaskName);
 	}
 }

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/groupTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/groupTask.ts
@@ -37,6 +37,19 @@ export class GroupTask extends Task {
 		}
 	}
 
+	public addDependentTasks(dependentTasks: Task[], isDefault: boolean): void {
+		if (isDefault) {
+			// Propagate to unnamed subtasks only if it's a default dependency
+			for (const task of this.subTasks) {
+				if (task.taskName === undefined) {
+					task.addDependentTasks(dependentTasks, isDefault);
+				}
+			}
+		} else {
+			super.addDependentTasks(dependentTasks, isDefault);
+		}
+	}
+
 	public collectLeafTasks(leafTasks: Set<LeafTask>) {
 		for (const task of this.subTasks) {
 			task.collectLeafTasks(leafTasks);


### PR DESCRIPTION
These are changes discovered while trying to use fluid-build in a non-fluid repo, but good general improvements.

For tasks that doesn't have dependencies config, default to topological order and depends on all the tasks from the dependent packages.  Add general support for "^*" dependency for "after" to support this.