### PR TITLE
tree: Remove redudant check in test utility

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
@@ -288,9 +288,7 @@ function computeChildChangeInputContext(inputState: OptionalFieldTestState): num
 			currentContent === finalContent &&
 			state.mostRecentEdit.changeset.change.childChanges.length > 0
 		) {
-			if (state.mostRecentEdit.changeset.change.childChanges !== undefined) {
-				intentions.push(state.mostRecentEdit.intention);
-			}
+			intentions.push(state.mostRecentEdit.intention);
 		}
 
 		currentContent = state.content;


### PR DESCRIPTION
## Description

Removed an unnecessary check in an optional field test utility. An if-block checked that an optional changeset had a defined `childChanges` field, but that field is mandatory.