### PR TITLE
Add random handles to fuzz 

### DIFF
--- a/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
@@ -108,7 +108,7 @@ function makeGenerator(optionsParam?: Partial<GeneratorOptions>): AsyncGenerator
 		value: random.pick([
 			(): number => random.integer(1, 50),
 			(): string => random.string(random.integer(3, 7)),
-			(): IFluidHandle => random.handle(),
+			(): IFluidHandle | undefined => random.handle(),
 		])(),
 	});
 	const deleteKey: Generator<DeleteKey, State> = ({ random }) => ({
@@ -137,6 +137,7 @@ describe.only("Map fuzz tests", () => {
 	createDDSFuzzSuite(model, {
 		defaultTestCount: 100,
 		numberOfClients: 3,
+		handleGenerationDisabled: false,
 		clientJoinOptions: {
 			maxNumberOfClients: 6,
 			clientAddProbability: 0.1,

--- a/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.fuzz.spec.ts
@@ -108,7 +108,7 @@ function makeGenerator(optionsParam?: Partial<GeneratorOptions>): AsyncGenerator
 		value: random.pick([
 			(): number => random.integer(1, 50),
 			(): string => random.string(random.integer(3, 7)),
-			(): IFluidHandle | undefined => random.handle(),
+			(): IFluidHandle => random.handle(),
 		])(),
 	});
 	const deleteKey: Generator<DeleteKey, State> = ({ random }) => ({
@@ -125,7 +125,7 @@ function makeGenerator(optionsParam?: Partial<GeneratorOptions>): AsyncGenerator
 	return async (state) => syncGenerator(state);
 }
 
-describe.only("Map fuzz tests", () => {
+describe("Map fuzz tests", () => {
 	const model: DDSFuzzModel<MapFactory, Operation> = {
 		workloadName: "default",
 		factory: new MapFactory(),
@@ -137,7 +137,6 @@ describe.only("Map fuzz tests", () => {
 	createDDSFuzzSuite(model, {
 		defaultTestCount: 100,
 		numberOfClients: 3,
-		handleGenerationDisabled: false,
 		clientJoinOptions: {
 			maxNumberOfClients: 6,
 			clientAddProbability: 0.1,

--- a/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
+++ b/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
@@ -12,6 +12,7 @@ import type { IFluidHandle } from '@fluidframework/core-interfaces';
 import type { IIdCompressor } from '@fluidframework/id-compressor';
 import type { IIdCompressorCore } from '@fluidframework/id-compressor/internal';
 import type { IMockContainerRuntimeOptions } from '@fluidframework/test-runtime-utils/internal';
+import type { IRandom } from '@fluid-private/stochastic-test-utils';
 import type { ISharedObject } from '@fluidframework/shared-object-base';
 import { MockContainerRuntimeFactoryForReconnection } from '@fluidframework/test-runtime-utils/internal';
 import type { MockContainerRuntimeForReconnection } from '@fluidframework/test-runtime-utils/internal';
@@ -146,7 +147,15 @@ export interface DDSFuzzTestState<TChannelFactory extends IChannelFactory> exten
     containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
     // (undocumented)
     isDetached: boolean;
+    // (undocumented)
+    random: DDSRandom;
     summarizerClient: Client<TChannelFactory>;
+}
+
+// @internal (undocumented)
+export interface DDSRandom extends IRandom {
+    // (undocumented)
+    handle(): IFluidHandle;
 }
 
 // @internal (undocumented)

--- a/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
+++ b/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
@@ -155,7 +155,7 @@ export interface DDSFuzzTestState<TChannelFactory extends IChannelFactory> exten
 // @internal (undocumented)
 export interface DDSRandom extends IRandom {
     // (undocumented)
-    handle(): IFluidHandle;
+    handle(): IFluidHandle | undefined;
 }
 
 // @internal (undocumented)
@@ -201,14 +201,6 @@ export interface Synchronize {
     clients?: string[];
     // (undocumented)
     type: "synchronize";
-}
-
-// @internal (undocumented)
-export interface UseHandle {
-    // (undocumented)
-    handle: IFluidHandle;
-    // (undocumented)
-    type: "useHandle";
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
+++ b/packages/dds/test-dds-utils/api-report/test-dds-utils.api.md
@@ -155,7 +155,7 @@ export interface DDSFuzzTestState<TChannelFactory extends IChannelFactory> exten
 // @internal (undocumented)
 export interface DDSRandom extends IRandom {
     // (undocumented)
-    handle(): IFluidHandle | undefined;
+    handle(): IFluidHandle;
 }
 
 // @internal (undocumented)

--- a/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHandle.ts
@@ -40,7 +40,5 @@ export class DDSFuzzHandle implements IFluidHandle<string> {
 		}
 	}
 
-	public bind(handle: IFluidHandle): void {
-		throw new Error("Method not implemented.");
-	}
+	public bind(handle: IFluidHandle): void {}
 }

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -65,7 +65,7 @@ const isOperationType = <O extends BaseOperation>(type: O["type"], op: BaseOpera
  * @internal
  */
 export interface DDSRandom extends IRandom {
-	handle(): IFluidHandle | undefined;
+	handle(): IFluidHandle;
 }
 
 /**
@@ -1424,21 +1424,19 @@ export async function runTestForSeed<
 		random: {
 			...random,
 			handle: () => {
-				if (options.handleGenerationDisabled !== true) {
-					handleGenerated = true;
-					return new DDSFuzzHandle(
-						random.pick(handles),
-						// this is wonky, as get on this handle will always resolve via
-						// the summarizer client, but since we just return the absolute path
-						// it doesn't really matter, and remote handles will use
-						// the right handle context when they are deserialized
-						// by the dds.
-						//
-						// we re-used this hack a few time below, because
-						// we don't have the real client
-						initialState.summarizerClient.dataStoreRuntime,
-					);
-				}
+				handleGenerated = true;
+				return new DDSFuzzHandle(
+					random.pick(handles),
+					// this is wonky, as get on this handle will always resolve via
+					// the summarizer client, but since we just return the absolute path
+					// it doesn't really matter, and remote handles will use
+					// the right handle context when they are deserialized
+					// by the dds.
+					//
+					// we re-used this hack a few time below, because
+					// we don't have the real client
+					initialState.summarizerClient.dataStoreRuntime,
+				);
 			},
 		},
 		client: makeUnreachableCodePathProxy("client"),

--- a/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
+++ b/packages/dds/test-dds-utils/src/ddsFuzzHarness.ts
@@ -44,6 +44,7 @@ import {
 import type { IMockContainerRuntimeOptions } from "@fluidframework/test-runtime-utils/internal";
 import { v4 as uuid } from "uuid";
 
+import { FluidSerializer } from "@fluidframework/shared-object-base/internal";
 import {
 	type Client,
 	type ClientLoadData,
@@ -63,9 +64,18 @@ const isOperationType = <O extends BaseOperation>(type: O["type"], op: BaseOpera
 /**
  * @internal
  */
+export interface DDSRandom extends IRandom {
+	handle(): IFluidHandle;
+}
+
+/**
+ * @internal
+ */
 export interface DDSFuzzTestState<TChannelFactory extends IChannelFactory>
 	extends BaseFuzzTestState {
 	containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
+
+	random: DDSRandom;
 
 	/**
 	 * Client which is responsible for summarizing. This client remains connected and read-only
@@ -1468,24 +1478,51 @@ export async function runTestForSeed<
 				),
 		  );
 	const summarizerClient = initialClient;
+	const handles = Array.from({ length: 5 }).map(() => uuid());
+	let handleGenerated = false;
 	const initialState: DDSFuzzTestState<TChannelFactory> = {
 		clients,
 		summarizerClient,
 		containerRuntimeFactory,
-		random,
+		random: {
+			...random,
+			handle: () => {
+				handleGenerated = true;
+				return new DDSFuzzHandle(
+					random.pick(handles),
+					// this is wonky, as get on this handle will always resolve via
+					// the summarizer client, but since we just return the absolute path
+					// it doesn't really matter, and remote handles will use
+					// the right handle context when they are deserialized
+					// by the dds.
+					//
+					// we re-used this hack a few time below, because
+					// we don't have the real client
+					initialState.summarizerClient.dataStoreRuntime,
+				);
+			},
+		},
 		client: makeUnreachableCodePathProxy("client"),
 		isDetached: startDetached,
 	};
 
 	options.emitter.emit("testStart", initialState);
 
+	const serializer = new FluidSerializer(initialState.summarizerClient.dataStoreRuntime);
+	const bind = new DDSFuzzHandle("", initialState.summarizerClient.dataStoreRuntime);
+
 	let operationCount = 0;
+	const generator = model.generatorFactory();
 	const finalState = await performFuzzActionsAsync(
-		model.generatorFactory(),
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		async (state) => serializer.encode(await generator(state), bind),
 		async (state, operation) => {
-			options.emitter.emit("operation", operation);
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			const decodedHandles = serializer.decode(operation);
+			options.emitter.emit("operation", decodedHandles);
 			operationCount++;
-			return model.reducer(state, operation);
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+			return model.reducer(state, decodedHandles);
 		},
 		initialState,
 		saveInfo,
@@ -1494,6 +1531,13 @@ export async function runTestForSeed<
 	// Sanity-check that the generator produced at least one operation. If it failed to do so,
 	// this usually indicates an error on the part of the test author.
 	assert(operationCount > 0, "Generator should have produced at least one operation.");
+
+	if (options.handleGenerationDisabled !== true) {
+		assert(
+			handleGenerated,
+			"no handles were generated; tests should generate and use handle via random.handle, or disable handles for the test",
+		);
+	}
 
 	options.emitter.emit("testEnd", finalState);
 
@@ -1542,7 +1586,6 @@ function runTest<TChannelFactory extends IChannelFactory, TOperation extends Bas
 			const minimizer = new FuzzTestMinimizer(model, options, operations, seed, saveInfo, 3);
 
 			const minimized = await minimizer.minimize();
-
 			await saveOpsToFile(savePath, minimized);
 
 			throw error;

--- a/packages/dds/test-dds-utils/src/index.ts
+++ b/packages/dds/test-dds-utils/src/index.ts
@@ -15,7 +15,6 @@ export type {
 	DDSFuzzTestState,
 	DDSFuzzHarnessEvents,
 	DDSRandom,
-	UseHandle,
 	Synchronize,
 } from "./ddsFuzzHarness.js";
 export { createDDSFuzzSuite, defaultDDSFuzzSuiteOptions, replayTest } from "./ddsFuzzHarness.js";

--- a/packages/dds/test-dds-utils/src/index.ts
+++ b/packages/dds/test-dds-utils/src/index.ts
@@ -14,6 +14,7 @@ export type {
 	DDSFuzzSuiteOptions,
 	DDSFuzzTestState,
 	DDSFuzzHarnessEvents,
+	DDSRandom,
 	UseHandle,
 	Synchronize,
 } from "./ddsFuzzHarness.js";


### PR DESCRIPTION
Instead of generating handles in the fuzz harness' reducer, generate them randomly in each DDS fuzz generator. This will make it easier to insert handles in each DDS. 