### PR TITLE
Adds AppInsightsTelemetryConsumer, new app-insights export subpath and README updates.

### DIFF
--- a/packages/framework/client-logger/fluid-telemetry/README.md
+++ b/packages/framework/client-logger/fluid-telemetry/README.md
@@ -52,6 +52,7 @@ appInsightsClient.loadAppInsights();
 const telemetryConfig: TelemetryConfig = {
     container: myAppContainer,
     containerId: myAppContainerId,
+    // We import AppInsightsTelemetryConsumer from the fluid-telemetry package
     consumers: [new AppInsightsTelemetryConsumer(appInsightsClient)],
 };
 
@@ -63,9 +64,7 @@ startTelemetry(telemetryConfig);
 
 Congrats, that's it for now! If you've decided to use Azure App Insights, we have designed useful prebuilt queries for you that utilize the generated telemetry
 
-**It's important to note that while you can create your own custom implementation of `ITelemetryConsumer` for sending telemetry to App Insights, if you change the shape of the telemetry emitted from our implementation, `AppInsightsTelemetryConsumer`, we make no guarentess of our provided App Insights queries or dashboards working as expected.**
-
-## Example 2: Extending ITelemtryConsumer to send Fluid telemetry to a custom destination
+## Example 2: Extending ITelemetryConsumer to send Fluid telemetry to a custom destination
 
 In this example, you'll walk through the basic setup process to start getting container telemetry to be produced and logging it to the console.
 
