### PR TITLE
ci(lts): Disable path-based label GitHub action

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,15 +4,6 @@ on:
     types: [ opened, synchronize, reopened ]
 
 jobs:
-  paths_label:
-    runs-on: ubuntu-latest
-    name: Label based on file paths
-    steps:
-      - uses: actions/labeler@26546f6c4d63b6c0623e8e39bde7869e3c2b1d7b # pin@v3
-        with:
-          configuration-path: ".github/actions-labeler.yml"
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: true # add/remove labels as modified paths in the PR change
   branches_label:
     runs-on: ubuntu-latest
     name: Label base branches


### PR DESCRIPTION
This workflow continually fails in LTS and is not that useful since we have few LTS PRs, so I just removed it completely.