### PR TITLE
clean up TODO comments in sharedTree.bench.ts

### DIFF
--- a/packages/dds/tree/src/test/scalableTestTrees.ts
+++ b/packages/dds/tree/src/test/scalableTestTrees.ts
@@ -82,8 +82,23 @@ type JSWideTreeRoot2 = InsertableFlexField<typeof wideSchema.rootFieldSchema>;
 	type _check2 = requireAssignableTo<JSWideTree, JSWideTreeRoot2>;
 }
 
+/**
+ *
+ * Creates a {@link JSDeepTree} with the specified depth and value.
+ * @remarks
+ * This method is done iteratively to prevent exceeding max callstack for very deep trees.
+ */
 export function makeJsDeepTree(depth: number, leafValue: number): JSDeepTree | number {
-	return depth === 0 ? leafValue : { foo: makeJsDeepTree(depth - 1, leafValue) };
+	if (depth === 0) {
+		return leafValue;
+	}
+
+	let result: JSDeepTree | number = leafValue;
+	for (let i = 0; i < depth; i++) {
+		result = { foo: result };
+	}
+
+	return result;
 }
 
 export function makeDeepContent(

--- a/packages/dds/tree/src/test/scalableTestTrees.ts
+++ b/packages/dds/tree/src/test/scalableTestTrees.ts
@@ -83,7 +83,6 @@ type JSWideTreeRoot2 = InsertableFlexField<typeof wideSchema.rootFieldSchema>;
 }
 
 /**
- *
  * Creates a {@link JSDeepTree} with the specified depth and value.
  * @remarks
  * This method is done iteratively to prevent exceeding max callstack for very deep trees.

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -50,17 +50,17 @@ import {
 	toJsonableTree,
 } from "../utils.js";
 
-// Number of nodes in test for wide trees.
+// number of nodes in test for wide trees
 const nodesCountWide = [
 	[1, BenchmarkType.Measurement],
 	[100, BenchmarkType.Perspective],
 	[1000, BenchmarkType.Measurement],
 	[10000, BenchmarkType.Measurement],
 ];
-// Number of nodes in test for deep trees.
+// number of nodes in test for deep trees
 // TODO: We currently run into a "maximum call stack size exceeded" error if we increase the node count,
-// due to recursive calls when calling flexTreeViewWithContent, or calling assert.deepEqual.
-// To include tests with higher node counts, we will likely need to replace these parts of the code to be done iteratively.
+// due to major limititations in a large portion of our tree processing code.
+// Our encoders, decoders, editing code, and more will fail with really deep trees.
 const nodesCountDeep = [
 	[1, BenchmarkType.Measurement],
 	[10, BenchmarkType.Perspective],


### PR DESCRIPTION
## Description

This PR includes tests for higher node count that we couldn't do before, as we were running into a "BatchTooLarge" error. It also adds a step to update the tree schemas so that chunk compression can be used.