### PR TITLE
adds @fluidframework/fluid-telemetry example app

### DIFF
--- a/examples/client-logger/fluid-telemetry/.eslintrc.cjs
+++ b/examples/client-logger/fluid-telemetry/.eslintrc.cjs
@@ -1,0 +1,11 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+	extends: [require.resolve("@fluidframework/eslint-config-fluid/recommended"), "prettier"],
+	parserOptions: {
+		project: ["./tsconfig.json"],
+	},
+};

--- a/examples/client-logger/fluid-telemetry/.npmignore
+++ b/examples/client-logger/fluid-telemetry/.npmignore
@@ -1,0 +1,14 @@
+# Build metadata
+*.tsbuildinfo
+
+# Test code
+src/test
+dist/test
+lib/test
+
+# Temporary api-extractor build artifacts
+_api-extractor-temp
+
+# Test output
+coverage
+nyc

--- a/examples/client-logger/fluid-telemetry/CHANGELOG.md
+++ b/examples/client-logger/fluid-telemetry/CHANGELOG.md
@@ -1,0 +1,77 @@
+# @fluid-example/app-insights-logger
+
+## 2.0.0-rc.2.0.0
+
+Dependency updates only.
+
+## 2.0.0-rc.1.0.0
+
+Dependency updates only.
+
+## 2.0.0-internal.8.0.0
+
+Dependency updates only.
+
+## 2.0.0-internal.7.4.0
+
+Dependency updates only.
+
+## 2.0.0-internal.7.3.0
+
+Dependency updates only.
+
+## 2.0.0-internal.7.2.0
+
+Dependency updates only.
+
+## 2.0.0-internal.7.1.0
+
+Dependency updates only.
+
+## 2.0.0-internal.7.0.0
+
+Dependency updates only.
+
+## 2.0.0-internal.6.4.0
+
+Dependency updates only.
+
+## 2.0.0-internal.6.3.0
+
+Dependency updates only.
+
+## 2.0.0-internal.6.2.0
+
+Dependency updates only.
+
+## 2.0.0-internal.6.1.0
+
+Dependency updates only.
+
+## 2.0.0-internal.6.0.0
+
+Dependency updates only.
+
+## 2.0.0-internal.5.4.0
+
+Dependency updates only.
+
+## 2.0.0-internal.5.3.0
+
+Dependency updates only.
+
+## 2.0.0-internal.5.2.0
+
+Dependency updates only.
+
+## 2.0.0-internal.5.1.0
+
+Dependency updates only.
+
+## 2.0.0-internal.5.0.0
+
+Dependency updates only.
+
+## 2.0.0-internal.4.4.0
+
+Dependency updates only.

