### PR TITLE
Node10 support for protocol-definitions

### DIFF
--- a/common/lib/common-definitions/package.json
+++ b/common/lib/common-definitions/package.json
@@ -26,8 +26,8 @@
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outDir ./lib",
+		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",
+		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib",
 		"build": "fluid-build . --task build",
 		"build:ci": "npm run build:compile",
 		"build:compile": "fluid-build . --task compile",
@@ -52,7 +52,7 @@
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.13.3",
+		"@arethetypeswrong/cli": "^0.15.2",
 		"@fluid-tools/build-cli": "^0.36.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.36.0",

--- a/common/lib/common-definitions/pnpm-lock.yaml
+++ b/common/lib/common-definitions/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
 
   .:
     specifiers:
-      '@arethetypeswrong/cli': ^0.13.3
+      '@arethetypeswrong/cli': ^0.15.2
       '@fluid-tools/build-cli': ^0.36.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.36.0
@@ -23,7 +23,7 @@ importers:
       rimraf: ^2.6.2
       typescript: ~5.1.6
     devDependencies:
-      '@arethetypeswrong/cli': 0.13.3
+      '@arethetypeswrong/cli': 0.15.3
       '@fluid-tools/build-cli': 0.36.0_@types+node@16.18.38
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.36.0_@types+node@16.18.38
@@ -50,28 +50,29 @@ packages:
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
     dev: true
 
