### PR TITLE
refactor: Update dev dep on webpack-dev-middleware

### DIFF
--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/package.json
@@ -54,7 +54,6 @@
 		"@types/express": "^4.11.0",
 		"@types/fs-extra": "^9.0.11",
 		"@types/node": "^18.19.0",
-		"@types/webpack-dev-middleware": "^5.3.0",
 		"@types/webpack-hot-middleware": "^2.25.9",
 		"buffer": "^6.0.3",
 		"c8": "^8.0.1",
@@ -69,7 +68,7 @@
 		"typescript": "~5.1.6",
 		"webpack": "^5.82.0",
 		"webpack-cli": "^4.9.2",
-		"webpack-dev-middleware": "^5.3.3",
+		"webpack-dev-middleware": "^7.1.1",
 		"webpack-hot-middleware": "^2.25.3",
 		"webpack-merge": "^5.8.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1262,7 +1262,6 @@ importers:
       '@types/express': ^4.11.0
       '@types/fs-extra': ^9.0.11
       '@types/node': ^18.19.0
-      '@types/webpack-dev-middleware': ^5.3.0
       '@types/webpack-hot-middleware': ^2.25.9
       buffer: ^6.0.3
       c8: ^8.0.1
@@ -1278,7 +1277,7 @@ importers:
       typescript: ~5.1.6
       webpack: ^5.82.0
       webpack-cli: ^4.9.2
-      webpack-dev-middleware: ^5.3.3
+      webpack-dev-middleware: ^7.1.1
       webpack-dev-server: ~4.15.1
       webpack-hot-middleware: ^2.25.3
       webpack-merge: ^5.8.0
@@ -1301,7 +1300,6 @@ importers:
       '@types/express': 4.17.21
       '@types/fs-extra': 9.0.13
       '@types/node': 18.19.1
-      '@types/webpack-dev-middleware': 5.3.0_webpack@5.89.0
       '@types/webpack-hot-middleware': 2.25.9_webpack-cli@4.10.0
       buffer: 6.0.3
       c8: 8.0.1
@@ -1316,7 +1314,7 @@ importers:
       typescript: 5.1.6
       webpack: 5.89.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_4fnl6fxs65yjb57cbmzmmxikci
-      webpack-dev-middleware: 5.3.3_webpack@5.89.0
+      webpack-dev-middleware: 7.1.1_webpack@5.89.0
       webpack-hot-middleware: 2.25.4
       webpack-merge: 5.10.0
 
@@ -22318,15 +22316,6 @@ packages:
       '@types/node': 18.19.1
     dev: true
 
-  /@types/webpack-dev-middleware/5.3.0_webpack@5.89.0:
-    resolution: {integrity: sha512-SklLlklFBfTyIXo1iWXxzeytjlysWfj5QfIcRJrCc7MgzuCjnZOHXviQwe81iFGq9ZkCUXAg2fpbZdHhj5lSWA==}
-    deprecated: This is a stub types definition. webpack-dev-middleware provides its own type definitions, so you do not need this installed.
-    dependencies:
-      webpack-dev-middleware: 5.3.3_webpack@5.89.0
-    transitivePeerDependencies:
-      - webpack
-    dev: true
-
   /@types/webpack-env/1.18.4:
     resolution: {integrity: sha512-I6e+9+HtWADAWeeJWDFQtdk4EVSAbj6Rtz4q8fJ7mSr1M0jzlFcs8/HZ+Xb5SHzVm1dxH7aUiI+A8kA8Gcrm0A==}
     dev: true
@@ -34574,6 +34563,13 @@ packages:
     dependencies:
       fs-monkey: 1.0.5
 
+  /memfs/4.8.0:
+    resolution: {integrity: sha512-fcs7trFxZlOMadmTw5nyfOwS3il9pr3y+6xzLfXNwmuR/D0i4wz6rJURxArAbcJDGalbpbMvQ/IFI0NojRZgRg==}
+    engines: {node: '>= 4.0.0'}
+    dependencies:
+      tslib: 2.6.2
+    dev: true
+
   /memoize-one/5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
     dev: false
@@ -43328,20 +43324,6 @@ packages:
       webpack: 5.89.0_webpack-cli@4.10.0
     dev: true
 
-  /webpack-dev-middleware/5.3.3_webpack@5.89.0:
-    resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
-    engines: {node: '>= 12.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0 || ^5.82.0
-    dependencies:
-      colorette: 2.0.20
-      memfs: 3.5.3
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.2.0
-      webpack: 5.89.0_webpack-cli@4.10.0
-    dev: true
-
   /webpack-dev-middleware/5.3.4_webpack@5.89.0:
     resolution: {integrity: sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==}
     engines: {node: '>= 12.13.0'}
@@ -43354,6 +43336,24 @@ packages:
       range-parser: 1.2.1
       schema-utils: 4.2.0
       webpack: 5.89.0_webpack-cli@4.10.0
+
+  /webpack-dev-middleware/7.1.1_webpack@5.89.0:
+    resolution: {integrity: sha512-NmRVq4AvRQs66dFWyDR4GsFDJggtSi2Yn38MXLk0nffgF9n/AIP4TFBg2TQKYaRAN4sHuKOTiz9BnNCENDLEVA==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      webpack: ^5.0.0 || ^5.82.0
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+    dependencies:
+      colorette: 2.0.20
+      memfs: 4.8.0
+      mime-types: 2.1.35
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      schema-utils: 4.2.0
+      webpack: 5.89.0_webpack-cli@4.10.0
+    dev: true
 
   /webpack-dev-server/4.15.2_rd5rsqvehm425nt6upzhjh73je:
     resolution: {integrity: sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==}


### PR DESCRIPTION
## Description

Update version of direct dependency on webpack-dev-middleware and removes dep on its @types package which [says it is not necessary](https://www.npmjs.com/package/@types/webpack-dev-middleware).

Addresses https://nvd.nist.gov/vuln/detail/CVE-2024-29180.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#7536](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7536)