### PR TITLE
Added support to log custom headers

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -137,6 +137,14 @@ export function create(
 					if (req.body?.isEphemeralContainer !== undefined) {
 						additionalProperties.isEphemeralContainer = req.body.isEphemeralContainer;
 					}
+					const customHeadersToLog = (config.get("customHeadersToLog") as string[]) ?? [];
+					if (customHeadersToLog) {
+						customHeadersToLog.forEach((header) => {
+							if (req.headers[header]) {
+								additionalProperties.header = req.headers[header];
+							}
+						});
+					}
 					return additionalProperties;
 				},
 				enableLatencyMetric,

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -140,8 +140,9 @@ export function create(
 					const customHeadersToLog = (config.get("customHeadersToLog") as string[]) ?? [];
 					if (customHeadersToLog) {
 						customHeadersToLog.forEach((header) => {
-							if (req.headers[header]) {
-								additionalProperties[header] = req.headers[header];
+							const lowerCaseHeader = header.toLowerCase();
+							if (req.headers[lowerCaseHeader]) {
+								additionalProperties[lowerCaseHeader] = req.headers[lowerCaseHeader];
 							}
 						});
 					}

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -142,7 +142,8 @@ export function create(
 						customHeadersToLog.forEach((header) => {
 							const lowerCaseHeader = header.toLowerCase();
 							if (req.headers[lowerCaseHeader]) {
-								additionalProperties[lowerCaseHeader] = req.headers[lowerCaseHeader];
+								additionalProperties[lowerCaseHeader] =
+									req.headers[lowerCaseHeader];
 							}
 						});
 					}

--- a/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/app.ts
@@ -141,7 +141,7 @@ export function create(
 					if (customHeadersToLog) {
 						customHeadersToLog.forEach((header) => {
 							if (req.headers[header]) {
-								additionalProperties.header = req.headers[header];
+								additionalProperties[header] = req.headers[header];
 							}
 						});
 					}


### PR DESCRIPTION
## Description

This PR adds support to log custom headers specified in the configmap. It will allow us to log custom headers without needing to hardcode them in the code. These can include Azure specific headers as well.
