### PR TITLE
Fix internalSchema()

### DIFF
--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -435,7 +435,7 @@ function internalSchema(
 				return `2.0.0-internal.7.4.7`;
 			}
 		}
-	} else {
+	} else if (semver.eq(publicVersion, "2.0.0") && semver.lt(internalVersion, "2.0.0")) {
 		if (requested === -1) {
 			return `^1.0.0-0`;
 		}

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -428,14 +428,14 @@ function internalSchema(
 	if (prereleaseIdentifier === "rc" || prereleaseIdentifier === "dev-rc") {
 		if (semver.eq(publicVersion, "2.0.0") && semver.lt(internalVersion, "2.0.0")) {
 			if (requested === -1) {
-				return `^2.0.0-internal.8.0.0`;
+				return `2.0.0-internal.8.0.0`;
 			}
 
 			if (requested === -2) {
-				return `^2.0.0-internal.7.0.0`;
+				return `2.0.0-internal.7.0.0`;
 			}
 		}
-	} else if (semver.eq(publicVersion, "2.0.0") && semver.lt(internalVersion, "2.0.0")) {
+	} else {
 		if (requested === -1) {
 			return `^1.0.0-0`;
 		}

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -428,11 +428,11 @@ function internalSchema(
 	if (prereleaseIdentifier === "rc" || prereleaseIdentifier === "dev-rc") {
 		if (semver.eq(publicVersion, "2.0.0") && semver.lt(internalVersion, "2.0.0")) {
 			if (requested === -1) {
-				return `2.0.0-internal.8.0.0`;
+				return `2.0.0-internal.8.0.8`;
 			}
 
 			if (requested === -2) {
-				return `2.0.0-internal.7.0.0`;
+				return `2.0.0-internal.7.4.7`;
 			}
 		}
 	} else {


### PR DESCRIPTION
The root cause of the issue was that getRequestedVersion() was returning 2.0.0-rc.2.0.0 to this: (!!!)
baseVersion === '2.0.0-rc.1.0.5' && requested === -1
The reason why we returned that is because internalSchema() returned `^2.0.0-internal.8.0.0` to such a case which is deeply wrong. Such a request to resolveVersion() will produce an array with all versions ahead of that one and return the latest. Probably the code was looking for the latest 2.0.0-internal.8.0.0 patch.
This hints me that there is a deeper issue here in how we manage these cases. Currently hard-coding the desired versions for testing and probably unblock the patch release for RC1. 
