### PR TITLE
refactor(tree): make Revertible.revert(dispose) dispose param optional

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -1491,6 +1491,7 @@ export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
 // @public
 export interface Revertible {
     [disposeSymbol](): void;
+    revert(): void;
     revert(dispose: boolean): void;
     readonly status: RevertibleStatus;
 }

--- a/packages/dds/tree/src/core/revertible/revertible.ts
+++ b/packages/dds/tree/src/core/revertible/revertible.ts
@@ -20,6 +20,10 @@ export interface Revertible {
 	readonly status: RevertibleStatus;
 
 	/**
+	 * Reverts the associated change and disposes it.
+	 */
+	revert(): void;
+	/**
 	 * Reverts the associated change and optionally disposes it.
 	 *
 	 * @param dispose - If true, the revertible will be disposed after being reverted.

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -442,7 +442,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 									? RevertibleStatus.Disposed
 									: RevertibleStatus.Valid;
 							},
-							revert: (release: boolean) => {
+							revert: (release: boolean = true) => {
 								assert(
 									revertible.status === RevertibleStatus.Valid,
 									0x904 /* a disposed revertible cannot be reverted */,

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -317,7 +317,7 @@ describe("Editing", () => {
 
 			expectJsonTree([tree1, tree2], []);
 
-			removal?.revert(true);
+			removal?.revert();
 
 			tree1.merge(tree2, false);
 			tree2.rebaseOnto(tree1);
@@ -692,7 +692,7 @@ describe("Editing", () => {
 			tree2.editor.sequenceField(rootField).remove(0, 1);
 
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			undoStack.pop()!.revert(true);
+			undoStack.pop()!.revert();
 
 			// This merge causes the move, remove, and restore to be composed and applied in one changeset on tree1
 			tree1.merge(tree2, false);
@@ -775,7 +775,7 @@ describe("Editing", () => {
 
 			expectJsonTree([tree, tree2], [{}]);
 
-			deletion?.revert(true);
+			deletion?.revert();
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], [{}, { bar: ["a"] }]);
@@ -818,7 +818,7 @@ describe("Editing", () => {
 
 			expectJsonTree([tree, tree2], [{ bar: ["a"] }]);
 
-			deletion?.revert(true);
+			deletion?.revert();
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], [{}, { bar: ["a"] }]);
@@ -846,7 +846,7 @@ describe("Editing", () => {
 			// Remove source's ancestor concurrently
 			sequence.remove(0, 1);
 			// Revive the ancestor
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 
 			tree2.editor.move(
 				{ parent: first, field: brand("foo") },
@@ -884,7 +884,7 @@ describe("Editing", () => {
 			tree.editor.sequenceField(rootField).remove(0, 1);
 			expectJsonTree(tree, [{}]);
 			// Revive source's ancestor
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 			expectJsonTree(tree, [{ foo: ["a"] }, {}]);
 			// Remove ["a"]
 			tree.editor.sequenceField({ parent: first, field: brand("foo") }).remove(0, 1);
@@ -925,7 +925,7 @@ describe("Editing", () => {
 			const sequence = tree2.editor.sequenceField(rootField);
 
 			sequence.remove(0, 1);
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 			tree2.editor
 				.sequenceField({ parent: sequenceUpPath, field: EmptyKey })
 				.insert(1, cursorForJsonableTreeNode({ type: leaf.string.name, value: "c" }));
@@ -960,9 +960,9 @@ describe("Editing", () => {
 			const sequence = tree.editor.sequenceField(rootField);
 
 			sequence.remove(0, 1);
-			undoStack.pop()?.revert(true);
-			redoStack.pop()?.revert(true);
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
+			redoStack.pop()?.revert();
+			undoStack.pop()?.revert();
 			tree.editor
 				.sequenceField({ parent: sequenceUpPath, field: EmptyKey })
 				.insert(1, cursorForJsonableTreeNode({ type: leaf.string.name, value: "c" }));
@@ -998,7 +998,7 @@ describe("Editing", () => {
 			tree.editor.sequenceField({ parent: first, field: brand("foo") }).remove(0, 1);
 			expectJsonTree(tree, [{}, {}]);
 			// Revive ["a"]
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 			expectJsonTree(tree, [{ foo: ["a"] }, {}]);
 			// Remove source's ancestor concurrently
 			tree.editor.sequenceField(rootField).remove(0, 1);
@@ -1052,7 +1052,7 @@ describe("Editing", () => {
 			// Remove ancestor of "a"
 			sequence.remove(1, 1);
 			// Undo move to bar
-			undoTree2.undoStack.pop()?.revert(true);
+			undoTree2.undoStack.pop()?.revert();
 
 			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
@@ -1060,7 +1060,7 @@ describe("Editing", () => {
 			expectJsonTree([tree, tree2], [{}]);
 
 			// Undo deletion of ancestor of "a"
-			undoTree1.undoStack.pop()?.revert(true);
+			undoTree1.undoStack.pop()?.revert();
 			tree2.rebaseOnto(tree);
 
 			expectJsonTree([tree, tree2], [{}, { bar: ["a"] }]);
@@ -1100,7 +1100,7 @@ describe("Editing", () => {
 			// Remove destination ancestor
 			sequence.remove(0, 1);
 			// Undo move to bar
-			undoStack[0].revert(true);
+			undoStack[0].revert();
 
 			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
@@ -1682,7 +1682,7 @@ describe("Editing", () => {
 
 			const tree3 = tree.fork();
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree3.events);
-			undoStack.pop()?.revert(true); // Restores "43"
+			undoStack.pop()?.revert(); // Restores "43"
 
 			tree.merge(tree3, false);
 			tree3.rebaseOnto(tree);
@@ -1804,7 +1804,7 @@ describe("Editing", () => {
 
 			const tree2 = tree1.fork();
 
-			undoStack.pop()?.revert(true); // Restores ac
+			undoStack.pop()?.revert(); // Restores ac
 			insert(tree1, 2, "b");
 			expectJsonTree(tree1, ["y", "a", "b", "c"]);
 
@@ -2025,7 +2025,7 @@ describe("Editing", () => {
 								break;
 							}
 							case StepType.Undo: {
-								peerUndoStacks[iPeer].undoStack.pop()?.revert(true);
+								peerUndoStacks[iPeer].undoStack.pop()?.revert();
 								presence = 1;
 								// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 								affectedNode = undoQueues[iPeer].pop()!;
@@ -2117,7 +2117,7 @@ describe("Editing", () => {
 
 								disruption.delegate(tree, action.nodeDst);
 
-								revertibleMove?.revert(true);
+								revertibleMove?.revert();
 								expectJsonTree(tree, [{ foo: "X" }]);
 								unsubscribe();
 							});
@@ -2138,7 +2138,7 @@ describe("Editing", () => {
 							tree1.merge(tree2, false);
 							tree2.rebaseOnto(tree1);
 
-							revertibleMove?.revert(true);
+							revertibleMove?.revert();
 							expectJsonTree(tree1, [{ foo: "X" }]);
 
 							tree1.merge(tree2, false);
@@ -2162,7 +2162,7 @@ describe("Editing", () => {
 							tree1.merge(tree2, false);
 							tree2.rebaseOnto(tree1);
 
-							revertibleMove?.revert(true);
+							revertibleMove?.revert();
 							expectJsonTree(tree2, [{ foo: "X" }]);
 
 							tree1.merge(tree2, false);
@@ -2287,7 +2287,7 @@ describe("Editing", () => {
 
 			tree1.editor.optionalField(rootField).set(singleJsonCursor({ foo: "41" }), false);
 
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 
 			const editor = tree2.editor.valueField({ parent: rootNode, field: brand("foo") });
 			editor.set(cursorForJsonableTreeNode({ type: leaf.string.name, value: "42" }));
@@ -2321,7 +2321,7 @@ describe("Editing", () => {
 
 			expectJsonTree(tree1, ["43"]);
 
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 
 			expectJsonTree(tree1, ["42"]);
 			unsubscribe();
@@ -2391,7 +2391,7 @@ describe("Editing", () => {
 
 							disruption.delegate(tree, action.isEmptyAfter);
 
-							revertible?.revert(true);
+							revertible?.revert();
 							expectJsonTree(tree, ["A"]);
 							unsubscribe();
 						});
@@ -2411,7 +2411,7 @@ describe("Editing", () => {
 							tree1.merge(tree2, false);
 							tree2.rebaseOnto(tree1);
 
-							revertible?.revert(true);
+							revertible?.revert();
 							expectJsonTree(tree1, ["A"]);
 
 							tree1.merge(tree2, false);
@@ -2435,7 +2435,7 @@ describe("Editing", () => {
 							tree1.merge(tree2, false);
 							tree2.rebaseOnto(tree1);
 
-							revertible?.revert(true);
+							revertible?.revert();
 							expectJsonTree(tree2, ["A"]);
 
 							tree1.merge(tree2, false);
@@ -2462,7 +2462,7 @@ describe("Editing", () => {
 			tree2.rebaseOnto(tree);
 
 			// Restore 42
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 
 			tree.merge(tree2, false);
 			tree2.rebaseOnto(tree);
@@ -2480,7 +2480,7 @@ describe("Editing", () => {
 
 			const tree3 = tree.fork();
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(tree3.events);
-			undoStack.pop()?.revert(true); // Restores "43"
+			undoStack.pop()?.revert(); // Restores "43"
 
 			tree.editor.optionalField(rootField).set(singleJsonCursor("45"), false);
 
@@ -2617,8 +2617,8 @@ describe("Editing", () => {
 
 			const { undoStack, redoStack } = createTestUndoRedoStacks(fork.events);
 			fork.editor.optionalField(rootField).set(undefined, false);
-			undoStack.pop()?.revert(true);
-			redoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
+			redoStack.pop()?.revert();
 
 			fork.rebaseOnto(tree);
 			tree.merge(fork, false);
@@ -2648,7 +2648,7 @@ describe("Editing", () => {
 				// Remove a
 				remove(tree, 0, 1);
 				// Undo remove of a
-				undoStack.pop()?.revert(true);
+				undoStack.pop()?.revert();
 
 				tree2.transaction.start();
 				// Put existence constraint on child field of a
@@ -2753,7 +2753,7 @@ describe("Editing", () => {
 
 				// Remove and revive second object in root sequence
 				remove(tree, 1, 1);
-				undoStack.pop()?.revert(true);
+				undoStack.pop()?.revert();
 
 				tree2.transaction.start();
 				tree2.editor.addNodeExistsConstraint(bPath);
@@ -2824,7 +2824,7 @@ describe("Editing", () => {
 				const tree2 = tree.fork();
 
 				optional.set(undefined, false);
-				undoStack.pop()?.revert(true);
+				undoStack.pop()?.revert();
 
 				tree2.transaction.start();
 				tree2.editor.addNodeExistsConstraint({
@@ -3086,7 +3086,7 @@ describe("Editing", () => {
 		tree.merge(restoreRoot, false);
 		expectJsonTree([tree, restoreRoot], []);
 
-		undoStack.pop()?.revert(true);
+		undoStack.pop()?.revert();
 		expectJsonTree(restoreRoot, [{ foo: "A" }]);
 
 		// Get access to the removed node

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -254,11 +254,11 @@ export function applyUndoRedoEdit(
 ): void {
 	switch (operation) {
 		case "undo": {
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 			break;
 		}
 		case "redo": {
-			redoStack.pop()?.revert(true);
+			redoStack.pop()?.revert();
 			break;
 		}
 		default:

--- a/packages/dds/tree/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
@@ -107,7 +107,7 @@ describe("Fuzz - undo/redo", () => {
 				 * Once the undo stack exposed, remove this array and use the stack to keep track instead.
 				 */
 				for (let j = 0; j < opsPerRun; j++) {
-					tree.undoStack.pop()?.revert(true);
+					tree.undoStack.pop()?.revert();
 				}
 			}
 
@@ -127,7 +127,7 @@ describe("Fuzz - undo/redo", () => {
 				const tree = viewFromState(finalState, client).checkout;
 				assert(isRevertibleSharedTreeView(tree));
 				for (let j = 0; j < opsPerRun; j++) {
-					tree.redoStack.pop()?.revert(true);
+					tree.redoStack.pop()?.revert();
 				}
 				validateTree(tree, finalTreeStates[i]);
 			}
@@ -197,7 +197,7 @@ describe("Fuzz - undo/redo", () => {
 			for (const clientIndex of undoOrderByClientIndex) {
 				const view = viewFromState(finalState, finalState.clients[clientIndex]).checkout;
 				assert(isRevertibleSharedTreeView(view));
-				view.undoStack.pop()?.revert(true);
+				view.undoStack.pop()?.revert();
 			}
 			// synchronize clients after undo
 			finalState.containerRuntimeFactory.processAllMessages();

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -236,7 +236,7 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(undoStack.length, 1);
 		assert.equal(redoStack.length, 0);
 
-		undoStack.pop()?.revert(true);
+		undoStack.pop()?.revert();
 		assert.equal(undoStack.length, 0);
 		assert.equal(redoStack.length, 1);
 	});

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -668,7 +668,7 @@ describe("SharedTree", () => {
 
 		const revertible = undoStack.pop();
 		assert(revertible !== undefined, "expected undo stack to have an entry");
-		revertible.revert(true);
+		revertible.revert();
 
 		validateTreeContent(summarizingTree.checkout, {
 			schema: stringSequenceRootSchema,
@@ -847,14 +847,14 @@ describe("SharedTree", () => {
 			assert.deepEqual([...tree2.flexTree], [value]);
 
 			// Undo node insertion
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 			provider.processMessages();
 
 			assert.deepEqual([...tree1.flexTree], []);
 			assert.deepEqual([...tree2.flexTree], []);
 
 			// Redo node insertion
-			redoStack.pop()?.revert(true);
+			redoStack.pop()?.revert();
 			provider.processMessages();
 
 			assert.deepEqual([...tree1.flexTree], [value]);
@@ -886,28 +886,28 @@ describe("SharedTree", () => {
 			assert.deepEqual([...tree2.flexTree], [value, value2, value3]);
 
 			// Undo node insertion
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 			provider.processMessages();
 
 			assert.deepEqual([...tree1.flexTree], [value2, value3]);
 			assert.deepEqual([...tree2.flexTree], [value2, value3]);
 
 			// Undo node insertion
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 			provider.processMessages();
 
 			assert.deepEqual([...tree1.flexTree], [value3]);
 			assert.deepEqual([...tree2.flexTree], [value3]);
 
 			// Undo node insertion
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 			provider.processMessages();
 
 			assert.deepEqual([...tree1.flexTree], []);
 			assert.deepEqual([...tree2.flexTree], []);
 
 			// Redo node insertion
-			redoStack.pop()?.revert(true);
+			redoStack.pop()?.revert();
 			provider.processMessages();
 
 			assert.deepEqual([...tree1.flexTree], [value3]);
@@ -954,10 +954,10 @@ describe("SharedTree", () => {
 			provider.processMessages();
 
 			// Undo node insertion on both trees
-			undoStack1.pop()?.revert(true);
+			undoStack1.pop()?.revert();
 			assert.deepEqual([...root1], ["A", "B", "C", "y", "D"]);
 
-			undoStack2.pop()?.revert(true);
+			undoStack2.pop()?.revert();
 			assert.deepEqual([...root2], ["A", "x", "B", "C", "D"]);
 
 			provider.processMessages();
@@ -970,10 +970,10 @@ describe("SharedTree", () => {
 
 			const expectedAfterRedo = ["0", "A", "x", "B", "C", "y", "D"];
 			// Redo node insertion on both trees
-			redoStack1.pop()?.revert(true);
+			redoStack1.pop()?.revert();
 			assert.deepEqual([...root1], ["0", "A", "x", "B", "C", "D"]);
 
-			redoStack2.pop()?.revert(true);
+			redoStack2.pop()?.revert();
 			assert.deepEqual([...root2], ["A", "B", "C", "y", "D"]);
 
 			provider.processMessages();
@@ -1029,14 +1029,14 @@ describe("SharedTree", () => {
 
 			// ensure the remove is out of the collab window
 			assert(removeSequenceNumber < provider.minimumSequenceNumber);
-			undoStack[0]?.revert(true);
+			undoStack[0]?.revert();
 
 			provider.processMessages();
 			assert.deepEqual([...root1], ["A", "B", "C", "D"]);
 			assert.deepEqual([...root2], ["A", "B", "C", "D"]);
 
 			assert.equal(redoStack.length, 1);
-			redoStack.pop()?.revert(true);
+			redoStack.pop()?.revert();
 
 			provider.processMessages();
 			assert.deepEqual([...root1], ["B", "C", "D"]);
@@ -1093,11 +1093,11 @@ describe("SharedTree", () => {
 					assert.deepEqual([...tree2.flexTree.content.content], []);
 
 					if (scenario === "restore then change") {
-						undoStack1.pop()?.revert(true);
-						undoStack2.pop()?.revert(true);
+						undoStack1.pop()?.revert();
+						undoStack2.pop()?.revert();
 					} else {
-						undoStack2.pop()?.revert(true);
-						undoStack1.pop()?.revert(true);
+						undoStack2.pop()?.revert();
+						undoStack1.pop()?.revert();
 					}
 
 					provider.processMessages();
@@ -1232,19 +1232,19 @@ describe("SharedTree", () => {
 
 					resubmitter.setConnected(false);
 
-					s2.revert(true);
-					s1.revert(true);
+					s2.revert();
+					s1.revert();
 					submitter.assertOuterListEquals([]);
 					submitter.assertInnerListEquals(["a", "r"]);
 
 					provider.processMessages();
 
 					if (scenario === "restore and edit") {
-						rRemove.revert(true);
-						rEdit.revert(true);
+						rRemove.revert();
+						rEdit.revert();
 					} else {
-						rEdit.revert(true);
-						rRemove.revert(true);
+						rEdit.revert();
+						rRemove.revert();
 					}
 					resubmitter.assertOuterListEquals([["a", "s1", "s2"]]);
 
@@ -1275,18 +1275,18 @@ describe("SharedTree", () => {
 					resubmitter.setConnected(false);
 
 					if (scenario === "restore and edit") {
-						sRemove.revert(true);
-						sEdit.revert(true);
+						sRemove.revert();
+						sEdit.revert();
 					} else {
-						sEdit.revert(true);
-						sRemove.revert(true);
+						sEdit.revert();
+						sRemove.revert();
 					}
 					submitter.assertOuterListEquals([["a", "r1", "r2"]]);
 
 					provider.processMessages();
 
-					r2.revert(true);
-					r1.revert(true);
+					r2.revert();
+					r1.revert();
 					resubmitter.assertOuterListEquals([]);
 					resubmitter.assertInnerListEquals(["a", "s"]);
 
@@ -1321,7 +1321,7 @@ describe("SharedTree", () => {
 				resubmitter.assertOuterListEquals([]);
 				resubmitter.assertInnerListEquals(["a", "f"]);
 
-				rRemove.revert(true);
+				rRemove.revert();
 				resubmitter.assertOuterListEquals([["a", "f"]]);
 
 				resubmitter.setConnected(true);
@@ -1369,7 +1369,7 @@ describe("SharedTree", () => {
 			assert.equal(undoStack1.length, 1);
 			assert.equal(undoStack2.length, 0);
 
-			undoStack1.pop()?.revert(true);
+			undoStack1.pop()?.revert();
 			provider.processMessages();
 
 			// Insert node
@@ -1381,7 +1381,7 @@ describe("SharedTree", () => {
 			assert.equal(undoStack2.length, 1);
 			assert.equal(redoStack2.length, 0);
 
-			redoStack1.pop()?.revert(true);
+			redoStack1.pop()?.revert();
 			provider.processMessages();
 
 			assert.equal(undoStack1.length, 1);
@@ -1656,7 +1656,7 @@ describe("SharedTree", () => {
 			expectSchemaEqual(tree.storedSchema, intoStoredSchema(jsonSequenceRootSchema));
 
 			const revertible = undoStack.pop();
-			revertible?.revert(true);
+			revertible?.revert();
 
 			expectSchemaEqual(tree.storedSchema, intoStoredSchema(stringSequenceRootSchema));
 		});

--- a/packages/dds/tree/src/test/shared-tree/treeApi.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeApi.spec.ts
@@ -92,10 +92,10 @@ describe("treeApi", () => {
 			});
 			assert.equal(view.root.content, 44);
 			assert.equal(undoStack.length, 1);
-			undoStack[0].revert(true);
+			undoStack[0].revert();
 			assert.equal(view.root.content, 42);
 			assert.equal(redoStack.length, 1);
-			redoStack[0].revert(true);
+			redoStack[0].revert();
 			assert.equal(view.root.content, 44);
 		});
 	});
@@ -173,10 +173,10 @@ describe("treeApi", () => {
 			});
 			assert.equal(view.root.content, 44);
 			assert.equal(undoStack.length, 1);
-			undoStack[0].revert(true);
+			undoStack[0].revert();
 			assert.equal(view.root.content, 42);
 			assert.equal(redoStack.length, 1);
-			redoStack[0].revert(true);
+			redoStack[0].revert();
 			assert.equal(view.root.content, 44);
 		});
 

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -381,7 +381,7 @@ describe("sharedTreeView", () => {
 			const anchor = cursor.buildAnchor();
 			cursor.clear();
 			insertFirstNode(view, "B");
-			undoStack.pop()?.revert(true);
+			undoStack.pop()?.revert();
 			cursor = view.forest.allocateCursor();
 			view.forest.tryMoveCursorToNode(anchor, cursor);
 			assert.equal(cursor.value, "A");
@@ -672,13 +672,13 @@ describe("sharedTreeView", () => {
 
 		checkout1.editor.sequenceField(rootField).remove(0, 1); // Remove "A"
 		checkout1.editor.sequenceField(rootField).remove(0, 1); // Remove 1
-		checkout1Revertibles.undoStack.pop()?.revert(true); // Restore 1
+		checkout1Revertibles.undoStack.pop()?.revert(); // Restore 1
 		provider.processMessages();
 
 		const checkout2Revertibles = createTestUndoRedoStacks(checkout2.events);
 		checkout2.editor.sequenceField(rootField).remove(1, 1); // Remove "B"
 		checkout2.editor.sequenceField(rootField).remove(1, 1); // Remove 2
-		checkout2Revertibles.undoStack.pop()?.revert(true); // Restore 2
+		checkout2Revertibles.undoStack.pop()?.revert(); // Restore 2
 		provider.processMessages();
 
 		const expectedContent = {
@@ -812,7 +812,7 @@ describe("sharedTreeView", () => {
 			assert.equal(revertiblesCreated.length, 2);
 
 			// Each revert also leads to the creation of a revertible event
-			revertiblesCreated[1].revert(true);
+			revertiblesCreated[1].revert();
 
 			assert.equal(revertiblesCreated.length, 3);
 
@@ -849,7 +849,7 @@ describe("sharedTreeView", () => {
 				revertiblesCreated[1].revert(false);
 				assert.equal(revertiblesDisposed.length, 1);
 
-				revertiblesCreated[1].revert(true);
+				revertiblesCreated[1].revert();
 				assert.equal(revertiblesDisposed.length, 2);
 
 				unsubscribe1();
@@ -927,8 +927,8 @@ describe("sharedTreeView", () => {
 			});
 
 			insertFirstNode(view, "A");
-			revertiblesCreated[0].revert(true);
-			revertiblesCreated[1].revert(true);
+			revertiblesCreated[0].revert();
+			revertiblesCreated[1].revert();
 
 			assert.deepEqual(commitKinds, [CommitKind.Default, CommitKind.Undo, CommitKind.Redo]);
 
@@ -980,10 +980,10 @@ describe("sharedTreeView", () => {
 			// It should still be possible to revert the the child branch's revertibles
 			assert.equal(stacks.undoStack.length, 2);
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			stacks.undoStack.pop()!.revert(true);
+			stacks.undoStack.pop()!.revert();
 			assert.equal(getTestValue(fork), "B");
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			stacks.undoStack.pop()!.revert(true);
+			stacks.undoStack.pop()!.revert();
 			assert.equal(getTestValue(fork), "A");
 
 			stacks.unsubscribe();

--- a/packages/dds/tree/src/test/shared-tree/undo.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/undo.spec.ts
@@ -155,14 +155,14 @@ describe("Undo and redo", () => {
 			expectJsonTree(fork, editedState);
 
 			for (let i = 0; i < count; i++) {
-				undoStack.pop()?.revert(true);
+				undoStack.pop()?.revert();
 			}
 
 			fork.rebaseOnto(view);
 			expectJsonTree(fork, undoState ?? initialState);
 
 			while (redoStack.length > 0) {
-				redoStack.pop()?.revert(true);
+				redoStack.pop()?.revert();
 			}
 
 			fork.rebaseOnto(view);
@@ -182,14 +182,14 @@ describe("Undo and redo", () => {
 			expectJsonTree(fork, editedState);
 
 			for (let i = 0; i < count; i++) {
-				undoStack.pop()?.revert(true);
+				undoStack.pop()?.revert();
 			}
 
 			fork.rebaseOnto(view);
 			expectJsonTree(fork, undoState ?? initialState);
 
 			while (redoStack.length > 0) {
-				redoStack.pop()?.revert(true);
+				redoStack.pop()?.revert();
 			}
 
 			fork.rebaseOnto(view);
@@ -208,14 +208,14 @@ describe("Undo and redo", () => {
 			expectJsonTree(view, editedState);
 
 			for (let i = 0; i < count; i++) {
-				undoStack.pop()?.revert(true);
+				undoStack.pop()?.revert();
 			}
 
 			view.merge(fork, false);
 			expectJsonTree(view, undoState ?? initialState);
 
 			while (redoStack.length > 0) {
-				redoStack.pop()?.revert(true);
+				redoStack.pop()?.revert();
 			}
 
 			view.merge(fork);
@@ -235,14 +235,14 @@ describe("Undo and redo", () => {
 			expectJsonTree(view, editedState);
 
 			for (let i = 0; i < count; i++) {
-				undoStack.pop()?.revert(true);
+				undoStack.pop()?.revert();
 			}
 
 			view.merge(fork, false);
 			expectJsonTree(view, undoState ?? initialState);
 
 			while (redoStack.length > 0) {
-				redoStack.pop()?.revert(true);
+				redoStack.pop()?.revert();
 			}
 
 			view.merge(fork);
@@ -259,11 +259,11 @@ describe("Undo and redo", () => {
 		tree1.editor.sequenceField(rootField).insert(3, singleJsonCursor(1));
 		tree2.editor.sequenceField(rootField).insert(0, singleJsonCursor(2));
 		tree2.editor.sequenceField(rootField).insert(0, singleJsonCursor(3));
-		undoStack.pop()?.revert(true);
+		undoStack.pop()?.revert();
 		expectJsonTree(tree2, [2, 0, 0, 0]);
 		tree2.rebaseOnto(tree1);
 		expectJsonTree(tree2, [2, 0, 0, 0, 1]);
-		undoStack.pop()?.revert(true);
+		undoStack.pop()?.revert();
 		expectJsonTree(tree2, [0, 0, 0, 1]);
 		unsubscribe();
 	});
@@ -283,9 +283,9 @@ describe("Undo and redo", () => {
 			tree2.events,
 		);
 		expectJsonTree(tree2, ["B"]);
-		undoStack1.pop()?.revert(true);
+		undoStack1.pop()?.revert();
 		expectJsonTree(tree2, ["B", "C"]);
-		undoStack2.pop()?.revert(true);
+		undoStack2.pop()?.revert();
 		expectJsonTree(tree2, ["A", "B", "C"]);
 		unsubscribe1();
 		unsubscribe2();
@@ -300,17 +300,17 @@ describe("Undo and redo", () => {
 		);
 		tree1.editor.sequenceField(rootField).insert(0, singleJsonCursor("A"));
 		tree1.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
-		undoStack1.pop()?.revert(true);
-		undoStack1.pop()?.revert(true);
+		undoStack1.pop()?.revert();
+		undoStack1.pop()?.revert();
 
 		const tree2 = tree1.fork();
 		const { redoStack: redoStack2, unsubscribe: unsubscribe2 } = createTestUndoRedoStacks(
 			tree2.events,
 		);
 		expectJsonTree(tree2, ["B"]);
-		redoStack2.pop()?.revert(true);
+		redoStack2.pop()?.revert();
 		expectJsonTree(tree2, ["A", "B"]);
-		redoStack2.pop()?.revert(true);
+		redoStack2.pop()?.revert();
 		expectJsonTree(tree2, ["A", "B", "C"]);
 		unsubscribe1();
 		unsubscribe2();
@@ -326,9 +326,9 @@ describe("Undo and redo", () => {
 		tree.transaction.commit();
 
 		expectJsonTree(tree, ["B", "C"]);
-		undoStack.pop()?.revert(true);
+		undoStack.pop()?.revert();
 		expectJsonTree(tree, ["A", "B"]);
-		redoStack.pop()?.revert(true);
+		redoStack.pop()?.revert();
 		expectJsonTree(tree, ["B", "C"]);
 		unsubscribe();
 	});
@@ -340,13 +340,13 @@ describe("Undo and redo", () => {
 		tree.editor.sequenceField(rootField).insert(2, singleJsonCursor("C"));
 
 		expectJsonTree(tree, ["A", "B", "C"]);
-		undoStack.pop()?.revert(true);
+		undoStack.pop()?.revert();
 		expectJsonTree(tree, ["A", "B"]);
-		redoStack.pop()?.revert(true);
+		redoStack.pop()?.revert();
 		expectJsonTree(tree, ["A", "B", "C"]);
-		undoStack.pop()?.revert(true);
+		undoStack.pop()?.revert();
 		expectJsonTree(tree, ["A", "B"]);
-		redoStack.pop()?.revert(true);
+		redoStack.pop()?.revert();
 		expectJsonTree(tree, ["A", "B", "C"]);
 		unsubscribe();
 	});
@@ -358,13 +358,13 @@ describe("Undo and redo", () => {
 		tree.editor.sequenceField(rootField).move(1, 1, 0);
 
 		expectJsonTree(tree, ["B", "A"]);
-		undoStack.pop()?.revert(true);
+		undoStack.pop()?.revert();
 		expectJsonTree(tree, ["A", "B"]);
-		redoStack.pop()?.revert(true);
+		redoStack.pop()?.revert();
 		expectJsonTree(tree, ["B", "A"]);
-		undoStack.pop()?.revert(true);
+		undoStack.pop()?.revert();
 		expectJsonTree(tree, ["A", "B"]);
-		redoStack.pop()?.revert(true);
+		redoStack.pop()?.revert();
 		expectJsonTree(tree, ["B", "A"]);
 		unsubscribe();
 	});

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -326,6 +326,7 @@ export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
 // @public
 export interface Revertible {
     [disposeSymbol](): void;
+    revert(): void;
     revert(dispose: boolean): void;
     readonly status: RevertibleStatus;
 }


### PR DESCRIPTION
## Description

Adds an overload that does not take a `dispose: boolean` parameter but disposes the revertible unconditionally.

Rationale: most users will not bother with attempting to revert multiple times.

## Breaking Changes

None
