### PR TITLE
tree: Remove child change generic parameter from sequence changeset

### DIFF
--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -12,7 +12,12 @@ import {
 	TaggedChange,
 } from "../../core/index.js";
 import { IdAllocator, brand, fail } from "../../util/index.js";
-import { CrossFieldManager, CrossFieldTarget } from "../modular-schema/index.js";
+import {
+	CrossFieldManager,
+	CrossFieldTarget,
+	NodeChangeComposer,
+	NodeId,
+} from "../modular-schema/index.js";
 
 import { CellOrderingMethod, sequenceConfig } from "./config.js";
 import { EmptyInputCellMark, MoveMarkEffect } from "./helperTypes.js";
@@ -72,14 +77,6 @@ import {
 } from "./utils.js";
 
 /**
- * @internal
- */
-export type NodeChangeComposer<TNodeChange> = (
-	change1: TNodeChange | undefined,
-	change2: TNodeChange | undefined,
-) => TNodeChange | undefined;
-
-/**
  * Composes a sequence of changesets into a single changeset.
  * @param changes - The changesets to be applied.
  * Parts of the input may be reused in the output, but the input is not mutated.
@@ -91,31 +88,31 @@ export type NodeChangeComposer<TNodeChange> = (
  * - Support for moves is not implemented.
  * - Support for slices is not implemented.
  */
