### PR TITLE
Snapshot refresh at loading e2e tests

### DIFF
--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -185,6 +185,15 @@ export class SerializedStateManager {
 			);
 			this.snapshot = this.latestSnapshot;
 			this.latestSnapshot = undefined;
+			this.mc.logger.sendTelemetryEvent({
+				eventName: "SnapshotRefreshed",
+				snapshotSequenceNumber,
+				firstProcessedOpSequenceNumber,
+				newFirstProcessedOpSequenceNumber:
+					this.processedOps.length === 0
+						? undefined
+						: this.processedOps[0].sequenceNumber,
+			});
 		}
 	}
 

--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
@@ -1,0 +1,203 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import assert from "assert";
+import {
+	ChannelFactoryRegistry,
+	ITestFluidObject,
+	DataObjectFactoryType,
+	createAndAttachContainer,
+	createDocumentId,
+	waitForContainerConnection,
+} from "@fluidframework/test-utils";
+import { describeCompat } from "@fluid-private/test-version-utils";
+import { IContainerExperimental } from "@fluidframework/container-loader/internal";
+import {
+	ConfigTypes,
+	IConfigProviderBase,
+	type ITelemetryBaseLogger,
+} from "@fluidframework/core-interfaces";
+import {
+	DefaultSummaryConfiguration,
+	type IContainerRuntimeOptions,
+} from "@fluidframework/container-runtime";
+import { MockLogger } from "@fluidframework/telemetry-utils";
+import { Deferred } from "@fluidframework/core-utils";
+import type { ISharedMap } from "@fluidframework/map";
+import { wrapObjectAndOverride } from "../mocking.js";
+
+const mapId = "map";
+const testKey = "test key";
+const testValue = "test value";
+const mockLogger = new MockLogger();
+
+describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider, apis) => {
+	const { SharedMap } = apis.dds;
+	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
+	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+		getRawConfig: (name: string): ConfigTypes => settings[name],
+	});
+	const runtimeOptions: IContainerRuntimeOptions = {
+		summaryOptions: {
+			summaryConfigOverrides: {
+				...DefaultSummaryConfiguration,
+				...{
+					maxTime: 5000 * 12,
+					maxAckWaitTime: 120000,
+					maxOps: 1,
+					initialSummarizerDelayMs: 20,
+				},
+			},
+		},
+		enableRuntimeIdCompressor: "on",
+	};
+
+	const waitForSummary = async (container) => {
+		await new Promise<void>((resolve, reject) => {
+			let summarized = false;
+			container.on("op", (op) => {
+				if (op.type === "summarize") {
+					summarized = true;
+				} else if (summarized && op.type === "summaryAck") {
+					resolve();
+				} else if (op.type === "summaryNack") {
+					reject(new Error("summaryNack"));
+				}
+			});
+		});
+	};
+
+	it("snapshot was refreshed", async () => {
+		const provider = getTestObjectProvider();
+		const deferred = new Deferred<void>();
+		const testContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry,
+			runtimeOptions,
+			loaderProps: {
+				logger: wrapObjectAndOverride<ITelemetryBaseLogger>(mockLogger, {
+					send: (tb) => (event) => {
+						tb.send(event);
+						if (
+							event.eventName ===
+							"fluid:telemetry:serializedStateManager:SnapshotRefreshed"
+						) {
+							assert(
+								event.snapshotSequenceNumber ?? 0 > 0,
+								"snapshot was not refreshed",
+							);
+							assert.strictEqual(
+								event.firstProcessedOpSequenceNumber ?? 0,
+								1,
+								"first sequenced op was not saved",
+							);
+							assert(
+								event.newFirstProcessedOpSequenceNumber ?? 0 > 1,
+								"processed ops were not refreshed",
+							);
+							deferred.resolve();
+						}
+					},
+				}),
+				configProvider: configProvider({
+					"Fluid.Container.enableOfflineLoad": true,
+				}),
+			},
+		};
+		const loader = provider.makeTestLoader(testContainerConfig);
+		const container: IContainerExperimental = await createAndAttachContainer(
+			provider.defaultCodeDetails,
+			loader,
+			provider.driver.createCreateNewRequest(createDocumentId()),
+		);
+
+		const url = await container.getAbsoluteUrl("");
+		assert(url, "no url");
+
+		const dataStore = (await container.getEntryPoint()) as ITestFluidObject;
+		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
+		map.set(testKey, testValue);
+		await waitForSummary(container);
+		const pendingOps = await container.closeAndGetPendingLocalState?.();
+		assert.ok(pendingOps);
+		// make sure we got stashed ops with seqnum === 0,
+		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
+
+		const container1: IContainerExperimental = await loader.resolve({ url }, pendingOps);
+		await deferred.promise;
+		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
+		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
+		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
+		await waitForContainerConnection(container2, true);
+		await provider.ensureSynchronized();
+		assert.strictEqual(map2.get(testKey), testValue);
+	});
+
+	it("snapshot was not refreshed", async () => {
+		const provider = getTestObjectProvider();
+		const deferred = new Deferred<void>();
+		const testContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry,
+			runtimeOptions,
+			loaderProps: {
+				logger: wrapObjectAndOverride<ITelemetryBaseLogger>(mockLogger, {
+					send: (tb) => (event) => {
+						tb.send(event);
+						if (
+							event.eventName ===
+							"fluid:telemetry:serializedStateManager:OldSnapshotFetchWhileRefreshing"
+						) {
+							assert.strictEqual(event.category, "generic", "wrong event category");
+							assert.strictEqual(
+								event.snapshotSequenceNumber ?? -1,
+								0,
+								"snapshot was refreshed when it shouldn't",
+							);
+							assert.strictEqual(
+								event.firstProcessedOpSequenceNumber ?? 0,
+								1,
+								"first sequenced op was not saved",
+							);
+							deferred.resolve();
+						}
+					},
+				}),
+				configProvider: configProvider({
+					"Fluid.Container.enableOfflineLoad": true,
+				}),
+			},
+		};
+		const loader = provider.makeTestLoader(testContainerConfig);
+		const container: IContainerExperimental = await createAndAttachContainer(
+			provider.defaultCodeDetails,
+			loader,
+			provider.driver.createCreateNewRequest(createDocumentId()),
+		);
+
+		const url = await container.getAbsoluteUrl("");
+		assert(url, "no url");
+
+		const dataStore = (await container.getEntryPoint()) as ITestFluidObject;
+		const map = await dataStore.getSharedObject<ISharedMap>(mapId);
+		map.set(testKey, testValue);
+		// not waiting for summary to reuse the stashed snapshot for new loaded containers
+		const pendingOps = await container.closeAndGetPendingLocalState?.();
+		assert.ok(pendingOps);
+		// make sure we got stashed ops with seqnum === 0,
+		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
+
+		const container1: IContainerExperimental = await loader.resolve({ url }, pendingOps);
+		await deferred.promise;
+		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
+		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
+		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
+		await waitForContainerConnection(container2, true);
+		await provider.ensureSynchronized();
+		assert.strictEqual(map2.get(testKey), testValue);
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
@@ -11,6 +11,8 @@ import {
 	createAndAttachContainer,
 	createDocumentId,
 	waitForContainerConnection,
+	timeoutPromise,
+	timeoutAwait,
 } from "@fluidframework/test-utils";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainerExperimental } from "@fluidframework/container-loader/internal";
