### PR TITLE
Allow asynchronous validation in DDS fuzz

### DIFF
--- a/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
@@ -17,6 +17,7 @@ import { DDSFuzzModel, DDSFuzzTestState, createDDSFuzzSuite } from "@fluid-priva
 import { Jsonable } from "@fluidframework/datastore-definitions/internal";
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
 
+import type { FluidObject, IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISharedMap, MapFactory } from "../../index.js";
 
 import { _dirname } from "./dirname.cjs";
@@ -41,12 +42,31 @@ type Operation = SetKey | DeleteKey | Clear;
 // This type gets used a lot as the state object of the suite; shorthand it here.
 type State = DDSFuzzTestState<MapFactory>;
 
-function assertMapsAreEquivalent(a: ISharedMap, b: ISharedMap): void {
+async function assertMapsAreEquivalent(a: ISharedMap, b: ISharedMap): Promise<void> {
 	assert.equal(a.size, b.size, `${a.id} and ${b.id} have different number of keys.`);
 	for (const key of a.keys()) {
 		const aVal: unknown = a.get(key);
 		const bVal: unknown = b.get(key);
-		assert.equal(aVal, bVal, `${a.id} and ${b.id} differ at ${key}: ${aVal} vs ${bVal}`);
+		if (
+			aVal !== null &&
+			typeof aVal === "object" &&
+			bVal !== null &&
+			typeof bVal === "object"
+		) {
+			const aObj: FluidObject<IFluidHandle> = aVal;
+			const bObj: FluidObject<IFluidHandle> = bVal;
+			const aHandle = aObj.IFluidHandle ? await aObj.IFluidHandle?.get() : aObj;
+			const bHandle = bObj.IFluidHandle ? await bObj.IFluidHandle?.get() : bObj;
+			assert.equal(
+				aHandle,
+				bHandle,
+				`${a.id} and ${b.id} differ at ${key}: ${JSON.stringify(
+					aHandle,
+				)} vs ${JSON.stringify(bHandle)}`,
+			);
+		} else {
+			assert.equal(aVal, bVal, `${a.id} and ${b.id} differ at ${key}: ${aVal} vs ${bVal}`);
+		}
 	}
 }
 

--- a/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
+++ b/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
@@ -86,7 +86,7 @@ export interface DDSFuzzModel<TChannelFactory extends IChannelFactory, TOperatio
     generatorFactory: () => AsyncGenerator_2<TOperation, TState>;
     minimizationTransforms?: MinimizationTransform<TOperation>[];
     reducer: AsyncReducer<TOperation, TState>;
-    validateConsistency: (channelA: ReturnType<TChannelFactory["create"]>, channelB: ReturnType<TChannelFactory["create"]>) => void;
+    validateConsistency: (channelA: ReturnType<TChannelFactory["create"]>, channelB: ReturnType<TChannelFactory["create"]>) => void | Promise<void>;
     workloadName: string;
 }
 

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -264,7 +264,7 @@ export interface DDSFuzzModel<
 	validateConsistency: (
 		channelA: ReturnType<TChannelFactory["create"]>,
 		channelB: ReturnType<TChannelFactory["create"]>,
-	) => void;
+	) => void | Promise<void>;
 
 	/**
 	 * An array of transforms used during fuzz test minimization to reduce test
@@ -781,7 +781,7 @@ export function mixinAttach<
 				options,
 			);
 
-			model.validateConsistency(clientA.channel, summarizerClient.channel);
+			await model.validateConsistency(clientA.channel, summarizerClient.channel);
 
 			return {
 				...state,
@@ -981,7 +981,7 @@ export function mixinSynchronization<
 			if (connectedClients.length > 0) {
 				const readonlyChannel = state.summarizerClient.channel;
 				for (const { channel } of connectedClients) {
-					model.validateConsistency(readonlyChannel, channel);
+					await model.validateConsistency(readonlyChannel, channel);
 				}
 			}
 


### PR DESCRIPTION
Small pr to allow the validate consistency function in the DDS fuzz harness to return a promise in the case of handle validation. Related to #20358. 