### PR TITLE
Drop TTL Index so it can be recreated

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -66,7 +66,7 @@ storage:
 
 checkpoints:
   localCheckpointEnabled: false
-  checkpointsTTLInSeconds: -1
+  checkpointsTTLInSeconds: 86400
   kafkaCheckpointOnReprocessingOp: false
 
 session:

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -198,6 +198,11 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 		const defaultTTLInSeconds = 864000;
 		const checkpointsTTLSeconds =
 			config.get("checkpoints:checkpointsTTLInSeconds") ?? defaultTTLInSeconds;
+		try {
+			await checkpointsCollection.dropIndex({ _ts: 1 });
+		} catch (error) {
+			Lumberjack.warning(`Did not drop ttl index.`);
+		}
 		await checkpointsCollection.createTTLIndex({ _ts: 1 }, checkpointsTTLSeconds);
 
 		const nodeCollectionName = config.get("mongo:collectionNames:nodes");

--- a/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
@@ -280,6 +280,13 @@ export class NexusResourcesFactory implements core.IResourcesFactory<NexusResour
 		const defaultTTLInSeconds = 864000;
 		const checkpointsTTLSeconds =
 			config.get("checkpoints:checkpointsTTLInSeconds") ?? defaultTTLInSeconds;
+
+		try {
+			await checkpointsCollection.dropIndex({ _ts: 1 });
+		} catch (error) {
+			Lumberjack.warning(`Did not drop ttl index.`);
+		}
+
 		await checkpointsCollection.createTTLIndex({ _ts: 1 }, checkpointsTTLSeconds);
 
 		const nodeCollectionName = config.get("mongo:collectionNames:nodes");

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -71,7 +71,7 @@
 	},
 	"checkpoints": {
 		"localCheckpointEnabled": true,
-		"checkpointsTTLInSeconds": -1,
+		"checkpointsTTLInSeconds": 86400,
 		"kafkaCheckpointOnReprocessingOp": false,
 		"ignoreCheckpointFlushException": false
 	},

--- a/server/routerlicious/packages/services-core/src/database.ts
+++ b/server/routerlicious/packages/services-core/src/database.ts
@@ -250,6 +250,8 @@ export interface ICollection<T> {
 	createIndex(index: any, unique: boolean): Promise<void>;
 
 	createTTLIndex?(index: any, mongoExpireAfterSeconds?: number): Promise<void>;
+
+	dropIndex?(index: any): Promise<void>;
 }
 
 /**

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -111,6 +111,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_MongoCollection": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -295,6 +295,19 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
 		}
 	}
 
+	public async dropIndex(indexName: any) {
+		const req = async () => this.collection.dropIndex(indexName);
+		try {
+			await this.requestWithRetry(
+				req, // request
+				"MongoCollection.dropIndex", // callerName
+			);
+			Lumberjack.info(`Dropped index ${indexName}`);
+		} catch (error) {
+			Lumberjack.error(`Failed to drop index`, undefined, error);
+		}
+	}
+
 	public async findOrCreate(
 		query: any,
 		value: any,

--- a/server/routerlicious/packages/services/src/test/types/validateServerServicesPrevious.generated.ts
+++ b/server/routerlicious/packages/services/src/test/types/validateServerServicesPrevious.generated.ts
@@ -319,6 +319,7 @@ declare function get_old_ClassDeclaration_MongoCollection():
 declare function use_current_ClassDeclaration_MongoCollection(
     use: TypeOnly<current.MongoCollection<any>>): void;
 use_current_ClassDeclaration_MongoCollection(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MongoCollection());
 
 /*


### PR DESCRIPTION
This change attempts to drop the TTL index before re-creating so it can be updated with the correct config value