### PR TITLE
Edit that keeps being generated on clean build

### DIFF
--- a/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
+++ b/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
@@ -48,6 +48,30 @@ use_old_InterfaceDeclaration_ContainerDevtoolsProps(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ContainerKey": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_ContainerKey():
+    TypeOnly<old.ContainerKey>;
+declare function use_current_TypeAliasDeclaration_ContainerKey(
+    use: TypeOnly<current.ContainerKey>): void;
+use_current_TypeAliasDeclaration_ContainerKey(
+    get_old_TypeAliasDeclaration_ContainerKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_ContainerKey": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_ContainerKey():
+    TypeOnly<current.ContainerKey>;
+declare function use_old_TypeAliasDeclaration_ContainerKey(
+    use: TypeOnly<old.ContainerKey>): void;
+use_old_TypeAliasDeclaration_ContainerKey(
+    get_current_TypeAliasDeclaration_ContainerKey());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_DevtoolsProps": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_DevtoolsProps():
@@ -68,6 +92,30 @@ declare function use_old_InterfaceDeclaration_DevtoolsProps(
     use: TypeOnly<old.DevtoolsProps>): void;
 use_old_InterfaceDeclaration_DevtoolsProps(
     get_current_InterfaceDeclaration_DevtoolsProps());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_HasContainerKey": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_HasContainerKey():
+    TypeOnly<old.HasContainerKey>;
+declare function use_current_InterfaceDeclaration_HasContainerKey(
+    use: TypeOnly<current.HasContainerKey>): void;
+use_current_InterfaceDeclaration_HasContainerKey(
+    get_old_InterfaceDeclaration_HasContainerKey());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_HasContainerKey": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_HasContainerKey():
+    TypeOnly<current.HasContainerKey>;
+declare function use_old_InterfaceDeclaration_HasContainerKey(
+    use: TypeOnly<old.HasContainerKey>): void;
+use_old_InterfaceDeclaration_HasContainerKey(
+    get_current_InterfaceDeclaration_HasContainerKey());
 
 /*
 * Validate forward compat by using old type in place of current type


### PR DESCRIPTION
These symbols keep getting generated on clean fork:
- get_old_TypeAliasDeclaration_ContainerKey
- get_current_TypeAliasDeclaration_ContainerKey
- get_old_InterfaceDeclaration_HasContainerKey
- get_current_InterfaceDeclaration_HasContainerKey