### PR TITLE
fix(historian): Fixes to Helm chart

### DIFF
--- a/server/charts/historian/templates/gitrest-deployment.yaml
+++ b/server/charts/historian/templates/gitrest-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: data
           mountPath: /home/node/documents
         - name: config
-          mountPath: /home/node/server/config.json
+          mountPath: /home/node/server/packages/gitrest/config.json
           subPath: config.json
       dnsConfig:
         options:

--- a/server/charts/historian/values.yaml
+++ b/server/charts/historian/values.yaml
@@ -74,7 +74,7 @@ gitrest:
     enableRedisFsOptimizedStat: false
     redisApiMetricsSamplingPeriod: 0
   redis:
-    host: redis
+    url: redis_url
     port: 6379
     connectTimeout: 10000
     maxRetriesPerRequest: 20


### PR DESCRIPTION
## Description

Fixes:
- The values yaml file was setting a `redis.host` property for gitrest configuration when [the templates are looking for `redis.url`](https://github.com/microsoft/FluidFramework/blob/main/server/charts/historian/templates/gitrest-configmap.yaml#L74). `redis.url` is also what the historian redis settings in the values yaml file have been using for a long time.
- The config file that gets mounted from a volume in the gitrest container was being mounted to the wrong path, so the package running inside the container is using the file in the repo with defaults instead of the mounted file with custom values.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
