### PR TITLE
Test enabling Chunking in end-to-end tests

### DIFF
--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -95,7 +95,7 @@ function filterRuntimeOptionsForVersion(
 		enableRuntimeIdCompressor = "on",
 		// Some t9s tests timeout with small settings. This is likely due to too many ops going through.
 		// Reduce chunking cut-off for such tests.
-		chunkSizeInBytes = driverType === "local" ? 200: 1000,
+		chunkSizeInBytes = driverType === "local" ? 200 : 1000,
 	} = options;
 
 	if (version.startsWith("1.")) {
@@ -222,11 +222,7 @@ export async function getVersionedTestObjectProviderFromApis(
 ) {
 	const type = driverConfig?.type ?? "local";
 
-	const driver = await createFluidTestDriver(
-		type,
-		driverConfig?.config,
-		apis.driver,
-	);
+	const driver = await createFluidTestDriver(type, driverConfig?.config, apis.driver);
 
 	const getDataStoreFactoryFn = createGetDataStoreFactoryFunction(apis.dataRuntime);
 	const containerFactoryFn = (containerOptions?: ITestContainerConfig) => {
@@ -342,7 +338,11 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 		return new factoryCtor(
 			TestDataObjectType,
 			dataStoreFactory,
-			filterRuntimeOptionsForVersion(minVersion, containerOptions?.runtimeOptions, driverConfig.type),
+			filterRuntimeOptionsForVersion(
+				minVersion,
+				containerOptions?.runtimeOptions,
+				driverConfig.type,
+			),
 			[innerRequestHandler],
 		);
 	};
@@ -362,7 +362,11 @@ export async function getCompatVersionedTestObjectProviderFromApis(
 		return new factoryCtor(
 			TestDataObjectType,
 			dataStoreFactory,
-			filterRuntimeOptionsForVersion(minVersion, containerOptions?.runtimeOptions, driverConfig.type),
+			filterRuntimeOptionsForVersion(
+				minVersion,
+				containerOptions?.runtimeOptions,
+				driverConfig.type,
+			),
 			[innerRequestHandler],
 		);
 	};

--- a/packages/test/test-version-utils/src/compatUtils.ts
+++ b/packages/test/test-version-utils/src/compatUtils.ts
@@ -92,7 +92,7 @@ function filterRuntimeOptionsForVersion(
 		},
 		enableGroupedBatching = true,
 		enableRuntimeIdCompressor = "on",
-		// chunkSizeInBytes = 200,
+		chunkSizeInBytes = 200,
 	} = options;
 
 	if (version.startsWith("1.")) {
@@ -129,8 +129,7 @@ function filterRuntimeOptionsForVersion(
 		options = {
 			compressionOptions,
 			enableGroupedBatching,
-			// need to investigate - some small number of t9s tests time out with this option on.
-			// chunkSizeInBytes,
+			chunkSizeInBytes,
 			enableRuntimeIdCompressor,
 			...options,
 		};


### PR DESCRIPTION
Continuation of https://github.com/microsoft/FluidFramework/pull/20109
Testing Chunking being enabled.

For whatever reason, I observe that some t9s tests fail on build machines with timeouts, but do not fail on a local machine.
Thus, it makes it extremely hard to experiment and see which setting screwing it.

Related PR (testing other things I've disabled for now):
https://github.com/microsoft/FluidFramework/pull/20256