### PR TITLE
FIX : Handle checkpoint error and proceed with remaining ops deletion batch

### DIFF
--- a/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
+++ b/server/routerlicious/packages/services-utils/src/deleteSummarizedOps.ts
@@ -45,6 +45,14 @@ export async function deleteSummarizedOps(
 				doc.documentId,
 			);
 
+			if (realDoc === null) {
+				Lumberjack.error(
+					`Unable to delete ops. Reason: Failed to get latest checkpoint`,
+					lumberjackProperties,
+				);
+				continue;
+			}
+
 			const lastSummarySequenceNumber = JSON.parse(realDoc.scribe).lastSummarySequenceNumber;
 
 			// first "soft delete" operations older than the offline window, which have been summarised
@@ -84,7 +92,6 @@ export async function deleteSummarizedOps(
 			}
 		} catch (error) {
 			Lumberjack.error(`Error while trying to delete ops`, lumberjackProperties, error);
-			throw error;
 		}
 	}
 }


### PR DESCRIPTION
## Description

Presently when using the deleteSummarizedOps.ts when the aggregated data regarding all the unique documentIds is passed, the process iterates through each of those and then adds soft delete markers to deltas (where applicable) and does hard delete of deltas (where applicable). And this is done in a sequential manner for each of the documents which are passed in.
Now the issue is whenever there is an error occurring for any of the documents, all the documents there after are not handled and the loop breaks in between
Ideally the error should be logged for the document for which the failure happens and all the subsequent documents deletion should take place
This commit intends to handle the checkpoint fetch error for specific documents gracefully, log the details of that document and proceed with processing rest of the batch
