### PR TITLE
tree: Fix create for Leaf schema

### DIFF
--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -125,23 +125,14 @@ export function getOrCreateNodeProxy(flexNode: FlexTreeNode): TreeNode | TreeVal
 	}
 
 	const schema = flexNode.schema;
-	let output: TreeNode | TreeValue;
 	const classSchema = getClassSchema(schema);
-	if (classSchema !== undefined) {
-		if (typeof classSchema === "function") {
-			const simpleSchema = classSchema as unknown as new (dummy: FlexTreeNode) => TreeNode;
-			output = new simpleSchema(flexNode);
-		} else {
-			output = (schema as unknown as { create: (data: FlexTreeNode) => TreeNode }).create(
-				flexNode,
-			);
-		}
+	assert(classSchema !== undefined, "node without schema");
+	if (typeof classSchema === "function") {
+		const simpleSchema = classSchema as unknown as new (dummy: FlexTreeNode) => TreeNode;
+		return new simpleSchema(flexNode);
 	} else {
-		// Fallback to createNodeProxy if needed.
-		// TODO: maybe remove this fallback and error once migration to class based schema is done.
-		output = createNodeProxy(flexNode, false);
+		return (classSchema as { create(data: FlexTreeNode): TreeNode }).create(flexNode);
 	}
-	return output;
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/schemaFactory.ts
@@ -16,6 +16,7 @@ import {
 	FlexMapNodeSchema,
 	FlexFieldNodeSchema,
 	isFluidHandle,
+	valueSchemaAllows,
 } from "../feature-libraries/index.js";
 import { leaf } from "../domains/index.js";
 import { TreeNodeSchemaIdentifier, TreeValue } from "../core/index.js";

--- a/packages/dds/tree/src/simple-tree/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/schemaFactory.ts
@@ -68,7 +68,12 @@ class LeafNodeSchema<T extends FlexLeafNodeSchema>
 	public readonly kind = NodeKind.Leaf;
 	public readonly info: T["info"];
 	public readonly implicitlyConstructable = true as const;
-	public create(data: TreeValue<T["info"]>): TreeValue<T["info"]> {
+	public create(data: TreeValue<T["info"]> | FlexTreeNode): TreeValue<T["info"]> {
+		if (isFlexTreeNode(data)) {
+			const value = data.value;
+			assert(valueSchemaAllows(this.info, value), "invalid value");
+			return value;
+		}
 		return data;
 	}
 

--- a/packages/dds/tree/src/simple-tree/toFlexSchema.ts
+++ b/packages/dds/tree/src/simple-tree/toFlexSchema.ts
@@ -249,7 +249,6 @@ export function convertNodeSchema(
 				setFlexSchemaFromClassSchema(schema, out);
 			}
 		}
-		(out as any)[simpleSchemaSymbol] = schema;
 		return out;
 	};
 	schemaMap.set(brand(schema.identifier), { original: schema, toFlex });
@@ -272,5 +271,8 @@ export function setFlexSchemaFromClassSchema(
 	simple: TreeNodeSchema,
 	flex: TreeNodeSchemaBase,
 ): void {
+	assert(!(flexSchemaSymbol in simple), "simple schema already marked");
+	assert(!(simpleSchemaSymbol in flex), "flex schema already marked");
 	(simple as any)[flexSchemaSymbol] = flex;
+	(flex as any)[simpleSchemaSymbol] = simple;
 }


### PR DESCRIPTION
## Description

getOrCreateNodeProxy was intended to use the create method for leaf schema. Three separate issues prevented this from working which are fixed in this change.

1. flex leaf schema were not associated with the simple leaf schema.
2. the create method did not handle flex-tree nodes being passed in.
3. getOrCreateNodeProxy called create on the flex schema not the simple schema.

This was unnoticed as leaves ended up going through the no schema fallback, which this also removes.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

