### PR TITLE
fix(build-common): Update base API-Extractor configs to include `tsdocMetadata` to ensure cross-package trimming is handled correctly

### DIFF
--- a/common/build/build-common/api-extractor-base.cjs.primary.json
+++ b/common/build/build-common/api-extractor-base.cjs.primary.json
@@ -12,9 +12,10 @@
 	"apiReport": {
 		"enabled": true
 	},
-	// API-Extractor uses the presence of this file to determine whether or not API members from other packages
-	// should be considered when making decisions about reports and rollups. This includes determining whether or
-	// not release tags on external members should be respected when making trimming decisions.
+	// API-Extractor uses the presence of this file in an npm package to determine whether or not its API members
+	// should be considered when making decisions about reports and rollups in consuming packages.
+	// This includes determining whether or not release tags on external members should be respected when
+	// making trimming decisions.
 	// We need to ensure this is enabled so that re-exports of API members across package boundaries are correctly
 	// trimmed based on their release tags.
 	// For more details on this option, see:

--- a/common/build/build-common/api-extractor-base.cjs.primary.json
+++ b/common/build/build-common/api-extractor-base.cjs.primary.json
@@ -11,5 +11,15 @@
 	},
 	"apiReport": {
 		"enabled": true
+	},
+	// For more details, see <https://api-extractor.com/pages/configs/api-extractor_json/#tsdoc-metadata-section>.
+	// API-Extractor uses the presence of this file to determine whether or not API members from other packages
+	// should be considered when making decisions about reports and rollups. This includes determining whether or
+	// not release tags on external members should be respected when making trimming decisions.
+	// We need to ensure this is enabled so that re-exports of API members across package boundaries are correctly
+	// trimmed based on their release tags.
+	"tsdocMetadata": {
+		"enabled": true,
+		"tsdocMetadataFilePath": "<projectFolder>/dist/tsdoc-metadata.json"
 	}
 }

--- a/common/build/build-common/api-extractor-base.cjs.primary.json
+++ b/common/build/build-common/api-extractor-base.cjs.primary.json
@@ -12,12 +12,13 @@
 	"apiReport": {
 		"enabled": true
 	},
-	// For more details, see <https://api-extractor.com/pages/configs/api-extractor_json/#tsdoc-metadata-section>.
 	// API-Extractor uses the presence of this file to determine whether or not API members from other packages
 	// should be considered when making decisions about reports and rollups. This includes determining whether or
 	// not release tags on external members should be respected when making trimming decisions.
 	// We need to ensure this is enabled so that re-exports of API members across package boundaries are correctly
 	// trimmed based on their release tags.
+	// For more details on this option, see:
+	// <https://api-extractor.com/pages/configs/api-extractor_json/#tsdoc-metadata-section>.
 	"tsdocMetadata": {
 		"enabled": true,
 		"tsdocMetadataFilePath": "<projectFolder>/dist/tsdoc-metadata.json"

--- a/common/build/build-common/api-extractor-base.cjs.secondary.json
+++ b/common/build/build-common/api-extractor-base.cjs.secondary.json
@@ -11,5 +11,8 @@
 	},
 	"apiReport": {
 		"enabled": false
+	},
+	"tsdocMetadata": {
+		"enabled": false
 	}
 }

--- a/common/build/build-common/api-extractor-base.esm.primary.json
+++ b/common/build/build-common/api-extractor-base.esm.primary.json
@@ -12,9 +12,10 @@
 	"apiReport": {
 		"enabled": true
 	},
-	// API-Extractor uses the presence of this file to determine whether or not API members from other packages
-	// should be considered when making decisions about reports and rollups. This includes determining whether or
-	// not release tags on external members should be respected when making trimming decisions.
+	// API-Extractor uses the presence of this file in an npm package to determine whether or not its API members
+	// should be considered when making decisions about reports and rollups in consuming packages.
+	// This includes determining whether or not release tags on external members should be respected when
+	// making trimming decisions.
 	// We need to ensure this is enabled so that re-exports of API members across package boundaries are correctly
 	// trimmed based on their release tags.
 	// For more details on this option, see:

--- a/common/build/build-common/api-extractor-base.esm.primary.json
+++ b/common/build/build-common/api-extractor-base.esm.primary.json
@@ -11,5 +11,15 @@
 	},
 	"apiReport": {
 		"enabled": true
+	},
+	// For more details, see <https://api-extractor.com/pages/configs/api-extractor_json/#tsdoc-metadata-section>.
+	// API-Extractor uses the presence of this file to determine whether or not API members from other packages
+	// should be considered when making decisions about reports and rollups. This includes determining whether or
+	// not release tags on external members should be respected when making trimming decisions.
+	// We need to ensure this is enabled so that re-exports of API members across package boundaries are correctly
+	// trimmed based on their release tags.
+	"tsdocMetadata": {
+		"enabled": true,
+		"tsdocMetadataFilePath": "<projectFolder>/lib/tsdoc-metadata.json"
 	}
 }

--- a/common/build/build-common/api-extractor-base.esm.primary.json
+++ b/common/build/build-common/api-extractor-base.esm.primary.json
@@ -12,12 +12,13 @@
 	"apiReport": {
 		"enabled": true
 	},
-	// For more details, see <https://api-extractor.com/pages/configs/api-extractor_json/#tsdoc-metadata-section>.
 	// API-Extractor uses the presence of this file to determine whether or not API members from other packages
 	// should be considered when making decisions about reports and rollups. This includes determining whether or
 	// not release tags on external members should be respected when making trimming decisions.
 	// We need to ensure this is enabled so that re-exports of API members across package boundaries are correctly
 	// trimmed based on their release tags.
+	// For more details on this option, see:
+	// <https://api-extractor.com/pages/configs/api-extractor_json/#tsdoc-metadata-section>.
 	"tsdocMetadata": {
 		"enabled": true,
 		"tsdocMetadataFilePath": "<projectFolder>/lib/tsdoc-metadata.json"

--- a/common/build/build-common/api-extractor-base.esm.secondary.json
+++ b/common/build/build-common/api-extractor-base.esm.secondary.json
@@ -11,5 +11,8 @@
 	},
 	"apiReport": {
 		"enabled": false
+	},
+	"tsdocMetadata": {
+		"enabled": false
 	}
 }


### PR DESCRIPTION
API-Extractor uses the presence of this file in an npm package to determine whether or not its API members should be considered when making decisions about reports and rollups in consuming packages.
This includes determining whether or not release tags on external members should be respected when making trimming decisions.
We need to ensure this is enabled so that re-exports of API members across package boundaries are correctly trimmed based on their release tags.