### PR TITLE
[main>lts] Whiteboard undo redo bug

### DIFF
--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -1506,7 +1506,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 * @internal
 	 */
 	public revertChanges(changes: readonly InternalizedChange[], before: RevisionView): ChangeInternal[] | undefined {
-		return revert(changes as unknown as readonly ChangeInternal[], before);
+		return revert(changes as unknown as readonly ChangeInternal[], before, this.logger);
 	}
 
 	/**

--- a/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
+++ b/experimental/dds/tree/src/test/HistoryEditFactory.tests.ts
@@ -5,7 +5,7 @@
 
 import { expect } from 'chai';
 import { revert } from '../HistoryEditFactory';
-import { DetachedSequenceId } from '../Identifiers';
+import { DetachedSequenceId, TraitLabel } from '../Identifiers';
 import { ChangeInternal, DetachInternal, Side, StablePlaceInternal, StableRangeInternal } from '../persisted-types';
 import { expectDefined } from './utilities/TestCommon';
 import { refreshTestTree } from './utilities/TestUtilities';
@@ -19,10 +19,10 @@ describe('revert', () => {
 		const firstBuild = ChangeInternal.build([node], firstDetachedId);
 		const insertedNodeId = 1 as DetachedSequenceId;
 		const insertedBuild = ChangeInternal.build([firstDetachedId], insertedNodeId);
-		const insertChange = ChangeInternal.insert(insertedNodeId, {
-			referenceTrait: testTree.left.traitLocation,
-			side: Side.After,
-		});
+		const insertChange = ChangeInternal.insert(
+			insertedNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
 		const result = expectDefined(revert([firstBuild, insertedBuild, insertChange], testTree.view));
 		expect(result.length).to.equal(1);
 		const revertedChange = result[0] as DetachInternal;
@@ -39,15 +39,87 @@ describe('revert', () => {
 		const secondBuild = ChangeInternal.build([secondNode], secondDetachedId);
 		const insertedNodeId = 2 as DetachedSequenceId;
 		const insertedBuild = ChangeInternal.build([firstDetachedId, secondDetachedId], insertedNodeId);
-		const insertChange = ChangeInternal.insert(insertedNodeId, {
-			referenceTrait: testTree.left.traitLocation,
-			side: Side.After,
-		});
+		const insertChange = ChangeInternal.insert(
+			insertedNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
 		const result = expectDefined(revert([firstBuild, secondBuild, insertedBuild, insertChange], testTree.view));
 		expect(result.length).to.equal(1);
 		const revertedChange = result[0] as DetachInternal;
 		expect(revertedChange.source.start.referenceSibling).to.deep.equal(firstNode.identifier);
 		expect(revertedChange.source.end.referenceSibling).to.deep.equal(secondNode.identifier);
+	});
+
+	it('handles reverting the insert of empty nodes, with subsequent non-empty nodes', () => {
+		// build and insert of empty traits
+		const emptyTraitNodeId = 0 as DetachedSequenceId;
+		const emptyTraitBuild = ChangeInternal.build([], emptyTraitNodeId);
+		const emptyTraitInsert = ChangeInternal.insert(
+			emptyTraitNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
+
+		// build and insert of non-empty traits
+		const firstDetachedId = 1 as DetachedSequenceId;
+		const firstNode = testTree.buildLeafInternal();
+		const firstBuild = ChangeInternal.build([firstNode], firstDetachedId);
+		const insertedNodeId = 3 as DetachedSequenceId;
+		const insertedBuild = ChangeInternal.build([firstDetachedId], insertedNodeId);
+		const insertChange = ChangeInternal.insert(
+			insertedNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
+		const result = expectDefined(
+			revert([emptyTraitBuild, emptyTraitInsert, firstBuild, insertedBuild, insertChange], testTree.view)
+		);
+		expect(result.length).to.equal(1);
+		const revertedChange = result[0] as DetachInternal;
+		expect(revertedChange.source.start.referenceSibling).to.deep.equal(firstNode.identifier);
+	});
+
+	/** This is a regression test for a bug where we make sure that any built/detached nodes are cleared when any
+	 *  empty insert/detach change is skipped once encountered. The expected outcome is undefined, as during the second
+	 *  empty insert (with the same DetachSequenceId), there should be no such node in the builtNodes.
+	 */
+	it('handles reverting the insert of empty nodes, with subsequent empty nodes of same DetachedSequenceId', () => {
+		const emptyTraitNodeId = 0 as DetachedSequenceId;
+		const emptyTraitBuild = ChangeInternal.build([], emptyTraitNodeId);
+		const emptyTraitInsert = ChangeInternal.insert(
+			emptyTraitNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
+		const result = revert([emptyTraitBuild, emptyTraitInsert, emptyTraitInsert], testTree.view);
+		expect(result).to.be.undefined;
+	});
+
+	it('handles reverting the detach of an empty trait', () => {
+		const insertedNodeId = 0 as DetachedSequenceId;
+		const result = expectDefined(
+			revert(
+				[
+					ChangeInternal.detach(
+						StableRangeInternal.all({
+							label: 'someNonExistentTraitLabel' as TraitLabel,
+							parent: testTree.identifier,
+						}),
+						insertedNodeId
+					),
+				],
+				testTree.view
+			)
+		);
+		expect(result).to.have.lengthOf(0);
+	});
+
+	it('handles reverting the insert of an empty trait', () => {
+		const emptyTraitNodeId = 0 as DetachedSequenceId;
+		const emptyTraitBuild = ChangeInternal.build([], emptyTraitNodeId);
+		const emptyTraitInsert = ChangeInternal.insert(
+			emptyTraitNodeId,
+			StablePlaceInternal.atStartOf(testTree.left.traitLocation)
+		);
+		const result = expectDefined(revert([emptyTraitBuild, emptyTraitInsert], testTree.view));
+		expect(result).to.have.lengthOf(0);
 	});
 
 	describe('returns undefined for reverts that require more context than the view directly before the edit', () => {


### PR DESCRIPTION
Cherry pick of PR #11260 from main to lts branch.

This change was ported from main to the 1.3 release branch in #12894, but the change was never ported to lts (so wouldn't be in 1.4 if/when we release it).