### PR TITLE
Add biome VSCode extension to the recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
+		"biomejs.biome",
 		"dbaeumer.vscode-eslint",
 		"esbenp.prettier-vscode",
 		"ms-azure-devops.azure-pipelines",


### PR DESCRIPTION
Some projects have started using Biome, so it's helpful to have that extension installed. This will help devs find it with little effort.