### PR TITLE
Relax asserts in AzureAudience and TinyliciousAudience to permit missing name field

### DIFF
--- a/packages/service-clients/azure-client/src/AzureAudience.ts
+++ b/packages/service-clients/azure-client/src/AzureAudience.ts
@@ -33,7 +33,8 @@ function assertIsAzureUser(user: IUser): asserts user is AzureUser<unknown> {
 	if (maybeAzureUser.id === undefined) {
 		throw new TypeError(`${baseMessage} Missing required "id" property.`);
 	}
-	if (maybeAzureUser.name === undefined) {
-		throw new TypeError(`${baseMessage} Missing required "name" property.`);
-	}
+	// AB#7448 to reenable this check.  Disabling to mitigate a bug that the name may be missing.
+	// if (maybeAzureUser.name === undefined) {
+	// 	throw new TypeError(`${baseMessage} Missing required "name" property.`);
+	// }
 }

--- a/packages/service-clients/tinylicious-client/src/TinyliciousAudience.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousAudience.ts
@@ -16,16 +16,22 @@ import { type TinyliciousMember, type TinyliciousUser } from "./interfaces.js";
  */
 export function createTinyliciousAudienceMember(audienceMember: IClient): TinyliciousMember {
 	const tinyliciousUser = audienceMember.user as Partial<TinyliciousUser>;
+	// AB#7448 to reenable this stronger check.  Relaxing to mitigate a bug that the name may be missing.
+	// assert(
+	// 	tinyliciousUser !== undefined &&
+	// 		typeof tinyliciousUser.id === "string" &&
+	// 		typeof tinyliciousUser.name === "string",
+	// 	0x313 /* Specified user was not of type "TinyliciousUser". */,
+	// );
 	assert(
-		tinyliciousUser !== undefined &&
-			typeof tinyliciousUser.id === "string" &&
-			typeof tinyliciousUser.name === "string",
+		tinyliciousUser !== undefined && typeof tinyliciousUser.id === "string",
 		0x313 /* Specified user was not of type "TinyliciousUser". */,
 	);
 
 	return {
 		userId: tinyliciousUser.id,
-		userName: tinyliciousUser.name,
+		// AB#7448 to remove this cast after the check above is strengthened again.
+		userName: tinyliciousUser.name as string,
 		connections: [],
 	};
 }


### PR DESCRIPTION
A recent change in FRS caused the id and name fields of the IUser to be removed from the quorumMembers snapshot, leaving them looking like `{"id":""}` - missing a real ID, and missing the name field entirely.

1.x clients are generally unaffected, since the Audience was always completely recreated from initialClients (which remain unaffected).  This meant the faulty quorumMembers were never seen by the ServiceAudience.  In 2.x the Audience now retains the quorumMembers (as of #12094), so the ServiceAudience does see these faulty members and hits these asserts.

This change is meant as a minimal mitigation to unblock load on 2.x clients while the service-side fix is made.  Once the fix is in, we'll restore these checks to their stronger form.

Note that since the data is missing, customers will hit bugs in code that explicitly interacts with the Audience while this issue persists.  As an example of possible symptom, here's the impact to our external-controller example (observe that the client on the right loaded later, and doesn't know the names of the other connected clients):

![image](https://github.com/microsoft/FluidFramework/assets/4276348/a282dec2-9844-400f-b275-1c8dd3ee94c1)

As an alternative, I considered omitting these faulty clients from the observable service audience entirely.  This would potentially have less impact on customers' audience-handling code that would normally expect any members to have their fields correctly populated.  However, since this approach would require changes in fluid-static (and thereby affect odsp-client as well) and would be less-scoped, I opted to go with just relaxing the asserts.

[AB#7449](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7449)