### PR TITLE
fix(tree): stop purging repair data and revertibles on schema changes

### DIFF
--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -365,7 +365,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 						// is also valid under the new schema.
 						// Note however, that such schema changes may in some cases be rolled back:
 						// Case 1: A transaction with a schema change may be aborted.
-						// The transaction may have made some data changes that would render the some trees invalid
+						// The transaction may have made some data changes that would render some trees invalid
 						// under the old schema, but these changes will also be rolled back, thereby putting the forest
 						// back in the state before the transaction, which is valid under the original (reinstated) schema.
 						// Case 2: A branch with a schema change may be rebased such that the schema change (because

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -360,14 +360,21 @@ export class TreeCheckout implements ITreeCheckoutFork {
 							visitDelta(delta, visitor, this.removedRoots);
 						});
 					} else if (change.type === "schema") {
-						// We purge all removed content because the schema change may render that repair data invalid.
-						// This happens on all peers that receive the schema change.
-						// Note that while the originator of the schema change could theoretically validate/update the
-						// repair data that it has, so that is it guaranteed to be valid with the new schema, we cannot
-						// guarantee that the originator has a superset of the repair data that other clients have.
-						// This means the originator cannot guarantee that the repair data on all peers is valid for
-						// the new schema.
-						this.purgeRemovedRoots();
+						// Schema changes from a current to a new schema are expected to be backwards compatible.
+						// This guarantees that all data in the forest (which is valid before the schema change)
+						// is also valid under the new schema.
+						// Note however, that such schema changes may in some cases be rolled back:
+						// Case 1: A transaction with a schema change may be aborted.
+						// The transaction may have made some data changes that would render the some trees invalid
+						// under the old schema, but these changes will also be rolled back, thereby putting the forest
+						// back in the state before the transaction, which is valid under the original (reinstated) schema.
+						// Case 2: A branch with a schema change may be rebased such that the schema change (because
+						// of a constraint) is no longer applied.
+						// Such a branch may contain data changes that would render some trees invalid under the
+						// original schema. These data changes may not necessarily be rolled back.
+						// They will however be rebased over the rollback of the schema change. This rebasing will
+						// ensure that these data changes are muted if they would render some trees invalid under the
+						// original (reinstated) schema.
 						storedSchema.apply(change.innerChange.schema.new);
 					} else {
 						fail("Unknown Shared Tree change type.");
@@ -399,19 +406,6 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		);
 		fn(combinedVisitor);
 		combinedVisitor.free();
-	}
-
-	private purgeRemovedRoots() {
-		// Revertibles are susceptible to use repair data so we purge them.
-		this.branch.purgeRevertibles();
-		this.withCombinedVisitor((visitor) => {
-			for (const { root } of this.removedRoots.entries()) {
-				const field = this.removedRoots.toFieldKey(root);
-				// TODO:AD5509 Handle arbitrary-length fields once the storage of removed roots is no longer atomized.
-				visitor.destroy(field, 1);
-			}
-		});
-		this.removedRoots.purge();
 	}
 
 	public get rootEvents(): ISubscribable<AnchorSetRootEvents> {

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -574,7 +574,7 @@ describe("sharedTreeView", () => {
 		});
 	});
 
-	it("schema edits cause all clients to purge all repair data and all revertibles", () => {
+	it("schema edits do not cause clients to purge repair data or revertibles", () => {
 		const provider = new TestTreeProviderLite(2);
 		const checkout1 = provider.trees[0].checkout;
 		const checkout2 = provider.trees[1].checkout;
@@ -621,16 +621,16 @@ describe("sharedTreeView", () => {
 
 		checkout1.updateSchema(intoStoredSchema(numberSequenceRootSchema));
 
-		// The undo stack is not empty because it contains the schema change
-		assert.equal(checkout1Revertibles.undoStack.length, 1);
-		assert.equal(checkout1Revertibles.redoStack.length, 0);
-		assert.deepEqual(checkout1.getRemovedRoots(), []);
+		// The undo stack contains both the removal of A and the schema change
+		assert.equal(checkout1Revertibles.undoStack.length, 2);
+		assert.equal(checkout1Revertibles.redoStack.length, 1);
+		assert.deepEqual(checkout1.getRemovedRoots().length, 2);
 
 		provider.processMessages();
 
-		assert.equal(checkout2Revertibles.undoStack.length, 0);
-		assert.equal(checkout2Revertibles.redoStack.length, 0);
-		assert.deepEqual(checkout2.getRemovedRoots(), []);
+		assert.equal(checkout2Revertibles.undoStack.length, 1);
+		assert.equal(checkout2Revertibles.redoStack.length, 1);
+		assert.deepEqual(checkout2.getRemovedRoots().length, 2);
 
 		checkout1Revertibles.unsubscribe();
 		checkout2Revertibles.unsubscribe();
@@ -676,15 +676,7 @@ describe("sharedTreeView", () => {
 			});
 		});
 
-		// AB#7256: This test fails because purging repair data upon application of schema changes makes it impossible
-		// to roll back the changes that were before that schema change on the branch being rebased.
-		// This is not a problem when the changes before the schema change are applied once rebased (because the
-		// rollback and reapplication cancel out). This is the scenario covered in the test above.
-		// It is a problem here because the rebased change does not apply due to the presence of a schema change on
-		// the destination branch. Note that the presence of a schema change on the destination branch is not strictly
-		// necessary for the problem to occur. For example, if the rebased change had a constraint, and the rebasing
-		// caused that constraint to become violated, then the same issue would occur.
-		it.skip("over schema changes", () => {
+		it("over schema changes", () => {
 			const provider = new TestTreeProviderLite(1);
 			const checkout1 = provider.trees[0].checkout;
 
@@ -718,7 +710,7 @@ describe("sharedTreeView", () => {
 
 			// All changes on the branch should be dropped
 			validateTreeContent(branch, {
-				schema: jsonSequenceRootSchema,
+				schema: stringSequenceRootSchema,
 				initialTree: ["B", "C"],
 			});
 		});


### PR DESCRIPTION
## Description

Removes the logic that purged the repair data (and revertibles) whenever a schema change is applied.
This fixes bug [AB#7265](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7265) and leads to a better user undo/redo and rebase/merge experience.

This change is safe because we have committed to only allowing backwards-compatible schema changes.

## Breaking Changes

While these changes will not break the build of any user, however a peer with this new logic may produce changes that a peer with the old logic may be unable to apply. Collaboration between such peers is therefore discouraged. Not that this issue can only arise in the presence of schema changes (either new one or recent-enough one to be in the latest summary's trailing ops).