### PR TITLE
refactor: Add lib/test to all .npmignore files

### DIFF
--- a/azure/packages/azure-local-service/.npmignore
+++ b/azure/packages/azure-local-service/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/azure/packages/azure-service-utils/.npmignore
+++ b/azure/packages/azure-service-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/build-tools/packages/build-tools/.npmignore
+++ b/build-tools/packages/build-tools/.npmignore
@@ -3,3 +3,4 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test

--- a/build-tools/packages/bundle-size-tools/.npmignore
+++ b/build-tools/packages/bundle-size-tools/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/build-tools/packages/version-tools/.npmignore
+++ b/build-tools/packages/version-tools/.npmignore
@@ -4,4 +4,5 @@ nyc
 src/test
 dist/test
 lib/test
+lib/test
 **/_api-extractor-temp/**

--- a/common/lib/common-definitions/.npmignore
+++ b/common/lib/common-definitions/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/common/lib/common-utils/.npmignore
+++ b/common/lib/common-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/common/lib/protocol-definitions/.npmignore
+++ b/common/lib/protocol-definitions/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/apps/attributable-map/.npmignore
+++ b/examples/apps/attributable-map/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/apps/collaborative-textarea/.npmignore
+++ b/examples/apps/collaborative-textarea/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/apps/contact-collection/.npmignore
+++ b/examples/apps/contact-collection/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/apps/data-object-grid/.npmignore
+++ b/examples/apps/data-object-grid/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/apps/presence-tracker/.npmignore
+++ b/examples/apps/presence-tracker/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/apps/task-selection/.npmignore
+++ b/examples/apps/task-selection/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/apps/tree-comparison/.npmignore
+++ b/examples/apps/tree-comparison/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/benchmarks/bubblebench/baseline/.npmignore
+++ b/examples/benchmarks/bubblebench/baseline/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/benchmarks/bubblebench/common/.npmignore
+++ b/examples/benchmarks/bubblebench/common/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/benchmarks/bubblebench/editable-shared-tree/.npmignore
+++ b/examples/benchmarks/bubblebench/editable-shared-tree/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/benchmarks/bubblebench/ot/.npmignore
+++ b/examples/benchmarks/bubblebench/ot/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/benchmarks/bubblebench/sharedtree/.npmignore
+++ b/examples/benchmarks/bubblebench/sharedtree/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/benchmarks/bubblebench/simple-tree/.npmignore
+++ b/examples/benchmarks/bubblebench/simple-tree/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/.npmignore
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/.npmignore
@@ -3,5 +3,6 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 webpack
 **/_api-extractor-temp/**

--- a/examples/benchmarks/tablebench/.npmignore
+++ b/examples/benchmarks/tablebench/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/client-logger/app-insights-logger/.npmignore
+++ b/examples/client-logger/app-insights-logger/.npmignore
@@ -4,6 +4,7 @@
 # Test code
 src/test
 dist/test
+lib/test
 
 # Temporary api-extractor build artifacts
 _api-extractor-temp

--- a/examples/data-objects/canvas/.npmignore
+++ b/examples/data-objects/canvas/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/clicker/.npmignore
+++ b/examples/data-objects/clicker/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/codemirror/.npmignore
+++ b/examples/data-objects/codemirror/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/diceroller/.npmignore
+++ b/examples/data-objects/diceroller/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/inventory-app/.npmignore
+++ b/examples/data-objects/inventory-app/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/monaco/.npmignore
+++ b/examples/data-objects/monaco/.npmignore
@@ -4,4 +4,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/multiview/constellation-model/.npmignore
+++ b/examples/data-objects/multiview/constellation-model/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/multiview/constellation-view/.npmignore
+++ b/examples/data-objects/multiview/constellation-view/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/multiview/container/.npmignore
+++ b/examples/data-objects/multiview/container/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/multiview/coordinate-model/.npmignore
+++ b/examples/data-objects/multiview/coordinate-model/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/multiview/interface/.npmignore
+++ b/examples/data-objects/multiview/interface/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/multiview/plot-coordinate-view/.npmignore
+++ b/examples/data-objects/multiview/plot-coordinate-view/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/multiview/slider-coordinate-view/.npmignore
+++ b/examples/data-objects/multiview/slider-coordinate-view/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/multiview/triangle-view/.npmignore
+++ b/examples/data-objects/multiview/triangle-view/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/prosemirror/.npmignore
+++ b/examples/data-objects/prosemirror/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/smde/.npmignore
+++ b/examples/data-objects/smde/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/table-document/.npmignore
+++ b/examples/data-objects/table-document/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/todo/.npmignore
+++ b/examples/data-objects/todo/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/data-objects/webflow/.npmignore
+++ b/examples/data-objects/webflow/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/external-data/.npmignore
+++ b/examples/external-data/.npmignore
@@ -1,6 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
-dist/test
+dist/tests
 lib/tests
 **/_api-extractor-temp/**

--- a/examples/external-data/.npmignore
+++ b/examples/external-data/.npmignore
@@ -1,5 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
-dist/tests
+dist/test
+lib/tests
 **/_api-extractor-temp/**

--- a/examples/service-clients/azure-client/external-controller/.npmignore
+++ b/examples/service-clients/azure-client/external-controller/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/service-clients/odsp-client/shared-tree-demo/.npmignore
+++ b/examples/service-clients/odsp-client/shared-tree-demo/.npmignore
@@ -1,5 +1,6 @@
 nyc
 *.log
 **/*.tsbuildinfo
