### PR TITLE
Expose ability to overwrite max ops before test hits nack with too many unsumarized ops

### DIFF
--- a/packages/test/test-drivers/api-report/test-drivers.api.md
+++ b/packages/test/test-drivers/api-report/test-drivers.api.md
@@ -76,7 +76,7 @@ export type LocalDriverApiType = typeof LocalDriverApi;
 
 // @internal (undocumented)
 export class LocalServerTestDriver implements ITestDriver {
-    constructor(api?: LocalDriverApiType);
+    constructor(api?: LocalDriverApiType, maxOps?: number);
     // (undocumented)
     createContainerUrl(testId: string): Promise<string>;
     // (undocumented)

--- a/packages/test/test-drivers/api-report/test-drivers.api.md
+++ b/packages/test/test-drivers/api-report/test-drivers.api.md
@@ -76,7 +76,7 @@ export type LocalDriverApiType = typeof LocalDriverApi;
 
 // @internal (undocumented)
 export class LocalServerTestDriver implements ITestDriver {
-    constructor(api?: LocalDriverApiType, maxOps?: number);
+    constructor(api?: LocalDriverApiType, maxOpsBeforeSummary?: number);
     // (undocumented)
     createContainerUrl(testId: string): Promise<string>;
     // (undocumented)

--- a/packages/test/test-drivers/src/localServerTestDriver.ts
+++ b/packages/test/test-drivers/src/localServerTestDriver.ts
@@ -25,15 +25,21 @@ export class LocalServerTestDriver implements ITestDriver {
 		return this._server;
 	}
 
+	/**
+	 * LocalServerTestDriver constructor
+	 * @param api - driver API
+	 * @param maxOpsBeforeSummary - tells how many ops service allows to be sequenced before requiring a summary.
+	 * If a test submits more ops, connection will disconnec with nack and error message "Submit a summary before inserting additional operations"
+	 */
 	constructor(
 		private readonly api: LocalDriverApiType = LocalDriverApi,
-		maxOps = 200,
+		maxOpsBeforeSummary = 200,
 	) {
 		this._server = api.LocalDeltaConnectionServer.create(undefined, {
 			deli: {
 				summaryNackMessages: {
 					enable: true,
-					maxOps,
+					maxOps: maxOpsBeforeSummary,
 					nackContent: {
 						retryAfter: 0,
 					},

--- a/packages/test/test-drivers/src/localServerTestDriver.ts
+++ b/packages/test/test-drivers/src/localServerTestDriver.ts
@@ -25,7 +25,10 @@ export class LocalServerTestDriver implements ITestDriver {
 		return this._server;
 	}
 
-	constructor(private readonly api: LocalDriverApiType = LocalDriverApi, maxOps = 200) {
+	constructor(
+		private readonly api: LocalDriverApiType = LocalDriverApi,
+		maxOps = 200,
+	) {
 		this._server = api.LocalDeltaConnectionServer.create(undefined, {
 			deli: {
 				summaryNackMessages: {

--- a/packages/test/test-drivers/src/localServerTestDriver.ts
+++ b/packages/test/test-drivers/src/localServerTestDriver.ts
@@ -25,12 +25,12 @@ export class LocalServerTestDriver implements ITestDriver {
 		return this._server;
 	}
 
-	constructor(private readonly api: LocalDriverApiType = LocalDriverApi) {
+	constructor(private readonly api: LocalDriverApiType = LocalDriverApi, maxOps = 200) {
 		this._server = api.LocalDeltaConnectionServer.create(undefined, {
 			deli: {
 				summaryNackMessages: {
 					enable: true,
-					maxOps: 200,
+					maxOps,
 					nackContent: {
 						retryAfter: 0,
 					},


### PR DESCRIPTION
My (local) tests are failing intermittently with current 200 limit. It's extremely hard to debug these issues.
Provide a way for test to specify arbitrary limit.

What's worse, tests fail very intermittently (likely because summarizer gets around sometimes).
And debugging it is very painful, includes these steps:
1. Notice that some container is closed in your test (test fails for other reasons as it did not make some progress)
2. arrive to a conclusion that it fails due to too many reconnects
3. learn about nack
4. chase repo in search on why it gets nacked -> arrive to server config
5. search for config -> find it in our test provider.