### PR TITLE
improvement(client): IDocumentDeltaConnection.submitSignal typing BREAKING CHANGE

### DIFF
--- a/.changeset/chatty-pears-doubt.md
+++ b/.changeset/chatty-pears-doubt.md
@@ -1,0 +1,11 @@
+---
+"@fluidframework/container-loader": minor
+"@fluidframework/driver-base": minor
+"@fluidframework/driver-definitions": minor
+"@fluidframework/local-driver": minor
+"@fluidframework/odsp-driver": minor
+---
+
+update submitSignal content type to string
+
+Change IDocumentDeltaConnection.submitSignal's content argument type to string which represents actual/known use.

--- a/packages/common/driver-definitions/api-report/driver-definitions.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.api.md
@@ -125,7 +125,7 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     relayServiceAgent?: string;
     serviceConfiguration: IClientConfiguration;
     submit(messages: IDocumentMessage[]): void;
-    submitSignal(content: any, targetClientId?: string): void;
+    submitSignal: (content: UnknownShouldBe<string>, targetClientId?: string) => void;
     version: string;
 }
 
@@ -320,6 +320,9 @@ export enum LoaderCachingPolicy {
     NoCaching = 0,
     Prefetch = 1
 }
+
+// @alpha
+export type UnknownShouldBe<_T> = unknown;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/common/driver-definitions/api-report/driver-definitions.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.api.md
@@ -125,7 +125,7 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     relayServiceAgent?: string;
     serviceConfiguration: IClientConfiguration;
     submit(messages: IDocumentMessage[]): void;
-    submitSignal: (content: UnknownShouldBe<string>, targetClientId?: string) => void;
+    submitSignal: (content: string, targetClientId?: string) => void;
     version: string;
 }
 
@@ -320,9 +320,6 @@ export enum LoaderCachingPolicy {
     NoCaching = 0,
     Prefetch = 1
 }
