### PR TITLE
Expose IFluidDataStoreRuntime.addChannel

### DIFF
--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -89,6 +89,7 @@ export interface IDeltaHandler {
 
 // @public
 export interface IFluidDataStoreRuntime extends IEventProvider<IFluidDataStoreRuntimeEvents>, IDisposable {
+    addChannel(channel: IChannel): void;
     readonly attachState: AttachState;
     bindChannel(channel: IChannel): void;
     // (undocumented)

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -89,6 +89,15 @@ export interface IFluidDataStoreRuntime
 	createChannel(id: string | undefined, type: string): IChannel;
 
 	/**
+	 * This api allows adding channel to data store after it was created.
+	 * The channel type should be present in the registry, otherwise the runtime would reject
+	 * the channel. The runtime used to create the channel object should be same to which
+	 * it is added.
+	 * @param channel - channel which needs to be added to the runtime.
+	 */
+	addChannel(channel: IChannel): void;
+
+	/**
 	 * Bind the channel with the data store runtime. If the runtime
 	 * is attached then we attach the channel to make it live.
 	 */

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -90,6 +90,12 @@ export interface IFluidDataStoreRuntime
 
 	/**
 	 * This api allows adding channel to data store after it was created.
+	 * This allows callers to cusmomize channel instance. For example, channel implementation
+	 * could have various modes of operations. As long as such configuration is provided at creation
+	 * and stored in summaries (such that all users of such channel instance behave the same), this
+	 * could be useful technique to have customized solutions without introducing a number of data structures
+	 * that all have same implementation.
+	 * This is also useful for scenarios like SharedTree DDS, where schema is provided at creation and stored in a summary.
 	 * The channel type should be present in the registry, otherwise the runtime would reject
 	 * the channel. The runtime used to create the channel object should be same to which
 	 * it is added.

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -415,6 +415,8 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     });
     // (undocumented)
     get absolutePath(): string;
+    // (undocumented)
+    addChannel(channel: IChannel): void;
     // @deprecated (undocumented)
     addedGCOutboundReference(srcHandle: IFluidHandle, outboundHandle: IFluidHandle): void;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -799,6 +799,8 @@ export class MockFluidDataStoreRuntime
 		return null as any as IChannel;
 	}
 
+	public addChannel(channel: IChannel): void {}
+
 	public get isAttached(): boolean {
 		return this.attachState !== AttachState.Detached;
 	}


### PR DESCRIPTION
FluidDataStoreRuntime.addChannel was added some time ago, but it was not properly exposed on interfaces.
This makes impossible to use this API from frameworks (like Aqueduct), where we do not have access to concrete class (implementation of runtime), only to interface.