### PR TITLE
Await promises from runWithRetry

### DIFF
--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -94,21 +94,25 @@ export async function createGitService(createArgs: createGitServiceArgs): Promis
 				getLumberBaseProperties(documentId, tenantId),
 			);
 			isEphemeral = isEphemeralContainer;
-			runWithRetry(
+			await runWithRetry(
 				async () => cache?.set(isEphemeralKey, isEphemeral) /* api */,
 				"utils.createGitService.set" /* callName */,
 				3 /* maxRetries */,
 				1000 /* retryAfterMs */,
 				getLumberBaseProperties(documentId, tenantId) /* telemetryProperties */,
-			).catch((error) => {
-				Lumberjack.error(
-					`Error setting ${isEphemeralKey} in redis`,
-					getLumberBaseProperties(documentId, tenantId),
-					error,
-				);
-			});
+			)
+				.then(() => {
+					Lumberjack.info(`[DHRUV DEBUG] Cache set for ${isEphemeralKey}.`);
+				})
+				.catch((error) => {
+					Lumberjack.error(
+						`Error setting ${isEphemeralKey} in redis`,
+						getLumberBaseProperties(documentId, tenantId),
+						error,
+					);
+				});
 		} else {
-			runWithRetry<boolean>(
+			await runWithRetry<boolean>(
 				async () => cache?.get(isEphemeralKey) /* api */,
 				"utils.createGitService.get" /* callName */,
 				3 /* maxRetries */,
@@ -116,6 +120,7 @@ export async function createGitService(createArgs: createGitServiceArgs): Promis
 				getLumberBaseProperties(documentId, tenantId) /* telemetryProperties */,
 			)
 				.then((value) => {
+					Lumberjack.info(`[DHRUV DEBUG], promise resolved: ${value}`);
 					isEphemeral = value;
 				})
 				.catch((error) => {

--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -100,17 +100,13 @@ export async function createGitService(createArgs: createGitServiceArgs): Promis
 				3 /* maxRetries */,
 				1000 /* retryAfterMs */,
 				getLumberBaseProperties(documentId, tenantId) /* telemetryProperties */,
-			)
-				.then(() => {
-					Lumberjack.info(`[DHRUV DEBUG] Cache set for ${isEphemeralKey}.`);
-				})
-				.catch((error) => {
-					Lumberjack.error(
-						`Error setting ${isEphemeralKey} in redis`,
-						getLumberBaseProperties(documentId, tenantId),
-						error,
-					);
-				});
+			).catch((error) => {
+				Lumberjack.error(
+					`Error setting ${isEphemeralKey} in redis`,
+					getLumberBaseProperties(documentId, tenantId),
+					error,
+				);
+			});
 		} else {
 			await runWithRetry<boolean>(
 				async () => cache?.get(isEphemeralKey) /* api */,
@@ -120,7 +116,6 @@ export async function createGitService(createArgs: createGitServiceArgs): Promis
 				getLumberBaseProperties(documentId, tenantId) /* telemetryProperties */,
 			)
 				.then((value) => {
-					Lumberjack.info(`[DHRUV DEBUG], promise resolved: ${value}`);
 					isEphemeral = value;
 				})
 				.catch((error) => {


### PR DESCRIPTION
## Description

This PR fixes a regression that was introduced in https://github.com/microsoft/FluidFramework/pull/20243. https://github.com/microsoft/FluidFramework/pull/20243 added the use of `runWithRetry` to historian which caused a bug in the ephemeral containers workflow. The bug was that the `isEphemeral` flag was not always set to `true` as the async call to set/get it from the cache was not awaited. This PR adds an `await` to fix the issue.