@@ -90,8 +89,10 @@ class MySimpleTelemetryConsumer implements ITelemetryConsumer {
 ```ts
 import { IFluidContainer } from "@fluidframework/fluid-static";
 import { ITelemetryConsumer , TelemetryConfig, startTelemetry, IFluidTelemetry } from "@fluidframework/external-telemetry"
+// 1: import our implementation of MySimpleTelemetryConsumer from step 1
+import { MySimpleTelemetryConsumer } from "./mySimpleTelmetryConsumer"
 
-// 1: This is supposed to be your code for creating/loading a Fluid Container
+// 2: This is supposed to be your code for creating/loading a Fluid Container
 let myAppContainer: IFluidContainer;
 let myAppContainerId: string;
 if (containerExists) {
@@ -100,13 +101,6 @@ if (containerExists) {
 } else {
     myAppContainer = {...your code to create a new Fluid Container}
     myAppContainerId = await myAppContainer.attach();
-}
-
-// 2: This is our implementation of ITelemetryConsumer
-class MySimpleTelemetryConsumer implements ITelemetryConsumer {
-    consume(event: IFluidTelemetry) {
-        console.log(event);
-    }
 }
 
 // 3. Next, we'll create the telemetry config object.

--- a/packages/framework/client-logger/fluid-telemetry/README.md
+++ b/packages/framework/client-logger/fluid-telemetry/README.md
@@ -1,6 +1,6 @@
 # Description
 
-This package contains code enabling the production and consumption of typed telemetry for Fluid Framework applications. The typed telemetry from this package is used as the backbone for different Fluid Framework cloud offerings such as dashboards and alarms for Fluid applications. This package can also be used as a reference for customizing and creating their own telemetry solution if desired.
+This package contains code enabling the production and consumption of typed telemetry for Fluid Framework applications. The typed telemetry from this package is used as the backbone for different Fluid Framework cloud offerings such as dashboards and alarms for Fluid applications. This package can also be used as a reference for customizing and creating your own telemetry solution if desired.
 
 At this time, the package enables collection of Fluid Container related telemetry. In the future more areas may be added as needed by customers.
 
@@ -47,8 +47,6 @@ if (containerExists) {
 
 // 2: This is our implementation of ITelemetryConsumer
 class MySimpleTelemetryConsumer implements ITelemetryConsumer {
-    constructor(private readonly appInsightsClient: ApplicationInsights) {}
-
     consume(event: IFluidTelemetry) {
         console.log(event);
     }

--- a/packages/framework/client-logger/fluid-telemetry/README.md
+++ b/packages/framework/client-logger/fluid-telemetry/README.md
@@ -8,7 +8,64 @@ At this time, the package enables collection of Fluid Container related telemetr
 
 Let's walk through some simple examples for getting started with Fluid telemetry for containers using the @fluidframework/fluid-telemetry package, we'll have to write some code.
 
-## Example 1: Logging container telemetry to the console.
+## Example 1: Logging container telemetry to Azure App Insights
+
+Before you can get telemetry sent to Azure App Insights, you'll need to create an Instance of App Insights on Azure. Then you'll be able to create an Azure App Insights client that you can easily turn into a ITelemetryConsumer and finally hook it up to container telemetry. [Learn more about Azure App Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
+
+### Step 1: Install the @fluidframework/fluid-telemetry package and Azure App Insights package dependencies
+
+-   Using NPM: `npm install @fluidframework/fluid-telemetry @microsoft/applicationinsights-web`
+
+#### Step 2: Now, let's start the telemetry production by initializing our telemetry collection where we initialize our containers:
+
+```ts
+import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+import { IFluidContainer } from "@fluidframework/fluid-static";
+import { ITelemetryConsumer , TelemetryConfig, startTelemetry, IFluidTelemetry } from "@fluidframework/fluid-telemetry"
+import { AppInsightsTelemetryConsumer } from "@fluidframework/fluid-telemetry/app-insights"
+
+// 1: This is supposed to be your code for creating/loading a Fluid Container
+let myAppContainer: IFluidContainer;
+let myAppContainerId: string;
+if (containerExists) {
+    myAppContainerId = {...your code to get the id of the existing container}
+    myAppContainer = {...your code to load a Fluid Container from myAppContainerId}
+} else {
+    myAppContainer = {...your code to create a new Fluid Container}
+    myAppContainerId = await myAppContainer.attach();
+}
+
+// 2a: Instantiate our Azure App Insights Client
+const appInsightsClient = new ApplicationInsights({
+    config: {
+        connectionString:
+            // Edit this with your app insights instance connection string (this is an example string)
+            "InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
+    },
+});
+
+// 2b: Initializes the App Insights client. Without this, logs will not be sent to Azure.
+appInsightsClient.loadAppInsights();
+
+// 3: Next, we'll create the telemetry config object.
+// Note that we have to obtain the containerId before we can do this.
+const telemetryConfig: TelemetryConfig = {
+    container: myAppContainer,
+    containerId: myAppContainerId,
+    consumers: [new AppInsightsTelemetryConsumer(appInsightsClient)],
+};
+
+// 4. Start Telemetry
+startTelemetry(telemetryConfig);
+
+// Done! Your container telemetry is now being created and sent to your Telemetry Consumer which will forward it to Azure App Insights.
+```
+
+Congrats, that's it for now! If you've decided to use Azure App Insights, we have designed useful prebuilt queries for you that utilize the generated telemetry
+
+**It's important to note that while you can create your own custom implementation of `ITelemetryConsumer` for sending telemetry to App Insights, if you change the shape of the telemetry emitted from our implementation, `AppInsightsTelemetryConsumer`, we make no guarentess of our provided App Insights queries or dashboards working as expected.**
+
+## Example 2: Extending ITelemtryConsumer to send Fluid telemetry to a custom destination
 
 In this example, you'll walk through the basic setup process to start getting container telemetry to be produced and logging it to the console.
 
@@ -65,87 +122,3 @@ startTelemetry(telemetryConfig);
 
 // Done! Your container telemetry is now being created and sent to your Telemetry Consumer
 ```
-
-## Example 2: Logging container telemetry to Azure App Insights
-
-Before you can get telemetry sent to Azure App Insights, you'll need to create an Instance of App Insights on Azure. Then you'll be able to create an Azure App Insights client that you can easily turn into a ITelemetryConsumer and finally hook it up to container telemetry. [Learn more about Azure App Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
-
-### Step 1: Install the @fluidframework/fluid-telemetry package and Azure App Insights package dependencies
-
--   Using NPM: `npm install @fluidframework/fluid-telemetry @microsoft/applicationinsights-web`
-
-### Step 2: First, we'll have to create our own telemetry consumer which extends the ITelemetryConsumer interface using our Azure App Insights client:
-
-```ts
-import { ApplicationInsights } from "@microsoft/applicationinsights-web";
-import { ITelemetryConsumer, IFluidTelemetry } from "@fluidframework/fluid-telemetry";
-
-class AppInsightsTelemetryConsumer implements ITelemetryConsumer {
-	constructor(private readonly appInsightsClient: ApplicationInsights) {}
-
-	consume(event: IFluidTelemetry) {
-		this.appInsightsClient.trackEvent({
-			name: event.eventName,
-			properties: event,
-		});
-	}
-}
-```
-
-#### Step 3: Now, let's start the telemetry production and hook in our telemetry consumer from step 2. We will be initializing our telemetry collection where we initialize our containers:
-
-```ts
-import { ApplicationInsights } from "@microsoft/applicationinsights-web";
-import { IFluidContainer } from "@fluidframework/fluid-static";
-import { ITelemetryConsumer , TelemetryConfig, startTelemetry, IFluidTelemetry } from "@fluidframework/external-telemetry"
-
-// 1: This is supposed to be your code for creating/loading a Fluid Container
-let myAppContainer: IFluidContainer;
-let myAppContainerId: string;
-if (containerExists) {
-    myAppContainerId = {...your code to get the id of the existing container}
-    myAppContainer = {...your code to load a Fluid Container from myAppContainerId}
-} else {
-    myAppContainer = {...your code to create a new Fluid Container}
-    myAppContainerId = await myAppContainer.attach();
-}
-
-// 2: This is our implementation of ITelemetryConsumer that will send telemetry to Azure App Insights
-class AppInsightsTelemetryConsumer implements ITelemetryConsumer {
-    constructor(private readonly appInsightsClient: ApplicationInsights) {}
-
-    consume(event: IFluidTelemetry) {
-        this.appInsightsClient.trackEvent({
-            name: event.eventName,
-            properties: event,
-        });
-    }
-}
-
-// 3a: Instantiate our Azure App Insights Client
-const appInsightsClient = new ApplicationInsights({
-    config: {
-        connectionString:
-            // Edit this with your app insights instance connection string (this is an example string)
-            "InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
-    },
-});
-
-// 3b: Initializes the App Insights client. Without this, logs will not be sent to Azure.
-appInsightsClient.loadAppInsights();
-
-// 4: Next, we'll Create the telemetry config object.
-// Note that we have to obtain the containerId before we can do this.
-const telemetryConfig: TelemetryConfig = {
-    container: myAppContainer,
-    containerId: myAppContainerId,
-    consumers: [new AppInsightsTelemetryConsumer(appInsightsClient)],
-};
-
-// 5. Start Telemetry
-startTelemetry(telemetryConfig);
-
-// Done! Your container telemetry is now being created and sent to your Telemetry Consumer which will forward it to Azure App Insights.
-```
-
-Congrats, that's it for now! If you've decided to use Azure App Insights, we have designed useful prebuilt queries for you that utilize the generated telemetry

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -52,6 +52,16 @@
 				"types": "./dist/index.d.ts",
 				"default": "./dist/index.js"
 			}
+		},
+		"./app-insights": {
+			"import": {
+				"types": "./lib/app-insights/index.d.ts",
+				"default": "./lib/app-insights/index.js"
+			},
+			"require": {
+				"types": "./dist/app-insights/index.d.ts",
+				"default": "./dist/app-insights/index.js"
+			}
 		}
 	},
 	"main": "dist/index.js",
