### PR TITLE
fix(ci): Disable jest cache for app-insights-logger tests

### DIFF
--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -32,8 +32,8 @@
 		"start:tinylicious": "tinylicious",
 		"test": "npm run test:jest",
 		"test:coverage": "npm run test:jest:coverage",
-		"test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --detectOpenHandles",
-		"test:jest:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --detectOpenHandles --coverage --ci",
+		"test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --detectOpenHandles --no-cache",
+		"test:jest:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --detectOpenHandles --coverage --no-cache --ci",
 		"tsc": "tsc",
 		"webpack": "webpack --env production",
 		"webpack:dev": "webpack --env development"


### PR DESCRIPTION
## Description

We've seen a few instances of these jest tests failing in CI pipeline runs (e.g. [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=243915&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=ca111d9b-56f7-5b3d-b8f6-661164061440&l=284) and [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=243924&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=ca111d9b-56f7-5b3d-b8f6-661164061440&l=285); msft internal), where the process seemingly crashes (no jest output). Locally, this reproduces for me every single time.

Investigation led me to [this](https://github.com/nodejs/node/issues/35889#issuecomment-1521334188) which made my local runs pass consistently. The issue seems to be with `--experimental-vm-modules` (they're still experimental, after all). At the end of that thread [this node issue is referenced](https://github.com/nodejs/node/pull/48510), which is fixed but the fix did not make it into Node20. When we move to Node21+ we might be able to remove this workaround.

Note: since these are the only tests that use `--experimental-vm-modules` (because they're the only ones which exercise a code path where we do a dynamic `import()`, if I recall correctly) I don't expect other jest tests in the repo to require the same workaround.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).