### PR TITLE
Port 120min Pipeline Timeout to rc1 branch

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -167,16 +167,16 @@ stages:
       - job: build
         displayName: Build
         ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-          timeoutInMinutes: 60
+          timeoutInMinutes: 120
         ${{ else }}:
           # CI builds run more aggressive compat configurations which can take longer.
           # See "FullCompat" under packages\test\test-version-utils\README.md for more details.
           # At the time of adding this comment, the full compat config is on the smaller side and so
-          # CI builds consistently pass with a 60 minutes timeout. However, it will naturally grow
+          # CI builds consistently pass with a 120 minutes timeout. However, it will naturally grow
           # over time and it might be necessary to bump it.
           # AB#6680 is also relevant here, which tracks rethinking how and where we run tests (likely with
           # a focus on e2e tests)
-          timeoutInMinutes: 60
+          timeoutInMinutes: 120
         pool: ${{ parameters.poolBuild }}
         variables:
           testCoverage: ${{ ne(variables['Build.Reason'], 'PullRequest') }}


### PR DESCRIPTION
Build Pipelines are timing out, blocking our ability to release. We recently bumped them up to 2 hrs in `main`, so no concerns doing so on this release branch as well.
