### PR TITLE
Add IServiceClient

### DIFF
--- a/packages/framework/fluid-static/api-report/fluid-static.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.api.md
@@ -117,6 +117,18 @@ export interface IServiceAudienceEvents<M extends IMember> extends IEvent {
 }
 
 // @public
+export interface IServiceClient<TServices> {
+    createContainer<const TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TServices;
+    }>;
+    getContainer<const TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TServices;
+    }>;
+}
+
+// @public
 export type LoadableObjectClass<T extends IFluidLoadable = IFluidLoadable> = ISharedObjectKind<T> | DataObjectClass<T>;
 
 // @public

--- a/packages/framework/fluid-static/src/index.ts
+++ b/packages/framework/fluid-static/src/index.ts
@@ -33,3 +33,4 @@ export {
 	type Myself,
 	type IProvideRootDataObject,
 } from "./types.js";
+export { type IServiceClient } from "./serviceClient.js";

--- a/packages/framework/fluid-static/src/serviceClient.ts
+++ b/packages/framework/fluid-static/src/serviceClient.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { IFluidContainer } from "./fluidContainer.js";
+import type { ContainerSchema } from "./types.js";
+
+/**
+ * Service specific portion of a Fluid client.
+ * @public
+ */
+export interface IServiceClient<TServices> {
+	/**
+	 * Creates a new detached container instance in service.
+	 * @typeparam TContainerSchema - Used to infer the the type of 'initialObjects' in the returned container.
+	 * (normally not explicitly specified.)
+	 * @param containerSchema - Container schema for the new container.
+	 * @returns New detached container instance along with associated services.
+	 */
+	createContainer<const TContainerSchema extends ContainerSchema>(
+		containerSchema: TContainerSchema,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
+		services: TServices;
+	}>;
+
+	/**
+	 * Accesses the existing container given its unique ID in the service.
+	 * @typeparam TContainerSchema - Used to infer the the type of 'initialObjects' in the returned container.
+	 * (normally not explicitly specified.)
+	 * @param id - Unique ID of the container in service.
+	 * @param containerSchema - Container schema used to access data objects in the container.
+	 * @returns Existing container instance along with associated services.
+	 */
+	getContainer<const TContainerSchema extends ContainerSchema>(
+		id: string,
+		containerSchema: TContainerSchema,
+	): Promise<{
+		container: IFluidContainer<TContainerSchema>;
+		services: TServices;
+	}>;
+}

--- a/packages/service-clients/azure-client/api-report/azure-client.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.api.md
@@ -10,6 +10,7 @@ import { IConfigProviderBase } from '@fluidframework/core-interfaces';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';
+import { IServiceClient } from '@fluidframework/fluid-static';
 import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenClaims } from '@fluidframework/protocol-definitions';
@@ -19,7 +20,7 @@ import { IUser } from '@fluidframework/protocol-definitions';
 import { ScopeType } from '@fluidframework/protocol-definitions';
 
 // @public
