### PR TITLE
fix(tree): enforce integer indices in generic field kind format

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKindFormat.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKindFormat.ts
@@ -23,7 +23,7 @@ class Wrapper<T extends TSchema> {
 
 export const EncodedGenericChange = <NodeChangesetSchema extends TSchema>(
 	tNodeChangeset: NodeChangesetSchema,
-) => Type.Tuple([Type.Number({ minimum: 0 }), tNodeChangeset]);
+) => Type.Tuple([Type.Number({ minimum: 0, multipleOf: 1 }), tNodeChangeset]);
 
 export type EncodedGenericChange<Schema extends TSchema = TAnySchema> = Static<
 	ReturnType<Wrapper<Schema>["encodedGenericChange"]>


### PR DESCRIPTION
## Description

Tweak the persisted format for the generic field kind so that the indices it represent are always integers.

## Breaking Changes

If prior documents had been written with non-integer values for this format, then those document could no longer be loaded by the new logic. This is tolerable because we have high confidence that no such documents were ever written.