-export function compose<TNodeChange>(
-	change1: TaggedChange<Changeset<TNodeChange>>,
-	change2: TaggedChange<Changeset<TNodeChange>>,
-	composeChild: NodeChangeComposer<TNodeChange>,
+export function compose(
+	change1: TaggedChange<Changeset>,
+	change2: TaggedChange<Changeset>,
+	composeChild: NodeChangeComposer,
 	_genId: IdAllocator,
 	manager: CrossFieldManager,
 	revisionMetadata: RevisionMetadataSource,
-): Changeset<TNodeChange> {
+): Changeset {
 	return composeMarkLists(
 		change1,
 		change2,
 		composeChild,
-		manager as MoveEffectTable<TNodeChange>,
+		manager as MoveEffectTable,
 		revisionMetadata,
 	);
 }
 
-function composeMarkLists<TNodeChange>(
-	{ change: baseMarkList, revision: baseRev }: TaggedChange<MarkList<TNodeChange>>,
-	{ change: newMarkList, revision: newRev }: TaggedChange<MarkList<TNodeChange>>,
-	composeChild: NodeChangeComposer<TNodeChange>,
-	moveEffects: MoveEffectTable<TNodeChange>,
+function composeMarkLists(
+	{ change: baseMarkList, revision: baseRev }: TaggedChange<MarkList>,
+	{ change: newMarkList, revision: newRev }: TaggedChange<MarkList>,
+	composeChild: NodeChangeComposer,
+	moveEffects: MoveEffectTable,
 	revisionMetadata: RevisionMetadataSource,
-): MarkList<TNodeChange> {
-	const factory = new MarkListFactory<TNodeChange>();
+): MarkList {
+	const factory = new MarkListFactory();
 	const queue = new ComposeQueue(
 		baseRev,
 		baseMarkList,
@@ -132,7 +129,7 @@ function composeMarkLists<TNodeChange>(
 				0x4db /* Non-empty queue should not return two undefined marks */,
 			);
 			factory.push(
-				composeMark(baseMark, baseRev, moveEffects, (node: TNodeChange) =>
+				composeMark(baseMark, baseRev, moveEffects, (node: NodeId) =>
 					composeChildChanges(node, undefined, composeChild),
 				),
 			);
@@ -142,7 +139,7 @@ function composeMarkLists<TNodeChange>(
 			const settledNewMark = settleMark(newMark, newRev, revisionMetadata);
 			if (baseMark === undefined) {
 				factory.push(
-					composeMark(settledNewMark, newRev, moveEffects, (node: TNodeChange) =>
+					composeMark(settledNewMark, newRev, moveEffects, (node: NodeId) =>
 						composeChildChanges(undefined, node, composeChild),
 					),
 				);
@@ -177,15 +174,15 @@ function composeMarkLists<TNodeChange>(
  * Its input range should be the same as `baseMark`'s output range.
  * @returns A mark that is equivalent to applying both `baseMark` and `newMark` successively.
  */
-function composeMarks<TNodeChange>(
+function composeMarks(
 	baseRev: RevisionTag | undefined,
-	baseMark: Mark<TNodeChange>,
+	baseMark: Mark,
 	newRev: RevisionTag | undefined,
-	newMark: Mark<TNodeChange>,
-	composeChild: NodeChangeComposer<TNodeChange>,
-	moveEffects: MoveEffectTable<TNodeChange>,
+	newMark: Mark,
+	composeChild: NodeChangeComposer,
+	moveEffects: MoveEffectTable,
 	revisionMetadata: RevisionMetadataSource,
-): Mark<TNodeChange> {
+): Mark {
 	const nodeChange = handleNodeChanges(baseMark, baseRev, newMark, composeChild, moveEffects);
 
 	// We apply endpoint updates after handling node changes because moved nodes should be sent to the endpoint in the base changeset,
@@ -206,19 +203,19 @@ function composeMarks<TNodeChange>(
 	);
 }
 
-function composeMarksIgnoreChild<TNodeChange>(
-	baseMark: Mark<TNodeChange>,
-	newMark: Mark<TNodeChange>,
-	moveEffects: MoveEffectTable<TNodeChange>,
+function composeMarksIgnoreChild(
+	baseMark: Mark,
+	newMark: Mark,
+	moveEffects: MoveEffectTable,
 	revisionMetadata: RevisionMetadataSource,
-): Mark<TNodeChange> {
+): Mark {
 	if (isImpactfulCellRename(newMark, undefined, revisionMetadata)) {
 		const newAttachAndDetach = asAttachAndDetach(newMark);
 		const newDetachRevision = newAttachAndDetach.detach.revision;
 		if (markEmptiesCells(baseMark)) {
 			// baseMark is a detach which cancels with the attach portion of the AttachAndDetach,
 			// so we are just left with the detach portion of the AttachAndDetach.
-			const newDetach: CellMark<Detach, TNodeChange> = {
+			const newDetach: CellMark<Detach> = {
 				...newAttachAndDetach.detach,
 				count: baseMark.count,
 			};
@@ -408,12 +405,12 @@ function composeMarksIgnoreChild<TNodeChange>(
 	}
 }
 
-function createNoopMark<TNodeChange>(
+function createNoopMark(
 	length: number,
-	nodeChange: TNodeChange | undefined,
+	nodeChange: NodeId | undefined,
 	cellId?: ChangeAtomId,
-): Mark<TNodeChange> {
-	const mark: CellMark<NoopMark, TNodeChange> = { count: length };
+): Mark {
+	const mark: CellMark<NoopMark> = { count: length };
 	if (nodeChange !== undefined) {
 		assert(length === 1, 0x692 /* A mark with a node change must have length one */);
 		mark.changes = nodeChange;
@@ -424,13 +421,13 @@ function createNoopMark<TNodeChange>(
 	return mark;
 }
 
-function handleNodeChanges<TNodeChange>(
-	baseMark: Mark<TNodeChange>,
+function handleNodeChanges(
+	baseMark: Mark,
 	baseRev: RevisionTag | undefined,
-	newMark: Mark<TNodeChange>,
-	composeChild: NodeChangeComposer<TNodeChange>,
-	moveEffects: MoveEffectTable<TNodeChange>,
-): TNodeChange | undefined {
+	newMark: Mark,
+	composeChild: NodeChangeComposer,
+	moveEffects: MoveEffectTable,
+): NodeId | undefined {
 	if (newMark.changes !== undefined) {
 		const baseSource = getMoveIn(baseMark);
 
@@ -444,11 +441,11 @@ function handleNodeChanges<TNodeChange>(
 	return composeChildChanges(baseMark.changes, newMark.changes, composeChild);
 }
 
-function composeChildChanges<TNodeChange>(
-	baseChange: TNodeChange | undefined,
-	newChange: TNodeChange | undefined,
-	composeChild: NodeChangeComposer<TNodeChange>,
-): TNodeChange | undefined {
+function composeChildChanges(
+	baseChange: NodeId | undefined,
+	newChange: NodeId | undefined,
+	composeChild: NodeChangeComposer,
+): NodeId | undefined {
 	if (baseChange === undefined && newChange === undefined) {
 		return undefined;
 	}
@@ -456,29 +453,29 @@ function composeChildChanges<TNodeChange>(
 	return composeChild(baseChange, newChange);
 }
 
-function composeMark<TNodeChange, TMark extends Mark<TNodeChange>>(
+function composeMark<TMark extends Mark>(
 	mark: TMark,
 	revision: RevisionTag | undefined,
-	moveEffects: MoveEffectTable<TNodeChange>,
-	composeChild: (node: TNodeChange) => TNodeChange | undefined,
+	moveEffects: MoveEffectTable,
+	composeChild: (node: NodeId) => NodeId | undefined,
 ): TMark {
 	const nodeChanges = mark.changes !== undefined ? composeChild(mark.changes) : undefined;
 	const updatedMark = withUpdatedEndpoint(mark, mark.count, revision, moveEffects);
 	return withNodeChange(withRevision(updatedMark, revision), nodeChanges);
 }
 
-export class ComposeQueue<T> {
-	private readonly baseMarks: MarkQueue<T>;
-	private readonly newMarks: MarkQueue<T>;
+export class ComposeQueue {
+	private readonly baseMarks: MarkQueue;
+	private readonly newMarks: MarkQueue;
 	private readonly baseMarksCellSources: ReadonlySet<RevisionTag | undefined>;
 	private readonly newMarksCellSources: ReadonlySet<RevisionTag | undefined>;
 
 	public constructor(
 		baseRevision: RevisionTag | undefined,
-		baseMarks: Changeset<T>,
+		baseMarks: Changeset,
 		private readonly newRevision: RevisionTag | undefined,
-		newMarks: Changeset<T>,
-		private readonly moveEffects: MoveEffectTable<T>,
+		newMarks: Changeset,
+		private readonly moveEffects: MoveEffectTable,
 		private readonly revisionMetadata: RevisionMetadataSource,
 	) {
 		this.baseMarks = new MarkQueue(baseMarks, baseRevision, moveEffects);
@@ -501,7 +498,7 @@ export class ComposeQueue<T> {
 		return this.baseMarks.isEmpty() && this.newMarks.isEmpty();
 	}
 
-	public pop(): ComposeMarks<T> {
+	public pop(): ComposeMarks {
 		const baseMark = this.baseMarks.peek();
 		const newMark = this.newMarks.peek();
 		if (baseMark === undefined && newMark === undefined) {
@@ -582,7 +579,7 @@ export class ComposeQueue<T> {
 		}
 	}
 
-	private dequeueBase(length: number = Infinity): ComposeMarks<T> {
+	private dequeueBase(length: number = Infinity): ComposeMarks {
 		const baseMark = this.baseMarks.dequeueUpTo(length);
 		const movedChanges = getMovedChangesFromMark(
 			this.moveEffects,
@@ -598,7 +595,7 @@ export class ComposeQueue<T> {
 		return { baseMark, newMark };
 	}
 
-	private dequeueNew(length: number = Infinity): ComposeMarks<T> {
+	private dequeueNew(length: number = Infinity): ComposeMarks {
 		const newMark = this.newMarks.dequeueUpTo(length);
 		const baseMark = createNoopMark(
 			newMark.count,
@@ -612,7 +609,7 @@ export class ComposeQueue<T> {
 		};
 	}
 
-	private dequeueBoth(): ComposeMarks<T> {
+	private dequeueBoth(): ComposeMarks {
 		const length = this.peekMinLength();
 		const baseMark = this.baseMarks.dequeueUpTo(length);
 		let newMark = this.newMarks.dequeueUpTo(length);
@@ -624,7 +621,7 @@ export class ComposeQueue<T> {
 
 		if (movedChanges !== undefined) {
 			assert(newMark.changes === undefined, 0x8da /* Unexpected node changeset collision */);
-			newMark = withNodeChange(newMark, movedChanges as T);
+			newMark = withNodeChange(newMark, movedChanges);
 		}
 
 		return {
@@ -645,9 +642,9 @@ export class ComposeQueue<T> {
 	}
 }
 
-interface ComposeMarks<T> {
-	baseMark?: Mark<T>;
-	newMark?: Mark<T>;
+interface ComposeMarks {
+	baseMark?: Mark;
+	newMark?: Mark;
 }
 
 // TODO: Try to share more logic with the version in rebase.ts.
@@ -662,7 +659,7 @@ interface ComposeMarks<T> {
 function compareCellPositions(
 	baseCellId: CellId,
 	baseCellCount: number,
-	newMark: EmptyInputCellMark<unknown>,
+	newMark: EmptyInputCellMark,
 	newIntention: RevisionTag | undefined,
 	metadata: RevisionMetadataSource,
 ): number {
@@ -737,11 +734,11 @@ function compareCellPositions(
 	return (baseRevisionIndex ?? -Infinity) > newRevisionIndex ? -Infinity : Infinity;
 }
 
-function getMovedChangesFromMark<T>(
-	moveEffects: MoveEffectTable<T>,
+function getMovedChangesFromMark(
+	moveEffects: MoveEffectTable,
 	markEffect: MarkEffect,
 	revision: RevisionTag | undefined,
-): T | undefined {
+): NodeId | undefined {
 	if (isAttachAndDetachEffect(markEffect)) {
 		return getMovedChangesFromMark(moveEffects, markEffect.detach, revision);
 	}
@@ -756,11 +753,11 @@ function getMovedChangesFromMark<T>(
 // The call sites to this function are making queries about a mark which has already been split by a `MarkQueue`
 // to match the ranges in `moveEffects`.
 // TODO: Reduce the duplication between this and other MoveEffect helpers
-function getModifyAfter<T>(
-	moveEffects: MoveEffectTable<T>,
+function getModifyAfter(
+	moveEffects: MoveEffectTable,
 	revision: RevisionTag | undefined,
 	id: MoveId,
-): T | undefined {
+): NodeId | undefined {
 	const target = CrossFieldTarget.Source;
 	const effect = getMoveEffect(moveEffects, target, revision, id, 1);
 
@@ -772,21 +769,21 @@ function getModifyAfter<T>(
 }
 
 // TODO: Reduce the duplication between this and other MoveEffect helpers
-function setModifyAfter<T>(
-	moveEffects: MoveEffectTable<T>,
+function setModifyAfter(
+	moveEffects: MoveEffectTable,
 	{ revision, localId: id }: ChangeAtomId,
-	modifyAfter: T,
+	modifyAfter: NodeId,
 ) {
 	const target = CrossFieldTarget.Source;
 	const count = 1;
 	const effect = getMoveEffect(moveEffects, target, revision, id, count, false);
-	const newEffect: MoveEffect<T> =
+	const newEffect: MoveEffect =
 		effect.value !== undefined ? { ...effect.value, modifyAfter } : { modifyAfter };
 	setMoveEffect(moveEffects, target, revision, id, count, newEffect);
 }
 
 function setEndpoint(
-	moveEffects: MoveEffectTable<unknown>,
+	moveEffects: MoveEffectTable,
 	target: CrossFieldTarget,
 	id: ChangeAtomId,
 	count: number,
@@ -812,7 +809,7 @@ function withUpdatedEndpoint<TMark extends MarkEffect>(
 	mark: TMark,
 	count: number,
 	revision: RevisionTag | undefined,
-	effects: MoveEffectTable<unknown>,
+	effects: MoveEffectTable,
 ): TMark {
 	if (isAttachAndDetachEffect(mark)) {
 		return {
@@ -854,7 +851,7 @@ function changeFinalEndpoint(mark: MoveMarkEffect, endpoint: ChangeAtomId) {
 }
 
 function getNewEndpoint(
-	moveEffects: MoveEffectTable<unknown>,
+	moveEffects: MoveEffectTable,
 	target: CrossFieldTarget,
 	revision: RevisionTag | undefined,
 	id: MoveId,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/helperTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/helperTypes.ts
@@ -14,13 +14,13 @@ import {
 	MoveOut,
 } from "./types.js";
 
-export type EmptyInputCellMark<TNodeChange> = Mark<TNodeChange> & DetachedCellMark;
+export type EmptyInputCellMark = Mark & DetachedCellMark;
 
 export interface DetachedCellMark extends HasMarkFields {
 	cellId: CellId;
 }
 
-export type EmptyOutputCellMark<TNodeChange> = CellMark<Detach | AttachAndDetach, TNodeChange>;
+export type EmptyOutputCellMark = CellMark<Detach | AttachAndDetach>;
 
 export type MoveMarkEffect = MoveOut | MoveIn;
 export type DetachOfRemovedNodes = Detach & { cellId: CellId };

--- a/packages/dds/tree/src/feature-libraries/sequence-field/index.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/index.ts
@@ -14,7 +14,6 @@ export {
 	MarkList,
 	MoveIn,
 	MoveOut,
-	NodeChangeType,
 	CellCount as NodeCount,
 	MoveId,
 	Attach,
@@ -35,12 +34,12 @@ export {
 } from "./sequenceFieldChangeHandler.js";
 export { SequenceChangeRebaser, sequenceFieldChangeRebaser } from "./sequenceFieldChangeRebaser.js";
 export { sequenceFieldChangeCodecFactory } from "./sequenceFieldCodecs.js";
-export { sequenceFieldToDelta, ToDelta } from "./sequenceFieldToDelta.js";
+export { sequenceFieldToDelta } from "./sequenceFieldToDelta.js";
 export { SequenceFieldEditor, sequenceFieldEditor } from "./sequenceFieldEditor.js";
 export { MarkListFactory } from "./markListFactory.js";
-export { NodeChangeRebaser, rebase } from "./rebase.js";
-export { invert, NodeChangeInverter } from "./invert.js";
-export { compose, NodeChangeComposer } from "./compose.js";
+export { rebase } from "./rebase.js";
+export { invert } from "./invert.js";
+export { compose } from "./compose.js";
 export {
 	getInputLength,
 	isDetach,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -7,7 +7,7 @@ import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 
 import { RevisionMetadataSource, RevisionTag, TaggedChange } from "../../core/index.js";
 import { IdAllocator, Mutable, fail } from "../../util/index.js";
-import { CrossFieldManager, CrossFieldTarget } from "../modular-schema/index.js";
+import { CrossFieldManager, CrossFieldTarget, NodeId } from "../modular-schema/index.js";
 
 import { DetachIdOverrideType } from "./format.js";
 import { MarkListFactory } from "./markListFactory.js";
@@ -39,8 +39,6 @@ import {
 	withNodeChange,
 } from "./utils.js";
 
-export type NodeChangeInverter<TNodeChange> = (change: TNodeChange) => TNodeChange;
-
 /**
  * Inverts a given changeset.
  * @param change - The changeset to produce the inverse of.
@@ -49,28 +47,28 @@ export type NodeChangeInverter<TNodeChange> = (change: TNodeChange) => TNodeChan
  * WARNING! This implementation is incomplete:
  * - Support for slices is not implemented.
  */
-export function invert<TNodeChange>(
-	change: TaggedChange<Changeset<TNodeChange>>,
+export function invert(
+	change: TaggedChange<Changeset>,
 	isRollback: boolean,
 	genId: IdAllocator,
 	crossFieldManager: CrossFieldManager,
 	revisionMetadata: RevisionMetadataSource,
-): Changeset<TNodeChange> {
+): Changeset {
 	return invertMarkList(
 		change.change,
 		change.revision,
-		crossFieldManager as CrossFieldManager<TNodeChange>,
+		crossFieldManager as CrossFieldManager<NodeId>,
 		revisionMetadata,
 	);
 }
 
-function invertMarkList<TNodeChange>(
-	markList: MarkList<TNodeChange>,
+function invertMarkList(
+	markList: MarkList,
 	revision: RevisionTag | undefined,
-	crossFieldManager: CrossFieldManager<TNodeChange>,
+	crossFieldManager: CrossFieldManager<NodeId>,
 	revisionMetadata: RevisionMetadataSource,
-): MarkList<TNodeChange> {
-	const inverseMarkList = new MarkListFactory<TNodeChange>();
+): MarkList {
+	const inverseMarkList = new MarkListFactory();
 
 	for (const mark of markList) {
 		const inverseMarks = invertMark(mark, revision, crossFieldManager, revisionMetadata);
@@ -80,12 +78,12 @@ function invertMarkList<TNodeChange>(
 	return inverseMarkList.list;
 }
 
-function invertMark<TNodeChange>(
-	mark: Mark<TNodeChange>,
+function invertMark(
+	mark: Mark,
 	revision: RevisionTag | undefined,
-	crossFieldManager: CrossFieldManager<TNodeChange>,
+	crossFieldManager: CrossFieldManager<NodeId>,
 	revisionMetadata: RevisionMetadataSource,
-): Mark<TNodeChange>[] {
+): Mark[] {
 	if (!isImpactful(mark, revision, revisionMetadata)) {
 		const inputId = getInputCellId(mark, revision, revisionMetadata);
 		return [invertNodeChangeOrSkip(mark.count, mark.changes, inputId)];
@@ -99,7 +97,7 @@ function invertMark<TNodeChange>(
 			assert(revision !== undefined, 0x5a1 /* Unable to revert to undefined revision */);
 			const outputId = getOutputCellId(mark, revision, revisionMetadata);
 			const inputId = getInputCellId(mark, revision, revisionMetadata);
-			const inverse: Mark<TNodeChange> =
+			const inverse: Mark =
 				inputId === undefined
 					? {
 							type: "Insert",
@@ -122,7 +120,7 @@ function invertMark<TNodeChange>(
 		case "Insert": {
 			const inputId = getInputCellId(mark, revision, revisionMetadata);
 			assert(inputId !== undefined, 0x80c /* Active inserts should target empty cells */);
-			const removeMark: Mutable<CellMark<Remove, TNodeChange>> = {
+			const removeMark: Mutable<CellMark<Remove>> = {
 				type: "Remove",
 				count: mark.count,
 				id: inputId.localId,
@@ -194,7 +192,7 @@ function invertMark<TNodeChange>(
 		case "MoveIn": {
 			const inputId = getInputCellId(mark, revision, revisionMetadata);
 			assert(inputId !== undefined, 0x89e /* Active move-ins should target empty cells */);
-			const invertedMark: Mutable<CellMark<MoveOut, TNodeChange>> = {
+			const invertedMark: Mutable<CellMark<MoveOut>> = {
 				type: "MoveOut",
 				id: mark.id,
 				count: mark.count,
@@ -215,7 +213,7 @@ function invertMark<TNodeChange>(
 		}
 		case "AttachAndDetach": {
 			// Which should get the child change? Don't want to invert twice
-			const attach: Mark<TNodeChange> = {
+			const attach: Mark = {
 				count: mark.count,
 				cellId: mark.cellId,
 				...mark.attach,
@@ -224,7 +222,7 @@ function invertMark<TNodeChange>(
 
 			// We put `mark.changes` on the detach so that if it is a move source
 			// the changes can be sent to the endpoint.
-			const detach: Mark<TNodeChange> = {
+			const detach: Mark = {
 				count: mark.count,
 				cellId: idAfterAttach,
 				changes: mark.changes,
@@ -255,9 +253,9 @@ function invertMark<TNodeChange>(
 			let detachInverse = detachInverses[0];
 			assert(isAttach(detachInverse), 0x80e /* Inverse of a detach should be an attach */);
 
-			const inverses: Mark<TNodeChange>[] = [];
+			const inverses: Mark[] = [];
 			for (const attachInverse of attachInverses) {
-				let detachInverseCurr: Mark<TNodeChange> = detachInverse;
+				let detachInverseCurr: Mark = detachInverse;
 				if (attachInverse.count !== detachInverse.count) {
 					[detachInverseCurr, detachInverse] = splitMark(
 						detachInverse,
@@ -281,7 +279,7 @@ function invertMark<TNodeChange>(
 					0x810 /* Inverse of an attach should be a detach */,
 				);
 
-				const inverted: Mark<TNodeChange> = {
+				const inverted: Mark = {
 					type: "AttachAndDetach",
 					count: attachInverse.count,
 					attach: extractMarkEffect(detachInverseCurr),
@@ -311,11 +309,11 @@ function invertMark<TNodeChange>(
 	}
 }
 
-function applyMovedChanges<TNodeChange>(
-	mark: CellMark<MoveOut, TNodeChange>,
+function applyMovedChanges(
+	mark: CellMark<MoveOut>,
 	revision: RevisionTag | undefined,
-	manager: CrossFieldManager<TNodeChange>,
-): Mark<TNodeChange>[] {
+	manager: CrossFieldManager<NodeId>,
+): Mark[] {
 	// Although this is a source mark, we query the destination because this was a destination mark during the original invert pass.
 	const entry = manager.get(
 		CrossFieldTarget.Destination,
@@ -329,32 +327,23 @@ function applyMovedChanges<TNodeChange>(
 		const [mark1, mark2] = splitMark(mark, entry.length);
 		const mark1WithChanges =
 			entry.value !== undefined
-				? withNodeChange<CellMark<MoveOut, TNodeChange>, MoveOut, TNodeChange>(
-						mark1,
-						entry.value,
-				  )
+				? withNodeChange<CellMark<MoveOut>, MoveOut>(mark1, entry.value)
 				: mark1;
 
 		return [mark1WithChanges, ...applyMovedChanges(mark2, revision, manager)];
 	}
 
 	if (entry.value !== undefined) {
-		return [
-			withNodeChange<CellMark<MoveOut, TNodeChange>, MoveOut, TNodeChange>(mark, entry.value),
-		];
+		return [withNodeChange<CellMark<MoveOut>, MoveOut>(mark, entry.value)];
 	}
 
 	return [mark];
 }
 
-function invertNodeChangeOrSkip<TNodeChange>(
-	count: number,
-	changes: TNodeChange | undefined,
-	cellId?: CellId,
-): Mark<TNodeChange> {
+function invertNodeChangeOrSkip(count: number, changes: NodeId | undefined, cellId?: CellId): Mark {
 	if (changes !== undefined) {
 		assert(count === 1, 0x66c /* A modify mark must have length equal to one */);
-		const noop: CellMark<NoopMark, TNodeChange> = {
+		const noop: CellMark<NoopMark> = {
 			count,
 			changes,
 		};

--- a/packages/dds/tree/src/feature-libraries/sequence-field/markListFactory.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/markListFactory.ts
@@ -14,13 +14,13 @@ import { isNoopMark, isTombstone, tryMergeMarks as tryMergeMarks } from "./utils
  * - Merges runs of offsets together
  * - Merges marks together
  */
-export class MarkListFactory<TNodeChange> {
+export class MarkListFactory {
 	private offset = 0;
-	public readonly list: MarkList<TNodeChange> = [];
+	public readonly list: MarkList = [];
 
 	public constructor() {}
 
-	public push(...marks: Mark<TNodeChange>[]): void {
+	public push(...marks: Mark[]): void {
 		for (const item of marks) {
 			this.pushContent(item);
 		}
@@ -30,7 +30,7 @@ export class MarkListFactory<TNodeChange> {
 		this.offset += offset;
 	}
 
-	public pushContent(mark: Mark<TNodeChange>): void {
+	public pushContent(mark: Mark): void {
 		if (isTombstone(mark) && sequenceConfig.cellOrdering !== "Tombstone") {
 			return;
 		}

--- a/packages/dds/tree/src/feature-libraries/sequence-field/markQueue.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/markQueue.ts
@@ -11,14 +11,14 @@ import { MoveEffectTable, splitMarkForMoveEffects } from "./moveEffectTable.js";
 import { Mark } from "./types.js";
 import { splitMark } from "./utils.js";
 
-export class MarkQueue<T> {
-	private readonly stack: Mark<T>[] = [];
+export class MarkQueue {
+	private readonly stack: Mark[] = [];
 	private index = 0;
 
 	public constructor(
-		private readonly list: readonly Mark<T>[],
+		private readonly list: readonly Mark[],
 		public readonly revision: RevisionTag | undefined,
-		private readonly moveEffects: MoveEffectTable<T>,
+		private readonly moveEffects: MoveEffectTable,
 	) {
 		this.list = list;
 	}
@@ -27,13 +27,13 @@ export class MarkQueue<T> {
 		return this.peek() === undefined;
 	}
 
-	public dequeue(): Mark<T> {
+	public dequeue(): Mark {
 		const output = this.tryDequeue();
 		assert(output !== undefined, 0x4e2 /* Unexpected end of mark queue */);
 		return output;
 	}
 
-	public tryDequeue(): Mark<T> | undefined {
+	public tryDequeue(): Mark | undefined {
 		const mark = this.stack.length > 0 ? this.stack.pop() : this.list[this.index++];
 		if (mark === undefined) {
 			return undefined;
@@ -51,7 +51,7 @@ export class MarkQueue<T> {
 	 * or the entire next mark if `length` is longer than the mark's length.
 	 * @param length - The length to dequeue, measured in the input context.
 	 */
-	public dequeueUpTo(length: number): Mark<T> {
+	public dequeueUpTo(length: number): Mark {
 		const mark = this.dequeue();
 		if (mark.count <= length) {
 			return mark;
@@ -62,7 +62,7 @@ export class MarkQueue<T> {
 		return mark1;
 	}
 
-	public peek(): Mark<T> | undefined {
+	public peek(): Mark | undefined {
 		const mark = this.tryDequeue();
 		if (mark !== undefined) {
 			this.stack.push(mark);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/moveEffectTable.ts
@@ -7,23 +7,23 @@ import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 
 import { ChangeAtomId, RevisionTag, TaggedChange } from "../../core/index.js";
 import { RangeQueryResult, brand } from "../../util/index.js";
-import { CrossFieldManager, CrossFieldTarget } from "../modular-schema/index.js";
+import { CrossFieldManager, CrossFieldTarget, NodeId } from "../modular-schema/index.js";
 
 import { MoveMarkEffect } from "./helperTypes.js";
 import { CellMark, Mark, MarkEffect, MoveId, MoveIn, MoveOut } from "./types.js";
 import { isAttachAndDetachEffect, splitMark, splitMarkEffect } from "./utils.js";
 
-export type MoveEffectTable<T> = CrossFieldManager<MoveEffect<T>>;
+export type MoveEffectTable = CrossFieldManager<MoveEffect>;
 
 /**
  * Changes to be applied to a move mark.
  */
-export interface MoveEffect<T> {
+export interface MoveEffect {
 	/**
 	 * Node changes which should be applied to this mark.
 	 * If this mark already has node changes, `modifyAfter` should be composed as later changes.
 	 */
-	modifyAfter?: T;
+	modifyAfter?: NodeId;
 
 	/**
 	 * Only used during rebasing.
@@ -34,7 +34,7 @@ export interface MoveEffect<T> {
 	/**
 	 * Rebased changes for a node which has been moved to the position of this mark.
 	 */
-	rebasedChanges?: T;
+	rebasedChanges?: NodeId;
 
 	/**
 	 * The ID of the new endpoint associated with this mark.
@@ -42,7 +42,7 @@ export interface MoveEffect<T> {
 	endpoint?: ChangeAtomId;
 }
 
-interface MoveEffectWithBasis<T> extends MoveEffect<T> {
+interface MoveEffectWithBasis extends MoveEffect {
 	/**
 	 * The ID for the start of the range this MoveEffect was created for.
 	 * This is used, for example, to correctly interpret `MoveEffect.endpoint` field.
@@ -55,43 +55,43 @@ export enum MoveEnd {
 	Dest,
 }
 
-export interface MovePartition<TNodeChange> {
+export interface MovePartition {
 	id: MoveId;
 
 	// Undefined means the partition is the same size as the input.
 	count?: number;
-	replaceWith?: Mark<TNodeChange>[];
-	modifyAfter?: TaggedChange<TNodeChange>;
+	replaceWith?: Mark[];
+	modifyAfter?: TaggedChange<NodeId>;
 }
 
-export function setMoveEffect<T>(
-	moveEffects: MoveEffectTable<T>,
+export function setMoveEffect(
+	moveEffects: MoveEffectTable,
 	target: CrossFieldTarget,
 	revision: RevisionTag | undefined,
 	id: MoveId,
 	count: number,
-	effect: MoveEffect<T>,
+	effect: MoveEffect,
 	invalidate: boolean = true,
 ) {
-	(effect as MoveEffectWithBasis<T>).basis = id;
+	(effect as MoveEffectWithBasis).basis = id;
 	moveEffects.set(target, revision, id, count, effect, invalidate);
 }
 
-export function getMoveEffect<T>(
-	moveEffects: MoveEffectTable<T>,
+export function getMoveEffect(
+	moveEffects: MoveEffectTable,
 	target: CrossFieldTarget,
 	revision: RevisionTag | undefined,
 	id: MoveId,
 	count: number,
 	addDependency: boolean = true,
-): RangeQueryResult<MoveEffect<T>> {
+): RangeQueryResult<MoveEffect> {
 	const result = moveEffects.get(target, revision, id, count, addDependency);
 	return result.value !== undefined
-		? { ...result, value: adjustMoveEffectBasis(result.value as MoveEffectWithBasis<T>, id) }
+		? { ...result, value: adjustMoveEffectBasis(result.value as MoveEffectWithBasis, id) }
 		: result;
 }
 
-export type MoveMark<T> = CellMark<MoveMarkEffect, T>;
+export type MoveMark = CellMark<MoveMarkEffect>;
 
 export function isMoveMark(effect: MarkEffect): effect is MoveMarkEffect {
 	return isMoveOut(effect) || isMoveIn(effect);
@@ -116,7 +116,7 @@ export function getMoveIn(effect: MarkEffect): MoveIn | undefined {
 	}
 }
 
-function adjustMoveEffectBasis<T>(effect: MoveEffectWithBasis<T>, newBasis: MoveId): MoveEffect<T> {
+function adjustMoveEffectBasis(effect: MoveEffectWithBasis, newBasis: MoveId): MoveEffect {
 	if (effect.basis === newBasis) {
 		return effect;
 	}
@@ -140,11 +140,11 @@ function adjustMoveEffectBasis<T>(effect: MoveEffectWithBasis<T>, newBasis: Move
 	return adjusted;
 }
 
-export function splitMarkForMoveEffects<T>(
-	mark: Mark<T>,
+export function splitMarkForMoveEffects(
+	mark: Mark,
 	revision: RevisionTag | undefined,
-	effects: MoveEffectTable<T>,
-): Mark<T>[] {
+	effects: MoveEffectTable,
+): Mark[] {
 	const length = getFirstMoveEffectLength(mark, mark.count, revision, effects);
 	return length < mark.count ? splitMark(mark, length) : [mark];
 }
@@ -153,7 +153,7 @@ function getFirstMoveEffectLength(
 	markEffect: MarkEffect,
 	count: number,
 	revision: RevisionTag | undefined,
-	effects: MoveEffectTable<unknown>,
+	effects: MoveEffectTable,
 ): number {
 	if (isMoveMark(markEffect)) {
 		return getMoveEffect(

--- a/packages/dds/tree/src/feature-libraries/sequence-field/prune.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/prune.ts
@@ -3,17 +3,13 @@
  * Licensed under the MIT License.
  */
 
+import { NodeChangePruner } from "../modular-schema/index.js";
 import { MarkListFactory } from "./markListFactory.js";
 import { Changeset } from "./types.js";
 import { withNodeChange } from "./utils.js";
 
-export type NodeChangePruner<TNodeChange> = (change: TNodeChange) => TNodeChange | undefined;
-
-export function prune<TNodeChange>(
-	changeset: Changeset<TNodeChange>,
-	pruneNode: NodeChangePruner<TNodeChange>,
-): Changeset<TNodeChange> {
-	const pruned = new MarkListFactory<TNodeChange>();
+export function prune(changeset: Changeset, pruneNode: NodeChangePruner): Changeset {
+	const pruned = new MarkListFactory();
 	for (let mark of changeset) {
 		if (mark.changes !== undefined) {
 			mark = withNodeChange(mark, pruneNode(mark.changes));

--- a/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
@@ -16,7 +16,9 @@ import { IdAllocator, brand, fail, getOrAddEmptyToMap } from "../../util/index.j
 import {
 	CrossFieldManager,
 	CrossFieldTarget,
+	NodeChangeRebaser,
 	NodeExistenceState,
+	NodeId,
 	RebaseRevisionMetadata,
 	getIntention,
 } from "../modular-schema/index.js";
@@ -85,15 +87,15 @@ import {
  * @param base - The changeset to rebase over.
  * @returns A changeset that performs the changes in `change` but does so assuming `base` has been applied first.
  */
-export function rebase<TNodeChange>(
-	change: Changeset<TNodeChange>,
-	base: TaggedChange<Changeset<TNodeChange>>,
-	rebaseChild: NodeChangeRebaser<TNodeChange>,
+export function rebase(
+	change: Changeset,
+	base: TaggedChange<Changeset>,
+	rebaseChild: NodeChangeRebaser,
 	genId: IdAllocator,
 	manager: CrossFieldManager,
 	revisionMetadata: RebaseRevisionMetadata,
 	nodeExistenceState: NodeExistenceState = NodeExistenceState.Alive,
-): Changeset<TNodeChange> {
+): Changeset {
 	return rebaseMarkList(
 		change,
 		base.change,
@@ -101,28 +103,22 @@ export function rebase<TNodeChange>(
 		revisionMetadata,
 		rebaseChild,
 		genId,
-		manager as MoveEffectTable<TNodeChange>,
+		manager as MoveEffectTable,
 		nodeExistenceState,
 	);
 }
 
-export type NodeChangeRebaser<TNodeChange> = (
-	change: TNodeChange | undefined,
-	baseChange: TNodeChange | undefined,
-	stateChange?: NodeExistenceState,
-) => TNodeChange | undefined;
-
-function rebaseMarkList<TNodeChange>(
-	currMarkList: MarkList<TNodeChange>,
-	baseMarkList: MarkList<TNodeChange>,
+function rebaseMarkList(
+	currMarkList: MarkList,
+	baseMarkList: MarkList,
 	baseRevision: RevisionTag | undefined,
 	metadata: RebaseRevisionMetadata,
-	rebaseChild: NodeChangeRebaser<TNodeChange>,
+	rebaseChild: NodeChangeRebaser,
 	genId: IdAllocator,
-	moveEffects: CrossFieldManager<MoveEffect<TNodeChange>>,
+	moveEffects: CrossFieldManager<MoveEffect>,
 	nodeExistenceState: NodeExistenceState,
-): MarkList<TNodeChange> {
-	const rebasedMarks: Mark<TNodeChange>[] = [];
+): MarkList {
+	const rebasedMarks: Mark[] = [];
 	const queue = new RebaseQueue(baseRevision, baseMarkList, currMarkList, metadata, moveEffects);
 
 	// Each mark with empty input cells in `currMarkList` should have a lineage event added for all adjacent detaches in the base changeset.
@@ -215,8 +211,8 @@ function rebaseMarkList<TNodeChange>(
 	return mergeMarkList(rebasedMarks);
 }
 
-function mergeMarkList<T>(marks: Mark<T>[]): Mark<T>[] {
-	const factory = new MarkListFactory<T>();
+function mergeMarkList(marks: Mark[]): Mark[] {
+	const factory = new MarkListFactory();
 	for (const mark of marks) {
 		factory.push(mark);
 	}
@@ -242,28 +238,28 @@ export function isRedetach(effect: MarkEffect): boolean {
  * @param revision - The revision, if available.
  * @returns A NoOp mark that targets the same cells as the input mark.
  */
-function generateNoOpWithCellId<T>(
-	mark: Mark<T>,
+function generateNoOpWithCellId(
+	mark: Mark,
 	revision: RevisionTag | undefined,
 	metadata: RevisionMetadataSource,
-): CellMark<NoopMark, T> {
+): CellMark<NoopMark> {
 	const length = mark.count;
 	const cellId = getInputCellId(mark, revision, metadata);
 	return cellId === undefined ? { count: length } : { count: length, cellId };
 }
 
-class RebaseQueue<T> {
-	private readonly baseMarks: MarkQueue<T>;
-	private readonly newMarks: MarkQueue<T>;
+class RebaseQueue {
+	private readonly baseMarks: MarkQueue;
+	private readonly newMarks: MarkQueue;
 	private readonly baseMarksCellSources: ReadonlySet<RevisionTag | undefined>;
 	private readonly newMarksCellSources: ReadonlySet<RevisionTag | undefined>;
 
 	public constructor(
 		baseRevision: RevisionTag | undefined,
-		baseMarks: Changeset<T>,
-		newMarks: Changeset<T>,
+		baseMarks: Changeset,
+		newMarks: Changeset,
 		private readonly metadata: RevisionMetadataSource,
-		private readonly moveEffects: MoveEffectTable<T>,
+		private readonly moveEffects: MoveEffectTable,
 	) {
 		this.baseMarks = new MarkQueue(baseMarks, baseRevision, moveEffects);
 		this.newMarks = new MarkQueue(newMarks, undefined, moveEffects);
@@ -285,7 +281,7 @@ class RebaseQueue<T> {
 		return this.baseMarks.isEmpty() && this.newMarks.isEmpty();
 	}
 
-	public pop(): RebaseMarks<T> {
+	public pop(): RebaseMarks {
 		const baseMark = this.baseMarks.peek();
 		const newMark = this.newMarks.peek();
 		assert(
@@ -363,11 +359,11 @@ class RebaseQueue<T> {
 		}
 	}
 
-	private dequeueBase(length?: number): RebaseMarks<T> {
+	private dequeueBase(length?: number): RebaseMarks {
 		const baseMark =
 			length !== undefined ? this.baseMarks.dequeueUpTo(length) : this.baseMarks.dequeue();
 
-		let newMark: Mark<T> = generateNoOpWithCellId(
+		let newMark: Mark = generateNoOpWithCellId(
 			baseMark,
 			this.baseMarks.revision,
 			this.metadata,
@@ -389,12 +385,12 @@ class RebaseQueue<T> {
 		};
 	}
 
-	private dequeueNew(): RebaseMarks<T> {
+	private dequeueNew(): RebaseMarks {
 		const newMark = this.newMarks.dequeue();
 		return { newMark, baseMark: generateNoOpWithCellId(newMark, undefined, this.metadata) };
 	}
 
-	private dequeueBoth(): RebaseMarks<T> {
+	private dequeueBoth(): RebaseMarks {
 		const baseMark = this.baseMarks.peek();
 		const newMark = this.newMarks.peek();
 		assert(
@@ -425,9 +421,9 @@ class RebaseQueue<T> {
  * and `effect` is an effect from the same changeset whose target has been moved by the base changeset.
  * @returns a mark which has the composite effect of `mark` and `effect`.
  */
-function addMovedMarkEffect<T>(mark: Mark<T>, effect: MarkEffect): Mark<T> {
+function addMovedMarkEffect(mark: Mark, effect: MarkEffect): Mark {
 	if (isMoveIn(mark) && isMoveOut(effect)) {
-		const result: Mark<T> = {
+		const result: Mark = {
 			...mark,
 			type: "Insert",
 			count: mark.count,
@@ -447,20 +443,20 @@ function addMovedMarkEffect<T>(mark: Mark<T>, effect: MarkEffect): Mark<T> {
  * Represents the marks rebasing should process next.
  * If `baseMark` and `newMark` are both defined, then they are `SizedMark`s covering the same range of nodes.
  */
-interface RebaseMarks<T> {
-	baseMark: Mark<T>;
-	newMark: Mark<T>;
+interface RebaseMarks {
+	baseMark: Mark;
+	newMark: Mark;
 }
 
-function rebaseMark<TNodeChange>(
-	currMark: Mark<TNodeChange>,
-	baseMark: Mark<TNodeChange>,
+function rebaseMark(
+	currMark: Mark,
+	baseMark: Mark,
 	baseRevision: RevisionTag | undefined,
 	metadata: RevisionMetadataSource,
-	rebaseChild: NodeChangeRebaser<TNodeChange>,
-	moveEffects: MoveEffectTable<TNodeChange>,
+	rebaseChild: NodeChangeRebaser,
+	moveEffects: MoveEffectTable,
 	nodeExistenceState: NodeExistenceState,
-): Mark<TNodeChange> {
+): Mark {
 	const rebasedMark = rebaseNodeChange(cloneMark(currMark), baseMark, rebaseChild);
 	const movedNodeChanges = getMovedChangesFromBaseMark(moveEffects, baseMark, baseRevision);
 	if (movedNodeChanges !== undefined) {
@@ -481,15 +477,15 @@ function rebaseMark<TNodeChange>(
 	);
 }
 
-function rebaseMarkIgnoreChild<TNodeChange>(
-	currMark: Mark<TNodeChange>,
-	baseMark: Mark<TNodeChange>,
+function rebaseMarkIgnoreChild(
+	currMark: Mark,
+	baseMark: Mark,
 	baseRevision: RevisionTag | undefined,
 	metadata: RevisionMetadataSource,
-	moveEffects: MoveEffectTable<TNodeChange>,
+	moveEffects: MoveEffectTable,
 	nodeExistenceState: NodeExistenceState,
-): Mark<TNodeChange> {
-	let rebasedMark: Mark<TNodeChange>;
+): Mark {
+	let rebasedMark: Mark;
 	if (isDetach(baseMark)) {
 		if (baseMark.cellId !== undefined) {
 			// Detaches on empty cells have an implicit revive effect.
@@ -599,7 +595,7 @@ function separateEffectsForMove(mark: MarkEffect): { remains?: MarkEffect; follo
 // TODO: Reduce the duplication between this and other MoveEffect helpers
 function sendEffectToDest(
 	markEffect: MarkEffect,
-	moveEffects: MoveEffectTable<unknown>,
+	moveEffects: MoveEffectTable,
 	{ revision, localId: id }: ChangeAtomId,
 	count: number,
 ) {
@@ -632,7 +628,7 @@ function sendEffectToDest(
 			count - effect.length,
 		);
 	} else {
-		const newEffect: MoveEffect<unknown> =
+		const newEffect: MoveEffect =
 			effect.value !== undefined
 				? { ...effect.value, movedEffect: markEffect }
 				: { movedEffect: markEffect };
@@ -640,9 +636,9 @@ function sendEffectToDest(
 	}
 }
 
-function moveRebasedChanges<TNodeChange>(
-	nodeChange: TNodeChange,
-	moveEffects: MoveEffectTable<TNodeChange>,
+function moveRebasedChanges(
+	nodeChange: NodeId,
+	moveEffects: MoveEffectTable,
 	{ revision, localId: id }: ChangeAtomId,
 ) {
 	const effect = getMoveEffect(
@@ -662,11 +658,7 @@ function moveRebasedChanges<TNodeChange>(
 	setMoveEffect(moveEffects, CrossFieldTarget.Destination, revision, id, 1, newEffect);
 }
 
-function rebaseNodeChange<TNodeChange>(
-	currMark: Mark<TNodeChange>,
-	baseMark: Mark<TNodeChange>,
-	nodeRebaser: NodeChangeRebaser<TNodeChange>,
-): Mark<TNodeChange> {
+function rebaseNodeChange(currMark: Mark, baseMark: Mark, nodeRebaser: NodeChangeRebaser): Mark {
 	const baseChange = baseMark.changes;
 	const currChange = currMark.changes;
 
@@ -689,12 +681,12 @@ function rebaseNodeChange<TNodeChange>(
 	return withNodeChange(currMark, nodeRebaser(currChange, baseChange));
 }
 
-function makeDetachedMark<T>(mark: Mark<T>, cellId: ChangeAtomId): Mark<T> {
+function makeDetachedMark(mark: Mark, cellId: ChangeAtomId): Mark {
 	assert(mark.cellId === undefined, 0x69f /* Expected mark to be attached */);
 	return { ...mark, cellId };
 }
 
-function withCellId<TMark extends Mark<unknown>>(mark: TMark, cellId: CellId | undefined): TMark {
+function withCellId<TMark extends Mark>(mark: TMark, cellId: CellId | undefined): TMark {
 	const newMark = { ...mark, cellId };
 	if (cellId === undefined) {
 		delete newMark.cellId;
@@ -703,8 +695,8 @@ function withCellId<TMark extends Mark<unknown>>(mark: TMark, cellId: CellId | u
 }
 
 function getMovedEffectFromBaseMark(
-	moveEffects: MoveEffectTable<unknown>,
-	baseMark: Mark<unknown>,
+	moveEffects: MoveEffectTable,
+	baseMark: Mark,
 	baseRevision: RevisionTag | undefined,
 ): MarkEffect | undefined {
 	if (isMoveIn(baseMark)) {
@@ -731,7 +723,7 @@ function getMovedEffectFromBaseMark(
 // to match the ranges in `moveEffects`.
 // TODO: Reduce the duplication between this and other MoveEffect helpers
 function getMovedEffect(
-	moveEffects: MoveEffectTable<unknown>,
+	moveEffects: MoveEffectTable,
 	revision: RevisionTag | undefined,
 	id: MoveId,
 	count: number,
@@ -741,11 +733,11 @@ function getMovedEffect(
 	return effect.value?.movedEffect;
 }
 
-function getMovedChangesFromBaseMark<T>(
-	moveEffects: MoveEffectTable<T>,
-	baseMark: Mark<T>,
+function getMovedChangesFromBaseMark(
+	moveEffects: MoveEffectTable,
+	baseMark: Mark,
 	baseRevision: RevisionTag | undefined,
-): T | undefined {
+): NodeId | undefined {
 	if (isMoveIn(baseMark)) {
 		return getMovedNodeChanges(moveEffects, baseMark.revision ?? baseRevision, baseMark.id);
 	} else if (isAttachAndDetachEffect(baseMark) && isMoveIn(baseMark.attach)) {
@@ -759,11 +751,11 @@ function getMovedChangesFromBaseMark<T>(
 	}
 }
 
-function getMovedNodeChanges<T>(
-	moveEffects: MoveEffectTable<T>,
+function getMovedNodeChanges(
+	moveEffects: MoveEffectTable,
 	revision: RevisionTag | undefined,
 	id: MoveId,
-): T | undefined {
+): NodeId | undefined {
 	return getMoveEffect(moveEffects, CrossFieldTarget.Destination, revision, id, 1).value
 		?.rebasedChanges;
 }
@@ -818,9 +810,9 @@ function getRevisionIndex(metadata: RevisionMetadataSource, revision: RevisionTa
 function updateLineageState(
 	cellBlocks: CellBlockList,
 	detachBlocks: Map<RevisionTag, IdRange[]>,
-	baseMark: Mark<unknown>,
+	baseMark: Mark,
 	baseRevision: RevisionTag | undefined,
-	rebasedMark: Mark<unknown>,
+	rebasedMark: Mark,
 	metadata: RevisionMetadataSource,
 ) {
 	const attachRevisionIndex = getAttachRevisionIndex(metadata, baseMark, baseRevision);
@@ -846,7 +838,7 @@ function updateLineageState(
 
 function getAttachRevisionIndex(
 	metadata: RevisionMetadataSource,
-	baseMark: Mark<unknown>,
+	baseMark: Mark,
 	baseRevision: RevisionTag | undefined,
 ): number {
 	if (!areInputCellsEmpty(baseMark)) {
@@ -873,7 +865,7 @@ function getAttachRevisionIndex(
 
 function getDetachRevisionIndex(
 	metadata: RevisionMetadataSource,
-	baseMark: Mark<unknown>,
+	baseMark: Mark,
 	baseRevision: RevisionTag | undefined,
 ): number {
 	if (!areOutputCellsEmpty(baseMark)) {
@@ -989,7 +981,7 @@ function addIdRange(lineageEntries: IdRange[], range: IdRange): void {
 	lineageEntries.push(range);
 }
 
-function setMarkAdjacentCells(mark: Mark<unknown>, adjacentCells: IdRange[]): void {
+function setMarkAdjacentCells(mark: Mark, adjacentCells: IdRange[]): void {
 	assert(
 		mark.cellId !== undefined,
 		0x74d /* Can only set adjacent cells on a mark with cell ID */,
@@ -1037,8 +1029,8 @@ function shouldReceiveLineage(
  */
 function compareCellPositions(
 	baseRevision: RevisionTag | undefined,
-	baseMark: EmptyInputCellMark<unknown>,
-	newMark: EmptyInputCellMark<unknown>,
+	baseMark: EmptyInputCellMark,
+	newMark: EmptyInputCellMark,
 	metadata: RevisionMetadataSource,
 ): number {
 	const baseId = getInputCellId(baseMark, baseRevision, metadata);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/relevantRemovedRoots.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/relevantRemovedRoots.ts
@@ -10,14 +10,11 @@ import { nodeIdFromChangeAtom } from "../deltaUtils.js";
 
 import { Changeset, Mark } from "./types.js";
 import { isAttachAndDetachEffect, isDetachOfRemovedNodes, isInsert } from "./utils.js";
+import { RelevantRemovedRootsFromChild } from "../modular-schema/index.js";
 
-export type RelevantRemovedRootsFromTChild<TChild> = (
-	child: TChild,
-) => Iterable<DeltaDetachedNodeId>;
-
-export function* relevantRemovedRoots<TChild>(
-	{ change, revision }: TaggedChange<Changeset<TChild>>,
-	relevantRemovedRootsFromChild: RelevantRemovedRootsFromTChild<TChild>,
+export function* relevantRemovedRoots(
+	{ change, revision }: TaggedChange<Changeset>,
+	relevantRemovedRootsFromChild: RelevantRemovedRootsFromChild,
 ): Iterable<DeltaDetachedNodeId> {
 	for (const mark of change) {
 		if (refersToRelevantRemovedRoots(mark)) {
@@ -36,7 +33,7 @@ export function* relevantRemovedRoots<TChild>(
 	}
 }
 
-function refersToRelevantRemovedRoots<TChild>(mark: Mark<TChild>): boolean {
+function refersToRelevantRemovedRoots(mark: Mark): boolean {
 	if (mark.cellId !== undefined) {
 		const effect = isAttachAndDetachEffect(mark) ? mark.attach : mark;
 		if (isInsert(effect)) {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
@@ -27,22 +27,19 @@ import {
 	Remove,
 } from "./types.js";
 import { isNoopMark } from "./utils.js";
-import { FieldChangeEncodingContext, NodeId } from "../index.js";
+import { FieldChangeEncodingContext } from "../index.js";
 import { EncodedNodeChangeset } from "../modular-schema/index.js";
 
-export const sequenceFieldChangeCodecFactory = <TNodeChange>(
+export const sequenceFieldChangeCodecFactory = (
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
 		ChangeEncodingContext
 	>,
-) =>
-	makeCodecFamily<Changeset<TNodeChange>, FieldChangeEncodingContext>([
-		[0, makeV0Codec(revisionTagCodec)],
-	]);
+) => makeCodecFamily<Changeset, FieldChangeEncodingContext>([[0, makeV0Codec(revisionTagCodec)]]);
 
-function makeV0Codec<TNodeChange>(
+function makeV0Codec(
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
@@ -50,7 +47,7 @@ function makeV0Codec<TNodeChange>(
 		ChangeEncodingContext
 	>,
 ): IJsonCodec<
-	Changeset<TNodeChange>,
+	Changeset,
 	JsonCompatibleReadOnly,
 	JsonCompatibleReadOnly,
 	FieldChangeEncodingContext
@@ -288,7 +285,7 @@ function makeV0Codec<TNodeChange>(
 
 	return {
 		encode: (
-			changeset: Changeset<TNodeChange>,
+			changeset: Changeset,
 			context: FieldChangeEncodingContext,
 		): JsonCompatibleReadOnly & Encoded.Changeset<NodeChangeSchema> => {
 			const jsonMarks: Encoded.Changeset<NodeChangeSchema> = [];
@@ -303,7 +300,7 @@ function makeV0Codec<TNodeChange>(
 					encodedMark.cellId = cellIdCodec.encode(mark.cellId, context.baseContext);
 				}
 				if (mark.changes !== undefined) {
-					encodedMark.changes = context.encodeNode(mark.changes as NodeId);
+					encodedMark.changes = context.encodeNode(mark.changes);
 				}
 				jsonMarks.push(encodedMark);
 			}
@@ -312,10 +309,10 @@ function makeV0Codec<TNodeChange>(
 		decode: (
 			changeset: Encoded.Changeset<NodeChangeSchema>,
 			context: FieldChangeEncodingContext,
-		): Changeset<TNodeChange> => {
-			const marks: Changeset<TNodeChange> = [];
+		): Changeset => {
+			const marks: Changeset = [];
 			for (const mark of changeset) {
-				const decodedMark: Mark<TNodeChange> = {
+				const decodedMark: Mark = {
 					count: mark.count,
 				};
 
@@ -329,7 +326,7 @@ function makeV0Codec<TNodeChange>(
 					decodedMark.cellId = cellIdCodec.decode(mark.cellId, context.baseContext);
 				}
 				if (mark.changes !== undefined) {
-					decodedMark.changes = context.decodeNode(mark.changes) as TNodeChange;
+					decodedMark.changes = context.decodeNode(mark.changes);
 				}
 				marks.push(decodedMark);
 			}

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldEditor.ts
@@ -7,7 +7,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 
 import { ChangesetLocalId } from "../../core/index.js";
 import { brand } from "../../util/index.js";
-import { FieldEditor } from "../modular-schema/index.js";
+import { FieldEditor, NodeId } from "../modular-schema/index.js";
 
 import { MarkListFactory } from "./markListFactory.js";
 import {
@@ -20,14 +20,13 @@ import {
 	MoveId,
 	MoveIn,
 	MoveOut,
-	NodeChangeType,
 } from "./types.js";
 import { splitMark } from "./utils.js";
 
 export interface SequenceFieldEditor extends FieldEditor<Changeset> {
-	insert(index: number, count: number, firstId: ChangesetLocalId): Changeset<never>;
-	remove(index: number, count: number, id: ChangesetLocalId): Changeset<never>;
-	revive(index: number, count: number, detachEvent: CellId, isIntention?: true): Changeset<never>;
+	insert(index: number, count: number, firstId: ChangesetLocalId): Changeset;
+	remove(index: number, count: number, id: ChangesetLocalId): Changeset;
+	revive(index: number, count: number, detachEvent: CellId, isIntention?: true): Changeset;
 
 	/**
 	 *
@@ -35,31 +34,19 @@ export interface SequenceFieldEditor extends FieldEditor<Changeset> {
 	 * @param count - The number of nodes to move
 	 * @param destIndex - The index the nodes should be moved to, interpreted before detaching the moved nodes
 	 */
-	move(
-		sourceIndex: number,
-		count: number,
-		destIndex: number,
-		id: ChangesetLocalId,
-	): Changeset<never>;
+	move(sourceIndex: number, count: number, destIndex: number, id: ChangesetLocalId): Changeset;
 
-	moveOut(sourceIndex: number, count: number, id: ChangesetLocalId): Changeset<never>;
-	moveIn(destIndex: number, count: number, id: ChangesetLocalId): Changeset<never>;
+	moveOut(sourceIndex: number, count: number, id: ChangesetLocalId): Changeset;
+	moveIn(destIndex: number, count: number, id: ChangesetLocalId): Changeset;
 
-	return(
-		sourceIndex: number,
-		count: number,
-		destIndex: number,
-		detachEvent: CellId,
-	): Changeset<never>;
+	return(sourceIndex: number, count: number, destIndex: number, detachEvent: CellId): Changeset;
 }
 
 export const sequenceFieldEditor = {
-	buildChildChange: <TNodeChange = NodeChangeType>(
-		index: number,
-		change: TNodeChange,
-	): Changeset<TNodeChange> => markAtIndex(index, { count: 1, changes: change }),
-	insert: (index: number, count: number, firstId: ChangesetLocalId): Changeset<never> => {
-		const mark: CellMark<Insert, never> = {
+	buildChildChange: (index: number, change: NodeId): Changeset =>
+		markAtIndex(index, { count: 1, changes: change }),
+	insert: (index: number, count: number, firstId: ChangesetLocalId): Changeset => {
+		const mark: CellMark<Insert> = {
 			type: "Insert",
 			id: firstId,
 			count,
@@ -67,12 +54,12 @@ export const sequenceFieldEditor = {
 		};
 		return markAtIndex(index, mark);
 	},
-	remove: (index: number, count: number, id: ChangesetLocalId): Changeset<never> =>
+	remove: (index: number, count: number, id: ChangesetLocalId): Changeset =>
 		count === 0 ? [] : markAtIndex(index, { type: "Remove", count, id }),
 
-	revive: (index: number, count: number, detachEvent: CellId): Changeset<never> => {
+	revive: (index: number, count: number, detachEvent: CellId): Changeset => {
 		assert(detachEvent.revision !== undefined, 0x724 /* Detach event must have a revision */);
-		const mark: CellMark<Insert, never> = {
+		const mark: CellMark<Insert> = {
 			type: "Insert",
 			id: detachEvent.localId,
 			count,
@@ -81,19 +68,14 @@ export const sequenceFieldEditor = {
 		return count === 0 ? [] : markAtIndex(index, mark);
 	},
 
-	move(
-		sourceIndex: number,
-		count: number,
-		destIndex: number,
-		id: ChangesetLocalId,
-	): Changeset<never> {
-		const moveIn: Mark<never> = {
+	move(sourceIndex: number, count: number, destIndex: number, id: ChangesetLocalId): Changeset {
+		const moveIn: Mark = {
 			type: "MoveIn",
 			id,
 			count,
 			cellId: { localId: id },
 		};
-		const moveOut: Mark<never> = {
+		const moveOut: Mark = {
 			type: "MoveOut",
 			id,
 			count,
@@ -101,8 +83,8 @@ export const sequenceFieldEditor = {
 		return moveMarksToMarkList(sourceIndex, count, destIndex, moveOut, moveIn);
 	},
 
-	moveOut(sourceIndex: number, count: number, id: ChangesetLocalId): Changeset<never> {
-		const moveOut: Mark<never> = {
+	moveOut(sourceIndex: number, count: number, id: ChangesetLocalId): Changeset {
+		const moveOut: Mark = {
 			type: "MoveOut",
 			id,
 			count,
@@ -110,8 +92,8 @@ export const sequenceFieldEditor = {
 		return markAtIndex(sourceIndex, moveOut);
 	},
 
-	moveIn(destIndex: number, count: number, id: ChangesetLocalId): Changeset<never> {
-		const moveIn: Mark<never> = {
+	moveIn(destIndex: number, count: number, id: ChangesetLocalId): Changeset {
+		const moveIn: Mark = {
 			type: "MoveIn",
 			id,
 			count,
@@ -120,20 +102,15 @@ export const sequenceFieldEditor = {
 		return markAtIndex(destIndex, moveIn);
 	},
 
-	return(
-		sourceIndex: number,
-		count: number,
-		destIndex: number,
-		detachEvent: CellId,
-	): Changeset<never> {
+	return(sourceIndex: number, count: number, destIndex: number, detachEvent: CellId): Changeset {
 		const id = brand<MoveId>(0);
-		const moveOut: CellMark<MoveOut, never> = {
+		const moveOut: CellMark<MoveOut> = {
 			type: "MoveOut",
 			id,
 			count,
 		};
 
-		const returnTo: CellMark<MoveIn, never> = {
+		const returnTo: CellMark<MoveIn> = {
 			type: "MoveIn",
 			id,
 			count,
@@ -148,14 +125,14 @@ function moveMarksToMarkList(
 	sourceIndex: number,
 	count: number,
 	destIndex: number,
-	detach: CellMark<MoveOut, never>,
-	attach: CellMark<MoveIn, never>,
-): MarkList<never> {
+	detach: CellMark<MoveOut>,
+	attach: CellMark<MoveIn>,
+): MarkList {
 	if (count === 0) {
 		return [];
 	}
 	const firstIndexBeyondMoveOut = sourceIndex + count;
-	const marks = new MarkListFactory<never>();
+	const marks = new MarkListFactory();
 	marks.pushOffset(Math.min(sourceIndex, destIndex));
 	if (destIndex <= sourceIndex) {
 		// The destination is fully before the source
@@ -178,6 +155,6 @@ function moveMarksToMarkList(
 	return marks.list;
 }
 
-function markAtIndex<TNodeChange>(index: number, mark: Mark<TNodeChange>): Changeset<TNodeChange> {
+function markAtIndex(index: number, mark: Mark): Changeset {
 	return index === 0 ? [mark] : [{ count: index }, mark];
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -9,7 +9,6 @@ import {
 	DeltaDetachedNodeChanges,
 	DeltaDetachedNodeRename,
 	DeltaFieldChanges,
-	DeltaFieldMap,
 	DeltaMark,
 	TaggedChange,
 	areEqualChangeAtomIds,
@@ -29,12 +28,11 @@ import {
 	getOutputCellId,
 	isAttachAndDetachEffect,
 } from "./utils.js";
+import { ToDelta } from "../modular-schema/index.js";
 
-export type ToDelta<TNodeChange> = (child: TNodeChange) => DeltaFieldMap;
-
-export function sequenceFieldToDelta<TNodeChange>(
-	{ change, revision }: TaggedChange<MarkList<TNodeChange>>,
-	deltaFromChild: ToDelta<TNodeChange>,
+export function sequenceFieldToDelta(
+	{ change, revision }: TaggedChange<MarkList>,
+	deltaFromChild: ToDelta,
 ): DeltaFieldChanges {
 	const local: DeltaMark[] = [];
 	const global: DeltaDetachedNodeChanges[] = [];

--- a/packages/dds/tree/src/feature-libraries/sequence-field/types.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/types.ts
@@ -25,8 +25,6 @@ export interface HasMoveId {
 	id: MoveId;
 }
 
-export type NodeChangeType = NodeId;
-
 /**
  * Represents a position within a contiguous range of nodes detached by a single changeset.
  * Note that `LineageEvent`s with the same revision are not necessarily referring to the same detach.
@@ -75,7 +73,7 @@ export interface CellId extends ChangeAtomId, HasLineage {
 /**
  * Mark which targets a range of existing cells instead of creating new cells.
  */
-export interface HasMarkFields<TNodeChange = never> {
+export interface HasMarkFields {
 	/**
 	 * Describes the detach which last emptied the target cells,
 	 * or the attach which allocated the cells if the cells have never been filled.
@@ -83,7 +81,7 @@ export interface HasMarkFields<TNodeChange = never> {
 	 */
 	cellId?: CellId;
 
-	changes?: TNodeChange;
+	changes?: NodeId;
 
 	count: CellCount;
 }
@@ -205,10 +203,10 @@ export interface AttachAndDetach {
 
 export type MarkEffect = NoopMark | Attach | Detach | AttachAndDetach;
 
-export type CellMark<TMark, TNodeChange> = TMark & HasMarkFields<TNodeChange>;
+export type CellMark<TMark> = TMark & HasMarkFields;
 
-export type Mark<TNodeChange = NodeChangeType> = CellMark<MarkEffect, TNodeChange>;
+export type Mark = CellMark<MarkEffect>;
 
-export type MarkList<TNodeChange = NodeChangeType> = Mark<TNodeChange>[];
+export type MarkList = Mark[];
 
-export type Changeset<TNodeChange = NodeChangeType> = MarkList<TNodeChange>;
+export type Changeset = MarkList;

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.test.ts
@@ -244,7 +244,11 @@ export function testCompose() {
 		it("remove ○ modify", () =>
 			withConfig(() => {
 				const deletion = Change.remove(0, 3);
-				const childChange = TestChange.mint([0, 1], 2);
+				const childChange = TestNodeId.create(
+					{ localId: brand(1) },
+					TestChange.mint([0, 1], 2),
+				);
+
 				const modify = Change.modify(0, childChange);
 				const expected = [Mark.remove(3, brand(0)), Mark.modify(childChange)];
 				const actual = shallowCompose([makeAnonChange(deletion), makeAnonChange(modify)]);
@@ -450,7 +454,11 @@ export function testCompose() {
 
 		it("modify ○ remove", () =>
 			withConfig(() => {
-				const changes = TestChange.mint([0, 1], 2);
+				const changes = TestNodeId.create(
+					{ localId: brand(1) },
+					TestChange.mint([0, 1], 2),
+				);
+
 				const modify = Change.modify(0, changes);
 				const deletion = Change.remove(0, 1);
 				const actual = shallowCompose([makeAnonChange(modify), makeAnonChange(deletion)]);
@@ -530,7 +538,11 @@ export function testCompose() {
 
 		it("modify ○ insert", () =>
 			withConfig(() => {
-				const childChange = TestChange.mint([0, 1], 2);
+				const childChange = TestNodeId.create(
+					{ localId: brand(3) },
+					TestChange.mint([0, 1], 2),
+				);
+
 				const modify = Change.modify(0, childChange);
 				const insert = Change.insert(0, 1, brand(2));
 				const expected = [Mark.insert(1, brand(2)), Mark.modify(childChange)];
@@ -594,7 +606,11 @@ export function testCompose() {
 
 		it("modify ○ revive", () =>
 			withConfig(() => {
-				const childChange = TestChange.mint([0, 1], 2);
+				const childChange = TestNodeId.create(
+					{ localId: brand(1) },
+					TestChange.mint([0, 1], 2),
+				);
+
 				const modify = Change.modify(0, childChange);
 				const revive = Change.revive(0, 2, { revision: tag1, localId: brand(0) });
 				const expected = [
@@ -782,7 +798,7 @@ export function testCompose() {
 		it("move ○ modify", () =>
 			withConfig(() => {
 				const move = Change.move(0, 1, 2);
-				const changes = TestChange.mint([], 42);
+				const changes = TestNodeId.create({ localId: brand(1) }, TestChange.mint([], 42));
 				const modify = Change.modify(1, changes);
 				const expected = [
 					Mark.moveOut(1, brand(0), { changes }),
@@ -796,7 +812,7 @@ export function testCompose() {
 		it("move ○ modify and return", () =>
 			withConfig(() => {
 				const move = [Mark.moveIn(1, brand(0)), { count: 1 }, Mark.moveOut(1, brand(0))];
-				const changes = TestChange.mint([], 42);
+				const changes = TestNodeId.create({ localId: brand(1) }, TestChange.mint([], 42));
 				const moveBack = [
 					Mark.moveOut(1, brand(0), { changes }),
 					{ count: 1 },
@@ -845,7 +861,7 @@ export function testCompose() {
 
 		it("modify ○ return", () =>
 			withConfig(() => {
-				const changes = TestChange.mint([], 42);
+				const changes = TestNodeId.create({ localId: brand(2) }, TestChange.mint([], 42));
 				const modify = tagChange(Change.modify(3, changes), tag3);
 				const ret = tagChange(
 					Change.return(3, 2, 0, { revision: tag1, localId: brand(0) }),
@@ -1015,8 +1031,8 @@ export function testCompose() {
 				// Revision 2 removes B
 				// Revision 3 modifies A
 				// Revision 4 modifies B
-				const nodeChange1 = "Change1";
-				const nodeChange2 = "Change2";
+				const nodeChange1: NodeId = { localId: brand(1) };
+				const nodeChange2: NodeId = { localId: brand(2) };
 				const lineage: SF.LineageEvent[] = [
 					{ revision: tag2, id: brand(0), count: 1, offset: 0 },
 				];
@@ -1042,8 +1058,8 @@ export function testCompose() {
 				// Revision 2 removes A
 				// Revision 3 modifies B
 				// Revision 4 modifies A
-				const nodeChange1 = "Change1";
-				const nodeChange2 = "Change2";
+				const nodeChange1: NodeId = { localId: brand(2) };
+				const nodeChange2: NodeId = { localId: brand(3) };
 				const lineage: SF.LineageEvent[] = [
 					{ revision: tag2, id: brand(0), count: 1, offset: 1 },
 				];
@@ -1069,8 +1085,8 @@ export function testCompose() {
 				// Revision 2 removes B
 				// Revision 3 modifies B
 				// Revision 4 modifies A
-				const nodeChange1 = "Change1";
-				const nodeChange2 = "Change2";
+				const nodeChange1: NodeId = { localId: brand(2) };
+				const nodeChange2: NodeId = { localId: brand(3) };
 				const lineage: SF.LineageEvent[] = [
 					{ revision: tag2, id: brand(0), count: 1, offset: 0 },
 				];
@@ -1096,8 +1112,8 @@ export function testCompose() {
 				// Revision 2 removes A
 				// Revision 3 modifies A
 				// Revision 4 modifies B
-				const nodeChange1 = "Change1";
-				const nodeChange2 = "Change2";
+				const nodeChange1: NodeId = { localId: brand(2) };
+				const nodeChange2: NodeId = { localId: brand(3) };
 
 				const lineage: SF.LineageEvent[] = [
 					{ revision: tag2, id: brand(0), count: 1, offset: 1 },
@@ -1401,7 +1417,7 @@ export function testCompose() {
 
 		it("move-in+remove ○ modify", () =>
 			withConfig(() => {
-				const changes = TestChange.mint([], 42);
+				const changes = TestNodeId.create({ localId: brand(5) }, TestChange.mint([], 42));
 				const [mo, mi] = Mark.move(1, { revision: tag1, localId: brand(1) });
 				const attachDetach = Mark.attachAndDetach(
 					mi,
@@ -1441,6 +1457,10 @@ export function testCompose() {
 			const tombB = Mark.tomb(tag1, brand(2));
 			const tombC = Mark.tomb(tag1, brand(3));
 
+			const nodeIdA: NodeId = { localId: brand(4) };
+			const nodeIdB: NodeId = { localId: brand(5) };
+			const nodeIdC: NodeId = { localId: brand(6) };
+
 			describe("cells named in the same earlier revision", () => {
 				it("A ○ A", () =>
 					withConfig(() => {
@@ -1476,12 +1496,12 @@ export function testCompose() {
 				it("A ○ B", () =>
 					withConfig(() => {
 						const adjacentCells: SF.IdRange[] = [{ id: brand(1), count: 2 }];
-						const markA = Mark.modify("A", {
+						const markA = Mark.modify(nodeIdA, {
 							revision: tag1,
 							localId: brand(1),
 							adjacentCells,
 						});
-						const markB = Mark.modify("B", {
+						const markB = Mark.modify(nodeIdB, {
 							revision: tag1,
 							localId: brand(2),
 							adjacentCells,
@@ -1498,12 +1518,12 @@ export function testCompose() {
 				it("B ○ A", () =>
 					withConfig(() => {
 						const adjacentCells: SF.IdRange[] = [{ id: brand(1), count: 2 }];
-						const markA = Mark.modify("A", {
+						const markA = Mark.modify(nodeIdA, {
 							revision: tag1,
 							localId: brand(1),
 							adjacentCells,
 						});
-						const markB = Mark.modify("B", {
+						const markB = Mark.modify(nodeIdB, {
 							revision: tag1,
 							localId: brand(2),
 							adjacentCells,
@@ -1521,12 +1541,12 @@ export function testCompose() {
 			describe("cells named in different earlier revisions", () => {
 				it("older A ○ newer B", () =>
 					withConfig(() => {
-						const markA = Mark.modify("A", {
+						const markA = Mark.modify(nodeIdA, {
 							revision: tag1,
 							localId: brand(1),
 							lineage: [{ revision: tag2, id: brand(2), count: 1, offset: 0 }],
 						});
-						const markB = Mark.modify("B", {
+						const markB = Mark.modify(nodeIdB, {
 							revision: tag2,
 							localId: brand(2),
 						});
@@ -1541,11 +1561,11 @@ export function testCompose() {
 
 				it("newer A ○ older B", () =>
 					withConfig(() => {
-						const markA = Mark.modify("A", {
+						const markA = Mark.modify(nodeIdA, {
 							revision: tag2,
 							localId: brand(1),
 						});
-						const markB = Mark.modify("B", {
+						const markB = Mark.modify(nodeIdB, {
 							revision: tag1,
 							localId: brand(2),
 							lineage: [{ revision: tag2, id: brand(1), count: 1, offset: 1 }],
@@ -1561,12 +1581,12 @@ export function testCompose() {
 
 				it("older B ○ newer A", () =>
 					withConfig(() => {
-						const markB = Mark.modify("B", {
+						const markB = Mark.modify(nodeIdB, {
 							revision: tag1,
 							localId: brand(2),
 							lineage: [{ revision: tag2, id: brand(1), count: 1, offset: 1 }],
 						});
-						const markA = Mark.modify("A", {
+						const markA = Mark.modify(nodeIdA, {
 							revision: tag2,
 							localId: brand(1),
 						});
@@ -1581,11 +1601,11 @@ export function testCompose() {
 
 				it("newer B ○ older A", () =>
 					withConfig(() => {
-						const markB = Mark.modify("B", {
+						const markB = Mark.modify(nodeIdB, {
 							revision: tag2,
 							localId: brand(2),
 						});
-						const markA = Mark.modify("A", {
+						const markA = Mark.modify(nodeIdA, {
 							revision: tag1,
 							localId: brand(1),
 							lineage: [{ revision: tag2, id: brand(2), count: 1, offset: 0 }],
@@ -1605,17 +1625,17 @@ export function testCompose() {
 					withConfig(() => {
 						const changeX = tagChange(
 							[
-								Mark.modify("A", { revision: tag1, localId: brand(1) }),
+								Mark.modify(nodeIdA, { revision: tag1, localId: brand(1) }),
 								Mark.remove(
 									1,
 									{ revision: tag2, localId: brand(2) },
 									{ cellId: { revision: tag1, localId: brand(2) } },
 								),
-								Mark.modify("C", { revision: tag1, localId: brand(3) }),
+								Mark.modify(nodeIdC, { revision: tag1, localId: brand(3) }),
 							],
 							tag2,
 						);
-						const markB = Mark.modify("B", {
+						const markB = Mark.modify(nodeIdB, {
 							revision: tag2,
 							localId: brand(2),
 							adjacentCells: [{ id: brand(2), count: 1 }],
@@ -1625,13 +1645,13 @@ export function testCompose() {
 						const composedXY = shallowCompose([changeX, changeY]);
 
 						const expected = [
-							Mark.modify("A", { revision: tag1, localId: brand(1) }),
+							Mark.modify(nodeIdA, { revision: tag1, localId: brand(1) }),
 							Mark.remove(
 								1,
 								{ revision: tag2, localId: brand(2) },
-								{ cellId: { revision: tag1, localId: brand(2) }, changes: "B" },
+								{ cellId: { revision: tag1, localId: brand(2) }, changes: nodeIdB },
 							),
-							Mark.modify("C", { revision: tag1, localId: brand(3) }),
+							Mark.modify(nodeIdC, { revision: tag1, localId: brand(3) }),
 						];
 						assertChangesetsEqual(composedXY, expected);
 					}));
@@ -1748,7 +1768,7 @@ export function testCompose() {
 
 				it("C ○ A - with lineage for B on C", () =>
 					withConfig(() => {
-						const cellA = Mark.modify("A", { revision: tag2, localId: brand(1) });
+						const cellA = Mark.modify(nodeIdA, { revision: tag2, localId: brand(1) });
 						const cellC = Mark.insert(1, {
 							revision: tag3,
 							localId: brand(3),
@@ -1771,7 +1791,7 @@ export function testCompose() {
 				it("ABC ○ B", () =>
 					withConfig(() => {
 						const markABC = Mark.remove(3, { revision: tag1, localId: brand(1) });
-						const markB = Mark.modify("B", {
+						const markB = Mark.modify(nodeIdB, {
 							revision: tag1,
 							localId: brand(2),
 							adjacentCells: [{ id: brand(1), count: 3 }],
@@ -1783,7 +1803,11 @@ export function testCompose() {
 
 						const expected = [
 							Mark.remove(1, { revision: tag1, localId: brand(1) }),
-							Mark.remove(1, { revision: tag1, localId: brand(2) }, { changes: "B" }),
+							Mark.remove(
+								1,
+								{ revision: tag1, localId: brand(2) },
+								{ changes: nodeIdB },
+							),
 							Mark.remove(1, { revision: tag1, localId: brand(3) }),
 						];
 						assertChangesetsEqual(composedXY, expected);
@@ -1794,7 +1818,7 @@ export function testCompose() {
 				// This case requires Tiebreak.Right to be supported.
 				it.skip("A ○ B", () =>
 					withConfig(() => {
-						const markA = Mark.modify("A", {
+						const markA = Mark.modify(nodeIdA, {
 							revision: tag1,
 							localId: brand(1),
 						});
@@ -1813,7 +1837,7 @@ export function testCompose() {
 					}));
 				it("B ○ A", () =>
 					withConfig(() => {
-						const markB = Mark.modify("B", {
+						const markB = Mark.modify(nodeIdB, {
 							revision: tag1,
 							localId: brand(2),
 						});
@@ -1835,7 +1859,7 @@ export function testCompose() {
 				describe("cell for later change named through removal", () => {
 					it("A ○ B", () =>
 						withConfig(() => {
-							const markA = Mark.modify("A", {
+							const markA = Mark.modify(nodeIdA, {
 								revision: tag1,
 								localId: brand(1),
 							});
@@ -1843,7 +1867,7 @@ export function testCompose() {
 								revision: tag3,
 								localId: brand(2),
 							});
-							const markB = Mark.modify("B", {
+							const markB = Mark.modify(nodeIdB, {
 								revision: tag3,
 								localId: brand(2),
 							});
@@ -1853,13 +1877,13 @@ export function testCompose() {
 							const change4 = tagChange([markB], tag4);
 							const composedXY = shallowCompose([change2, change3, change4]);
 
-							const expected = [markA, { ...markNamesB, changes: "B" }];
+							const expected = [markA, { ...markNamesB, changes: nodeIdB }];
 							assertChangesetsEqual(composedXY, expected);
 						}));
 
 					it("B ○ A", () =>
 						withConfig(() => {
-							const markB = Mark.modify("B", {
+							const markB = Mark.modify(nodeIdB, {
 								revision: tag1,
 								localId: brand(2),
 							});
@@ -1867,7 +1891,7 @@ export function testCompose() {
 								revision: tag3,
 								localId: brand(1),
 							});
-							const markA = Mark.modify("A", {
+							const markA = Mark.modify(nodeIdA, {
 								revision: tag3,
 								localId: brand(1),
 							});
@@ -1877,7 +1901,7 @@ export function testCompose() {
 							const change4 = tagChange([markA], tag4);
 							const composedXY = shallowCompose([change2, change3, change4]);
 
-							const expected = [{ ...markNamesA, changes: "A" }, markB];
+							const expected = [{ ...markNamesA, changes: nodeIdA }, markB];
 							assertChangesetsEqual(composedXY, expected);
 						}));
 				});
@@ -1886,7 +1910,7 @@ export function testCompose() {
 					// This case requires Tiebreak.Right to be supported.
 					it.skip("A ○ B", () =>
 						withConfig(() => {
-							const markA = Mark.modify("A", {
+							const markA = Mark.modify(nodeIdA, {
 								revision: tag1,
 								localId: brand(1),
 							});
@@ -1898,7 +1922,7 @@ export function testCompose() {
 								}),
 								Mark.remove(1, { revision: tag3, localId: brand(2) }),
 							);
-							const markB = Mark.modify("B", {
+							const markB = Mark.modify(nodeIdB, {
 								revision: tag3,
 								localId: brand(2),
 							});
@@ -1908,13 +1932,13 @@ export function testCompose() {
 							const change4 = tagChange([markB], tag4);
 							const composedXY = shallowCompose([change2, change3, change4]);
 
-							const expected = [markA, { ...markNamesB, changes: "B" }];
+							const expected = [markA, { ...markNamesB, changes: nodeIdB }];
 							assertChangesetsEqual(composedXY, expected);
 						}));
 
 					it("B ○ A", () =>
 						withConfig(() => {
-							const markB = Mark.modify("B", {
+							const markB = Mark.modify(nodeIdB, {
 								revision: tag1,
 								localId: brand(2),
 							});
@@ -1922,7 +1946,7 @@ export function testCompose() {
 								Mark.insert(1, { revision: tag3, localId: brand(1) }),
 								Mark.remove(1, { revision: tag3, localId: brand(1) }),
 							);
-							const markA = Mark.modify("A", {
+							const markA = Mark.modify(nodeIdA, {
 								revision: tag3,
 								localId: brand(1),
 							});
@@ -1932,7 +1956,7 @@ export function testCompose() {
 							const change4 = tagChange([markA], tag4);
 							const composedXY = shallowCompose([change2, change3, change4]);
 
-							const expected = [{ ...markNamesA, changes: "A" }, markB];
+							const expected = [{ ...markNamesA, changes: nodeIdA }, markB];
 							assertChangesetsEqual(composedXY, expected);
 						}));
 				});
@@ -1945,7 +1969,7 @@ export function testCompose() {
 							Mark.insert(1, { revision: tag2, localId: brand(1) }),
 							Mark.remove(1, { revision: tag2, localId: brand(1) }),
 						);
-						const markB = Mark.modify("B", {
+						const markB = Mark.modify(nodeIdB, {
 							localId: brand(2),
 							revision: tag1,
 							lineage: [{ revision: tag2, id: brand(1), count: 1, offset: 1 }],
@@ -1964,7 +1988,7 @@ export function testCompose() {
 							Mark.insert(1, { revision: tag2, localId: brand(2) }),
 							Mark.remove(1, { revision: tag2, localId: brand(2) }),
 						);
-						const markA = Mark.modify("A", {
+						const markA = Mark.modify(nodeIdA, {
 							localId: brand(1),
 							revision: tag1,
 							lineage: [{ revision: tag2, id: brand(2), count: 1, offset: 0 }],

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
@@ -25,7 +25,7 @@ import {
 } from "./utils.js";
 import { ChangeMaker as Change, MarkMaker as Mark, TestChangeset } from "./testEdits.js";
 
-function invert<T>(change: SF.Changeset<T>, tag?: RevisionTag): SF.Changeset<T> {
+function invert(change: SF.Changeset, tag?: RevisionTag): SF.Changeset {
 	return invertChange(tagChange(change, tag ?? tag1));
 }
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/populatedMarks.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/populatedMarks.ts
@@ -20,9 +20,7 @@ import { TestNodeId } from "../../testNodeId.js";
 import { Populated, brand } from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 
-export type PopulatedMark<TNodeChange = TestNodeId> = Populated<
-	CellMark<Populated<MarkEffect>, TNodeChange>
->;
+export type PopulatedMark = Populated<CellMark<Populated<MarkEffect>>>;
 
 /**
  * Generates a list of marks with all fields populated.

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
@@ -74,7 +74,7 @@ function generateAdjacentCells(maxId: number): SF.IdRange[] {
 	return [{ id: brand(0), count: maxId + 1 }];
 }
 
-const hasAdjacentCells = (m: SF.Mark<unknown>): boolean => m.cellId?.adjacentCells !== undefined;
+const hasAdjacentCells = (m: SF.Mark): boolean => m.cellId?.adjacentCells !== undefined;
 function withAdjacentTombstones(marks: readonly SF.Mark[]): SF.Mark[] {
 	const output = [...marks];
 	let markIdx = marks.findIndex(hasAdjacentCells);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldUtils.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldUtils.test.ts
@@ -15,7 +15,6 @@ import {
 } from "../../../feature-libraries/sequence-field/utils.js";
 import { brand } from "../../../util/index.js";
 import { deepFreeze, testIdCompressor } from "../../utils.js";
-import { TestNodeId } from "../../testNodeId.js";
 import { generatePopulatedMarks } from "./populatedMarks.js";
 import { describeForBothConfigs, withOrderingMethod } from "./utils.js";
 
@@ -37,7 +36,7 @@ export function testUtils() {
 			].forEach((mark, index) => {
 				it(`${index}: ${"type" in mark ? mark.type : "NoOp"}`, () =>
 					withConfig(() => {
-						const splitable: SF.Mark<TestNodeId> = { ...mark, count: 3 };
+						const splitable: SF.Mark = { ...mark, count: 3 };
 						delete splitable.changes;
 						deepFreeze(splitable);
 						const [part1, part2] = splitMark(splitable, 2);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -16,6 +16,7 @@ import { ChangeAtomId } from "../../../core/index.js";
 
 const tag: RevisionTag = mintRevisionTag();
 
+// TODO: Remove this
 export type TestChangeset = SF.Changeset;
 
 const nodeId1: NodeId = { localId: brand(1) };
@@ -56,11 +57,7 @@ export const cases: {
 	],
 };
 
-function createInsertChangeset(
-	index: number,
-	count: number,
-	id?: ChangesetLocalId,
-): SF.Changeset<never> {
+function createInsertChangeset(index: number, count: number, id?: ChangesetLocalId): SF.Changeset {
 	return SF.sequenceFieldEditor.insert(index, count, id ?? brand(0));
 }
 
@@ -68,7 +65,7 @@ function createRemoveChangeset(
 	startIndex: number,
 	size: number,
 	id?: ChangesetLocalId,
-): SF.Changeset<never> {
+): SF.Changeset {
 	return SF.sequenceFieldEditor.remove(startIndex, size, id ?? brand(0));
 }
 
@@ -76,7 +73,7 @@ function createRedundantRemoveChangeset(
 	index: number,
 	size: number,
 	detachEvent: ChangeAtomId,
-): SF.Changeset<never> {
+): SF.Changeset {
 	const changeset = createRemoveChangeset(index, size);
 	changeset[changeset.length - 1].cellId = detachEvent;
 	return changeset;
@@ -86,7 +83,7 @@ function createRedundantReviveChangeset(
 	startIndex: number,
 	count: number,
 	detachEvent: SF.CellId,
-): SF.Changeset<never> {
+): SF.Changeset {
 	const markList = SF.sequenceFieldEditor.revive(startIndex, count, detachEvent);
 	const mark = markList[markList.length - 1];
 	delete mark.cellId;
@@ -97,7 +94,7 @@ function createReviveChangeset(
 	startIndex: number,
 	count: number,
 	detachEvent: SF.CellId,
-): SF.Changeset<never> {
+): SF.Changeset {
 	return SF.sequenceFieldEditor.revive(startIndex, count, detachEvent);
 }
 
@@ -106,7 +103,7 @@ function createMoveChangeset(
 	count: number,
 	destIndex: number,
 	id: ChangesetLocalId = brand(0),
-): SF.Changeset<never> {
+): SF.Changeset {
 	return SF.sequenceFieldEditor.move(sourceIndex, count, destIndex, id);
 }
 
@@ -115,24 +112,21 @@ function createReturnChangeset(
 	count: number,
 	destIndex: number,
 	detachEvent: SF.CellId,
-): SF.Changeset<never> {
+): SF.Changeset {
 	return SF.sequenceFieldEditor.return(sourceIndex, count, destIndex, detachEvent);
 }
 
-function createModifyChangeset<TNodeChange>(
-	index: number,
-	change: TNodeChange,
-): SF.Changeset<TNodeChange> {
+function createModifyChangeset(index: number, change: NodeId): SF.Changeset {
 	return SF.sequenceFieldEditor.buildChildChange(index, change);
 }
 
-function createModifyDetachedChangeset<TNodeChange>(
+function createModifyDetachedChangeset(
 	index: number,
-	change: TNodeChange,
+	change: NodeId,
 	detachEvent: SF.CellId,
-): SF.Changeset<TNodeChange> {
+): SF.Changeset {
 	const changeset = createModifyChangeset(index, change);
-	const modify = changeset[changeset.length - 1] as SF.CellMark<SF.NoopMark, TNodeChange>;
+	const modify = changeset[changeset.length - 1] as SF.CellMark<SF.NoopMark>;
 	modify.cellId = detachEvent;
 	return changeset;
 }
@@ -143,13 +137,13 @@ function createModifyDetachedChangeset<TNodeChange>(
  * Also defines the ChangeAtomId to associate with the mark.
  * @param overrides - Any additional properties to add to the mark.
  */
-function createInsertMark<TChange = never>(
+function createInsertMark(
 	count: number,
 	cellId: ChangesetLocalId | SF.CellId,
-	overrides?: Partial<SF.CellMark<SF.Insert, TChange>>,
-): SF.CellMark<SF.Insert, TChange> {
+	overrides?: Partial<SF.CellMark<SF.Insert>>,
+): SF.CellMark<SF.Insert> {
 	const cellIdObject: SF.CellId = typeof cellId === "object" ? cellId : { localId: cellId };
-	const mark: SF.CellMark<SF.Insert, TChange> = {
+	const mark: SF.CellMark<SF.Insert> = {
 		type: "Insert",
 		count,
 		id: cellIdObject.localId,
@@ -171,11 +165,11 @@ function createInsertMark<TChange = never>(
  * @param overrides - Any additional properties to add to the mark.
  * Use this to give the mark a `RevisionTag`
  */
-function createReviveMark<TChange = never>(
+function createReviveMark(
 	count: number,
 	cellId: SF.CellId,
-	overrides?: Partial<SF.CellMark<SF.Insert, TChange>>,
-): SF.CellMark<SF.Insert, TChange> {
+	overrides?: Partial<SF.CellMark<SF.Insert>>,
+): SF.CellMark<SF.Insert> {
 	return {
 		type: "Insert",
 		count,
@@ -185,11 +179,11 @@ function createReviveMark<TChange = never>(
 	};
 }
 
-function createPinMark<TChange = never>(
+function createPinMark(
 	count: number,
 	id: SF.MoveId,
-	overrides?: Partial<SF.CellMark<SF.Insert, TChange>>,
-): SF.CellMark<SF.Insert, TChange> {
+	overrides?: Partial<SF.CellMark<SF.Insert>>,
+): SF.CellMark<SF.Insert> {
 	return {
 		type: "Insert",
 		count,
@@ -204,13 +198,13 @@ function createPinMark<TChange = never>(
  * Defines how later edits refer the emptied cells.
  * @param overrides - Any additional properties to add to the mark.
  */
-function createRemoveMark<TChange = never>(
+function createRemoveMark(
 	count: number,
 	markId: ChangesetLocalId | ChangeAtomId,
-	overrides?: Partial<SF.CellMark<SF.Remove, TChange>>,
-): SF.CellMark<SF.Remove, TChange> {
+	overrides?: Partial<SF.CellMark<SF.Remove>>,
+): SF.CellMark<SF.Remove> {
 	const cellId: ChangeAtomId = typeof markId === "object" ? markId : { localId: markId };
-	const mark: SF.CellMark<SF.Remove, TChange> = {
+	const mark: SF.CellMark<SF.Remove> = {
 		type: "Remove",
 		count,
 		id: cellId.localId,
@@ -228,11 +222,11 @@ function createRemoveMark<TChange = never>(
  * @param overrides - Any additional properties to add to the mark.
  * @returns A pair of marks, the first for moving out, the second for moving in.
  */
-function createMoveMarks<TChange = never>(
+function createMoveMarks(
 	count: number,
 	markId: ChangesetLocalId | ChangeAtomId,
-	overrides?: Partial<SF.CellMark<(SF.MoveOut & SF.MoveIn) | { changes?: TChange }, TChange>>,
-): [moveOut: SF.CellMark<SF.MoveOut, TChange>, moveIn: SF.CellMark<SF.MoveIn, never>] {
+	overrides?: Partial<SF.CellMark<(SF.MoveOut & SF.MoveIn) | { changes?: NodeId }>>,
+): [moveOut: SF.CellMark<SF.MoveOut>, moveIn: SF.CellMark<SF.MoveIn>] {
 	const moveOut = createMoveOutMark(count, markId, overrides);
 	const { changes: _, ...overridesWithNoChanges } = overrides ?? {};
 	const moveIn = createMoveInMark(count, markId, overridesWithNoChanges);
@@ -245,13 +239,13 @@ function createMoveMarks<TChange = never>(
  * Defines how later edits refer the emptied cells.
  * @param overrides - Any additional properties to add to the mark.
  */
-function createMoveOutMark<TChange = never>(
+function createMoveOutMark(
 	count: number,
 	markId: ChangesetLocalId | ChangeAtomId,
-	overrides?: Partial<SF.CellMark<SF.MoveOut, TChange>>,
-): SF.CellMark<SF.MoveOut, TChange> {
+	overrides?: Partial<SF.CellMark<SF.MoveOut>>,
+): SF.CellMark<SF.MoveOut> {
 	const atomId: ChangeAtomId = typeof markId === "object" ? markId : { localId: markId };
-	const mark: SF.CellMark<SF.MoveOut, TChange> = {
+	const mark: SF.CellMark<SF.MoveOut> = {
 		type: "MoveOut",
 		count,
 		id: atomId.localId,
@@ -271,10 +265,10 @@ function createMoveOutMark<TChange = never>(
 function createMoveInMark(
 	count: number,
 	cellId: ChangesetLocalId | SF.CellId,
-	overrides?: Partial<SF.CellMark<SF.MoveIn, never>>,
-): SF.CellMark<SF.MoveIn, never> {
+	overrides?: Partial<SF.CellMark<SF.MoveIn>>,
+): SF.CellMark<SF.MoveIn> {
 	const cellIdObject: SF.CellId = typeof cellId === "object" ? cellId : { localId: cellId };
-	const mark: SF.CellMark<SF.MoveIn, never> = {
+	const mark: SF.CellMark<SF.MoveIn> = {
 		type: "MoveIn",
 		id: cellIdObject.localId,
 		cellId: cellIdObject,
@@ -297,10 +291,10 @@ function createReturnToMark(
 	count: number,
 	markId: ChangesetLocalId | ChangeAtomId,
 	cellId?: SF.CellId,
-	overrides?: Partial<SF.CellMark<SF.MoveIn, never>>,
-): SF.CellMark<SF.MoveIn, never> {
+	overrides?: Partial<SF.CellMark<SF.MoveIn>>,
+): SF.CellMark<SF.MoveIn> {
 	const atomId: ChangeAtomId = typeof markId === "object" ? markId : { localId: markId };
-	const mark: SF.CellMark<SF.MoveIn, never> = {
+	const mark: SF.CellMark<SF.MoveIn> = {
 		type: "MoveIn",
 		id: atomId.localId,
 		count,
@@ -318,11 +312,8 @@ function createReturnToMark(
  * @param changes - The changes to apply to the node.
  * @param cellId - Describes the cell that the target node used to reside in. Used when the target node is removed.
  */
-function createModifyMark<TChange>(
-	changes: TChange,
-	cellId?: SF.CellId,
-): SF.CellMark<SF.NoopMark, TChange> {
-	const mark: SF.CellMark<SF.NoopMark, TChange> = {
+function createModifyMark(changes: NodeId, cellId?: SF.CellId): SF.CellMark<SF.NoopMark> {
+	const mark: SF.CellMark<SF.NoopMark> = {
 		count: 1,
 		changes,
 	};
@@ -332,7 +323,7 @@ function createModifyMark<TChange>(
 	return mark;
 }
 
-function createSkipMark(count: number): SF.CellMark<SF.NoopMark, never> {
+function createSkipMark(count: number): SF.CellMark<SF.NoopMark> {
 	return { count };
 }
 
@@ -340,15 +331,15 @@ function createTomb(
 	revision: RevisionTag | undefined,
 	localId: ChangesetLocalId = brand(0),
 	count: number = 1,
-): SF.CellMark<SF.NoopMark, never> {
+): SF.CellMark<SF.NoopMark> {
 	return { count, cellId: { revision, localId } };
 }
 
 function createAttachAndDetachMark<TChange>(
-	attach: SF.CellMark<SF.Attach, TChange>,
-	detach: SF.CellMark<SF.Detach, TChange>,
-	overrides?: Partial<SF.CellMark<SF.AttachAndDetach, TChange>>,
-): SF.CellMark<SF.AttachAndDetach, TChange> {
+	attach: SF.CellMark<SF.Attach>,
+	detach: SF.CellMark<SF.Detach>,
+	overrides?: Partial<SF.CellMark<SF.AttachAndDetach>>,
+): SF.CellMark<SF.AttachAndDetach> {
 	assert(attach.count === detach.count, "Attach and detach must have the same count");
 	assert(attach.cellId !== undefined, "AttachAndDetach attach should apply to an empty cell");
 	assert(detach.cellId === undefined, "AttachAndDetach detach should apply to an populated cell");
@@ -359,7 +350,7 @@ function createAttachAndDetachMark<TChange>(
 	// As a matter of normalization, we only use AttachAndDetach marks to represent cases where the detach's
 	// implicit revival semantics would not be a sufficient representation.
 	assert(attach.type === "MoveIn" || isNewAttach(attach), "Unnecessary AttachAndDetach mark");
-	const mark: SF.CellMark<SF.AttachAndDetach, TChange> = {
+	const mark: SF.CellMark<SF.AttachAndDetach> = {
 		type: "AttachAndDetach",
 		count: attach.count,
 		cellId: attach.cellId,
@@ -370,10 +361,7 @@ function createAttachAndDetachMark<TChange>(
 	return mark;
 }
 
-function overrideCellId<TMark extends SF.HasMarkFields<unknown>>(
-	cellId: SF.CellId,
-	mark: TMark,
-): TMark {
+function overrideCellId<TMark extends SF.HasMarkFields>(cellId: SF.CellId, mark: TMark): TMark {
 	mark.cellId = cellId;
 	return mark;
 }


### PR DESCRIPTION
## Description

Sequence field had a generic parameter for child changes. This was previously used to allow for `NodeChangeset` children in production and other types such as `TestChange` in testing. This PR removes this generic parameter and requires that child changes of a sequence are always represented as a `NodeId`. In testing a `TestChange` can either be embedded in the `NodeId` or it can be associated with it out of line using `ChangesetWrapper`.