-
-// @alpha
-export type UnknownShouldBe<_T> = unknown;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/common/driver-definitions/src/index.ts
+++ b/packages/common/driver-definitions/src/index.ts
@@ -32,6 +32,7 @@ export type {
 	IStream,
 	IStreamResult,
 	ISummaryContext,
+	UnknownShouldBe,
 } from "./storage.js";
 export { FetchSource, LoaderCachingPolicy } from "./storage.js";
 export type {

--- a/packages/common/driver-definitions/src/index.ts
+++ b/packages/common/driver-definitions/src/index.ts
@@ -32,7 +32,6 @@ export type {
 	IStream,
 	IStreamResult,
 	ISummaryContext,
-	UnknownShouldBe,
 } from "./storage.js";
 export { FetchSource, LoaderCachingPolicy } from "./storage.js";
 export type {

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -239,18 +239,6 @@ export interface IDocumentDeltaConnectionEvents extends IErrorEvent {
 }
 
 /**
- * This type is `unknown` but formally should only be what is passed as _T.
- *
- * @privateRemarks
- * Use this where we don't want to create a type breaking change, have been
- * handling `unknown` successfully, and will continue to do so. Once no longer
- * alpha the more strict type can be used.
- *
- * @alpha
- */
-export type UnknownShouldBe<_T> = unknown;
-
-/**
  * @alpha
  */
 export interface IDocumentDeltaConnection
@@ -329,7 +317,7 @@ export interface IDocumentDeltaConnection
 	 * @privateRemarks
 	 * UnknownShouldBe<string> can be string if {@link IDocumentServiceFactory} becomes internal.
 	 */
-	submitSignal: (content: UnknownShouldBe<string>, targetClientId?: string) => void;
+	submitSignal: (content: string, targetClientId?: string) => void;
 }
 
 /**

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -239,6 +239,18 @@ export interface IDocumentDeltaConnectionEvents extends IErrorEvent {
 }
 
 /**
+ * This type is `unknown` but formally should only be what is passed as _T.
+ *
+ * @privateRemarks
+ * Use this where we don't want to create a type breaking change, have been
+ * handling `unknown` successfully, and will continue to do so. Once no longer
+ * alpha the more strict type can be used.
+ *
+ * @alpha
+ */
+export type UnknownShouldBe<_T> = unknown;
+
+/**
  * @alpha
  */
 export interface IDocumentDeltaConnection
@@ -313,10 +325,11 @@ export interface IDocumentDeltaConnection
 
 	/**
 	 * Submits a new signal to the server
+	 *
+	 * @privateRemarks
+	 * UnknownShouldBe<string> can be string if {@link IDocumentServiceFactory} becomes internal.
 	 */
-	// TODO: Use something other than `any`.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	submitSignal(content: any, targetClientId?: string): void;
+	submitSignal: (content: UnknownShouldBe<string>, targetClientId?: string) => void;
 }
 
 /**

--- a/packages/drivers/driver-base/api-report/driver-base.api.md
+++ b/packages/drivers/driver-base/api-report/driver-base.api.md
@@ -14,7 +14,6 @@ import { IDisposable } from '@fluidframework/core-interfaces';
 import { IDocumentDeltaConnection } from '@fluidframework/driver-definitions';
 import { IDocumentDeltaConnectionEvents } from '@fluidframework/driver-definitions';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
-import { ISentSignalMessage } from '@fluidframework/protocol-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISignalClient } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
@@ -53,7 +52,7 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     // (undocumented)
     protected emitMessages(type: "submitOp", messages: IDocumentMessage[][]): void;
     // (undocumented)
-    protected emitMessages(type: "submitSignal", messages: string[][] | ISentSignalMessage[]): void;
+    protected emitMessages(type: "submitSignal", messages: string[][]): void;
     // (undocumented)
     static readonly eventsAlwaysForwarded: string[];
     // (undocumented)

--- a/packages/drivers/driver-base/api-report/driver-base.api.md
+++ b/packages/drivers/driver-base/api-report/driver-base.api.md
@@ -21,7 +21,6 @@ import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
 import { ITokenClaims } from '@fluidframework/protocol-definitions';
 import type { Socket } from 'socket.io-client';
-import { UnknownShouldBe } from '@fluidframework/driver-definitions';
 
 // @internal
 export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocumentDeltaConnectionEvents> implements IDocumentDeltaConnection, IDisposable {
@@ -54,7 +53,7 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     // (undocumented)
     protected emitMessages(type: "submitOp", messages: IDocumentMessage[][]): void;
     // (undocumented)
-    protected emitMessages(type: "submitSignal", messages: UnknownShouldBe<string>[][] | ISentSignalMessage[]): void;
+    protected emitMessages(type: "submitSignal", messages: string[][] | ISentSignalMessage[]): void;
     // (undocumented)
     static readonly eventsAlwaysForwarded: string[];
     // (undocumented)
@@ -86,7 +85,7 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     // (undocumented)
     protected readonly socket: Socket;
     submit(messages: IDocumentMessage[]): void;
-    submitSignal(content: UnknownShouldBe<string>, targetClientId?: string): void;
+    submitSignal(content: string, targetClientId?: string): void;
     get version(): string;
 }
 

--- a/packages/drivers/driver-base/api-report/driver-base.api.md
+++ b/packages/drivers/driver-base/api-report/driver-base.api.md
@@ -14,12 +14,14 @@ import { IDisposable } from '@fluidframework/core-interfaces';
 import { IDocumentDeltaConnection } from '@fluidframework/driver-definitions';
 import { IDocumentDeltaConnectionEvents } from '@fluidframework/driver-definitions';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
+import { ISentSignalMessage } from '@fluidframework/protocol-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISignalClient } from '@fluidframework/protocol-definitions';
 import { ISignalMessage } from '@fluidframework/protocol-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils';
 import { ITokenClaims } from '@fluidframework/protocol-definitions';
 import type { Socket } from 'socket.io-client';
+import { UnknownShouldBe } from '@fluidframework/driver-definitions';
 
 // @internal
 export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocumentDeltaConnectionEvents> implements IDocumentDeltaConnection, IDisposable {
@@ -50,7 +52,9 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     // (undocumented)
     protected earlySignalHandler: (msg: ISignalMessage | ISignalMessage[]) => void;
     // (undocumented)
-    protected emitMessages(type: string, messages: IDocumentMessage[][]): void;
+    protected emitMessages(type: "submitOp", messages: IDocumentMessage[][]): void;
+    // (undocumented)
+    protected emitMessages(type: "submitSignal", messages: UnknownShouldBe<string>[][] | ISentSignalMessage[]): void;
     // (undocumented)
     static readonly eventsAlwaysForwarded: string[];
     // (undocumented)
@@ -82,7 +86,7 @@ export class DocumentDeltaConnection extends EventEmitterWithErrorHandling<IDocu
     // (undocumented)
     protected readonly socket: Socket;
     submit(messages: IDocumentMessage[]): void;
-    submitSignal(content: IDocumentMessage, targetClientId?: string): void;
+    submitSignal(content: UnknownShouldBe<string>, targetClientId?: string): void;
     get version(): string;
 }
 

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -9,7 +9,6 @@ import {
 	IAnyDriverError,
 	IDocumentDeltaConnection,
 	IDocumentDeltaConnectionEvents,
-	type UnknownShouldBe,
 } from "@fluidframework/driver-definitions";
 import { UsageError, createGenericNetworkError } from "@fluidframework/driver-utils";
 import {
@@ -313,10 +312,7 @@ export class DocumentDeltaConnection
 	}
 
 	protected emitMessages(type: "submitOp", messages: IDocumentMessage[][]): void;
-	protected emitMessages(
-		type: "submitSignal",
-		messages: UnknownShouldBe<string>[][] | ISentSignalMessage[],
-	): void;
+	protected emitMessages(type: "submitSignal", messages: string[][] | ISentSignalMessage[]): void;
 	protected emitMessages(type: string, messages: unknown): void {
 		// Although the implementation here disconnects the socket and does not reuse it, other subclasses
 		// (e.g. OdspDocumentDeltaConnection) may reuse the socket.  In these cases, we need to avoid emitting
@@ -342,7 +338,7 @@ export class DocumentDeltaConnection
 	 * @param content - Content of the signal.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(content: UnknownShouldBe<string>, targetClientId?: string): void {
+	public submitSignal(content: string, targetClientId?: string): void {
 		this.checkNotDisposed();
 
 		if (targetClientId && this.details.supportedFeatures?.submit_signals_v2 !== true) {

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -9,6 +9,7 @@ import {
 	IAnyDriverError,
 	IDocumentDeltaConnection,
 	IDocumentDeltaConnectionEvents,
+	type UnknownShouldBe,
 } from "@fluidframework/driver-definitions";
 import { UsageError, createGenericNetworkError } from "@fluidframework/driver-utils";
 import {
@@ -17,6 +18,7 @@ import {
 	IConnect,
 	IConnected,
 	IDocumentMessage,
+	type ISentSignalMessage,
 	ISequencedDocumentMessage,
 	ISignalClient,
 	ISignalMessage,
@@ -310,7 +312,12 @@ export class DocumentDeltaConnection
 		return this.details.initialClients;
 	}
 
-	protected emitMessages(type: string, messages: IDocumentMessage[][]) {
+	protected emitMessages(type: "submitOp", messages: IDocumentMessage[][]): void;
+	protected emitMessages(
+		type: "submitSignal",
+		messages: UnknownShouldBe<string>[][] | ISentSignalMessage[],
+	): void;
+	protected emitMessages(type: string, messages: unknown): void {
 		// Although the implementation here disconnects the socket and does not reuse it, other subclasses
 		// (e.g. OdspDocumentDeltaConnection) may reuse the socket.  In these cases, we need to avoid emitting
 		// on the still-live socket.
@@ -335,7 +342,7 @@ export class DocumentDeltaConnection
 	 * @param content - Content of the signal.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(content: IDocumentMessage, targetClientId?: string): void {
+	public submitSignal(content: UnknownShouldBe<string>, targetClientId?: string): void {
 		this.checkNotDisposed();
 
 		if (targetClientId && this.details.supportedFeatures?.submit_signals_v2 !== true) {

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -17,7 +17,6 @@ import {
 	IConnect,
 	IConnected,
 	IDocumentMessage,
-	type ISentSignalMessage,
 	ISequencedDocumentMessage,
 	ISignalClient,
 	ISignalMessage,
@@ -312,7 +311,7 @@ export class DocumentDeltaConnection
 	}
 
 	protected emitMessages(type: "submitOp", messages: IDocumentMessage[][]): void;
-	protected emitMessages(type: "submitSignal", messages: string[][] | ISentSignalMessage[]): void;
+	protected emitMessages(type: "submitSignal", messages: string[][]): void;
 	protected emitMessages(type: string, messages: unknown): void {
 		// Although the implementation here disconnects the socket and does not reuse it, other subclasses
 		// (e.g. OdspDocumentDeltaConnection) may reuse the socket.  In these cases, we need to avoid emitting

--- a/packages/drivers/local-driver/api-report/local-driver.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.api.md
@@ -39,7 +39,6 @@ import { IWebSocketServer } from '@fluidframework/server-services-core';
 import { NackErrorType } from '@fluidframework/protocol-definitions';
 import type { Socket } from 'socket.io-client';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
-import type { UnknownShouldBe } from '@fluidframework/driver-definitions';
 
 // @internal
 export function createLocalDocumentService(resolvedUrl: IResolvedUrl, localDeltaConnectionServer: ILocalDeltaConnectionServer, tokenProvider: ITokenProvider, tenantId: string, documentId: string, documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>, policies?: IDocumentServicePolicies, innerDocumentService?: IDocumentService, logger?: ITelemetryBaseLogger): IDocumentService;
@@ -61,7 +60,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
     disconnectClient(disconnectReason: string): void;
     nackClient(code: number | undefined, type: NackErrorType | undefined, message: any): void;
     submit(messages: IDocumentMessage[]): void;
-    submitSignal(message: UnknownShouldBe<string>): void;
+    submitSignal(message: string): void;
 }
 
 // @internal

--- a/packages/drivers/local-driver/api-report/local-driver.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.api.md
@@ -39,6 +39,7 @@ import { IWebSocketServer } from '@fluidframework/server-services-core';
 import { NackErrorType } from '@fluidframework/protocol-definitions';
 import type { Socket } from 'socket.io-client';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
+import type { UnknownShouldBe } from '@fluidframework/driver-definitions';
 
 // @internal
 export function createLocalDocumentService(resolvedUrl: IResolvedUrl, localDeltaConnectionServer: ILocalDeltaConnectionServer, tokenProvider: ITokenProvider, tenantId: string, documentId: string, documentDeltaConnectionsMap: Map<string, LocalDocumentDeltaConnection>, policies?: IDocumentServicePolicies, innerDocumentService?: IDocumentService, logger?: ITelemetryBaseLogger): IDocumentService;
@@ -60,7 +61,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
     disconnectClient(disconnectReason: string): void;
     nackClient(code: number | undefined, type: NackErrorType | undefined, message: any): void;
     submit(messages: IDocumentMessage[]): void;
-    submitSignal(message: any): void;
+    submitSignal(message: UnknownShouldBe<string>): void;
 }
 
 // @internal

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -5,7 +5,6 @@
 
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";
-import type { UnknownShouldBe } from "@fluidframework/driver-definitions";
 import {
 	IClient,
 	IConnect,
@@ -81,7 +80,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 	/**
 	 * Submits a new signal to the server
 	 */
