### PR TITLE
Export ISnapshotInfo and create conversions

### DIFF
--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -71,15 +71,15 @@ export interface IPendingDetachedContainerState extends SnapshotWithBlobs {
 	pendingRuntimeState?: unknown;
 }
 
-interface SnapshotInfo extends SnapshotWithBlobs {
+export interface ISnapshotInfo extends SnapshotWithBlobs {
 	snapshotSequenceNumber: number;
 }
 
 export class SerializedStateManager {
 	private readonly processedOps: ISequencedDocumentMessage[] = [];
-	private snapshot: SnapshotInfo | undefined;
+	private snapshot: ISnapshotInfo | undefined;
 	private readonly mc: MonitoringContext;
-	private latestSnapshot: SnapshotInfo | undefined;
+	private latestSnapshot: ISnapshotInfo | undefined;
 	private refreshSnapshot: Promise<void> | undefined;
 
 	constructor(
@@ -276,7 +276,7 @@ export async function getLatestSnapshotInfo(
 		"getSnapshot" | "getSnapshotTree" | "getVersions" | "readBlob"
 	>,
 	supportGetSnapshotApi: boolean,
-): Promise<SnapshotInfo | undefined> {
+): Promise<ISnapshotInfo | undefined> {
 	return PerformanceEvent.timedExecAsync(
 		mc.logger,
 		{ eventName: "GetLatestSnapshotInfo" },

--- a/packages/loader/container-loader/src/test/utils.spec.ts
+++ b/packages/loader/container-loader/src/test/utils.spec.ts
@@ -5,10 +5,21 @@
 
 import { strict as assert } from "assert";
 
-import { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
+import {
+	IDocumentStorageService,
+	type ISnapshot,
+} from "@fluidframework/driver-definitions/internal";
 import { IDocumentAttributes, ISnapshotTree } from "@fluidframework/protocol-definitions";
 
-import { getDocumentAttributes, runSingle } from "../utils.js";
+import { stringToBuffer } from "@fluid-internal/client-utils";
+import {
+	convertSnapshotInfoToSnapshot,
+	convertSnapshotToSnapshotInfo,
+	getDocumentAttributes,
+	runSingle,
+} from "../utils.js";
+import type { ISnapshotInfo } from "../serializedStateManager.js";
+import type { ISerializableBlobContents } from "../containerStorageAdapter.js";
 
 describe("container-loader utils", () => {
 	describe("runSingle", () => {
@@ -121,6 +132,53 @@ describe("container-loader utils", () => {
 
 			assert.strictEqual(attributes.minimumSequenceNumber, 10);
 			assert.strictEqual(attributes.sequenceNumber, 20);
+		});
+	});
+
+	describe("SnapshotInfo and Snapshot", () => {
+		const snapshotTree: ISnapshotTree = {
+			trees: {
+				".protocol": {
+					blobs: {
+						attributes: "someKey",
+					},
+					trees: {},
+				},
+			},
+			blobs: {},
+		};
+
+		const snapshotBlobs: ISerializableBlobContents = {
+			someKey: JSON.stringify({ some: 10, data: 20 }),
+		};
+
+		const blobContents: Map<string, ArrayBufferLike> = new Map([
+			["someKey", stringToBuffer(JSON.stringify({ some: 10, data: 20 }), "utf8")],
+		]);
+
+		const snapshot: ISnapshot = {
+			snapshotTree,
+			blobContents,
+			ops: [],
+			sequenceNumber: 123,
+			latestSequenceNumber: undefined,
+			snapshotFormatV: 1,
+		};
+
+		const snapshotInfo: ISnapshotInfo = {
+			snapshotSequenceNumber: 123,
+			baseSnapshot: snapshotTree,
+			snapshotBlobs,
+		};
+
+		it("Converts SnapshotInfo to Snapshot", async () => {
+			const convertedSnapshot = convertSnapshotInfoToSnapshot(snapshotInfo, 123);
+			assert.deepEqual(convertedSnapshot, snapshot);
+		});
+
+		it("Converts Snapshot to SnapshotInfo", async () => {
+			const convertedSnapshotInfo = convertSnapshotToSnapshotInfo(snapshot);
+			assert.deepEqual(convertedSnapshotInfo, snapshotInfo);
 		});
 	});
 });

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -3,10 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { Uint8ArrayToString, stringToBuffer } from "@fluid-internal/client-utils";
+import { Uint8ArrayToString, bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
 import { assert, compareArrays, unreachableCase } from "@fluidframework/core-utils/internal";
 import { DriverErrorTypes } from "@fluidframework/driver-definitions";
-import { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
+import {
+	IDocumentStorageService,
+	type ISnapshot,
+} from "@fluidframework/driver-definitions/internal";
 import {
 	CombinedAppAndProtocolSummary,
 	DeltaStreamConnectionForbiddenError,
@@ -25,6 +28,7 @@ import { v4 as uuid } from "uuid";
 import { ISerializableBlobContents } from "./containerStorageAdapter.js";
 import type {
 	IPendingDetachedContainerState,
+	ISnapshotInfo,
 	SnapshotWithBlobs,
 } from "./serializedStateManager.js";
 
@@ -167,6 +171,51 @@ function convertSummaryToSnapshotAndBlobs(summary: ISummaryTree): SnapshotWithBl
 	}
 	const pendingSnapshot = { baseSnapshot: treeNode, snapshotBlobs: blobContents };
 	return pendingSnapshot;
+}
+
+/**
+ * Converts a snapshot to snapshotInfo with its blob contents
+ * to align detached container format with IPendingContainerState
+ *
+ * Note, this assumes the ISnapshot sequence number is defined. Otherwise an assert will be thrown
+ * @param snapshot - ISnapshot
+ */
+export function convertSnapshotToSnapshotInfo(snapshot: ISnapshot): ISnapshotInfo {
+	assert(snapshot.sequenceNumber !== undefined, "Snapshot sequence number is missing");
+	const snapshotBlobs: ISerializableBlobContents = {};
+	for (const [blobId, arrayBufferLike] of snapshot.blobContents.entries()) {
+		snapshotBlobs[blobId] = bufferToString(arrayBufferLike, "utf8");
+	}
+	return {
+		baseSnapshot: snapshot.snapshotTree,
+		snapshotBlobs,
+		snapshotSequenceNumber: snapshot.sequenceNumber,
+	};
+}
+
+/**
+ * Converts a snapshot to snapshotInfo with its blob contents
+ * to align detached container format with IPendingContainerState
+ *
+ * Note, this assumes the ISnapshot sequence number is defined. Otherwise an assert will be thrown
+ * @param snapshot - ISnapshot
+ */
+export function convertSnapshotInfoToSnapshot(
+	snapshotInfo: ISnapshotInfo,
+	snapshotSequenceNumber: number,
+): ISnapshot {
+	const blobContents = new Map<string, ArrayBufferLike>();
+	for (const [blobId, serializedContent] of Object.entries(snapshotInfo.snapshotBlobs)) {
+		blobContents.set(blobId, stringToBuffer(serializedContent, "utf8"));
+	}
+	return {
+		snapshotTree: snapshotInfo.baseSnapshot,
+		blobContents,
+		ops: [],
+		sequenceNumber: snapshotSequenceNumber,
+		latestSequenceNumber: undefined,
+		snapshotFormatV: 1,
+	};
 }
 
 /**


### PR DESCRIPTION
Part of a bigger effort for Data virtualization and offline, this is the reference PR: https://github.com/microsoft/FluidFramework/pull/20342

[AB#7670](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7670)

Enable conversion from `ISnapshotInfo` to `ISnapshot` as they are relatively similar. The conversion of `ISnapshot` to `ISnapshotInfo` and vice versa is important as offline uses `ISnapshotInfo` as it is serializable and `ArrayBufferLike` doesn't survive serialization. `ISnapshot` is what data virtualization to load the snapshot.