### PR TITLE
refactor: Remove obsolete variable group from docs pipeline

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -6,8 +6,8 @@
 # Note that the method for getting the api json for main differs from previous versions. For main, the pipeline bundles
 # the published artifacts from other pipeline resources and publishes an artifact to the pipeline which can be later downloaded.
 # However, for previous version branches (in this case: 1.0) cannot run on the pipeline to generate resources. Thus, api-extractor
-# was run on 1.0 locally and manually published to the azure storage as "lts-1.0.tar.gz" which is later downloaded using 
-# the AzureCLI@2 task. 
+# was run on 1.0 locally and manually published to the azure storage as "lts-1.0.tar.gz" which is later downloaded using
+# the AzureCLI@2 task.
 # For now, the only previous version which is manually uploaded is lts. However, for any previous versions which cannot run on the
 # pipeline, we assume that the api json content would be uploaded to the azure storage in the format: latest-${{version}}.tar.gz
 
@@ -45,7 +45,6 @@ parameters:
 variables:
   - group: doc-versions
   - group: storage-vars
-  - group: InfoSec-SecurityResults
   - name: repoToTrigger
     value: microsoft/FluidFramework
   - name: latestPipeline
@@ -88,9 +87,9 @@ variables:
   - name: pnpmStorePath
     value: $(Pipeline.Workspace)/.pnpm-store
 
-# TODO: Move trigger to pipeline designated for artifact model generation. Currently, 
-# the website docs builds and deploys on each commit. However, inconsistencies between 
-# the release branches and main is causing the website to change unexpectedly we can 
+# TODO: Move trigger to pipeline designated for artifact model generation. Currently,
+# the website docs builds and deploys on each commit. However, inconsistencies between
+# the release branches and main is causing the website to change unexpectedly we can
 # move the release/* trigger after separating the deploy step to another pipeline
 # no PR triggers
 trigger:


### PR DESCRIPTION
## Description

The variable group in ADO says `** this variable group is obsolete and can be removed from all the pipelines **` and only has a `dummyVariable` which doesn't seem to be used anywhere. So removing it from the pipeline, and I'll follow up deleting the variable group in ADO.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
