### PR TITLE
Adding verbose logs for a few error events

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/contextManager.ts
@@ -11,6 +11,7 @@ import {
 	IQueuedMessage,
 	IRoutingKey,
 } from "@fluidframework/server-services-core";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { DocumentContext } from "./documentContext";
 
 const LastCheckpointedOffset: IQueuedMessage = {
@@ -60,9 +61,10 @@ export class DocumentContextManager extends EventEmitter {
 		context.addListener("checkpoint", (restartOnCheckpointFailure?: boolean) =>
 			this.updateCheckpoint(restartOnCheckpointFailure),
 		);
-		context.addListener("error", (error, errorData: IContextErrorData) =>
-			this.emit("error", error, errorData),
-		);
+		context.addListener("error", (error, errorData: IContextErrorData) => {
+			Lumberjack.verbose("Emitting error from contextManager, context error event.");
+			this.emit("error", error, errorData);
+		});
 		return context;
 	}
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentContext.ts
@@ -12,6 +12,7 @@ import {
 	IContextErrorData,
 	IRoutingKey,
 } from "@fluidframework/server-services-core";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
 
 /**
  * @internal
@@ -95,6 +96,7 @@ export class DocumentContext extends EventEmitter implements IContext {
 
 	public error(error: any, errorData: IContextErrorData) {
 		this.contextError = error;
+		Lumberjack.verbose("Emitting error from documentContext");
 		this.emit("error", error, errorData);
 	}
 

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
@@ -40,6 +40,7 @@ export class DocumentLambda implements IPartitionLambda {
 	) {
 		this.contextManager = new DocumentContextManager(context);
 		this.contextManager.on("error", (error, errorData: IContextErrorData) => {
+			Lumberjack.verbose("Listening for errors in documentLambda, contextManager error event");
 			context.error(error, errorData);
 		});
 		this.activityCheckTimer = setInterval(

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentLambda.ts
@@ -40,7 +40,9 @@ export class DocumentLambda implements IPartitionLambda {
 	) {
 		this.contextManager = new DocumentContextManager(context);
 		this.contextManager.on("error", (error, errorData: IContextErrorData) => {
-			Lumberjack.verbose("Listening for errors in documentLambda, contextManager error event");
+			Lumberjack.verbose(
+				"Listening for errors in documentLambda, contextManager error event",
+			);
 			context.error(error, errorData);
 		});
 		this.activityCheckTimer = setInterval(

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -71,6 +71,7 @@ export class DocumentPartition {
 		this.q.pause();
 
 		this.context.on("error", (error: any, errorData: IContextErrorData) => {
+			Lumberjack.verbose("Listening for errors in documentPartition, context error event");
 			if (errorData.markAsCorrupt) {
 				this.markAsCorrupt(error, errorData.markAsCorrupt);
 			} else if (errorData.restart) {

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/context.ts
@@ -10,6 +10,7 @@ import {
 	ILogger,
 	IContextErrorData,
 } from "@fluidframework/server-services-core";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { CheckpointManager } from "./checkpointManager";
 
 export class Context extends EventEmitter implements IContext {
@@ -48,6 +49,7 @@ export class Context extends EventEmitter implements IContext {
 	 * @param errorData - Additional information about the error
 	 */
 	public error(error: any, errorData: IContextErrorData) {
+		Lumberjack.verbose("Emitting error from context");
 		this.emit("error", error, errorData);
 	}
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partition.ts
@@ -43,6 +43,7 @@ export class Partition extends EventEmitter {
 		this.checkpointManager = new CheckpointManager(id, consumer);
 		this.context = new Context(this.checkpointManager, this.logger);
 		this.context.on("error", (error: any, errorData: IContextErrorData) => {
+			Lumberjack.verbose("Emitting error from partition, context error event");
 			this.emit("error", error, errorData);
 		});
 

--- a/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/kafka-service/partitionManager.ts
@@ -228,7 +228,7 @@ export class PartitionManager extends EventEmitter {
 					);
 					return;
 				}
-
+				Lumberjack.verbose("Emitting error from partitionManager, partition error event");
 				this.emit("error", error, errorData);
 			});
 


### PR DESCRIPTION
## Description

Adding some verbose logs to track the error handling in case of document corruption - `markAsCorrupt` function calls `this.context.error` and the exception goes unhandled somewhere in that flow, causing the service to restart. So adding these logs to track that in prod as it is not reproducible locally. Verbose logs will be logged only in pilot clusters.

![image](https://github.com/microsoft/FluidFramework/assets/22322514/e36223a5-4d24-4ed4-a3b8-b06a74cb3a1c)
