### PR TITLE
re-enable minimization in fuzz tests

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -91,7 +91,6 @@ describe("Fuzz - Top-Level", () => {
 			},
 			reconnectProbability: 0.1,
 			idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),
-			skipMinimization: true,
 			// AB#7594: Skipping seed 13 as it hits runs into assert 0x33f (double freeing cursor).
 			skip: [13],
 		};
@@ -128,7 +127,6 @@ describe("Fuzz - Top-Level", () => {
 				directory: failureDirectory,
 			},
 			idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),
-			skipMinimization: true,
 		};
 
 		createDDSFuzzSuite(model, options);


### PR DESCRIPTION
## Description

This PR re-enables minimization in the top level sharedTree fuzz tests.