### PR TITLE
refactor(tree): decouple field-kind format versioning from ModularChangeFamily codec

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -36,7 +36,12 @@ import {
 } from "../modular-schema/index.js";
 import { OptionalChangeset } from "../optional-field/index.js";
 import { TreeCompressionStrategy } from "../treeCompressionUtils.js";
-import { fieldKinds, optional, sequence, required as valueFieldKind } from "./defaultFieldKinds.js";
+import {
+	fieldKindConfiguration,
+	optional,
+	sequence,
+	required as valueFieldKind,
+} from "./defaultFieldKinds.js";
 
 export type DefaultChangeset = ModularChangeset;
 
@@ -55,7 +60,7 @@ export class DefaultChangeFamily implements ChangeFamily<DefaultEditBuilder, Def
 		chunkCompressionStrategy?: TreeCompressionStrategy,
 	) {
 		this.modularFamily = new ModularChangeFamily(
-			fieldKinds,
+			fieldKindConfiguration,
 			revisionTagCodec,
 			fieldBatchCodec,
 			codecOptions,
@@ -80,7 +85,7 @@ export class DefaultChangeFamily implements ChangeFamily<DefaultEditBuilder, Def
  * @param change - The change to convert into a delta.
  */
 export function intoDelta(taggedChange: TaggedChange<ModularChangeset>): DeltaRoot {
-	return intoModularDelta(taggedChange, fieldKinds);
+	return intoModularDelta(taggedChange, fieldKindConfiguration);
 }
 
 /**
@@ -100,7 +105,7 @@ export function intoDelta(taggedChange: TaggedChange<ModularChangeset>): DeltaRo
 export function relevantRemovedRoots(
 	taggedChange: TaggedChange<ModularChangeset>,
 ): Iterable<DeltaDetachedNodeId> {
-	return relevantModularRemovedRoots(taggedChange, fieldKinds);
+	return relevantModularRemovedRoots(taggedChange, fieldKindConfiguration);
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -14,6 +14,8 @@ import { fail } from "../../util/index.js";
 import {
 	FieldChangeHandler,
 	FieldEditor,
+	FieldKindConfiguration,
+	FieldKindConfigurationEntry,
 	FieldKindWithEditor,
 	FlexFieldKind,
 	ToDelta,
@@ -171,8 +173,28 @@ export const forbidden = new FieldKindWithEditor(
 	new Set(),
 );
 
+const fieldKindConfigurations: ReadonlyMap<number, FieldKindConfiguration> = new Map([
+	[
+		0,
+		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
+			[nodeKey.identifier, { kind: nodeKey, formatVersion: 0 }],
+			[required.identifier, { kind: required, formatVersion: 0 }],
+			[optional.identifier, { kind: optional, formatVersion: 0 }],
+			[sequence.identifier, { kind: sequence, formatVersion: 0 }],
+			[forbidden.identifier, { kind: forbidden, formatVersion: 0 }],
+		]),
+	],
+]);
+
 /**
- * Default field kinds by identifier
+ * The current configuration for field kinds.
+ * Each field kind has an associated format version that will be used for encoding purposes.
+ */
+export const fieldKindConfiguration: FieldKindConfiguration =
+	fieldKindConfigurations.get(0) ?? fail("Unknown field kind configuration");
+
+/**
+ * All supported field kinds.
  */
 export const fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor> = new Map(
 	[required, optional, sequence, nodeKey, forbidden].map((s) => [s.identifier, s]),

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultSchema.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultSchema.ts
@@ -4,12 +4,14 @@
  */
 
 import { FullSchemaPolicy } from "../modular-schema/index.js";
-import { fieldKinds } from "./defaultFieldKinds.js";
+import { fieldKindConfiguration } from "./defaultFieldKinds.js";
 
 /**
  * FullSchemaPolicy with the default field kinds.
  * @internal
  */
 export const defaultSchemaPolicy: FullSchemaPolicy = {
-	fieldKinds,
+	fieldKinds: new Map(
+		Array.from(fieldKindConfiguration.entries(), ([key, value]) => [key, value.kind]),
+	),
 };

--- a/packages/dds/tree/src/feature-libraries/default-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/index.ts
@@ -11,6 +11,7 @@ export {
 	NodeKeyFieldKind,
 	Forbidden,
 	fieldKinds,
+	fieldKindConfiguration,
 } from "./defaultFieldKinds.js";
 
 export {

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -123,6 +123,8 @@ export {
 	makeV0Codec,
 	RelevantRemovedRootsFromChild,
 	EncodedModularChangeset,
+	FieldKindConfiguration,
+	FieldKindConfigurationEntry,
 } from "./modular-schema/index.js";
 
 export { Multiplicity } from "./multiplicity.js";
@@ -222,6 +224,7 @@ export {
 	SequenceFieldEditBuilder,
 	defaultSchemaPolicy,
 	fieldKinds,
+	fieldKindConfiguration,
 	intoDelta,
 	relevantRemovedRoots,
 } from "./default-schema/index.js";

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldKindConfiguration.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldKindConfiguration.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { FieldKindIdentifier } from "../../core/index.js";
+import { FieldKindWithEditor } from "./fieldKindWithEditor.js";
+
+/**
+ * Configuration for a single field kind.
+ */
+export interface FieldKindConfigurationEntry {
+	readonly kind: FieldKindWithEditor;
+	/**
+	 * The format to be used for encoding changesets for this field kind.
+	 */
+	readonly formatVersion: number;
+}
+
+/**
+ * Configuration for as set of field kinds.
+ */
+export type FieldKindConfiguration = ReadonlyMap<FieldKindIdentifier, FieldKindConfigurationEntry>;

--- a/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
@@ -67,3 +67,4 @@ export {
 	relevantRemovedRoots,
 } from "./modularChangeFamily.js";
 export { makeV0Codec } from "./modularChangeCodecs.js";
+export { FieldKindConfiguration, FieldKindConfigurationEntry } from "./fieldKindConfiguration.js";

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -30,7 +30,7 @@ import {
 	defaultChunkPolicy,
 } from "../chunked-forest/index.js";
 import { TreeCompressionStrategy } from "../treeCompressionUtils.js";
-import { FieldKindWithEditor } from "./fieldKindWithEditor.js";
+import { FieldKindConfiguration, FieldKindConfigurationEntry } from "./fieldKindConfiguration.js";
 import { genericFieldKind } from "./genericFieldKind.js";
 import {
 	EncodedBuilds,
@@ -49,7 +49,7 @@ import {
 } from "./modularChangeTypes.js";
 
 export function makeV0Codec(
-	fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor>,
+	fieldKinds: FieldKindConfiguration,
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
@@ -76,10 +76,10 @@ export function makeV0Codec(
 		encodedSchema: EncodedNodeChangeset,
 	};
 
-	const getMapEntry = (field: FieldKindWithEditor) => {
-		const codec = field.changeHandler
+	const getMapEntry = ({ kind, formatVersion }: FieldKindConfigurationEntry) => {
+		const codec = kind.changeHandler
 			.codecsFactory(nodeChangesetCodec, revisionTagCodec)
-			.resolve(0);
+			.resolve(formatVersion);
 		return {
 			codec,
 			compiledSchema: codec.json.encodedSchema
@@ -95,16 +95,25 @@ export function makeV0Codec(
 		ChangeEncodingContext
 	>;
 
+	/**
+	 * The codec version for the generic field kind.
+	 */
+	const genericFieldKindFormatVersion = 0;
 	const fieldChangesetCodecs: Map<
 		FieldKindIdentifier,
 		{
 			compiledSchema?: SchemaValidationFunction<TAnySchema>;
 			codec: FieldCodec;
 		}
-	> = new Map([[genericFieldKind.identifier, getMapEntry(genericFieldKind)]]);
+	> = new Map([
+		[
+			genericFieldKind.identifier,
+			getMapEntry({ kind: genericFieldKind, formatVersion: genericFieldKindFormatVersion }),
+		],
+	]);
 
-	fieldKinds.forEach((fieldKind, identifier) => {
-		fieldChangesetCodecs.set(identifier, getMapEntry(fieldKind));
+	fieldKinds.forEach((entry, identifier) => {
+		fieldChangesetCodecs.set(identifier, getMapEntry(entry));
 	});
 
 	const getFieldChangesetCodec = (

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -75,7 +75,7 @@ import {
 	NodeExistenceState,
 	RebaseRevisionMetadata,
 } from "./fieldChangeHandler.js";
-import { FlexFieldKind } from "./fieldKind.js";
+import { FieldKindConfiguration } from "./fieldKindConfiguration.js";
 import { FieldKindWithEditor, withEditor } from "./fieldKindWithEditor.js";
 import { convertGenericChange, genericFieldKind, newGenericChangeset } from "./genericFieldKind.js";
 import { GenericChangeset } from "./genericFieldKindTypes.js";
@@ -102,7 +102,7 @@ export class ModularChangeFamily
 	public readonly codecs: ICodecFamily<ModularChangeset, ChangeEncodingContext>;
 
 	public constructor(
-		public readonly fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor>,
+		public readonly fieldKinds: FieldKindConfiguration,
 		revisionTagCodec: RevisionTagCodec,
 		fieldBatchCodec: FieldBatchCodec,
 		codecOptions: ICodecOptions,
@@ -1007,7 +1007,7 @@ function invertBuilds(
  */
 export function* relevantRemovedRoots(
 	{ change, revision }: TaggedChange<ModularChangeset>,
-	fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor>,
+	fieldKinds: FieldKindConfiguration,
 ): Iterable<DeltaDetachedNodeId> {
 	yield* relevantRemovedRootsFromFields(change.fieldChanges, revision, fieldKinds);
 }
@@ -1015,7 +1015,7 @@ export function* relevantRemovedRoots(
 function* relevantRemovedRootsFromFields(
 	change: FieldChangeMap,
 	revision: RevisionTag | undefined,
-	fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor>,
+	fieldKinds: FieldKindConfiguration,
 ): Iterable<DeltaDetachedNodeId> {
 	for (const [_, fieldChange] of change) {
 		const fieldRevision = fieldChange.revision ?? revision;
@@ -1079,7 +1079,7 @@ export function updateRefreshers(
  */
 export function intoDelta(
 	taggedChange: TaggedChange<ModularChangeset>,
-	fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor>,
+	fieldKinds: FieldKindConfiguration,
 ): DeltaRoot {
 	const change = taggedChange.change;
 	// Return an empty delta for changes with constraint violations
@@ -1139,7 +1139,7 @@ function intoDeltaImpl(
 	change: FieldChangeMap,
 	revision: RevisionTag | undefined,
 	idAllocator: MemoizedIdRangeAllocator,
-	fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor>,
+	fieldKinds: FieldKindConfiguration,
 ): Map<FieldKey, DeltaFieldChanges> {
 	const delta: Map<FieldKey, DeltaFieldChanges> = new Map();
 	for (const [field, fieldChange] of change) {
@@ -1160,7 +1160,7 @@ function intoDeltaImpl(
 function deltaFromNodeChange(
 	{ change, revision }: TaggedChange<NodeChangeset>,
 	idAllocator: MemoizedIdRangeAllocator,
-	fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor>,
+	fieldKinds: FieldKindConfiguration,
 ): DeltaFieldMap {
 	if (change.fieldChanges !== undefined) {
 		return intoDeltaImpl(change.fieldChanges, revision, idAllocator, fieldKinds);
@@ -1203,7 +1203,7 @@ function isEmptyNodeChangeset(change: NodeChangeset): boolean {
 }
 
 export function getFieldKind(
-	fieldKinds: ReadonlyMap<FieldKindIdentifier, FlexFieldKind>,
+	fieldKinds: FieldKindConfiguration,
 	kind: FieldKindIdentifier,
 ): FieldKindWithEditor {
 	if (kind === genericFieldKind.identifier) {
@@ -1211,11 +1211,11 @@ export function getFieldKind(
 	}
 	const fieldKind = fieldKinds.get(kind);
 	assert(fieldKind !== undefined, 0x3ad /* Unknown field kind */);
-	return withEditor(fieldKind);
+	return withEditor(fieldKind.kind);
 }
 
 export function getChangeHandler(
-	fieldKinds: ReadonlyMap<FieldKindIdentifier, FlexFieldKind>,
+	fieldKinds: FieldKindConfiguration,
 	kind: FieldKindIdentifier,
 ): FieldChangeHandler<unknown> {
 	return getFieldKind(fieldKinds, kind).changeHandler;

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -19,7 +19,7 @@ import {
 	ModularChangeFamily,
 	ModularChangeset,
 	TreeCompressionStrategy,
-	fieldKinds,
+	fieldKindConfiguration,
 } from "../feature-libraries/index.js";
 import { Mutable, fail } from "../util/index.js";
 import { makeSharedTreeChangeCodecFamily } from "./sharedTreeChangeCodecs.js";
@@ -50,7 +50,7 @@ export class SharedTreeChangeFamily
 		chunkCompressionStrategy?: TreeCompressionStrategy,
 	) {
 		this.modularChangeFamily = new ModularChangeFamily(
-			fieldKinds,
+			fieldKindConfiguration,
 			revisionTagCodec,
 			fieldBatchCodec,
 			codecOptions,

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -28,6 +28,8 @@ import {
 	FieldChangeHandler,
 	FieldChangeRebaser,
 	FieldEditor,
+	FieldKindConfiguration,
+	FieldKindConfigurationEntry,
 	FieldKindWithEditor,
 	ModularChangeset,
 	Multiplicity,
@@ -99,15 +101,19 @@ const singleNodeField = new FieldKindWithEditor(
 	new Set(),
 );
 
-const fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor> = new Map(
-	[singleNodeField, valueField].map((field) => [field.identifier, field]),
-);
+export const fieldKindConfiguration: FieldKindConfiguration = new Map<
+	FieldKindIdentifier,
+	FieldKindConfigurationEntry
+>([
+	[singleNodeField.identifier, { kind: singleNodeField, formatVersion: 0 }],
+	[valueField.identifier, { kind: valueField, formatVersion: 0 }],
+]);
 
 const codecOptions: ICodecOptions = {
 	jsonValidator: ajvValidator,
 };
 const family = new ModularChangeFamily(
-	fieldKinds,
+	fieldKindConfiguration,
 	testRevisionTagCodec,
 	makeFieldBatchCodec(codecOptions),
 	codecOptions,
@@ -1041,7 +1047,9 @@ describe("ModularChangeFamily", () => {
 			() => false,
 			new Set(),
 		);
-		const mockFieldKinds = new Map([[fieldKind, hasRemovedRootsRefsField]]);
+		const mockFieldKinds = new Map([
+			[fieldKind, { kind: hasRemovedRootsRefsField, formatVersion: 0 }],
+		]);
 
 		function relevantRemovedRoots(
 			input: TaggedChange<ModularChangeset>,

--- a/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -11,7 +11,6 @@ import {
 	DeltaMark,
 	DeltaRoot,
 	FieldKey,
-	FieldKindIdentifier,
 	RevisionTag,
 	UpPath,
 	makeAnonChange,
@@ -22,7 +21,7 @@ import {
 import { typeboxValidator } from "../../external-utilities/index.js";
 import {
 	DefaultEditBuilder,
-	FieldKindWithEditor,
+	FieldKindConfiguration,
 	FieldKinds,
 	ModularChangeset,
 	cursorForJsonableTreeNode,
@@ -52,9 +51,9 @@ import { MarkMaker } from "./sequence-field/testEdits.js";
 // eslint-disable-next-line import/no-internal-modules
 import { purgeUnusedCellOrderingInfo } from "./sequence-field/utils.js";
 
-const fieldKinds: ReadonlyMap<FieldKindIdentifier, FieldKindWithEditor> = new Map(
-	[sequence].map((f) => [f.identifier, f]),
-);
+const fieldKinds: FieldKindConfiguration = new Map([
+	[sequence.identifier, { kind: sequence, formatVersion: 0 }],
+]);
 
 const family = new ModularChangeFamily(fieldKinds, testRevisionTagCodec, failCodec, {
 	jsonValidator: typeboxValidator,

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
@@ -13,15 +13,17 @@ import { decode } from "../../feature-libraries/chunked-forest/codec/chunkDecodi
 import { uncompressedEncode } from "../../feature-libraries/chunked-forest/codec/uncompressedEncode.js";
 // eslint-disable-next-line import/no-internal-modules
 import { EncodedFieldBatch } from "../../feature-libraries/chunked-forest/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import { sequence } from "../../feature-libraries/default-schema/defaultFieldKinds.js";
+import {
+	fieldKindConfiguration,
+	sequence,
+	// eslint-disable-next-line import/no-internal-modules
+} from "../../feature-libraries/default-schema/defaultFieldKinds.js";
 import {
 	FieldBatch,
 	FieldBatchEncodingContext,
 	ModularChangeset,
 	SequenceField,
 	defaultSchemaPolicy,
-	fieldKinds,
 	makeV0Codec,
 } from "../../feature-libraries/index.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -46,7 +48,7 @@ describe("sharedTreeChangeCodec", () => {
 			},
 		};
 		const modularChangeCodec = makeV0Codec(
-			fieldKinds,
+			fieldKindConfiguration,
 			testRevisionTagCodec,
 			dummyFieldBatchCodec,
 			codecOptions,

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
@@ -19,7 +19,7 @@ import {
 	ModularChangeFamily,
 	ModularChangeset,
 	cursorForJsonableTreeNode,
-	fieldKinds,
+	fieldKindConfiguration,
 } from "../../feature-libraries/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { SharedTreeChangeFamily } from "../../shared-tree/sharedTreeChangeFamily.js";
@@ -36,7 +36,7 @@ const fieldBatchCodec = {
 };
 
 const modularFamily = new ModularChangeFamily(
-	fieldKinds,
+	fieldKindConfiguration,
 	testRevisionTagCodec,
 	fieldBatchCodec,
 	codecOptions,


### PR DESCRIPTION
## Description

Introduces `fieldKindConfigurations` in `src\feature-libraries\default-schema\defaultFieldKinds.ts` where the versioning of sets of field kinds can be described.

Note that this is independent from the format version of `ModularChangeFamily` because the set of field kinds used by a `ModularChangeFamily` instance in dynamically injected.

## Breaking Changes

None