### PR TITLE
tree: Fix bug with decoding optional changeset

### DIFF
--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecs.ts
@@ -206,6 +206,13 @@ function makeOptionalFieldCodec<TChildChange = NodeChangeset>(
 					isEmpty: false,
 					dst: detached,
 				};
+			} else if (encoded.d !== undefined) {
+				const detachId = registerIdCodec.decode(encoded.d, context);
+				assert(detachId !== "self", "Invalid detach ID");
+				decoded.valueReplace = {
+					isEmpty: true,
+					dst: detachId,
+				};
 			}
 			return decoded;
 		},

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
@@ -59,6 +59,8 @@ const change1WithChildChange = Change.atOnce(
 	Change.child(nodeChange1),
 );
 
+const clearEmpty = Change.reserve("self", brand(3));
+
 export function testCodecs() {
 	describe("Codecs", () => {
 		const sessionId = { originatorId: "session1" as SessionId };
@@ -73,6 +75,7 @@ export function testCodecs() {
 				["child change", changeWithChildChange, sessionId],
 				["field set with child change", change1WithChildChange, sessionId], // Note: should only get sent over the wire when using transaction APIs.
 				["undone field change", change2Inverted, sessionId],
+				["clear from empty", clearEmpty, sessionId],
 			],
 		};
 


### PR DESCRIPTION
## Description

An optional change representing a clear of an empty field was incorrectly being decoded as an empty change. This PR adds a test to cover this case and fixes the issue.