### PR TITLE
refactor(tree): rename ReferenceCountedBase.dispose to onUnreferenced

### DIFF
--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -1124,7 +1124,7 @@ class PathNode extends ReferenceCountedBase implements UpPath<PathNode>, AnchorN
 
 	// Called when refcount is set to 0.
 	// Node may be kept alive by children or events after this point.
-	protected dispose(): void {
+	protected onUnreferenced(): void {
 		this.considerDispose();
 	}
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
@@ -59,7 +59,7 @@ export class BasicChunk extends ReferenceCountedBase implements TreeChunk {
 		return new BasicChunkCursor([this], [], [], [], [], [dummyRoot], 0, 0, 0, undefined);
 	}
 
-	protected dispose(): void {
+	protected onUnreferenced(): void {
 		for (const v of this.fields.values()) {
 			for (const child of v) {
 				child.referenceRemoved();

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/sequenceChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/sequenceChunk.ts
@@ -55,7 +55,7 @@ export class SequenceChunk extends ReferenceCountedBase implements TreeChunk {
 		);
 	}
 
-	protected dispose(): void {
+	protected onUnreferenced(): void {
 		for (const child of this.subChunks) {
 			child.referenceRemoved();
 		}

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
@@ -66,7 +66,7 @@ export class UniformChunk extends ReferenceCountedBase implements TreeChunk {
 		return new Cursor(this);
 	}
 
-	protected dispose(): void {}
+	protected onUnreferenced(): void {}
 }
 
 /**

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/basicChunk.spec.ts
@@ -233,7 +233,7 @@ class WrapperChunk extends ReferenceCountedBase implements TreeChunk {
 		chunk.referenceAdded();
 	}
 
-	protected dispose(): void {
+	protected onUnreferenced(): void {
 		this.chunk.referenceRemoved();
 	}
 

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
@@ -65,7 +65,7 @@ class TestChunk1 extends ReferenceCountedBase implements TreeChunk {
 		fail("not implemented");
 	}
 
-	protected dispose(): void {}
+	protected onUnreferenced(): void {}
 }
 
 class TestChunk2 extends ReferenceCountedBase implements TreeChunk {
@@ -83,7 +83,7 @@ class TestChunk2 extends ReferenceCountedBase implements TreeChunk {
 		fail("not implemented");
 	}
 
-	protected dispose(): void {}
+	protected onUnreferenced(): void {}
 }
 
 const decoderLibrary = new DiscriminatedUnionDispatcher<

--- a/packages/dds/tree/src/util/referenceCounting.ts
+++ b/packages/dds/tree/src/util/referenceCounting.ts
@@ -32,7 +32,7 @@ export abstract class ReferenceCountedBase implements ReferenceCounted {
 		this.refCount -= count;
 		assert(this.refCount >= 0, 0x4c4 /* Negative ref count */);
 		if (this.refCount === 0) {
-			this.dispose();
+			this.onUnreferenced();
 		}
 	}
 
@@ -47,5 +47,5 @@ export abstract class ReferenceCountedBase implements ReferenceCounted {
 	/**
 	 * Called when refcount reaches 0.
 	 */
-	protected abstract dispose(): void;
+	protected abstract onUnreferenced(): void;
 }


### PR DESCRIPTION
## Description

Rationale: the implementer of this class may not dispose of the object when its reference count reaches zero. `AnchorSet`'s `PathNode`s are an example of that.

## Breaking Changes

None

