### PR TITLE
doc(tree): fix comment on disposeSymbol

### DIFF
--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -395,8 +395,8 @@ export function compareNamed(a: Named<string>, b: Named<string>): -1 | 0 | 1 {
 
 /**
  * Placeholder for `Symbol.dispose`.
- *
- * Replace this with `Symbol.dispose` when it is available.
+ * @privateRemarks
+ * TODO: replace this with `Symbol.dispose` when it is available or make it a valid polyfill.
  * @public
  */
 export const disposeSymbol: unique symbol = Symbol("Symbol.dispose placeholder");


### PR DESCRIPTION
## Description

Clarify a comment so that users don't interpret the TODO as applying to them.

## Breaking Changes

None