-  /@arethetypeswrong/cli/0.13.3:
-    resolution: {integrity: sha512-lA29j9fkRGq+hNE3zQGxD/d8WmjhimSaPU2887CBe0Yv3C1UbIWvy51mYerp3/NoevjBLKSWhHmP5oY/eavtjQ==}
+  /@arethetypeswrong/cli/0.15.3:
+    resolution: {integrity: sha512-sIMA9ZJBWDEg1+xt5RkAEflZuf8+PO8SdKj17x6PtETuUho+qlZJg4DgmKc3q+QwQ9zOB5VLK6jVRbFdNLdUIA==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      '@arethetypeswrong/core': 0.13.3
+      '@arethetypeswrong/core': 0.15.1
       chalk: 4.1.2
       cli-table3: 0.6.3
       commander: 10.0.1
       marked: 9.1.6
       marked-terminal: 6.2.0_marked@9.1.6
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
-  /@arethetypeswrong/core/0.13.3:
-    resolution: {integrity: sha512-oxa26D3z5DEv9LGzfJWV/6PhQd170dFfDOXl9J3cGRNLo2B68zj6/YOD1RJaYF/kmxechdXT1XyGUPOtkXv8Lg==}
+  /@arethetypeswrong/core/0.15.1:
+    resolution: {integrity: sha512-FYp6GBAgsNz81BkfItRz8RLZO03w5+BaeiPma1uCfmxTnxbtuMrI/dbzGiOk8VghO108uFI0oJo0OkewdSHw7g==}
     engines: {node: '>=18'}
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      fflate: 0.7.4
-      semver: 7.5.4
-      typescript: 5.3.2
+      fflate: 0.8.2
+      semver: 7.6.0
+      ts-expose-internals-conditionally: 1.0.0-empty.0
+      typescript: 5.3.3
       validate-npm-package-name: 5.0.0
     dev: true
 
@@ -4455,8 +4456,8 @@ packages:
       reusify: 1.0.4
     dev: true
 
-  /fflate/0.7.4:
-    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+  /fflate/0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
     dev: true
 
   /figures/3.2.0:
@@ -8200,6 +8201,10 @@ packages:
       typescript: 5.1.6
     dev: true
 
+  /ts-expose-internals-conditionally/1.0.0-empty.0:
+    resolution: {integrity: sha512-F8m9NOF6ZhdOClDVdlM8gj3fDCav4ZIFSs/EI3ksQbAAXVSCN/Jh5OCJDDZWBuBy9psFc6jULGDlPwjMYMhJDw==}
+    dev: true
+
   /ts-morph/21.0.1:
     resolution: {integrity: sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg==}
     dependencies:
@@ -8343,12 +8348,6 @@ packages:
 
   /typescript/5.1.6:
     resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
-
-  /typescript/5.3.2:
-    resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/common/lib/protocol-definitions/CHANGELOG.md
+++ b/common/lib/protocol-definitions/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @fluidframework/protocol-definitions Changelog
 
+## [4.0.0](https://github.com/microsoft/FluidFramework/releases/tag/protocol-definitions_v4.0.0)
+
+### BREAKING CHANGE: Some APIs no longer exported
+
+The public API surface of this package has been trimmed. This means that some APIs may no longer be available.
+
+### Explicit package entrypoints using "exports" field
+
+This release adds the ["exports" field](https://nodejs.org/docs/latest-v18.x/api/packages.html#exports) to package.json
+to enforce package entrypoints. Any imports of APIs that are not explicitly exported will no longer work.
+
+In addition, TypeScript users should compile Fluid Framework using the following tsconfig settings:
+
+- `moduleResolution: Node16` or `moduleResolution: Bundler`. See the
+  [TypeScript documentation](https://www.typescriptlang.org/tsconfig#moduleResolution) for more information.
+
 ## [3.2.0](https://github.com/microsoft/FluidFramework/releases/tag/protocol-definitions_v3.2.0)
 
 This release includes new optional properties on several interfaces. Note that these new properties are not yet used by

--- a/common/lib/protocol-definitions/CHANGELOG.md
+++ b/common/lib/protocol-definitions/CHANGELOG.md
@@ -13,8 +13,8 @@ to enforce package entrypoints. Any imports of APIs that are not explicitly expo
 
 In addition, TypeScript users should compile Fluid Framework using the following tsconfig settings:
 
-- `moduleResolution: Node16` or `moduleResolution: Bundler`. See the
-  [TypeScript documentation](https://www.typescriptlang.org/tsconfig#moduleResolution) for more information.
+-   `moduleResolution: Node16` or `moduleResolution: Bundler`. See the
+    [TypeScript documentation](https://www.typescriptlang.org/tsconfig#moduleResolution) for more information.
 
 ## [3.2.0](https://github.com/microsoft/FluidFramework/releases/tag/protocol-definitions_v3.2.0)
 

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -23,13 +23,13 @@
 				"default": "./dist/index.js"
 			}
 		},
-		"./alpha": {
+		"./lib/legacy": {
 			"import": {
-				"types": "./lib/alpha.d.ts",
+				"types": "./lib/legacy.d.ts",
 				"default": "./lib/index.js"
 			},
 			"require": {
-				"types": "./dist/alpha.d.ts",
+				"types": "./dist/legacy.d.ts",
 				"default": "./dist/index.js"
 			}
 		},
@@ -48,13 +48,13 @@
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outDir ./lib",
+		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",
+		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib",
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json",
-		"check:are-the-types-wrong": "attw --pack . --entrypoints .",
+		"check:are-the-types-wrong": "attw --pack . --entrypoints . ./lib/legacy",
 		"check:release-tags": "api-extractor run --local --config ./api-extractor-lint.json",
 		"ci:build": "npm run build:compile",
 		"ci:build:docs": "api-extractor run",
@@ -73,7 +73,7 @@
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.13.3",
+		"@arethetypeswrong/cli": "^0.15.2",
 		"@fluid-tools/build-cli": "^0.36.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.36.0",

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/protocol-definitions",
-	"version": "3.3.0",
+	"version": "4.0.0",
 	"description": "Fluid protocol definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {
@@ -23,13 +23,13 @@
 				"default": "./dist/index.js"
 			}
 		},
-		"./alpha": {
+		"./lib/legacy": {
 			"import": {
-				"types": "./lib/alpha.d.ts",
+				"types": "./lib/legacy.d.ts",
 				"default": "./lib/index.js"
 			},
 			"require": {
-				"types": "./dist/alpha.d.ts",
+				"types": "./dist/legacy.d.ts",
 				"default": "./dist/index.js"
 			}
 		},
@@ -44,12 +44,12 @@
 			}
 		}
 	},
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "lib/public.js",
+	"types": "lib/public.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outDir ./lib",
+		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy ./dist",
+		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy ./lib",
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",

