### PR TITLE
Refactor serializedStateManager fetchSnapshot

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1578,10 +1578,14 @@ export class Container
 		};
 
 		timings.phase2 = performance.now();
+
+		const supportGetSnapshotApi: boolean =
+			this.mc.config.getBoolean("Fluid.Container.UseLoadingGroupIdForSnapshotFetch") ===
+				true && this.service?.policies?.supportGetSnapshotApi === true;
 		// Fetch specified snapshot.
 		const { snapshotTree, version } = await this.serializedStateManager.fetchSnapshot(
 			specifiedVersion,
-			this.service?.policies?.supportGetSnapshotApi,
+			supportGetSnapshotApi,
 		);
 		this._loadedFromVersion = version;
 		const attributes: IDocumentAttributes = await this.getDocumentAttributes(

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -61,104 +61,31 @@ export class SerializedStateManager {
 		}
 	}
 
-	private async getVersion(version: string | null): Promise<IVersion | undefined> {
-		const versions = await this.storageAdapter.getVersions(version, 1);
-		return versions[0];
-	}
-
 	public async fetchSnapshot(
 		specifiedVersion: string | undefined,
-		supportGetSnapshotApi: boolean | undefined,
+		supportGetSnapshotApi: boolean,
 	) {
-		const { snapshot, version } =
-			this.pendingLocalState === undefined
-				? await this.fetchSnapshotCore(specifiedVersion, supportGetSnapshotApi)
-				: { snapshot: this.pendingLocalState.baseSnapshot, version: undefined };
-		const snapshotTree: ISnapshotTree | undefined = isInstanceOfISnapshot(snapshot)
-			? snapshot.snapshotTree
-			: snapshot;
-		if (this.pendingLocalState) {
-			this.snapshot = {
-				tree: this.pendingLocalState.baseSnapshot,
-				blobs: this.pendingLocalState.snapshotBlobs,
-			};
-		} else {
+		if (this.pendingLocalState === undefined) {
+			const { snapshot, version } = supportGetSnapshotApi
+				? await fetchISnapshot(this.mc, this.storageAdapter, specifiedVersion)
+				: await fetchISnapshotTree(this.mc, this.storageAdapter, specifiedVersion);
+			const snapshotTree: ISnapshotTree | undefined = isInstanceOfISnapshot(snapshot)
+				? snapshot.snapshotTree
+				: snapshot;
 			assert(snapshotTree !== undefined, 0x8e4 /* Snapshot should exist */);
 			// non-interactive clients will not have any pending state we want to save
 			if (this.offlineLoadEnabled) {
 				const blobs = await getBlobContentsFromTree(snapshotTree, this.storageAdapter);
 				this.snapshot = { tree: snapshotTree, blobs };
 			}
+			return { snapshotTree, version };
+		} else {
+			this.snapshot = {
+				tree: this.pendingLocalState.baseSnapshot,
+				blobs: this.pendingLocalState.snapshotBlobs,
+			};
+			return { snapshotTree: this.pendingLocalState.baseSnapshot, version: undefined };
 		}
-		return { snapshotTree, version };
-	}
-
-	private async fetchSnapshotCore(
-		specifiedVersion: string | undefined,
-		supportGetSnapshotApi: boolean | undefined,
-	): Promise<{ snapshot?: ISnapshot | ISnapshotTree; version?: IVersion }> {
-		if (
-			this.mc.config.getBoolean("Fluid.Container.UseLoadingGroupIdForSnapshotFetch") ===
-				true &&
-			supportGetSnapshotApi === true
-		) {
-			const snapshot =
-				(await this.storageAdapter.getSnapshot?.({
-					versionId: specifiedVersion,
-				})) ?? undefined;
-			const version: IVersion | undefined =
-				snapshot?.snapshotTree.id === undefined
-					? undefined
-					: {
-							id: snapshot.snapshotTree.id,
-							treeId: snapshot.snapshotTree.id,
-					  };
-
-			if (snapshot === undefined && specifiedVersion !== undefined) {
-				this.mc.logger.sendErrorEvent({
-					eventName: "getSnapshotTreeFailed",
-					id: specifiedVersion,
-				});
-				// Not sure if this should be here actually
-			} else if (snapshot !== undefined && version?.id === undefined) {
-				this.mc.logger.sendErrorEvent({
-					eventName: "getSnapshotFetchedTreeWithoutVersionId",
-					hasVersion: version !== undefined, // if hasVersion is true, this means that the contract with the service was broken.
-				});
-			}
-			return { snapshot, version };
-		}
-		return this.fetchSnapshotTree(specifiedVersion);
-	}
-
-	/**
-	 * Get the most recent snapshot, or a specific version.
-	 * @param specifiedVersion - The specific version of the snapshot to retrieve
-	 * @returns The snapshot requested, or the latest snapshot if no version was specified, plus version ID
-	 */
-	private async fetchSnapshotTree(
-		specifiedVersion: string | undefined,
-	): Promise<{ snapshot?: ISnapshotTree; version?: IVersion | undefined }> {
-		const version = await this.getVersion(specifiedVersion ?? null);
-
-		if (version === undefined && specifiedVersion !== undefined) {
-			// We should have a defined version to load from if specified version requested
-			this.mc.logger.sendErrorEvent({
-				eventName: "NoVersionFoundWhenSpecified",
-				id: specifiedVersion,
-			});
-		}
-		const snapshot = (await this.storageAdapter.getSnapshotTree(version)) ?? undefined;
-
-		if (snapshot === undefined && version !== undefined) {
-			this.mc.logger.sendErrorEvent({ eventName: "getSnapshotTreeFailed", id: version.id });
-		} else if (snapshot !== undefined && version?.id === undefined) {
-			this.mc.logger.sendErrorEvent({
-				eventName: "getSnapshotFetchedTreeWithoutVersionId",
-				hasVersion: version !== undefined, // if hasVersion is true, this means that the contract with the service was broken.
-			});
-		}
-		return { snapshot, version };
 	}
 
 	/**
@@ -214,4 +141,69 @@ export class SerializedStateManager {
 			},
 		);
 	}
+}
+
+export async function fetchISnapshot(
+	mc: MonitoringContext,
+	storageAdapter: Pick<IDocumentStorageService, "getSnapshot">,
+	specifiedVersion: string | undefined,
+): Promise<{ snapshot?: ISnapshot | ISnapshotTree; version?: IVersion }> {
+	const snapshot =
+		(await storageAdapter.getSnapshot?.({
+			versionId: specifiedVersion,
+		})) ?? undefined;
+	const version: IVersion | undefined =
+		snapshot?.snapshotTree.id === undefined
+			? undefined
+			: {
+					id: snapshot.snapshotTree.id,
+					treeId: snapshot.snapshotTree.id,
+			  };
+
+	if (snapshot === undefined && specifiedVersion !== undefined) {
+		mc.logger.sendErrorEvent({
+			eventName: "getSnapshotTreeFailed",
+			id: specifiedVersion,
+		});
+		// Not sure if this should be here actually
+	} else if (snapshot !== undefined && version?.id === undefined) {
+		mc.logger.sendErrorEvent({
+			eventName: "getSnapshotFetchedTreeWithoutVersionId",
+			hasVersion: version !== undefined, // if hasVersion is true, this means that the contract with the service was broken.
+		});
+	}
+	return { snapshot, version };
+}
+
+/**
+ * Get the most recent snapshot, or a specific version.
+ * @param specifiedVersion - The specific version of the snapshot to retrieve
+ * @returns The snapshot requested, or the latest snapshot if no version was specified, plus version ID
+ */
+export async function fetchISnapshotTree(
+	mc: MonitoringContext,
+	storageAdapter: Pick<IDocumentStorageService, "getSnapshotTree" | "getVersions">,
+	specifiedVersion: string | undefined,
+): Promise<{ snapshot?: ISnapshotTree; version?: IVersion | undefined }> {
+	const versions = await storageAdapter.getVersions(specifiedVersion ?? null, 1);
+	const version = versions[0];
+
+	if (version === undefined && specifiedVersion !== undefined) {
+		// We should have a defined version to load from if specified version requested
+		mc.logger.sendErrorEvent({
+			eventName: "NoVersionFoundWhenSpecified",
+			id: specifiedVersion,
+		});
+	}
+	const snapshot = (await storageAdapter.getSnapshotTree(version)) ?? undefined;
+
+	if (snapshot === undefined && version !== undefined) {
+		mc.logger.sendErrorEvent({ eventName: "getSnapshotTreeFailed", id: version.id });
+	} else if (snapshot !== undefined && version?.id === undefined) {
+		mc.logger.sendErrorEvent({
+			eventName: "getSnapshotFetchedTreeWithoutVersionId",
+			hasVersion: version !== undefined, // if hasVersion is true, this means that the contract with the service was broken.
+		});
+	}
+	return { snapshot, version };
 }

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -80,9 +80,10 @@ export class SerializedStateManager {
 			}
 			return { snapshotTree, version };
 		} else {
+			const { baseSnapshot, snapshotBlobs } = this.pendingLocalState;
 			this.snapshot = {
-				tree: this.pendingLocalState.baseSnapshot,
-				blobs: this.pendingLocalState.snapshotBlobs,
+				tree: baseSnapshot,
+				blobs: snapshotBlobs,
 			};
 			return { snapshotTree: this.pendingLocalState.baseSnapshot, version: undefined };
 		}