-dist/tests
+dist/test
+lib/tests
 **/_api-extractor-temp/**

--- a/examples/service-clients/odsp-client/shared-tree-demo/.npmignore
+++ b/examples/service-clients/odsp-client/shared-tree-demo/.npmignore
@@ -2,5 +2,5 @@ nyc
 *.log
 **/*.tsbuildinfo
 dist/test
-lib/tests
+lib/test
 **/_api-extractor-temp/**

--- a/examples/utils/bundle-size-tests/.npmignore
+++ b/examples/utils/bundle-size-tests/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/utils/example-utils/.npmignore
+++ b/examples/utils/example-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/utils/webpack-fluid-loader/.npmignore
+++ b/examples/utils/webpack-fluid-loader/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/version-migration/live-schema-upgrade/.npmignore
+++ b/examples/version-migration/live-schema-upgrade/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/version-migration/same-container/.npmignore
+++ b/examples/version-migration/same-container/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/version-migration/schema-upgrade/.npmignore
+++ b/examples/version-migration/schema-upgrade/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/version-migration/tree-shim/.npmignore
+++ b/examples/version-migration/tree-shim/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/view-integration/container-views/.npmignore
+++ b/examples/view-integration/container-views/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/view-integration/external-views/.npmignore
+++ b/examples/view-integration/external-views/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/examples/view-integration/view-framework-sampler/.npmignore
+++ b/examples/view-integration/view-framework-sampler/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/PropertyDDS/examples/property-inspector/.npmignore
+++ b/experimental/PropertyDDS/examples/property-inspector/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/PropertyDDS/examples/schemas/.npmignore
+++ b/experimental/PropertyDDS/examples/schemas/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/PropertyDDS/packages/property-binder/.npmignore
+++ b/experimental/PropertyDDS/packages/property-binder/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/PropertyDDS/packages/property-changeset/.npmignore
+++ b/experimental/PropertyDDS/packages/property-changeset/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/PropertyDDS/packages/property-common/.npmignore
+++ b/experimental/PropertyDDS/packages/property-common/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/PropertyDDS/packages/property-dds/.npmignore
+++ b/experimental/PropertyDDS/packages/property-dds/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/PropertyDDS/packages/property-inspector-table/.npmignore
+++ b/experimental/PropertyDDS/packages/property-inspector-table/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/PropertyDDS/packages/property-properties/.npmignore
+++ b/experimental/PropertyDDS/packages/property-properties/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/PropertyDDS/packages/property-proxy/.npmignore
+++ b/experimental/PropertyDDS/packages/property-proxy/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/PropertyDDS/packages/property-shared-tree-interop/.npmignore
+++ b/experimental/PropertyDDS/packages/property-shared-tree-interop/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/dds/attributable-map/.npmignore
+++ b/experimental/dds/attributable-map/.npmignore
@@ -3,6 +3,7 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**
 
 # These are large test files that we don't need to distribute.

--- a/experimental/dds/ot/ot/.npmignore
+++ b/experimental/dds/ot/ot/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/dds/ot/sharejs/json1/.npmignore
+++ b/experimental/dds/ot/sharejs/json1/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/dds/sequence-deprecated/.npmignore
+++ b/experimental/dds/sequence-deprecated/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/dds/tree/.npmignore
+++ b/experimental/dds/tree/.npmignore
@@ -3,6 +3,7 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**
 
 # These are large test files that we don't need to distribute.

--- a/experimental/framework/data-objects/.npmignore
+++ b/experimental/framework/data-objects/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/experimental/framework/last-edited/.npmignore
+++ b/experimental/framework/last-edited/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/common/client-utils/.npmignore
+++ b/packages/common/client-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/common/container-definitions/.npmignore
+++ b/packages/common/container-definitions/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/common/core-interfaces/.npmignore
+++ b/packages/common/core-interfaces/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/common/core-utils/.npmignore
+++ b/packages/common/core-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/common/driver-definitions/.npmignore
+++ b/packages/common/driver-definitions/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/dds/cell/.npmignore
+++ b/packages/dds/cell/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/dds/counter/.npmignore
+++ b/packages/dds/counter/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/dds/ink/.npmignore
+++ b/packages/dds/ink/.npmignore
@@ -3,6 +3,7 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**
 
 TODO.md

--- a/packages/dds/map/.npmignore
+++ b/packages/dds/map/.npmignore
@@ -3,6 +3,7 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**
 
 # These are large test files that we don't need to distribute.

--- a/packages/dds/matrix/.npmignore
+++ b/packages/dds/matrix/.npmignore
@@ -3,6 +3,7 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**
 
 bench/

--- a/packages/dds/merge-tree/.npmignore
+++ b/packages/dds/merge-tree/.npmignore
@@ -16,6 +16,6 @@ docs/
 # then the ./test export is invalid, so it will fail to import anywhere outside the repo. However, some of the contents
 # of the test folder is not needed for testing, so we exclude additional paths.
 # dist/test
-lib/test
-dist/test
+# lib/test
+dist/test/types
 lib/test/types

--- a/packages/dds/merge-tree/.npmignore
+++ b/packages/dds/merge-tree/.npmignore
@@ -16,4 +16,6 @@ docs/
 # then the ./test export is invalid, so it will fail to import anywhere outside the repo. However, some of the contents
 # of the test folder is not needed for testing, so we exclude additional paths.
 # dist/test
-dist/test/types
+lib/test
+dist/test
+lib/test/types

--- a/packages/dds/ordered-collection/.npmignore
+++ b/packages/dds/ordered-collection/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/dds/pact-map/.npmignore
+++ b/packages/dds/pact-map/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/dds/register-collection/.npmignore
+++ b/packages/dds/register-collection/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/dds/sequence/.npmignore
+++ b/packages/dds/sequence/.npmignore
@@ -3,6 +3,7 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**
 
 .vscode/

--- a/packages/dds/shared-object-base/.npmignore
+++ b/packages/dds/shared-object-base/.npmignore
@@ -3,6 +3,7 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**
 
 bench/

--- a/packages/dds/shared-summary-block/.npmignore
+++ b/packages/dds/shared-summary-block/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/dds/task-manager/.npmignore
+++ b/packages/dds/task-manager/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/dds/test-dds-utils/.npmignore
+++ b/packages/dds/test-dds-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/dds/tree/.npmignore
+++ b/packages/dds/tree/.npmignore
@@ -3,6 +3,7 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**
 
 # These are large test files that we don't need to distribute.

--- a/packages/drivers/debugger/.npmignore
+++ b/packages/drivers/debugger/.npmignore
@@ -3,6 +3,7 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**
 
 images/

--- a/packages/drivers/driver-base/.npmignore
+++ b/packages/drivers/driver-base/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/drivers/driver-web-cache/.npmignore
+++ b/packages/drivers/driver-web-cache/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/drivers/file-driver/.npmignore
+++ b/packages/drivers/file-driver/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/drivers/local-driver/.npmignore
+++ b/packages/drivers/local-driver/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/drivers/odsp-driver-definitions/.npmignore
+++ b/packages/drivers/odsp-driver-definitions/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/drivers/odsp-driver/.npmignore
+++ b/packages/drivers/odsp-driver/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/drivers/odsp-urlResolver/.npmignore
+++ b/packages/drivers/odsp-urlResolver/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/drivers/replay-driver/.npmignore
+++ b/packages/drivers/replay-driver/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/drivers/routerlicious-driver/.npmignore
+++ b/packages/drivers/routerlicious-driver/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/drivers/routerlicious-urlResolver/.npmignore
+++ b/packages/drivers/routerlicious-urlResolver/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/drivers/tinylicious-driver/.npmignore
+++ b/packages/drivers/tinylicious-driver/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/agent-scheduler/.npmignore
+++ b/packages/framework/agent-scheduler/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/aqueduct/.npmignore
+++ b/packages/framework/aqueduct/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/attributor/.npmignore
+++ b/packages/framework/attributor/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/client-logger/app-insights-logger/.npmignore
+++ b/packages/framework/client-logger/app-insights-logger/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/data-object-base/.npmignore
+++ b/packages/framework/data-object-base/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/dds-interceptions/.npmignore
+++ b/packages/framework/dds-interceptions/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/fluid-framework/.npmignore
+++ b/packages/framework/fluid-framework/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/fluid-static/.npmignore
+++ b/packages/framework/fluid-static/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/oldest-client-observer/.npmignore
+++ b/packages/framework/oldest-client-observer/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/request-handler/.npmignore
+++ b/packages/framework/request-handler/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/synthesize/.npmignore
+++ b/packages/framework/synthesize/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/framework/undo-redo/.npmignore
+++ b/packages/framework/undo-redo/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/loader/container-loader/.npmignore
+++ b/packages/loader/container-loader/.npmignore
@@ -3,6 +3,7 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**
 
 closeAndGetPendingLocalState.md

--- a/packages/loader/driver-utils/.npmignore
+++ b/packages/loader/driver-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/runtime/container-runtime-definitions/.npmignore
+++ b/packages/runtime/container-runtime-definitions/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/runtime/container-runtime/.npmignore
+++ b/packages/runtime/container-runtime/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/runtime/datastore-definitions/.npmignore
+++ b/packages/runtime/datastore-definitions/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/runtime/datastore/.npmignore
+++ b/packages/runtime/datastore/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/runtime/id-compressor/.npmignore
+++ b/packages/runtime/id-compressor/.npmignore
@@ -2,5 +2,6 @@ nyc
 *.log
 **/*.tsbuildinfo
 src/test/**/*.spec.ts
