### PR TITLE
fix(build-tools): handle special export cases

### DIFF
--- a/build-tools/packages/build-cli/src/commands/modify/fluid-imports.ts
+++ b/build-tools/packages/build-cli/src/commands/modify/fluid-imports.ts
@@ -587,7 +587,7 @@ class ApiLevelReader {
 		this.log.verbose(`\tLoading ${packageName} API data from ${internalSource.getFilePath()}`);
 
 		const exports = getApiExports(internalSource);
-		for (const { name } of exports.unknown) {
+		for (const name of exports.unknown.keys()) {
 			// Suppress any warning for EventEmitter as this export is currently a special case.
 			// See AB#7377 for replacement status upon which this can be removed.
 			if (name !== "EventEmitter") {

--- a/build-tools/packages/build-cli/src/library/typescriptApi.ts
+++ b/build-tools/packages/build-cli/src/library/typescriptApi.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import type { SourceFile, ExportedDeclarations } from "ts-morph";
-import { Node } from "ts-morph";
+import type { ExportDeclaration, ExportedDeclarations, SourceFile } from "ts-morph";
+import { JSDoc, Node, SyntaxKind } from "ts-morph";
 
 import { ApiLevel, isKnownApiLevel } from "./apiLevel";
 
@@ -23,7 +23,7 @@ interface ExportRecords {
 	 * ExportedDeclarations provides context for the origin of
 	 * such cases.
 	 */
-	unknown: { name: string; decl: ExportedDeclarations }[];
+	unknown: Map<string, { exportedDecl: ExportedDeclarations; exportDecl?: ExportDeclaration }>;
 }
 
 /**
@@ -36,28 +36,46 @@ function isTypeExport(_decl: ExportedDeclarations): boolean {
 }
 
 /**
+ * Searches given JSDocs for known {@link ApiLevel} tag.
+ *
+ * @returns Recognized {@link ApiLevel} from JSDocs or undefined.
+ */
+function getLevelFromDocs(jsdocs: JSDoc[]): ApiLevel | undefined {
+	for (const jsdoc of jsdocs) {
+		for (const tag of jsdoc.getTags()) {
+			const tagName = tag.getTagName();
+			if (isKnownApiLevel(tagName)) {
+				return tagName;
+			}
+		}
+	}
+	return undefined;
+}
+
+/**
  * Searches given Node's JSDocs for known {@link ApiLevel} tag.
  *
  * @returns Recognized {@link ApiLevel} from JSDocs or undefined.
  */
 function getNodeLevel(node: Node): ApiLevel | undefined {
 	if (Node.isJSDocable(node)) {
-		for (const jsdoc of node.getJsDocs()) {
-			for (const tag of jsdoc.getTags()) {
-				const tagName = tag.getTagName();
-				if (isKnownApiLevel(tagName)) {
-					return tagName;
-				}
-			}
-		}
-	} else {
-		// Some nodes like `VariableDeclaration`s are not JSDocable, but an ancestor
-		// like `VariableStatement` is and may contain tag.
-		const parent = node.getParent();
-		if (parent !== undefined) {
-			return getNodeLevel(parent);
-		}
+		return getLevelFromDocs(node.getJsDocs());
 	}
+
+	// Some nodes like `ExportSpecifier` are not JSDocable per ts-morph, but
+	// a JSDoc is present.
+	const jsdocChildren = node.getChildrenOfKind(SyntaxKind.JSDoc);
+	if (jsdocChildren.length > 0) {
+		return getLevelFromDocs(jsdocChildren);
+	}
+
+	// Some nodes like `VariableDeclaration`s are not JSDocable, but an ancestor
+	// like `VariableStatement` is and may contain tag.
+	const parent = node.getParent();
+	if (parent !== undefined) {
+		return getNodeLevel(parent);
+	}
+
 	return undefined;
 }
 
@@ -72,7 +90,7 @@ export function getApiExports(sourceFile: SourceFile): ExportRecords {
 		beta: [],
 		alpha: [],
 		internal: [],
-		unknown: [],
+		unknown: new Map(),
 	};
 	// We can't (don't know how to) distinguish duplication in exports
 	// from a type and a value export. We expect however that those will
@@ -82,7 +100,7 @@ export function getApiExports(sourceFile: SourceFile): ExportRecords {
 		for (const exportedDecl of exportedDecls) {
 			const level = getNodeLevel(exportedDecl);
 			if (level === undefined) {
-				records.unknown.push({ name, decl: exportedDecl });
+				records.unknown.set(name, { exportedDecl });
 			} else {
 				const existingLevel = foundNameLevels.get(name);
 				if (existingLevel === undefined) {
@@ -94,6 +112,74 @@ export function getApiExports(sourceFile: SourceFile): ExportRecords {
 							.getSourceFile()
 							.getFilePath()}:${exportedDecl.getStartLineNumber()}.`,
 					);
+				}
+			}
+		}
+	}
+
+	// If we have found levels for all things exported, then nothing else left to look for.
+	if (records.unknown.size === 0) {
+		return records;
+	}
+
+	// Otherwise, look for some special cases where level tagging may appear in source itself.
+
+	// Note that these are not exported declarations, but specifically
+	// given file's export declarations.
+	const exportDeclarations = sourceFile.getExportDeclarations();
+	for (const exportDeclaration of exportDeclarations) {
+		// console.log(`export @ ${exportDeclaration.getStartLineNumber()} has children:\n\t${exportDeclaration.getChildren().map((c) => c.getKindName()).join('\n\t')}`);
+
+		// Look first for namespace exports like `export * as foo`.
+		for (const namespaceDecl of exportDeclaration.getChildrenOfKind(
+			SyntaxKind.NamespaceExport,
+		)) {
+			const name = namespaceDecl.getName();
+			const unknownExported = records.unknown.get(name);
+			if (unknownExported !== undefined) {
+				console.log(
+					`namespace exports of the form 'export * as foo' are speculatively supported. See ${sourceFile.getFilePath()}:${namespaceDecl.getStartLineNumber()}:\n${namespaceDecl.getText()}`,
+				);
+				const namespaceLevel = getNodeLevel(exportDeclaration);
+				if (namespaceLevel === undefined) {
+					unknownExported.exportDecl = exportDeclaration;
+				} else {
+					records[namespaceLevel].push({ name, isTypeOnly: exportDeclaration.isTypeOnly() });
+					records.unknown.delete(name);
+					if (records.unknown.size === 0) {
+						return records;
+					}
+				}
+			}
+		}
+
+		// Then process named exports. Common case for named export is patch for api-extractor
+		// limitation on namespace exports:
+		//   import * as foo from "bar";
+		//   export { foo }
+		// Entire foo namespace may be tagged by:
+		//   export {
+		//     /** @internal */
+		//     foo
+		//   }
+		// Note that per namespace level tags maybe different than the namespace. To avoid any
+		// accidental exposure only tag a namespace with the most limited tag present.
+		for (const exportSpecifier of exportDeclaration.getNamedExports()) {
+			const name = exportSpecifier.getName();
+			const unknownExported = records.unknown.get(name);
+			if (unknownExported !== undefined) {
+				const exportLevel = getNodeLevel(exportSpecifier);
+				if (exportLevel === undefined) {
+					unknownExported.exportDecl = exportDeclaration;
+				} else {
+					records[exportLevel].push({
+						name,
+						isTypeOnly: exportDeclaration.isTypeOnly() || exportSpecifier.isTypeOnly(),
+					});
+					records.unknown.delete(name);
+					if (records.unknown.size === 0) {
+						return records;
+					}
 				}
 			}
 		}

--- a/build-tools/packages/build-cli/src/library/typescriptApi.ts
+++ b/build-tools/packages/build-cli/src/library/typescriptApi.ts
@@ -30,6 +30,11 @@ interface ExportRecords {
  * This function is a placeholder for functionality that could
  * be very useful to have when working with multiple exports
  * using the same name (basically both a type and value export).
+ *
+ * This may be addressable by walking the various ExportDeclarations
+ * from the source. This is done for some special cases, but
+ * should reveal the type-only-ness and then records could be
+ * updated.
  */
 function isTypeExport(_decl: ExportedDeclarations): boolean {
 	return false;
@@ -128,7 +133,13 @@ export function getApiExports(sourceFile: SourceFile): ExportRecords {
 	// given file's export declarations.
 	const exportDeclarations = sourceFile.getExportDeclarations();
 	for (const exportDeclaration of exportDeclarations) {
-		// console.log(`export @ ${exportDeclaration.getStartLineNumber()} has children:\n\t${exportDeclaration.getChildren().map((c) => c.getKindName()).join('\n\t')}`);
+		// Uncomment below lines for some extra debugging help to show document structure:
+		// console.log(
+		// 	`export @ ${exportDeclaration.getStartLineNumber()} has children:\n\t${exportDeclaration
+		// 		.getChildren()
+		// 		.map((c) => c.getKindName())
+		// 		.join("\n\t")}`,
+		// );
 
 		// Look first for namespace exports like `export * as foo`.
 		for (const namespaceDecl of exportDeclaration.getChildrenOfKind(

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
@@ -50,7 +50,7 @@ const executableToLeafTask: {
 	"flub list": FlubListTask,
 	"flub check layers": FlubCheckLayerTask,
 	"flub check policy": FlubCheckPolicyTask,
-	"flub generate entrypoint": GenerateEntrypointsTask,
+	"flub generate entrypoints": GenerateEntrypointsTask,
 	"flub generate typetests": TypeValidationTask,
 	"fluid-type-test-generator": TypeValidationTask,
 	"depcruise": DepCruiseTask,


### PR DESCRIPTION
- Look for namespace exports and source local exports that may have JSDocs that are determined using ExportedDeclarations.
- Export all unknown matching api-extractor.
- Change unknown case to be a map and additional data as collected.
- Don't export anything when there are none (otherwise it exported all)

- Fix incrementality task typo