### PR TITLE
GC: bump timeouts to avoid flaky failures

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepUnreferencePhases.spec.ts
@@ -36,8 +36,8 @@ import {
 describeCompat("GC unreference phases", "NoCompat", (getTestObjectProvider) => {
 	// Since these tests depend on these timing windows, they should not be run against drivers talking over the network
 	// (see this.skip() call below)
-	const tombstoneTimeoutMs = 200; // Tombstone at 200ms
-	const sweepGracePeriodMs = 200; // Sweep at 400ms
+	const tombstoneTimeoutMs = 300; // Tombstone at 300ms
+	const sweepGracePeriodMs = 300; // Sweep at 600ms
 
 	const configProvider = createTestConfigProvider();
 	const gcOptions: IGCRuntimeOptions = {


### PR DESCRIPTION
## Description

Fixes [AB#7598](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7598)

This is a cop-out.  We should switch to sinon fake timers in GC tests.  But don't have time for that now, so doing this instead.  The test has only failed once so I think this modest bump should be enough.