### PR TITLE
fix(fluid-build): Fix dynamic import with absolute file path in windows

### DIFF
--- a/build-tools/packages/build-tools/src/common/utils.ts
+++ b/build-tools/packages/build-tools/src/common/utils.ts
@@ -8,6 +8,7 @@ import * as glob from "glob";
 import isEqual from "lodash.isequal";
 import * as path from "path";
 import * as util from "util";
+import { pathToFileURL } from "node:url";
 
 export function getExecutableFromCommand(command: string) {
 	let toReturn: string;
@@ -253,7 +254,7 @@ export async function loadModule(modulePath: string, moduleType?: string) {
 	const ext = path.extname(modulePath);
 	const esm = ext === ".mjs" || (ext === ".js" && moduleType === "module");
 	if (esm) {
-		return await import(modulePath);
+		return await import(pathToFileURL(modulePath).toString());
 	}
 	return require(modulePath);
 }


### PR DESCRIPTION
Dynamic import absolute path on windows needs to be in URL form (i.e. file://) because of the drive name.