### PR TITLE
Lint against import of @fluidframework/datastore in e2e tests

### DIFF
--- a/packages/test/test-end-to-end-tests/.eslintrc.cjs
+++ b/packages/test/test-end-to-end-tests/.eslintrc.cjs
@@ -30,6 +30,7 @@ module.exports = {
 					"@fluidframework/sequence",
 					"@fluid-experimental/sequence-deprecated",
 					"@fluidframework/aqueduct",
+					"@fluidframework/datastore",
 				].map((importName) => ({
 					name: importName,
 					message:

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
@@ -9,7 +9,7 @@ import type { PureDataObject } from "@fluidframework/aqueduct";
 import { IContainer } from "@fluidframework/container-definitions";
 import { IContainerRuntimeOptions, ISummarizer } from "@fluidframework/container-runtime";
 import { FluidObject, IFluidHandle } from "@fluidframework/core-interfaces";
-import { FluidDataStoreRuntime, mixinSummaryHandler } from "@fluidframework/datastore";
+import type { FluidDataStoreRuntime } from "@fluidframework/datastore";
 import type { ISharedMap } from "@fluidframework/map";
 import type { SharedMatrix } from "@fluidframework/matrix";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
@@ -46,7 +46,8 @@ describeCompat(
 	"NoCompat",
 	(getTestObjectProvider, apis) => {
 		const { SharedMap, SharedMatrix } = apis.dds;
-		const { DataObject, DataObjectFactory } = apis.dataRuntime;
+		const { DataObject, DataObjectFactory, FluidDataStoreRuntime } = apis.dataRuntime;
+		const { mixinSummaryHandler } = apis.dataRuntime.packages.datastore;
 		const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 
 		function createDataStoreRuntime(

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -18,7 +18,7 @@ import {
 } from "@fluidframework/container-runtime";
 import { FluidObject, IFluidHandle } from "@fluidframework/core-interfaces";
 import type { SharedCounter } from "@fluidframework/counter";
-import { FluidDataStoreRuntime, mixinSummaryHandler } from "@fluidframework/datastore";
+import type { FluidDataStoreRuntime } from "@fluidframework/datastore";
 import {
 	DriverHeader,
 	type IDocumentServiceFactory,
@@ -155,7 +155,8 @@ describeCompat(
 	"NoCompat",
 	(getTestObjectProvider, apis) => {
 		const { SharedMatrix, SharedCounter } = apis.dds;
-		const { DataObject, DataObjectFactory } = apis.dataRuntime;
+		const { DataObject, DataObjectFactory, FluidDataStoreRuntime } = apis.dataRuntime;
+		const { mixinSummaryHandler } = apis.dataRuntime.packages.datastore;
 		const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 
 		class TestDataObject2 extends DataObject {

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -17,7 +17,6 @@ import { ConnectionState, Loader } from "@fluidframework/container-loader";
 import { ContainerMessageType } from "@fluidframework/container-runtime";
 import { FluidObject, IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
 import { Deferred } from "@fluidframework/core-utils";
-import { DataStoreMessageType } from "@fluidframework/datastore";
 import { IDocumentServiceFactory, IResolvedUrl } from "@fluidframework/driver-definitions";
 import type { ISharedMap, SharedDirectory } from "@fluidframework/map";
 import type { SharedMatrix } from "@fluidframework/matrix";
@@ -70,6 +69,7 @@ describeCompat("Detached Container", "FullCompat", (getTestObjectProvider, apis)
 		ConsensusQueue,
 		SparseMatrix,
 	} = apis.dds;
+	const { DataStoreMessageType } = apis.dataRuntime.packages.datastore;
 
 	const registry: ChannelFactoryRegistry = [
 		[sharedStringId, SharedString.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
@@ -13,6 +13,9 @@ import {
 	IRequest,
 	IResponse,
 } from "@fluidframework/core-interfaces";
+// This test doesn't care to test compat of the fluid handle implementation, it's just used for convenience
+// to simulate an unknown object.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { FluidObjectHandle } from "@fluidframework/datastore";
 import {
 	ITestObjectProvider,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
@@ -13,7 +13,7 @@ import {
 	IRequest,
 	IResponse,
 } from "@fluidframework/core-interfaces";
-// This test doesn't care to test compat of the fluid handle implementation, it's just used for convenience
+// This test doesn't care to test compat of the Fluid handle implementation, it's just used for convenience
 // to simulate an unknown object.
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { FluidObjectHandle } from "@fluidframework/datastore";

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -14,7 +14,7 @@ import {
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer } from "@fluidframework/container-definitions";
 import { ContainerRuntime } from "@fluidframework/container-runtime";
-import { FluidDataStoreRuntime } from "@fluidframework/datastore";
+import type { FluidDataStoreRuntime } from "@fluidframework/datastore";
 import type { ISharedMap, IValueChanged } from "@fluidframework/map";
 import {
 	ChannelFactoryRegistry,

--- a/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
@@ -23,7 +23,7 @@ import {
 	ITelemetryBaseEvent,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import { FluidDataStoreRuntime, mixinSummaryHandler } from "@fluidframework/datastore";
+import type { FluidDataStoreRuntime } from "@fluidframework/datastore";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import { IFluidDataStoreFactory } from "@fluidframework/runtime-definitions";
 import { MockLogger } from "@fluidframework/telemetry-utils";
@@ -51,6 +51,7 @@ async function waitForSummaryOp(container: IContainer): Promise<boolean> {
 
 describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvider, apis) => {
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
+	const { mixinSummaryHandler } = apis.dataRuntime.packages.datastore;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 
 	/**

--- a/packages/test/test-version-utils/api-report/test-version-utils.api.md
+++ b/packages/test/test-version-utils/api-report/test-version-utils.api.md
@@ -12,6 +12,7 @@ import { ContainerRuntimeFactoryWithDefaultDataStore } from '@fluidframework/aqu
 import * as counter from '@fluidframework/counter';
 import { DataObject } from '@fluidframework/aqueduct';
 import { DataObjectFactory } from '@fluidframework/aqueduct';
+import * as datastore from '@fluidframework/datastore';
 import { DriverApi } from '@fluid-private/test-drivers';
 import { FluidTestDriverConfig } from '@fluid-private/test-drivers';
 import { IFluidDataStoreContext } from '@fluidframework/runtime-definitions';
@@ -77,6 +78,7 @@ export const DataRuntimeApi: {
     version: string;
     DataObject: typeof DataObject;
     DataObjectFactory: typeof DataObjectFactory;
+    FluidDataStoreRuntime: typeof datastore.FluidDataStoreRuntime;
     TestFluidObjectFactory: typeof TestFluidObjectFactory;
     dds: {
         SharedCell: typeof cell.SharedCell;
@@ -92,6 +94,7 @@ export const DataRuntimeApi: {
     packages: {
         cell: typeof cell;
         counter: typeof counter;
+        datastore: typeof datastore;
         map: typeof map;
         matrix: typeof matrix;
         orderedCollection: typeof orderedCollection;

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -81,6 +81,7 @@
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/counter": "workspace:~",
+		"@fluidframework/datastore": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/driver-utils": "workspace:~",

--- a/packages/test/test-version-utils/src/testApi.ts
+++ b/packages/test/test-version-utils/src/testApi.ts
@@ -29,6 +29,8 @@ import { ConsensusRegisterCollection } from "@fluidframework/register-collection
 import * as sequence from "@fluidframework/sequence";
 import { SharedString } from "@fluidframework/sequence";
 import { TestFluidObjectFactory } from "@fluidframework/test-utils";
+import * as datastore from "@fluidframework/datastore";
+import { FluidDataStoreRuntime } from "@fluidframework/datastore";
 
 // ContainerRuntime and Data Runtime API
 import {
@@ -53,6 +55,7 @@ import {
 // List of package that needs to be install for legacy versions
 const packageList = [
 	"@fluidframework/aqueduct",
+	"@fluidframework/datastore",
 	"@fluidframework/test-utils",
 	"@fluidframework/container-loader",
 	"@fluidframework/container-runtime",
@@ -137,6 +140,7 @@ export const DataRuntimeApi = {
 	version: pkgVersion,
 	DataObject,
 	DataObjectFactory,
+	FluidDataStoreRuntime,
 	TestFluidObjectFactory,
 	// TODO: SharedTree is not included included here. Perhaps it should be added?
 	dds: {
@@ -162,6 +166,7 @@ export const DataRuntimeApi = {
 	packages: {
 		cell,
 		counter,
+		datastore,
 		map,
 		matrix,
 		orderedCollection,
@@ -232,6 +237,7 @@ async function loadDataRuntime(baseVersion: string, requested?: number | string)
 		/* eslint-disable @typescript-eslint/no-shadow */
 		const [
 			{ DataObject, DataObjectFactory },
+			datastore,
 			{ TestFluidObjectFactory },
 			map,
 			sequence,
@@ -244,6 +250,7 @@ async function loadDataRuntime(baseVersion: string, requested?: number | string)
 			agentScheduler,
 		] = await Promise.all([
 			loadPackage(modulePath, "@fluidframework/aqueduct"),
+			loadPackage(modulePath, "@fluidframework/datastore"),
 			loadPackage(modulePath, "@fluidframework/test-utils"),
 			loadPackage(modulePath, "@fluidframework/map"),
 			loadPackage(modulePath, "@fluidframework/sequence"),
@@ -260,6 +267,7 @@ async function loadDataRuntime(baseVersion: string, requested?: number | string)
 			),
 			loadPackage(modulePath, "@fluidframework/agent-scheduler"),
 		]);
+		const { FluidDataStoreRuntime } = datastore;
 		const { SharedCell } = cell;
 		const { SharedCounter } = counter;
 		const { SharedDirectory, SharedMap } = map;
@@ -274,6 +282,7 @@ async function loadDataRuntime(baseVersion: string, requested?: number | string)
 			version,
 			DataObject,
 			DataObjectFactory,
+			FluidDataStoreRuntime,
 			TestFluidObjectFactory,
 			dds: {
 				SharedCell,
@@ -287,6 +296,7 @@ async function loadDataRuntime(baseVersion: string, requested?: number | string)
 				SparseMatrix,
 			},
 			packages: {
+				datastore,
 				map,
 				sequence,
 				cell,

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -32,7 +32,7 @@ const getModulePath = (version: string) => path.join(baseModulePath, version);
 const resolutionCache = new Map<string, string>();
 
 // Increment the revision if we want to force installation (e.g. package list changed)
-const revision = 2;
+const revision = 3;
 
 interface InstalledJson {
 	revision: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10309,6 +10309,7 @@ importers:
       '@fluidframework/core-interfaces': workspace:~
       '@fluidframework/core-utils': workspace:~
       '@fluidframework/counter': workspace:~
+      '@fluidframework/datastore': workspace:~
       '@fluidframework/datastore-definitions': workspace:~
       '@fluidframework/driver-definitions': workspace:~
       '@fluidframework/driver-utils': workspace:~
@@ -10363,6 +10364,7 @@ importers:
       '@fluidframework/core-interfaces': link:../../common/core-interfaces
       '@fluidframework/core-utils': link:../../common/core-utils
       '@fluidframework/counter': link:../../dds/counter
+      '@fluidframework/datastore': link:../../runtime/datastore
       '@fluidframework/datastore-definitions': link:../../runtime/datastore-definitions
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
       '@fluidframework/driver-utils': link:../../loader/driver-utils


### PR DESCRIPTION
## Description

Adds a linter rule to prevent imports from `@fluidframework/datastore` in e2e tests. This helps to ensure that compat tests actually exercise meaningful compat scenarios.

This only affects a few files, since most tests inherit this dependency via aqueduct (handled in #20261).