### PR TITLE
feat(stochastic-test-utils): allow the creation of weighted generator with 0 weight

### DIFF
--- a/packages/test/stochastic-test-utils/src/generators.ts
+++ b/packages/test/stochastic-test-utils/src/generators.ts
@@ -55,14 +55,14 @@ export function createWeightedGenerator<T, TState extends BaseFuzzTestState>(
 		}
 		totalWeight = cumulativeWeight;
 	}
-	if (totalWeight === 0) {
-		throw new Error("createWeightedGenerator must have some positive weight");
-	}
 
 	// Note: if this is a perf bottleneck in usage, the cumulative weights array could be
 	// binary searched, and for small likelihood of acceptance (i.e. disproportional weights)
 	// we could pre-filter the acceptance conditions rather than rejection sample the outcome.
 	return (state) => {
+		if (totalWeight === 0) {
+			throw new Error("createWeightedGenerator must have some positive weight");
+		}
 		const { random } = state;
 		const sample = () => {
 			const weightSelected = random.real(0, totalWeight);


### PR DESCRIPTION
## Description

Weights are a mechanism to control the proportion in which different options are selected by a generator. A weight of zero can conveniently be used to ensure a specific option is never selected. This can lead the creation of generators for which all options are given a weight of zero. Before this PR, `createWeightedGenerator` would throw when invoked with weights that sum to zero.  This PR changes `createWeightedGenerator` to instead successfully return a generator that will throw when invoked.

This change allows usage patterns where a generator is created with zero weights but never invoked.