### PR TITLE
fix(generate:upcoming): Include all changesets when release type is major

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/upcoming.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/upcoming.ts
@@ -85,7 +85,7 @@ export default class GenerateUpcomingCommand extends BaseCommand<
 
 		let body: string = "";
 		for (const change of changes) {
-			if (change.changeTypes.includes(flags.releaseType)) {
+			if (change.changeTypes.includes("minor") || flags.releaseType === "major") {
 				body += `## ${change.summary}\n\n${change.content}\n\n`;
 			} else {
 				this.info(


### PR DESCRIPTION
Previously, a given changeset was assumed to have only a single change type (major or minor). Moving forward releases will contain both major and minor changes, so the `generate upcoming` command has been updated to no longer filter out changesets with only minor changes when a major release type is selected.