### PR TITLE
fix(test-dds-utils): minification logic

### DIFF
--- a/packages/dds/test-dds-utils/src/minification.ts
+++ b/packages/dds/test-dds-utils/src/minification.ts
@@ -226,8 +226,12 @@ export class FuzzTestMinimizer<
 
 			const stackTop = stackLines.findIndex((s) => s.startsWith("at"));
 
-			// reproduce based on the final two lines+col of the error
-			const message = stackLines.slice(stackTop, stackTop + 2).join("\n");
+			const message = stackLines[stackTop].startsWith("at assert ")
+				? // Reproduce based on the final two lines+col of the error if it is an assert error
+				  // This ensures the same assert is triggered by the minified test
+				  stackLines.slice(stackTop, stackTop + 2).join("\n")
+				: // Otherwise the final line is sufficient
+				  stackLines[stackTop];
 
 			if (this.initialError === undefined) {
 				this.initialError = { message, op: lastOp };


### PR DESCRIPTION
## Description

The minification logic needs to ensure that the error produced by a minified run is the same as the original (non-minified) one. This logic only took into account the top line of the stack error message, but this is often just:

> at assert (C:\Work\ffya6\packages\common\core-utils\src\assert.ts:19:9)

This PR ensures that the top two lines are taken into account. For example:

> at assert (C:\Work\ffya6\packages\common\core-utils\src\assert.ts:19:9)
> at compareCellPositionsUsingTombstones (src\feature-libraries\sequence-field\utils.ts:213:9)