### PR TITLE
Some SharedMatrix hardening

### DIFF
--- a/packages/dds/matrix/api-report/matrix.api.md
+++ b/packages/dds/matrix/api-report/matrix.api.md
@@ -9,6 +9,8 @@ import { IChannelAttributes } from '@fluidframework/datastore-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IChannelServices } from '@fluidframework/datastore-definitions';
 import { IChannelStorageService } from '@fluidframework/datastore-definitions';
+import { IEvent } from '@fluidframework/core-interfaces';
+import { IEventProvider } from '@fluidframework/core-interfaces';
 import { IEventThisPlaceHolder } from '@fluidframework/core-interfaces';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidSerializer } from '@fluidframework/shared-object-base';
@@ -31,8 +33,22 @@ export interface IRevertible {
     revert(): void;
 }
 
+// @alpha (undocumented)
+export interface ISharedMatrix<T = any> extends IEventProvider<ISharedMatrixEvents<T>>, IMatrixProducer<MatrixItem<T>>, IMatrixReader<MatrixItem<T>>, IMatrixWriter<MatrixItem<T>> {
+    // (undocumented)
+    insertCols(colStart: number, count: number): void;
+    // (undocumented)
+    insertRows(rowStart: number, count: number): void;
+    // (undocumented)
+    openUndo(consumer: IUndoConsumer): void;
+    // (undocumented)
+    removeCols(colStart: number, count: number): void;
+    // (undocumented)
+    removeRows(rowStart: number, count: number): void;
+}
+
 // @alpha
-export interface ISharedMatrixEvents<T> extends ISharedObjectEvents {
+export interface ISharedMatrixEvents<T> extends IEvent {
     (event: "conflict", listener: (row: number, col: number, currentValue: MatrixItem<T>, conflictingValue: MatrixItem<T>, target: IEventThisPlaceHolder) => void): void;
 }
 
@@ -46,7 +62,7 @@ export interface IUndoConsumer {
 export type MatrixItem<T> = Serializable<Exclude<T, null>> | undefined;
 
 // @alpha
-export class SharedMatrix<T = any> extends SharedObject<ISharedMatrixEvents<T>> implements IMatrixProducer<MatrixItem<T>>, IMatrixReader<MatrixItem<T>>, IMatrixWriter<MatrixItem<T>> {
+export class SharedMatrix<T = any> extends SharedObject<ISharedMatrixEvents<T> & ISharedObjectEvents> implements ISharedMatrix<T> {
     constructor(runtime: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes, _isSetCellConflictResolutionPolicyFWW?: boolean);
     protected applyStashedOp(_content: unknown): void;
     // (undocumented)

--- a/packages/dds/matrix/src/index.ts
+++ b/packages/dds/matrix/src/index.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-export { ISharedMatrixEvents, SharedMatrix, MatrixItem } from "./matrix.js";
+export { ISharedMatrixEvents, SharedMatrix, ISharedMatrix } from "./matrix.js";
+export { MatrixItem } from "./ops.js";
 export { SharedMatrixFactory } from "./runtime.js";
 
 // TODO: We temporarily duplicate these contracts from 'framework/undo-redo' to unblock development

--- a/packages/dds/matrix/src/ops.ts
+++ b/packages/dds/matrix/src/ops.ts
@@ -3,32 +3,45 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * This file tracks types that are serialized in summaries / snapshots, and thus can't easily be changed
+ * Use caustion when making changes and consider backward and forward compatibility of your changes!
+ */
+
 import { Serializable } from "@fluidframework/datastore-definitions";
+import { IMergeTreeOp } from "@fluidframework/merge-tree";
 
 export enum MatrixOp {
 	spliceCols,
 	spliceRows,
 	set,
-	changeSetCellPolicy,
 }
 
-export interface IMatrixMsg {
-	type: MatrixOp;
+export enum SnapshotPath {
+	rows = "rows",
+	cols = "cols",
+	cells = "cells",
 }
 
-export interface IMatrixSpliceMsg extends IMatrixMsg {
-	type: MatrixOp.spliceCols | MatrixOp.spliceRows;
-	start: number;
-	count: number;
-}
+/**
+ * A matrix cell value may be undefined (indicating an empty cell) or any serializable type,
+ * excluding null.  (However, nulls may be embedded inside objects and arrays.)
+ * @alpha
+ */
+// eslint-disable-next-line @rushstack/no-new-null -- Using 'null' to disallow 'null'.
+export type MatrixItem<T> = Serializable<Exclude<T, null>> | undefined;
 
-export interface IMatrixCellMsg extends IMatrixMsg {
+export interface ISetOp<T> {
+	// Historically, VectorOp format did not use type at all, so all swtich logic is done by target.
+	// That said, old code asserts that if target === undefined, type should be set to "set", do we have to keep it here.
 	type: MatrixOp.set;
+	target?: never;
 	row: number;
 	col: number;
-	value: Serializable<unknown>;
+	value: MatrixItem<T>;
+	fwwMode?: boolean;
 }
 
-export interface IMatrixSwitchSetCellPolicy extends IMatrixMsg {
-	type: MatrixOp.changeSetCellPolicy;
-}
+export type VectorOp = IMergeTreeOp & Record<"target", SnapshotPath.rows | SnapshotPath.cols>;
+
+export type MatrixSetOrVectorOp<T> = VectorOp | ISetOp<T>;

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -191,7 +191,10 @@ export class PermutationVector extends Client {
 		return handle;
 	}
 
-	public adjustPosition(pos: number, op: ISequencedDocumentMessage) {
+	public adjustPosition(
+		pos: number,
+		op: Pick<ISequencedDocumentMessage, "referenceSequenceNumber" | "clientId">,
+	) {
 		const { segment, offset } = this.getContainingSegment(pos, {
 			referenceSequenceNumber: op.referenceSequenceNumber,
 			clientId: op.clientId,

--- a/packages/dds/matrix/src/test/matrix.fuzz.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.fuzz.spec.ts
@@ -24,7 +24,8 @@ import {
 	takeAsync,
 } from "@fluid-private/stochastic-test-utils";
 import { FlushMode } from "@fluidframework/runtime-definitions";
-import { MatrixItem, SharedMatrix } from "../matrix.js";
+import { SharedMatrix } from "../matrix.js";
+import { MatrixItem } from "../ops.js";
 import { SharedMatrixFactory } from "../runtime.js";
 import { _dirname } from "./dirname.cjs";
 

--- a/packages/dds/matrix/src/undoprovider.ts
+++ b/packages/dds/matrix/src/undoprovider.ts
@@ -15,7 +15,8 @@ import {
 	TrackingGroup,
 	ITrackingGroup,
 } from "@fluidframework/merge-tree";
-import { MatrixItem, SharedMatrix } from "./matrix.js";
+import { SharedMatrix } from "./matrix.js";
+import { MatrixItem } from "./ops.js";
 import { Handle, isHandleValid } from "./handletable.js";
 import { PermutationSegment, PermutationVector } from "./permutationvector.js";
 import { IUndoConsumer } from "./types.js";


### PR DESCRIPTION
Extracting Matrix changes from https://github.com/microsoft/FluidFramework/pull/19692

These are relatively unrelated changes (could break into multiple PRs if desired):
1. More robust APIs not taking garbage in - it's expensive to debug issues when your code misbehaves.
2. Create & export ISharedMatrix
3. Move protocol related things into ops.ts
