### PR TITLE
Add new SharedTree format leveraging optional-field v2

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -1707,6 +1707,7 @@ export interface SharedTreeFormatOptions {
 // @internal
 export const SharedTreeFormatVersion: {
     readonly v1: 1;
+    readonly v2: 2;
 };
 
 // @internal

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -202,6 +202,17 @@ export const fieldKindConfigurations: ReadonlyMap<number, FieldKindConfiguration
 			[identifier.identifier, { kind: identifier, formatVersion: 1 }],
 		]),
 	],
+	[
+		2,
+		new Map<FieldKindIdentifier, FieldKindConfigurationEntry>([
+			[nodeKey.identifier, { kind: nodeKey, formatVersion: 1 }],
+			[required.identifier, { kind: required, formatVersion: 2 }],
+			[optional.identifier, { kind: optional, formatVersion: 2 }],
+			[sequence.identifier, { kind: sequence, formatVersion: 1 }],
+			[forbidden.identifier, { kind: forbidden, formatVersion: 1 }],
+			[identifier.identifier, { kind: identifier, formatVersion: 1 }],
+		]),
+	],
 ]);
 
 /**

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -67,7 +67,10 @@ export function makeEditManagerCodecs<TChangeset>(
 	>,
 	options: ICodecOptions,
 ): ICodecFamily<SummaryData<TChangeset>, EditManagerEncodingContext> {
-	return makeCodecFamily([[1, makeV1Codec(changeCodecs.resolve(1), revisionTagCodec, options)]]);
+	return makeCodecFamily([
+		[1, makeV1Codec(changeCodecs.resolve(1), revisionTagCodec, options)],
+		[2, makeV1Codec(changeCodecs.resolve(2), revisionTagCodec, options)],
+	]);
 }
 
 function makeV1Codec<TChangeset>(

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -67,6 +67,7 @@ export function makeMessageCodecs<TChangeset>(
 		// Back-compat: messages weren't always written with an explicit version field.
 		[undefined, v1Codec],
 		[1, v1Codec],
+		[2, makeV1Codec(changeCodecs.resolve(2).json, revisionTagCodec, options)],
 	]);
 }
 

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -126,6 +126,7 @@ interface ExplicitCodecVersions extends ExplicitCoreCodecVersions {
 
 const formatVersionToTopLevelCodecVersions = new Map<number, ExplicitCodecVersions>([
 	[1, { forest: 1, schema: 1, detachedFieldIndex: 1, editManager: 1, message: 1, fieldBatch: 1 }],
+	[2, { forest: 1, schema: 1, detachedFieldIndex: 1, editManager: 2, message: 2, fieldBatch: 1 }],
 ]);
 
 function getCodecVersions(formatVersion: number): ExplicitCodecVersions {
@@ -314,6 +315,11 @@ export const SharedTreeFormatVersion = {
 	 * Requires \@fluidframework/tree \>= 2.0.0.
 	 */
 	v1: 1,
+
+	/**
+	 * Requires \@fluidframework/tree \>= 2.0.0.
+	 */
+	v2: 2,
 } as const;
 
 /**

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
@@ -37,6 +37,14 @@ export function makeSharedTreeChangeCodecFamily(
 				options,
 			),
 		],
+		[
+			2,
+			makeSharedTreeChangeCodec(
+				modularChangeCodecFamily.resolve(2).json,
+				schemaChangeCodecs.resolve(1).json,
+				options,
+			),
+		],
 	]);
 }
 

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
@@ -5,7 +5,6 @@
 
 import { SessionId } from "@fluidframework/id-compressor";
 
-import { makeCodecFamily, withDefaultBinaryEncoding } from "../../../codec/index.js";
 import { ChangeEncodingContext } from "../../../core/index.js";
 import { typeboxValidator } from "../../../external-utilities/index.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -165,13 +164,9 @@ const testCases: EncodingTestData<SummaryData<TestChange>, unknown, ChangeEncodi
 
 export function testCodec() {
 	describe("Codec", () => {
-		const family = makeEditManagerCodecs(
-			makeCodecFamily([[1, withDefaultBinaryEncoding(TestChange.codec)]]),
-			testRevisionTagCodec,
-			{
-				jsonValidator: typeboxValidator,
-			},
-		);
+		const family = makeEditManagerCodecs(TestChange.codecs, testRevisionTagCodec, {
+			jsonValidator: typeboxValidator,
+		});
 
 		makeEncodingTestSuite(family, testCases);
 

--- a/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
@@ -199,7 +199,7 @@ describe("message codec", () => {
 				revision,
 				originatorId,
 				changeset: {},
-				version: 3,
+				version: -1,
 			} satisfies Message);
 			assert.throws(
 				() => codec.decode(JSON.parse(encoded), {}),

--- a/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
@@ -199,7 +199,7 @@ describe("message codec", () => {
 				revision,
 				originatorId,
 				changeset: {},
-				version: 2,
+				version: 3,
 			} satisfies Message);
 			assert.throws(
 				() => codec.decode(JSON.parse(encoded), {}),

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -2056,7 +2056,7 @@ describe("Editing", () => {
 			const startState = makeArray(nbNodes, (n) => `N${n}`);
 			const scenarios = buildScenarios();
 
-			// Increased timeout because the default in CI is 2s but this test fixture naturally takes ~1.9s and was
+			// Increased timeout because the default in CI is 2s but this test fixture naturally takes longer and was
 			// timing out frequently
 			outerFixture("All Scenarios", () => {
 				for (const scenario of scenarios) {
@@ -2067,7 +2067,7 @@ describe("Editing", () => {
 						runScenario(scenario, true);
 					}
 				}
-			}).timeout(5000);
+			}).timeout(10000);
 		});
 
 		describe("revert semantics", () => {

--- a/packages/dds/tree/src/test/testChange.ts
+++ b/packages/dds/tree/src/test/testChange.ts
@@ -228,7 +228,10 @@ export const TestChange = {
 	toDelta,
 	isEmpty,
 	codec,
-	codecs: makeCodecFamily([[1, codec]]),
+	codecs: makeCodecFamily([
+		[1, codec],
+		[2, codec],
+	]),
 };
 deepFreeze(TestChange);
 


### PR DESCRIPTION
## Description

Exposes the option to use the new optional-field format on SharedTree.

This does not change the default format.