### PR TITLE
tree: Reduce use of Field Nodes in simple-tree

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -726,6 +726,7 @@ export interface FlexTreeNode extends FlexTreeEntity<FlexTreeNodeSchema> {
     readonly anchorNode: AnchorNode;
     // (undocumented)
     boxedIterator(): IterableIterator<FlexTreeField>;
+    getBoxed(key: FieldKey): FlexTreeField;
     is<TSchema extends FlexTreeNodeSchema>(schema: TSchema): this is FlexTreeTypedNode<TSchema>;
     on<K extends keyof FlexTreeNodeEvents>(eventName: K, listener: FlexTreeNodeEvents[K]): () => void;
     readonly parentField: {
@@ -1479,7 +1480,7 @@ export const reservedObjectNodeFieldPropertyNamePrefixes: readonly ["set", "boxe
 export type ReservedObjectNodeFieldPropertyNames = (typeof reservedObjectNodeFieldPropertyNames)[number];
 
 // @internal
-export const reservedObjectNodeFieldPropertyNames: readonly ["anchorNode", "constructor", "context", "is", "on", "parentField", "schema", "treeStatus", "tryGetField", "type", "value", "localNodeKey", "boxedIterator", "iterator"];
+export const reservedObjectNodeFieldPropertyNames: readonly ["anchorNode", "constructor", "context", "is", "on", "parentField", "schema", "treeStatus", "tryGetField", "type", "value", "localNodeKey", "boxedIterator", "iterator", "getBoxed"];
 
 // @public
 export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -173,6 +173,17 @@ export interface FlexTreeNode extends FlexTreeEntity<FlexTreeNodeSchema> {
 	tryGetField(key: FieldKey): undefined | FlexTreeField;
 
 	/**
+	 * Get the field for `key`.
+	 * @param key - which entry to look up.
+	 *
+	 * @remarks
+	 * All fields implicitly exist, so `getBoxed` can be called with any key and will always return a field.
+	 * Even if the field is empty, it will still be returned, and can be edited to insert content if allowed by the field kind.
+	 * See {@link FlexTreeNode.tryGetField} for a variant that does not allocate afield in the empty case.
+	 */
+	getBoxed(key: FieldKey): FlexTreeField;
+
+	/**
 	 * The field this tree is in, and the index within that field.
 	 */
 	readonly parentField: { readonly parent: FlexTreeField; readonly index: number };
@@ -592,6 +603,7 @@ export const reservedObjectNodeFieldPropertyNames = [
 	"localNodeKey",
 	"boxedIterator",
 	"iterator",
+	"getBoxed",
 ] as const;
 
 /**

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -201,6 +201,12 @@ export abstract class LazyTreeNode<TSchema extends FlexTreeNodeSchema = FlexTree
 		});
 	}
 
+	public getBoxed(key: FieldKey): FlexTreeField {
+		return inCursorField(this[cursorSymbol], brand(key), (cursor) =>
+			makeField(this.context, this.schema.getFieldSchema(key), cursor),
+		);
+	}
+
 	public boxedIterator(): IterableIterator<FlexTreeField> {
 		return mapCursorFields(this[cursorSymbol], (cursor) =>
 			makeField(this.context, this.schema.getFieldSchema(cursor.getFieldKey()), cursor),
@@ -403,10 +409,8 @@ export class LazyMap<TSchema extends FlexMapNodeSchema>
 		) as FlexTreeUnboxField<TSchema["info"]>;
 	}
 
-	public getBoxed(key: string): FlexTreeTypedField<TSchema["info"]> {
-		return inCursorField(this[cursorSymbol], brand(key), (cursor) =>
-			makeField(this.context, this.schema.info, cursor),
-		) as FlexTreeTypedField<TSchema["info"]>;
+	public override getBoxed(key: string): FlexTreeTypedField<TSchema["info"]> {
+		return super.getBoxed(brand(key)) as FlexTreeTypedField<TSchema["info"]>;
 	}
 
 	public set(key: string, content: FlexibleFieldContent<TSchema["info"]> | undefined): void {

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -230,8 +230,11 @@ export function createObjectProxy<TSchema extends FlexObjectNodeSchema>(
 /**
  * Given a array node proxy, returns its underlying LazySequence field.
  */
-export const getSequenceField = <TTypes extends FlexAllowedTypes>(arrayNode: TreeArrayNode) =>
-	getFlexNode(arrayNode).content as FlexTreeSequenceField<TTypes>;
+export function getSequenceField<TTypes extends FlexAllowedTypes>(
+	arrayNode: TreeArrayNode,
+): FlexTreeSequenceField<TTypes> {
+	return getFlexNode(arrayNode).getBoxed(EmptyKey) as FlexTreeSequenceField<TTypes>;
+}
 
 // Used by 'insert*()' APIs to converts new content (expressed as a proxy union) to contextually
 // typed data prior to forwarding to 'LazySequence.insert*()'.

--- a/packages/dds/tree/src/simple-tree/proxyBinding.ts
+++ b/packages/dds/tree/src/simple-tree/proxyBinding.ts
@@ -7,10 +7,9 @@ import { assert } from "@fluidframework/core-utils/internal";
 
 import { AnchorNode, AnchorSet, UpPath, anchorSlot } from "../core/index.js";
 import {
-	FlexFieldNodeSchema,
+	FlexTreeNodeSchema,
 	FlexMapNodeSchema,
 	FlexObjectNodeSchema,
-	FlexTreeFieldNode,
 	FlexTreeMapNode,
 	FlexTreeNode,
 	FlexTreeObjectNode,
@@ -44,7 +43,7 @@ const proxyToAnchorNode = new WeakMap<TreeNode, AnchorNode>();
  * The raw node exists when the proxy is first created but before it has been associated with a real {@link FlexTreeNode}.
  * For example, after a user calls `const proxy = new Foo({})` but before `proxy` is inserted into the tree and queried.
  */
-const proxyToRawFlexNode = new WeakMap<TreeNode, RawTreeNode<FlexFieldNodeSchema, unknown>>();
+const proxyToRawFlexNode = new WeakMap<TreeNode, RawTreeNode<FlexTreeNodeSchema, unknown>>();
 /** Used by `anchorProxy` as an optimization to ensure that only one anchor is remembered at a time for a given anchor node */
 const anchorForgetters = new WeakMap<TreeNode, () => void>();
 
@@ -77,10 +76,7 @@ export function getFlexNode(
 	proxy: TypedNode<FlexObjectNodeSchema>,
 	allowFreed?: true,
 ): FlexTreeObjectNode;
-export function getFlexNode(
-	proxy: TreeArrayNode,
-	allowFreed?: true,
-): FlexTreeFieldNode<FlexFieldNodeSchema>;
+export function getFlexNode(proxy: TreeArrayNode, allowFreed?: true): FlexTreeNode;
 export function getFlexNode(
 	proxy: TreeMapNode,
 	allowFreed?: true,

--- a/packages/dds/tree/src/simple-tree/rawNode.ts
+++ b/packages/dds/tree/src/simple-tree/rawNode.ts
@@ -113,6 +113,10 @@ export abstract class RawTreeNode<TSchema extends FlexTreeNodeSchema, TContent>
 		throw rawError("Reading fields");
 	}
 
+	public getBoxed(key: string): never {
+		throw rawError("Reading boxed fields");
+	}
+
 	public boxedIterator(): IterableIterator<FlexTreeField> {
 		throw rawError("Boxed iteration");
 	}
@@ -163,9 +167,6 @@ export class RawMapNode<TSchema extends FlexMapNodeSchema>
 	}
 	public get(key: string): FlexTreeUnboxField<TSchema["info"]> {
 		return this[nodeContent].get(key) as FlexTreeUnboxField<TSchema["info"]>;
-	}
-	public getBoxed(key: string): FlexTreeTypedField<TSchema["info"]> {
-		throw rawError("Reading boxed map values");
 	}
 	public keys(): IterableIterator<FieldKey> {
 		return this[nodeContent].keys() as IterableIterator<FieldKey>;

--- a/packages/dds/tree/src/simple-tree/types.ts
+++ b/packages/dds/tree/src/simple-tree/types.ts
@@ -3,11 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	FlexFieldNodeSchema,
-	FlexMapNodeSchema,
-	FlexObjectNodeSchema,
-} from "../feature-libraries/index.js";
+import { FlexTreeNodeSchema } from "../feature-libraries/index.js";
 
 import { WithType, type } from "./schemaTypes.js";
 import { IterableTreeArrayContent } from "./treeArrayNode.js";
@@ -238,6 +234,4 @@ export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 /**
  * Given a node's schema, return the corresponding object in the proxy-based API.
  */
-export type TypedNode<
-	TSchema extends FlexObjectNodeSchema | FlexFieldNodeSchema | FlexMapNodeSchema,
-> = TreeNode & WithType<TSchema["name"]>;
+export type TypedNode<TSchema extends FlexTreeNodeSchema> = TreeNode & WithType<TSchema["name"]>;


### PR DESCRIPTION
## Description

Cleanup some unnecessary references to FlexFieldNodeSchema.

Add FlexNode.getBoxed which provides a schema agnostic way to get a single field even if it does not have any content. 

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
