### PR TITLE
Add mocha-test-setup to published packages

### DIFF
--- a/feeds/internal-build.txt
+++ b/feeds/internal-build.txt
@@ -9,6 +9,7 @@
 @fluid-internal/test-service-load
 @fluidframework/test-driver-definitions
 @fluid-internal/test-app-insights-logger
+@fluid-internal/mocha-test-setup
 @fluidframework/tinylicious-client
 @fluid-experimental/odsp-client
 @fluid-experimental/odsp-end-to-end-tests

--- a/feeds/internal-dev.txt
+++ b/feeds/internal-dev.txt
@@ -3,6 +3,5 @@
 @fluid-private/test-end-to-end-tests
 @fluid-private/test-drivers
 @fluid-private/stochastic-test-utils
-@fluid-internal/mocha-test-setup
 @fluid-private/test-loader-utils
 @fluid-private/test-dds-utils

--- a/feeds/public.txt
+++ b/feeds/public.txt
@@ -7,6 +7,7 @@
 @fluidframework/devtools
 @fluidframework/test-utils
 @fluidframework/test-driver-definitions
+@fluid-internal/mocha-test-setup
 @fluidframework/tinylicious-client
 @fluid-experimental/odsp-client
 @fluid-experimental/odsp-end-to-end-tests

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -382,6 +382,7 @@ module.exports = {
 					"@fluidframework",
 					"fluid-framework",
 					"@fluid-internal/client-utils",
+					"@fluid-internal/mocha-test-setup",
 					"tinylicious",
 				],
 				// A list of packages published to our internal-build feed. Note that packages published


### PR DESCRIPTION
This package was demoted from `@fluidframework` scope to discourage external use, but we still need to publish it since it's consumed in other groups (specifically: benchmark, tinylicious, api-markdown-documenter).