### PR TITLE
feat(merge-tree): do not emit events for concurrently obliterated segments

### DIFF
--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1331,10 +1331,16 @@ export class MergeTree {
 
 		// opArgs == undefined => loading snapshot or test code
 		if (opArgs !== undefined) {
-			this.mergeTreeDeltaCallback?.(opArgs, {
-				operation: MergeTreeDeltaType.INSERT,
-				deltaSegments: segments.map((segment) => ({ segment })),
-			});
+			const deltaSegments = segments
+				.filter((segment) => !toMoveInfo(segment))
+				.map((segment) => ({ segment }));
+
+			if (deltaSegments.length > 0) {
+				this.mergeTreeDeltaCallback?.(opArgs, {
+					operation: MergeTreeDeltaType.INSERT,
+					deltaSegments,
+				});
+			}
 		}
 
 		if (
@@ -1960,7 +1966,9 @@ export class MergeTree {
 				segment.localMovedSeq = localSeq;
 				segment.movedSeqs = [seq];
 
-				movedSegments.push({ segment });
+				if (!toRemovalInfo(segment)) {
+					movedSegments.push({ segment });
+				}
 			}
 
 			// Save segment so can assign moved sequence number when acked by server
@@ -2070,7 +2078,9 @@ export class MergeTree {
 				segment.removedSeq = seq;
 				segment.localRemovedSeq = localSeq;
 
-				removedSegments.push({ segment });
+				if (!toMoveInfo(segment)) {
+					removedSegments.push({ segment });
+				}
 			}
 
 			// Save segment so we can assign removed sequence number when acked by server

--- a/packages/dds/merge-tree/src/test/obliterate.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.deltaCallback.spec.ts
@@ -1,0 +1,165 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { MergeTreeDeltaType } from "../ops.js";
+import { MergeTreeDeltaCallback } from "../mergeTreeDeltaCallback.js";
+import { useStrictPartialLengthChecks } from "./testUtils.js";
+import { ReconnectTestHelper } from "./reconnectHelper.js";
+
+describe("obliterate delta callback", () => {
+	useStrictPartialLengthChecks();
+
+	let length: number;
+	let cb: MergeTreeDeltaCallback;
+
+	beforeEach(() => {
+		length = 0;
+		cb = (opArgs, deltaArgs) => {
+			switch (opArgs.op.type) {
+				case MergeTreeDeltaType.INSERT: {
+					for (const { segment } of deltaArgs.deltaSegments) {
+						length += segment.cachedLength;
+					}
+					break;
+				}
+				case MergeTreeDeltaType.REMOVE:
+				case MergeTreeDeltaType.OBLITERATE: {
+					for (const { segment } of deltaArgs.deltaSegments) {
+						length -= segment.cachedLength;
+					}
+					break;
+				}
+				default: {
+				}
+			}
+		};
+	});
+
+	it("works", () => {
+		const helper = new ReconnectTestHelper();
+
+		let count = 0;
+
+		helper.clients.A.on("delta", (opArgs, deltaArgs) => {
+			if (opArgs.op.type === MergeTreeDeltaType.OBLITERATE) {
+				count += 1;
+			}
+		});
+
+		// local
+		helper.insertText("A", 0, "a");
+		assert.equal(count, 0);
+		helper.obliterateRange("A", 0, 1);
+		assert.equal(count, 1);
+		helper.processAllOps();
+		assert.equal(count, 1);
+		assert.equal(helper.clients.A.getText(), "");
+
+		// remote
+		helper.insertText("B", 0, "a");
+		assert.equal(count, 1);
+		helper.obliterateRange("B", 0, 1);
+		assert.equal(count, 1);
+		helper.processAllOps();
+		assert.equal(count, 2);
+		assert.equal(helper.clients.A.getText(), "");
+
+		helper.logger.validate();
+	});
+
+	it("overlapping obliterate+remove", () => {
+		const helper = new ReconnectTestHelper();
+
+		helper.clients.A.on("delta", cb);
+
+		const text = "abcdef";
+
+		// obliterate first
+		helper.insertText("B", 0, text);
+		helper.processAllOps();
+		assert.equal(length, text.length);
+		helper.obliterateRange("C", 0, text.length);
+		helper.removeRange("B", 0, text.length);
+		helper.processAllOps();
+		assert.equal(length, 0);
+
+		helper.logger.validate();
+
+		helper.clients.A.off("delta", cb);
+	});
+
+	it("overlapping remove+obliterate", () => {
+		const helper = new ReconnectTestHelper();
+
+		helper.clients.A.on("delta", cb);
+
+		const text = "abcdef";
+
+		// remove first
+		helper.insertText("A", 0, text);
+		helper.processAllOps();
+		assert.equal(length, text.length);
+		helper.removeRange("B", 0, text.length);
+		helper.obliterateRange("C", 0, text.length);
+		helper.processAllOps();
+		assert.equal(length, 0);
+
+		helper.logger.validate();
+
+		helper.clients.A.off("delta", cb);
+	});
+
+	it("overlapping obliterate+obliterate", () => {
+		const helper = new ReconnectTestHelper();
+
+		helper.clients.A.on("delta", cb);
+
+		const text = "abcdef";
+
+		// obliterate first
+		helper.insertText("B", 0, text);
+		helper.processAllOps();
+		assert.equal(length, text.length);
+		helper.obliterateRange("B", 0, text.length);
+		helper.obliterateRange("C", 0, text.length);
+		helper.processAllOps();
+		assert.equal(length, 0);
+
+		helper.logger.validate();
+
+		helper.clients.A.off("delta", cb);
+	});
+
+	it("insert into obliterated range", () => {
+		const helper = new ReconnectTestHelper();
+
+		helper.clients.A.on("delta", cb);
+
+		const text = "abcdef";
+
+		// insert first
+		helper.insertText("B", 0, text);
+		helper.processAllOps();
+		assert.equal(length, text.length);
+		helper.insertText("B", 3, text);
+		helper.obliterateRange("C", 0, text.length);
+		helper.processAllOps();
+		assert.equal(length, 0);
+
+		// obliterate first
+		helper.insertText("B", 0, text);
+		helper.processAllOps();
+		assert.equal(length, text.length);
+		helper.obliterateRange("C", 0, text.length);
+		helper.insertText("B", 3, text);
+		helper.processAllOps();
+		assert.equal(length, 0);
+
+		helper.logger.validate();
+
+		helper.clients.A.off("delta", cb);
+	});
+});

--- a/packages/dds/merge-tree/src/test/obliterate.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.deltaCallback.spec.ts
@@ -9,7 +9,7 @@ import { MergeTreeDeltaCallback } from "../mergeTreeDeltaCallback.js";
 import { useStrictPartialLengthChecks } from "./testUtils.js";
 import { ReconnectTestHelper } from "./reconnectHelper.js";
 
-describe.only("obliterate delta callback", () => {
+describe("obliterate delta callback", () => {
 	useStrictPartialLengthChecks();
 
 	let length: number;

--- a/packages/dds/merge-tree/src/test/obliterate.deltaCallback.spec.ts
+++ b/packages/dds/merge-tree/src/test/obliterate.deltaCallback.spec.ts
@@ -9,7 +9,7 @@ import { MergeTreeDeltaCallback } from "../mergeTreeDeltaCallback.js";
 import { useStrictPartialLengthChecks } from "./testUtils.js";
 import { ReconnectTestHelper } from "./reconnectHelper.js";
 
-describe("obliterate delta callback", () => {
+describe.only("obliterate delta callback", () => {
 	useStrictPartialLengthChecks();
 
 	let length: number;
@@ -73,11 +73,11 @@ describe("obliterate delta callback", () => {
 			});
 
 			helper.insertText("B", 0, "a");
-			assert.equal(count, 1);
+			assert.equal(count, 0);
 			helper.obliterateRange("B", 0, 1);
-			assert.equal(count, 1);
+			assert.equal(count, 0);
 			helper.processAllOps();
-			assert.equal(count, 2);
+			assert.equal(count, 1);
 			assert.equal(helper.clients.A.getText(), "");
 
 			helper.logger.validate();


### PR DESCRIPTION
Do not emit delta events for segments which are superfluous due to an overlapping obliterate.

[AB#7438](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7438)