### PR TITLE
fix(build-tools): relax fluid-build-tasks-eslint for lint only projects

### DIFF
--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
@@ -149,7 +149,10 @@ function findTscMultiScript(json: PackageJson, config: string): string | undefin
  *
  * @remarks
  */
-function findFluidTscScript(json: PackageJson, project: string | undefined): string | undefined {
+function findFluidTscScript(
+	json: PackageJson,
+	project: string | undefined,
+): string | undefined {
 	for (const [script, scriptCommands] of Object.entries(json.scripts)) {
 		if (scriptCommands === undefined) {
 			continue;
@@ -394,12 +397,7 @@ function checkTaskDeps(
 	const missingTaskDependencies = taskDeps
 		.filter(
 			(taskDep) =>
-				!hasTaskDependency(
-					root,
-					json,
-					taskName,
-					Array.isArray(taskDep) ? taskDep : [taskDep],
-				),
+				!hasTaskDependency(root, json, taskName, Array.isArray(taskDep) ? taskDep : [taskDep]),
 		)
 		.map((dep) => (Array.isArray(dep) ? dep.join(" or ") : dep));
 
@@ -534,9 +532,7 @@ function getTscCommandDependencies(
 			// that builds the referenced project is listed as a dependency.
 			const referencedScript = findTscScripts(json, refConfigPath);
 			if (referencedScript === undefined) {
-				throw new Error(
-					`Unable to find tsc script for referenced project ${refConfigPath}`,
-				);
+				throw new Error(`Unable to find tsc script for referenced project ${refConfigPath}`);
 			}
 			deps.push(referencedScript);
 		}
@@ -670,9 +666,7 @@ export const handlers: Handler[] = [
 					// If the project has a referenced project, depend on that instead of the default
 					const parsedCommand = TscUtils.parseCommandLine(command);
 					if (!parsedCommand) {
-						throw new Error(
-							`Error parsing tsc command for script '${script}': ${command}`,
-						);
+						throw new Error(`Error parsing tsc command for script '${script}': ${command}`);
 					}
 					const configFile = TscUtils.findConfigFile(packageDir, parsedCommand);
 					const previousUse = projectMap.get(configFile);


### PR DESCRIPTION
Some projects are easier to cover with lint only tsconfig files that won't have corresponding script entries. Expect such projects referenced in eslint config to have ".lint." in the name.

[AB#7630](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7630)