### PR TITLE
Send error telemetry if we fetch a tree without a version

### DIFF
--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -116,6 +116,10 @@ export class SerializedStateManager {
 					eventName: "getSnapshotTreeFailed",
 					id: version.id,
 				});
+			} else if (snapshot !== undefined && version === undefined) {
+				this.mc.logger.sendErrorEvent({
+					eventName: "getSnapshotFetchedTreeWithoutVersion",
+				});
 			}
 			return { snapshot, version };
 		}


### PR DESCRIPTION
Tries to detect in tinylicious (or any other service) whether or not we are able to fetch a snapshot from the service without fetching the id. This will break summaries as if we don't get both the snapshot and the `version.id`, we will not be able to submit summaries.