-export class AzureClient {
+export class AzureClient implements IServiceClient<AzureContainerServices> {
     constructor(properties: AzureClientProps);
     copyContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, version?: AzureContainerVersion): Promise<{
         container: IFluidContainer<TContainerSchema>;

--- a/packages/service-clients/azure-client/src/AzureClient.ts
+++ b/packages/service-clients/azure-client/src/AzureClient.ts
@@ -16,7 +16,11 @@ import {
 	type IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
 import { applyStorageCompression } from "@fluidframework/driver-utils/internal";
-import { type ContainerSchema, type IFluidContainer } from "@fluidframework/fluid-static";
+import {
+	type ContainerSchema,
+	type IFluidContainer,
+	type IServiceClient,
+} from "@fluidframework/fluid-static";
 import {
 	type IRootDataObject,
 	createDOProviderContainerRuntimeFactory,
@@ -87,7 +91,7 @@ function wrapConfigProvider(baseConfigProvider?: IConfigProviderBase): IConfigPr
  * when running with local tenantId, have it be backed by a local Azure Fluid Relay instance.
  * @public
  */
-export class AzureClient {
+export class AzureClient implements IServiceClient<AzureContainerServices> {
 	private readonly documentServiceFactory: IDocumentServiceFactory;
 	private readonly urlResolver: IUrlResolver;
 	private readonly configProvider: IConfigProviderBase | undefined;
@@ -117,11 +121,7 @@ export class AzureClient {
 	}
 
 	/**
-	 * Creates a new detached container instance in the Azure Fluid Relay.
-	 * @typeparam TContainerSchema - Used to infer the the type of 'initialObjects' in the returned container.
-	 * (normally not explicitly specified.)
-	 * @param containerSchema - Container schema for the new container.
-	 * @returns New detached container instance along with associated services.
+	 * {@inheritdoc @fluidframework/fluid-static#IServiceClient.createContainer}
 	 */
 	public async createContainer<const TContainerSchema extends ContainerSchema>(
 		containerSchema: TContainerSchema,
@@ -198,12 +198,7 @@ export class AzureClient {
 	}
 
 	/**
-	 * Accesses the existing container given its unique ID in the Azure Fluid Relay.
-	 * @typeparam TContainerSchema - Used to infer the the type of 'initialObjects' in the returned container.
-	 * (normally not explicitly specified.)
-	 * @param id - Unique ID of the container in Azure Fluid Relay.
-	 * @param containerSchema - Container schema used to access data objects in the container.
-	 * @returns Existing container instance along with associated services.
+	 * {@inheritdoc @fluidframework/fluid-static#IServiceClient.getContainer}
 	 */
 	public async getContainer<TContainerSchema extends ContainerSchema>(
 		id: string,

--- a/packages/service-clients/odsp-client/api-report/odsp-client.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.api.md
@@ -9,6 +9,7 @@ import { IConfigProviderBase } from '@fluidframework/core-interfaces';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 import type { IMember } from '@fluidframework/fluid-static';
 import type { IServiceAudience } from '@fluidframework/fluid-static';
+import { IServiceClient } from '@fluidframework/fluid-static';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { TokenResponse } from '@fluidframework/odsp-driver-definitions/internal';
 
@@ -22,14 +23,12 @@ export interface IOdspTokenProvider {
 }
 
 // @beta @sealed
-export class OdspClient {
+export class OdspClient implements IServiceClient<OdspContainerServices> {
     constructor(properties: OdspClientProps);
-    // (undocumented)
     createContainer<T extends ContainerSchema>(containerSchema: T): Promise<{
         container: IFluidContainer<T>;
         services: OdspContainerServices;
     }>;
-    // (undocumented)
     getContainer<T extends ContainerSchema>(id: string, containerSchema: T): Promise<{
         container: IFluidContainer<T>;
         services: OdspContainerServices;

--- a/packages/service-clients/odsp-client/src/odspClient.ts
+++ b/packages/service-clients/odsp-client/src/odspClient.ts
@@ -20,6 +20,7 @@ import {
 	ContainerAttachProps,
 	type ContainerSchema,
 	IFluidContainer,
+	type IServiceClient,
 } from "@fluidframework/fluid-static";
 import {
 	IRootDataObject,
@@ -109,7 +110,7 @@ function wrapConfigProvider(baseConfigProvider?: IConfigProviderBase): IConfigPr
  * @sealed
  * @beta
  */
-export class OdspClient {
+export class OdspClient implements IServiceClient<OdspContainerServices> {
 	private readonly documentServiceFactory: IDocumentServiceFactory;
 	private readonly urlResolver: OdspDriverUrlResolver;
 	private readonly configProvider: IConfigProviderBase | undefined;
@@ -124,6 +125,9 @@ export class OdspClient {
 		this.configProvider = wrapConfigProvider(properties.configProvider);
 	}
 
+	/**
+	 * {@inheritdoc @fluidframework/fluid-static#IServiceClient.createContainer}
+	 */
 	public async createContainer<T extends ContainerSchema>(
 		containerSchema: T,
 	): Promise<{
@@ -147,6 +151,9 @@ export class OdspClient {
 		return { container: fluidContainer as IFluidContainer<T>, services };
 	}
 
+	/**
+	 * {@inheritdoc @fluidframework/fluid-static#IServiceClient.getContainer}
+	 */
 	public async getContainer<T extends ContainerSchema>(
 		id: string,
 		containerSchema: T,

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.api.md
@@ -8,6 +8,7 @@ import { ContainerSchema } from '@fluidframework/fluid-static';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';
+import { IServiceClient } from '@fluidframework/fluid-static';
 import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
@@ -21,7 +22,7 @@ export { ITelemetryBaseLogger }
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @internal
-class TinyliciousClient {
+class TinyliciousClient implements IServiceClient<TinyliciousContainerServices> {
     constructor(props?: TinyliciousClientProps | undefined);
     createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema): Promise<{
         container: IFluidContainer<TContainerSchema>;

--- a/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
@@ -16,7 +16,11 @@ import {
 	type IDocumentServiceFactory,
 	type IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
-import { type ContainerSchema, type IFluidContainer } from "@fluidframework/fluid-static";
+import {
+	type ContainerSchema,
+	type IFluidContainer,
+	type IServiceClient,
+} from "@fluidframework/fluid-static";
 import {
 	type IRootDataObject,
 	createDOProviderContainerRuntimeFactory,
@@ -41,7 +45,7 @@ import { type TinyliciousClientProps, type TinyliciousContainerServices } from "
  * @see {@link https://fluidframework.com/docs/testing/tinylicious/}
  * @internal
  */
-export class TinyliciousClient {
+export class TinyliciousClient implements IServiceClient<TinyliciousContainerServices> {
 	private readonly documentServiceFactory: IDocumentServiceFactory;
 	private readonly urlResolver: IUrlResolver;
 
@@ -61,9 +65,7 @@ export class TinyliciousClient {
 	}
 
 	/**
-	 * Creates a new detached container instance in Tinylicious server.
-	 * @param containerSchema - Container schema for the new container.
-	 * @returns New detached container instance along with associated services.
+	 * {@inheritdoc @fluidframework/fluid-static#IServiceClient.createContainer}
 	 */
 	public async createContainer<TContainerSchema extends ContainerSchema>(
 		containerSchema: TContainerSchema,
@@ -110,10 +112,7 @@ export class TinyliciousClient {
 	}
 
 	/**
-	 * Accesses the existing container given its unique ID in the tinylicious server.
-	 * @param id - Unique ID of the container.
-	 * @param containerSchema - Container schema used to access data objects in the container.
-	 * @returns Existing container instance along with associated services.
+	 * {@inheritdoc @fluidframework/fluid-static#IServiceClient.getContainer}
 	 */
 	public async getContainer<TContainerSchema extends ContainerSchema>(
 		id: string,


### PR DESCRIPTION
## Description

Adds an IServiceClient interface implemented by the service-client. This allows:
- Sharing of documentation between service clients
- Compile time validation that the implementations are kept in sync API wise
- Allows some app and utility code to abstract over service-clients making porting apps between services easier

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
