### PR TITLE
[v2-rc1] Port GC Auto-Recovery and Reference Tracking fixes to 2.0.0-rc.1.0

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -100,7 +100,11 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     protected constructor(context: IContainerContext, registry: IFluidDataStoreRegistry, metadata: IContainerRuntimeMetadata | undefined, electedSummarizerData: ISerializedElection | undefined, chunks: [string, string[]][], dataStoreAliasMap: [string, string][], runtimeOptions: Readonly<Required<IContainerRuntimeOptions>>, containerScope: FluidObject, logger: ITelemetryLoggerExt, existing: boolean, blobManagerSnapshot: IBlobManagerLoadInfo, _storage: IDocumentStorageService, idCompressor: (IIdCompressor & IIdCompressorCore) | undefined, provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>, requestHandler?: ((request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>) | undefined, summaryConfiguration?: ISummaryConfiguration);
     // (undocumented)
     protected addContainerStateToSummary(summaryTree: ISummaryTreeWithStats, fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext): void;
-    addedGCOutboundReference(srcHandle: IFluidHandle, outboundHandle: IFluidHandle): void;
+    addedGCOutboundReference(srcHandle: {
+        absolutePath: string;
+    }, outboundHandle: {
+        absolutePath: string;
+    }): void;
     // (undocumented)
     get attachState(): AttachState;
     // (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2920,6 +2920,12 @@ export class ContainerRuntime
 	 * data store or an attachment blob.
 	 */
 	public async getGCNodePackagePath(nodePath: string): Promise<readonly string[] | undefined> {
+		// GC uses "/" when adding "root" references, e.g. for Aliasing or as part of Tombstone Auto-Recovery.
+		// These have no package path so return a special value.
+		if (nodePath === "/") {
+			return ["<GCROOT>"];
+		}
+
 		switch (this.getNodeType(nodePath)) {
 			case GCNodeType.Blob:
 				return [BlobManager.basePath];
@@ -3702,6 +3708,7 @@ export class ContainerRuntime
 		localOpMetadata: unknown,
 		opMetadata: Record<string, unknown> | undefined,
 	) {
+		assert(!this.isSummarizerClient, "Summarizer never reconnects so should never resubmit");
 		switch (message.type) {
 			case ContainerMessageType.FluidDataStoreOp:
 				// For Operations, call resubmitDataStoreOp which will find the right store
@@ -3723,8 +3730,8 @@ export class ContainerRuntime
 				this.submit(message);
 				break;
 			case ContainerMessageType.GC:
-				// GC op is only sent in summarizer which should never reconnect.
-				throw new LoggingError("GC op not expected to be resubmitted in summarizer");
+				this.submit(message);
+				break;
 			default: {
 				// This case should be very rare - it would imply an op was stashed from a
 				// future version of runtime code and now is being applied on an older version

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2991,7 +2991,10 @@ export class ContainerRuntime
 	 * @param srcHandle - The handle of the node that added the reference.
 	 * @param outboundHandle - The handle of the outbound node that is referenced.
 	 */
-	public addedGCOutboundReference(srcHandle: IFluidHandle, outboundHandle: IFluidHandle) {
+	public addedGCOutboundReference(
+		srcHandle: { absolutePath: string },
+		outboundHandle: { absolutePath: string },
+	) {
 		this.garbageCollector.addedOutboundReference(
 			srcHandle.absolutePath,
 			outboundHandle.absolutePath,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2923,7 +2923,7 @@ export class ContainerRuntime
 		// GC uses "/" when adding "root" references, e.g. for Aliasing or as part of Tombstone Auto-Recovery.
 		// These have no package path so return a special value.
 		if (nodePath === "/") {
-			return ["<GCROOT>"];
+			return ["_gcRoot"];
 		}
 
 		switch (this.getNodeType(nodePath)) {

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -57,7 +57,10 @@ import {
 import { runGarbageCollection } from "./gcReferenceGraphAlgorithm";
 import { IGarbageCollectionSnapshotData, IGarbageCollectionState } from "./gcSummaryDefinitions";
 import { GCSummaryStateTracker } from "./gcSummaryStateTracker";
-import { UnreferencedStateTracker } from "./gcUnreferencedStateTracker";
+import {
+	UnreferencedStateTracker,
+	UnreferencedStateTrackerMap,
+} from "./gcUnreferencedStateTracker";
 import { GCTelemetryTracker } from "./gcTelemetry";
 
 /**
@@ -111,8 +114,15 @@ export class GarbageCollector implements IGarbageCollector {
 	private readonly initializeGCStateFromBaseSnapshotP: Promise<void>;
 	// The GC details generated from the base snapshot.
 	private readonly baseGCDetailsP: Promise<IGarbageCollectionDetailsBase>;
-	// Map of node ids to their unreferenced state tracker.
-	private readonly unreferencedNodesState: Map<string, UnreferencedStateTracker> = new Map();
+
+	/**
+	 * Map of node ids to their unreferenced state tracker
+	 * NOTE: The set of keys in this map is considered as the set of unreferenced nodes
+	 * as of the last GC run. So in between runs, nothing should be added or removed.
+	 */
+	private readonly unreferencedNodesState: UnreferencedStateTrackerMap =
+		new UnreferencedStateTrackerMap();
+
 	// The Timer responsible for closing the container when the session has expired
 	private sessionExpiryTimer: Timer | undefined;
 
@@ -594,16 +604,10 @@ export class GarbageCollector implements IGarbageCollector {
 	): { tombstoneReadyNodeIds: Set<string>; sweepReadyNodeIds: Set<string> } {
 		// 1. Marks all referenced nodes by clearing their unreferenced tracker, if any.
 		for (const nodeId of allReferencedNodeIds) {
-			const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
-			if (nodeStateTracker !== undefined) {
-				// Stop tracking so as to clear out any running timers.
-				nodeStateTracker.stopTracking();
-				// Delete the node as we don't need to track it any more.
-				this.unreferencedNodesState.delete(nodeId);
-			}
+			this.unreferencedNodesState.delete(nodeId);
 		}
 
-		// 2. Mark unreferenced nodes in this run by starting unreferenced tracking for them.
+		// 2. Mark unreferenced nodes in this run by starting or updating unreferenced tracking for them.
 		const tombstoneReadyNodeIds: Set<string> = new Set();
 		const sweepReadyNodeIds: Set<string> = new Set();
 		for (const nodeId of gcResult.deletedNodeIds) {
@@ -944,13 +948,9 @@ export class GarbageCollector implements IGarbageCollector {
 
 		// Clear unreferenced state tracking for deleted nodes.
 		for (const nodeId of deletedNodeIds) {
-			const nodeStateTracker = this.unreferencedNodesState.get(nodeId);
-			if (nodeStateTracker !== undefined) {
-				// Stop tracking so as to clear out any running timers.
-				nodeStateTracker.stopTracking();
-				// Delete the node as we don't need to track it any more.
-				this.unreferencedNodesState.delete(nodeId);
-			}
+			// Usually we avoid modifying the set of unreferencedNodesState keys in between GC runs,
+			// but this is ok since this node won't exist at all in the next GC run.
+			this.unreferencedNodesState.delete(nodeId);
 			this.deletedNodes.add(nodeId);
 		}
 	}
@@ -1103,6 +1103,12 @@ export class GarbageCollector implements IGarbageCollector {
 			fromId: fromNodePath,
 			autorecovery,
 		});
+
+		// This node is referenced - Clear its unreferenced state
+		// But don't delete the node id from the map yet.
+		// When generating GC stats, the set of nodes in here is used as the baseline for
+		// what was unreferenced in the last GC run.
+		this.unreferencedNodesState.get(toNodePath)?.stopTracking();
 	}
 
 	/**
@@ -1136,17 +1142,17 @@ export class GarbageCollector implements IGarbageCollector {
 			updatedAttachmentBlobCount: 0,
 		};
 
-		const updateNodeStats = (nodeId: string, referenced: boolean) => {
+		const updateNodeStats = (nodeId: string, isReferenced: boolean) => {
 			markPhaseStats.nodeCount++;
 			// If there is no previous GC data, every node's state is generated and is considered as updated.
 			// Otherwise, find out if any node went from referenced to unreferenced or vice-versa.
+			const wasNotReferenced = this.unreferencedNodesState.has(nodeId);
 			const stateUpdated =
-				this.gcDataFromLastRun === undefined ||
-				this.unreferencedNodesState.has(nodeId) === referenced;
+				this.gcDataFromLastRun === undefined || wasNotReferenced === isReferenced;
 			if (stateUpdated) {
 				markPhaseStats.updatedNodeCount++;
 			}
-			if (!referenced) {
+			if (!isReferenced) {
 				markPhaseStats.unrefNodeCount++;
 			}
 
@@ -1155,7 +1161,7 @@ export class GarbageCollector implements IGarbageCollector {
 				if (stateUpdated) {
 					markPhaseStats.updatedDataStoreCount++;
 				}
-				if (!referenced) {
+				if (!isReferenced) {
 					markPhaseStats.unrefDataStoreCount++;
 				}
 			}
@@ -1164,7 +1170,7 @@ export class GarbageCollector implements IGarbageCollector {
 				if (stateUpdated) {
 					markPhaseStats.updatedAttachmentBlobCount++;
 				}
-				if (!referenced) {
+				if (!isReferenced) {
 					markPhaseStats.unrefAttachmentBlobCount++;
 				}
 			}

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -454,7 +454,9 @@ export class GarbageCollector implements IGarbageCollector {
 	): Promise<IGCStats | undefined> {
 		const fullGC =
 			options.fullGC ??
-			(this.configs.runFullGC === true || this.summaryStateTracker.doesSummaryStateNeedReset);
+			(this.configs.runFullGC === true ||
+				this.summaryStateTracker.autoRecovery.fullGCRequested() ||
+				this.summaryStateTracker.doesSummaryStateNeedReset);
 
 		// Add the options that are used to run GC to the telemetry context.
 		telemetryContext?.setMultiple("fluid_GC", "Options", {
@@ -891,7 +893,11 @@ export class GarbageCollector implements IGarbageCollector {
 
 				// Mark the node as referenced to ensure it isn't Swept
 				const tombstonedNodePath = message.contents.nodePath;
-				this.addedOutboundReference("/", tombstonedNodePath);
+				this.addedOutboundReference("/", tombstonedNodePath, true /* autorecovery */);
+
+				// In case the cause of the TombstoneLoaded event is incorrect GC Data (i.e. the object is actually reachable),
+				// do fullGC on the next run to get a chance to repair (in the likely case the bug is not deterministic)
+				this.summaryStateTracker.autoRecovery.requestFullGCOnNextRun();
 
 				break;
 			}
@@ -1055,7 +1061,7 @@ export class GarbageCollector implements IGarbageCollector {
 		const containerGCMessage: ContainerRuntimeGCMessage = {
 			type: ContainerMessageType.GC,
 			contents: {
-				type: "TombstoneLoaded",
+				type: GarbageCollectionMessageType.TombstoneLoaded,
 				nodePath,
 			},
 			compatDetails: { behavior: "Ignore" },

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -375,7 +375,7 @@ export interface IGarbageCollector {
 		headerData?: RuntimeHeaderData,
 	): void;
 	/** Called when a reference is added to a node. Used to identify nodes that were referenced between summaries. */
-	addedOutboundReference(fromNodePath: string, toNodePath: string): void;
+	addedOutboundReference(fromNodePath: string, toNodePath: string, autorecovery?: true): void;
 	/** Called to process a garbage collection message. */
 	processMessage(message: ContainerRuntimeGCMessage, local: boolean): void;
 	/** Returns true if this node has been deleted by GC during sweep phase. */

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -80,6 +80,8 @@ export const gcVersionUpgradeToV4Key = "Fluid.GarbageCollection.GCVersionUpgrade
 export const disableDatastoreSweepKey = "Fluid.GarbageCollection.DisableDataStoreSweep";
 /** Config key to revert new paradigm of detecting outbound routes in ContainerRuntime layer (use true) */
 export const detectOutboundRoutesViaDDSKey = "Fluid.GarbageCollection.DetectOutboundRoutesViaDDS";
+/** Config key to disable auto-recovery mechanism that protects Tombstones that are loaded from being swept (use true) */
+export const disableAutoRecoveryKey = "Fluid.GarbageCollection.DisableAutoRecovery";
 
 // One day in milliseconds.
 export const oneDayMs = 1 * 24 * 60 * 60 * 1000;
@@ -257,6 +259,8 @@ export type GCNodeType = (typeof GCNodeType)[keyof typeof GCNodeType];
 export const GarbageCollectionMessageType = {
 	/** Message sent directing GC to delete the given nodes */
 	Sweep: "Sweep",
+	/** Message sent notifying GC that a Tombstoned object was Loaded */
+	TombstoneLoaded: "TombstoneLoaded",
 } as const;
 
 /**
@@ -270,16 +274,28 @@ export type GarbageCollectionMessageType =
  * @internal
  */
 export interface ISweepMessage {
-	type: "Sweep";
-	// The ids of nodes that are deleted.
+	/** @see GarbageCollectionMessageType.Sweep */
+	type: typeof GarbageCollectionMessageType.Sweep;
+	/** The ids of nodes that are deleted. */
 	deletedNodeIds: string[];
+}
+
+/**
+ * The GC TombstoneLoaded message.
+ * @internal
+ */
+export interface ITombstoneLoadedMessage {
+	/** @see GarbageCollectionMessageType.TombstoneLoaded */
+	type: typeof GarbageCollectionMessageType.TombstoneLoaded;
+	/** The id of Tombstoned node that was loaded. */
+	nodePath: string;
 }
 
 /**
  * Type for a message to be used for sending / received garbage collection messages.
  * @internal
  */
-export type GarbageCollectionMessage = ISweepMessage;
+export type GarbageCollectionMessage = ISweepMessage | ITombstoneLoadedMessage;
 
 /**
  * Defines the APIs for the runtime object to be passed to the garbage collector.

--- a/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcSummaryStateTracker.ts
@@ -51,6 +51,18 @@ export class GCSummaryStateTracker {
 	// to unreferenced or vice-versa.
 	public updatedDSCountSinceLastSummary: number = 0;
 
+	/** API for ensuring the correct auto-recovery mitigations */
+	public autoRecovery = {
+		requestFullGCOnNextRun: () => {
+			this.fullGCModeForAutoRecovery = true;
+		},
+		fullGCRequested: () => {
+			return this.fullGCModeForAutoRecovery;
+		},
+	};
+	/** If true, the next GC run will do fullGC mode to regenerate the GC data for each node */
+	private fullGCModeForAutoRecovery: boolean = false;
+
 	constructor(
 		// Tells whether GC should run or not.
 		private readonly configs: Pick<
@@ -267,7 +279,7 @@ export class GCSummaryStateTracker {
 	}
 
 	/**
-	 * Called to refresh the latest summary state. This happens when either a pending summary is acked.
+	 * Called to refresh the latest summary state. This happens when a pending summary is acked.
 	 */
 	public async refreshLatestSummary(result: IRefreshSummaryResult): Promise<void> {
 		if (!result.isSummaryTracked) {
@@ -287,6 +299,7 @@ export class GCSummaryStateTracker {
 		this.latestSummaryData = this.pendingSummaryData;
 		this.pendingSummaryData = undefined;
 		this.updatedDSCountSinceLastSummary = 0;
+		this.fullGCModeForAutoRecovery = false;
 		return;
 	}
 

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -343,7 +343,9 @@ export class GCTelemetryTracker {
 			}
 
 			if (missingExplicitRoutes.length > 0) {
-				logger.sendErrorEvent({
+				// Send as Generic not Error since there are known corner cases where this will fire.
+				// E.g. If an old client re-references a node via an attach op (that doesn't include GC Data)
+				logger.sendTelemetryEvent({
 					eventName: "gcUnknownOutboundReferences",
 					...tagCodeArtifacts({
 						id: nodeId,

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -190,8 +190,6 @@ export class GCTelemetryTracker {
 		};
 
 		// If the node that is used is tombstoned, log a tombstone telemetry.
-		// Note that this is done before checking if "nodeStateTracker" is undefined below because unreferenced
-		// tracking may not have yet been enabled. That happens only after the client transitions to write mode.
 		if (nodeUsageProps.isTombstoned) {
 			this.logTombstoneUsageTelemetry(nodeUsageProps, unrefEventProps, nodeType, usageType);
 		}

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -63,6 +63,7 @@ interface INodeUsageProps extends ICommonProps {
 	currentReferenceTimestampMs: number | undefined;
 	packagePath: readonly string[] | undefined;
 	fromId?: string;
+	autorecovery?: true;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/gc/gcUnreferencedStateTracker.ts
+++ b/packages/runtime/container-runtime/src/gc/gcUnreferencedStateTracker.ts
@@ -25,6 +25,17 @@ class TimerWithNoDefaultTimeout extends Timer {
 	}
 }
 
+/** The collection of UnreferencedStateTrackers for all unreferenced nodes. Ensures stopTracking is called when deleting */
+export class UnreferencedStateTrackerMap extends Map<string, UnreferencedStateTracker> {
+	/** Delete the given key, and stop tracking if that node was actually unreferenced */
+	delete(key: string): boolean {
+		// Stop tracking so as to clear out any running timers.
+		this.get(key)?.stopTracking();
+		// Delete the node as we don't need to track it any more.
+		return super.delete(key);
+	}
+}
+
 /**
  * Helper class that tracks the state of an unreferenced node such as the time it was unreferenced and if it can
  * be tombstoned or deleted by the sweep phase.

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -39,6 +39,7 @@ export {
 	UnreferencedState,
 	throwOnTombstoneLoadOverrideKey,
 	GarbageCollectionMessage,
+	GarbageCollectionMessageType,
 	ISweepMessage,
 } from "./gcDefinitions";
 export {

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -33,6 +33,7 @@ export {
 	runSessionExpiryKey,
 	runSweepKey,
 	stableGCVersion,
+	disableAutoRecoveryKey,
 	disableDatastoreSweepKey,
 	detectOutboundRoutesViaDDSKey,
 	UnreferencedState,

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -32,7 +32,7 @@ import {
 	CreateSummarizerNodeSource,
 	channelsTreeName,
 } from "@fluidframework/runtime-definitions";
-import { GCDataBuilder } from "@fluidframework/runtime-utils";
+import { GCDataBuilder, convertSummaryTreeToITree } from "@fluidframework/runtime-utils";
 import {
 	isFluidError,
 	MockLogger,
@@ -205,9 +205,13 @@ describe("Data Store Context Tests", () => {
 				});
 
 				await localDataStoreContext.realize();
-				const attachMessage = localDataStoreContext.generateAttachMessage();
+				const {
+					attachSummary: { summary },
+					type,
+				} = localDataStoreContext.getAttachData(/* includeGCData: */ false);
+				const snapshot = convertSummaryTreeToITree(summary);
 
-				const attributesEntry = attachMessage.snapshot.entries.find(
+				const attributesEntry = snapshot.entries.find(
 					(e) => e.path === dataStoreAttributesBlobName,
 				);
 				assert(
@@ -239,11 +243,7 @@ describe("Data Store Context Tests", () => {
 					dataStoreAttributes.isRootDataStore,
 					"Local DataStore root state does not match",
 				);
-				assert.strictEqual(
-					attachMessage.type,
-					"TestDataStore1",
-					"Attach message type does not match.",
-				);
+				assert.strictEqual(type, "TestDataStore1", "Attach message type does not match.");
 			});
 
 			it("should generate exception when incorrectly created with array of packages", async () => {
@@ -296,8 +296,12 @@ describe("Data Store Context Tests", () => {
 
 				await localDataStoreContext.realize();
 
-				const attachMessage = localDataStoreContext.generateAttachMessage();
-				const attributesEntry = attachMessage.snapshot.entries.find(
+				const {
+					attachSummary: { summary },
+					type,
+				} = localDataStoreContext.getAttachData(/* includeGCData: */ false);
+				const snapshot = convertSummaryTreeToITree(summary);
+				const attributesEntry = snapshot.entries.find(
 					(e) => e.path === dataStoreAttributesBlobName,
 				);
 				assert(
@@ -328,11 +332,7 @@ describe("Data Store Context Tests", () => {
 					dataStoreAttributes.isRootDataStore,
 					"Local DataStore root state does not match",
 				);
-				assert.strictEqual(
-					attachMessage.type,
-					"SubComp",
-					"Attach message type does not match.",
-				);
+				assert.strictEqual(type, "SubComp", "Attach message type does not match.");
 			});
 
 			it("can correctly initialize root context", async () => {

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -52,7 +52,9 @@ import {
 	UnreferencedState,
 	defaultSweepGracePeriodMs,
 	GarbageCollectionMessage,
+	GarbageCollectionMessageType,
 	GCTelemetryTracker,
+	IGCStats,
 } from "../../gc";
 import { ContainerMessageType, ContainerRuntimeGCMessage } from "../../messageTypes";
 import {
@@ -63,16 +65,19 @@ import {
 import { pkgVersion } from "../../packageVersion";
 import { configProvider } from "./gcUnitTestHelpers";
 
+type WithPrivates<T, TPrivates> = Omit<T, keyof TPrivates> & TPrivates;
+
 type GcWithPrivates = IGarbageCollector & {
 	readonly runtime: IGarbageCollectionRuntime;
 	readonly configs: IGarbageCollectorConfigs;
-	readonly summaryStateTracker: Omit<
+	readonly summaryStateTracker: WithPrivates<
 		GCSummaryStateTracker,
-		"latestSummaryGCVersion" | "latestSummaryData"
-	> & {
-		latestSummaryGCVersion: GCVersion;
-		latestSummaryData: IGCSummaryTrackingData | undefined;
-	};
+		{
+			latestSummaryGCVersion: GCVersion;
+			latestSummaryData: IGCSummaryTrackingData | undefined;
+			fullGCModeForAutoRecovery: boolean;
+		}
+	>;
 	readonly telemetryTracker: GCTelemetryTracker;
 	readonly mc: MonitoringContext;
 	readonly sessionExpiryTimer: Omit<Timer, "defaultTimeout"> & { defaultTimeout: number };
@@ -81,6 +86,7 @@ type GcWithPrivates = IGarbageCollector & {
 	readonly deletedNodes: Set<string>;
 	readonly unreferencedNodesState: Map<string, UnreferencedStateTracker>;
 	readonly submitMessage: (message: ContainerRuntimeGCMessage) => void;
+	runGC: (fullGC: boolean) => Promise<IGCStats>;
 };
 
 describe("Garbage Collection Tests", () => {
@@ -123,12 +129,24 @@ describe("Garbage Collection Tests", () => {
 	}
 
 	function createGarbageCollector(
-		createParams: Partial<IGarbageCollectorCreateParams> = {},
-		gcBlobsMap: Map<string, any> = new Map(),
-		gcMetadata: IGCMetadata = {},
-		closeFn: (error?: ICriticalContainerError) => void = () => {},
-		isSummarizerClient: boolean = true,
+		params: {
+			createParams?: Partial<IGarbageCollectorCreateParams>;
+			gcBlobsMap?: Map<string, any>;
+			gcMetadata?: IGCMetadata;
+			closeFn?: (error?: ICriticalContainerError) => void;
+			isSummarizerClient?: boolean;
+			getGCData?: (fullGC?: boolean) => Promise<IGarbageCollectionData>;
+		} = {},
 	): GcWithPrivates {
+		const {
+			createParams = {},
+			gcBlobsMap = new Map(),
+			gcMetadata = {},
+			closeFn = () => {},
+			isSummarizerClient = true,
+			getGCData = async () => defaultGCData,
+		} = params;
+
 		const getNodeType = (nodePath: string) => {
 			if (nodePath.split("/").length !== 2) {
 				return GCNodeType.Other;
@@ -139,7 +157,7 @@ describe("Garbage Collection Tests", () => {
 		// The runtime to be passed to the garbage collector.
 		const gcRuntime: IGarbageCollectionRuntime = {
 			updateStateBeforeGC: async () => {},
-			getGCData: async (fullGC?: boolean) => defaultGCData,
+			getGCData,
 			updateUsedRoutes: (usedRoutes: string[]) => {
 				return { totalNodeCount: 0, unusedNodeCount: 0 };
 			},
@@ -218,14 +236,11 @@ describe("Garbage Collection Tests", () => {
 			return closeCalled;
 		}
 
-		gc = createGarbageCollector(
-			{},
-			undefined /* gcBlobsMap */,
-			undefined /* gcMetadata */,
+		gc = createGarbageCollector({closeFn:
 			() => {
 				closeCalled = true;
 			},
-		);
+			}	);
 		assert(
 			closeCalledAfterExactTicks(defaultSessionExpiryDurationMs),
 			"Close should have been called at exactly defaultSessionExpiryDurationMs",
@@ -267,7 +282,7 @@ describe("Garbage Collection Tests", () => {
 		});
 	});
 
-	describe("runSweepPhase", () => {
+	describe("Tombstone and Sweep", () => {
 		it("Tombstone then Delete", async () => {
 			// Simple starting reference graph - root and two nodes
 			defaultGCData.gcNodes["/"] = [nodes[0], nodes[1]];
@@ -275,7 +290,7 @@ describe("Garbage Collection Tests", () => {
 			defaultGCData.gcNodes[nodes[1]] = [];
 
 			// Sweep enabled
-			gc = createGarbageCollector({ gcOptions: { enableGCSweep: true } });
+			gc = createGarbageCollector({ createParams: { gcOptions: { enableGCSweep: true } } });
 			// These spies will let us monitor how each of these functions are called (or not) during runSweepPhase.
 			// The original behavior of the function is preserved, but we can check how it was called.
 			const spies = {
@@ -364,6 +379,125 @@ describe("Garbage Collection Tests", () => {
 				"submitMessage should not be called since Sweep is disabled",
 			);
 		});
+
+		it("Autorecovery upon loading a Tombstoned node", async () => {
+			// Simple starting reference graph - root and two nodes
+			defaultGCData.gcNodes["/"] = [nodes[0], nodes[1]];
+			defaultGCData.gcNodes[nodes[0]] = [];
+			defaultGCData.gcNodes[nodes[1]] = [];
+
+			// Simulate GC Data with a route missing (nodes[0] is referenced but missing here)
+			// We'll return this from getGCData unless fullGC is passed in.
+			const corruptedGCData: IGarbageCollectionData = JSON.parse(
+				JSON.stringify(defaultGCData),
+			);
+			corruptedGCData.gcNodes["/"] = [nodes[1]];
+
+			// getGCData set up to sometimes return the corrupted data
+			gc = createGarbageCollector({
+				getGCData: async (fullGC?: boolean) => {
+					return fullGC ? defaultGCData : corruptedGCData;
+				},
+			});
+			// These spies will let us monitor how each of these functions are called (or not) during runSweepPhase.
+			// The original behavior of the function is preserved, but we can check how it was called.
+			const spies = {
+				gc: {
+					submitMessage: spy(gc, "submitMessage"),
+					addedOutboundReference: spy(gc, "addedOutboundReference"),
+					runGC: spy(gc, "runGC"),
+				},
+			};
+
+			// Nodes 0 and 1 are referenced (use correct gcData via fullGC true)
+			// Simulate successful summary ack to clear doesGCStateNeedReset flag so it doesn't interfere (it leads to fullGC too)
+			await gc.collectGarbage({ fullGC: true });
+			await gc.summaryStateTracker.refreshLatestSummary({
+				isSummaryTracked: true,
+				isSummaryNewer: false,
+			});
+			assert(
+				!gc.unreferencedNodesState.has(nodes[0]),
+				"node 0 should not be unreferenced to start",
+			);
+
+			// Now run GC again - this time with the corrupted data (via fullGC false)
+			clock.tick(10);
+			await gc.collectGarbage({ fullGC: false });
+			assert.equal(
+				gc.unreferencedNodesState.get(nodes[0])?.state,
+				UnreferencedState.Active, // This means recently unreferenced
+				"node 0 should appear unreferenced after running GC with corrupted GC Data",
+			);
+
+			// Let node 0 become Tombstoned and verify it
+			clock.tick(defaultTombstoneTimeoutMs);
+			await gc.collectGarbage({});
+			assert.equal(
+				gc.unreferencedNodesState.get(nodes[0])?.state,
+				UnreferencedState.TombstoneReady,
+				"node 0 should be TombstoneReady",
+			);
+			assert.deepEqual(gc.tombstones, [nodes[0]], "node 0 should be in the Tombstones list");
+
+			// Simulate usage to trigger TombstoneLoaded op.
+			gc.nodeUpdated(nodes[0], "Loaded");
+			const [gcTombstoneLoadedMessage] = spies.gc.submitMessage.args[0];
+			assert.deepEqual(
+				gcTombstoneLoadedMessage,
+				{
+					type: ContainerMessageType.GC,
+					contents: {
+						type: GarbageCollectionMessageType.TombstoneLoaded,
+						nodePath: nodes[0],
+					},
+					compatDetails: { behavior: "Ignore" },
+				} satisfies ContainerRuntimeGCMessage,
+				"submitted message not as expected",
+			);
+
+			// Plumb the message to processMessage fn to trigger autorecovery
+			// Autorecovery: addedOutboundReference should be called with the tombstoned node, which should transition to "Active" state
+			gc.processMessage(gcTombstoneLoadedMessage, true /* local */);
+			assert.deepEqual(
+				spies.gc.addedOutboundReference.args[0],
+				["/", nodes[0], /* autorecovery: */ true],
+				"addedOutboundReference should be called with node 0",
+			);
+			assert.equal(
+				gc.unreferencedNodesState.get(nodes[0])?.state,
+				UnreferencedState.Active,
+				"node 0 should be unreferenced but 'Active' after initial Autorecovery moment (it was TombstoneReady)",
+			);
+
+			// Simulate a successful GC/Summary.
+			// GC Data corruption should be fixed (nodes[0] should be referenced again) and autorecovery fullGC state should be reset
+			spies.gc.runGC.resetHistory();
+			await gc.collectGarbage({});
+			assert(
+				spies.gc.runGC.calledWith(/* fullGC: */ true),
+				"runGC should be called with fullGC true",
+			);
+			assert(
+				gc.summaryStateTracker.fullGCModeForAutoRecovery,
+				"fullGCModeForAutoRecovery should NOT have been reset to false yet",
+			);
+			await gc.summaryStateTracker.refreshLatestSummary({
+				isSummaryTracked: true,
+				isSummaryNewer: false,
+			});
+			assert(
+				!gc.summaryStateTracker.fullGCModeForAutoRecovery,
+				"fullGCModeForAutoRecovery should have been reset to false now",
+			);
+
+			// Lastly, confirm that the node was successfully restored
+			// (not actually that interesting since we're hardcoding the GC Data, but still)
+			assert(
+				!gc.unreferencedNodesState.has(nodes[0]),
+				"node 0 should not be unreferenced after repairing GC Data",
+			);
+		});
 	});
 
 	describe("errors when unreferenced objects are used after they are inactive / deleted", () => {
@@ -422,8 +556,12 @@ describe("Garbage Collection Tests", () => {
 						? timeout - sweepGracePeriodMs
 						: undefined;
 				const gcOptions = { sweepGracePeriodMs };
-				return createGarbageCollector({ baseSnapshot, gcOptions }, gcBlobsMap, {
-					tombstoneTimeoutMs,
+				return createGarbageCollector({
+					createParams: { baseSnapshot, gcOptions },
+					gcBlobsMap,
+					gcMetadata: {
+						tombstoneTimeoutMs,
+					},
 				});
 			};
 
@@ -1032,11 +1170,11 @@ describe("Garbage Collection Tests", () => {
 					gcFeature,
 				};
 				const { snapshotTree, gcBlobsMap } = getSnapshotWithGCVersion(gcFeature);
-				return createGarbageCollector(
-					{ baseSnapshot: snapshotTree },
+				return createGarbageCollector({
+					createParams: { baseSnapshot: snapshotTree },
 					gcBlobsMap,
 					gcMetadata,
-				);
+				});
 			}
 
 			it("reads all GC data from base snapshot when GC version does not change", async () => {
@@ -1180,7 +1318,10 @@ describe("Garbage Collection Tests", () => {
 			baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
 
 			// Create and initialize garbage collector.
-			const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
+			const garbageCollector = createGarbageCollector({
+				createParams: { baseSnapshot },
+				gcBlobsMap,
+			});
 			await garbageCollector.initializeBaseState();
 
 			// The nodes in deletedNodeIds should be marked as deleted.
@@ -1234,7 +1375,10 @@ describe("Garbage Collection Tests", () => {
 			baseSnapshot.trees[gcTreeKey] = gcSnapshotTree;
 
 			// Create and initialize garbage collector.
-			const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobsMap);
+			const garbageCollector = createGarbageCollector({
+				createParams: { baseSnapshot },
+				gcBlobsMap,
+			});
 			await garbageCollector.initializeBaseState();
 
 			// Run GC and summarize. The summary should contain the deleted nodes.
@@ -1880,12 +2024,16 @@ describe("Garbage Collection Tests", () => {
 		baseSnapshot.trees[channelsTreeName] = channelsTree;
 
 		// Set up the getNodeGCDetails function to return the GC details for node 3 when asked by garbage collector.
-		const gcBlobMap = new Map([
+		const gcBlobsMap = new Map([
 			[gcBlobId, node3GCDetails],
 			[attributesBlobId, {}],
 		]);
-		const garbageCollector = createGarbageCollector({ baseSnapshot }, gcBlobMap, {
-			tombstoneTimeoutMs: defaultTombstoneTimeoutMs,
+		const garbageCollector = createGarbageCollector({
+			createParams: { baseSnapshot },
+			gcBlobsMap,
+			gcMetadata: {
+				tombstoneTimeoutMs: defaultTombstoneTimeoutMs,
+			},
 		});
 
 		// GC state and tombstone state should be discarded but deleted nodes should be read from base snapshot.
@@ -1910,7 +2058,9 @@ describe("Garbage Collection Tests", () => {
 
 		let garbageCollector: IGarbageCollector;
 		beforeEach(async () => {
-			garbageCollector = createGarbageCollector({ gcOptions: { enableGCSweep: true } });
+			garbageCollector = createGarbageCollector({
+				createParams: { gcOptions: { enableGCSweep: true } },
+			});
 		});
 
 		it("can submit GC op compat behavior", async () => {

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -236,11 +236,11 @@ describe("Garbage Collection Tests", () => {
 			return closeCalled;
 		}
 
-		gc = createGarbageCollector({closeFn:
-			() => {
+		gc = createGarbageCollector({
+			closeFn: () => {
 				closeCalled = true;
 			},
-			}	);
+		});
 		assert(
 			closeCalledAfterExactTicks(defaultSessionExpiryDurationMs),
 			"Close should have been called at exactly defaultSessionExpiryDurationMs",

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -168,6 +168,36 @@ describe("GCSummaryStateTracker tests", () => {
 		});
 	});
 
+	it("Autorecovery: requesting Full GC", async () => {
+		const tracker: GCSummaryStateTrackerWithPrivates = new GCSummaryStateTracker(
+			{
+				shouldRunGC: true,
+				tombstoneMode: false,
+				gcVersionInBaseSnapshot: 1,
+				gcVersionInEffect: 1,
+			},
+			false /* wasGCRunInBaseSnapshot */,
+		) as any;
+		assert.equal(tracker.autoRecovery.fullGCRequested(), false, "Should be false by default");
+
+		tracker.autoRecovery.requestFullGCOnNextRun();
+
+		assert.equal(
+			tracker.autoRecovery.fullGCRequested(),
+			true,
+			"Should be true after requesting full GC",
+		);
+
+		// After the first summary succeeds (refreshLatestSummary called), the state should be reset.
+		await tracker.refreshLatestSummary({ isSummaryTracked: true, isSummaryNewer: true });
+
+		assert.equal(
+			tracker.autoRecovery.fullGCRequested(),
+			false,
+			"Should be false after Summary Ack",
+		);
+	});
+
 	/**
 	 * These tests validate that the GC data is written in summary incrementally. Basically, only parts of the GC
 	 * data that has changed since the last successful summary is re-written, rest is written as SummaryHandle.

--- a/packages/runtime/datastore/api-report/datastore.api.md
+++ b/packages/runtime/datastore/api-report/datastore.api.md
@@ -73,6 +73,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     ensureNoDataModelChanges<T>(callback: () => T): T;
     // (undocumented)
     readonly entryPoint: IFluidHandle<FluidObject>;
+    getAttachGCData(telemetryContext?: ITelemetryContext): IGarbageCollectionData;
     // (undocumented)
     getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     // (undocumented)

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -171,6 +171,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_FluidDataStoreRuntime": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -97,6 +97,7 @@ export function createChannelServiceEndpoints(
 	};
 }
 
+/** Used to get the channel's summary for the DDS or DataStore attach op */
 export function summarizeChannel(
 	channel: IChannel,
 	fullTree: boolean = false,

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -52,6 +52,7 @@ import {
 	VisibilityState,
 	ITelemetryContext,
 	IIdCompressor,
+	gcDataBlobKey,
 } from "@fluidframework/runtime-definitions";
 import {
 	convertSnapshotTreeToSummaryTree,
@@ -64,6 +65,8 @@ import {
 	exceptionToResponse,
 	GCDataBuilder,
 	unpackChildNodesUsedRoutes,
+	addBlobToSummary,
+	processAttachMessageGCData,
 } from "@fluidframework/runtime-utils";
 import {
 	IChannel,
@@ -482,7 +485,7 @@ export class FluidDataStoreRuntime
 		this.notBoundedChannelContextSet.delete(channel.id);
 		// If our data store is attached, then attach the channel.
 		if (this.isAttached) {
-			this.attachChannel(channel);
+			this.makeChannelLocallyVisible(channel);
 			return;
 		}
 
@@ -609,6 +612,13 @@ export class FluidDataStoreRuntime
 				case DataStoreMessageType.Attach: {
 					const attachMessage = message.contents as IAttachMessage;
 					const id = attachMessage.id;
+
+					// We need to process the GC Data for both local and remote attach messages
+					processAttachMessageGCData(attachMessage.snapshot, (nodeId, toPath) => {
+						// Note: nodeId will be "/" unless and until we support sub-DDS GC Nodes
+						const fromPath = `/${this.id}/${id}${nodeId === "/" ? "" : nodeId}`;
+						this.dataStoreContext.addedGCOutboundRoute?.(fromPath, toPath);
+					});
 
 					// If a non-local operation then go and create the object
 					// Otherwise mark it as officially attached.
@@ -812,6 +822,64 @@ export class FluidDataStoreRuntime
 	}
 
 	public getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats {
+		const summaryBuilder = new SummaryTreeBuilder();
+		this.visitLocalBoundContextsDuringAttach(
+			(contextId: string, context: LocalChannelContextBase) => {
+				let summaryTree: ISummaryTreeWithStats;
+				if (context.isLoaded) {
+					const contextSummary = context.getAttachSummary(telemetryContext);
+					assert(
+						contextSummary.summary.type === SummaryType.Tree,
+						0x180 /* "getAttachSummary should always return a tree" */,
+					);
+
+					summaryTree = { stats: contextSummary.stats, summary: contextSummary.summary };
+				} else {
+					// If this channel is not yet loaded, then there should be no changes in the snapshot from which
+					// it was created as it is detached container. So just use the previous snapshot.
+					assert(
+						!!this.dataStoreContext.baseSnapshot,
+						0x181 /* "BaseSnapshot should be there as detached container loaded from snapshot" */,
+					);
+					summaryTree = convertSnapshotTreeToSummaryTree(
+						this.dataStoreContext.baseSnapshot.trees[contextId],
+					);
+				}
+				summaryBuilder.addWithStats(contextId, summaryTree);
+			},
+		);
+
+		return summaryBuilder.getSummaryTree();
+	}
+
+	/**
+	 * Get the GC Data for the initial state being attached so remote clients can learn of this DataStore's outbound routes
+	 */
+	public getAttachGCData(telemetryContext?: ITelemetryContext): IGarbageCollectionData {
+		const gcDataBuilder = new GCDataBuilder();
+		this.visitLocalBoundContextsDuringAttach(
+			(contextId: string, context: LocalChannelContextBase) => {
+				if (context.isLoaded) {
+					const contextGCData = context.getAttachGCData(telemetryContext);
+
+					// Incorporate the GC Data for this context
+					gcDataBuilder.prefixAndAddNodes(contextId, contextGCData.gcNodes);
+				}
+				// else: Rehydrating detached container case. GC doesn't run until the container is attached, so nothing to do here.
+			},
+		);
+		this.updateGCNodes(gcDataBuilder);
+
+		return gcDataBuilder.getGCData();
+	}
+
+	/**
+	 * Helper method for preparing to attach this dataStore.
+	 * Runs the callback for each bound context to incorporate its data however the caller specifies
+	 */
+	private visitLocalBoundContextsDuringAttach(
+		visitor: (contextId: string, context: LocalChannelContextBase) => void,
+	): void {
 		/**
 		 * back-compat 0.59.1000 - getAttachSummary() is called when making a data store globally visible (previously
 		 * attaching state). Ideally, attachGraph() should have already be called making it locally visible. However,
@@ -832,39 +900,15 @@ export class FluidDataStoreRuntime
 		//  "The data store should be locally visible when generating attach summary",
 		// );
 
-		const summaryBuilder = new SummaryTreeBuilder();
-
-		// Craft the .attributes file for each shared object
 		for (const [contextId, context] of this.contexts) {
 			if (!(context instanceof LocalChannelContextBase)) {
 				throw new LoggingError("Should only be called with local channel handles");
 			}
 
 			if (!this.notBoundedChannelContextSet.has(contextId)) {
-				let summaryTree: ISummaryTreeWithStats;
-				if (context.isLoaded) {
-					const contextSummary = context.getAttachSummary(telemetryContext);
-					assert(
-						contextSummary.summary.type === SummaryType.Tree,
-						0x180 /* "getAttachSummary should always return a tree" */,
-					);
-					summaryTree = { stats: contextSummary.stats, summary: contextSummary.summary };
-				} else {
-					// If this channel is not yet loaded, then there should be no changes in the snapshot from which
-					// it was created as it is detached container. So just use the previous snapshot.
-					assert(
-						!!this.dataStoreContext.baseSnapshot,
-						0x181 /* "BaseSnapshot should be there as detached container loaded from snapshot" */,
-					);
-					summaryTree = convertSnapshotTreeToSummaryTree(
-						this.dataStoreContext.baseSnapshot.trees[contextId],
-					);
-				}
-				summaryBuilder.addWithStats(contextId, summaryTree);
+				visitor(contextId, context);
 			}
 		}
-
-		return summaryBuilder.getSummaryTree();
 	}
 
 	public submitMessage(type: DataStoreMessageType, content: any, localOpMetadata: unknown) {
@@ -890,9 +934,10 @@ export class FluidDataStoreRuntime
 	}
 
 	/**
-	 * Attach channel should only be called after the data store has been attached
+	 * Assuming this DataStore is already attached, this will make the given channel locally visible
+	 * by submitting its attach op.
 	 */
-	private attachChannel(channel: IChannel): void {
+	private makeChannelLocallyVisible(channel: IChannel): void {
 		this.verifyNotClosed();
 		// If this handle is already attached no need to attach again.
 		if (channel.handle.isAttached) {
@@ -912,6 +957,11 @@ export class FluidDataStoreRuntime
 			true /* fullTree */,
 			false /* trackState */,
 		);
+
+		// We need to include the channel's GC Data so remote clients can learn of this channel's outbound routes
+		const gcData = channel.getGCData(/* fullGC: */ true);
+		addBlobToSummary(summarizeResult, gcDataBlobKey, JSON.stringify(gcData));
+
 		// Attach message needs the summary in ITree format. Convert the ISummaryTree into an ITree.
 		const snapshot = convertSummaryTreeToITree(summarizeResult.summary);
 

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -125,6 +125,11 @@ export abstract class LocalChannelContextBase implements IChannelContext {
 		return summarizeChannelAsync(channel, fullTree, trackState, telemetryContext);
 	}
 
+	/**
+	 * For crafting the DataStore attach op. Only to be called when the channel is loaded (if applicable).
+	 *
+	 * Synchronously generates the channel's attach summary to be joined with the same from the DataStore's other channels
+	 */
 	public getAttachSummary(telemetryContext?: ITelemetryContext): ISummarizeResult {
 		assert(
 			this._channel !== undefined,
@@ -136,6 +141,19 @@ export abstract class LocalChannelContextBase implements IChannelContext {
 			false /* trackState */,
 			telemetryContext,
 		);
+	}
+
+	/**
+	 * For crafting the DataStore attach op. Only to be called when the channel is loaded (if applicable).
+	 *
+	 * Synchronously generates the channel's attach GC data (set of outbound routes in the initial state)
+	 * to be joined with the same from the DataStore's other channels
+	 */
+	public getAttachGCData(telemetryContext?: ITelemetryContext): IGarbageCollectionData {
+		assert(this._channel !== undefined, "Local Channel should be loaded before being attached");
+
+		// We need the GC Data to detect references added in this attach op
+		return this._channel.getGCData(/* fullGC: */ true);
 	}
 
 	public makeVisible(): void {

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
@@ -55,6 +55,7 @@ declare function get_old_ClassDeclaration_FluidDataStoreRuntime():
 declare function use_current_ClassDeclaration_FluidDataStoreRuntime(
     use: TypeOnly<current.FluidDataStoreRuntime>): void;
 use_current_ClassDeclaration_FluidDataStoreRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_FluidDataStoreRuntime());
 
 /*

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -109,6 +109,9 @@ export enum FlushModeExperimental {
 export const gcBlobPrefix = "__gc";
 
 // @internal
+export const gcDataBlobKey = ".gcdata";
+
+// @internal
 export const gcDeletedBlobKey = "__deletedNodes";
 
 // @internal
@@ -186,6 +189,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
     attachGraph(): void;
     readonly attachState: AttachState;
     readonly entryPoint: IFluidHandle<FluidObject>;
+    getAttachGCData?(telemetryContext?: ITelemetryContext): IGarbageCollectionData;
     getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     // (undocumented)
@@ -208,6 +212,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
 export interface IFluidDataStoreContext extends IEventProvider<IFluidDataStoreContextEvents>, Partial<IProvideFluidDataStoreRegistry>, IProvideFluidHandleContext {
     // @deprecated (undocumented)
     addedGCOutboundReference?(srcHandle: IFluidHandle, outboundHandle: IFluidHandle): void;
+    addedGCOutboundRoute?(fromPath: string, toPath: string): void;
     readonly attachState: AttachState;
     // (undocumented)
     readonly baseSnapshot: ISnapshotTree | undefined;

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -258,9 +258,14 @@ export interface IFluidDataStoreChannel extends IDisposable {
 	makeVisibleAndAttachGraph(): void;
 
 	/**
-	 * Retrieves the summary used as part of the initial summary message
+	 * Synchronously retrieves the summary used as part of the initial summary message
 	 */
 	getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+
+	/**
+	 * Synchronously retrieves GC Data (representing the outbound routes present) for the initial state of the DataStore
+	 */
+	getAttachGCData?(telemetryContext?: ITelemetryContext): IGarbageCollectionData;
 
 	/**
 	 * Processes the op.
@@ -486,12 +491,25 @@ export interface IFluidDataStoreContext
 	 * @deprecated There is no replacement for this, its functionality is no longer needed at this layer.
 	 * It will be removed in a future release, sometime after 2.0.0-internal.8.0.0
 	 *
+	 * Similar capability is exposed with from/to string paths instead of handles via @see addedGCOutboundRoute
+	 *
 	 * Called when a new outbound reference is added to another node. This is used by garbage collection to identify
 	 * all references added in the system.
 	 * @param srcHandle - The handle of the node that added the reference.
 	 * @param outboundHandle - The handle of the outbound node that is referenced.
 	 */
 	addedGCOutboundReference?(srcHandle: IFluidHandle, outboundHandle: IFluidHandle): void;
+
+	/**
+	 * (Same as @see addedGCOutboundReference, but with string paths instead of handles)
+	 *
+	 * Called when a new outbound reference is added to another node. This is used by garbage collection to identify
+	 * all references added in the system.
+	 *
+	 * @param fromPath - The absolute path of the node that added the reference.
+	 * @param toPath - The absolute path of the outbound node that is referenced.
+	 */
+	addedGCOutboundRoute?(fromPath: string, toPath: string): void;
 }
 
 /**

--- a/packages/runtime/runtime-definitions/src/garbageCollection.ts
+++ b/packages/runtime/runtime-definitions/src/garbageCollection.ts
@@ -10,7 +10,7 @@
  */
 export const gcTreeKey = "gc";
 /**
- * They prefix for GC blobs in the GC tree in summary.
+ * The prefix for GC blobs in the GC tree in summary.
  *
  * @internal
  */
@@ -27,6 +27,12 @@ export const gcTombstoneBlobKey = "__tombstones";
  * @internal
  */
 export const gcDeletedBlobKey = "__deletedNodes";
+/**
+ * The key for the GC Data blob in attach summaries.
+ *
+ * @internal
+ */
+export const gcDataBlobKey = ".gcdata";
 
 /**
  * Garbage collection data returned by nodes in a Container.

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -34,6 +34,7 @@ export {
 } from "./dataStoreRegistry";
 export {
 	gcBlobPrefix,
+	gcDataBlobKey,
 	gcDeletedBlobKey,
 	gcTombstoneBlobKey,
 	gcTreeKey,

--- a/packages/runtime/runtime-utils/api-report/runtime-utils.api.md
+++ b/packages/runtime/runtime-utils/api-report/runtime-utils.api.md
@@ -129,6 +129,9 @@ export class ObjectStoragePartition implements IChannelStorageService {
 }
 
 // @internal
+export function processAttachMessageGCData(snapshot: ITree | null, addedGCOutboundRoute: (fromNodeId: string, toPath: string) => void): boolean;
+
+// @internal
 export type ReadAndParseBlob = <T>(id: string) => Promise<T>;
 
 // @alpha

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -29,6 +29,7 @@ export {
 	GCDataBuilder,
 	getBlobSize,
 	mergeStats,
+	processAttachMessageGCData,
 	SummaryTreeBuilder,
 	TelemetryContext,
 	utf8ByteLength,

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -10,7 +10,7 @@ import {
 	IsoBuffer,
 	Uint8ArrayToString,
 } from "@fluid-internal/client-utils";
-import { unreachableCase } from "@fluidframework/core-utils";
+import { assert, unreachableCase } from "@fluidframework/core-utils";
 import { AttachmentTreeEntry, BlobTreeEntry, TreeTreeEntry } from "@fluidframework/driver-utils";
 import {
 	ITree,
@@ -373,6 +373,45 @@ export function convertSummaryTreeToITree(summaryTree: ISummaryTree): ITree {
 		entries,
 		unreferenced: summaryTree.unreferenced,
 	};
+}
+
+/**
+ * Looks in the given attach message snapshot for the .gcdata blob, which would
+ * contain the initial GC Data for the node being attached.
+ * If it finds it, it notifies GC of all the new outbound routes being added by the attach.
+ *
+ * @param snapshot - The snapshot from the attach message
+ * @param addedGCOutboundRoute - Callback to notify GC of a new outbound route.
+ * IMPORTANT: addedGCOutboundRoute's param nodeId is "/" for the attaching node itself, or "/<id>" for its children.
+ *
+ * @returns true if it found/processed GC Data, false otherwise
+ *
+ * @internal
+ */
+export function processAttachMessageGCData(
+	snapshot: ITree | null,
+	addedGCOutboundRoute: (fromNodeId: string, toPath: string) => void,
+): boolean {
+	const gcDataEntry = snapshot?.entries.find((e) => e.path === ".gcdata");
+
+	// Old attach messages won't have GC Data
+	// (And REALLY old DataStore Attach messages won't even have a snapshot!)
+	if (gcDataEntry === undefined) {
+		return false;
+	}
+
+	assert(
+		gcDataEntry.type === TreeEntry.Blob && gcDataEntry.value.encoding === "utf-8",
+		"GC data should be a utf-8-encoded blob",
+	);
+
+	const gcData = JSON.parse(gcDataEntry.value.contents) as IGarbageCollectionData;
+	for (const [nodeId, outboundRoutes] of Object.entries(gcData.gcNodes)) {
+		outboundRoutes.forEach((toPath) => {
+			addedGCOutboundRoute(nodeId, toPath);
+		});
+	}
+	return true;
 }
 
 /**

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import { strict as assert } from "assert";
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions";
@@ -30,6 +32,7 @@ import {
 	TestDataObjectType,
 } from "@fluid-private/test-version-utils";
 import { delay } from "@fluidframework/core-utils";
+import type { ISharedDirectory } from "@fluidframework/map";
 import {
 	manufactureHandle,
 	waitForContainerWriteModeConnectionWrite,
@@ -40,7 +43,7 @@ import {
  * unreferenced for a certain amount of time, using the node results in an error telemetry.
  */
 describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, apis) => {
-	const { SharedMap } = apis.dds;
+	const { SharedMap, SharedDirectory } = apis.dds;
 	const revivedEvent = "fluid:telemetry:ContainerRuntime:InactiveObject_Revived";
 	const changedEvent = "fluid:telemetry:ContainerRuntime:InactiveObject_Changed";
 	const loadedEvent = "fluid:telemetry:ContainerRuntime:InactiveObject_Loaded";
@@ -140,8 +143,8 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 			return summaryResult.summaryVersion;
 		};
 
-		async function createNewDataObject() {
-			const dataStore = await containerRuntime.createDataStore(TestDataObjectType);
+		async function createNewDataObject(runtime: IContainerRuntimeBase = containerRuntime) {
+			const dataStore = await runtime.createDataStore(TestDataObjectType);
 			return dataStore.entryPoint.get() as Promise<ITestDataObject>;
 		}
 
@@ -808,7 +811,7 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 				defaultDataObject2._context.IFluidHandleContext, // yields the ContaineRuntime's handleContext
 				idA,
 			);
-			await handleA_2?.get();
+			await handleA_2.get();
 			mockLogger2.assertMatch([
 				{
 					eventName:
@@ -823,7 +826,7 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 
 			// Since A was directly revived, its unreferenced state was cleared immediately so we shouldn't see InactiveObject logs for it
 			const handleA_3 = defaultDataObject3._root.get<IFluidHandle<ITestDataObject>>("A");
-			const dataObjectA_3 = await handleA_3?.get();
+			const dataObjectA_3 = await handleA_3!.get();
 			mockLogger3.assertMatchNone([
 				{
 					eventName:
@@ -833,7 +836,7 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 
 			// Since B wasn't directly revived, it wrongly still thinks it's Inactive. Next GC will clear it up.
 			const handleB_3 = dataObjectA_3?._root.get<IFluidHandle<ITestDataObject>>("B");
-			await handleB_3?.get();
+			await handleB_3!.get();
 			mockLogger3.assertMatch([
 				{
 					eventName:
@@ -842,5 +845,115 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 				},
 			]);
 		});
+
+		const newDDSFn = async (
+			dataObject: ITestDataObject,
+		): Promise<[ISharedDirectory, IFluidHandle]> => {
+			const dds = SharedDirectory.create(dataObject._runtime, "dds");
+			return [dds, dds.handle];
+		};
+		const newDataStoreFn = async (
+			dataObject: ITestDataObject,
+		): Promise<[ISharedDirectory, IFluidHandle]> => {
+			const dataObject2 = await createNewDataObject(dataObject._context.containerRuntime);
+			return [dataObject2._root, dataObject2.handle];
+		};
+		[[newDDSFn, "DDS"] as const, [newDataStoreFn, "DataStore"] as const].forEach(
+			([newDirectoryFn, type]) => {
+				it(`Reviving an InactiveObject via [${type}] Attach Op clears Inactive state immediately in interactive client (but not for its subtree)`, async () => {
+					const container1 = mainContainer;
+					const { summarizer: summarizer1 } = await createSummarizer(
+						provider,
+						container1,
+						testContainerConfig,
+					);
+					const defaultDataObject1 =
+						(await container1.getEntryPoint()) as ITestDataObject;
+					await waitForContainerConnection(container1);
+
+					const dataObjectA_1 = await createNewDataObject();
+					const dataObjectB_1 = await createNewDataObject();
+					const idA = dataObjectA_1._context.id;
+					const idB = dataObjectB_1._context.id;
+
+					// Reference A from the container entrypoint, and B from A
+					defaultDataObject1._root.set("A", dataObjectA_1.handle);
+					dataObjectA_1._root.set("B", dataObjectB_1.handle);
+
+					// Then unreference the A-B chain (but leave it intact), and Summarize to start unreferenced tracking
+					defaultDataObject1._root.delete("A");
+					await provider.ensureSynchronized();
+					const { summaryVersion: summaryVersion1 } = await summarizeNow(summarizer1);
+
+					// A and B are unreferenced in container2/container3. Timers will be set
+					// We need two containers because each event type is only logged once per container
+					const mockLogger2 = new MockLogger();
+					const container2 = await loadContainer(
+						testContainerConfig,
+						summaryVersion1,
+						mockLogger2,
+					);
+					const defaultDataObject2 =
+						(await container2.getEntryPoint()) as ITestDataObject;
+					const mockLogger3 = new MockLogger();
+					const container3 = await loadContainer(
+						testContainerConfig,
+						summaryVersion1,
+						mockLogger3,
+					);
+					const defaultDataObject3 =
+						(await container3.getEntryPoint()) as ITestDataObject;
+
+					// Wait the Inactive Timeout. Timers will fire
+					await delay(inactiveTimeoutMs);
+
+					// Load A in container2 and ensure InactiveObject_Loaded is logged
+					const handleA_2 = manufactureHandle<ITestDataObject>(
+						defaultDataObject2._context.IFluidHandleContext, // yields the ContaineRuntime's handleContext
+						idA,
+					);
+					await handleA_2.get();
+					mockLogger2.assertMatch([
+						{
+							eventName:
+								"fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded",
+							id: { value: `/${idA}`, tag: "CodeArtifact" },
+						},
+					]);
+
+					// Reference A again in container3 via DataStore attach op. Should be properly revived in container3 itself
+					const manufacturedHandleA_3 = manufactureHandle<ITestDataObject>(
+						defaultDataObject3._context.IFluidHandleContext, // yields the ContaineRuntime's handleContext
+						idA,
+					);
+					const [newDirectory_3, handleToAttach_3] =
+						await newDirectoryFn(defaultDataObject3);
+					newDirectory_3.set("A", manufacturedHandleA_3);
+					defaultDataObject3._root.set("NewDirectory", handleToAttach_3);
+					await provider.ensureSynchronized();
+
+					// Since A was directly revived, its unreferenced state was cleared immediately so we shouldn't see InactiveObject logs for it
+					const handleA_3 = newDirectory_3.get<IFluidHandle<ITestDataObject>>("A");
+					const dataObjectA_3 = await handleA_3!.get();
+					mockLogger3.assertMatchNone([
+						{
+							eventName:
+								"fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded",
+						},
+					]);
+
+					// Since B wasn't directly revived, it wrongly still thinks it's Inactive. Next GC will clear it up.
+					const handleB_3 = dataObjectA_3?._root.get<IFluidHandle<ITestDataObject>>("B");
+					await handleB_3!.get();
+					mockLogger3.assertMatch([
+						{
+							eventName:
+								"fluid:telemetry:ContainerRuntime:GarbageCollector:InactiveObject_Loaded",
+							id: { value: `/${idB}`, tag: "CodeArtifact" },
+						},
+					]);
+				});
+			},
+		);
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -402,7 +402,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 
 		// Nothing should be unreferenced.
 		let gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+		assert.deepStrictEqual(gcStats, expectedGCStats, "1. GC stats is not as expected");
 
 		// Remove both data store handles to mark them unreferenced.
 		mainDataObject._root.delete("dataStore1");
@@ -417,7 +417,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		expectedGCStats.updatedDataStoreCount = 2;
 
 		gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+		assert.deepStrictEqual(gcStats, expectedGCStats, "2. GC stats is not as expected");
 
 		// Add their handle back to re-reference them.
 		mainDataObject._root.set("dataStore1", dataStore1.handle);
@@ -430,6 +430,6 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		expectedGCStats.unrefDataStoreCount -= 2;
 
 		gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+		assert.deepStrictEqual(gcStats, expectedGCStats, "3. GC stats is not as expected");
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -3,10 +3,13 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import { strict as assert } from "assert";
 import {
 	AllowTombstoneRequestHeaderKey,
 	ContainerRuntime,
+	IOnDemandSummarizeOptions,
 	ISummarizer,
 	TombstoneResponseHeaderKey,
 } from "@fluidframework/container-runtime";
@@ -36,11 +39,19 @@ import {
 } from "@fluidframework/core-interfaces";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
-import { IFluidDataStoreChannel } from "@fluidframework/runtime-definitions";
+import {
+	IFluidDataStoreChannel,
+	IGarbageCollectionDetailsBase,
+} from "@fluidframework/runtime-definitions";
 import { MockLogger } from "@fluidframework/telemetry-utils";
 import { FluidSerializer, parseHandles } from "@fluidframework/shared-object-base";
 import type { SharedMap } from "@fluidframework/map";
 import { getGCStateFromSummary, getGCTombstoneStateFromSummary } from "./gcTestSummaryUtils.js";
+
+type ExpectedTombstoneError = Error & {
+	code: number;
+	underlyingResponseHeaders?: { [TombstoneResponseHeaderKey]: boolean };
+};
 
 /**
  * These tests validate that TombstoneReady data stores are correctly marked as tombstones. Tombstones should be added
@@ -124,9 +135,9 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 			logger,
 		);
 	};
-	const summarize = async (summarizer: ISummarizer) => {
+	const summarize = async (summarizer: ISummarizer, options?: IOnDemandSummarizeOptions) => {
 		await provider.ensureSynchronized();
-		return summarizeNow(summarizer);
+		return summarizeNow(summarizer, options);
 	};
 
 	// This function creates an unreferenced datastore and returns the datastore's id and the summary version that
@@ -620,7 +631,6 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 			async function () {
 				// This will become the persisted value in the container(s) created below (except the one with disableTombstoneFailureViaOption)
 				// NOTE: IT IS RESET AT THE END OF THE TEST
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				testContainerConfig.runtimeOptions!.gcOptions!.gcGeneration = 1;
 
 				// Note: The Summarizers in this test don't use the "future" GC option - it only matters for the interactive client
@@ -653,7 +663,6 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 					"DID NOT Expect tombstone header to be set on the response",
 				);
 
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				testContainerConfig.runtimeOptions!.gcOptions!.gcGeneration = undefined;
 			},
 		);
@@ -698,12 +707,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 				);
 
 				// This fails because the DataStore is tombstoned
-				let tombstoneError:
-					| (Error & {
-							code: number;
-							underlyingResponseHeaders?: { [TombstoneResponseHeaderKey]: boolean };
-					  })
-					| undefined;
+				let tombstoneError: ExpectedTombstoneError | undefined;
 				try {
 					await handle.get();
 				} catch (error: any) {
@@ -1055,6 +1059,205 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 					tombstoneErrorResponse3B.value,
 					`DataStore was tombstoned: ${dataStoreBId}`,
 					"Expected the Tombstone error message (3B)",
+				);
+			},
+		);
+
+		itExpects(
+			"Requesting WRONGLY-tombstoned datastore triggers auto-recovery and self-repair",
+			[
+				// 1A
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
+					clientType: "interactive",
+					category: "error",
+				},
+				// 1A again
+				{
+					eventName:
+						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
+					clientType: "interactive",
+					category: "error",
+				},
+				// During the Summarize after auto-recovery is triggered (results in summaryVersion2)
+				{
+					eventName: "fluid:telemetry:Summarizer:Running:gcUnknownOutboundReferences",
+					clientType: "noninteractive/summarizer",
+					// id: { value: "/default/root", tag: "CodeArtifact" }, (nested object comparison not supported)
+					summarizeReason: "onDemand/Summarize after auto-recovery",
+				},
+			],
+			async () => {
+				const mockLogger = new MockLogger();
+				const summarizerMockLogger = new MockLogger();
+				const initialContainer = await makeContainer();
+				const { container: summarizingContainer0, summarizer: summarizer0 } =
+					await loadSummarizer(
+						initialContainer,
+						/* summaryVersion: */ undefined,
+						summarizerMockLogger,
+					);
+				await waitForContainerConnection(initialContainer);
+
+				const defaultDataObject =
+					(await initialContainer.getEntryPoint()) as ITestDataObject;
+
+				// Create dataStoreA and dataStoreX and reference them from the default data object.
+				// They will both remain referenced, but the reference will be "lost" (by intentionally corrupting the GC Data)
+				// dataStoreX's purpose is for updating the currentReferenceTimestamp before summarizing by sending ops
+				const dataStoreA = await createDataStore(defaultDataObject);
+				const dataStoreX = await createDataStore(defaultDataObject);
+				const dataStoreAId = dataStoreA._context.id;
+				defaultDataObject._root.set("dsA", dataStoreA.handle);
+				defaultDataObject._root.set("dsX", dataStoreX.handle);
+
+				// Summarize to get a baseline for incremental summary/GC, then load a new summarizer (and close the first one)
+				const { summaryVersion: summaryVersion0 } = await summarize(summarizer0);
+				summarizingContainer0.close();
+				const { container: closeMe, summarizer: summarizer_toBeCorrupted } =
+					await loadSummarizer(initialContainer, summaryVersion0, summarizerMockLogger);
+
+				// Monkey patch in the tweak to GC Data, removing outbound routes from default's root DDS
+				const garbageCollector_toBeCorrupted = (
+					summarizer_toBeCorrupted as unknown as {
+						runtime: {
+							garbageCollector: {
+								baseGCDetailsP: Promise<IGarbageCollectionDetailsBase>;
+							};
+						};
+					}
+				).runtime.garbageCollector;
+				garbageCollector_toBeCorrupted.baseGCDetailsP =
+					garbageCollector_toBeCorrupted.baseGCDetailsP.then((baseGCDetails) => {
+						// baseGCDetails outbound routes for this DDS currently include dataStoreA and dataStoreX. Remove those.
+						baseGCDetails.gcData!.gcNodes["/default/root"] = ["/default"];
+						return baseGCDetails;
+					});
+
+				// Generate a summary with corrupted GC Data (missing route to dataStore A)
+				const { summaryVersion: summaryVersion_corrupted } = await summarize(
+					summarizer_toBeCorrupted,
+					{
+						reason: "Summarize with corrupted GC Data",
+					},
+				);
+				closeMe.close();
+
+				// Then wait the Tombstone timeout and update current timestamp, and summarize again
+				await delay(tombstoneTimeoutMs);
+				dataStoreX._root.set("update", "timestamp");
+				const { summarizer } = await loadSummarizer(
+					initialContainer,
+					summaryVersion_corrupted,
+					summarizerMockLogger,
+				);
+				const { summaryVersion: summaryVersion_withTombstone } =
+					await summarize(summarizer);
+
+				// The datastore should be tombstoned in the snapshot this container loads from,
+				// even though the datastores are properly referenced and easily reachable.
+				const container1 = await loadContainer(
+					summaryVersion_withTombstone,
+					/* disableTombstoneFailureViaGCGenerationOption: */ false,
+					mockLogger,
+				);
+
+				// Load DataStoreA, which will incorrectly be Tombstoned, triggering auto-recovery.
+				const defaultDataObject1 = (await container1.getEntryPoint()) as ITestDataObject;
+				const handleA1 = defaultDataObject1._root.get<IFluidHandle>("dsA");
+				let tombstoneError: ExpectedTombstoneError | undefined;
+				try {
+					await handleA1!.get();
+				} catch (error: any) {
+					tombstoneError = error;
+				}
+				assert.equal(
+					tombstoneError?.code,
+					404,
+					"Tombstone error from handle.get should have 404 status code (1A)",
+				);
+				assert.equal(
+					tombstoneError?.message,
+					`DataStore was tombstoned: /${dataStoreAId}`,
+					"Incorrect message for Tombstone error from handle.get (1A)",
+				);
+				assert.equal(
+					tombstoneError?.underlyingResponseHeaders?.[TombstoneResponseHeaderKey],
+					true,
+					"Tombstone error from handle.get should include the tombstone flag (1A)",
+				);
+
+				// The GC TombstoneLoaded op should roundtrip here
+				await provider.ensureSynchronized();
+
+				// TombstoneLoaded op should trigger Revived event
+				[mockLogger, summarizerMockLogger].forEach((logger, i) =>
+					logger.assertMatch(
+						[
+							{
+								eventName:
+									"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Revived",
+								clientType: i === 0 ? "interactive" : "noninteractive/summarizer",
+							},
+						],
+						`Missing expected revived event from Auto-Recovery [${
+							i === 0 ? "mockLogger" : "summarizerMockLogger"
+						}]`,
+					),
+				);
+
+				// This request still fails because Auto-Recovery only affects the next summary (via next GC run)
+				// NOTE: We have to use request pattern because handleA1 has its result cached so will not exercise the right codepath
+				const tombstoneErrorResponse_Interactive = await (
+					defaultDataObject1._context.containerRuntime as ContainerRuntime
+				).resolveHandle({
+					url: dataStoreAId,
+				});
+				assert.equal(
+					tombstoneErrorResponse_Interactive.status,
+					404,
+					"Expected tombstone error - Auto-Recovery shouldn't affect in-progress Interactive sessions (1A again)",
+				);
+
+				// Auto-Recovery: This summary will have the unref timestamp reset and will run full GC due to the GC TombstoneLoaded op
+				const { summaryVersion: summaryVersion_repaired } = await summarize(summarizer, {
+					reason: "Summarize after auto-recovery",
+				});
+				const container2 = await loadContainer(summaryVersion_repaired);
+
+				// Verify that the object is not Tombstoned in summarizingContainer - it just summarized with the TombstoneLoaded op
+				const tombstones = (
+					summarizer as unknown as {
+						runtime: { garbageCollector: { tombstones: string[] } };
+					}
+				).runtime.garbageCollector.tombstones;
+				assert.deepEqual(
+					tombstones,
+					[],
+					"Expected no Tombstones. Auto-Recovery should have kicked in immediately in Summarizer after summarizing with the TombstoneLoaded op",
+				);
+
+				// Container2 loaded after auto-recovery: These requests succeed because the datastores are no longer tombstoned
+				const entryPoint2 = (await container2.getEntryPoint()) as ITestDataObject;
+				await assert.doesNotReject(
+					async () => entryPoint2._root.get<IFluidHandle>("dsA")!.get(),
+					"Auto-Recovery should have made the object no longer tombstoned (2A)",
+				);
+
+				// Wait the Tombstone timeout then summarize and load another container
+				// Since auto-recovery triggered full GC, the corruption was repaired and GC knows dataStoreA is referenced
+				// Otherwise it would have been unreferenced and would have become tombstoned again
+				await delay(tombstoneTimeoutMs);
+				dataStoreX._root.set("update", "timestamp again");
+				const { summaryVersion: summaryVersion_stillRepaired } =
+					await summarize(summarizer);
+				const container3 = await loadContainer(summaryVersion_stillRepaired);
+				const defaultDataObject3 = (await container3.getEntryPoint()) as ITestDataObject;
+				const handleA3 = defaultDataObject3._root.get<IFluidHandle>("dsA");
+				await assert.doesNotReject(
+					async () => handleA3!.get(),
+					"Corrupted GC Data should have been repaired such that this object is known to be referenced (3A)",
 				);
 			},
 		);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -36,7 +36,7 @@ describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, 
 	let mainContainer: IContainer;
 	let containerRuntime: IContainerRuntime;
 	let dataStoreA: ITestDataObject;
-	let settings: Record<string, ConfigTypes> = {};
+	const settings: Record<string, ConfigTypes> = {};
 
 	/**
 	 * Submits a summary and returns the unreferenced timestamp for all the nodes in the container. If a node is
@@ -654,7 +654,7 @@ describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, 
 			 */
 			it(`Scenario 8 - Node re-referenced via new DDS attaching`, async () => {
 				const { summarizer } = await createSummarizer(provider, mainContainer, {
-					loaderProps: { configProvider },
+					loaderProps: { configProvider: mockConfigProvider(settings) },
 				});
 
 				// Create data store C and mark it referenced by storing its handle in data store A.
@@ -720,7 +720,7 @@ describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, 
 			 */
 			it(`Scenario 9 - Node re-referenced via new DDS attaching (extra indirection)`, async () => {
 				const { summarizer } = await createSummarizer(provider, mainContainer, {
-					loaderProps: { configProvider },
+					loaderProps: { configProvider: mockConfigProvider(settings) },
 				});
 
 				// Create data store C and mark it referenced by storing its handle in data store A.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -22,19 +22,14 @@ import {
 	TestDataObjectType,
 } from "@fluid-private/test-version-utils";
 import { ConfigTypes } from "@fluidframework/core-interfaces";
-// eslint-disable-next-line import/no-internal-modules
-import { detectOutboundRoutesViaDDSKey } from "@fluidframework/container-runtime/test/gc";
 import { defaultGCConfig } from "./gcTestConfigs.js";
 import { getGCStateFromSummary } from "./gcTestSummaryUtils.js";
 
 /**
  * Validates that the unreferenced timestamp is correctly set in the GC summary tree. Also, the timestamp is removed
  * when an unreferenced node becomes referenced again.
- *
- * Run in FullCompat to get coverage of DataStoreRuntime/ContainerRuntime n/n-1 compatibility
- * (skip all other compat types)
  */
-describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider, apis) => {
+describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 
 	let provider: ITestObjectProvider;
@@ -68,12 +63,6 @@ describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider
 			this.skip();
 		}
 
-		// We only want to do compat testing for Container Runtime and Data Runtime compat
-		if (!this.test?.parent?.title.includes("runtime")) {
-			this.skip();
-		}
-
-		settings = {};
 		const testContainerConfig = {
 			...defaultGCConfig,
 			loaderProps: { configProvider: mockConfigProvider(settings) },
@@ -539,13 +528,9 @@ describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider
 			 * Validates that the unreferenced time for C is t2 which is > t1.
 			 *
 			 * The difference from previous test case is that the reference from B to C is added before B is referenced and
-			 * observed by summarizer. So, the summarizer does not see this reference directly but only when B is realized.
+			 * observed by summarizer. So, the summarizer does not see this reference until B is attached.
 			 */
-			it(`Scenario 6 - Reference added via new unreferenced nodes and removed`, async () => {
-				// Disable new Reference Detection behavior for now
-				// The re-referencing happens via attach op which we don't detect yet.
-				settings[detectOutboundRoutesViaDDSKey] = true;
-
+			it(`Scenario 6 - Node re-referenced via new DataStore attaching`, async () => {
 				const { summarizer } = await createSummarizer(provider, mainContainer, {
 					loaderProps: { configProvider: mockConfigProvider(settings) },
 				});
@@ -578,9 +563,6 @@ describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider
 				dataStoreB._root.delete("dataStoreC");
 
 				// 6. Get summary 2 and validate that C's unreferenced timestamps updated. E = [A -> B].
-				// NOTE: The attach op for B has the reference from B->C, but we don't detect it here.
-				// Instead, we happen to detect it during Summarize, since the DDS is parsed when loaded.
-				// This relies on the old behavior (see detectOutboundRoutesViaDDSKey setting above)
 				await provider.ensureSynchronized();
 				const summaryResult2 = await summarizeNow(summarizer);
 				const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
@@ -606,11 +588,7 @@ describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider
 			 * This difference from the previous test case is that there is another level of indirection here that
 			 * references the node which was unreferenced in previous summary.
 			 */
-			it(`Scenario 7 - Reference added transitively via new nodes and removed`, async () => {
-				// Disable new Reference Detection behavior for now
-				// Same reason as Scenario 6 - The re-referencing happens via attach op which we don't detect yet.
-				settings[detectOutboundRoutesViaDDSKey] = true;
-
+			it(`Scenario 7 - Node re-referenced via new DataStore attaching (extra indirection)`, async () => {
 				const { summarizer } = await createSummarizer(provider, mainContainer, {
 					loaderProps: { configProvider: mockConfigProvider(settings) },
 				});
@@ -634,12 +612,15 @@ describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider
 				const dataStoreC = await createNewDataStore();
 
 				// 3. Add reference from B to C. E = [].
+				// No op sent since B is not attached
 				dataStoreB._root.set("dataStoreC", dataStoreC.handle);
 
 				// 4. Add reference from C to D. E = [].
+				// No op sent since C is not attached
 				dataStoreC._root.set("dataStoreD", dataStoreD.handle);
 
 				// 5. Add reference from A to B. E = [A -> B, B -> C, C -> D].
+				// Attach op for B is sent here
 				dataStoreA._root.set("dataStoreB", dataStoreB.handle);
 
 				// 6. Remove reference from C to D. E = [A -> B, B -> C].
@@ -657,13 +638,147 @@ describeCompat("GC unreferenced timestamp", "FullCompat", (getTestObjectProvider
 			});
 
 			/*
+			 * Similar to 6 but using a DDS attach op instead of a DataStore attach op
+			 *
+			 * Validates that we can detect references that were added via new DDSes before they are referenced
+			 * themselves, and then the reference from the new data store is removed.
+			 * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+			 * 2. Data store B is created and referenced from A. E = [A.root -> B].
+			 * 3. DDS B.1 under B is created but not referenced. E = [A.root -> B].
+			 * 4. Add reference from DDS B.1 to C. E = [A -> B].
+			 * 5. Op adds reference from B's root to DDS B.1. E = [A.root -> B, B.root -> B.1, B.1 -> C].
+			 * 6. Op removes reference from DDS B.1 to C. E = [A.root -> B, B.root -> B.1].
+			 * 7. Summary 2 at t2. V = [A*, B, C]. E = [A.root -> B, B.root -> B.1]. C has unreferenced time t2.
+			 *
+			 * Validates that the unreferenced time for C is t2 which is > t1.
+			 */
+			it(`Scenario 8 - Node re-referenced via new DDS attaching`, async () => {
+				const { summarizer } = await createSummarizer(provider, mainContainer, {
+					loaderProps: { configProvider },
+				});
+
+				// Create data store C and mark it referenced by storing its handle in data store A.
+				const dataStoreC = await createNewDataStore();
+				dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+
+				// Remove the reference to C which marks it as unreferenced.
+				dataStoreA._root.delete("dataStoreC");
+
+				// 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
+				await provider.ensureSynchronized();
+				const summaryResult1 = await summarizeNow(summarizer);
+				const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+				const dsCTime1 = timestamps1.get(dataStoreC._context.id);
+				assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+
+				// 2. Create and reference data store B. E = [].
+				// Ensure Synchronized to let B fully attach
+				const dataStoreB = await createNewDataStore();
+				dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+				await provider.ensureSynchronized();
+
+				// 3. DDS B.1 under B is created but not referenced. E = [A.root -> B].
+				const ddsB1 = SharedMap.create(dataStoreB._runtime, "B.1");
+
+				// 4. Add reference from DDS B.1 to C. E = [A -> B].
+				// No op sent since DDS B.1 is not attached
+				ddsB1.set("dataStoreC", dataStoreC.handle);
+
+				// 5. Op adds reference from B's root to DDS B.1. E = [A.root -> B, B.root -> B.1, B.1 -> C].
+				// Attach op for DDS B1 is sent here
+				dataStoreB._root.set("ddsB1", ddsB1.handle);
+				await provider.ensureSynchronized();
+
+				// 6. Op removes reference from DDS B.1 to C. E = [A.root -> B, B.root -> B.1].
+				ddsB1.delete("dataStoreC");
+
+				// 7. Summary 2 at t2. V = [A*, B, C]. E = [A.root -> B, B.root -> B.1]. C has unreferenced time t2.
+				await provider.ensureSynchronized();
+				const summaryResult2 = await summarizeNow(summarizer);
+				const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+				const dsDTime2 = timestamps2.get(dataStoreC._context.id);
+				assert(
+					dsDTime2 !== undefined && dsDTime2 > dsCTime1,
+					`D's timestamp should have updated`,
+				);
+			});
+
+			/*
+			 * Similar to 8 but with another DDS in the middle
+			 *
+			 * Validates that we can detect references that were added transitively via new DDSes before they are referenced
+			 * themselves, and then the reference from the new data store is removed.
+			 * 1. Summary 1 at t1. V = [A*, C]. E = []. C has unreferenced time t1.
+			 * 2. Data store B is created and referenced from A. E = [A.root -> B].
+			 * 3. DDSes B.1 and B.2 under B are created but not referenced. E = [A.root -> B].
+			 * 4. Add reference from B.1 to B.2 and B.2 to C. E = [A -> B].
+			 * 5. Add reference from B's root to DDS B.1. E = [A.root -> B, B.root -> B.1, B.1 -> B.2, B.2 -> C].
+			 * 6. Remove reference from DDS B.2 to C. E = [A.root -> B, B.root -> B.1, B.1 -> B.2].
+			 * 7. Summary 2 at t2. V = [A*, B, C]. E = [A.root -> B, B.root -> B.1, B.1 -> B.2]. C has unreferenced time t2.
+			 *
+			 * Validates that the unreferenced time for C is t2 which is > t1.
+			 */
+			it(`Scenario 9 - Node re-referenced via new DDS attaching (extra indirection)`, async () => {
+				const { summarizer } = await createSummarizer(provider, mainContainer, {
+					loaderProps: { configProvider },
+				});
+
+				// Create data store C and mark it referenced by storing its handle in data store A.
+				const dataStoreC = await createNewDataStore();
+				dataStoreA._root.set("dataStoreC", dataStoreC.handle);
+
+				// Remove the reference to C which marks it as unreferenced.
+				dataStoreA._root.delete("dataStoreC");
+
+				// 1. Get summary 1 and validate that C is has unreferenced timestamp. E = [].
+				await provider.ensureSynchronized();
+				const summaryResult1 = await summarizeNow(summarizer);
+				const timestamps1 = await getUnreferencedTimestamps(summaryResult1.summaryTree);
+				const dsCTime1 = timestamps1.get(dataStoreC._context.id);
+				assert(dsCTime1 !== undefined, `C should have unreferenced timestamp`);
+
+				// 2. Create and reference data store B. E = [].
+				// Ensure Synchronized to let B fully attach
+				const dataStoreB = await createNewDataStore();
+				dataStoreA._root.set("dataStoreB", dataStoreB.handle);
+				await provider.ensureSynchronized();
+
+				// 3. DDSes B.1 and B.2 under B are created but not referenced. E = [A.root -> B].
+				const ddsB1 = SharedMap.create(dataStoreB._runtime, "B.1");
+				const ddsB2 = SharedMap.create(dataStoreB._runtime, "B.2");
+
+				// 4. Add reference from B.1 to B.2 and B.2 to C. E = [A -> B].
+				// No op sent since DDS B.1 is not attached
+				ddsB1.set("ddsB.2", ddsB2.handle);
+				ddsB2.set("dataStoreC", dataStoreC.handle);
+
+				// 5. Add reference from B's root to DDS B.1. E = [A.root -> B, B.root -> B.1, B.1 -> B.2, B.2 -> C].
+				// Attach op for DDS B1 is sent here
+				dataStoreB._root.set("ddsB1", ddsB1.handle);
+				await provider.ensureSynchronized();
+
+				// 6. Remove reference from DDS B.2 to C. E = [A.root -> B, B.root -> B.1, B.1 -> B.2].
+				ddsB2.delete("dataStoreC");
+
+				// 7. Summary 2 at t2. V = [A*, B, C]. E = [A.root -> B, B.root -> B.1, B.1 -> B.2]. C has unreferenced time t2.
+				await provider.ensureSynchronized();
+				const summaryResult2 = await summarizeNow(summarizer);
+				const timestamps2 = await getUnreferencedTimestamps(summaryResult2.summaryTree);
+				const dsDTime2 = timestamps2.get(dataStoreC._context.id);
+				assert(
+					dsDTime2 !== undefined && dsDTime2 > dsCTime1,
+					`D's timestamp should have updated`,
+				);
+			});
+
+			/*
 			 * Validates that DDSes are referenced even though we don't detect their referenced between summaries. Once we
 			 * do GC at DDS level, this test will fail - https://github.com/microsoft/FluidFramework/issues/8470.
 			 * 1. Summary 1 at t1. V = [A*]. E = [].
 			 * 2. DDS B is created. No reference is added to it.
 			 * 3. Summary 2 at t2. V = [A*, B]. E = []. B is still referenced.
 			 */
-			it(`Scenario 8 - Reference to DDS not added`, async () => {
+			it(`Scenario 10 - Reference to DDS not added`, async () => {
 				const { summarizer } = await createSummarizer(provider, mainContainer);
 
 				// 1. Get summary 1 and validate that A is referenced. E = [].

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -181,9 +181,6 @@ export async function loadContainer(
 	};
 	// This is to align with the snapshot tests which may upgrade GC Version before the default is changed.
 	settings["Fluid.GarbageCollection.GCVersionUpgradeToV4"] = false;
-	// Due to a bug where references added by an attach op are missed, we need to keep the old code for now.
-	settings["Fluid.GarbageCollection.DetectOutboundRoutesViaDDS"] = true;
-
 	// Load the Fluid document while forcing summarizeProtocolTree option
 	const loader = new Loader({
 		urlResolver,


### PR DESCRIPTION
Cherry-picking the following commits:

* dd9ff1665bfb5f10ff59e02ce4caa2b674f4de47
* 3508d8fea297da88faca784b4062112059aeaf2a
* b6c8421ed2ceefd2e0b517e0105dbda20c848c90
* 0ba031d9af5b0b9346577029bd50b1e514ccbe56

This brings key protections/fixes to GC as some partners are rolling it out to production.
