### PR TITLE
TestHistorian.getBlob() to better handle sha = undefined calls.

### DIFF
--- a/server/routerlicious/packages/test-utils/src/testHistorian.ts
+++ b/server/routerlicious/packages/test-utils/src/testHistorian.ts
@@ -103,7 +103,13 @@ export class TestHistorian implements IHistorian {
 	}
 
 	public async getBlob(sha: string): Promise<IBlob> {
+		// TestCollection.findOneInternal() will return whole collection and first element will be retured!
+		// So better throw here to avoid running into hard to debug issues.
+		if (sha === undefined) {
+			throw new Error("blob ID is undefined");
+		}
 		const blob = await this.blobs.findOne({ _id: sha });
+
 		return {
 			content: IsoBuffer.from(
 				blob.content ?? blob.value?.content,


### PR DESCRIPTION
I run into a problem where due to a bug in my code I ended up hitting this function with sha === undefined.

Without this fix, we are getting some random blob content back, which is very hard to figure out, unless you debug this code. The issue is described in comment I'm adding - it's some weird expectations that I do not fully understand, so adding specific case that should be scoped to solve the problem at hand.
