### PR TITLE
build(protocol-definitions): Update type tests

### DIFF
--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/protocol-definitions",
-	"version": "3.2.0",
+	"version": "3.3.0",
 	"description": "Fluid protocol definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {
@@ -58,7 +58,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@3.1.0",
+		"@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@3.2.0",
 		"@microsoft/api-extractor": "^7.42.3",
 		"concurrently": "^6.2.0",
 		"copyfiles": "^2.4.1",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -58,7 +58,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.26.1",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@2.0.0",
+		"@fluidframework/protocol-definitions-previous": "npm:@fluidframework/protocol-definitions@3.1.0",
 		"@microsoft/api-extractor": "^7.42.3",
 		"concurrently": "^6.2.0",
 		"copyfiles": "^2.4.1",

--- a/common/lib/protocol-definitions/pnpm-lock.yaml
+++ b/common/lib/protocol-definitions/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/eslint-config-fluid': ^4.0.0
-      '@fluidframework/protocol-definitions-previous': npm:@fluidframework/protocol-definitions@2.0.0
+      '@fluidframework/protocol-definitions-previous': npm:@fluidframework/protocol-definitions@3.1.0
       '@microsoft/api-extractor': ^7.42.3
       concurrently: ^6.2.0
       copyfiles: ^2.4.1
@@ -33,7 +33,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.1
       '@fluidframework/eslint-config-fluid': 4.0.0_bpztyfltmpuv6lhsgzfwtmxhte
-      '@fluidframework/protocol-definitions-previous': /@fluidframework/protocol-definitions/2.0.0
+      '@fluidframework/protocol-definitions-previous': /@fluidframework/protocol-definitions/3.1.0
       '@microsoft/api-extractor': 7.42.3
       concurrently: 6.5.1
       copyfiles: 2.4.1
@@ -337,10 +337,6 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/common-definitions/0.20.1:
-    resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
-    dev: true
-
   /@fluidframework/eslint-config-fluid/4.0.0_bpztyfltmpuv6lhsgzfwtmxhte:
     resolution: {integrity: sha512-mLE+1uocMaMACF51EPhnGgLi2okbKRAPE53RzC3Jd2CfqqIGk2sk8yrsvw7KVfeBp8w0Mf646ZM17yAbNTErDg==}
     dependencies:
