### PR TITLE
refactor: Update dev dep on package 'start-server-and-test'

### DIFF
--- a/azure/packages/test/scenario-runner/package.json
+++ b/azure/packages/test/scenario-runner/package.json
@@ -87,7 +87,7 @@
 		"js-yaml": "^4.1.0",
 		"mocha": "^10.2.0",
 		"sinon": "^17.0.1",
-		"start-server-and-test": "^1.11.7",
+		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^4.0.0",
 		"uuid": "^9.0.0"
 	},

--- a/examples/benchmarks/tablebench/package.json
+++ b/examples/benchmarks/tablebench/package.json
@@ -75,7 +75,7 @@
 		"moment": "^2.21.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
-		"start-server-and-test": "^1.11.7",
+		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^4.0.0",
 		"ts-loader": "^9.3.0",
 		"typescript": "~5.1.6",

--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -78,7 +78,7 @@
 		"jest-junit": "^10.0.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
-		"start-server-and-test": "^1.11.7",
+		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^4.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/external-data/package.json
+++ b/examples/external-data/package.json
@@ -111,7 +111,7 @@
 		"process": "^0.11.10",
 		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
-		"start-server-and-test": "^1.11.7",
+		"start-server-and-test": "^2.0.3",
 		"stream-http": "^3.2.0",
 		"supertest": "^3.4.2",
 		"tinylicious": "^4.0.0",

--- a/examples/service-clients/azure-client/external-controller/package.json
+++ b/examples/service-clients/azure-client/external-controller/package.json
@@ -81,7 +81,7 @@
 		"process": "^0.11.10",
 		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
-		"start-server-and-test": "^1.11.7",
+		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^4.0.0",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",

--- a/examples/version-migration/tree-shim/package.json
+++ b/examples/version-migration/tree-shim/package.json
@@ -83,7 +83,7 @@
 		"process": "^0.11.10",
 		"puppeteer": "^22.2.0",
 		"rimraf": "^4.4.0",
-		"start-server-and-test": "^1.11.7",
+		"start-server-and-test": "^2.0.3",
 		"style-loader": "^1.0.0",
 		"tinylicious": "^4.0.0",
 		"ts-jest": "^29.1.1",

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -140,7 +140,7 @@
 		"mocha": "^10.2.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
-		"start-server-and-test": "^1.11.7",
+		"start-server-and-test": "^2.0.3",
 		"typescript": "~5.1.6",
 		"uuid": "^9.0.0"
 	},

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -77,7 +77,7 @@
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.21.0",
 		"sinon": "^17.0.1",
-		"start-server-and-test": "^1.11.7",
+		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^4.0.0",
 		"uuid": "^9.0.0"
 	},

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -115,7 +115,7 @@
 		"mocha": "^10.2.0",
 		"prettier": "~3.0.3",
 		"rimraf": "^4.4.0",
-		"start-server-and-test": "^1.11.7",
+		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^4.0.0",
 		"typescript": "~5.1.6"
 	},

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -125,7 +125,7 @@
 		"mocha": "^10.2.0",
 		"semver": "^7.5.3",
 		"sinon": "^17.0.1",
-		"start-server-and-test": "^1.11.7",
+		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^4.0.0",
 		"uuid": "^9.0.0"
 	},

--- a/packages/test/test-service-load/package.json
+++ b/packages/test/test-service-load/package.json
@@ -102,7 +102,7 @@
 		"@fluidframework/tool-utils": "workspace:~",
 		"commander": "^5.1.0",
 		"ps-node": "^0.1.6",
