### PR TITLE
fix(tree): handling of implicit build revisions in updateRefreshers

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1040,16 +1040,17 @@ function* relevantRemovedRootsFromFields(
  * Can be retrieved by calling {@link relevantRemovedRoots}.
  */
 export function updateRefreshers(
-	change: TaggedChange<ModularChangeset>,
+	{ change, revision }: TaggedChange<ModularChangeset>,
 	getDetachedNode: (id: DeltaDetachedNodeId) => TreeChunk | undefined,
 	removedRoots: Iterable<DeltaDetachedNodeId>,
 ): ModularChangeset {
 	const refreshers: ChangeAtomIdMap<TreeChunk> = new Map();
 
 	for (const root of removedRoots) {
-		if (change.change.builds !== undefined) {
+		if (change.builds !== undefined) {
+			const major = root.major === revision ? undefined : root.major;
 			// if the root exists in the original builds map, it does not need to be added as a refresher
-			const original = tryGetFromNestedMap(change.change.builds, root.major, root.minor);
+			const original = tryGetFromNestedMap(change.builds, major, root.minor);
 			if (original !== undefined) {
 				continue;
 			}
@@ -1060,8 +1061,7 @@ export function updateRefreshers(
 		setInNestedMap(refreshers, root.major, root.minor, node);
 	}
 
-	const { fieldChanges, maxId, revisions, constraintViolationCount, builds, destroys } =
-		change.change;
+	const { fieldChanges, maxId, revisions, constraintViolationCount, builds, destroys } = change;
 	return makeModularChangeset(
 		fieldChanges,
 		maxId,

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -1337,6 +1337,33 @@ describe("ModularChangeFamily", () => {
 				);
 			});
 		});
+
+		describe("handles implicit and explicit build revision representations", () => {
+			it("explicit builds", () => {
+				const explicitBuild: ModularChangeset = {
+					fieldChanges: new Map([]),
+					builds: new Map([[tag1, new Map([[brand(1), node1Chunk]])]]),
+				};
+				const withBuilds = updateRefreshers(
+					makeAnonChange(explicitBuild),
+					getDetachedNode,
+					[{ major: tag1, minor: 1 }],
+				);
+				assert.deepEqual(withBuilds, explicitBuild);
+			});
+			it("implicit builds", () => {
+				const implicitBuild: ModularChangeset = {
+					fieldChanges: new Map([]),
+					builds: new Map([[undefined, new Map([[brand(1), node1Chunk]])]]),
+				};
+				const withBuilds = updateRefreshers(
+					tagChange(implicitBuild, tag1),
+					getDetachedNode,
+					[{ major: tag1, minor: 1 }],
+				);
+				assert.deepEqual(withBuilds, implicitBuild);
+			});
+		});
 	});
 
 	describe("Encoding", () => {


### PR DESCRIPTION
Update `updateRefreshers` to handle the fact that builds use implicit revision tags when possible whereas relevant removed roots use explicit revision tags.