### PR TITLE
Process blobs using localId to fix cross version uncompatibility

### DIFF
--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -184,7 +184,7 @@ export class BlobManager {
         }
         this.blobIds.add(blobId);
         if (localId) {
-            this.blobIds.add(localId);
+            this.redirectTable?.set(localId, blobId);
         }
     }
 

--- a/packages/runtime/container-runtime/src/blobManager.ts
+++ b/packages/runtime/container-runtime/src/blobManager.ts
@@ -175,7 +175,7 @@ export class BlobManager {
         return handle;
     }
 
-    public processBlobAttachOp(blobId: string, local: boolean) {
+    public processBlobAttachOp(blobId: string, local: boolean, localId?: string) {
         if (local) {
             const pendingBlobP = this.pendingBlobIds.get(blobId);
             assert(pendingBlobP !== undefined, 0x1f8 /* "local BlobAttach op with no pending blob" */);
@@ -183,6 +183,9 @@ export class BlobManager {
             this.pendingBlobIds.delete(blobId);
         }
         this.blobIds.add(blobId);
+        if (localId) {
+            this.blobIds.add(localId);
+        }
     }
 
     /**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1855,7 +1855,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents>
                     break;
                 case ContainerMessageType.BlobAttach:
                     assert(message?.metadata?.blobId, 0x12a /* "Missing blob id on metadata" */);
-                    this.blobManager.processBlobAttachOp(message.metadata.blobId, local);
+                    this.blobManager.processBlobAttachOp(message.metadata.blobId, local, message.metadata.localId);
                     break;
                 default:
             }


### PR DESCRIPTION
https://dev.azure.com/fluidframework/internal/_workitems/edit/6286

Add localId to blobsId list if present. This is being done in order to fix cross version compatibility tests with blobs. More details in ADO item.