### PR TITLE
Port: Relax asserts in AzureAudience and TinyliciousAudience to permit missing name field

### DIFF
--- a/packages/service-clients/azure-client/src/AzureAudience.ts
+++ b/packages/service-clients/azure-client/src/AzureAudience.ts
@@ -33,7 +33,8 @@ function assertIsAzureUser(user: IUser): asserts user is AzureUser<unknown> {
 	if (maybeAzureUser.id === undefined) {
 		throw new TypeError(`${baseMessage} Missing required "id" property.`);
 	}
-	if (maybeAzureUser.name === undefined) {
-		throw new TypeError(`${baseMessage} Missing required "name" property.`);
-	}
+	// AB#7448 to reenable this check.  Disabling to mitigate a bug that the name may be missing.
+	// if (maybeAzureUser.name === undefined) {
+	// 	throw new TypeError(`${baseMessage} Missing required "name" property.`);
+	// }
 }

--- a/packages/service-clients/tinylicious-client/src/TinyliciousAudience.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousAudience.ts
@@ -16,16 +16,22 @@ import { type TinyliciousMember, type TinyliciousUser } from "./interfaces.js";
  */
 export function createTinyliciousAudienceMember(audienceMember: IClient): TinyliciousMember {
 	const tinyliciousUser = audienceMember.user as Partial<TinyliciousUser>;
+	// AB#7448 to reenable this stronger check.  Relaxing to mitigate a bug that the name may be missing.
+	// assert(
+	// 	tinyliciousUser !== undefined &&
+	// 		typeof tinyliciousUser.id === "string" &&
+	// 		typeof tinyliciousUser.name === "string",
+	// 	0x313 /* Specified user was not of type "TinyliciousUser". */,
+	// );
 	assert(
-		tinyliciousUser !== undefined &&
-			typeof tinyliciousUser.id === "string" &&
-			typeof tinyliciousUser.name === "string",
+		tinyliciousUser !== undefined && typeof tinyliciousUser.id === "string",
 		0x313 /* Specified user was not of type "TinyliciousUser". */,
 	);
 
 	return {
 		userId: tinyliciousUser.id,
-		userName: tinyliciousUser.name,
+		// AB#7448 to remove this cast after the check above is strengthened again.
+		userName: tinyliciousUser.name as string,
 		connections: [],
 	};
 }


### PR DESCRIPTION
Porting https://github.com/microsoft/FluidFramework/pull/20131 to rc2.0.0 in order to address the issue of the missing 'name' field.