### PR TITLE
Retry joinsession only when ReconnectMode = Enabled

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -644,38 +644,46 @@ export class ConnectionManager implements IConnectionManager {
 
 				lastError = origError;
 
-				const waitStartTime = performance.now();
-				const retryDelayFromError = getRetryDelayFromError(origError);
-				// If the error told us to wait or browser signals us that we are offline, then calculate the time we
-				// want to wait for before retrying. then we wait for that time. If the error didn't tell us to wait,
-				// let's still wait a little bit before retrying. We can skip this delay if we're confident we're offline,
-				// because we probably just need to wait to come back online. But we never have strong signal of being
-				// offline, so we at least wait for sometime.
-				if (retryDelayFromError !== undefined || globalThis.navigator?.onLine !== false) {
-					delayMs = calculateMaxWaitTime(delayMs, origError);
+				// We will not perform retries if the container disconnected, so break out of the while loop after first attempt to connect
+				if (this.reconnectMode == ReconnectMode.Disabled) {
+					break;
+				} else {
+					const waitStartTime = performance.now();
+					const retryDelayFromError = getRetryDelayFromError(origError);
+					// If the error told us to wait or browser signals us that we are offline, then calculate the time we
+					// want to wait for before retrying. then we wait for that time. If the error didn't tell us to wait,
+					// let's still wait a little bit before retrying. We can skip this delay if we're confident we're offline,
+					// because we probably just need to wait to come back online. But we never have strong signal of being
+					// offline, so we at least wait for sometime.
+					if (
+						retryDelayFromError !== undefined ||
+						globalThis.navigator?.onLine !== false
+					) {
+						delayMs = calculateMaxWaitTime(delayMs, origError);
+					}
+
+					// Raise event in case the delay was there from the error.
+					if (retryDelayFromError !== undefined) {
+						this.props.reconnectionDelayHandler(delayMs, origError);
+					}
+
+					await new Promise<void>((resolve) => {
+						setTimeout(resolve, delayMs);
+					});
+
+					// If we believe we're offline, we assume there's no point in trying until we at least think we're online.
+					// NOTE: This isn't strictly true for drivers that don't require network (e.g. local driver).  Really this logic
+					// should probably live in the driver.
+					await waitForOnline();
+					this.logger.sendPerformanceEvent({
+						eventName: "WaitBetweenConnectionAttempts",
+						duration: performance.now() - waitStartTime,
+						details: JSON.stringify({
+							retryDelayFromError,
+							delayMs,
+						}),
+					});
 				}
-
-				// Raise event in case the delay was there from the error.
-				if (retryDelayFromError !== undefined) {
-					this.props.reconnectionDelayHandler(delayMs, origError);
-				}
-
-				await new Promise<void>((resolve) => {
-					setTimeout(resolve, delayMs);
-				});
-
-				// If we believe we're offline, we assume there's no point in trying until we at least think we're online.
-				// NOTE: This isn't strictly true for drivers that don't require network (e.g. local driver).  Really this logic
-				// should probably live in the driver.
-				await waitForOnline();
-				this.logger.sendPerformanceEvent({
-					eventName: "WaitBetweenConnectionAttempts",
-					duration: performance.now() - waitStartTime,
-					details: JSON.stringify({
-						retryDelayFromError,
-						delayMs,
-					}),
-				});
 			}
 		}
 

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -647,7 +647,7 @@ export class ConnectionManager implements IConnectionManager {
 				// We will not perform retries if the container disconnected and the ReconnectMode is set to Disabled or Never
 				// so break out of the re-connecting while-loop after first attempt
 				if (this.reconnectMode !== ReconnectMode.Enabled) {
-					break;
+					return;
 				}
 
 				const waitStartTime = performance.now();
@@ -698,21 +698,19 @@ export class ConnectionManager implements IConnectionManager {
 			);
 		}
 
