### PR TITLE
tree: Add missing schema agnostic indexed field traversal to flex tree, use in proxy binding

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -669,6 +669,7 @@ export enum FlexTreeEntityKind {
 export interface FlexTreeField extends FlexTreeEntity<FlexFieldSchema> {
     // (undocumented)
     readonly [flexTreeMarker]: FlexTreeEntityKind.Field;
+    boxedAt(index: number): FlexTreeNode | undefined;
     // (undocumented)
     boxedIterator(): IterableIterator<FlexTreeNode>;
     is<TSchema extends FlexFieldSchema>(schema: TSchema): this is FlexTreeTypedField<TSchema>;

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -248,6 +248,18 @@ export interface FlexTreeField extends FlexTreeEntity<FlexFieldSchema> {
 	 * Implementing this will require some care to preserve lazy-ness and work efficiently (without leaks) for empty fields, particularly on MapNodes.
 	 */
 	isSameAs(other: FlexTreeField): boolean;
+
+	/**
+	 * Gets a node of this field by its index without unboxing.
+	 * @param index - Zero-based index of the item to retrieve. Negative values are interpreted from the end of the sequence.
+	 *
+	 * @returns The element in the sequence matching the given index. Always returns undefined if index \< -sequence.length
+	 * or index \>= array.length.
+	 *
+	 * @remarks
+	 * Semantics match {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at | Array.at}.
+	 */
+	boxedAt(index: number): FlexTreeNode | undefined;
 }
 
 // #region Node Kinds
@@ -716,14 +728,7 @@ export interface FlexTreeSequenceField<in out TTypes extends FlexAllowedTypes>
 	at(index: number): FlexTreeUnboxNodeUnion<TTypes> | undefined;
 
 	/**
-	 * Gets a node of this field by its index without unboxing.
-	 * @param index - Zero-based index of the item to retrieve. Negative values are interpreted from the end of the sequence.
-	 *
-	 * @returns The element in the sequence matching the given index. Always returns undefined if index \< -sequence.length
-	 * or index \>= array.length.
-	 *
-	 * @remarks
-	 * Semantics match {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at | Array.at}.
+	 * {@inheritdoc FlexTreeField.boxedAt}
 	 */
 	boxedAt(index: number): FlexTreeTypedNodeUnion<TTypes> | undefined;
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -254,7 +254,7 @@ export interface FlexTreeField extends FlexTreeEntity<FlexFieldSchema> {
 	 * @param index - Zero-based index of the item to retrieve. Negative values are interpreted from the end of the sequence.
 	 *
 	 * @returns The element in the sequence matching the given index. Always returns undefined if index \< -sequence.length
-	 * or index \>= array.length.
+	 * or index \>= sequence.length.
 	 *
 	 * @remarks
 	 * Semantics match {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at | Array.at}.


### PR DESCRIPTION
## Description

Flex-tree is supposed to provide good APIs for working with the tree in non-schema aware code.
While it had iteration APIs, it was missing indexed access. This fixes that omission, and uses it (instead of down casting to the schema aware api) in proxyBinding's demandSpine.

This also documents some TODOs to cleanup demandSpine.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