-		"start-server-and-test": "^1.11.7",
+		"start-server-and-test": "^2.0.3",
 		"tinylicious": "^4.0.0"
 	},
 	"devDependencies": {

--- a/packages/tools/devtools/devtools-browser-extension/package.json
+++ b/packages/tools/devtools/devtools-browser-extension/package.json
@@ -137,7 +137,6 @@
 		"rimraf": "^4.4.0",
 		"sinon": "^17.0.1",
 		"sinon-chrome": "^3.0.1",
-		"start-server-and-test": "^1.11.7",
 		"ts-jest": "^29.1.1",
 		"ts-loader": "^9.3.0",
 		"typescript": "~5.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,7 @@ importers:
       prettier: ~3.0.3
       rimraf: ^4.4.0
       sinon: ^17.0.1
-      start-server-and-test: ^1.11.7
+      start-server-and-test: ^2.0.3
       tinylicious: ^4.0.0
       typescript: ~5.1.6
       uuid: ^9.0.0
@@ -212,7 +212,7 @@ importers:
       js-yaml: 4.1.0
       mocha: 10.2.0
       sinon: 17.0.1
-      start-server-and-test: 1.15.5
+      start-server-and-test: 2.0.3
       tinylicious: 4.0.0
       uuid: 9.0.1
     devDependencies:
@@ -1347,7 +1347,7 @@ importers:
       moment: ^2.21.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
-      start-server-and-test: ^1.11.7
+      start-server-and-test: ^2.0.3
       tinylicious: ^4.0.0
       ts-loader: ^9.3.0
       typescript: ~5.1.6
@@ -1382,7 +1382,7 @@ importers:
       moment: 2.29.4
       prettier: 3.0.3
       rimraf: 4.4.1
-      start-server-and-test: 1.15.5
+      start-server-and-test: 2.0.3
       tinylicious: 4.0.0
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
       typescript: 5.1.6
@@ -1429,7 +1429,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
-      start-server-and-test: ^1.11.7
+      start-server-and-test: ^2.0.3
       tinylicious: ^4.0.0
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
@@ -1477,7 +1477,7 @@ importers:
       jest-junit: 10.0.0
       prettier: 3.0.3
       rimraf: 4.4.1
-      start-server-and-test: 1.15.5
+      start-server-and-test: 2.0.3
       tinylicious: 4.0.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -2739,7 +2739,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
-      start-server-and-test: ^1.11.7
+      start-server-and-test: ^2.0.3
       stream-http: ^3.2.0
       style-loader: ^1.0.0
       supertest: ^3.4.2
@@ -2814,7 +2814,7 @@ importers:
       process: 0.11.10
       puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
-      start-server-and-test: 1.15.5
+      start-server-and-test: 2.0.3
       stream-http: 3.2.0
       supertest: 3.4.2
       tinylicious: 4.0.0
@@ -2865,7 +2865,7 @@ importers:
       process: ^0.11.10
       puppeteer: ^22.2.0
       rimraf: ^4.4.0
-      start-server-and-test: ^1.11.7
+      start-server-and-test: ^2.0.3
       tinylicious: ^4.0.0
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
@@ -2915,7 +2915,7 @@ importers:
       process: 0.11.10
       puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
-      start-server-and-test: 1.15.5
+      start-server-and-test: 2.0.3
       tinylicious: 4.0.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
@@ -3628,7 +3628,7 @@ importers:
       react: ^17.0.1
       react-dom: ^17.0.1
       rimraf: ^4.4.0
-      start-server-and-test: ^1.11.7
+      start-server-and-test: ^2.0.3
       style-loader: ^1.0.0
       tiny-typed-emitter: ^2.1.0
       tinylicious: ^4.0.0
@@ -3686,7 +3686,7 @@ importers:
       process: 0.11.10
       puppeteer: 22.2.0_typescript@5.1.6
       rimraf: 4.4.1
-      start-server-and-test: 1.15.5
+      start-server-and-test: 2.0.3
       style-loader: 1.3.0_webpack@5.89.0
       tinylicious: 4.0.0
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
@@ -9027,7 +9027,7 @@ importers:
       mocha: ^10.2.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
-      start-server-and-test: ^1.11.7
+      start-server-and-test: ^2.0.3
       typescript: ~5.1.6
       uuid: ^9.0.0
     dependencies:
@@ -9068,7 +9068,7 @@ importers:
       mocha: 10.2.0
       prettier: 3.0.3
       rimraf: 4.4.1
-      start-server-and-test: 1.15.5
+      start-server-and-test: 2.0.3
       typescript: 5.1.6
       uuid: 9.0.1
 
@@ -9108,7 +9108,7 @@ importers:
       prettier: ~3.0.3
       rimraf: ^4.4.0
       sinon: ^17.0.1
-      start-server-and-test: ^1.11.7
+      start-server-and-test: ^2.0.3
       tinylicious: ^4.0.0
       typescript: ~5.1.6
       uuid: ^9.0.0
@@ -9133,7 +9133,7 @@ importers:
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
       moment: 2.29.4
       sinon: 17.0.1
-      start-server-and-test: 1.15.5
+      start-server-and-test: 2.0.3
       tinylicious: 4.0.0
       uuid: 9.0.1
     devDependencies:
@@ -9337,7 +9337,7 @@ importers:
       mocha: ^10.2.0
       prettier: ~3.0.3
       rimraf: ^4.4.0
-      start-server-and-test: ^1.11.7
+      start-server-and-test: ^2.0.3
       tinylicious: ^4.0.0
       typescript: ~5.1.6
     dependencies:
@@ -9374,7 +9374,7 @@ importers:
       mocha: 10.2.0
       prettier: 3.0.3
       rimraf: 4.4.1
-      start-server-and-test: 1.15.5
+      start-server-and-test: 2.0.3
       tinylicious: 4.0.0
       typescript: 5.1.6
 
@@ -9978,7 +9978,7 @@ importers:
       rimraf: ^4.4.0
       semver: ^7.5.3
       sinon: ^17.0.1
-      start-server-and-test: ^1.11.7
+      start-server-and-test: ^2.0.3
       tinylicious: ^4.0.0
       typescript: ~5.1.6
       uuid: ^9.0.0
@@ -10032,7 +10032,7 @@ importers:
       mocha: 10.2.0
       semver: 7.5.4
       sinon: 17.0.1
-      start-server-and-test: 1.15.5
+      start-server-and-test: 2.0.3
       tinylicious: 4.0.0
       uuid: 9.0.1
     devDependencies:
@@ -10139,7 +10139,7 @@ importers:
       prettier: ~3.0.3
       ps-node: ^0.1.6
       rimraf: ^4.4.0
-      start-server-and-test: ^1.11.7
+      start-server-and-test: ^2.0.3
       tinylicious: ^4.0.0
       typescript: ~5.1.6
     dependencies:
@@ -10168,7 +10168,7 @@ importers:
       '@fluidframework/tool-utils': link:../../utils/tool-utils
       commander: 5.1.0
       ps-node: 0.1.6
-      start-server-and-test: 1.15.5
+      start-server-and-test: 2.0.3
       tinylicious: 4.0.0
     devDependencies:
       '@biomejs/biome': 1.6.2
@@ -10544,7 +10544,6 @@ importers:
       rimraf: ^4.4.0
       sinon: ^17.0.1
       sinon-chrome: ^3.0.1
-      start-server-and-test: ^1.11.7
       ts-jest: ^29.1.1
       ts-loader: ^9.3.0
       tslib: ^1.10.0
@@ -10620,7 +10619,6 @@ importers:
       rimraf: 4.4.1
       sinon: 17.0.1
       sinon-chrome: 3.0.1
-      start-server-and-test: 1.15.5
       ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
       ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
       typescript: 5.1.6
@@ -23988,14 +23986,6 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: true
-
-  /axios/0.27.2_debug@4.3.4:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-    dependencies:
-      follow-redirects: 1.15.3_debug@4.3.4
-      form-data: 4.0.0
-    transitivePeerDependencies:
-      - debug
 
   /axios/1.6.2:
     resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
@@ -40484,10 +40474,9 @@ packages:
   /standard-as-callback/2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
-  /start-server-and-test/1.15.5:
-    resolution: {integrity: sha512-o3EmkX0++GV+qsvIJ/OKWm3w91fD8uS/bPQVPrh/7loaxkpXSuAIHdnmN/P/regQK9eNAK76aBJcHt+OSTk+nA==}
-    engines: {node: '>=6'}
-    deprecated: this package has been deprecated
+  /start-server-and-test/2.0.3:
+    resolution: {integrity: sha512-QsVObjfjFZKJE6CS6bSKNwWZCKBG6975/jKRPPGFfFh+yOQglSeGXiNWjzgQNXdphcBI9nXbyso9tPfX4YAUhg==}
+    engines: {node: '>=16'}
     hasBin: true
     dependencies:
       arg: 5.0.2
@@ -40497,7 +40486,7 @@ packages:
       execa: 5.1.1
       lazy-ass: 1.6.0
       ps-tree: 1.2.0
-      wait-on: 7.0.1_debug@4.3.4
+      wait-on: 7.2.0_debug@4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -43025,19 +43014,6 @@ packages:
       xml-name-validator: 4.0.0
     dev: true
 
-  /wait-on/7.0.1_debug@4.3.4:
-    resolution: {integrity: sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
-    dependencies:
-      axios: 0.27.2_debug@4.3.4
-      joi: 17.12.2
-      lodash: 4.17.21
-      minimist: 1.2.8
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - debug
-
   /wait-on/7.2.0:
     resolution: {integrity: sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==}
     engines: {node: '>=12.0.0'}
@@ -43051,6 +43027,19 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: true
+
+  /wait-on/7.2.0_debug@4.3.4:
+    resolution: {integrity: sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    dependencies:
+      axios: 1.6.2_debug@4.3.4
+      joi: 17.12.2
+      lodash: 4.17.21
+      minimist: 1.2.8
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - debug
 
   /walk-up-path/1.0.0:
     resolution: {integrity: sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==}


### PR DESCRIPTION
## Description

Updates dev dependency on `start-server-and-test` to latest major, which includes transitive dep updates to stop using vulnerable versions of `axios`.

There was technically [a breaking change between v1 and v2](https://www.npmjs.com/package/start-server-and-test#v1-to-v2), but it seems to affect a usage pattern we don't use. I smoke tested one of the packages' scripts that use `start-server-and-test` and things still worked.

Also removes the dependency in devtools-browser-extension, which didn't use it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
