### PR TITLE
fix: Include and use lib/test in test file tarballs 

### DIFF
--- a/experimental/dds/attributable-map/package.json
+++ b/experimental/dds/attributable-map/package.json
@@ -70,7 +70,7 @@
 		"format:prettier": "prettier --write . --cache --ignore-path ../../../.prettierignore",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./map.test-files.tar ./src/test ./dist/test",
+		"postpack": "tar -cf ./map.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
 		"test:memory": "mocha --config ./src/test/memory/.mocharc.cjs",

--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -52,7 +52,7 @@
 		"format:prettier": "prettier --write . --cache --ignore-path ../../../.prettierignore",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./experimental-tree.test-files.tar ./src/test ./dist/test",
+		"postpack": "tar -cf ./experimental-tree.test-files.tar ./src/test ./dist/test ./lib/test",
 		"perf": "cross-env FLUID_TEST_VERBOSE=1 mocha \"dist/**/*.tests.js\" --node-option unhandled-rejections=strict,expose-gc --exit -r node_modules/@fluid-internal/mocha-test-setup --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",
 		"perf:measure": "npm run perf -- --fgrep @Measurement",
 		"test": "npm run test:mocha",

--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -80,7 +80,7 @@
 		"format:prettier": "prettier --write . --cache --ignore-path ../../../.prettierignore",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./map.test-files.tar ./src/test ./dist/test",
+		"postpack": "tar -cf ./map.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
 		"test:memory": "mocha --config ./src/test/memory/.mocharc.cjs",

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -72,7 +72,7 @@
 		"format:prettier": "prettier --write . --cache --ignore-path ../../../.prettierignore",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./matrix.test-files.tar ./src/test ./dist/test",
+		"postpack": "tar -cf ./matrix.test-files.tar ./src/test ./dist/test ./lib/test",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
 		"test:memory": "mocha --config src/test/memory/.mocharc.cjs",

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -79,7 +79,7 @@
 		"format:prettier": "prettier --write . --cache --ignore-path ../../../.prettierignore",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cvf ./merge-tree.test-files.tar ./src/test ./dist/test",
+		"postpack": "tar -cvf ./merge-tree.test-files.tar ./src/test ./dist/test ./lib/test",
 		"perf": "cross-env FLUID_TEST_VERBOSE=1 mocha \"dist/**/*.spec.*js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",
 		"perf:measure": "npm run perf -- --fgrep @Measurement",
 		"perf:profile": "node --inspect-brk ./node_modules/mocha/bin/mocha.js \"dist/**/*.spec.*js\" --node-option unhandled-rejections=strict,expose-gc --exit --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js --timeout 30000",

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -79,7 +79,7 @@
 		"format:prettier": "prettier --write . --cache --ignore-path ../../../.prettierignore",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
-		"postpack": "tar -cf ./azure-client.test-files.tar ./dist/test",
+		"postpack": "tar -cf ./azure-client.test-files.tar ./dist/test ./lib/test",
 		"start:tinylicious:test": "npx @fluidframework/azure-local-service > tinylicious.log 2>&1",
 		"test": "npm run test:realsvc",
 		"test:realsvc": "npm run test:realsvc:tinylicious",

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -278,19 +278,24 @@ jobs:
         - task: Bash@3
           displayName: Unpack test files
           inputs:
-            workingDir: ${{ parameters.testWorkspace }}
+            workingDirectory: ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}
             targetType: 'inline'
             script: |
