### PR TITLE
tree: remove unneeded utilities from SchemaBuilder

### DIFF
--- a/packages/dds/tree/src/domains/schemaBuilder.ts
+++ b/packages/dds/tree/src/domains/schemaBuilder.ts
@@ -3,10 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils";
-
 import {
-	Any,
 	FieldKinds,
 	FlexFieldKind,
 	FlexFieldNodeSchema,
@@ -14,14 +11,12 @@ import {
 	FlexImplicitAllowedTypes,
 	FlexImplicitFieldSchema,
 	FlexObjectNodeSchema,
-	FlexTreeNodeSchema,
 	NormalizeAllowedTypes,
 	SchemaBuilderBase,
 	SchemaBuilderOptions,
-	TreeNodeSchemaBase,
 	Unenforced,
 } from "../feature-libraries/index.js";
-import { RestrictiveReadonlyRecord, getOrCreate, isAny, requireFalse } from "../util/index.js";
+import { RestrictiveReadonlyRecord } from "../util/index.js";
 
 import { leaf } from "./leafDomain.js";
 
@@ -51,8 +46,6 @@ export class SchemaBuilder<
 	TScope extends string = string,
 	TName extends string | number = string,
 > extends SchemaBuilderBase<TScope, typeof FieldKinds.required, TName> {
-	private readonly structuralTypes: Map<string, FlexTreeNodeSchema> = new Map();
-
 	public constructor(options: SchemaBuilderOptions<TScope>) {
 		super(FieldKinds.required, {
 			...options,
@@ -71,76 +64,11 @@ export class SchemaBuilder<
 	}
 
 	/**
-	 * Define (and add to this library if not already present) a structurally typed {@link FlexFieldNodeSchema} for a {@link (TreeListNode:interface)}.
-	 *
-	 * @remarks
-	 * The {@link TreeNodeSchemaIdentifier} for this List is defined as a function of the provided types.
-	 * It is still scoped to this SchemaBuilder, but multiple calls with the same arguments will return the same schema object, providing somewhat structural typing.
-	 * This does not support recursive types.
-	 *
-	 * If using these structurally named lists, other types in this schema builder should avoid names of the form `List<${string}>`.
-	 *
-	 * @privateRemarks
-	 * The name produced at the type level here is not as specific as it could be, however doing type level sorting and escaping is a real mess.
-	 * There are cases where not having this full type provided will be less than ideal since TypeScript's structural types.
-	 * For example attempts to narrow unions of structural lists by name won't work.
-	 * Planned future changes to move to a class based schema system as well as factor function based node construction should mostly avoid these issues,
-	 * though there may still be some problematic cases even after that work is done.
-	 */
-	public list<const T extends FlexTreeNodeSchema | Any | readonly FlexTreeNodeSchema[]>(
-		allowedTypes: T,
-	): FlexFieldNodeSchema<
-		`${TScope}.List<${string}>`,
-		FlexFieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>
-	>;
-
-	/**
-	 * Define (and add to this library) a {@link FlexFieldNodeSchema} for a {@link (TreeListNode:interface)}.
+	 * Define (and add to this library) a {@link FlexFieldNodeSchema} for a {@link Sequence}.
 	 *
 	 * The name must be unique among all TreeNodeSchema in the the document schema.
 	 */
 	public list<Name extends TName, const T extends FlexImplicitAllowedTypes>(
-		name: Name,
-		allowedTypes: T,
-	): FlexFieldNodeSchema<
-		`${TScope}.${Name}`,
-		FlexFieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>
-	>;
-
-	public list<const T extends FlexImplicitAllowedTypes>(
-		nameOrAllowedTypes:
-			| TName
-			| ((T & FlexTreeNodeSchema) | Any | readonly FlexTreeNodeSchema[]),
-		allowedTypes?: T,
-	): FlexFieldNodeSchema<
-		`${TScope}.${string}`,
-		FlexFieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>
-	> {
-		if (allowedTypes === undefined) {
-			const types = nameOrAllowedTypes as
-				| (T & FlexTreeNodeSchema)
-				| Any
-				| readonly FlexTreeNodeSchema[];
-			const fullName = structuralName("List", types);
-			return getOrCreate(this.structuralTypes, fullName, () =>
-				this.namedList(fullName, nameOrAllowedTypes as T),
-			) as FlexFieldNodeSchema<
-				`${TScope}.${string}`,
-				FlexFieldSchema<typeof FieldKinds.sequence, NormalizeAllowedTypes<T>>
-			>;
-		}
-		return this.namedList(nameOrAllowedTypes as TName, allowedTypes);
-	}
-
-	/**
-	 * Define (and add to this library) a {@link FlexFieldNodeSchema} for a {@link (TreeListNode:interface)}.
-	 *
-	 * The name must be unique among all TreeNodeSchema in the the document schema.
-	 *
-	 * @privateRemarks
-	 * TODO: If A custom "List" API is added as a subtype of {@link FieldNode}, this would opt into that.
-	 */
-	private namedList<Name extends TName | string, const T extends FlexImplicitAllowedTypes>(
 		name: Name,
 		allowedTypes: T,
 	): FlexFieldNodeSchema<
@@ -223,40 +151,4 @@ function fieldHelper<Kind extends FlexFieldKind>(kind: Kind) {
 	return <const T extends FlexImplicitAllowedTypes>(
 		allowedTypes: T,
 	): FlexFieldSchema<Kind, NormalizeAllowedTypes<T>> => SchemaBuilder.field(kind, allowedTypes);
-}
-
-export function structuralName<const T extends string>(
-	collectionName: T,
-	allowedTypes: FlexTreeNodeSchema | Any | readonly FlexTreeNodeSchema[],
-): `${T}<${string}>` {
-	let inner: string;
-	if (allowedTypes === Any) {
-		inner = "Any";
-	} else if (allowedTypes instanceof TreeNodeSchemaBase) {
-		return structuralName(collectionName, [allowedTypes]);
-	} else {
-		assert(Array.isArray(allowedTypes), 0x7c7 /* Types should be an array */);
-		const names = allowedTypes.map((t): string => {
-			// Ensure that lazy types (functions) don't slip through here.
-			assert(t instanceof TreeNodeSchemaBase, 0x7c8 /* invalid type provided */);
-			// TypeScript should know `t.name` is a string (from the extends constraint on TreeNodeSchema's name), but the linter objects.
-			// @ts-expect-error: Apparently TypeScript also fails to apply this constraint for some reason and is giving any:
-			type _check = requireFalse<isAny<typeof t.name>>;
-			// Adding `as string` here would silence the linter, but make this code less type safe (since if this became not a string, it would still build).
-			// Thus we explicitly check that this satisfies string.
-			// This would best be done by appending `satisfies string`, but the linter also rejects this.
-			// Therefor introducing a variable to do the same thing as `satisfies string` but such that the linter can understand:
-			const name: string = t.name;
-			// Just incase the compiler and linter really are onto something and this might sometimes not be a string, validate it:
-			assert(typeof name === "string", 0x7c9 /* Name should be a string */);
-			return name;
-		});
-		// Ensure name is order independent
-		names.sort();
-		// Ensure name can't have collisions by quoting and escaping any quotes in the names of types.
-		// Using JSON is a simple way to accomplish this.
-		// The outer `[]` around the result are also needed so that a single type name "Any" would not collide with the "any" case above.
-		inner = JSON.stringify(names);
-	}
-	return `${collectionName}<${inner}>`;
 }

--- a/packages/dds/tree/src/domains/schemaBuilder.ts
+++ b/packages/dds/tree/src/domains/schemaBuilder.ts
@@ -13,17 +13,13 @@ import {
 	FlexFieldSchema,
 	FlexImplicitAllowedTypes,
 	FlexImplicitFieldSchema,
-	FlexMapFieldSchema,
-	FlexMapNodeSchema,
 	FlexObjectNodeSchema,
 	FlexTreeNodeSchema,
 	NormalizeAllowedTypes,
-	NormalizeField,
 	SchemaBuilderBase,
 	SchemaBuilderOptions,
 	TreeNodeSchemaBase,
 	Unenforced,
-	normalizeField,
 } from "../feature-libraries/index.js";
 import { RestrictiveReadonlyRecord, getOrCreate, isAny, requireFalse } from "../util/index.js";
 
@@ -158,65 +154,6 @@ export class SchemaBuilder<
 		);
 		this.addNodeSchema(schema);
 		return schema;
-	}
-
-	/**
-	 * Define (and add to this library if not already present) a structurally typed {@link FlexMapNodeSchema} for a {@link TreeMapNode}.
-	 *
-	 * @remarks
-	 * The {@link TreeNodeSchemaIdentifier} for this Map is defined as a function of the provided types.
-	 * It is still scoped to this SchemaBuilder, but multiple calls with the same arguments will return the same schema object, providing somewhat structural typing.
-	 * This does not support recursive types.
-	 *
-	 * If using these structurally named maps, other types in this schema builder should avoid names of the form `Map<${string}>`.
-	 *
-	 * @privateRemarks
-	 * See note on list.
-	 */
-	public override map<const T extends FlexTreeNodeSchema | Any | readonly FlexTreeNodeSchema[]>(
-		allowedTypes: T,
-	): FlexMapNodeSchema<`${TScope}.Map<${string}>`, NormalizeField<T, typeof FieldKinds.optional>>;
-
-	/**
-	 * Define (and add to this library) a {@link FlexMapNodeSchema} for a {@link TreeMapNode}.
-	 */
-	public override map<
-		Name extends TName,
-		const T extends FlexMapFieldSchema | FlexImplicitAllowedTypes,
-	>(
-		name: Name,
-		fieldSchema: T,
-	): FlexMapNodeSchema<`${TScope}.${Name}`, NormalizeField<T, typeof FieldKinds.optional>>;
-
-	public override map<const T extends FlexMapFieldSchema | FlexImplicitAllowedTypes>(
-		nameOrAllowedTypes:
-			| TName
-			| ((T & FlexTreeNodeSchema) | Any | readonly FlexTreeNodeSchema[]),
-		allowedTypes?: T,
-	): FlexMapNodeSchema<`${TScope}.${string}`, NormalizeField<T, typeof FieldKinds.optional>> {
-		if (allowedTypes === undefined) {
-			const types = nameOrAllowedTypes as
-				| (T & FlexTreeNodeSchema)
-				| Any
-				| readonly FlexTreeNodeSchema[];
-			const fullName = structuralName("Map", types);
-			return getOrCreate(
-				this.structuralTypes,
-				fullName,
-				() =>
-					super.map(
-						fullName as TName,
-						normalizeField(nameOrAllowedTypes as T, FieldKinds.optional),
-					) as FlexTreeNodeSchema,
-			) as FlexMapNodeSchema<
-				`${TScope}.${string}`,
-				NormalizeField<T, typeof FieldKinds.optional>
-			>;
-		}
-		return super.map(
-			nameOrAllowedTypes as TName,
-			normalizeField(allowedTypes, FieldKinds.optional),
-		);
 	}
 
 	/**

--- a/packages/dds/tree/src/domains/schemaBuilder.ts
+++ b/packages/dds/tree/src/domains/schemaBuilder.ts
@@ -277,31 +277,6 @@ export class SchemaBuilder<
 	 * therefore this method is the same as the static version.
 	 */
 	public readonly sequence = SchemaBuilder.sequence;
-
-	/**
-	 * {@link leaf.number}
-	 */
-	public readonly number = leaf.number;
-
-	/**
-	 * {@link leaf.boolean}
-	 */
-	public readonly boolean = leaf.boolean;
-
-	/**
-	 * {@link leaf.string}
-	 */
-	public readonly string = leaf.string;
-
-	/**
-	 * {@link leaf.handle}
-	 */
-	public readonly handle = leaf.handle;
-
-	/**
-	 * {@link leaf.null}
-	 */
-	public readonly null = leaf.null;
 }
 
 /**

--- a/packages/dds/tree/src/test/domains/schemaBuilder.spec.ts
+++ b/packages/dds/tree/src/test/domains/schemaBuilder.spec.ts
@@ -16,7 +16,6 @@ import {
 	FlexTreeSequenceField,
 	FlexTreeTypedNode,
 	schemaIsFieldNode,
-	schemaIsMap,
 } from "../../feature-libraries/index.js";
 import { areSafelyAssignable, isAny, requireFalse, requireTrue } from "../../util/index.js";
 
@@ -125,53 +124,6 @@ describe("domains - SchemaBuilder", () => {
 				assert((builder.list(leaf.number) as FlexTreeNodeSchema) !== list);
 				// Creating again errors instead or reuses
 				assert.throws(() => builder.list("Foo", leaf.number));
-			});
-		});
-	});
-
-	describe("map", () => {
-		describe("structural", () => {
-			it("implicit", () => {
-				const builder = new SchemaBuilder({ scope: "scope" });
-				const mapAny = builder.map(Any);
-				assert(schemaIsMap(mapAny));
-				// Correct name
-				assert.equal(mapAny.name, "scope.Map<Any>");
-				// Infers optional kind
-				assert(mapAny.mapFields.equals(FlexFieldSchema.create(FieldKinds.optional, [Any])));
-				// Cached and reused
-				assert.equal(builder.map(Any), mapAny);
-			});
-
-			describe("named map", () => {
-				it("implicit normalizes", () => {
-					const builder = new SchemaBuilder({ scope: "scope" });
-
-					const map = builder.map("Foo", leaf.number);
-					assert(schemaIsMap(map));
-					assert.equal(map.name, `scope.Foo`);
-					assert(
-						map.mapFields.equals(
-							FlexFieldSchema.create(FieldKinds.optional, [leaf.number]),
-						),
-					);
-				});
-
-				it("explicit", () => {
-					const builder = new SchemaBuilder({ scope: "scope" });
-
-					const map = builder.map(
-						"Foo",
-						FlexFieldSchema.create(FieldKinds.sequence, [leaf.string]),
-					);
-					assert(schemaIsMap(map));
-					assert.equal(map.name, `scope.Foo`);
-					assert(
-						map.mapFields.equals(
-							FlexFieldSchema.create(FieldKinds.sequence, [leaf.string]),
-						),
-					);
-				});
 			});
 		});
 	});

--- a/packages/dds/tree/src/test/domains/schemaBuilder.spec.ts
+++ b/packages/dds/tree/src/test/domains/schemaBuilder.spec.ts
@@ -41,30 +41,30 @@ describe("domains - SchemaBuilder", () => {
 			it("implicit", () => {
 				const builder = new SchemaBuilder({ scope: "scope2" });
 
-				const listImplicit = builder.list(builder.number);
+				const listImplicit = builder.list(leaf.number);
 				assert(schemaIsFieldNode(listImplicit));
-				assert.equal(listImplicit.name, `scope2.List<["${builder.number.name}"]>`);
+				assert.equal(listImplicit.name, `scope2.List<["${leaf.number.name}"]>`);
 				assert(
 					listImplicit.info.equals(
-						FlexFieldSchema.create(FieldKinds.sequence, [builder.number]),
+						FlexFieldSchema.create(FieldKinds.sequence, [leaf.number]),
 					),
 				);
 				type ListImplicit = FlexTreeTypedNode<typeof listImplicit>["content"];
 				type _check = requireTrue<
 					areSafelyAssignable<
 						ListImplicit,
-						FlexTreeSequenceField<readonly [typeof builder.number]>
+						FlexTreeSequenceField<readonly [typeof leaf.number]>
 					>
 				>;
 
-				assert.equal(builder.list(builder.number), listImplicit);
+				assert.equal(builder.list(leaf.number), listImplicit);
 			});
 
 			it("implicit normalizes", () => {
 				const builder = new SchemaBuilder({ scope: "scope" });
 
-				const listImplicit = builder.list(builder.number);
-				const listExplicit = builder.list([builder.number]);
+				const listImplicit = builder.list(leaf.number);
+				const listExplicit = builder.list([leaf.number]);
 
 				assert.equal(listImplicit, listExplicit);
 			});
@@ -72,29 +72,24 @@ describe("domains - SchemaBuilder", () => {
 			it("union", () => {
 				const builder = new SchemaBuilder({ scope: "scope" });
 
-				const listUnion = builder.list([builder.number, builder.boolean]);
+				const listUnion = builder.list([leaf.number, leaf.boolean]);
 				assert(schemaIsFieldNode(listUnion));
 
 				assert.equal(
 					listUnion.name,
 					// Sorted alphabetically
-					`scope.List<["${builder.boolean.name}","${builder.number.name}"]>`,
+					`scope.List<["${leaf.boolean.name}","${leaf.number.name}"]>`,
 				);
 				assert(
 					listUnion.info.equals(
-						FlexFieldSchema.create(FieldKinds.sequence, [
-							builder.number,
-							builder.boolean,
-						]),
+						FlexFieldSchema.create(FieldKinds.sequence, [leaf.number, leaf.boolean]),
 					),
 				);
 				type ListUnion = FlexTreeTypedNode<typeof listUnion>["content"];
 				type _check = requireTrue<
 					areSafelyAssignable<
 						ListUnion,
-						FlexTreeSequenceField<
-							readonly [typeof builder.number, typeof builder.boolean]
-						>
+						FlexTreeSequenceField<readonly [typeof leaf.number, typeof leaf.boolean]>
 					>
 				>;
 				// TODO: this should compile: ideally FlexTree's use of AllowedTypes would be compile time order independent like it is runtime order independent, but its currently not.
@@ -102,14 +97,12 @@ describe("domains - SchemaBuilder", () => {
 					// @ts-expect-error Currently not order independent: ideally this would compile
 					areSafelyAssignable<
 						ListUnion,
-						FlexTreeSequenceField<
-							readonly [typeof builder.boolean, typeof builder.number]
-						>
+						FlexTreeSequenceField<readonly [typeof leaf.boolean, typeof leaf.number]>
 					>
 				>;
 
-				assert.equal(builder.list([builder.number, builder.boolean]), listUnion);
-				assert.equal(builder.list([builder.boolean, builder.number]), listUnion);
+				assert.equal(builder.list([leaf.number, leaf.boolean]), listUnion);
+				assert.equal(builder.list([leaf.boolean, leaf.number]), listUnion);
 			});
 		});
 
@@ -117,24 +110,21 @@ describe("domains - SchemaBuilder", () => {
 			it("implicit normalizes", () => {
 				const builder = new SchemaBuilder({ scope: "scope" });
 
-				const list = builder.list("Foo", builder.number);
+				const list = builder.list("Foo", leaf.number);
 				assert(schemaIsFieldNode(list));
 				assert.equal(list.name, `scope.Foo`);
 				assert(
-					list.info.equals(FlexFieldSchema.create(FieldKinds.sequence, [builder.number])),
+					list.info.equals(FlexFieldSchema.create(FieldKinds.sequence, [leaf.number])),
 				);
 				type List = FlexTreeTypedNode<typeof list>["content"];
 				type _check = requireTrue<
-					areSafelyAssignable<
-						List,
-						FlexTreeSequenceField<readonly [typeof builder.number]>
-					>
+					areSafelyAssignable<List, FlexTreeSequenceField<readonly [typeof leaf.number]>>
 				>;
 
 				// Not cached for structural use
-				assert((builder.list(builder.number) as FlexTreeNodeSchema) !== list);
+				assert((builder.list(leaf.number) as FlexTreeNodeSchema) !== list);
 				// Creating again errors instead or reuses
-				assert.throws(() => builder.list("Foo", builder.number));
+				assert.throws(() => builder.list("Foo", leaf.number));
 			});
 		});
 	});
@@ -157,12 +147,12 @@ describe("domains - SchemaBuilder", () => {
 				it("implicit normalizes", () => {
 					const builder = new SchemaBuilder({ scope: "scope" });
 
-					const map = builder.map("Foo", builder.number);
+					const map = builder.map("Foo", leaf.number);
 					assert(schemaIsMap(map));
 					assert.equal(map.name, `scope.Foo`);
 					assert(
 						map.mapFields.equals(
-							FlexFieldSchema.create(FieldKinds.optional, [builder.number]),
+							FlexFieldSchema.create(FieldKinds.optional, [leaf.number]),
 						),
 					);
 				});
@@ -212,7 +202,7 @@ describe("domains - SchemaBuilder", () => {
 		const builder = new SchemaBuilder({ scope: "Test Domain" });
 
 		const testObject = builder.object("object", {
-			number: builder.number,
+			number: leaf.number,
 		});
 
 		type _0 = requireFalse<isAny<typeof testObject>>;
@@ -227,7 +217,7 @@ describe("domains - SchemaBuilder", () => {
 
 		const recursiveObject = builder.objectRecursive("object", {
 			recursive: FlexFieldSchema.createUnsafe(FieldKinds.optional, [() => recursiveObject]),
-			number: SchemaBuilder.required(builder.number),
+			number: SchemaBuilder.required(leaf.number),
 		});
 
 		type _0 = requireFalse<isAny<typeof recursiveObject>>;

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
@@ -30,7 +30,6 @@ import {
 import { DecoderContext } from "../../../../feature-libraries/chunked-forest/codec/chunkDecodingGeneric.js";
 import {
 	EncodedChunkShape,
-	EncodedFieldBatch,
 	version,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/format.js";
@@ -85,34 +84,6 @@ describe("chunkDecoding", () => {
 				shapes: [{ a: 0 }],
 				data: [[0, []]],
 			});
-			assert.deepEqual(result, [emptyChunk]);
-		});
-
-		it("regression", () => {
-			const data: EncodedFieldBatch = [
-				5,
-				"5703557480152899",
-				0,
-				"Hello",
-				"amauricio@a2mac1.com",
-				1711531476552,
-				1711531476552,
-				0,
-				"/project/A0000023BUTIDV01",
-				0,
-				0,
-				0,
-				"",
-				false,
-				0,
-				"",
-				"",
-			] as any;
-			const stream = {
-				data,
-				offset: 16,
-			};
-			const result = decode(stream.data);
 			assert.deepEqual(result, [emptyChunk]);
 		});
 	});

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecoding.spec.ts
@@ -30,6 +30,7 @@ import {
 import { DecoderContext } from "../../../../feature-libraries/chunked-forest/codec/chunkDecodingGeneric.js";
 import {
 	EncodedChunkShape,
+	EncodedFieldBatch,
 	version,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/format.js";
@@ -84,6 +85,34 @@ describe("chunkDecoding", () => {
 				shapes: [{ a: 0 }],
 				data: [[0, []]],
 			});
+			assert.deepEqual(result, [emptyChunk]);
+		});
+
+		it("regression", () => {
+			const data: EncodedFieldBatch = [
+				5,
+				"5703557480152899",
+				0,
+				"Hello",
+				"amauricio@a2mac1.com",
+				1711531476552,
+				1711531476552,
+				0,
+				"/project/A0000023BUTIDV01",
+				0,
+				0,
+				0,
+				"",
+				false,
+				0,
+				"",
+				"",
+			] as any;
+			const stream = {
+				data,
+				offset: 16,
+			};
+			const result = decode(stream.data);
 			assert.deepEqual(result, [emptyChunk]);
 		});
 	});

--- a/packages/dds/tree/src/test/feature-libraries/schema-aware/schemaComplex.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schema-aware/schemaComplex.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable no-inner-declarations */
 
-import { SchemaBuilder } from "../../../domains/index.js";
+import { SchemaBuilder, leaf } from "../../../domains/index.js";
 import {
 	AllowedTypesToFlexInsertableTree,
 	FieldKinds,
@@ -18,7 +18,7 @@ import { requireAssignableTo } from "../../../util/index.js";
 const builder = new SchemaBuilder({ scope: "Complex Schema Example" });
 
 // Schema
-export const stringTaskSchema = builder.fieldNode("StringTask", builder.string);
+export const stringTaskSchema = builder.fieldNode("StringTask", leaf.string);
 // Polymorphic recursive schema:
 export const listTaskSchema = builder.objectRecursive("ListTask", {
 	items: FlexFieldSchema.createUnsafe(FieldKinds.sequence, [

--- a/packages/dds/tree/src/test/feature-libraries/schema-aware/schemaSimple.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schema-aware/schemaSimple.ts
@@ -10,8 +10,8 @@ const builder = new SchemaBuilder({ scope: "Simple Schema" });
 
 // Schema
 export const pointSchema = builder.object("point", {
-	x: builder.number,
-	y: builder.number,
+	x: leaf.number,
+	y: leaf.number,
 });
 
 export const appSchemaData = builder.intoSchema(builder.sequence(pointSchema));

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1047,7 +1047,7 @@ describe("SharedTree", () => {
 
 		describe("can concurrently restore and edit removed tree", () => {
 			const sb = new SchemaBuilder({ scope: "shared tree undo tests" });
-			const schema = sb.intoSchema(sb.list(sb.list(sb.string)));
+			const schema = sb.intoSchema(sb.list(sb.list(leaf.string)));
 
 			for (const scenario of ["restore then change", "change then restore"]) {
 				it(`with the ${scenario} sequenced`, () => {
@@ -1338,7 +1338,7 @@ describe("SharedTree", () => {
 	describe("Events", () => {
 		const builder = new SchemaBuilder({ scope: "Events test schema" });
 		const rootTreeNodeSchema = builder.object("root", {
-			x: builder.number,
+			x: leaf.number,
 		});
 		const schema = builder.intoSchema(builder.optional(Any));
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1047,7 +1047,7 @@ describe("SharedTree", () => {
 
 		describe("can concurrently restore and edit removed tree", () => {
 			const sb = new SchemaBuilder({ scope: "shared tree undo tests" });
-			const schema = sb.intoSchema(sb.list(sb.list(leaf.string)));
+			const schema = sb.intoSchema(sb.list("A", sb.list("B", leaf.string)));
 
 			for (const scenario of ["restore then change", "change then restore"]) {
 				it(`with the ${scenario} sequenced`, () => {

--- a/packages/dds/tree/src/test/snapshots/testTrees.ts
+++ b/packages/dds/tree/src/test/snapshots/testTrees.ts
@@ -256,7 +256,7 @@ export function generateTestTrees(useUncompressedEncode?: boolean) {
 					scope: "optional-field",
 					libraries: [leaf.library],
 				});
-				const testNode = innerBuilder.map("TestNode", leaf.all);
+				const testNode = innerBuilder.map("TestNode", SchemaBuilder.optional(leaf.all));
 				const docSchema = innerBuilder.intoSchema(SchemaBuilder.optional(testNode));
 
 				const config = {


### PR DESCRIPTION
## Description

Since Schema Builder is no longer part of the public API this removes some cruft from the API that's not needed to simplify it and help align it better with our internal flex-tree abstraction.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
