### PR TITLE
Add expected node types for tests that are missing them

### DIFF
--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -205,6 +205,7 @@
 		"@microsoft/api-extractor": "^7.42.3",
 		"@types/double-ended-queue": "^2.1.0",
 		"@types/mocha": "^9.1.1",
+		"@types/node": "^18.19.0",
 		"@types/sinon": "^17.0.3",
 		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",

--- a/packages/runtime/container-runtime/src/test/tsconfig.json
+++ b/packages/runtime/container-runtime/src/test/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",
-		"types": ["mocha"],
+		"types": ["mocha", "node"],
 	},
 	"include": ["./**/*"],
 	"references": [

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -151,6 +151,7 @@
 		"@fluidframework/id-compressor-previous": "npm:@fluidframework/id-compressor@2.0.0-internal.8.0.0",
 		"@microsoft/api-extractor": "^7.42.3",
 		"@types/mocha": "^9.1.1",
+		"@types/node": "^18.19.0",
 		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"copyfiles": "^2.4.1",

--- a/packages/runtime/id-compressor/src/test/tsconfig.json
+++ b/packages/runtime/id-compressor/src/test/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",
-		"types": ["mocha"],
+		"types": ["mocha", "node"],
 
 		// The package exports utilities for test code from the test folder, so we need to build types for test files, which we typically
 		// don't do.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8905,6 +8905,7 @@ importers:
       '@tylerbu/sorted-btree-es6': ^1.8.0
       '@types/double-ended-queue': ^2.1.0
       '@types/mocha': ^9.1.1
+      '@types/node': ^18.19.0
       '@types/sinon': ^17.0.3
       '@types/uuid': ^9.0.2
       c8: ^8.0.1
@@ -8945,15 +8946,16 @@ importers:
       '@fluid-internal/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluid-private/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.34.0_bpztyfltmpuv6lhsgzfwtmxhte
+      '@fluid-tools/build-cli': 0.34.0_u673t2dmpu2di5cxot3t45f7wi
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.34.0
+      '@fluidframework/build-tools': 0.34.0_@types+node@18.19.1
       '@fluidframework/container-runtime-previous': /@fluidframework/container-runtime/2.0.0-internal.8.0.0
       '@fluidframework/eslint-config-fluid': 4.0.0_bpztyfltmpuv6lhsgzfwtmxhte
       '@fluidframework/test-runtime-utils': link:../test-runtime-utils
-      '@microsoft/api-extractor': 7.42.3
+      '@microsoft/api-extractor': 7.42.3_@types+node@18.19.1
       '@types/double-ended-queue': 2.1.7
       '@types/mocha': 9.1.1
+      '@types/node': 18.19.1
       '@types/sinon': 17.0.3
       '@types/uuid': 9.0.7
       c8: 8.0.1
@@ -9146,6 +9148,7 @@ importers:
       '@microsoft/api-extractor': ^7.42.3
       '@tylerbu/sorted-btree-es6': ^1.8.0
       '@types/mocha': ^9.1.1
+      '@types/node': ^18.19.0
       '@types/uuid': ^9.0.2
       c8: ^8.0.1
       copyfiles: ^2.4.1
@@ -9171,13 +9174,14 @@ importers:
       '@fluid-internal/mocha-test-setup': link:../../test/mocha-test-setup
       '@fluid-private/stochastic-test-utils': link:../../test/stochastic-test-utils
       '@fluid-tools/benchmark': 0.48.0
-      '@fluid-tools/build-cli': 0.34.0_bpztyfltmpuv6lhsgzfwtmxhte
+      '@fluid-tools/build-cli': 0.34.0_u673t2dmpu2di5cxot3t45f7wi
       '@fluidframework/build-common': 2.0.3
-      '@fluidframework/build-tools': 0.34.0
+      '@fluidframework/build-tools': 0.34.0_@types+node@18.19.1
       '@fluidframework/eslint-config-fluid': 4.0.0_bpztyfltmpuv6lhsgzfwtmxhte
       '@fluidframework/id-compressor-previous': /@fluidframework/id-compressor/2.0.0-internal.8.0.0
-      '@microsoft/api-extractor': 7.42.3
+      '@microsoft/api-extractor': 7.42.3_@types+node@18.19.1
       '@types/mocha': 9.1.1
+      '@types/node': 18.19.1
       '@types/uuid': 9.0.7
       c8: 8.0.1
       copyfiles: 2.4.1


### PR DESCRIPTION
These packages use node assert in their tests, but lack the node typings in their devDependencies.  This just adds them in, similar to most other tests and packages.