### PR TITLE
Expose configuredSharedTree

### DIFF
--- a/examples/data-objects/inventory-app/src/reactSharedTreeView.tsx
+++ b/examples/data-objects/inventory-app/src/reactSharedTreeView.tsx
@@ -10,17 +10,28 @@ import {
 	ITree,
 	type ImplicitFieldSchema,
 	SchemaIncompatible,
-	SharedTree,
 	TreeConfiguration,
 	TreeFieldFromImplicitField,
 	TreeView,
 } from "@fluidframework/tree";
+import {
+	configuredSharedTree,
+	typeboxValidator,
+	// eslint-disable-next-line import/no-internal-modules
+} from "@fluidframework/tree/internal";
 import * as React from "react";
 
 /**
  * This file contains logic not specific to this particular sample that other apps may want to use.
  * Eventually this should be published as part of a package apps can use.
  */
+
+/**
+ * Opt into extra validation to detect detect encoding bugs and data corruption.
+ */
+const SharedTree = configuredSharedTree({
+	jsonValidator: typeboxValidator,
+});
 
 /**
  * TODO: once we add options to factory (for example controlling the write format),

--- a/examples/data-objects/inventory-app/src/reactSharedTreeView.tsx
+++ b/examples/data-objects/inventory-app/src/reactSharedTreeView.tsx
@@ -27,7 +27,7 @@ import * as React from "react";
  */
 
 /**
- * Opt into extra validation to detect detect encoding bugs and data corruption.
+ * Opt into extra validation to detect encoding bugs and data corruption.
  */
 const SharedTree = configuredSharedTree({
 	jsonValidator: typeboxValidator,

--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -247,6 +247,9 @@ export interface CommitMetadata {
 export function compareLocalNodeKeys(a: LocalNodeKey, b: LocalNodeKey): -1 | 0 | 1;
 
 // @internal
+export function configuredSharedTree(options: SharedTreeOptions): ISharedObjectKind<ITree>;
+
+// @internal
 export type ContextuallyTypedFieldData = ContextuallyTypedNodeData | undefined;
 
 // @internal

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -327,7 +327,7 @@ export {
 	test_RecursiveObject_base,
 	test_RecursiveObjectPojoMode,
 } from "./simple-tree/index.js";
-export { SharedTree } from "./treeFactory.js";
+export { SharedTree, configuredSharedTree } from "./treeFactory.js";
 
 export type { ICodecOptions, JsonValidator, SchemaValidationFunction } from "./codec/index.js";
 export { noopValidator } from "./codec/index.js";

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -51,17 +51,44 @@ export class TreeFactory implements IChannelFactory<ITree> {
 /**
  * SharedTree is a hierarchical data structure for collaboratively editing strongly typed JSON-like trees
  * of objects, arrays, and other data types.
- * @privateRemarks
- * Due to the dependency structure and the placement of that interface SharedObjectClass,
- * this interface implementation can not be recorded in the type here.
  * @public
  */
-export const SharedTree: ISharedObjectKind<ITree> = {
-	getFactory(): IChannelFactory<ITree> {
-		return new TreeFactory({});
-	},
+export const SharedTree: ISharedObjectKind<ITree> = configuredSharedTree({});
 
-	create(runtime: IFluidDataStoreRuntime, id?: string): ITree {
-		return runtime.createChannel(id, TreeFactory.type) as ITree;
-	},
-};
+/**
+ * {@link SharedTree} but allowing a non-default configuration.
+ * @remarks
+ * This is useful for debugging and testing to opt into extra validation or see if opting out of some optimizations fixes an issue.
+ * @example
+ * ```typescript
+ * import {
+ * 	ForestType,
+ * 	TreeCompressionStrategy,
+ * 	configuredSharedTree,
+ * 	typeboxValidator,
+ * 	// eslint-disable-next-line import/no-internal-modules
+ * } from "@fluidframework/tree/internal";
+ * const SharedTree = configuredSharedTree({
+ * 	forest: ForestType.Reference,
+ * 	jsonValidator: typeboxValidator,
+ * 	treeEncodeType: TreeCompressionStrategy.Uncompressed,
+ * });
+ * ```
+ * @privateRemarks
+ * TODO:
+ * Expose Ajv validator for better error message quality somehow.
+ * Maybe as part of a test utils or dev-tool package?
+ * @internal
+ */
+export function configuredSharedTree(options: SharedTreeOptions): ISharedObjectKind<ITree> {
+	const factory = new TreeFactory(options);
+	return {
+		getFactory(): IChannelFactory<ITree> {
+			return factory;
+		},
+
+		create(runtime: IFluidDataStoreRuntime, id?: string): ITree {
+			return runtime.createChannel(id, TreeFactory.type) as ITree;
+		},
+	};
+}


### PR DESCRIPTION
## Description

Expose an `@internal` api, `configuredSharedTree` which can be used to opt into various internal/debug shared tree settings.

This should help cases like https://github.com/microsoft/FluidFramework/issues/20274 root cause the bug.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

