### PR TITLE
server: fix mutable quorum snapshot

### DIFF
--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -159,14 +159,17 @@ export class ProtocolOpHandler implements IProtocolHandler {
 
 		if (scrubUserData) {
 			// In place, remove any identifying client information
-			snapshot.members.forEach((member) => {
-				member[1] = {
-					...member[1],
-					client: {
-						...member[1].client,
-						user: { id: "" },
+			snapshot.members = snapshot.members.map(([id, sequencedClient]) => {
+				return [
+					id,
+					{
+						...sequencedClient,
+						client: {
+							...sequencedClient.client,
+							user: { id: "" },
+						},
 					},
-				};
+				];
 			});
 		}
 

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -159,18 +159,16 @@ export class ProtocolOpHandler implements IProtocolHandler {
 
 		if (scrubUserData) {
 			// In place, remove any identifying client information
-			snapshot.members = snapshot.members.map(([id, sequencedClient]) => {
-				return [
-					id,
-					{
-						...sequencedClient,
-						client: {
-							...sequencedClient.client,
-							user: { id: "" },
-						},
+			snapshot.members = snapshot.members.map(([id, sequencedClient]) => [
+				id,
+				{
+					...sequencedClient,
+					client: {
+						...sequencedClient.client,
+						user: { id: "" },
 					},
-				];
-			});
+				},
+			]);
 		}
 
 		return {

--- a/server/routerlicious/packages/protocol-base/src/test/protocol.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/protocol.spec.ts
@@ -221,6 +221,18 @@ describe("Protocol", () => {
 			});
 			assert.strictEqual(protocolOpHandler.attributes.sequenceNumber, 2);
 
+			const scrubbedProtocolState = protocolOpHandler.getProtocolState(true);
+			scrubbedProtocolState.members.forEach(([, member]) => {
+				assert(!member.client.user.id, "user id should be empty");
+				assert(
+					!(member.client.user as unknown as any).name,
+					"user name should not be present",
+				);
+				assert(
+					!(member.client.user as unknown as any).additionalDetails?.favoriteColor,
+					"user additional details should not be present",
+				);
+			});
 			const protocolState = protocolOpHandler.getProtocolState();
 			protocolState.members.forEach(([, member]) => {
 				assert(member.client.user.id, "user id should be present");


### PR DESCRIPTION
## Description

Quorum snapshot is supposed to be an immutable clone of the real quorum members. However, the members are _not_ deep cloned. Rather than doing expensive deep cloning always right now, I just created a deep-_er_ clone when needed.