### PR TITLE
Fix Nexus shutdown order

### DIFF
--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -133,7 +133,11 @@ class SocketIoServer implements core.IWebSocketServer {
 			const drainTime = this.socketIoConfig?.gracefulShutdownDrainTimeMs ?? 30000;
 			const drainInterval = this.socketIoConfig?.gracefulShutdownDrainIntervalMs ?? 1000;
 			if (drainTime > 0 && drainInterval > 0) {
-				// we are assuming no new connections appear once we start. any leftover connections will be closed when close is called
+				// Stop receiving new connections
+				this.io.engine.use((_, res, __) => {
+					res.status(503).send("Graceful Shutdown");
+				});
+
 				const connections = await this.io.fetchSockets();
 				const connectionCount = connections.length;
 				const telemetryProperties = {

--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -5,7 +5,6 @@
 
 import { EventEmitter } from "events";
 import * as http from "http";
-import * as util from "util";
 import * as core from "@fluidframework/server-services-core";
 import {
 	BaseTelemetryProperties,
@@ -196,17 +195,12 @@ class SocketIoServer implements core.IWebSocketServer {
 			}
 		}
 
-		// eslint-disable-next-line @typescript-eslint/promise-function-async
-		const pubClosedP = util.promisify(((callback) =>
-			this.redisClientConnectionManagerForPub.getRedisClient().quit(callback)) as any)();
-		// eslint-disable-next-line @typescript-eslint/promise-function-async
-		const subClosedP = util.promisify(((callback) =>
-			this.redisClientConnectionManagerForSub.getRedisClient().quit(callback)) as any)();
-		const ioClosedP = util.promisify(((callback) => this.io.close(callback)) as any)();
-
-		await ioClosedP;
-		await sleep(2000); // Give time for disconnect handlers to execute before closing Redis resources
-		await Promise.all([pubClosedP, subClosedP]);
+		this.io.close();
+		await sleep(3000); // Give time for any  disconnect handlers to execute before closing Redis resources
+		await Promise.all([
+			this.redisClientConnectionManagerForPub.getRedisClient().quit(),
+			this.redisClientConnectionManagerForSub.getRedisClient().quit(),
+		]);
 	}
 }
 

--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -189,7 +189,9 @@ class SocketIoServer implements core.IWebSocketServer {
 				} else {
 					metricForTimeTaken.success("Graceful shutdown finished");
 					const reconnections = await this.io.fetchSockets();
-					Lumberjack.info("Graceful shutdown. Closing last reconnected connections", { connectionsCount: reconnections.length });
+					Lumberjack.info("Graceful shutdown. Closing last reconnected connections", {
+						connectionsCount: reconnections.length,
+					});
 				}
 			}
 		}


### PR DESCRIPTION

## Description

During graceful shutdown, make sure to:
 1) disconnect any remaining connections 
 2) ensure the server stops receiving connections 
 3) give time for  "disconnected" handlers to execute before removing Redis resources