@@ -369,10 +365,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/protocol-definitions/2.0.0:
-    resolution: {integrity: sha512-4t6JzyGoO+QR95X+NHQ2EQH7ZmxLICA3xIyAYO4x/XJsom4QFzrxiAVt2Vu1iBEv7CGNO9O2WHBOuFBRkJznLQ==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
+  /@fluidframework/protocol-definitions/3.1.0:
+    resolution: {integrity: sha512-BgGF82z4sk5M4torMR38NGjHjFG9t6Y653UcGOlXiIaGQMDZpRfrxiIuq53Gb12OTfUgbNtvBJL1W46JfLvzQw==}
     dev: true
 
   /@gar/promisify/1.1.3:

--- a/common/lib/protocol-definitions/pnpm-lock.yaml
+++ b/common/lib/protocol-definitions/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.26.1
       '@fluidframework/eslint-config-fluid': ^4.0.0
-      '@fluidframework/protocol-definitions-previous': npm:@fluidframework/protocol-definitions@3.1.0
+      '@fluidframework/protocol-definitions-previous': npm:@fluidframework/protocol-definitions@3.2.0
       '@microsoft/api-extractor': ^7.42.3
       concurrently: ^6.2.0
       copyfiles: ^2.4.1
@@ -33,7 +33,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.26.1
       '@fluidframework/eslint-config-fluid': 4.0.0_bpztyfltmpuv6lhsgzfwtmxhte
-      '@fluidframework/protocol-definitions-previous': /@fluidframework/protocol-definitions/3.1.0
+      '@fluidframework/protocol-definitions-previous': /@fluidframework/protocol-definitions/3.2.0
       '@microsoft/api-extractor': 7.42.3
       concurrently: 6.5.1
       copyfiles: 2.4.1
@@ -365,8 +365,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/protocol-definitions/3.1.0:
-    resolution: {integrity: sha512-BgGF82z4sk5M4torMR38NGjHjFG9t6Y653UcGOlXiIaGQMDZpRfrxiIuq53Gb12OTfUgbNtvBJL1W46JfLvzQw==}
+  /@fluidframework/protocol-definitions/3.2.0:
+    resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
     dev: true
 
   /@gar/promisify/1.1.3:

--- a/common/lib/protocol-definitions/src/test/types/validateProtocolDefinitionsPrevious.generated.ts
+++ b/common/lib/protocol-definitions/src/test/types/validateProtocolDefinitionsPrevious.generated.ts
@@ -744,6 +744,30 @@ use_old_InterfaceDeclaration_IQuorumProposalsEvents(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_ISentSignalMessage": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ISentSignalMessage():
+    TypeOnly<old.ISentSignalMessage>;
+declare function use_current_RemovedInterfaceDeclaration_ISentSignalMessage(
+    use: TypeOnly<current.ISentSignalMessage>);
+use_current_RemovedInterfaceDeclaration_ISentSignalMessage(
+    get_old_InterfaceDeclaration_ISentSignalMessage());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedInterfaceDeclaration_ISentSignalMessage": {"backCompat": false}
+*/
+declare function get_current_RemovedInterfaceDeclaration_ISentSignalMessage():
+    TypeOnly<current.ISentSignalMessage>;
+declare function use_old_InterfaceDeclaration_ISentSignalMessage(
+    use: TypeOnly<old.ISentSignalMessage>);
+use_old_InterfaceDeclaration_ISentSignalMessage(
+    get_current_RemovedInterfaceDeclaration_ISentSignalMessage());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ISequencedClient": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ISequencedClient():
@@ -812,6 +836,30 @@ declare function use_old_InterfaceDeclaration_ISequencedDocumentMessage(
     use: TypeOnly<old.ISequencedDocumentMessage>);
 use_old_InterfaceDeclaration_ISequencedDocumentMessage(
     get_current_InterfaceDeclaration_ISequencedDocumentMessage());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ISequencedDocumentMessageExperimental": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_ISequencedDocumentMessageExperimental():
+    TypeOnly<old.ISequencedDocumentMessageExperimental>;
+declare function use_current_TypeAliasDeclaration_ISequencedDocumentMessageExperimental(
+    use: TypeOnly<current.ISequencedDocumentMessageExperimental>);
+use_current_TypeAliasDeclaration_ISequencedDocumentMessageExperimental(
+    get_old_TypeAliasDeclaration_ISequencedDocumentMessageExperimental());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ISequencedDocumentMessageExperimental": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_ISequencedDocumentMessageExperimental():
+    TypeOnly<current.ISequencedDocumentMessageExperimental>;
+declare function use_old_TypeAliasDeclaration_ISequencedDocumentMessageExperimental(
+    use: TypeOnly<old.ISequencedDocumentMessageExperimental>);
+use_old_TypeAliasDeclaration_ISequencedDocumentMessageExperimental(
+    get_current_TypeAliasDeclaration_ISequencedDocumentMessageExperimental());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -932,6 +980,30 @@ declare function use_old_InterfaceDeclaration_ISignalMessage(
     use: TypeOnly<old.ISignalMessage>);
 use_old_InterfaceDeclaration_ISignalMessage(
     get_current_InterfaceDeclaration_ISignalMessage());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISignalMessageBase": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ISignalMessageBase():
+    TypeOnly<old.ISignalMessageBase>;
+declare function use_current_InterfaceDeclaration_ISignalMessageBase(
+    use: TypeOnly<current.ISignalMessageBase>);
+use_current_InterfaceDeclaration_ISignalMessageBase(
+    get_old_InterfaceDeclaration_ISignalMessageBase());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ISignalMessageBase": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ISignalMessageBase():
+    TypeOnly<current.ISignalMessageBase>;
+declare function use_old_InterfaceDeclaration_ISignalMessageBase(
+    use: TypeOnly<old.ISignalMessageBase>);
+use_old_InterfaceDeclaration_ISignalMessageBase(
+    get_current_InterfaceDeclaration_ISignalMessageBase());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/common/lib/protocol-definitions/src/test/types/validateProtocolDefinitionsPrevious.generated.ts
+++ b/common/lib/protocol-definitions/src/test/types/validateProtocolDefinitionsPrevious.generated.ts
@@ -744,26 +744,26 @@ use_old_InterfaceDeclaration_IQuorumProposalsEvents(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISentSignalMessage": {"forwardCompat": false}
+* "TypeAliasDeclaration_ISentSignalMessage": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_ISentSignalMessage():
+declare function get_old_TypeAliasDeclaration_ISentSignalMessage():
     TypeOnly<old.ISentSignalMessage>;
-declare function use_current_RemovedInterfaceDeclaration_ISentSignalMessage(
+declare function use_current_TypeAliasDeclaration_ISentSignalMessage(
     use: TypeOnly<current.ISentSignalMessage>);
-use_current_RemovedInterfaceDeclaration_ISentSignalMessage(
-    get_old_InterfaceDeclaration_ISentSignalMessage());
+use_current_TypeAliasDeclaration_ISentSignalMessage(
+    get_old_TypeAliasDeclaration_ISentSignalMessage());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedInterfaceDeclaration_ISentSignalMessage": {"backCompat": false}
+* "TypeAliasDeclaration_ISentSignalMessage": {"backCompat": false}
 */
-declare function get_current_RemovedInterfaceDeclaration_ISentSignalMessage():
+declare function get_current_TypeAliasDeclaration_ISentSignalMessage():
     TypeOnly<current.ISentSignalMessage>;
-declare function use_old_InterfaceDeclaration_ISentSignalMessage(
+declare function use_old_TypeAliasDeclaration_ISentSignalMessage(
     use: TypeOnly<old.ISentSignalMessage>);
-use_old_InterfaceDeclaration_ISentSignalMessage(
-    get_current_RemovedInterfaceDeclaration_ISentSignalMessage());
+use_old_TypeAliasDeclaration_ISentSignalMessage(
+    get_current_TypeAliasDeclaration_ISentSignalMessage());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
We have released protocol-definitions 3.2.0, so I bumped the in-repo version to 3.3.0 and updated the type tests:

```shell
pnpm run typetests:prepare
pnpm i
pnpm build
```