-		if (connection) {
-			// Check for abort signal after while loop as well or we've been disposed
-			if (abortSignal.aborted === true || this._disposed) {
-				connection.dispose();
-				this.logger.sendTelemetryEvent({
-					eventName: "ConnectionAttemptCancelled",
-					attempts: connectRepeatCount,
-					duration: formatTick(performance.now() - connectStartTime),
-					connectionEstablished: true,
-				});
-				return;
-			}
-
-			this.setupNewSuccessfulConnection(connection, requestedMode, reason);
+		// Check for abort signal after while loop as well or we've been disposed
+		if (abortSignal.aborted === true || this._disposed) {
+			connection.dispose();
+			this.logger.sendTelemetryEvent({
+				eventName: "ConnectionAttemptCancelled",
+				attempts: connectRepeatCount,
+				duration: formatTick(performance.now() - connectStartTime),
+				connectionEstablished: true,
+			});
+			return;
 		}
+
+		this.setupNewSuccessfulConnection(connection, requestedMode, reason);
 	}
 
 	/**

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -644,10 +644,8 @@ export class ConnectionManager implements IConnectionManager {
 
 				lastError = origError;
 
-				// We will not perform retries if the container disconnected, so break out of the while loop after first attempt to connect
-				if (this.reconnectMode == ReconnectMode.Disabled) {
-					break;
-				} else {
+				// We will not perform retries if the container ReconnectMode is Enabled
+				if (this.reconnectMode == ReconnectMode.Enabled) {
 					const waitStartTime = performance.now();
 					const retryDelayFromError = getRetryDelayFromError(origError);
 					// If the error told us to wait or browser signals us that we are offline, then calculate the time we
@@ -683,6 +681,10 @@ export class ConnectionManager implements IConnectionManager {
 							delayMs,
 						}),
 					});
+				} else {
+					// We will not perform retries if the container disconnected and the ReconnectMode is set to Disabled or Never
+					// so break out of the re-connecting while-loop after first attempt
+					break;
 				}
 			}
 		}

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -702,19 +702,21 @@ export class ConnectionManager implements IConnectionManager {
 			);
 		}
 
-		// Check for abort signal after while loop as well or we've been disposed
-		if (abortSignal.aborted === true || this._disposed) {
-			connection.dispose();
-			this.logger.sendTelemetryEvent({
-				eventName: "ConnectionAttemptCancelled",
-				attempts: connectRepeatCount,
-				duration: formatTick(performance.now() - connectStartTime),
-				connectionEstablished: true,
-			});
-			return;
-		}
+		if (connection) {
+			// Check for abort signal after while loop as well or we've been disposed
+			if (abortSignal.aborted === true || this._disposed) {
+				connection.dispose();
+				this.logger.sendTelemetryEvent({
+					eventName: "ConnectionAttemptCancelled",
+					attempts: connectRepeatCount,
+					duration: formatTick(performance.now() - connectStartTime),
+					connectionEstablished: true,
+				});
+				return;
+			}
 
-		this.setupNewSuccessfulConnection(connection, requestedMode, reason);
+			this.setupNewSuccessfulConnection(connection, requestedMode, reason);
+		}
 	}
 
 	/**

--- a/packages/loader/container-loader/src/test/connectionManager.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionManager.spec.ts
@@ -269,14 +269,14 @@ describe("connectionManager", () => {
 		});
 		connectionManager.connect({ text: "Test reconnect" });
 
-		await clock.tickAsync(retryAfter * 1000 * 5);
+		await clock.tickAsync(retryAfter * 1000 * 10);
 		assert(
 			stubbedConnectToDeltaStream.callCount > 1,
 			"Reconnection should have been attempted after failure",
 		);
 
 		const calledTimes = stubbedConnectToDeltaStream.callCount;
-		clock.tick(retryAfter * 1000 * 5);
+		clock.tick(retryAfter * 1000 * 10);
 		assert.equal(
 			stubbedConnectToDeltaStream.callCount,
 			calledTimes,
@@ -299,13 +299,13 @@ describe("connectionManager", () => {
 		const connectionManager = createConnectionManager();
 		connectionManager.connect({ text: "Test reconnect" });
 
-		await clock.tickAsync(retryAfter * 1000 * 5);
+		await clock.tickAsync(retryAfter * 1000 * 10);
 		assert(
 			stubbedConnectToDeltaStream.callCount > 1,
 			"Reconnection should have been attempted after failure",
 		);
 		const calledTimes = stubbedConnectToDeltaStream.callCount;
-		await clock.tickAsync(retryAfter * 1000 * 5);
+		await clock.tickAsync(retryAfter * 1000 * 10);
 		assert(
 			stubbedConnectToDeltaStream.callCount > calledTimes,
 			"Reattempt for connection should continue to happen",

--- a/packages/loader/container-loader/src/test/connectionManager.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionManager.spec.ts
@@ -86,14 +86,16 @@ describe("connectionManager", () => {
 		clock.restore();
 	});
 
-	function createConnectionManager(): ConnectionManager {
+	function createConnectionManager(
+		customProps?: IConnectionManagerFactoryArgs,
+	): ConnectionManager {
 		return new ConnectionManager(
 			() => mockDocumentService,
 			() => false,
 			client as IClient,
 			true /* reconnectAllowed */,
 			mockLogger.toTelemetryLogger(),
-			props,
+			customProps ?? props,
 		);
 	}
 
