### PR TITLE
refactor(ci): Skip test result publishing for stress tests

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -60,6 +60,12 @@ parameters:
   type: string
   default: '@ff-internal/aria-logger'
 
+# If true, skip publishing report files for test results.
+# Useful because our stress tests pipeline doesn't generate any test result files.
+- name: skipTestResultPublishing
+  type: boolean
+  default: false
+
 # Custom steps specified by the "caller" of this template, for any additional things that need to be done
 # after the steps in this template complete.
 - name: additionalSteps
@@ -315,37 +321,38 @@ jobs:
           workingDir: ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}
           customCommand: 'run ${{ parameters.testCommand }} -- ${{ variant.flags }}'
 
-      # filter report
-      - task: Bash@3
-        displayName: Filter skipped test from report
-        condition: succeededOrFailed()
-        inputs:
-          workingDir: ${{ variables.testPackageDir }}/nyc
-          targetType: 'inline'
-          script: |
-            if [[ -d ${{ variables.testPackageDir }}/nyc ]]; then
-              echo "directory '${{ variables.testPackageDir }}/nyc' exists."
-              cd ${{ variables.testPackageDir }}/nyc
-              if ! [[ -z "$(ls -A .)" ]]; then
-                curdirfiles=`ls`
-                echo "report file(s) ${curdirfiles} found. Filtering skipped tests..."
-                for i in `ls`; do sed -i '/<skipped/d' $i; done
+      - ${{ if eq(parameters.skipTestResultPublishing, false) }}:
+        # filter report
+        - task: Bash@3
+          displayName: Filter skipped test from report
+          condition: succeededOrFailed()
+          inputs:
+            workingDir: ${{ variables.testPackageDir }}/nyc
+            targetType: 'inline'
+            script: |
+              if [[ -d ${{ variables.testPackageDir }}/nyc ]]; then
+                echo "directory '${{ variables.testPackageDir }}/nyc' exists."
+                cd ${{ variables.testPackageDir }}/nyc
+                if ! [[ -z "$(ls -A .)" ]]; then
+                  curdirfiles=`ls`
+                  echo "report file(s) ${curdirfiles} found. Filtering skipped tests..."
+                  for i in `ls`; do sed -i '/<skipped/d' $i; done
+                else
+                  echo "No report files found in '${{ variables.testPackageDir }}/nyc'"
+                fi
               else
-                echo "No report files found in '${{ variables.testPackageDir }}/nyc'"
+                echo "Directory '${{ variables.testPackageDir }}/nyc' not found"
               fi
-            else
-              echo "Directory '${{ variables.testPackageDir }}/nyc' not found"
-            fi
 
-      # Upload results
-      - task: PublishTestResults@2
-        displayName: Publish Test Results
-        inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '**/*junit-report.xml'
-          searchFolder: ${{ variables.testPackageDir }}/nyc
-          mergeTestResults: false
-        condition: succeededOrFailed()
+        # Upload results
+        - task: PublishTestResults@2
+          displayName: Publish Test Results
+          inputs:
+            testResultsFormat: 'JUnit'
+            testResultsFiles: '**/*junit-report.xml'
+            searchFolder: ${{ variables.testPackageDir }}/nyc
+            mergeTestResults: false
+          condition: succeededOrFailed()
 
       # Publish tinylicious log for troubleshooting
       - ${{ if or(contains(convertToJson(parameters.testCommand), 'tinylicious'), contains(convertToJson(parameters.testCommand), 't9s')) }}:

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -49,6 +49,7 @@ stages:
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120
         testCommand: start:odsp
+        skipTestResultPublishing: true
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)
           login__microsoft__secret: $(login-microsoft-secret)
@@ -71,6 +72,7 @@ stages:
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120
         testCommand: start:odspdf
+        skipTestResultPublishing: true
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)
           login__microsoft__secret: $(login-microsoft-secret)
@@ -90,6 +92,7 @@ stages:
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120
         testCommand: start:t9s
+        skipTestResultPublishing: true
         env:
           FLUID_TEST_LOGGER_PKG_SPECIFIER: '@ff-internal/aria-logger' # Contains getTestLogger impl to inject
           # Disable colorization for tinylicious logs (not useful when printing to a file)
@@ -112,9 +115,11 @@ stages:
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120
         testCommand: start:frs
+        skipTestResultPublishing: true
         env:
           fluid__test__driver__frs: $(automation-fluid-test-driver-frs-stress-test)
           FLUID_TEST_LOGGER_PKG_SPECIFIER: '@ff-internal/aria-logger' # Contains getTestLogger impl to inject
+
   # stress tests frs canary
   - stage: stress_tests_frs_canary
     displayName: Stress tests - frs canary
@@ -131,6 +136,7 @@ stages:
         artifactBuildId: $(resources.pipeline.client.runID)
         timeoutInMinutes: 120
         testCommand: start:frs:canary
+        skipTestResultPublishing: true
         env:
           fluid__test__driver__frsCanary: $(automation-fluid-driver-frs-canary-stress-test)
           FLUID_TEST_LOGGER_PKG_SPECIFIER: '@ff-internal/aria-logger' # Contains getTestLogger impl to inject


### PR DESCRIPTION
## Description

Our stress tests pipeline doesn't generate any test results file (it doesn't really "run tests", it's more of a "stress scenario simulator"), but it always tries to publish a test results file because it uses the same template as the e2e tests pipeline, which does generate test result files.

This adds a parameter so that stress tests doesn't try to do things that can't work for it, so we don't see these warnings on every run:

![image](https://github.com/microsoft/FluidFramework/assets/716334/30d2066b-2f58-4995-ac1c-8e087644e747)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

If you turn on the hide-whitespace checkbox in Github diff viewer, the PR will be easier to validate.