### PR TITLE
build(prosemirror): use node16 module resolution -- blocked on 'data-object-grid'

### DIFF
--- a/examples/data-objects/prosemirror/package.json
+++ b/examples/data-objects/prosemirror/package.json
@@ -11,14 +11,22 @@
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/index.d.ts",
+				"default": "./lib/index.js"
+			}
+		}
+	},
 	"main": "lib/index.js",
-	"module": "lib/index.js",
 	"types": "lib/index.d.ts",
 	"scripts": {
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
 		"build:copy": "copyfiles -u 1 \"src/**/*.css\" lib/",
-		"build:esnext": "tsc",
+		"build:esnext": "tsc --project ./tsconfig.json",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\"",
 		"dev": "npm run webpack:dev",
 		"eslint": "eslint --format stylish src",

--- a/examples/data-objects/prosemirror/tsconfig.json
+++ b/examples/data-objects/prosemirror/tsconfig.json
@@ -1,10 +1,8 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": "../../../common/build/build-common/tsconfig.node16.json",
 	"compilerOptions": {
-		"module": "esnext",
 		"target": "es6",
-		"outDir": "lib",
-		"jsx": "react",
+		"outDir": "./lib",
 		"types": ["node", "react"],
 	},
 	"include": ["src/**/*"],


### PR DESCRIPTION
```
@fluid-example/data-object-grid: error during command 'eslint --format stylish src' (exit code 1)
@fluid-example/data-object-grid: 
@fluid-example/data-object-grid: /mnt/vss/_work/1/s/examples/apps/data-object-grid/src/dataObjectRegistry.ts
@fluid-example/data-object-grid:   17:71  error  Unable to resolve path to module '@fluid-example/prosemirror'  import/no-unresolved
@fluid-example/data-object-grid: 
@fluid-example/data-object-grid: ✖ 1 problem (1 error, 0 warnings)
@fluid-example/data-object-grid: 
@fluid-example/data-object-grid: error during command 'tsc' (exit code 2)
@fluid-example/data-object-grid: src/dataObjectRegistry.ts:17:71 - error TS2307: Cannot find module '@fluid-example/prosemirror' or its corresponding type declarations.
@fluid-example/data-object-grid: 
@fluid-example/data-object-grid: 17 import { ProseMirror, ProseMirrorFactory, ProseMirrorReactView } from "@fluid-example/prosemirror";
@fluid-example/data-object-grid:                                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@fluid-example/data-object-grid: 
@fluid-example/data-object-grid: 
@fluid-example/data-object-grid: Found 1 error in src/dataObjectRegistry.ts:17
```

Semi-automatic PR to switch to node16 module resolution