### PR TITLE
refactor(ci): Move to PublishCodeCoverageResults@2

### DIFF
--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -416,9 +416,7 @@ extends:
               - task: PublishCodeCoverageResults@2
                 displayName: Publish Code Coverage
                 inputs:
-                  codeCoverageTool: Cobertura
                   summaryFileLocation: '$(hostPathToTestResultsArtifact)/**/report/cobertura-coverage.xml'
-                  reportDirectory: '$(hostPathToTestResultsArtifact)/**/report'
                   failIfCoverageEmpty: true
                 condition: succeededOrFailed()
             # Test - No coverage

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -413,7 +413,7 @@ extends:
                   volumes:
                     $(hostPathToTestResultsArtifact):${{ parameters.containerBaseDir }}/nyc
 
-              - task: PublishCodeCoverageResults@1
+              - task: PublishCodeCoverageResults@2
                 displayName: Publish Code Coverage
                 inputs:
                   codeCoverageTool: Cobertura

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -398,9 +398,7 @@ extends:
                       - task: PublishCodeCoverageResults@2
                         displayName: Publish Code Coverage
                         inputs:
-                          codeCoverageTool: Cobertura
                           summaryFileLocation: ${{ parameters.buildDirectory }}/nyc/report/cobertura-coverage-patched.xml
-                          reportDirectory: ${{ parameters.buildDirectory }}/nyc/report
                           failIfCoverageEmpty: true
                         condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
 

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -395,7 +395,7 @@ extends:
                           script: |
                             sed -e 's/\(filename=\".*[\\/]external .*\)"\(.*\)""/\1\&quot;\2\&quot;"/' cobertura-coverage.xml > cobertura-coverage-patched.xml
                         condition: and(succeededOrFailed(), eq(variables['ReportDirExists'], 'true'))
-                      - task: PublishCodeCoverageResults@1
+                      - task: PublishCodeCoverageResults@2
                         displayName: Publish Code Coverage
                         inputs:
                           codeCoverageTool: Cobertura


### PR DESCRIPTION
## Description

Replace uses of v1 of the task with the new v2. I noticed a warning in the CI pipeline, where we run code coverage, that the v1 task is now deprecated ([example](https://dev.azure.com/fluidframework/internal/_build/results?buildId=249117&view=results) (msft internal), the first warning). [Here is the public announcement](https://devblogs.microsoft.com/devops/new-pccr-task/) guiding users to migrate to v2.

This example of using the v2 task seems to indicate that the removed properties are not necessary anymore; the task can auto-detect that the summary file is generated by a cobertura-compatible tool, and it seems like it generates an HTML report itself.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The report looks different in ADO ([example](https://dev.azure.com/fluidframework/internal/_build/results?buildId=249150&view=codecoverage-tab), msft internal) but I think still serves our purposes.
