### PR TITLE
Add stashedSnapshotSequenceNumber to OldSnapshotFetchWhileRefreshing event

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1281,8 +1281,8 @@ export class Container
 							throw normalizeErrorAndClose(error);
 						});
 					}
-
-					this.serializedStateManager.setSnapshot(await attachP);
+					const snapshotWithBlobs = await attachP;
+					this.serializedStateManager.setInitialSnapshot(snapshotWithBlobs);
 					if (!this.closed) {
 						this.handleDeltaConnectionArg(
 							{

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -156,6 +156,8 @@ export class SerializedStateManager {
 	 */
 	private updateSnapshotAndProcessedOpsMaybe() {
 		if (this.latestSnapshot === undefined || this.processedOps.length === 0) {
+			// can't refresh latest snapshot until we have processed the ops up to it.
+			// Pending state would be behind the latest snapshot.
 			return;
 		}
 		const snapshotSequenceNumber = this.latestSnapshot.snapshotSequenceNumber;

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -174,10 +174,6 @@ export class SerializedStateManager {
 			// Snapshot seq number is older than our first processed op, which could mean we're fetching
 			// the same snapshot that we already have or snapshot is too old, implicating an unexpected behavior.
 			this.mc.logger.sendTelemetryEvent({
-				category:
-					snapshotSequenceNumber < firstProcessedOpSequenceNumber - 1
-						? "error"
-						: "generic",
 				eventName: "OldSnapshotFetchWhileRefreshing",
 				snapshotSequenceNumber,
 				firstProcessedOpSequenceNumber,

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -55,7 +55,6 @@ const pendingLocalState: IPendingContainerState = {
 	attached: true,
 	baseSnapshot: snapshot,
 	snapshotBlobs: { attributesId: '{"minimumSequenceNumber" : 0, "sequenceNumber": 0}' },
-	snapshotSequenceNumber: 0,
 	pendingRuntimeState: {},
 	savedOps: [],
 	url: "fluid",
@@ -349,6 +348,8 @@ describe("serializedStateManager", () => {
 				eventName: "serializedStateManager:OldSnapshotFetchWhileRefreshing",
 				snapshotSequenceNumber,
 				firstProcessedOpSequenceNumber,
+				lastProcessedOpSequenceNumber,
+				stashedSnapshotSequenceNumber: snapshotSequenceNumber,
 			},
 		]);
 		const state = await serializedStateManager.getPendingLocalStateCore(

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -293,7 +293,6 @@ describe("serializedStateManager", () => {
 		await getLatestSnapshotInfoP.promise;
 		logger.assertMatchAny([
 			{
-				category: "generic",
 				eventName: "serializedStateManager:OldSnapshotFetchWhileRefreshing",
 				snapshotSequenceNumber: 0,
 				firstProcessedOpSequenceNumber: 1,
@@ -343,7 +342,6 @@ describe("serializedStateManager", () => {
 		await getLatestSnapshotInfoP.promise;
 		logger.assertMatchAny([
 			{
-				category: "error",
 				eventName: "serializedStateManager:OldSnapshotFetchWhileRefreshing",
 				snapshotSequenceNumber,
 				firstProcessedOpSequenceNumber,

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -28,6 +28,7 @@ import {
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { type IPendingContainerState, SerializedStateManager } from "../serializedStateManager.js";
+import { failProxy } from "./failProxy.js";
 
 type ISerializedStateManagerDocumentStorageService = Pick<
 	IDocumentStorageService,
@@ -188,7 +189,7 @@ describe("serializedStateManager", () => {
 		const serializedStateManager = new SerializedStateManager(
 			undefined,
 			logger.toTelemetryLogger(),
-			new MockStorageAdapter(),
+			failProxy(), // no calls to storage expected
 			true,
 		);
 		// equivalent to attach

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -29,8 +29,6 @@ import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { type IPendingContainerState, SerializedStateManager } from "../serializedStateManager.js";
 
-import { failProxy } from "./failProxy.js";
-
 type ISerializedStateManagerDocumentStorageService = Pick<
 	IDocumentStorageService,
 	"getSnapshot" | "getSnapshotTree" | "getVersions" | "readBlob"
@@ -190,13 +188,13 @@ describe("serializedStateManager", () => {
 		const serializedStateManager = new SerializedStateManager(
 			undefined,
 			logger.toTelemetryLogger(),
-			failProxy(), // no calls to storage expected
+			new MockStorageAdapter(),
 			true,
 		);
 		// equivalent to attach
-		serializedStateManager.setSnapshot({
-			baseSnapshot: { trees: {}, blobs: {} },
-			snapshotBlobs: {},
+		serializedStateManager.setInitialSnapshot({
+			baseSnapshot: snapshot,
+			snapshotBlobs: { attributesId: '{"minimumSequenceNumber" : 0, "sequenceNumber": 0}' },
 		});
 		await serializedStateManager.getPendingLocalStateCore(
 			{ notifyImminentClosure: false },

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -55,6 +55,7 @@ const pendingLocalState: IPendingContainerState = {
 	attached: true,
 	baseSnapshot: snapshot,
 	snapshotBlobs: { attributesId: '{"minimumSequenceNumber" : 0, "sequenceNumber": 0}' },
+	snapshotSequenceNumber: 0,
 	pendingRuntimeState: {},
 	savedOps: [],
 	url: "fluid",


### PR DESCRIPTION
Taking some changes from PR https://github.com/microsoft/FluidFramework/pull/20342 to easier addition of stashedSnapshotSequenceNumber  to OldSnapshotFetchWhileRefreshing event. 

This will help to figure out root cause of recent errors in the stress tests. If stashedSnapshotSequenceNumber is greater than snapshotSequenceNumber (from recent fetched snapshot) will indicate that we don't always get the latest snapshot from our getLatestSnapshoInfo call, since worst case we should get the same snapshot. IF we get the same snapshot, that would mean that we're missing saved ops at loading. 