### PR TITLE
Keep pending checkpoint message for future summaries

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -116,7 +116,7 @@ export class ScribeLambda implements IPartitionLambda {
 		private readonly kafkaCheckpointOnReprocessingOp: boolean,
 		private readonly isEphemeralContainer: boolean,
 		private readonly localCheckpointEnabled: boolean,
-		private readonly maxLogtailLength: number,
+		private readonly maxPendingCheckpointMessagesLength: number,
 	) {
 		this.lastOffset = scribe.logOffset;
 		this.setStateFromCheckpoint(scribe);
@@ -700,7 +700,7 @@ export class ScribeLambda implements IPartitionLambda {
 				inserts[inserts.length - 1].operation.sequenceNumber;
 			const cappedNumber = Math.max(
 				this.protocolHead,
-				this.lastCheckpointInsertedNumber - this.maxLogtailLength,
+				this.lastCheckpointInsertedNumber - this.maxPendingCheckpointMessagesLength,
 			);
 			while (
 				this.pendingCheckpointMessages.length > 0 &&

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -680,7 +680,9 @@ export class ScribeLambda implements IPartitionLambda {
 	}
 
 	private async writeCheckpoint(checkpoint: IScribe) {
-		const inserts = this.pendingCheckpointMessages.toArray().filter(pcm=>pcm.operation.sequenceNumber > this.lastCheckpointInsertedNumber);
+		const inserts = this.pendingCheckpointMessages
+			.toArray()
+			.filter((pcm) => pcm.operation.sequenceNumber > this.lastCheckpointInsertedNumber);
 		await this.checkpointManager.write(
 			checkpoint,
 			this.protocolHead,
@@ -694,13 +696,16 @@ export class ScribeLambda implements IPartitionLambda {
 			// 1. For client summary, we can cap these pending ops to the last protocol head
 			// 2. For service summary, given the logtail is appended and protocol head not advance, we should still keep these
 			//    pending ops to reduce db/alfred call to fetch ops, but should cap to a maxtlogtail limit to avoid memory leak.;
-			this.lastCheckpointInsertedNumber = inserts[inserts.length - 1].operation.sequenceNumber;
-			const cappedNumber = Math.max(this.protocolHead, this.lastCheckpointInsertedNumber - this.maxLogtailLength);
+			this.lastCheckpointInsertedNumber =
+				inserts[inserts.length - 1].operation.sequenceNumber;
+			const cappedNumber = Math.max(
+				this.protocolHead,
+				this.lastCheckpointInsertedNumber - this.maxLogtailLength,
+			);
 			while (
 				this.pendingCheckpointMessages.length > 0 &&
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				this.pendingCheckpointMessages.peekFront()!.operation.sequenceNumber <=
-				cappedNumber
+				this.pendingCheckpointMessages.peekFront()!.operation.sequenceNumber <= cappedNumber
 			) {
 				this.pendingCheckpointMessages.removeFront();
 			}

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -327,6 +327,7 @@ export class ScribeLambdaFactory
 			this.kafkaCheckpointOnReprocessingOp,
 			document.isEphemeralContainer ?? false,
 			this.checkpointService.getLocalCheckpointEnabled(),
+			this.maxLogtailLength,
 		);
 
 		await this.sendLambdaStartResult(tenantId, documentId, {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -89,6 +89,7 @@ export class ScribeLambdaFactory
 		private readonly restartOnCheckpointFailure: boolean,
 		private readonly kafkaCheckpointOnReprocessingOp: boolean,
 		private readonly maxLogtailLength: number,
+		private readonly maxPendingCheckpointMessagesLength: number,
 	) {
 		super();
 	}
@@ -327,7 +328,7 @@ export class ScribeLambdaFactory
 			this.kafkaCheckpointOnReprocessingOp,
 			document.isEphemeralContainer ?? false,
 			this.checkpointService.getLocalCheckpointEnabled(),
-			this.maxLogtailLength,
+			this.maxPendingCheckpointMessagesLength,
 		);
 
 		await this.sendLambdaStartResult(tenantId, documentId, {

--- a/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
@@ -149,6 +149,7 @@ describe("Routerlicious", () => {
 					true,
 					true,
 					2000,
+					2000,
 				);
 
 				testContext = new TestContext();

--- a/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrderer.ts
@@ -379,6 +379,8 @@ export class LocalOrderer implements IOrderer {
 			checkpointService,
 		);
 
+		const maxPendingCheckpointMessagesLength = 2000;
+
 		return new ScribeLambda(
 			context,
 			this.tenantId,
@@ -399,6 +401,7 @@ export class LocalOrderer implements IOrderer {
 			true,
 			this.details.value.isEphemeralContainer,
 			checkpointService.getLocalCheckpointEnabled(),
+			maxPendingCheckpointMessagesLength,
 		);
 	}
 

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -53,6 +53,8 @@ export async function scribeCreate(
 	const internalAlfredUrl = config.get("worker:alfredUrl");
 	const getDeltasViaAlfred = config.get("scribe:getDeltasViaAlfred") as boolean;
 	const maxLogtailLength = (config.get("scribe:maxLogtailLength") as number) ?? 2000;
+	const maxPendingCheckpointMessagesLength =
+		(config.get("scribe:maxPendingCheckpointMessagesLength") as number) ?? 2000;
 	const verifyLastOpPersistence =
 		(config.get("scribe:verifyLastOpPersistence") as boolean) ?? false;
 	const transientTenants = config.get("shared:transientTenants") as string[];
@@ -169,6 +171,7 @@ export async function scribeCreate(
 		restartOnCheckpointFailure,
 		kafkaCheckpointOnReprocessingOp,
 		maxLogtailLength,
+		maxPendingCheckpointMessagesLength,
 	);
 }
 


### PR DESCRIPTION
## Description

During a session, we might do multiple client/service summary, and independently, multiple checkpoints. Checkpoint, will clear messages storage in `pendingCheckpointMessages`, which is also used for writing summary. Because of this cleanup, when write new summaries, summary write often need to request the ops from alfred again, which is not quite efficient. 

So changed the behavior to keep `pendingCheckpointMessages` to max of:
1. protocolHead for efficient
2. max sn - max logtail length to avoid memory leak.

And used `lastCheckpointInsertedNumber` to preserve the backwards compatibility when insert db (FRS not use DB)
