### PR TITLE
test(tree): fuzz tests can now insert multiple nodes at once

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -30,7 +30,7 @@ import {
 	SharedTreeFactory,
 	TreeContent,
 } from "../../../shared-tree/index.js";
-import { brand, fail, getOrCreate } from "../../../util/index.js";
+import { brand, fail, getOrCreate, makeArray } from "../../../util/index.js";
 import { schematizeFlexTree } from "../../utils.js";
 import { FuzzNode, FuzzNodeSchema, fuzzNode, fuzzSchema } from "./fuzzUtils.js";
 import {
@@ -264,7 +264,7 @@ export const makeEditGenerator = (
 					parent: maybeDownPathFromNode(field.parent),
 					key: field.key,
 					index: state.random.integer(0, field.length),
-					value: jsonableTree(state),
+					content: makeArray(state.random.integer(1, 3), () => jsonableTree(state)),
 				};
 				return {
 					type: "sequence",

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -110,7 +110,7 @@ function applySequenceFieldEdit(tree: FuzzView, change: FuzzFieldChange): void {
 			assert(parent?.is(nodeSchema), "Defined down-path should point to a valid parent");
 			const field = parent.boxedSequenceChildren;
 			assert(field !== undefined);
-			field.insertAt(change.index, cursorForJsonableTreeField([change.value]));
+			field.insertAt(change.index, cursorForJsonableTreeField(change.content));
 			break;
 		}
 		case "remove": {

--- a/packages/dds/tree/src/test/shared-tree/fuzz/operationTypes.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/operationTypes.ts
@@ -43,10 +43,10 @@ export interface FuzzInsert {
 	 */
 	key: FieldKey;
 	/**
-	 * Index to insert within the field.
+	 * Index to insert at within the field.
 	 */
 	index: number;
-	value: JsonableTree;
+	content: JsonableTree[];
 }
 
 export interface FuzzSet {


### PR DESCRIPTION
Update the sequence insert fuzz generator and reducer so that it sometimes generates inserts of multiple nodes.