### PR TITLE
Add isGlobalDb flag to the db errors

### DIFF
--- a/server/routerlicious/packages/services-core/src/mongo.ts
+++ b/server/routerlicious/packages/services-core/src/mongo.ts
@@ -77,8 +77,9 @@ export class MongoManager {
 		});
 
 		databaseP.catch((error) => {
+			error.isGlobalDb = global;
 			debug("DB Connection Error", error);
-			Lumberjack.error("DB Connection Error", undefined, error);
+			Lumberjack.error("DB Connection Error", { isGlobalDb: global }, error);
 			this.reconnect(this.reconnectDelayMs);
 		});
 

--- a/server/routerlicious/packages/services/src/mongodb.ts
+++ b/server/routerlicious/packages/services/src/mongodb.ts
@@ -74,6 +74,7 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
 		private readonly apiFailureRateTerminationThreshold: number,
 		private readonly apiMinimumCountToEnableTermination: number,
 		private readonly consecutiveFailedThresholdForLowerTotalRequests: number,
+		private readonly isGlobalDb = false,
 	) {
 		setInterval(() => {
 			if (!this.apiCounter.countersAreActive) {
@@ -400,6 +401,7 @@ export class MongoCollection<T> implements core.ICollection<T>, core.IRetryable 
 				(error: any, numRetries: number, retryAfterInterval: number) =>
 					numRetries * retryAfterInterval, // calculateIntervalMs
 				(error) => {
+					error.isGlobalDb = this.isGlobalDb;
 					const facadeError = this.cloneError(error);
 					this.sanitizeError(facadeError);
 				} /* onErrorFn */,
@@ -550,6 +552,7 @@ export class MongoDb implements core.IDb {
 		private readonly apiFailureRateTerminationThreshold: number,
 		private readonly apiMinimumCountToEnableTermination: number,
 		private readonly consecutiveFailedThresholdForLowerTotalRequests: number,
+		private readonly isGlobalDb = false,
 	) {}
 
 	// eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -573,6 +576,7 @@ export class MongoDb implements core.IDb {
 			this.apiFailureRateTerminationThreshold,
 			this.apiMinimumCountToEnableTermination,
 			this.consecutiveFailedThresholdForLowerTotalRequests,
+			this.isGlobalDb,
 		);
 	}
 
@@ -779,6 +783,7 @@ export class MongoDbFactory implements core.IDbFactory {
 			this.apiFailureRateTerminationThreshold,
 			this.apiMinimumCountToEnableTermination,
 			this.consecutiveFailedThresholdForLowerTotalRequests,
+			global,
 		);
 	}
 }


### PR DESCRIPTION
## Description
Adding isGlobalDb flag to the db errors so that we can identify if the error happened due to local db or global db.