@@ -55,7 +57,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 	};
 
 	const waitForSummary = async (container) => {
-		await new Promise<void>((resolve, reject) => {
+		await timeoutPromise((resolve, reject) => {
 			let summarized = false;
 			container.on("op", (op) => {
 				if (op.type === "summarize") {
@@ -126,7 +128,9 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
 
 		const container1: IContainerExperimental = await loader.resolve({ url }, pendingOps);
-		await getLatestSnapshotInfoP.promise;
+		await timeoutAwait(getLatestSnapshotInfoP.promise, {
+			errorMsg: "Timeout on waiting for getLatestSnapshotInfo",
+		});
 		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
 		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
@@ -191,7 +195,9 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
 
 		const container1: IContainerExperimental = await loader.resolve({ url }, pendingOps);
-		await getLatestSnapshotInfoP.promise;
+		await timeoutAwait(getLatestSnapshotInfoP.promise, {
+			errorMsg: "Timeout on waiting for getLatestSnapshotInfo",
+		});
 		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
 		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;

--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
@@ -71,7 +71,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 
 	it("snapshot was refreshed", async () => {
 		const provider = getTestObjectProvider();
-		const deferred = new Deferred<void>();
+		const getLatestSnapshotInfoP = new Deferred<void>();
 		const testContainerConfig = {
 			fluidDataObjectType: DataObjectFactoryType.Test,
 			registry,
@@ -97,7 +97,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 								event.newFirstProcessedOpSequenceNumber ?? 0 > 1,
 								"processed ops were not refreshed",
 							);
-							deferred.resolve();
+							getLatestSnapshotInfoP.resolve();
 						}
 					},
 				}),
@@ -126,7 +126,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
 
 		const container1: IContainerExperimental = await loader.resolve({ url }, pendingOps);
-		await deferred.promise;
+		await getLatestSnapshotInfoP.promise;
 		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
 		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
@@ -138,7 +138,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 
 	it("snapshot was not refreshed", async () => {
 		const provider = getTestObjectProvider();
-		const deferred = new Deferred<void>();
+		const getLatestSnapshotInfoP = new Deferred<void>();
 		const testContainerConfig = {
 			fluidDataObjectType: DataObjectFactoryType.Test,
 			registry,
@@ -162,7 +162,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 								1,
 								"first sequenced op was not saved",
 							);
-							deferred.resolve();
+							getLatestSnapshotInfoP.resolve();
 						}
 					},
 				}),
@@ -191,7 +191,7 @@ describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider
 		assert(/sequenceNumber[^\w,}]*0/.test(pendingOps));
 
 		const container1: IContainerExperimental = await loader.resolve({ url }, pendingOps);
-		await deferred.promise;
+		await getLatestSnapshotInfoP.promise;
 		const pendingOps2 = await container1.closeAndGetPendingLocalState?.();
 		const container2: IContainerExperimental = await loader.resolve({ url }, pendingOps2);
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;


### PR DESCRIPTION
Overriding ITelemetryBaseLogger send method to detect snapshot refresh at loading. These e2e tests cover the 2 main scenarios in which the snapshot will be refreshed at loading a new container using pending local state depending on new snapshot availability. 