### PR TITLE
tree: Remove need for demandSpine

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -80,6 +80,7 @@ export interface AnchorLocator {
 
 // @internal
 export interface AnchorNode extends UpPath<AnchorNode>, ISubscribable<AnchorEvents> {
+    readonly anchorSet: AnchorSet;
     child(key: FieldKey, index: number): UpPath<AnchorNode>;
     getOrCreateChildRef(key: FieldKey, index: number): [Anchor, AnchorNode];
     readonly slots: BrandedMapSubset<AnchorSlot<any>>;

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -199,6 +199,11 @@ export interface AnchorNode extends UpPath<AnchorNode>, ISubscribable<AnchorEven
 	readonly slots: BrandedMapSubset<AnchorSlot<any>>;
 
 	/**
+	 * The set this anchor is part of.
+	 */
+	readonly anchorSet: AnchorSet;
+
+	/**
 	 * Gets a child of this node.
 	 *
 	 * @remarks

--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -199,7 +199,7 @@ export interface AnchorNode extends UpPath<AnchorNode>, ISubscribable<AnchorEven
 	readonly slots: BrandedMapSubset<AnchorSlot<any>>;
 
 	/**
-	 * The set this anchor is part of.
+	 * The set this anchor node is part of.
 	 */
 	readonly anchorSet: AnchorSet;
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/context.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/context.ts
@@ -10,6 +10,7 @@ import {
 	ForestEvents,
 	IForestSubscription,
 	TreeFieldStoredSchema,
+	anchorSlot,
 	moveToDetachedField,
 } from "../../core/index.js";
 import { ISubscribable } from "../../events/index.js";
@@ -54,6 +55,15 @@ export interface FlexTreeContext extends ISubscribable<ForestEvents> {
 }
 
 /**
+ * Creating multiple flex tree contexts for the same branch, and thus with the same underlying AnchorSet does not work due to how TreeNode caching works.
+ * This slot is used to detect if one already exists and error if creating a second.
+ *
+ * TODO:
+ * 1. API docs need to reflect this limitation or the limitation has to be removed.
+ */
+export const ContextSlot = anchorSlot<Context>();
+
+/**
  * Implementation of `FlexTreeContext`.
  *
  * @remarks An editor is required to edit the FlexTree.
@@ -84,6 +94,12 @@ export class Context implements FlexTreeContext, IDisposable {
 				this.prepareForEdit();
 			}),
 		];
+
+		assert(
+			!this.forest.anchors.slots.has(ContextSlot),
+			"Cannot create second flex-tree from checkout",
+		);
+		this.forest.anchors.slots.set(ContextSlot, this);
 	}
 
 	/**
@@ -106,6 +122,9 @@ export class Context implements FlexTreeContext, IDisposable {
 			unregister();
 		}
 		this.eventUnregister.length = 0;
+
+		const deleted = this.forest.anchors.slots.delete(ContextSlot);
+		assert(deleted, 0x8c4 /* unexpected dispose */);
 	}
 
 	/**

--- a/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
@@ -45,7 +45,7 @@ export {
 	visitIterableTreeWithState,
 } from "./navigation.js";
 
-export { getTreeContext, FlexTreeContext, Context } from "./context.js";
+export { getTreeContext, FlexTreeContext, Context, ContextSlot } from "./context.js";
 
 export { TreeEvent, FlexTreeNodeEvents } from "./treeEvents.js";
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -76,6 +76,9 @@ import { FlexTreeNodeEvents, TreeEvent } from "./treeEvents.js";
 import { unboxedField } from "./unboxed.js";
 import { treeStatusFromAnchorCache } from "./utilities.js";
 
+/**
+ * @param cursor - This does not take ownership of this cursor: Node will fork it as needed.
+ */
 export function makeTree(context: Context, cursor: ITreeSubscriptionCursor): LazyTreeNode {
 	const anchor = cursor.buildAnchor();
 	const anchorNode =

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -253,6 +253,7 @@ export {
 	FlexTreeNodeEvents,
 	FlexTreeUnknownUnboxed,
 	isFlexTreeNode,
+	ContextSlot,
 
 	// Internal
 	FlexTreeTypedFieldInner,

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -6,13 +6,14 @@
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { AllowedUpdateType, Compatibility, FieldKey, anchorSlot } from "../core/index.js";
+import { AllowedUpdateType, Compatibility, FieldKey } from "../core/index.js";
 import { HasListeners, IEmitter, ISubscribable, createEmitter } from "../events/index.js";
 import {
 	FlexFieldSchema,
 	NodeKeyManager,
 	ViewSchema,
 	defaultSchemaPolicy,
+	ContextSlot,
 } from "../feature-libraries/index.js";
 import {
 	ImplicitFieldSchema,
@@ -229,15 +230,6 @@ export class SchematizeError implements SchemaIncompatible {
 }
 
 /**
- * Creating multiple flex tree contexts for the same branch, and thus with the same underlying AnchorSet does not work due to how TreeNode caching works.
- * This slot is used to detect if one already exists and error if creating a second.
- *
- * TODO:
- * 1. API docs need to reflect this limitation or the limitation has to be removed.
- */
-const ViewSlot = anchorSlot<CheckoutFlexTreeView<any>>();
-
-/**
  * Flex-Tree schematizing layer.
  * Creates a view that self-disposes when stored schema becomes incompatible.
  * This may only be called when the schema is already known to be compatible (typically via ensureSchema).
@@ -250,7 +242,7 @@ export function requireSchema<TRoot extends FlexFieldSchema>(
 	nodeKeyFieldKey: FieldKey,
 ): CheckoutFlexTreeView<TRoot> {
 	const slots = checkout.forest.anchors.slots;
-	assert(!slots.has(ViewSlot), 0x8c2 /* Cannot create second view from checkout */);
+	assert(!slots.has(ContextSlot), 0x8c2 /* Cannot create second view from checkout */);
 
 	{
 		const compatibility = viewSchema.checkCompatibility(checkout.storedSchema);
@@ -266,14 +258,9 @@ export function requireSchema<TRoot extends FlexFieldSchema>(
 		viewSchema.schema,
 		nodeKeyManager,
 		nodeKeyFieldKey,
-		() => {
-			const deleted = slots.delete(ViewSlot);
-			assert(deleted, 0x8c4 /* unexpected dispose */);
-			onDispose();
-		},
+		onDispose,
 	);
-	assert(!slots.has(ViewSlot), 0x8c5 /* Cannot create second view from checkout */);
-	slots.set(ViewSlot, view);
+	assert(slots.has(ContextSlot), "Context should be tracked in slot");
 
 	const unregister = checkout.storedSchema.on("afterSchemaChange", () => {
 		const compatibility = viewSchema.checkCompatibility(checkout.storedSchema);

--- a/packages/dds/tree/src/simple-tree/ProxyBinding.md
+++ b/packages/dds/tree/src/simple-tree/ProxyBinding.md
@@ -21,7 +21,7 @@ function addPoint(curve: Curve, x: number, y: number): Point {
 ## Implementation
 
 This feature is supported by doing some bookkeeping to ensure that the proxy objects,
-flex nodes and anchor nodes in the tree get associated and disassociated at the right times.
+flex tree nodes and anchor nodes in the tree get associated and disassociated at the right times.
 There are three states that a node proxy can be in: "raw", "marinated" and "cooked".
 
 ### Raw Proxies
@@ -79,9 +79,8 @@ This laziness prevents the proxy tree from generating unnecessary `FlexTreeNodes
 Cooking a marinated proxy works as follows:
 
 1. Get the `AnchorNode` associated with the marinated proxy.
-2. Walk up the `AnchorNode` ancestry (parent-by-parent) until an `AnchorNode` is found which already has a corresponding `FlexTreeNode`
-3. Walk back down the same path that was walked up in step 2, but this time via the `FlexTreeNode`s.
-   This will cause the `FlexTreeNode`s all along the way to be generated, down to and including the original target node.
+2. Get or create a `FlexTreeNode` for the anchor.
+3. This will cause the `FlexTreeNode` to be generated which corresponds to the proxy.
 
 ### Mappings
 

--- a/packages/dds/tree/src/simple-tree/proxyBinding.ts
+++ b/packages/dds/tree/src/simple-tree/proxyBinding.ts
@@ -7,6 +7,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 
 import { AnchorNode, AnchorSet, UpPath, anchorSlot } from "../core/index.js";
 import {
+	ContextSlot,
 	FlexFieldNodeSchema,
 	FlexMapNodeSchema,
 	FlexObjectNodeSchema,
@@ -18,11 +19,13 @@ import {
 	flexTreeSlot,
 } from "../feature-libraries/index.js";
 import { fail } from "../util/index.js";
-
 import { RawTreeNode } from "./rawNode.js";
 import { TreeMapNode } from "./schemaTypes.js";
 import { TreeArrayNode } from "./treeArrayNode.js";
 import { TreeNode, TypedNode } from "./types.js";
+// TODO: decide how to deal with dependencies on flex-tree implementation.
+// eslint-disable-next-line import/no-internal-modules
+import { makeTree } from "../feature-libraries/flex-tree/lazyNode.js";
 
 // This file contains various maps and helpers for supporting proxy binding (a.k.a. proxy hydration).
 // See ./ProxyBinding.md for a high-level overview of the process.
@@ -93,8 +96,12 @@ export function getFlexNode(proxy: TreeNode, allowFreed = false): FlexTreeNode {
 		const flexNode = anchorNode.slots.get(flexTreeSlot);
 		if (flexNode !== undefined) {
 			return flexNode; // If it does have a flex node, return it...
-		} // ...otherwise, the flex node must be created by walking downwards from an existing ancestor
-		const newFlexNode = demandSpine(anchorNode);
+		} // ...otherwise, the flex node must be created
+		const context = anchorNode.anchorSet.slots.get(ContextSlot) ?? fail("missing context");
+		const cursor = context.forest.allocateCursor();
+		context.forest.moveCursorToPath(anchorNode, cursor);
+		const newFlexNode = makeTree(context, cursor);
+		cursor.free();
 		// Calling this is a performance improvement, however, do this only after demand to avoid momentarily having no anchors to anchorNode
 		anchorForgetters?.get(proxy)?.();
 		if (!allowFreed) {
@@ -104,60 +111,6 @@ export function getFlexNode(proxy: TreeNode, allowFreed = false): FlexTreeNode {
 	}
 
 	return proxyToRawFlexNode.get(proxy) ?? fail("Expected raw tree node for proxy");
-}
-
-/**
- * Walks up from the given anchor node until an anchor node that has an associated flex node is found.
- * Then, walks back down from that flex node so as to cause the original anchor node to generate a flex node.
- * Fails if there is no ancestor of `anchorNode` bound to a flex node.
- *
- * TODO:
- * Its practical to construct the desired flex-tree node without constructing the spine to it.
- * For example makeTree in lazyNode can do it from a cursor and a context.
- * flex-tree currently doesn't expose a public API for this, but depending on it being lazy tree could make it possible, or the API could be changed.
- *
- * TODO:
- * Its not clear that there always will be an existing flex-tree node above the desired node.
- * If the desired node is a root (main document root or a removed root) for example, this would fail.
- * Avoiding the spine walking (see above) would remove these edge cases and improve performance.
- */
-function demandSpine(node: AnchorNode): FlexTreeNode {
-	const spine = getAnchorNodeSpine(node);
-	const parentAnchorNode = spine[spine.length - 1];
-	let flexTreeNode =
-		parentAnchorNode.slots.get(flexTreeSlot) ?? fail("Expected flex tree for anchor node");
-
-	for (let i = spine.length - 2; i >= 0; i--) {
-		const child = spine[i];
-
-		const childField =
-			flexTreeNode.tryGetField(child.parentField) ??
-			fail("Expected child to be under non-empty field");
-
-		flexTreeNode =
-			childField.boxedAt(child.parentIndex) ?? fail("Expected child to be in range");
-	}
-	return spine[0].slots.get(flexTreeSlot) ?? fail("Failed to demand flex node");
-}
-
-/**
- * Returns the ancestry of the given anchor node up to the first node which is bound to a flex node.
- * For example, given `node`, it might return:
- * ```
- * [node, nodeParent, nodeGrandparent, nodeGreatGrandparent]
- *   ^-------^-- no flex nodes --^       ^-- has a flex node
- * ```
- */
-function getAnchorNodeSpine(node: AnchorNode): readonly AnchorNode[] {
-	const spine: AnchorNode[] = [node];
-	while (spine[spine.length - 1].slots.get(flexTreeSlot) === undefined) {
-		const parent =
-			spine[spine.length - 1].parent ??
-			fail("Failed to hydrate proxy: tree root is unhydrated");
-
-		spine.push(parent);
-	}
-	return spine;
 }
 
 /**

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -674,7 +674,12 @@ export function checkoutWithContent(
 			HasListeners<CheckoutEvents>;
 	},
 ): TreeCheckout {
-	return flexTreeViewWithContent(content, args).checkout;
+	const forest = forestWithContent(content);
+	return createTreeCheckout(testIdCompressor, mintRevisionTag, testRevisionTagCodec, {
+		...args,
+		forest,
+		schema: new TreeStoredSchemaRepository(intoStoredSchema(content.schema)),
+	});
 }
 
 export function flexTreeViewWithContent<TRoot extends FlexFieldSchema>(
@@ -687,12 +692,7 @@ export function flexTreeViewWithContent<TRoot extends FlexFieldSchema>(
 		nodeKeyFieldKey?: FieldKey;
 	},
 ): CheckoutFlexTreeView<TRoot> {
-	const forest = forestWithContent(content);
-	const view = createTreeCheckout(testIdCompressor, mintRevisionTag, testRevisionTagCodec, {
-		...args,
-		forest,
-		schema: new TreeStoredSchemaRepository(intoStoredSchema(content.schema)),
-	});
+	const view = checkoutWithContent(content, args);
 	return new CheckoutFlexTreeView(
 		view,
 		content.schema,


### PR DESCRIPTION
## Description

Switch to store flex-tree context instead of view on anchorset slot: this avoids dependency issues when simple-tree wants to look up the context while also making more cases benefit from the multi-context detection asserts.

Allow getting the AnchorSet from an AnchorNode.

Use AnchorNode to get AnchorSet to get Context in proxy binder to remove the need to walk the spine.
This depends on makeTree from the flex tree implementation, which is not ideal, but proxy.ts already does this pattern, and there isn't anything wrong particularly harmful about it unless we add multiple flex-tree implementations  and if we did, however the correct one is selected would have to be used there.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

