### PR TITLE
refactor(gitrest): Update isomorphic-git

### DIFF
--- a/server/gitrest/packages/gitrest-base/package.json
+++ b/server/gitrest/packages/gitrest-base/package.json
@@ -69,7 +69,7 @@
 		"debug": "^4.3.4",
 		"express": "^4.19.2",
 		"ioredis": "^5.2.3",
-		"isomorphic-git": "^1.14.0",
+		"isomorphic-git": "^1.25.7",
 		"json-stringify-safe": "^5.0.1",
 		"memfs": "^3.4.12",
 		"nconf": "^0.11.4",

--- a/server/gitrest/packages/gitrest-base/src/test/storageAccess.ts
+++ b/server/gitrest/packages/gitrest-base/src/test/storageAccess.ts
@@ -37,26 +37,26 @@ export type StorageAccessCallCounts = { [K in keyof IFileSystemPromises]?: numbe
  */
 
 const initialWriteStorageAccessBaselinePerformance: StorageAccessCallCounts = {
-	readFile: 23,
+	readFile: 13,
 	writeFile: 79,
 	mkdir: 56,
 	stat: 46,
 };
 const initialWriteStorageAccessBaselinePerformanceLowIo: StorageAccessCallCounts = {
-	readFile: 9,
+	readFile: 23,
 	writeFile: 9,
 	mkdir: 21,
 	stat: 11,
 };
 
 const fullTestStorageAccessBaselinePerformance: StorageAccessCallCounts = {
-	readFile: 259,
+	readFile: 731,
 	writeFile: 115,
 	mkdir: 71,
 	stat: 92,
 };
 const fullTestStorageAccessBaselinePerformanceLowIo: StorageAccessCallCounts = {
-	readFile: 62,
+	readFile: 128,
 	writeFile: 20,
 	mkdir: 26,
 	stat: 18,

--- a/server/gitrest/packages/gitrest/package.json
+++ b/server/gitrest/packages/gitrest/package.json
@@ -35,7 +35,7 @@
 		"cors": "^2.8.5",
 		"debug": "^4.3.4",
 		"express": "^4.19.2",
-		"isomorphic-git": "^1.14.0",
+		"isomorphic-git": "^1.25.7",
 		"json-stringify-safe": "^5.0.1",
 		"nconf": "^0.11.4",
 		"uuid": "^3.3.2",

--- a/server/gitrest/pnpm-lock.yaml
+++ b/server/gitrest/pnpm-lock.yaml
@@ -87,7 +87,7 @@ importers:
       debug: ^4.3.4
       eslint: ~8.55.0
       express: ^4.19.2
-      isomorphic-git: ^1.14.0
+      isomorphic-git: ^1.25.7
       json-stringify-safe: ^5.0.1
       nconf: ^0.11.4
       prettier: ~3.0.3
@@ -106,7 +106,7 @@ importers:
       cors: 2.8.5
       debug: 4.3.4
       express: 4.19.2
-      isomorphic-git: 1.21.0
+      isomorphic-git: 1.25.7
       json-stringify-safe: 5.0.1
       nconf: 0.11.4
       uuid: 3.4.0
@@ -174,7 +174,7 @@ importers:
       express: ^4.19.2
       ioredis: ^5.2.3
       ioredis-mock: ^8.9.0
-      isomorphic-git: ^1.14.0
+      isomorphic-git: ^1.25.7
       json-stringify-safe: ^5.0.1
       lorem-ipsum: ^1.0.6
       memfs: ^3.4.12
@@ -209,7 +209,7 @@ importers:
       debug: 4.3.4
       express: 4.19.2
       ioredis: 5.3.2
-      isomorphic-git: 1.21.0
+      isomorphic-git: 1.25.7
       json-stringify-safe: 5.0.1
       memfs: 3.4.13
       nconf: 0.11.4
@@ -4426,6 +4426,7 @@ packages:
   /crc-32/1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
+    hasBin: true
     dev: false
 
   /create-require/1.1.1:
@@ -6677,15 +6678,9 @@ packages:
       minimatch: 6.2.0
     dev: true
 
-  /ignore/5.2.4:
-    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
-    engines: {node: '>= 4'}
-    dev: false
-
   /ignore/5.3.0:
     resolution: {integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==}
     engines: {node: '>= 4'}
-    dev: true
 
   /immediate/3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
@@ -7154,19 +7149,20 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
-  /isomorphic-git/1.21.0:
-    resolution: {integrity: sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==}
+  /isomorphic-git/1.25.7:
+    resolution: {integrity: sha512-KE10ejaIsEpQ+I/apS33qqTjyzCXgOniEaL32DwNbXtboKG8H3cu+RiBcdp3G9w4MpOOTQfGPsWp4i8UxRfDLg==}
     engines: {node: '>=12'}
+    hasBin: true
     dependencies:
       async-lock: 1.4.0
       clean-git-ref: 2.0.1
       crc-32: 1.2.2
       diff3: 0.0.3
-      ignore: 5.2.4
+      ignore: 5.3.0
       minimisted: 2.0.1
       pako: 1.0.11
       pify: 4.0.1
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
       sha.js: 2.4.11
       simple-get: 4.0.1
     dev: false
@@ -8069,15 +8065,15 @@ packages:
 
   /minimist/1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
+    dev: true
 
   /minimist/1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: true
 
   /minimisted/2.0.1:
     resolution: {integrity: sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==}
     dependencies:
-      minimist: 1.2.7
+      minimist: 1.2.8
     dev: false
 
   /minipass-collect/1.0.2:
@@ -10408,7 +10404,7 @@ packages:
     dependencies:
       detect-indent: 5.0.0
       detect-newline: 2.1.0
-      minimist: 1.2.7
+      minimist: 1.2.8
     dev: true
 
   /sort-keys/4.2.0:


### PR DESCRIPTION
## Description

Updates to v1.25.7 of isomorphic-git which contains a fix for a race condition. The rest of the repo was updated in https://github.com/microsoft/FluidFramework/pull/20473.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Tests break when updating to 1.24.0, unrelated to the race condition fix. I suspect it is because isomorphic-git started doing calls to certain `fs` methods for some internal checks, e.g. [here](https://github.com/isomorphic-git/isomorphic-git/compare/v1.23.0...v1.24.0#diff-19e2ada2026d7d90a298ed12b31d9e99235fef7c81b7e6ae764b5444f15474fdR12), and that throws off the baseline number of expected calls we had calculated.

@znewton I gave a shot at updating the baselines but kept running into new expected values. I'm not sure how urgent this would be for server (i.e. how much a prod deployment relies on isomorpic-git vs redis or some other fs). We know it caused issues in t9s (existing refs would sometimes get resolved from the filesystem as an empty string if read too close to an update) and this was a source of flakiness in tests. Maybe someone on your end can take this over for gitrest?