### PR TITLE
fix(tree): correct PathNode ref counting in AnchorSet visitor

### DIFF
--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -637,6 +637,7 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents>, AnchorLoca
 			0x767 /* Must release existing visitor before acquiring another */,
 		);
 
+		const referencedPathNodes: PathNode[] = [];
 		const visitor = {
 			anchorSet: this,
 			// Run `withNode` on anchorNode for parent if there is such an anchorNode.
@@ -651,6 +652,8 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents>, AnchorLoca
 					// Delta traversal should early out in this case because no work is needed (and all move outs are known to not contain anchors).
 					this.parent = this.anchorSet.internalizePath(this.parent);
 					if (this.parent instanceof PathNode) {
+						this.parent.addRef();
+						referencedPathNodes.push(this.parent);
 						withNode(this.parent);
 					}
 				}
@@ -666,6 +669,9 @@ export class AnchorSet implements ISubscribable<AnchorSetRootEvents>, AnchorLoca
 					this.anchorSet.activeVisitor !== undefined,
 					0x768 /* Multiple free calls for same visitor */,
 				);
+				for (const node of referencedPathNodes) {
+					node.removeRef();
+				}
 				this.anchorSet.activeVisitor = undefined;
 			},
 			notifyChildrenChanging(): void {

--- a/packages/dds/tree/src/test/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/tree/anchorSet.spec.ts
@@ -318,7 +318,7 @@ describe("AnchorSet", () => {
 		assert.throws(() => anchors.locate(anchor3));
 	});
 
-	it("visitor increases references as it descends", () => {
+	it("visitor can descend in under anchors and detach all their remaining children", () => {
 		const [anchors, anchor1, anchor2, anchor3, anchor4] = setup();
 
 		// This leaves anchor1 with no refs. It is kelp alive by anchor4 which is below it.
@@ -328,7 +328,7 @@ describe("AnchorSet", () => {
 			v.enterField(fieldFoo);
 			v.enterNode(5);
 			v.enterField(fieldBar);
-			// This moves anchor4 out from under anchor1.
+			// This moves anchor4 (the only anchor under anchor1) out from under anchor1.
 			// If the visitor did not increase the ref count of anchor1 on its way down,
 			// anchor1 will be disposed as part of this operation.
 			v.detach({ start: 4, end: 5 }, detachedField);


### PR DESCRIPTION
## Description

Fixes a bug in the AnchorSet visitor where the visitor could depend on a PathNode remaining valid but the visitor did not ensure that PathNode's validity for the duration of its usage.

## Breaking Changes

None