### PR TITLE
feat(tree): ITreeCheckoutFork extends IDisposable

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -1097,7 +1097,7 @@ export interface ITreeCheckout extends AnchorLocator {
 }
 
 // @internal
-export interface ITreeCheckoutFork extends ITreeCheckout {
+export interface ITreeCheckoutFork extends ITreeCheckout, IDisposable {
     rebaseOnto(view: ITreeCheckout): void;
 }
 

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -40,7 +40,7 @@ import {
 	makeFieldBatchCodec,
 } from "../feature-libraries/index.js";
 import { SharedTreeBranch, getChangeReplaceType } from "../shared-tree-core/index.js";
-import { TransactionResult, fail } from "../util/index.js";
+import { IDisposable, TransactionResult, disposeSymbol, fail } from "../util/index.js";
 
 import { SharedTreeChangeFamily, hasSchemaChange } from "./sharedTreeChangeFamily.js";
 import { SharedTreeChange } from "./sharedTreeChangeTypes.js";
@@ -319,7 +319,7 @@ class Transaction implements ITransaction {
  * {@link ITreeCheckout} that has forked off of the main trunk/branch.
  * @internal
  */
-export interface ITreeCheckoutFork extends ITreeCheckout {
+export interface ITreeCheckoutFork extends ITreeCheckout, IDisposable {
 	/**
 	 * Rebase the changes that have been applied to this view over all the new changes in the given view.
 	 * @param view - Either the root view or a view that was created by a call to `fork()`. It is not modified by this operation.
@@ -331,6 +331,8 @@ export interface ITreeCheckoutFork extends ITreeCheckout {
  * An implementation of {@link ITreeCheckoutFork}.
  */
 export class TreeCheckout implements ITreeCheckoutFork {
+	private isDisposed = false;
+
 	public constructor(
 		public readonly transaction: ITransaction,
 		private readonly branch: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange>,
@@ -416,19 +418,26 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		combinedVisitor.free();
 	}
 
+	private checkNotDisposed(): void {
+		assert(!this.isDisposed, "Invalid operation on a disposed TreeCheckout");
+	}
+
 	public get rootEvents(): ISubscribable<AnchorSetRootEvents> {
 		return this.forest.anchors;
 	}
 
 	public get editor(): ISharedTreeEditor {
+		this.checkNotDisposed();
 		return this.branch.editor;
 	}
 
 	public locate(anchor: Anchor): AnchorNode | undefined {
+		this.checkNotDisposed();
 		return this.forest.anchors.locate(anchor);
 	}
 
 	public fork(): TreeCheckout {
+		this.checkNotDisposed();
 		const anchors = new AnchorSet();
 		const branch = this.branch.fork();
 		const storedSchema = this.storedSchema.clone();
@@ -447,16 +456,19 @@ export class TreeCheckout implements ITreeCheckoutFork {
 	}
 
 	public rebase(view: TreeCheckout): void {
+		this.checkNotDisposed();
 		view.branch.rebaseOnto(this.branch);
 	}
 
 	public rebaseOnto(view: ITreeCheckout): void {
+		this.checkNotDisposed();
 		view.rebase(this);
 	}
 
 	public merge(view: TreeCheckout): void;
 	public merge(view: TreeCheckout, disposeView: boolean): void;
 	public merge(view: TreeCheckout, disposeView = true): void {
+		this.checkNotDisposed();
 		assert(
 			!this.transaction.inProgress() || disposeView,
 			0x710 /* A view that is merged into an in-progress transaction must be disposed */,
@@ -466,19 +478,18 @@ export class TreeCheckout implements ITreeCheckoutFork {
 		}
 		this.branch.merge(view.branch);
 		if (disposeView) {
-			view.dispose();
+			view[disposeSymbol]();
 		}
 	}
 
 	public updateSchema(newSchema: TreeStoredSchema): void {
+		this.checkNotDisposed();
 		this.editor.schema.setStoredSchema(this.storedSchema.clone(), newSchema);
 	}
 
-	/**
-	 * Dispose this view, freezing its state and allowing the SharedTree to release resources required by it.
-	 * Attempts to further mutate or dispose this view will error.
-	 */
-	public dispose(): void {
+	public [disposeSymbol](): void {
+		this.checkNotDisposed();
+		this.isDisposed = true;
 		this.branch.dispose();
 	}
 

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -7,6 +7,7 @@ import { strict as assert, fail } from "assert";
 
 import { validateAssertionError } from "@fluidframework/test-runtime-utils";
 
+import { disposeSymbol } from "../../index.js";
 import {
 	AllowedUpdateType,
 	FieldUpPath,
@@ -629,6 +630,22 @@ describe("sharedTreeView", () => {
 				"N",
 				"O",
 			]);
+		});
+	});
+
+	describe("disposal", () => {
+		itView("forks can be disposed", (view) => {
+			const fork = view.fork();
+			fork[disposeSymbol]();
+		});
+
+		itView("disposed forks cannot be edited or double-disposed", (view) => {
+			const fork = view.fork();
+			fork[disposeSymbol]();
+
+			assert.throws(() => insertFirstNode(fork, "A"));
+			assert.throws(() => fork.updateSchema(intoStoredSchema(numberSequenceRootSchema)));
+			assert.throws(() => fork[disposeSymbol]());
 		});
 	});
 


### PR DESCRIPTION
## Description

Allows `ITreeCheckoutFork` instances to be explicitly disposed. This is needed by users that create a fork but do not wish to merge it (or do not want to dispose of it at the time they merge, but want to dispose of it later).

This PR also adds some logic to ensure that invalid calls on disposed `ITreeCheckoutFork` instances will error early.

The `merge` API contract is unchanged but may need to be revisited.

## Breaking Changes

None