--- a/examples/client-logger/fluid-telemetry/LICENSE
+++ b/examples/client-logger/fluid-telemetry/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/client-logger/fluid-telemetry/README.md
+++ b/examples/client-logger/fluid-telemetry/README.md
@@ -1,0 +1,141 @@
+# @fluid-example/fluid-telemetry
+
+## Overview
+
+This package provides a simple Fluid application complete with a UI view in [React](https://react.dev/) to test the Fluid App Insights telemetry logger that will route typical Fluid telemetry to configured Azure App Insights.
+
+## Configuring fluid telemetry to be sent to your app insights instance
+
+-   within `src/components/ClientUtilities.ts`, update the function definition for `createAppInsightsClient` to change the App Insights connection string to yours. In most cases, this is simply the most basic config containing your correct connection string:
+
+```typescript
+function createAppInsightsClient(): ApplicationInsights {
+	const appInsightsClient = new ApplicationInsights({
+		config: {
+			connectionString:
+				// Edit this with your app insights instance connection string (this is an example string)
+				"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
+		},
+	});
+
+	// This must be called or telemetry will not be sent to azure
+	appInsightsClient.loadAppInsights();
+
+	return appInsightsClient;
+}
+```
+
+### How the telemetry is configured and started
+
+-   within `src/components/ClientUtilities.ts`,take a look within the functions `loadExistingFluidContainer()` and `createFluidContainer()`. you will see the following code:
+
+```ts
+// Initialize fluid telemetry collection with Azure App insights
+const appInsightsClient = createAppInsightsClient();
+startTelemetry({
+	container,
+	containerId,
+	consumers: [new AppInsightsTelemetryConsumer(appInsightsClient)],
+});
+```
+
+<!-- AUTO-GENERATED-CONTENT:START (README_EXAMPLE_GETTING_STARTED_SECTION:usesTinylicious=FALSE) -->
+
+<!-- prettier-ignore-start -->
+<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
+
+## Getting Started
+
+You can run this example using the following steps:
+
+1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
+1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
+    - For an even faster build, you can add the package name to the build command, like this:
+      `pnpm run build:fast --nolint @fluid-example/fluid-telemetry`
+1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.
+
+<!-- prettier-ignore-end -->
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+## Starting the test
+
+-   run `pnpm run start` and navigate to http://localhost:8080/ in your web browser.
+
+## Generating telemetry events
+
+-   There will be telemetry events that flow automatically when you start the test app. In addition to these events, you can control creating telemetry events yourself by interacting with UI app, incremeting/decrementing the shared counter and editing the shared string provided in this example
+
+## Viewing Telemetry Logs in App Insights
+
+From the Azure web portal, navigate to your app insights instance. Now, go to the "Logs" for your instance, this should be an option within the left side panel. Finally, from this page, you can query for telemetry events, which will be stored in the customEvents table. As an example, you can issue this simple query to get recent telemetry events sent to the customEvents table:
+
+-   Get a count of each distinct log event name
+
+    ```
+    customEvents
+    | summarize count() by name
+    ```
+
+<!-- AUTO-GENERATED-CONTENT:START (README_HELP_SECTION:includeHeading=TRUE) -->
+
+<!-- prettier-ignore-start -->
+<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
+
+## Help
+
+Not finding what you're looking for in this README? Check out our [GitHub
+Wiki](https://github.com/microsoft/FluidFramework/wiki) or [fluidframework.com](https://fluidframework.com/docs/).
+
+Still not finding what you're looking for? Please [file an
+issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
+
+Thank you!
+
+<!-- prettier-ignore-end -->
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
+
+<!-- prettier-ignore-start -->
+<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
+
+## Contribution Guidelines
+
+There are many ways to [contribute](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md) to Fluid.
+
+-   Participate in Q&A in our [GitHub Discussions](https://github.com/microsoft/FluidFramework/discussions).
+-   [Submit bugs](https://github.com/microsoft/FluidFramework/issues) and help us verify fixes as they are checked in.
+-   Review the [source code changes](https://github.com/microsoft/FluidFramework/pulls).
+-   [Contribute bug fixes](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).
+
+Detailed instructions for working in the repo can be found in the [Wiki](https://github.com/microsoft/FluidFramework/wiki).
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services.
+Use of these trademarks or logos must follow Microsoft’s [Trademark & Brand Guidelines](https://www.microsoft.com/trademarks).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+
+<!-- prettier-ignore-end -->
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->
+
+<!-- prettier-ignore-start -->
+<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
+
+## Trademark
+
+This project may contain Microsoft trademarks or logos for Microsoft projects, products, or services.
+
+Use of these trademarks or logos must follow Microsoft's [Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+
+<!-- prettier-ignore-end -->
+
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/examples/client-logger/fluid-telemetry/jest.config.cjs
+++ b/examples/client-logger/fluid-telemetry/jest.config.cjs
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+	preset: "ts-jest",
+	roots: ["<rootDir>/src"],
+	transform: {
+		"^.+\\.tsx?$": "ts-jest",
+	},
+	testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(ts|tsx)?$",
+	testPathIgnorePatterns: ["/node_modules/", "dist"],
+	moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+	coveragePathIgnorePatterns: ["/node_modules/", "/src/test/"],
+	testEnvironment: "jsdom",
+	// While we still have transitive dependencies on 'uuid<9.0.0', force the CJS entry point:
+	// See: https://stackoverflow.com/questions/73203367/jest-syntaxerror-unexpected-token-export-with-uuid-library
+	moduleNameMapper: {
+		// Remove explicit .js from local paths to allow jest to find the .ts* files
+		"^(\\.{1,2}/.*)\\.js$": "$1",
+		// While we still have transitive dependencies on 'uuid<9.0.0', force the CJS entry point:
+		// See: https://stackoverflow.com/questions/73203367/jest-syntaxerror-unexpected-token-export-with-uuid-library
+		"^uuid$": "uuid",
+	},
+	reporters: [
+		"default",
+		[
+			"jest-junit",
+			{
+				outputDirectory: "nyc",
+				outputName: "jest-junit-report.xml",
+			},
+		],
+	],
+};

--- a/examples/client-logger/fluid-telemetry/package.json
+++ b/examples/client-logger/fluid-telemetry/package.json
@@ -1,0 +1,104 @@
+{
+	"name": "@fluid-example/fluid-telemetry",
+	"version": "2.0.0-rc.3.0.0",
+	"private": true,
+	"description": "Provides a simple Fluid application with a UI view written in React to test the @fluidframework/fluid-telemetry package that will route IFluidTelemetry to Azure App Insights",
+	"homepage": "https://fluidframework.com",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/FluidFramework.git",
+		"directory": "packages/examples/client-logger/fluid-telemetry"
+	},
+	"license": "MIT",
+	"author": "Microsoft and contributors",
+	"sideEffects": false,
+	"type": "module",
+	"scripts": {
+		"build": "fluid-build . --task build",
+		"build:compile": "fluid-build . --task compile",
+		"build:esnext": "tsc --project ./tsconfig.json",
+		"check:prettier": "prettier --check . --cache --ignore-path ../../../.prettierignore",
+		"clean": "rimraf --glob coverage dist lib nyc \"**/*.tsbuildinfo\" \"**/*.build.log\"",
+		"eslint": "eslint src",
+		"eslint:fix": "eslint src --fix",
+		"format": "fluid-build --task format .",
+		"format-and-build": "npm run format && npm run build",
+		"format-and-compile": "npm run format && npm run build:compile",
+		"format:prettier": "prettier --write . --cache --ignore-path ../../../.prettierignore",
+		"lint": "fluid-build . --task lint",
+		"lint:fix": "fluid-build . --task eslint:fix --task format",
+		"start": "start-server-and-test start:tinylicious 7070 start:test-app:client",
+		"start:test-app:client": "webpack serve --config webpack.config.cjs",
+		"start:tinylicious": "tinylicious",
+		"test": "npm run test:jest",
+		"test:coverage": "npm run test:jest:coverage",
+		"test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --detectOpenHandles --no-cache",
+		"test:jest:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --detectOpenHandles --coverage --no-cache --ci",
+		"webpack": "webpack --env production",
+		"webpack:dev": "webpack --env development"
+	},
+	"dependencies": {
+		"@fluid-example/example-utils": "workspace:~",
+		"@fluidframework/container-loader": "workspace:~",
+		"@fluidframework/core-interfaces": "workspace:~",
+		"@fluidframework/counter": "workspace:~",
+		"@fluidframework/fluid-static": "workspace:~",
+		"@fluidframework/fluid-telemetry": "workspace:~",
+		"@fluidframework/map": "workspace:~",
+		"@fluidframework/sequence": "workspace:~",
+		"@fluidframework/tinylicious-client": "workspace:~",
+		"@microsoft/applicationinsights-web": "^2.8.11",
+		"react": "^17.0.1",
+		"react-dom": "^17.0.1"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^1.6.2",
+		"@fluidframework/build-common": "^2.0.3",
+		"@fluidframework/build-tools": "^0.34.0",
+		"@fluidframework/eslint-config-fluid": "^5.1.0",
+		"@testing-library/dom": "^8.2.0",
+		"@testing-library/jest-dom": "^5.16.5",
+		"@testing-library/react": "^12.0.0",
+		"@testing-library/user-event": "^14.4.3",
+		"@types/jest": "29.5.3",
+		"@types/react": "^17.0.44",
+		"@types/react-dom": "^17.0.18",
+		"@types/testing-library__jest-dom": "^5.14.5",
+		"cross-env": "^7.0.3",
+		"eslint": "~8.55.0",
+		"eslint-config-prettier": "~9.0.0",
+		"eslint-plugin-jest": "~27.4.2",
+		"eslint-plugin-react": "~7.33.2",
+		"eslint-plugin-react-hooks": "~4.6.0",
+		"html-webpack-plugin": "^5.5.0",
+		"jest": "^29.6.2",
+		"jest-environment-jsdom": "^29.6.2",
+		"jest-junit": "^10.0.0",
+		"prettier": "~3.0.3",
+		"rimraf": "^4.4.0",
+		"start-server-and-test": "^2.0.3",
+		"tinylicious": "^4.0.0",
+		"ts-jest": "^29.1.1",
+		"ts-loader": "^9.3.0",
+		"tslib": "^1.10.0",
+		"typescript": "~5.1.6",
+		"webpack": "^5.82.0",
+		"webpack-cli": "^4.9.2",
+		"webpack-dev-server": "~4.15.1",
+		"webpack-merge": "^5.8.0"
+	},
+	"fluid": {
+		"browser": {
+			"umd": {
+				"files": [
+					"dist/main.bundle.js"
+				],
+				"library": "main"
+			}
+		}
+	},
+	"typeValidation": {
+		"disabled": true,
+		"broken": {}
+	}
+}

--- a/examples/client-logger/fluid-telemetry/prettier.config.cjs
+++ b/examples/client-logger/fluid-telemetry/prettier.config.cjs
@@ -1,0 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+	...require("@fluidframework/build-common/prettier.config.cjs"),
+};

--- a/examples/client-logger/fluid-telemetry/src/app/index.html
+++ b/examples/client-logger/fluid-telemetry/src/app/index.html
@@ -1,0 +1,14 @@
+<!-- Copyright (c) Microsoft Corporation and contributors. All rights reserved. -->
+<!-- Licensed under the MIT License. -->
+
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width,initial-scale=1.0" />
+		<title>Fluid App Insights Logger Test App</title>
+	</head>
+	<body>
+		<div id="content"></div>
+	</body>
+</html>

--- a/examples/client-logger/fluid-telemetry/src/app/index.tsx
+++ b/examples/client-logger/fluid-telemetry/src/app/index.tsx
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { App } from "../components/index.js";
+
+console.log("Rendering app...");
+
+ReactDOM.render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>,
+	document.querySelector("#content"),
+	() => {
+		console.log("App rendered!");
+	},
+);

--- a/examples/client-logger/fluid-telemetry/src/components/App.tsx
+++ b/examples/client-logger/fluid-telemetry/src/components/App.tsx
@@ -1,0 +1,261 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { CollaborativeTextArea, SharedStringHelper } from "@fluid-example/example-utils";
+import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { SharedCounter } from "@fluidframework/counter/internal";
+import { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
+import { type ISharedMap, SharedMap } from "@fluidframework/map";
+import { SharedString } from "@fluidframework/sequence/internal";
+import React from "react";
+
+import {
+	ContainerInfo,
+	createFluidContainer,
+	loadExistingFluidContainer,
+} from "./ClientUtilities.js";
+
+/**
+ * Key in the app's `rootMap` under which the SharedString object is stored.
+ */
+const sharedTextKey = "shared-text";
+
+/**
+ * Key in the app's `rootMap` under which the SharedCounter object is stored.
+ */
+const sharedCounterKey = "shared-counter";
+
+/**
+ * Schema used by the app.
+ */
+const containerSchema: ContainerSchema = {
+	initialObjects: {
+		rootMap: SharedMap,
+	},
+	dynamicObjectTypes: [SharedCounter, SharedMap, SharedString],
+};
+
+/**
+ * Helper function to read the container ID from the URL location.
+ */
+function getContainerIdFromLocation(location: Location): string {
+	return location.hash.slice(1);
+}
+
+/**
+ * Populate the app's `rootMap` with the desired initial data for use with the client debug view.
+ */
+async function populateRootMap(container: IFluidContainer): Promise<void> {
+	const rootMap = container.initialObjects.rootMap as ISharedMap;
+	if (rootMap === undefined) {
+		throw new Error('"rootMap" not found in initialObjects tree.');
+	}
+
+	// Set up SharedText for text form
+	const sharedText = await container.create(SharedString);
+	sharedText.insertText(0, "Enter text here.");
+	rootMap.set(sharedTextKey, sharedText.handle);
+
+	// Set up SharedCounter for counter widget
+	const sharedCounter = await container.create(SharedCounter);
+	rootMap.set(sharedCounterKey, sharedCounter.handle);
+	// Also set a couple of primitives for testing the debug view
+	rootMap.set("numeric-value", 42);
+	rootMap.set("string-value", "Hello world!");
+	rootMap.set("record-value", {
+		aNumber: 37,
+		aString: "Here is some text content.",
+		anObject: {
+			a: "a",
+			b: "b",
+		},
+	});
+}
+
+/**
+ * Root application component.
+ * Initializes the Fluid Container and displays app view once it is ready.
+ * @internal
+ */
+export function App(): React.ReactElement {
+	const [containerInfo, setContainerInfo] = React.useState<ContainerInfo | undefined>();
+
+	const getSharedFluidData = async (): Promise<ContainerInfo> => {
+		const containerId = getContainerIdFromLocation(window.location);
+		return containerId.length === 0
+			? createFluidContainer(containerSchema, populateRootMap)
+			: loadExistingFluidContainer(containerId, containerSchema);
+	};
+
+	// Get the Fluid Data data on app startup and store in the state
+	React.useEffect(() => {
+		getSharedFluidData().then(
+			(data) => {
+				if (getContainerIdFromLocation(window.location) !== data.containerId) {
+					window.location.hash = data.containerId;
+				}
+				setContainerInfo(data);
+			},
+			(error) => {
+				throw error;
+			},
+		);
+	}, []);
+
+	return (
+		<>
+			{containerInfo === undefined ? (
+				<div style={{ padding: "10px" }}>
+					<h1>Loading Shared container...</h1>
+				</div>
+			) : (
+				<AppView containerInfo={containerInfo} />
+			)}
+		</>
+	);
+}
+
+/**
+ * {@link AppView} input props.
+ */
+interface AppViewProps {
+	containerInfo: ContainerInfo;
+}
+
+/**
+ * Inner app view.
+ *
+ * @remarks Valid to display once the container has been created / loaded.
+ */
+function AppView(props: AppViewProps): React.ReactElement {
+	const { containerInfo } = props;
+	const { container, containerId } = containerInfo;
+
+	const rootMap = container.initialObjects.rootMap as ISharedMap;
+	if (rootMap === undefined) {
+		throw new Error('"rootMap" not found in initialObjects tree.');
+	}
+
+	const sharedTextHandle = rootMap.get(sharedTextKey) as IFluidHandle<SharedString>;
+	if (sharedTextHandle === undefined) {
+		throw new Error(`"${sharedTextKey}" entry not found in rootMap.`);
+	}
+
+	const sharedCounterHandle = rootMap.get(sharedCounterKey) as IFluidHandle<SharedCounter>;
+	if (sharedCounterHandle === undefined) {
+		throw new Error(`"${sharedCounterKey}" entry not found in rootMap.`);
+	}
+
+	return (
+		<div style={{ padding: "10px" }}>
+			<div style={{ padding: "10px" }}>
+				<h4>{`Container Id: ${containerId}`}</h4>
+			</div>
+
+			<div style={{ padding: "10px" }}>
+				<CounterView sharedCounterHandle={sharedCounterHandle} />
+			</div>
+			<div style={{ padding: "10px" }}>
+				<TextView sharedTextHandle={sharedTextHandle} />
+			</div>
+		</div>
+	);
+}
+
+interface TextViewProps {
+	sharedTextHandle: IFluidHandle<SharedString>;
+}
+
+function TextView(props: TextViewProps): React.ReactElement {
+	const { sharedTextHandle } = props;
+
+	const [sharedText, setSharedText] = React.useState<SharedString | undefined>();
+
+	React.useEffect(() => {
+		sharedTextHandle.get().then(setSharedText, (error) => {
+			console.error(`Error encountered loading SharedString: "${error}".`);
+			throw error;
+		});
+	}, [sharedTextHandle, setSharedText]);
+
+	return sharedText === undefined ? (
+		<h4> Loading...</h4>
+	) : (
+		<div data-testid="collaborative-text-area-widget">
+			<CollaborativeTextArea sharedStringHelper={new SharedStringHelper(sharedText)} />
+		</div>
+	);
+}
+
+interface CounterViewProps {
+	sharedCounterHandle: IFluidHandle<SharedCounter>;
+}
+
+function CounterView(props: CounterViewProps): React.ReactElement {
+	const { sharedCounterHandle } = props;
+
+	const [sharedCounter, setSharedCounter] = React.useState<SharedCounter | undefined>();
+
+	React.useEffect(() => {
+		sharedCounterHandle.get().then(setSharedCounter, (error) => {
+			console.error(`Error encountered loading SharedCounter: "${error}".`);
+			throw error;
+		});
+	}, [sharedCounterHandle, setSharedCounter]);
+
+	return sharedCounter === undefined ? (
+		<h4> Loading...</h4>
+	) : (
+		<CounterWidget counter={sharedCounter} />
+	);
+}
+
+/**
+ * {@link CounterWidget} input props.
+ */
+export interface CounterWidgetProps {
+	counter: SharedCounter;
+}
+
+/**
+ * Simple counter widget.
+ * Backed by a {@link @fluidframework/counter#SharedCounter}.
+ * Affords simple incrementing and decrementing via buttons.
+ */
+export function CounterWidget(props: CounterWidgetProps): React.ReactElement {
+	const { counter } = props;
+
+	const [counterValue, setCounterValue] = React.useState<number>(counter.value);
+
+	React.useEffect(() => {
+		counter.on("incremented", () => {
+			setCounterValue(counter.value);
+		});
+	}, [counter]);
+
+	return (
+		<div
+			data-testid="shared-counter-widget"
+			style={{ display: "flex", flexDirection: "row", gap: "10px" }}
+		>
+			<button
+				onClick={(): void => counter.increment(-1)}
+				disabled={counterValue === 0}
+				aria-describedby={"decrement-counter-button"}
+			>
+				Decrement
+			</button>
+
+			<div>{counterValue}</div>
+
+			<button
+				onClick={(): void => counter.increment(1)}
+				aria-describedby={"increment-counter-button"}
+			>
+				Increment
+			</button>
+		</div>
+	);
+}

--- a/examples/client-logger/fluid-telemetry/src/components/ClientUtilities.ts
+++ b/examples/client-logger/fluid-telemetry/src/components/ClientUtilities.ts
@@ -1,0 +1,174 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ConnectionState } from "@fluidframework/container-loader";
+import { ContainerSchema, IFluidContainer } from "@fluidframework/fluid-static";
+import {
+	TinyliciousClient,
+	TinyliciousContainerServices,
+} from "@fluidframework/tinylicious-client/internal";
+import { ApplicationInsights } from "@microsoft/applicationinsights-web";
+import { AppInsightsTelemetryConsumer, startTelemetry } from "@fluidframework/fluid-telemetry";
+
+/**
+ * This module contains Fluid Client utilities, including Container creation / loading.
+ */
+
+/**
+ * Type returned from when creating / loading the Container.
+ */
+export interface ContainerLoadResult {
+	container: IFluidContainer;
+	services: TinyliciousContainerServices;
+}
+
+/**
+ * Basic information about the container, as well as the associated audience.
+ */
+export interface ContainerInfo {
+	/**
+	 * {@link ContainerInfo.container}'s unique ID.
+	 */
+	containerId: string;
+
+	/**
+	 * The initialized Fluid Container.
+	 */
+	container: IFluidContainer;
+}
+
+function initializeTinyliciousClient(): TinyliciousClient {
+	return new TinyliciousClient();
+}
+
+/**
+ * Creates a new Fluid Container from the provided client and container schema.
+ *
+ * @param containerSchema - Schema with which to create the container.
+ * @param setContentsPreAttach - Optional callback for setting initial content state on the
+ * container *before* it is attached.
+ *
+ * @throws If container creation or attaching fails for any reason.
+ */
+export async function createFluidContainer(
+	containerSchema: ContainerSchema,
+	setContentsPreAttach?: (container: IFluidContainer) => Promise<void>,
+): Promise<ContainerInfo> {
+	// Initialize Tinylicious client
+	const client = initializeTinyliciousClient();
+
+	// Create the container
+	console.log("Creating new container...");
+	let createContainerResult: ContainerLoadResult;
+	try {
+		createContainerResult = await client.createContainer(containerSchema);
+	} catch (error) {
+		console.error(`Encountered error creating Fluid container: "${error}".`);
+		throw error;
+	}
+	console.log("Container created!");
+
+	const { container } = createContainerResult;
+
+	// Populate the container with initial app contents (*before* attaching)
+	if (setContentsPreAttach !== undefined) {
+		console.log("Populating initial app data...");
+		await setContentsPreAttach(container);
+		console.log("Initial data populated!");
+	}
+
+	// Attach container
+	console.log("Awaiting container attach...");
+	let containerId: string;
+	try {
+		containerId = await container.attach();
+	} catch (error) {
+		console.error(`Encountered error attaching Fluid container: "${error}".`);
+		throw error;
+	}
+	console.log("Fluid container attached!");
+
+	// Initialize fluid telemetry collection with Azure App insights
+	const appInsightsClient = createAppInsightsClient();
+	startTelemetry({
+		container,
+		containerId,
+		consumers: [new AppInsightsTelemetryConsumer(appInsightsClient)],
+	});
+
+	return {
+		container,
+		containerId,
+	};
+}
+
+/**
+ * Loads an existing Container for the given ID.
+ *
+ * @param containerId - The unique ID of the existing Fluid Container being loaded.
+ * @param containerSchema - Schema with which to load the Container.
+ *
+ * @throws If no container exists with the specified ID, or if loading / connecting fails for any reason.
+ */
+export async function loadExistingFluidContainer(
+	containerId: string,
+	containerSchema: ContainerSchema,
+): Promise<ContainerInfo> {
+	// Initialize Tinylicious client
+	const client = initializeTinyliciousClient();
+
+	console.log("Loading existing container...");
+	let loadContainerResult: ContainerLoadResult;
+	try {
+		loadContainerResult = await client.getContainer(containerId, containerSchema);
+	} catch (error) {
+		console.error(`Encountered error loading Fluid container: "${error}".`);
+		throw error;
+	}
+	console.log("Container loaded!");
+
+	const { container } = loadContainerResult;
+
+	// Initialize fluid telemetry collection with Azure App insights
+	const appInsightsClient = createAppInsightsClient();
+	startTelemetry({
+		container,
+		containerId,
+		consumers: [new AppInsightsTelemetryConsumer(appInsightsClient)],
+	});
+
+	if (container.connectionState !== ConnectionState.Connected) {
+		console.log("Connecting to container...");
+		await new Promise<void>((resolve) => {
+			container.once("connected", () => {
+				resolve();
+			});
+		});
+		console.log("Connected!");
+	}
+
+	return {
+		container,
+		containerId,
+	};
+}
+
+/**
+ * Creates and initializes Azure app insights client
+ */
+function createAppInsightsClient(): ApplicationInsights {
+	const appInsightsClient = new ApplicationInsights({
+		config: {
+			connectionString:
+				// Edit this with your app insights instance connection string (this is an example string)
+				"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
+		},
+	});
+
+	// This must be called or telemetry will not be sent to azure
+	appInsightsClient.loadAppInsights();
+
+	return appInsightsClient;
+}

--- a/examples/client-logger/fluid-telemetry/src/components/index.ts
+++ b/examples/client-logger/fluid-telemetry/src/components/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { App } from "./App.js";

--- a/examples/client-logger/fluid-telemetry/src/test/components/App.test.tsx
+++ b/examples/client-logger/fluid-telemetry/src/test/components/App.test.tsx
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { App } from "../../components/index.js";
+
+describe("App Insights Example App UI test", () => {
+	it("App renders", async (): Promise<void> => {
+		render(<App />);
+		await screen.findByText("Loading Shared container...");
+	});
+});

--- a/examples/client-logger/fluid-telemetry/tsconfig.cjs.json
+++ b/examples/client-logger/fluid-telemetry/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use fluid-tsc commonjs.)
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+	},
+}