@@ -234,37 +236,6 @@ describe("connectionManager", () => {
 	});
 
 	it("Does not re-try connection on error if ReconnectMode=Disabled", async () => {
-		const connectionManager = createConnectionManager();
-		// mock connectToDeltaStream method so that it throws a retriable error when connect() is called in connectionManager
-		const stubbedConnectToDeltaStream = stub(mockDocumentService, "connectToDeltaStream");
-		const retryAfter = 0.2; // seconds
-		stubbedConnectToDeltaStream.throws(
-			// Throw retryable error
-			new RetryableError("Test message", NackErrorType.ThrottlingError, {
-				retryAfterSeconds: retryAfter,
-				driverVersion: "1",
-			}),
-		);
-		// This step will also disconnect the connection.
-		connectionManager.setAutoReconnect(ReconnectMode.Disabled, { text: "Test" });
-		connectionManager.connect({ text: "Test reconnect" });
-		assert(
-			stubbedConnectToDeltaStream.calledOnce,
-			"Connection should have been attempted only once",
-		);
-		clock.tick(retryAfter * 1000 + 10);
-
-		// Check if there has been any retry attempt after the retryAfter time as elapsed.
-		assert.equal(
-			stubbedConnectToDeltaStream.callCount,
-			1,
-			"Connection should have been attempted only once (when the connect() was called above), even after the retry timeout",
-		);
-		stubbedConnectToDeltaStream.restore();
-	});
-
-	it("Does try re-connection on error if ReconnectMode=Enabled", async () => {
-		const connectionManager = createConnectionManager();
 		// mock connectToDeltaStream method so that it throws a retriable error when connect() is called in connectionManager
 		const stubbedConnectToDeltaStream = stub(mockDocumentService, "connectToDeltaStream");
 		const retryAfter = 3; // seconds
@@ -275,20 +246,69 @@ describe("connectionManager", () => {
 				driverVersion: "1",
 			}),
 		);
-		connectionManager.setAutoReconnect(ReconnectMode.Enabled, { text: "Test" });
+		let isTimeoutSet = false;
+		const connectionManager = createConnectionManager({
+			...props,
+			// reconnectionDelayHandler should be invoked by connectionManager when the throttling errors occur causing it to attept retries
+			reconnectionDelayHandler: () => {
+				// Ideally this function from deltaManager emits "throttled" warning event which is bubbled up as container warning that host can listen to
+				// and call container.disconnect() if they wish.
+				// Emulate calling container.disconnect() which results in setting connectionManager reconnect state as "Disabled" after random amount of time
+				if (!isTimeoutSet) {
+					isTimeoutSet = true;
+					setTimeout(
+						() => {
+							connectionManager.setAutoReconnect(ReconnectMode.Disabled, {
+								text: "Container disconnected",
+							});
+						},
+						retryAfter * 1000 * 5,
+					);
+				}
+			},
+		});
 		connectionManager.connect({ text: "Test reconnect" });
 
+		await clock.tickAsync(retryAfter * 1000 * 5);
 		assert(
-			stubbedConnectToDeltaStream.calledOnce,
-			"Connection should have been attempted only once",
+			stubbedConnectToDeltaStream.callCount > 1,
+			"Reconnection should have been attempted after failure",
 		);
-		await clock.tickAsync(retryAfter * 1000);
 
-		// Check if there has been any retry attempt after the retryAfter time as elapsed.
+		const calledTimes = stubbedConnectToDeltaStream.callCount;
+		clock.tick(retryAfter * 1000 * 5);
 		assert.equal(
 			stubbedConnectToDeltaStream.callCount,
-			2,
-			"Connection should have been attempted twice by now",
+			calledTimes,
+			"Reattempt counts should remain the same as before i.e. no new attempts should be made after ReconnectMode.Disabled is set",
+		);
+		stubbedConnectToDeltaStream.restore();
+	});
+
+	it("Does try re-connection on error if ReconnectMode=Enabled", async () => {
+		// mock connectToDeltaStream method so that it throws a retriable error when connect() is called in connectionManager
+		const stubbedConnectToDeltaStream = stub(mockDocumentService, "connectToDeltaStream");
+		const retryAfter = 3; // seconds
+		stubbedConnectToDeltaStream.throws(
+			// Throw retryable error
+			new RetryableError("Test message", NackErrorType.ThrottlingError, {
+				retryAfterSeconds: retryAfter,
+				driverVersion: "1",
+			}),
+		);
+		const connectionManager = createConnectionManager();
+		connectionManager.connect({ text: "Test reconnect" });
+
+		await clock.tickAsync(retryAfter * 1000 * 5);
+		assert(
+			stubbedConnectToDeltaStream.callCount > 1,
+			"Reconnection should have been attempted after failure",
+		);
+		const calledTimes = stubbedConnectToDeltaStream.callCount;
+		await clock.tickAsync(retryAfter * 1000 * 5);
+		assert(
+			stubbedConnectToDeltaStream.callCount > calledTimes,
+			"Reattempt for connection should continue to happen",
 		);
 		stubbedConnectToDeltaStream.restore();
 	});


### PR DESCRIPTION
connnectionManager went to an infinite loop of retrying to connect to delta stream service even when the container was disconnected and the ReconnectMode was set to Disabled or Never. This adds a check for ReconnectMode value before performing a re-try.