### PR TITLE
build(test-snapshots): Build both ESM and CJS with node16 moduleResolution

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -205,11 +205,13 @@ module.exports = {
 			],
 			"fluid-build-tasks-eslint": [
 				// eslint doesn't really depend on build. Doing so just slows down a package build.
+				"^packages/test/snapshots/package.json",
 				"^packages/test/test-utils/package.json",
 			],
 			"fluid-build-tasks-tsc": [
 				// TODO: AB#7460 fix tsconfig reference path match on Windows
 				"^packages/tools/devtools/devtools-view/package.json",
+				"^packages/test/snapshots/package.json",
 			],
 			"html-copyright-file-header": [
 				// Tests generate HTML "snapshot" artifacts

--- a/packages/test/snapshots/.npmignore
+++ b/packages/test/snapshots/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -12,8 +12,8 @@
 	"license": "MIT",
 	"author": "Microsoft and contributors",
 	"sideEffects": false,
-	"main": "dist/generateSnapshotFiles.js",
-	"types": "dist/generateSnapshotFiles.js",
+	"type": "module",
+	"main": "lib/generateSnapshotFiles.js",
 	"scripts": {
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
@@ -31,11 +31,11 @@
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
-		"test:mocha": "mocha --experimental-worker --ignore \"dist/test/generate/*\" dist/test",
+		"test:mocha": "mocha --experimental-worker --ignore \"lib/test/generate/*\" lib/test",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
-		"test:new": "mocha --experimental-worker \"dist/test/generate/new.spec.*js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
-		"test:update": "mocha --experimental-worker \"dist/test/generate/update.spec.*js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
-		"tsc": "tsc"
+		"test:new": "mocha --experimental-worker \"lib/test/generate/new.spec.*js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
+		"test:update": "mocha --experimental-worker \"lib/test/generate/update.spec.*js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
+		"build:esnext": "tsc --project tsconfig.json"
 	},
 	"c8": {
 		"all": true,

--- a/packages/test/snapshots/package.json
+++ b/packages/test/snapshots/package.json
@@ -17,8 +17,11 @@
 	"scripts": {
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
+		"build:esnext": "tsc --project tsconfig.json",
 		"build:genver": "gen-version",
-		"build:test": "tsc --project ./src/test/tsconfig.json",
+		"build:test": "npm run build:test:esm && npm run build:test:cjs",
+		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
+		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
 		"check:biome": "biome check .",
 		"check:prettier": "prettier --check . --cache --ignore-path ../../../.prettierignore",
 		"clean": "rimraf --glob dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
@@ -31,23 +34,25 @@
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
-		"test:mocha": "mocha --experimental-worker --ignore \"lib/test/generate/*\" lib/test",
+		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
+		"test:mocha:cjs": "mocha --ignore \"dist/test/generate/*\" dist/test",
+		"test:mocha:esm": "mocha --ignore \"lib/test/generate/*\" lib/test",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"test:new": "mocha --experimental-worker \"lib/test/generate/new.spec.*js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
 		"test:update": "mocha --experimental-worker \"lib/test/generate/update.spec.*js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
-		"build:esnext": "tsc --project tsconfig.json"
+		"tsc": "fluid-tsc commonjs --project ./tsconfig.cjs.json"
 	},
 	"c8": {
 		"all": true,
 		"cache-dir": "nyc/.cache",
 		"exclude": [
 			"src/test/**/*.*ts",
-			"dist/test/**/*.*js"
+			"lib/test/**/*.*js"
 		],
 		"exclude-after-remap": false,
 		"include": [
 			"src/**/*.*ts",
-			"dist/**/*.*js"
+			"lib/**/*.*js"
 		],
 		"report-dir": "nyc/report",
 		"reporter": [

--- a/packages/test/snapshots/src/dirname.cts
+++ b/packages/test/snapshots/src/dirname.cts
@@ -1,0 +1,13 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Problem:
+//   - `__dirname` is not defined in ESM
+//   - `import.meta.url` is not defined in CJS
+// Solution:
+//   - Export '__dirname' from a .cjs file in the same directory.
+//
+// Note that *.cjs files are always CommonJS, but can be imported from ESM.
+export const _dirname = __dirname;

--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -19,7 +19,7 @@ import { validateSnapshots } from "./validateSnapshots.js";
 function getFileLocations(): [string, string] {
 	// Correct if executing from working directory of package root
 	const testCollateral = getTestContent("snapshotTestContent");
-	let workerPath = "./dist/replayWorker.js";
+	let workerPath = "./lib/replayWorker.js";
 	if (fs.existsSync(workerPath) && testCollateral.exists) {
 		return [testCollateral.path, workerPath];
 	}

--- a/packages/test/snapshots/src/replayMultipleFiles.ts
+++ b/packages/test/snapshots/src/replayMultipleFiles.ts
@@ -9,10 +9,11 @@ import nodePath from "path";
 import { ReplayArgs, ReplayTool } from "@fluid-internal/replay-tool";
 import { Deferred } from "@fluidframework/core-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
-import { getMetadata, writeMetadataFile } from "./metadata";
-import { pkgVersion } from "./packageVersion";
-import { getTestContent } from "./testContent";
-import { validateSnapshots } from "./validateSnapshots";
+import { _dirname } from "./dirname.cjs";
+import { getMetadata, writeMetadataFile } from "./metadata.js";
+import { pkgVersion } from "./packageVersion.js";
+import { getTestContent } from "./testContent.js";
+import { validateSnapshots } from "./validateSnapshots.js";
 
 // Determine relative file locations
 function getFileLocations(): [string, string] {
@@ -23,7 +24,7 @@ function getFileLocations(): [string, string] {
 		return [testCollateral.path, workerPath];
 	}
 	// Relative to this generated js file being executed
-	workerPath = nodePath.join(__dirname, "..", workerPath);
+	workerPath = nodePath.join(_dirname, "..", workerPath);
 	assert(
 		fs.existsSync(workerPath),
 		`Cannot find worker js or test content file: ${workerPath}, ${testCollateral.path}`,

--- a/packages/test/snapshots/src/replayWorker.ts
+++ b/packages/test/snapshots/src/replayWorker.ts
@@ -4,7 +4,7 @@
  */
 
 import threads from "worker_threads";
-import { IWorkerArgs, processOneNode } from "./replayMultipleFiles";
+import { IWorkerArgs, processOneNode } from "./replayMultipleFiles.js";
 
 const data = threads.workerData as IWorkerArgs;
 processOneNode(data)

--- a/packages/test/snapshots/src/test/generate/new.spec.ts
+++ b/packages/test/snapshots/src/test/generate/new.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Mode, processContent } from "../../replayMultipleFiles";
+import { Mode, processContent } from "../../replayMultipleFiles.js";
 
 describe("Create snapshots", function () {
 	this.timeout(300000);

--- a/packages/test/snapshots/src/test/generate/update.spec.ts
+++ b/packages/test/snapshots/src/test/generate/update.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Mode, processContent } from "../../replayMultipleFiles";
+import { Mode, processContent } from "../../replayMultipleFiles.js";
 
 describe("Update snapshots", function () {
 	this.timeout(300000);

--- a/packages/test/snapshots/src/test/replay.spec.ts
+++ b/packages/test/snapshots/src/test/replay.spec.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { Mode, processContent } from "../replayMultipleFiles";
-import { getTestContent, skipOrFailIfTestContentMissing } from "../testContent";
+import { Mode, processContent } from "../replayMultipleFiles.js";
+import { getTestContent, skipOrFailIfTestContentMissing } from "../testContent.js";
 
 describe("Snapshots", function () {
 	this.timeout(300000);

--- a/packages/test/snapshots/src/test/serialized.spec.ts
+++ b/packages/test/snapshots/src/test/serialized.spec.ts
@@ -23,7 +23,7 @@ import {
 	TestFluidObject,
 	TestFluidObjectFactory,
 } from "@fluidframework/test-utils";
-import { getTestContent, skipOrFailIfTestContentMissing } from "../testContent";
+import { getTestContent, skipOrFailIfTestContentMissing } from "../testContent.js";
 
 describe(`Container Serialization Backwards Compatibility`, () => {
 	const loaderContainerTracker = new LoaderContainerTracker();

--- a/packages/test/snapshots/src/test/tsconfig.cjs.json
+++ b/packages/test/snapshots/src/test/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use fluid-tsc commonjs.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/test",
+	},
+	"references": [
+		{
+			"path": "../../tsconfig.cjs.json",
+		},
+	],
+}

--- a/packages/test/snapshots/src/test/tsconfig.json
+++ b/packages/test/snapshots/src/test/tsconfig.json
@@ -1,14 +1,14 @@
 {
-	"extends": ["../../../../../common/build/build-common/tsconfig.test.json"],
+	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../../lib/test",
+		"types": ["mocha", "node"],
+	},
 	"include": ["./**/*"],
 	"references": [
 		{
 			"path": "../..",
 		},
 	],
-	"compilerOptions": {
-		"rootDir": "./",
-		"outDir": "../../dist/test",
-		"types": ["node", "mocha"],
-	},
 }

--- a/packages/test/snapshots/src/test/tsconfig.json
+++ b/packages/test/snapshots/src/test/tsconfig.json
@@ -8,7 +8,7 @@
 	"include": ["./**/*"],
 	"references": [
 		{
-			"path": "../..",
+			"path": "../../tsconfig.json",
 		},
 	],
 }

--- a/packages/test/snapshots/src/testContent.ts
+++ b/packages/test/snapshots/src/testContent.ts
@@ -6,6 +6,7 @@
 import fs from "fs";
 import nodePath from "path";
 import * as Mocha from "mocha";
+import { _dirname } from "./dirname.cjs";
 
 export interface TestContent {
 	exists: boolean;
@@ -22,7 +23,7 @@ export function getTestContent(subPath?: string): TestContent {
 		};
 	}
 	// Relative to this generated js file being executed
-	path = nodePath.join(__dirname, "..", path);
+	path = nodePath.join(_dirname, "..", path);
 	if (fs.existsSync(path)) {
 		return {
 			exists: true,

--- a/packages/test/snapshots/src/validateSnapshots.ts
+++ b/packages/test/snapshots/src/validateSnapshots.ts
@@ -15,7 +15,7 @@ import { assert } from "@fluidframework/core-utils";
 import { FileStorageDocumentName } from "@fluidframework/file-driver";
 import { ISequencedDocumentMessage, TreeEntry } from "@fluidframework/protocol-definitions";
 import { IFileSnapshot, StaticStorageDocumentServiceFactory } from "@fluidframework/replay-driver";
-import { SnapshotStorageService } from "./snapshotStorageService";
+import { SnapshotStorageService } from "./snapshotStorageService.js";
 
 const metadataBlobName = ".metadata";
 

--- a/packages/test/snapshots/tsconfig.cjs.json
+++ b/packages/test/snapshots/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use fluid-tsc commonjs.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+	},
+}

--- a/packages/test/snapshots/tsconfig.json
+++ b/packages/test/snapshots/tsconfig.json
@@ -1,14 +1,13 @@
 {
-	"extends": [
-		"../../../common/build/build-common/tsconfig.base.json",
-		"../../../common/build/build-common/tsconfig.cjs.json",
-	],
+	"extends": "../../../common/build/build-common/tsconfig.node16.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
-		"strict": false,
 		"rootDir": "./src",
-		"outDir": "./dist",
+		"outDir": "./lib",
 		"types": ["node"],
+
+		// TODO: this should be updated to use strict mode ASAP
+		"strict": false,
 	},
 }


### PR DESCRIPTION
Updates test-snapshots to build ESM-first, then CJS.

Notable changes:

- CJS tests are skipped in CI.
- ts2esm updated all imports to use extensions.
- __dirname usage replaced by dirname.cts.
- I had to exclude the package from some policies around tsc and esnext scripts. I think these are false positives that Jason fixed in the latest build-tools, so I added exclusions.