### PR TITLE
build(client-container-runtime): remove deprecated internal APIs

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -4,14 +4,12 @@
 
 ```ts
 
-import { assertIsStableId } from '@fluidframework/id-compressor';
 import { AttachState } from '@fluidframework/container-definitions';
 import { ContainerWarning } from '@fluidframework/container-definitions';
 import { CreateChildSummarizerNodeParam } from '@fluidframework/runtime-definitions';
 import { FluidDataStoreRegistryEntry } from '@fluidframework/runtime-definitions';
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { FlushMode } from '@fluidframework/runtime-definitions';
-import { generateStableId } from '@fluidframework/id-compressor';
 import { IAudience } from '@fluidframework/container-definitions';
 import { IClientDetails } from '@fluidframework/protocol-definitions';
 import { IContainerContext } from '@fluidframework/container-definitions';
@@ -45,7 +43,6 @@ import { IRuntime } from '@fluidframework/container-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ISnapshotTree } from '@fluidframework/protocol-definitions';
-import { isStableId } from '@fluidframework/id-compressor';
 import { ISummarizerNodeWithGC } from '@fluidframework/runtime-definitions';
 import { ISummaryAck } from '@fluidframework/protocol-definitions';
 import { ISummaryContent } from '@fluidframework/protocol-definitions';
@@ -68,8 +65,6 @@ export const AllowInactiveRequestHeaderKey = "allowInactive";
 
 // @alpha
 export const AllowTombstoneRequestHeaderKey = "allowTombstone";
-
-export { assertIsStableId }
 
 // @internal (undocumented)
 export class ChannelCollectionFactory implements IFluidDataStoreFactory {
@@ -307,8 +302,6 @@ export type GCNodeType = (typeof GCNodeType)[keyof typeof GCNodeType];
 
 // @alpha (undocumented)
 export type GCVersion = number;
-
-export { generateStableId }
 
 // @alpha
 export interface IAckedSummary {
@@ -548,8 +541,6 @@ export interface ISerializedElection {
 
 // @internal @deprecated (undocumented)
 export function isRuntimeMessage(message: ISequencedDocumentMessage): boolean;
-
-export { isStableId }
 
 // @alpha
 export interface ISubmitSummaryOpResult extends Omit<IUploadSummaryResult, "stage" | "error"> {

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -240,6 +240,18 @@
 			},
 			"InterfaceDeclaration_ISubmitSummaryOptions": {
 				"forwardCompat": false
+			},
+			"RemovedFunctionDeclaration_assertIsStableId": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"RemovedFunctionDeclaration_generateStableId": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"RemovedFunctionDeclaration_isStableId": {
+				"backCompat": false,
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -98,20 +98,3 @@ export {
 	ISummarizeEventProps,
 } from "./summary/index.js";
 export { IChunkedOp, unpackRuntimeMessage } from "./opLifecycle/index.js";
-
-// Re-exports for backwards compatibility.
-// Will be removed in the future.
-export {
-	/**
-	 * @deprecated Import from `@fluidframework/id-compressor` instead.
-	 */
-	assertIsStableId,
-	/**
-	 * @deprecated Import from `@fluidframework/id-compressor` instead.
-	 */
-	generateStableId,
-	/**
-	 * @deprecated Import from `@fluidframework/id-compressor` instead.
-	 */
-	isStableId,
-} from "@fluidframework/id-compressor";

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -1971,50 +1971,26 @@ use_old_VariableDeclaration_agentSchedulerId(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_assertIsStableId": {"forwardCompat": false}
+* "RemovedFunctionDeclaration_assertIsStableId": {"forwardCompat": false}
 */
-declare function get_old_FunctionDeclaration_assertIsStableId():
-    TypeOnly<typeof old.assertIsStableId>;
-declare function use_current_FunctionDeclaration_assertIsStableId(
-    use: TypeOnly<typeof current.assertIsStableId>): void;
-use_current_FunctionDeclaration_assertIsStableId(
-    get_old_FunctionDeclaration_assertIsStableId());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_assertIsStableId": {"backCompat": false}
+* "RemovedFunctionDeclaration_assertIsStableId": {"backCompat": false}
 */
-declare function get_current_FunctionDeclaration_assertIsStableId():
-    TypeOnly<typeof current.assertIsStableId>;
-declare function use_old_FunctionDeclaration_assertIsStableId(
-    use: TypeOnly<typeof old.assertIsStableId>): void;
-use_old_FunctionDeclaration_assertIsStableId(
-    get_current_FunctionDeclaration_assertIsStableId());
 
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_generateStableId": {"forwardCompat": false}
+* "RemovedFunctionDeclaration_generateStableId": {"forwardCompat": false}
 */
-declare function get_old_FunctionDeclaration_generateStableId():
-    TypeOnly<typeof old.generateStableId>;
-declare function use_current_FunctionDeclaration_generateStableId(
-    use: TypeOnly<typeof current.generateStableId>): void;
-use_current_FunctionDeclaration_generateStableId(
-    get_old_FunctionDeclaration_generateStableId());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_generateStableId": {"backCompat": false}
+* "RemovedFunctionDeclaration_generateStableId": {"backCompat": false}
 */
-declare function get_current_FunctionDeclaration_generateStableId():
-    TypeOnly<typeof current.generateStableId>;
-declare function use_old_FunctionDeclaration_generateStableId(
-    use: TypeOnly<typeof old.generateStableId>): void;
-use_old_FunctionDeclaration_generateStableId(
-    get_current_FunctionDeclaration_generateStableId());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -2043,26 +2019,14 @@ use_old_FunctionDeclaration_isRuntimeMessage(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_isStableId": {"forwardCompat": false}
+* "RemovedFunctionDeclaration_isStableId": {"forwardCompat": false}
 */
-declare function get_old_FunctionDeclaration_isStableId():
-    TypeOnly<typeof old.isStableId>;
-declare function use_current_FunctionDeclaration_isStableId(
-    use: TypeOnly<typeof current.isStableId>): void;
-use_current_FunctionDeclaration_isStableId(
-    get_old_FunctionDeclaration_isStableId());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "FunctionDeclaration_isStableId": {"backCompat": false}
+* "RemovedFunctionDeclaration_isStableId": {"backCompat": false}
 */
-declare function get_current_FunctionDeclaration_isStableId():
-    TypeOnly<typeof current.isStableId>;
-declare function use_old_FunctionDeclaration_isStableId(
-    use: TypeOnly<typeof old.isStableId>): void;
-use_old_FunctionDeclaration_isStableId(
-    get_current_FunctionDeclaration_isStableId());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
internal APIs don't need a deprecation stage.