### PR TITLE
Make attribution policy factory exposure consistent

### DIFF
--- a/packages/dds/merge-tree/api-report/merge-tree.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.api.md
@@ -225,6 +225,12 @@ export function createMap<T>(): MapLike<T>;
 export function createObliterateRangeOp(start: number, end: number): IMergeTreeObliterateMsg;
 
 // @internal
+export function createPropertyTrackingAndInsertionAttributionPolicyFactory(...propNames: string[]): () => AttributionPolicy;
+
+// @internal (undocumented)
+export function createPropertyTrackingAttributionPolicyFactory(...propNames: string[]): () => AttributionPolicy;
+
+// @internal
 export function createRemoveRangeOp(start: number, end: number): IMergeTreeRemoveMsg;
 
 // @internal

--- a/packages/dds/merge-tree/src/attributionPolicy.ts
+++ b/packages/dds/merge-tree/src/attributionPolicy.ts
@@ -223,7 +223,7 @@ export function createInsertOnlyAttributionPolicy(): AttributionPolicy {
  * const lastBoldedAttributionKey = segment.attribution?.getAtOffset(0, "bold");
  * const lastItalicizedAttributionKey = segment.attribution?.getAtOffset(0, "italic");
  * ```
- * @alpha
+ * @internal
  */
 export function createPropertyTrackingAttributionPolicyFactory(
 	...propNames: string[]
@@ -241,7 +241,7 @@ export function createPropertyTrackingAttributionPolicyFactory(
  * Creates an attribution policy which tracks insertion as well as annotation of certain property names.
  * This combines the policies creatable using {@link createPropertyTrackingAttributionPolicyFactory} and
  * {@link createInsertOnlyAttributionPolicy}: see there for more details.
- * @alpha
+ * @internal
  */
 export function createPropertyTrackingAndInsertionAttributionPolicyFactory(
 	...propNames: string[]

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -10,7 +10,11 @@ export {
 	SerializedAttributionCollection,
 	SequenceOffsets,
 } from "./attributionCollection.js";
-export { createInsertOnlyAttributionPolicy } from "./attributionPolicy.js";
+export {
+	createInsertOnlyAttributionPolicy,
+	createPropertyTrackingAttributionPolicyFactory,
+	createPropertyTrackingAndInsertionAttributionPolicyFactory,
+} from "./attributionPolicy.js";
 export { Client, IClientEvents } from "./client.js";
 export {
 	ConflictAction,

--- a/packages/dds/sequence/README.md
+++ b/packages/dds/sequence/README.md
@@ -547,7 +547,7 @@ Using the interval collection API has two main benefits:
 
 ### Attribution
 
-**Important: Attribution is currently in alpha: expect breaking changes in minor releases as we get feedback on the API shape.**
+**Important: Attribution is currently in alpha development and is marked internal: expect breaking changes in minor releases as we get feedback on the API shape.**
 
 SharedString supports storing information attributing each character position to the user who inserted it and the time at which that insertion happened.
 This functionality is off by default.


### PR DESCRIPTION
## Description

This exposes property-based attribution policy factories from merge-tree. These two functions were intended to have the same visibility as `createInsertOnlyAttributionPolicy`, but were never exported. Since original definition, we've changed the intent of the \@alpha tag from API extractor. It makes more sense to leave both of these functions internal (as `createInsertOnlyAttributionPolicy` is), so I've updated the attribution section of the README as well to be more accurate.
