### PR TITLE
Updated exported members of devtools and devtools-core to beta

### DIFF
--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -89,7 +89,7 @@ export namespace ContainerDevtoolsFeatures {
     }
 }
 
-// @internal
+// @beta
 export interface ContainerDevtoolsProps extends HasContainerKey {
     container: IContainer;
     containerData?: Record<string, IFluidLoadable>;
@@ -244,7 +244,7 @@ export const EditType: {
 // @internal
 export type EditType = (typeof EditType)[keyof typeof EditType];
 
-// @internal
+// @beta
 export interface FluidDevtoolsProps {
     initialContainers?: ContainerDevtoolsProps[];
     logger?: IDevtoolsLogger;
@@ -385,7 +385,7 @@ export interface IDevtoolsMessage<TData = unknown> {
     type: string;
 }
 
-// @internal
+// @beta
 export interface IFluidDevtools extends IDisposable {
     closeContainerDevtools(containerKey: ContainerKey): void;
     registerContainerDevtools(props: ContainerDevtoolsProps): void;
@@ -406,7 +406,7 @@ export interface InboundHandlers {
     [type: string]: (message: ISourcedDevtoolsMessage) => Promise<boolean>;
 }
 
-// @internal
+// @beta
 export function initializeDevtools(props?: FluidDevtoolsProps): IFluidDevtools;
 
 // @internal

--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -95,7 +95,7 @@ export interface ContainerDevtoolsProps extends HasContainerKey {
     containerData?: Record<string, IFluidLoadable>;
 }
 
-// @alpha
+// @beta
 export type ContainerKey = string;
 
 // @internal
@@ -365,7 +365,7 @@ export function handleIncomingMessage(message: Partial<ISourcedDevtoolsMessage>,
 // @internal
 export function handleIncomingWindowMessage(event: MessageEvent<Partial<ISourcedDevtoolsMessage>>, handlers: InboundHandlers, loggingOptions?: MessageLoggingOptions): void;
 
-// @alpha
+// @beta
 export interface HasContainerKey {
     containerKey: ContainerKey;
 }
@@ -375,7 +375,7 @@ export interface HasFluidObjectId {
     fluidObjectId: FluidObjectId;
 }
 
-// @alpha @sealed
+// @beta @sealed
 export interface IDevtoolsLogger extends ITelemetryBaseLogger {
 }
 

--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -152,7 +152,7 @@ export interface ContainerStateMetadata extends HasContainerKey {
     userId?: string;
 }
 
-// @alpha
+// @beta
 export function createDevtoolsLogger(baseLogger?: ITelemetryBaseLogger): IDevtoolsLogger;
 
 // @internal

--- a/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
+++ b/packages/tools/devtools/devtools-core/src/CommonInterfaces.ts
@@ -11,13 +11,13 @@
  * @example
  *
  * "Canvas Container"
- * @alpha
+ * @beta
  */
 export type ContainerKey = string;
 
 /**
  * Common interface for data associated with a particular Container registered with the Devtools.
- * @alpha
+ * @beta
  */
 export interface HasContainerKey {
 	/**

--- a/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
@@ -48,7 +48,7 @@ import {
 
 /**
  * Properties for registering a {@link @fluidframework/container-definitions#IContainer} with the Devtools.
- * @internal
+ * @beta
  */
 export interface ContainerDevtoolsProps extends HasContainerKey {
 	/**

--- a/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
+++ b/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
@@ -157,7 +157,7 @@ class DevtoolsLogger implements IDevtoolsLogger {
 /**
  * Creates a new {@link IDevtoolsLogger} by wrapping the provided (optional) base logger.
  *
- * @alpha
+ * @beta
  */
 export function createDevtoolsLogger(baseLogger?: ITelemetryBaseLogger): IDevtoolsLogger {
 	return new DevtoolsLogger(baseLogger);

--- a/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
+++ b/packages/tools/devtools/devtools-core/src/DevtoolsLogger.ts
@@ -31,7 +31,7 @@ import {
  * initializing the Devtools.
  *
  * @sealed
- * @alpha
+ * @beta
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IDevtoolsLogger extends ITelemetryBaseLogger {}

--- a/packages/tools/devtools/devtools-core/src/FluidDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/FluidDevtools.ts
@@ -62,7 +62,7 @@ export function getContainerAlreadyRegisteredErrorText(containerKey: ContainerKe
 
 /**
  * Properties for configuring the Devtools.
- * @internal
+ * @beta
  */
 export interface FluidDevtoolsProps {
 	/**
@@ -395,7 +395,7 @@ export class FluidDevtools implements IFluidDevtools {
  *
  * It is automatically disposed on webpage unload, but it can be closed earlier by calling `dispose`
  * on the returned handle.
- * @internal
+ * @beta
  */
 export function initializeDevtools(props?: FluidDevtoolsProps): IFluidDevtools {
 	return FluidDevtools.initialize(props);

--- a/packages/tools/devtools/devtools-core/src/IFluidDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/IFluidDevtools.ts
@@ -20,7 +20,7 @@ import { type ContainerDevtoolsProps } from "./ContainerDevtools.js";
  * The lifetime of the associated singleton is bound by that of the Window (globalThis), and it will be automatically
  * disposed of on Window unload.
  * If you wish to dispose of it earlier, you may call its {@link @fluidframework/core-interfaces#IDisposable.dispose} method.
- * @internal
+ * @beta
  */
 export interface IFluidDevtools extends IDisposable {
 	/**

--- a/packages/tools/devtools/devtools/api-report/devtools.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.api.md
@@ -11,7 +11,7 @@ import { IDevtoolsLogger } from '@fluidframework/devtools-core';
 import { IDisposable } from '@fluidframework/core-interfaces';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 
-// @alpha
+// @beta
 export interface ContainerDevtoolsProps extends HasContainerKey {
     container: IFluidContainer;
 }
@@ -20,7 +20,7 @@ export { ContainerKey }
 
 export { createDevtoolsLogger }
 
-// @alpha
+// @beta
 export interface DevtoolsProps {
     initialContainers?: ContainerDevtoolsProps[];
     logger?: IDevtoolsLogger;
@@ -28,7 +28,7 @@ export interface DevtoolsProps {
 
 export { HasContainerKey }
 
-// @alpha
+// @beta
 export interface IDevtools extends IDisposable {
     closeContainerDevtools(id: string): void;
     registerContainerDevtools(props: ContainerDevtoolsProps): void;
@@ -36,7 +36,7 @@ export interface IDevtools extends IDisposable {
 
 export { IDevtoolsLogger }
 
-// @alpha
+// @beta
 export function initializeDevtools(props: DevtoolsProps): IDevtools;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/tools/devtools/devtools/src/index.ts
+++ b/packages/tools/devtools/devtools/src/index.ts
@@ -31,7 +31,7 @@ import { type IFluidContainer } from "@fluidframework/fluid-static";
 
 /**
  * Properties for configuring {@link IDevtools}.
- * @alpha
+ * @beta
  */
 export interface DevtoolsProps {
 	/**
@@ -58,7 +58,7 @@ export interface DevtoolsProps {
 
 /**
  * Properties for configuring Devtools for an individual {@link @fluidframework/fluid-static#IFluidContainer}.
- * @alpha
+ * @beta
  */
 export interface ContainerDevtoolsProps extends HasContainerKey {
 	/**
@@ -81,7 +81,7 @@ export interface ContainerDevtoolsProps extends HasContainerKey {
  * The lifetime of the associated singleton is bound by that of the Window (globalThis), and it will be automatically
  * disposed of on Window unload.
  * If you wish to dispose of it earlier, you may call its {@link @fluidframework/core-interfaces#IDisposable.dispose} method.
- * @alpha
+ * @beta
  */
 export interface IDevtools extends IDisposable {
 	/**
@@ -144,7 +144,7 @@ class Devtools implements IDevtools {
  * Initializes the Devtools singleton and returns a handle to it.
  *
  * @see {@link @fluidframework/devtools-core#initializeDevtoolsBase}
- * @alpha
+ * @beta
  */
 export function initializeDevtools(props: DevtoolsProps): IDevtools {
 	const { initialContainers, logger } = props;


### PR DESCRIPTION
[AB#6559](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6559)

## Description

 This PR updates the exported members of the `@fluidframework/devtools` package and marks them as `@beta`. Relevant exports from devtools-core were also marked as beta.