### PR TITLE
Remove impossible case test for serializedStateManager

### DIFF
--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -176,30 +176,6 @@ describe("serializedStateManager", () => {
 		);
 	});
 
-	it("can't get pending local state when there is no base snapshot", async () => {
-		const storageAdapter = new MockStorageAdapter();
-		const serializedStateManager = new SerializedStateManager(
-			undefined,
-			logger,
-			storageAdapter,
-			true,
-		);
-
-		await assert.rejects(
-			async () =>
-				serializedStateManager.getPendingLocalStateCore(
-					{
-						notifyImminentClosure: false,
-					},
-					"clientId",
-					new MockRuntime(),
-					resolvedUrl,
-				),
-			(error: Error) => errorFn(error, "no base data"),
-			"container can get local state with no base snapshot",
-		);
-	});
-
 	it("can get snapshot from previous local state", async () => {
 		const pendingLocalState: IPendingContainerState = {
 			attached: true,


### PR DESCRIPTION
To unblock https://github.com/microsoft/FluidFramework/pull/20038
This test was added recently but it's really strict, testing for an assert that is impossible to hit. 