### PR TITLE
tree: Remove use of fixRecursiveReference pattern

### DIFF
--- a/packages/dds/tree/src/domains/schemaBuilder.ts
+++ b/packages/dds/tree/src/domains/schemaBuilder.ts
@@ -20,7 +20,6 @@ import {
 	FlexImplicitFieldSchema,
 	FlexObjectNodeSchema,
 	Unenforced,
-	FlexAllowedTypes,
 	FlexFieldNodeSchema,
 	FlexMapNodeSchema,
 	TreeNodeSchemaBase,
@@ -301,19 +300,6 @@ export class SchemaBuilder<
 	 * {@link leaf.null}
 	 */
 	public readonly null = leaf.null;
-
-	/**
-	 * Function which can be used for its compile time side-effects to tweak the evaluation order of recursive types to make them compile.
-	 * @remarks
-	 * Some related information in https://github.com/microsoft/TypeScript/issues/55758.
-	 *
-	 * Also be aware that code which relies on this (or the "recursive" SchemaBuilder methods tends to break VSCode's IntelliSense every time anything related to that code (even comments) is edited.
-	 * The command `TypeScript: Restart TS Server` should fix it.
-	 * Sometimes this does not work: the exact cause has not been confirmed but if you have the file open multiple times (for example in both sides of a window split into two columns): closing the extra copy may help.
-	 * Focusing the file with the errors before running `TypeScript: Restart TS Server` can also help.
-	 * Real compile errors (for example elsewhere in the file) can also cause the IntelliSense to not work correctly ever after `TypeScript: Restart TS Server`.
-	 */
-	public fixRecursiveReference<T extends FlexAllowedTypes>(...types: T): void {}
 }
 
 /**

--- a/packages/dds/tree/src/domains/testRecursiveDomain.ts
+++ b/packages/dds/tree/src/domains/testRecursiveDomain.ts
@@ -10,13 +10,7 @@
  * Currently we do not have tooling in place to test this in our test suite, and exporting these types here is a temporary crutch to aid in diagnosing this issue.
  */
 
-import {
-	FlexAllowedTypes,
-	FieldKinds,
-	SchemaBuilderBase,
-	FlexFieldSchema,
-} from "../feature-libraries/index.js";
-import { areSafelyAssignable, isAny, requireFalse, requireTrue } from "../util/index.js";
+import { FieldKinds, SchemaBuilderBase, FlexFieldSchema } from "../feature-libraries/index.js";
 import { leaf } from "./leafDomain.js";
 
 const builder = new SchemaBuilderBase(FieldKinds.optional, { scope: "Test Recursive Domain" });
@@ -25,24 +19,6 @@ export const recursiveObject = builder.objectRecursive("object", {
 	recursive: FlexFieldSchema.createUnsafe(FieldKinds.optional, [() => recursiveObject]),
 	number: leaf.number,
 });
-
-function fixRecursiveReference<T extends FlexAllowedTypes>(...types: T): void {}
-
-const recursiveReference = () => recursiveObject2;
-fixRecursiveReference(recursiveReference);
-
-export const recursiveObject2 = builder.object("object2", {
-	recursive: FlexFieldSchema.create(FieldKinds.optional, [recursiveReference]),
-	number: leaf.number,
-});
-
-type _0 = requireFalse<isAny<typeof recursiveObject2>>;
-type _1 = requireTrue<
-	areSafelyAssignable<
-		typeof recursiveObject2,
-		ReturnType<(typeof recursiveObject2.objectNodeFieldsObject.recursive.allowedTypes)[0]>
-	>
->;
 
 export const library = builder.intoLibrary();
 

--- a/packages/dds/tree/src/simple-tree/README.md
+++ b/packages/dds/tree/src/simple-tree/README.md
@@ -58,12 +58,6 @@ There is currently no good API to dump tree content or compare it which includes
 Related to this there is also no good way to round trip a tree through an external system.
 The lower-level APIs have solutions, but there currently aren't any for the simple/class tree layer.
 
-### Recursive types are still very sketchy
-
-Recursive objects can work ok, see notes on `SchemaFactory.fixRecursiveReference`.
-This does not seem to fix directly recursive array nodes or map nodes (but some cases of co-recursive through object does seem to work).
-Experiments are ongoing for how to fix them.
-
 ## Ideas to consider in the future
 
 1. allow class schema to override methods to provide hooks. For example "serializeSessionState", to allow persisting things like selection. Maybe support via decorator? override methods for events?

--- a/packages/dds/tree/src/test/domains/schemaBuilder.spec.ts
+++ b/packages/dds/tree/src/test/domains/schemaBuilder.spec.ts
@@ -236,32 +236,4 @@ describe("domains - SchemaBuilder", () => {
 			const z: number | undefined = x.recursive?.recursive?.number;
 		}
 	});
