### PR TITLE
Demonstrate issues with op pipeline consistency

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2528,6 +2528,15 @@ export class ContainerRuntime
 	public process(messageArg: ISequencedDocumentMessage, local: boolean) {
 		this.verifyNotClosed();
 
+		assert(
+			messageArg.sequenceNumber === this.deltaManager.lastSequenceNumber,
+			"sequence numbers match",
+		);
+		assert(
+			messageArg.minimumSequenceNumber === this.deltaManager.minimumSequenceNumber,
+			"MSN match",
+		);
+
 		// Whether or not the message appears to be a runtime message from an up-to-date client.
 		// It may be a legacy runtime message (ie already unpacked and ContainerMessageType)
 		// or something different, like a system message.


### PR DESCRIPTION
This PR can't be merged as a ton of tests failed.
It is for demonstration purposes only.

Our API surface is very fragmented - there are many sources of information, and in many cases those sources tell slightly different story. One example of that is "connected' events and where and how clientId is exposed and when it changes - I'm trying to start fixing these issues with https://github.com/microsoft/FluidFramework/pull/20215

This PR is  result of observation that we call this.processRemoteMessage in Container.load for pendingLocalState.savedOps. This leaves system in not very consistent state while we are processing these ops. I believe we need to fix it - you just never know where this kind of inconsistency will bite our customers.

Tests (failing) clearly support my premise that it's broken. There are failures in other tests (that feel like should not fail), but majority of failures are in tests dealing with rehydrating container.

I'm not sure what is the right solution here, but worth pointing out that we are discussing having a DeltaManager proxy to lie about MSN through connection flow - we want to keep MSN below reference sequence number of any pending op, such that DDSs could rebase them properly, even though real MSN (according to inbound ops) moved higher.
We could use similar approach here.

Saving you some clicks: test failures: https://dev.azure.com/fluidframework/public/_build/results?buildId=254883&view=ms.vss-test-web.build-test-results-tab
