### PR TITLE
fix(build-tools): tsc task policy Windows

### DIFF
--- a/build-tools/packages/build-tools/src/common/tsCompile.ts
+++ b/build-tools/packages/build-tools/src/common/tsCompile.ts
@@ -6,13 +6,7 @@
 import type * as tsTypes from "typescript";
 import path from "path";
 import { defaultLogger } from "./logging.js";
-import { getTscUtils } from "./tscUtils.js";
-
-// Any paths given by typescript will be normalized to forward slashes.
-// Local paths should be normalized to make any comparisons.
-function normalizeSlashes(path: string): string {
-	return path.replace(/\\/g, "/");
-}
+import { getTscUtils, normalizeSlashes } from "./tscUtils.js";
 
 export function tsCompile({
 	command,

--- a/build-tools/packages/build-tools/src/common/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/common/tscUtils.ts
@@ -264,3 +264,9 @@ export function getTscUtils(path: string): TscUtil {
 	tscUtilLibPathCache.set(tsPath, tscUtil);
 	return tscUtil;
 }
+
+// Any paths given by typescript will be normalized to forward slashes.
+// Local paths should be normalized to make any comparisons.
+export function normalizeSlashes(path: string): string {
+	return path.replace(/\\/g, "/");
+}

--- a/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
+++ b/build-tools/packages/build-tools/src/repoPolicyCheck/handlers/fluidBuildTasks.ts
@@ -489,7 +489,12 @@ function getTscCommandDependencies(
 			if (fileInfo.isDirectory()) {
 				refConfigPath = path.join(refConfigPath, "tsconfig.json");
 			}
-			refConfigPath = `./${path.relative(packageDir, refConfigPath)}`;
+			// Environment path separator may be \, but find helpers all do
+			// simple string comparisons where paths are expected to use /.
+			// So, ensure search project is set with only / separators.
+			refConfigPath = TscUtils.normalizeSlashes(
+				`./${path.relative(packageDir, refConfigPath)}`,
+			);
 
 			// Warning: This check will find any script that references the project, but
 			// there may be multiple scripts that reference the same project with tsc-multi


### PR DESCRIPTION
normalize relative paths to use / when searching scripts

[AB#7460](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7460)