### PR TITLE
Removal of `any` on `submitSignal` content

### DIFF
--- a/.changeset/lazy-walls-drive.md
+++ b/.changeset/lazy-walls-drive.md
@@ -1,0 +1,22 @@
+---
+"@fluidframework/azure-client": minor
+"@fluidframework/container-definitions": minor
+"@fluidframework/container-loader": minor
+"@fluidframework/container-runtime": minor
+"@fluidframework/datastore": minor
+"@fluidframework/datastore-definitions": minor
+"@fluidframework/devtools": minor
+"@fluidframework/driver-base": minor
+"@fluidframework/driver-definitions": minor
+"@fluidframework/file-driver": minor
+"@fluidframework/local-driver": minor
+"@fluidframework/odsp-driver": minor
+"@fluidframework/replay-driver": minor
+"@fluidframework/runtime-definitions": minor
+"@fluid-private/test-loader-utils": minor
+"@fluidframework/test-runtime-utils": minor
+---
+
+Stricter typing on `submitSignal` content
+
+Update `content` typing on submitSignal from `any` to `unknown` or `string` (after unknown has been JSON.stringified)

--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -242,7 +242,7 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
     // (undocumented)
     readonly readOnlyInfo: ReadOnlyInfo;
     readonly serviceConfiguration: IClientConfiguration | undefined;
-    submitSignal(content: any, targetClientId?: string): void;
+    submitSignal(content: string, targetClientId?: string): void;
     readonly version: string;
 }
 

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -227,9 +227,7 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
 	/**
 	 * Submit a signal to the service to be broadcast to other connected clients, but not persisted
 	 */
-	// TODO: use `unknown` instead (API breaking)
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	submitSignal(content: any, targetClientId?: string): void;
+	submitSignal(content: string, targetClientId?: string): void;
 }
 
 /**

--- a/packages/common/driver-definitions/api-report/driver-definitions.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.api.md
@@ -125,7 +125,7 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     relayServiceAgent?: string;
     serviceConfiguration: IClientConfiguration;
     submit(messages: IDocumentMessage[]): void;
-    submitSignal(content: any, targetClientId?: string): void;
+    submitSignal(content: string, targetClientId?: string): void;
     version: string;
 }
 

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -314,9 +314,7 @@ export interface IDocumentDeltaConnection
 	/**
 	 * Submits a new signal to the server
 	 */
-	// TODO: Use something other than `any`.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	submitSignal(content: any, targetClientId?: string): void;
+	submitSignal(content: string, targetClientId?: string): void;
 }
 
 /**

--- a/packages/drivers/driver-base/api-report/driver-base.api.md
+++ b/packages/drivers/driver-base/api-report/driver-base.api.md
@@ -50,7 +50,7 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     // (undocumented)
     protected earlySignalHandler: (msg: ISignalMessage | ISignalMessage[]) => void;
     // (undocumented)
-    protected emitMessages(type: string, messages: IDocumentMessage[][]): void;
+    protected emitMessages(type: string, messages: (IDocumentMessage | string)[][]): void;
     // (undocumented)
     static readonly eventsAlwaysForwarded: string[];
     // (undocumented)
@@ -82,7 +82,7 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     // (undocumented)
     protected readonly socket: Socket;
     submit(messages: IDocumentMessage[]): void;
-    submitSignal(content: IDocumentMessage, targetClientId?: string): void;
+    submitSignal(content: string, targetClientId?: string): void;
     get version(): string;
 }
 

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -310,7 +310,7 @@ export class DocumentDeltaConnection
 		return this.details.initialClients;
 	}
 
-	protected emitMessages(type: string, messages: IDocumentMessage[][]) {
+	protected emitMessages(type: string, messages: (IDocumentMessage | string)[][]) {
 		// Although the implementation here disconnects the socket and does not reuse it, other subclasses
 		// (e.g. OdspDocumentDeltaConnection) may reuse the socket.  In these cases, we need to avoid emitting
 		// on the still-live socket.
@@ -334,8 +334,11 @@ export class DocumentDeltaConnection
 	 *
 	 * @param content - Content of the signal.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
+	 *
+	 * TODO: Support targeted signals once server supports them
+	 * @see {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/7146}
 	 */
