### PR TITLE
[main>lts] Handle creation range interleaving

### DIFF
--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -576,14 +576,13 @@ export class IdCompressor {
 				const lastKnownFinal =
 					this.sessionIdNormalizer.getLastFinalId() ??
 					fail('Cluster exists but normalizer does not have an entry for it.');
-				const lastFinalInCluster = (currentBaseFinalId +
+				const lastAlignedFinalInCluster = (currentBaseFinalId +
 					Math.min(currentCluster.count + finalizeCount, currentCluster.capacity) -
 					1) as FinalCompressedId;
-				if (lastFinalInCluster > lastKnownFinal) {
-					eagerFinalIdCount = lastFinalInCluster - (lastKnownFinal + 1);
+				if (lastAlignedFinalInCluster > lastKnownFinal) {
 					this.sessionIdNormalizer.addFinalIds(
 						(lastKnownFinal + 1) as FinalCompressedId,
-						lastFinalInCluster,
+						lastAlignedFinalInCluster,
 						currentCluster
 					);
 				}
@@ -619,9 +618,20 @@ export class IdCompressor {
 						//                  overflow = 2:    ----
 						//                       localIdPivot^
 						//                    lastFinalizedFinal^
-						const lastFinalizedFinal = (currentBaseFinalId + currentCluster.count - 1) as FinalCompressedId;
-						const finalPivot = (lastFinalizedFinal - overflow + 1) as FinalCompressedId;
-						this.sessionIdNormalizer.addFinalIds(finalPivot, lastFinalizedFinal, currentCluster);
+						const newLastFinalizedFinal = (currentBaseFinalId +
+							currentCluster.count -
+							1) as FinalCompressedId;
+						assert(
+							session.lastFinalizedLocalId !== undefined,
+							'Cluster already exists for session but there is no finalized local ID'
+						);
+						const finalPivot = (newLastFinalizedFinal - overflow + 1) as FinalCompressedId;
+						// Inform the normalizer of all IDs that we now know will end up being finalized into this cluster, including the ones
+						// that were given out as locals (non-eager) because they exceeded the bounds of the current cluster before it was expanded.
+						// It is safe to associate the unfinalized locals with their future final IDs even before the ranges for those locals are
+						// actually finalized, because total order broadcast guarantees that any usage of those final IDs will be observed after
+						// the finalization of the ranges.
+						this.sessionIdNormalizer.registerFinalIdBlock(finalPivot, expansionAmount, currentCluster);
 						this.logger?.sendTelemetryEvent({
 							eventName: 'IdCompressor:ClusterExpansion',
 							sessionId: this.localSessionId,
@@ -690,8 +700,7 @@ export class IdCompressor {
 					clusterCapacity: newCapacity,
 					clusterCount: remainingCount,
 				});
-				const lastFinalizedFinal = (newBaseFinalId + newCluster.count - 1) as FinalCompressedId;
-				this.sessionIdNormalizer.addFinalIds(newBaseFinalId, lastFinalizedFinal, newCluster);
+				this.sessionIdNormalizer.registerFinalIdBlock(newBaseFinalId, newCluster.capacity, newCluster);
 			}
 
 			this.checkClusterForCollision(newCluster);
@@ -975,10 +984,12 @@ export class IdCompressor {
 		let eagerFinalId: (FinalCompressedId & SessionSpaceCompressedId) | undefined;
 		let cluster: IdCluster | undefined;
 		if (currentClusterDetails !== undefined) {
-			const { clusterBase } = currentClusterDetails;
 			cluster = currentClusterDetails.cluster;
 			const lastFinalKnown = sessionIdNormalizer.getLastFinalId();
-			if (lastFinalKnown !== undefined && lastFinalKnown - clusterBase + 1 < cluster.capacity) {
+			if (
+				lastFinalKnown !== undefined &&
+				lastFinalKnown - currentClusterDetails.clusterBase + 1 < cluster.capacity
+			) {
 				eagerFinalId = (lastFinalKnown + 1) as FinalCompressedId & SessionSpaceCompressedId;
 			}
 		}
@@ -1155,15 +1166,14 @@ export class IdCompressor {
 				const inversionKey = IdCompressor.createInversionKey(override);
 				const compressionMapping =
 					this.clustersAndOverridesInversion.get(inversionKey) ?? fail('Bimap is malformed.');
-				if (
-					!IdCompressor.isClusterInfo(compressionMapping) &&
+				return !IdCompressor.isClusterInfo(compressionMapping) &&
 					!IdCompressor.isUnfinalizedOverride(compressionMapping) &&
 					compressionMapping.associatedLocalId === id
-				) {
-					return compressionMapping.originalOverridingFinal;
-				}
+					? compressionMapping.originalOverridingFinal
+					: (id as OpSpaceCompressedId);
 			}
-			return id as OpSpaceCompressedId;
+			const possibleFinal = this.sessionIdNormalizer.getFinalId(id);
+			return possibleFinal?.[0] ?? (id as OpSpaceCompressedId);
 		}
 		const [correspondingFinal, cluster] =
 			this.sessionIdNormalizer.getFinalId(id) ??

--- a/experimental/dds/tree/src/id-compressor/IdCompressor.ts
+++ b/experimental/dds/tree/src/id-compressor/IdCompressor.ts
@@ -580,6 +580,7 @@ export class IdCompressor {
 					Math.min(currentCluster.count + finalizeCount, currentCluster.capacity) -
 					1) as FinalCompressedId;
 				if (lastAlignedFinalInCluster > lastKnownFinal) {
+					eagerFinalIdCount = lastAlignedFinalInCluster - (lastKnownFinal + 1);
 					this.sessionIdNormalizer.addFinalIds(
 						(lastKnownFinal + 1) as FinalCompressedId,
 						lastAlignedFinalInCluster,

--- a/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
+++ b/experimental/dds/tree/src/id-compressor/SessionIdNormalizer.ts
@@ -222,16 +222,17 @@ export class SessionIdNormalizer<TRangeObject> {
 	}
 
 	/**
-	 * Registers a final ID with this normalizer.
-	 * If there are any local IDs at the tip of session-space that do not have a corresponding final, it will be registered (aligned) with
-	 * the first of those. Otherwise, will be registered as the next ID in session space in creation order. An example:
+	 * Registers one or more final IDs with this normalizer.
+	 * If there are any local IDs at the tip of session-space that do not have a corresponding final, they will be registered (aligned)
+	 * starting with the first of those. Otherwise, will be registered as the next ID in session space in creation order.
 	 *
+	 * An example:
 	 * Locals: [-1, -2,  X,  -4]
 	 * Finals: [ 0,  1,  2,   X]
 	 * Calling `addFinalIds` with first === last === 5 results in the following:
 	 * Locals: [-1, -2,  X,  -4]
 	 * Finals: [ 0,  1,  2,   5]
-	 * Calling `addFinalIds` with first === last === 6 results in the following:
+	 * Subsequently calling `addFinalIds` with first === last === 6 results in the following:
 	 * Locals: [-1, -2,  X,  -4,  X]
 	 * Finals: [ 0,  1,  2,   5,  6]
 	 *
@@ -252,18 +253,8 @@ export class SessionIdNormalizer<TRangeObject> {
 			finalRangesObj[1] = [firstFinal, lastFinal, rangeObject];
 			nextLocal = Math.min(this.nextLocalId, firstLocal - (lastFinal - firstFinal) - 1) as LocalCompressedId;
 		} else {
-			const isSingle = isSingleRange(finalRanges);
-			let lastFinalRange: FinalRange<TRangeObject>;
-			let firstAlignedLocal: LocalCompressedId;
-			if (isSingle) {
-				firstAlignedLocal = firstLocal;
-				lastFinalRange = finalRanges;
-			} else {
-				[firstAlignedLocal, lastFinalRange] = finalRanges.last() ?? fail('Map should be non-empty.');
-			}
-
-			const [firstAlignedFinal, lastAlignedFinal] = lastFinalRange;
-			const lastAlignedLocal = firstAlignedLocal - (lastAlignedFinal - firstAlignedFinal);
+			const [firstAlignedLocal, lastAlignedLocal, lastAlignedFinal, lastFinalRange] =
+				this.getAlignmentOfLastRange(firstLocal, finalRanges);
 			nextLocal = Math.min(
 				this.nextLocalId,
 				lastAlignedLocal - (lastFinal - firstFinal) - 2
@@ -273,7 +264,7 @@ export class SessionIdNormalizer<TRangeObject> {
 			} else {
 				const alignedLocal = (lastAlignedLocal - 1) as LocalCompressedId;
 				let rangeMap: FinalRangesMap<TRangeObject>;
-				if (isSingle) {
+				if (isSingleRange(finalRanges)) {
 					// Convert the single range to a range collection
 					rangeMap = SessionIdNormalizer.makeFinalRangesMap();
 					rangeMap.append(firstAlignedLocal, lastFinalRange);
@@ -290,6 +281,70 @@ export class SessionIdNormalizer<TRangeObject> {
 		}
 
 		this.nextLocalId = nextLocal;
+	}
+
+	/**
+	 * Alerts the normalizer to the existence of a block of final IDs that are *allocated* (but may not be entirely used).
+	 *
+	 * The normalizer may have unaligned (unfinalized) local IDs; any such outstanding locals will be eagerly aligned with
+	 * as many finals from the registered block as possible.
+	 *
+	 * It is important to register blocks via this method as soon as they are created for future eager final generations to be utilized, as such
+	 * generation is dependant on the normalizer being up-to-date with which local IDs have been aligned with finals. If, for instance,
+	 * a block of finals is not immediately registered with the normalizer and there are outstanding locals that would have aligned with them,
+	 * those locals will not be finalized until their creation range is finalized, which could be later if the block was created by an earlier
+	 * creation range's finalization but is large enough to span them both. In this scenario, no eager finals can be generated until the second
+	 * creation range is finalized.
+	 *
+	 * A usage example:
+	 * Locals: [-1, -2,  X,  -4, -5, -6]
+	 * Finals: [ 0,  1,  2,   X,  X,  X]
+	 * Calling `registerFinalIdBlock` with firstFinalInBlock === 5 and count === 10 results in the following:
+	 * Locals: [-1, -2,  X,  -4, -5, -6]
+	 * Finals: [ 0,  1,  2,   5,  6,  7]
+	 * Instead calling `registerFinalIdBlock` with firstFinalInBlock === 5 and count === 2 results in the following:
+	 * Locals: [-1, -2,  X,  -4, -5, -6]
+	 * Finals: [ 0,  1,  2,   5,  6,  X]
+	 *
+	 */
+	public registerFinalIdBlock(firstFinalInBlock: FinalCompressedId, count: number, rangeObject: TRangeObject): void {
+		assert(count >= 1, 'Malformed normalization block.');
+		const [firstLocal, [lastLocal, finalRanges]] =
+			this.idRanges.last() ?? fail('Final ID block should not be registered before any locals.');
+		let unalignedLocalCount: number;
+		if (finalRanges === undefined) {
+			unalignedLocalCount = firstLocal - lastLocal + 1;
+		} else {
+			const [_, lastAlignedLocal] = this.getAlignmentOfLastRange(firstLocal, finalRanges);
+			unalignedLocalCount = lastAlignedLocal - lastLocal;
+		}
+		assert(unalignedLocalCount > 0, 'Final ID block should not be registered without an existing local range.');
+		const lastFinal = (firstFinalInBlock + Math.min(unalignedLocalCount, count) - 1) as FinalCompressedId;
+		this.addFinalIds(firstFinalInBlock, lastFinal, rangeObject);
+	}
+
+	private getAlignmentOfLastRange(
+		firstLocal: LocalCompressedId,
+		finalRanges: FinalRanges<TRangeObject>
+	): [
+		firstAlignedLocal: LocalCompressedId,
+		lastAlignedLocal: LocalCompressedId,
+		lastAlignedFinal: FinalCompressedId,
+		lastFinalRange: FinalRange<TRangeObject>
+	] {
+		const isSingle = isSingleRange(finalRanges);
+		let lastFinalRange: FinalRange<TRangeObject>;
+		let firstAlignedLocal: LocalCompressedId;
+		if (isSingle) {
+			firstAlignedLocal = firstLocal;
+			lastFinalRange = finalRanges;
+		} else {
+			[firstAlignedLocal, lastFinalRange] = finalRanges.last() ?? fail('Map should be non-empty.');
+		}
+
+		const [firstAlignedFinal, lastAlignedFinal] = lastFinalRange;
+		const lastAlignedLocal = firstAlignedLocal - (lastAlignedFinal - firstAlignedFinal);
+		return [firstAlignedLocal, lastAlignedLocal as LocalCompressedId, lastAlignedFinal, lastFinalRange];
 	}
 
 	/**

--- a/experimental/dds/tree/src/test/IdCompressor.tests.ts
+++ b/experimental/dds/tree/src/test/IdCompressor.tests.ts
@@ -19,6 +19,7 @@ import {
 	SessionSpaceCompressedId,
 	OpSpaceCompressedId,
 	SessionId,
+	StableId,
 } from '../Identifiers';
 import { assert, assertNotUndefined, fail } from '../Common';
 import {
@@ -442,6 +443,23 @@ describe('IdCompressor', () => {
 			expect(() => compressor.finalizeCreationRange(secondRange)).to.throw('Ranges finalized out of order.');
 		});
 
+		it('can finalize ranges into clusters of varying sizes', () => {
+			for (let i = 1; i < 5; i++) {
+				for (let j = 0; j <= i; j++) {
+					const compressor = createCompressor(Client.Client1, i);
+					const ids = new Set<SessionSpaceCompressedId>();
+					for (let k = 0; k <= j; k++) {
+						ids.add(compressor.generateCompressedId());
+					}
+					compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+					const opIds = new Set<OpSpaceCompressedId>();
+					ids.forEach((id) => opIds.add(compressor.normalizeToOpSpace(id)));
+					expect(ids.size).to.equal(opIds.size);
+					opIds.forEach((id) => expect(isFinalId(id)).to.be.true);
+				}
+			}
+		});
+
 		it('prevents finalizing unacceptably enormous amounts of ID allocation', () => {
 			const compressor1 = createCompressor(Client.Client1);
 			const integerLargerThanHalfMax = Math.round((Number.MAX_SAFE_INTEGER / 3) * 2);
@@ -695,6 +713,243 @@ describe('IdCompressor', () => {
 				compressor2.localSessionId
 			);
 			expect(normalizedToClient1SessionSpace).to.equal(id);
+		});
+	});
+
+	describe('Eager final ID allocation', () => {
+		it('eagerly allocates final IDs when cluster creation has been finalized', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+			const localId2 = compressor.generateCompressedId();
+			expect(isLocalId(localId2)).to.be.true;
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			const finalId3 = compressor.generateCompressedId();
+			expect(isFinalId(finalId3)).to.be.true;
+			const finalId4 = compressor.generateCompressedId();
+			expect(isFinalId(finalId4)).to.be.true;
+			const finalId5 = compressor.generateCompressedId();
+			expect(isFinalId(finalId5)).to.be.true;
+			const localId6 = compressor.generateCompressedId();
+			expect(isLocalId(localId6)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
+			const opSpaceId3 = compressor.normalizeToOpSpace(finalId3);
+			const opSpaceId4 = compressor.normalizeToOpSpace(finalId4);
+			const opSpaceId5 = compressor.normalizeToOpSpace(finalId5);
+			const opSpaceId6 = compressor.normalizeToOpSpace(localId6);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+			expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId3);
+			expectAssert(isFinalId(opSpaceId4) && opSpaceId4 === finalId4);
+			expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId5);
+			expectAssert(isFinalId(opSpaceId6));
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
+			expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId3);
+			expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(finalId4);
+			expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId5);
+			expect(compressor.normalizeToSessionSpace(opSpaceId6)).to.equal(localId6);
+		});
+
+		it('does not eagerly allocate final IDs for IDs with overrides', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const override1 = compressor.generateCompressedId('override1');
+			expect(isLocalId(override1)).to.be.true;
+			const finalId1 = compressor.generateCompressedId();
+			expect(isFinalId(finalId1)).to.be.true;
+
+			generateCompressedIds(compressor, 5);
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const override2 = compressor.generateCompressedId('override2');
+			expect(isLocalId(override2)).to.be.true;
+			const finalId2 = compressor.generateCompressedId();
+			expect(isFinalId(finalId2)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(override1);
+			const opSpaceId3 = compressor.normalizeToOpSpace(finalId1);
+			const opSpaceId4 = compressor.normalizeToOpSpace(override2);
+			const opSpaceId5 = compressor.normalizeToOpSpace(finalId2);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+			expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId1);
+			expectAssert(isFinalId(opSpaceId4));
+			expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId2);
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(override1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(override2);
+			expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId2);
+		});
+
+		it('correctly normalizes eagerly allocated final IDs', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			const range1 = compressor.takeNextCreationRange();
+			const localId2 = compressor.generateCompressedId();
+			const range2 = compressor.takeNextCreationRange();
+			expect(isLocalId(localId1)).to.be.true;
+			expect(isLocalId(localId2)).to.be.true;
+
+			compressor.finalizeCreationRange(range1);
+			compressor.finalizeCreationRange(range2);
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
+		});
+
+		it('generates correct eager finals when there are outstanding locals after cluster expansion', () => {
+			const compressor = createCompressor(Client.Client1, 2);
+
+			// Before cluster expansion
+			expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+			const rangeA = compressor.takeNextCreationRange();
+			compressor.finalizeCreationRange(rangeA);
+			expect(isFinalId(compressor.generateCompressedId())).to.be.true;
+
+			// After cluster expansion
+			expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+			const rangeB = compressor.takeNextCreationRange();
+			const localId = compressor.generateCompressedId();
+			expect(isLocalId(localId)).to.be.true;
+
+			// Take a range that won't be finalized in this test; the finalizing of range B should associate this range with finals
+			const rangeC = compressor.takeNextCreationRange();
+
+			compressor.finalizeCreationRange(rangeB);
+			const eagerId = compressor.generateCompressedId();
+			expect(isFinalId(eagerId)).to.be.true;
+
+			expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+			expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+
+			compressor.finalizeCreationRange(rangeC);
+
+			expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+			expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+		});
+
+		it('generates unique eager finals when multiple outstanding creation ranges during finalizing', () => {
+			const compressor = createCompressor(Client.Client1, 10 /* must be 10 for the test to make sense */);
+
+			// Make a first outstanding range
+			const id1_1 = compressor.generateCompressedId();
+			const id1_2 = compressor.generateCompressedId();
+			expect(isLocalId(id1_1)).to.be.true;
+			expect(isLocalId(id1_2)).to.be.true;
+			const range1 = compressor.takeNextCreationRange();
+
+			// Make a second outstanding range
+			const id2_1 = compressor.generateCompressedId();
+			const id2_2 = compressor.generateCompressedId();
+			expect(isLocalId(id2_1)).to.be.true;
+			expect(isLocalId(id2_2)).to.be.true;
+			const range2 = compressor.takeNextCreationRange();
+
+			// Finalize just the first one, which should create finals that align with both outstanding ranges
+			compressor.finalizeCreationRange(range1);
+
+			// Make a third range. This one should be composed of eager finals that align after the two ranges above.
+			const id3_1 = compressor.generateCompressedId();
+			const id3_2 = compressor.generateCompressedId();
+			expect(isFinalId(id3_1)).to.be.true;
+			expect(isFinalId(id3_2)).to.be.true;
+			const range3 = compressor.takeNextCreationRange();
+
+			// Finalize both initial ranges.
+			compressor.finalizeCreationRange(range2);
+			compressor.finalizeCreationRange(range3);
+
+			// Make some more eager finals that should be aligned correctly.
+			const id4_1 = compressor.generateCompressedId();
+			const id4_2 = compressor.generateCompressedId();
+			expect(isFinalId(id4_1)).to.be.true;
+			expect(isFinalId(id4_2)).to.be.true;
+
+			// Assert everything is unique and consistent.
+			const ids = new Set<SessionSpaceCompressedId>();
+			const uuids = new Set<StableId | string>();
+			[id1_1, id1_2, id2_1, id2_2, id3_1, id3_2, id4_1, id4_2].forEach((id) => {
+				ids.add(id);
+				uuids.add(compressor.decompress(id));
+			});
+			expect(ids.size).to.equal(8);
+			expect(uuids.size).to.equal(8);
+		});
+
+		it('generates unique eager finals when there are still outstanding locals after a cluster is expanded', () => {
+			// const compressor = createCompressor(Client.Client1, 4 /* must be 4 for the test to make sense */);
+
+			const compressor = new IdCompressor(sessionIds.get(Client.Client1), 0);
+			compressor.clusterCapacity = 4;
+
+			// Make locals to fill half the future cluster
+			const id1_1 = compressor.generateCompressedId();
+			const id1_2 = compressor.generateCompressedId();
+			expect(isLocalId(id1_1)).to.be.true;
+			expect(isLocalId(id1_2)).to.be.true;
+			const range1 = compressor.takeNextCreationRange();
+
+			// Make locals to overflow the future cluster
+			const id2_1 = compressor.generateCompressedId();
+			const id2_2 = compressor.generateCompressedId();
+			const id2_3 = compressor.generateCompressedId();
+			expect(isLocalId(id2_1)).to.be.true;
+			expect(isLocalId(id2_2)).to.be.true;
+			expect(isLocalId(id2_3)).to.be.true;
+			const range2 = compressor.takeNextCreationRange();
+
+			// Finalize the first range. This should align the first four locals (i.e. all of range1, and 2/3 of range2)
+			compressor.finalizeCreationRange(range1);
+
+			// Make a single range that should still be overflowing the initial cluster (i.e. be local)
+			const id3_1 = compressor.generateCompressedId();
+			expect(isLocalId(id3_1)).to.be.true;
+			const range3 = compressor.takeNextCreationRange();
+
+			// First finalize should expand the cluster and align all outstanding ranges.
+			compressor.finalizeCreationRange(range2);
+
+			// All generated IDs should have aligned finals (even though range3 has not been finalized)
+			const allIds = [id1_1, id1_2, id2_1, id2_2, id2_3, id3_1];
+			allIds.forEach((id) => expect(isFinalId(compressor.normalizeToOpSpace(id))).to.be.true);
+
+			compressor.finalizeCreationRange(range3);
+
+			// Make one eager final
+			const id4_1 = compressor.generateCompressedId();
+			allIds.push(id4_1);
+			expect(isFinalId(id4_1)).to.be.true;
+
+			// Assert everything is unique and consistent.
+			const ids = new Set<SessionSpaceCompressedId>();
+			const uuids = new Set<StableId | string>();
+			allIds.forEach((id) => {
+				ids.add(id);
+				uuids.add(compressor.decompress(id));
+			});
+			expect(ids.size).to.equal(7);
+			expect(uuids.size).to.equal(7);
 		});
 	});
 
@@ -1109,7 +1364,7 @@ describe('IdCompressor', () => {
 		});
 
 		itNetwork('produces consistent IDs with large fuzz input', (network) => {
-			const generator = take(1000, makeOpGenerator({ includeOverrides: true }));
+			const generator = take(2000, makeOpGenerator({ includeOverrides: true }));
 			performFuzzActions(generator, network, 1984, undefined, true, (network) => network.assertNetworkState());
 			network.deliverOperations(DestinationClient.All);
 		});
@@ -1153,109 +1408,6 @@ describe('IdCompressor', () => {
 			expect(() => network.getCompressor(Client.Client2).decompress(emptyId)).to.throw(
 				'Compressed ID was not generated by this compressor'
 			);
-		});
-
-		describe('Eager final ID allocation', () => {
-			it('eagerly allocates final IDs when cluster creation has been finalized', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-				const localId2 = compressor.generateCompressedId();
-				expect(isLocalId(localId2)).to.be.true;
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				const finalId3 = compressor.generateCompressedId();
-				expect(isFinalId(finalId3)).to.be.true;
-				const finalId4 = compressor.generateCompressedId();
-				expect(isFinalId(finalId4)).to.be.true;
-				const finalId5 = compressor.generateCompressedId();
-				expect(isFinalId(finalId5)).to.be.true;
-				const localId6 = compressor.generateCompressedId();
-				expect(isLocalId(localId6)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
-				const opSpaceId3 = compressor.normalizeToOpSpace(finalId3);
-				const opSpaceId4 = compressor.normalizeToOpSpace(finalId4);
-				const opSpaceId5 = compressor.normalizeToOpSpace(finalId5);
-				const opSpaceId6 = compressor.normalizeToOpSpace(localId6);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-				expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId3);
-				expectAssert(isFinalId(opSpaceId4) && opSpaceId4 === finalId4);
-				expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId5);
-				expectAssert(isFinalId(opSpaceId6));
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
-				expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId3);
-				expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(finalId4);
-				expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId5);
-				expect(compressor.normalizeToSessionSpace(opSpaceId6)).to.equal(localId6);
-			});
-
-			it('does not eagerly allocate final IDs for IDs with overrides', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const override1 = compressor.generateCompressedId('override1');
-				expect(isLocalId(override1)).to.be.true;
-				const finalId1 = compressor.generateCompressedId();
-				expect(isFinalId(finalId1)).to.be.true;
-
-				generateCompressedIds(compressor, 5);
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const override2 = compressor.generateCompressedId('override2');
-				expect(isLocalId(override2)).to.be.true;
-				const finalId2 = compressor.generateCompressedId();
-				expect(isFinalId(finalId2)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(override1);
-				const opSpaceId3 = compressor.normalizeToOpSpace(finalId1);
-				const opSpaceId4 = compressor.normalizeToOpSpace(override2);
-				const opSpaceId5 = compressor.normalizeToOpSpace(finalId2);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-				expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId1);
-				expectAssert(isFinalId(opSpaceId4));
-				expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId2);
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(override1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(override2);
-				expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId2);
-			});
-
-			it('correctly normalizes eagerly allocated final IDs', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				const range1 = compressor.takeNextCreationRange();
-				const localId2 = compressor.generateCompressedId();
-				const range2 = compressor.takeNextCreationRange();
-				expect(isLocalId(localId1)).to.be.true;
-				expect(isLocalId(localId2)).to.be.true;
-
-				compressor.finalizeCreationRange(range1);
-				compressor.finalizeCreationRange(range2);
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
-			});
 		});
 
 		describe('Finalizing', () => {
@@ -1423,7 +1575,7 @@ describe('IdCompressor', () => {
 			});
 
 			itNetwork('can serialize after a large fuzz input', 3, (network) => {
-				const generator = take(1000, makeOpGenerator({ includeOverrides: true }));
+				const generator = take(2000, makeOpGenerator({ includeOverrides: true }));
 				performFuzzActions(generator, network, Math.PI, undefined, true, (network) => {
 					// Periodically check that everyone in the network has the same serialized state
 					network.deliverOperations(DestinationClient.All);

--- a/experimental/dds/tree/src/test/IdCompressor.tests.ts
+++ b/experimental/dds/tree/src/test/IdCompressor.tests.ts
@@ -19,6 +19,7 @@ import {
 	SessionSpaceCompressedId,
 	OpSpaceCompressedId,
 	SessionId,
+	StableId,
 } from '../Identifiers';
 import { assert, assertNotUndefined, fail } from '../Common';
 import {
@@ -442,6 +443,23 @@ describe('IdCompressor', () => {
 			expect(() => compressor.finalizeCreationRange(secondRange)).to.throw('Ranges finalized out of order.');
 		});
 
+		it('can finalize ranges into clusters of varying sizes', () => {
+			for (let i = 1; i < 5; i++) {
+				for (let j = 0; j <= i; j++) {
+					const compressor = createCompressor(Client.Client1, i);
+					const ids = new Set<SessionSpaceCompressedId>();
+					for (let k = 0; k <= j; k++) {
+						ids.add(compressor.generateCompressedId());
+					}
+					compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+					const opIds = new Set<OpSpaceCompressedId>();
+					ids.forEach((id) => opIds.add(compressor.normalizeToOpSpace(id)));
+					expect(ids.size).to.equal(opIds.size);
+					opIds.forEach((id) => expect(isFinalId(id)).to.be.true);
+				}
+			}
+		});
+
 		it('prevents finalizing unacceptably enormous amounts of ID allocation', () => {
 			const compressor1 = createCompressor(Client.Client1);
 			const integerLargerThanHalfMax = Math.round((Number.MAX_SAFE_INTEGER / 3) * 2);
@@ -695,6 +713,461 @@ describe('IdCompressor', () => {
 				compressor2.localSessionId
 			);
 			expect(normalizedToClient1SessionSpace).to.equal(id);
+		});
+	});
+
+	describe('Telemetry', () => {
+		it('emits first cluster and new cluster telemetry events', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			mockLogger.assertMatch([
+				{
+					eventName: 'SharedTreeIdCompressor:FirstCluster',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+				{
+					eventName: 'SharedTreeIdCompressor:NewCluster',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+					clusterCapacity: 5,
+					clusterCount: 1,
+				},
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+					eagerFinalIdCount: 0,
+					overridesCount: 0,
+					localIdCount: 1,
+				},
+			]);
+		});
+
+		it('emits new cluster event on second cluster', () => {
+			// Fill the first cluster
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			for (let i = 0; i < 5; i++) {
+				compressor.generateCompressedId();
+			}
+			const range = compressor.takeNextCreationRange();
+			compressor.finalizeCreationRange(range);
+
+			// Create another cluster with a different client so that expansion doesn't happen
+			const mockLogger2 = new MockLogger();
+			const compressor2 = createCompressor(Client.Client2, 5, undefined, mockLogger2);
+			compressor2.finalizeCreationRange(range);
+			compressor2.generateCompressedId();
+			const range2 = compressor2.takeNextCreationRange();
+			compressor2.finalizeCreationRange(range2);
+			compressor.finalizeCreationRange(range2);
+			// Make sure we emitted the FirstCluster event
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:FirstCluster',
+				},
+			]);
+			mockLogger.clear();
+
+			// Trigger a new cluster creation and make sure FirstCluster isn't emitted
+			compressor.generateCompressedId();
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:NewCluster',
+				},
+			]);
+			mockLogger.assertMatchNone([
+				{
+					eventName: 'SharedTreeIdCompressor:FirstCluster',
+				},
+			]);
+		});
+
+		it('correctly logs telemetry events for eager final id allocations', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 0,
+					localIdCount: 1,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+			const finalId1 = compressor.generateCompressedId();
+			const finalId2 = compressor.generateCompressedId();
+			expect(isFinalId(finalId1)).to.be.true;
+			expect(isFinalId(finalId2)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 2,
+					localIdCount: 0,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+		});
+
+		it('correctly logs telemetry events for expansion case', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 0,
+					localIdCount: 1,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+
+			for (let i = 0; i < 4; i++) {
+				const id = compressor.generateCompressedId();
+				expect(isFinalId(id)).to.be.true;
+			}
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 4,
+					localIdCount: 0,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+
+			const expansionId1 = compressor.generateCompressedId();
+			const expansionId2 = compressor.generateCompressedId();
+			expect(isLocalId(expansionId1)).to.be.true;
+			expect(isLocalId(expansionId2)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatch([
+				{
+					eventName: 'SharedTreeIdCompressor:ClusterExpansion',
+					sessionId: '88888888-8888-4888-b088-888888888888',
+					previousCapacity: 5,
+					newCapacity: 12,
+					overflow: 2,
+				},
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 2,
+					localIdCount: 0,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+		});
+
+		it('emits correct telemetry status with overrides', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 0,
+					localIdCount: 1,
+					overridesCount: 0,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+			mockLogger.clear();
+
+			const finalId2 = compressor.generateCompressedId();
+			const overrideId3 = compressor.generateCompressedId('override');
+			expect(isFinalId(finalId2)).to.be.true;
+			expect(isLocalId(overrideId3)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
+					eagerFinalIdCount: 1,
+					localIdCount: 1,
+					overridesCount: 1,
+					sessionId: '88888888-8888-4888-b088-888888888888',
+				},
+			]);
+		});
+
+		it('emits telemetry when serialized', () => {
+			const mockLogger = new MockLogger();
+			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			compressor.serialize(false);
+
+			mockLogger.assertMatchAny([
+				{
+					eventName: 'SharedTreeIdCompressor:SerializedIdCompressorSize',
+					size: 137,
+					clusterCount: 1,
+					sessionCount: 1,
+				},
+			]);
+		});
+	});
+
+	describe('Eager final ID allocation', () => {
+		it('eagerly allocates final IDs when cluster creation has been finalized', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			expect(isLocalId(localId1)).to.be.true;
+			const localId2 = compressor.generateCompressedId();
+			expect(isLocalId(localId2)).to.be.true;
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+			const finalId3 = compressor.generateCompressedId();
+			expect(isFinalId(finalId3)).to.be.true;
+			const finalId4 = compressor.generateCompressedId();
+			expect(isFinalId(finalId4)).to.be.true;
+			const finalId5 = compressor.generateCompressedId();
+			expect(isFinalId(finalId5)).to.be.true;
+			const localId6 = compressor.generateCompressedId();
+			expect(isLocalId(localId6)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
+			const opSpaceId3 = compressor.normalizeToOpSpace(finalId3);
+			const opSpaceId4 = compressor.normalizeToOpSpace(finalId4);
+			const opSpaceId5 = compressor.normalizeToOpSpace(finalId5);
+			const opSpaceId6 = compressor.normalizeToOpSpace(localId6);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+			expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId3);
+			expectAssert(isFinalId(opSpaceId4) && opSpaceId4 === finalId4);
+			expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId5);
+			expectAssert(isFinalId(opSpaceId6));
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
+			expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId3);
+			expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(finalId4);
+			expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId5);
+			expect(compressor.normalizeToSessionSpace(opSpaceId6)).to.equal(localId6);
+		});
+
+		it('does not eagerly allocate final IDs for IDs with overrides', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const override1 = compressor.generateCompressedId('override1');
+			expect(isLocalId(override1)).to.be.true;
+			const finalId1 = compressor.generateCompressedId();
+			expect(isFinalId(finalId1)).to.be.true;
+
+			generateCompressedIds(compressor, 5);
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const override2 = compressor.generateCompressedId('override2');
+			expect(isLocalId(override2)).to.be.true;
+			const finalId2 = compressor.generateCompressedId();
+			expect(isFinalId(finalId2)).to.be.true;
+
+			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(override1);
+			const opSpaceId3 = compressor.normalizeToOpSpace(finalId1);
+			const opSpaceId4 = compressor.normalizeToOpSpace(override2);
+			const opSpaceId5 = compressor.normalizeToOpSpace(finalId2);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+			expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId1);
+			expectAssert(isFinalId(opSpaceId4));
+			expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId2);
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(override1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(override2);
+			expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId2);
+		});
+
+		it('correctly normalizes eagerly allocated final IDs', () => {
+			const compressor = createCompressor(Client.Client1, 5);
+			const localId1 = compressor.generateCompressedId();
+			const range1 = compressor.takeNextCreationRange();
+			const localId2 = compressor.generateCompressedId();
+			const range2 = compressor.takeNextCreationRange();
+			expect(isLocalId(localId1)).to.be.true;
+			expect(isLocalId(localId2)).to.be.true;
+
+			compressor.finalizeCreationRange(range1);
+			compressor.finalizeCreationRange(range2);
+
+			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+			const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
+
+			expectAssert(isFinalId(opSpaceId1));
+			expectAssert(isFinalId(opSpaceId2));
+
+			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
+		});
+
+		it('generates correct eager finals when there are outstanding locals after cluster expansion', () => {
+			const compressor = createCompressor(Client.Client1, 2);
+
+			// Before cluster expansion
+			expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+			const rangeA = compressor.takeNextCreationRange();
+			compressor.finalizeCreationRange(rangeA);
+			expect(isFinalId(compressor.generateCompressedId())).to.be.true;
+
+			// After cluster expansion
+			expect(isLocalId(compressor.generateCompressedId())).to.be.true;
+			const rangeB = compressor.takeNextCreationRange();
+			const localId = compressor.generateCompressedId();
+			expect(isLocalId(localId)).to.be.true;
+
+			// Take a range that won't be finalized in this test; the finalizing of range B should associate this range with finals
+			const rangeC = compressor.takeNextCreationRange();
+
+			compressor.finalizeCreationRange(rangeB);
+			const eagerId = compressor.generateCompressedId();
+			expect(isFinalId(eagerId)).to.be.true;
+
+			expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+			expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+
+			compressor.finalizeCreationRange(rangeC);
+
+			expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
+			expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
+		});
+
+		it('generates unique eager finals when multiple outstanding creation ranges during finalizing', () => {
+			const compressor = createCompressor(Client.Client1, 10 /* must be 10 for the test to make sense */);
+
+			// Make a first outstanding range
+			const id1_1 = compressor.generateCompressedId();
+			const id1_2 = compressor.generateCompressedId();
+			expect(isLocalId(id1_1)).to.be.true;
+			expect(isLocalId(id1_2)).to.be.true;
+			const range1 = compressor.takeNextCreationRange();
+
+			// Make a second outstanding range
+			const id2_1 = compressor.generateCompressedId();
+			const id2_2 = compressor.generateCompressedId();
+			expect(isLocalId(id2_1)).to.be.true;
+			expect(isLocalId(id2_2)).to.be.true;
+			const range2 = compressor.takeNextCreationRange();
+
+			// Finalize just the first one, which should create finals that align with both outstanding ranges
+			compressor.finalizeCreationRange(range1);
+
+			// Make a third range. This one should be composed of eager finals that align after the two ranges above.
+			const id3_1 = compressor.generateCompressedId();
+			const id3_2 = compressor.generateCompressedId();
+			expect(isFinalId(id3_1)).to.be.true;
+			expect(isFinalId(id3_2)).to.be.true;
+			const range3 = compressor.takeNextCreationRange();
+
+			// Finalize both initial ranges.
+			compressor.finalizeCreationRange(range2);
+			compressor.finalizeCreationRange(range3);
+
+			// Make some more eager finals that should be aligned correctly.
+			const id4_1 = compressor.generateCompressedId();
+			const id4_2 = compressor.generateCompressedId();
+			expect(isFinalId(id4_1)).to.be.true;
+			expect(isFinalId(id4_2)).to.be.true;
+
+			// Assert everything is unique and consistent.
+			const ids = new Set<SessionSpaceCompressedId>();
+			const uuids = new Set<StableId | string>();
+			[id1_1, id1_2, id2_1, id2_2, id3_1, id3_2, id4_1, id4_2].forEach((id) => {
+				ids.add(id);
+				uuids.add(compressor.decompress(id));
+			});
+			expect(ids.size).to.equal(8);
+			expect(uuids.size).to.equal(8);
+		});
+
+		it('generates unique eager finals when there are still outstanding locals after a cluster is expanded', () => {
+			// const compressor = createCompressor(Client.Client1, 4 /* must be 4 for the test to make sense */);
+
+			const compressor = new IdCompressor(sessionIds.get(Client.Client1), 0);
+			compressor.clusterCapacity = 4;
+
+			// Make locals to fill half the future cluster
+			const id1_1 = compressor.generateCompressedId();
+			const id1_2 = compressor.generateCompressedId();
+			expect(isLocalId(id1_1)).to.be.true;
+			expect(isLocalId(id1_2)).to.be.true;
+			const range1 = compressor.takeNextCreationRange();
+
+			// Make locals to overflow the future cluster
+			const id2_1 = compressor.generateCompressedId();
+			const id2_2 = compressor.generateCompressedId();
+			const id2_3 = compressor.generateCompressedId();
+			expect(isLocalId(id2_1)).to.be.true;
+			expect(isLocalId(id2_2)).to.be.true;
+			expect(isLocalId(id2_3)).to.be.true;
+			const range2 = compressor.takeNextCreationRange();
+
+			// Finalize the first range. This should align the first four locals (i.e. all of range1, and 2/3 of range2)
+			compressor.finalizeCreationRange(range1);
+
+			// Make a single range that should still be overflowing the initial cluster (i.e. be local)
+			const id3_1 = compressor.generateCompressedId();
+			expect(isLocalId(id3_1)).to.be.true;
+			const range3 = compressor.takeNextCreationRange();
+
+			// First finalize should expand the cluster and align all outstanding ranges.
+			compressor.finalizeCreationRange(range2);
+
+			// All generated IDs should have aligned finals (even though range3 has not been finalized)
+			const allIds = [id1_1, id1_2, id2_1, id2_2, id2_3, id3_1];
+			allIds.forEach((id) => expect(isFinalId(compressor.normalizeToOpSpace(id))).to.be.true);
+
+			compressor.finalizeCreationRange(range3);
+
+			// Make one eager final
+			const id4_1 = compressor.generateCompressedId();
+			allIds.push(id4_1);
+			expect(isFinalId(id4_1)).to.be.true;
+
+			// Assert everything is unique and consistent.
+			const ids = new Set<SessionSpaceCompressedId>();
+			const uuids = new Set<StableId | string>();
+			allIds.forEach((id) => {
+				ids.add(id);
+				uuids.add(compressor.decompress(id));
+			});
+			expect(ids.size).to.equal(7);
+			expect(uuids.size).to.equal(7);
 		});
 	});
 
