### PR TITLE
Add explicit version field to tree ops

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/core-utils";
 import { TAnySchema, Type } from "@sinclair/typebox";
 import { ICodecOptions, IJsonCodec, withSchemaValidation } from "../codec/index.js";
 import {
@@ -35,7 +36,6 @@ export function makeMessageCodec<TChangeset>(
 	JsonCompatibleReadOnly,
 	MessageEncodingContext
 > {
-	// TODO: consider adding version and using makeVersionedValidatedCodec
 	return withSchemaValidation<
 		DecodedMessage<TChangeset>,
 		TAnySchema,
@@ -56,11 +56,14 @@ export function makeMessageCodec<TChangeset>(
 						originatorId,
 						schema: context.schema,
 					}),
+					version: 1,
 				};
 				return message as unknown as JsonCompatibleReadOnly;
 			},
 			decode: (encoded: JsonCompatibleReadOnly) => {
-				const { revision, originatorId, changeset } = encoded as unknown as Message;
+				const { revision, originatorId, changeset, version } =
+					encoded as unknown as Message;
+				assert(version === undefined || version === 1, "Unsupported message version");
 				return {
 					commit: {
 						revision: revisionTagCodec.decode(revision, { originatorId }),

--- a/packages/dds/tree/src/shared-tree-core/messageFormat.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormat.ts
@@ -24,6 +24,14 @@ export interface Message {
 	 * The changeset to be applied.
 	 */
 	readonly changeset: JsonCompatibleReadOnly;
+
+	/**
+	 * The version of the message. This controls how the message is encoded.
+	 *
+	 * This was not set historically and was added before making any breaking changes to the format.
+	 * For that reason, absence of a 'version' field is synonymous with version 1.
+	 */
+	readonly version?: number;
 }
 
 export const Message = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
@@ -31,4 +39,5 @@ export const Message = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
 		revision: RevisionTagSchema,
 		originatorId: SessionIdSchema,
 		changeset: tChange,
+		version: Type.Optional(Type.Number()),
 	});

--- a/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
@@ -1,0 +1,100 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import { type SessionId, createSessionId } from "@fluidframework/id-compressor";
+import { validateAssertionError } from "@fluidframework/test-runtime-utils";
+import type { EncodedRevisionTag, GraphCommit } from "../../core/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { makeMessageCodec } from "../../shared-tree-core/messageCodecs.js";
+// eslint-disable-next-line import/no-internal-modules
+import type { Message } from "../../shared-tree-core/messageFormat.js";
+// eslint-disable-next-line import/no-internal-modules
+import type { DecodedMessage } from "../../shared-tree-core/messageTypes.js";
+import { ajvValidator } from "../codec/index.js";
+import { TestChange } from "../testChange.js";
+import { testIdCompressor, testRevisionTagCodec } from "../utils.js";
+
+const codec = makeMessageCodec(TestChange.codec, testRevisionTagCodec, {
+	jsonValidator: ajvValidator,
+});
+
+describe("MessageCodec", () => {
+	const sessionId: SessionId = "sessionId" as SessionId;
+	it("Drops inverse and parent commit fields on encode", () => {
+		const revision = testIdCompressor.generateCompressedId();
+		const message: DecodedMessage<TestChange> = {
+			sessionId,
+			commit: {
+				revision,
+				change: TestChange.mint([], 1),
+				inverse: "Extra field that should be dropped" as unknown as TestChange,
+				parent: "Extra field that should be dropped" as unknown as GraphCommit<TestChange>,
+			},
+		};
+
+		const actual = codec.decode(codec.encode(message, {}), {});
+		assert.deepEqual(actual, {
+			sessionId,
+			commit: {
+				revision,
+				change: TestChange.mint([], 1),
+			},
+		});
+	});
+
+	it("accepts unversioned messages as version 1", () => {
+		const revision = 1 as EncodedRevisionTag;
+		const originatorId = createSessionId();
+		const encoded = JSON.stringify({
+			revision,
+			originatorId,
+			changeset: {},
+		} satisfies Message);
+		const actual = codec.decode(JSON.parse(encoded), {});
+		assert.deepEqual(actual, {
+			commit: {
+				revision: testRevisionTagCodec.decode(revision, { originatorId }),
+				change: {},
+			},
+			sessionId: originatorId,
+		} satisfies DecodedMessage<unknown>);
+	});
+
+	it("accepts version 1 messages as version 1", () => {
+		const revision = 1 as EncodedRevisionTag;
+		const originatorId = createSessionId();
+		const encoded = JSON.stringify({
+			revision,
+			originatorId,
+			changeset: {},
+			version: 1,
+		} satisfies Message);
+		const actual = codec.decode(JSON.parse(encoded), {});
+		assert.deepEqual(actual, {
+			commit: {
+				revision: testRevisionTagCodec.decode(revision, { originatorId }),
+				change: {},
+			},
+			sessionId: originatorId,
+		} satisfies DecodedMessage<unknown>);
+	});
+
+	it("rejects messages with invalid versions", () => {
+		const revision = 1 as EncodedRevisionTag;
+		const originatorId = createSessionId();
+		const encoded = JSON.stringify({
+			revision,
+			originatorId,
+			changeset: {},
+			version: 2,
+		} satisfies Message);
+		assert.throws(
+			() => codec.decode(JSON.parse(encoded), {}),
+			(e: Error) => validateAssertionError(e, "Unsupported message version"),
+			"Expected decoding to fail validation",
+		);
+	});
+});

--- a/packages/dds/tree/src/test/snapshots/op-format/field change.json
+++ b/packages/dds/tree/src/test/snapshots/op-format/field change.json
@@ -1,0 +1,77 @@
+[
+  {
+    "revision": -5,
+    "originatorId": "00000000-0000-4000-b000-000000000000",
+    "changeset": [
+      {
+        "data": {
+          "maxId": 1,
+          "changes": [
+            {
+              "fieldKey": "rootFieldKey",
+              "fieldKind": "ModularEditBuilder.Generic",
+              "change": [
+                [
+                  0,
+                  {
+                    "fieldChanges": [
+                      {
+                        "fieldKey": "x",
+                        "fieldKind": "Value",
+                        "change": {
+                          "m": [
+                            [
+                              0,
+                              null,
+                              true
+                            ],
+                            [
+                              null,
+                              1,
+                              false
+                            ]
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ],
+          "builds": {
+            "builds": [
+              [
+                [
+                  [
+                    0,
+                    0
+                  ]
+                ]
+              ]
+            ],
+            "trees": {
+              "version": 1,
+              "identifiers": [],
+              "shapes": [
+                {
+                  "c": {
+                    "type": "com.fluidframework.leaf.number",
+                    "value": true
+                  }
+                }
+              ],
+              "data": [
+                [
+                  0,
+                  1
+                ]
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "version": 1
+  }
+]

--- a/packages/dds/tree/src/test/snapshots/op-format/schema change.json
+++ b/packages/dds/tree/src/test/snapshots/op-format/schema change.json
@@ -1,0 +1,183 @@
+[
+  {
+    "revision": -4,
+    "originatorId": "00000000-0000-4000-b000-000000000000",
+    "changeset": [
+      {
+        "schema": {
+          "new": {
+            "version": 1,
+            "nodes": {
+              "com.fluidframework.leaf.number": {
+                "leaf": 0
+              },
+              "snapshots.Point": {
+                "object": {
+                  "x": {
+                    "kind": "Value",
+                    "types": [
+                      "com.fluidframework.leaf.number"
+                    ]
+                  },
+                  "y": {
+                    "kind": "Value",
+                    "types": [
+                      "com.fluidframework.leaf.number"
+                    ]
+                  }
+                }
+              }
+            },
+            "root": {
+              "kind": "Optional",
+              "types": [
+                "snapshots.Point"
+              ]
+            }
+          },
+          "old": {
+            "version": 1,
+            "nodes": {},
+            "root": {
+              "kind": "Forbidden",
+              "types": []
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "maxId": 1,
+          "changes": [
+            {
+              "fieldKey": "rootFieldKey",
+              "fieldKind": "Optional",
+              "change": {
+                "m": [
+                  [
+                    1,
+                    null,
+                    true
+                  ]
+                ],
+                "d": 0
+              }
+            }
+          ],
+          "builds": {
+            "builds": [
+              [
+                [
+                  [
+                    1,
+                    0
+                  ]
+                ]
+              ]
+            ],
+            "trees": {
+              "version": 1,
+              "identifiers": [],
+              "shapes": [
+                {
+                  "c": {
+                    "type": "com.fluidframework.leaf.number",
+                    "value": true
+                  }
+                },
+                {
+                  "c": {
+                    "type": "snapshots.Point",
+                    "value": false,
+                    "fields": [
+                      [
+                        "x",
+                        0
+                      ],
+                      [
+                        "y",
+                        0
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "data": [
+                [
+                  1,
+                  0,
+                  0
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "schema": {
+          "new": {
+            "version": 1,
+            "nodes": {
+              "com.fluidframework.leaf.number": {
+                "leaf": 0
+              },
+              "snapshots.Point": {
+                "object": {
+                  "x": {
+                    "kind": "Value",
+                    "types": [
+                      "com.fluidframework.leaf.number"
+                    ]
+                  },
+                  "y": {
+                    "kind": "Value",
+                    "types": [
+                      "com.fluidframework.leaf.number"
+                    ]
+                  }
+                }
+              }
+            },
+            "root": {
+              "kind": "Value",
+              "types": [
+                "snapshots.Point"
+              ]
+            }
+          },
+          "old": {
+            "version": 1,
+            "nodes": {
+              "com.fluidframework.leaf.number": {
+                "leaf": 0
+              },
+              "snapshots.Point": {
+                "object": {
+                  "x": {
+                    "kind": "Value",
+                    "types": [
+                      "com.fluidframework.leaf.number"
+                    ]
+                  },
+                  "y": {
+                    "kind": "Value",
+                    "types": [
+                      "com.fluidframework.leaf.number"
+                    ]
+                  }
+                }
+              }
+            },
+            "root": {
+              "kind": "Optional",
+              "types": [
+                "snapshots.Point"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "version": 1
+  }
+]

--- a/packages/dds/tree/src/test/snapshots/opFormat.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/opFormat.spec.ts
@@ -1,0 +1,75 @@
+import { AttachState } from "@fluidframework/container-definitions";
+import { type SessionId, createIdCompressor } from "@fluidframework/id-compressor";
+import {
+	type MockContainerRuntime,
+	MockContainerRuntimeFactory,
+	MockFluidDataStoreRuntime,
+	MockStorage,
+} from "@fluidframework/test-runtime-utils";
+import { type ITree, SchemaFactory } from "../../index.js";
+import { SharedTree } from "../../treeFactory.js";
+import { takeJsonSnapshot, useSnapshotDirectory } from "./snapshotTools.js";
+
+/**
+ * This suite provides some e2e snapshot coverage for how SharedTree ops look.
+ * Prefer to put exhaustive aspects of the op format in more specific snapshot tests.
+ */
+describe("SharedTree op format snapshots", () => {
+	useSnapshotDirectory("op-format");
+
+	function spyOnFutureMessages(runtime: MockContainerRuntime): any[] {
+		const messages: any[] = [];
+		const originalSubmit = runtime.submit.bind(runtime);
+		runtime.submit = (content, localOpMetadata) => {
+			messages.push(content);
+			return originalSubmit(content, localOpMetadata);
+		};
+		return messages;
+	}
+
+	const sb = new SchemaFactory("snapshots");
+	class Point extends sb.object("Point", {
+		x: sb.number,
+		y: sb.number,
+	}) {}
+
+	let containerRuntime: MockContainerRuntime;
+	let tree: ITree;
+
+	beforeEach(() => {
+		const factory = SharedTree.getFactory();
+		const containerRuntimeFactory = new MockContainerRuntimeFactory();
+		const sessionId = "00000000-0000-4000-b000-000000000000" as SessionId;
+		const runtime = new MockFluidDataStoreRuntime({
+			idCompressor: createIdCompressor(sessionId),
+			attachState: AttachState.Attached,
+		});
+		containerRuntime = containerRuntimeFactory.createContainerRuntime(runtime);
+		tree = factory.create(runtime, "1");
+		tree.connect({
+			deltaConnection: runtime.createDeltaConnection(),
+			objectStorage: new MockStorage(),
+		});
+	});
+
+	it("schema change", () => {
+		const messages = spyOnFutureMessages(containerRuntime);
+		tree.schematize({
+			schema: Point,
+			initialTree: () => new Point({ x: 0, y: 0 }),
+		});
+
+		takeJsonSnapshot(messages);
+	});
+
+	it("field change", () => {
+		const view = tree.schematize({
+			schema: Point,
+			initialTree: () => new Point({ x: 0, y: 2 }),
+		});
+
+		const messages = spyOnFutureMessages(containerRuntime);
+		view.root.x = 1;
+		takeJsonSnapshot(messages);
+	});
+});

--- a/packages/dds/tree/src/test/snapshots/opFormat.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/opFormat.spec.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import { AttachState } from "@fluidframework/container-definitions";
 import { type SessionId, createIdCompressor } from "@fluidframework/id-compressor";
 import {


### PR DESCRIPTION
## Description

Adds an explicit version field to the op format for tree. This is necessary to conveniently support op encoding choices, and aligns with the strategy of stamping summarizables' persisted formats with versions at the top level.

This PR makes minimal changes to MessageCodec to accomplish this, notably it doesn't yet introduce a simple procedure for "bumping the version".