### PR TITLE
[test] Use min compat version parameter in e2e tests 

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizeFetchValidation.spec.ts
@@ -43,7 +43,7 @@ export const TestDataObjectType1 = "@fluid-example/test-dataStore1";
  */
 describeCompat(
 	"Summarizer fetches expected number of times",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const { SharedMatrix } = apis.dds;
 		const { DataObject, DataObjectFactory } = apis.dataRuntime;

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithOutOfOrderDataStoreRealization.spec.ts
@@ -44,7 +44,7 @@ export const TestDataObjectType2 = "@fluid-example/test-dataStore2";
  */
 describeCompat(
 	"Summary where data store is loaded out of order",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const { SharedMap, SharedMatrix } = apis.dds;
 		const { DataObject, DataObjectFactory, FluidDataStoreRuntime } = apis.dataRuntime;

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -159,7 +159,7 @@ export const TestDataObjectType2 = "@fluid-example/test-dataStore2";
  */
 describeCompat(
 	"Prepare for Summary with Search Blobs",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const { SharedMatrix, SharedCounter } = apis.dds;
 		const { DataObject, DataObjectFactory, FluidDataStoreRuntime } = apis.dataRuntime;

--- a/packages/test/test-end-to-end-tests/src/test/attachLegacyTree.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attachLegacyTree.spec.ts
@@ -9,7 +9,7 @@ import { BuildNode, Change, SharedTree, StablePlace, TraitLabel } from "@fluid-e
 import { ITestDataObject, describeCompat } from "@fluid-private/test-version-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils/internal";
 
-describeCompat("Can attach Legacy Shared Tree", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Can attach Legacy Shared Tree", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -86,7 +86,7 @@ function assertAttributionMatches(
 
 // TODO: Expand the e2e tests in this suite to cover interesting combinations of configuration and versioning that aren't covered by mixinAttributor
 // unit tests.
-describeCompat("Attributor", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Attributor", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedString } = apis.dds;
 	const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
 	const testContainerConfig: ITestContainerConfig = {

--- a/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batchBreakRegression.spec.ts
@@ -111,7 +111,7 @@ async function runAndValidateBatch(
 	}
 }
 
-describeCompat("Batching failures", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Batching failures", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	it("working proxy", async function () {
 		const provider = getTestObjectProvider({ resetAfterEach: true });
 

--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -93,7 +93,7 @@ async function waitForCleanContainers(...dataStores: ITestFluidObject[]) {
 	);
 }
 
-describeCompat("Flushing ops", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Flushing ops", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 	const registry: ChannelFactoryRegistry = [
 		[map1Id, SharedMap.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
@@ -25,7 +25,7 @@ function createString(id: string, dataStoreRuntime: MockFluidDataStoreRuntime) {
 	return new SharedString(dataStoreRuntime, id, SharedStringFactory.Attributes);
 }
 
-describeCompat("PAS Test", "NoCompat", () => {
+describeCompat("PAS Test", "2.0.0-rc.3.0.0", () => {
 	const dataStoreRuntime = new MockFluidDataStoreRuntime();
 	const rowSize = 6;
 	const columnSize = 5;

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/SimpleTest.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/SimpleTest.all.spec.ts
@@ -11,7 +11,7 @@ import { ITestObjectProvider } from "@fluidframework/test-utils/internal";
 
 import { IBenchmarkParameters, benchmarkAll } from "./DocumentCreator.js";
 
-describeCompat("Simple Scenario Title", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Simple Scenario Title", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 
 	before(async () => {

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.memory.spec.ts
@@ -25,7 +25,7 @@ import { v4 as uuid } from "uuid";
 
 const codeDetails: IFluidCodeDetails = { package: "test" };
 
-describeCompat("Container - memory usage benchmarks", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Container - memory usage benchmarks", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let loader: Loader;
 	let fileName: string;

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/container.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/container.time.spec.ts
@@ -21,7 +21,7 @@ import { v4 as uuid } from "uuid";
 
 const codeDetails: IFluidCodeDetails = { package: "test" };
 
-describeCompat("Container - runtime benchmarks", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Container - runtime benchmarks", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let loader: Loader;
 	let fileName: string;

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/counter.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/counter.time.spec.ts
@@ -21,7 +21,7 @@ const testContainerConfig: ITestContainerConfig = {
 	registry,
 };
 
-describeCompat("SharedCounter - runtime benchmarks", "NoCompat", (getTestObjectProvider) => {
+describeCompat("SharedCounter - runtime benchmarks", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	const counters: ISharedCounter[] = [];
 

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
@@ -35,7 +35,7 @@ function readBlobContent(content: ISummaryBlob["content"]): unknown {
 	return JSON.parse(json);
 }
 
-describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Summarization - runtime benchmarks", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;
 	before(async () => {

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
@@ -35,7 +35,7 @@ function readBlobContent(content: ISummaryBlob["content"]): unknown {
 	return JSON.parse(json);
 }
 
-describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Summarization - runtime benchmarks", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;
 

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -270,7 +270,7 @@ describeCompat("blobs", "FullCompat", (getTestObjectProvider, apis) => {
 
 // this functionality was added in 0.47 and can be added to the compat-enabled
 // tests above when the LTS version is bumped > 0.47
-describeCompat("blobs", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("blobs", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedString } = apis.dds;
 	const testContainerConfig = makeTestContainerConfig([
 		["sharedString", SharedString.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
@@ -29,7 +29,7 @@ import { MockDetachedBlobStorage, driverSupportsBlobs } from "./mockDetachedBlob
 const mapId = "map";
 const directoryId = "directoryKey";
 
-describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("blob handle isAttached", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap, SharedDirectory } = apis.dds;
 	const registry: ChannelFactoryRegistry = [
 		[mapId, SharedMap.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
@@ -71,7 +71,7 @@ function assertAttributionMatches(
 	}
 }
 
-describeCompat("Attributor for SharedCell", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Attributor for SharedCell", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedCell } = apis.dds;
 
 	const cellId = "sharedCellKey";

--- a/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -304,7 +304,7 @@ describeCompat("SharedCell", "FullCompat", (getTestObjectProvider, apis) => {
 	});
 });
 
-describeCompat("SharedCell orderSequentially", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("SharedCell orderSequentially", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedCell } = apis.dds;
 
 	let provider: ITestObjectProvider;

--- a/packages/test/test-end-to-end-tests/src/test/codeProposal.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/codeProposal.spec.ts
@@ -39,7 +39,7 @@ function isCodeProposalTestPackage(pkg: unknown): pkg is ICodeProposalTestPackag
 }
 
 // REVIEW: enable compat testing?
-describeCompat("CodeProposal.EndToEnd", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("CodeProposal.EndToEnd", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 	const packageV1: ICodeProposalTestPackage = {
 		name: "test",

--- a/packages/test/test-end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/consensusRegisterCollectionEndToEndTests.spec.ts
@@ -283,7 +283,7 @@ describeCompat("ConsensusRegisterCollection", "FullCompat", (getTestObjectProvid
 
 describeCompat(
 	"ConsensusRegisterCollection grouped batching",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const { SharedMap, ConsensusRegisterCollection } = apis.dds;
 		const registry: ChannelFactoryRegistry = [

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -64,7 +64,7 @@ const codeDetails: IFluidCodeDetails = { package: "test" };
 const timeoutMs = 500;
 
 // REVIEW: enable compat testing?
-describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Container", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	const loaderContainerTracker = new LoaderContainerTracker();
 	before(function () {
@@ -845,7 +845,7 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 	});
 });
 
-describeCompat("Driver", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Driver", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	it("Driver Storage Policy Values", async () => {
 		const provider = getTestObjectProvider();
 		const fiveDaysMs: FiveDaysMs = 432_000_000;

--- a/packages/test/test-end-to-end-tests/src/test/containerDirtyFlag.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerDirtyFlag.spec.ts
@@ -35,7 +35,7 @@ type MapCallback = (
 	map: ISharedMap,
 ) => void | Promise<void>;
 
-describeCompat("Container dirty flag", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Container dirty flag", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
 	const testContainerConfig: ITestContainerConfig = {

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -166,70 +166,74 @@ describeCompat("SharedCounter", "FullCompat", (getTestObjectProvider, apis) => {
 	});
 });
 
-describeCompat("SharedCounter orderSequentially", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
-	const { SharedCounter } = apis.dds;
+describeCompat(
+	"SharedCounter orderSequentially",
+	"2.0.0-rc.3.0.0",
+	(getTestObjectProvider, apis) => {
+		const { SharedCounter } = apis.dds;
 
-	const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
-	const testContainerConfig: ITestContainerConfig = {
-		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
-	};
-
-	let provider: ITestObjectProvider;
-	beforeEach("getTestObjectProvider", () => {
-		provider = getTestObjectProvider();
-	});
-
-	let container: IContainer;
-	let dataObject: ITestFluidObject;
-	let dataStore: ITestFluidObject;
-	let sharedCounter: SharedCounter;
-	let containerRuntime: ContainerRuntime;
-
-	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
-		getRawConfig: (name: string): ConfigTypes => settings[name],
-	});
-	const errorMessage = "callback failure";
-
-	beforeEach("setup", async () => {
-		const configWithFeatureGates = {
-			...testContainerConfig,
-			loaderProps: {
-				configProvider: configProvider({
-					"Fluid.ContainerRuntime.EnableRollback": true,
-				}),
-			},
+		const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];
+		const testContainerConfig: ITestContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry,
 		};
-		container = await provider.makeTestContainer(configWithFeatureGates);
-		dataObject = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
-		dataStore = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
-		sharedCounter = await dataStore.getSharedObject<SharedCounter>(counterId);
-		containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
-	});
 
-	itExpects(
-		"Closes container when rollback fails",
-		[
-			{
-				eventName: "fluid:telemetry:Container:ContainerClose",
-				error: "RollbackError: rollback not supported",
-				errorType: ContainerErrorTypes.dataProcessingError,
+		let provider: ITestObjectProvider;
+		beforeEach("getTestObjectProvider", () => {
+			provider = getTestObjectProvider();
+		});
+
+		let container: IContainer;
+		let dataObject: ITestFluidObject;
+		let dataStore: ITestFluidObject;
+		let sharedCounter: SharedCounter;
+		let containerRuntime: ContainerRuntime;
+
+		const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+			getRawConfig: (name: string): ConfigTypes => settings[name],
+		});
+		const errorMessage = "callback failure";
+
+		beforeEach("setup", async () => {
+			const configWithFeatureGates = {
+				...testContainerConfig,
+				loaderProps: {
+					configProvider: configProvider({
+						"Fluid.ContainerRuntime.EnableRollback": true,
+					}),
+				},
+			};
+			container = await provider.makeTestContainer(configWithFeatureGates);
+			dataObject = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
+			dataStore = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
+			sharedCounter = await dataStore.getSharedObject<SharedCounter>(counterId);
+			containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
+		});
+
+		itExpects(
+			"Closes container when rollback fails",
+			[
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+					error: "RollbackError: rollback not supported",
+					errorType: ContainerErrorTypes.dataProcessingError,
+				},
+			],
+			async () => {
+				let error: Error | undefined;
+				try {
+					containerRuntime.orderSequentially(() => {
+						sharedCounter.increment(1);
+						throw new Error(errorMessage);
+					});
+				} catch (err) {
+					error = err as Error;
+				}
+
+				assert.notEqual(error, undefined, "No error");
+				assert.ok(error?.message.startsWith("RollbackError:"), "Unexpected error message");
+				assert.equal(container.closed, true);
 			},
-		],
-		async () => {
-			let error: Error | undefined;
-			try {
-				containerRuntime.orderSequentially(() => {
-					sharedCounter.increment(1);
-					throw new Error(errorMessage);
-				});
-			} catch (err) {
-				error = err as Error;
-			}
-
-			assert.notEqual(error, undefined, "No error");
-			assert.ok(error?.message.startsWith("RollbackError:"), "Unexpected error message");
-			assert.equal(container.closed, true);
-		},
-	);
-});
+		);
+	},
+);

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -166,7 +166,7 @@ describeCompat("SharedCounter", "FullCompat", (getTestObjectProvider, apis) => {
 	});
 });
 
-describeCompat("SharedCounter orderSequentially", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("SharedCounter orderSequentially", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedCounter } = apis.dds;
 
 	const registry: ChannelFactoryRegistry = [[counterId, SharedCounter.getFactory()]];

--- a/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createContainerStats.spec.ts
@@ -21,7 +21,7 @@ import {
 	getContainerEntryPointBackCompat,
 } from "@fluidframework/test-utils/internal";
 
-describeCompat("Generate Summary Stats", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Generate Summary Stats", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const {
 		dataRuntime: { DataObject, DataObjectFactory },
 		containerRuntime: { ContainerRuntimeFactoryWithDefaultDataStore },

--- a/packages/test/test-end-to-end-tests/src/test/createNewSummaryCachingTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/createNewSummaryCachingTests.spec.ts
@@ -21,7 +21,7 @@ import {
 
 import { wrapObjectAndOverride } from "../mocking.js";
 
-describeCompat("Cache CreateNewSummary", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Cache CreateNewSummary", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const {
 		dataRuntime: { DataObject, DataObjectFactory },
 		containerRuntime: { ContainerRuntimeFactoryWithDefaultDataStore },

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -37,7 +37,7 @@ const interceptResult = <T>(
 	return fn;
 };
 
-describeCompat("Create data store with group id", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Create data store with group id", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObjectFactory, DataObject } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -37,369 +37,403 @@ const interceptResult = <T>(
 	return fn;
 };
 
-describeCompat("Create data store with group id", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
-	const { DataObjectFactory, DataObject } = apis.dataRuntime;
-	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+describeCompat(
+	"Create data store with group id",
+	"2.0.0-rc.3.0.0",
+	(getTestObjectProvider, apis) => {
+		const { DataObjectFactory, DataObject } = apis.dataRuntime;
+		const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 
-	// A Test Data Object that exposes some basic functionality.
-	class TestDataObject extends DataObject {
-		public get _root() {
-			return this.root;
+		// A Test Data Object that exposes some basic functionality.
+		class TestDataObject extends DataObject {
+			public get _root() {
+				return this.root;
+			}
+
+			public get containerRuntime() {
+				return this.context.containerRuntime as ContainerRuntime;
+			}
+
+			public get loadingGroupId() {
+				return this.context.loadingGroupId;
+			}
 		}
 
-		public get containerRuntime() {
-			return this.context.containerRuntime as ContainerRuntime;
-		}
-
-		public get loadingGroupId() {
-			return this.context.loadingGroupId;
-		}
-	}
-
-	// Allow us to control summaries
-	const runtimeOptions: IContainerRuntimeOptions = {
-		summaryOptions: {
-			summaryConfigOverrides: {
-				state: "disabled",
+		// Allow us to control summaries
+		const runtimeOptions: IContainerRuntimeOptions = {
+			summaryOptions: {
+				summaryConfigOverrides: {
+					state: "disabled",
+				},
 			},
-		},
-	};
+		};
 
-	const testDataObjectType = "TestDataObject";
-	const dataObjectFactory = new DataObjectFactory(testDataObjectType, TestDataObject, [], {});
+		const testDataObjectType = "TestDataObject";
+		const dataObjectFactory = new DataObjectFactory(testDataObjectType, TestDataObject, [], {});
 
-	// The 1st runtime factory, V1 of the code
-	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
-		defaultFactory: dataObjectFactory,
-		registryEntries: [dataObjectFactory.registryEntry],
-		runtimeOptions,
-	});
-
-	let provider: ITestObjectProvider;
-
-	const assertOmittedTree = (
-		snapshotTree: ISnapshotTree,
-		groupId: string | undefined,
-		message: string,
-	) => {
-		assert(snapshotTree.omitted, message);
-		assert(snapshotTree.groupId === groupId, message);
-		assert(Object.entries(snapshotTree.trees).length === 0, message);
-		assert(Object.entries(snapshotTree.blobs).length === 0, message);
-	};
-
-	const assertPopulatedTree = (
-		snapshotTree: ISnapshotTree,
-		groupId: string | undefined,
-		message: string,
-	) => {
-		assert(snapshotTree.omitted === undefined, message);
-		assert(snapshotTree.groupId === groupId, message);
-		assert(Object.entries(snapshotTree.trees).length > 0, message);
-		assert(Object.entries(snapshotTree.blobs).length > 0, message);
-	};
-
-	let dataObjectA = {} as unknown as TestDataObject;
-	let dataObjectB = {} as unknown as TestDataObject;
-	let dataObjectC = {} as unknown as TestDataObject;
-	let dataObjectD = {} as unknown as TestDataObject;
-	beforeEach("setup", async () => {
-		provider = getTestObjectProvider();
-		dataObjectA = {} as unknown as TestDataObject;
-		dataObjectB = {} as unknown as TestDataObject;
-		dataObjectC = {} as unknown as TestDataObject;
-		dataObjectD = {} as unknown as TestDataObject;
-	});
-
-	const noId = undefined;
-	const loadingGroupId = "loadingGroupId";
-	const loadingGroupId2 = "loadingGroupId2";
-	const createDataObjectsWithGroupIds = async (
-		mainObject: TestDataObject,
-		containerRuntime: ContainerRuntime,
-	) => {
-		dataObjectA = await dataObjectFactory.createInstance(
-			containerRuntime,
-			undefined,
-			loadingGroupId,
-		);
-		const dataStoreB = await containerRuntime.createDataStore(
-			testDataObjectType,
-			loadingGroupId,
-		);
-		dataObjectB = (await dataStoreB.entryPoint.get()) as TestDataObject;
-
-		[dataObjectC] = await dataObjectFactory.createInstanceWithDataStore(
-			containerRuntime,
-			undefined,
-			undefined,
-			loadingGroupId2,
-		);
-		const [objD, dataStoreD] = await dataObjectFactory.createInstanceWithDataStore(
-			containerRuntime,
-			undefined,
-			undefined,
-			loadingGroupId2,
-		);
-		dataObjectD = objD;
-
-		mainObject._root.set("dataObjectA", dataObjectA.handle);
-		mainObject._root.set("dataObjectB", dataObjectB.handle);
-		mainObject._root.set("dataObjectC", dataObjectC.handle);
-		const result = await dataStoreD.trySetAlias("dataObjectD");
-		assert(result === "Success", "Alias should be set");
-	};
-
-	it("Can create loadingGroupId", async () => {
-		const container = await provider.createContainer(runtimeFactory);
-		const mainObject = (await container.getEntryPoint()) as TestDataObject;
-		const containerRuntime = mainObject.containerRuntime;
-
-		// Testing all apis for creating a data store with a loadingGroupId
-		await createDataObjectsWithGroupIds(mainObject, containerRuntime);
-
-		const { summarizer } = await createSummarizerFromFactory(
-			provider,
-			container,
-			dataObjectFactory,
-		);
-		await provider.ensureSynchronized();
-		const { summaryVersion, summaryTree } = await summarizeNow(summarizer);
-		const channelsTree = summaryTree.tree[".channels"];
-		assert(channelsTree.type === SummaryType.Tree, "channels should be a tree");
-		const dataObjectTree = channelsTree.tree[dataObjectA.id];
-		assert(dataObjectTree !== undefined, "dataObjectTree should exist");
-		assert(dataObjectTree.type === SummaryType.Tree, "dataObjectTree should be a tree");
-		assert(dataObjectTree.groupId === loadingGroupId, "GroupId should be on the summary tree");
-
-		const container2 = await provider.loadContainer(runtimeFactory, undefined, {
-			[LoaderHeader.version]: summaryVersion,
+		// The 1st runtime factory, V1 of the code
+		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
+			defaultFactory: dataObjectFactory,
+			registryEntries: [dataObjectFactory.registryEntry],
+			runtimeOptions,
 		});
 
-		const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
-		const handleA2 = mainObject2._root.get("dataObjectA");
-		const handleB2 = mainObject2._root.get("dataObjectB");
-		const handleC2 = mainObject2._root.get("dataObjectC");
-		const handleD2 =
-			await mainObject2.containerRuntime.getAliasedDataStoreEntryPoint("dataObjectD");
-		assert(handleA2 !== undefined, "handleA2 should not be undefined");
-		assert(handleB2 !== undefined, "handleB2 should not be undefined");
-		assert(handleC2 !== undefined, "handleC2 should not be undefined");
-		assert(handleD2 !== undefined, "handleD2 should not be undefined");
-		const dataObjectA2 = (await handleA2.get()) as TestDataObject;
-		const dataObjectB2 = (await handleB2.get()) as TestDataObject;
-		const dataObjectC2 = (await handleC2.get()) as TestDataObject;
-		const dataObjectD2 = (await handleD2.get()) as TestDataObject;
+		let provider: ITestObjectProvider;
 
-		// TODO: Enable this portion in tinylicious
-		// This allows us to test against services without groupId enabled.
-		// Round tripping of groupId only works for local driver, regardless the rest should just work as intended
-		if (provider.driver.type === "local") {
-			assert.equal(dataObjectA2.loadingGroupId, loadingGroupId, "A groupId not set");
-			assert.equal(dataObjectB2.loadingGroupId, loadingGroupId, "B groupId not set");
-			assert.equal(dataObjectC2.loadingGroupId, loadingGroupId2, "B groupId not set");
-			assert.equal(dataObjectD2.loadingGroupId, loadingGroupId2, "B groupId not set");
-		}
-	});
+		const assertOmittedTree = (
+			snapshotTree: ISnapshotTree,
+			groupId: string | undefined,
+			message: string,
+		) => {
+			assert(snapshotTree.omitted, message);
+			assert(snapshotTree.groupId === groupId, message);
+			assert(Object.entries(snapshotTree.trees).length === 0, message);
+			assert(Object.entries(snapshotTree.blobs).length === 0, message);
+		};
 
-	it("Can create loadingGroupId via detached flow", async () => {
-		const container = await provider.createDetachedContainer(runtimeFactory);
-		const mainObject = (await container.getEntryPoint()) as TestDataObject;
-		const containerRuntime = mainObject.containerRuntime;
+		const assertPopulatedTree = (
+			snapshotTree: ISnapshotTree,
+			groupId: string | undefined,
+			message: string,
+		) => {
+			assert(snapshotTree.omitted === undefined, message);
+			assert(snapshotTree.groupId === groupId, message);
+			assert(Object.entries(snapshotTree.trees).length > 0, message);
+			assert(Object.entries(snapshotTree.blobs).length > 0, message);
+		};
 
-		await createDataObjectsWithGroupIds(mainObject, containerRuntime);
+		let dataObjectA = {} as unknown as TestDataObject;
+		let dataObjectB = {} as unknown as TestDataObject;
+		let dataObjectC = {} as unknown as TestDataObject;
+		let dataObjectD = {} as unknown as TestDataObject;
+		beforeEach("setup", async () => {
+			provider = getTestObjectProvider();
+			dataObjectA = {} as unknown as TestDataObject;
+			dataObjectB = {} as unknown as TestDataObject;
+			dataObjectC = {} as unknown as TestDataObject;
+			dataObjectD = {} as unknown as TestDataObject;
+		});
 
-		await provider.attachDetachedContainer(container);
-		// TODO: Enable this portion in tinylicious
-		if (provider.driver.type === "local") {
-			const container2 = await provider.loadContainer(runtimeFactory);
+		const noId = undefined;
+		const loadingGroupId = "loadingGroupId";
+		const loadingGroupId2 = "loadingGroupId2";
+		const createDataObjectsWithGroupIds = async (
+			mainObject: TestDataObject,
+			containerRuntime: ContainerRuntime,
+		) => {
+			dataObjectA = await dataObjectFactory.createInstance(
+				containerRuntime,
+				undefined,
+				loadingGroupId,
+			);
+			const dataStoreB = await containerRuntime.createDataStore(
+				testDataObjectType,
+				loadingGroupId,
+			);
+			dataObjectB = (await dataStoreB.entryPoint.get()) as TestDataObject;
+
+			[dataObjectC] = await dataObjectFactory.createInstanceWithDataStore(
+				containerRuntime,
+				undefined,
+				undefined,
+				loadingGroupId2,
+			);
+			const [objD, dataStoreD] = await dataObjectFactory.createInstanceWithDataStore(
+				containerRuntime,
+				undefined,
+				undefined,
+				loadingGroupId2,
+			);
+			dataObjectD = objD;
+
+			mainObject._root.set("dataObjectA", dataObjectA.handle);
+			mainObject._root.set("dataObjectB", dataObjectB.handle);
+			mainObject._root.set("dataObjectC", dataObjectC.handle);
+			const result = await dataStoreD.trySetAlias("dataObjectD");
+			assert(result === "Success", "Alias should be set");
+		};
+
+		it("Can create loadingGroupId", async () => {
+			const container = await provider.createContainer(runtimeFactory);
+			const mainObject = (await container.getEntryPoint()) as TestDataObject;
+			const containerRuntime = mainObject.containerRuntime;
+
+			// Testing all apis for creating a data store with a loadingGroupId
+			await createDataObjectsWithGroupIds(mainObject, containerRuntime);
+
+			const { summarizer } = await createSummarizerFromFactory(
+				provider,
+				container,
+				dataObjectFactory,
+			);
 			await provider.ensureSynchronized();
+			const { summaryVersion, summaryTree } = await summarizeNow(summarizer);
+			const channelsTree = summaryTree.tree[".channels"];
+			assert(channelsTree.type === SummaryType.Tree, "channels should be a tree");
+			const dataObjectTree = channelsTree.tree[dataObjectA.id];
+			assert(dataObjectTree !== undefined, "dataObjectTree should exist");
+			assert(dataObjectTree.type === SummaryType.Tree, "dataObjectTree should be a tree");
+			assert(
+				dataObjectTree.groupId === loadingGroupId,
+				"GroupId should be on the summary tree",
+			);
+
+			const container2 = await provider.loadContainer(runtimeFactory, undefined, {
+				[LoaderHeader.version]: summaryVersion,
+			});
 
 			const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
 			const handleA2 = mainObject2._root.get("dataObjectA");
 			const handleB2 = mainObject2._root.get("dataObjectB");
+			const handleC2 = mainObject2._root.get("dataObjectC");
+			const handleD2 =
+				await mainObject2.containerRuntime.getAliasedDataStoreEntryPoint("dataObjectD");
 			assert(handleA2 !== undefined, "handleA2 should not be undefined");
 			assert(handleB2 !== undefined, "handleB2 should not be undefined");
+			assert(handleC2 !== undefined, "handleC2 should not be undefined");
+			assert(handleD2 !== undefined, "handleD2 should not be undefined");
 			const dataObjectA2 = (await handleA2.get()) as TestDataObject;
 			const dataObjectB2 = (await handleB2.get()) as TestDataObject;
-			assert.equal(
-				dataObjectA2.loadingGroupId,
-				loadingGroupId,
-				"dataObjectA groupId should be set",
+			const dataObjectC2 = (await handleC2.get()) as TestDataObject;
+			const dataObjectD2 = (await handleD2.get()) as TestDataObject;
+
+			// TODO: Enable this portion in tinylicious
+			// This allows us to test against services without groupId enabled.
+			// Round tripping of groupId only works for local driver, regardless the rest should just work as intended
+			if (provider.driver.type === "local") {
+				assert.equal(dataObjectA2.loadingGroupId, loadingGroupId, "A groupId not set");
+				assert.equal(dataObjectB2.loadingGroupId, loadingGroupId, "B groupId not set");
+				assert.equal(dataObjectC2.loadingGroupId, loadingGroupId2, "B groupId not set");
+				assert.equal(dataObjectD2.loadingGroupId, loadingGroupId2, "B groupId not set");
+			}
+		});
+
+		it("Can create loadingGroupId via detached flow", async () => {
+			const container = await provider.createDetachedContainer(runtimeFactory);
+			const mainObject = (await container.getEntryPoint()) as TestDataObject;
+			const containerRuntime = mainObject.containerRuntime;
+
+			await createDataObjectsWithGroupIds(mainObject, containerRuntime);
+
+			await provider.attachDetachedContainer(container);
+			// TODO: Enable this portion in tinylicious
+			if (provider.driver.type === "local") {
+				const container2 = await provider.loadContainer(runtimeFactory);
+				await provider.ensureSynchronized();
+
+				const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
+				const handleA2 = mainObject2._root.get("dataObjectA");
+				const handleB2 = mainObject2._root.get("dataObjectB");
+				assert(handleA2 !== undefined, "handleA2 should not be undefined");
+				assert(handleB2 !== undefined, "handleB2 should not be undefined");
+				const dataObjectA2 = (await handleA2.get()) as TestDataObject;
+				const dataObjectB2 = (await handleB2.get()) as TestDataObject;
+				assert.equal(
+					dataObjectA2.loadingGroupId,
+					loadingGroupId,
+					"dataObjectA groupId should be set",
+				);
+				assert.equal(
+					dataObjectB2.loadingGroupId,
+					loadingGroupId,
+					"dataObjectB groupId should be set",
+				);
+			}
+		});
+
+		it("Excludes dataStores with loadingGroupId from summary", async () => {
+			if (provider.driver.type !== "local") {
+				return;
+			}
+			// Load basic container stuff
+			const container = await provider.createContainer(runtimeFactory);
+			const mainObject = (await container.getEntryPoint()) as TestDataObject;
+			const containerRuntime = mainObject.containerRuntime;
+
+			await createDataObjectsWithGroupIds(mainObject, containerRuntime);
+			dataObjectA._root.set("A", "A");
+			mainObject._root.set("doubleHandleA", dataObjectA.handle);
+			dataObjectB._root.set("B", "B");
+
+			// Summarize
+			await provider.ensureSynchronized();
+			const { summarizer } = await createSummarizerFromFactory(
+				provider,
+				container,
+				dataObjectFactory,
 			);
-			assert.equal(
-				dataObjectB2.loadingGroupId,
-				loadingGroupId,
-				"dataObjectB groupId should be set",
+			const { summaryVersion, summaryRefSeq } = await summarizeNow(summarizer);
+
+			// Intercept the first snapshot call via the creation of the driver
+			const documentServiceFactory = provider.documentServiceFactory;
+			let snapshotCaptured: ISnapshot | undefined;
+			let callCount = 0;
+			interceptResult(
+				documentServiceFactory,
+				documentServiceFactory.createDocumentService,
+				(documentService) => {
+					interceptResult(
+						documentService,
+						documentService.connectToStorage,
+						(storage) => {
+							assert(
+								storage.getSnapshot !== undefined,
+								"Test can't run without getSnapshot",
+							);
+							interceptResult(storage, storage.getSnapshot, (snapshot) => {
+								snapshotCaptured = snapshot;
+								callCount++;
+							});
+						},
+					);
+				},
 			);
-		}
-	});
 
-	it("Excludes dataStores with loadingGroupId from summary", async () => {
-		if (provider.driver.type !== "local") {
-			return;
-		}
-		// Load basic container stuff
-		const container = await provider.createContainer(runtimeFactory);
-		const mainObject = (await container.getEntryPoint()) as TestDataObject;
-		const containerRuntime = mainObject.containerRuntime;
+			// Load from the summary
+			const configProvider = createTestConfigProvider();
+			configProvider.set("Fluid.Container.UseLoadingGroupIdForSnapshotFetch", true);
+			const container2 = await provider.loadContainer(
+				runtimeFactory,
+				{ configProvider },
+				{
+					[LoaderHeader.version]: summaryVersion,
+				},
+			);
 
-		await createDataObjectsWithGroupIds(mainObject, containerRuntime);
-		dataObjectA._root.set("A", "A");
-		mainObject._root.set("doubleHandleA", dataObjectA.handle);
-		dataObjectB._root.set("B", "B");
+			// Get the snapshot and runtime we just loaded from
+			const loadingSnapshot = snapshotCaptured;
+			assert(loadingSnapshot !== undefined, "should have captured loading snapshot!");
 
-		// Summarize
-		await provider.ensureSynchronized();
-		const { summarizer } = await createSummarizerFromFactory(
-			provider,
-			container,
-			dataObjectFactory,
-		);
-		const { summaryVersion, summaryRefSeq } = await summarizeNow(summarizer);
+			// Testing the get snapshot call
+			const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
+			const runtime2 = mainObject2.containerRuntime;
+			assert(runtime2.storage.getSnapshot !== undefined, "getSnapshot should be defined");
+			assert(callCount === 1, "Should have only called getSnapshot once");
+			assert(loadingSnapshot.sequenceNumber === summaryRefSeq, "Loaded from wrong snapshot");
 
-		// Intercept the first snapshot call via the creation of the driver
-		const documentServiceFactory = provider.documentServiceFactory;
-		let snapshotCaptured: ISnapshot | undefined;
-		let callCount = 0;
-		interceptResult(
-			documentServiceFactory,
-			documentServiceFactory.createDocumentService,
-			(documentService) => {
-				interceptResult(documentService, documentService.connectToStorage, (storage) => {
-					assert(storage.getSnapshot !== undefined, "Test can't run without getSnapshot");
-					interceptResult(storage, storage.getSnapshot, (snapshot) => {
-						snapshotCaptured = snapshot;
-						callCount++;
-					});
-				});
-			},
-		);
+			// Snapshot validation (a snapshot call with NO loadingGroupIds)
+			const channelsTree = loadingSnapshot.snapshotTree.trees[".channels"];
+			const mainObjectTree = channelsTree.trees[mainObject.id];
+			const dataObjectATree = channelsTree.trees[dataObjectA.id];
+			const dataObjectBTree = channelsTree.trees[dataObjectB.id];
+			const dataObjectCTree = channelsTree.trees[dataObjectC.id];
+			const dataObjectDTree = channelsTree.trees[dataObjectD.id];
 
-		// Load from the summary
-		const configProvider = createTestConfigProvider();
-		configProvider.set("Fluid.Container.UseLoadingGroupIdForSnapshotFetch", true);
-		const container2 = await provider.loadContainer(
-			runtimeFactory,
-			{ configProvider },
-			{
-				[LoaderHeader.version]: summaryVersion,
-			},
-		);
+			assertPopulatedTree(mainObjectTree, noId, "mainObject tree not right");
+			assertOmittedTree(dataObjectATree, loadingGroupId, "Wrong tree for A");
+			assertOmittedTree(dataObjectBTree, loadingGroupId, "Wrong tree for B");
+			assertOmittedTree(dataObjectCTree, loadingGroupId2, "Wrong tree for C");
+			assertOmittedTree(dataObjectDTree, loadingGroupId2, "Wrong tree for D");
 
-		// Get the snapshot and runtime we just loaded from
-		const loadingSnapshot = snapshotCaptured;
-		assert(loadingSnapshot !== undefined, "should have captured loading snapshot!");
+			callCount = 0;
 
-		// Testing the get snapshot call
-		const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
-		const runtime2 = mainObject2.containerRuntime;
-		assert(runtime2.storage.getSnapshot !== undefined, "getSnapshot should be defined");
-		assert(callCount === 1, "Should have only called getSnapshot once");
-		assert(loadingSnapshot.sequenceNumber === summaryRefSeq, "Loaded from wrong snapshot");
+			// Try to load the data stores with groupIds
+			const doubleHandleA2 =
+				mainObject2._root.get<IFluidHandle<TestDataObject>>("doubleHandleA");
+			const handleA2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
+			const handleB2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectB");
+			assert(doubleHandleA2 !== undefined, "doubleHandleA2 should not be undefined");
+			assert(handleA2 !== undefined, "handleA2 should not be undefined");
+			assert(handleB2 !== undefined, "handleB2 should not be undefined");
 
-		// Snapshot validation (a snapshot call with NO loadingGroupIds)
-		const channelsTree = loadingSnapshot.snapshotTree.trees[".channels"];
-		const mainObjectTree = channelsTree.trees[mainObject.id];
-		const dataObjectATree = channelsTree.trees[dataObjectA.id];
-		const dataObjectBTree = channelsTree.trees[dataObjectB.id];
-		const dataObjectCTree = channelsTree.trees[dataObjectC.id];
-		const dataObjectDTree = channelsTree.trees[dataObjectD.id];
+			// Prep context snapshot intercept
+			// Hack to inspect the runtime's dataStores
+			const stores = (runtime2 as any).channelCollection;
+			const contextA = (await stores.getDataStore(
+				dataObjectA.id,
+				{},
+			)) as IFluidDataStoreContext;
+			const contextB = (await stores.getDataStore(
+				dataObjectB.id,
+				{},
+			)) as IFluidDataStoreContext;
+			const contextC = (await stores.getDataStore(
+				dataObjectC.id,
+				{},
+			)) as IFluidDataStoreContext;
+			const contextD = (await stores.getDataStore(
+				dataObjectD.id,
+				{},
+			)) as IFluidDataStoreContext;
+			assert(contextA.baseSnapshot !== undefined, "contextA should have a baseSnapshot");
+			assert(contextB.baseSnapshot !== undefined, "contextB should have a baseSnapshot");
+			assert(contextC.baseSnapshot !== undefined, "contextC should have a baseSnapshot");
+			assert(contextD.baseSnapshot !== undefined, "contextD should have a baseSnapshot");
 
-		assertPopulatedTree(mainObjectTree, noId, "mainObject tree not right");
-		assertOmittedTree(dataObjectATree, loadingGroupId, "Wrong tree for A");
-		assertOmittedTree(dataObjectBTree, loadingGroupId, "Wrong tree for B");
-		assertOmittedTree(dataObjectCTree, loadingGroupId2, "Wrong tree for C");
-		assertOmittedTree(dataObjectDTree, loadingGroupId2, "Wrong tree for D");
+			assert.equal(callCount, 0, "Should not have made any network calls");
+			assertOmittedTree(contextA.baseSnapshot, loadingGroupId, "contextA tree not omitted");
+			assertOmittedTree(contextB.baseSnapshot, loadingGroupId, "contextB tree not omitted");
+			assertOmittedTree(contextC.baseSnapshot, loadingGroupId2, "contextC tree not omitted");
+			assertOmittedTree(contextD.baseSnapshot, loadingGroupId2, "contextD tree not omitted");
 
-		callCount = 0;
+			// loading group call
+			assert.equal(callCount, 0, "Should not have made any network calls");
+			const [dataObjectA2, dataObjectB2] = await Promise.all([
+				handleA2.get(),
+				handleB2.get(),
+			]);
+			assert.equal(callCount, 1, "Should have only called getSnapshot once!");
+			assert.equal(dataObjectA2._root.get("A"), "A", "A should be set");
+			assert.equal(dataObjectB2._root.get("B"), "B", "B should be set");
+			assert.equal(callCount, 1, "retrieving data should not have made any network calls");
 
-		// Try to load the data stores with groupIds
-		const doubleHandleA2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("doubleHandleA");
-		const handleA2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
-		const handleB2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectB");
-		assert(doubleHandleA2 !== undefined, "doubleHandleA2 should not be undefined");
-		assert(handleA2 !== undefined, "handleA2 should not be undefined");
-		assert(handleB2 !== undefined, "handleB2 should not be undefined");
+			callCount = 0;
+			const aDataObjectA2 = await doubleHandleA2.get();
+			assert.equal(callCount, 0, "Network call made on same object!");
+			assert.equal(aDataObjectA2, dataObjectA2, "Should be the same object");
 
-		// Prep context snapshot intercept
-		// Hack to inspect the runtime's dataStores
-		const stores = (runtime2 as any).channelCollection;
-		const contextA = (await stores.getDataStore(dataObjectA.id, {})) as IFluidDataStoreContext;
-		const contextB = (await stores.getDataStore(dataObjectB.id, {})) as IFluidDataStoreContext;
-		const contextC = (await stores.getDataStore(dataObjectC.id, {})) as IFluidDataStoreContext;
-		const contextD = (await stores.getDataStore(dataObjectD.id, {})) as IFluidDataStoreContext;
-		assert(contextA.baseSnapshot !== undefined, "contextA should have a baseSnapshot");
-		assert(contextB.baseSnapshot !== undefined, "contextB should have a baseSnapshot");
-		assert(contextC.baseSnapshot !== undefined, "contextC should have a baseSnapshot");
-		assert(contextD.baseSnapshot !== undefined, "contextD should have a baseSnapshot");
+			// Testing the get snapshot call with loadingGroupId
+			const groupSnapshot = snapshotCaptured;
+			assert(groupSnapshot !== undefined, "should have captured group snapshot!");
+			assert.deepEqual(
+				groupSnapshot.sequenceNumber,
+				summaryRefSeq,
+				"Should be groupId snapshot",
+			);
 
-		assert.equal(callCount, 0, "Should not have made any network calls");
-		assertOmittedTree(contextA.baseSnapshot, loadingGroupId, "contextA tree not omitted");
-		assertOmittedTree(contextB.baseSnapshot, loadingGroupId, "contextB tree not omitted");
-		assertOmittedTree(contextC.baseSnapshot, loadingGroupId2, "contextC tree not omitted");
-		assertOmittedTree(contextD.baseSnapshot, loadingGroupId2, "contextD tree not omitted");
+			// Snapshot validation (a snapshot call for loadingGroupIds = [loadingGroupId])
+			const channelsTree2 = groupSnapshot.snapshotTree.trees[".channels"];
+			const mainObjectTree2 = channelsTree2.trees[mainObject.id];
+			const dataObjectATree2 = channelsTree2.trees[dataObjectA.id];
+			const dataObjectBTree2 = channelsTree2.trees[dataObjectB.id];
+			const dataObjectCTree2 = channelsTree2.trees[dataObjectC.id];
+			const dataObjectDTree2 = channelsTree2.trees[dataObjectD.id];
 
-		// loading group call
-		assert.equal(callCount, 0, "Should not have made any network calls");
-		const [dataObjectA2, dataObjectB2] = await Promise.all([handleA2.get(), handleB2.get()]);
-		assert.equal(callCount, 1, "Should have only called getSnapshot once!");
-		assert.equal(dataObjectA2._root.get("A"), "A", "A should be set");
-		assert.equal(dataObjectB2._root.get("B"), "B", "B should be set");
-		assert.equal(callCount, 1, "retrieving data should not have made any network calls");
+			assertOmittedTree(mainObjectTree2, noId, "mainObject tree incorrect");
+			assertPopulatedTree(dataObjectATree2, loadingGroupId, "Incorrect tree for A2");
+			assertPopulatedTree(dataObjectBTree2, loadingGroupId, "Incorrect tree for B2");
+			assertOmittedTree(dataObjectCTree2, loadingGroupId2, "Incorrect tree for C2");
+			assertOmittedTree(dataObjectDTree2, loadingGroupId2, "Incorrect tree for D2");
 
-		callCount = 0;
-		const aDataObjectA2 = await doubleHandleA2.get();
-		assert.equal(callCount, 0, "Network call made on same object!");
-		assert.equal(aDataObjectA2, dataObjectA2, "Should be the same object");
+			const handleC2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectC");
+			assert.equal(callCount, 0, "call count should be reset");
+			// This call realizes the data object
+			const handleD2 = await runtime2.getAliasedDataStoreEntryPoint("dataObjectD");
+			assert.equal(callCount, 1, "Extra calls made");
+			assert(handleC2 !== undefined, "handleC2 should not be undefined");
+			assert(handleD2 !== undefined, "handleD2 should not be undefined");
 
-		// Testing the get snapshot call with loadingGroupId
-		const groupSnapshot = snapshotCaptured;
-		assert(groupSnapshot !== undefined, "should have captured group snapshot!");
-		assert.deepEqual(groupSnapshot.sequenceNumber, summaryRefSeq, "Should be groupId snapshot");
+			callCount = 0;
+			await handleC2.get();
+			await handleD2.get();
+			assert.equal(callCount, 0, "Some extra calls were made");
 
-		// Snapshot validation (a snapshot call for loadingGroupIds = [loadingGroupId])
-		const channelsTree2 = groupSnapshot.snapshotTree.trees[".channels"];
-		const mainObjectTree2 = channelsTree2.trees[mainObject.id];
-		const dataObjectATree2 = channelsTree2.trees[dataObjectA.id];
-		const dataObjectBTree2 = channelsTree2.trees[dataObjectB.id];
-		const dataObjectCTree2 = channelsTree2.trees[dataObjectC.id];
-		const dataObjectDTree2 = channelsTree2.trees[dataObjectD.id];
+			// Snapshot validation (a snapshot call for loadingGroupIds = [loadingGroupId])
+			const group2Snapshot = snapshotCaptured;
+			assert(group2Snapshot !== undefined, "should have captured group2 snapshot!");
+			assert.deepEqual(group2Snapshot.sequenceNumber, summaryRefSeq, "Unexpected snapshot");
+			const channels2Tree2 = group2Snapshot.snapshotTree.trees[".channels"];
+			const mainObject2Tree2 = channels2Tree2.trees[mainObject.id];
+			const dataObjectA2Tree2 = channels2Tree2.trees[dataObjectA.id];
+			const dataObjectB2Tree2 = channels2Tree2.trees[dataObjectB.id];
+			const dataObjectC2Tree2 = channels2Tree2.trees[dataObjectC.id];
+			const dataObjectD2Tree2 = channels2Tree2.trees[dataObjectD.id];
 
-		assertOmittedTree(mainObjectTree2, noId, "mainObject tree incorrect");
-		assertPopulatedTree(dataObjectATree2, loadingGroupId, "Incorrect tree for A2");
-		assertPopulatedTree(dataObjectBTree2, loadingGroupId, "Incorrect tree for B2");
-		assertOmittedTree(dataObjectCTree2, loadingGroupId2, "Incorrect tree for C2");
-		assertOmittedTree(dataObjectDTree2, loadingGroupId2, "Incorrect tree for D2");
-
-		const handleC2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectC");
-		assert.equal(callCount, 0, "call count should be reset");
-		// This call realizes the data object
-		const handleD2 = await runtime2.getAliasedDataStoreEntryPoint("dataObjectD");
-		assert.equal(callCount, 1, "Extra calls made");
-		assert(handleC2 !== undefined, "handleC2 should not be undefined");
-		assert(handleD2 !== undefined, "handleD2 should not be undefined");
-
-		callCount = 0;
-		await handleC2.get();
-		await handleD2.get();
-		assert.equal(callCount, 0, "Some extra calls were made");
-
-		// Snapshot validation (a snapshot call for loadingGroupIds = [loadingGroupId])
-		const group2Snapshot = snapshotCaptured;
-		assert(group2Snapshot !== undefined, "should have captured group2 snapshot!");
-		assert.deepEqual(group2Snapshot.sequenceNumber, summaryRefSeq, "Unexpected snapshot");
-		const channels2Tree2 = group2Snapshot.snapshotTree.trees[".channels"];
-		const mainObject2Tree2 = channels2Tree2.trees[mainObject.id];
-		const dataObjectA2Tree2 = channels2Tree2.trees[dataObjectA.id];
-		const dataObjectB2Tree2 = channels2Tree2.trees[dataObjectB.id];
-		const dataObjectC2Tree2 = channels2Tree2.trees[dataObjectC.id];
-		const dataObjectD2Tree2 = channels2Tree2.trees[dataObjectD.id];
-
-		assertOmittedTree(mainObject2Tree2, noId, "Not omitted tree for mainObject");
-		assertOmittedTree(dataObjectA2Tree2, loadingGroupId, "Not omitted tree for A2");
-		assertOmittedTree(dataObjectB2Tree2, loadingGroupId, "Not omitted tree for B2");
-		assertPopulatedTree(dataObjectC2Tree2, loadingGroupId2, "Not populated tree for C2");
-		assertPopulatedTree(dataObjectD2Tree2, loadingGroupId2, "Not populated tree for D2");
-	});
-});
+			assertOmittedTree(mainObject2Tree2, noId, "Not omitted tree for mainObject");
+			assertOmittedTree(dataObjectA2Tree2, loadingGroupId, "Not omitted tree for A2");
+			assertOmittedTree(dataObjectB2Tree2, loadingGroupId, "Not omitted tree for B2");
+			assertPopulatedTree(dataObjectC2Tree2, loadingGroupId2, "Not populated tree for C2");
+			assertPopulatedTree(dataObjectD2Tree2, loadingGroupId2, "Not populated tree for D2");
+		});
+	},
+);

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
@@ -46,7 +46,7 @@ const overrideResult = <T>(parent: any, fn: (...args: any[]) => Promise<T>, resu
 	parent[fn.name] = overrideFn;
 };
 
-describeCompat("Create data store with group id", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Create data store with group id", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObjectFactory, DataObject } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
@@ -46,234 +46,68 @@ const overrideResult = <T>(parent: any, fn: (...args: any[]) => Promise<T>, resu
 	parent[fn.name] = overrideFn;
 };
 
-describeCompat("Create data store with group id", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
-	const { DataObjectFactory, DataObject } = apis.dataRuntime;
-	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+describeCompat(
+	"Create data store with group id",
+	"2.0.0-rc.3.0.0",
+	(getTestObjectProvider, apis) => {
+		const { DataObjectFactory, DataObject } = apis.dataRuntime;
+		const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 
-	// A Test Data Object that exposes some basic functionality.
-	class TestDataObject extends DataObject {
-		public get _root() {
-			return this.root;
-		}
-
-		public get containerRuntime() {
-			return this.context.containerRuntime as ContainerRuntime;
-		}
-
-		public get loadingGroupId() {
-			return this.context.loadingGroupId;
-		}
-	}
-	// Allow us to control summaries
-	const runtimeOptions: IContainerRuntimeOptions = {
-		summaryOptions: {
-			summaryConfigOverrides: {
-				state: "disabled",
-			},
-		},
-	};
-	const configProvider = createTestConfigProvider();
-	configProvider.set("Fluid.Container.UseLoadingGroupIdForSnapshotFetch", true);
-
-	const testDataObjectType = "TestDataObject";
-	const dataObjectFactory = new DataObjectFactory(testDataObjectType, TestDataObject, [], {});
-
-	// The 1st runtime factory, V1 of the code
-	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
-		defaultFactory: dataObjectFactory,
-		registryEntries: [dataObjectFactory.registryEntry],
-		runtimeOptions,
-	});
-
-	let provider: ITestObjectProvider;
-
-	const assertPopulatedGroupIdTree = (snapshotTree: ISnapshotTree, message: string) => {
-		assert(snapshotTree.omitted === undefined, message);
-		assert(snapshotTree.groupId === loadingGroupId, message);
-		assert(Object.entries(snapshotTree.trees).length > 0, message);
-		assert(Object.entries(snapshotTree.blobs).length > 0, message);
-	};
-
-	beforeEach("setup", async () => {
-		provider = getTestObjectProvider();
-	});
-
-	const loadingGroupId = "loadingGroupId";
-	it("Load datastore via groupId with snapshot in the future, with seq < all the ops", async () => {
-		if (provider.driver.type !== "local") {
-			return;
-		}
-		// Load basic container stuff
-		const container = await provider.createContainer(runtimeFactory, { configProvider });
-		const mainObject = (await container.getEntryPoint()) as TestDataObject;
-		const containerRuntime = mainObject.containerRuntime;
-
-		// Create data stores with loadingGroupIds
-		const dataStoreA = await containerRuntime.createDataStore(
-			testDataObjectType,
-			loadingGroupId,
-		);
-
-		// Attach the data stores
-		const dataObjectA = (await dataStoreA.entryPoint.get()) as TestDataObject;
-		mainObject._root.set("dataObjectA", dataObjectA.handle);
-		dataObjectA._root.set("A", "A");
-
-		// Summarize
-		await provider.ensureSynchronized();
-		const { summarizer } = await createSummarizerFromFactory(
-			provider,
-			container,
-			dataObjectFactory,
-		);
-		const { summaryVersion } = await summarizeNow(summarizer);
-
-		const container2 = await provider.loadContainer(
-			runtimeFactory,
-			{ configProvider },
-			{ [LoaderHeader.version]: summaryVersion },
-		);
-		await provider.ensureSynchronized();
-
-		dataObjectA._root.set("B", "B");
-		await provider.ensureSynchronized();
-		const { summaryRefSeq } = await summarizeNow(summarizer);
-
-		// Testing the get snapshot call
-		const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
-		const runtime2 = mainObject2.containerRuntime;
-
-		// Try to load the data stores with groupIds
-		const handleA2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
-		assert(handleA2 !== undefined, "handleA2 should not be undefined");
-
-		const snapshotADeferred: Deferred<ISnapshot> = new Deferred();
-		assert(runtime2.storage.getSnapshot !== undefined, "getSnapshot not defined for runtime2");
-		interceptResult(runtime2.storage, runtime2.storage.getSnapshot, (snapshot) => {
-			snapshotADeferred.resolve(snapshot);
-		});
-
-		// loading group call
-		const dataObjectA2 = await handleA2.get();
-		assert.equal(dataObjectA2._root.get("A"), "A", "A should be set");
-		assert.equal(dataObjectA2._root.get("B"), "B", "B should be set");
-
-		const groupSnapshot = await snapshotADeferred.promise;
-		const snapshotTreeA = groupSnapshot.snapshotTree.trees[".channels"].trees[dataObjectA2.id];
-		assertPopulatedGroupIdTree(snapshotTreeA, "Should be a populated groupId tree");
-		assert(
-			groupSnapshot.sequenceNumber === summaryRefSeq,
-			"failed to load snapshot with correct sequence number",
-		);
-	});
-
-	it("Load datastore via groupId with snapshot in the future, with seq > some ops", async () => {
-		if (provider.driver.type !== "local") {
-			return;
-		}
-		// Load basic container stuff
-		const container = await provider.createContainer(runtimeFactory, { configProvider });
-		const mainObject = (await container.getEntryPoint()) as TestDataObject;
-		const containerRuntime = mainObject.containerRuntime;
-
-		// Create data stores with loadingGroupIds
-		const dataStoreA = await containerRuntime.createDataStore(
-			testDataObjectType,
-			loadingGroupId,
-		);
-
-		// Attach the data stores
-		const dataObjectA = (await dataStoreA.entryPoint.get()) as TestDataObject;
-		mainObject._root.set("dataObjectA", dataObjectA.handle);
-		dataObjectA._root.set("A", "A");
-
-		// Summarize
-		await provider.ensureSynchronized();
-		const { summarizer, container: summarizingContainer } = await createSummarizerFromFactory(
-			provider,
-			container,
-			dataObjectFactory,
-		);
-		const { summaryVersion } = await summarizeNow(summarizer);
-		// Work around getEntryPoint returning the summarizer instead of a datastore
-		const runtimeS = (summarizingContainer as any).runtime as ContainerRuntime;
-		const handleS = await runtimeS.getAliasedDataStoreEntryPoint("default");
-		assert(handleS !== undefined, "handleS should not be undefined");
-		const mainObjectS = (await handleS.get()) as TestDataObject;
-
-		await provider.ensureSynchronized();
-		const handleAS = mainObjectS._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
-		assert(handleAS !== undefined, "handleA2 should not be undefined");
-		const dataObjectAS = await handleAS.get();
-
-		const container2 = await provider.loadContainer(
-			runtimeFactory,
-			{ configProvider },
-			{ [LoaderHeader.version]: summaryVersion },
-		);
-		// Testing the get snapshot call
-		const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
-		const handleA2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
-		assert(handleA2 !== undefined, "handleA2 should not be undefined");
-
-		container2.disconnect();
-		const waitForOp = new Deferred<void>();
-		dataObjectAS._root.on("valueChanged", (changed) => {
-			if (changed.key === "B") {
-				waitForOp.resolve();
+		// A Test Data Object that exposes some basic functionality.
+		class TestDataObject extends DataObject {
+			public get _root() {
+				return this.root;
 			}
-		});
-		dataObjectA._root.set("B", "B");
 
-		await waitForOp.promise;
-		await summarizeNow(summarizer);
+			public get containerRuntime() {
+				return this.context.containerRuntime as ContainerRuntime;
+			}
 
-		// start loading group call
-		const dataObjectA2Promise = handleA2.get();
-		const deferred = new Deferred<void>();
-
-		void dataObjectA2Promise.then(() => {
-			deferred.resolve();
-		});
-
-		await delay(100);
-
-		// Loading group call should wait for ops to come through
-		assert(!deferred.isCompleted, "Promise should not be resolved yet");
-
-		// This should cause the ops to come through
-		container2.connect();
-		const dataObjectA2 = await dataObjectA2Promise;
-
-		// Get the latest data
-		await provider.ensureSynchronized();
-		// Force ops to come through
-		assert(deferred.isCompleted, "Promise should be resolved");
-		assert(dataObjectA2._root.get("A") === "A", "A should be set");
-		assert(dataObjectA2._root.get("B") === "B", "B should be set");
-	});
-
-	itExpects(
-		"Summarizer load datastore via groupId with snapshot in the future, with seq > some ops",
-		[
-			{
-				eventName: "fluid:telemetry:FluidDataStoreContext:RealizeError",
-				error: "Summarizer client behind, loaded newer snapshot with loadingGroupId",
+			public get loadingGroupId() {
+				return this.context.loadingGroupId;
+			}
+		}
+		// Allow us to control summaries
+		const runtimeOptions: IContainerRuntimeOptions = {
+			summaryOptions: {
+				summaryConfigOverrides: {
+					state: "disabled",
+				},
 			},
-		],
-		async () => {
+		};
+		const configProvider = createTestConfigProvider();
+		configProvider.set("Fluid.Container.UseLoadingGroupIdForSnapshotFetch", true);
+
+		const testDataObjectType = "TestDataObject";
+		const dataObjectFactory = new DataObjectFactory(testDataObjectType, TestDataObject, [], {});
+
+		// The 1st runtime factory, V1 of the code
+		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
+			defaultFactory: dataObjectFactory,
+			registryEntries: [dataObjectFactory.registryEntry],
+			runtimeOptions,
+		});
+
+		let provider: ITestObjectProvider;
+
+		const assertPopulatedGroupIdTree = (snapshotTree: ISnapshotTree, message: string) => {
+			assert(snapshotTree.omitted === undefined, message);
+			assert(snapshotTree.groupId === loadingGroupId, message);
+			assert(Object.entries(snapshotTree.trees).length > 0, message);
+			assert(Object.entries(snapshotTree.blobs).length > 0, message);
+		};
+
+		beforeEach("setup", async () => {
+			provider = getTestObjectProvider();
+		});
+
+		const loadingGroupId = "loadingGroupId";
+		it("Load datastore via groupId with snapshot in the future, with seq < all the ops", async () => {
 			if (provider.driver.type !== "local") {
-				provider.logger?.send({
-					category: "error",
-					eventName: "fluid:telemetry:FluidDataStoreContext:RealizeError",
-					error: "Summarizer client behind, loaded newer snapshot with loadingGroupId",
-				});
 				return;
 			}
 			// Load basic container stuff
-			const container = await provider.createContainer(runtimeFactory, {
-				configProvider,
-			});
+			const container = await provider.createContainer(runtimeFactory, { configProvider });
 			const mainObject = (await container.getEntryPoint()) as TestDataObject;
 			const containerRuntime = mainObject.containerRuntime;
 
@@ -288,159 +122,336 @@ describeCompat("Create data store with group id", "2.0.0-rc.3.0.0", (getTestObje
 			mainObject._root.set("dataObjectA", dataObjectA.handle);
 			dataObjectA._root.set("A", "A");
 
+			// Summarize
+			await provider.ensureSynchronized();
+			const { summarizer } = await createSummarizerFromFactory(
+				provider,
+				container,
+				dataObjectFactory,
+			);
+			const { summaryVersion } = await summarizeNow(summarizer);
+
+			const container2 = await provider.loadContainer(
+				runtimeFactory,
+				{ configProvider },
+				{ [LoaderHeader.version]: summaryVersion },
+			);
+			await provider.ensureSynchronized();
+
+			dataObjectA._root.set("B", "B");
+			await provider.ensureSynchronized();
+			const { summaryRefSeq } = await summarizeNow(summarizer);
+
+			// Testing the get snapshot call
+			const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
+			const runtime2 = mainObject2.containerRuntime;
+
+			// Try to load the data stores with groupIds
+			const handleA2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
+			assert(handleA2 !== undefined, "handleA2 should not be undefined");
+
+			const snapshotADeferred: Deferred<ISnapshot> = new Deferred();
+			assert(
+				runtime2.storage.getSnapshot !== undefined,
+				"getSnapshot not defined for runtime2",
+			);
+			interceptResult(runtime2.storage, runtime2.storage.getSnapshot, (snapshot) => {
+				snapshotADeferred.resolve(snapshot);
+			});
+
+			// loading group call
+			const dataObjectA2 = await handleA2.get();
+			assert.equal(dataObjectA2._root.get("A"), "A", "A should be set");
+			assert.equal(dataObjectA2._root.get("B"), "B", "B should be set");
+
+			const groupSnapshot = await snapshotADeferred.promise;
+			const snapshotTreeA =
+				groupSnapshot.snapshotTree.trees[".channels"].trees[dataObjectA2.id];
+			assertPopulatedGroupIdTree(snapshotTreeA, "Should be a populated groupId tree");
+			assert(
+				groupSnapshot.sequenceNumber === summaryRefSeq,
+				"failed to load snapshot with correct sequence number",
+			);
+		});
+
+		it("Load datastore via groupId with snapshot in the future, with seq > some ops", async () => {
+			if (provider.driver.type !== "local") {
+				return;
+			}
+			// Load basic container stuff
+			const container = await provider.createContainer(runtimeFactory, { configProvider });
+			const mainObject = (await container.getEntryPoint()) as TestDataObject;
+			const containerRuntime = mainObject.containerRuntime;
+
+			// Create data stores with loadingGroupIds
+			const dataStoreA = await containerRuntime.createDataStore(
+				testDataObjectType,
+				loadingGroupId,
+			);
+
+			// Attach the data stores
+			const dataObjectA = (await dataStoreA.entryPoint.get()) as TestDataObject;
+			mainObject._root.set("dataObjectA", dataObjectA.handle);
+			dataObjectA._root.set("A", "A");
+
+			// Summarize
+			await provider.ensureSynchronized();
+			const { summarizer, container: summarizingContainer } =
+				await createSummarizerFromFactory(provider, container, dataObjectFactory);
+			const { summaryVersion } = await summarizeNow(summarizer);
+			// Work around getEntryPoint returning the summarizer instead of a datastore
+			const runtimeS = (summarizingContainer as any).runtime as ContainerRuntime;
+			const handleS = await runtimeS.getAliasedDataStoreEntryPoint("default");
+			assert(handleS !== undefined, "handleS should not be undefined");
+			const mainObjectS = (await handleS.get()) as TestDataObject;
+
+			await provider.ensureSynchronized();
+			const handleAS = mainObjectS._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
+			assert(handleAS !== undefined, "handleA2 should not be undefined");
+			const dataObjectAS = await handleAS.get();
+
+			const container2 = await provider.loadContainer(
+				runtimeFactory,
+				{ configProvider },
+				{ [LoaderHeader.version]: summaryVersion },
+			);
+			// Testing the get snapshot call
+			const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
+			const handleA2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
+			assert(handleA2 !== undefined, "handleA2 should not be undefined");
+
+			container2.disconnect();
+			const waitForOp = new Deferred<void>();
+			dataObjectAS._root.on("valueChanged", (changed) => {
+				if (changed.key === "B") {
+					waitForOp.resolve();
+				}
+			});
+			dataObjectA._root.set("B", "B");
+
+			await waitForOp.promise;
+			await summarizeNow(summarizer);
+
+			// start loading group call
+			const dataObjectA2Promise = handleA2.get();
+			const deferred = new Deferred<void>();
+
+			void dataObjectA2Promise.then(() => {
+				deferred.resolve();
+			});
+
+			await delay(100);
+
+			// Loading group call should wait for ops to come through
+			assert(!deferred.isCompleted, "Promise should not be resolved yet");
+
+			// This should cause the ops to come through
+			container2.connect();
+			const dataObjectA2 = await dataObjectA2Promise;
+
+			// Get the latest data
+			await provider.ensureSynchronized();
+			// Force ops to come through
+			assert(deferred.isCompleted, "Promise should be resolved");
+			assert(dataObjectA2._root.get("A") === "A", "A should be set");
+			assert(dataObjectA2._root.get("B") === "B", "B should be set");
+		});
+
+		itExpects(
+			"Summarizer load datastore via groupId with snapshot in the future, with seq > some ops",
+			[
+				{
+					eventName: "fluid:telemetry:FluidDataStoreContext:RealizeError",
+					error: "Summarizer client behind, loaded newer snapshot with loadingGroupId",
+				},
+			],
+			async () => {
+				if (provider.driver.type !== "local") {
+					provider.logger?.send({
+						category: "error",
+						eventName: "fluid:telemetry:FluidDataStoreContext:RealizeError",
+						error: "Summarizer client behind, loaded newer snapshot with loadingGroupId",
+					});
+					return;
+				}
+				// Load basic container stuff
+				const container = await provider.createContainer(runtimeFactory, {
+					configProvider,
+				});
+				const mainObject = (await container.getEntryPoint()) as TestDataObject;
+				const containerRuntime = mainObject.containerRuntime;
+
+				// Create data stores with loadingGroupIds
+				const dataStoreA = await containerRuntime.createDataStore(
+					testDataObjectType,
+					loadingGroupId,
+				);
+
+				// Attach the data stores
+				const dataObjectA = (await dataStoreA.entryPoint.get()) as TestDataObject;
+				mainObject._root.set("dataObjectA", dataObjectA.handle);
+				dataObjectA._root.set("A", "A");
+
+				const { summarizer } = await createSummarizerFromFactory(
+					provider,
+					container,
+					dataObjectFactory,
+				);
+
+				await provider.ensureSynchronized();
+				const { summaryVersion } = await summarizeNow(summarizer);
+				dataObjectA._root.set("B", "B");
+				summarizer.close();
+
+				const { summarizer: summarizer1, container: container1 } =
+					await createSummarizerFromFactory(
+						provider,
+						container,
+						dataObjectFactory,
+						summaryVersion,
+						undefined,
+						undefined,
+						undefined,
+						configProvider,
+					);
+
+				const { summarizer: summarizer2, container: container2 } =
+					await createSummarizerFromFactory(
+						provider,
+						container,
+						dataObjectFactory,
+						summaryVersion,
+						undefined,
+						undefined,
+						undefined,
+						configProvider,
+					);
+				await provider.ensureSynchronized();
+				// Pause the summarizer2 so we can generate a summary in the future
+				// Note: The summarizing containers don't get added to the loader container tracker, so we manually pause here
+				await container2.deltaManager.inbound.pause();
+
+				// Send an op
+				dataObjectA._root.set("C", "C");
+
+				// All this casting is to get the the dataObject from the summarizer2 container to wait for the op we just sent
+				const runtime1 = (summarizer1 as any).runtime as ContainerRuntime;
+				const mainObjectHandle1 = await runtime1.getAliasedDataStoreEntryPoint("default");
+				assert(mainObjectHandle1 !== undefined, "mainObject1 should not be undefined");
+				const mainObject1 = (await mainObjectHandle1.get()) as TestDataObject;
+				const dataObjectA1Handle = mainObject1._root.get<IFluidHandle>("dataObjectA");
+				assert(
+					dataObjectA1Handle !== undefined,
+					"dataObjectA1Handle should not be undefined",
+				);
+				const dataObjectA1 = (await dataObjectA1Handle.get()) as TestDataObject;
+
+				// Make sure that summarizer1 gets the op
+				const waitForOp = new Deferred<void>();
+				dataObjectA1._root.on("valueChanged", (changed) => {
+					if (changed.key === "C") {
+						waitForOp.resolve();
+					}
+				});
+				await waitForOp.promise;
+
+				// Generate a summary in the future with summarizer 1
+				await summarizeNow(summarizer1);
+
+				// Hack to get the summarizer2 to summarize, there's a bunch of state in the summarizer that prevents us from
+				// summarizing, so it's easier to just skip it and call submitSummary directly
+				const neverCancel = new Deferred<SummarizerStopReason>();
+				const runtime2 = (summarizer2 as any).runtime as ContainerRuntime;
+				const result = await runtime2.submitSummary({
+					summaryLogger: new MockLogger().toTelemetryLogger(),
+					cancellationToken: {
+						cancelled: false,
+						waitCancelled: neverCancel.promise,
+					},
+					latestSummaryRefSeqNum: 0,
+				});
+
+				assert(result.stage === "base", "submitSummary should fail in base stage");
+				assert.equal(
+					result.error.message,
+					"Summarizer client behind, loaded newer snapshot with loadingGroupId",
+					"submitSummary should fail in base stage because summarizer is behind",
+				);
+			},
+		);
+
+		it("Load datastore via groupId getting a snapshot older than snapshot we loaded from", async () => {
+			if (provider.driver.type !== "local") {
+				return;
+			}
+			// Load basic container stuff
+			const container = await provider.createContainer(runtimeFactory, { configProvider });
+			const mainObject = (await container.getEntryPoint()) as TestDataObject;
+			const containerRuntime = mainObject.containerRuntime;
+
+			// Create data store with loadingGroupId
+			const dataStoreA = await containerRuntime.createDataStore(
+				testDataObjectType,
+				loadingGroupId,
+			);
+
+			// Attach the data store
+			const dataObjectA = (await dataStoreA.entryPoint.get()) as TestDataObject;
+			mainObject._root.set("dataObjectA", dataObjectA.handle);
+			dataObjectA._root.set("A", "A");
+
 			const { summarizer } = await createSummarizerFromFactory(
 				provider,
 				container,
 				dataObjectFactory,
 			);
 
+			// Summarize
 			await provider.ensureSynchronized();
-			const { summaryVersion } = await summarizeNow(summarizer);
+			const { summaryVersion: summaryVersion1 } = await summarizeNow(summarizer);
+
 			dataObjectA._root.set("B", "B");
-			summarizer.close();
 
-			const { summarizer: summarizer1, container: container1 } =
-				await createSummarizerFromFactory(
-					provider,
-					container,
-					dataObjectFactory,
-					summaryVersion,
-					undefined,
-					undefined,
-					undefined,
-					configProvider,
-				);
-
-			const { summarizer: summarizer2, container: container2 } =
-				await createSummarizerFromFactory(
-					provider,
-					container,
-					dataObjectFactory,
-					summaryVersion,
-					undefined,
-					undefined,
-					undefined,
-					configProvider,
-				);
 			await provider.ensureSynchronized();
-			// Pause the summarizer2 so we can generate a summary in the future
-			// Note: The summarizing containers don't get added to the loader container tracker, so we manually pause here
-			await container2.deltaManager.inbound.pause();
+			const { summaryVersion: summaryVersion2 } = await summarizeNow(summarizer);
 
-			// Send an op
-			dataObjectA._root.set("C", "C");
-
-			// All this casting is to get the the dataObject from the summarizer2 container to wait for the op we just sent
-			const runtime1 = (summarizer1 as any).runtime as ContainerRuntime;
-			const mainObjectHandle1 = await runtime1.getAliasedDataStoreEntryPoint("default");
-			assert(mainObjectHandle1 !== undefined, "mainObject1 should not be undefined");
-			const mainObject1 = (await mainObjectHandle1.get()) as TestDataObject;
-			const dataObjectA1Handle = mainObject1._root.get<IFluidHandle>("dataObjectA");
-			assert(dataObjectA1Handle !== undefined, "dataObjectA1Handle should not be undefined");
-			const dataObjectA1 = (await dataObjectA1Handle.get()) as TestDataObject;
-
-			// Make sure that summarizer1 gets the op
-			const waitForOp = new Deferred<void>();
-			dataObjectA1._root.on("valueChanged", (changed) => {
-				if (changed.key === "C") {
-					waitForOp.resolve();
-				}
-			});
-			await waitForOp.promise;
-
-			// Generate a summary in the future with summarizer 1
-			await summarizeNow(summarizer1);
-
-			// Hack to get the summarizer2 to summarize, there's a bunch of state in the summarizer that prevents us from
-			// summarizing, so it's easier to just skip it and call submitSummary directly
-			const neverCancel = new Deferred<SummarizerStopReason>();
-			const runtime2 = (summarizer2 as any).runtime as ContainerRuntime;
-			const result = await runtime2.submitSummary({
-				summaryLogger: new MockLogger().toTelemetryLogger(),
-				cancellationToken: {
-					cancelled: false,
-					waitCancelled: neverCancel.promise,
-				},
-				latestSummaryRefSeqNum: 0,
-			});
-
-			assert(result.stage === "base", "submitSummary should fail in base stage");
-			assert.equal(
-				result.error.message,
-				"Summarizer client behind, loaded newer snapshot with loadingGroupId",
-				"submitSummary should fail in base stage because summarizer is behind",
+			// Load the container with the second summary
+			const container2 = await provider.loadContainer(
+				runtimeFactory,
+				{ configProvider },
+				{ [LoaderHeader.version]: summaryVersion2 },
 			);
-		},
-	);
+			const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
+			const runtime2 = mainObject2.containerRuntime;
+			const dataObjectA2Handle =
+				mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
+			assert(dataObjectA2Handle !== undefined, "dataObjectA2Handle should not be undefined");
 
-	it("Load datastore via groupId getting a snapshot older than snapshot we loaded from", async () => {
-		if (provider.driver.type !== "local") {
-			return;
-		}
-		// Load basic container stuff
-		const container = await provider.createContainer(runtimeFactory, { configProvider });
-		const mainObject = (await container.getEntryPoint()) as TestDataObject;
-		const containerRuntime = mainObject.containerRuntime;
+			assert(
+				runtime2.storage.getSnapshot !== undefined,
+				"getSnapshot not defined for runtime2",
+			);
+			const olderSnapshot = await runtime2.storage.getSnapshot({
+				versionId: summaryVersion1,
+				loadingGroupIds: [loadingGroupId],
+			});
+			overrideResult(runtime2.storage, runtime2.storage.getSnapshot, olderSnapshot);
+			// TODO: update when this assert changes to a hex.
+			await assert.rejects(
+				dataObjectA2Handle.get(),
+				(error: Error & any) => {
+					const correctError: boolean =
+						error.errorFromRequestFluidObject === true &&
+						error.code === 500 &&
+						error.message !== undefined &&
+						error.message.includes(
+							"Downloaded snapshot older than snapshot we loaded from",
+						);
 
-		// Create data store with loadingGroupId
-		const dataStoreA = await containerRuntime.createDataStore(
-			testDataObjectType,
-			loadingGroupId,
-		);
-
-		// Attach the data store
-		const dataObjectA = (await dataStoreA.entryPoint.get()) as TestDataObject;
-		mainObject._root.set("dataObjectA", dataObjectA.handle);
-		dataObjectA._root.set("A", "A");
-
-		const { summarizer } = await createSummarizerFromFactory(
-			provider,
-			container,
-			dataObjectFactory,
-		);
-
-		// Summarize
-		await provider.ensureSynchronized();
-		const { summaryVersion: summaryVersion1 } = await summarizeNow(summarizer);
-
-		dataObjectA._root.set("B", "B");
-
-		await provider.ensureSynchronized();
-		const { summaryVersion: summaryVersion2 } = await summarizeNow(summarizer);
-
-		// Load the container with the second summary
-		const container2 = await provider.loadContainer(
-			runtimeFactory,
-			{ configProvider },
-			{ [LoaderHeader.version]: summaryVersion2 },
-		);
-		const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
-		const runtime2 = mainObject2.containerRuntime;
-		const dataObjectA2Handle =
-			mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
-		assert(dataObjectA2Handle !== undefined, "dataObjectA2Handle should not be undefined");
-
-		assert(runtime2.storage.getSnapshot !== undefined, "getSnapshot not defined for runtime2");
-		const olderSnapshot = await runtime2.storage.getSnapshot({
-			versionId: summaryVersion1,
-			loadingGroupIds: [loadingGroupId],
+					return correctError;
+				},
+				"Loading an older snapshot than the snapshot the runtime loaded from should fail",
+			);
 		});
-		overrideResult(runtime2.storage, runtime2.storage.getSnapshot, olderSnapshot);
-		// TODO: update when this assert changes to a hex.
-		await assert.rejects(
-			dataObjectA2Handle.get(),
-			(error: Error & any) => {
-				const correctError: boolean =
-					error.errorFromRequestFluidObject === true &&
-					error.code === 500 &&
-					error.message !== undefined &&
-					error.message.includes(
-						"Downloaded snapshot older than snapshot we loaded from",
-					);
-
-				return correctError;
-			},
-			"Loading an older snapshot than the snapshot the runtime loaded from should fail",
-		);
-	});
-});
+	},
+);

--- a/packages/test/test-end-to-end-tests/src/test/dataStoresNested.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/dataStoresNested.spec.ts
@@ -35,7 +35,7 @@ interface IDataStores extends IFluidDataStoreChannel {
 	createDataStoreContext(pkg: string[], props?: any, loadingGroupId?: string): any;
 }
 
-describeCompat("Nested DataStores", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Nested DataStores", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 	const { SharedMap } = apis.dds;
 

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -848,7 +848,7 @@ describeCompat("Detached Container", "FullCompat", (getTestObjectProvider, apis)
 });
 
 // Review: Run with Full Compat?
-describeCompat("Detached Container", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Detached Container", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const {
 		SharedString,
 		SharedMap,

--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -832,441 +832,453 @@ describeCompat("SharedDirectory", "FullCompat", (getTestObjectProvider, apis) =>
 	});
 });
 
-describeCompat("SharedDirectory orderSequentially", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
-	const { SharedDirectory } = apis.dds;
-	const directoryId = "directoryKey";
-	const registry: ChannelFactoryRegistry = [[directoryId, SharedDirectory.getFactory()]];
-	const testContainerConfig: ITestContainerConfig = {
-		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
-	};
-
-	let provider: ITestObjectProvider;
-	beforeEach("getTestObjectProvider", () => {
-		provider = getTestObjectProvider();
-	});
-
-	let container: IContainer;
-	let dataObject: ITestFluidObject;
-	let sharedDir: ISharedDirectory;
-	let containerRuntime: ContainerRuntime;
-	let clearEventCount: number;
-	let changedEventData: IDirectoryValueChanged[];
-	let subDirCreatedEventData: string[];
-	let subDirDeletedEventData: string[];
-	let undisposedEventData: string[];
-	let disposedEventData: string[];
-
-	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
-		getRawConfig: (name: string): ConfigTypes => settings[name],
-	});
-	const errorMessage = "callback failure";
-
-	beforeEach("setup", async () => {
-		const configWithFeatureGates = {
-			...testContainerConfig,
-			loaderProps: {
-				configProvider: configProvider({
-					"Fluid.ContainerRuntime.EnableRollback": true,
-				}),
-			},
+describeCompat(
+	"SharedDirectory orderSequentially",
+	"2.0.0-rc.3.0.0",
+	(getTestObjectProvider, apis) => {
+		const { SharedDirectory } = apis.dds;
+		const directoryId = "directoryKey";
+		const registry: ChannelFactoryRegistry = [[directoryId, SharedDirectory.getFactory()]];
+		const testContainerConfig: ITestContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry,
 		};
-		container = await provider.makeTestContainer(configWithFeatureGates);
-		dataObject = (await container.getEntryPoint()) as ITestFluidObject;
-		sharedDir = await dataObject.getSharedObject<SharedDirectory>(directoryId);
-		containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
-		clearEventCount = 0;
-		changedEventData = [];
-		subDirCreatedEventData = [];
-		subDirDeletedEventData = [];
-		undisposedEventData = [];
-		disposedEventData = [];
-		sharedDir.on("valueChanged", (changed, _local, _target) => {
-			changedEventData.push(changed);
+
+		let provider: ITestObjectProvider;
+		beforeEach("getTestObjectProvider", () => {
+			provider = getTestObjectProvider();
 		});
-		sharedDir.on("clear", (local, target) => {
-			clearEventCount++;
+
+		let container: IContainer;
+		let dataObject: ITestFluidObject;
+		let sharedDir: ISharedDirectory;
+		let containerRuntime: ContainerRuntime;
+		let clearEventCount: number;
+		let changedEventData: IDirectoryValueChanged[];
+		let subDirCreatedEventData: string[];
+		let subDirDeletedEventData: string[];
+		let undisposedEventData: string[];
+		let disposedEventData: string[];
+
+		const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+			getRawConfig: (name: string): ConfigTypes => settings[name],
 		});
-		sharedDir.on("subDirectoryCreated", (path, _local, _target) => {
-			subDirCreatedEventData.push(path);
+		const errorMessage = "callback failure";
+
+		beforeEach("setup", async () => {
+			const configWithFeatureGates = {
+				...testContainerConfig,
+				loaderProps: {
+					configProvider: configProvider({
+						"Fluid.ContainerRuntime.EnableRollback": true,
+					}),
+				},
+			};
+			container = await provider.makeTestContainer(configWithFeatureGates);
+			dataObject = (await container.getEntryPoint()) as ITestFluidObject;
+			sharedDir = await dataObject.getSharedObject<SharedDirectory>(directoryId);
+			containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
+			clearEventCount = 0;
+			changedEventData = [];
+			subDirCreatedEventData = [];
+			subDirDeletedEventData = [];
+			undisposedEventData = [];
+			disposedEventData = [];
+			sharedDir.on("valueChanged", (changed, _local, _target) => {
+				changedEventData.push(changed);
+			});
+			sharedDir.on("clear", (local, target) => {
+				clearEventCount++;
+			});
+			sharedDir.on("subDirectoryCreated", (path, _local, _target) => {
+				subDirCreatedEventData.push(path);
+			});
+			sharedDir.on("subDirectoryDeleted", (path, _local, _target) => {
+				subDirDeletedEventData.push(path);
+			});
 		});
-		sharedDir.on("subDirectoryDeleted", (path, _local, _target) => {
-			subDirDeletedEventData.push(path);
+
+		it("Should rollback set", () => {
+			let error: Error | undefined;
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedDir.set("key", 0);
+					throw new Error(errorMessage);
+				});
+			} catch (err) {
+				error = err as Error;
+			}
+
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false, "Container disposed");
+			assert.equal(sharedDir.size, 0);
+			assert.equal(sharedDir.has("key"), false);
+			assert.equal(clearEventCount, 0);
+			assert.equal(changedEventData.length, 2);
+			assert.equal(changedEventData[0].key, "key");
+			assert.equal(changedEventData[0].previousValue, undefined);
+			// rollback
+			assert.equal(changedEventData[1].key, "key");
+			assert.equal(changedEventData[1].previousValue, 0);
 		});
-	});
 
-	it("Should rollback set", () => {
-		let error: Error | undefined;
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.set("key", 0);
-				throw new Error(errorMessage);
-			});
-		} catch (err) {
-			error = err as Error;
-		}
+		it("Should rollback set to prior value", () => {
+			sharedDir.set("key", "old");
+			let error: Error | undefined;
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedDir.set("key", "new");
+					sharedDir.set("key", "last");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
 
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedDir.size, 0);
-		assert.equal(sharedDir.has("key"), false);
-		assert.equal(clearEventCount, 0);
-		assert.equal(changedEventData.length, 2);
-		assert.equal(changedEventData[0].key, "key");
-		assert.equal(changedEventData[0].previousValue, undefined);
-		// rollback
-		assert.equal(changedEventData[1].key, "key");
-		assert.equal(changedEventData[1].previousValue, 0);
-	});
-
-	it("Should rollback set to prior value", () => {
-		sharedDir.set("key", "old");
-		let error: Error | undefined;
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.set("key", "new");
-				sharedDir.set("key", "last");
-				throw new Error("callback failure");
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedDir.size, 1);
-		assert.equal(sharedDir.get("key"), "old", `Unexpected value ${sharedDir.get("key")}`);
-		assert.equal(clearEventCount, 0);
-		assert.equal(changedEventData.length, 5);
-		assert.equal(changedEventData[0].key, "key");
-		assert.equal(changedEventData[0].previousValue, undefined);
-		assert.equal(changedEventData[1].key, "key");
-		assert.equal(changedEventData[1].previousValue, "old");
-		assert.equal(changedEventData[2].key, "key");
-		assert.equal(changedEventData[2].previousValue, "new");
-		// rollback
-		assert.equal(changedEventData[3].key, "key");
-		assert.equal(changedEventData[3].previousValue, "last");
-		assert.equal(changedEventData[4].key, "key");
-		assert.equal(changedEventData[4].previousValue, "new");
-	});
-
-	it("Should rollback delete", () => {
-		sharedDir.set("key", "old");
-		let error: Error | undefined;
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.delete("key");
-				throw new Error("callback failure");
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedDir.size, 1);
-		assert.equal(sharedDir.get("key"), "old", `Unexpected value ${sharedDir.get("key")}`);
-		assert.equal(clearEventCount, 0);
-		assert.equal(changedEventData.length, 3);
-		assert.equal(changedEventData[0].key, "key");
-		assert.equal(changedEventData[0].previousValue, undefined);
-		assert.equal(changedEventData[1].key, "key");
-		assert.equal(changedEventData[1].previousValue, "old");
-		// rollback
-		assert.equal(changedEventData[2].key, "key");
-		assert.equal(changedEventData[2].previousValue, undefined);
-	});
-
-	it("Should rollback clear", () => {
-		sharedDir.set("key1", "old1");
-		sharedDir.set("key2", "old2");
-		let error: Error | undefined;
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.clear();
-				throw new Error("callback failure");
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedDir.size, 2);
-		assert.equal(sharedDir.get("key1"), "old1", `Unexpected value ${sharedDir.get("key1")}`);
-		assert.equal(sharedDir.get("key2"), "old2", `Unexpected value ${sharedDir.get("key2")}`);
-		assert.equal(changedEventData.length, 4);
-		assert.equal(changedEventData[0].key, "key1");
-		assert.equal(changedEventData[0].previousValue, undefined);
-		assert.equal(changedEventData[1].key, "key2");
-		assert.equal(changedEventData[1].previousValue, undefined);
-		assert.equal(clearEventCount, 1);
-		// rollback
-		assert.equal(changedEventData[2].key, "key1");
-		assert.equal(changedEventData[2].previousValue, undefined);
-		assert.equal(changedEventData[3].key, "key2");
-		assert.equal(changedEventData[3].previousValue, undefined);
-	});
-
-	it("Should rollback newly created subdirectory", () => {
-		let error: Error | undefined;
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.createSubDirectory("subDirName");
-				throw new Error("callback failure");
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedDir.countSubDirectory?.(), 0);
-		assert.equal(subDirCreatedEventData.length, 1);
-		assert.equal(subDirCreatedEventData[0], "subDirName");
-		// rollback
-		assert.equal(subDirDeletedEventData.length, 1);
-		assert.equal(subDirDeletedEventData[0], "subDirName");
-	});
-
-	it("Should not rollback creating existing subdirectory", () => {
-		let error: Error | undefined;
-		const subDir = sharedDir.createSubDirectory("subDirName");
-		subDir.on("undisposed", (value: IDirectory) => {
-			undisposedEventData.push(value.absolutePath);
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false);
+			assert.equal(sharedDir.size, 1);
+			assert.equal(sharedDir.get("key"), "old", `Unexpected value ${sharedDir.get("key")}`);
+			assert.equal(clearEventCount, 0);
+			assert.equal(changedEventData.length, 5);
+			assert.equal(changedEventData[0].key, "key");
+			assert.equal(changedEventData[0].previousValue, undefined);
+			assert.equal(changedEventData[1].key, "key");
+			assert.equal(changedEventData[1].previousValue, "old");
+			assert.equal(changedEventData[2].key, "key");
+			assert.equal(changedEventData[2].previousValue, "new");
+			// rollback
+			assert.equal(changedEventData[3].key, "key");
+			assert.equal(changedEventData[3].previousValue, "last");
+			assert.equal(changedEventData[4].key, "key");
+			assert.equal(changedEventData[4].previousValue, "new");
 		});
-		subDir.on("disposed", (value: IDirectory) => {
-			disposedEventData.push(value.absolutePath);
+
+		it("Should rollback delete", () => {
+			sharedDir.set("key", "old");
+			let error: Error | undefined;
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedDir.delete("key");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
+
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false);
+			assert.equal(sharedDir.size, 1);
+			assert.equal(sharedDir.get("key"), "old", `Unexpected value ${sharedDir.get("key")}`);
+			assert.equal(clearEventCount, 0);
+			assert.equal(changedEventData.length, 3);
+			assert.equal(changedEventData[0].key, "key");
+			assert.equal(changedEventData[0].previousValue, undefined);
+			assert.equal(changedEventData[1].key, "key");
+			assert.equal(changedEventData[1].previousValue, "old");
+			// rollback
+			assert.equal(changedEventData[2].key, "key");
+			assert.equal(changedEventData[2].previousValue, undefined);
 		});
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.createSubDirectory("subDirName");
-				throw new Error("callback failure");
-			});
-		} catch (err) {
-			error = err as Error;
-		}
 
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedDir.countSubDirectory?.(), 1);
-		assert.notEqual(sharedDir.getSubDirectory("subDirName"), undefined);
-		assert.equal(subDirCreatedEventData.length, 1);
-		assert.equal(subDirCreatedEventData[0], "subDirName");
-		// rollback
-		assert.equal(subDirDeletedEventData.length, 0);
-		// ensure that dispose/undispose aren't fired
-		assert.equal(undisposedEventData.length, 0);
-		assert.equal(disposedEventData.length, 0);
-	});
+		it("Should rollback clear", () => {
+			sharedDir.set("key1", "old1");
+			sharedDir.set("key2", "old2");
+			let error: Error | undefined;
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedDir.clear();
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
 
-	it("Should rollback created subdirectory with content", () => {
-		let error: Error | undefined;
-		try {
-			containerRuntime.orderSequentially(() => {
-				const subdir = sharedDir.createSubDirectory("subDirName");
-				subdir.set("key1", "content1");
-				subdir.createSubDirectory("subSubDirName");
-				throw new Error("callback failure");
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedDir.countSubDirectory?.(), 0);
-		assert.equal(
-			subDirCreatedEventData.length,
-			2,
-			`subDirCreatedEventData.length: ${subDirCreatedEventData.length}`,
-		);
-		assert.equal(subDirCreatedEventData[0], "subDirName");
-		assert.equal(subDirCreatedEventData[1], "subDirName/subSubDirName");
-		assert.equal(changedEventData.length, 2);
-		assert.equal(changedEventData[0].key, "key1");
-		assert.equal(changedEventData[0].previousValue, undefined);
-		// rollback
-		assert.equal(changedEventData[1].key, "key1");
-		assert.equal(changedEventData[1].previousValue, "content1");
-		assert.equal(
-			subDirDeletedEventData.length,
-			2,
-			`subDirDeletedEventData.length: ${subDirDeletedEventData.length}`,
-		);
-		assert.equal(subDirDeletedEventData[0], "subDirName/subSubDirName");
-		assert.equal(subDirDeletedEventData[1], "subDirName");
-	});
-
-	it("Should rollback deleted subdirectory", () => {
-		let error: Error | undefined;
-		const subDir = sharedDir.createSubDirectory("subDirName");
-		subDir.on("undisposed", (value: IDirectory) => {
-			undisposedEventData.push(value.absolutePath);
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false);
+			assert.equal(sharedDir.size, 2);
+			assert.equal(
+				sharedDir.get("key1"),
+				"old1",
+				`Unexpected value ${sharedDir.get("key1")}`,
+			);
+			assert.equal(
+				sharedDir.get("key2"),
+				"old2",
+				`Unexpected value ${sharedDir.get("key2")}`,
+			);
+			assert.equal(changedEventData.length, 4);
+			assert.equal(changedEventData[0].key, "key1");
+			assert.equal(changedEventData[0].previousValue, undefined);
+			assert.equal(changedEventData[1].key, "key2");
+			assert.equal(changedEventData[1].previousValue, undefined);
+			assert.equal(clearEventCount, 1);
+			// rollback
+			assert.equal(changedEventData[2].key, "key1");
+			assert.equal(changedEventData[2].previousValue, undefined);
+			assert.equal(changedEventData[3].key, "key2");
+			assert.equal(changedEventData[3].previousValue, undefined);
 		});
-		subDir.on("disposed", (value: IDirectory) => {
-			disposedEventData.push(value.absolutePath);
+
+		it("Should rollback newly created subdirectory", () => {
+			let error: Error | undefined;
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedDir.createSubDirectory("subDirName");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
+
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false);
+			assert.equal(sharedDir.countSubDirectory?.(), 0);
+			assert.equal(subDirCreatedEventData.length, 1);
+			assert.equal(subDirCreatedEventData[0], "subDirName");
+			// rollback
+			assert.equal(subDirDeletedEventData.length, 1);
+			assert.equal(subDirDeletedEventData[0], "subDirName");
 		});
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.deleteSubDirectory("subDirName");
-				throw new Error("callback failure");
+
+		it("Should not rollback creating existing subdirectory", () => {
+			let error: Error | undefined;
+			const subDir = sharedDir.createSubDirectory("subDirName");
+			subDir.on("undisposed", (value: IDirectory) => {
+				undisposedEventData.push(value.absolutePath);
 			});
-		} catch (err) {
-			error = err as Error;
-		}
-
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedDir.countSubDirectory?.(), 1);
-		assert.notEqual(sharedDir.getSubDirectory("subDirName"), undefined);
-		assert.equal(subDirCreatedEventData.length, 2);
-		assert.equal(subDirCreatedEventData[0], "subDirName");
-		assert.equal(subDirDeletedEventData.length, 1);
-		assert.equal(subDirDeletedEventData[0], "subDirName");
-		// rollback
-		assert.equal(subDirCreatedEventData[1], "subDirName");
-		assert.equal(undisposedEventData.length, 1);
-		assert.equal(undisposedEventData[0], "/subDirName");
-		assert.equal(disposedEventData.length, 1);
-	});
-
-	it("Should not rollback deleting nonexistent subdirectory", () => {
-		let error: Error | undefined;
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.deleteSubDirectory("subDirName");
-				throw new Error("callback failure");
+			subDir.on("disposed", (value: IDirectory) => {
+				disposedEventData.push(value.absolutePath);
 			});
-		} catch (err) {
-			error = err as Error;
-		}
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedDir.createSubDirectory("subDirName");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
 
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedDir.countSubDirectory?.(), 0);
-		assert.equal(subDirDeletedEventData.length, 0);
-		// rollback
-		assert.equal(subDirCreatedEventData.length, 0);
-	});
-
-	it("Should rollback deleted subdirectory with content", () => {
-		let error: Error | undefined;
-		const subdir = sharedDir.createSubDirectory("subDirName");
-		subdir.on("undisposed", (value: IDirectory) => {
-			undisposedEventData.push(value.absolutePath);
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false);
+			assert.equal(sharedDir.countSubDirectory?.(), 1);
+			assert.notEqual(sharedDir.getSubDirectory("subDirName"), undefined);
+			assert.equal(subDirCreatedEventData.length, 1);
+			assert.equal(subDirCreatedEventData[0], "subDirName");
+			// rollback
+			assert.equal(subDirDeletedEventData.length, 0);
+			// ensure that dispose/undispose aren't fired
+			assert.equal(undisposedEventData.length, 0);
+			assert.equal(disposedEventData.length, 0);
 		});
-		subdir.on("disposed", (value: IDirectory) => {
-			disposedEventData.push(value.absolutePath);
+
+		it("Should rollback created subdirectory with content", () => {
+			let error: Error | undefined;
+			try {
+				containerRuntime.orderSequentially(() => {
+					const subdir = sharedDir.createSubDirectory("subDirName");
+					subdir.set("key1", "content1");
+					subdir.createSubDirectory("subSubDirName");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
+
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false);
+			assert.equal(sharedDir.countSubDirectory?.(), 0);
+			assert.equal(
+				subDirCreatedEventData.length,
+				2,
+				`subDirCreatedEventData.length: ${subDirCreatedEventData.length}`,
+			);
+			assert.equal(subDirCreatedEventData[0], "subDirName");
+			assert.equal(subDirCreatedEventData[1], "subDirName/subSubDirName");
+			assert.equal(changedEventData.length, 2);
+			assert.equal(changedEventData[0].key, "key1");
+			assert.equal(changedEventData[0].previousValue, undefined);
+			// rollback
+			assert.equal(changedEventData[1].key, "key1");
+			assert.equal(changedEventData[1].previousValue, "content1");
+			assert.equal(
+				subDirDeletedEventData.length,
+				2,
+				`subDirDeletedEventData.length: ${subDirDeletedEventData.length}`,
+			);
+			assert.equal(subDirDeletedEventData[0], "subDirName/subSubDirName");
+			assert.equal(subDirDeletedEventData[1], "subDirName");
 		});
-		subdir.set("key1", "content1");
-		const subsubdir = subdir.createSubDirectory("subSubDirName");
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.deleteSubDirectory("subDirName");
-				throw new Error("callback failure");
+
+		it("Should rollback deleted subdirectory", () => {
+			let error: Error | undefined;
+			const subDir = sharedDir.createSubDirectory("subDirName");
+			subDir.on("undisposed", (value: IDirectory) => {
+				undisposedEventData.push(value.absolutePath);
 			});
-		} catch (err) {
-			error = err as Error;
-		}
-
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		assert.equal(sharedDir.countSubDirectory?.(), 1);
-		const readSubdir = sharedDir.getSubDirectory("subDirName");
-		assert.equal(readSubdir, subdir);
-		assert.equal(subdir.size, 1);
-		assert.equal(subdir.get("key1"), "content1");
-		assert.equal(subdir.countSubDirectory ? subdir.countSubDirectory() : 0, 1);
-		assert.notEqual(subdir.getSubDirectory("subSubDirName"), undefined);
-		assert.equal(subDirCreatedEventData.length, 3);
-		assert.equal(subDirCreatedEventData[0], "subDirName");
-		assert.equal(subDirCreatedEventData[1], "subDirName/subSubDirName");
-		assert.equal(
-			changedEventData.length,
-			1,
-			`changedEventData.length:${changedEventData.length}`,
-		);
-		assert.equal(changedEventData[0].key, "key1");
-		assert.equal(changedEventData[0].previousValue, undefined);
-		assert.equal(subDirDeletedEventData.length, 1);
-		assert.equal(subDirDeletedEventData[0], "subDirName");
-		// rollback
-		assert.equal(subDirCreatedEventData[2], "subDirName");
-		assert.equal(undisposedEventData.length, 1);
-		assert.equal(undisposedEventData[0], "/subDirName");
-		assert.equal(disposedEventData.length, 1);
-
-		// verify we still get events on restored content
-		readSubdir.set("key2", "content2");
-
-		assert.equal(changedEventData.length, 2);
-		assert.equal(changedEventData[1].key, "key2");
-		assert.equal(changedEventData[1].previousValue, undefined);
-	});
-
-	it("Should rollback deleted subdirectories with the original order", () => {
-		let error: Error | undefined;
-
-		sharedDir.createSubDirectory("dir2");
-		sharedDir.createSubDirectory("dir3");
-		sharedDir.createSubDirectory("dir1");
-
-		let dirNames = Array.from(sharedDir.subdirectories()).map(([dirName, _]) => dirName);
-		assert.deepStrictEqual(dirNames, ["dir2", "dir3", "dir1"]);
-
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.deleteSubDirectory("dir3");
-				throw new Error("callback failure");
+			subDir.on("disposed", (value: IDirectory) => {
+				disposedEventData.push(value.absolutePath);
 			});
-		} catch (err) {
-			error = err as Error;
-		}
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedDir.deleteSubDirectory("subDirName");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
 
-		// rollback
-		dirNames = Array.from(sharedDir.subdirectories()).map(([dirName, _]) => dirName);
-		assert.deepStrictEqual(dirNames, ["dir2", "dir3", "dir1"]);
-	});
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false);
+			assert.equal(sharedDir.countSubDirectory?.(), 1);
+			assert.notEqual(sharedDir.getSubDirectory("subDirName"), undefined);
+			assert.equal(subDirCreatedEventData.length, 2);
+			assert.equal(subDirCreatedEventData[0], "subDirName");
+			assert.equal(subDirDeletedEventData.length, 1);
+			assert.equal(subDirDeletedEventData[0], "subDirName");
+			// rollback
+			assert.equal(subDirCreatedEventData[1], "subDirName");
+			assert.equal(undisposedEventData.length, 1);
+			assert.equal(undisposedEventData[0], "/subDirName");
+			assert.equal(disposedEventData.length, 1);
+		});
 
-	it("Should rollback deleted subdirectory when multiple subdirectories exist", () => {
-		let error: Error | undefined;
+		it("Should not rollback deleting nonexistent subdirectory", () => {
+			let error: Error | undefined;
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedDir.deleteSubDirectory("subDirName");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
 
-		sharedDir.createSubDirectory("dir2");
-		sharedDir.createSubDirectory("dir3");
-		sharedDir.createSubDirectory("dir1");
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false);
+			assert.equal(sharedDir.countSubDirectory?.(), 0);
+			assert.equal(subDirDeletedEventData.length, 0);
+			// rollback
+			assert.equal(subDirCreatedEventData.length, 0);
+		});
 
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedDir.deleteSubDirectory("dir3");
-				throw new Error("callback failure");
+		it("Should rollback deleted subdirectory with content", () => {
+			let error: Error | undefined;
+			const subdir = sharedDir.createSubDirectory("subDirName");
+			subdir.on("undisposed", (value: IDirectory) => {
+				undisposedEventData.push(value.absolutePath);
 			});
-		} catch (err) {
-			error = err as Error;
-		}
+			subdir.on("disposed", (value: IDirectory) => {
+				disposedEventData.push(value.absolutePath);
+			});
+			subdir.set("key1", "content1");
+			const subsubdir = subdir.createSubDirectory("subSubDirName");
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedDir.deleteSubDirectory("subDirName");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
 
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false);
-		// rollback
-		assert.equal(sharedDir.countSubDirectory?.(), 3);
-		assert.equal(subDirCreatedEventData.length, 4);
-		assert.deepStrictEqual(subDirCreatedEventData, ["dir2", "dir3", "dir1", "dir3"]);
-		assert.equal(subDirDeletedEventData.length, 1);
-		assert.equal(subDirDeletedEventData[0], "dir3");
-	});
-});
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false);
+			assert.equal(sharedDir.countSubDirectory?.(), 1);
+			const readSubdir = sharedDir.getSubDirectory("subDirName");
+			assert.equal(readSubdir, subdir);
+			assert.equal(subdir.size, 1);
+			assert.equal(subdir.get("key1"), "content1");
+			assert.equal(subdir.countSubDirectory ? subdir.countSubDirectory() : 0, 1);
+			assert.notEqual(subdir.getSubDirectory("subSubDirName"), undefined);
+			assert.equal(subDirCreatedEventData.length, 3);
+			assert.equal(subDirCreatedEventData[0], "subDirName");
+			assert.equal(subDirCreatedEventData[1], "subDirName/subSubDirName");
+			assert.equal(
+				changedEventData.length,
+				1,
+				`changedEventData.length:${changedEventData.length}`,
+			);
+			assert.equal(changedEventData[0].key, "key1");
+			assert.equal(changedEventData[0].previousValue, undefined);
+			assert.equal(subDirDeletedEventData.length, 1);
+			assert.equal(subDirDeletedEventData[0], "subDirName");
+			// rollback
+			assert.equal(subDirCreatedEventData[2], "subDirName");
+			assert.equal(undisposedEventData.length, 1);
+			assert.equal(undisposedEventData[0], "/subDirName");
+			assert.equal(disposedEventData.length, 1);
+
+			// verify we still get events on restored content
+			readSubdir.set("key2", "content2");
+
+			assert.equal(changedEventData.length, 2);
+			assert.equal(changedEventData[1].key, "key2");
+			assert.equal(changedEventData[1].previousValue, undefined);
+		});
+
+		it("Should rollback deleted subdirectories with the original order", () => {
+			let error: Error | undefined;
+
+			sharedDir.createSubDirectory("dir2");
+			sharedDir.createSubDirectory("dir3");
+			sharedDir.createSubDirectory("dir1");
+
+			let dirNames = Array.from(sharedDir.subdirectories()).map(([dirName, _]) => dirName);
+			assert.deepStrictEqual(dirNames, ["dir2", "dir3", "dir1"]);
+
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedDir.deleteSubDirectory("dir3");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
+
+			// rollback
+			dirNames = Array.from(sharedDir.subdirectories()).map(([dirName, _]) => dirName);
+			assert.deepStrictEqual(dirNames, ["dir2", "dir3", "dir1"]);
+		});
+
+		it("Should rollback deleted subdirectory when multiple subdirectories exist", () => {
+			let error: Error | undefined;
+
+			sharedDir.createSubDirectory("dir2");
+			sharedDir.createSubDirectory("dir3");
+			sharedDir.createSubDirectory("dir1");
+
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedDir.deleteSubDirectory("dir3");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
+
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false);
+			// rollback
+			assert.equal(sharedDir.countSubDirectory?.(), 3);
+			assert.equal(subDirCreatedEventData.length, 4);
+			assert.deepStrictEqual(subDirCreatedEventData, ["dir2", "dir3", "dir1", "dir3"]);
+			assert.equal(subDirDeletedEventData.length, 1);
+			assert.equal(subDirDeletedEventData[0], "dir3");
+		});
+	},
+);
 
 describeCompat(
 	"SharedDirectory ordering maintenance",

--- a/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/directoryEndToEndTests.spec.ts
@@ -832,7 +832,7 @@ describeCompat("SharedDirectory", "FullCompat", (getTestObjectProvider, apis) =>
 	});
 });
 
-describeCompat("SharedDirectory orderSequentially", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("SharedDirectory orderSequentially", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedDirectory } = apis.dds;
 	const directoryId = "directoryKey";
 	const registry: ChannelFactoryRegistry = [[directoryId, SharedDirectory.getFactory()]];
@@ -1270,7 +1270,7 @@ describeCompat("SharedDirectory orderSequentially", "NoCompat", (getTestObjectPr
 
 describeCompat(
 	"SharedDirectory ordering maintenance",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const { SharedDirectory } = apis.dds;
 		const directoryId = "directoryKey";

--- a/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
@@ -52,7 +52,7 @@ describe("entryPoint compat", () => {
 		return provider.createContainer(runtimeFactory);
 	}
 
-	describeCompat("no compat", "NoCompat", (getTestObjectProvider) => {
+	describeCompat("no compat", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 		beforeEach("getTestObjectProvider", async () => {
 			provider = getTestObjectProvider();
 		});

--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -22,7 +22,7 @@ import { v4 as uuid } from "uuid";
 import { wrapObjectAndOverride } from "../mocking.js";
 
 // REVIEW: enable compat testing?
-describeCompat("Errors Types", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Errors Types", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let fileName: string;
 	let containerUrl: IResolvedUrl;

--- a/packages/test/test-end-to-end-tests/src/test/fewerBatches.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/fewerBatches.spec.ts
@@ -21,7 +21,7 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 
-describeCompat("Fewer batches", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Fewer batches", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 
 	const mapId = "mapId";

--- a/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/flushModeValidation.spec.ts
@@ -23,7 +23,7 @@ import {
  * This test validates that changing the FlushMode does not hit any validation errors in PendingStateManager.
  * It also validates the scenario in this bug - https://github.com/microsoft/FluidFramework/issues/9398.
  */
-describeCompat("Flush mode validation", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Flush mode validation", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 	const map1Id = "map1Key";
 	const registry: ChannelFactoryRegistry = [[map1Id, SharedMap.getFactory()]];

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -32,7 +32,7 @@ import {
 /**
  * Validates that unreferenced blobs are marked as unreferenced and deleted correctly.
  */
-describeCompat("Garbage collection of blobs", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Garbage collection of blobs", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	// If deleteUnreferencedContent is true, GC is run in test mode where content that is not referenced is
 	// deleted after each GC run.
 	const tests = (deleteUnreferencedContent: boolean = false) => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -97,7 +97,7 @@ describeCompat("GC Data Store Aliased Full Compat", "FullCompat", (getTestObject
 	});
 });
 
-describeCompat("GC Data Store Aliased No Compat", "NoCompat", (getTestObjectProvider) => {
+describeCompat("GC Data Store Aliased No Compat", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 
 	beforeEach("getTestObjectProvider", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreDuplicateRoutes.spec.ts
@@ -29,7 +29,7 @@ import { defaultGCConfig } from "./gcTestConfigs.js";
  * Validates this scenario: When two DDSes in the same datastore has one change, gets summarized, and then gc is called
  * from loading a new container. We do not want to allow duplicate GC routes to be created in this scenario.
  */
-describeCompat("GC Data Store Duplicates", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("GC Data Store Duplicates", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
@@ -381,7 +381,7 @@ async function validateBlobsReferenceState(
 /**
  * Validates that when running in GC test mode, unreferenced content is deleted from the summary.
  */
-describeCompat("GC delete attachment blobs in test mode", "NoCompat", (getTestObjectProvider) => {
+describeCompat("GC delete attachment blobs in test mode", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	// If deleteContent is true, GC is run in test mode where content that is not referenced is
 	// deleted after each GC run.
 	const tests = (deleteContent: boolean = false) => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
@@ -381,93 +381,97 @@ async function validateBlobsReferenceState(
 /**
  * Validates that when running in GC test mode, unreferenced content is deleted from the summary.
  */
-describeCompat("GC delete attachment blobs in test mode", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
-	// If deleteContent is true, GC is run in test mode where content that is not referenced is
-	// deleted after each GC run.
-	const tests = (deleteContent: boolean = false) => {
-		let provider: ITestObjectProvider;
-		let summarizerContainerRuntime: ContainerRuntime;
-		let mainDataStore: ITestDataObject;
+describeCompat(
+	"GC delete attachment blobs in test mode",
+	"2.0.0-rc.3.0.0",
+	(getTestObjectProvider) => {
+		// If deleteContent is true, GC is run in test mode where content that is not referenced is
+		// deleted after each GC run.
+		const tests = (deleteContent: boolean = false) => {
+			let provider: ITestObjectProvider;
+			let summarizerContainerRuntime: ContainerRuntime;
+			let mainDataStore: ITestDataObject;
 
-		beforeEach("setup", async function () {
-			provider = getTestObjectProvider({ syncSummarizer: true });
-			if (provider.driver.type !== "local") {
-				this.skip();
-			}
-			const testContainerConfig: ITestContainerConfig = {
-				...defaultGCConfig,
-				runtimeOptions: {
-					...defaultGCConfig.runtimeOptions,
-					gcOptions: {
-						gcAllowed: true,
-						runGCInTestMode: deleteContent,
+			beforeEach("setup", async function () {
+				provider = getTestObjectProvider({ syncSummarizer: true });
+				if (provider.driver.type !== "local") {
+					this.skip();
+				}
+				const testContainerConfig: ITestContainerConfig = {
+					...defaultGCConfig,
+					runtimeOptions: {
+						...defaultGCConfig.runtimeOptions,
+						gcOptions: {
+							gcAllowed: true,
+							runGCInTestMode: deleteContent,
+						},
 					},
-				},
-			};
-			const container = await provider.makeTestContainer(testContainerConfig);
-			mainDataStore = (await container.getEntryPoint()) as ITestDataObject;
-			summarizerContainerRuntime = mainDataStore._context
-				.containerRuntime as ContainerRuntime;
-			await waitForContainerConnection(container);
+				};
+				const container = await provider.makeTestContainer(testContainerConfig);
+				mainDataStore = (await container.getEntryPoint()) as ITestDataObject;
+				summarizerContainerRuntime = mainDataStore._context
+					.containerRuntime as ContainerRuntime;
+				await waitForContainerConnection(container);
+			});
+
+			it("marks attachment blobs as referenced / unreferenced correctly", async () => {
+				// Upload couple of attachment blobs and mark them referenced.
+				const blob1Contents = "Blob contents 1";
+				const blob2Contents = "Blob contents 2";
+				const blob1Handle = await mainDataStore._context.uploadBlob(
+					stringToBuffer(blob1Contents, "utf-8"),
+				);
+				const blob2Handle = await mainDataStore._context.uploadBlob(
+					stringToBuffer(blob2Contents, "utf-8"),
+				);
+				mainDataStore._root.set("blob1", blob1Handle);
+				mainDataStore._root.set("blob2", blob2Handle);
+				await validateBlobsReferenceState(
+					provider,
+					summarizerContainerRuntime,
+					deleteContent,
+					blob1Handle,
+					true /* referenced */,
+				);
+				await validateBlobsReferenceState(
+					provider,
+					summarizerContainerRuntime,
+					deleteContent,
+					blob2Handle,
+					true /* referenced */,
+				);
+
+				// Remove blob1's handle and verify its marked as unreferenced.
+				mainDataStore._root.delete("blob1");
+				await validateBlobsReferenceState(
+					provider,
+					summarizerContainerRuntime,
+					deleteContent,
+					blob1Handle,
+					false /* referenced */,
+				);
+
+				// Add blob1's handle back. If deleteContent is true, the blob should get deleted and should
+				// remain unreferenced. Otherwise, it should be referenced back.
+				// Also, if deleteContent is true, it won't be in the GC state in the summary anymore.
+				mainDataStore._root.set("blob1", blob1Handle);
+				await validateBlobsReferenceState(
+					provider,
+					summarizerContainerRuntime,
+					deleteContent,
+					blob1Handle,
+					deleteContent ? false : true /* referenced */,
+					deleteContent ? true : false /* deletedFromGCState */,
+				);
+			});
+		};
+
+		describe("Verify attachment blob state when unreferenced content is marked", () => {
+			tests();
 		});
 
-		it("marks attachment blobs as referenced / unreferenced correctly", async () => {
-			// Upload couple of attachment blobs and mark them referenced.
-			const blob1Contents = "Blob contents 1";
-			const blob2Contents = "Blob contents 2";
-			const blob1Handle = await mainDataStore._context.uploadBlob(
-				stringToBuffer(blob1Contents, "utf-8"),
-			);
-			const blob2Handle = await mainDataStore._context.uploadBlob(
-				stringToBuffer(blob2Contents, "utf-8"),
-			);
-			mainDataStore._root.set("blob1", blob1Handle);
-			mainDataStore._root.set("blob2", blob2Handle);
-			await validateBlobsReferenceState(
-				provider,
-				summarizerContainerRuntime,
-				deleteContent,
-				blob1Handle,
-				true /* referenced */,
-			);
-			await validateBlobsReferenceState(
-				provider,
-				summarizerContainerRuntime,
-				deleteContent,
-				blob2Handle,
-				true /* referenced */,
-			);
-
-			// Remove blob1's handle and verify its marked as unreferenced.
-			mainDataStore._root.delete("blob1");
-			await validateBlobsReferenceState(
-				provider,
-				summarizerContainerRuntime,
-				deleteContent,
-				blob1Handle,
-				false /* referenced */,
-			);
-
-			// Add blob1's handle back. If deleteContent is true, the blob should get deleted and should
-			// remain unreferenced. Otherwise, it should be referenced back.
-			// Also, if deleteContent is true, it won't be in the GC state in the summary anymore.
-			mainDataStore._root.set("blob1", blob1Handle);
-			await validateBlobsReferenceState(
-				provider,
-				summarizerContainerRuntime,
-				deleteContent,
-				blob1Handle,
-				deleteContent ? false : true /* referenced */,
-				deleteContent ? true : false /* deletedFromGCState */,
-			);
+		describe("Verify attachment blob state when unreferenced content is deleted", () => {
+			tests(true /* deleteContent */);
 		});
-	};
-
-	describe("Verify attachment blob state when unreferenced content is marked", () => {
-		tests();
-	});
-
-	describe("Verify attachment blob state when unreferenced content is deleted", () => {
-		tests(true /* deleteContent */);
-	});
-});
+	},
+);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -44,7 +44,7 @@ import {
  * Validates this scenario: When a GC node (data store or attachment blob) becomes inactive, i.e, it has been
  * unreferenced for a certain amount of time, using the node results in an error telemetry.
  */
-describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("GC inactive nodes tests", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap, SharedDirectory } = apis.dds;
 	const revivedEvent = "fluid:telemetry:ContainerRuntime:InactiveObject_Revived";
 	const changedEvent = "fluid:telemetry:ContainerRuntime:InactiveObject_Changed";

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcIncrementalSummaries.spec.ts
@@ -32,7 +32,7 @@ import { defaultGCConfig } from "./gcTestConfigs.js";
  * - It received an op.
  * - Its reference state changed, i.e., it was referenced and became unreferenced or vice-versa.
  */
-describeCompat("GC incremental summaries", "NoCompat", (getTestObjectProvider) => {
+describeCompat("GC incremental summaries", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;
 	let dataStoreA: ITestDataObject;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcLoadingFromOlderSummaries.spec.ts
@@ -32,7 +32,7 @@ import { getGCStateFromSummary } from "./gcTestSummaryUtils.js";
  * Validates that when a summarizer loads from an older summary and gets an ack for a newer summary, it disposes
  * rather than trying to update its state from the new summary.
  */
-describeCompat("GC loading from older summaries", "NoCompat", (getTestObjectProvider) => {
+describeCompat("GC loading from older summaries", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;
 	let containerRuntime: IContainerRuntime;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStateResetInSummaries.spec.ts
@@ -36,7 +36,7 @@ import { getGCStateFromSummary } from "./gcTestSummaryUtils.js";
  * This validates scenarios where due to some bug the GC state in summary is incorrect and we need to quickly recover
  * documents. Disabling GC will ensure that we are not deleting / marking things unreferenced incorrectly.
  */
-describeCompat("GC state reset in summaries", "NoCompat", (getTestObjectProvider) => {
+describeCompat("GC state reset in summaries", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -34,7 +34,7 @@ import { waitForContainerWriteModeConnectionWrite } from "./gcTestSummaryUtils.j
  * Validates that we generate correct garbage collection stats, such as total number of nodes, number of unreferenced
  * nodes, data stores, blobs, etc.
  */
-describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Garbage Collection Stats", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let mainContainer: IContainer;
 	let mainDataObject: ITestDataObject;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -102,7 +102,7 @@ function validateBlobStateInSummary(
  * These tests validate that SweepReady attachment blobs are correctly swept. Swept attachment blobs should be
  * removed from the summary, added to the GC deleted blob, and retrieving them should be prevented.
  */
-describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvider) => {
+describeCompat("GC attachment blob sweep tests", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	const sweepGracePeriodMs = 50;
 	const tombstoneTimeoutMs = 150;
 	const sweepTimeoutMs = tombstoneTimeoutMs + sweepGracePeriodMs;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -276,7 +276,7 @@ describeCompat("V1/V2 compat", "FullCompat", (getTestObjectProvider) => {
  *
  * NOTE: These tests speak of "Sweep" but simply use "tombstoneTimeoutMs" throughout, since sweepGracePeriod is set to 0.
  */
-describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) => {
+describeCompat("GC data store sweep tests", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	beforeEach("setup", async function () {
 		provider = getTestObjectProvider({ syncSummarizer: true });
 		if (provider.driver.type !== "local") {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
@@ -33,7 +33,7 @@ import {
 /**
  * Validates that an unreferenced datastore goes through all the GC phases without overlapping.
  */
-describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
+describeCompat("GC unreference phases", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	// Since these tests depend on these timing windows, they should not be run against drivers talking over the network
 	// (see this.skip() call below)
 	const tombstoneTimeoutMs = 200; // Tombstone at 200ms

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -31,7 +31,7 @@ import { waitForContainerWriteModeConnectionWrite } from "./gcTestSummaryUtils.j
  * These tests validate that SweepReady attachment blobs are correctly marked as tombstones. Tombstones should be added
  * to the summary and changing them (sending / receiving ops, loading, etc.) is not allowed.
  */
-describeCompat("GC attachment blob tombstone tests", "NoCompat", (getTestObjectProvider) => {
+describeCompat("GC attachment blob tombstone tests", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	const tombstoneTimeoutMs = 200;
 	const configProvider = createTestConfigProvider();
 	const gcOptions: IGCRuntimeOptions = {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -59,7 +59,7 @@ type ExpectedTombstoneError = Error & {
  * These tests validate that TombstoneReady data stores are correctly marked as tombstones. Tombstones should be added
  * to the summary and changing them (sending / receiving ops, loading, etc.) is not allowed.
  */
-describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("GC data store tombstone tests", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 	const remainingTimeUntilSweepMs = 100;
 	const tombstoneTimeoutMs = 200;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTrailingOps.spec.ts
@@ -35,7 +35,7 @@ import { getGCDeletedStateFromSummary, getGCStateFromSummary } from "./gcTestSum
  * after the last summary was submitted. These should not be missed by GC before is runs the next time as they
  * can result in incorrect GC state or worse - incorrect deletion of objects.
  */
-describeCompat("GC trailing ops tests", "NoCompat", (getTestObjectProvider) => {
+describeCompat("GC trailing ops tests", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	/**
 	 * @param transition - The referenced state transition that the trailing op would do.
 	 * @param when - Whether the trailing op should be sent before or after sweep timeout.

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -192,7 +192,7 @@ async function submitAndAckSummary(
  */
 describeCompat(
 	"GC Tree stored as a handle in summaries",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const {
 			containerRuntime: { ContainerRuntimeFactoryWithDefaultDataStore },

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedFlagInSnapshot.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedFlagInSnapshot.spec.ts
@@ -31,7 +31,7 @@ import { defaultGCConfig } from "./gcTestConfigs.js";
  */
 describeCompat(
 	"GC unreferenced flag in downloaded snapshot",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider) => {
 		let provider: ITestObjectProvider;
 		let mainContainer: IContainer;

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnreferencedTimestamp.spec.ts
@@ -30,7 +30,7 @@ import { getGCStateFromSummary } from "./gcTestSummaryUtils.js";
  * Validates that the unreferenced timestamp is correctly set in the GC summary tree. Also, the timestamp is removed
  * when an unreferenced node becomes referenced again.
  */
-describeCompat("GC unreferenced timestamp", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("GC unreferenced timestamp", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 
 	const configProvider = createTestConfigProvider();

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
@@ -35,7 +35,7 @@ type IContainerRuntimeWithPrivates = IContainerRuntime & {
  * Validates that when the runtime GC version changes, we reset GC state and regenerate summary. Basically, when we
  * update the GC version due to bugs, newer versions re-run GC and older versions stop running GC.
  */
-describeCompat("GC version update", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("GC version update", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const {
 		containerRuntime: { ContainerRuntimeFactoryWithDefaultDataStore },
 	} = apis;

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -617,60 +617,70 @@ describeCompat("Runtime IdCompressor", "2.0.0-rc.3.0.0", (getTestObjectProvider,
 
 // No-compat: 2.0.0-internal.8.x and earlier versions of container-runtime don't finalize ids prior to attaching.
 // Even older versions of the runtime also don't have an id compression feature enabled.
-describeCompat("IdCompressor in detached container", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
-	let provider: ITestObjectProvider;
-	let request: IRequest;
+describeCompat(
+	"IdCompressor in detached container",
+	"2.0.0-rc.3.0.0",
+	(getTestObjectProvider, apis) => {
+		let provider: ITestObjectProvider;
+		let request: IRequest;
 
-	beforeEach("getTestObjectProvider", () => {
-		provider = getTestObjectProvider();
-		request = provider.driver.createCreateNewRequest(provider.documentId);
-	});
+		beforeEach("getTestObjectProvider", () => {
+			provider = getTestObjectProvider();
+			request = provider.driver.createCreateNewRequest(provider.documentId);
+		});
 
-	it("Compressors sync after detached container attaches and sends an op", async () => {
-		const testConfig: ITestContainerConfig = {
-			fluidDataObjectType: DataObjectFactoryType.Test,
-			registry: [["sharedCell", apis.dds.SharedCell.getFactory()]],
-			runtimeOptions: {
-				enableRuntimeIdCompressor: "on",
-			},
-		};
-		const loader = provider.makeTestLoader(testConfig);
-		const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
+		it("Compressors sync after detached container attaches and sends an op", async () => {
+			const testConfig: ITestContainerConfig = {
+				fluidDataObjectType: DataObjectFactoryType.Test,
+				registry: [["sharedCell", apis.dds.SharedCell.getFactory()]],
+				runtimeOptions: {
+					enableRuntimeIdCompressor: "on",
+				},
+			};
+			const loader = provider.makeTestLoader(testConfig);
+			const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
 
-		// Get the root dataStore from the detached container.
-		const dataStore = (await container.getEntryPoint()) as ITestFluidObject;
-		const testChannel1 = await dataStore.getSharedObject<SharedCell>("sharedCell");
+			// Get the root dataStore from the detached container.
+			const dataStore = (await container.getEntryPoint()) as ITestFluidObject;
+			const testChannel1 = await dataStore.getSharedObject<SharedCell>("sharedCell");
 
-		// Generate an Id before attaching the container
-		(testChannel1 as any).runtime.idCompressor.generateCompressedId();
-		// Attach the container. The generated Id won't be synced until another op
-		// is sent after attaching becuase most DDSs don't send ops until they are attached.
-		await container.attach(request);
+			// Generate an Id before attaching the container
+			(testChannel1 as any).runtime.idCompressor.generateCompressedId();
+			// Attach the container. The generated Id won't be synced until another op
+			// is sent after attaching becuase most DDSs don't send ops until they are attached.
+			await container.attach(request);
 
-		// Create another container to test sync
-		const url: any = await container.getAbsoluteUrl("");
-		const loader2 = provider.makeTestLoader(testConfig) as Loader;
-		const container2 = await loader2.resolve({ url });
-		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
-		const testChannel2 = await dataStore2.getSharedObject<SharedCell>("sharedCell");
-		// Generate an Id in the second attached container and send an op to send the Ids
-		(testChannel2 as any).runtime.idCompressor.generateCompressedId();
-		testChannel2.set("value");
+			// Create another container to test sync
+			const url: any = await container.getAbsoluteUrl("");
+			const loader2 = provider.makeTestLoader(testConfig) as Loader;
+			const container2 = await loader2.resolve({ url });
+			const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
+			const testChannel2 = await dataStore2.getSharedObject<SharedCell>("sharedCell");
+			// Generate an Id in the second attached container and send an op to send the Ids
+			(testChannel2 as any).runtime.idCompressor.generateCompressedId();
+			testChannel2.set("value");
 
-		await provider.ensureSynchronized();
+			await provider.ensureSynchronized();
 
-		// Send an op in the first container to get its Ids sent
-		testChannel1.set("value2");
+			// Send an op in the first container to get its Ids sent
+			testChannel1.set("value2");
 
-		await provider.ensureSynchronized();
+			await provider.ensureSynchronized();
 
-		// Compressor from first container will get the first 512 Ids (0-511) as its id should be finalized
-		// on attach
-		assert.strictEqual((testChannel1 as any).runtime.idCompressor.normalizeToOpSpace(-1), 0);
-		// Compressor from second container gets second cluster starting at 512 after sending an op
-		assert.strictEqual((testChannel2 as any).runtime.idCompressor.normalizeToOpSpace(-1), 513);
-	});
-});
+			// Compressor from first container will get the first 512 Ids (0-511) as its id should be finalized
+			// on attach
+			assert.strictEqual(
+				(testChannel1 as any).runtime.idCompressor.normalizeToOpSpace(-1),
+				0,
+			);
+			// Compressor from second container gets second cluster starting at 512 after sending an op
+			assert.strictEqual(
+				(testChannel2 as any).runtime.idCompressor.normalizeToOpSpace(-1),
+				513,
+			);
+		});
+	},
+);
 
 describeCompat("IdCompressor Summaries", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -39,7 +39,7 @@ function getIdCompressor(dds: IChannel): IIdCompressor {
 	return (dds as any).runtime.idCompressor as IIdCompressor;
 }
 
-describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Runtime IdCompressor", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const {
 		dataRuntime: { DataObject, DataObjectFactory },
 		containerRuntime: { ContainerRuntimeFactoryWithDefaultDataStore },
@@ -617,7 +617,7 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 
 // No-compat: 2.0.0-internal.8.x and earlier versions of container-runtime don't finalize ids prior to attaching.
 // Even older versions of the runtime also don't have an id compression feature enabled.
-describeCompat("IdCompressor in detached container", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("IdCompressor in detached container", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	let provider: ITestObjectProvider;
 	let request: IRequest;
 
@@ -672,7 +672,7 @@ describeCompat("IdCompressor in detached container", "NoCompat", (getTestObjectP
 	});
 });
 
-describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider) => {
+describeCompat("IdCompressor Summaries", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	const disableConfig: ITestContainerConfig = {
 		runtimeOptions: { enableRuntimeIdCompressor: undefined },

--- a/packages/test/test-end-to-end-tests/src/test/intervalCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/intervalCollectionEndToEndTests.spec.ts
@@ -57,7 +57,7 @@ const assertIntervals = (
 	assert.deepEqual(actualPos, expected, "intervals are not as expected");
 };
 
-describeCompat("IntervalCollection with stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("IntervalCollection with stashed ops", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedString } = apis.dds;
 
 	const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];

--- a/packages/test/test-end-to-end-tests/src/test/intervalCollectionEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/intervalCollectionEndToEndTests.spec.ts
@@ -57,117 +57,122 @@ const assertIntervals = (
 	assert.deepEqual(actualPos, expected, "intervals are not as expected");
 };
 
-describeCompat("IntervalCollection with stashed ops", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
-	const { SharedString } = apis.dds;
+describeCompat(
+	"IntervalCollection with stashed ops",
+	"2.0.0-rc.3.0.0",
+	(getTestObjectProvider, apis) => {
+		const { SharedString } = apis.dds;
 
-	const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
-	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
-		getRawConfig: (name: string): ConfigTypes => settings[name],
-	});
+		const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];
+		const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+			getRawConfig: (name: string): ConfigTypes => settings[name],
+		});
 
-	const testContainerConfig: ITestContainerConfig = {
-		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
-		runtimeOptions: {
-			summaryOptions: {
-				summaryConfigOverrides: {
-					...DefaultSummaryConfiguration,
-					...{
-						maxTime: 5000 * 12,
-						maxAckWaitTime: 120000,
-						maxOps: 1,
-						initialSummarizerDelayMs: 20,
+		const testContainerConfig: ITestContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry,
+			runtimeOptions: {
+				summaryOptions: {
+					summaryConfigOverrides: {
+						...DefaultSummaryConfiguration,
+						...{
+							maxTime: 5000 * 12,
+							maxAckWaitTime: 120000,
+							maxOps: 1,
+							initialSummarizerDelayMs: 20,
+						},
 					},
 				},
+				enableRuntimeIdCompressor: "on",
 			},
-			enableRuntimeIdCompressor: "on",
-		},
-		loaderProps: {
-			configProvider: configProvider({
-				"Fluid.Container.enableOfflineLoad": true,
-			}),
-		},
-	};
+			loaderProps: {
+				configProvider: configProvider({
+					"Fluid.Container.enableOfflineLoad": true,
+				}),
+			},
+		};
 
-	let provider: ITestObjectProvider;
-	let container1: IContainerExperimental;
-	let sharedString1: SharedString;
-	let sharedString2: SharedString;
-	let dataObject1: ITestFluidObject;
-	let dataObject2: ITestFluidObject;
-	let collection1: IIntervalCollection<SequenceInterval>;
-	let collection2: IIntervalCollection<SequenceInterval>;
-	let loader: IHostLoader;
-	let url;
+		let provider: ITestObjectProvider;
+		let container1: IContainerExperimental;
+		let sharedString1: SharedString;
+		let sharedString2: SharedString;
+		let dataObject1: ITestFluidObject;
+		let dataObject2: ITestFluidObject;
+		let collection1: IIntervalCollection<SequenceInterval>;
+		let collection2: IIntervalCollection<SequenceInterval>;
+		let loader: IHostLoader;
+		let url;
 
-	beforeEach(async () => {
-		provider = getTestObjectProvider();
-		container1 = await provider.makeTestContainer(testContainerConfig);
-		dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
-		sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
-		sharedString1.insertText(0, "hello world");
-		collection1 = sharedString1.getIntervalCollection(collectionId);
-		loader = provider.makeTestLoader(testContainerConfig);
-		url = await container1.getAbsoluteUrl("");
-	});
+		beforeEach(async () => {
+			provider = getTestObjectProvider();
+			container1 = await provider.makeTestContainer(testContainerConfig);
+			dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
+			sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+			sharedString1.insertText(0, "hello world");
+			collection1 = sharedString1.getIntervalCollection(collectionId);
+			loader = provider.makeTestLoader(testContainerConfig);
+			url = await container1.getAbsoluteUrl("");
+		});
 
-	it("doesn't resend successful op", async () => {
-		// add an interval
-		const id = collection1.add({ start: 4, end: 7 }).getIntervalId();
+		it("doesn't resend successful op", async () => {
+			// add an interval
+			const id = collection1.add({ start: 4, end: 7 }).getIntervalId();
 
-		// pending ops stuff from e2e tests - make a new container, pause op processing,
-		// make a change, close the container, then resume op processing and reload container
-		const container: IContainerExperimental =
-			await provider.loadTestContainer(testContainerConfig);
-		await waitForContainerConnection(container);
-		const dataStore = (await container.getEntryPoint()) as ITestFluidObject;
+			// pending ops stuff from e2e tests - make a new container, pause op processing,
+			// make a change, close the container, then resume op processing and reload container
+			const container: IContainerExperimental =
+				await provider.loadTestContainer(testContainerConfig);
+			await waitForContainerConnection(container);
+			const dataStore = (await container.getEntryPoint()) as ITestFluidObject;
 
-		[...Array(30).keys()].map((i) =>
-			dataStore.root.set(`make sure csn is > 1 so it doesn't hide bugs ${i}`, i),
-		);
+			[...Array(30).keys()].map((i) =>
+				dataStore.root.set(`make sure csn is > 1 so it doesn't hide bugs ${i}`, i),
+			);
 
-		await provider.ensureSynchronized();
-		await provider.opProcessingController.pauseProcessing(container);
-		assert(dataStore.runtime.deltaManager.outbound.paused);
+			await provider.ensureSynchronized();
+			await provider.opProcessingController.pauseProcessing(container);
+			assert(dataStore.runtime.deltaManager.outbound.paused);
 
-		// the "callback" portion of the original e2e test
-		const sharedString = await dataStore.getSharedObject<SharedString>(stringId);
-		const collection = sharedString.getIntervalCollection(collectionId);
-		collection.change(id, { start: 3, end: 8 });
+			// the "callback" portion of the original e2e test
+			const sharedString = await dataStore.getSharedObject<SharedString>(stringId);
+			const collection = sharedString.getIntervalCollection(collectionId);
+			collection.change(id, { start: 3, end: 8 });
 
-		const pendingState: string | undefined = await container.closeAndGetPendingLocalState?.();
-		provider.opProcessingController.resumeProcessing();
-		assert.ok(pendingState);
+			const pendingState: string | undefined =
+				await container.closeAndGetPendingLocalState?.();
+			provider.opProcessingController.resumeProcessing();
+			assert.ok(pendingState);
 
-		container1 = await provider.loadTestContainer(testContainerConfig);
-		await waitForContainerConnection(container1);
-		dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
-		sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
-		collection1 = sharedString1.getIntervalCollection(collectionId);
-		await provider.ensureSynchronized();
-		assertIntervals(sharedString1, collection1, [{ start: 4, end: 7 }]);
+			container1 = await provider.loadTestContainer(testContainerConfig);
+			await waitForContainerConnection(container1);
+			dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
+			sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+			collection1 = sharedString1.getIntervalCollection(collectionId);
+			await provider.ensureSynchronized();
+			assertIntervals(sharedString1, collection1, [{ start: 4, end: 7 }]);
 
-		let container2 = await loader.resolve({ url }, pendingState);
-		await waitForContainerConnection(container1);
-		dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
-		sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
-		collection2 = sharedString2.getIntervalCollection(collectionId);
-		await provider.ensureSynchronized();
-		assertIntervals(sharedString2, collection2, [{ start: 3, end: 8 }]);
+			let container2 = await loader.resolve({ url }, pendingState);
+			await waitForContainerConnection(container1);
+			dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
+			sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
+			collection2 = sharedString2.getIntervalCollection(collectionId);
+			await provider.ensureSynchronized();
+			assertIntervals(sharedString2, collection2, [{ start: 3, end: 8 }]);
 
-		collection1.change(id, { start: 2, end: 9 });
-		await provider.ensureSynchronized();
+			collection1.change(id, { start: 2, end: 9 });
+			await provider.ensureSynchronized();
 
-		// reload the container and verify that the above change takes effect
-		container2 = await provider.loadTestContainer(testContainerConfig);
-		dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
-		sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
-		collection2 = sharedString2.getIntervalCollection(collectionId);
+			// reload the container and verify that the above change takes effect
+			container2 = await provider.loadTestContainer(testContainerConfig);
+			dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
+			sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
+			collection2 = sharedString2.getIntervalCollection(collectionId);
 
-		await waitForContainerConnection(container2);
-		await provider.ensureSynchronized();
+			await waitForContainerConnection(container2);
+			await provider.ensureSynchronized();
 
-		assertIntervals(sharedString1, collection1, [{ start: 2, end: 9 }]);
-		assertIntervals(sharedString2, collection2, [{ start: 2, end: 9 }]);
-	});
-});
+			assertIntervals(sharedString1, collection1, [{ start: 2, end: 9 }]);
+			assertIntervals(sharedString2, collection2, [{ start: 2, end: 9 }]);
+		});
+	},
+);

--- a/packages/test/test-end-to-end-tests/src/test/loadModes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/loadModes.spec.ts
@@ -29,7 +29,7 @@ import {
 const counterKey = "count";
 
 // REVIEW: enable compat testing?
-describeCompat("LoadModes", "NoCompat", (getTestObjectProvider, apis: CompatApis) => {
+describeCompat("LoadModes", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis: CompatApis) => {
 	const { SharedCounter } = apis.dds;
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;

--- a/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localLoader.spec.ts
@@ -28,7 +28,7 @@ import {
 const counterKey = "count";
 
 // REVIEW: enable compat testing?
-describeCompat("LocalLoader", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("LocalLoader", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedCounter, SharedString } = apis.dds;
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -382,7 +382,7 @@ describeCompat("SharedMap", "FullCompat", (getTestObjectProvider, apis) => {
 	});
 });
 
-describeCompat("SharedMap orderSequentially", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("SharedMap orderSequentially", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 	const mapId = "mapKey";
 	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
@@ -554,7 +554,7 @@ describeCompat("SharedMap orderSequentially", "NoCompat", (getTestObjectProvider
 
 describeCompat(
 	"addChannel() tests for the SharedMap",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const { SharedMap } = apis.dds;
 		const mapId = "mapKey";

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -32,7 +32,7 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 
-describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Message size", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 	const mapId = "mapId";
 	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/dataMigration.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/dataMigration.spec.ts
@@ -51,7 +51,7 @@ function getNewTreeView(tree: ITree): TreeView<InventorySchema> {
 	);
 }
 
-describeCompat("HotSwap", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("HotSwap", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/migrationShim.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/migrationShim.spec.ts
@@ -84,7 +84,7 @@ function getQuantity(tree: LegacySharedTree): number {
 
 const testValue = 5;
 
-describeCompat("MigrationShim", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("MigrationShim", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/reconnect.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/reconnect.spec.ts
@@ -70,7 +70,7 @@ function getNewTreeView(tree: ITree) {
 	return tree.schematize(new TreeConfiguration(QuantityType, () => ({ quantity: 0 })));
 }
 
-describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Stamped v2 ops", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/sharedTreeShim.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/sharedTreeShim.spec.ts
@@ -38,7 +38,7 @@ function getNewTreeView(tree: ITree): TreeView<RootType> {
 
 const testValue = 5;
 
-describeCompat("SharedTreeShim", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("SharedTreeShim", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 	// Allow us to control summaries

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
@@ -66,7 +66,7 @@ function getNewTreeView(tree: ITree): TreeView<QuantityType> {
 	return tree.schematize(new TreeConfiguration(QuantityType, () => ({ quantity: 0 })));
 }
 
-describeCompat("Stamped v2 ops", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Stamped v2 ops", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandles.spec.ts
@@ -73,7 +73,7 @@ function getNewTreeView(tree: ITree): TreeView<HandleType> {
 	);
 }
 
-describeCompat("Storing handles", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Storing handles", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandlesDetached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandlesDetached.spec.ts
@@ -26,7 +26,7 @@ import {
 	type TreeView,
 } from "@fluidframework/tree";
 
-describeCompat("Storing handles detached", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Storing handles detached", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/opPerfTelemetry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/opPerfTelemetry.spec.ts
@@ -20,8 +20,7 @@ import {
  */
 describeCompat(
 	"All clients generate OpRoundtripTime telemetry",
-	// TODO: this should be "2.0.0-rc.2.0.0" (I think) once the bugs with describeCompat are fixed and versions are used correctly
-	"NoCompat",
+	"2.0.0-rc.2.0.0",
 	(getTestObjectProvider, apis) => {
 		const { SharedString } = apis.dds;
 

--- a/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
@@ -24,7 +24,7 @@ import {
 
 describeCompat(
 	"Concurrent op processing via DDS event handlers",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const { SharedMap, SharedDirectory, SharedString } = apis.dds;
 		const mapId = "mapKey";

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -28,356 +28,360 @@ const dirId = "sharedDirKey";
 const cellId = "cellKey";
 const mapId = "mapKey";
 
-describeCompat("Multiple DDS orderSequentially", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
-	const { SharedMap, SharedDirectory, SharedString, SharedCell } = apis.dds;
-	const { SequenceDeltaEvent } = apis.dataRuntime.packages.sequence;
+describeCompat(
+	"Multiple DDS orderSequentially",
+	"2.0.0-rc.3.0.0",
+	(getTestObjectProvider, apis) => {
+		const { SharedMap, SharedDirectory, SharedString, SharedCell } = apis.dds;
+		const { SequenceDeltaEvent } = apis.dataRuntime.packages.sequence;
 
-	const registry: ChannelFactoryRegistry = [
-		[stringId, SharedString.getFactory()],
-		[string2Id, SharedString.getFactory()],
-		[dirId, SharedDirectory.getFactory()],
-		[cellId, SharedCell.getFactory()],
-		[mapId, SharedMap.getFactory()],
-	];
-	const testContainerConfig: ITestContainerConfig = {
-		fluidDataObjectType: DataObjectFactoryType.Test,
-		registry,
-	};
-
-	let provider: ITestObjectProvider;
-	beforeEach("getTestObjectProvider", () => {
-		provider = getTestObjectProvider();
-	});
-
-	let container: IContainer;
-	let dataObject: ITestFluidObject;
-	let sharedString: SharedString;
-	let sharedString2: SharedString;
-	let sharedDir: SharedDirectory;
-	let sharedCell: SharedCell;
-	let sharedMap: ISharedMap;
-	let changedEventData: (IValueChanged | Serializable<unknown>)[];
-	let containerRuntime: ContainerRuntime;
-	let error: Error | undefined;
-
-	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
-		getRawConfig: (name: string): ConfigTypes => settings[name],
-	});
-	const errorMessage = "callback failure";
-
-	beforeEach("setup", async () => {
-		const configWithFeatureGates = {
-			...testContainerConfig,
-			loaderProps: {
-				configProvider: configProvider({
-					"Fluid.ContainerRuntime.EnableRollback": true,
-				}),
-			},
+		const registry: ChannelFactoryRegistry = [
+			[stringId, SharedString.getFactory()],
+			[string2Id, SharedString.getFactory()],
+			[dirId, SharedDirectory.getFactory()],
+			[cellId, SharedCell.getFactory()],
+			[mapId, SharedMap.getFactory()],
+		];
+		const testContainerConfig: ITestContainerConfig = {
+			fluidDataObjectType: DataObjectFactoryType.Test,
+			registry,
 		};
-		container = await provider.makeTestContainer(configWithFeatureGates);
-		dataObject = (await container.getEntryPoint()) as ITestFluidObject;
-		sharedString = await dataObject.getSharedObject<SharedString>(stringId);
-		sharedString2 = await dataObject.getSharedObject<SharedString>(string2Id);
-		sharedDir = await dataObject.getSharedObject<SharedDirectory>(dirId);
-		sharedCell = await dataObject.getSharedObject<SharedCell>(cellId);
-		sharedMap = await dataObject.getSharedObject<ISharedMap>(mapId);
 
-		containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
-		changedEventData = [];
-		sharedString.on("sequenceDelta", (changed, _local, _target) => {
-			changedEventData.push(changed);
+		let provider: ITestObjectProvider;
+		beforeEach("getTestObjectProvider", () => {
+			provider = getTestObjectProvider();
 		});
-		sharedString2.on("sequenceDelta", (changed, _local, _target) => {
-			changedEventData.push(changed);
-		});
-		sharedDir.on("valueChanged", (changed, _local, _target) => {
-			changedEventData.push(changed);
-		});
-		sharedCell.on("valueChanged", (value) => {
-			changedEventData.push(value);
-		});
-		sharedCell.on("delete", (value) => {
-			changedEventData.push(value);
-		});
-		sharedMap.on("valueChanged", (value) => {
-			changedEventData.push(value);
-		});
-	});
 
-	it("Should rollback simple edits on multiple DDS types", () => {
-		sharedString.insertText(0, "abcde");
-		sharedMap.set("key1", 0);
-		sharedCell.set(2);
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedString.removeRange(0, 5);
-				sharedMap.delete("key1");
-				sharedCell.delete();
-				throw new Error(errorMessage);
+		let container: IContainer;
+		let dataObject: ITestFluidObject;
+		let sharedString: SharedString;
+		let sharedString2: SharedString;
+		let sharedDir: SharedDirectory;
+		let sharedCell: SharedCell;
+		let sharedMap: ISharedMap;
+		let changedEventData: (IValueChanged | Serializable<unknown>)[];
+		let containerRuntime: ContainerRuntime;
+		let error: Error | undefined;
+
+		const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
+			getRawConfig: (name: string): ConfigTypes => settings[name],
+		});
+		const errorMessage = "callback failure";
+
+		beforeEach("setup", async () => {
+			const configWithFeatureGates = {
+				...testContainerConfig,
+				loaderProps: {
+					configProvider: configProvider({
+						"Fluid.ContainerRuntime.EnableRollback": true,
+					}),
+				},
+			};
+			container = await provider.makeTestContainer(configWithFeatureGates);
+			dataObject = (await container.getEntryPoint()) as ITestFluidObject;
+			sharedString = await dataObject.getSharedObject<SharedString>(stringId);
+			sharedString2 = await dataObject.getSharedObject<SharedString>(string2Id);
+			sharedDir = await dataObject.getSharedObject<SharedDirectory>(dirId);
+			sharedCell = await dataObject.getSharedObject<SharedCell>(cellId);
+			sharedMap = await dataObject.getSharedObject<ISharedMap>(mapId);
+
+			containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
+			changedEventData = [];
+			sharedString.on("sequenceDelta", (changed, _local, _target) => {
+				changedEventData.push(changed);
 			});
-		} catch (err) {
-			error = err as Error;
-		}
-
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedString.getText(), "abcde");
-		assert.equal(sharedMap.size, 1);
-		assert.equal(sharedMap.has("key1"), true);
-		assert.equal(sharedMap.get("key1"), 0);
-		assert.equal(sharedCell.get(), 2);
-
-		assert.equal(changedEventData.length, 9);
-		assert(
-			changedEventData[0] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[0]}`,
-		);
-
-		assert.deepEqual(changedEventData[1], { key: "key1", previousValue: undefined });
-
-		assert.equal(changedEventData[2], 2);
-
-		assert(
-			changedEventData[3] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[3]}`,
-		);
-
-		assert.deepEqual(changedEventData[4], { key: "key1", previousValue: 0 });
-
-		assert.equal(changedEventData[5], undefined);
-
-		// rollback
-		assert.equal(changedEventData[6], 2);
-
-		assert.deepEqual(changedEventData[7], { key: "key1", previousValue: undefined });
-
-		assert(
-			changedEventData[8] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[6]}`,
-		);
-	});
-
-	it("Should rollback complex edits on multiple DDS types", () => {
-		sharedString.insertText(0, "abcde");
-		sharedMap.set("key1", 0);
-		sharedString.annotateRange(2, 5, { foo: "old" });
-		sharedCell.set(2);
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedMap.set("key1", 3);
-				sharedString.annotateRange(0, 3, { foo: "new" });
-				sharedCell.set(5);
-				sharedString.removeRange(0, 5);
-				sharedCell.delete();
-				throw new Error(errorMessage);
+			sharedString2.on("sequenceDelta", (changed, _local, _target) => {
+				changedEventData.push(changed);
 			});
-		} catch (err) {
-			error = err as Error;
-		}
+			sharedDir.on("valueChanged", (changed, _local, _target) => {
+				changedEventData.push(changed);
+			});
+			sharedCell.on("valueChanged", (value) => {
+				changedEventData.push(value);
+			});
+			sharedCell.on("delete", (value) => {
+				changedEventData.push(value);
+			});
+			sharedMap.on("valueChanged", (value) => {
+				changedEventData.push(value);
+			});
+		});
 
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedString.getText(), "abcde");
-		for (let i = 0; i < sharedString.getText().length; i++) {
-			const props = sharedString.getPropertiesAtPosition(i);
-			if (i >= 2 && i < 5) {
-				assert.equal(props?.foo, "old");
-			} else {
-				assert(props === undefined || props.foo === undefined);
+		it("Should rollback simple edits on multiple DDS types", () => {
+			sharedString.insertText(0, "abcde");
+			sharedMap.set("key1", 0);
+			sharedCell.set(2);
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedString.removeRange(0, 5);
+					sharedMap.delete("key1");
+					sharedCell.delete();
+					throw new Error(errorMessage);
+				});
+			} catch (err) {
+				error = err as Error;
 			}
-		}
-		assert.equal(sharedMap.size, 1);
-		assert.equal(sharedMap.has("key1"), true);
-		assert.equal(sharedMap.get("key1"), 0);
-		assert.equal(sharedCell.get(), 2);
 
-		assert.equal(changedEventData.length, 17);
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false, "Container disposed");
+			assert.equal(sharedString.getText(), "abcde");
+			assert.equal(sharedMap.size, 1);
+			assert.equal(sharedMap.has("key1"), true);
+			assert.equal(sharedMap.get("key1"), 0);
+			assert.equal(sharedCell.get(), 2);
 
-		assert(
-			changedEventData[0] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[0]}`,
-		);
+			assert.equal(changedEventData.length, 9);
+			assert(
+				changedEventData[0] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[0]}`,
+			);
 
-		assert.deepEqual(changedEventData[1], { key: "key1", previousValue: undefined });
+			assert.deepEqual(changedEventData[1], { key: "key1", previousValue: undefined });
 
-		assert(
-			changedEventData[2] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[2]}`,
-		);
+			assert.equal(changedEventData[2], 2);
 
-		assert.equal(changedEventData[3], 2);
+			assert(
+				changedEventData[3] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[3]}`,
+			);
 
-		assert.deepEqual(changedEventData[4], { key: "key1", previousValue: 0 });
+			assert.deepEqual(changedEventData[4], { key: "key1", previousValue: 0 });
 
-		assert(
-			changedEventData[5] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[5]}`,
-		);
+			assert.equal(changedEventData[5], undefined);
 
-		assert.equal(changedEventData[6], 5);
+			// rollback
+			assert.equal(changedEventData[6], 2);
 
-		assert(
-			changedEventData[7] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[7]}`,
-		);
+			assert.deepEqual(changedEventData[7], { key: "key1", previousValue: undefined });
 
-		assert.equal(changedEventData[8], undefined);
+			assert(
+				changedEventData[8] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[6]}`,
+			);
+		});
 
-		// rollback
-		assert.equal(changedEventData[9], 5);
+		it("Should rollback complex edits on multiple DDS types", () => {
+			sharedString.insertText(0, "abcde");
+			sharedMap.set("key1", 0);
+			sharedString.annotateRange(2, 5, { foo: "old" });
+			sharedCell.set(2);
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedMap.set("key1", 3);
+					sharedString.annotateRange(0, 3, { foo: "new" });
+					sharedCell.set(5);
+					sharedString.removeRange(0, 5);
+					sharedCell.delete();
+					throw new Error(errorMessage);
+				});
+			} catch (err) {
+				error = err as Error;
+			}
 
-		// segments are split up at some point - reason for multiple events
-		assert(
-			changedEventData[10] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[10]}`,
-		);
-		assert(
-			changedEventData[11] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[11]}`,
-		);
-		assert(
-			changedEventData[12] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[12]}`,
-		);
-
-		assert.equal(changedEventData[13], 2);
-		// segments are split up at some point - reason for multiple events
-		assert(
-			changedEventData[14] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[14]}`,
-		);
-		assert(
-			changedEventData[15] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[15]}`,
-		);
-
-		assert.deepEqual(changedEventData[16], { key: "key1", previousValue: 3 });
-	});
-
-	it("Should handle rollback on multiple instances of the same DDS type", () => {
-		sharedString.insertText(0, "abcde");
-		sharedMap.set("key", 1);
-		sharedString2.insertText(0, "12345");
-
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedMap.delete("key");
-				sharedString2.removeRange(0, 2);
-				sharedString.insertText(1, "123");
-				throw new Error("callback failure");
-			});
-		} catch (err) {
-			error = err as Error;
-		}
-
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedString.getText(), "abcde");
-		assert.equal(sharedString2.getText(), "12345");
-		assert.equal(sharedMap.size, 1);
-		assert.equal(sharedMap.has("key"), true);
-		assert.equal(sharedMap.get("key"), 1);
-
-		assert.equal(changedEventData.length, 9);
-
-		assert(
-			changedEventData[0] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[0]}`,
-		);
-
-		assert.deepEqual(changedEventData[1], { key: "key", previousValue: undefined });
-
-		assert(
-			changedEventData[2] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[2]}`,
-		);
-
-		assert.deepEqual(changedEventData[3], { key: "key", previousValue: 1 });
-
-		assert(
-			changedEventData[4] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[4]}`,
-		);
-
-		assert(
-			changedEventData[5] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[5]}`,
-		);
-
-		// rollback
-		assert(
-			changedEventData[6] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[6]}`,
-		);
-
-		assert(
-			changedEventData[7] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[7]}`,
-		);
-
-		assert.deepEqual(changedEventData[8], { key: "key", previousValue: undefined });
-	});
-
-	it("Should handle nested calls to orderSequentially", () => {
-		sharedString.insertText(0, "abcde");
-		sharedMap.set("key", 1);
-
-		try {
-			containerRuntime.orderSequentially(() => {
-				sharedMap.set("key", 0);
-				try {
-					containerRuntime.orderSequentially(() => {
-						sharedString.removeRange(0, 2);
-						throw new Error("callback failure");
-					});
-				} catch (err) {
-					error = err as Error;
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false, "Container disposed");
+			assert.equal(sharedString.getText(), "abcde");
+			for (let i = 0; i < sharedString.getText().length; i++) {
+				const props = sharedString.getPropertiesAtPosition(i);
+				if (i >= 2 && i < 5) {
+					assert.equal(props?.foo, "old");
+				} else {
+					assert(props === undefined || props.foo === undefined);
 				}
-				sharedMap.delete("key");
-				throw new Error("callback failure");
-			});
-		} catch (err) {
-			error = err as Error;
-		}
+			}
+			assert.equal(sharedMap.size, 1);
+			assert.equal(sharedMap.has("key1"), true);
+			assert.equal(sharedMap.get("key1"), 0);
+			assert.equal(sharedCell.get(), 2);
 
-		assert.notEqual(error, undefined, "No error");
-		assert.equal(error?.message, errorMessage, "Unexpected error message");
-		assert.equal(containerRuntime.disposed, false, "Container disposed");
-		assert.equal(sharedString.getText(), "abcde");
-		assert.equal(sharedMap.size, 1);
-		assert.equal(sharedMap.has("key"), true);
-		assert.equal(sharedMap.get("key"), 1);
+			assert.equal(changedEventData.length, 17);
 
-		assert.equal(changedEventData.length, 8);
+			assert(
+				changedEventData[0] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[0]}`,
+			);
 
-		assert(
-			changedEventData[0] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[0]}`,
-		);
+			assert.deepEqual(changedEventData[1], { key: "key1", previousValue: undefined });
 
-		assert.deepEqual(changedEventData[1], { key: "key", previousValue: undefined });
+			assert(
+				changedEventData[2] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[2]}`,
+			);
 
-		assert.deepEqual(changedEventData[2], { key: "key", previousValue: 1 });
+			assert.equal(changedEventData[3], 2);
 
-		assert(
-			changedEventData[3] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[3]}`,
-		);
+			assert.deepEqual(changedEventData[4], { key: "key1", previousValue: 0 });
 
-		// rollback - inner orderSequentially call
-		assert(
-			changedEventData[4] instanceof SequenceDeltaEvent,
-			`Unexpected event type - ${typeof changedEventData[4]}`,
-		);
+			assert(
+				changedEventData[5] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[5]}`,
+			);
 
-		assert.deepEqual(changedEventData[5], { key: "key", previousValue: 0 });
+			assert.equal(changedEventData[6], 5);
 
-		// rollback - outer orderSequentially call
-		assert.deepEqual(changedEventData[6], { key: "key", previousValue: undefined });
+			assert(
+				changedEventData[7] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[7]}`,
+			);
 
-		assert.deepEqual(changedEventData[7], { key: "key", previousValue: 0 });
-	});
-});
+			assert.equal(changedEventData[8], undefined);
+
+			// rollback
+			assert.equal(changedEventData[9], 5);
+
+			// segments are split up at some point - reason for multiple events
+			assert(
+				changedEventData[10] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[10]}`,
+			);
+			assert(
+				changedEventData[11] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[11]}`,
+			);
+			assert(
+				changedEventData[12] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[12]}`,
+			);
+
+			assert.equal(changedEventData[13], 2);
+			// segments are split up at some point - reason for multiple events
+			assert(
+				changedEventData[14] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[14]}`,
+			);
+			assert(
+				changedEventData[15] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[15]}`,
+			);
+
+			assert.deepEqual(changedEventData[16], { key: "key1", previousValue: 3 });
+		});
+
+		it("Should handle rollback on multiple instances of the same DDS type", () => {
+			sharedString.insertText(0, "abcde");
+			sharedMap.set("key", 1);
+			sharedString2.insertText(0, "12345");
+
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedMap.delete("key");
+					sharedString2.removeRange(0, 2);
+					sharedString.insertText(1, "123");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
+
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false, "Container disposed");
+			assert.equal(sharedString.getText(), "abcde");
+			assert.equal(sharedString2.getText(), "12345");
+			assert.equal(sharedMap.size, 1);
+			assert.equal(sharedMap.has("key"), true);
+			assert.equal(sharedMap.get("key"), 1);
+
+			assert.equal(changedEventData.length, 9);
+
+			assert(
+				changedEventData[0] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[0]}`,
+			);
+
+			assert.deepEqual(changedEventData[1], { key: "key", previousValue: undefined });
+
+			assert(
+				changedEventData[2] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[2]}`,
+			);
+
+			assert.deepEqual(changedEventData[3], { key: "key", previousValue: 1 });
+
+			assert(
+				changedEventData[4] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[4]}`,
+			);
+
+			assert(
+				changedEventData[5] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[5]}`,
+			);
+
+			// rollback
+			assert(
+				changedEventData[6] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[6]}`,
+			);
+
+			assert(
+				changedEventData[7] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[7]}`,
+			);
+
+			assert.deepEqual(changedEventData[8], { key: "key", previousValue: undefined });
+		});
+
+		it("Should handle nested calls to orderSequentially", () => {
+			sharedString.insertText(0, "abcde");
+			sharedMap.set("key", 1);
+
+			try {
+				containerRuntime.orderSequentially(() => {
+					sharedMap.set("key", 0);
+					try {
+						containerRuntime.orderSequentially(() => {
+							sharedString.removeRange(0, 2);
+							throw new Error("callback failure");
+						});
+					} catch (err) {
+						error = err as Error;
+					}
+					sharedMap.delete("key");
+					throw new Error("callback failure");
+				});
+			} catch (err) {
+				error = err as Error;
+			}
+
+			assert.notEqual(error, undefined, "No error");
+			assert.equal(error?.message, errorMessage, "Unexpected error message");
+			assert.equal(containerRuntime.disposed, false, "Container disposed");
+			assert.equal(sharedString.getText(), "abcde");
+			assert.equal(sharedMap.size, 1);
+			assert.equal(sharedMap.has("key"), true);
+			assert.equal(sharedMap.get("key"), 1);
+
+			assert.equal(changedEventData.length, 8);
+
+			assert(
+				changedEventData[0] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[0]}`,
+			);
+
+			assert.deepEqual(changedEventData[1], { key: "key", previousValue: undefined });
+
+			assert.deepEqual(changedEventData[2], { key: "key", previousValue: 1 });
+
+			assert(
+				changedEventData[3] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[3]}`,
+			);
+
+			// rollback - inner orderSequentially call
+			assert(
+				changedEventData[4] instanceof SequenceDeltaEvent,
+				`Unexpected event type - ${typeof changedEventData[4]}`,
+			);
+
+			assert.deepEqual(changedEventData[5], { key: "key", previousValue: 0 });
+
+			// rollback - outer orderSequentially call
+			assert.deepEqual(changedEventData[6], { key: "key", previousValue: undefined });
+
+			assert.deepEqual(changedEventData[7], { key: "key", previousValue: 0 });
+		});
+	},
+);

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -28,7 +28,7 @@ const dirId = "sharedDirKey";
 const cellId = "cellKey";
 const mapId = "mapKey";
 
-describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Multiple DDS orderSequentially", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap, SharedDirectory, SharedString, SharedCell } = apis.dds;
 	const { SequenceDeltaEvent } = apis.dataRuntime.packages.sequence;
 

--- a/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
@@ -25,7 +25,7 @@ import {
 
 describeCompat(
 	"Op reentry and rebasing during pending batches",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const {
 			SharedMap,

--- a/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pongEvent.spec.ts
@@ -21,7 +21,7 @@ import {
 const codeDetails: IFluidCodeDetails = { package: "test" };
 
 describe("Pong", () => {
-	describeCompat("Pong", "NoCompat", (getTestObjectProvider) => {
+	describeCompat("Pong", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 		let provider: ITestObjectProvider;
 		const loaderContainerTracker = new LoaderContainerTracker();
 

--- a/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/refreshSerializedStateManager.spec.ts
@@ -37,7 +37,7 @@ const testKey = "test key";
 const testValue = "test value";
 const mockLogger = new MockLogger();
 
-describeCompat("Snapshot refresh at loading", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Snapshot refresh at loading", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
 	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({

--- a/packages/test/test-end-to-end-tests/src/test/serializeAfterFailedAttach.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/serializeAfterFailedAttach.spec.ts
@@ -26,7 +26,7 @@ import { wrapObjectAndOverride } from "../mocking.js";
 
 describeCompat(
 	`Serialize After Failure to Attach Container Test`,
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const { SharedMap, SharedString } = apis.dds;
 

--- a/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedInterval.spec.ts
@@ -247,7 +247,7 @@ function testIntervalOperations(intervalCollection: IIntervalCollection<Sequence
 		intervalCollection.removeIntervalById(id);
 	}
 }
-describeCompat("SharedInterval", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("SharedInterval", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap, SharedString } = apis.dds;
 	const { createOverlappingIntervalsIndex } = apis.dataRuntime.packages.sequence;
 	let provider: ITestObjectProvider;

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringEndToEndTests.spec.ts
@@ -124,7 +124,7 @@ describeCompat("SharedString", "FullCompat", (getTestObjectProvider, apis) => {
 	});
 });
 
-describeCompat("SharedString grouped batching", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("SharedString grouped batching", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedString } = apis.dds;
 
 	const registry: ChannelFactoryRegistry = [[stringId, SharedString.getFactory()]];

--- a/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/sharedStringLoading.spec.ts
@@ -25,7 +25,7 @@ import { wrapObjectAndOverride } from "../mocking.js";
 import { pkgVersion } from "../packageVersion.js";
 
 // REVIEW: enable compat testing?
-describeCompat("SharedString", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("SharedString", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedString } = apis.dds;
 
 	itExpects(

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -90,7 +90,7 @@ type SharedObjCallback = (
 
 // Introduced in 0.37
 // REVIEW: enable compat testing
-describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("stashed ops", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap, SharedDirectory, SharedCounter, SharedString, SharedCell } = apis.dds;
 	const { getTextAndMarkers } = apis.dataRuntime.packages.sequence;
 
@@ -1810,7 +1810,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 	});
 });
 
-describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("stashed ops", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap, SharedDirectory, SharedCounter, SharedString, SharedCell } = apis.dds;
 	const registry: ChannelFactoryRegistry = [
 		[mapId, SharedMap.getFactory()],

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -104,7 +104,7 @@ function readBlobContent(content: ISummaryBlob["content"]): unknown {
 	return JSON.parse(json);
 }
 
-describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Summaries", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedString } = apis.dds;
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
@@ -507,7 +507,7 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 	});
 });
 
-describeCompat("Summaries", "NoCompat", (getTestObjectProvider) => {
+describeCompat("Summaries", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	beforeEach("getTestObjectProvider", () => {
 		provider = getTestObjectProvider();
@@ -566,7 +566,7 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider) => {
 	it("TelemetryContext is populated with data even if summarize fails", getTestFn(true));
 });
 
-describeCompat("SingleCommit Summaries Tests", "NoCompat", (getTestObjectProvider) => {
+describeCompat("SingleCommit Summaries Tests", "2.0.0-rc.3.0.0", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let configForSingleCommitSummary: ITestContainerConfig;
 	beforeEach("setup", () => {

--- a/packages/test/test-end-to-end-tests/src/test/summarizationEdgeCases.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizationEdgeCases.spec.ts
@@ -25,7 +25,7 @@ import {
 } from "@fluidframework/test-utils/internal";
 
 // These tests intend to ensure that summarization succeeds in edge case scenarios that rarely happen
-describeCompat("Summarization edge cases", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Summarization edge cases", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 	const testContainerConfig: ITestContainerConfig = {
 		runtimeOptions: {

--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementallySubDds.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementallySubDds.spec.ts
@@ -461,7 +461,7 @@ class TestIncrementalSummaryTreeDDS extends SharedObject {
  */
 describeCompat(
 	"Incremental summaries can be generated for DDS content",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/summarizeRefreshLatestSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeRefreshLatestSummary.spec.ts
@@ -25,7 +25,7 @@ import {
 
 describeCompat(
 	"Summarizer can refresh a snapshot from the server",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider) => {
 		let provider: ITestObjectProvider;
 		beforeEach("getTestObjectProvider", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeRestart.spec.ts
@@ -19,7 +19,7 @@ import {
 
 describeCompat(
 	"Summarizer closes instead of refreshing",
-	"NoCompat",
+	"2.0.0-rc.3.0.0",
 	(getTestObjectProvider, apis) => {
 		const { SharedCounter } = apis.dds;
 

--- a/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizerWithLocalChanges.spec.ts
@@ -50,7 +50,7 @@ async function waitForSummaryOp(container: IContainer): Promise<boolean> {
 	});
 }
 
-describeCompat("Summarizer with local changes", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Summarizer with local changes", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { mixinSummaryHandler } = apis.dataRuntime.packages.datastore;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;

--- a/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaryDataStoreStats.spec.ts
@@ -17,7 +17,7 @@ import { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
 import { MockLogger, createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import { ITestObjectProvider, timeoutAwait } from "@fluidframework/test-utils/internal";
 
-describeCompat("Generate Summary Stats", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("Generate Summary Stats", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const { DataObject, DataObjectFactory } = apis.dataRuntime;
 	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
 

--- a/packages/test/test-end-to-end-tests/src/test/t9sregressiontest.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/t9sregressiontest.spec.ts
@@ -18,7 +18,7 @@ import {
 const mapId = "map";
 
 // This is a regression test for https://github.com/microsoft/FluidFramework/issues/9163
-describeCompat("t9s issue regression test", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat("t9s issue regression test", "2.0.0-rc.3.0.0", (getTestObjectProvider, apis) => {
 	const registry: ChannelFactoryRegistry = [[mapId, apis.dds.SharedMap.getFactory()]];
 	const testContainerConfig: ITestContainerConfig = {
 		fluidDataObjectType: DataObjectFactoryType.Test,


### PR DESCRIPTION
Changing NoCompat parameter for specific version for further release bump testing. There is at least one test suite that uses an older version than 2.0.0-rc.3.0.0 which will also help for validation, as well as the summarizeIncrementally test suite which is still using 1.3.7 version.