### PR TITLE
Fix document schema summarization bug

### DIFF
--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -472,9 +472,9 @@ export class DocumentsSchemaController {
 			},
 		};
 
-		// Schema coming from document (summary). If it's a new container, make sure that it's
-		// equal to desired / session schema (it's one and the same in such case), as that's what will
-		// go into summary.
+		// Schema coming from document metadata (snapshot we loaded from), or if no document exists
+		// (this is a new document) then this is the same as desiredSchema (same as session schema in such case).
+		// Latter is importnat sure that's what will go into summary.
 		this.documentSchema = !existing
 			? this.desiredSchema
 			: (documentMetadataSchema as IDocumentSchemaCurrent) ??

--- a/packages/runtime/container-runtime/src/test/documentSchema.spec.ts
+++ b/packages/runtime/container-runtime/src/test/documentSchema.spec.ts
@@ -279,11 +279,11 @@ describe("Runtime", () => {
 				version: 1,
 				refSeq: 0,
 				runtime: {
-					explicitSchemaControl: boolToProp(features.explicitSchemaControl),
-					compressionLz4: boolToProp(features.compressionLz4),
-					idCompressorMode: features.idCompressorMode,
-					opGroupingEnabled: boolToProp(features.opGroupingEnabled),
-					disallowedVersions: arrayToProp(features.disallowedVersions),
+					explicitSchemaControl: boolToProp(featuresModified.explicitSchemaControl),
+					compressionLz4: boolToProp(featuresModified.compressionLz4),
+					idCompressorMode: featuresModified.idCompressorMode,
+					opGroupingEnabled: boolToProp(featuresModified.opGroupingEnabled),
+					disallowedVersions: arrayToProp(featuresModified.disallowedVersions),
 				},
 			};
 			assert.deepEqual(

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -39,6 +39,88 @@ function getIdCompressor(dds: IChannel): IIdCompressor {
 	return (dds as any).runtime.idCompressor as IIdCompressor;
 }
 
+describeCompat(
+	"Runtime IdCompressor - Schema changes",
+	"NoCompat",
+	(getTestObjectProvider, apis) => {
+		function runTests(explicitSchemaCreation: boolean, explicitSchemaLoading: boolean) {
+			let provider: ITestObjectProvider;
+
+			beforeEach("setupContainers", async () => {
+				provider = getTestObjectProvider();
+			});
+
+			const {
+				containerRuntime: { ContainerRuntimeFactoryWithDefaultDataStore },
+				dds: { SharedMap, SharedCell },
+			} = apis;
+
+			const containerConfigNoCompressor: ITestContainerConfig = {
+				registry: [
+					["mapId", SharedMap.getFactory()],
+					["cellId", SharedCell.getFactory()],
+				],
+				fluidDataObjectType: DataObjectFactoryType.Test,
+				loaderProps: {},
+				runtimeOptions: {
+					enableRuntimeIdCompressor: undefined,
+					explicitSchemaControl: explicitSchemaCreation,
+				},
+			};
+
+			const containerConfigWithCompressor: ITestContainerConfig = {
+				...containerConfigNoCompressor,
+				runtimeOptions: {
+					enableRuntimeIdCompressor: "on",
+					explicitSchemaControl: explicitSchemaLoading,
+				},
+			};
+
+			it("has no compressor if not enabled", async () => {
+				provider.reset();
+				const container = await provider.makeTestContainer(containerConfigNoCompressor);
+				const dataObject = (await container.getEntryPoint()) as ITestFluidObject;
+				const map = await dataObject.getSharedObject<ISharedMap>("mapId");
+
+				assert(getIdCompressor(map) === undefined);
+			});
+
+			it("can't enable compressor on an existing container", async () => {
+				provider.reset();
+				const container = await provider.makeTestContainer(containerConfigNoCompressor);
+				const dataObject = (await container.getEntryPoint()) as ITestFluidObject;
+				const map = await dataObject.getSharedObject<ISharedMap>("mapId");
+				assert(getIdCompressor(map) === undefined);
+
+				const enabledContainer = await provider.loadTestContainer(
+					containerConfigWithCompressor,
+				);
+				const enabledDataObject =
+					(await enabledContainer.getEntryPoint()) as ITestFluidObject;
+				const enabledMap = await enabledDataObject.getSharedObject<ISharedMap>("mapId");
+				assert(getIdCompressor(enabledMap) === undefined);
+			});
+
+			it("can't disable compressor if previously enabled on existing container", async () => {
+				const container = await provider.makeTestContainer(containerConfigWithCompressor);
+				const dataObject = (await container.getEntryPoint()) as ITestFluidObject;
+				const map = await dataObject.getSharedObject<ISharedMap>("mapId");
+				assert(getIdCompressor(map) !== undefined);
+
+				const container2 = await provider.loadTestContainer(containerConfigNoCompressor);
+				const dataObject2 = (await container2.getEntryPoint()) as ITestFluidObject;
+				const map2 = await dataObject2.getSharedObject<ISharedMap>("mapId");
+				assert(getIdCompressor(map2) !== undefined);
+			});
+		}
+
+		describe("Explicit Schema", () => runTests(true, true));
+		describe("Implicit Schema", () => runTests(false, false));
+		describe("Explicit Schema on load", () => runTests(false, true));
+		describe("Implicit Schema on create", () => runTests(true, false));
+	},
+);
+
 describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis) => {
 	const {
 		dataRuntime: { DataObject, DataObjectFactory },
@@ -153,51 +235,6 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 			enableRuntimeIdCompressor: "on",
 		},
 	};
-
-	it("has no compressor if not enabled", async () => {
-		provider.reset();
-		const container = await provider.makeTestContainer(containerConfigNoCompressor);
-		const dataObject = (await container.getEntryPoint()) as ITestFluidObject;
-		const map = await dataObject.getSharedObject<ISharedMap>("mapId");
-
-		assert(getIdCompressor(map) === undefined);
-	});
-
-	it("can't enable compressor on an existing container", async () => {
-		provider.reset();
-		const container = await provider.makeTestContainer(containerConfigNoCompressor);
-		const dataObject = (await container.getEntryPoint()) as ITestFluidObject;
-		const map = await dataObject.getSharedObject<ISharedMap>("mapId");
-		assert(getIdCompressor(map) === undefined);
-
-		const enabledContainer = await provider.loadTestContainer(containerConfigWithCompressor);
-		const enabledDataObject = (await enabledContainer.getEntryPoint()) as ITestFluidObject;
-		const enabledMap = await enabledDataObject.getSharedObject<ISharedMap>("mapId");
-		assert(getIdCompressor(enabledMap) === undefined);
-	});
-
-	it("can't disable compressor if previously enabled on existing container", async () => {
-		// Create a container without the runtime option to enable the compressor.
-		// The first container should set a metadata property that automatically should
-		// enable it for any other container runtimes that are created.
-		const runtimeFactoryWithoutCompressorEnabled =
-			createContainerRuntimeFactoryWithDefaultDataStore(
-				ContainerRuntimeFactoryWithDefaultDataStore,
-				{
-					defaultFactory,
-					registryEntries: [[defaultFactory.type, Promise.resolve(defaultFactory)]],
-				},
-			);
-
-		const container4 = await provider.loadContainer(runtimeFactoryWithoutCompressorEnabled);
-		const container4MainDataStore = (await container4.getEntryPoint()) as TestDataObject;
-		const sharedMapContainer4 = container4MainDataStore.map;
-
-		assert(
-			getIdCompressor(sharedMapContainer4) !== undefined,
-			"Compressor should exist if it has ever been enabled",
-		);
-	});
 
 	it("can normalize session space IDs to op space", async () => {
 		// None of these clusters will be ack'd yet and as such they will all


### PR DESCRIPTION
When we create a new document, we incorrectly produce a summary with empty schema, the same way as if we loaded from a document without any schema defined (=== default schema).
This is incorrect, as what we summarize should be equal to current session schema in such case.
This bug happens only if explicit schema management is ON - this explains why this bug was not caught by end-to-end tests.

Also changed out end-to-end tests to test all combinations regarding explicit vs. implicit schema management.