### PR TITLE
fix(ci): Fix build of telemetry-generator

### DIFF
--- a/tools/telemetry-generator/package-lock.json
+++ b/tools/telemetry-generator/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/test-driver-definitions": ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0",
+				"@fluidframework/core-interfaces": "^2.0.0-rc.1.0.4",
+				"@fluidframework/test-driver-definitions": "^2.0.0-rc.1.0.4",
 				"@oclif/core": "^1.12.0",
 				"applicationinsights": "^2.4.1"
 			},
@@ -410,24 +410,18 @@
 				"gen-version": "bin/gen-version"
 			}
 		},
-		"node_modules/@fluidframework/common-definitions": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-			"integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
-		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "2.0.0-internal.1.0.0.84253",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-internal.1.0.0.84253.tgz",
-			"integrity": "sha512-l70zkACBXqmLGArg1QOchvIT3wR1KT4EpAKHhVYxTVOUiVMR6fP1Ui5s6KPCBdX6YeEydZEyLmBsuDPNENQ+9w=="
+			"version": "2.0.0-rc.1.0.4",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.0.0-rc.1.0.4.tgz",
+			"integrity": "sha512-b9DCsA8z9ParTxNQNL3G8V4Cb6RxNzszXUdp8NWcSp+KJQUcGP3ypTIo5udI9RQuntXxDN93NTGW0mWvoToYQA=="
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "2.0.0-internal.1.0.0.84253",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-internal.1.0.0.84253.tgz",
-			"integrity": "sha512-SKXNJpyPeaLb6DgbQRMXUjZ4XsHdkk7aKN9ztOXixhS3QL3wH4RqVfrX38xv5kMWzQ6EiHPO+KEPtUtliKmv3Q==",
+			"version": "2.0.0-rc.1.0.4",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.0.0-rc.1.0.4.tgz",
+			"integrity": "sha512-h8hzdK7kdgJCE8XV3PQS11ipfppvTfqkcoHGaeQ9tLatdNqpJW2nGFCAZ6KorCIdiNYnStjxFmhhHmZ1jraK4w==",
 			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "2.0.0-internal.1.0.0.84253",
-				"@fluidframework/protocol-definitions": "^1.0.0"
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.4 <2.0.0-rc.1.1.0",
+				"@fluidframework/protocol-definitions": "^3.1.0"
 			}
 		},
 		"node_modules/@fluidframework/eslint-config-fluid": {
@@ -456,23 +450,31 @@
 			}
 		},
 		"node_modules/@fluidframework/protocol-definitions": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.0.0.tgz",
-			"integrity": "sha512-ulowxU/6yVLQ2A+bJ2BD2yomKjRkGYwj91jdvmEtb7dWICnQpvgwxdcGnbxd2F6g3FnP9BmtZYRB2IQNMovk3A==",
-			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1"
-			}
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-3.2.0.tgz",
+			"integrity": "sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA=="
 		},
 		"node_modules/@fluidframework/test-driver-definitions": {
-			"version": "2.0.0-internal.1.0.0.84253",
-			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-internal.1.0.0.84253.tgz",
-			"integrity": "sha512-r27bTX2bXAgSJeoIw9p7u7zhNz+eLbKlGRS/gBivFy2DPC9y3YJEY/XbDyn3710dS/2RJT5NEv22fgSw3h107A==",
+			"version": "2.0.0-rc.1.0.4",
+			"resolved": "https://registry.npmjs.org/@fluidframework/test-driver-definitions/-/test-driver-definitions-2.0.0-rc.1.0.4.tgz",
+			"integrity": "sha512-Mcq/cdG+uke0LuplZ5VxDYrj9rX0dr5OG40nRrJJ68jzW3NZHC8yRzFqxglUIraTOHGgUKdaizn3vUzyzXvIhQ==",
 			"dependencies": {
-				"@fluidframework/common-definitions": "^0.20.1",
-				"@fluidframework/core-interfaces": "2.0.0-internal.1.0.0.84253",
-				"@fluidframework/driver-definitions": "2.0.0-internal.1.0.0.84253",
-				"@fluidframework/protocol-definitions": "^1.0.0",
-				"uuid": "^8.3.1"
+				"@fluidframework/core-interfaces": ">=2.0.0-rc.1.0.4 <2.0.0-rc.1.1.0",
+				"@fluidframework/driver-definitions": ">=2.0.0-rc.1.0.4 <2.0.0-rc.1.1.0",
+				"@fluidframework/protocol-definitions": "^3.1.0",
+				"uuid": "^9.0.0"
+			}
+		},
+		"node_modules/@fluidframework/test-driver-definitions/node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {

--- a/tools/telemetry-generator/package.json
+++ b/tools/telemetry-generator/package.json
@@ -29,8 +29,8 @@
 		"tsc": "tsc"
 	},
 	"dependencies": {
-		"@fluidframework/common-definitions": "^0.20.1",
-		"@fluidframework/test-driver-definitions": ">=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0",
+		"@fluidframework/core-interfaces": "^2.0.0-rc.1.0.4",
+		"@fluidframework/test-driver-definitions": "^2.0.0-rc.1.0.4",
 		"@oclif/core": "^1.12.0",
 		"applicationinsights": "^2.4.1"
 	},


### PR DESCRIPTION
## Description

https://github.com/microsoft/FluidFramework/pull/20097 broke telemetry-generator by replacing a package name in an import but not updating the package dependencies to match. Not caught in that PR because we're missing a build pipeline for telemetry generator ([AB#4242](https://dev.azure.com/fluidframework/internal/_workitems/edit/4242) tracks this).

This is preventing our pipelines from sending telemetry to Kusto, and thus "hid" a break in CI.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

This is an internal tool so I think it's fine to have it depend on the latest rc bits for the few Fluid things it needs.