### PR TITLE
Adding baseVersionForMinCompat for min compat version testing

### DIFF
--- a/packages/test/test-version-utils/src/baseVersion.ts
+++ b/packages/test/test-version-utils/src/baseVersion.ts
@@ -40,6 +40,13 @@ export const baseVersion = resolveVersion(
 );
 
 /**
+ * Base version used for N min compat versions calculations. Decoupled from baseVersion or codeVersion to avoid
+ * running with issues while bumping a new version or releasing.
+ *
+ * @internal
+ */
+export const baseVersionForMinCompat = "2.0.0-rc.2.0.0";
+/**
  * The problem with just using the code version, is that the current version in the test is actually 0.0.0-xyz-test
  * we want to tell the test to use 0.0.0-xyz-test as the current version. If we are asking for an N-1 version, that
  * value needs to be different. I.e. the current head is at 2.0.0-internal.6.2.0, then N-1 is 2.0.0-internal.5.x.y.

--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -243,7 +243,11 @@ const genFullBackCompatConfig = (driverVersionsAboveV2Int1: number = 0): CompatC
  * It helps to filter out lower verions configs that the ones intended to be tested on a
  * particular suite.
  */
-export function isCompatVersionBelowMinVersion(minVersion: string, config: CompatConfig) {
+export function isCompatVersionBelowMinVersion(
+	minVersion: string,
+	config: CompatConfig,
+	base?: string,
+) {
 	let lowerVersion: string | number = config.compatVersion;
 	// For CrossVersion there are 2 versions being tested. Get the lower one.
 	if (config.kind === CompatKind.CrossVersion) {
@@ -252,7 +256,7 @@ export function isCompatVersionBelowMinVersion(minVersion: string, config: Compa
 				? (config.loadVersion as string)
 				: config.compatVersion;
 	}
-	const compatVersion = getRequestedVersion(testBaseVersion(lowerVersion), lowerVersion);
+	const compatVersion = getRequestedVersion(base ?? testBaseVersion(lowerVersion), lowerVersion);
 	const minReqVersion = getRequestedVersion(testBaseVersion(minVersion), minVersion);
 	return semver.compare(compatVersion, minReqVersion) < 0;
 }

--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -246,7 +246,7 @@ const genFullBackCompatConfig = (driverVersionsAboveV2Int1: number = 0): CompatC
 export function isCompatVersionBelowMinVersion(
 	minVersion: string,
 	config: CompatConfig,
-	base?: string,
+	base: string,
 ) {
 	let lowerVersion: string | number = config.compatVersion;
 	// For CrossVersion there are 2 versions being tested. Get the lower one.
@@ -256,7 +256,7 @@ export function isCompatVersionBelowMinVersion(
 				? (config.loadVersion as string)
 				: config.compatVersion;
 	}
-	const compatVersion = getRequestedVersion(base ?? testBaseVersion(lowerVersion), lowerVersion);
+	const compatVersion = getRequestedVersion(base, lowerVersion);
 	const minReqVersion = getRequestedVersion(testBaseVersion(minVersion), minVersion);
 	return semver.compare(compatVersion, minReqVersion) < 0;
 }

--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -16,7 +16,12 @@ import {
 } from "../compatOptions.cjs";
 import { ensurePackageInstalled } from "./testApi.js";
 import { pkgVersion } from "./packageVersion.js";
-import { baseVersion, codeVersion, testBaseVersion } from "./baseVersion.js";
+import {
+	baseVersion,
+	baseVersionForMinCompat,
+	codeVersion,
+	testBaseVersion,
+} from "./baseVersion.js";
 import { getRequestedVersion } from "./versionUtils.js";
 
 /**
@@ -243,11 +248,7 @@ const genFullBackCompatConfig = (driverVersionsAboveV2Int1: number = 0): CompatC
  * It helps to filter out lower verions configs that the ones intended to be tested on a
  * particular suite.
  */
-export function isCompatVersionBelowMinVersion(
-	minVersion: string,
-	config: CompatConfig,
-	base: string,
-) {
+export function isCompatVersionBelowMinVersion(minVersion: string, config: CompatConfig) {
 	let lowerVersion: string | number = config.compatVersion;
 	// For CrossVersion there are 2 versions being tested. Get the lower one.
 	if (config.kind === CompatKind.CrossVersion) {
@@ -256,7 +257,7 @@ export function isCompatVersionBelowMinVersion(
 				? (config.loadVersion as string)
 				: config.compatVersion;
 	}
-	const compatVersion = getRequestedVersion(base, lowerVersion);
+	const compatVersion = getRequestedVersion(baseVersionForMinCompat, lowerVersion);
 	const minReqVersion = getRequestedVersion(testBaseVersion(minVersion), minVersion);
 	return semver.compare(compatVersion, minReqVersion) < 0;
 }

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -17,7 +17,7 @@ import {
 	getVersionedTestObjectProviderFromApis,
 	getCompatVersionedTestObjectProviderFromApis,
 } from "./compatUtils.js";
-import { baseVersionForMinCompat, testBaseVersion } from "./baseVersion.js";
+import { testBaseVersion } from "./baseVersion.js";
 import {
 	getContainerRuntimeApi,
 	getDataRuntimeApi,
@@ -48,10 +48,7 @@ function createCompatSuite(
 			configs = configs.filter((value) => compatFilter.includes(value.kind));
 		}
 		for (const config of configs) {
-			if (
-				minVersion &&
-				isCompatVersionBelowMinVersion(minVersion, config, baseVersionForMinCompat)
-			) {
+			if (minVersion && isCompatVersionBelowMinVersion(minVersion, config)) {
 				// skip current config if compat version is below min version supported for test suite
 				continue;
 			}

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -17,7 +17,7 @@ import {
 	getVersionedTestObjectProviderFromApis,
 	getCompatVersionedTestObjectProviderFromApis,
 } from "./compatUtils.js";
-import { testBaseVersion } from "./baseVersion.js";
+import { baseVersionForMinCompat, testBaseVersion } from "./baseVersion.js";
 import {
 	getContainerRuntimeApi,
 	getDataRuntimeApi,
@@ -48,7 +48,10 @@ function createCompatSuite(
 			configs = configs.filter((value) => compatFilter.includes(value.kind));
 		}
 		for (const config of configs) {
-			if (minVersion && isCompatVersionBelowMinVersion(minVersion, config)) {
+			if (
+				minVersion &&
+				isCompatVersionBelowMinVersion(minVersion, config, baseVersionForMinCompat)
+			) {
 				// skip current config if compat version is below min version supported for test suite
 				continue;
 			}

--- a/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
+++ b/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
@@ -19,15 +19,11 @@ describe("Minimum Compat Version", () => {
 		const invalidString = "invalid string";
 		assert.throws(
 			() =>
-				isCompatVersionBelowMinVersion(
-					invalidString,
-					{
-						name: `test`,
-						kind: CompatKind.None,
-						compatVersion: "2.0.0-internal.8.0.0",
-					},
-					baseVersionForMinCompat,
-				),
+				isCompatVersionBelowMinVersion(invalidString, {
+					name: `test`,
+					kind: CompatKind.None,
+					compatVersion: "2.0.0-internal.8.0.0",
+				}),
 			(error: Error) => {
 				return (
 					error.message?.startsWith(
@@ -43,15 +39,11 @@ describe("Minimum Compat Version", () => {
 	for (let i = 1; i < numCompatVersions; i++) {
 		it(`compatVersion N-${i} < ${baseVersionForMinCompat}`, () => {
 			assert.strictEqual(
-				isCompatVersionBelowMinVersion(
-					baseVersionForMinCompat,
-					{
-						name: `test`,
-						kind: CompatKind.None,
-						compatVersion: -i,
-					},
-					baseVersionForMinCompat,
-				),
+				isCompatVersionBelowMinVersion(baseVersionForMinCompat, {
+					name: `test`,
+					kind: CompatKind.None,
+					compatVersion: -i,
+				}),
 				true,
 				`N-${i} version is not lower than min version: ${baseVersionForMinCompat}`,
 			);
@@ -62,15 +54,11 @@ describe("Minimum Compat Version", () => {
 	for (let i = 1; i < numCompatVersions; i++) {
 		it(`compatVersion N-${i} > ${oldVersion}`, () => {
 			assert.strictEqual(
-				isCompatVersionBelowMinVersion(
-					oldVersion,
-					{
-						name: `test`,
-						kind: CompatKind.None,
-						compatVersion: -i,
-					},
-					baseVersionForMinCompat,
-				),
+				isCompatVersionBelowMinVersion(oldVersion, {
+					name: `test`,
+					kind: CompatKind.None,
+					compatVersion: -i,
+				}),
 				false,
 				`N-${i} version: is lower than min version: ${oldVersion}`,
 			);
@@ -79,62 +67,46 @@ describe("Minimum Compat Version", () => {
 
 	it("cross compat. filters out if loadVersion is lower than minVersion", () => {
 		assert.strictEqual(
-			isCompatVersionBelowMinVersion(
-				greaterVersion,
-				{
-					name: "test",
-					kind: CompatKind.CrossVersion,
-					compatVersion: greaterVersion,
-					loadVersion: lowerVersion,
-				},
-				baseVersionForMinCompat,
-			),
+			isCompatVersionBelowMinVersion(greaterVersion, {
+				name: "test",
+				kind: CompatKind.CrossVersion,
+				compatVersion: greaterVersion,
+				loadVersion: lowerVersion,
+			}),
 			true,
 		);
 	});
 
 	it("cross compat. filters out if compatVersion is lower than minVersion", () => {
 		assert.strictEqual(
-			isCompatVersionBelowMinVersion(
-				greaterVersion,
-				{
-					name: "test",
-					kind: CompatKind.CrossVersion,
-					compatVersion: lowerVersion,
-					loadVersion: greaterVersion,
-				},
-				baseVersionForMinCompat,
-			),
+			isCompatVersionBelowMinVersion(greaterVersion, {
+				name: "test",
+				kind: CompatKind.CrossVersion,
+				compatVersion: lowerVersion,
+				loadVersion: greaterVersion,
+			}),
 			true,
 		);
 	});
 
 	it("cross compat. does not filter out valid versions", () => {
 		assert.strictEqual(
-			isCompatVersionBelowMinVersion(
-				lowerVersion,
-				{
-					name: "test",
-					kind: CompatKind.CrossVersion,
-					compatVersion: greaterVersion,
-					loadVersion: lowerVersion,
-				},
-				baseVersionForMinCompat,
-			),
+			isCompatVersionBelowMinVersion(lowerVersion, {
+				name: "test",
+				kind: CompatKind.CrossVersion,
+				compatVersion: greaterVersion,
+				loadVersion: lowerVersion,
+			}),
 			false,
 			`fails with minVersion: ${lowerVersion} compatversion: ${greaterVersion} loadVersion: ${lowerVersion}`,
 		);
 		assert.strictEqual(
-			isCompatVersionBelowMinVersion(
-				lowerVersion,
-				{
-					name: "test",
-					kind: CompatKind.CrossVersion,
-					compatVersion: lowerVersion,
-					loadVersion: greaterVersion,
-				},
-				baseVersionForMinCompat,
-			),
+			isCompatVersionBelowMinVersion(lowerVersion, {
+				name: "test",
+				kind: CompatKind.CrossVersion,
+				compatVersion: lowerVersion,
+				loadVersion: greaterVersion,
+			}),
 			false,
 			`fails with minVersion: ${lowerVersion} compatversion: ${lowerVersion} loadVersion: ${greaterVersion}`,
 		);

--- a/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
+++ b/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
@@ -126,16 +126,16 @@ describe("Minimum Compat Version", () => {
 		});
 	}
 
-	for (let i = 0; i < versions.length; i++) {
-		for (let j = i + 1; j < versions.length; j++) {
-			it(`version ${versions[i]} should be below version ${versions[j]}`, () => {
+	for (let i = numCompatVersions; i < versions.length; i++) {
+		for (let j = i - 1; j >= i - numCompatVersions; j--) {
+			it(`version ${versions[j]} should be below version ${versions[i]}`, () => {
 				assert.strictEqual(
 					isCompatVersionBelowMinVersion(versions[i], {
 						name: `test`,
 						kind: CompatKind.None,
 						compatVersion: versions[j],
 					}),
-					false,
+					true,
 					`version: "${versions[i]}" is not lower than ${versions[j]}`,
 				);
 			});

--- a/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
+++ b/packages/test/test-version-utils/src/test/minCompatVersion.spec.ts
@@ -72,7 +72,7 @@ describe("Minimum Compat Version", () => {
 					baseVersionForMinCompat,
 				),
 				false,
-				`N-${i} version: is not lower than min version: ${oldVersion}`,
+				`N-${i} version: is lower than min version: ${oldVersion}`,
 			);
 		});
 	}


### PR DESCRIPTION
Every time we release, the base version in which N-i calculations are based changes. This causes issues at testing specially at bumping the release version. By hard coding the version in which these calculations are made, we decoupled the min version testing from the release process, although we will need to update this hard coded value shortly after the release as after work to make sure that min versions are going to work with the new version. I really believe this is the best attempt so far to test this functionality, given that it's a middle ground between both contending arguments of making the tests deterministic and at the same time not requiring too much of maintenance.