--- a/common/lib/protocol-definitions/pnpm-lock.yaml
+++ b/common/lib/protocol-definitions/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
 
   .:
     specifiers:
-      '@arethetypeswrong/cli': ^0.13.3
+      '@arethetypeswrong/cli': ^0.15.2
       '@fluid-tools/build-cli': ^0.36.0
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.36.0
@@ -22,7 +22,7 @@ importers:
       rimraf: ^2.6.2
       typescript: ~5.1.6
     devDependencies:
-      '@arethetypeswrong/cli': 0.13.3
+      '@arethetypeswrong/cli': 0.15.3
       '@fluid-tools/build-cli': 0.36.0
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.36.0
@@ -48,28 +48,29 @@ packages:
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
     dev: true
 
-  /@arethetypeswrong/cli/0.13.3:
-    resolution: {integrity: sha512-lA29j9fkRGq+hNE3zQGxD/d8WmjhimSaPU2887CBe0Yv3C1UbIWvy51mYerp3/NoevjBLKSWhHmP5oY/eavtjQ==}
+  /@arethetypeswrong/cli/0.15.3:
+    resolution: {integrity: sha512-sIMA9ZJBWDEg1+xt5RkAEflZuf8+PO8SdKj17x6PtETuUho+qlZJg4DgmKc3q+QwQ9zOB5VLK6jVRbFdNLdUIA==}
     engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      '@arethetypeswrong/core': 0.13.3
+      '@arethetypeswrong/core': 0.15.1
       chalk: 4.1.2
       cli-table3: 0.6.3
       commander: 10.0.1
       marked: 9.1.6
       marked-terminal: 6.2.0_marked@9.1.6
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
-  /@arethetypeswrong/core/0.13.3:
-    resolution: {integrity: sha512-oxa26D3z5DEv9LGzfJWV/6PhQd170dFfDOXl9J3cGRNLo2B68zj6/YOD1RJaYF/kmxechdXT1XyGUPOtkXv8Lg==}
+  /@arethetypeswrong/core/0.15.1:
+    resolution: {integrity: sha512-FYp6GBAgsNz81BkfItRz8RLZO03w5+BaeiPma1uCfmxTnxbtuMrI/dbzGiOk8VghO108uFI0oJo0OkewdSHw7g==}
     engines: {node: '>=18'}
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
-      fflate: 0.7.4
-      semver: 7.5.4
-      typescript: 5.3.2
+      fflate: 0.8.2
+      semver: 7.6.0
+      ts-expose-internals-conditionally: 1.0.0-empty.0
+      typescript: 5.3.3
       validate-npm-package-name: 5.0.0
     dev: true
 
@@ -4438,8 +4439,8 @@ packages:
       reusify: 1.0.4
     dev: true
 
-  /fflate/0.7.4:
-    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+  /fflate/0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
     dev: true
 
   /figures/3.2.0:
@@ -8180,6 +8181,10 @@ packages:
       typescript: 5.1.6
     dev: true
 
+  /ts-expose-internals-conditionally/1.0.0-empty.0:
+    resolution: {integrity: sha512-F8m9NOF6ZhdOClDVdlM8gj3fDCav4ZIFSs/EI3ksQbAAXVSCN/Jh5OCJDDZWBuBy9psFc6jULGDlPwjMYMhJDw==}
+    dev: true
+
   /ts-morph/21.0.1:
     resolution: {integrity: sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg==}
     dependencies:
@@ -8322,12 +8327,6 @@ packages:
 
   /typescript/5.1.6:
     resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
-
-  /typescript/5.3.2:
-    resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Missed 'protocol-definitions' in #20582.

(Also bumped attw for 'common-definitions'.)