### PR TITLE
Add bundle size tests for azure-client, odsp-client, and fluid-framework packages

### DIFF
--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -32,6 +32,7 @@
 	},
 	"dependencies": {
 		"@fluidframework/aqueduct": "workspace:~",
+		"@fluidframework/azure-client": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/container-runtime": "workspace:~",
 		"@fluidframework/container-runtime-definitions": "workspace:~",
@@ -40,6 +41,7 @@
 		"@fluidframework/odsp-driver": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@fluidframework/tree": "workspace:~",
+		"fluid-framework": "workspace:~",
 		"source-map-loader": "^2.0.0"
 	},
 	"devDependencies": {

--- a/examples/utils/bundle-size-tests/package.json
+++ b/examples/utils/bundle-size-tests/package.json
@@ -31,6 +31,7 @@
 		"webpack:profile": "npm run webpack"
 	},
 	"dependencies": {
+		"@fluid-experimental/odsp-client": "workspace:~",
 		"@fluidframework/aqueduct": "workspace:~",
 		"@fluidframework/azure-client": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",

--- a/examples/utils/bundle-size-tests/src/azureClient.ts
+++ b/examples/utils/bundle-size-tests/src/azureClient.ts
@@ -1,0 +1,10 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { AzureClient } from "@fluidframework/azure-client";
+
+export function apisToBundle() {
+	new AzureClient({} as any);
+}

--- a/examples/utils/bundle-size-tests/src/fluidFramework.ts
+++ b/examples/utils/bundle-size-tests/src/fluidFramework.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { SharedMap, SharedTree } from "fluid-framework";
+
+export function apisToBundle() {
+	SharedMap.getFactory();
+	SharedMap.create({} as any);
+	SharedTree.getFactory();
+}

--- a/examples/utils/bundle-size-tests/src/odspClient.ts
+++ b/examples/utils/bundle-size-tests/src/odspClient.ts
@@ -1,0 +1,10 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { OdspClient } from "@fluid-experimental/odsp-client";
+
+export function apisToBundle() {
+	new OdspClient({} as any);
+}

--- a/examples/utils/bundle-size-tests/webpack.config.cjs
+++ b/examples/utils/bundle-size-tests/webpack.config.cjs
@@ -69,8 +69,10 @@ webpackModuleRules.push(
 module.exports = {
 	entry: {
 		aqueduct: "./src/aqueduct",
+		azureClient: "./src/azureClient",
 		connectionState: "./src/connectionState",
 		containerRuntime: "./src/containerRuntime",
+		fluidFramework: "./src/fluidFramework",
 		loader: "./src/loader",
 		map: "./src/map",
 		matrix: "./src/matrix",

--- a/examples/utils/bundle-size-tests/webpack.config.cjs
+++ b/examples/utils/bundle-size-tests/webpack.config.cjs
@@ -76,6 +76,7 @@ module.exports = {
 		loader: "./src/loader",
 		map: "./src/map",
 		matrix: "./src/matrix",
+		odspClient: "./src/odspClient",
 		odspDriver: "./src/odspDriver",
 		odspPrefetchSnapshot: "./src/odspPrefetchSnapshot",
 		sharedString: "./src/sharedString",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2994,6 +2994,7 @@ importers:
       '@cerner/duplicate-package-checker-webpack-plugin': ~2.3.0
       '@fluid-tools/version-tools': ^0.34.0
       '@fluidframework/aqueduct': workspace:~
+      '@fluidframework/azure-client': workspace:~
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.34.0
       '@fluidframework/bundle-size-tools': ^0.34.0
@@ -3009,6 +3010,7 @@ importers:
       '@mixer/webpack-bundle-compare': ^0.1.0
       '@types/node': ^18.19.0
       eslint: ~8.55.0
+      fluid-framework: workspace:~
       prettier: ~3.0.3
       puppeteer: ^22.2.0
       rimraf: ^4.4.0
@@ -3021,6 +3023,7 @@ importers:
       webpack-cli: ^4.9.2
     dependencies:
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
+      '@fluidframework/azure-client': link:../../../packages/service-clients/azure-client
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader
       '@fluidframework/container-runtime': link:../../../packages/runtime/container-runtime
       '@fluidframework/container-runtime-definitions': link:../../../packages/runtime/container-runtime-definitions
@@ -3029,6 +3032,7 @@ importers:
       '@fluidframework/odsp-driver': link:../../../packages/drivers/odsp-driver
       '@fluidframework/sequence': link:../../../packages/dds/sequence
       '@fluidframework/tree': link:../../../packages/dds/tree
+      fluid-framework: link:../../../packages/framework/fluid-framework
       source-map-loader: 2.0.2_webpack@5.89.0
     devDependencies:
       '@biomejs/biome': 1.6.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2992,6 +2992,7 @@ importers:
     specifiers:
       '@biomejs/biome': ^1.6.1
       '@cerner/duplicate-package-checker-webpack-plugin': ~2.3.0
+      '@fluid-experimental/odsp-client': workspace:~
       '@fluid-tools/version-tools': ^0.34.0
       '@fluidframework/aqueduct': workspace:~
       '@fluidframework/azure-client': workspace:~
@@ -3022,6 +3023,7 @@ importers:
       webpack-bundle-analyzer: ^4.5.0
       webpack-cli: ^4.9.2
     dependencies:
+      '@fluid-experimental/odsp-client': link:../../../packages/service-clients/odsp-client
       '@fluidframework/aqueduct': link:../../../packages/framework/aqueduct
       '@fluidframework/azure-client': link:../../../packages/service-clients/azure-client
       '@fluidframework/container-loader': link:../../../packages/loader/container-loader


### PR DESCRIPTION
These are the packages directly consumed by customers, so it makes sense to monitor their bundle sizes directly.  The more-granular checks (e.g. containerRuntime, loader, etc.) still make sense to pin down where regressions are coming from, but we should also be keeping tabs on the direct metrics that customers will care about.