### PR TITLE
[bump] server: 2.0.2 => 2.0.3 (patch)

### DIFF
--- a/server/routerlicious/lerna.json
+++ b/server/routerlicious/lerna.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"npmClient": "pnpm",
 	"useWorkspaces": true
 }

--- a/server/routerlicious/package.json
+++ b/server/routerlicious/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "root",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/gitresources",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Git resource definitions for Fluid services",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-kafka-orderer",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid ordering services",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-lambdas-driver",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server lambda driver components",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-lambdas",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid service lambdas",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-local-server",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid local server implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-memory-orderer",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server in memory orderer",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/memory-orderer/src/packageVersion.ts
+++ b/server/routerlicious/packages/memory-orderer/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/server-memory-orderer";
-export const pkgVersion = "2.0.2";
+export const pkgVersion = "2.0.3";

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/protocol-base",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid protocol base",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-routerlicious-base",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server base classes for routerlicious",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-routerlicious",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid reference server implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-services-client",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server isomorphic services for communicating with Fluid",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/services-client/src/packageVersion.ts
+++ b/server/routerlicious/packages/services-client/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/server-services-client";
-export const pkgVersion = "2.0.2";
+export const pkgVersion = "2.0.3";

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-services-core",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server services core definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/services-core/src/packageVersion.ts
+++ b/server/routerlicious/packages/services-core/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/server-services-core";
-export const pkgVersion = "2.0.2";
+export const pkgVersion = "2.0.3";

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-services-ordering-kafkanode",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server services kafka-node orderer implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/packageVersion.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/server-services-ordering-kafkanode";
-export const pkgVersion = "2.0.2";
+export const pkgVersion = "2.0.3";

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-services-ordering-rdkafka",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server services rdkafka orderer implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-services-ordering-zookeeper",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server services zookeeper client implementation",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-services-shared",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server shared services",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/services-shared/src/packageVersion.ts
+++ b/server/routerlicious/packages/services-shared/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/server-services-shared";
-export const pkgVersion = "2.0.2";
+export const pkgVersion = "2.0.3";

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-services-telemetry",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server telemetry utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-services-utils",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server services shared utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/services-utils/src/packageVersion.ts
+++ b/server/routerlicious/packages/services-utils/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/server-services-utils";
-export const pkgVersion = "2.0.2";
+export const pkgVersion = "2.0.3";

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-services",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server services",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/server/routerlicious/packages/services/src/packageVersion.ts
+++ b/server/routerlicious/packages/services/src/packageVersion.ts
@@ -6,4 +6,4 @@
  */
 
 export const pkgName = "@fluidframework/server-services";
-export const pkgVersion = "2.0.2";
+export const pkgVersion = "2.0.3";

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/server-test-utils",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Fluid server test utilities",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
## Description

Bumps patch version in the `release/server/2.0` branch in preparation for https://github.com/microsoft/FluidFramework/pull/20189.

Done with `npx flub bump server -t patch` from the `release/server/2.0` branch.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
