### PR TITLE
Remove 1M limit as it screws local testing

### DIFF
--- a/server/routerlicious/packages/local-server/src/localWebSocketServer.ts
+++ b/server/routerlicious/packages/local-server/src/localWebSocketServer.ts
@@ -43,12 +43,6 @@ export class LocalWebSocket implements IWebSocket {
 	}
 
 	public emit(event: string, ...args: any[]) {
-		// Disconnect from the "socket" if the message is greater than 1MB
-		if (JSON.stringify(args).length > 1e6) {
-			this.disconnect();
-			return;
-		}
-
 		this.events.emit(event, ...args);
 	}
 


### PR DESCRIPTION
### Background

Please see https://github.com/microsoft/FluidFramework/pull/10666 and specifically my comment https://github.com/microsoft/FluidFramework/pull/10666#discussion_r1479254635

### Description

This change causes trouble. What I see is that local tests (running in-memory server) fail for large payloads as the "server" accumulates a ton of ops (each of them is smaller than 1Mb) and hits that check when broadcasting them to client.
Test gets into infinite loop of disconnects & reconnects & retries (maybe it's not infinite, but test stops making any progress).
If I comment this code out, everything works fine.

It's possible we need something like that on receiving side. And possibly we need to break payloads into individual messages on broadcast - all this would be great to have. But original fix is wrong, and thus I simply backing it out.

Repro is simple - a UT that sends a ton of largish ops (anything in 250K - 800K range). Batching is done in runtime (not using protocol capability), so every op shows up as one op in a batch.