-              mkdir ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/dist/test
-              mkdir ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/src/test
-              tar -xvf $(Pipeline.Workspace)/test-files/${{ parameters.testFileTarName }}.test-files.tar -C $(Pipeline.Workspace)/test-files
-              mv $(Pipeline.Workspace)/test-files/dist/test/* ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/dist/test
-              mv $(Pipeline.Workspace)/test-files/src/test/* ${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/src/test
+              TAR_PATH=$(Pipeline.Workspace)/test-files/${{ parameters.testFileTarName }}.test-files.tar
+              echo "Unpacking test files for ${{ parameters.testPackage }} from file '$TAR_PATH' in '$(pwd)'"
+              # Note: we could skip the last argument and have it unpack everything at once, but if we later change
+              # the structure/contents of the tests tar file, the extraction could overwrite things we didn't intend to,
+              # so keeping the paths to extract explicit.
+              # Also, extracting is finicky with the exact format of the last argument, it needs to match how the
+              # tarfile was created (e.g. './lib/test' works here but 'lib/test' does not).
+              tar --extract --verbose --file $TAR_PATH ./lib/test
+              tar --extract --verbose --file $TAR_PATH ./dist/test
+              tar --extract --verbose --file $TAR_PATH ./src/test
 
         - task: Bash@3
           displayName: Copy devDependencies
           inputs:
-            workingDir: ${{ parameters.testWorkspace }}
+            workingDirectory: ${{ parameters.testWorkspace }}
             targetType: 'inline'
             script: |
               testPkgJsonPath=${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/package.json

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -118,13 +118,18 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              echo "Unpack test files for ${{ testPackage }}"
-              TAR_FILE=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
-              mkdir -p ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
-              mkdir -p ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
-              tar -xvf $(testFilesPath)/$TAR_FILE.test-files.tar -C $(testFilesPath)
-              mv $(testFilesPath)/dist/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
-              mv $(testFilesPath)/src/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
+              TAR_FILENAME=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
+              TAR_PATH=$(testFilesPath)/$TAR_FILENAME.test-files.tar
+              cd ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
+              echo "Unpacking test files for ${{ testPackage }} from file '$TAR_PATH' in '$(pwd)'"
+              # Note: we could skip the last argument and have it unpack everything at once, but if we later change
+              # the structure/contents of the tests tar file, the extraction could overwrite things we didn't intend to,
+              # so keeping the paths to extract explicit.
+              # Also, extracting is finicky with the exact format of the last argument, it needs to match how the
+              # tarfile was created (e.g. './lib/test' works here but 'lib/test' does not).
+              tar --extract --verbose --file $TAR_PATH ./lib/test
+              tar --extract --verbose --file $TAR_PATH ./dist/test
+              tar --extract --verbose --file $TAR_PATH ./src/test
 
         # Install package dependencies (this gets devDependencies installed so we can then run the package's tests).
         # Note: the required .npmrc file is created by the include-test-perf-benchmarks.yml template above.
@@ -237,13 +242,18 @@ stages:
           inputs:
             targetType: 'inline'
             script: |
-              echo "Unpack test files for ${{ testPackage }}"
-              TAR_FILE=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
-              mkdir -p ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
-              mkdir -p ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
-              tar -xvf $(testFilesPath)/$TAR_FILE.test-files.tar -C $(testFilesPath)
-              mv $(testFilesPath)/src/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/src/test
-              mv $(testFilesPath)/dist/test/* ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}/dist/test
+              TAR_FILENAME=${{ replace(replace(replace(replace(testPackage, '@fluidframework/', '' ), '@fluid-internal/', '' ),'@fluid-', '' ), '/', '-') }}
+              TAR_PATH=$(testFilesPath)/$TAR_FILENAME.test-files.tar
+              cd ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
+              echo "Unpacking test files for ${{ testPackage }} from file '$TAR_PATH' in '$(pwd)'"
+              # Note: we could skip the last argument and have it unpack everything at once, but if we later change
+              # the structure/contents of the tests tar file, the extraction could overwrite things we didn't intend to,
+              # so keeping the paths to extract explicit.
+              # Also, extracting is finicky with the exact format of the last argument, it needs to match how the
+              # tarfile was created (e.g. './lib/test' works here but 'lib/test' does not).
+              tar --extract --verbose --file $TAR_PATH ./lib/test
+              tar --extract --verbose --file $TAR_PATH ./dist/test
+              tar --extract --verbose --file $TAR_PATH ./src/test
 
         # Install package dependencies (this gets devDependencies installed so we can then run the package's tests)
         # and run tests.


### PR DESCRIPTION
## Description

Once we [added lib/test to all .npmignore files](https://github.com/microsoft/FluidFramework/pull/20464), we started seeing failed runs of the Performance Benchmarks pipeline ([example](https://dev.azure.com/fluidframework/internal/_build/results?buildId=252993&view=logs&j=96c48626-beae-58bd-70f1-ce94e154dbad&t=620696d2-075a-525f-76c5-0a9ca31efdb7), msft internal) because it actually didn't process lib/test files from the test-file-tarballs generated by some packages, it was actually getting lucky that lib/test was present in the package and able to execute the tests directly from there.

This PR updates the Performance Benchmarks pipeline and the E2E tests pipeline so they correctly extract the lib/test files from the test-files tarballs (plus a bit of general improvement in that script) and makes sure that all packages that generate test-files tarballs are including lib/test.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
