### PR TITLE
refactor(server): Update typetests to correct previous version

### DIFF
--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -33,7 +33,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@2.0.0",
+		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@4.0.0",
 		"@microsoft/api-extractor": "^7.42.3",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -36,7 +36,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@2.0.0",
+		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@4.0.0",
 		"@types/node": "^18.17.1",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -68,7 +68,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@2.0.0",
+		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@4.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/async": "^3.2.9",
 		"@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -80,7 +80,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@2.0.0",
+		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@4.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/async": "^3.2.9",
 		"@types/json-stringify-safe": "^5.0.0",
@@ -103,11 +103,6 @@
 		"webpack": "^5.82.0"
 	},
 	"typeValidation": {
-		"broken": {
-			"InterfaceDeclaration_IBroadcastSignalEventPayload": {
-				"backCompat": false,
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/server/routerlicious/packages/lambdas/src/test/types/validateServerLambdasPrevious.generated.ts
+++ b/server/routerlicious/packages/lambdas/src/test/types/validateServerLambdasPrevious.generated.ts
@@ -192,6 +192,30 @@ use_old_ClassDeclaration_DeliLambdaFactory(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_DocumentCheckpointManager": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_DocumentCheckpointManager():
+    TypeOnly<old.DocumentCheckpointManager>;
+declare function use_current_ClassDeclaration_DocumentCheckpointManager(
+    use: TypeOnly<current.DocumentCheckpointManager>): void;
+use_current_ClassDeclaration_DocumentCheckpointManager(
+    get_old_ClassDeclaration_DocumentCheckpointManager());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_DocumentCheckpointManager": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_DocumentCheckpointManager():
+    TypeOnly<current.DocumentCheckpointManager>;
+declare function use_old_ClassDeclaration_DocumentCheckpointManager(
+    use: TypeOnly<old.DocumentCheckpointManager>): void;
+use_old_ClassDeclaration_DocumentCheckpointManager(
+    get_current_ClassDeclaration_DocumentCheckpointManager());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IBroadcastSignalEventPayload": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IBroadcastSignalEventPayload():
@@ -199,7 +223,6 @@ declare function get_old_InterfaceDeclaration_IBroadcastSignalEventPayload():
 declare function use_current_InterfaceDeclaration_IBroadcastSignalEventPayload(
     use: TypeOnly<current.IBroadcastSignalEventPayload>): void;
 use_current_InterfaceDeclaration_IBroadcastSignalEventPayload(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IBroadcastSignalEventPayload());
 
 /*
@@ -212,7 +235,6 @@ declare function get_current_InterfaceDeclaration_IBroadcastSignalEventPayload()
 declare function use_old_InterfaceDeclaration_IBroadcastSignalEventPayload(
     use: TypeOnly<old.IBroadcastSignalEventPayload>): void;
 use_old_InterfaceDeclaration_IBroadcastSignalEventPayload(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IBroadcastSignalEventPayload());
 
 /*
@@ -410,6 +432,30 @@ use_old_InterfaceDeclaration_IRoom(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IRuntimeSignalEnvelope": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IRuntimeSignalEnvelope():
+    TypeOnly<old.IRuntimeSignalEnvelope>;
+declare function use_current_InterfaceDeclaration_IRuntimeSignalEnvelope(
+    use: TypeOnly<current.IRuntimeSignalEnvelope>): void;
+use_current_InterfaceDeclaration_IRuntimeSignalEnvelope(
+    get_old_InterfaceDeclaration_IRuntimeSignalEnvelope());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IRuntimeSignalEnvelope": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IRuntimeSignalEnvelope():
+    TypeOnly<current.IRuntimeSignalEnvelope>;
+declare function use_old_InterfaceDeclaration_IRuntimeSignalEnvelope(
+    use: TypeOnly<old.IRuntimeSignalEnvelope>): void;
+use_old_InterfaceDeclaration_IRuntimeSignalEnvelope(
+    get_current_InterfaceDeclaration_IRuntimeSignalEnvelope());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ISummaryReader": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ISummaryReader():
@@ -550,6 +596,30 @@ declare function use_old_ClassDeclaration_NoOpLambda(
     use: TypeOnly<old.NoOpLambda>): void;
 use_old_ClassDeclaration_NoOpLambda(
     get_current_ClassDeclaration_NoOpLambda());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_NoOpLambdaCheckpointConfiguration": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_NoOpLambdaCheckpointConfiguration():
+    TypeOnly<old.NoOpLambdaCheckpointConfiguration>;
+declare function use_current_InterfaceDeclaration_NoOpLambdaCheckpointConfiguration(
+    use: TypeOnly<current.NoOpLambdaCheckpointConfiguration>): void;
+use_current_InterfaceDeclaration_NoOpLambdaCheckpointConfiguration(
+    get_old_InterfaceDeclaration_NoOpLambdaCheckpointConfiguration());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_NoOpLambdaCheckpointConfiguration": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_NoOpLambdaCheckpointConfiguration():
+    TypeOnly<current.NoOpLambdaCheckpointConfiguration>;
+declare function use_old_InterfaceDeclaration_NoOpLambdaCheckpointConfiguration(
+    use: TypeOnly<old.NoOpLambdaCheckpointConfiguration>): void;
+use_old_InterfaceDeclaration_NoOpLambdaCheckpointConfiguration(
+    get_current_InterfaceDeclaration_NoOpLambdaCheckpointConfiguration());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@2.0.0",
+		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@4.0.0",
 		"@microsoft/api-extractor": "^7.42.3",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -82,7 +82,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@2.0.0",
+		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@4.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -69,7 +69,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@2.0.0",
+		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@4.0.0",
 		"@microsoft/api-extractor": "^7.42.3",
 		"@types/assert": "^1.5.1",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -91,7 +91,7 @@
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
 		"@fluidframework/server-local-server": "workspace:~",
-		"@fluidframework/server-routerlicious-base-previous": "npm:@fluidframework/server-routerlicious-base@2.0.0",
+		"@fluidframework/server-routerlicious-base-previous": "npm:@fluidframework/server-routerlicious-base@4.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/body-parser": "^1.19.2",
 		"@types/bytes": "^3.0.0",
@@ -131,15 +131,8 @@
 	},
 	"typeValidation": {
 		"broken": {
-			"ClassDeclaration_RiddlerResources": {
-				"forwardCompat": false,
+			"ClassDeclaration_NexusResources": {
 				"backCompat": false
-			},
-			"ClassDeclaration_AlfredResources": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_IAlfredResourcesCustomizations": {
-				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
@@ -43,7 +43,6 @@ declare function get_current_ClassDeclaration_AlfredResources():
 declare function use_old_ClassDeclaration_AlfredResources(
     use: TypeOnly<old.AlfredResources>): void;
 use_old_ClassDeclaration_AlfredResources(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_AlfredResources());
 
 /*
@@ -200,7 +199,6 @@ declare function get_old_InterfaceDeclaration_IAlfredResourcesCustomizations():
 declare function use_current_InterfaceDeclaration_IAlfredResourcesCustomizations(
     use: TypeOnly<current.IAlfredResourcesCustomizations>): void;
 use_current_InterfaceDeclaration_IAlfredResourcesCustomizations(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IAlfredResourcesCustomizations());
 
 /*
@@ -242,6 +240,30 @@ use_old_InterfaceDeclaration_IDocumentDeleteService(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_INexusResourcesCustomizations": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_INexusResourcesCustomizations():
+    TypeOnly<old.INexusResourcesCustomizations>;
+declare function use_current_InterfaceDeclaration_INexusResourcesCustomizations(
+    use: TypeOnly<current.INexusResourcesCustomizations>): void;
+use_current_InterfaceDeclaration_INexusResourcesCustomizations(
+    get_old_InterfaceDeclaration_INexusResourcesCustomizations());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_INexusResourcesCustomizations": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_INexusResourcesCustomizations():
+    TypeOnly<current.INexusResourcesCustomizations>;
+declare function use_old_InterfaceDeclaration_INexusResourcesCustomizations(
+    use: TypeOnly<old.INexusResourcesCustomizations>): void;
+use_old_InterfaceDeclaration_INexusResourcesCustomizations(
+    get_current_InterfaceDeclaration_INexusResourcesCustomizations());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IPlugin": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IPlugin():
@@ -266,6 +288,30 @@ use_old_InterfaceDeclaration_IPlugin(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IRiddlerResourcesCustomizations": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IRiddlerResourcesCustomizations():
+    TypeOnly<old.IRiddlerResourcesCustomizations>;
+declare function use_current_InterfaceDeclaration_IRiddlerResourcesCustomizations(
+    use: TypeOnly<current.IRiddlerResourcesCustomizations>): void;
+use_current_InterfaceDeclaration_IRiddlerResourcesCustomizations(
+    get_old_InterfaceDeclaration_IRiddlerResourcesCustomizations());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IRiddlerResourcesCustomizations": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IRiddlerResourcesCustomizations():
+    TypeOnly<current.IRiddlerResourcesCustomizations>;
+declare function use_old_InterfaceDeclaration_IRiddlerResourcesCustomizations(
+    use: TypeOnly<old.IRiddlerResourcesCustomizations>): void;
+use_old_InterfaceDeclaration_IRiddlerResourcesCustomizations(
+    get_current_InterfaceDeclaration_IRiddlerResourcesCustomizations());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ITenantDocument": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ITenantDocument():
@@ -286,6 +332,127 @@ declare function use_old_InterfaceDeclaration_ITenantDocument(
     use: TypeOnly<old.ITenantDocument>): void;
 use_old_InterfaceDeclaration_ITenantDocument(
     get_current_InterfaceDeclaration_ITenantDocument());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITenantRepository": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITenantRepository():
+    TypeOnly<old.ITenantRepository>;
+declare function use_current_InterfaceDeclaration_ITenantRepository(
+    use: TypeOnly<current.ITenantRepository>): void;
+use_current_InterfaceDeclaration_ITenantRepository(
+    get_old_InterfaceDeclaration_ITenantRepository());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITenantRepository": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITenantRepository():
+    TypeOnly<current.ITenantRepository>;
+declare function use_old_InterfaceDeclaration_ITenantRepository(
+    use: TypeOnly<old.ITenantRepository>): void;
+use_old_InterfaceDeclaration_ITenantRepository(
+    get_current_InterfaceDeclaration_ITenantRepository());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_MongoTenantRepository": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_MongoTenantRepository():
+    TypeOnly<old.MongoTenantRepository>;
+declare function use_current_ClassDeclaration_MongoTenantRepository(
+    use: TypeOnly<current.MongoTenantRepository>): void;
+use_current_ClassDeclaration_MongoTenantRepository(
+    get_old_ClassDeclaration_MongoTenantRepository());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_MongoTenantRepository": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_MongoTenantRepository():
+    TypeOnly<current.MongoTenantRepository>;
+declare function use_old_ClassDeclaration_MongoTenantRepository(
+    use: TypeOnly<old.MongoTenantRepository>): void;
+use_old_ClassDeclaration_MongoTenantRepository(
+    get_current_ClassDeclaration_MongoTenantRepository());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_NexusResources": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_NexusResources():
+    TypeOnly<old.NexusResources>;
+declare function use_current_ClassDeclaration_NexusResources(
+    use: TypeOnly<current.NexusResources>): void;
+use_current_ClassDeclaration_NexusResources(
+    get_old_ClassDeclaration_NexusResources());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_NexusResources": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_NexusResources():
+    TypeOnly<current.NexusResources>;
+declare function use_old_ClassDeclaration_NexusResources(
+    use: TypeOnly<old.NexusResources>): void;
+use_old_ClassDeclaration_NexusResources(
+    // @ts-expect-error compatibility expected to be broken
+    get_current_ClassDeclaration_NexusResources());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_NexusResourcesFactory": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_NexusResourcesFactory():
+    TypeOnly<old.NexusResourcesFactory>;
+declare function use_current_ClassDeclaration_NexusResourcesFactory(
+    use: TypeOnly<current.NexusResourcesFactory>): void;
+use_current_ClassDeclaration_NexusResourcesFactory(
+    get_old_ClassDeclaration_NexusResourcesFactory());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_NexusResourcesFactory": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_NexusResourcesFactory():
+    TypeOnly<current.NexusResourcesFactory>;
+declare function use_old_ClassDeclaration_NexusResourcesFactory(
+    use: TypeOnly<old.NexusResourcesFactory>): void;
+use_old_ClassDeclaration_NexusResourcesFactory(
+    get_current_ClassDeclaration_NexusResourcesFactory());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_NexusRunnerFactory": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_NexusRunnerFactory():
+    TypeOnly<old.NexusRunnerFactory>;
+declare function use_current_ClassDeclaration_NexusRunnerFactory(
+    use: TypeOnly<current.NexusRunnerFactory>): void;
+use_current_ClassDeclaration_NexusRunnerFactory(
+    get_old_ClassDeclaration_NexusRunnerFactory());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_NexusRunnerFactory": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_NexusRunnerFactory():
+    TypeOnly<current.NexusRunnerFactory>;
+declare function use_old_ClassDeclaration_NexusRunnerFactory(
+    use: TypeOnly<old.NexusRunnerFactory>): void;
+use_old_ClassDeclaration_NexusRunnerFactory(
+    get_current_ClassDeclaration_NexusRunnerFactory());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -345,7 +512,6 @@ declare function get_old_ClassDeclaration_RiddlerResources():
 declare function use_current_ClassDeclaration_RiddlerResources(
     use: TypeOnly<current.RiddlerResources>): void;
 use_current_ClassDeclaration_RiddlerResources(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_RiddlerResources());
 
 /*
@@ -358,7 +524,6 @@ declare function get_current_ClassDeclaration_RiddlerResources():
 declare function use_old_ClassDeclaration_RiddlerResources(
     use: TypeOnly<old.RiddlerResources>): void;
 use_old_ClassDeclaration_RiddlerResources(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_RiddlerResources());
 
 /*

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -64,7 +64,7 @@
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
 		"@fluidframework/server-local-server": "workspace:~",
-		"@fluidframework/server-routerlicious-previous": "npm:@fluidframework/server-routerlicious@2.0.0",
+		"@fluidframework/server-routerlicious-previous": "npm:@fluidframework/server-routerlicious@4.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/nconf": "^0.10.2",
 		"@types/node": "^18.17.1",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@2.0.0",
+		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@4.0.0",
 		"@microsoft/api-extractor": "^7.42.3",
 		"@types/debug": "^4.1.5",
 		"@types/jsrsasign": "^10.5.12",

--- a/server/routerlicious/packages/services-client/src/test/types/validateServerServicesClientPrevious.generated.ts
+++ b/server/routerlicious/packages/services-client/src/test/types/validateServerServicesClientPrevious.generated.ts
@@ -168,6 +168,30 @@ use_old_ClassDeclaration_GitManager(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_Heap": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_Heap():
+    TypeOnly<old.Heap<any>>;
+declare function use_current_ClassDeclaration_Heap(
+    use: TypeOnly<current.Heap<any>>): void;
+use_current_ClassDeclaration_Heap(
+    get_old_ClassDeclaration_Heap());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_Heap": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_Heap():
+    TypeOnly<current.Heap<any>>;
+declare function use_old_ClassDeclaration_Heap(
+    use: TypeOnly<old.Heap<any>>): void;
+use_old_ClassDeclaration_Heap(
+    get_current_ClassDeclaration_Heap());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_Historian": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_Historian():
@@ -288,6 +312,30 @@ use_old_InterfaceDeclaration_IEmbeddedSummaryHandle(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IExternalWriterConfig": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IExternalWriterConfig():
+    TypeOnly<old.IExternalWriterConfig>;
+declare function use_current_InterfaceDeclaration_IExternalWriterConfig(
+    use: TypeOnly<current.IExternalWriterConfig>): void;
+use_current_InterfaceDeclaration_IExternalWriterConfig(
+    get_old_InterfaceDeclaration_IExternalWriterConfig());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IExternalWriterConfig": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IExternalWriterConfig():
+    TypeOnly<current.IExternalWriterConfig>;
+declare function use_old_InterfaceDeclaration_IExternalWriterConfig(
+    use: TypeOnly<old.IExternalWriterConfig>): void;
+use_old_InterfaceDeclaration_IExternalWriterConfig(
+    get_current_InterfaceDeclaration_IExternalWriterConfig());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IGetRefParamsExternal": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IGetRefParamsExternal():
@@ -380,6 +428,30 @@ declare function use_old_InterfaceDeclaration_IGitService(
     use: TypeOnly<old.IGitService>): void;
 use_old_InterfaceDeclaration_IGitService(
     get_current_InterfaceDeclaration_IGitService());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IHeapComparator": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IHeapComparator():
+    TypeOnly<old.IHeapComparator<any>>;
+declare function use_current_InterfaceDeclaration_IHeapComparator(
+    use: TypeOnly<current.IHeapComparator<any>>): void;
+use_current_InterfaceDeclaration_IHeapComparator(
+    get_old_InterfaceDeclaration_IHeapComparator());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IHeapComparator": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IHeapComparator():
+    TypeOnly<current.IHeapComparator<any>>;
+declare function use_old_InterfaceDeclaration_IHeapComparator(
+    use: TypeOnly<old.IHeapComparator<any>>): void;
+use_old_InterfaceDeclaration_IHeapComparator(
+    get_current_InterfaceDeclaration_IHeapComparator());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -548,6 +620,30 @@ declare function use_old_InterfaceDeclaration_ISummaryUploadManager(
     use: TypeOnly<old.ISummaryUploadManager>): void;
 use_old_InterfaceDeclaration_ISummaryUploadManager(
     get_current_InterfaceDeclaration_ISummaryUploadManager());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITimeoutContext": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITimeoutContext():
+    TypeOnly<old.ITimeoutContext>;
+declare function use_current_InterfaceDeclaration_ITimeoutContext(
+    use: TypeOnly<current.ITimeoutContext>): void;
+use_current_InterfaceDeclaration_ITimeoutContext(
+    get_old_InterfaceDeclaration_ITimeoutContext());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITimeoutContext": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITimeoutContext():
+    TypeOnly<current.ITimeoutContext>;
+declare function use_old_InterfaceDeclaration_ITimeoutContext(
+    use: TypeOnly<old.ITimeoutContext>): void;
+use_old_InterfaceDeclaration_ITimeoutContext(
+    get_current_InterfaceDeclaration_ITimeoutContext());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1416,6 +1512,30 @@ use_old_FunctionDeclaration_createFluidServiceNetworkError(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_dedupeSortedArray": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_dedupeSortedArray():
+    TypeOnly<typeof old.dedupeSortedArray>;
+declare function use_current_FunctionDeclaration_dedupeSortedArray(
+    use: TypeOnly<typeof current.dedupeSortedArray>): void;
+use_current_FunctionDeclaration_dedupeSortedArray(
+    get_old_FunctionDeclaration_dedupeSortedArray());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_dedupeSortedArray": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_dedupeSortedArray():
+    TypeOnly<typeof current.dedupeSortedArray>;
+declare function use_old_FunctionDeclaration_dedupeSortedArray(
+    use: TypeOnly<typeof old.dedupeSortedArray>): void;
+use_old_FunctionDeclaration_dedupeSortedArray(
+    get_current_FunctionDeclaration_dedupeSortedArray());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "VariableDeclaration_defaultHash": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_defaultHash():
@@ -1532,6 +1652,30 @@ declare function use_old_VariableDeclaration_getAuthorizationTokenFromCredential
     use: TypeOnly<typeof old.getAuthorizationTokenFromCredentials>): void;
 use_old_VariableDeclaration_getAuthorizationTokenFromCredentials(
     get_current_VariableDeclaration_getAuthorizationTokenFromCredentials());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_getGlobalTimeoutContext": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_getGlobalTimeoutContext():
+    TypeOnly<typeof old.getGlobalTimeoutContext>;
+declare function use_current_VariableDeclaration_getGlobalTimeoutContext(
+    use: TypeOnly<typeof current.getGlobalTimeoutContext>): void;
+use_current_VariableDeclaration_getGlobalTimeoutContext(
+    get_old_VariableDeclaration_getGlobalTimeoutContext());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_getGlobalTimeoutContext": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_getGlobalTimeoutContext():
+    TypeOnly<typeof current.getGlobalTimeoutContext>;
+declare function use_old_VariableDeclaration_getGlobalTimeoutContext(
+    use: TypeOnly<typeof old.getGlobalTimeoutContext>): void;
+use_old_VariableDeclaration_getGlobalTimeoutContext(
+    get_current_VariableDeclaration_getGlobalTimeoutContext());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -1704,6 +1848,54 @@ use_old_FunctionDeclaration_mergeAppAndProtocolTree(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_mergeKArrays": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_mergeKArrays():
+    TypeOnly<typeof old.mergeKArrays>;
+declare function use_current_FunctionDeclaration_mergeKArrays(
+    use: TypeOnly<typeof current.mergeKArrays>): void;
+use_current_FunctionDeclaration_mergeKArrays(
+    get_old_FunctionDeclaration_mergeKArrays());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_mergeKArrays": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_mergeKArrays():
+    TypeOnly<typeof current.mergeKArrays>;
+declare function use_old_FunctionDeclaration_mergeKArrays(
+    use: TypeOnly<typeof old.mergeKArrays>): void;
+use_old_FunctionDeclaration_mergeKArrays(
+    get_current_FunctionDeclaration_mergeKArrays());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_mergeSortedArrays": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_mergeSortedArrays():
+    TypeOnly<typeof old.mergeSortedArrays>;
+declare function use_current_FunctionDeclaration_mergeSortedArrays(
+    use: TypeOnly<typeof current.mergeSortedArrays>): void;
+use_current_FunctionDeclaration_mergeSortedArrays(
+    get_old_FunctionDeclaration_mergeSortedArrays());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_mergeSortedArrays": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_mergeSortedArrays():
+    TypeOnly<typeof current.mergeSortedArrays>;
+declare function use_old_FunctionDeclaration_mergeSortedArrays(
+    use: TypeOnly<typeof old.mergeSortedArrays>): void;
+use_old_FunctionDeclaration_mergeSortedArrays(
+    get_current_FunctionDeclaration_mergeSortedArrays());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "FunctionDeclaration_promiseTimeout": {"forwardCompat": false}
 */
 declare function get_old_FunctionDeclaration_promiseTimeout():
@@ -1724,6 +1916,30 @@ declare function use_old_FunctionDeclaration_promiseTimeout(
     use: TypeOnly<typeof old.promiseTimeout>): void;
 use_old_FunctionDeclaration_promiseTimeout(
     get_current_FunctionDeclaration_promiseTimeout());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_setGlobalTimeoutContext": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_setGlobalTimeoutContext():
+    TypeOnly<typeof old.setGlobalTimeoutContext>;
+declare function use_current_VariableDeclaration_setGlobalTimeoutContext(
+    use: TypeOnly<typeof current.setGlobalTimeoutContext>): void;
+use_current_VariableDeclaration_setGlobalTimeoutContext(
+    get_old_VariableDeclaration_setGlobalTimeoutContext());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_setGlobalTimeoutContext": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_setGlobalTimeoutContext():
+    TypeOnly<typeof current.setGlobalTimeoutContext>;
+declare function use_old_VariableDeclaration_setGlobalTimeoutContext(
+    use: TypeOnly<typeof old.setGlobalTimeoutContext>): void;
+use_old_VariableDeclaration_setGlobalTimeoutContext(
+    get_current_VariableDeclaration_setGlobalTimeoutContext());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@2.0.0",
+		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@4.0.0",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",
 		"prettier": "~3.0.3",
@@ -62,14 +62,6 @@
 	},
 	"typeValidation": {
 		"broken": {
-			"RemovedInterfaceDeclaration_IPartitionConfig": {
-				"backCompat": false,
-				"forwardCompat": false
-			},
-			"RemovedInterfaceDeclaration_IPartitionWithEpoch": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
 			"VariableDeclaration_DefaultServiceConfiguration": {
 				"forwardCompat": false
 			},
@@ -82,23 +74,7 @@
 			"InterfaceDeclaration_IScribeServerConfiguration": {
 				"forwardCompat": false
 			},
-			"InterfaceDeclaration_IDeliServerConfiguration": {
-				"forwardCompat": false,
-				"backCompat": true
-			},
 			"InterfaceDeclaration_IOrdererConnection": {
-				"forwardCompat": false,
-				"backCompat": true
-			},
-			"ClassDeclaration_CheckpointService": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ICheckpointService": {
-				"forwardCompat": false,
-				"backCompat": false
-			},
-			"InterfaceDeclaration_IWebSocketTracker": {
 				"forwardCompat": false
 			},
 			"InterfaceDeclaration_IScribe": {

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -55,7 +55,6 @@ declare function get_old_ClassDeclaration_CheckpointService():
 declare function use_current_ClassDeclaration_CheckpointService(
     use: TypeOnly<current.CheckpointService>): void;
 use_current_ClassDeclaration_CheckpointService(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_CheckpointService());
 
 /*
@@ -68,7 +67,6 @@ declare function get_current_ClassDeclaration_CheckpointService():
 declare function use_old_ClassDeclaration_CheckpointService(
     use: TypeOnly<old.CheckpointService>): void;
 use_old_ClassDeclaration_CheckpointService(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_CheckpointService());
 
 /*
@@ -466,7 +464,6 @@ declare function get_old_InterfaceDeclaration_ICheckpointService():
 declare function use_current_InterfaceDeclaration_ICheckpointService(
     use: TypeOnly<current.ICheckpointService>): void;
 use_current_InterfaceDeclaration_ICheckpointService(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_ICheckpointService());
 
 /*
@@ -479,7 +476,6 @@ declare function get_current_InterfaceDeclaration_ICheckpointService():
 declare function use_old_InterfaceDeclaration_ICheckpointService(
     use: TypeOnly<old.ICheckpointService>): void;
 use_old_InterfaceDeclaration_ICheckpointService(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ICheckpointService());
 
 /*
@@ -529,6 +525,30 @@ declare function use_old_InterfaceDeclaration_IClientSequenceNumber(
     use: TypeOnly<old.IClientSequenceNumber>): void;
 use_old_InterfaceDeclaration_IClientSequenceNumber(
     get_current_InterfaceDeclaration_IClientSequenceNumber());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IClusterDrainingChecker": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IClusterDrainingChecker():
+    TypeOnly<old.IClusterDrainingChecker>;
+declare function use_current_InterfaceDeclaration_IClusterDrainingChecker(
+    use: TypeOnly<current.IClusterDrainingChecker>): void;
+use_current_InterfaceDeclaration_IClusterDrainingChecker(
+    get_old_InterfaceDeclaration_IClusterDrainingChecker());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IClusterDrainingChecker": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IClusterDrainingChecker():
+    TypeOnly<current.IClusterDrainingChecker>;
+declare function use_old_InterfaceDeclaration_IClusterDrainingChecker(
+    use: TypeOnly<old.IClusterDrainingChecker>): void;
+use_old_InterfaceDeclaration_IClusterDrainingChecker(
+    get_current_InterfaceDeclaration_IClusterDrainingChecker());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -780,7 +800,6 @@ declare function get_old_InterfaceDeclaration_IDeliServerConfiguration():
 declare function use_current_InterfaceDeclaration_IDeliServerConfiguration(
     use: TypeOnly<current.IDeliServerConfiguration>): void;
 use_current_InterfaceDeclaration_IDeliServerConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IDeliServerConfiguration());
 
 /*
@@ -2123,6 +2142,30 @@ use_old_InterfaceDeclaration_IServiceConfiguration(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IServiceMessageResourceManager": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IServiceMessageResourceManager():
+    TypeOnly<old.IServiceMessageResourceManager>;
+declare function use_current_InterfaceDeclaration_IServiceMessageResourceManager(
+    use: TypeOnly<current.IServiceMessageResourceManager>): void;
+use_current_InterfaceDeclaration_IServiceMessageResourceManager(
+    get_old_InterfaceDeclaration_IServiceMessageResourceManager());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IServiceMessageResourceManager": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IServiceMessageResourceManager():
+    TypeOnly<current.IServiceMessageResourceManager>;
+declare function use_old_InterfaceDeclaration_IServiceMessageResourceManager(
+    use: TypeOnly<old.IServiceMessageResourceManager>): void;
+use_old_InterfaceDeclaration_IServiceMessageResourceManager(
+    get_current_InterfaceDeclaration_IServiceMessageResourceManager());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IStorageNameAllocator": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IStorageNameAllocator():
@@ -2874,7 +2917,6 @@ declare function get_old_InterfaceDeclaration_IWebSocketTracker():
 declare function use_current_InterfaceDeclaration_IWebSocketTracker(
     use: TypeOnly<current.IWebSocketTracker>): void;
 use_current_InterfaceDeclaration_IWebSocketTracker(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IWebSocketTracker());
 
 /*

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -43,7 +43,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@2.0.0",
+		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@4.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",
 		"@types/lru-cache": "^5.1.0",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -42,7 +42,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@2.0.0",
+		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@4.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/amqplib": "^0.5.17",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -36,7 +36,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@2.0.0",
+		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@4.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",
 		"@types/lru-cache": "^5.1.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -82,7 +82,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@2.0.0",
+		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@4.0.0",
 		"@types/body-parser": "^1.19.2",
 		"@types/debug": "^4.1.5",
 		"@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/services-shared/src/test/types/validateServerServicesSharedPrevious.generated.ts
+++ b/server/routerlicious/packages/services-shared/src/test/types/validateServerServicesSharedPrevious.generated.ts
@@ -48,6 +48,30 @@ use_old_ClassDeclaration_BasicWebServerFactory(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_ConfigDumper": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_ConfigDumper():
+    TypeOnly<old.ConfigDumper>;
+declare function use_current_ClassDeclaration_ConfigDumper(
+    use: TypeOnly<current.ConfigDumper>): void;
+use_current_ClassDeclaration_ConfigDumper(
+    get_old_ClassDeclaration_ConfigDumper());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_ConfigDumper": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_ConfigDumper():
+    TypeOnly<current.ConfigDumper>;
+declare function use_old_ClassDeclaration_ConfigDumper(
+    use: TypeOnly<old.ConfigDumper>): void;
+use_old_ClassDeclaration_ConfigDumper(
+    get_current_ClassDeclaration_ConfigDumper());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_DocumentStorage": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_DocumentStorage():
@@ -116,6 +140,30 @@ declare function use_old_InterfaceDeclaration_IHttpServerConfig(
     use: TypeOnly<old.IHttpServerConfig>): void;
 use_old_InterfaceDeclaration_IHttpServerConfig(
     get_current_InterfaceDeclaration_IHttpServerConfig());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_INodeClusterConfig": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_INodeClusterConfig():
+    TypeOnly<old.INodeClusterConfig>;
+declare function use_current_InterfaceDeclaration_INodeClusterConfig(
+    use: TypeOnly<current.INodeClusterConfig>): void;
+use_current_InterfaceDeclaration_INodeClusterConfig(
+    get_old_InterfaceDeclaration_INodeClusterConfig());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_INodeClusterConfig": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_INodeClusterConfig():
+    TypeOnly<current.INodeClusterConfig>;
+declare function use_old_InterfaceDeclaration_INodeClusterConfig(
+    use: TypeOnly<old.INodeClusterConfig>): void;
+use_old_InterfaceDeclaration_INodeClusterConfig(
+    get_current_InterfaceDeclaration_INodeClusterConfig());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -216,6 +264,30 @@ use_old_VariableDeclaration_IsEphemeralContainer(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_NodeClusterWebServerFactory": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_NodeClusterWebServerFactory():
+    TypeOnly<old.NodeClusterWebServerFactory>;
+declare function use_current_ClassDeclaration_NodeClusterWebServerFactory(
+    use: TypeOnly<current.NodeClusterWebServerFactory>): void;
+use_current_ClassDeclaration_NodeClusterWebServerFactory(
+    get_old_ClassDeclaration_NodeClusterWebServerFactory());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_NodeClusterWebServerFactory": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_NodeClusterWebServerFactory():
+    TypeOnly<current.NodeClusterWebServerFactory>;
+declare function use_old_ClassDeclaration_NodeClusterWebServerFactory(
+    use: TypeOnly<old.NodeClusterWebServerFactory>): void;
+use_old_ClassDeclaration_NodeClusterWebServerFactory(
+    get_current_ClassDeclaration_NodeClusterWebServerFactory());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_RedisSocketIoAdapter": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_RedisSocketIoAdapter():
@@ -284,6 +356,30 @@ declare function use_old_ClassDeclaration_RestLessServer(
     use: TypeOnly<old.RestLessServer>): void;
 use_old_ClassDeclaration_RestLessServer(
     get_current_ClassDeclaration_RestLessServer());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_SocketIoNodeClusterWebServerFactory": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_SocketIoNodeClusterWebServerFactory():
+    TypeOnly<old.SocketIoNodeClusterWebServerFactory>;
+declare function use_current_ClassDeclaration_SocketIoNodeClusterWebServerFactory(
+    use: TypeOnly<current.SocketIoNodeClusterWebServerFactory>): void;
+use_current_ClassDeclaration_SocketIoNodeClusterWebServerFactory(
+    get_old_ClassDeclaration_SocketIoNodeClusterWebServerFactory());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_SocketIoNodeClusterWebServerFactory": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_SocketIoNodeClusterWebServerFactory():
+    TypeOnly<current.SocketIoNodeClusterWebServerFactory>;
+declare function use_old_ClassDeclaration_SocketIoNodeClusterWebServerFactory(
+    use: TypeOnly<old.SocketIoNodeClusterWebServerFactory>): void;
+use_old_ClassDeclaration_SocketIoNodeClusterWebServerFactory(
+    get_current_ClassDeclaration_SocketIoNodeClusterWebServerFactory());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -548,6 +644,30 @@ declare function use_old_FunctionDeclaration_runService(
     use: TypeOnly<typeof old.runService>): void;
 use_old_FunctionDeclaration_runService(
     get_current_FunctionDeclaration_runService());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_runnerHttpServerStop": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_runnerHttpServerStop():
+    TypeOnly<typeof old.runnerHttpServerStop>;
+declare function use_current_FunctionDeclaration_runnerHttpServerStop(
+    use: TypeOnly<typeof current.runnerHttpServerStop>): void;
+use_current_FunctionDeclaration_runnerHttpServerStop(
+    get_old_FunctionDeclaration_runnerHttpServerStop());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_runnerHttpServerStop": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_runnerHttpServerStop():
+    TypeOnly<typeof current.runnerHttpServerStop>;
+declare function use_old_FunctionDeclaration_runnerHttpServerStop(
+    use: TypeOnly<typeof old.runnerHttpServerStop>): void;
+use_old_FunctionDeclaration_runnerHttpServerStop(
+    get_current_FunctionDeclaration_runnerHttpServerStop());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -63,7 +63,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@2.0.0",
+		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@4.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.17.1",
 		"@types/supertest": "^2.0.5",

--- a/server/routerlicious/packages/services-telemetry/src/test/types/validateServerServicesTelemetryPrevious.generated.ts
+++ b/server/routerlicious/packages/services-telemetry/src/test/types/validateServerServicesTelemetryPrevious.generated.ts
@@ -72,6 +72,30 @@ use_old_ClassDeclaration_BasePropertiesValidator(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_BaseSanitizationLumberFormatter": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_BaseSanitizationLumberFormatter():
+    TypeOnly<old.BaseSanitizationLumberFormatter>;
+declare function use_current_ClassDeclaration_BaseSanitizationLumberFormatter(
+    use: TypeOnly<current.BaseSanitizationLumberFormatter>): void;
+use_current_ClassDeclaration_BaseSanitizationLumberFormatter(
+    get_old_ClassDeclaration_BaseSanitizationLumberFormatter());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_BaseSanitizationLumberFormatter": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_BaseSanitizationLumberFormatter():
+    TypeOnly<current.BaseSanitizationLumberFormatter>;
+declare function use_old_ClassDeclaration_BaseSanitizationLumberFormatter(
+    use: TypeOnly<old.BaseSanitizationLumberFormatter>): void;
+use_old_ClassDeclaration_BaseSanitizationLumberFormatter(
+    get_current_ClassDeclaration_BaseSanitizationLumberFormatter());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "EnumDeclaration_BaseTelemetryProperties": {"forwardCompat": false}
 */
 declare function get_old_EnumDeclaration_BaseTelemetryProperties():
@@ -140,6 +164,30 @@ declare function use_old_EnumDeclaration_HttpProperties(
     use: TypeOnly<old.HttpProperties>): void;
 use_old_EnumDeclaration_HttpProperties(
     get_current_EnumDeclaration_HttpProperties());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ILumberFormatter": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ILumberFormatter():
+    TypeOnly<old.ILumberFormatter>;
+declare function use_current_InterfaceDeclaration_ILumberFormatter(
+    use: TypeOnly<current.ILumberFormatter>): void;
+use_current_InterfaceDeclaration_ILumberFormatter(
+    get_old_InterfaceDeclaration_ILumberFormatter());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ILumberFormatter": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ILumberFormatter():
+    TypeOnly<current.ILumberFormatter>;
+declare function use_old_InterfaceDeclaration_ILumberFormatter(
+    use: TypeOnly<old.ILumberFormatter>): void;
+use_old_InterfaceDeclaration_ILumberFormatter(
+    get_current_InterfaceDeclaration_ILumberFormatter());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -456,6 +504,30 @@ use_old_EnumDeclaration_QueuedMessageProperties(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_SanitizationLumberFormatter": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_SanitizationLumberFormatter():
+    TypeOnly<old.SanitizationLumberFormatter>;
+declare function use_current_ClassDeclaration_SanitizationLumberFormatter(
+    use: TypeOnly<current.SanitizationLumberFormatter>): void;
+use_current_ClassDeclaration_SanitizationLumberFormatter(
+    get_old_ClassDeclaration_SanitizationLumberFormatter());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_SanitizationLumberFormatter": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_SanitizationLumberFormatter():
+    TypeOnly<current.SanitizationLumberFormatter>;
+declare function use_old_ClassDeclaration_SanitizationLumberFormatter(
+    use: TypeOnly<old.SanitizationLumberFormatter>): void;
+use_old_ClassDeclaration_SanitizationLumberFormatter(
+    get_current_ClassDeclaration_SanitizationLumberFormatter());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "EnumDeclaration_SessionState": {"forwardCompat": false}
 */
 declare function get_old_EnumDeclaration_SessionState():
@@ -524,6 +596,30 @@ declare function use_old_ClassDeclaration_TestEngine2(
     use: TypeOnly<old.TestEngine2>): void;
 use_old_ClassDeclaration_TestEngine2(
     get_current_ClassDeclaration_TestEngine2());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_TestFormatter": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_TestFormatter():
+    TypeOnly<old.TestFormatter>;
+declare function use_current_ClassDeclaration_TestFormatter(
+    use: TypeOnly<current.TestFormatter>): void;
+use_current_ClassDeclaration_TestFormatter(
+    get_old_ClassDeclaration_TestFormatter());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_TestFormatter": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_TestFormatter():
+    TypeOnly<current.TestFormatter>;
+declare function use_old_ClassDeclaration_TestFormatter(
+    use: TypeOnly<old.TestFormatter>): void;
+use_old_ClassDeclaration_TestFormatter(
+    get_current_ClassDeclaration_TestFormatter());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@2.0.0",
+		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@4.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",
 		"@types/express": "^4.17.21",
@@ -108,8 +108,9 @@
 	},
 	"typeValidation": {
 		"broken": {
-			"ClassDeclaration_WebSocketTracker": {
-				"forwardCompat": false
+			"RemovedFunctionDeclaration_getRedisClient": {
+				"forwardCompat": false,
+				"backCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
@@ -24,6 +24,78 @@ type TypeOnly<T> = T extends number
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_AsyncLocalStorageContextProvider": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_AsyncLocalStorageContextProvider():
+    TypeOnly<old.AsyncLocalStorageContextProvider<any>>;
+declare function use_current_ClassDeclaration_AsyncLocalStorageContextProvider(
+    use: TypeOnly<current.AsyncLocalStorageContextProvider<any>>): void;
+use_current_ClassDeclaration_AsyncLocalStorageContextProvider(
+    get_old_ClassDeclaration_AsyncLocalStorageContextProvider());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_AsyncLocalStorageContextProvider": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_AsyncLocalStorageContextProvider():
+    TypeOnly<current.AsyncLocalStorageContextProvider<any>>;
+declare function use_old_ClassDeclaration_AsyncLocalStorageContextProvider(
+    use: TypeOnly<old.AsyncLocalStorageContextProvider<any>>): void;
+use_old_ClassDeclaration_AsyncLocalStorageContextProvider(
+    get_current_ClassDeclaration_AsyncLocalStorageContextProvider());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_AsyncLocalStorageTelemetryContext": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_AsyncLocalStorageTelemetryContext():
+    TypeOnly<old.AsyncLocalStorageTelemetryContext>;
+declare function use_current_ClassDeclaration_AsyncLocalStorageTelemetryContext(
+    use: TypeOnly<current.AsyncLocalStorageTelemetryContext>): void;
+use_current_ClassDeclaration_AsyncLocalStorageTelemetryContext(
+    get_old_ClassDeclaration_AsyncLocalStorageTelemetryContext());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_AsyncLocalStorageTelemetryContext": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_AsyncLocalStorageTelemetryContext():
+    TypeOnly<current.AsyncLocalStorageTelemetryContext>;
+declare function use_old_ClassDeclaration_AsyncLocalStorageTelemetryContext(
+    use: TypeOnly<old.AsyncLocalStorageTelemetryContext>): void;
+use_old_ClassDeclaration_AsyncLocalStorageTelemetryContext(
+    get_current_ClassDeclaration_AsyncLocalStorageTelemetryContext());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_AsyncLocalStorageTimeoutContext": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_AsyncLocalStorageTimeoutContext():
+    TypeOnly<old.AsyncLocalStorageTimeoutContext>;
+declare function use_current_ClassDeclaration_AsyncLocalStorageTimeoutContext(
+    use: TypeOnly<current.AsyncLocalStorageTimeoutContext>): void;
+use_current_ClassDeclaration_AsyncLocalStorageTimeoutContext(
+    get_old_ClassDeclaration_AsyncLocalStorageTimeoutContext());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_AsyncLocalStorageTimeoutContext": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_AsyncLocalStorageTimeoutContext():
+    TypeOnly<current.AsyncLocalStorageTimeoutContext>;
+declare function use_old_ClassDeclaration_AsyncLocalStorageTimeoutContext(
+    use: TypeOnly<old.AsyncLocalStorageTimeoutContext>): void;
+use_old_ClassDeclaration_AsyncLocalStorageTimeoutContext(
+    get_current_ClassDeclaration_AsyncLocalStorageTimeoutContext());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_DummyRevokedTokenChecker": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_DummyRevokedTokenChecker():
@@ -319,7 +391,6 @@ declare function get_old_ClassDeclaration_WebSocketTracker():
 declare function use_current_ClassDeclaration_WebSocketTracker(
     use: TypeOnly<current.WebSocketTracker>): void;
 use_current_ClassDeclaration_WebSocketTracker(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_WebSocketTracker());
 
 /*
@@ -433,6 +504,30 @@ use_old_VariableDeclaration_bindTelemetryContext(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_bindTimeoutContext": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_bindTimeoutContext():
+    TypeOnly<typeof old.bindTimeoutContext>;
+declare function use_current_VariableDeclaration_bindTimeoutContext(
+    use: TypeOnly<typeof current.bindTimeoutContext>): void;
+use_current_VariableDeclaration_bindTimeoutContext(
+    get_old_VariableDeclaration_bindTimeoutContext());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_bindTimeoutContext": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_bindTimeoutContext():
+    TypeOnly<typeof current.bindTimeoutContext>;
+declare function use_old_VariableDeclaration_bindTimeoutContext(
+    use: TypeOnly<typeof old.bindTimeoutContext>): void;
+use_old_VariableDeclaration_bindTimeoutContext(
+    get_current_VariableDeclaration_bindTimeoutContext());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "VariableDeclaration_choose": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_choose():
@@ -453,6 +548,54 @@ declare function use_old_VariableDeclaration_choose(
     use: TypeOnly<typeof old.choose>): void;
 use_old_VariableDeclaration_choose(
     get_current_VariableDeclaration_choose());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_configureGlobalTelemetryContext": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_configureGlobalTelemetryContext():
+    TypeOnly<typeof old.configureGlobalTelemetryContext>;
+declare function use_current_FunctionDeclaration_configureGlobalTelemetryContext(
+    use: TypeOnly<typeof current.configureGlobalTelemetryContext>): void;
+use_current_FunctionDeclaration_configureGlobalTelemetryContext(
+    get_old_FunctionDeclaration_configureGlobalTelemetryContext());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_configureGlobalTelemetryContext": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_configureGlobalTelemetryContext():
+    TypeOnly<typeof current.configureGlobalTelemetryContext>;
+declare function use_old_FunctionDeclaration_configureGlobalTelemetryContext(
+    use: TypeOnly<typeof old.configureGlobalTelemetryContext>): void;
+use_old_FunctionDeclaration_configureGlobalTelemetryContext(
+    get_current_FunctionDeclaration_configureGlobalTelemetryContext());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_configureGlobalTimeoutContext": {"forwardCompat": false}
+*/
+declare function get_old_FunctionDeclaration_configureGlobalTimeoutContext():
+    TypeOnly<typeof old.configureGlobalTimeoutContext>;
+declare function use_current_FunctionDeclaration_configureGlobalTimeoutContext(
+    use: TypeOnly<typeof current.configureGlobalTimeoutContext>): void;
+use_current_FunctionDeclaration_configureGlobalTimeoutContext(
+    get_old_FunctionDeclaration_configureGlobalTimeoutContext());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "FunctionDeclaration_configureGlobalTimeoutContext": {"backCompat": false}
+*/
+declare function get_current_FunctionDeclaration_configureGlobalTimeoutContext():
+    TypeOnly<typeof current.configureGlobalTimeoutContext>;
+declare function use_old_FunctionDeclaration_configureGlobalTimeoutContext(
+    use: TypeOnly<typeof old.configureGlobalTimeoutContext>): void;
+use_old_FunctionDeclaration_configureGlobalTimeoutContext(
+    get_current_FunctionDeclaration_configureGlobalTimeoutContext());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -837,6 +980,42 @@ declare function use_old_FunctionDeclaration_getRandomName(
     use: TypeOnly<typeof old.getRandomName>): void;
 use_old_FunctionDeclaration_getRandomName(
     get_current_FunctionDeclaration_getRandomName());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedFunctionDeclaration_getRedisClient": {"forwardCompat": false}
+*/
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "RemovedFunctionDeclaration_getRedisClient": {"backCompat": false}
+*/
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_getRedisClusterRetryStrategy": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_getRedisClusterRetryStrategy():
+    TypeOnly<typeof old.getRedisClusterRetryStrategy>;
+declare function use_current_VariableDeclaration_getRedisClusterRetryStrategy(
+    use: TypeOnly<typeof current.getRedisClusterRetryStrategy>): void;
+use_current_VariableDeclaration_getRedisClusterRetryStrategy(
+    get_old_VariableDeclaration_getRedisClusterRetryStrategy());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_getRedisClusterRetryStrategy": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_getRedisClusterRetryStrategy():
+    TypeOnly<typeof current.getRedisClusterRetryStrategy>;
+declare function use_old_VariableDeclaration_getRedisClusterRetryStrategy(
+    use: TypeOnly<typeof old.getRedisClusterRetryStrategy>): void;
+use_old_VariableDeclaration_getRedisClusterRetryStrategy(
+    get_current_VariableDeclaration_getRedisClusterRetryStrategy());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -81,7 +81,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@2.0.0",
+		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@4.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/amqplib": "^0.5.17",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services/src/test/types/validateServerServicesPrevious.generated.ts
+++ b/server/routerlicious/packages/services/src/test/types/validateServerServicesPrevious.generated.ts
@@ -216,6 +216,30 @@ use_old_InterfaceDeclaration_IHttpServerConfig(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_INodeClusterConfig": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_INodeClusterConfig():
+    TypeOnly<old.INodeClusterConfig>;
+declare function use_current_InterfaceDeclaration_INodeClusterConfig(
+    use: TypeOnly<current.INodeClusterConfig>): void;
+use_current_InterfaceDeclaration_INodeClusterConfig(
+    get_old_InterfaceDeclaration_INodeClusterConfig());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_INodeClusterConfig": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_INodeClusterConfig():
+    TypeOnly<current.INodeClusterConfig>;
+declare function use_old_InterfaceDeclaration_INodeClusterConfig(
+    use: TypeOnly<old.INodeClusterConfig>): void;
+use_old_InterfaceDeclaration_INodeClusterConfig(
+    get_current_InterfaceDeclaration_INodeClusterConfig());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_ISocketIoRedisConnection": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_ISocketIoRedisConnection():
@@ -408,6 +432,30 @@ use_old_ClassDeclaration_NodeAllowList(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_NodeClusterWebServerFactory": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_NodeClusterWebServerFactory():
+    TypeOnly<old.NodeClusterWebServerFactory>;
+declare function use_current_ClassDeclaration_NodeClusterWebServerFactory(
+    use: TypeOnly<current.NodeClusterWebServerFactory>): void;
+use_current_ClassDeclaration_NodeClusterWebServerFactory(
+    get_old_ClassDeclaration_NodeClusterWebServerFactory());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_NodeClusterWebServerFactory": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_NodeClusterWebServerFactory():
+    TypeOnly<current.NodeClusterWebServerFactory>;
+declare function use_old_ClassDeclaration_NodeClusterWebServerFactory(
+    use: TypeOnly<old.NodeClusterWebServerFactory>): void;
+use_old_ClassDeclaration_NodeClusterWebServerFactory(
+    get_current_ClassDeclaration_NodeClusterWebServerFactory());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_NodeCodeLoader": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_NodeCodeLoader():
@@ -572,6 +620,30 @@ declare function use_old_ClassDeclaration_SecretManager(
     use: TypeOnly<old.SecretManager>): void;
 use_old_ClassDeclaration_SecretManager(
     get_current_ClassDeclaration_SecretManager());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_SocketIoNodeClusterWebServerFactory": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_SocketIoNodeClusterWebServerFactory():
+    TypeOnly<old.SocketIoNodeClusterWebServerFactory>;
+declare function use_current_ClassDeclaration_SocketIoNodeClusterWebServerFactory(
+    use: TypeOnly<current.SocketIoNodeClusterWebServerFactory>): void;
+use_current_ClassDeclaration_SocketIoNodeClusterWebServerFactory(
+    get_old_ClassDeclaration_SocketIoNodeClusterWebServerFactory());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_SocketIoNodeClusterWebServerFactory": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_SocketIoNodeClusterWebServerFactory():
+    TypeOnly<current.SocketIoNodeClusterWebServerFactory>;
+declare function use_old_ClassDeclaration_SocketIoNodeClusterWebServerFactory(
+    use: TypeOnly<old.SocketIoNodeClusterWebServerFactory>): void;
+use_old_ClassDeclaration_SocketIoNodeClusterWebServerFactory(
+    get_current_ClassDeclaration_SocketIoNodeClusterWebServerFactory());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@2.0.0",
+		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@4.0.0",
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.17.1",
@@ -90,11 +90,6 @@
 		"typescript": "~4.5.5"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_TestNotImplementedCheckpointService": {
-				"forwardCompat": false,
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
@@ -439,7 +439,6 @@ declare function get_old_ClassDeclaration_TestNotImplementedCheckpointService():
 declare function use_current_ClassDeclaration_TestNotImplementedCheckpointService(
     use: TypeOnly<current.TestNotImplementedCheckpointService>): void;
 use_current_ClassDeclaration_TestNotImplementedCheckpointService(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TestNotImplementedCheckpointService());
 
 /*
@@ -452,7 +451,6 @@ declare function get_current_ClassDeclaration_TestNotImplementedCheckpointServic
 declare function use_old_ClassDeclaration_TestNotImplementedCheckpointService(
     use: TypeOnly<old.TestNotImplementedCheckpointService>): void;
 use_old_ClassDeclaration_TestNotImplementedCheckpointService(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_TestNotImplementedCheckpointService());
 
 /*

--- a/server/routerlicious/packages/tinylicious/package.json
+++ b/server/routerlicious/packages/tinylicious/package.json
@@ -105,5 +105,9 @@
 	},
 	"engines": {
 		"node": ">=14.0.0"
-	}
+	},
+  "typeValidation": {
+    "disabled": true,
+    "broken": {}
+  }
 }

--- a/server/routerlicious/packages/tinylicious/package.json
+++ b/server/routerlicious/packages/tinylicious/package.json
@@ -106,8 +106,8 @@
 	"engines": {
 		"node": ">=14.0.0"
 	},
-  "typeValidation": {
-    "disabled": true,
-    "broken": {}
-  }
+	"typeValidation": {
+		"disabled": true,
+		"broken": {}
+	}
 }

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.34.0
       '@fluidframework/eslint-config-fluid': ^4.0.0
-      '@fluidframework/gitresources-previous': npm:@fluidframework/gitresources@2.0.0
+      '@fluidframework/gitresources-previous': npm:@fluidframework/gitresources@4.0.0
       '@microsoft/api-extractor': ^7.42.3
       concurrently: ^8.2.1
       copyfiles: ^2.4.1
@@ -63,7 +63,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/gitresources-previous': /@fluidframework/gitresources/2.0.0
+      '@fluidframework/gitresources-previous': /@fluidframework/gitresources/4.0.0
       '@microsoft/api-extractor': 7.42.3
       concurrently: 8.2.1
       copyfiles: 2.4.1
@@ -79,7 +79,7 @@ importers:
       '@fluidframework/build-tools': ^0.34.0
       '@fluidframework/eslint-config-fluid': ^4.0.0
       '@fluidframework/protocol-definitions': ^3.2.0
-      '@fluidframework/server-kafka-orderer-previous': npm:@fluidframework/server-kafka-orderer@2.0.0
+      '@fluidframework/server-kafka-orderer-previous': npm:@fluidframework/server-kafka-orderer@4.0.0
       '@fluidframework/server-services-core': workspace:~
       '@types/node': ^18.17.1
       concurrently: ^8.2.1
@@ -95,7 +95,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-kafka-orderer-previous': /@fluidframework/server-kafka-orderer/2.0.0
+      '@fluidframework/server-kafka-orderer-previous': /@fluidframework/server-kafka-orderer/4.0.0
       '@types/node': 18.17.6
       concurrently: 8.2.1
       eslint: 8.55.0
@@ -115,7 +115,7 @@ importers:
       '@fluidframework/protocol-base': workspace:~
       '@fluidframework/protocol-definitions': ^3.2.0
       '@fluidframework/server-lambdas-driver': workspace:~
-      '@fluidframework/server-lambdas-previous': npm:@fluidframework/server-lambdas@2.0.0
+      '@fluidframework/server-lambdas-previous': npm:@fluidframework/server-lambdas@4.0.0
       '@fluidframework/server-services-client': workspace:~
       '@fluidframework/server-services-core': workspace:~
       '@fluidframework/server-services-telemetry': workspace:~
@@ -180,7 +180,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-lambdas-previous': /@fluidframework/server-lambdas/2.0.0
+      '@fluidframework/server-lambdas-previous': /@fluidframework/server-lambdas/4.0.0
       '@fluidframework/server-test-utils': link:../test-utils
       '@types/async': 3.2.20
       '@types/json-stringify-safe': 5.0.0
@@ -209,7 +209,7 @@ importers:
       '@fluidframework/build-tools': ^0.34.0
       '@fluidframework/common-utils': ^3.1.0
       '@fluidframework/eslint-config-fluid': ^4.0.0
-      '@fluidframework/server-lambdas-driver-previous': npm:@fluidframework/server-lambdas-driver@2.0.0
+      '@fluidframework/server-lambdas-driver-previous': npm:@fluidframework/server-lambdas-driver@4.0.0
       '@fluidframework/server-services-client': workspace:~
       '@fluidframework/server-services-core': workspace:~
       '@fluidframework/server-services-telemetry': workspace:~
@@ -247,7 +247,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-lambdas-driver-previous': /@fluidframework/server-lambdas-driver/2.0.0
+      '@fluidframework/server-lambdas-driver-previous': /@fluidframework/server-lambdas-driver/4.0.0
       '@fluidframework/server-test-utils': link:../test-utils
       '@types/async': 3.2.20
       '@types/lodash': 4.14.195
@@ -270,7 +270,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^4.0.0
       '@fluidframework/protocol-definitions': ^3.2.0
       '@fluidframework/server-lambdas': workspace:~
-      '@fluidframework/server-local-server-previous': npm:@fluidframework/server-local-server@2.0.0
+      '@fluidframework/server-local-server-previous': npm:@fluidframework/server-local-server@4.0.0
       '@fluidframework/server-memory-orderer': workspace:~
       '@fluidframework/server-services-client': workspace:~
       '@fluidframework/server-services-core': workspace:~
@@ -318,7 +318,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_qiwzlxsc7nv6vcdymu2njnpbxe
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-local-server-previous': /@fluidframework/server-local-server/2.0.0
+      '@fluidframework/server-local-server-previous': /@fluidframework/server-local-server/4.0.0
       '@microsoft/api-extractor': 7.42.3_@types+node@18.17.6
       '@types/jsrsasign': 10.5.12
       '@types/mocha': 10.0.1
@@ -350,7 +350,7 @@ importers:
       '@fluidframework/protocol-base': workspace:~
       '@fluidframework/protocol-definitions': ^3.2.0
       '@fluidframework/server-lambdas': workspace:~
-      '@fluidframework/server-memory-orderer-previous': npm:@fluidframework/server-memory-orderer@2.0.0
+      '@fluidframework/server-memory-orderer-previous': npm:@fluidframework/server-memory-orderer@4.0.0
       '@fluidframework/server-services-client': workspace:~
       '@fluidframework/server-services-core': workspace:~
       '@fluidframework/server-services-telemetry': workspace:~
@@ -403,7 +403,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-memory-orderer-previous': /@fluidframework/server-memory-orderer/2.0.0
+      '@fluidframework/server-memory-orderer-previous': /@fluidframework/server-memory-orderer/4.0.0
       '@types/mocha': 10.0.1
       '@types/uuid': 9.0.2
       c8: 8.0.1
@@ -423,7 +423,7 @@ importers:
       '@fluidframework/common-utils': ^3.1.0
       '@fluidframework/eslint-config-fluid': ^4.0.0
       '@fluidframework/gitresources': workspace:~
-      '@fluidframework/protocol-base-previous': npm:@fluidframework/protocol-base@2.0.0
+      '@fluidframework/protocol-base-previous': npm:@fluidframework/protocol-base@4.0.0
       '@fluidframework/protocol-definitions': ^3.2.0
       '@microsoft/api-extractor': ^7.42.3
       '@types/assert': ^1.5.1
@@ -448,7 +448,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/protocol-base-previous': /@fluidframework/protocol-base/2.0.0
+      '@fluidframework/protocol-base-previous': /@fluidframework/protocol-base/4.0.0
       '@microsoft/api-extractor': 7.42.3_@types+node@18.17.6
       '@types/assert': 1.5.6
       '@types/mocha': 10.0.1
@@ -477,7 +477,7 @@ importers:
       '@fluidframework/server-local-server': workspace:~
       '@fluidframework/server-memory-orderer': workspace:~
       '@fluidframework/server-routerlicious-base': workspace:~
-      '@fluidframework/server-routerlicious-previous': npm:@fluidframework/server-routerlicious@2.0.0
+      '@fluidframework/server-routerlicious-previous': npm:@fluidframework/server-routerlicious@4.0.0
       '@fluidframework/server-services': workspace:~
       '@fluidframework/server-services-client': workspace:~
       '@fluidframework/server-services-core': workspace:~
@@ -523,7 +523,7 @@ importers:
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
       '@fluidframework/server-local-server': link:../local-server
-      '@fluidframework/server-routerlicious-previous': /@fluidframework/server-routerlicious/2.0.0
+      '@fluidframework/server-routerlicious-previous': /@fluidframework/server-routerlicious/4.0.0
       '@fluidframework/server-test-utils': link:../test-utils
       '@types/nconf': 0.10.3
       '@types/node': 18.17.6
@@ -547,7 +547,7 @@ importers:
       '@fluidframework/server-lambdas-driver': workspace:~
       '@fluidframework/server-local-server': workspace:~
       '@fluidframework/server-memory-orderer': workspace:~
-      '@fluidframework/server-routerlicious-base-previous': npm:@fluidframework/server-routerlicious-base@2.0.0
+      '@fluidframework/server-routerlicious-base-previous': npm:@fluidframework/server-routerlicious-base@4.0.0
       '@fluidframework/server-services': workspace:~
       '@fluidframework/server-services-client': workspace:~
       '@fluidframework/server-services-core': workspace:~
@@ -642,7 +642,7 @@ importers:
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
       '@fluidframework/server-local-server': link:../local-server
-      '@fluidframework/server-routerlicious-base-previous': /@fluidframework/server-routerlicious-base/2.0.0
+      '@fluidframework/server-routerlicious-base-previous': /@fluidframework/server-routerlicious-base/4.0.0
       '@fluidframework/server-test-utils': link:../test-utils
       '@types/body-parser': 1.19.2
       '@types/bytes': 3.1.1
@@ -684,7 +684,7 @@ importers:
       '@fluidframework/server-services-core': workspace:~
       '@fluidframework/server-services-ordering-kafkanode': workspace:~
       '@fluidframework/server-services-ordering-rdkafka': workspace:~
-      '@fluidframework/server-services-previous': npm:@fluidframework/server-services@2.0.0
+      '@fluidframework/server-services-previous': npm:@fluidframework/server-services@4.0.0
       '@fluidframework/server-services-shared': workspace:~
       '@fluidframework/server-services-telemetry': workspace:~
       '@fluidframework/server-services-utils': workspace:~
@@ -752,7 +752,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-services-previous': /@fluidframework/server-services/2.0.0
+      '@fluidframework/server-services-previous': /@fluidframework/server-services/4.0.0
       '@fluidframework/server-test-utils': link:../test-utils
       '@types/amqplib': 0.5.17
       '@types/debug': 4.1.8
@@ -783,7 +783,7 @@ importers:
       '@fluidframework/gitresources': workspace:~
       '@fluidframework/protocol-base': workspace:~
       '@fluidframework/protocol-definitions': ^3.2.0
-      '@fluidframework/server-services-client-previous': npm:@fluidframework/server-services-client@2.0.0
+      '@fluidframework/server-services-client-previous': npm:@fluidframework/server-services-client@4.0.0
       '@microsoft/api-extractor': ^7.42.3
       '@types/debug': ^4.1.5
       '@types/jsrsasign': ^10.5.12
@@ -825,7 +825,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-services-client-previous': /@fluidframework/server-services-client/2.0.0
+      '@fluidframework/server-services-client-previous': /@fluidframework/server-services-client/4.0.0
       '@microsoft/api-extractor': 7.42.3_@types+node@18.17.6
       '@types/debug': 4.1.8
       '@types/jsrsasign': 10.5.12
@@ -852,7 +852,7 @@ importers:
       '@fluidframework/gitresources': workspace:~
       '@fluidframework/protocol-definitions': ^3.2.0
       '@fluidframework/server-services-client': workspace:~
-      '@fluidframework/server-services-core-previous': npm:@fluidframework/server-services-core@2.0.0
+      '@fluidframework/server-services-core-previous': npm:@fluidframework/server-services-core@4.0.0
       '@fluidframework/server-services-telemetry': workspace:~
       '@types/nconf': ^0.10.2
       '@types/node': ^18.17.1
@@ -880,7 +880,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-services-core-previous': /@fluidframework/server-services-core/2.0.0
+      '@fluidframework/server-services-core-previous': /@fluidframework/server-services-core/4.0.0
       concurrently: 8.2.1
       eslint: 8.55.0
       prettier: 3.0.3
@@ -895,7 +895,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^4.0.0
       '@fluidframework/server-services-client': workspace:~
       '@fluidframework/server-services-core': workspace:~
-      '@fluidframework/server-services-ordering-kafkanode-previous': npm:@fluidframework/server-services-ordering-kafkanode@2.0.0
+      '@fluidframework/server-services-ordering-kafkanode-previous': npm:@fluidframework/server-services-ordering-kafkanode@4.0.0
       '@fluidframework/server-services-ordering-zookeeper': workspace:~
       '@fluidframework/server-services-telemetry': workspace:~
       '@fluidframework/server-test-utils': workspace:~
@@ -927,7 +927,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-services-ordering-kafkanode-previous': /@fluidframework/server-services-ordering-kafkanode/2.0.0
+      '@fluidframework/server-services-ordering-kafkanode-previous': /@fluidframework/server-services-ordering-kafkanode/4.0.0
       '@fluidframework/server-test-utils': link:../test-utils
       '@types/debug': 4.1.8
       '@types/lru-cache': 5.1.1
@@ -949,7 +949,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^4.0.0
       '@fluidframework/server-services-client': workspace:~
       '@fluidframework/server-services-core': workspace:~
-      '@fluidframework/server-services-ordering-rdkafka-previous': npm:@fluidframework/server-services-ordering-rdkafka@2.0.0
+      '@fluidframework/server-services-ordering-rdkafka-previous': npm:@fluidframework/server-services-ordering-rdkafka@4.0.0
       '@fluidframework/server-services-telemetry': workspace:~
       '@fluidframework/server-test-utils': workspace:~
       '@types/amqplib': ^0.5.17
@@ -981,7 +981,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-services-ordering-rdkafka-previous': /@fluidframework/server-services-ordering-rdkafka/2.0.0
+      '@fluidframework/server-services-ordering-rdkafka-previous': /@fluidframework/server-services-ordering-rdkafka/4.0.0
       '@fluidframework/server-test-utils': link:../test-utils
       '@types/amqplib': 0.5.17
       '@types/debug': 4.1.8
@@ -1002,7 +1002,7 @@ importers:
       '@fluidframework/build-tools': ^0.34.0
       '@fluidframework/eslint-config-fluid': ^4.0.0
       '@fluidframework/server-services-core': workspace:~
-      '@fluidframework/server-services-ordering-zookeeper-previous': npm:@fluidframework/server-services-ordering-zookeeper@2.0.0
+      '@fluidframework/server-services-ordering-zookeeper-previous': npm:@fluidframework/server-services-ordering-zookeeper@4.0.0
       '@fluidframework/server-test-utils': workspace:~
       '@types/debug': ^4.1.5
       '@types/lru-cache': ^5.1.0
@@ -1023,7 +1023,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-services-ordering-zookeeper-previous': /@fluidframework/server-services-ordering-zookeeper/2.0.0
+      '@fluidframework/server-services-ordering-zookeeper-previous': /@fluidframework/server-services-ordering-zookeeper/4.0.0
       '@fluidframework/server-test-utils': link:../test-utils
       '@types/debug': 4.1.8
       '@types/lru-cache': 5.1.1
@@ -1048,7 +1048,7 @@ importers:
       '@fluidframework/protocol-definitions': ^3.2.0
       '@fluidframework/server-services-client': workspace:~
       '@fluidframework/server-services-core': workspace:~
-      '@fluidframework/server-services-shared-previous': npm:@fluidframework/server-services-shared@2.0.0
+      '@fluidframework/server-services-shared-previous': npm:@fluidframework/server-services-shared@4.0.0
       '@fluidframework/server-services-telemetry': workspace:~
       '@fluidframework/server-services-utils': workspace:~
       '@socket.io/redis-adapter': ^7.2.0
@@ -1115,7 +1115,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-services-shared-previous': /@fluidframework/server-services-shared/2.0.0
+      '@fluidframework/server-services-shared-previous': /@fluidframework/server-services-shared/4.0.0
       '@types/body-parser': 1.19.2
       '@types/debug': 4.1.8
       '@types/lodash': 4.14.195
@@ -1142,7 +1142,7 @@ importers:
       '@fluidframework/build-tools': ^0.34.0
       '@fluidframework/common-utils': ^3.1.0
       '@fluidframework/eslint-config-fluid': ^4.0.0
-      '@fluidframework/server-services-telemetry-previous': npm:@fluidframework/server-services-telemetry@2.0.0
+      '@fluidframework/server-services-telemetry-previous': npm:@fluidframework/server-services-telemetry@4.0.0
       '@types/mocha': ^10.0.1
       '@types/node': ^18.17.1
       '@types/supertest': ^2.0.5
@@ -1170,7 +1170,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-services-telemetry-previous': /@fluidframework/server-services-telemetry/2.0.0
+      '@fluidframework/server-services-telemetry-previous': /@fluidframework/server-services-telemetry/4.0.0
       '@types/mocha': 10.0.1
       '@types/node': 18.17.6
       '@types/supertest': 2.0.12
@@ -1194,7 +1194,7 @@ importers:
       '@fluidframework/server-services-client': workspace:~
       '@fluidframework/server-services-core': workspace:~
       '@fluidframework/server-services-telemetry': workspace:~
-      '@fluidframework/server-services-utils-previous': npm:@fluidframework/server-services-utils@2.0.0
+      '@fluidframework/server-services-utils-previous': npm:@fluidframework/server-services-utils@4.0.0
       '@fluidframework/server-test-utils': workspace:~
       '@types/debug': ^4.1.5
       '@types/express': ^4.17.21
@@ -1251,7 +1251,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-services-utils-previous': /@fluidframework/server-services-utils/2.0.0
+      '@fluidframework/server-services-utils-previous': /@fluidframework/server-services-utils/4.0.0
       '@fluidframework/server-test-utils': link:../test-utils
       '@types/debug': 4.1.8
       '@types/express': 4.17.21
@@ -1286,7 +1286,7 @@ importers:
       '@fluidframework/server-services-client': workspace:~
       '@fluidframework/server-services-core': workspace:~
       '@fluidframework/server-services-telemetry': workspace:~
-      '@fluidframework/server-test-utils-previous': npm:@fluidframework/server-test-utils@2.0.0
+      '@fluidframework/server-test-utils-previous': npm:@fluidframework/server-test-utils@4.0.0
       '@types/ioredis-mock': ^8.2.1
       '@types/lodash': ^4.14.118
       '@types/mocha': ^10.0.1
@@ -1332,7 +1332,7 @@ importers:
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.34.0_@types+node@18.17.6
       '@fluidframework/eslint-config-fluid': 4.0.0_yzjfgl2l2fa2siv5ppqhbzvdbi
-      '@fluidframework/server-test-utils-previous': /@fluidframework/server-test-utils/2.0.0
+      '@fluidframework/server-test-utils-previous': /@fluidframework/server-test-utils/4.0.0
       '@types/lodash': 4.14.195
       '@types/mocha': 10.0.1
       '@types/node': 18.17.6
@@ -2881,12 +2881,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/gitresources/2.0.0:
-    resolution: {integrity: sha512-A4e5dixApwICz5RcD3f2D0qDWPo7gPhJxKH/lrBrPrWotDfg2eCR+sVIMbG95C/uW4gQQpDIGYw2w5vu2hQjDA==}
-    dev: true
-
-  /@fluidframework/gitresources/2.0.2:
-    resolution: {integrity: sha512-v9hI+uT8B5kwFAs+x6naqb7rOAX84r9ixjyIrE7Gqa9sBHIZ8pP9zKqNIdcS+Y14IqGiJYGDmwzM7Km6ThILCw==}
+  /@fluidframework/gitresources/4.0.0:
+    resolution: {integrity: sha512-3E4bjOp0/el0EFIzut8fb5XDM5xF/zWKyKn8n1RLEsstMM9nktjFOhCHoP57tRsfc16p3g9GoXhtpWCwe0vqnQ==}
     dev: true
 
   /@fluidframework/mocha-test-setup/2.0.0-internal.7.0.0:
@@ -2898,20 +2894,11 @@ packages:
       source-map-support: 0.5.21
     dev: true
 
-  /@fluidframework/protocol-base/2.0.0:
-    resolution: {integrity: sha512-vbA2tHDkBzu3MoO+TG9sBwwcUT2iVtHJWsJUegm8m72yGicOCZsrIoHdzSQDGTlwySlarxB21Z9Cr3ryg/zS+A==}
+  /@fluidframework/protocol-base/4.0.0:
+    resolution: {integrity: sha512-mpuYXOOfCXKKEdzauxQ3KTY+ZWNj+NTEQTEJW8PD/xqN95g3AYoYXiikEkuzPbKghkAWcr6gYNxmK//MLbIVFw==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-definitions': 3.2.0
-      events: 3.3.0
-    dev: true
-
-  /@fluidframework/protocol-base/2.0.2:
-    resolution: {integrity: sha512-9AbQ8FuZ5UNZgOWmNaWxs7CH08H9qRYX6OkTUbRXNjdJaFRSCBCkPSA23aHD85EN49UEkkpfoyH1SsQchHuR4Q==}
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
+      '@fluidframework/gitresources': 4.0.0
       '@fluidframework/protocol-definitions': 3.2.0
       events: 3.3.0
     dev: true
@@ -2919,31 +2906,22 @@ packages:
   /@fluidframework/protocol-definitions/3.2.0:
     resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
 
-  /@fluidframework/server-kafka-orderer/2.0.0:
-    resolution: {integrity: sha512-3Wn0XLecbz8kytyfE4mukFUUeoEEnzAFFfEBzjBelpkS6bbAZ/7TdLLJ34q9JS8Cnb5vqreFfJCaHbboIUe6YQ==}
+  /@fluidframework/server-kafka-orderer/4.0.0:
+    resolution: {integrity: sha512-5JXFs004R3J9kfJGYQGNVJt5aHeq+BTeAuVYTtXhQ8r/NKGYyU+EinFmQDQX8rNLYcY5T8iwrFZB8HCJX81Y4g==}
     dependencies:
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-core': 2.0.2
+      '@fluidframework/server-services-core': 4.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/server-kafka-orderer/2.0.2:
-    resolution: {integrity: sha512-cHcqDN8SVghBKXh0sslJyVK93Bu7LBVa9al2TbUCGw0irGOU+F8J9jE58LKQcnEeJsfTkyizKa3biKvfzr9lZg==}
-    dependencies:
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-core': 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/server-lambdas-driver/2.0.0:
-    resolution: {integrity: sha512-DJS/YFS2DqvPq8g9vsXAtZyE32oDvN81wSTNxoI6jhQyJOuMwB6Uii7kPYtkyiRN2N5jdHu3dsfrhtuZL5hZLA==}
+  /@fluidframework/server-lambdas-driver/4.0.0:
+    resolution: {integrity: sha512-3RM55xj1PrlUBYjGbtiBTMk8oFcNKUa+aofTBcoYiJsNvI7qOSifRvgl7TBLxPKLBSjZ25NjYBo0NXSG0p0l5A==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
       assert: 2.1.0
       async: 3.2.5
       events: 3.3.0
@@ -2954,39 +2932,22 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-lambdas-driver/2.0.2:
-    resolution: {integrity: sha512-Xj7luVWFmkxGKODsmkaFn3FRg34/6/IrTuJUXmQNGZyCxPiS3O+UiY20/qX0FKzTVyHTYQuO55rIorI/3UTnqw==}
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      assert: 2.1.0
-      async: 3.2.5
-      events: 3.3.0
-      lodash: 4.17.21
-      nconf: 0.12.1
-      serialize-error: 8.1.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/server-lambdas/2.0.0:
-    resolution: {integrity: sha512-+ORFTBjZmCdk4E6K5+1VKYHSzB4Q4EtI+VopDFm8vysngy00IiXuOFlJ0oiGPNuSzdLxwc2F5Ggn3ol9XzKcGg==}
+  /@fluidframework/server-lambdas/4.0.0:
+    resolution: {integrity: sha512-htB+QpkRzzrJnKTl0MIxEiaD3d2l0fx7mUy3rQ6/oJzs1ZisD2KoTG4ZNaKmWBcBZpNwFYPdOfvfeKGCKovuHg==}
     dependencies:
       '@fluidframework/common-definitions': 1.1.0
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/gitresources': 4.0.0
+      '@fluidframework/protocol-base': 4.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas-driver': 2.0.2
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
+      '@fluidframework/server-lambdas-driver': 4.0.0
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
       '@types/semver': 7.5.6
       assert: 2.1.0
       async: 3.2.5
-      axios: 0.26.1
+      axios: 1.6.2
       buffer: 6.0.3
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -3001,22 +2962,22 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-lambdas/2.0.2:
-    resolution: {integrity: sha512-9hwIA/QLejMKR5SZwR6VFUlLqybVBFk2ErgwKc5FLB1L88CEdyhjTnqK9tCZ2Xc9845ZQATyL5TjmmYCHUea3Q==}
+  /@fluidframework/server-lambdas/4.0.0_debug@4.3.4:
+    resolution: {integrity: sha512-htB+QpkRzzrJnKTl0MIxEiaD3d2l0fx7mUy3rQ6/oJzs1ZisD2KoTG4ZNaKmWBcBZpNwFYPdOfvfeKGCKovuHg==}
     dependencies:
       '@fluidframework/common-definitions': 1.1.0
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/gitresources': 4.0.0
+      '@fluidframework/protocol-base': 4.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas-driver': 2.0.2
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
+      '@fluidframework/server-lambdas-driver': 4.0.0
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
       '@types/semver': 7.5.6
       assert: 2.1.0
       async: 3.2.5
-      axios: 0.26.1
+      axios: 1.6.2_debug@4.3.4
       buffer: 6.0.3
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -3031,50 +2992,20 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-lambdas/2.0.2_debug@4.3.4:
-    resolution: {integrity: sha512-9hwIA/QLejMKR5SZwR6VFUlLqybVBFk2ErgwKc5FLB1L88CEdyhjTnqK9tCZ2Xc9845ZQATyL5TjmmYCHUea3Q==}
-    dependencies:
-      '@fluidframework/common-definitions': 1.1.0
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas-driver': 2.0.2
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      '@types/semver': 7.5.6
-      assert: 2.1.0
-      async: 3.2.5
-      axios: 0.26.1_debug@4.3.4
-      buffer: 6.0.3
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      json-stringify-safe: 5.0.1
-      lodash: 4.17.21
-      nconf: 0.12.1
-      semver: 7.5.4
-      sha.js: 2.4.11
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-    dev: true
-
-  /@fluidframework/server-local-server/2.0.0:
-    resolution: {integrity: sha512-Dy19eFNKaX/dXTmDzWP6FFZarLLBRFwPCo/ZC8ylsJMjr7ueU+Gw9RG00TsDKX9OKfwRz1anYBZKmiaxiMXWjQ==}
+  /@fluidframework/server-local-server/4.0.0:
+    resolution: {integrity: sha512-fHycWdu0GnP5yziN/2/l1SL3nLk82E7RwczGdhnoLEcLsZIT9paEFr0XYrNliYX9Tu82ZA1m1mHrxhAOyYHkYg==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 2.0.2_debug@4.3.4
-      '@fluidframework/server-memory-orderer': 2.0.2
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      '@fluidframework/server-test-utils': 2.0.2
+      '@fluidframework/server-lambdas': 4.0.0_debug@4.3.4
+      '@fluidframework/server-memory-orderer': 4.0.0
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
+      '@fluidframework/server-test-utils': 4.0.0
       debug: 4.3.4
       events: 3.3.0
-      jsrsasign: 10.9.0
+      jsrsasign: 11.0.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - bufferutil
@@ -3082,16 +3013,16 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/server-memory-orderer/2.0.0:
-    resolution: {integrity: sha512-5LauJcZUQ20LPVveHSBZeI1nbH/mVvCSZcN3EcqRQD+4BxGey2G7keiRvj2acsjMjD+MMNN8QQb/GM4yRT3S3g==}
+  /@fluidframework/server-memory-orderer/4.0.0:
+    resolution: {integrity: sha512-/Da91g+VnTUJu8Byp58csSRGsjLB9Ju+a0788Ag/IcwUBjYEDUWe8jlCLCdnNOScZnFW9W88R+F2RTC0LFlMOg==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/protocol-base': 4.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 2.0.2_debug@4.3.4
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
+      '@fluidframework/server-lambdas': 4.0.0_debug@4.3.4
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
       '@types/debug': 4.1.12
       '@types/double-ended-queue': 2.1.7
       '@types/lodash': 4.14.202
@@ -3111,53 +3042,25 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/server-memory-orderer/2.0.2:
-    resolution: {integrity: sha512-ft8byikNXnOV19JpaRnbMtHqQ46Kzv+Q/omFdfpoIRSZw4TlfR5esuhveHILVKLViJtU/KQR305wiDIOSk9WOw==}
+  /@fluidframework/server-routerlicious-base/4.0.0:
+    resolution: {integrity: sha512-rQTjI3lSPrSqgVooFGzMXzPCfaynbUHCTI3U5IiQ0PDpBD9BOJQsq1nj2ZxlfRRz3/HRKFn/mWlmaIUsaoROpg==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/gitresources': 4.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 2.0.2_debug@4.3.4
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      '@types/debug': 4.1.12
-      '@types/double-ended-queue': 2.1.7
-      '@types/lodash': 4.14.202
-      '@types/node': 18.19.3
-      '@types/ws': 6.0.4
-      assert: 2.1.0
-      debug: 4.3.4
-      double-ended-queue: 2.1.0-0
-      events: 3.3.0
-      lodash: 4.17.21
-      sillyname: 0.1.0
-      uuid: 9.0.1
-      ws: 7.5.9
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/server-routerlicious-base/2.0.0:
-    resolution: {integrity: sha512-4vK98dX/Vwj/dq5t0Y8HYrZaVrve1x013Qy/Jf6cXylo/Tf+TA/UNKvnPUAf4E6aARCrQ4jHiUvZbsOisds1Qw==}
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-kafka-orderer': 2.0.2
-      '@fluidframework/server-lambdas': 2.0.2
-      '@fluidframework/server-lambdas-driver': 2.0.2
-      '@fluidframework/server-memory-orderer': 2.0.2
-      '@fluidframework/server-services': 2.0.2
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-ordering-kafkanode': 2.0.2
-      '@fluidframework/server-services-ordering-rdkafka': 2.0.2
-      '@fluidframework/server-services-ordering-zookeeper': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      '@fluidframework/server-services-utils': 2.0.2
+      '@fluidframework/server-kafka-orderer': 4.0.0
+      '@fluidframework/server-lambdas': 4.0.0
+      '@fluidframework/server-lambdas-driver': 4.0.0
+      '@fluidframework/server-memory-orderer': 4.0.0
+      '@fluidframework/server-services': 4.0.0
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-ordering-kafkanode': 4.0.0
+      '@fluidframework/server-services-ordering-rdkafka': 4.0.0
+      '@fluidframework/server-services-ordering-zookeeper': 4.0.0
+      '@fluidframework/server-services-shared': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
+      '@fluidframework/server-services-utils': 4.0.0
       body-parser: 1.20.2
       bytes: 3.1.2
       compression: 1.7.4
@@ -3170,6 +3073,7 @@ packages:
       lodash: 4.17.21
       nconf: 0.12.1
       serialize-error: 8.1.0
+      sha.js: 2.4.11
       sillyname: 0.1.0
       uuid: 9.0.1
       winston: 3.9.0
@@ -3182,65 +3086,23 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/server-routerlicious-base/2.0.2:
-    resolution: {integrity: sha512-8maKG8fV+2GmHZv+6ap+hvzLKip5WfkiH+jzejzlGGu+uMtxKaFcwmQLn83DMby4oJjhJZF6L6vZhrz2yxDM2A==}
+  /@fluidframework/server-routerlicious/4.0.0:
+    resolution: {integrity: sha512-y2VREZ50RAj7/cKYSiQ4CFTcl/mdoZXBhG8tAdXfQOw7Xmsqg6O5LWTUTS+puajFO47oWofhcIQWBTtDOdKqhg==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
+      '@fluidframework/gitresources': 4.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-kafka-orderer': 2.0.2
-      '@fluidframework/server-lambdas': 2.0.2
-      '@fluidframework/server-lambdas-driver': 2.0.2
-      '@fluidframework/server-memory-orderer': 2.0.2
-      '@fluidframework/server-services': 2.0.2
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-ordering-kafkanode': 2.0.2
-      '@fluidframework/server-services-ordering-rdkafka': 2.0.2
-      '@fluidframework/server-services-ordering-zookeeper': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      '@fluidframework/server-services-utils': 2.0.2
-      body-parser: 1.20.2
-      bytes: 3.1.2
-      compression: 1.7.4
-      cookie-parser: 1.4.6
-      cors: 2.8.5
-      express: 4.19.2
-      ioredis: 5.3.2
-      json-stringify-safe: 5.0.1
-      jsonwebtoken: 9.0.2
-      lodash: 4.17.21
-      nconf: 0.12.1
-      serialize-error: 8.1.0
-      sillyname: 0.1.0
-      uuid: 9.0.1
-      winston: 3.9.0
-      ws: 7.5.9
-    transitivePeerDependencies:
-      - aws-crt
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/server-routerlicious/2.0.0:
-    resolution: {integrity: sha512-pCYr3FTQQezRflneFF6TAItXz6FhTwe6zx927gAiyj1p49QPytUh9hm0sPd8sPfXf2CpzzGm69koi3uqSpFlGw==}
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-kafka-orderer': 2.0.2
-      '@fluidframework/server-lambdas': 2.0.2
-      '@fluidframework/server-lambdas-driver': 2.0.2
-      '@fluidframework/server-memory-orderer': 2.0.2
-      '@fluidframework/server-routerlicious-base': 2.0.2
-      '@fluidframework/server-services': 2.0.2
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-shared': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      '@fluidframework/server-services-utils': 2.0.2
+      '@fluidframework/server-kafka-orderer': 4.0.0
+      '@fluidframework/server-lambdas': 4.0.0
+      '@fluidframework/server-lambdas-driver': 4.0.0
+      '@fluidframework/server-memory-orderer': 4.0.0
+      '@fluidframework/server-routerlicious-base': 4.0.0
+      '@fluidframework/server-services': 4.0.0
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-shared': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
+      '@fluidframework/server-services-utils': 4.0.0
       commander: 2.20.3
       express: 4.19.2
       ioredis: 5.3.2
@@ -3254,54 +3116,33 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/server-services-client/2.0.0:
-    resolution: {integrity: sha512-ZWk93IsE65UME7qcQMBEh7IuUwIwcI8tRjlCFvHcdptKJOOUxgAyNwWUGBvG/UL4FPJvAUg5NQdBCOu3uyBTTg==}
+  /@fluidframework/server-services-client/4.0.0:
+    resolution: {integrity: sha512-ExvztSQrliaYMSeLLxlACdWkuDk6auDle4eIQ2euvkgl0RWnupatPYgUVdfnNMIE6vBIeOwDzJaWy2giFx7Z6Q==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/gitresources': 4.0.0
+      '@fluidframework/protocol-base': 4.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      axios: 0.26.1_debug@4.3.4
+      axios: 1.6.2_debug@4.3.4
       crc-32: 1.2.0
       debug: 4.3.4
       json-stringify-safe: 5.0.1
-      jsrsasign: 10.9.0
-      jwt-decode: 3.1.2
-      querystring: 0.2.1
+      jsrsasign: 11.0.0
+      jwt-decode: 4.0.0
       sillyname: 0.1.0
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services-client/2.0.2:
-    resolution: {integrity: sha512-YbK9Hz2URRJreK1IoZZCOCFrIPNxnayIT3xbu7SfeU8nG9ui6+QyjO1WS58/oTM9+raQCmgZaIfzfENXzpVqZA==}
+  /@fluidframework/server-services-core/4.0.0:
+    resolution: {integrity: sha512-gt8GLNIDf8ZALbZGsS7WDytSLXwVPYEBCmuE+J3bikd3mItGxFhxQQI/6ZynUz/lue7GvoZtSuDyeal3DarwCQ==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/gitresources': 4.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      axios: 0.26.1_debug@4.3.4
-      crc-32: 1.2.0
-      debug: 4.3.4
-      json-stringify-safe: 5.0.1
-      jsrsasign: 10.9.0
-      jwt-decode: 3.1.2
-      querystring: 0.2.1
-      sillyname: 0.1.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/server-services-core/2.0.0:
-    resolution: {integrity: sha512-qyx2Ghu4GDSlY88NbPOAe1qPutcvv4C1QtH4SB1jkNzmqxTWJlXJl8glm+KukbjFNk+ULr7S1GYPQtD3lTafmQ==}
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
       '@types/nconf': 0.10.6
       '@types/node': 18.19.3
       debug: 4.3.4
@@ -3311,30 +3152,13 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services-core/2.0.2:
-    resolution: {integrity: sha512-k0S0h3iS3iAxxA2bRHPc+wZaSWknQbfVyA0T0SHgb3emgAC8fs10xQJPlDKEHcMv3ivSlMlUMhepHWoPZbFojw==}
+  /@fluidframework/server-services-ordering-kafkanode/4.0.0:
+    resolution: {integrity: sha512-ThfJUiLdIl+N9v2KJU+WQF7wUwIPpkQpO+KeQAfCMZg8xLTDzrSRA45FRexztXS9UKx2jnKT/g1GzY4ySGc2oA==}
     dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      '@types/nconf': 0.10.6
-      '@types/node': 18.19.3
-      debug: 4.3.4
-      events: 3.3.0
-      nconf: 0.12.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/server-services-ordering-kafkanode/2.0.0:
-    resolution: {integrity: sha512-Zwu9gHKoCdB25NWqgojGJSMtjR2sM9l0bUOggRMx4E1X+ifI1Ul6l9IOwZ6qUPOBLPHO/0gB1oKJehV80ra3HA==}
-    dependencies:
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-ordering-zookeeper': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-ordering-zookeeper': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
       events: 3.3.0
       kafka-node: 5.0.0
       nconf: 0.12.1
@@ -3343,28 +3167,13 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services-ordering-kafkanode/2.0.2:
-    resolution: {integrity: sha512-iDtKUo69fwIxaT4KtyKZF2JOQJLTTZfWGRFG8QSRigEFksgrMuhmMOXr11cppRKk0W8OpdpsC+OYvIUNxsW87w==}
-    dependencies:
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-ordering-zookeeper': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      events: 3.3.0
-      kafka-node: 5.0.0
-      nconf: 0.12.1
-      sillyname: 0.1.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/server-services-ordering-rdkafka/2.0.0:
-    resolution: {integrity: sha512-sF7Ags7y3JeKhkUje3HSU0x1c2Poeb0Kgt0jELF4Xwl37Y9s/18y3jMu07RZNOn2dTSOULqDiCDMVRU9rgUlaA==}
+  /@fluidframework/server-services-ordering-rdkafka/4.0.0:
+    resolution: {integrity: sha512-o4K+RQbAhiKjn/ZOcSnpaHwdEXPZ/k+GYWUqfjC/1v6wp/8Pb7n7O6evonkvuNxsUzwx/NMeAWou39y5Hx98qA==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
       events: 3.3.0
       nconf: 0.12.1
       node-rdkafka: 2.18.0
@@ -3373,58 +3182,36 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services-ordering-rdkafka/2.0.2:
-    resolution: {integrity: sha512-bmdwk4v9Tdw1QdyRWyEh4rinhmdP9mHk7p/9SoV9hffJ6BKgTm42eWc7zTLO12jpkIEsXxWRMsdN5sbxuF2J/Q==}
+  /@fluidframework/server-services-ordering-zookeeper/4.0.0:
+    resolution: {integrity: sha512-snj4yOeNHPLdYS6PbTsJOzV4QIYNgFbWAP2/k2fdz/xLnP3kDiGFltOa8NmxMOkkIIe8u/nKdZ5vn0jHl509yg==}
     dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      events: 3.3.0
-      nconf: 0.12.1
-      node-rdkafka: 2.18.0
-      sillyname: 0.1.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/server-services-ordering-zookeeper/2.0.0:
-    resolution: {integrity: sha512-pl+BUpakXYuEdfXKXgTNCqNd8kAlS9j0oubmBCVs/rhkXpca6yNnA9mPnjxaaDnSIySQeL2tvWbBStdvS1bHEw==}
-    dependencies:
-      '@fluidframework/server-services-core': 2.0.2
+      '@fluidframework/server-services-core': 4.0.0
       zookeeper: 5.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services-ordering-zookeeper/2.0.2:
-    resolution: {integrity: sha512-P7os2kHfgvR6zT3Qi5TdyYo8wmUxwekWp9WAs1jdMozOYcN0/FAHHZo/Jyzno5rXdZzeVuNtORmikx4cVZlztA==}
-    dependencies:
-      '@fluidframework/server-services-core': 2.0.2
-      zookeeper: 5.6.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/server-services-shared/2.0.0:
-    resolution: {integrity: sha512-wqs5ALcPWocNSRmunmGCGtQ684l31cZR+BKvPNBpL5NXuAEbljIzg4FDdsvQiZlzdj1wUe6VzXkR5Nz9RxoSIg==}
+  /@fluidframework/server-services-shared/4.0.0:
+    resolution: {integrity: sha512-R2HpaqcESJFekx5WMB9oh02j89yP+6IVye6hcp4L6potwMV/SCjuntX+tUAFaK/lUHIxTcI0wtkXJypHe+rAXw==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/gitresources': 4.0.0
+      '@fluidframework/protocol-base': 4.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
+      '@fluidframework/server-services-utils': 4.0.0
       '@socket.io/redis-adapter': 7.2.0
+      '@socket.io/sticky': 1.0.4
       body-parser: 1.20.2
       debug: 4.3.4
       events: 3.3.0
+      fast-redact: 3.3.0
       ioredis: 5.3.2
       lodash: 4.17.21
       nconf: 0.12.1
       notepack.io: 2.3.0
-      querystring: 0.2.1
       serialize-error: 8.1.0
       socket.io: 4.7.2
       socket.io-adapter: 2.5.2
@@ -3437,39 +3224,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/server-services-shared/2.0.2:
-    resolution: {integrity: sha512-vpts9M258nKmGLOBtVvUkeGi8+xLHi/yxA5ZnQEeUJMYbufYeXb3f1koSfJVxIK0dDNZ6yeLhcX9/N4PECP2Ng==}
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      '@socket.io/redis-adapter': 7.2.0
-      body-parser: 1.20.2
-      debug: 4.3.4
-      events: 3.3.0
-      ioredis: 5.3.2
-      lodash: 4.17.21
-      nconf: 0.12.1
-      notepack.io: 2.3.0
-      querystring: 0.2.1
-      serialize-error: 8.1.0
-      socket.io: 4.7.2
-      socket.io-adapter: 2.5.2
-      socket.io-parser: 4.2.4
-      uuid: 9.0.1
-      winston: 3.9.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/server-services-telemetry/2.0.0:
-    resolution: {integrity: sha512-sKDBO2sYxMn0pEn673HL/aXeWJzxZjXTUGgY5337EzZ7f1U06EA4pKLm1s59QPPaVNQ0lBhqwANwVgvKfQc4cA==}
+  /@fluidframework/server-services-telemetry/4.0.0:
+    resolution: {integrity: sha512-EK3+l1a2x4rOwBr688h3DqGrDmgJnv6kYxHKaoxJ9gVPXgg866m2ajEU75IvneqOyomqUINE2oZOrRqjdvJR1Q==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       json-stringify-safe: 5.0.1
@@ -3478,23 +3234,13 @@ packages:
       uuid: 9.0.1
     dev: true
 
-  /@fluidframework/server-services-telemetry/2.0.2:
-    resolution: {integrity: sha512-HcuO2YcubWhMlnQ/dPI9VwoXtulZuq794slj4oY6Tjm54ZbDF8S1eVqORRDr2RGBgeMOQ7rdNGsWYe0cz4XPGw==}
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      json-stringify-safe: 5.0.1
-      path-browserify: 1.0.1
-      serialize-error: 8.1.0
-      uuid: 9.0.1
-    dev: true
-
-  /@fluidframework/server-services-utils/2.0.0:
-    resolution: {integrity: sha512-EG/t7WtEpOJfROUJzTz34skLDSYlsYbJvW20+4xYPY1olO39YXugHOTf78HRVel7OnMUjPVwgL3Zws3Oj5XojA==}
+  /@fluidframework/server-services-utils/4.0.0:
+    resolution: {integrity: sha512-Lo4RTPZ0GDtz0ul69VRHhiWE/ZGfbPWPZp9Kqwh0nsv/tAzxd3lWCdxZjhPegHtCEWzAxDBzOhPP1muKhLMWDQ==}
     dependencies:
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
       debug: 4.3.4
       express: 4.19.2
       ioredis: 5.3.2
@@ -3512,124 +3258,50 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services-utils/2.0.2:
-    resolution: {integrity: sha512-0oADQbRJl/5TtrinRh7N1ttFtn+E6NouB0TZceuC90sJVnGBDiyzffZyDdiFTDfOGi3EcEpMiyUP1cOJsPZGvg==}
-    dependencies:
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      debug: 4.3.4
-      express: 4.19.2
-      ioredis: 5.3.2
-      json-stringify-safe: 5.0.1
-      jsonwebtoken: 9.0.2
-      morgan: 1.10.0
-      nconf: 0.12.1
-      serialize-error: 8.1.0
-      sillyname: 0.1.0
-      split: 1.0.1
-      uuid: 9.0.1
-      winston: 3.9.0
-      winston-transport: 4.6.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@fluidframework/server-services/2.0.0:
-    resolution: {integrity: sha512-viIDTqmDPl0RnEsEpY7DWTDCzjjbUnfLlsXqWsOg4LRA1h8alf1MhoJtKouKYwX4lEXpGXrqEABl5bKbllg+3Q==}
+  /@fluidframework/server-services/4.0.0:
+    resolution: {integrity: sha512-8ZyrPlOXdL19+O5rvPkuahnQaQDyBb/eXTLS1UyEy8EQNJaWslHnXgU6xnXOyy/JsBHnowF8wqMyXXqcEj2OwQ==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-ordering-kafkanode': 2.0.2
-      '@fluidframework/server-services-ordering-rdkafka': 2.0.2
-      '@fluidframework/server-services-shared': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      '@fluidframework/server-services-utils': 2.0.2
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-ordering-kafkanode': 4.0.0
+      '@fluidframework/server-services-ordering-rdkafka': 4.0.0
+      '@fluidframework/server-services-shared': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
+      '@fluidframework/server-services-utils': 4.0.0
       '@socket.io/redis-emitter': 4.1.1
+      '@types/lodash': 4.14.202
       amqplib: 0.10.3
-      axios: 0.26.1_debug@4.3.4
+      axios: 1.6.2_debug@4.3.4
       debug: 4.3.4
       events: 3.3.0
       ioredis: 5.3.2
-      lru-cache: 6.0.0
-      mongodb: 4.17.0
-      nconf: 0.12.1
-      socket.io: 4.7.2
-      telegrafjs: 0.1.3
-      uuid: 9.0.1
-      winston: 3.9.0
-    transitivePeerDependencies:
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/server-services/2.0.2:
-    resolution: {integrity: sha512-pWsH2uX+iSz2wvlPYXL+plto4YrZDi7dNWDcpuwmKM+DMSpqGIRfE60xGQ1LDQKBl2XspngEULnJJP7H0DN/4A==}
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-ordering-kafkanode': 2.0.2
-      '@fluidframework/server-services-ordering-rdkafka': 2.0.2
-      '@fluidframework/server-services-shared': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      '@fluidframework/server-services-utils': 2.0.2
-      '@socket.io/redis-emitter': 4.1.1
-      amqplib: 0.10.3
-      axios: 0.26.1_debug@4.3.4
-      debug: 4.3.4
-      events: 3.3.0
-      ioredis: 5.3.2
-      lru-cache: 6.0.0
-      mongodb: 4.17.0
-      nconf: 0.12.1
-      socket.io: 4.7.2
-      telegrafjs: 0.1.3
-      uuid: 9.0.1
-      winston: 3.9.0
-    transitivePeerDependencies:
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@fluidframework/server-test-utils/2.0.0:
-    resolution: {integrity: sha512-/u5lH/yxS+aJHZGsLsvb2VSrmNAeBRw4B3gGCvl3cE48YQtuXSj2VKNuE7Xs0GrvQzMaKW9UHDpL1FiYJHKRDg==}
-    dependencies:
-      '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-base': 2.0.2
-      '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
-      assert: 2.1.0
-      debug: 4.3.4
-      events: 3.3.0
       lodash: 4.17.21
-      string-hash: 1.1.3
+      lru-cache: 6.0.0
+      mongodb: 4.17.1
+      nconf: 0.12.1
+      socket.io: 4.7.2
+      telegrafjs: 0.1.3
       uuid: 9.0.1
+      winston: 3.9.0
     transitivePeerDependencies:
+      - aws-crt
+      - bufferutil
       - supports-color
+      - utf-8-validate
     dev: true
 
-  /@fluidframework/server-test-utils/2.0.2:
-    resolution: {integrity: sha512-1J6jWpkJbi72qTKhHIoLHmHyjnvV2RGQEtBYRofkGW59zoW5g/4Z19duv4XNLMPf/L+PxYjyaln0JWYaXHygXA==}
+  /@fluidframework/server-test-utils/4.0.0:
+    resolution: {integrity: sha512-tygY1aWGswuY0qWJ3EOk4HlWjuCSiyPJu6OQNlSzzT50B43Ku146MQe8WdTdWmxxgQjk+/R5BPLxrCugu74LJw==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 2.0.2
-      '@fluidframework/protocol-base': 2.0.2
+      '@fluidframework/gitresources': 4.0.0
+      '@fluidframework/protocol-base': 4.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 2.0.2
-      '@fluidframework/server-services-core': 2.0.2
-      '@fluidframework/server-services-telemetry': 2.0.2
+      '@fluidframework/server-services-client': 4.0.0
+      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-telemetry': 4.0.0
       assert: 2.1.0
       debug: 4.3.4
       events: 3.3.0
@@ -5774,7 +5446,6 @@ packages:
 
   /@socket.io/sticky/1.0.4:
     resolution: {integrity: sha512-VuauT5CJLvzYtKIgouFSQ8rUaygseR+zRutnwh6ZA2QYcXx+8g52EoJ8V2SLxfo+Tfs3ELUDy08oEXxlWNrxaw==}
-    dev: false
 
   /@szmarczak/http-timer/1.1.2:
     resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==}
@@ -7197,22 +6868,6 @@ packages:
       is-buffer: 2.0.5
     dev: true
 
-  /axios/0.26.1:
-    resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
-    dependencies:
-      follow-redirects: 1.15.3
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
-  /axios/0.26.1_debug@4.3.4:
-    resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
-    dependencies:
-      follow-redirects: 1.15.3_debug@4.3.4
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
   /axios/1.6.2:
     resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
     dependencies:
@@ -7221,7 +6876,6 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
-    dev: false
 
   /axios/1.6.2_debug@4.3.4:
     resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
@@ -9759,7 +9413,6 @@ packages:
   /fast-redact/3.3.0:
     resolution: {integrity: sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==}
     engines: {node: '>=6'}
-    dev: false
 
   /fast-xml-parser/4.2.5:
     resolution: {integrity: sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==}
@@ -11536,13 +11189,8 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /jsrsasign/10.9.0:
-    resolution: {integrity: sha512-QWLUikj1SBJGuyGK8tjKSx3K7Y69KYJnrs/pQ1KZ6wvZIkHkWjZ1PJDpuvc1/28c1uP0KW9qn1eI1LzHQqDOwQ==}
-    dev: true
-
   /jsrsasign/11.0.0:
     resolution: {integrity: sha512-BtRwVKS+5dsgPpAtzJcpo5OoWjSs1/zllSBG0+8o8/aV0Ki76m6iZwHnwnsqoTdhfFZDN1XIdcaZr5ZkP+H2gg==}
-    dev: false
 
   /jssm/5.89.2:
     resolution: {integrity: sha512-I70+UdH7KZs542loBlsh1xKDsT5Lx5RZWf6hKmujzgvSJj9DRymEe46HUCTd6+hzouIebuNwQo5I2ftMzfrhnQ==}
@@ -11595,14 +11243,9 @@ packages:
       jwa: 1.4.1
       safe-buffer: 5.2.1
 
-  /jwt-decode/3.1.2:
-    resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
-    dev: true
-
   /jwt-decode/4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
-    dev: false
 
   /kafka-node/5.0.0:
     resolution: {integrity: sha512-dD2ga5gLcQhsq1yNoQdy1MU4x4z7YnXM5bcG9SdQuiNr5KKuAmXixH1Mggwdah5o7EfholFbcNDPSVA6BIfaug==}
@@ -12541,20 +12184,6 @@ packages:
       '@types/whatwg-url': 8.2.2
       whatwg-url: 11.0.0
 
-  /mongodb/4.17.0:
-    resolution: {integrity: sha512-LZGMIPjPfWEfhPJATk1s9IvVTD18tyfKdT/0blCMih5vGagk2SwA9wFAUPMdtJpTrhXmyfGgwAaMkvneX2bn2A==}
-    engines: {node: '>=12.9.0'}
-    dependencies:
-      bson: 4.7.2
-      mongodb-connection-string-url: 2.6.0
-      socks: 2.7.1
-    optionalDependencies:
-      '@aws-sdk/credential-providers': 3.470.0
-      '@mongodb-js/saslprep': 1.1.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: true
-
   /mongodb/4.17.1:
     resolution: {integrity: sha512-MBuyYiPUPRTqfH2dV0ya4dcr2E5N52ocBuZ8Sgg/M030nGF78v855B3Z27mZJnp8PxjnUquEnAtjOsphgMZOlQ==}
     engines: {node: '>=12.9.0'}
@@ -12567,7 +12196,6 @@ packages:
       '@mongodb-js/saslprep': 1.1.1
     transitivePeerDependencies:
       - aws-crt
-    dev: false
 
   /morgan/1.10.0:
     resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}
@@ -14259,12 +13887,6 @@ packages:
 
   /querystring/0.2.0:
     resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
-    engines: {node: '>=0.4.x'}
-    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
-    dev: true
-
-  /querystring/0.2.1:
-    resolution: {integrity: sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==}
     engines: {node: '>=0.4.x'}
     deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
     dev: true


### PR DESCRIPTION
## Description

Type tests were still using the 2.0 release of server as reference instead of 4.0. Updated them using `npx flub typetests -v -p --reset --releaseGroup=server` from `server/routerlicious` and then updated the "broken" section of package.json files as necessary to get the tests to pass, and reverting the changes to tinylicious' package.json (updated by the command to use type-tests; it doesn't have any today, and adding them to it is not part of this PRs purpose).

This gets rid of several older dependencies in the server/routerlicious lockfile (e.g. axios 0.26.1), which will contribute towards Component Governance not flagging our pipeline runs for referencing deps with CVEs.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