-dist/test/**/*.spec.js
+dist/test
+lib/test/**/*.spec.js
 **/_api-extractor-temp/**

--- a/packages/runtime/id-compressor/.npmignore
+++ b/packages/runtime/id-compressor/.npmignore
@@ -2,6 +2,6 @@ nyc
 *.log
 **/*.tsbuildinfo
 src/test/**/*.spec.ts
-dist/test
+dist/test/**/*.spec.js
 lib/test/**/*.spec.js
 **/_api-extractor-temp/**

--- a/packages/runtime/runtime-definitions/.npmignore
+++ b/packages/runtime/runtime-definitions/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/runtime/runtime-utils/.npmignore
+++ b/packages/runtime/runtime-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/runtime/test-runtime-utils/.npmignore
+++ b/packages/runtime/test-runtime-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/service-clients/azure-client/.npmignore
+++ b/packages/service-clients/azure-client/.npmignore
@@ -3,6 +3,7 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**
 
 # These are large test files that we don't need to distribute.

--- a/packages/service-clients/odsp-client/.npmignore
+++ b/packages/service-clients/odsp-client/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/service-clients/tinylicious-client/.npmignore
+++ b/packages/service-clients/tinylicious-client/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/functional-tests/.npmignore
+++ b/packages/test/functional-tests/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/local-server-tests/.npmignore
+++ b/packages/test/local-server-tests/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/mocha-test-setup/.npmignore
+++ b/packages/test/mocha-test-setup/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/snapshots/.npmignore
+++ b/packages/test/snapshots/.npmignore
@@ -4,4 +4,5 @@ nyc
 src/test
 dist/test
 lib/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/stochastic-test-utils/.npmignore
+++ b/packages/test/stochastic-test-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/test-app-insights-logger/.npmignore
+++ b/packages/test/test-app-insights-logger/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/test-driver-definitions/.npmignore
+++ b/packages/test/test-driver-definitions/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/test-drivers/.npmignore
+++ b/packages/test/test-drivers/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/test-pairwise-generator/.npmignore
+++ b/packages/test/test-pairwise-generator/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/test-utils/.npmignore
+++ b/packages/test/test-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/test/test-version-utils/.npmignore
+++ b/packages/test/test-version-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/tools/devtools/devtools-core/.npmignore
+++ b/packages/tools/devtools/devtools-core/.npmignore
@@ -5,6 +5,7 @@
 # Test code
 src/test
 dist/test
+lib/test
 
 # Temporary api-extractor build artifacts
 _api-extractor-temp

--- a/packages/tools/devtools/devtools-example/.npmignore
+++ b/packages/tools/devtools/devtools-example/.npmignore
@@ -5,6 +5,7 @@
 # Test code
 src/test
 dist/test
+lib/test
 
 # Temporary api-extractor build artifacts
 _api-extractor-temp

--- a/packages/tools/devtools/devtools-view/.npmignore
+++ b/packages/tools/devtools/devtools-view/.npmignore
@@ -5,6 +5,7 @@
 # Test code
 src/test
 dist/test
+lib/test
 
 # Temporary api-extractor build artifacts
 _api-extractor-temp

--- a/packages/tools/devtools/devtools/.npmignore
+++ b/packages/tools/devtools/devtools/.npmignore
@@ -5,6 +5,7 @@
 # Test code
 src/test
 dist/test
+lib/test
 
 # Temporary api-extractor build artifacts
 _api-extractor-temp

--- a/packages/tools/fetch-tool/.npmignore
+++ b/packages/tools/fetch-tool/.npmignore
@@ -3,3 +3,4 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test

--- a/packages/tools/fluid-runner/.npmignore
+++ b/packages/tools/fluid-runner/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/utils/odsp-doclib-utils/.npmignore
+++ b/packages/utils/odsp-doclib-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/utils/telemetry-utils/.npmignore
+++ b/packages/utils/telemetry-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/packages/utils/tool-utils/.npmignore
+++ b/packages/utils/tool-utils/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/gitresources/.npmignore
+++ b/server/routerlicious/packages/gitresources/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/kafka-orderer/.npmignore
+++ b/server/routerlicious/packages/kafka-orderer/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/lambdas-driver/.npmignore
+++ b/server/routerlicious/packages/lambdas-driver/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/lambdas/.npmignore
+++ b/server/routerlicious/packages/lambdas/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/local-server/.npmignore
+++ b/server/routerlicious/packages/local-server/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/memory-orderer/.npmignore
+++ b/server/routerlicious/packages/memory-orderer/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/protocol-base/.npmignore
+++ b/server/routerlicious/packages/protocol-base/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/routerlicious-base/.npmignore
+++ b/server/routerlicious/packages/routerlicious-base/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/routerlicious/.npmignore
+++ b/server/routerlicious/packages/routerlicious/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-client/.npmignore
+++ b/server/routerlicious/packages/services-client/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-core/.npmignore
+++ b/server/routerlicious/packages/services-core/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-ordering-kafkanode/.npmignore
+++ b/server/routerlicious/packages/services-ordering-kafkanode/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-ordering-rdkafka/.npmignore
+++ b/server/routerlicious/packages/services-ordering-rdkafka/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-ordering-zookeeper/.npmignore
+++ b/server/routerlicious/packages/services-ordering-zookeeper/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-shared/.npmignore
+++ b/server/routerlicious/packages/services-shared/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-telemetry/.npmignore
+++ b/server/routerlicious/packages/services-telemetry/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/services-utils/.npmignore
+++ b/server/routerlicious/packages/services-utils/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/services/.npmignore
+++ b/server/routerlicious/packages/services/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/test-utils/.npmignore
+++ b/server/routerlicious/packages/test-utils/.npmignore
@@ -7,4 +7,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/server/routerlicious/packages/tinylicious/.npmignore
+++ b/server/routerlicious/packages/tinylicious/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/tools/benchmark/.npmignore
+++ b/tools/benchmark/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**

--- a/tools/test-tools/.npmignore
+++ b/tools/test-tools/.npmignore
@@ -3,4 +3,5 @@ nyc
 **/*.tsbuildinfo
 src/test
 dist/test
+lib/test
 **/_api-extractor-temp/**


### PR DESCRIPTION
## Description

While working on the new fluid-telemetry package (https://github.com/microsoft/FluidFramework/pull/20228/) we noticed that our current "standard" `.npmignore` file excludes source test files and output test files in dist/ but not output test files in lib/, which we're probably generating much more consistently thanks to the Node16-resolution work.

This change adds lib/test to all `.npmignore` files in the repo that already had an entry for dist/test.

Applied with a regex-based global search-and-replace in VSCode, followed by a few manual adjustments:

- `examples/external-data` uses a `tests` folder instead of `test`. Should probably be brought to standard but didn't want to do it in this PR.
- `service-clients/odsp-client/shared-tree-demo` was probably copied from the one above and had `dist/tests` in its `.npmignore` file, but it doesn't even have tests today. Updated the `.npmignore` entry to the standard `dist/test` and added `lib/test`.
- `packages/dds/merge-tree` deliberately includes test files in the package but excludes type-test files. Followed that pattern and added `lib/test/types`.
- `packages/runtime/id-compressor` uses a custom pattern for some reason, I added the new entry sticking to the existing pattern.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
