### PR TITLE
build: Add 'api' to 'compile' task definition

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -34,7 +34,7 @@ module.exports = {
 			script: false,
 		},
 		"compile": {
-			dependsOn: ["commonjs", "build:esnext", "build:test", "build:copy"],
+			dependsOn: ["commonjs", "build:esnext", "api", "build:test", "build:copy"],
 			script: false,
 		},
 		"commonjs": {

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -37,6 +37,7 @@ trigger:
   paths:
     include:
     - .prettierignore
+    - fluidBuild.config.cjs
     - common/build/build-common
     - common/lib/common-definitions
     - tools/pipelines/build-common-definitions.yml

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -37,6 +37,7 @@ trigger:
   paths:
     include:
     - .prettierignore
+    - fluidBuild.config.cjs
     - common/build/build-common
     - common/lib/protocol-definitions
     - tools/pipelines/build-protocol-definitions.yml


### PR DESCRIPTION
Now that we are doing API trimming in packages, the `api` task needs to be considered part of the core package compilation. The task definition is updated to reflect this.

Practically speaking this will mean that each package will invoke its `api` task, whereas before, the task was invoked by another package that depended on it, because the `compile` task _did_ include `^api` in its task chain already.

I also updated the CI pipelines for protocol-defs and common-defs, since they now use fluid-build and should be triggered when changes are made to the config file.