### PR TITLE
fix(tree): prevent schema changes from being reverted

### DIFF
--- a/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeCodecs.ts
@@ -15,7 +15,7 @@ export function makeSchemaChangeCodec({
 	const schemaCodec = makeSchemaCodec({ jsonValidator: validator });
 	return {
 		encode: (schemaChange) => {
-			assert(!schemaChange.isRollback, "Rollback schema changes should never be transmitted");
+			assert(!schemaChange.isInverse, "Inverse schema changes should never be transmitted");
 			return {
 				new: schemaCodec.encode(schemaChange.schema.new),
 				old: schemaCodec.encode(schemaChange.schema.old),
@@ -27,7 +27,7 @@ export function makeSchemaChangeCodec({
 					new: schemaCodec.decode(encoded.new),
 					old: schemaCodec.decode(encoded.old),
 				},
-				isRollback: false,
+				isInverse: false,
 			};
 		},
 		encodedSchema: EncodedSchemaChange,

--- a/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeCodecs.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/core-utils";
 import { ICodecOptions, IJsonCodec } from "../../codec/index.js";
 import { makeSchemaCodec } from "../schema-index/index.js";
 import { EncodedSchemaChange } from "./schemaChangeFormat.js";
@@ -14,6 +15,7 @@ export function makeSchemaChangeCodec({
 	const schemaCodec = makeSchemaCodec({ jsonValidator: validator });
 	return {
 		encode: (schemaChange) => {
+			assert(!schemaChange.isRollback, "Rollback schema changes should never be transmitted");
 			return {
 				new: schemaCodec.encode(schemaChange.schema.new),
 				old: schemaCodec.encode(schemaChange.schema.old),
@@ -25,6 +27,7 @@ export function makeSchemaChangeCodec({
 					new: schemaCodec.decode(encoded.new),
 					old: schemaCodec.decode(encoded.old),
 				},
+				isRollback: false,
 			};
 		},
 		encodedSchema: EncodedSchemaChange,

--- a/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeTypes.ts
@@ -15,8 +15,8 @@ export interface SchemaChange {
 	readonly schema: { new: TreeStoredSchema; old: TreeStoredSchema };
 
 	/**
-	 * Whether this change rolls back a previous schema change.
-	 * While non-rollback changes are expected to be backwards compatible, rollback changes are not.
+	 * Whether this change reverses a previous schema change.
+	 * While non-inverse changes are expected to be backwards compatible, inverse changes are not.
 	 */
-	readonly isRollback: boolean;
+	readonly isInverse: boolean;
 }

--- a/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-edits/schemaChangeTypes.ts
@@ -13,4 +13,10 @@ export interface SchemaChange {
 	 * This property contains the new stored schema for the document and the old schema for inverting.
 	 */
 	readonly schema: { new: TreeStoredSchema; old: TreeStoredSchema };
+
+	/**
+	 * Whether this change rolls back a previous schema change.
+	 * While non-rollback changes are expected to be backwards compatible, rollback changes are not.
+	 */
+	readonly isRollback: boolean;
 }

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -116,6 +116,7 @@ export class SharedTreeChangeFamily
 								new: innerChange.innerChange.schema.old,
 								old: innerChange.innerChange.schema.new,
 							},
+							isRollback: true,
 						},
 					};
 				}

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -179,6 +179,6 @@ export class SharedTreeChangeFamily
 	}
 }
 
-function hasSchemaChange(change: SharedTreeChange): boolean {
+export function hasSchemaChange(change: SharedTreeChange): boolean {
 	return change.changes.some((innerChange) => innerChange.type === "schema");
 }

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -116,7 +116,7 @@ export class SharedTreeChangeFamily
 								new: innerChange.innerChange.schema.old,
 								old: innerChange.innerChange.schema.new,
 							},
-							isRollback: true,
+							isInverse: true,
 						},
 					};
 				}

--- a/packages/dds/tree/src/shared-tree/sharedTreeEditBuilder.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeEditBuilder.ts
@@ -64,7 +64,7 @@ export class SharedTreeEditBuilder
 							type: "schema",
 							innerChange: {
 								schema: { new: newSchema, old: oldSchema },
-								isRollback: false,
+								isInverse: false,
 							},
 						},
 					],