@@ -1109,7 +1582,7 @@ describe('IdCompressor', () => {
 		});
 
 		itNetwork('produces consistent IDs with large fuzz input', (network) => {
-			const generator = take(1000, makeOpGenerator({ includeOverrides: true }));
+			const generator = take(2000, makeOpGenerator({ includeOverrides: true }));
 			performFuzzActions(generator, network, 1984, undefined, true, (network) => network.assertNetworkState());
 			network.deliverOperations(DestinationClient.All);
 		});
@@ -1153,109 +1626,6 @@ describe('IdCompressor', () => {
 			expect(() => network.getCompressor(Client.Client2).decompress(emptyId)).to.throw(
 				'Compressed ID was not generated by this compressor'
 			);
-		});
-
-		describe('Eager final ID allocation', () => {
-			it('eagerly allocates final IDs when cluster creation has been finalized', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				expect(isLocalId(localId1)).to.be.true;
-				const localId2 = compressor.generateCompressedId();
-				expect(isLocalId(localId2)).to.be.true;
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-				const finalId3 = compressor.generateCompressedId();
-				expect(isFinalId(finalId3)).to.be.true;
-				const finalId4 = compressor.generateCompressedId();
-				expect(isFinalId(finalId4)).to.be.true;
-				const finalId5 = compressor.generateCompressedId();
-				expect(isFinalId(finalId5)).to.be.true;
-				const localId6 = compressor.generateCompressedId();
-				expect(isLocalId(localId6)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
-				const opSpaceId3 = compressor.normalizeToOpSpace(finalId3);
-				const opSpaceId4 = compressor.normalizeToOpSpace(finalId4);
-				const opSpaceId5 = compressor.normalizeToOpSpace(finalId5);
-				const opSpaceId6 = compressor.normalizeToOpSpace(localId6);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-				expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId3);
-				expectAssert(isFinalId(opSpaceId4) && opSpaceId4 === finalId4);
-				expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId5);
-				expectAssert(isFinalId(opSpaceId6));
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
-				expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId3);
-				expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(finalId4);
-				expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId5);
-				expect(compressor.normalizeToSessionSpace(opSpaceId6)).to.equal(localId6);
-			});
-
-			it('does not eagerly allocate final IDs for IDs with overrides', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const override1 = compressor.generateCompressedId('override1');
-				expect(isLocalId(override1)).to.be.true;
-				const finalId1 = compressor.generateCompressedId();
-				expect(isFinalId(finalId1)).to.be.true;
-
-				generateCompressedIds(compressor, 5);
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const override2 = compressor.generateCompressedId('override2');
-				expect(isLocalId(override2)).to.be.true;
-				const finalId2 = compressor.generateCompressedId();
-				expect(isFinalId(finalId2)).to.be.true;
-
-				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(override1);
-				const opSpaceId3 = compressor.normalizeToOpSpace(finalId1);
-				const opSpaceId4 = compressor.normalizeToOpSpace(override2);
-				const opSpaceId5 = compressor.normalizeToOpSpace(finalId2);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-				expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId1);
-				expectAssert(isFinalId(opSpaceId4));
-				expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId2);
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(override1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(override2);
-				expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId2);
-			});
-
-			it('correctly normalizes eagerly allocated final IDs', () => {
-				const compressor = createCompressor(Client.Client1, 5);
-				const localId1 = compressor.generateCompressedId();
-				const range1 = compressor.takeNextCreationRange();
-				const localId2 = compressor.generateCompressedId();
-				const range2 = compressor.takeNextCreationRange();
-				expect(isLocalId(localId1)).to.be.true;
-				expect(isLocalId(localId2)).to.be.true;
-
-				compressor.finalizeCreationRange(range1);
-				compressor.finalizeCreationRange(range2);
-
-				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-				const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
-
-				expectAssert(isFinalId(opSpaceId1));
-				expectAssert(isFinalId(opSpaceId2));
-
-				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
-			});
 		});
 
 		describe('Finalizing', () => {
@@ -1423,7 +1793,7 @@ describe('IdCompressor', () => {
 			});
 
 			itNetwork('can serialize after a large fuzz input', 3, (network) => {
-				const generator = take(1000, makeOpGenerator({ includeOverrides: true }));
+				const generator = take(2000, makeOpGenerator({ includeOverrides: true }));
 				performFuzzActions(generator, network, Math.PI, undefined, true, (network) => {
 					// Periodically check that everyone in the network has the same serialized state
 					network.deliverOperations(DestinationClient.All);

--- a/experimental/dds/tree/src/test/IdCompressor.tests.ts
+++ b/experimental/dds/tree/src/test/IdCompressor.tests.ts
@@ -19,7 +19,6 @@ import {
 	SessionSpaceCompressedId,
 	OpSpaceCompressedId,
 	SessionId,
-	StableId,
 } from '../Identifiers';
 import { assert, assertNotUndefined, fail } from '../Common';
 import {
@@ -443,23 +442,6 @@ describe('IdCompressor', () => {
 			expect(() => compressor.finalizeCreationRange(secondRange)).to.throw('Ranges finalized out of order.');
 		});
 
-		it('can finalize ranges into clusters of varying sizes', () => {
-			for (let i = 1; i < 5; i++) {
-				for (let j = 0; j <= i; j++) {
-					const compressor = createCompressor(Client.Client1, i);
-					const ids = new Set<SessionSpaceCompressedId>();
-					for (let k = 0; k <= j; k++) {
-						ids.add(compressor.generateCompressedId());
-					}
-					compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-					const opIds = new Set<OpSpaceCompressedId>();
-					ids.forEach((id) => opIds.add(compressor.normalizeToOpSpace(id)));
-					expect(ids.size).to.equal(opIds.size);
-					opIds.forEach((id) => expect(isFinalId(id)).to.be.true);
-				}
-			}
-		});
-
 		it('prevents finalizing unacceptably enormous amounts of ID allocation', () => {
 			const compressor1 = createCompressor(Client.Client1);
 			const integerLargerThanHalfMax = Math.round((Number.MAX_SAFE_INTEGER / 3) * 2);
@@ -713,461 +695,6 @@ describe('IdCompressor', () => {
 				compressor2.localSessionId
 			);
 			expect(normalizedToClient1SessionSpace).to.equal(id);
-		});
-	});
-
-	describe('Telemetry', () => {
-		it('emits first cluster and new cluster telemetry events', () => {
-			const mockLogger = new MockLogger();
-			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-			const localId1 = compressor.generateCompressedId();
-			expect(isLocalId(localId1)).to.be.true;
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-			mockLogger.assertMatch([
-				{
-					eventName: 'SharedTreeIdCompressor:FirstCluster',
-					sessionId: '88888888-8888-4888-b088-888888888888',
-				},
-				{
-					eventName: 'SharedTreeIdCompressor:NewCluster',
-					sessionId: '88888888-8888-4888-b088-888888888888',
-					clusterCapacity: 5,
-					clusterCount: 1,
-				},
-				{
-					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-					sessionId: '88888888-8888-4888-b088-888888888888',
-					eagerFinalIdCount: 0,
-					overridesCount: 0,
-					localIdCount: 1,
-				},
-			]);
-		});
-
-		it('emits new cluster event on second cluster', () => {
-			// Fill the first cluster
-			const mockLogger = new MockLogger();
-			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-			for (let i = 0; i < 5; i++) {
-				compressor.generateCompressedId();
-			}
-			const range = compressor.takeNextCreationRange();
-			compressor.finalizeCreationRange(range);
-
-			// Create another cluster with a different client so that expansion doesn't happen
-			const mockLogger2 = new MockLogger();
-			const compressor2 = createCompressor(Client.Client2, 5, undefined, mockLogger2);
-			compressor2.finalizeCreationRange(range);
-			compressor2.generateCompressedId();
-			const range2 = compressor2.takeNextCreationRange();
-			compressor2.finalizeCreationRange(range2);
-			compressor.finalizeCreationRange(range2);
-			// Make sure we emitted the FirstCluster event
-			mockLogger.assertMatchAny([
-				{
-					eventName: 'SharedTreeIdCompressor:FirstCluster',
-				},
-			]);
-			mockLogger.clear();
-
-			// Trigger a new cluster creation and make sure FirstCluster isn't emitted
-			compressor.generateCompressedId();
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-			mockLogger.assertMatchAny([
-				{
-					eventName: 'SharedTreeIdCompressor:NewCluster',
-				},
-			]);
-			mockLogger.assertMatchNone([
-				{
-					eventName: 'SharedTreeIdCompressor:FirstCluster',
-				},
-			]);
-		});
-
-		it('correctly logs telemetry events for eager final id allocations', () => {
-			const mockLogger = new MockLogger();
-			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-			const localId1 = compressor.generateCompressedId();
-			expect(isLocalId(localId1)).to.be.true;
-
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-			mockLogger.assertMatchAny([
-				{
-					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-					eagerFinalIdCount: 0,
-					localIdCount: 1,
-					overridesCount: 0,
-					sessionId: '88888888-8888-4888-b088-888888888888',
-				},
-			]);
-			mockLogger.clear();
-			const finalId1 = compressor.generateCompressedId();
-			const finalId2 = compressor.generateCompressedId();
-			expect(isFinalId(finalId1)).to.be.true;
-			expect(isFinalId(finalId2)).to.be.true;
-
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-			mockLogger.assertMatchAny([
-				{
-					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-					eagerFinalIdCount: 2,
-					localIdCount: 0,
-					overridesCount: 0,
-					sessionId: '88888888-8888-4888-b088-888888888888',
-				},
-			]);
-		});
-
-		it('correctly logs telemetry events for expansion case', () => {
-			const mockLogger = new MockLogger();
-			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-			const localId1 = compressor.generateCompressedId();
-			expect(isLocalId(localId1)).to.be.true;
-
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-			mockLogger.assertMatchAny([
-				{
-					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-					eagerFinalIdCount: 0,
-					localIdCount: 1,
-					overridesCount: 0,
-					sessionId: '88888888-8888-4888-b088-888888888888',
-				},
-			]);
-			mockLogger.clear();
-
-			for (let i = 0; i < 4; i++) {
-				const id = compressor.generateCompressedId();
-				expect(isFinalId(id)).to.be.true;
-			}
-
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-			mockLogger.assertMatchAny([
-				{
-					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-					eagerFinalIdCount: 4,
-					localIdCount: 0,
-					overridesCount: 0,
-					sessionId: '88888888-8888-4888-b088-888888888888',
-				},
-			]);
-			mockLogger.clear();
-
-			const expansionId1 = compressor.generateCompressedId();
-			const expansionId2 = compressor.generateCompressedId();
-			expect(isLocalId(expansionId1)).to.be.true;
-			expect(isLocalId(expansionId2)).to.be.true;
-
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-			mockLogger.assertMatch([
-				{
-					eventName: 'SharedTreeIdCompressor:ClusterExpansion',
-					sessionId: '88888888-8888-4888-b088-888888888888',
-					previousCapacity: 5,
-					newCapacity: 12,
-					overflow: 2,
-				},
-				{
-					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-					eagerFinalIdCount: 2,
-					localIdCount: 0,
-					overridesCount: 0,
-					sessionId: '88888888-8888-4888-b088-888888888888',
-				},
-			]);
-		});
-
-		it('emits correct telemetry status with overrides', () => {
-			const mockLogger = new MockLogger();
-			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-			const localId1 = compressor.generateCompressedId();
-			expect(isLocalId(localId1)).to.be.true;
-
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-			mockLogger.assertMatchAny([
-				{
-					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-					eagerFinalIdCount: 0,
-					localIdCount: 1,
-					overridesCount: 0,
-					sessionId: '88888888-8888-4888-b088-888888888888',
-				},
-			]);
-			mockLogger.clear();
-
-			const finalId2 = compressor.generateCompressedId();
-			const overrideId3 = compressor.generateCompressedId('override');
-			expect(isFinalId(finalId2)).to.be.true;
-			expect(isLocalId(overrideId3)).to.be.true;
-
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-			mockLogger.assertMatchAny([
-				{
-					eventName: 'SharedTreeIdCompressor:IdCompressorStatus',
-					eagerFinalIdCount: 1,
-					localIdCount: 1,
-					overridesCount: 1,
-					sessionId: '88888888-8888-4888-b088-888888888888',
-				},
-			]);
-		});
-
-		it('emits telemetry when serialized', () => {
-			const mockLogger = new MockLogger();
-			const compressor = createCompressor(Client.Client1, 5, undefined, mockLogger);
-			const localId1 = compressor.generateCompressedId();
-			expect(isLocalId(localId1)).to.be.true;
-
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-			compressor.serialize(false);
-
-			mockLogger.assertMatchAny([
-				{
-					eventName: 'SharedTreeIdCompressor:SerializedIdCompressorSize',
-					size: 137,
-					clusterCount: 1,
-					sessionCount: 1,
-				},
-			]);
-		});
-	});
-
-	describe('Eager final ID allocation', () => {
-		it('eagerly allocates final IDs when cluster creation has been finalized', () => {
-			const compressor = createCompressor(Client.Client1, 5);
-			const localId1 = compressor.generateCompressedId();
-			expect(isLocalId(localId1)).to.be.true;
-			const localId2 = compressor.generateCompressedId();
-			expect(isLocalId(localId2)).to.be.true;
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-			const finalId3 = compressor.generateCompressedId();
-			expect(isFinalId(finalId3)).to.be.true;
-			const finalId4 = compressor.generateCompressedId();
-			expect(isFinalId(finalId4)).to.be.true;
-			const finalId5 = compressor.generateCompressedId();
-			expect(isFinalId(finalId5)).to.be.true;
-			const localId6 = compressor.generateCompressedId();
-			expect(isLocalId(localId6)).to.be.true;
-
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-			const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
-			const opSpaceId3 = compressor.normalizeToOpSpace(finalId3);
-			const opSpaceId4 = compressor.normalizeToOpSpace(finalId4);
-			const opSpaceId5 = compressor.normalizeToOpSpace(finalId5);
-			const opSpaceId6 = compressor.normalizeToOpSpace(localId6);
-
-			expectAssert(isFinalId(opSpaceId1));
-			expectAssert(isFinalId(opSpaceId2));
-			expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId3);
-			expectAssert(isFinalId(opSpaceId4) && opSpaceId4 === finalId4);
-			expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId5);
-			expectAssert(isFinalId(opSpaceId6));
-
-			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
-			expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId3);
-			expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(finalId4);
-			expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId5);
-			expect(compressor.normalizeToSessionSpace(opSpaceId6)).to.equal(localId6);
-		});
-
-		it('does not eagerly allocate final IDs for IDs with overrides', () => {
-			const compressor = createCompressor(Client.Client1, 5);
-			const localId1 = compressor.generateCompressedId();
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-			const override1 = compressor.generateCompressedId('override1');
-			expect(isLocalId(override1)).to.be.true;
-			const finalId1 = compressor.generateCompressedId();
-			expect(isFinalId(finalId1)).to.be.true;
-
-			generateCompressedIds(compressor, 5);
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-			const override2 = compressor.generateCompressedId('override2');
-			expect(isLocalId(override2)).to.be.true;
-			const finalId2 = compressor.generateCompressedId();
-			expect(isFinalId(finalId2)).to.be.true;
-
-			compressor.finalizeCreationRange(compressor.takeNextCreationRange());
-
-			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-			const opSpaceId2 = compressor.normalizeToOpSpace(override1);
-			const opSpaceId3 = compressor.normalizeToOpSpace(finalId1);
-			const opSpaceId4 = compressor.normalizeToOpSpace(override2);
-			const opSpaceId5 = compressor.normalizeToOpSpace(finalId2);
-
-			expectAssert(isFinalId(opSpaceId1));
-			expectAssert(isFinalId(opSpaceId2));
-			expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId1);
-			expectAssert(isFinalId(opSpaceId4));
-			expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId2);
-
-			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(override1);
-			expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId1);
-			expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(override2);
-			expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId2);
-		});
-
-		it('correctly normalizes eagerly allocated final IDs', () => {
-			const compressor = createCompressor(Client.Client1, 5);
-			const localId1 = compressor.generateCompressedId();
-			const range1 = compressor.takeNextCreationRange();
-			const localId2 = compressor.generateCompressedId();
-			const range2 = compressor.takeNextCreationRange();
-			expect(isLocalId(localId1)).to.be.true;
-			expect(isLocalId(localId2)).to.be.true;
-
-			compressor.finalizeCreationRange(range1);
-			compressor.finalizeCreationRange(range2);
-
-			const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
-			const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
-
-			expectAssert(isFinalId(opSpaceId1));
-			expectAssert(isFinalId(opSpaceId2));
-
-			expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
-			expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
-		});
-
-		it('generates correct eager finals when there are outstanding locals after cluster expansion', () => {
-			const compressor = createCompressor(Client.Client1, 2);
-
-			// Before cluster expansion
-			expect(isLocalId(compressor.generateCompressedId())).to.be.true;
-			const rangeA = compressor.takeNextCreationRange();
-			compressor.finalizeCreationRange(rangeA);
-			expect(isFinalId(compressor.generateCompressedId())).to.be.true;
-
-			// After cluster expansion
-			expect(isLocalId(compressor.generateCompressedId())).to.be.true;
-			const rangeB = compressor.takeNextCreationRange();
-			const localId = compressor.generateCompressedId();
-			expect(isLocalId(localId)).to.be.true;
-
-			// Take a range that won't be finalized in this test; the finalizing of range B should associate this range with finals
-			const rangeC = compressor.takeNextCreationRange();
-
-			compressor.finalizeCreationRange(rangeB);
-			const eagerId = compressor.generateCompressedId();
-			expect(isFinalId(eagerId)).to.be.true;
-
-			expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
-			expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
-
-			compressor.finalizeCreationRange(rangeC);
-
-			expect(compressor.recompress(compressor.decompress(localId))).to.equal(localId);
-			expect(compressor.recompress(compressor.decompress(eagerId))).to.equal(eagerId);
-		});
-
-		it('generates unique eager finals when multiple outstanding creation ranges during finalizing', () => {
-			const compressor = createCompressor(Client.Client1, 10 /* must be 10 for the test to make sense */);
-
-			// Make a first outstanding range
-			const id1_1 = compressor.generateCompressedId();
-			const id1_2 = compressor.generateCompressedId();
-			expect(isLocalId(id1_1)).to.be.true;
-			expect(isLocalId(id1_2)).to.be.true;
-			const range1 = compressor.takeNextCreationRange();
-
-			// Make a second outstanding range
-			const id2_1 = compressor.generateCompressedId();
-			const id2_2 = compressor.generateCompressedId();
-			expect(isLocalId(id2_1)).to.be.true;
-			expect(isLocalId(id2_2)).to.be.true;
-			const range2 = compressor.takeNextCreationRange();
-
-			// Finalize just the first one, which should create finals that align with both outstanding ranges
-			compressor.finalizeCreationRange(range1);
-
-			// Make a third range. This one should be composed of eager finals that align after the two ranges above.
-			const id3_1 = compressor.generateCompressedId();
-			const id3_2 = compressor.generateCompressedId();
-			expect(isFinalId(id3_1)).to.be.true;
-			expect(isFinalId(id3_2)).to.be.true;
-			const range3 = compressor.takeNextCreationRange();
-
-			// Finalize both initial ranges.
-			compressor.finalizeCreationRange(range2);
-			compressor.finalizeCreationRange(range3);
-
-			// Make some more eager finals that should be aligned correctly.
-			const id4_1 = compressor.generateCompressedId();
-			const id4_2 = compressor.generateCompressedId();
-			expect(isFinalId(id4_1)).to.be.true;
-			expect(isFinalId(id4_2)).to.be.true;
-
-			// Assert everything is unique and consistent.
-			const ids = new Set<SessionSpaceCompressedId>();
-			const uuids = new Set<StableId | string>();
-			[id1_1, id1_2, id2_1, id2_2, id3_1, id3_2, id4_1, id4_2].forEach((id) => {
-				ids.add(id);
-				uuids.add(compressor.decompress(id));
-			});
-			expect(ids.size).to.equal(8);
-			expect(uuids.size).to.equal(8);
-		});
-
-		it('generates unique eager finals when there are still outstanding locals after a cluster is expanded', () => {
-			// const compressor = createCompressor(Client.Client1, 4 /* must be 4 for the test to make sense */);
-
-			const compressor = new IdCompressor(sessionIds.get(Client.Client1), 0);
-			compressor.clusterCapacity = 4;
-
-			// Make locals to fill half the future cluster
-			const id1_1 = compressor.generateCompressedId();
-			const id1_2 = compressor.generateCompressedId();
-			expect(isLocalId(id1_1)).to.be.true;
-			expect(isLocalId(id1_2)).to.be.true;
-			const range1 = compressor.takeNextCreationRange();
-
-			// Make locals to overflow the future cluster
-			const id2_1 = compressor.generateCompressedId();
-			const id2_2 = compressor.generateCompressedId();
-			const id2_3 = compressor.generateCompressedId();
-			expect(isLocalId(id2_1)).to.be.true;
-			expect(isLocalId(id2_2)).to.be.true;
-			expect(isLocalId(id2_3)).to.be.true;
-			const range2 = compressor.takeNextCreationRange();
-
-			// Finalize the first range. This should align the first four locals (i.e. all of range1, and 2/3 of range2)
-			compressor.finalizeCreationRange(range1);
-
-			// Make a single range that should still be overflowing the initial cluster (i.e. be local)
-			const id3_1 = compressor.generateCompressedId();
-			expect(isLocalId(id3_1)).to.be.true;
-			const range3 = compressor.takeNextCreationRange();
-
-			// First finalize should expand the cluster and align all outstanding ranges.
-			compressor.finalizeCreationRange(range2);
-
-			// All generated IDs should have aligned finals (even though range3 has not been finalized)
-			const allIds = [id1_1, id1_2, id2_1, id2_2, id2_3, id3_1];
-			allIds.forEach((id) => expect(isFinalId(compressor.normalizeToOpSpace(id))).to.be.true);
-
-			compressor.finalizeCreationRange(range3);
-
-			// Make one eager final
-			const id4_1 = compressor.generateCompressedId();
-			allIds.push(id4_1);
-			expect(isFinalId(id4_1)).to.be.true;
-
-			// Assert everything is unique and consistent.
-			const ids = new Set<SessionSpaceCompressedId>();
-			const uuids = new Set<StableId | string>();
-			allIds.forEach((id) => {
-				ids.add(id);
-				uuids.add(compressor.decompress(id));
-			});
-			expect(ids.size).to.equal(7);
-			expect(uuids.size).to.equal(7);
 		});
 	});
 
