### PR TITLE
fix(tree): fix revision-tagging during invert

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -547,7 +547,7 @@ export class ModularChangeFamily
 				localId,
 				this.invertNodeChange(
 					// TODO: This does not allow inheriting revision from parent
-					tagChange(nodeChangeset, revision ?? change.revision),
+					tagChange(nodeChangeset, change.revision),
 					isRollback,
 					genId,
 					crossFieldTable,


### PR DESCRIPTION
## Description

Fixes a bug in `ModularChangeFamily` that would result in nested changes being tagged with the wrong revision.

## Breaking Changes

None