### PR TITLE
Make factory tag object for DataObjectClass readonly

### DIFF
--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -89,7 +89,7 @@ export interface ContainerSchema {
 // @public
 export type DataObjectClass<T extends IFluidLoadable = IFluidLoadable> = {
     readonly factory: {
-        IFluidDataStoreFactory: DataObjectClass<T>["factory"];
+        readonly IFluidDataStoreFactory: DataObjectClass<T>["factory"];
     };
 } & (new (...args: any[]) => T);
 

--- a/packages/framework/fluid-static/api-report/fluid-static.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.api.md
@@ -44,7 +44,7 @@ export function createServiceAudience<TMember extends IMember = IMember>(props: 
 // @public
 export type DataObjectClass<T extends IFluidLoadable = IFluidLoadable> = {
     readonly factory: {
-        IFluidDataStoreFactory: DataObjectClass<T>["factory"];
+        readonly IFluidDataStoreFactory: DataObjectClass<T>["factory"];
     };
 } & (new (...args: any[]) => T);
 

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -48,7 +48,7 @@ export type LoadableObjectClass<T extends IFluidLoadable = IFluidLoadable> =
  * @public
  */
 export type DataObjectClass<T extends IFluidLoadable = IFluidLoadable> = {
-	readonly factory: { IFluidDataStoreFactory: DataObjectClass<T>["factory"] };
+	readonly factory: { readonly IFluidDataStoreFactory: DataObjectClass<T>["factory"] };
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 } & (new (...args: any[]) => T);
 


### PR DESCRIPTION
## Description

Make factory tag object for DataObjectClass readonly.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

