### PR TITLE
Align telemetryContextPrefix for SharedTree

### DIFF
--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -544,7 +544,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 		private writeFormat: WriteFormat,
 		options: SharedTreeOptions<typeof writeFormat> = {}
 	) {
-		super(id, runtime, SharedTreeFactory.Attributes, 'fluid_sharedTree_');
+		super(id, runtime, SharedTreeFactory.Attributes, 'fluid_legacySharedTree_');
 		const historyPolicy = this.getHistoryPolicy(options);
 		this.summarizeHistory = historyPolicy.summarizeHistory;
 

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -97,7 +97,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		id: string,
 		runtime: IFluidDataStoreRuntime,
 		attributes: IChannelAttributes,
-		telemetryContextPrefix: string = "fluid_sharedTreeCore_",
+		telemetryContextPrefix: string,
 		schemaAndPolicy: SchemaAndPolicy,
 	) {
 		super(id, runtime, attributes, telemetryContextPrefix);

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -87,7 +87,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 	 * @param id - The id of the shared object
 	 * @param runtime - The IFluidDataStoreRuntime which contains the shared object
 	 * @param attributes - Attributes of the shared object
-	 * @param telemetryContextPrefix - the context for any telemetry logs/errors emitted
+	 * @param telemetryContextPrefix - The property prefix for telemetry pertaining to this object. See {@link ITelemetryContext}
 	 */
 	public constructor(
 		summarizables: readonly Summarizable[],
@@ -97,7 +97,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		id: string,
 		runtime: IFluidDataStoreRuntime,
 		attributes: IChannelAttributes,
-		telemetryContextPrefix: string,
+		telemetryContextPrefix: string = "fluid_sharedTreeCore_",
 		schemaAndPolicy: SchemaAndPolicy,
 	) {
 		super(id, runtime, attributes, telemetryContextPrefix);

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -132,7 +132,7 @@ export class SharedTree
 		runtime: IFluidDataStoreRuntime,
 		attributes: IChannelAttributes,
 		optionsParam: SharedTreeOptions,
-		telemetryContextPrefix: string,
+		telemetryContextPrefix: string = "fluid_sharedTree_",
 	) {
 		if (runtime.idCompressor === undefined) {
 			throw new UsageError("IdCompressor must be enabled to use SharedTree");
@@ -325,13 +325,13 @@ export class SharedTreeFactory implements IChannelFactory<ISharedTree> {
 		services: IChannelServices,
 		channelAttributes: Readonly<IChannelAttributes>,
 	): Promise<ISharedTree> {
-		const tree = new SharedTree(id, runtime, channelAttributes, this.options, "SharedTree");
+		const tree = new SharedTree(id, runtime, channelAttributes, this.options);
 		await tree.load(services);
 		return tree;
 	}
 
 	public create(runtime: IFluidDataStoreRuntime, id: string): ISharedTree {
-		const tree = new SharedTree(id, runtime, this.attributes, this.options, "SharedTree");
+		const tree = new SharedTree(id, runtime, this.attributes, this.options);
 		tree.initializeLocal();
 		return tree;
 	}

--- a/packages/dds/tree/src/test/snapshots/gc.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/gc.spec.ts
@@ -35,13 +35,7 @@ function createConnectedTree(id: string, runtimeFactory: MockContainerRuntimeFac
 	const dataStoreRuntime = new MockFluidDataStoreRuntime({
 		idCompressor: createIdCompressor(),
 	});
-	const tree = new SharedTree(
-		id,
-		dataStoreRuntime,
-		new SharedTreeFactory().attributes,
-		{},
-		"SharedTree",
-	);
+	const tree = new SharedTree(id, dataStoreRuntime, new SharedTreeFactory().attributes, {});
 	runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
 		deltaConnection: dataStoreRuntime.createDeltaConnection(),

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1172,7 +1172,6 @@ export function treeTestFactory(
 			}),
 		options.attributes ?? new SharedTreeFactory().attributes,
 		options.options ?? { jsonValidator: typeboxValidator },
-		options.telemetryContextPrefix ?? "SharedTree",
 	);
 }
 

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1172,6 +1172,7 @@ export function treeTestFactory(
 			}),
 		options.attributes ?? new SharedTreeFactory().attributes,
 		options.options ?? { jsonValidator: typeboxValidator },
+		options.telemetryContextPrefix,
 	);
 }
 

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -36,13 +36,13 @@ export class TreeFactory implements IChannelFactory<ITree> {
 		services: IChannelServices,
 		channelAttributes: Readonly<IChannelAttributes>,
 	): Promise<ITree> {
-		const tree = new SharedTreeImpl(id, runtime, channelAttributes, this.options, "SharedTree");
+		const tree = new SharedTreeImpl(id, runtime, channelAttributes, this.options);
 		await tree.load(services);
 		return tree;
 	}
 
 	public create(runtime: IFluidDataStoreRuntime, id: string): ITree {
-		const tree = new SharedTreeImpl(id, runtime, this.attributes, this.options, "SharedTree");
+		const tree = new SharedTreeImpl(id, runtime, this.attributes, this.options);
 		tree.initializeLocal();
 		return tree;
 	}


### PR DESCRIPTION
https://github.com/microsoft/FluidFramework/pull/10294 added the capability to collect some summarize telemetry from DDSes. Whenever this `SharedTreeCore` object was created it used a different convention than the other DDSes.

Ideally the `telemetryContextPrefix` wouldn't need to be present in the ctor, but that's a breaking change for these classes.

Note that `"fluid_sharedTree_"` is currently used in [`experimental/.../SharedTree.ts`](https://github.com/microsoft/FluidFramework/blob/main/experimental/dds/tree/src/SharedTree.ts#L544). Querying on `Data_runtimeVersion` will be needed as it will now be using `"fluid_legacySharedTree_"`.