### PR TITLE
server: cover edge cases for scrubbed checkpoint users

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -266,7 +266,7 @@ export class ScribeLambdaFactory
 						lumberProperties,
 					);
 				}
-				lastCheckpoint = latestSummaryCheckpoint ?? DefaultScribe;
+				lastCheckpoint = latestSummaryCheckpoint;
 				opMessages = latestSummary.messages;
 				// Since the document was originated elsewhere or cache was cleared, logOffset info is irrelavant.
 				// Currently the lambda checkpoints only after updating the logOffset so setting this to lower

--- a/server/routerlicious/packages/lambdas/src/scribe/utils.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/utils.ts
@@ -77,15 +77,18 @@ export const isGlobalCheckpoint = (noActiveClients: boolean, globalCheckpointOnl
  * Whether the quorum members represented in the checkpoint's protocol state have had their user data scrubbed
  * for privacy compliance.
  */
-export const isCheckpointQuorumScrubbed = (stringifiedCheckpoint: string): boolean => {
-	if (!stringifiedCheckpoint) {
+export const isScribeCheckpointQuorumScrubbed = (
+	checkpoint: string | IScribe | undefined,
+): boolean => {
+	if (!checkpoint) {
 		return false;
 	}
-	const checkpoint: IScribe = JSON.parse(stringifiedCheckpoint);
-	for (const [, sequencedClient] of checkpoint.protocolState.members) {
+	const parsedCheckpoint: IScribe =
+		typeof checkpoint === "string" ? JSON.parse(checkpoint) : checkpoint;
+	for (const [, sequencedClient] of parsedCheckpoint.protocolState.members) {
 		const user: IUser = sequencedClient.client.user;
-		// User information was scrubbed.
 		if (!user.id) {
+			// User information was scrubbed.
 			return true;
 		}
 	}

--- a/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
@@ -115,6 +115,11 @@ describe("Routerlicious", () => {
 					"getLocalCheckpointEnabled",
 					Sinon.fake.returns(false),
 				);
+				Sinon.replace(
+					testCheckpointService,
+					"restoreFromCheckpoint",
+					Sinon.fake.returns(undefined),
+				);
 
 				testMessageCollection = new TestCollection([]);
 				testKafka = new TestKafka();

--- a/server/routerlicious/packages/services-core/src/checkpointService.ts
+++ b/server/routerlicious/packages/services-core/src/checkpointService.ts
@@ -218,7 +218,7 @@ export class CheckpointService implements ICheckpointService {
 		const parseCheckpointString = (
 			checkpointString: string | undefined,
 		): IDeliState | IScribe | undefined =>
-			checkpointString ? JSON.parse(checkpointString) : undefined;
+			checkpointString ? (JSON.parse(checkpointString) as IDeliState | IScribe) : undefined;
 
 		try {
 			if (!this.localCheckpointEnabled || !this.checkpointRepository) {

--- a/server/routerlicious/packages/services-core/src/checkpointService.ts
+++ b/server/routerlicious/packages/services-core/src/checkpointService.ts
@@ -14,7 +14,7 @@ import {
 	Lumberjack,
 } from "@fluidframework/server-services-telemetry";
 import { ICheckpointRepository, IDocumentRepository } from "./database";
-import { IDeliState, IDocument, IScribe } from "./document";
+import { IDeliState, IDocument, IScribe, type ICheckpoint } from "./document";
 
 type DocumentLambda = "deli" | "scribe";
 
@@ -204,46 +204,73 @@ export class CheckpointService implements ICheckpointService {
 		service: DocumentLambda,
 		document: IDocument,
 	) {
-		let checkpoint;
-		let lastCheckpoint: IDeliState | IScribe;
+		let lastCheckpoint: IDeliState | IScribe | undefined;
 		let isLocalCheckpoint = false;
-		let localLogOffset;
-		let globalLogOffset;
-		let localSequenceNumber;
-		let globalSequenceNumber;
+		let localLogOffset: number | undefined;
+		let globalLogOffset: number | undefined;
+		let localSequenceNumber: number | undefined;
+		let globalSequenceNumber: number | undefined;
+		let checkpointSource = "notFound";
 
 		const restoreFromCheckpointMetric = Lumberjack.newLumberMetric(
 			LumberEventName.RestoreFromCheckpoint,
 		);
-		let checkpointSource = "defaultGlobalCollection";
+		const parseCheckpointString = (
+			checkpointString: string | undefined,
+		): IDeliState | IScribe | undefined =>
+			checkpointString ? JSON.parse(checkpointString) : undefined;
 
 		try {
 			if (!this.localCheckpointEnabled || !this.checkpointRepository) {
 				// If we cannot checkpoint locally, use document
-				lastCheckpoint = JSON.parse(document[service]);
+				lastCheckpoint = parseCheckpointString(document[service]);
 				globalLogOffset = lastCheckpoint.logOffset;
 				globalSequenceNumber = lastCheckpoint.sequenceNumber;
+				checkpointSource = "defaultGlobalCollection";
 			} else {
 				// Search checkpoints collection for checkpoint
-				try {
-					checkpoint = await this.checkpointRepository.getCheckpoint(
-						documentId,
-						tenantId,
+				const checkpoint: ICheckpoint | undefined = await this.checkpointRepository
+					.getCheckpoint(documentId, tenantId)
+					.catch((error) => {
+						Lumberjack.error(
+							`Error retrieving local checkpoint`,
+							getLumberBaseProperties(documentId, tenantId),
+						);
+						return undefined;
+					});
+
+				const localCheckpoint: IDeliState | IScribe | undefined = parseCheckpointString(
+					checkpoint?.[service],
+				);
+				const globalCheckpoint: IDeliState | IScribe | undefined = parseCheckpointString(
+					document[service],
+				);
+				localLogOffset = localCheckpoint?.logOffset;
+				globalLogOffset = globalCheckpoint?.logOffset;
+				localSequenceNumber = localCheckpoint?.sequenceNumber;
+				globalSequenceNumber = globalCheckpoint?.sequenceNumber;
+
+				if (localCheckpoint && !globalCheckpoint) {
+					// If checkpoint does not exist in document (global), use local
+					Lumberjack.info(
+						`Global checkpoint not found.`,
+						getLumberBaseProperties(documentId, tenantId),
 					);
-				} catch (error) {
-					checkpoint = undefined;
-					Lumberjack.error(
-						`Error retrieving local checkpoint`,
+					lastCheckpoint = localCheckpoint;
+					checkpointSource = "notFoundInGlobalCollection";
+					isLocalCheckpoint = true;
+				} else if (!localCheckpoint && globalCheckpoint) {
+					// If checkpoint does not exist in local, use document (global)
+					Lumberjack.info(
+						`Local checkpoint not found.`,
 						getLumberBaseProperties(documentId, tenantId),
 					);
 					checkpointSource = "notFoundInLocalCollection";
-				}
-
-				if (checkpoint?.[service]) {
-					const localCheckpoint: IDeliState | IScribe = JSON.parse(checkpoint[service]);
-					const globalCheckpoint: IDeliState | IScribe = JSON.parse(document[service]);
-
-					// Compare local and global checkpoints to use latest version
+					lastCheckpoint = globalCheckpoint;
+					isLocalCheckpoint = false;
+				} else if (localCheckpoint && globalCheckpoint) {
+					// If both checkpoints exist,
+					// compare local and global checkpoints to use latest version
 					if (localCheckpoint.sequenceNumber < globalCheckpoint.sequenceNumber) {
 						// if local checkpoint is behind global, use global
 						lastCheckpoint = globalCheckpoint;
@@ -254,20 +281,6 @@ export class CheckpointService implements ICheckpointService {
 						checkpointSource = "latestFoundInLocalCollection";
 						isLocalCheckpoint = true;
 					}
-					localLogOffset = localCheckpoint.logOffset;
-					globalLogOffset = globalCheckpoint.logOffset;
-					localSequenceNumber = localCheckpoint.sequenceNumber;
-					globalSequenceNumber = globalCheckpoint.sequenceNumber;
-				} else {
-					// If checkpoint does not exist, use document
-					Lumberjack.info(
-						`Local checkpoint not found.`,
-						getLumberBaseProperties(documentId, tenantId),
-					);
-					checkpointSource = "notFoundInLocalCollection";
-					lastCheckpoint = JSON.parse(document[service]);
-					globalLogOffset = lastCheckpoint.logOffset;
-					globalSequenceNumber = lastCheckpoint.sequenceNumber;
 				}
 			}
 			restoreFromCheckpointMetric.setProperties({


### PR DESCRIPTION
## Description

Continuing the work from #20150 to make sure we cover all the possible edge cases.

## Reviewer Guidance

The control flow in Scribe LambdaFactory was a bit confusing, so hopefully I didn't mess it up.
I understand the current control flow to be:

```
if (no global checkpoint)
  use Default checkpoint
elsif (global checkpoint was cleared or global checkpoint quorum was scrubbed)
  use Summary checkpoint
else
  use latest DB checkpoint (local or global)
```

My goal was to make the control flow behave as follows:

```
if (no global and no local checkpoint and no summary checkpoint)
  use Default checkpoint
elsif (
    global checkpoint was cleared and summary checkpoint ahead of local db checkpoint
    or latest DB checkpoint quorum was scrubbed
    or summary checkpoint ahead of latest DB checkpoint
  )
  use Summary checkpoint
else
  use latest DB checkpoint (local or global)
```
