### PR TITLE
[v2int/8.0] Port GC Auto-recovery feature (PRs 19115 and 19392)

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2909,6 +2909,12 @@ export class ContainerRuntime
 	 * data store or an attachment blob.
 	 */
 	public async getGCNodePackagePath(nodePath: string): Promise<readonly string[] | undefined> {
+		// GC uses "/" when adding "root" references, e.g. for Aliasing or as part of Tombstone Auto-Recovery.
+		// These have no package path so return a special value.
+		if (nodePath === "/") {
+			return ["<GCROOT>"];
+		}
+
 		switch (this.getNodeType(nodePath)) {
 			case GCNodeType.Blob:
 				return [BlobManager.basePath];
@@ -3691,6 +3697,7 @@ export class ContainerRuntime
 		localOpMetadata: unknown,
 		opMetadata: Record<string, unknown> | undefined,
 	) {
+		assert(!this.isSummarizerClient, "Summarizer never reconnects so should never resubmit");
 		switch (message.type) {
 			case ContainerMessageType.FluidDataStoreOp:
 				// For Operations, call resubmitDataStoreOp which will find the right store
@@ -3712,8 +3719,8 @@ export class ContainerRuntime
 				this.submit(message);
 				break;
 			case ContainerMessageType.GC:
-				// GC op is only sent in summarizer which should never reconnect.
-				throw new LoggingError("GC op not expected to be resubmitted in summarizer");
+				this.submit(message);
+				break;
 			default: {
 				// This case should be very rare - it would imply an op was stashed from a
 				// future version of runtime code and now is being applied on an older version

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2912,7 +2912,7 @@ export class ContainerRuntime
 		// GC uses "/" when adding "root" references, e.g. for Aliasing or as part of Tombstone Auto-Recovery.
 		// These have no package path so return a special value.
 		if (nodePath === "/") {
-			return ["<GCROOT>"];
+			return ["_gcRoot"];
 		}
 
 		switch (this.getNodeType(nodePath)) {

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -45,6 +45,7 @@ import {
 	ISweepPhaseStats,
 	GarbageCollectionMessage,
 	GarbageCollectionMessageType,
+	disableAutoRecoveryKey,
 } from "./gcDefinitions";
 import {
 	cloneGCData,
@@ -870,21 +871,33 @@ export class GarbageCollector implements IGarbageCollector {
 	 * @param local - Whether it was send by this client.
 	 */
 	public processMessage(message: ContainerRuntimeGCMessage, local: boolean) {
-		switch (message.contents.type) {
-			case "Sweep": {
+		const gcMessageType = message.contents.type;
+		switch (gcMessageType) {
+			case GarbageCollectionMessageType.Sweep: {
 				// Delete the nodes whose ids are present in the contents.
 				this.deleteSweepReadyNodes(message.contents.deletedNodeIds);
+				break;
+			}
+			case GarbageCollectionMessageType.TombstoneLoaded: {
+				if (this.mc.config.getBoolean(disableAutoRecoveryKey) === true) {
+					break;
+				}
+
+				// Mark the node as referenced to ensure it isn't Swept
+				const tombstonedNodePath = message.contents.nodePath;
+				this.addedOutboundReference("/", tombstonedNodePath);
+
 				break;
 			}
 			default: {
 				if (
 					!compatBehaviorAllowsGCMessageType(
-						message.contents.type,
+						gcMessageType,
 						message.compatDetails?.behavior,
 					)
 				) {
 					const error = DataProcessingError.create(
-						`Garbage collection message of unknown type ${message.contents.type}`,
+						`Garbage collection message of unknown type ${gcMessageType}`,
 						"processMessage",
 					);
 					throw error;
@@ -977,6 +990,15 @@ export class GarbageCollector implements IGarbageCollector {
 			headers: headerData,
 		});
 
+		// Any time we log a Tombstone Loaded error (via Telemetry Tracker),
+		// we want to also trigger autorecovery to avoid the object being deleted
+		// Note: We don't need to trigger on "Changed" because any change will cause the object
+		// to be loaded by the Summarizer, and auto-recovery will be triggered then.
+		if (isTombstoned && reason === "Loaded") {
+			// Note that when a DataStore and its DDS are all loaded, each will trigger AutoRecovery for itself.
+			this.triggerAutoRecovery(nodePath);
+		}
+
 		const nodeType = this.runtime.getNodeType(nodePath);
 
 		// Unless this is a Loaded event for a Blob or DataStore, we're done after telemetry tracking
@@ -985,7 +1007,6 @@ export class GarbageCollector implements IGarbageCollector {
 		}
 
 		const errorRequest: IRequest = request ?? { url: nodePath };
-		// If the object is tombstoned and tombstone enforcement is configured, throw an error.
 		if (isTombstoned && this.throwOnTombstoneLoad && headerData?.allowTombstone !== true) {
 			// The requested data store is removed by gc. Create a 404 gc response exception.
 			throw responseToException(
@@ -1014,13 +1035,41 @@ export class GarbageCollector implements IGarbageCollector {
 	}
 
 	/**
+	 * The given node should have its unreferenced state reset in the next GC,
+	 * even if the true GC graph shows it is unreferenced. This will
+	 * prevent it from being deleted by Sweep (after the Grace Period).
+	 *
+	 * Submit a GC op indicating that the Tombstone with the given path has been loaded.
+	 * Broadcasting this information in the op stream allows the Summarizer to reset unreferenced state
+	 * before runnint GC next.
+	 */
+	private triggerAutoRecovery(nodePath: string) {
+		if (this.mc.config.getBoolean(disableAutoRecoveryKey) === true) {
+			return;
+		}
+
+		// Use compat behavior "Ignore" since this is an optimization to opportunistically protect
+		// objects from deletion, so it's fine for older clients to ignore this op.
+		const containerGCMessage: ContainerRuntimeGCMessage = {
+			type: ContainerMessageType.GC,
+			contents: {
+				type: "TombstoneLoaded",
+				nodePath,
+			},
+			compatDetails: { behavior: "Ignore" },
+		};
+		this.submitMessage(containerGCMessage);
+	}
+
+	/**
 	 * Called when an outbound reference is added to a node. This is used to identify all nodes that have been
 	 * referenced between summaries so that their unreferenced timestamp can be reset.
 	 *
 	 * @param fromNodePath - The node from which the reference is added.
 	 * @param toNodePath - The node to which the reference is added.
+	 * @param autorecovery - This reference is added artificially, for autorecovery. Used for logging.
 	 */
-	public addedOutboundReference(fromNodePath: string, toNodePath: string) {
+	public addedOutboundReference(fromNodePath: string, toNodePath: string, autorecovery?: true) {
 		if (!this.configs.shouldRunGC) {
 			return;
 		}
@@ -1038,6 +1087,7 @@ export class GarbageCollector implements IGarbageCollector {
 			isTombstoned: this.tombstones.includes(toNodePath),
 			lastSummaryTime: this.getLastSummaryTimestampMs(),
 			fromId: fromNodePath,
+			autorecovery,
 		});
 	}
 

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -1095,6 +1095,12 @@ export class GarbageCollector implements IGarbageCollector {
 			fromId: fromNodePath,
 			autorecovery,
 		});
+
+		// This node is referenced - Clear its unreferenced state
+		// But don't delete the node id from the map yet.
+		// When generating GC stats, the set of nodes in here is used as the baseline for
+		// what was unreferenced in the last GC run.
+		this.unreferencedNodesState.get(toNodePath)?.stopTracking();
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -78,6 +78,8 @@ export const throwOnTombstoneUsageKey = "Fluid.GarbageCollection.ThrowOnTombston
 export const gcVersionUpgradeToV4Key = "Fluid.GarbageCollection.GCVersionUpgradeToV4";
 /** Config key to disable GC sweep for datastores. They'll merely be Tombstoned. */
 export const disableDatastoreSweepKey = "Fluid.GarbageCollection.DisableDataStoreSweep";
+/** Config key to disable auto-recovery mechanism that protects Tombstones that are loaded from being swept (use true) */
+export const disableAutoRecoveryKey = "Fluid.GarbageCollection.DisableAutoRecovery";
 
 // One day in milliseconds.
 export const oneDayMs = 1 * 24 * 60 * 60 * 1000;
@@ -233,6 +235,8 @@ export type GCNodeType = (typeof GCNodeType)[keyof typeof GCNodeType];
 export const GarbageCollectionMessageType = {
 	/** Message sent directing GC to delete the given nodes */
 	Sweep: "Sweep",
+	/** Message sent notifying GC that a Tombstoned object was Loaded */
+	TombstoneLoaded: "TombstoneLoaded",
 } as const;
 
 /**
@@ -246,16 +250,28 @@ export type GarbageCollectionMessageType =
  * @internal
  */
 export interface ISweepMessage {
-	type: "Sweep";
-	// The ids of nodes that are deleted.
+	/** @see GarbageCollectionMessageType.Sweep */
+	type: typeof GarbageCollectionMessageType.Sweep;
+	/** The ids of nodes that are deleted. */
 	deletedNodeIds: string[];
+}
+
+/**
+ * The GC TombstoneLoaded message.
+ * @internal
+ */
+export interface ITombstoneLoadedMessage {
+	/** @see GarbageCollectionMessageType.TombstoneLoaded */
+	type: typeof GarbageCollectionMessageType.TombstoneLoaded;
+	/** The id of Tombstoned node that was loaded. */
+	nodePath: string;
 }
 
 /**
  * Type for a message to be used for sending / received garbage collection messages.
  * @internal
  */
-export type GarbageCollectionMessage = ISweepMessage;
+export type GarbageCollectionMessage = ISweepMessage | ITombstoneLoadedMessage;
 
 /**
  * Defines the APIs for the runtime object to be passed to the garbage collector.

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -351,7 +351,7 @@ export interface IGarbageCollector {
 		headerData?: RuntimeHeaderData,
 	): void;
 	/** Called when a reference is added to a node. Used to identify nodes that were referenced between summaries. */
-	addedOutboundReference(fromNodePath: string, toNodePath: string): void;
+	addedOutboundReference(fromNodePath: string, toNodePath: string, autorecovery?: true): void;
 	/** Called to process a garbage collection message. */
 	processMessage(message: ContainerRuntimeGCMessage, local: boolean): void;
 	/** Returns true if this node has been deleted by GC during sweep phase. */

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -51,6 +51,18 @@ export class GCSummaryStateTracker {
 	// to unreferenced or vice-versa.
 	public updatedDSCountSinceLastSummary: number = 0;
 
+	/** API for ensuring the correct auto-recovery mitigations */
+	public autoRecovery = {
+		requestFullGCOnNextRun: () => {
+			this.fullGCModeForAutoRecovery = true;
+		},
+		fullGCRequested: () => {
+			return this.fullGCModeForAutoRecovery;
+		},
+	};
+	/** If true, the next GC run will do fullGC mode to regenerate the GC data for each node */
+	private fullGCModeForAutoRecovery: boolean = false;
+
 	constructor(
 		// Tells whether GC should run or not.
 		private readonly configs: Pick<
@@ -267,7 +279,7 @@ export class GCSummaryStateTracker {
 	}
 
 	/**
-	 * Called to refresh the latest summary state. This happens when either a pending summary is acked.
+	 * Called to refresh the latest summary state. This happens when a pending summary is acked.
 	 */
 	public async refreshLatestSummary(result: IRefreshSummaryResult): Promise<void> {
 		if (!result.isSummaryTracked) {
@@ -287,6 +299,7 @@ export class GCSummaryStateTracker {
 		this.latestSummaryData = this.pendingSummaryData;
 		this.pendingSummaryData = undefined;
 		this.updatedDSCountSinceLastSummary = 0;
+		this.fullGCModeForAutoRecovery = false;
 		return;
 	}
 

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -63,6 +63,7 @@ interface INodeUsageProps extends ICommonProps {
 	currentReferenceTimestampMs: number | undefined;
 	packagePath: readonly string[] | undefined;
 	fromId?: string;
+	autorecovery?: true;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -37,6 +37,8 @@ export {
 	UnreferencedState,
 	throwOnTombstoneLoadOverrideKey,
 	GarbageCollectionMessage,
+	GarbageCollectionMessageType,
+	ISweepMessage,
 } from "./gcDefinitions";
 export {
 	cloneGCData,

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -32,6 +32,7 @@ export {
 	runSessionExpiryKey,
 	runSweepKey,
 	stableGCVersion,
+	disableAutoRecoveryKey,
 	disableDatastoreSweepKey,
 	UnreferencedState,
 	throwOnTombstoneLoadOverrideKey,

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -52,6 +52,9 @@ import {
 	UnreferencedState,
 	defaultSweepGracePeriodMs,
 	GarbageCollectionMessage,
+	GarbageCollectionMessageType,
+	IGCStats,
+	GCTelemetryTracker,
 } from "../../gc";
 import { ContainerMessageType, ContainerRuntimeGCMessage } from "../../messageTypes";
 import {
@@ -62,22 +65,28 @@ import {
 import { pkgVersion } from "../../packageVersion";
 import { configProvider } from "./gcUnitTestHelpers";
 
+type WithPrivates<T, TPrivates> = Omit<T, keyof TPrivates> & TPrivates;
+
 type GcWithPrivates = IGarbageCollector & {
 	readonly runtime: IGarbageCollectionRuntime;
 	readonly configs: IGarbageCollectorConfigs;
-	readonly summaryStateTracker: Omit<
+	readonly summaryStateTracker: WithPrivates<
 		GCSummaryStateTracker,
-		"latestSummaryGCVersion" | "latestSummaryData"
-	> & {
-		latestSummaryGCVersion: GCVersion;
-		latestSummaryData: IGCSummaryTrackingData | undefined;
-	};
+		{
+			latestSummaryGCVersion: GCVersion;
+			latestSummaryData: IGCSummaryTrackingData | undefined;
+			fullGCModeForAutoRecovery: boolean;
+		}
+	>;
+	readonly telemetryTracker: GCTelemetryTracker;
+	readonly mc: MonitoringContext;
 	readonly sessionExpiryTimer: Omit<Timer, "defaultTimeout"> & { defaultTimeout: number };
 	readonly baseSnapshotDataP: Promise<IGarbageCollectionSnapshotData | undefined>;
 	readonly tombstones: string[];
 	readonly deletedNodes: Set<string>;
 	readonly unreferencedNodesState: Map<string, UnreferencedStateTracker>;
 	readonly submitMessage: (message: ContainerRuntimeGCMessage) => void;
+	runGC: (fullGC: boolean) => Promise<IGCStats>;
 };
 
 describe("Garbage Collection Tests", () => {
@@ -120,12 +129,24 @@ describe("Garbage Collection Tests", () => {
 	}
 
 	function createGarbageCollector(
-		createParams: Partial<IGarbageCollectorCreateParams> = {},
-		gcBlobsMap: Map<string, any> = new Map(),
-		gcMetadata: IGCMetadata = {},
-		closeFn: (error?: ICriticalContainerError) => void = () => {},
-		isSummarizerClient: boolean = true,
+		params: {
+			createParams?: Partial<IGarbageCollectorCreateParams>;
+			gcBlobsMap?: Map<string, any>;
+			gcMetadata?: IGCMetadata;
+			closeFn?: (error?: ICriticalContainerError) => void;
+			isSummarizerClient?: boolean;
+			getGCData?: (fullGC?: boolean) => Promise<IGarbageCollectionData>;
+		} = {},
 	): GcWithPrivates {
+		const {
+			createParams = {},
+			gcBlobsMap = new Map(),
+			gcMetadata = {},
+			closeFn = () => {},
+			isSummarizerClient = true,
+			getGCData = async () => defaultGCData,
+		} = params;
+
 		const getNodeType = (nodePath: string) => {
 			if (nodePath.split("/").length !== 2) {
 				return GCNodeType.Other;
@@ -136,7 +157,7 @@ describe("Garbage Collection Tests", () => {
 		// The runtime to be passed to the garbage collector.
 		const gcRuntime: IGarbageCollectionRuntime = {
 			updateStateBeforeGC: async () => {},
-			getGCData: async (fullGC?: boolean) => defaultGCData,
+			getGCData,
 			updateUsedRoutes: (usedRoutes: string[]) => {
 				return { totalNodeCount: 0, unusedNodeCount: 0 };
 			},
@@ -215,21 +236,18 @@ describe("Garbage Collection Tests", () => {
 			return closeCalled;
 		}
 
-		gc = createGarbageCollector(
-			{},
-			undefined /* gcBlobsMap */,
-			undefined /* gcMetadata */,
-			() => {
+		gc = createGarbageCollector({
+			closeFn: () => {
 				closeCalled = true;
 			},
-		);
+		});
 		assert(
 			closeCalledAfterExactTicks(defaultSessionExpiryDurationMs),
 			"Close should have been called at exactly defaultSessionExpiryDurationMs",
 		);
 	});
 
-	describe("runSweepPhase", () => {
+	describe("Tombstone and Sweep", () => {
 		it("Tombstone then Delete", async () => {
 			// Simple starting reference graph - root and two nodes
 			defaultGCData.gcNodes["/"] = [nodes[0], nodes[1]];
@@ -237,7 +255,7 @@ describe("Garbage Collection Tests", () => {
 			defaultGCData.gcNodes[nodes[1]] = [];
 
 			// Sweep enabled
-			gc = createGarbageCollector({ gcOptions: { enableGCSweep: true } });
+			gc = createGarbageCollector({ createParams: { gcOptions: { enableGCSweep: true } } });
 			// These spies will let us monitor how each of these functions are called (or not) during runSweepPhase.
 			// The original behavior of the function is preserved, but we can check how it was called.
 			const spies = {
@@ -326,6 +344,125 @@ describe("Garbage Collection Tests", () => {
 				"submitMessage should not be called since Sweep is disabled",
 			);
 		});
+
+		it("Autorecovery upon loading a Tombstoned node", async () => {
+			// Simple starting reference graph - root and two nodes
+			defaultGCData.gcNodes["/"] = [nodes[0], nodes[1]];
+			defaultGCData.gcNodes[nodes[0]] = [];
+			defaultGCData.gcNodes[nodes[1]] = [];
+
+			// Simulate GC Data with a route missing (nodes[0] is referenced but missing here)
+			// We'll return this from getGCData unless fullGC is passed in.
+			const corruptedGCData: IGarbageCollectionData = JSON.parse(
+				JSON.stringify(defaultGCData),
+			);
+			corruptedGCData.gcNodes["/"] = [nodes[1]];
+
+			// getGCData set up to sometimes return the corrupted data
+			gc = createGarbageCollector({
+				getGCData: async (fullGC?: boolean) => {
+					return fullGC ? defaultGCData : corruptedGCData;
+				},
+			});
+			// These spies will let us monitor how each of these functions are called (or not) during runSweepPhase.
+			// The original behavior of the function is preserved, but we can check how it was called.
+			const spies = {
+				gc: {
+					submitMessage: spy(gc, "submitMessage"),
+					addedOutboundReference: spy(gc, "addedOutboundReference"),
+					runGC: spy(gc, "runGC"),
+				},
+			};
+
+			// Nodes 0 and 1 are referenced (use correct gcData via fullGC true)
+			// Simulate successful summary ack to clear doesGCStateNeedReset flag so it doesn't interfere (it leads to fullGC too)
+			await gc.collectGarbage({ fullGC: true });
+			await gc.summaryStateTracker.refreshLatestSummary({
+				isSummaryTracked: true,
+				isSummaryNewer: false,
+			});
+			assert(
+				!gc.unreferencedNodesState.has(nodes[0]),
+				"node 0 should not be unreferenced to start",
+			);
+
+			// Now run GC again - this time with the corrupted data (via fullGC false)
+			clock.tick(10);
+			await gc.collectGarbage({ fullGC: false });
+			assert.equal(
+				gc.unreferencedNodesState.get(nodes[0])?.state,
+				UnreferencedState.Active, // This means recently unreferenced
+				"node 0 should appear unreferenced after running GC with corrupted GC Data",
+			);
+
+			// Let node 0 become Tombstoned and verify it
+			clock.tick(defaultSweepTimeoutMs);
+			await gc.collectGarbage({});
+			assert.equal(
+				gc.unreferencedNodesState.get(nodes[0])?.state,
+				UnreferencedState.TombstoneReady,
+				"node 0 should be TombstoneReady",
+			);
+			assert.deepEqual(gc.tombstones, [nodes[0]], "node 0 should be in the Tombstones list");
+
+			// Simulate usage to trigger TombstoneLoaded op.
+			gc.nodeUpdated(nodes[0], "Loaded");
+			const [gcTombstoneLoadedMessage] = spies.gc.submitMessage.args[0];
+			assert.deepEqual(
+				gcTombstoneLoadedMessage,
+				{
+					type: ContainerMessageType.GC,
+					contents: {
+						type: GarbageCollectionMessageType.TombstoneLoaded,
+						nodePath: nodes[0],
+					},
+					compatDetails: { behavior: "Ignore" },
+				} satisfies ContainerRuntimeGCMessage,
+				"submitted message not as expected",
+			);
+
+			// Plumb the message to processMessage fn to trigger autorecovery
+			// Autorecovery: addedOutboundReference should be called with the tombstoned node, which should transition to "Active" state
+			gc.processMessage(gcTombstoneLoadedMessage, true /* local */);
+			assert.deepEqual(
+				spies.gc.addedOutboundReference.args[0],
+				["/", nodes[0], /* autorecovery: */ true],
+				"addedOutboundReference should be called with node 0",
+			);
+			assert.equal(
+				gc.unreferencedNodesState.get(nodes[0])?.state,
+				UnreferencedState.Active,
+				"node 0 should be unreferenced but 'Active' after initial Autorecovery moment (it was TombstoneReady)",
+			);
+
+			// Simulate a successful GC/Summary.
+			// GC Data corruption should be fixed (nodes[0] should be referenced again) and autorecovery fullGC state should be reset
+			spies.gc.runGC.resetHistory();
+			await gc.collectGarbage({});
+			assert(
+				spies.gc.runGC.calledWith(/* fullGC: */ true),
+				"runGC should be called with fullGC true",
+			);
+			assert(
+				gc.summaryStateTracker.fullGCModeForAutoRecovery,
+				"fullGCModeForAutoRecovery should NOT have been reset to false yet",
+			);
+			await gc.summaryStateTracker.refreshLatestSummary({
+				isSummaryTracked: true,
+				isSummaryNewer: false,
+			});
+			assert(
+				!gc.summaryStateTracker.fullGCModeForAutoRecovery,
+				"fullGCModeForAutoRecovery should have been reset to false now",
+			);
+
+			// Lastly, confirm that the node was successfully restored
+			// (not actually that interesting since we're hardcoding the GC Data, but still)
+			assert(
+				!gc.unreferencedNodesState.has(nodes[0]),
+				"node 0 should not be unreferenced after repairing GC Data",
+			);
+		});
 	});
 
 	describe("errors when unreferenced objects are used after they are inactive / deleted", () => {
@@ -384,8 +521,12 @@ describe("Garbage Collection Tests", () => {
 						? timeout - sweepGracePeriodMs
 						: undefined;
 				const gcOptions = { sweepGracePeriodMs };
-				return createGarbageCollector({ baseSnapshot, gcOptions }, gcBlobsMap, {
-					sweepTimeoutMs,
+				return createGarbageCollector({
+					createParams: { baseSnapshot, gcOptions },
+					gcBlobsMap,
+					gcMetadata: {
+						sweepTimeoutMs,
+					},
 				});
 			};
 
@@ -906,11 +1047,11 @@ describe("Garbage Collection Tests", () => {
 					gcFeature,
 				};
 				const { snapshotTree, gcBlobsMap } = getSnapshotWithGCVersion(gcFeature);
-				return createGarbageCollector(
-					{ baseSnapshot: snapshotTree },
+				return createGarbageCollector({
+					createParams: { baseSnapshot: snapshotTree },
 					gcBlobsMap,
 					gcMetadata,
-				);
+				});
 			}
 
 			it("reads all GC data from base snapshot when GC version does not change", async () => {
@@ -1054,7 +1195,10 @@ describe("Garbage Collection Tests", () => {
 			baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
 
 			// Create and initialize garbage collector.
-			const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
+			const garbageCollector = createGarbageCollector({
+				createParams: { baseSnapshot },
+				gcBlobsMap,
+			});
 			await garbageCollector.initializeBaseState();
 
 			// The nodes in deletedNodeIds should be marked as deleted.
@@ -1108,7 +1252,10 @@ describe("Garbage Collection Tests", () => {
 			baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
 
 			// Create and initialize garbage collector.
-			const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
+			const garbageCollector = createGarbageCollector({
+				createParams: { baseSnapshot },
+				gcBlobsMap,
+			});
 			await garbageCollector.initializeBaseState();
 
 			// Run GC and summarize. The summary should contain the deleted nodes.
@@ -1754,12 +1901,16 @@ describe("Garbage Collection Tests", () => {
 		baseSnapshot.trees[channelsTreeName] = channelsTree;
 
 		// Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
-		const gcBlobMap = new Map([
+		const gcBlobsMap = new Map([
 			[gcBlobId, node3GCDetails],
 			[attributesBlobId, {}],
 		]);
-		const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobMap, {
-			sweepTimeoutMs: defaultSweepTimeoutMs,
+		const garbageCollector = createGarbageCollector({
+			createParams: { baseSnapshot },
+			gcBlobsMap,
+			gcMetadata: {
+				sweepTimeoutMs: defaultSweepTimeoutMs,
+			},
 		});
 
 		// GC state and tombstone state should be discarded but deleted nodes should be read from base snapshot.
@@ -1784,7 +1935,9 @@ describe("Garbage Collection Tests", () => {
 
 		let garbageCollector: IGarbageCollector;
 		beforeEach(async () => {
-			garbageCollector = createGarbageCollector({ gcOptions: { enableGCSweep: true } });
+			garbageCollector = createGarbageCollector({
+				createParams: { gcOptions: { enableGCSweep: true } },
+			});
 		});
 
 		it("can submit GC op compat behavior", async () => {

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -168,6 +168,36 @@ describe("GCSummaryStateTracker tests", () => {
 		});
 	});
 
+	it("Autorecovery: requesting Full GC", async () => {
+		const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+			{
+				shouldRunGC: true,
+				tombstoneMode: false,
+				gcVersionInBaseSnapshot: 1,
+				gcVersionInEffect: 1,
+			},
+			false /* wasGCRunInBaseSnapshot */,
+		) as any;
+		assert.equal(tracker.autoRecovery.fullGCRequested(), false, "Should be false by default");
+
+		tracker.autoRecovery.requestFullGCOnNextRun();
+
+		assert.equal(
+			tracker.autoRecovery.fullGCRequested(),
+			true,
+			"Should be true after requesting full GC",
+		);
+
+		// After the first summary succeeds (refreshLatestSummary called), the state should be reset.
+		await tracker.refreshLatestSummary({ isSummaryTracked: true, isSummaryNewer: true });
+
+		assert.equal(
+			tracker.autoRecovery.fullGCRequested(),
+			false,
+			"Should be false after Summary Ack",
+		);
+	});
+
 	/**
 	 * These tests validate that the GC data is written in summary incrementally. Basically, only parts of the GC
 	 * data that has changed since the last successful summary is re-written, rest is written as SummaryHandle.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -1144,7 +1144,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 				closeMe.close();
 
 				// Then wait the Tombstone timeout and update current timestamp, and summarize again
-				await delay(tombstoneTimeoutMs);
+				await delay(sweepTimeoutMs);
 				dataStoreX._root.set("update", "timestamp");
 				const { summarizer } = await loadSummarizer(
 					initialContainer,
@@ -1247,7 +1247,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 				// Wait the Tombstone timeout then summarize and load another container
 				// Since auto-recovery triggered full GC, the corruption was repaired and GC knows dataStoreA is referenced
 				// Otherwise it would have been unreferenced and would have become tombstoned again
-				await delay(tombstoneTimeoutMs);
+				await delay(sweepTimeoutMs);
 				dataStoreX._root.set("update", "timestamp again");
 				const { summaryVersion: summaryVersion_stillRepaired } =
 					await summarize(summarizer);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -3,10 +3,13 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import { strict as assert } from "assert";
 import {
 	AllowTombstoneRequestHeaderKey,
 	ContainerRuntime,
+	IOnDemandSummarizeOptions,
 	ISummarizer,
 	TombstoneResponseHeaderKey,
 } from "@fluidframework/container-runtime";
@@ -36,11 +39,19 @@ import {
 } from "@fluidframework/core-interfaces";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
-import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
+import {
+	IFluidDataStoreChannel,
+	IGarbageCollectionDetailsBase,
+} from "@fluidframework/runtime-definitions";
 import { MockLogger, tagCodeArtifacts } from "@fluidframework/telemetry-utils";
 import { FluidSerializer, parseHandles } from "@fluidframework/shared-object-base";
 import { SharedMap } from "@fluidframework/map";
 import { getGCStateFromSummary, getGCTombstoneStateFromSummary } from "./gcTestSummaryUtils.js";
+
+type ExpectedTombstoneError = Error & {
+	code: number;
+	underlyingResponseHeaders?: { [TombstoneResponseHeaderKey]: boolean };
+};
 
 /**
  * These tests validate that TombstoneReady data stores are correctly marked as tombstones. Tombstones should be added
@@ -123,9 +134,9 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 			logger,
 		);
 	};
-	const summarize = async (summarizer: ISummarizer) => {
+	const summarize = async (summarizer: ISummarizer, options?: IOnDemandSummarizeOptions) => {
 		await provider.ensureSynchronized();
-		return summarizeNow(summarizer);
+		return summarizeNow(summarizer, options);
 	};
 
 	// This function creates an unreferenced datastore and returns the datastore's id and the summary version that
@@ -619,7 +630,6 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 			async function () {
 				// This will become the persisted value in the container(s) created below (except the one with disableTombstoneFailureViaOption)
 				// NOTE: IT IS RESET AT THE END OF THE TEST
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				testContainerConfig.runtimeOptions!.gcOptions!.gcGeneration = 1;
 
 				// Note: The Summarizers in this test don't use the "future" GC option - it only matters for the interactive client
@@ -652,7 +662,6 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 					"DID NOT Expect tombstone header to be set on the response",
 				);
 
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				testContainerConfig.runtimeOptions!.gcOptions!.gcGeneration = undefined;
 			},
 		);
@@ -697,12 +706,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 				);
 
 				// This fails because the DataStore is tombstoned
-				let tombstoneError:
-					| (Error & {
-							code: number;
-							underlyingResponseHeaders?: { [TombstoneResponseHeaderKey]: boolean };
-					  })
-					| undefined;
+				let tombstoneError: ExpectedTombstoneError | undefined;
 				try {
 					await handle.get();
 				} catch (error: any) {
@@ -1054,6 +1058,205 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 					tombstoneErrorResponse3B.value,
 					`DataStore was tombstoned: ${dataStoreBId}`,
 					"Expected the Tombstone error message (3B)",
+				);
+			},
+		);
+
+		itExpects(
+			"Requesting WRONGLY-tombstoned datastore triggers auto-recovery and self-repair",
+			[
+				// 1A
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
+					clientType: "interactive",
+					category: "error",
+				},
+				// 1A again
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
+					clientType: "interactive",
+					category: "error",
+				},
+				// During the Summarize after auto-recovery is triggered (results in summaryVersion2)
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:gcUnknownOutboundReferences",
+					clientType: "noninteractive/summarizer",
+					// id: { value: "/default/root", tag: "CodeArtifact" }, (nested object comparison not supported)
+					summarizeReason: "onDemand/Summarize after auto-recovery",
+				},
+			],
+			async () => {
+				const mockLogger = new MockLogger();
+				const summarizerMockLogger = new MockLogger();
+				const initialContainer = await makeContainer();
+				const { container: summarizingContainer0, summarizer: summarizer0 } =
+					await loadSummarizer(
+						initialContainer,
+						/* summaryVersion: */ undefined,
+						summarizerMockLogger,
+					);
+				await waitForContainerConnection(initialContainer);
+
+				const defaultDataObject =
+					(await initialContainer.getEntryPoint()) as ITestDataObject;
+
+				// Create dataStoreA and dataStoreX and reference them from the default data object.
+				// They will both remain referenced, but the reference will be "lost" (by intentionally corrupting the GC Data)
+				// dataStoreX's purpose is for updating the currentReferenceTimestamp before summarizing by sending ops
+				const dataStoreA = await createDataStore(defaultDataObject);
+				const dataStoreX = await createDataStore(defaultDataObject);
+				const dataStoreAId = dataStoreA._context.id;
+				defaultDataObject._root.set("dsA", dataStoreA.handle);
+				defaultDataObject._root.set("dsX", dataStoreX.handle);
+
+				// Summarize to get a baseline for incremental summary/GC, then load a new summarizer (and close the first one)
+				const { summaryVersion: summaryVersion0 } = await summarize(summarizer0);
+				summarizingContainer0.close();
+				const { container: closeMe, summarizer: summarizer_toBeCorrupted } =
+					await loadSummarizer(initialContainer, summaryVersion0, summarizerMockLogger);
+
+				// Monkey patch in the tweak to GC Data, removing outbound routes from default's root DDS
+				const garbageCollector_toBeCorrupted = (
+					summarizer_toBeCorrupted as unknown as {
+						runtime: {
+							garbageCollector: {
+								baseGCDetailsP: Promise<IGarbageCollectionDetailsBase>;
+							};
+						};
+					}
+				).runtime.garbageCollector;
+				garbageCollector_toBeCorrupted.baseGCDetailsP =
+					garbageCollector_toBeCorrupted.baseGCDetailsP.then((baseGCDetails) => {
+						// baseGCDetails outbound routes for this DDS currently include dataStoreA and dataStoreX. Remove those.
+						baseGCDetails.gcData!.gcNodes["/default/root"] = ["/default"];
+						return baseGCDetails;
+					});
+
+				// Generate a summary with corrupted GC Data (missing route to dataStore A)
+				const { summaryVersion: summaryVersion_corrupted } = await summarize(
+					summarizer_toBeCorrupted,
+					{
+						reason: "Summarize with corrupted GC Data",
+					},
+				);
+				closeMe.close();
+
+				// Then wait the Tombstone timeout and update current timestamp, and summarize again
+				await delay(tombstoneTimeoutMs);
+				dataStoreX._root.set("update", "timestamp");
+				const { summarizer } = await loadSummarizer(
+					initialContainer,
+					summaryVersion_corrupted,
+					summarizerMockLogger,
+				);
+				const { summaryVersion: summaryVersion_withTombstone } =
+					await summarize(summarizer);
+
+				// The datastore should be tombstoned in the snapshot this container loads from,
+				// even though the datastores are properly referenced and easily reachable.
+				const container1 = await loadContainer(
+					summaryVersion_withTombstone,
+					/* disableTombstoneFailureViaGCGenerationOption: */ false,
+					mockLogger,
+				);
+
+				// Load DataStoreA, which will incorrectly be Tombstoned, triggering auto-recovery.
+				const defaultDataObject1 = (await container1.getEntryPoint()) as ITestDataObject;
+				const handleA1 = defaultDataObject1._root.get<IFluidHandle>("dsA");
+				let tombstoneError: ExpectedTombstoneError | undefined;
+				try {
+					await handleA1!.get();
+				} catch (error: any) {
+					tombstoneError = error;
+				}
+				assert.equal(
+					tombstoneError?.code,
+					404,
+					"Tombstone error from handle.get should have 404 status code (1A)",
+				);
+				assert.equal(
+					tombstoneError?.message,
+					`DataStore was tombstoned: /${dataStoreAId}`,
+					"Incorrect message for Tombstone error from handle.get (1A)",
+				);
+				assert.equal(
+					tombstoneError?.underlyingResponseHeaders?.[TombstoneResponseHeaderKey],
+					true,
+					"Tombstone error from handle.get should include the tombstone flag (1A)",
+				);
+
+				// The GC TombstoneLoaded op should roundtrip here
+				await provider.ensureSynchronized();
+
+				// TombstoneLoaded op should trigger Revived event
+				[mockLogger, summarizerMockLogger].forEach((logger, i) =>
+					logger.assertMatch(
+						[
+							{
+								eventName:
+									"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Revived",
+								clientType: i === 0 ? "interactive" : "noninteractive/summarizer",
+							},
+						],
+						`Missing expected revived event from Auto-Recovery [${
+							i === 0 ? "mockLogger" : "summarizerMockLogger"
+						}]`,
+					),
+				);
+
+				// This request still fails because Auto-Recovery only affects the next summary (via next GC run)
+				// NOTE: We have to use request pattern because handleA1 has its result cached so will not exercise the right codepath
+				const tombstoneErrorResponse_Interactive = await (
+					defaultDataObject1._context.containerRuntime as ContainerRuntime
+				).resolveHandle({
+					url: dataStoreAId,
+				});
+				assert.equal(
+					tombstoneErrorResponse_Interactive.status,
+					404,
+					"Expected tombstone error - Auto-Recovery shouldn't affect in-progress Interactive sessions (1A again)",
+				);
+
+				// Auto-Recovery: This summary will have the unref timestamp reset and will run full GC due to the GC TombstoneLoaded op
+				const { summaryVersion: summaryVersion_repaired } = await summarize(summarizer, {
+					reason: "Summarize after auto-recovery",
+				});
+				const container2 = await loadContainer(summaryVersion_repaired);
+
+				// Verify that the object is not Tombstoned in summarizingContainer - it just summarized with the TombstoneLoaded op
+				const tombstones = (
+					summarizer as unknown as {
+						runtime: { garbageCollector: { tombstones: string[] } };
+					}
+				).runtime.garbageCollector.tombstones;
+				assert.deepEqual(
+					tombstones,
+					[],
+					"Expected no Tombstones. Auto-Recovery should have kicked in immediately in Summarizer after summarizing with the TombstoneLoaded op",
+				);
+
+				// Container2 loaded after auto-recovery: These requests succeed because the datastores are no longer tombstoned
+				const entryPoint2 = (await container2.getEntryPoint()) as ITestDataObject;
+				await assert.doesNotReject(
+					async () => entryPoint2._root.get<IFluidHandle>("dsA")!.get(),
+					"Auto-Recovery should have made the object no longer tombstoned (2A)",
+				);
+
+				// Wait the Tombstone timeout then summarize and load another container
+				// Since auto-recovery triggered full GC, the corruption was repaired and GC knows dataStoreA is referenced
+				// Otherwise it would have been unreferenced and would have become tombstoned again
+				await delay(tombstoneTimeoutMs);
+				dataStoreX._root.set("update", "timestamp again");
+				const { summaryVersion: summaryVersion_stillRepaired } =
+					await summarize(summarizer);
+				const container3 = await loadContainer(summaryVersion_stillRepaired);
+				const defaultDataObject3 = (await container3.getEntryPoint()) as ITestDataObject;
+				const handleA3 = defaultDataObject3._root.get<IFluidHandle>("dsA");
+				await assert.doesNotReject(
+					async () => handleA3!.get(),
+					"Corrupted GC Data should have been repaired such that this object is known to be referenced (3A)",
 				);
 			},
 		);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -1079,13 +1079,6 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 					clientType: "interactive",
 					category: "error",
 				},
-				// During the Summarize after auto-recovery is triggered (results in summaryVersion2)
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:gcUnknownOutboundReferences",
-					clientType: "noninteractive/summarizer",
-					// id: { value: "/default/root", tag: "CodeArtifact" }, (nested object comparison not supported)
-					summarizeReason: "onDemand/Summarize after auto-recovery",
-				},
 			],
 			async () => {
 				const mockLogger = new MockLogger();

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -260,7 +260,6 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 		}
 	}
 
-	// If these tests start failing due to "runtime is closed" errors try first adjusting `sweepTimeoutMs` above
 	describe("Using tombstone data stores not allowed (per config)", () => {
 		beforeEach(() => {
 			// Allow Loading but not Usage
@@ -444,8 +443,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 		);
 	});
 
-	// If these tests start failing due to "runtime is closed" errors try first adjusting `sweepTimeoutMs` above
-	describe("Loading tombstone data stores not allowed (per config)", () => {
+	describe("Loading tombstoned data stores", () => {
 		const expectedHeadersLogged = {
 			request: "{}",
 			handleGet: JSON.stringify({ viaHandle: true }),
@@ -844,6 +842,218 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 				assert(
 					sendingContainer.closed !== true,
 					`Revived datastore should not close a container when sending signals and ops.`,
+				);
+			},
+		);
+
+		itExpects(
+			"Requesting tombstoned datastore triggers auto-recovery",
+			[
+				// 1A
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
+					clientType: "interactive",
+					category: "error",
+				},
+				// 1A again
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
+					clientType: "interactive",
+					category: "error",
+				},
+				// 3A
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
+					clientType: "interactive",
+					category: "error",
+				},
+				// 3B
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
+					clientType: "interactive",
+					category: "error",
+				},
+			],
+			async () => {
+				const mockLogger = new MockLogger();
+				const summarizerMockLogger = new MockLogger();
+				const initialContainer = await makeContainer();
+				const { container: summarizingContainer, summarizer } = await loadSummarizer(
+					initialContainer,
+					/* summaryVersion: */ undefined,
+					summarizerMockLogger,
+				);
+				await waitForContainerConnection(initialContainer);
+
+				const defaultDataObject =
+					(await initialContainer.getEntryPoint()) as ITestDataObject;
+
+				// Create dataStoreA and dataStoreB. dataStoreA has reference to dataStoreB. Then unreference dataStoreA.
+				const dataStoreA = await createDataStore(defaultDataObject);
+				const dataStoreB = await createDataStore(defaultDataObject);
+				const dataStoreAId = dataStoreA._context.id;
+				const dataStoreBId = dataStoreB._context.id;
+				dataStoreA._root.set("dsB", dataStoreB.handle);
+				defaultDataObject._root.set("dsA", dataStoreA.handle);
+				defaultDataObject._root.delete("dsA");
+
+				// Summarize to set unreferenced timestamp.
+				// Then wait the Tombstone timeout and update current timestamp, and summarize again
+				await summarize(summarizer);
+				await delay(sweepTimeoutMs);
+				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer, true);
+				const { summaryVersion } = await summarize(summarizer);
+
+				// The datastore should be tombstoned in the snapshot this container loads from
+				const container1 = await loadContainer(
+					summaryVersion,
+					/* disableTombstoneFailureViaGCGenerationOption: */ false,
+					mockLogger,
+				);
+
+				// Simulate an invalid reference to DataStoreA from the app, for this properly unreferenced (Tombstoned) object (will affect subtree including B too)
+				const entryPoint1 = (await container1.getEntryPoint()) as ITestDataObject;
+				const tombstoneErrorResponse1 = await (
+					entryPoint1._context.containerRuntime as ContainerRuntime
+				).resolveHandle({
+					url: dataStoreAId,
+				});
+				assert.equal(
+					tombstoneErrorResponse1.status,
+					404,
+					"Should not be able to retrieve a tombstoned datastore in non-summarizer clients (1A)",
+				);
+				assert.equal(
+					tombstoneErrorResponse1.value,
+					`DataStore was tombstoned: ${dataStoreAId}`,
+					"Expected the Tombstone error message (1A)",
+				);
+				assert.equal(
+					tombstoneErrorResponse1.headers?.[TombstoneResponseHeaderKey],
+					true,
+					"Expected the Tombstone header (1A)",
+				);
+
+				// The GC TombstoneLoaded op should roundtrip here
+				await provider.ensureSynchronized();
+
+				// TombstoneLoaded op should trigger Revived event
+				[mockLogger, summarizerMockLogger].forEach((logger, i) =>
+					logger.assertMatch(
+						[
+							{
+								eventName:
+									"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Revived",
+								clientType: i === 0 ? "interactive" : "noninteractive/summarizer",
+							},
+						],
+						`Missing expected revived event from Auto-Recovery [${
+							i === 0 ? "mockLogger" : "summarizerMockLogger"
+						}]`,
+					),
+				);
+
+				// This request still fails because Auto-Recovery only affects the next summary (via next GC run)
+				const tombstoneErrorResponse_Interactive = await (
+					entryPoint1._context.containerRuntime as ContainerRuntime
+				).resolveHandle({
+					url: dataStoreAId,
+				});
+				assert.equal(
+					tombstoneErrorResponse_Interactive.status,
+					404,
+					"Expected tombstone error - Auto-Recovery shouldn't affect in-progress Interactive sessions (1A again)",
+				);
+
+				// Auto-Recovery: This summary will have the unref timestamp reset due to the GC TombstoneLoaded op
+				const { summaryVersion: summaryVersion2 } = await summarize(summarizer);
+				const container2 = await loadContainer(summaryVersion2);
+
+				// Verify that the object is not Tombstoned in summarizingContainer - it just summarized with the TombstoneLoaded op
+				const summarizerResponse = await (
+					summarizer as unknown as { runtime: ContainerRuntime }
+				).runtime.resolveHandle({
+					url: dataStoreAId,
+				});
+				assert.equal(
+					summarizerResponse.status,
+					200,
+					"Auto-Recovery should have kicked in immediately in Summarizer after summarizing with the TombstoneLoaded op",
+				);
+
+				// Container2 loaded after auto-recovery: These requests succeed because the datastores are no longer tombstoned
+				const entryPoint2 = (await container2.getEntryPoint()) as ITestDataObject;
+				const successResponse2A = await (
+					entryPoint2._context.containerRuntime as ContainerRuntime
+				).resolveHandle({
+					url: dataStoreAId,
+				});
+				assert.equal(
+					successResponse2A.status,
+					200,
+					"Auto-Recovery should have made the object no longer tombstoned (2A)",
+				);
+				assert.notEqual(
+					successResponse2A.headers?.[TombstoneResponseHeaderKey],
+					true,
+					"DID NOT Expect tombstone header to be set on the success response (2A)",
+				);
+				const successResponse2B = await (
+					entryPoint2._context.containerRuntime as ContainerRuntime
+				).resolveHandle({
+					url: dataStoreBId,
+				});
+				assert.equal(
+					successResponse2B.status,
+					200,
+					"Auto-Recovery should have made the object no longer tombstoned (2B)",
+				);
+				assert.notEqual(
+					successResponse2B.headers?.[TombstoneResponseHeaderKey],
+					true,
+					"DID NOT Expect tombstone header to be set on the success response (2B)",
+				);
+
+				// Wait the Tombstone timeout then summarize and load another container
+				// It will be tombstoned again since it's been unreferenced the whole time
+				await delay(sweepTimeoutMs);
+				await sendOpToUpdateSummaryTimestampToNow(summarizingContainer, true);
+				const { summaryVersion: summaryVersion3 } = await summarize(summarizer);
+				const container3 = await loadContainer(summaryVersion3);
+				const entryPoint3 = (await container3.getEntryPoint()) as ITestDataObject;
+				const tombstoneErrorResponse3A = await (
+					entryPoint3._context.containerRuntime as ContainerRuntime
+				).resolveHandle({
+					url: dataStoreAId,
+				});
+				assert.equal(
+					tombstoneErrorResponse3A.status,
+					404,
+					"Object should become tombstoned again after the timeout (3A)",
+				);
+				assert.equal(
+					tombstoneErrorResponse3A.value,
+					`DataStore was tombstoned: ${dataStoreAId}`,
+					"Expected the Tombstone error message (3A)",
+				);
+				const tombstoneErrorResponse3B = await (
+					entryPoint3._context.containerRuntime as ContainerRuntime
+				).resolveHandle({
+					url: dataStoreBId,
+				});
+				assert.equal(
+					tombstoneErrorResponse3B.status,
+					404,
+					"Object should become tombstoned again after the timeout (3B)",
+				);
+				assert.equal(
+					tombstoneErrorResponse3B.value,
+					`DataStore was tombstoned: ${dataStoreBId}`,
+					"Expected the Tombstone error message (3B)",
 				);
 			},
 		);
@@ -1277,6 +1487,10 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 		beforeEach(() => {
 			settings["Fluid.GarbageCollection.ThrowOnTombstoneLoadOverride"] = false;
 			settings["Fluid.GarbageCollection.ThrowOnTombstoneUsage"] = false;
+
+			// Disable AutoRecovery because these tests request tombstoned objects to validate they're tombstones,
+			// And then are testing to ensure that various neutral actions don't revive them - but AutoRecovery would!
+			settings["Fluid.GarbageCollection.DisableAutoRecovery"] = true;
 		});
 		/**
 		 * In interactive clients, when a tombstoned data store is loaded that has reference to another tombstoned
@@ -1560,7 +1774,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 					mockLogger,
 				);
 				// Send an op from dataStore2's root DDS and request dataStore2 so that the DDS is loaded and the
-				// handle to dds2 is parsed resulting in a notification to GC of references.
+				// handle to dds2 is parsed - should not result in a notification to GC of references.
 				dataStore2._root.set("just", "an op");
 				await provider.ensureSynchronized();
 				// Note: Summarizer client never throws on loading tombstoned data stores.


### PR DESCRIPTION
## Description

Port https://github.com/microsoft/FluidFramework/pull/19115 and https://github.com/microsoft/FluidFramework/pull/19392 to `release/v2int/8.0` branch.  Also need the heart of https://github.com/microsoft/FluidFramework/pull/19234 - not porting that whole PR, just the [1 line of material change](https://github.com/microsoft/FluidFramework/commit/3508d8fea297da88faca784b4062112059aeaf2a#diff-c3ce6c73bad3de069b6926257ec501d2927d2b6552fdc814475c4626e498b0e3R1091) (+comments).

One of our partners is enabling the Garbage Collection feature and we want this feature to fast-follow the initial roll-out.
