### PR TITLE
test(client-tree): ESM test focus and fix

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -66,16 +66,16 @@
 		"format:prettier": "prettier --write . --cache --ignore-path ../../../.prettierignore",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./tree.test-files.tar ./src/test ./dist/test",
+		"postpack": "tar -cf ./tree.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:benchmark:report": "mocha --exit --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 60000",
 		"test:coverage": "c8 npm test",
-		"test:mocha": "npm run test:mocha:cjs && echo skip npm run test:mocha:esm",
+		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "cross-env MOCHA_SPEC=dist/test mocha",
 		"test:mocha:esm": "mocha",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
-		"test:snapshots:regen": "npm run test:mocha:cjs -- --snapshot",
-		"test:stress": "cross-env FUZZ_TEST_COUNT=20 FUZZ_STRESS_RUN=true mocha --ignore \"dist/test/memory/**/*\" --recursive \"dist/test/**/*.spec.js\" -r @fluid-internal/mocha-test-setup",
+		"test:snapshots:regen": "pnpm test:mocha:esm --snapshot",
+		"test:stress": "cross-env FUZZ_TEST_COUNT=20 FUZZ_STRESS_RUN=true mocha --ignore \"lib/test/memory/**/*\" --recursive \"lib/test/**/*.spec.js\"",
 		"tsc": "fluid-tsc commonjs --project ./tsconfig.cjs.json && copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist",
 		"typetests:gen": "fluid-type-test-generator",
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
@@ -85,12 +85,12 @@
 		"cache-dir": "nyc/.cache",
 		"exclude": [
 			"src/test/**/*.*ts",
-			"dist/test/**/*.*js"
+			"lib/test/**/*.*js"
 		],
 		"exclude-after-remap": false,
 		"include": [
 			"src/**/*.*ts",
-			"dist/**/*.*js"
+			"lib/**/*.*js"
 		],
 		"report-dir": "nyc/report",
 		"reporter": [
@@ -168,11 +168,11 @@
 			},
 			"build:test:cjs": [
 				"...",
-				"@fluidframework/id-compressor#build:test"
+				"@fluidframework/id-compressor#build:test:cjs"
 			],
 			"build:test:esm": [
 				"...",
-				"@fluidframework/id-compressor#build:test"
+				"@fluidframework/id-compressor#build:test:esm"
 			],
 			"check:release-tags": [
 				"build:esnext"

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
@@ -30,6 +30,7 @@ import {
 	intoStoredSchema,
 } from "../../../feature-libraries/index.js";
 import { ITreeCheckout, SharedTree } from "../../../shared-tree/index.js";
+import { testSrcPath } from "../../testSrcPath.cjs";
 import { expectEqualPaths } from "../../utils.js";
 
 const builder = new SchemaBuilder({ scope: "tree2fuzz", libraries: [leaf.library] });
@@ -104,10 +105,7 @@ export function isRevertibleSharedTreeView(s: ITreeCheckout): s is RevertibleSha
 	return (s as RevertibleSharedTreeView).undoStack !== undefined;
 }
 
-export const failureDirectory = pathJoin(
-	__dirname,
-	"../../../../src/test/shared-tree/fuzz/failures",
-);
+export const failureDirectory = pathJoin(testSrcPath, "shared-tree/fuzz/failures");
 
 export const createOrDeserializeCompressor = (
 	sessionId: SessionId,

--- a/packages/dds/tree/src/test/snapshots/snapshotTools.ts
+++ b/packages/dds/tree/src/test/snapshots/snapshotTools.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "assert";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import path from "path";
 import { JsonCompatibleReadOnly } from "../../util/index.js";
+import { testSrcPath } from "../testSrcPath.cjs";
 
 const regenerateSnapshots = process.argv.includes("--snapshot");
 
@@ -70,8 +71,7 @@ let currentTestFile: string | undefined;
 // Simple filter to avoid tests with a name that would accidentally be parsed as directory traversal or other confusing things.
 const nameCheck = new RegExp(/^[^"/\\]+$/);
 
-assert(__dirname.match(/dist[/\\]test[/\\]snapshots$/));
-const snapshotsFolder = path.join(__dirname, `../../../src/test/snapshots`);
+const snapshotsFolder = path.join(testSrcPath, "snapshots");
 assert(existsSync(snapshotsFolder));
 
 /**

--- a/packages/dds/tree/src/test/testSrcPath.cts
+++ b/packages/dds/tree/src/test/testSrcPath.cts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+import path from "node:path";
+
+// FUTURE: Without CommonJS requirement __dirname can be acquired from import.meta.url
+// In Node 20+ use:
+// const __dirname = import.meta.dirname;
+// In Node 14+ use:
+// import { dirname } from "node:path";
+// import { fileURLToPath } from "node:url";
+// const __dirname = dirname(fileURLToPath(import.meta.url));
+
+assert(__dirname.match(/(dist|lib)[/\\]test$/));
+
+/**
+ * Path to the test source folder - ./src/test
+ */
+export const testSrcPath = path.join(__dirname, `../../src/test`);


### PR DESCRIPTION
- use ESM __dirname workaround
- enable general ESM test by default (perf already was)
- update id-compressor build dependencies