### PR TITLE
build(partial-checkout): Node16 follow-up

### DIFF
--- a/experimental/PropertyDDS/examples/partial-checkout/package.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/package.json
@@ -15,9 +15,10 @@
 	"scripts": {
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
+		"build:esnext": "tsc --project ./tsconfig.json",
 		"build:webpack": "npm run webpack",
 		"build:webpack:dev": "webpack --env.clean",
-		"clean": "rimraf --glob dist \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
+		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
 		"eslint": "eslint --format stylish src",
 		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
 		"format": "npm run prettier:fix",
@@ -34,7 +35,6 @@
 		"test:jest": "jest",
 		"test:jest:verbose": "cross-env FLUID_TEST_VERBOSE=1 jest",
 		"test:watch": "npm run test:jest -- --watch",
-		"tsc": "tsc",
 		"webpack": "webpack --color --no-stats"
 	},
 	"dependencies": {
@@ -111,7 +111,7 @@
 				],
 				"script": false
 			},
-			"tsc": [
+			"build:esnext": [
 				"...",
 				"@fluid-experimental/property-inspector-table#build:copy-resources"
 			],
@@ -122,7 +122,7 @@
 		},
 		"buildDependencies": {
 			"merge": {
-				"tsc": {
+				"build:esnext": {
 					"@fluid-experimental/property-inspector-table": [
 						"build:webpack"
 					]

--- a/experimental/PropertyDDS/examples/partial-checkout/tsconfig.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/tsconfig.json
@@ -1,13 +1,9 @@
 {
-	"extends": [
-		"../../../../common/build/build-common/tsconfig.base.json",
-		"../../../../common/build/build-common/tsconfig.esm-only.json",
-	],
+	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
 		"target": "es6",
-		"outDir": "dist",
-		"jsx": "react",
+		"outDir": "./lib",
 		"types": ["jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer"],
 	},
 	"include": ["src/**/*", "tests/**/*"],

--- a/experimental/PropertyDDS/examples/partial-checkout/tsconfig.json
+++ b/experimental/PropertyDDS/examples/partial-checkout/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
-		"target": "es6",
 		"outDir": "./lib",
 		"types": ["jest", "puppeteer", "jest-environment-puppeteer", "expect-puppeteer"],
 	},


### PR DESCRIPTION
refresh configuration to meet common pattern and be clear that build is ESM (output to lib)