--- a/examples/client-logger/fluid-telemetry/tsconfig.json
+++ b/examples/client-logger/fluid-telemetry/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "./lib",
+		"types": ["jest"],
+	},
+	"include": ["src/**/*"],
+}

--- a/examples/client-logger/fluid-telemetry/webpack.config.cjs
+++ b/examples/client-logger/fluid-telemetry/webpack.config.cjs
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const path = require("path");
+
+const { merge } = require("webpack-merge");
+
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+const testAppSrcPath = path.join(__dirname, "src", "app");
+
+module.exports = (env) => {
+	const isProduction = env && env.production;
+
+	return merge(
+		{
+			entry: {
+				main: path.join(testAppSrcPath, "index.tsx"),
+			},
+			resolve: {
+				extensionAlias: {
+					".cjs": [".cts", ".cjs"],
+					".js": [".ts", ".tsx", ".js"],
+					".mjs": [".mts", ".mjs"],
+				},
+				extensions: [".ts", ".tsx", ".js", ".cjs", ".mjs"],
+			},
+			module: {
+				rules: [
+					{
+						test: /\.tsx?$/,
+						loader: require.resolve("ts-loader"),
+					},
+				],
+			},
+			output: {
+				filename: "[name].bundle.js",
+				path: path.resolve(__dirname, "dist"),
+				library: "[name]",
+				devtoolNamespace: "fluid-tools/client-debugger-view",
+				libraryTarget: "umd",
+			},
+			plugins: [new HtmlWebpackPlugin({ template: path.join(testAppSrcPath, "index.html") })],
+			// This impacts which files are watched by the dev server (and likely by webpack if watch is true).
+			// This should be configurable under devServer.static.watch
+			// (see https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md) but that does not seem to work.
+			// The CLI options for disabling watching don't seem to work either, so this may be a symptom of using webpack4 with the newer webpack-cli and webpack-dev-server.
+			watchOptions: {
+				ignored: "**/node_modules/**",
+			},
+		},
+		isProduction ? require("./webpack.prod.cjs") : require("./webpack.dev.cjs"),
+	);
+};

