### PR TITLE
refactor(eslint-config-fluid): Disable import/order rule

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @fluidframework/eslint-config-fluid Changelog
 
+## [5.2.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.2.0)
+
+The import/order rule is now disabled in all configs.
+
+## [5.1.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.1.0)
+
+Enables new API trimming rules.
+
+## [5.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v5.0.0)
+
+Adds eslint-plugin-fluid to eslint-config-fluid. This new dependency adds new Fluid-specific rules.
+
 ## [4.0.0](https://github.com/microsoft/FluidFramework/releases/tag/eslint-config-fluid_v4.0.0)
 
 Deprecates this package's `minimal` configuration.

--- a/common/build/eslint-config-fluid/base.js
+++ b/common/build/eslint-config-fluid/base.js
@@ -153,7 +153,7 @@ module.exports = {
 			},
 		],
 		"import/no-unused-modules": "error",
-		"import/order": "error",
+		"import/order": "off",
 
 		// eslint-plugin-unicorn
 		"unicorn/better-regex": "error",

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -630,7 +630,7 @@
             "error"
         ],
         "import/order": [
-            "error"
+            "off"
         ],
         "indent": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -623,7 +623,7 @@
             "error"
         ],
         "import/order": [
-            "error"
+            "off"
         ],
         "indent": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -632,7 +632,7 @@
             "error"
         ],
         "import/order": [
-            "error"
+            "off"
         ],
         "indent": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -630,7 +630,7 @@
             "error"
         ],
         "import/order": [
-            "error"
+            "off"
         ],
         "indent": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -646,7 +646,7 @@
             "error"
         ],
         "import/order": [
-            "error"
+            "off"
         ],
         "indent": [
             "off"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -632,7 +632,7 @@
             "error"
         ],
         "import/order": [
-            "error"
+            "off"
         ],
         "indent": [
             "off"


### PR DESCRIPTION
This rule conflicts with our upcoming import organization, which is faster and more featureful that the lint rule.