@@ -1582,7 +1109,7 @@ describe('IdCompressor', () => {
 		});
 
 		itNetwork('produces consistent IDs with large fuzz input', (network) => {
-			const generator = take(2000, makeOpGenerator({ includeOverrides: true }));
+			const generator = take(1000, makeOpGenerator({ includeOverrides: true }));
 			performFuzzActions(generator, network, 1984, undefined, true, (network) => network.assertNetworkState());
 			network.deliverOperations(DestinationClient.All);
 		});
@@ -1626,6 +1153,109 @@ describe('IdCompressor', () => {
 			expect(() => network.getCompressor(Client.Client2).decompress(emptyId)).to.throw(
 				'Compressed ID was not generated by this compressor'
 			);
+		});
+
+		describe('Eager final ID allocation', () => {
+			it('eagerly allocates final IDs when cluster creation has been finalized', () => {
+				const compressor = createCompressor(Client.Client1, 5);
+				const localId1 = compressor.generateCompressedId();
+				expect(isLocalId(localId1)).to.be.true;
+				const localId2 = compressor.generateCompressedId();
+				expect(isLocalId(localId2)).to.be.true;
+				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+				const finalId3 = compressor.generateCompressedId();
+				expect(isFinalId(finalId3)).to.be.true;
+				const finalId4 = compressor.generateCompressedId();
+				expect(isFinalId(finalId4)).to.be.true;
+				const finalId5 = compressor.generateCompressedId();
+				expect(isFinalId(finalId5)).to.be.true;
+				const localId6 = compressor.generateCompressedId();
+				expect(isLocalId(localId6)).to.be.true;
+
+				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+				const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
+				const opSpaceId3 = compressor.normalizeToOpSpace(finalId3);
+				const opSpaceId4 = compressor.normalizeToOpSpace(finalId4);
+				const opSpaceId5 = compressor.normalizeToOpSpace(finalId5);
+				const opSpaceId6 = compressor.normalizeToOpSpace(localId6);
+
+				expectAssert(isFinalId(opSpaceId1));
+				expectAssert(isFinalId(opSpaceId2));
+				expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId3);
+				expectAssert(isFinalId(opSpaceId4) && opSpaceId4 === finalId4);
+				expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId5);
+				expectAssert(isFinalId(opSpaceId6));
+
+				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
+				expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId3);
+				expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(finalId4);
+				expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId5);
+				expect(compressor.normalizeToSessionSpace(opSpaceId6)).to.equal(localId6);
+			});
+
+			it('does not eagerly allocate final IDs for IDs with overrides', () => {
+				const compressor = createCompressor(Client.Client1, 5);
+				const localId1 = compressor.generateCompressedId();
+				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+				const override1 = compressor.generateCompressedId('override1');
+				expect(isLocalId(override1)).to.be.true;
+				const finalId1 = compressor.generateCompressedId();
+				expect(isFinalId(finalId1)).to.be.true;
+
+				generateCompressedIds(compressor, 5);
+				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+				const override2 = compressor.generateCompressedId('override2');
+				expect(isLocalId(override2)).to.be.true;
+				const finalId2 = compressor.generateCompressedId();
+				expect(isFinalId(finalId2)).to.be.true;
+
+				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+
+				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+				const opSpaceId2 = compressor.normalizeToOpSpace(override1);
+				const opSpaceId3 = compressor.normalizeToOpSpace(finalId1);
+				const opSpaceId4 = compressor.normalizeToOpSpace(override2);
+				const opSpaceId5 = compressor.normalizeToOpSpace(finalId2);
+
+				expectAssert(isFinalId(opSpaceId1));
+				expectAssert(isFinalId(opSpaceId2));
+				expectAssert(isFinalId(opSpaceId3) && opSpaceId3 === finalId1);
+				expectAssert(isFinalId(opSpaceId4));
+				expectAssert(isFinalId(opSpaceId5) && opSpaceId5 === finalId2);
+
+				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(override1);
+				expect(compressor.normalizeToSessionSpace(opSpaceId3)).to.equal(finalId1);
+				expect(compressor.normalizeToSessionSpace(opSpaceId4)).to.equal(override2);
+				expect(compressor.normalizeToSessionSpace(opSpaceId5)).to.equal(finalId2);
+			});
+
+			it('correctly normalizes eagerly allocated final IDs', () => {
+				const compressor = createCompressor(Client.Client1, 5);
+				const localId1 = compressor.generateCompressedId();
+				const range1 = compressor.takeNextCreationRange();
+				const localId2 = compressor.generateCompressedId();
+				const range2 = compressor.takeNextCreationRange();
+				expect(isLocalId(localId1)).to.be.true;
+				expect(isLocalId(localId2)).to.be.true;
+
+				compressor.finalizeCreationRange(range1);
+				compressor.finalizeCreationRange(range2);
+
+				const opSpaceId1 = compressor.normalizeToOpSpace(localId1);
+				const opSpaceId2 = compressor.normalizeToOpSpace(localId2);
+
+				expectAssert(isFinalId(opSpaceId1));
+				expectAssert(isFinalId(opSpaceId2));
+
+				expect(compressor.normalizeToSessionSpace(opSpaceId1)).to.equal(localId1);
+				expect(compressor.normalizeToSessionSpace(opSpaceId2)).to.equal(localId2);
+			});
 		});
 
 		describe('Finalizing', () => {
@@ -1793,7 +1423,7 @@ describe('IdCompressor', () => {
 			});
 
 			itNetwork('can serialize after a large fuzz input', 3, (network) => {
-				const generator = take(2000, makeOpGenerator({ includeOverrides: true }));
+				const generator = take(1000, makeOpGenerator({ includeOverrides: true }));
 				performFuzzActions(generator, network, Math.PI, undefined, true, (network) => {
 					// Periodically check that everyone in the network has the same serialized state
 					network.deliverOperations(DestinationClient.All);

--- a/experimental/dds/tree/src/test/SessionIdNormalizer.tests.ts
+++ b/experimental/dds/tree/src/test/SessionIdNormalizer.tests.ts
@@ -24,7 +24,7 @@ import { FinalCompressedId, LocalCompressedId, SessionSpaceCompressedId } from '
 describe('SessionIdNormalizer', () => {
 	it('fails when adding finals with no corresponding locals', () => {
 		const normalizer = makeTestNormalizer();
-		expect(() => normalizer.addFinalIds(final(0), final(1), undefined)).to.throw(
+		expect(() => normalizer.addFinalIds(final(0), final(1), dummy)).to.throw(
 			'Final IDs must be added to an existing local range.'
 		);
 	});
@@ -32,7 +32,26 @@ describe('SessionIdNormalizer', () => {
 	it('fails when adding finals out of order', () => {
 		const normalizer = makeTestNormalizer();
 		normalizer.addLocalId();
-		expect(() => normalizer.addFinalIds(final(1), final(0), undefined)).to.throw('Malformed normalization range.');
+		expect(() => normalizer.addFinalIds(final(1), final(0), dummy)).to.throw('Malformed normalization range.');
+	});
+
+	it('fails when registering final blocks with no corresponding locals', () => {
+		const normalizer = makeTestNormalizer();
+		expect(() => normalizer.registerFinalIdBlock(final(0), 5, dummy)).to.throw(
+			'Final ID block should not be registered before any locals.'
+		);
+		normalizer.addLocalId();
+		addFinalIds(normalizer, final(0), final(0));
+		expect(() => normalizer.registerFinalIdBlock(final(1), 5, dummy)).to.throw(
+			'Final ID block should not be registered without an existing local range.'
+		);
+	});
+
+	it('fails when registering final blocks with an invalid count', () => {
+		const normalizer = makeTestNormalizer();
+		normalizer.addLocalId();
+		expect(() => normalizer.registerFinalIdBlock(final(1), 0, dummy)).to.throw('Malformed normalization block.');
+		expect(() => normalizer.registerFinalIdBlock(final(1), -1, dummy)).to.throw('Malformed normalization block.');
 	});
 
 	it('fails when gaps in finals do not align with a local', () => {
@@ -47,11 +66,59 @@ describe('SessionIdNormalizer', () => {
 		const normalizer = makeTestNormalizer();
 		normalizer.addLocalId(); // -1
 		normalizer.addLocalId(); // -2
-		normalizer.addFinalIds(final(0), final(2), undefined);
+		addFinalIds(normalizer, final(0), final(2));
 		normalizer.addLocalId(); // -4
-		normalizer.addFinalIds(final(5), final(5), undefined);
-		expect(() => normalizer.addFinalIds(final(9), final(9), undefined)).to.throw(
+		addFinalIds(normalizer, final(5), final(5));
+		expect(() => addFinalIds(normalizer, final(9), final(9))).to.throw(
 			'Gaps in final space must align to a local.'
+		);
+	});
+
+	it('aligns outstanding locals when a block of finals is registered', () => {
+		/**
+		 * Locals: [-1, -2,  -3,  -4]
+		 * Finals: [ 0,  X,   X,   X]
+		 * Calling `registerFinalIdBlock` with first === 3, count === 10 results in the following:
+		 * Locals: [-1, -2,  -3,  -4]
+		 * Finals: [ 0,  3,   4,   5]
+		 *
+		 */
+		const normalizer = makeTestNormalizer();
+		const local1 = normalizer.addLocalId(); // -1
+		const local2 = normalizer.addLocalId(); // -2
+		const local3 = normalizer.addLocalId(); // -3
+		const local4 = normalizer.addLocalId(); // -4
+		normalizer.addFinalIds(final(0), final(0), dummy);
+
+		normalizer.registerFinalIdBlock(final(3), 10, dummy);
+		const locals = [local1, local2, local3, local4];
+		for (let i = 1; i < locals.length; i++) {
+			const expectedFinal = final(i + 2);
+			const finalObj = normalizer.getFinalId(locals[i]);
+			if (finalObj === undefined) {
+				expect.fail();
+			} else {
+				expect(finalObj[0]).to.equal(expectedFinal);
+			}
+		}
+
+		const local5 = normalizer.addLocalId();
+		expect(local5).to.equal(-5);
+		expect(normalizer.getFinalId(local5)).to.be.undefined;
+	});
+
+	it('fails to align a block of finals when there are no outstanding local IDs', () => {
+		/**
+		 * Locals: [-1,  X]
+		 * Finals: [ 0,  1]
+		 * Calling `registerFinalIdBlock` with first === 5, count === 10 should fail.
+		 */
+		const normalizer = makeTestNormalizer();
+		normalizer.addLocalId(); // -1
+		normalizer.addFinalIds(final(0), final(1), dummy);
+
+		expect(() => normalizer.registerFinalIdBlock(final(5), 10, dummy)).to.throw(
+			'Final ID block should not be registered without an existing local range.'
 		);
 	});
 
@@ -63,7 +130,7 @@ describe('SessionIdNormalizer', () => {
 		const local = normalizer.addLocalId();
 		const secondLocal = (local - 1) as LocalCompressedId;
 		expect(() => normalizer.getFinalId(secondLocal)).to.throw('Local ID was never recorded with this normalizer.');
-		normalizer.addFinalIds(final(0), final(5), undefined);
+		addFinalIds(normalizer, final(0), final(5));
 		expect(() => normalizer.getFinalId(secondLocal)).to.throw('Local ID was never recorded with this normalizer.');
 	});
 
@@ -80,14 +147,14 @@ describe('SessionIdNormalizer', () => {
 
 	itWithNormalizer('can normalize IDs with trailing finals', (normalizer) => {
 		normalizer.addLocalId();
-		normalizer.addFinalIds(final(0), final(1), undefined);
-		normalizer.addFinalIds(final(2), final(3), undefined);
-		normalizer.addFinalIds(final(4), final(10), undefined);
+		addFinalIds(normalizer, final(0), final(1));
+		addFinalIds(normalizer, final(2), final(3));
+		addFinalIds(normalizer, final(4), final(10));
 	});
 
 	itWithNormalizer('can normalize IDs with trailing locals', (normalizer) => {
 		normalizer.addLocalId();
-		normalizer.addFinalIds(final(0), final(1), undefined);
+		addFinalIds(normalizer, final(0), final(1));
 		normalizer.addLocalId();
 		normalizer.addLocalId();
 	});
@@ -96,22 +163,22 @@ describe('SessionIdNormalizer', () => {
 		normalizer.addLocalId();
 		normalizer.addLocalId();
 		normalizer.addLocalId();
-		normalizer.addFinalIds(final(0), final(1), undefined);
-		normalizer.addFinalIds(final(10), final(11), undefined);
+		addFinalIds(normalizer, final(0), final(1));
+		addFinalIds(normalizer, final(10), final(11));
 	});
 
 	itWithNormalizer('can normalize IDs with and without corresponding local forms', (normalizer) => {
 		normalizer.addLocalId(); // -1
 		normalizer.addLocalId(); // -2
 		normalizer.addLocalId(); // -3
-		normalizer.addFinalIds(final(0), final(3), dummy);
+		addFinalIds(normalizer, final(0), final(3));
 		normalizer.addLocalId(); // -5
 		normalizer.addLocalId(); // -6
-		normalizer.addFinalIds(final(4), final(5), dummy);
+		addFinalIds(normalizer, final(4), final(5));
 		normalizer.addLocalId(); // -7
-		normalizer.addFinalIds(final(8), final(9), dummy);
+		addFinalIds(normalizer, final(8), final(9));
 		normalizer.addLocalId(); // -9
-		normalizer.addFinalIds(final(14), final(15), dummy);
+		addFinalIds(normalizer, final(14), final(15));
 		normalizer.addLocalId(); // -11
 		normalizer.addLocalId(); // -12
 	});
@@ -122,11 +189,11 @@ describe('SessionIdNormalizer', () => {
 		normalizer.addLocalId(); // -3
 		normalizer.addLocalId(); // -4
 		expect(normalizer.getLastFinalId()).to.be.undefined;
-		normalizer.addFinalIds(final(0), final(1), undefined);
+		addFinalIds(normalizer, final(0), final(1));
 		expect(normalizer.getLastFinalId()).to.equal(1);
-		normalizer.addFinalIds(final(2), final(2), undefined);
+		addFinalIds(normalizer, final(2), final(2));
 		expect(normalizer.getLastFinalId()).to.equal(2);
-		normalizer.addFinalIds(final(10), final(15), undefined);
+		addFinalIds(normalizer, final(10), final(15));
 		expect(normalizer.getLastFinalId()).to.equal(15);
 	});
 
@@ -241,6 +308,14 @@ function itWithNormalizer(title: string, itFn: (normalizer: SessionIdNormalizer<
 	});
 }
 
+function addFinalIds(
+	normalizer: SessionIdNormalizer<DummyRange>,
+	firstFinal: FinalCompressedId,
+	lastFinal: FinalCompressedId
+): void {
+	normalizer.addFinalIds(firstFinal, lastFinal, dummy);
+}
+
 function makeNormalizerProxy(
 	normalizer: SessionIdNormalizer<DummyRange>,
 	locals: (LocalCompressedId | undefined)[],
@@ -249,30 +324,47 @@ function makeNormalizerProxy(
 	return new Proxy<SessionIdNormalizer<DummyRange>>(normalizer, {
 		get(target, property: keyof SessionIdNormalizer<DummyRange>) {
 			if (typeof target[property] === 'function') {
-				if (property === 'addLocalId') {
-					return new Proxy(target[property], {
-						apply: (func, thisArg, argumentsList) => {
-							const local = Reflect.apply(func, thisArg, argumentsList);
-							if (locals.length > 0) {
-								for (let i = (locals[locals.length - 1] ?? fail()) - 1; i > local; i--) {
-									locals.push(undefined);
+				switch (property) {
+					case 'addLocalId': {
+						return new Proxy(target[property], {
+							apply: (func, thisArg, argumentsList) => {
+								const local = Reflect.apply(func, thisArg, argumentsList);
+								if (locals.length > 0) {
+									for (let i = (locals[locals.length - 1] ?? fail()) - 1; i > local; i--) {
+										locals.push(undefined);
+									}
 								}
-							}
-							locals.push(local);
-							return local;
-						},
-					});
-				} else if (property === 'addFinalIds') {
-					return new Proxy(target[property], {
-						apply: (func, thisArg, argumentsList) => {
-							const firstFinal: FinalCompressedId = argumentsList[0];
-							const lastFinal: FinalCompressedId = argumentsList[1];
-							for (let i = firstFinal; i <= lastFinal; i++) {
-								finals.push(i);
-							}
-							return Reflect.apply(func, thisArg, argumentsList);
-						},
-					});
+								locals.push(local);
+								return local;
+							},
+						});
+					}
+					case 'addFinalIds': {
+						return new Proxy(target[property], {
+							apply: (func, thisArg, argumentsList) => {
+								const firstFinal: FinalCompressedId = argumentsList[0];
+								const lastFinal: FinalCompressedId = argumentsList[1];
+								for (let i = firstFinal; i <= lastFinal; i++) {
+									finals.push(i);
+								}
+								return Reflect.apply(func, thisArg, argumentsList);
+							},
+						});
+					}
+					case 'registerFinalIdBlock': {
+						return new Proxy(target[property], {
+							apply: (func, thisArg, argumentsList) => {
+								const firstFinal: FinalCompressedId = argumentsList[0];
+								const count: FinalCompressedId = argumentsList[1];
+								const usedFinals = Math.max(0, Math.min(locals.length - finals.length, count));
+								for (let i = firstFinal; i < usedFinals; i++) {
+									finals.push(i);
+								}
+								return Reflect.apply(func, thisArg, argumentsList);
+							},
+						});
+					}
+					// No default
 				}
 			}
 			return Reflect.get(target, property);
@@ -330,7 +422,11 @@ function makeOpGenerator(numOperations: number): Generator<Operation, FuzzTestSt
 			state.currentFinal += random.integer(1, 4);
 		}
 		const lastFinal = state.currentFinal + random.integer(0, 10);
-		const addFinal: AddFinalIds = { type: 'addFinalIds', first: final(state.currentFinal), last: final(lastFinal) };
+		const addFinal: AddFinalIds = {
+			type: 'addFinalIds',
+			first: final(state.currentFinal),
+			last: final(lastFinal),
+		};
 		state.currentFinal = lastFinal + 1;
 		state.prevWasLocal = false;
 		return addFinal;
@@ -375,7 +471,7 @@ function fuzzNormalizer(
 				return state;
 			},
 			addFinalIds: (state, { first, last }) => {
-				state.normalizer.addFinalIds(first, last, undefined);
+				state.normalizer.addFinalIds(first, last, dummy);
 				return state;
 			},
 		},

--- a/experimental/dds/tree/src/test/utilities/IdCompressorTestUtilities.ts
+++ b/experimental/dds/tree/src/test/utilities/IdCompressorTestUtilities.ts
@@ -178,6 +178,13 @@ export class IdCompressorTestNetwork {
 	}
 
 	/**
+	 * Returns the number of undelivered operations for the given client that are in flight in the network.
+	 */
+	public getPendingOperations(destination: Client): number {
+		return this.serverOperations.length - this.clientProgress.get(destination);
+	}
+
+	/**
 	 * Returns an immutable handle to a compressor in the network.
 	 */
 	public getCompressor(client: Client): ReadonlyIdCompressor {
@@ -318,9 +325,29 @@ export class IdCompressorTestNetwork {
 	/**
 	 * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
 	 */
-	public deliverOperations(clientTakingDelivery: DestinationClient) {
+	public deliverOperations(clientTakingDelivery: Client, opsToDeliver?: number);
+
+	/**
+	 * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
+	 */
+	public deliverOperations(clientTakingDelivery: DestinationClient);
+
+	/**
+	 * Delivers all undelivered ID ranges and cluster capacity changes from the server to the target clients.
+	 */
+	public deliverOperations(clientTakingDelivery: DestinationClient, opsToDeliver?: number) {
+		let opIndexBound: number;
+		if (clientTakingDelivery === DestinationClient.All) {
+			assert(opsToDeliver === undefined);
+			opIndexBound = this.serverOperations.length;
+		} else {
+			opIndexBound =
+				opsToDeliver !== undefined
+					? this.clientProgress.get(clientTakingDelivery) + opsToDeliver
+					: this.serverOperations.length;
+		}
 		for (const [clientTo, compressorTo] of this.getTargetCompressors(clientTakingDelivery)) {
-			for (let i = this.clientProgress.get(clientTo); i < this.serverOperations.length; i++) {
+			for (let i = this.clientProgress.get(clientTo); i < opIndexBound; i++) {
 				const operation = this.serverOperations[i];
 				if (typeof operation === 'number') {
 					compressorTo.clusterCapacity = operation;
@@ -350,7 +377,7 @@ export class IdCompressorTestNetwork {
 				}
 			}
 
-			this.clientProgress.set(clientTo, this.serverOperations.length);
+			this.clientProgress.set(clientTo, opIndexBound);
 		}
 	}
 
@@ -370,6 +397,16 @@ export class IdCompressorTestNetwork {
 		const sequencedLogs = Object.values(Client).map(
 			(client) => [this.compressors.get(client), this.getSequencedIdLog(client)] as const
 		);
+
+		// First, ensure all clients each generated a unique ID for each of their own calls to generate.
+		for (const [compressor, ids] of sequencedLogs) {
+			const uuids = new Set<StableId | string>();
+			for (const idData of ids) {
+				const uuid = compressor.decompress(idData.id);
+				expect(!uuids.has(uuid), 'Duplicate UUID generated.');
+				uuids.add(uuid);
+			}
+		}
 
 		const maxLogLength = sequencedLogs.map(([_, data]) => data.length).reduce((p, n) => Math.max(p, n));
 
@@ -560,7 +597,7 @@ export function expectSerializes(
 
 		for (const cluster of serialized.clusters) {
 			const [sessionIndex] = cluster;
-			expect(sessionIndex < serialized.sessions.length);
+			expect(sessionIndex < serialized.sessions.length).to.be.true;
 			chainCount[sessionIndex]++;
 		}
 
@@ -568,9 +605,9 @@ export function expectSerializes(
 			const [sessionIndex, capacity, maybeSize] = cluster;
 			const chainIndex = chainProcessed[sessionIndex];
 			if (chainIndex < chainCount[sessionIndex] - 1) {
-				expect(maybeSize === undefined);
+				expect(typeof maybeSize !== 'number').to.be.true;
 			} else {
-				expect(maybeSize === undefined || typeof maybeSize !== 'number' || maybeSize < capacity);
+				expect(maybeSize === undefined || typeof maybeSize !== 'number' || maybeSize < capacity).to.be.true;
 			}
 			chainProcessed[sessionIndex]++;
 		}
@@ -610,9 +647,14 @@ interface AllocateIds {
 	overrides: { [index: number]: string };
 }
 
-interface DeliverOperations {
-	type: 'deliverOperations';
-	client: DestinationClient;
+interface DeliverAllOperations {
+	type: 'deliverAllOperations';
+}
+
+interface DeliverSomeOperations {
+	type: 'deliverSomeOperations';
+	client: Client;
+	count: number;
 }
 
 interface ChangeCapacity {
@@ -637,7 +679,14 @@ interface Validate {
 	type: 'validate';
 }
 
-type Operation = AllocateIds | DeliverOperations | ChangeCapacity | GenerateUnifyingIds | Reconnect | Validate;
+type Operation =
+	| AllocateIds
+	| DeliverSomeOperations
+	| DeliverAllOperations
+	| ChangeCapacity
+	| GenerateUnifyingIds
+	| Reconnect
+	| Validate;
 
 interface FuzzTestState extends BaseFuzzTestState {
 	network: IdCompressorTestNetwork;
@@ -691,10 +740,30 @@ export function makeOpGenerator(options: OperationGenerationConfig): Generator<O
 		};
 	}
 
-	function deliverOperationsGenerator({ random, selectableClients }: FuzzTestState): DeliverOperations {
+	function deliverAllOperationsGenerator(): DeliverAllOperations {
 		return {
-			type: 'deliverOperations',
-			client: random.pick([...selectableClients, MetaClient.All]),
+			type: 'deliverAllOperations',
+		};
+	}
+
+	function deliverSomeOperationsGenerator({
+		random,
+		selectableClients,
+		network,
+	}: FuzzTestState): DeliverSomeOperations {
+		const pendingClients = selectableClients.filter((c) => network.getPendingOperations(c) > 0);
+		if (pendingClients.length === 0) {
+			return {
+				type: 'deliverSomeOperations',
+				client: random.pick(selectableClients),
+				count: 0,
+			};
+		}
+		const client = random.pick(pendingClients);
+		return {
+			type: 'deliverSomeOperations',
+			client,
+			count: random.integer(1, network.getPendingOperations(client)),
 		};
 	}
 
@@ -711,9 +780,10 @@ export function makeOpGenerator(options: OperationGenerationConfig): Generator<O
 	return interleave(
 		createWeightedGenerator<Operation, FuzzTestState>([
 			[changeCapacityGenerator, 1],
-			[allocateIdsGenerator, 8],
-			[deliverOperationsGenerator, 4],
-			[generateUnifyingIdsGenerator, 1],
+			[allocateIdsGenerator, 16],
+			[deliverAllOperationsGenerator, 2],
+			[deliverSomeOperationsGenerator, 6],
+			[generateUnifyingIdsGenerator, 2],
 			[reconnectGenerator, 1],
 		]),
 		take(1, repeat<Operation, FuzzTestState>({ type: 'validate' })),
@@ -761,8 +831,12 @@ export function performFuzzActions(
 				network.enqueueCapacityChange(op.newSize);
 				return { ...state, clusterSize: op.newSize };
 			},
-			deliverOperations: (state, op) => {
-				network.deliverOperations(op.client);
+			deliverSomeOperations: (state, op) => {
+				network.deliverOperations(op.client, op.count);
+				return state;
+			},
+			deliverAllOperations: (state) => {
+				network.deliverOperations(DestinationClient.All);
 				return state;
 			},
 			generateUnifyingIds: (state, { clientA, clientB, uuid }) => {


### PR DESCRIPTION
Cherry pick of [#13640](https://github.com/microsoft/FluidFramework/pull/13640) from main to lts.

This PR was originally ported from main to release/1.3 in[ #13669](https://github.com/microsoft/FluidFramework/pull/13669)
but was not ported to lts.