--- a/examples/client-logger/fluid-telemetry/webpack.dev.cjs
+++ b/examples/client-logger/fluid-telemetry/webpack.dev.cjs
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+	mode: "development",
+	devtool: "inline-source-map",
+};

--- a/examples/client-logger/fluid-telemetry/webpack.prod.cjs
+++ b/examples/client-logger/fluid-telemetry/webpack.prod.cjs
@@ -1,0 +1,9 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports = {
+	mode: "production",
+	devtool: "source-map",
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1565,6 +1565,103 @@ importers:
       webpack-dev-server: 4.15.2_xufw7vsm4hgw2efzchq5tzqpge
       webpack-merge: 5.10.0
 
+  examples/client-logger/fluid-telemetry:
+    specifiers:
+      '@biomejs/biome': ^1.6.2
+      '@fluid-example/example-utils': workspace:~
+      '@fluidframework/build-common': ^2.0.3
+      '@fluidframework/build-tools': ^0.34.0
+      '@fluidframework/container-loader': workspace:~
+      '@fluidframework/core-interfaces': workspace:~
+      '@fluidframework/counter': workspace:~
+      '@fluidframework/eslint-config-fluid': ^5.1.0
+      '@fluidframework/fluid-static': workspace:~
+      '@fluidframework/fluid-telemetry': workspace:~
+      '@fluidframework/map': workspace:~
+      '@fluidframework/sequence': workspace:~
+      '@fluidframework/tinylicious-client': workspace:~
+      '@microsoft/applicationinsights-web': ^2.8.11
+      '@testing-library/dom': ^8.2.0
+      '@testing-library/jest-dom': ^5.16.5
+      '@testing-library/react': ^12.0.0
+      '@testing-library/user-event': ^14.4.3
+      '@types/jest': 29.5.3
+      '@types/react': ^17.0.44
+      '@types/react-dom': ^17.0.18
+      '@types/testing-library__jest-dom': ^5.14.5
+      cross-env: ^7.0.3
+      eslint: ~8.55.0
+      eslint-config-prettier: ~9.0.0
+      eslint-plugin-jest: ~27.4.2
+      eslint-plugin-react: ~7.33.2
+      eslint-plugin-react-hooks: ~4.6.0
+      html-webpack-plugin: ^5.5.0
+      jest: ^29.6.2
+      jest-environment-jsdom: ^29.6.2
+      jest-junit: ^10.0.0
+      prettier: ~3.0.3
+      react: ^17.0.1
+      react-dom: ^17.0.1
+      rimraf: ^4.4.0
+      start-server-and-test: ^2.0.3
+      tinylicious: ^4.0.0
+      ts-jest: ^29.1.1
+      ts-loader: ^9.3.0
+      tslib: ^1.10.0
+      typescript: ~5.1.6
+      webpack: ^5.82.0
+      webpack-cli: ^4.9.2
+      webpack-dev-server: ~4.15.1
+      webpack-merge: ^5.8.0
+    dependencies:
+      '@fluid-example/example-utils': link:../../utils/example-utils
+      '@fluidframework/container-loader': link:../../../packages/loader/container-loader
+      '@fluidframework/core-interfaces': link:../../../packages/common/core-interfaces
+      '@fluidframework/counter': link:../../../packages/dds/counter
+      '@fluidframework/fluid-static': link:../../../packages/framework/fluid-static
+      '@fluidframework/fluid-telemetry': link:../../../packages/framework/client-logger/fluid-telemetry
+      '@fluidframework/map': link:../../../packages/dds/map
+      '@fluidframework/sequence': link:../../../packages/dds/sequence
+      '@fluidframework/tinylicious-client': link:../../../packages/service-clients/tinylicious-client
+      '@microsoft/applicationinsights-web': 2.8.16_tslib@1.14.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    devDependencies:
+      '@biomejs/biome': 1.6.2
+      '@fluidframework/build-common': 2.0.3
+      '@fluidframework/build-tools': 0.34.0_webpack-cli@4.10.0
+      '@fluidframework/eslint-config-fluid': 5.1.0_bpztyfltmpuv6lhsgzfwtmxhte
+      '@testing-library/dom': 8.20.1
+      '@testing-library/jest-dom': 5.17.0
+      '@testing-library/react': 12.1.5_sfoxds7t5ydpegc3knd667wn6m
+      '@testing-library/user-event': 14.5.1_szfc7t2zqsdonxwckqxkjn2the
+      '@types/jest': 29.5.3
+      '@types/react': 17.0.71
+      '@types/react-dom': 17.0.25
+      '@types/testing-library__jest-dom': 5.14.9
+      cross-env: 7.0.3
+      eslint: 8.55.0
+      eslint-config-prettier: 9.0.0_eslint@8.55.0
+      eslint-plugin-jest: 27.4.3_oqxbtqzkjhd5hdlnlrx4nuqdoa
+      eslint-plugin-react: 7.33.2_eslint@8.55.0
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.55.0
+      html-webpack-plugin: 5.5.3_webpack@5.89.0
+      jest: 29.7.0
+      jest-environment-jsdom: 29.7.0
+      jest-junit: 10.0.0
+      prettier: 3.0.3
+      rimraf: 4.4.1
+      start-server-and-test: 2.0.3
+      tinylicious: 4.0.0
+      ts-jest: 29.1.1_gvmt7aj7nai5bnvsxmiksfugce
+      ts-loader: 9.5.1_535b6rdv6xzubhvm4whegmtnju
+      tslib: 1.14.1
+      typescript: 5.1.6
+      webpack: 5.89.0_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_4fnl6fxs65yjb57cbmzmmxikci
+      webpack-dev-server: 4.15.2_xufw7vsm4hgw2efzchq5tzqpge
+      webpack-merge: 5.10.0
+
   examples/data-objects/canvas:
     specifiers:
       '@biomejs/biome': ^1.6.2
@@ -11643,14 +11740,6 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/code-frame/7.23.4:
-    resolution: {integrity: sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/highlight': 7.23.4
-      chalk: 2.4.2
-    dev: true
-
   /@babel/code-frame/7.24.2:
     resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
     engines: {node: '>=6.9.0'}
@@ -11815,7 +11904,7 @@ packages:
       '@babel/core': 7.24.4
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-imports': 7.24.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/traverse': 7.24.1
       debug: 4.3.4
       lodash.debounce: 4.0.8
@@ -11910,11 +11999,6 @@ packages:
 
   /@babel/helper-plugin-utils/7.10.4:
     resolution: {integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==}
-    dev: true
-
-  /@babel/helper-plugin-utils/7.22.5:
-    resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
-    engines: {node: '>=6.9.0'}
     dev: true
 
   /@babel/helper-plugin-utils/7.24.0:
@@ -12012,15 +12096,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/highlight/7.23.4:
-    resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    dev: true
-
   /@babel/highlight/7.24.2:
     resolution: {integrity: sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==}
     engines: {node: '>=6.9.0'}
@@ -12098,7 +12173,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-create-class-features-plugin': 7.22.15_@babel+core@7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-proposal-decorators/7.24.1_@babel+core@7.24.4:
@@ -12120,7 +12195,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-export-default-from': 7.23.3_@babel+core@7.24.4
     dev: true
 
@@ -12132,7 +12207,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.24.4
     dev: true
 
@@ -12143,7 +12218,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.9
       '@babel/plugin-transform-parameters': 7.23.3_@babel+core@7.12.9
     dev: true
@@ -12158,7 +12233,7 @@ packages:
       '@babel/compat-data': 7.24.4
       '@babel/core': 7.24.4
       '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.24.4
       '@babel/plugin-transform-parameters': 7.23.3_@babel+core@7.24.4
     dev: true
@@ -12171,7 +12246,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.24.4
     dev: true
@@ -12185,7 +12260,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-create-class-features-plugin': 7.22.15_@babel+core@7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-proposal-private-property-in-object/7.21.0-placeholder-for-preset-env.2_@babel+core@7.24.4:
@@ -12207,7 +12282,7 @@ packages:
       '@babel/core': 7.24.4
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.22.15_@babel+core@7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.24.4
     dev: true
 
@@ -12226,7 +12301,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.24.4:
@@ -12274,7 +12349,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.24.4:
@@ -12293,7 +12368,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-syntax-import-assertions/7.24.1_@babel+core@7.24.4:
@@ -12340,7 +12415,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-syntax-jsx/7.23.3_@babel+core@7.24.4:
@@ -12350,7 +12425,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.24.4:
@@ -12443,7 +12518,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-syntax-unicode-sets-regex/7.18.6_@babel+core@7.24.4:
@@ -12464,7 +12539,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-arrow-functions/7.24.1_@babel+core@7.24.4:
@@ -12519,7 +12594,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-block-scoping/7.24.4_@babel+core@7.24.4:
@@ -12567,7 +12642,7 @@ packages:
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-replace-supers': 7.22.20_@babel+core@7.24.4
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
@@ -12608,7 +12683,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-destructuring/7.24.1_@babel+core@7.24.4:
@@ -12682,7 +12757,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-flow': 7.23.3_@babel+core@7.24.4
     dev: true
 
@@ -12693,7 +12768,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-for-of/7.24.1_@babel+core@7.24.4:
@@ -12780,7 +12855,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-module-transforms': 7.23.3_@babel+core@7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-simple-access': 7.22.5
     dev: true
 
@@ -12917,7 +12992,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-parameters/7.23.3_@babel+core@7.24.4:
@@ -12927,7 +13002,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-parameters/7.24.1_@babel+core@7.24.4:
@@ -12981,7 +13056,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-react-jsx-development/7.22.5_@babel+core@7.24.4:
@@ -13001,7 +13076,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-react-jsx-source/7.23.3_@babel+core@7.24.4:
@@ -13011,7 +13086,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-react-jsx/7.23.4_@babel+core@7.24.4:
@@ -13023,7 +13098,7 @@ packages:
       '@babel/core': 7.24.4
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.24.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-jsx': 7.23.3_@babel+core@7.24.4
       '@babel/types': 7.24.0
     dev: true
@@ -13036,7 +13111,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-regenerator/7.24.1_@babel+core@7.24.4:
@@ -13067,7 +13142,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-shorthand-properties/7.24.1_@babel+core@7.24.4:
@@ -13087,7 +13162,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: true
 
@@ -13119,7 +13194,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
   /@babel/plugin-transform-template-literals/7.24.1_@babel+core@7.24.4:
@@ -13151,7 +13226,7 @@ packages:
       '@babel/core': 7.24.4
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.22.15_@babel+core@7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-typescript': 7.23.3_@babel+core@7.24.4
     dev: true
 
@@ -13297,7 +13372,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-transform-flow-strip-types': 7.23.3_@babel+core@7.24.4
     dev: true
@@ -13320,7 +13395,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-transform-react-display-name': 7.23.3_@babel+core@7.24.4
       '@babel/plugin-transform-react-jsx': 7.23.4_@babel+core@7.24.4
@@ -13335,7 +13410,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-syntax-jsx': 7.23.3_@babel+core@7.24.4
       '@babel/plugin-transform-modules-commonjs': 7.23.3_@babel+core@7.24.4
@@ -13365,6 +13440,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
+    dev: false
 
   /@babel/runtime/7.24.4:
     resolution: {integrity: sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==}
@@ -13795,7 +13871,7 @@ packages:
       '@emotion/memoize': 0.8.1
       '@emotion/unitless': 0.8.1
       '@emotion/utils': 1.2.1
-      csstype: 3.1.2
+      csstype: 3.1.3
     dev: false
 
   /@emotion/sheet/1.2.2:
@@ -17811,7 +17887,7 @@ packages:
     dependencies:
       '@emotion/hash': 0.9.1
       '@griffel/style-types': 1.0.2
-      csstype: 3.1.2
+      csstype: 3.1.3
       rtl-css-js: 1.16.1
       stylis: 4.3.0
       tslib: 2.6.2
@@ -17830,7 +17906,7 @@ packages:
   /@griffel/style-types/1.0.2:
     resolution: {integrity: sha512-ka/Tpl1WU8js88LObwB/4EvpgXzx/EEJfbHhAr4ZNt29hrQKgL93X1zSY6M/FRhMhWrGIawauWkZP6/y6w/WiQ==}
     dependencies:
-      csstype: 3.1.2
+      csstype: 3.1.3
     dev: false
 
   /@hapi/hoek/9.3.0:
@@ -21690,8 +21766,8 @@ packages:
     resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
     engines: {node: '>=12'}
     dependencies:
-      '@babel/code-frame': 7.23.4
-      '@babel/runtime': 7.23.4
+      '@babel/code-frame': 7.24.2
+      '@babel/runtime': 7.24.4
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -21705,7 +21781,7 @@ packages:
     engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
     dependencies:
       '@adobe/css-tools': 4.3.1
-      '@babel/runtime': 7.23.4
+      '@babel/runtime': 7.24.4
       '@types/testing-library__jest-dom': 5.14.9
       aria-query: 5.3.0
       chalk: 3.0.0
@@ -21722,7 +21798,7 @@ packages:
       react: <18.0.0 || 17.0.2
       react-dom: <18.0.0 || 17.0.2
     dependencies:
-      '@babel/runtime': 7.23.4
+      '@babel/runtime': 7.24.4
       '@testing-library/dom': 8.20.1
       '@types/react-dom': 17.0.25
       react: 17.0.2
@@ -22431,7 +22507,7 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.11
       '@types/scheduler': 0.16.8
-      csstype: 3.1.2
+      csstype: 3.1.3
 
   /@types/recharts/1.8.28:
     resolution: {integrity: sha512-31D+dVBdVMtBnRMOjfM9210oRsclujQetwDNnCfapy/gF1BruvQkiK9WZ2ZMqDZY2xnDpIV8sWjISBcY+wgkLw==}
@@ -24324,7 +24400,7 @@ packages:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -26646,12 +26722,8 @@ packages:
     resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
     dev: false
 
-  /csstype/3.1.2:
-    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
-
   /csstype/3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-    dev: false
 
   /csv-generate/3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
@@ -27379,7 +27451,7 @@ packages:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
     dependencies:
       '@babel/runtime': 7.24.4
-      csstype: 3.1.2
+      csstype: 3.1.3
     dev: false
 
   /dom-serializer/0.2.2:
@@ -33122,7 +33194,7 @@ packages:
     resolution: {integrity: sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==}
     dependencies:
       '@babel/runtime': 7.24.4
-      csstype: 3.1.2
+      csstype: 3.1.3
       is-in-browser: 1.1.3
       tiny-warning: 1.0.3
     dev: false


### PR DESCRIPTION
# @fluid-example/fluid-telemetry

## Overview

This package provides a simple Fluid application complete with a UI view in [React](https://react.dev/) to test the @fluidframework/fluid-telemetry package that will route Fluid telemetry to configured Azure App Insights.

## Configuring fluid telemetry to be sent to your app insights instance

-   within `src/components/ClientUtilities.ts`, update the function definition for `createAppInsightsClient` to change the App Insights connection string to yours. In most cases, this is simply the most basic config containing your correct connection string:

```typescript
function createAppInsightsClient(): ApplicationInsights {
	const appInsightsClient = new ApplicationInsights({
		config: {
			connectionString:
				// Edit this with your app insights instance connection string (this is an example string)
				"InstrumentationKey=abcdefgh-ijkl-mnop-qrst-uvwxyz6ffd9c;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/",
		},
	});

	// This must be called or telemetry will not be sent to azure
	appInsightsClient.loadAppInsights();

	return appInsightsClient;
}
```

### How the telemetry is configured and started

-   within `src/components/ClientUtilities.ts`,take a look within the functions `loadExistingFluidContainer()` and `createFluidContainer()`. you will see the following code:

```ts
// Initialize fluid telemetry collection with Azure App insights
const appInsightsClient = createAppInsightsClient();
startTelemetry({
	container,
	containerId,
	consumers: [new AppInsightsTelemetryConsumer(appInsightsClient)],
});
```

## Getting Started

You can run this example using the following steps:

1. Enable [corepack](https://nodejs.org/docs/latest-v16.x/api/corepack.html) by running `corepack enable`.
1. Run `pnpm install` and `pnpm run build:fast --nolint` from the `FluidFramework` root directory.
    - For an even faster build, you can add the package name to the build command, like this:
      `pnpm run build:fast --nolint @fluid-example/fluid-telemetry`
1. Run `pnpm start` from this directory and open <http://localhost:8080> in a web browser to see the app running.

<!-- prettier-ignore-end -->

<!-- AUTO-GENERATED-CONTENT:END -->

## Starting the test

-   run `pnpm run start` and navigate to http://localhost:8080/ in your web browser.

## Generating telemetry events

-   There will be telemetry events that flow automatically when you start the test app. In addition to these events, you can control creating telemetry events yourself by interacting with UI app, incremeting/decrementing the shared counter and editing the shared string provided in this example

## Viewing Telemetry Logs in App Insights

From the Azure web portal, navigate to your app insights instance. Now, go to the "Logs" for your instance, this should be an option within the left side panel. Finally, from this page, you can query for telemetry events, which will be stored in the customEvents table. As an example, you can issue this simple query to get recent telemetry events sent to the customEvents table:

-   Get a count of each distinct log event name

    ```
    customEvents
    | summarize count() by name
    ```