### PR TITLE
Move and refine type erasure tooling from tree to core-interfaces

### DIFF
--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -7,6 +7,12 @@
 // @public
 export type ConfigTypes = string | number | boolean | number[] | string[] | boolean[] | undefined;
 
+// @public @sealed
+export abstract class ErasedType<out Name = unknown> {
+    static [Symbol.hasInstance](value: never): value is never;
+    protected abstract brand(dummy: never): Name;
+}
+
 // @public
 export type ExtendEventProvider<TBaseEvent extends IEvent, TBase extends IEventProvider<TBaseEvent>, TEvent extends TBaseEvent> = Omit<Omit<Omit<TBase, "on">, "once">, "off"> & IEventProvider<TBaseEvent> & IEventProvider<TEvent>;
 

--- a/packages/common/core-interfaces/src/erasedType.ts
+++ b/packages/common/core-interfaces/src/erasedType.ts
@@ -1,0 +1,81 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * "Erased" handle which can be used to expose a opaque/erased version of a type without referencing the actual type.
+ * @remarks
+ * This similar to the standard [type erasure](https://en.wikipedia.org/wiki/Type_erasure) pattern,
+ * but for erasing types at the package boundary.
+ *
+ * Recommended usage is to use `interface` instead of `type` so tooling (such as tsc and refactoring tools)
+ * uses the type name instead of expanding it.
+ *
+ * @example
+ * ```typescript
+ * // public
+ * export interface ErasedMyType extends ErasedType<"myPackage.MyType"> {}
+ * // internal
+ * export interface MyType {
+ * 	example: number;
+ * }
+ * // Usage
+ * function extract(input: ErasedMyType): MyType {
+ * 	return input as unknown as MyType;
+ * }
+ * function erase(input: MyType): ErasedMyType {
+ * 	return input as unknown as ErasedMyType;
+ * }
+ * ```
+ *
+ * Do not use this class with `instanceof`: this will always be false at runtime,
+ * but the compiler may think it's true in some cases.
+ * @privateRemarks
+ * For this pattern to work well it needs to be difficult for a user of the erased type to
+ * implicitly use something other than a instance received from the package as an instance of the erased type in type safe code.
+ *
+ * This means that this type must not be able to be implicitly converted to from any strong type (not `any` or `never`),
+ * and no amount of auto complete or auto-implement refactoring will produce something that can be used as an erased type.
+ * This is accomplished by:
+ *
+ * 1. requiring that values of this type be an instance of this class.
+ * Typescript does not enforce this requirement for class: only for classes with protected or private members, so such member is included.
+ *
+ * 2. making this class impossible to get an instance of.
+ * This is done by having a private constructor.
+ *
+ * 3. ensuring different erased types also using this library can not be implicitly converted between each-other.
+ * This is done by using the "Name" type parameter.
+ * Note that just having the type parameter is not enough since the presence of type parameters has no impact on implicit conversion in TypeScript:
+ * only the usages of the type parameter matter.
+ *
+ * @sealed
+ * @public
+ */
+export abstract class ErasedType<out Name = unknown> {
+	/**
+	 * Compile time only marker to make type checking more strict.
+	 * This method will not exist at runtime and accessing it is invalid.
+	 * @privateRemarks
+	 * `Name` is used as the return type of a method rather than a a simple readonly member as this allows types with two brands to be intersected without getting `never`.
+	 * The method takes in never to help emphasize that its not callable.
+	 */
+	protected abstract brand(dummy: never): Name;
+
+	/**
+	 * This class should never exist at runtime, so make it un-constructable.
+	 */
+	private constructor() {}
+
+	/**
+	 * Since this class is a compile time only type brand, `instanceof` will never work with it.
+	 * This `Symbol.hasInstance` implementation ensures that `instanceof` will error if used,
+	 * and in TypeScript 5.3 and newer will produce a compile time error if used.
+	 */
+	public static [Symbol.hasInstance](value: never): value is never {
+		throw new Error(
+			"ErasedType is a compile time type brand not a real class that can be used with `instancof` at runtime.",
+		);
+	}
+}

--- a/packages/common/core-interfaces/src/erasedType.ts
+++ b/packages/common/core-interfaces/src/erasedType.ts
@@ -4,10 +4,14 @@
  */
 
 /**
- * "Erased" handle which can be used to expose a opaque/erased version of a type without referencing the actual type.
+ * Erased type which can be used to expose a opaque/erased version of a type without referencing the actual type.
  * @remarks
- * This similar to the standard [type erasure](https://en.wikipedia.org/wiki/Type_erasure) pattern,
+ * This similar to the [type erasure](https://en.wikipedia.org/wiki/Type_erasure) pattern,
  * but for erasing types at the package boundary.
+ *
+ * This can be used to implement the TypeScript typing for the [handle](https://en.wikipedia.org/wiki/Handle_(computing)) pattern,
+ * allowing code outside of a package to have a reference/handle to something in the package in a type safe way without the package having to publicly export the types of the object.
+ * This should not be confused with the more specific IFluidHandle which is also named after this design pattern.
  *
  * Recommended usage is to use `interface` instead of `type` so tooling (such as tsc and refactoring tools)
  * uses the type name instead of expanding it.

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -42,3 +42,4 @@ export { LogLevel } from "./logger.js";
 export type { FluidObjectProviderKeys, FluidObject, FluidObjectKeys } from "./provider.js";
 export type { ConfigTypes, IConfigProviderBase } from "./config.js";
 export type { ISignalEnvelope } from "./messages.js";
+export type { ErasedType } from "./erasedType.js";

--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import type { ErasedType } from '@fluidframework/core-interfaces';
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { IChannel } from '@fluidframework/datastore-definitions';
 import { IChannelAttributes } from '@fluidframework/datastore-definitions';
@@ -162,10 +163,10 @@ export type AssignableFieldKinds = typeof FieldKinds.optional | typeof FieldKind
 export type Assume<TInput, TAssumeToBe> = [TInput] extends [TAssumeToBe] ? TInput : TAssumeToBe;
 
 // @internal
-export type Brand<ValueType, Name extends string | ErasedType<string>> = ValueType & BrandedType<ValueType, Name extends Erased<infer TName> ? TName : Assume<Name, string>>;
+export type Brand<ValueType, Name> = ValueType & BrandedType<ValueType, Name>;
 
 // @internal
-export function brand<T>(value: T extends BrandedType<infer ValueType, string> ? ValueType : never): T;
+export function brand<T>(value: T extends BrandedType<infer ValueType, unknown> ? ValueType : never): T;
 
 // @internal
 export type BrandedKey<TKey, TContent> = TKey & Invariant<TContent>;
@@ -186,7 +187,7 @@ export interface BrandedMapSubset<K extends BrandedKey<unknown, any>> {
 }
 
 // @internal @sealed
-export abstract class BrandedType<out ValueType, Name extends string> {
+export abstract class BrandedType<out ValueType, Name> {
     static [Symbol.hasInstance](value: never): value is never;
     protected abstract brand(dummy: never): Name;
     // (undocumented)
@@ -427,16 +428,7 @@ export function enumFromStrings<TScope extends string, const Members extends str
 })>;
 
 // @internal
-export type Erased<Name extends string> = ErasedType<Name>;
-
-// @internal
-export interface ErasedTreeNodeSchemaDataFormat extends Erased<"TreeNodeSchemaDataFormat"> {
-}
-
-// @internal @sealed
-export abstract class ErasedType<out Name extends string> {
-    static [Symbol.hasInstance](value: never): value is never;
-    protected abstract brand(dummy: never): Name;
+export interface ErasedTreeNodeSchemaDataFormat extends ErasedType<"TreeNodeSchemaDataFormat"> {
 }
 
 // @public
@@ -445,10 +437,10 @@ export type Events<E> = {
 };
 
 // @internal
-export type ExtractFromOpaque<TOpaque extends BrandedType<any, string>> = TOpaque extends BrandedType<infer ValueType, infer Name> ? isAny<ValueType> extends true ? unknown : Brand<ValueType, Name> : never;
+export type ExtractFromOpaque<TOpaque extends BrandedType<any, unknown>> = TOpaque extends BrandedType<infer ValueType, infer Name> ? isAny<ValueType> extends true ? unknown : Brand<ValueType, Name> : never;
 
 // @internal
-export function extractFromOpaque<TOpaque extends BrandedType<any, string>>(value: TOpaque): ExtractFromOpaque<TOpaque>;
+export function extractFromOpaque<TOpaque extends BrandedType<any, unknown>>(value: TOpaque): ExtractFromOpaque<TOpaque>;
 
 // @public
 export type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? Result : Item;
@@ -1282,7 +1274,7 @@ export interface Named<TName> {
 }
 
 // @internal
-export type NameFromBranded<T extends BrandedType<unknown, string>> = T extends BrandedType<unknown, infer Name> ? Name : never;
+export type NameFromBranded<T extends BrandedType<unknown, unknown>> = T extends BrandedType<unknown, infer Name> ? Name : never;
 
 // @internal
 export type NestedMap<Key1, Key2, Value> = Map<Key1, Map<Key2, Value>>;
@@ -1383,7 +1375,7 @@ export class ObjectNodeStoredSchema extends TreeNodeStoredSchema {
 export function oneFromSet<T>(set: ReadonlySet<T> | undefined): T | undefined;
 
 // @internal
-export type Opaque<T extends Brand<any, string>> = T extends BrandedType<infer ValueType, infer Name> ? BrandedType<ValueType, Name> : never;
+export type Opaque<T extends Brand<any, unknown>> = T extends BrandedType<infer ValueType, infer Name> ? BrandedType<ValueType, Name> : never;
 
 // @internal (undocumented)
 export interface Optional extends FlexFieldKind<"Optional", Multiplicity.Optional> {
@@ -2096,7 +2088,7 @@ export interface ValueFieldEditBuilder {
 }
 
 // @internal
-export type ValueFromBranded<T extends BrandedType<unknown, string>> = T extends BrandedType<infer ValueType, string> ? ValueType : never;
+export type ValueFromBranded<T extends BrandedType<unknown, unknown>> = T extends BrandedType<infer ValueType, unknown> ? ValueType : never;
 
 // @internal
 export enum ValueSchema {

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -136,7 +136,7 @@ export {
 	LeafNodeStoredSchema,
 	ObjectNodeStoredSchema,
 	MapNodeStoredSchema,
-	BrandedTreeNodeSchemaDataFormat,
+	toTreeNodeSchemaDataFormat,
 	decodeFieldSchema,
 	encodeFieldSchema,
 	storedSchemaDecodeDispatcher,

--- a/packages/dds/tree/src/core/schema-stored/index.ts
+++ b/packages/dds/tree/src/core/schema-stored/index.ts
@@ -16,11 +16,11 @@ export {
 	LeafNodeStoredSchema,
 	ObjectNodeStoredSchema,
 	MapNodeStoredSchema,
-	BrandedTreeNodeSchemaDataFormat,
 	decodeFieldSchema,
 	encodeFieldSchema,
 	storedSchemaDecodeDispatcher,
 	ErasedTreeNodeSchemaDataFormat,
+	toTreeNodeSchemaDataFormat,
 	SchemaAndPolicy,
 	SchemaPolicy,
 } from "./schema.js";

--- a/packages/dds/tree/src/core/schema-stored/schema.ts
+++ b/packages/dds/tree/src/core/schema-stored/schema.ts
@@ -3,16 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import type { ErasedType } from "@fluidframework/core-interfaces";
 import { DiscriminatedUnionDispatcher } from "../../codec/index.js";
-import {
-	Brand,
-	Erased,
-	MakeNominal,
-	brand,
-	brandErased,
-	fail,
-	invertMap,
-} from "../../util/index.js";
+import { MakeNominal, brand, fail, invertMap } from "../../util/index.js";
 import {
 	FieldKey,
 	FieldKindIdentifier,
@@ -144,9 +137,19 @@ export const storedEmptyFieldSchema: TreeFieldStoredSchema = {
  * Opaque type erased handle to the encoded representation of the contents of a stored schema.
  * @internal
  */
-export interface ErasedTreeNodeSchemaDataFormat extends Erased<"TreeNodeSchemaDataFormat"> {}
-export interface BrandedTreeNodeSchemaDataFormat
-	extends Brand<TreeNodeSchemaDataFormat, ErasedTreeNodeSchemaDataFormat> {}
+export interface ErasedTreeNodeSchemaDataFormat extends ErasedType<"TreeNodeSchemaDataFormat"> {}
+
+function toErasedTreeNodeSchemaDataFormat(
+	data: TreeNodeSchemaDataFormat,
+): ErasedTreeNodeSchemaDataFormat {
+	return data as unknown as ErasedTreeNodeSchemaDataFormat;
+}
+
+export function toTreeNodeSchemaDataFormat(
+	data: ErasedTreeNodeSchemaDataFormat,
+): TreeNodeSchemaDataFormat {
+	return data as unknown as TreeNodeSchemaDataFormat;
+}
 
 /**
  * @internal
@@ -193,7 +196,7 @@ export class ObjectNodeStoredSchema extends TreeNodeStoredSchema {
 				value: encodeFieldSchema(this.objectNodeFields.get(key) ?? fail("missing field")),
 			});
 		}
-		return brandErased<BrandedTreeNodeSchemaDataFormat>({
+		return toErasedTreeNodeSchemaDataFormat({
 			object: fieldsObject,
 		});
 	}
@@ -216,7 +219,7 @@ export class MapNodeStoredSchema extends TreeNodeStoredSchema {
 	}
 
 	public override encode(): ErasedTreeNodeSchemaDataFormat {
-		return brandErased<BrandedTreeNodeSchemaDataFormat>({
+		return toErasedTreeNodeSchemaDataFormat({
 			map: encodeFieldSchema(this.mapFields),
 		});
 	}
@@ -243,7 +246,7 @@ export class LeafNodeStoredSchema extends TreeNodeStoredSchema {
 	}
 
 	public override encode(): ErasedTreeNodeSchemaDataFormat {
-		return brandErased<BrandedTreeNodeSchemaDataFormat>({
+		return toErasedTreeNodeSchemaDataFormat({
 			leaf: encodeValueSchema(this.leafValue),
 		});
 	}

--- a/packages/dds/tree/src/feature-libraries/schema-index/codec.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/codec.ts
@@ -5,7 +5,6 @@
 
 import { ICodecOptions, IJsonCodec, makeVersionedValidatedCodec } from "../../codec/index.js";
 import {
-	BrandedTreeNodeSchemaDataFormat,
 	TreeNodeSchemaIdentifier,
 	TreeNodeStoredSchema,
 	TreeStoredSchema,
@@ -13,8 +12,9 @@ import {
 	encodeFieldSchema,
 	schemaFormat,
 	storedSchemaDecodeDispatcher,
+	toTreeNodeSchemaDataFormat,
 } from "../../core/index.js";
-import { brand, fail, fromErased } from "../../util/index.js";
+import { brand, fail } from "../../util/index.js";
 
 import { Format } from "./format.js";
 
@@ -27,7 +27,7 @@ export function encodeRepo(repo: TreeStoredSchema): Format {
 			enumerable: true,
 			configurable: true,
 			writable: true,
-			value: fromErased<BrandedTreeNodeSchemaDataFormat>(schema.encode()),
+			value: toTreeNodeSchemaDataFormat(schema.encode()),
 		});
 	}
 	return {

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -354,8 +354,6 @@ export {
 	AllowOptionalNotFlattened,
 	isAny,
 	BrandedKeyContent,
-	ErasedType,
-	Erased,
 	RestrictiveReadonlyRecord,
 	MakeNominal,
 } from "./util/index.js";

--- a/packages/dds/tree/src/test/util/brand.spec.ts
+++ b/packages/dds/tree/src/test/util/brand.spec.ts
@@ -3,21 +3,14 @@
  * Licensed under the MIT License.
  */
 
+import { ErasedType } from "@fluidframework/core-interfaces";
 import {
 	Brand,
-	Erased,
 	brand,
-	brandErased,
-	fromErased,
 	// Allow importing from this specific file which is being tested:
 	/* eslint-disable-next-line import/no-internal-modules */
 } from "../../util/brand.js";
-import {
-	areSafelyAssignable,
-	isAssignableTo,
-	requireFalse,
-	requireTrue,
-} from "../../util/index.js";
+import { isAssignableTo, requireFalse, requireTrue } from "../../util/index.js";
 
 // These tests currently just cover the type checking, so its all compile time.
 
@@ -46,16 +39,10 @@ const _branded3 = brand(0);
 const _branded4: number = brand(0);
 
 // Erased
-interface E4 extends Erased<"4"> {}
-interface E5 extends Erased<"5"> {}
+interface E4 extends ErasedType<"4"> {}
+interface E5 extends ErasedType<"5"> {}
 export type T4 = Brand<{ test: number }, E4>;
 export type T5 = Brand<{ test: number }, E5>;
 
-const erased = brandErased<T4>({ test: 5 });
-const branded = fromErased<T4>(erased);
-type _check1 =
-	| requireTrue<areSafelyAssignable<typeof erased, E4>>
-	| requireTrue<areSafelyAssignable<typeof branded, T4>>
-	// Check strong typing
-	| requireFalse<isAssignableTo<E4, E5>>
-	| requireFalse<isAssignableTo<T4, T5>>;
+// Check strong typing
+type _check1 = requireFalse<isAssignableTo<E4, E5>> | requireFalse<isAssignableTo<T4, T5>>;

--- a/packages/dds/tree/src/test/util/opaque.spec.ts
+++ b/packages/dds/tree/src/test/util/opaque.spec.ts
@@ -6,7 +6,6 @@
 import {
 	Brand,
 	BrandedType,
-	Erased,
 	areSafelyAssignable,
 	isAny,
 	isAssignableTo,
@@ -44,9 +43,3 @@ const untypedOpaque = brandOpaque(0);
 // If somehow an untyped opaque handle is produced, make sure any does not leak out:
 const extracted = extractFromOpaque(0 as any as BrandedType<any, string>);
 type _check2 = requireFalse<isAny<typeof extracted>>;
-
-// Erased
-interface E4 extends Erased<"4"> {}
-interface E5 extends Erased<"5"> {}
-export type T4 = Brand<{ test: number }, E4>;
-export type T5 = Brand<{ test: number }, E5>;

--- a/packages/dds/tree/src/util/brand.ts
+++ b/packages/dds/tree/src/util/brand.ts
@@ -5,8 +5,7 @@
 
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import type { Covariant, isAny } from "./typeCheck.js";
-import type { Assume } from "./typeUtils.js";
+import type { Covariant } from "./typeCheck.js";
 
 /**
  * Constructs a "Branded" type, adding a type-checking only field to `ValueType`.
@@ -21,84 +20,12 @@ import type { Assume } from "./typeUtils.js";
  * These branded types are not opaque: A `Brand<A, B>` can still be used as a `B`.
  * @internal
  */
-export type Brand<ValueType, Name extends string | ErasedType<string>> = ValueType &
-	BrandedType<ValueType, Name extends Erased<infer TName> ? TName : Assume<Name, string>>;
-
-/**
- * "opaque" handle which can be used to expose a branded type without referencing its value type.
- * @remarks
- * Recommended usage is to use `interface` instead of `type` so tooling (such as tsc and refactoring tools)
- * uses the type name instead of expanding it.
- *
- * @example
- * ```typescript
- * // Public
- * export interface ErasedMyType extends Erased<"myPackage.MyType"> {}
- * // Internal
- * export interface MyType {
- * 	example: number;
- * }
- * export interface BrandedMyType extends Brand<MyType, ErasedMyType> {}
- * // Usage
- * export function extract(input: ErasedMyType): BrandedMyType {
- * 	return fromErased<BrandedMyType>(input);
- * }
- * export function erase(input: MyType): ErasedMyType {
- * 	return brandErased<BrandedMyType>(input);
- * }
- * ```
- * @internal
- */
-export type Erased<Name extends string> = ErasedType<Name>;
-
-/**
- * Helper for {@link Erased}.
- * This is split out into its own as that's the only way to:
- * - have doc comments for the member.
- * - make the member protected (so you don't accidentally try and read it).
- * - get nominal typing (so types produced without using this class can never be assignable to it).
- *
- * See {@link MakeNominal} for more details.
- *
- * Do not use this class with `instanceof`: this will always be false at runtime,
- * but the compiler may think it's true in some cases.
- *
- * @sealed
- * @internal
- */
-export abstract class ErasedType<out Name extends string> {
-	/**
-	 * Compile time only marker to make type checking more strict.
-	 * This method will not exist at runtime and accessing it is invalid.
-	 * See {@link Brand} for details.
-	 *
-	 * @privateRemarks
-	 * `Name` is used as the return type of a method rather than a a simple readonly member as this allows types with two brands to be intersected without getting `never`.
-	 * The method takes in never to help emphasize that its not callable.
-	 */
-	protected abstract brand(dummy: never): Name;
-
-	/**
-	 * This class should never exist at runtime, so make it un-constructable.
-	 */
-	private constructor() {}
-
-	/**
-	 * Since this class is a compile time only type brand, `instanceof` will never work with it.
-	 * This `Symbol.hasInstance` implementation ensures that `instanceof` will error if used,
-	 * and in TypeScript 5.3 and newer will produce a compile time error if used.
-	 */
-	public static [Symbol.hasInstance](value: never): value is never {
-		throw new UsageError(
-			"ErasedType is a compile time type brand not a real class that can be used with `instancof` at runtime.",
-		);
-	}
-}
+export type Brand<ValueType, Name> = ValueType & BrandedType<ValueType, Name>;
 
 /**
  * Helper for {@link Brand}.
  *
- * See `InternalTypes.MakeNominal` for some more details.
+ * See `MakeNominal` for some more details.
  *
  * Do not use this class with `instanceof`: this will always be false at runtime,
  * but the compiler may think it's true in some cases.
@@ -117,7 +44,7 @@ export abstract class ErasedType<out Name extends string> {
  * @sealed
  * @internal
  */
-export abstract class BrandedType<out ValueType, Name extends string> {
+export abstract class BrandedType<out ValueType, Name> {
 	protected _typeCheck?: Covariant<ValueType>;
 	/**
 	 * Compile time only marker to make type checking more strict.
@@ -152,9 +79,9 @@ export abstract class BrandedType<out ValueType, Name extends string> {
  * but shows up as part of branded types so API-Extractor requires it to be exported.
  * @internal
  */
-export type ValueFromBranded<T extends BrandedType<unknown, string>> = T extends BrandedType<
+export type ValueFromBranded<T extends BrandedType<unknown, unknown>> = T extends BrandedType<
 	infer ValueType,
-	string
+	unknown
 >
 	? ValueType
 	: never;
@@ -164,26 +91,12 @@ export type ValueFromBranded<T extends BrandedType<unknown, string>> = T extends
  * but shows up as part of branded types so API-Extractor requires it to be exported.
  * @internal
  */
-export type NameFromBranded<T extends BrandedType<unknown, string>> = T extends BrandedType<
+export type NameFromBranded<T extends BrandedType<unknown, unknown>> = T extends BrandedType<
 	unknown,
 	infer Name
 >
 	? Name
 	: never;
-
-/**
- * Converts a {@link Erased} handle to the underlying branded type.
- *
- * It is assumed that only code that produces these "opaque" handles does this conversion,
- * allowing these handles to be considered opaque.
- * @internal
- */
-export function fromErased<
-	TBranded extends BrandedType<unknown, string>,
-	TName extends string = NameFromBranded<TBranded>,
->(value: ErasedType<TName>): TBranded {
-	return value as unknown as TBranded;
-}
 
 /**
  * Adds a type {@link Brand} to a value.
@@ -199,19 +112,7 @@ export function fromErased<
  * @internal
  */
 export function brand<T>(
-	value: T extends BrandedType<infer ValueType, string> ? ValueType : never,
+	value: T extends BrandedType<infer ValueType, unknown> ? ValueType : never,
 ): T {
 	return value as T;
-}
-
-/**
- * Adds a type {@link Brand} to a value, returning it as a {@link Erased} handle.
- *
- * Only do this when specifically allowed by the requirements of the type being converted to.
- * @internal
- */
-export function brandErased<T extends BrandedType<unknown, string>>(
-	value: isAny<ValueFromBranded<T>> extends true ? never : ValueFromBranded<T>,
-): ErasedType<NameFromBranded<T>> {
-	return value as ErasedType<NameFromBranded<T>>;
 }

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -3,17 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export {
-	brand,
-	Brand,
-	BrandedType,
-	fromErased,
-	Erased,
-	ErasedType,
-	NameFromBranded,
-	ValueFromBranded,
-	brandErased,
-} from "./brand.js";
+export { brand, Brand, BrandedType, NameFromBranded, ValueFromBranded } from "./brand.js";
 export { brandedNumberType, brandedStringType } from "./typeboxBrand.js";
 export { brandOpaque, extractFromOpaque, ExtractFromOpaque, Opaque } from "./opaque.js";
 export {

--- a/packages/dds/tree/src/util/opaque.ts
+++ b/packages/dds/tree/src/util/opaque.ts
@@ -10,7 +10,7 @@ import type { isAny } from "./typeCheck.js";
  * Converts a Branded type into an "opaque" handle.
  * This prevents the value from being used directly, but does not fully type erase it.
  * @remarks
- * Like {@link Erased},
+ * Like {@link @fluidframework/core-interfaces#ErasedType},
  * but more type safe and cannot be used to hide the internal type from API extractor at package boundaries.
  *
  * The type can be recovered using {@link extractFromOpaque},
@@ -24,7 +24,7 @@ import type { isAny } from "./typeCheck.js";
  * ```
  * @internal
  */
-export type Opaque<T extends Brand<any, string>> = T extends BrandedType<
+export type Opaque<T extends Brand<any, unknown>> = T extends BrandedType<
 	infer ValueType,
 	infer Name
 >
@@ -35,7 +35,7 @@ export type Opaque<T extends Brand<any, string>> = T extends BrandedType<
  * See {@link extractFromOpaque}.
  * @internal
  */
-export type ExtractFromOpaque<TOpaque extends BrandedType<any, string>> =
+export type ExtractFromOpaque<TOpaque extends BrandedType<any, unknown>> =
 	TOpaque extends BrandedType<infer ValueType, infer Name>
 		? isAny<ValueType> extends true
 			? unknown
@@ -49,7 +49,7 @@ export type ExtractFromOpaque<TOpaque extends BrandedType<any, string>> =
  * allowing these handles to be considered opaque.
  * @internal
  */
-export function extractFromOpaque<TOpaque extends BrandedType<any, string>>(
+export function extractFromOpaque<TOpaque extends BrandedType<any, unknown>>(
 	value: TOpaque,
 ): ExtractFromOpaque<TOpaque> {
 	return value as ExtractFromOpaque<TOpaque>;
@@ -61,7 +61,7 @@ export function extractFromOpaque<TOpaque extends BrandedType<any, string>>(
  * Only do this when specifically allowed by the requirements of the type being converted to.
  * @internal
  */
-export function brandOpaque<T extends BrandedType<any, string>>(
+export function brandOpaque<T extends BrandedType<any, unknown>>(
 	value: isAny<ValueFromBranded<T>> extends true ? never : ValueFromBranded<T>,
 ): BrandedType<ValueFromBranded<T>, NameFromBranded<T>> {
 	return value as BrandedType<ValueFromBranded<T>, NameFromBranded<T>>;


### PR DESCRIPTION
## Description

Move and refine type erasure tooling from tree to core-interfaces.

This will be used by https://github.com/microsoft/FluidFramework/pull/20123 to type erase the internals of IFluidHandle

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

