### PR TITLE
fix(ci): Fix indentation in YAML file so task to copy tinylicious log runs when expected

### DIFF
--- a/tools/pipelines/templates/1ES/build-npm-package.yml
+++ b/tools/pipelines/templates/1ES/build-npm-package.yml
@@ -359,11 +359,11 @@ extends:
                     # CopyFiles@2 failed with OOM for some reason so doing it "by hand".
                     - task: Bash@3
                       displayName: Copy tinylicious.log to artifact staging directory
+                      condition: succeededOrFailed()
+                      continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
                       inputs:
                         targetType: inline
                         workingDirectory: '${{ parameters.buildDirectory }}/packages/test/test-end-to-end-tests'
-                        condition: succeededOrFailed()
-                        continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
                         script: |
                           mkdir -p $(Build.ArtifactStagingDirectory)/tinyliciousLog
                           cp tinylicious.log $(Build.ArtifactStagingDirectory)/tinyliciousLog/tinylicious.log


### PR DESCRIPTION
## Description

See title. Indentation of a few properties in an ADO pipeline YAML file was incorrect since we created the 1ES version of it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
