### PR TITLE
fix: send correct connection scopes for client

### DIFF
--- a/server/routerlicious/packages/lambdas/src/nexus/index.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/index.ts
@@ -427,6 +427,7 @@ export function configureWebSocketServices(
 			const isSummarizer = messageClient.details?.type === summarizerClientType;
 			messageClient.user = claims.user;
 			messageClient.scopes = claims.scopes;
+			messageClient.mode = hasWriteAccess(claims.scopes) ? "write" : "read";
 
 			// 1. Do not give SummaryWrite scope to clients that are not summarizers.
 			// 2. Store connection timestamp for all clients but the summarizer.

--- a/server/routerlicious/packages/lambdas/src/nexus/index.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/index.ts
@@ -427,7 +427,7 @@ export function configureWebSocketServices(
 			const isSummarizer = messageClient.details?.type === summarizerClientType;
 			messageClient.user = claims.user;
 			messageClient.scopes = claims.scopes;
-			messageClient.mode = hasWriteAccess(claims.scopes) ? "write" : "read";
+			messageClient.mode = isWriter(claims.scopes, message.mode) ? "write" : "read";
 
 			// 1. Do not give SummaryWrite scope to clients that are not summarizers.
 			// 2. Store connection timestamp for all clients but the summarizer.


### PR DESCRIPTION
## Description

When a client joins with AzureClient, it will always try to join in `write` even if it only has `read` permissions according to its token claims. On the server (Nexus Lambda), we handle that correctly by creating a read-scoped connection. However, the server would incorrectly handle client details and send connection info like this:

```js
socket.emit("connect_document_success", { /* ... */, mode: "read");
// ...
socket.emitToRoom(
    "tenantId/documentId",
    "signal",
    { 
       /* ... join signal message ...*/,
       client: { /* ... */, mode: "write"
    });
```

I'm not sure about the specifics of what's happening on the client, but when testing read client Audience and Signals usage in #20042, I realized that the read client audience is not working appropriately without this change. My understanding is it's because Audience is trying to use Quorum (Join Ops) instead of Join Signals because the Join Signal client details said `{ mode: "write" }` even though Connection details said `{ mode: "read" }`
