### PR TITLE
tree: Add root editing, make TreeView parameterized over schema

### DIFF
--- a/.changeset/hot-streets-smell.md
+++ b/.changeset/hot-streets-smell.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/tree": minor
+---
+
+Allow root editing and make TreeView parameterized over schema.
+
+TreeView now is parameterized over the field schema instead of the root field type. This was needed to infer the correct input type when reassigning the root.
+Code providing an explicit type to TreeView, like `TreeView<Foo>` can usually be updated by replacing that with `TreeView<typeof Foo>`.

--- a/examples/benchmarks/bubblebench/simple-tree/src/appState.ts
+++ b/examples/benchmarks/bubblebench/simple-tree/src/appState.ts
@@ -16,7 +16,7 @@ export class AppState implements IAppState {
 	readonly localClient: Client;
 
 	constructor(
-		private readonly tree: TreeView<App>,
+		private readonly tree: TreeView<typeof App>,
 		public width: number,
 		public height: number,
 		numBubbles: number,

--- a/examples/benchmarks/bubblebench/simple-tree/src/bubblebench.ts
+++ b/examples/benchmarks/bubblebench/simple-tree/src/bubblebench.ts
@@ -17,7 +17,7 @@ const treeKey = "treeKey";
 export class Bubblebench extends DataObject {
 	public static readonly Name = "@fluid-example/bubblebench-simpletree";
 
-	private view: TreeView<App> | undefined;
+	private view: TreeView<typeof App> | undefined;
 	private _appState: AppState | undefined;
 
 	protected async initializingFirstTime() {
@@ -75,7 +75,7 @@ export class Bubblebench extends DataObject {
 	 * Get the SharedTree.
 	 * Cannot be accessed until after initialization has completed.
 	 */
-	private get tree(): TreeView<App> {
+	private get tree(): TreeView<typeof App> {
 		return this.view ?? fail("not initialized");
 	}
 

--- a/examples/data-objects/inventory-app/src/reactSharedTreeView.tsx
+++ b/examples/data-objects/inventory-app/src/reactSharedTreeView.tsx
@@ -47,9 +47,9 @@ export const factory: IChannelFactory = SharedTree.getFactory();
 export abstract class TreeDataObject<
 	TSchema extends ImplicitFieldSchema = ImplicitFieldSchema,
 > extends DataObject {
-	#tree?: TreeView<TreeFieldFromImplicitField<TSchema>>;
+	#tree?: TreeView<TSchema>;
 
-	public get tree(): TreeView<TreeFieldFromImplicitField<TSchema>> {
+	public get tree(): TreeView<TSchema> {
 		if (this.#tree === undefined) throw new Error(this.getUninitializedErrorString("tree"));
 		return this.#tree;
 	}

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
@@ -127,7 +127,7 @@ function TopRow(props: { app: App }): JSX.Element {
 }
 
 export function ReactApp(props: {
-	data: TreeView<App>;
+	data: TreeView<typeof App>;
 	container: IFluidContainer;
 	cellSize: { x: number; y: number };
 	canvasSize: { x: number; y: number };

--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -1085,7 +1085,7 @@ export interface ITransaction {
 
 // @public
 export interface ITree extends IChannel {
-    schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TreeFieldFromImplicitField<TRoot>>;
+    schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TRoot>;
 }
 
 // @internal
@@ -1779,7 +1779,7 @@ export interface TreeAdapter {
 // @public
 export interface TreeApi extends TreeNodeApi {
     runTransaction<TNode extends TreeNode>(node: TNode, transaction: (node: TNode) => void | "rollback"): void;
-    runTransaction<TRoot>(tree: TreeView<TRoot>, transaction: (root: TRoot) => void | "rollback"): void;
+    runTransaction<TView extends TreeView<ImplicitFieldSchema>>(tree: TView, transaction: (root: TView["root"]) => void | "rollback"): void;
 }
 
 // @public
@@ -2008,10 +2008,11 @@ export type TreeValue<TSchema extends ValueSchema = ValueSchema> = [
 ][_InlineTrick];
 
 // @public
-export interface TreeView<in out TRoot> extends IDisposable {
+export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable {
     readonly error?: SchemaIncompatible;
     readonly events: ISubscribable<TreeViewEvents>;
-    readonly root: TRoot;
+    get root(): TreeFieldFromImplicitField<TSchema>;
+    set root(newRoot: InsertableTreeFieldFromImplicitField<TSchema>);
     upgradeSchema(): void;
 }
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -205,9 +205,7 @@ export abstract class LazyTreeNode<TSchema extends FlexTreeNodeSchema = FlexTree
 	}
 
 	public getBoxed(key: FieldKey): FlexTreeField {
-		return inCursorField(this[cursorSymbol], brand(key), (cursor) =>
-			makeField(this.context, this.schema.getFieldSchema(key), cursor),
-		);
+		return getBoxedField(this, key, this.schema.getFieldSchema(key));
 	}
 
 	public boxedIterator(): IterableIterator<FlexTreeField> {
@@ -520,7 +518,7 @@ const cachedStructClasses = new WeakMap<
 	) => LazyObjectNode<FlexObjectNodeSchema>
 >();
 
-export function getBoxedField(
+function getBoxedField(
 	objectNode: LazyTreeNode,
 	key: FieldKey,
 	fieldSchema: FlexFieldSchema,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -42,13 +42,7 @@ import {
 	makeTreeChunker,
 } from "../feature-libraries/index.js";
 import { ExplicitCoreCodecVersions, SharedTreeCore } from "../shared-tree-core/index.js";
-import {
-	ITree,
-	ImplicitFieldSchema,
-	TreeConfiguration,
-	TreeFieldFromImplicitField,
-	TreeView,
-} from "../simple-tree/index.js";
+import { ITree, ImplicitFieldSchema, TreeConfiguration, TreeView } from "../simple-tree/index.js";
 import { brand } from "../util/index.js";
 
 import { InitializeAndSchematizeConfiguration, ensureSchema } from "./schematizeTree.js";
@@ -289,7 +283,7 @@ export class SharedTree
 
 	public schematize<TRoot extends ImplicitFieldSchema>(
 		config: TreeConfiguration<TRoot>,
-	): TreeView<TreeFieldFromImplicitField<TRoot>> {
+	): TreeView<TRoot> {
 		const view = new SchematizingSimpleTreeView(
 			this.checkout,
 			config,

--- a/packages/dds/tree/src/shared-tree/treeApi.ts
+++ b/packages/dds/tree/src/shared-tree/treeApi.ts
@@ -6,7 +6,14 @@
 import { assert } from "@fluidframework/core-utils/internal";
 
 import { Context } from "../feature-libraries/index.js";
-import { TreeNode, TreeNodeApi, TreeView, getFlexNode, treeNodeApi } from "../simple-tree/index.js";
+import {
+	ImplicitFieldSchema,
+	TreeNode,
+	TreeNodeApi,
+	TreeView,
+	getFlexNode,
+	treeNodeApi,
+} from "../simple-tree/index.js";
 import { fail } from "../util/index.js";
 
 import { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
@@ -55,9 +62,9 @@ export interface TreeApi extends TreeNodeApi {
 	 * Local change events will be emitted for each change as the transaction is being applied.
 	 * If the transaction is cancelled and rolled back, a corresponding change event will also be emitted for the rollback.
 	 */
-	runTransaction<TRoot>(
-		tree: TreeView<TRoot>,
-		transaction: (root: TRoot) => void | "rollback",
+	runTransaction<TView extends TreeView<ImplicitFieldSchema>>(
+		tree: TView,
+		transaction: (root: TView["root"]) => void | "rollback",
 	): void;
 }
 
@@ -67,7 +74,7 @@ export interface TreeApi extends TreeNodeApi {
  */
 export const treeApi: TreeApi = {
 	...treeNodeApi,
-	runTransaction<TNode extends TreeNode, TRoot>(
+	runTransaction<TNode extends TreeNode, TRoot extends ImplicitFieldSchema>(
 		treeOrNode: TNode | TreeView<TRoot>,
 		transaction: ((node: TNode) => void | "rollback") | ((root: TRoot) => void | "rollback"),
 	) {

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -27,6 +27,7 @@ export {
 	InsertableTypedNode,
 	NodeBuilderData,
 	type FieldProps,
+	normalizeFieldSchema,
 } from "./schemaTypes.js";
 export { SchemaFactory, type ScopedSchemaName } from "./schemaFactory.js";
 export { getFlexNode } from "./proxyBinding.js";
@@ -48,7 +49,7 @@ export {
 	NodeFromSchemaUnsafe,
 } from "./typesUnsafe.js";
 export { SchemaFactoryRecursive, ValidateRecursiveSchema } from "./schemaFactoryRecursive.js";
-export { getProxyForField } from "./proxies.js";
+export { getProxyForField, InsertableContent } from "./proxies.js";
 
 export {
 	adaptEnum,
@@ -71,5 +72,6 @@ export {
 	InsertableObjectFromSchemaRecord,
 	ObjectFromSchemaRecord,
 	TreeObjectNode,
+	setField,
 } from "./objectNode.js";
 export { TreeMapNode } from "./mapNode.js";

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -44,9 +44,6 @@ import { TreeNode } from "./types.js";
 import { RestrictiveReadonlyRecord, brand, fail } from "../util/index.js";
 import { getFlexSchema } from "./toFlexSchema.js";
 import { RawTreeNode, rawError } from "./rawNode.js";
-// TODO: decide how to deal with dependencies on flex-tree implementation.
-// eslint-disable-next-line import/no-internal-modules
-import { LazyObjectNode } from "../feature-libraries/flex-tree/lazyNode.js";
 
 /**
  * Helper used to produce types for object nodes.
@@ -182,9 +179,6 @@ function createObjectProxy(
 			}
 			assert(typeof viewKey === "string", 0x7e1 /* invalid key */);
 			const flexKey: FieldKey | undefined = getFlexKey(viewKey);
-
-			// TODO: Is it safe to assume 'content' is a LazyObjectNode?
-			assert(flexNode instanceof LazyObjectNode, 0x7e0 /* invalid content */);
 
 			const field = flexNode.getBoxed(flexKey);
 

--- a/packages/dds/tree/src/simple-tree/tree.ts
+++ b/packages/dds/tree/src/simple-tree/tree.ts
@@ -60,7 +60,7 @@ export interface ITree extends IChannel {
 	 */
 	schematize<TRoot extends ImplicitFieldSchema>(
 		config: TreeConfiguration<TRoot>,
-	): TreeView<TreeFieldFromImplicitField<TRoot>>;
+	): TreeView<TRoot>;
 }
 
 /**
@@ -98,7 +98,7 @@ export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFie
  * it could be mitigated by adding a `rootOrError` member and deprecating `root` to give users a warning if they might be missing the error checking.
  * @public
  */
-export interface TreeView<in out TRoot> extends IDisposable {
+export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable {
 	/**
 	 * The current root of the tree.
 	 *
@@ -108,7 +108,9 @@ export interface TreeView<in out TRoot> extends IDisposable {
 	 * To get notified about changes to this field (including to it being in an `error` state),
 	 * use {@link TreeViewEvents.rootChanged} via `view.events.on("rootChanged", callback)`.
 	 */
-	readonly root: TRoot;
+	get root(): TreeFieldFromImplicitField<TSchema>;
+
+	set root(newRoot: InsertableTreeFieldFromImplicitField<TSchema>);
 
 	/**
 	 * Description of the error state, if any.

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -7,9 +7,6 @@ import { strict as assert } from "assert";
 
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { leaf } from "../../domains/index.js";
-// eslint-disable-next-line import/no-internal-modules
-import { required } from "../../feature-libraries/default-schema/defaultFieldKinds.js";
 import {
 	FieldKinds,
 	FlexFieldSchema,
@@ -117,11 +114,7 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(view.root, 5);
 		const log: [string, unknown][] = [];
 
-		// Currently there is no way to edit the root using the simple-tree API, so use flex-tree to do it:
-		const flexView = view.getViewOrError();
-		assert(!(flexView instanceof SchematizeError));
-		assert(flexView.flexTree.is(FlexFieldSchema.create(required, [leaf.number])));
-		flexView.flexTree.content = 6;
+		view.root = 6;
 
 		assert.deepEqual(log, [
 			["rootChanged", 6],

--- a/packages/dds/tree/src/test/simple-tree/schemaCreationUtilities.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaCreationUtilities.spec.ts
@@ -42,7 +42,7 @@ describe("schemaCreationUtilities", () => {
 			new MockFluidDataStoreRuntime({ idCompressor: testIdCompressor }),
 			"tree",
 		);
-		const view: TreeView<Parent> = tree.schematize(config);
+		const view: TreeView<typeof Parent> = tree.schematize(config);
 		const mode = view.root.mode;
 		switch (true) {
 			case mode instanceof Mode.Bonus: {
@@ -116,7 +116,7 @@ describe("schemaCreationUtilities", () => {
 			new MockFluidDataStoreRuntime({ idCompressor: testIdCompressor }),
 			"tree",
 		);
-		const view: TreeView<Parent> = tree.schematize(config);
+		const view: TreeView<typeof Parent> = tree.schematize(config);
 		const mode = view.root.mode;
 		switch (mode.value) {
 			case "Fun": {

--- a/packages/dds/tree/src/test/simple-tree/schemaFactory.examples.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactory.examples.spec.ts
@@ -95,7 +95,7 @@ const config2 = new TreeConfiguration(
 );
 
 function setup(tree: ITree): Note[] {
-	const view: TreeView<Canvas> = tree.schematize(config1);
+	const view: TreeView<typeof Canvas> = tree.schematize(config1);
 	const stuff = view.root.stuff;
 	if (stuff instanceof NodeMap) {
 		return f(stuff);
@@ -129,6 +129,6 @@ describe("Class based end to end example", () => {
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<Canvas> = theTree.schematize(config2);
+		const view: TreeView<typeof Canvas> = theTree.schematize(config2);
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
@@ -364,7 +364,7 @@ describe("schemaFactory", () => {
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<Canvas> = tree.schematize(config);
+		const view: TreeView<typeof Canvas> = tree.schematize(config);
 		const stuff = view.root.stuff;
 		assert(stuff instanceof NodeList);
 		const item = stuff[0];
@@ -668,7 +668,7 @@ describe("schemaFactory", () => {
 		function test(
 			parentType: (typeof objectTypes)[number],
 			childType: (typeof objectTypes)[number],
-			validate: (view: TreeView<ComboRoot>, nodes: ComboNode[]) => void,
+			validate: (view: TreeView<typeof ComboRoot>, nodes: ComboNode[]) => void,
 		) {
 			const config = new TreeConfiguration(ComboRoot, () => ({ root: undefined }));
 			const factory = new TreeFactory({});

--- a/packages/dds/tree/src/test/simple-tree/schemaFactoryRecursive.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactoryRecursive.spec.ts
@@ -83,7 +83,7 @@ describe("SchemaFactoryRecursive", () => {
 				"tree",
 			);
 
-			const view: TreeView<Box> = tree.schematize(config);
+			const view: TreeView<typeof Box> = tree.schematize(config);
 			assert.equal(view.root?.text, "hi");
 
 			const stuff: undefined | Box = view.root.child;

--- a/packages/dds/tree/src/test/simple-tree/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/tree.spec.ts
@@ -26,7 +26,7 @@ describe("class-tree tree", () => {
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<NodeList> = tree.schematize(config);
+		const view: TreeView<typeof NodeList> = tree.schematize(config);
 		assert.deepEqual([...view.root], ["a", "b"]);
 	});
 
@@ -36,7 +36,7 @@ describe("class-tree tree", () => {
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<NodeList> = tree.schematize(config);
+		const view: TreeView<typeof NodeList> = tree.schematize(config);
 		assert.deepEqual([...view.root], ["a", "b"]);
 	});
 
@@ -46,7 +46,7 @@ describe("class-tree tree", () => {
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<Canvas> = tree.schematize(config);
+		const view: TreeView<typeof Canvas> = tree.schematize(config);
 	});
 
 	it("ObjectRoot - unhydrated", () => {
@@ -55,7 +55,7 @@ describe("class-tree tree", () => {
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<Canvas> = tree.schematize(config);
+		const view: TreeView<typeof Canvas> = tree.schematize(config);
 	});
 
 	it("Union Root", () => {
@@ -64,7 +64,7 @@ describe("class-tree tree", () => {
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<number | string> = tree.schematize(config);
+		const view = tree.schematize(config);
 		assert.equal(view.root, "a");
 	});
 
@@ -74,7 +74,7 @@ describe("class-tree tree", () => {
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<undefined | string> = tree.schematize(config);
+		const view = tree.schematize(config);
 		assert.equal(view.root, undefined);
 	});
 
@@ -84,7 +84,7 @@ describe("class-tree tree", () => {
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<undefined | string> = tree.schematize(config);
+		const view = tree.schematize(config);
 		assert.equal(view.root, "x");
 	});
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -269,7 +269,7 @@ export class IterableTreeArrayContent<T> implements Iterable<T> {
 
 // @public
 export interface ITree extends IChannel {
-    schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TreeFieldFromImplicitField<TRoot>>;
+    schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TRoot>;
 }
 
 // @public @sealed
@@ -382,7 +382,7 @@ export const Tree: TreeApi;
 // @public
 export interface TreeApi extends TreeNodeApi {
     runTransaction<TNode extends TreeNode>(node: TNode, transaction: (node: TNode) => void | "rollback"): void;
-    runTransaction<TRoot>(tree: TreeView<TRoot>, transaction: (root: TRoot) => void | "rollback"): void;
+    runTransaction<TView extends TreeView<ImplicitFieldSchema>>(tree: TView, transaction: (root: TView["root"]) => void | "rollback"): void;
 }
 
 // @public
@@ -496,10 +496,11 @@ export enum TreeStatus {
 }
 
 // @public
-export interface TreeView<in out TRoot> extends IDisposable {
+export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable {
     readonly error?: SchemaIncompatible;
     readonly events: ISubscribable<TreeViewEvents>;
-    readonly root: TRoot;
+    get root(): TreeFieldFromImplicitField<TSchema>;
+    set root(newRoot: InsertableTreeFieldFromImplicitField<TSchema>);
     upgradeSchema(): void;
 }
 

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/dataMigration.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/dataMigration.spec.ts
@@ -43,7 +43,7 @@ class InventorySchema extends builder.object("abcInventory", {
 	quantity: builder.number,
 }) {}
 
-function getNewTreeView(tree: ITree): TreeView<InventorySchema> {
+function getNewTreeView(tree: ITree): TreeView<typeof InventorySchema> {
 	return tree.schematize(
 		new TreeConfiguration(InventorySchema, () => ({
 			quantity: 0,

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/migrationShim.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/migrationShim.spec.ts
@@ -43,7 +43,7 @@ const builder = new SchemaFactory("test");
 class RootType extends builder.object("abc", {
 	quantity: builder.number,
 }) {}
-function getNewTreeView(tree: ITree): TreeView<RootType> {
+function getNewTreeView(tree: ITree): TreeView<typeof RootType> {
 	return tree.schematize(
 		new TreeConfiguration(RootType, () => ({
 			quantity: 0,

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/sharedTreeShim.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/sharedTreeShim.spec.ts
@@ -32,7 +32,7 @@ class RootType extends builder.object("abc", {
 	quantity: builder.number,
 }) {}
 
-function getNewTreeView(tree: ITree): TreeView<RootType> {
+function getNewTreeView(tree: ITree): TreeView<typeof RootType> {
 	return tree.schematize(new TreeConfiguration(RootType, () => ({ quantity: 0 })));
 }
 

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/stampedV2Ops.spec.ts
@@ -62,7 +62,7 @@ class QuantityType extends builder.object("quantityObj", {
 	quantity: builder.number,
 }) {}
 
-function getNewTreeView(tree: ITree): TreeView<QuantityType> {
+function getNewTreeView(tree: ITree): TreeView<typeof QuantityType> {
 	return tree.schematize(new TreeConfiguration(QuantityType, () => ({ quantity: 0 })));
 }
 

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandles.spec.ts
@@ -65,7 +65,7 @@ class HandleType extends builder.object("handleObj", {
 	handle: builder.optional(builder.handle),
 }) {}
 
-function getNewTreeView(tree: ITree): TreeView<HandleType> {
+function getNewTreeView(tree: ITree): TreeView<typeof HandleType> {
 	return tree.schematize(
 		new TreeConfiguration(HandleType, () => ({
 			handle: undefined,

--- a/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandlesDetached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/migration-shim/storingHandlesDetached.spec.ts
@@ -37,7 +37,7 @@ describeCompat("Storing handles detached", "NoCompat", (getTestObjectProvider, a
 		handle: builder.optional(builder.handle),
 	}) {}
 
-	function getNewTreeView(tree: ITree): TreeView<HandleType> {
+	function getNewTreeView(tree: ITree): TreeView<typeof HandleType> {
 		return tree.schematize(
 			new TreeConfiguration(HandleType, () => ({
 				handle: undefined,


### PR DESCRIPTION
## Description

Allow root editing and make TreeView parameterized over schema.

## Breaking Changes

TreeView now is parameterized over the field schema instead of the root field type. This was needed to infer the correct input type when reassigning the root.
Code providing an explicit type to TreeView, like `TreeView<Foo>` can usually be updated by replacing that with `TreeView<typeof Foo>`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

