### PR TITLE
test(tree): fix fuzz generation weight summing

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -475,8 +475,26 @@ export function makeOpGenerator(
 		...defaultEditGeneratorOpWeights,
 		...weightsArg,
 	};
-	const { insert, remove, abort, commit, start, undo, redo } = weights;
-	const editWeight = sumWeights([remove, insert]);
+	const {
+		insert,
+		remove,
+		move,
+		set,
+		clear,
+		abort,
+		commit,
+		start,
+		undo,
+		redo,
+		fieldSelection,
+		schema,
+		synchronizeTrees,
+		...others
+	} = weights;
+	// This assert will trigger when new weights are added to EditGeneratorOpWeights but this function has not been
+	// updated to take into account the new weights.
+	assert(Object.keys(others).length === 0, "Unexpected weight");
+	const editWeight = sumWeights([insert, remove, move, set, clear]);
 	const transactionWeight = sumWeights([abort, commit, start]);
 	const undoRedoWeight = sumWeights([undo, redo]);
 


### PR DESCRIPTION
## Description

Fixes in a bug in the generation of weights in the fuzz generator functions.
Adds a check to prevent trivial omissions like the one being fixed.

## Breaking Changes

None