### PR TITLE
Remove assert 0x260 - Consider disposed as valid and equivalent to disconnected for this codepath

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1924,6 +1924,9 @@ export class ContainerRuntime
 			error,
 		);
 
+		// Connected but Disposed doesn't make sense as a valid state, so ensure Disconnected
+		this.setConnectionState(false);
+
 		if (this.summaryManager !== undefined) {
 			this.summaryManager.dispose();
 		}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1924,9 +1924,6 @@ export class ContainerRuntime
 			error,
 		);
 
-		// Connected but Disposed doesn't make sense as a valid state, so ensure Disconnected
-		this.setConnectionState(false);
-
 		if (this.summaryManager !== undefined) {
 			this.summaryManager.dispose();
 		}

--- a/packages/runtime/container-runtime/src/summary/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryManager.ts
@@ -190,7 +190,7 @@ export class SummaryManager extends TypedEventEmitter<ISummarizerEvents> impleme
 			return { shouldSummarize: false, stopReason: "notElectedClient" };
 		}
 
-		if (!this.connectedState.connected || this.disposed) {
+		if (!this.connectedState.connected) {
 			return { shouldSummarize: false, stopReason: "parentNotConnected" };
 		}
 

--- a/packages/runtime/container-runtime/src/summary/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryManager.ts
@@ -238,6 +238,10 @@ export class SummaryManager extends TypedEventEmitter<ISummarizerEvents> impleme
 
 		this.delayBeforeCreatingSummarizer()
 			.then(async (startWithInitialDelay: boolean) => {
+				if (this.disposed) {
+					return "early exit (disposed)";
+				}
+
 				// Re-validate that it need to be running. Due to asynchrony, it may be not the case anymore
 				// but only if creation was delayed. If it was not, then we want to ensure we always create
 				// a summarizer to kick off lastSummary. Without that, we would not be able to summarize and get

--- a/packages/runtime/container-runtime/src/summary/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryManager.ts
@@ -168,6 +168,10 @@ export class SummaryManager extends TypedEventEmitter<ISummarizerEvents> impleme
 		state === SummaryManagerState.Starting || state === SummaryManagerState.Running;
 
 	private getShouldSummarizeState(): ShouldSummarizeState {
+		if (this.disposed) {
+			return { shouldSummarize: false, stopReason: "parentNotConnected" };
+		}
+
 		// Note that if we're in the Running state, the electedClient may be a summarizer client, so we can't
 		// enforce connectedState.clientId === clientElection.electedClientId. But once we're Running, we should
 		// only transition to Stopping when the electedParentId changes. Stopping the summarizer without

--- a/packages/runtime/container-runtime/src/summary/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryManager.ts
@@ -186,15 +186,11 @@ export class SummaryManager extends TypedEventEmitter<ISummarizerEvents> impleme
 			return { shouldSummarize: false, stopReason: "notElectedClient" };
 		}
 
-		if (!this.connectedState.connected) {
+		if (!this.connectedState.connected || this.disposed) {
 			return { shouldSummarize: false, stopReason: "parentNotConnected" };
 		}
 
-		if (this.disposed) {
-			assert(false, 0x260 /* "Disposed should mean disconnected!" */);
-		} else {
-			return { shouldSummarize: true };
-		}
+		return { shouldSummarize: true };
 	}
 
 	private readonly refreshSummarizer = () => {


### PR DESCRIPTION
## Description

Fixes [AB#6634](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6634)

Assert 0x260 says `"Disposed should mean disconnected!"`. We see this hit on occasion in our e2e tests with this sequence of events in the logs (in the case I investigated):

Data_eventName | Data_error
-- | --
fluid:telemetry:ContainerRuntime:ContainerRuntimeDisposed |  
fluid:telemetry:Container:ConnectionStateChange_Disconnected |  
fluid:telemetry:DeltaConnection:ClientClosingDeltaConnection |  
fluid:telemetry:Container:noWaitOnDisconnected |  
fluid:telemetry:Container:ContainerClose |  
fluid:telemetry:SummaryManager:EndingSummarizer | 0x260

The second event there would result in this function on `Container` being called, but note it's a no-op if ContainerRuntime is already disposed:

```ts
	private setContextConnectedState(state: boolean, readonly: boolean): void {
		if (this._runtime?.disposed === false) {
			/**
			 * We want to lie to the ContainerRuntime when we are in readonly mode to prevent issues with pending
			 * ops getting through to the DeltaManager.
			 * The ContainerRuntime's "connected" state simply means it is ok to send ops
			 * See https://dev.azure.com/fluidframework/internal/_workitems/edit/1246
			 */
			this.runtime.setConnectionState(state && !readonly, this.clientId);
		}
	}
```

~So the proposed fix is to explicitly transition the ContainerRuntime to Disconnected state at the top of `dispose`.~

So the proposed fix is to allow this state (connected but disposed) and just return `{ shouldSummarize: false}`