-
-	it("fixRecursiveReference", () => {
-		const builder = new SchemaBuilder({ scope: "Test Recursive Domain" });
-
-		const recursiveReference = () => recursiveObject2;
-		builder.fixRecursiveReference(recursiveReference);
-
-		// Renaming this to recursiveObject causes IntelliSense to never work for this, instead of work after restarted until this code it touched.
-		const recursiveObject2 = builder.object("object2", {
-			recursive: builder.optional([recursiveReference]),
-			number: leaf.number,
-		});
-
-		type _0 = requireFalse<isAny<typeof recursiveObject2>>;
-		type _1 = requireTrue<
-			areSafelyAssignable<
-				typeof recursiveObject2,
-				ReturnType<
-					(typeof recursiveObject2.objectNodeFieldsObject.recursive.allowedTypes)[0]
-				>
-			>
-		>;
-
-		function typeTests2(x: FlexTreeTypedNode<typeof recursiveObject2>) {
-			const y: number = x.number;
-			const z: number | undefined = x.recursive?.recursive?.number;
-		}
-	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/contextuallyTyped.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/contextuallyTyped.spec.ts
@@ -105,11 +105,9 @@ describe("ContextuallyTyped", () => {
 				libraries: [leaf.library],
 			});
 
-			const recursiveReference = () => nodeSchema;
-			builder.fixRecursiveReference(recursiveReference);
-			const nodeSchema = builder.object("node", {
+			const nodeSchema = builder.objectRecursive("node", {
 				foo: builder.required(leaf.string),
-				child: FlexFieldSchema.createUnsafe(FieldKinds.optional, [recursiveReference]),
+				child: FlexFieldSchema.createUnsafe(FieldKinds.optional, [() => nodeSchema]),
 			});
 
 			const nodeSchemaData = builder.intoSchema(builder.optional(nodeSchema));

--- a/packages/dds/tree/src/test/feature-libraries/schemaBuilder.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schemaBuilder.spec.ts
@@ -5,22 +5,8 @@
 
 import { strict as assert } from "node:assert";
 
-import {
-	areSafelyAssignable,
-	brand,
-	isAny,
-	requireAssignableTo,
-	requireFalse,
-	requireTrue,
-} from "../../util/index.js";
-import {
-	FlexAllowedTypes,
-	Any,
-	FieldKinds,
-	LeafNodeSchema,
-	FlexFieldSchema,
-	FlexTreeNodeSchema,
-} from "../../feature-libraries/index.js";
+import { areSafelyAssignable, brand, requireTrue } from "../../util/index.js";
+import { Any, FieldKinds, LeafNodeSchema, FlexFieldSchema } from "../../feature-libraries/index.js";
 
 import {
 	normalizeAllowedTypes,
@@ -39,52 +25,6 @@ describe("SchemaBuilderBase", () => {
 				foo: FlexFieldSchema.createUnsafe(FieldKinds.optional, [() => recursiveStruct]),
 			});
 
-			type _1 = requireTrue<
-				areSafelyAssignable<
-					typeof recursiveStruct,
-					ReturnType<(typeof recursiveStruct.objectNodeFieldsObject.foo.allowedTypes)[0]>
-				>
-			>;
-		});
-
-		it("recursive without special functions", () => {
-			// Recursive helper function are needed but can be avoided due to issues covered in https://github.com/microsoft/TypeScript/issues/55758.
-			// This workaround seems to only work for compile time, not for intellisense, which makes it not very useful in practice and hard to verify that it works.
-			const builder = new SchemaBuilderBase(FieldKinds.required, { scope: "test" });
-
-			const recursiveReference = () => recursiveStruct;
-			type _trickCompilerIntoWorking = requireAssignableTo<
-				typeof recursiveReference,
-				() => FlexTreeNodeSchema
-			>;
-			const recursiveStruct = builder.object("recursiveStruct2", {
-				foo: FlexFieldSchema.create(FieldKinds.optional, [recursiveReference]),
-			});
-
-			type _0 = requireFalse<isAny<typeof recursiveStruct>>;
-			type _1 = requireTrue<
-				areSafelyAssignable<
-					typeof recursiveStruct,
-					ReturnType<(typeof recursiveStruct.objectNodeFieldsObject.foo.allowedTypes)[0]>
-				>
-			>;
-		});
-
-		// Slightly different variant of the above test
-		it("recursive without special functions2", () => {
-			// This function helps the TypeScript compiler imagine a world where it solves for types in a different order, and thus handles the cases we need.
-			// Some related information in https://github.com/microsoft/TypeScript/issues/55758.
-			function fixRecursiveReference<T extends FlexAllowedTypes>(...types: T): void {}
-
-			const builder = new SchemaBuilderBase(FieldKinds.required, { scope: "test" });
-
-			const recursiveReference = () => recursiveStruct;
-			fixRecursiveReference(recursiveReference);
-			const recursiveStruct = builder.object("recursiveStruct2", {
-				foo: FlexFieldSchema.create(FieldKinds.optional, [recursiveReference]),
-			});
-
-			type _0 = requireFalse<isAny<typeof recursiveStruct>>;
 			type _1 = requireTrue<
 				areSafelyAssignable<
 					typeof recursiveStruct,


### PR DESCRIPTION
## Description

The "fixRecursiveReference" has been abandoned, and this removes use of it.
This pattern triggered an order dependence bug in TSC which often led to broken incremental builds and broken IntelliSense.

The other approach, removing all extends clauses in the recursive path, has been adopted everywhere so there is no longer a need to have tests for the fixRecursiveReference pattern.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

