### PR TITLE
Reduce mutability of types in bubbleBench/common

### DIFF
--- a/examples/benchmarks/bubblebench/baseline/src/state.ts
+++ b/examples/benchmarks/bubblebench/baseline/src/state.ts
@@ -6,15 +6,15 @@
 import {
 	IAppState,
 	IBubble,
-	IClient,
+	SimpleClient,
 	makeBubble,
 	makeClient,
 } from "@fluid-example/bubblebench-common";
 
 export class AppState implements IAppState {
 	public readonly applyEdits = (): void => {};
-	public readonly localClient: IClient;
-	public readonly clients: IClient[];
+	public readonly localClient: SimpleClient;
+	public readonly clients: SimpleClient[];
 
 	constructor(
 		private _width: number,

--- a/examples/benchmarks/bubblebench/common/src/index.ts
+++ b/examples/benchmarks/bubblebench/common/src/index.ts
@@ -4,6 +4,6 @@
  */
 
 export { AppView } from "./view/index.js";
-export { IAppState, IArrayish, IBubble, IClient, makeBubble, makeClient } from "./types.js";
+export { IAppState, IBubble, IClient, makeBubble, makeClient, SimpleClient } from "./types.js";
 export { normal, randomColor, rnd } from "./rnd.js";
 export { Stats } from "./stats.js";

--- a/examples/benchmarks/bubblebench/common/src/types.ts
+++ b/examples/benchmarks/bubblebench/common/src/types.ts
@@ -8,14 +8,6 @@ import { normal, randomColor, rnd } from "./rnd.js";
 /**
  * @internal
  */
-export interface IArrayish<T>
-	extends ArrayLike<T>,
-		Pick<T[], "push" | "pop" | "map">,
-		Iterable<T> {}
-
-/**
- * @internal
- */
 export interface IBubble {
 	x: number;
 	y: number;
@@ -28,9 +20,9 @@ export interface IBubble {
  * @internal
  */
 export interface IClient {
-	clientId: string;
-	color: string;
-	bubbles: IBubble[];
+	readonly clientId: string;
+	readonly color: string;
+	readonly bubbles: readonly IBubble[];
 }
 
 /**
@@ -38,7 +30,7 @@ export interface IClient {
  */
 export interface IAppState {
 	readonly localClient: IClient;
-	readonly clients: IArrayish<IClient>;
+	readonly clients: Iterable<IClient>;
 	readonly width: number;
 	readonly height: number;
 	setSize(width?: number, height?: number);
@@ -65,16 +57,27 @@ export function makeBubble(stageWidth: number, stageHeight: number): IBubble {
 	};
 }
 
-// eslint-disable-next-line jsdoc/require-description
 /**
+ * Simple mutable type implementing IClient.
+ */
+export interface SimpleClient extends IClient {
+	clientId: string;
+	readonly color: string;
+	readonly bubbles: IBubble[];
+}
+
+/**
+ * Creates a SimpleClient with random values.
  * @internal
  */
-export const makeClient = (
+export function makeClient(
 	stageWidth: number,
 	stageHeight: number,
 	numBubbles: number,
-): IClient => ({
-	clientId: "pending",
-	color: randomColor(),
-	bubbles: Array.from({ length: numBubbles }).map(() => makeBubble(stageWidth, stageHeight)),
-});
+): SimpleClient {
+	return {
+		clientId: "pending",
+		color: randomColor(),
+		bubbles: Array.from({ length: numBubbles }).map(() => makeBubble(stageWidth, stageHeight)),
+	};
+}

--- a/examples/benchmarks/bubblebench/ot/src/state.ts
+++ b/examples/benchmarks/bubblebench/ot/src/state.ts
@@ -5,23 +5,25 @@
 
 import {
 	IAppState,
-	IArrayish,
 	IClient,
 	makeBubble,
 	randomColor,
+	type SimpleClient,
 } from "@fluid-example/bubblebench-common";
 import { SharedJson1 } from "@fluid-experimental/sharejs-json1";
 
 import { observe } from "./proxy/index.js";
 
 interface IApp {
-	clients: IArrayish<IClient>;
+	clients: IArrayish<SimpleClient>;
 }
+
+interface IArrayish<T> extends ArrayLike<T>, Pick<T[], "push">, Iterable<T> {}
 
 export class AppState implements IAppState {
 	private readonly root: IApp;
 
-	public readonly localClient: IClient;
+	public readonly localClient: SimpleClient;
 
 	constructor(
 		tree: SharedJson1,

--- a/examples/benchmarks/bubblebench/sharedtree/src/main.tsx
+++ b/examples/benchmarks/bubblebench/sharedtree/src/main.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IArrayish, IClient } from "@fluid-example/bubblebench-common";
+import { IClient } from "@fluid-example/bubblebench-common";
 import { SharedTree, WriteFormat } from "@fluid-experimental/tree";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
@@ -12,7 +12,7 @@ import { TreeObjectProxy } from "./proxy/index.js";
 import { AppState } from "./state.js";
 
 interface IApp {
-	clients: IArrayish<IClient>;
+	clients: IClient[];
 }
 
 /**

--- a/examples/benchmarks/bubblebench/sharedtree/src/proxy/tree.ts
+++ b/examples/benchmarks/bubblebench/sharedtree/src/proxy/tree.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { IArrayish } from "@fluid-example/bubblebench-common";
 import {
 	Change,
 	ChangeNode,
@@ -80,7 +79,7 @@ export const TreeObjectProxy = <T extends Object>(
 		// },
 	});
 
-export class TreeArrayProxy<T> implements IArrayish<Serializable<T>> {
+export class TreeArrayProxy<T> {
 	constructor(
 		private readonly tree: SharedTree,
 		private readonly nodeId: NodeId,

--- a/examples/benchmarks/bubblebench/sharedtree/src/state.ts
+++ b/examples/benchmarks/bubblebench/sharedtree/src/state.ts
@@ -5,17 +5,17 @@
 
 import {
 	IAppState,
-	IArrayish,
 	IClient,
 	makeBubble,
 	makeClient,
+	SimpleClient,
 } from "@fluid-example/bubblebench-common";
 import { Change, SharedTree } from "@fluid-experimental/tree";
 
 import { TreeArrayProxy, TreeObjectProxy, fromJson } from "./proxy/index.js";
 
 interface IApp {
-	clients: IArrayish<IClient>;
+	readonly clients: SimpleClient[];
 }
 
 export class AppState implements IAppState {
@@ -23,7 +23,7 @@ export class AppState implements IAppState {
 	public readonly applyEdits: () => void;
 	private readonly root: IApp;
 
-	public readonly localClient: IClient;
+	public readonly localClient: SimpleClient;
 
 	private readonly deferredUpdates = true;
 	private readonly deferredChanges: Change[] = [];
@@ -67,7 +67,7 @@ export class AppState implements IAppState {
 		return this._height;
 	}
 
-	public get clients(): IArrayish<IClient> {
+	public get clients(): Iterable<IClient> {
 		return this.root.clients;
 	}
 


### PR DESCRIPTION
## Description

The types in examples/benchmarks/bubblebench/common/src/types.ts place a lot of unnecessary restrictions on the implementations which can make implementing the interfaces difficult. This removes unneeded requirements around mutability.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