-	public submitSignal(message: UnknownShouldBe<string>): void {
+	public submitSignal(message: string): void {
 		this.emitMessages("submitSignal", [[message]]);
 	}
 

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -5,6 +5,7 @@
 
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";
+import type { UnknownShouldBe } from "@fluidframework/driver-definitions";
 import {
 	IClient,
 	IConnect,
@@ -80,7 +81,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 	/**
 	 * Submits a new signal to the server
 	 */
-	public submitSignal(message: any): void {
+	public submitSignal(message: UnknownShouldBe<string>): void {
 		this.emitMessages("submitSignal", [[message]]);
 	}
 

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -740,9 +740,12 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 		return !this.disposed && this.socket.connected;
 	}
 
-	protected emitMessages(type: "submitOp", messages: IDocumentMessage[][]): void;
-	protected emitMessages(type: "submitSignal", messages: string[][] | ISentSignalMessage[]): void;
-	protected emitMessages(type: string, messages: unknown): void {
+	protected override emitMessages(type: "submitOp", messages: IDocumentMessage[][]): void;
+	protected override emitMessages(
+		type: "submitSignal",
+		messages: string[][] | ISentSignalMessage[],
+	): void;
+	protected override emitMessages(type: string, messages: unknown): void {
 		// Only submit the op/signals if we are connected.
 		if (this.connected) {
 			this.socket.emit(type, this.clientId, messages);

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -8,7 +8,6 @@ import { IEvent } from "@fluidframework/core-interfaces";
 import { assert, Deferred } from "@fluidframework/core-utils";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base";
 import { IAnyDriverError } from "@fluidframework/driver-definitions";
-import type { UnknownShouldBe } from "@fluidframework/driver-definitions";
 import { createGenericNetworkError } from "@fluidframework/driver-utils";
 import { OdspError } from "@fluidframework/odsp-driver-definitions";
 import {
@@ -742,10 +741,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 	}
 
 	protected emitMessages(type: "submitOp", messages: IDocumentMessage[][]): void;
-	protected emitMessages(
-		type: "submitSignal",
-		messages: UnknownShouldBe<string>[][] | ISentSignalMessage[],
-	): void;
+	protected emitMessages(type: "submitSignal", messages: string[][] | ISentSignalMessage[]): void;
 	protected emitMessages(type: string, messages: unknown): void {
 		// Only submit the op/signals if we are connected.
 		if (this.connected) {
@@ -767,7 +763,7 @@ export class OdspDocumentDeltaConnection extends DocumentDeltaConnection {
 	 * @param content - Content of the signal.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(content: UnknownShouldBe<string>, targetClientId?: string): void {
+	public submitSignal(content: string, targetClientId?: string): void {
 		const signal: ISentSignalMessage = {
 			content,
 			targetClientId,

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -1069,7 +1069,7 @@ export class ConnectionManager implements IConnectionManager {
 		};
 	}
 
-	public submitSignal(content: any, targetClientId?: string) {
+	public submitSignal(content: string, targetClientId?: string) {
 		if (this.connection !== undefined) {
 			this.connection.submitSignal(content, targetClientId);
 		} else {

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -100,7 +100,7 @@ export interface IConnectionManager {
 	 * Submits signal to relay service.
 	 * Called only when active connection is present.
 	 */
-	submitSignal(content: any, targetClientId?: string): void;
+	submitSignal: (content: string, targetClientId?: string) => void;
 
 	/**
 	 * Submits messages to relay service.

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -325,7 +325,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		return message.clientSequenceNumber;
 	}
 
-	public submitSignal(content: any, targetClientId?: string) {
+	public submitSignal(content: string, targetClientId?: string) {
 		return this.connectionManager.submitSignal(content, targetClientId);
 	}
 


### PR DESCRIPTION
`IDocumentDeltaConnection.submitSignal` is not known to actually be used externally. Internally only string is used and we'll use the most strict type until there is need to do something else.

`Jsonable<>` content is the least restrictive type that could be used, but that type filter currently has defects; so, keep with the simple strict string.

Driver `emitMessages` is now broken down into the two uses with specific and accurate typing.