### PR TITLE
Fix container GET API not return 404 on non-existing container

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -24,6 +24,7 @@
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
 		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
+		"test:debug": "mocha inspect --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -24,8 +24,8 @@
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
 		"test": "mocha --recursive \"dist/test/**/*.spec.*js\"",
-		"test:debug": "mocha inspect --recursive \"dist/test/**/*.spec.*js\"",
 		"test:coverage": "c8 npm test -- --reporter xunit --reporter-option output=nyc/junit-report.xml",
+		"test:debug": "mocha inspect --recursive \"dist/test/**/*.spec.*js\"",
 		"tsc": "tsc",
 		"typetests:gen": "fluid-type-test-generator",
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
@@ -136,13 +136,10 @@
 				"backCompat": false
 			},
 			"ClassDeclaration_AlfredResources": {
-				"forwardCompat": false
+				"backCompat": false
 			},
 			"InterfaceDeclaration_IAlfredResourcesCustomizations": {
 				"forwardCompat": false
-			},
-			"ClassDeclaration_AlfredResources": {
-				"backCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -134,24 +134,11 @@ export function create(
 					getParam(request.params, "id"),
 				)
 				.then((document) => {
-					console.log(`yunho: type of document: ${typeof document}`);
-					console.log(document);
 					if (!document || document.scheduledDeletionTime) {
-						console.log(
-							`yunho: flag: ${
-								!document || document.scheduledDeletionTime
-							}, output 404`,
-						);
-						// response.status(404);
 						throw new NetworkError(404, "Document not found.");
 					}
-					console.log(`yunho: output 200`);
-					// response.status(200).json(document);
 					return document;
 				});
-			// .catch((error) => {
-			// 	response.status(400).json(error);
-			// });
 			handleResponse(documentP, response);
 		},
 	);

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/routes/api/documents.ts
@@ -128,20 +128,31 @@ export function create(
 		throttle(generalTenantThrottler, winston, tenantThrottleOptions),
 		verifyStorageToken(tenantManager, config, defaultTokenValidationOptions),
 		(request, response, next) => {
-			const documentP = storage.getDocument(
-				getParam(request.params, "tenantId") || appTenants[0].id,
-				getParam(request.params, "id"),
-			);
-			documentP
+			const documentP = storage
+				.getDocument(
+					getParam(request.params, "tenantId") || appTenants[0].id,
+					getParam(request.params, "id"),
+				)
 				.then((document) => {
+					console.log(`yunho: type of document: ${typeof document}`);
+					console.log(document);
 					if (!document || document.scheduledDeletionTime) {
-						response.status(404);
+						console.log(
+							`yunho: flag: ${
+								!document || document.scheduledDeletionTime
+							}, output 404`,
+						);
+						// response.status(404);
+						throw new NetworkError(404, "Document not found.");
 					}
-					response.status(200).json(document);
-				})
-				.catch((error) => {
-					response.status(400).json(error);
+					console.log(`yunho: output 200`);
+					// response.status(200).json(document);
+					return document;
 				});
+			// .catch((error) => {
+			// 	response.status(400).json(error);
+			// });
+			handleResponse(documentP, response);
 		},
 	);
 


### PR DESCRIPTION
GET container API should return 404 if the container doesn't exist. Currently it returns 200. The reason is that we call response.status twice and the last call will overwrite the previous results and hence 200 replaces 404.
Change the code to use handleResponse flow