### PR TITLE
Renaming processed ops in serializedStateManager

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2302,7 +2302,7 @@ export class Container
 
 		// Forward messages to the loaded runtime for processing
 		this.runtime.process(message, local);
-		this.serializedStateManager.addSavedOp(message);
+		this.serializedStateManager.addProcessedOp(message);
 		// Inactive (not in quorum or not writers) clients don't take part in the minimum sequence number calculation.
 		if (this.activeConnection()) {
 			if (this.noopHeuristic === undefined) {

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -27,7 +27,7 @@ import { ISerializableBlobContents, getBlobContentsFromTree } from "./containerS
 import { IPendingContainerState } from "./container.js";
 
 export class SerializedStateManager {
-	private readonly savedOps: ISequencedDocumentMessage[] = [];
+	private readonly processedOps: ISequencedDocumentMessage[] = [];
 	private snapshot:
 		| {
 				tree: ISnapshotTree;
@@ -55,9 +55,9 @@ export class SerializedStateManager {
 		return this._offlineLoadEnabled;
 	}
 
-	public addSavedOp(message: ISequencedDocumentMessage) {
+	public addProcessedOp(message: ISequencedDocumentMessage) {
 		if (this.offlineLoadEnabled) {
-			this.savedOps.push(message);
+			this.processedOps.push(message);
 		}
 	}
 
@@ -178,7 +178,7 @@ export class SerializedStateManager {
 			{
 				eventName: "getPendingLocalState",
 				notifyImminentClosure: props.notifyImminentClosure,
-				savedOpsSize: this.savedOps.length,
+				savedOpsSize: this.processedOps.length,
 				clientId,
 			},
 			async () => {
@@ -194,7 +194,7 @@ export class SerializedStateManager {
 					pendingRuntimeState,
 					baseSnapshot: this.snapshot.tree,
 					snapshotBlobs: this.snapshot.blobs,
-					savedOps: this.savedOps,
+					savedOps: this.processedOps,
 					url: resolvedUrl.url,
 					// no need to save this if there is no pending runtime state
 					clientId: pendingRuntimeState !== undefined ? clientId : undefined,

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -178,7 +178,7 @@ export class SerializedStateManager {
 			{
 				eventName: "getPendingLocalState",
 				notifyImminentClosure: props.notifyImminentClosure,
-				savedOpsSize: this.processedOps.length,
+				processedOpsSize: this.processedOps.length,
 				clientId,
 			},
 			async () => {

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -242,7 +242,7 @@ describe("serializedStateManager", () => {
 		// equivalent to attach
 		serializedStateManager.setSnapshot({ tree: { trees: {}, blobs: {} }, blobs: {} });
 		for (let num = 0; num < 10; ++num) {
-			serializedStateManager.addSavedOp(generateSavedOp());
+			serializedStateManager.addProcessedOp(generateSavedOp());
 		}
 		await serializedStateManager.getPendingLocalStateCore(
 			{ notifyImminentClosure: false },


### PR DESCRIPTION
Small renaming of serializedStateManager.savedOps to processedOps to avoid confusion with the ones actually saved when we close and get pending local state.