### PR TITLE
Exclude IdAllocation ops from dirty state calculation

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2816,6 +2816,7 @@ export class ContainerRuntime
 				}
 				break;
 			}
+			case ContainerMessageType.IdAllocation:
 			case ContainerMessageType.GC: {
 				return false;
 			}


### PR DESCRIPTION
Scenario:
1. At the time of reconnect / rebasing, we have two ops: IdAllocation & some other op
2. IdAllocation ops gets resubmitted as is
2. The other op rebases to nothing.

Result:
- Document is dirty.

Expected:
- Document is not dirty.

This is relatively minor, but annoying (IMHO)

That said, the lack of this change causes failures (in production, the moment we enable ID compressor). See https://github.com/microsoft/FluidFramework/pull/20089 for a fix.
So, to some extent, lack of this change helped me find a bug