### PR TITLE
sequence: fix lost '\n' for eslint disable comments

### DIFF
--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -13,7 +13,8 @@ import {
 	MergeTreeDeltaType,
 	PropertySet,
 	ReferenceType,
-	SlidingPreference, // eslint-disable-next-line import/no-deprecated
+	SlidingPreference,
+	// eslint-disable-next-line import/no-deprecated
 	SortedSet,
 	appendToMergeTreeDeltaRevertibles,
 	discardMergeTreeDeltaRevertible,

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -32,7 +32,8 @@ import {
 	ReferenceType,
 	SegmentGroup,
 	SlidingPreference,
-	createAnnotateRangeOp, // eslint-disable-next-line import/no-deprecated
+	createAnnotateRangeOp,
+	// eslint-disable-next-line import/no-deprecated
 	createGroupOp,
 	createInsertOp,
 	createObliterateRangeOp,


### PR DESCRIPTION
Automatic import writing lost a couple of new lines for eslint-disable-next-comments.

Restored by this PR.