@@ -89,6 +99,7 @@
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",
 		"@fluidframework/fluid-static": "workspace:~",
+		"@microsoft/applicationinsights-web": "^2.8.11",
 		"uuid": "^9.0.0"
 	},
 	"devDependencies": {
@@ -98,7 +109,6 @@
 		"@fluid-tools/build-cli": "^0.34.0",
 		"@fluidframework/build-tools": "^0.34.0",
 		"@microsoft/api-extractor": "^7.42.3",
-		"@microsoft/applicationinsights-web": "^2.8.11",
 		"@types/chai": "^4.0.0",
 		"@types/mocha": "^9.1.1",
 		"@types/sinon": "^17.0.3",

--- a/packages/framework/client-logger/fluid-telemetry/src/app-insights/appInsightsTelemetryConsumer.ts
+++ b/packages/framework/client-logger/fluid-telemetry/src/app-insights/appInsightsTelemetryConsumer.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { type ApplicationInsights } from "@microsoft/applicationinsights-web";
+import type { IFluidTelemetry, ITelemetryConsumer } from "../common/index.js";
+
+/**
+ * An implementation of {@link ITelemetryConsumer} that routes {@link IFluidTelemetry} to Azure App Insights
+ * in a format that is supported by Fluid Framework service offerings such as Cloud dashboards and alarms.
+ */
+export class AppInsightsTelemetryConsumer implements ITelemetryConsumer {
+	public constructor(private readonly appInsightsClient: ApplicationInsights) {}
+
+	public consume(event: IFluidTelemetry): void {
+		this.appInsightsClient.trackEvent({
+			name: event.eventName,
+			properties: event,
+		});
+	}
+}

--- a/packages/framework/client-logger/fluid-telemetry/src/app-insights/index.ts
+++ b/packages/framework/client-logger/fluid-telemetry/src/app-insights/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { AppInsightsTelemetryConsumer } from "./appInsightsTelemetryConsumer.js";

--- a/packages/framework/client-logger/fluid-telemetry/src/common/consumers/index.ts
+++ b/packages/framework/client-logger/fluid-telemetry/src/common/consumers/index.ts
@@ -10,20 +10,7 @@ import type { IFluidTelemetry } from "../index.js";
  * Conusmers are intended to take incoming produced {@link IFluidTelemetry} and do something of your choice with it.
  * This could be sending the telemetry to a cloud platform or just console logging.
  *
- * @example
- * Here is an example of how we construct a consumer to send telemetry to Azure App Insights, a cloud logging platform:
- * ```ts
- * class AppInsightsTelemetryConsumer implements ITelemetryConsumer {
- *	   constructor(private readonly appInsightsClient: ApplicationInsights) {}
- *
- *	   consume(event: IFluidTelemetry) {
- *		   this.appInsightsClient.trackEvent({
- *			   name: event.eventName,
- *			   properties: event,
- *		   });
- *	   }
- * }
- *```
+ * @see {@link @fluidframework/fluid-telemetry/app-insights#AppInsightsTelemetryConsumer}
  *
  * @beta
  */

--- a/packages/framework/client-logger/fluid-telemetry/src/common/consumers/index.ts
+++ b/packages/framework/client-logger/fluid-telemetry/src/common/consumers/index.ts
@@ -10,7 +10,20 @@ import type { IFluidTelemetry } from "../index.js";
  * Conusmers are intended to take incoming produced {@link IFluidTelemetry} and do something of your choice with it.
  * This could be sending the telemetry to a cloud platform or just console logging.
  *
- * @see {@link @fluidframework/fluid-telemetry/app-insights#AppInsightsTelemetryConsumer}
+ * @example
+ * Here is an example of how we construct a consumer to send telemetry to Azure App Insights, a cloud logging platform:
+ * ```ts
+ * class AppInsightsTelemetryConsumer implements ITelemetryConsumer {
+ *	   constructor(private readonly appInsightsClient: ApplicationInsights) {}
+ *
+ *	   consume(event: IFluidTelemetry) {
+ *		   this.appInsightsClient.trackEvent({
+ *			   name: event.eventName,
+ *			   properties: event,
+ *		   });
+ *	   }
+ * }
+ *```
  *
  * @beta
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7888,6 +7888,7 @@ importers:
       '@fluidframework/container-definitions': link:../../../common/container-definitions
       '@fluidframework/container-loader': link:../../../loader/container-loader
       '@fluidframework/fluid-static': link:../../fluid-static
+      '@microsoft/applicationinsights-web': 2.8.16_tslib@1.14.1
       uuid: 9.0.1
     devDependencies:
       '@arethetypeswrong/cli': 0.13.3
@@ -7896,7 +7897,6 @@ importers:
       '@fluid-tools/build-cli': 0.34.0_bpztyfltmpuv6lhsgzfwtmxhte
       '@fluidframework/build-tools': 0.34.0
       '@microsoft/api-extractor': 7.42.3
-      '@microsoft/applicationinsights-web': 2.8.16_tslib@1.14.1
       '@types/chai': 4.3.11
       '@types/mocha': 9.1.1
       '@types/sinon': 17.0.3


### PR DESCRIPTION
## Description
- Adds the concrete implementation of ITelemetryConsumer, `AppInsightsTelemetryConsumer` to the package and exports it under a new subpath `/app-insights`
-  Flips README xample 1 and 2 around so the Azure App insights example is first
- README.md updated with usage of new AppInsightsTelemetryConsumer
