### PR TITLE
fix(example-utils): Use correct return type on getter

### DIFF
--- a/examples/utils/example-utils/api-report/example-utils.api.md
+++ b/examples/utils/example-utils/api-report/example-utils.api.md
@@ -346,7 +346,7 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
     // (undocumented)
     protected initializingFirstTime(): Promise<void>;
     // (undocumented)
-    get migrationState(): "collaborating" | "migrated" | "proposingMigration" | "stoppingCollaboration" | "proposingV2Code" | "waitingForV2ProposalCompletion" | "readyForMigration";
+    get migrationState(): SameContainerMigrationState;
     // (undocumented)
     get proposedVersion(): string | undefined;
     // (undocumented)

--- a/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
+++ b/examples/utils/example-utils/src/migrationTool/sameContainerMigrationTool.ts
@@ -11,7 +11,10 @@ import type { ISequencedDocumentMessage } from "@fluidframework/protocol-definit
 import { MessageType } from "@fluidframework/protocol-definitions";
 
 import { assert } from "@fluidframework/core-utils";
-import type { ISameContainerMigrationTool } from "../migrationInterfaces/index.js";
+import type {
+	ISameContainerMigrationTool,
+	SameContainerMigrationState,
+} from "../migrationInterfaces/index.js";
 
 const pactMapKey = "pact-map";
 const newVersionKey = "newVersion";
@@ -89,7 +92,7 @@ export class SameContainerMigrationTool extends DataObject implements ISameConta
 		return this._pactMap;
 	}
 
-	public get migrationState() {
+	public get migrationState(): SameContainerMigrationState {
 		// TODO: Other states
 		if (this._v2SummaryDone) {
 			return "migrated";


### PR DESCRIPTION
When return types on functions are inferred, TypeScript does not guarantee the order in which a union type's members will be enumerated. This means that API reports for APIs with inferred return types can appear to "flip flop" build to build. Using explicit function return types solves the problem, and we have a lint rule @typescript-eslint/explicit-function-return-type that is enabled in our recommended and strict configs - but of course this project is using minimal.

I added a return type for the one getter that causes flip-flopping in our API docs, but I didn't do the larger change of updating the lint config to require return types.