@@ -148,10 +149,7 @@ export async function fetchISnapshot(
 	storageAdapter: Pick<IDocumentStorageService, "getSnapshot">,
 	specifiedVersion: string | undefined,
 ): Promise<{ snapshot?: ISnapshot | ISnapshotTree; version?: IVersion }> {
-	const snapshot =
-		(await storageAdapter.getSnapshot?.({
-			versionId: specifiedVersion,
-		})) ?? undefined;
+	const snapshot = await storageAdapter.getSnapshot?.({ versionId: specifiedVersion });
 	const version: IVersion | undefined =
 		snapshot?.snapshotTree.id === undefined
 			? undefined

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -194,7 +194,7 @@ describe("serializedStateManager", () => {
 		);
 		const { snapshotTree, version } = await serializedStateManager.fetchSnapshot(
 			undefined,
-			undefined,
+			false,
 		);
 		assert(snapshotTree);
 		assert.strictEqual(version, undefined);
@@ -238,7 +238,7 @@ describe("serializedStateManager", () => {
 		);
 		const { snapshotTree, version } = await serializedStateManager.fetchSnapshot(
 			undefined,
-			undefined,
+			false,
 		);
 		assert(snapshotTree);
 		assert.strictEqual(version?.id, "test");


### PR DESCRIPTION
Some refactoring aroung serializedStateManager.fetchSnapshot including:
- making a clear difference between the two flows involving whether or not we're loading using a pendinglocalstate or not instead of having both flows awkwardly merged. 
- making 2 free functions to get the snapshot and version from storage depending on which api we're using (getSnapshot or getSnapshotTree) 
- fusion "Fluid.Container.UseLoadingGroupIdForSnapshotFetch" with supportGetSnapshotApi since they both serve the same purpose of just choosing between getSnapshot or getSnapshotFree.

I considered writing some unit tests for the new free functions but they don't do anything special but handling undefined cases.