### PR TITLE
fix(tree): optional field composition bug

### DIFF
--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -297,7 +297,8 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 			invertedMoves.push([taggedDst, taggedSrc]);
 		}
 		if (change.valueReplace !== undefined) {
-			if (change.valueReplace.isEmpty === false) {
+			const effectfulDst = getEffectfulDst(change.valueReplace);
+			if (effectfulDst !== undefined) {
 				invertIdMap.set("self", tagAtomId(change.valueReplace.dst));
 			}
 			if (change.valueReplace.src !== undefined) {
@@ -365,7 +366,8 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 			forwardMap.set(tagAtomId(src), tagAtomId(dst));
 		}
 		if (overChange.valueReplace !== undefined) {
-			if (overChange.valueReplace.isEmpty === false) {
+			const effectfulDst = getEffectfulDst(overChange.valueReplace);
+			if (effectfulDst !== undefined) {
 				forwardMap.set("self", tagAtomId(overChange.valueReplace.dst));
 			}
 			if (overChange.valueReplace.src !== undefined) {

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -156,7 +156,7 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 	): OptionalChangeset => {
 		const { srcToDst, dstToSrc } = getBidirectionalMaps(change1.moves, revision1);
 		const change1FieldSrc = taggedOptRegister(change1.valueReplace?.src, revision1);
-		const change1FieldDst = taggedOptAtomId(change1.valueReplace?.dst, revision1);
+		const change1FieldDst = taggedOptAtomId(getEffectfulDst(change1.valueReplace), revision1);
 
 		const change2FieldSrc = taggedOptRegister(change2.valueReplace?.src, revision2);
 		let composedFieldSrc: RegisterId | undefined;
@@ -164,10 +164,8 @@ export const optionalChangeRebaser: FieldChangeRebaser<OptionalChangeset> = {
 			if (change2FieldSrc === "self") {
 				composedFieldSrc = change1FieldSrc ?? change2FieldSrc;
 			} else if (
-				change1.valueReplace !== undefined &&
-				isReplaceEffectful(change1.valueReplace) &&
 				change1FieldDst !== undefined &&
-				areEqualRegisterIds(change2FieldSrc, change1FieldDst)
+				areEqualRegisterIds(change1FieldDst, change2FieldSrc)
 			) {
 				composedFieldSrc = "self";
 			} else {
@@ -530,6 +528,12 @@ function isReplaceEffectful(replace: Replace): replace is EffectfulReplace {
 		return false;
 	}
 	return !replace.isEmpty || replace.src !== undefined;
+}
+
+function getEffectfulDst(replace: Replace | undefined): ChangeAtomId | undefined {
+	return replace === undefined || replace.isEmpty || replace.src === "self"
+		? undefined
+		: replace.dst;
 }
 
 function taggedOptRegister(

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 
 import {
+	ChangeAtomId,
 	DeltaFieldChanges,
 	TaggedChange,
 	makeAnonChange,
@@ -137,6 +138,24 @@ describe("optionalField", () => {
 			);
 
 			assertEqual(composed, change1And2);
+		});
+
+		it("pin ○ child change", () => {
+			const detach: ChangeAtomId = { localId: brand(42), revision: tag };
+			const pin = makeAnonChange(Change.pin(detach));
+			const withChild = makeAnonChange(Change.childAt(detach, nodeChange1));
+			const composed = optionalChangeRebaser.compose(
+				pin,
+				withChild,
+				TestNodeId.composeChild,
+				fakeIdAllocator,
+				failCrossFieldManager,
+				defaultRevisionMetadataFromChanges([pin, withChild]),
+			);
+
+			const expected = Change.atOnce(pin.change, withChild.change);
+
+			assertEqual(composed, expected);
 		});
 
 		it("can compose child changes", () => {


### PR DESCRIPTION
## Description

Fixes a bug in optional field changeset composition where a child change at location X on the second changeset would get wrongly moved to self when composing with the first changeset. This happened when the first changeset had a *reserved* detach as well as a move from self to self (i.e., a pin of self). In such a scenario, the reserved detach from self to X in the first change is not effective, so the changes under X should not be moved backward along it.

Invert and rebase were not subject to the same bug because, while they fail to correctly categorize such a reserved detach as non-effectful, they discard its information by overwiting it with information from the src->self action. Since this is only true because the ordering of the code, this PR also updates the invert and rebase implementations (to be resilient to this ordering being changed) by correctly ignoring the ineffectiful reserved detach.

## Breaking Changes
None