--- a/packages/dds/tree/src/shared-tree/sharedTreeEditBuilder.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeEditBuilder.ts
@@ -62,7 +62,10 @@ export class SharedTreeEditBuilder
 					changes: [
 						{
 							type: "schema",
-							innerChange: { schema: { new: newSchema, old: oldSchema } },
+							innerChange: {
+								schema: { new: newSchema, old: oldSchema },
+								isRollback: false,
+							},
 						},
 					],
 				});

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -40,7 +40,7 @@ import {
 } from "../feature-libraries/index.js";
 import { SharedTreeBranch, getChangeReplaceType } from "../shared-tree-core/index.js";
 import { TransactionResult, fail } from "../util/index.js";
-import { SharedTreeChangeFamily } from "./sharedTreeChangeFamily.js";
+import { SharedTreeChangeFamily, hasSchemaChange } from "./sharedTreeChangeFamily.js";
 import { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import { ISharedTreeEditor, SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
 
@@ -390,7 +390,13 @@ export class TreeCheckout implements ITreeCheckoutFork {
 			}
 		});
 		branch.on("commitApplied", (data, getRevertible) => {
-			this.events.emit("commitApplied", data, getRevertible);
+			this.events.emit(
+				"commitApplied",
+				data,
+				// Commits that contain schema changes are not revertible.
+				// Allowing a schema change to be reverted could render some of the forest content out-of-schema.
+				hasSchemaChange(branch.getHead().change) ? undefined : getRevertible,
+			);
 		});
 		branch.on("revertibleDisposed", (revertible, revision) => {
 			// We do not expose the revision in this API

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1639,7 +1639,9 @@ describe("SharedTree", () => {
 			validateTreeConsistency(provider.trees[0], provider.trees[1]);
 		});
 
-		it("can be undone at the tip", async () => {
+		// Undoing schema changes is not supported because it may render some of the forest contents invalid.
+		// This may be revisited in the future.
+		it.skip("can be undone at the tip", async () => {
 			const provider = await TestTreeProvider.create(2, SummarizeType.disabled);
 
 			const tree = provider.trees[0];

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
@@ -72,7 +72,7 @@ const stSchemaChange: SharedTreeChange = {
 	changes: [
 		{
 			type: "schema",
-			innerChange: { schema: { new: emptySchema, old: emptySchema }, isRollback: false },
+			innerChange: { schema: { new: emptySchema, old: emptySchema }, isInverse: false },
 		},
 	],
 };

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
@@ -69,7 +69,12 @@ const emptySchema: TreeStoredSchema = {
 	},
 };
 const stSchemaChange: SharedTreeChange = {
-	changes: [{ type: "schema", innerChange: { schema: { new: emptySchema, old: emptySchema } } }],
+	changes: [
+		{
+			type: "schema",
+			innerChange: { schema: { new: emptySchema, old: emptySchema }, isRollback: false },
+		},
+	],
 };
 const stEmptyChange: SharedTreeChange = {
 	changes: [],

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -142,6 +142,62 @@ describe("sharedTreeView", () => {
 				"editStart",
 			]);
 		});
+
+		describe("commitApplied", () => {
+			it("is fired for data and schema changes", () => {
+				const provider = new TestTreeProviderLite(1);
+				const checkout1 = provider.trees[0].checkout;
+
+				const log: string[] = [];
+				const unsubscribe = checkout1.events.on("commitApplied", () =>
+					log.push("commitApplied"),
+				);
+
+				assert.equal(log.length, 0);
+
+				checkout1.updateSchema(intoStoredSchema(jsonSequenceRootSchema));
+
+				assert.equal(log.length, 1);
+
+				checkout1.editor
+					.sequenceField(rootField)
+					.insert(
+						0,
+						cursorForJsonableTreeField([{ type: leaf.string.name, value: "A" }]),
+					);
+
+				assert.equal(log.length, 2);
+
+				checkout1.updateSchema(intoStoredSchema(stringSequenceRootSchema));
+
+				assert.equal(log.length, 3);
+				unsubscribe();
+			});
+
+			it("does not allow schema changes to be reverted", () => {
+				const provider = new TestTreeProviderLite(1);
+				const checkout1 = provider.trees[0].checkout;
+
+				const log: string[] = [];
+				const unsubscribe = checkout1.events.on("commitApplied", (data, getRevertible) =>
+					log.push(getRevertible === undefined ? "not-revertible" : "revertible"),
+				);
+
+				assert.deepEqual(log, []);
+
+				checkout1.updateSchema(intoStoredSchema(jsonSequenceRootSchema));
+				checkout1.editor
+					.sequenceField(rootField)
+					.insert(
+						0,
+						cursorForJsonableTreeField([{ type: leaf.string.name, value: "A" }]),
+					);
+				checkout1.updateSchema(intoStoredSchema(stringSequenceRootSchema));
+
+				assert.deepEqual(log, ["not-revertible", "revertible", "not-revertible"]);
+				unsubscribe();
+			});
+		});
 	});
 
 	describe("Views", () => {
@@ -621,8 +677,8 @@ describe("sharedTreeView", () => {
 
 		checkout1.updateSchema(intoStoredSchema(numberSequenceRootSchema));
 
-		// The undo stack contains both the removal of A and the schema change
-		assert.equal(checkout1Revertibles.undoStack.length, 2);
+		// The undo stack contains the removal of A but not the schema change
+		assert.equal(checkout1Revertibles.undoStack.length, 1);
 		assert.equal(checkout1Revertibles.redoStack.length, 1);
 		assert.deepEqual(checkout1.getRemovedRoots().length, 2);
 

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -146,20 +146,20 @@ describe("sharedTreeView", () => {
 		describe("commitApplied", () => {
 			it("is fired for data and schema changes", () => {
 				const provider = new TestTreeProviderLite(1);
-				const checkout1 = provider.trees[0].checkout;
+				const checkout = provider.trees[0].checkout;
 
 				const log: string[] = [];
-				const unsubscribe = checkout1.events.on("commitApplied", () =>
+				const unsubscribe = checkout.events.on("commitApplied", () =>
 					log.push("commitApplied"),
 				);
 
 				assert.equal(log.length, 0);
 
-				checkout1.updateSchema(intoStoredSchema(jsonSequenceRootSchema));
+				checkout.updateSchema(intoStoredSchema(jsonSequenceRootSchema));
 
 				assert.equal(log.length, 1);
 
-				checkout1.editor
+				checkout.editor
 					.sequenceField(rootField)
 					.insert(
 						0,
@@ -168,7 +168,7 @@ describe("sharedTreeView", () => {
 
 				assert.equal(log.length, 2);
 
-				checkout1.updateSchema(intoStoredSchema(stringSequenceRootSchema));
+				checkout.updateSchema(intoStoredSchema(stringSequenceRootSchema));
 
 				assert.equal(log.length, 3);
 				unsubscribe();
@@ -176,23 +176,23 @@ describe("sharedTreeView", () => {
 
 			it("does not allow schema changes to be reverted", () => {
 				const provider = new TestTreeProviderLite(1);
-				const checkout1 = provider.trees[0].checkout;
+				const checkout = provider.trees[0].checkout;
 
 				const log: string[] = [];
-				const unsubscribe = checkout1.events.on("commitApplied", (data, getRevertible) =>
+				const unsubscribe = checkout.events.on("commitApplied", (data, getRevertible) =>
 					log.push(getRevertible === undefined ? "not-revertible" : "revertible"),
 				);
 
 				assert.deepEqual(log, []);
 
-				checkout1.updateSchema(intoStoredSchema(jsonSequenceRootSchema));
-				checkout1.editor
+				checkout.updateSchema(intoStoredSchema(jsonSequenceRootSchema));
+				checkout.editor
 					.sequenceField(rootField)
 					.insert(
 						0,
 						cursorForJsonableTreeField([{ type: leaf.string.name, value: "A" }]),
 					);
-				checkout1.updateSchema(intoStoredSchema(stringSequenceRootSchema));
+				checkout.updateSchema(intoStoredSchema(stringSequenceRootSchema));
 
 				assert.deepEqual(log, ["not-revertible", "revertible", "not-revertible"]);
 				unsubscribe();


### PR DESCRIPTION
## Description

Updates `TreeCheckout` so that it does not allow commits with schema changes to be reverted.
This is because it may render some of the forest contents out-of-schema.
This may be revisited in the future.

## Breaking Changes

This will not break compilation of user code but it will break runtime scenarios that expect schema changes to be revertible.
Specifically, listeners of `commitApplied` will now receive `undefined` for the `getRevertible` parameter for commits that contain schema changes when they used to receive a valid thunk.

Note that while it was supported before this change, reverting commits that contain schema changes was never safe. Consider the following sequence of commits:
1. Change the schema to allow Foo instances in a field
2. Insert a Foo instance to the field
3. Revert commit 1 -> leads to a forest with out-of-schema data
