### PR TITLE
Change compatVersion argument of describeCompat() from string to enum

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementally.spec.ts
@@ -103,7 +103,7 @@ function validateDDSStateInSummary(
  */
 describeCompat(
 	"Incremental summaries for data store and DDS",
-	"1.3.7" /** equivalent to FullCompat. Currently used for testing purposes on ADO pipelines */,
+	"FullCompat",
 	(getTestObjectProvider, apis) => {
 		const { SharedDirectory } = apis.dds;
 		let provider: ITestObjectProvider;

--- a/packages/test/test-version-utils/api-report/test-version-utils.api.md
+++ b/packages/test/test-version-utils/api-report/test-version-utils.api.md
@@ -66,6 +66,9 @@ export interface CompatApis {
 }
 
 // @internal (undocumented)
+export type CompatType = "FullCompat" | "LoaderCompat" | "NoCompat";
+
+// @internal (undocumented)
 export const ContainerRuntimeApi: {
     version: string;
     BaseContainerRuntimeFactory: typeof BaseContainerRuntimeFactory;
@@ -116,7 +119,7 @@ export type DescribeCompat = DescribeCompatSuite & {
 export const describeCompat: DescribeCompat;
 
 // @internal (undocumented)
-export type DescribeCompatSuite = (name: string, compatVersion: string, tests: (this: Mocha.Suite, provider: (options?: ITestObjectProviderOptions) => ITestObjectProvider, apis: CompatApis) => void) => Mocha.Suite | void;
+export type DescribeCompatSuite = (name: string, compatVersion: CompatType, tests: (this: Mocha.Suite, provider: (options?: ITestObjectProviderOptions) => ITestObjectProvider, apis: CompatApis) => void) => Mocha.Suite | void;
 
 // @internal (undocumented)
 export interface DescribeE2EDocInfo {

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import {
 	getUnexpectedLogErrorException,
@@ -185,7 +185,7 @@ export interface ITestObjectProviderOptions {
  */
 export type DescribeCompatSuite = (
 	name: string,
-	compatVersion: string,
+	compatVersion: CompatType,
 	tests: (
 		this: Mocha.Suite,
 		provider: (options?: ITestObjectProviderOptions) => ITestObjectProvider,
@@ -217,10 +217,13 @@ export type DescribeCompat = DescribeCompatSuite & {
 	noCompat: DescribeCompatSuite;
 };
 
+/** @internal */
+export type CompatType = "FullCompat" | "LoaderCompat" | "NoCompat";
+
 function createCompatDescribe(): DescribeCompat {
 	const createCompatSuiteWithDefault = (
 		tests: (this: Mocha.Suite, provider: () => ITestObjectProvider, apis: CompatApis) => void,
-		compatVersion: string,
+		compatVersion: CompatType,
 	) => {
 		switch (compatVersion) {
 			case "FullCompat":
@@ -230,19 +233,19 @@ function createCompatDescribe(): DescribeCompat {
 			case "NoCompat":
 				return createCompatSuite(tests, [CompatKind.None]);
 			default:
-				return createCompatSuite(tests, undefined, compatVersion);
+				unreachableCase(compatVersion, "unknown compat version");
 		}
 	};
-	const d: DescribeCompat = (name: string, compatVersion: string, tests) =>
+	const d: DescribeCompat = (name: string, compatVersion: CompatType, tests) =>
 		describe(name, createCompatSuiteWithDefault(tests, compatVersion));
-	d.skip = (name, compatVersion, tests) =>
+	d.skip = (name, compatVersion: CompatType, tests) =>
 		describe.skip(name, createCompatSuiteWithDefault(tests, compatVersion));
 
-	d.only = (name, compatVersion, tests) =>
+	d.only = (name, compatVersion: CompatType, tests) =>
 		describe.only(name, createCompatSuiteWithDefault(tests, compatVersion));
 
 	d.noCompat = (name, _, tests) =>
-		describe(name, createCompatSuiteWithDefault(tests, pkgVersion));
+		describe(name, createCompatSuite(tests, undefined, pkgVersion));
 
 	return d;
 }

--- a/packages/test/test-version-utils/src/index.ts
+++ b/packages/test/test-version-utils/src/index.ts
@@ -22,6 +22,7 @@ export {
 	DescribeCompatSuite,
 	describeCompat,
 	ITestObjectProviderOptions,
+	type CompatType,
 } from "./describeCompat.js";
 export {
 	DescribeE2EDocSuite,


### PR DESCRIPTION
A bit easier to track allowed values, as well as see what it takes to add a new type (if required)