-	public submitSignal(content: IDocumentMessage, targetClientId?: string): void {
+	public submitSignal(content: string, targetClientId?: string): void {
 		this.checkNotDisposed();
 
 		if (targetClientId && this.details.supportedFeatures?.submit_signals_v2 !== true) {

--- a/packages/drivers/file-driver/api-report/file-driver.api.md
+++ b/packages/drivers/file-driver/api-report/file-driver.api.md
@@ -163,7 +163,7 @@ export class ReplayFileDeltaConnection extends TypedEventEmitter<IDocumentDeltaC
     // (undocumented)
     submit(documentMessages: IDocumentMessage[]): void;
     // (undocumented)
-    submitSignal(message: any): Promise<void>;
+    submitSignal(message: string): Promise<void>;
     // (undocumented)
     get version(): string;
 }

--- a/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
@@ -209,7 +209,7 @@ export class ReplayFileDeltaConnection
 		throw new Error("ReplayFileDeltaConnection.submit() can't be called");
 	}
 
-	public async submitSignal(message: any) {}
+	public async submitSignal(message: string) {}
 
 	private _disposed = false;
 	public get disposed() {

--- a/packages/drivers/local-driver/api-report/local-driver.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.api.md
@@ -60,7 +60,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
     disconnectClient(disconnectReason: string): void;
     nackClient(code: number | undefined, type: NackErrorType | undefined, message: any): void;
     submit(messages: IDocumentMessage[]): void;
-    submitSignal(message: any): void;
+    submitSignal(message: string): void;
 }
 
 // @internal

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -80,7 +80,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 	/**
 	 * Submits a new signal to the server
 	 */
-	public submitSignal(message: any): void {
+	public submitSignal(message: string): void {
 		this.emitMessages("submitSignal", [[message]]);
 	}
 

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -761,7 +761,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 	 * @param content - Content of the signal.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(content: IDocumentMessage, targetClientId?: string): void {
+	public submitSignal(content: string, targetClientId?: string): void {
 		const signal: ISentSignalMessage = {
 			content,
 			targetClientId,

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -285,7 +285,7 @@ export class ReplayDocumentDeltaConnection
 		throw new Error("ReplayDocumentDeltaConnection.submit() can't be called");
 	}
 
-	public async submitSignal(message: any) {}
+	public async submitSignal(message: string) {}
 
 	private _disposed = false;
 	public get disposed() {

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -138,7 +138,7 @@ class NoDeltaStream
 			}),
 		);
 	}
-	submitSignal(message: any): void {
+	submitSignal(message: string): void {
 		this.emit("nack", this.clientId, {
 			operation: message,
 			content: { message: "Cannot submit signal with storage-only connection", code: 403 },
@@ -1069,7 +1069,7 @@ export class ConnectionManager implements IConnectionManager {
 		};
 	}
 
-	public submitSignal(content: any, targetClientId?: string) {
+	public submitSignal(content: string, targetClientId?: string) {
 		if (this.connection !== undefined) {
 			this.connection.submitSignal(content, targetClientId);
 		} else {

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -100,7 +100,7 @@ export interface IConnectionManager {
 	 * Submits signal to relay service.
 	 * Called only when active connection is present.
 	 */
-	submitSignal(content: any, targetClientId?: string): void;
+	submitSignal(content: string, targetClientId?: string): void;
 
 	/**
 	 * Submits messages to relay service.

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -325,7 +325,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		return message.clientSequenceNumber;
 	}
 
-	public submitSignal(content: any, targetClientId?: string) {
+	public submitSignal(content: string, targetClientId?: string) {
 		return this.connectionManager.submitSignal(content, targetClientId);
 	}
 

--- a/packages/loader/test-loader-utils/api-report/test-loader-utils.api.md
+++ b/packages/loader/test-loader-utils/api-report/test-loader-utils.api.md
@@ -65,7 +65,7 @@ export class MockDocumentDeltaConnection extends TypedEventEmitter<IDocumentDelt
     // (undocumented)
     submit(messages: IDocumentMessage[]): void;
     // (undocumented)
-    submitSignal(message: any): void;
+    submitSignal(message: string): void;
     // (undocumented)
     readonly version: string;
 }

--- a/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
+++ b/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
@@ -71,7 +71,7 @@ export class MockDocumentDeltaConnection
 		}
 	}
 
-	public submitSignal(message: any): void {
+	public submitSignal(message: string): void {
 		if (this.submitSignalHandler !== undefined) {
 			this.submitSignalHandler(message);
 		}

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -326,7 +326,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     get storage(): IDocumentStorageService;
     // (undocumented)
     submitMessage(type: ContainerMessageType.FluidDataStoreOp | ContainerMessageType.Alias | ContainerMessageType.Attach, contents: any, localOpMetadata?: unknown): void;
-    submitSignal(type: string, content: any, targetClientId?: string): void;
+    submitSignal(type: string, content: unknown, targetClientId?: string): void;
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
     summarize(options: {
         fullTree?: boolean;
@@ -526,7 +526,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     readonly storage: IDocumentStorageService;
     // (undocumented)
     submitMessage(type: string, content: any, localOpMetadata: unknown): void;
-    submitSignal(type: string, content: any, targetClientId?: string): void;
+    submitSignal(type: string, content: unknown, targetClientId?: string): void;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;
     // (undocumented)
     protected readonly summarizerNode: ISummarizerNodeWithGC;

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2862,7 +2862,7 @@ export class ContainerRuntime
 	 * @param content - Content of the signal.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(type: string, content: any, targetClientId?: string) {
+	public submitSignal(type: string, content: unknown, targetClientId?: string) {
 		this.verifyNotClosed();
 		const envelope = this.createNewSignalEnvelope(undefined /* address */, type, content);
 		return this.submitSignalFn(envelope, targetClientId);

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -802,7 +802,7 @@ export abstract class FluidDataStoreContext
 	 * @param content - Content of the signal.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(type: string, content: any, targetClientId?: string) {
+	public submitSignal(type: string, content: unknown, targetClientId?: string) {
 		this.verifyNotClosed("submitSignal");
 
 		assert(!!this.channel, 0x147 /* "Channel must exist on submitting signal" */);

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -120,7 +120,7 @@ export interface IFluidDataStoreRuntime extends IEventProvider<IFluidDataStoreRu
     readonly options: Record<string | number, any>;
     // (undocumented)
     readonly rootRoutingContext: IFluidHandleContext;
-    submitSignal(type: string, content: any, targetClientId?: string): void;
+    submitSignal(type: string, content: unknown, targetClientId?: string): void;
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
     waitAttached(): Promise<void>;
 }

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -122,7 +122,7 @@ export interface IFluidDataStoreRuntime
 	 * @param content - Content of the signal.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	submitSignal(type: string, content: any, targetClientId?: string): void;
+	submitSignal(type: string, content: unknown, targetClientId?: string): void;
 
 	/**
 	 * Returns the current quorum.

--- a/packages/runtime/datastore/api-report/datastore.api.md
+++ b/packages/runtime/datastore/api-report/datastore.api.md
@@ -116,7 +116,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     setConnectionState(connected: boolean, clientId?: string): void;
     // (undocumented)
     submitMessage(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
-    submitSignal(type: string, content: any, targetClientId?: string): void;
+    submitSignal(type: string, content: unknown, targetClientId?: string): void;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
     updateUsedRoutes(usedRoutes: string[]): void;
     // (undocumented)

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -952,7 +952,7 @@ export class FluidDataStoreRuntime
 	 * @param content - Content of the signal.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(type: string, content: any, targetClientId?: string) {
+	public submitSignal(type: string, content: unknown, targetClientId?: string) {
 		this.verifyNotClosed();
 		return this.dataStoreContext.submitSignal(type, content, targetClientId);
 	}

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -138,7 +138,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
     // (undocumented)
     readonly logger: ITelemetryBaseLogger;
     orderSequentially(callback: () => void): void;
-    submitSignal(type: string, content: any, targetClientId?: string): void;
+    submitSignal(type: string, content: unknown, targetClientId?: string): void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -185,7 +185,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
 	 * @param content - Content of the signal.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	submitSignal(type: string, content: any, targetClientId?: string): void;
+	submitSignal(type: string, content: unknown, targetClientId?: string): void;
 
 	/**
 	 * @deprecated 0.16 Issue #1537, #3631

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -270,7 +270,7 @@ export class MockDeltaManager extends TypedEventEmitter<IDeltaManagerEvents> imp
     // (undocumented)
     submit(type: MessageType, contents: any, batch: boolean | undefined, localOpMetadata: any): number;
     // (undocumented)
-    submitSignal(content: any): void;
+    submitSignal(content: string): void;
     // (undocumented)
     get version(): string;
 }
@@ -398,7 +398,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // (undocumented)
     submitMessage(type: string, content: any, localOpMetadata: unknown): void;
     // (undocumented)
-    submitSignal(type: string, content: any): void;
+    submitSignal(type: string, content: unknown): void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike): Promise<IFluidHandle<ArrayBufferLike>>;
 }
@@ -521,7 +521,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     // (undocumented)
     submitMessage(type: MessageType, content: any): null;
     // (undocumented)
-    submitSignal(type: string, content: any): null;
+    submitSignal(type: string, content: unknown): null;
     // (undocumented)
     summarize(fullTree?: boolean, trackState?: boolean): Promise<ISummaryTreeWithStats>;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/src/mockDeltas.ts
+++ b/packages/runtime/test-runtime-utils/src/mockDeltas.ts
@@ -153,7 +153,7 @@ export class MockDeltaManager
 
 	public close(): void {}
 
-	public submitSignal(content: any): void {}
+	public submitSignal(content: string): void {}
 
 	public flush() {}
 

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -874,7 +874,7 @@ export class MockFluidDataStoreRuntime
 		return this.containerRuntime.dirty();
 	}
 
-	public submitSignal(type: string, content: any) {
+	public submitSignal(type: string, content: unknown) {
 		return null;
 	}
 

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -102,7 +102,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 		throw new Error("Method not implemented.");
 	}
 
-	public submitSignal(type: string, content: any): void {
+	public submitSignal(type: string, content: unknown): void {
 		throw new Error("Method not implemented.");
 	}
 

--- a/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
+++ b/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
@@ -48,30 +48,6 @@ use_old_InterfaceDeclaration_ContainerDevtoolsProps(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_ContainerKey": {"forwardCompat": false}
-*/
-declare function get_old_TypeAliasDeclaration_ContainerKey():
-    TypeOnly<old.ContainerKey>;
-declare function use_current_TypeAliasDeclaration_ContainerKey(
-    use: TypeOnly<current.ContainerKey>): void;
-use_current_TypeAliasDeclaration_ContainerKey(
-    get_old_TypeAliasDeclaration_ContainerKey());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "TypeAliasDeclaration_ContainerKey": {"backCompat": false}
-*/
-declare function get_current_TypeAliasDeclaration_ContainerKey():
-    TypeOnly<current.ContainerKey>;
-declare function use_old_TypeAliasDeclaration_ContainerKey(
-    use: TypeOnly<old.ContainerKey>): void;
-use_old_TypeAliasDeclaration_ContainerKey(
-    get_current_TypeAliasDeclaration_ContainerKey());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_DevtoolsProps": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_DevtoolsProps():
@@ -92,30 +68,6 @@ declare function use_old_InterfaceDeclaration_DevtoolsProps(
     use: TypeOnly<old.DevtoolsProps>): void;
 use_old_InterfaceDeclaration_DevtoolsProps(
     get_current_InterfaceDeclaration_DevtoolsProps());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_HasContainerKey": {"forwardCompat": false}
-*/
-declare function get_old_InterfaceDeclaration_HasContainerKey():
-    TypeOnly<old.HasContainerKey>;
-declare function use_current_InterfaceDeclaration_HasContainerKey(
-    use: TypeOnly<current.HasContainerKey>): void;
-use_current_InterfaceDeclaration_HasContainerKey(
-    get_old_InterfaceDeclaration_HasContainerKey());
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_HasContainerKey": {"backCompat": false}
-*/
-declare function get_current_InterfaceDeclaration_HasContainerKey():
-    TypeOnly<current.HasContainerKey>;
-declare function use_old_InterfaceDeclaration_HasContainerKey(
-    use: TypeOnly<old.HasContainerKey>): void;
-use_old_InterfaceDeclaration_HasContainerKey(
-    get_current_InterfaceDeclaration_HasContainerKey());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
+++ b/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
@@ -48,6 +48,30 @@ use_old_InterfaceDeclaration_ContainerDevtoolsProps(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ContainerKey": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_ContainerKey():
+    TypeOnly<old.ContainerKey>;
+declare function use_current_TypeAliasDeclaration_ContainerKey(
+    use: TypeOnly<current.ContainerKey>): void;
+use_current_TypeAliasDeclaration_ContainerKey(
+    get_old_TypeAliasDeclaration_ContainerKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ContainerKey": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_ContainerKey():
+    TypeOnly<current.ContainerKey>;
+declare function use_old_TypeAliasDeclaration_ContainerKey(
+    use: TypeOnly<old.ContainerKey>): void;
+use_old_TypeAliasDeclaration_ContainerKey(
+    get_current_TypeAliasDeclaration_ContainerKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_DevtoolsProps": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_DevtoolsProps():
@@ -68,6 +92,30 @@ declare function use_old_InterfaceDeclaration_DevtoolsProps(
     use: TypeOnly<old.DevtoolsProps>): void;
 use_old_InterfaceDeclaration_DevtoolsProps(
     get_current_InterfaceDeclaration_DevtoolsProps());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_HasContainerKey": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_HasContainerKey():
+    TypeOnly<old.HasContainerKey>;
+declare function use_current_InterfaceDeclaration_HasContainerKey(
+    use: TypeOnly<current.HasContainerKey>): void;
+use_current_InterfaceDeclaration_HasContainerKey(
+    get_old_InterfaceDeclaration_HasContainerKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_HasContainerKey": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_HasContainerKey():
+    TypeOnly<current.HasContainerKey>;
+declare function use_old_InterfaceDeclaration_HasContainerKey(
+    use: TypeOnly<old.HasContainerKey>): void;
+use_old_InterfaceDeclaration_HasContainerKey(
+    get_current_InterfaceDeclaration_HasContainerKey());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
## Description

This PR updates `content` typing from `any` to `unknown` or `string` (after `unknown` content has been stringified).

Changeset is included as this PR includes public API changes
