### PR TITLE
feat(devtools): Filter incoming ops so Op Latency graph only displays relevant data p…

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
@@ -103,6 +103,10 @@ export function OpLatencyView(): React.ReactElement {
 				if (!eventContents.eventName.endsWith("OpRoundtripTime")) {
 					return false;
 				}
+				// If any of the required fields are missing, we can't use this data
+				if(eventContents.durationNetwork === undefined) {
+					return false;
+				}
 
 				setDurationOutboundBatchingData((currentData) => {
 					const newDataPoint = {

--- a/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
@@ -104,7 +104,7 @@ export function OpLatencyView(): React.ReactElement {
 					return false;
 				}
 				// If any of the required fields are missing, we can't use this data
-				if(eventContents.durationNetwork === undefined) {
+				if (eventContents.durationNetwork === undefined) {
 					return false;
 				}
 

--- a/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
@@ -104,6 +104,7 @@ export function OpLatencyView(): React.ReactElement {
 					return false;
 				}
 				// If any of the required fields are missing, we can't use this data
+				// TODO: AB#7583 Investigates the ops being skipped and their source.
 				if (eventContents.durationNetwork === undefined) {
 					return false;
 				}


### PR DESCRIPTION
[AB#6993](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6993)

## Description

This PR addresses a bug in the Op Latency graph where  incoming ops without the relevant durationNetwork, durationOutboundBatching, durationInboundToProcessing properties were still being rendered causing gaps in the graph with NaN values.

This bug was fixed by filtering and only displaying data from the ops that contain the relevant properties.