### PR TITLE
build(map): trim API

### DIFF
--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -15,16 +15,6 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./lib/index.d.ts",
-				"default": "./lib/index.js"
-			},
-			"require": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.js"
-			}
-		},
-		"./public": {
-			"import": {
 				"types": "./lib/public.d.ts",
 				"default": "./lib/index.js"
 			},
@@ -55,7 +45,7 @@
 		}
 	},
 	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"types": "./dist/public.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
 		"api-extractor:commonjs": "flub generate entrypoints --outDir ./dist",


### PR DESCRIPTION
Either a bad merge, or SharedMap accidently slipped through.  Either way, it looks like imports have already been rewritten.