### PR TITLE
build(protocol-definitions): Add ./lib/legacy export path

### DIFF
--- a/common/lib/protocol-definitions/CHANGELOG.md
+++ b/common/lib/protocol-definitions/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @fluidframework/protocol-definitions Changelog
 
+## [4.0.0](https://github.com/microsoft/FluidFramework/releases/tag/protocol-definitions_v4.0.0)
+
+### BREAKING CHANGE: Some APIs no longer exported
+
+The public API surface of this package has been trimmed. This means that some APIs may no longer be available.
+
+### Explicit package entrypoints using "exports" field
+
+This release adds the ["exports" field](https://nodejs.org/docs/latest-v18.x/api/packages.html#exports) to package.json
+to enforce package entrypoints. Any imports of APIs that are not explicitly exported will no longer work.
+
+In addition, TypeScript users should compile Fluid Framework using the following tsconfig settings:
+
+- `moduleResolution: Node16` or `moduleResolution: Bundler`. See the
+  [TypeScript documentation](https://www.typescriptlang.org/tsconfig#moduleResolution) for more information.
+
 ## [3.2.0](https://github.com/microsoft/FluidFramework/releases/tag/protocol-definitions_v3.2.0)
 
 This release includes new optional properties on several interfaces. Note that these new properties are not yet used by

--- a/common/lib/protocol-definitions/package.json
+++ b/common/lib/protocol-definitions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/protocol-definitions",
-	"version": "3.3.0",
+	"version": "4.0.0",
 	"description": "Fluid protocol definitions",
 	"homepage": "https://fluidframework.com",
 	"repository": {
@@ -23,13 +23,13 @@
 				"default": "./dist/index.js"
 			}
 		},
-		"./alpha": {
+		"./lib/legacy": {
 			"import": {
-				"types": "./lib/alpha.d.ts",
+				"types": "./lib/legacy.d.ts",
 				"default": "./lib/index.js"
 			},
 			"require": {
-				"types": "./dist/alpha.d.ts",
+				"types": "./dist/legacy.d.ts",
 				"default": "./dist/index.js"
 			}
 		},
@@ -44,12 +44,12 @@
 			}
 		}
 	},
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "lib/public.js",
+	"types": "lib/public.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outDir ./lib",
+		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy ./dist",
+		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy ./lib",
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",


### PR DESCRIPTION
Adds the ./lib/legacy export path to protocol-defs, replacing alpha.