### PR TITLE
build(client-examples): make Bundler resolution a standard

### DIFF
--- a/common/build/build-common/tsconfig.bundler.json
+++ b/common/build/build-common/tsconfig.bundler.json
@@ -1,0 +1,9 @@
+{
+	// This configuration should only be used when emitted code is only used with a bundler
+	// and never used in Node.js. Use tsconfig.node*.json if run under Node.js.
+	"extends": ["./tsconfig.base.json"],
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+	},
+}

--- a/examples/apps/data-object-grid/src/collapsible.cts
+++ b/examples/apps/data-object-grid/src/collapsible.cts
@@ -1,0 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import react_collapsible from "react-collapsible";
+
+export { react_collapsible as Collapsible };

--- a/examples/apps/data-object-grid/src/toolbar.tsx
+++ b/examples/apps/data-object-grid/src/toolbar.tsx
@@ -4,9 +4,9 @@
  */
 
 import React from "react";
-import Collapsible from "react-collapsible";
 import { Button } from "@fluentui/react-components";
 import { ChevronUpFilled, ChevronDownFilled, TargetEditFilled } from "@fluentui/react-icons";
+import { Collapsible } from "./collapsible.cjs";
 import { IDataObjectGridItemEntry } from "./dataObjectRegistry.js";
 import "./toolbar.css";
 import { iconMap } from "./icons.js";

--- a/examples/apps/data-object-grid/tsconfig.json
+++ b/examples/apps/data-object-grid/tsconfig.json
@@ -1,10 +1,7 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	// Use Bundler over Node16 as there are no tests run under Node.js.
+	"extends": "../../../common/build/build-common/tsconfig.bundler.json",
 	"compilerOptions": {
-		// ESNext/Bundler works better than Node16/Node16 for this example because of the <Collapsible> React control
-		// and it is intended to be used via a bundler anyway
-		"module": "ESNext",
-		"moduleResolution": "Bundler",
 		"outDir": "./lib",
 		"types": [
 			"jest",

--- a/examples/apps/data-object-grid/webpack.config.cjs
+++ b/examples/apps/data-object-grid/webpack.config.cjs
@@ -21,7 +21,9 @@ module.exports = (env) => {
 			},
 			resolve: {
 				extensionAlias: {
-					".js": [".ts", ".tsx", ".js", ".cjs", ".mjs"],
+					".cjs": [".cts", ".cjs"],
+					".js": [".ts", ".tsx", ".js"],
+					".mjs": [".mts", ".mjs"],
 				},
 				extensions: [".ts", ".tsx", ".js", ".cjs", ".mjs"],
 				fallback: {

--- a/examples/data-objects/multiview/constellation-model/tsconfig.json
+++ b/examples/data-objects/multiview/constellation-model/tsconfig.json
@@ -3,7 +3,6 @@
 	"compilerOptions": {
 		"outDir": "./lib",
 		"rootDir": "./src",
-		"types": [],
 	},
 	"include": ["src/**/*"],
 }

--- a/examples/data-objects/multiview/constellation-model/webpack.config.cjs
+++ b/examples/data-objects/multiview/constellation-model/webpack.config.cjs
@@ -17,7 +17,9 @@ module.exports = (env) => {
 			},
 			resolve: {
 				extensionAlias: {
-					".js": [".ts", ".tsx", ".js", ".cjs", ".mjs"],
+					".cjs": [".cts", ".cjs"],
+					".js": [".ts", ".tsx", ".js"],
+					".mjs": [".mts", ".mjs"],
 				},
 				extensions: [".ts", ".tsx", ".js", ".cjs", ".mjs"],
 			},

--- a/examples/data-objects/multiview/coordinate-model/webpack.config.cjs
+++ b/examples/data-objects/multiview/coordinate-model/webpack.config.cjs
@@ -17,7 +17,9 @@ module.exports = (env) => {
 			},
 			resolve: {
 				extensionAlias: {
-					".js": [".ts", ".tsx", ".js", ".cjs", ".mjs"],
+					".cjs": [".cts", ".cjs"],
+					".js": [".ts", ".tsx", ".js"],
+					".mjs": [".mts", ".mjs"],
 				},
 				extensions: [".ts", ".tsx", ".js", ".cjs", ".mjs"],
 			},


### PR DESCRIPTION
follow up from PR #20045:
- use tsconfig.bundler.json
- correct webpack extensionAlias to support .cts/mts files
- make data-object-grid full ESM buildable (but stick with Bundler resolution)