### PR TITLE
refactor(tree): Remove parameter from abstract methods in LazyEntity

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -186,6 +186,11 @@ export interface FlexTreeNode extends FlexTreeEntity<FlexTreeNodeSchema> {
 
 	/**
 	 * The anchor node associated with this node
+	 *
+	 * @remarks
+	 * The ref count keeping this alive is owned by the FlexTreeNode:
+	 * if holding onto this anchor for longer than the FlexTreeNode might be alive,
+	 * a separate Anchor (and thus ref count) must be allocated to keep it alive.
 	 */
 	readonly anchorNode: AnchorNode;
 }

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
@@ -21,7 +21,7 @@ export const tryMoveCursorToAnchorSymbol = Symbol("tryMoveCursorToAnchor");
 export const forgetAnchorSymbol = Symbol("forgetAnchor");
 export const cursorSymbol = Symbol("cursor");
 /**
- * Symbol used to access the (generic) anchor of a {@link LazyEntity }.
+ * Symbol used to access the (generic) anchor of a {@link LazyEntity}.
  */
 export const anchorSymbol = Symbol("anchor");
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
@@ -20,6 +20,9 @@ export const isFreedSymbol = Symbol("isFreed");
 export const tryMoveCursorToAnchorSymbol = Symbol("tryMoveCursorToAnchor");
 export const forgetAnchorSymbol = Symbol("forgetAnchor");
 export const cursorSymbol = Symbol("cursor");
+/**
+ * Symbol used to access the (generic) anchor of a {@link LazyEntity }.
+ */
 export const anchorSymbol = Symbol("anchor");
 
 /**
@@ -62,7 +65,7 @@ export abstract class LazyEntity<TSchema = unknown, TAnchor = unknown>
 	public [disposeSymbol](): void {
 		this.#lazyCursor.free();
 		this.context.withCursors.delete(this);
-		this[forgetAnchorSymbol](this[anchorSymbol]);
+		this[forgetAnchorSymbol]();
 		this.context.withAnchors.delete(this);
 	}
 
@@ -85,7 +88,7 @@ export abstract class LazyEntity<TSchema = unknown, TAnchor = unknown>
 				this[anchorSymbol] !== undefined,
 				0x779 /* FlexTree should have an anchor if it does not have a cursor */,
 			);
-			const result = this[tryMoveCursorToAnchorSymbol](this[anchorSymbol], this.#lazyCursor);
+			const result = this[tryMoveCursorToAnchorSymbol](this.#lazyCursor);
 			assert(
 				result === TreeNavigationResult.Ok,
 				0x77a /* It is invalid to access a FlexTree node which no longer exists */,
@@ -96,14 +99,13 @@ export abstract class LazyEntity<TSchema = unknown, TAnchor = unknown>
 	}
 
 	protected abstract [tryMoveCursorToAnchorSymbol](
-		anchor: TAnchor,
 		cursor: ITreeSubscriptionCursor,
 	): TreeNavigationResult;
 
 	/**
 	 * Called when disposing of this target, iff it has an anchor.
 	 */
-	protected abstract [forgetAnchorSymbol](anchor: TAnchor): void;
+	protected abstract [forgetAnchorSymbol](): void;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -175,15 +175,14 @@ export abstract class LazyField<TKind extends FlexFieldKind, TTypes extends Flex
 	}
 
 	protected override [tryMoveCursorToAnchorSymbol](
-		anchor: FieldAnchor,
 		cursor: ITreeSubscriptionCursor,
 	): TreeNavigationResult {
-		return this.context.forest.tryMoveCursorToField(anchor, cursor);
+		return this.context.forest.tryMoveCursorToField(this[anchorSymbol], cursor);
 	}
 
-	protected override [forgetAnchorSymbol](anchor: FieldAnchor): void {
-		if (anchor.parent === undefined) return;
-		this.context.forest.anchors.forget(anchor.parent);
+	protected override [forgetAnchorSymbol](): void {
+		if (this[anchorSymbol].parent === undefined) return;
+		this.context.forest.anchors.forget(this[anchorSymbol].parent);
 	}
 
 	public get length(): number {

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -65,6 +65,7 @@ import {
 } from "./flexTreeTypes.js";
 import {
 	LazyEntity,
+	anchorSymbol,
 	cursorSymbol,
 	forgetAnchorSymbol,
 	isFreedSymbol,
@@ -172,19 +173,18 @@ export abstract class LazyTreeNode<TSchema extends FlexTreeNodeSchema = FlexTree
 	}
 
 	protected override [tryMoveCursorToAnchorSymbol](
-		anchor: Anchor,
 		cursor: ITreeSubscriptionCursor,
 	): TreeNavigationResult {
-		return this.context.forest.tryMoveCursorToNode(anchor, cursor);
+		return this.context.forest.tryMoveCursorToNode(this[anchorSymbol], cursor);
 	}
 
-	protected override [forgetAnchorSymbol](anchor: Anchor): void {
+	protected override [forgetAnchorSymbol](): void {
 		// This type unconditionally has an anchor, so `forgetAnchor` is always called and cleanup can be done here:
 		// After this point this node will not be usable,
 		// so remove it from the anchor incase a different context (or the same context later) uses this AnchorSet.
 		this.anchorNode.slots.delete(flexTreeSlot);
 		this.#removeDeleteCallback();
-		this.context.forest.anchors.forget(anchor);
+		this.context.forest.anchors.forget(this[anchorSymbol]);
 	}
 
 	public get value(): Value {


### PR DESCRIPTION
## Description

Extracting part of [this proposal](https://github.com/microsoft/FluidFramework/pull/19797/) (which became https://github.com/microsoft/FluidFramework/pull/20286) into its own PR for independent review.

Removes a parameter in a few abstract methods in the abstract class `LazyEntity`. Concrete classes already have access to what the parameter is passing through a symbol-keyed property in the abstract class, so this is technically doable... but I'm not sure I like it. Particularly the fact that the abstract class actually makes a call to one of the abstract methods, which guarantees that the passed parameter will be the symbol-keyed property owned by it. After the change, concrete classes can technically provide something else (although they don't in this PR), but I'm not familiar enough with this code to know if that's a potential bug, or a feature.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
