### PR TITLE
Increase maxCacheExpiryTimeoutMs to 5 days, and validate in FluidCache

### DIFF
--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { DriverError } from '@fluidframework/driver-definitions';
+import { FiveDaysMs } from '@fluidframework/driver-definitions';
 import { IDriverErrorBase } from '@fluidframework/driver-definitions';
 import { IResolvedUrl } from '@fluidframework/driver-definitions';
 
@@ -199,6 +200,9 @@ export interface ISocketStorageDiscovery {
 
 // @internal
 export const isTokenFromCache: (tokenResponse: string | TokenResponse | null) => boolean | undefined;
+
+// @internal
+export const maximumCacheDurationMs: FiveDaysMs;
 
 // @alpha (undocumented)
 export type OdspError = IOdspError | (DriverError & IOdspErrorAugmentations);

--- a/packages/drivers/odsp-driver-definitions/src/index.ts
+++ b/packages/drivers/odsp-driver-definitions/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from "./factory.js";
 export {
 	CacheContentType,
+	maximumCacheDurationMs,
 	getKeyForCacheEntry,
 	ICacheEntry,
 	IEntry,

--- a/packages/drivers/odsp-driver-definitions/src/odspCache.ts
+++ b/packages/drivers/odsp-driver-definitions/src/odspCache.ts
@@ -6,7 +6,10 @@
 import { IResolvedUrl, type FiveDaysMs } from "@fluidframework/driver-definitions";
 
 /**
- * Must be less than policy of 5 days
+ * Must be less than IDocumentStorageServicePolicies.maximumCacheDurationMs policy of 5 days.
+ * That policy is the outward expression and this value is the implementation - using a larger value
+ * would violate that statement of the driver's behavior.
+ * Other parts of the system (such as Garbage Collection) depend on that policy being properly implemented.
  *
  * @internal
  */

--- a/packages/drivers/odsp-driver-definitions/src/odspCache.ts
+++ b/packages/drivers/odsp-driver-definitions/src/odspCache.ts
@@ -3,7 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { IResolvedUrl } from "@fluidframework/driver-definitions";
+import { IResolvedUrl, type FiveDaysMs } from "@fluidframework/driver-definitions";
+
+/**
+ * Must be less than policy of 5 days
+ *
+ * @internal
+ */
+export const maximumCacheDurationMs: FiveDaysMs = 432_000_000; // 5 days in ms
 
 /**
  * Describes what kind of content is stored in cache entry.

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -29,6 +29,7 @@ import {
 	IOdspError,
 	IOdspErrorAugmentations,
 	IOdspResolvedUrl,
+	maximumCacheDurationMs,
 } from "@fluidframework/odsp-driver-definitions";
 import {
 	fetchAndParseAsJSONHelper,
@@ -65,9 +66,6 @@ export type FetchType =
 export type FetchTypeInternal = FetchType | "cache";
 
 export const Odsp409Error = "Odsp409Error";
-
-// Must be less than policy of 5 days
-export const defaultCacheExpiryTimeoutMs: number = 2 * 24 * 60 * 60 * 1000; // 2 days in ms
 
 /**
  * In ODSP, the concept of "epoch" refers to binary updates to files. For example, this might include using
@@ -107,7 +105,7 @@ export class EpochTracker implements IPersistedFileCache {
 			"Fluid.Driver.Odsp.TestOverride.DisableSnapshotCache",
 		)
 			? 0
-			: defaultCacheExpiryTimeoutMs;
+			: maximumCacheDurationMs;
 	}
 
 	// public for UT purposes only!

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -14,10 +14,9 @@ import {
 	ISnapshot,
 	ISnapshotFetchOptions,
 } from "@fluidframework/driver-definitions";
+import { maximumCacheDurationMs } from "@fluidframework/odsp-driver-definitions";
 import * as api from "@fluidframework/protocol-definitions";
 import { IConfigProvider } from "@fluidframework/telemetry-utils";
-
-const maximumCacheDurationMs: FiveDaysMs = 432000000; // 5 * 24 * 60 * 60 * 1000 = 5 days in ms
 
 class BlobCache {
 	// Save the timeout so we can cancel and reschedule it as needed

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "node:assert";
-import { IDocumentStorageServicePolicies } from "@fluidframework/driver-definitions";
 import {
 	OdspErrorTypes,
 	IOdspResolvedUrl,
@@ -12,7 +11,7 @@ import {
 	IEntry,
 } from "@fluidframework/odsp-driver-definitions";
 import { IFluidErrorBase, createChildLogger } from "@fluidframework/telemetry-utils";
-import { defaultCacheExpiryTimeoutMs, EpochTracker } from "../epochTracker.js";
+import { EpochTracker } from "../epochTracker.js";
 import { LocalPersistentCache } from "../odspCache.js";
 import { getHashedDocumentId } from "../odspPublicUtils.js";
 import { IVersionedValueWithEpoch, persistedCacheValueVersion } from "../contracts.js";
@@ -53,19 +52,6 @@ describe("Tests for Epoch Tracker", () => {
 
 	afterEach(async () => {
 		await epochTracker.removeEntries().catch(() => {});
-	});
-
-	it("defaultCacheExpiryTimeoutMs <= maximumCacheDurationMs policy", () => {
-		// This is the maximum allowed value per the policy - 5 days
-		const maximumCacheDurationMs: Exclude<
-			IDocumentStorageServicePolicies["maximumCacheDurationMs"],
-			undefined
-		> = 432000000;
-
-		assert(
-			defaultCacheExpiryTimeoutMs <= maximumCacheDurationMs,
-			"Actual cache expiry used must meet the policy",
-		);
 	});
 
 	it("Cache, old versions", async () => {

--- a/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/epochTests.spec.ts
@@ -4,11 +4,13 @@
  */
 
 import { strict as assert } from "node:assert";
+import { IDocumentStorageServicePolicies } from "@fluidframework/driver-definitions";
 import {
 	OdspErrorTypes,
 	IOdspResolvedUrl,
 	ICacheEntry,
 	IEntry,
+	maximumCacheDurationMs,
 } from "@fluidframework/odsp-driver-definitions";
 import { IFluidErrorBase, createChildLogger } from "@fluidframework/telemetry-utils";
 import { EpochTracker } from "../epochTracker.js";
@@ -52,6 +54,16 @@ describe("Tests for Epoch Tracker", () => {
 
 	afterEach(async () => {
 		await epochTracker.removeEntries().catch(() => {});
+	});
+
+	it("defaultCacheExpiryTimeoutMs <= maximumCacheDurationMs policy", () => {
+		// This is the maximum allowed value per the policy - 5 days
+		const expected: Exclude<
+			IDocumentStorageServicePolicies["maximumCacheDurationMs"],
+			undefined
+		> = 432000000;
+
+		assert(maximumCacheDurationMs <= expected, "Actual cache expiry used must meet the policy");
 	});
 
 	it("Cache, old versions", async () => {

--- a/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getVersions.spec.ts
@@ -5,10 +5,14 @@
 
 import { strict as assert } from "node:assert";
 import { ISnapshot } from "@fluidframework/driver-definitions";
-import { IOdspResolvedUrl, ICacheEntry } from "@fluidframework/odsp-driver-definitions";
+import {
+	IOdspResolvedUrl,
+	ICacheEntry,
+	maximumCacheDurationMs,
+} from "@fluidframework/odsp-driver-definitions";
 import { createChildLogger } from "@fluidframework/telemetry-utils";
 import { delay } from "@fluidframework/core-utils";
-import { EpochTracker, defaultCacheExpiryTimeoutMs } from "../epochTracker.js";
+import { EpochTracker } from "../epochTracker.js";
 import {
 	IOdspSnapshot,
 	HostStoragePolicyInternal,
@@ -335,7 +339,7 @@ describe("Tests for snapshot fetch", () => {
 				type: "snapshot",
 				file: { docId: hashedDocumentId, resolvedUrl },
 			};
-			await localCache.put(cacheEntry, valueWithExpiredCache(defaultCacheExpiryTimeoutMs));
+			await localCache.put(cacheEntry, valueWithExpiredCache(maximumCacheDurationMs));
 
 			const version = await mockFetchSingle(
 				async () => service.getVersions(null, 1),
@@ -355,7 +359,7 @@ describe("Tests for snapshot fetch", () => {
 				type: "snapshot",
 				file: { docId: hashedDocumentId, resolvedUrl },
 			};
-			await localCache.put(cacheEntry, valueWithExpiredCache(defaultCacheExpiryTimeoutMs));
+			await localCache.put(cacheEntry, valueWithExpiredCache(maximumCacheDurationMs));
 
 			await assert.rejects(
 				async () => {


### PR DESCRIPTION
This change increases the default cache expiry timeout to the maximum and renames it as such. It also moves the value to odsp-definitions so that it can be reused by FluidCache. FluidCache uses the value to validate that the user provided expiry time is below the maximum or logs an error to inform the user.