### PR TITLE
Remove packageVersion.ts from source tree code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,3 +47,8 @@
 
 # Fluid Devtools source
 /packages/tools/devtools/**/src                   @microsoft/fluid-cr-devtools
+
+# Package version files are not generally interesting to review by teams signing up for source tree ownership.
+# If a release team wanted to sign up to block on changes relevant for package release,
+# that would be the appropriate owner here. For now, explicitly give these files no owner.
+/**/packageVersion.ts


### PR DESCRIPTION
## Description

Removes packageVersion.ts files (which are autogenerated) from those package authors subscribe to when adding an entry for a package's source tree. This should give less friction to bump PRs in future release branches.
