### PR TITLE
fix(tree): handling of (pin & detach) in sequence field

### DIFF
--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -26,7 +26,7 @@ import {
 } from "./types.js";
 import {
 	extractMarkEffect,
-	getDetachOutputId,
+	getDetachOutputCellId,
 	getEndpoint,
 	getInputCellId,
 	getOutputCellId,
@@ -154,7 +154,7 @@ function invertMark(
 				);
 			}
 
-			const cellId = getDetachOutputId(
+			const cellId = getDetachOutputCellId(
 				mark,
 				mark.revision ?? revision ?? fail("Revision must be defined"),
 				revisionMetadata,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
@@ -423,17 +423,9 @@ class RebaseQueue {
  */
 function addMovedMarkEffect(mark: Mark, effect: MarkEffect): Mark {
 	if (isMoveIn(mark) && isMoveOut(effect)) {
-		const result: Mark = { ...mark, type: "Insert" };
-		if (effect.revision !== undefined) {
-			result.revision = effect.revision;
-		}
-		return result;
+		return { ...mark, type: "Insert" };
 	} else if (isAttachAndDetachEffect(mark) && isMoveIn(mark.attach) && isMoveOut(effect)) {
-		const result: Mark = { ...mark.detach, count: mark.count };
-		if (effect.revision !== undefined) {
-			result.revision = effect.revision;
-		}
-		return result;
+		return { ...mark.detach, count: mark.count };
 	} else if (isTombstone(mark)) {
 		return { ...mark, ...effect };
 	}

--- a/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
@@ -423,9 +423,17 @@ class RebaseQueue {
  */
 function addMovedMarkEffect(mark: Mark, effect: MarkEffect): Mark {
 	if (isMoveIn(mark) && isMoveOut(effect)) {
-		return { ...mark, type: "Insert" };
+		const result: Mark = { ...mark, type: "Insert" };
+		if (effect.revision !== undefined) {
+			result.revision = effect.revision;
+		}
+		return result;
 	} else if (isAttachAndDetachEffect(mark) && isMoveIn(mark.attach) && isMoveOut(effect)) {
-		return { ...mark.detach, count: mark.count };
+		const result: Mark = { ...mark.detach, count: mark.count };
+		if (effect.revision !== undefined) {
+			result.revision = effect.revision;
+		}
+		return result;
 	} else if (isTombstone(mark)) {
 		return { ...mark, ...effect };
 	}

--- a/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
@@ -424,17 +424,9 @@ class RebaseQueue {
  */
 function addMovedMarkEffect(mark: Mark, effect: MarkEffect): Mark {
 	if (isMoveIn(mark) && isMoveOut(effect)) {
-		const result: Mark = {
-			...mark,
-			type: "Insert",
-		};
-		return result;
+		return { ...mark, type: "Insert" };
 	} else if (isAttachAndDetachEffect(mark) && isMoveIn(mark.attach) && isMoveOut(effect)) {
-		const result: Mark & AttachAndDetach = {
-			...mark,
-			attach: { ...mark.attach, type: "Insert" },
-		};
-		return result;
+		return { ...mark.detach, count: mark.count };
 	} else if (isTombstone(mark)) {
 		return { ...mark, ...effect };
 	}

--- a/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
@@ -38,7 +38,6 @@ import {
 	setMoveEffect,
 } from "./moveEffectTable.js";
 import {
-	AttachAndDetach,
 	CellId,
 	CellMark,
 	Changeset,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
@@ -519,7 +519,9 @@ function rebaseMarkIgnoreChild(
 		}
 		rebasedMark = makeDetachedMark(rebasedMark, cloneCellId(baseCellId));
 	} else if (markFillsCells(baseMark)) {
-		rebasedMark = withCellId(currMark, undefined);
+		rebasedMark = isAttachAndDetachEffect(currMark)
+			? withNodeChange({ ...currMark.detach, count: currMark.count }, currMark.changes)
+			: withCellId(currMark, undefined);
 	} else if (isAttachAndDetachEffect(baseMark)) {
 		assert(
 			baseMark.cellId !== undefined,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -12,7 +12,6 @@ import {
 	DeltaMark,
 	TaggedChange,
 	areEqualChangeAtomIds,
-	makeDetachedNodeId,
 } from "../../core/index.js";
 import { Mutable } from "../../util/index.js";
 import { nodeIdFromChangeAtom } from "../deltaUtils.js";
@@ -22,10 +21,9 @@ import { MarkList, NoopMarkType } from "./types.js";
 import {
 	areInputCellsEmpty,
 	areOutputCellsEmpty,
-	getDetachOutputId,
+	getDetachedNodeId,
 	getEndpoint,
 	getInputCellId,
-	getOutputCellId,
 	isAttachAndDetachEffect,
 } from "./utils.js";
 import { ToDelta } from "../modular-schema/index.js";
@@ -74,7 +72,7 @@ export function sequenceFieldToDelta(
 				continue;
 			}
 
-			const outputId = getOutputCellId(mark, revision, undefined);
+			const outputId = getDetachedNodeId(mark.detach, revision, undefined);
 			assert(
 				outputId !== undefined,
 				0x820 /* AttachAndDetach mark should have defined output cell ID */,
@@ -107,7 +105,7 @@ export function sequenceFieldToDelta(
 					break;
 				}
 				case "Remove": {
-					const newDetachId = getDetachOutputId(mark, revision, undefined);
+					const newDetachId = getDetachedNodeId(mark, revision, undefined);
 					if (inputCellId === undefined) {
 						deltaMark.detach = nodeIdFromChangeAtom(newDetachId);
 						local.push(deltaMark);
@@ -133,7 +131,9 @@ export function sequenceFieldToDelta(
 				}
 				case "MoveOut": {
 					// The move destination will look for the detach ID of the source, so we can ignore `finalEndpoint`.
-					const detachId = makeDetachedNodeId(mark.revision ?? revision, mark.id);
+					const detachId = nodeIdFromChangeAtom(
+						getDetachedNodeId(mark, revision, undefined),
+					);
 					if (inputCellId === undefined) {
 						deltaMark.detach = detachId;
 						local.push(deltaMark);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -344,8 +344,11 @@ export function normalizeCellRename(
 	mark: CellMark<AttachAndDetach>,
 ): CellMark<AttachAndDetach | DetachOfRemovedNodes> {
 	assert(mark.cellId !== undefined, 0x823 /* AttachAndDetach marks should have a cell ID */);
+	// We must keep the attach information when the attach is a move-in because the input-context cell ID may not be
+	// enough to identify the move ID.
+	// TODO: revisit if we still need the attach information for new inserts.
 	if (mark.attach.type !== "Insert" || isNewAttachEffect(mark.attach, mark.cellId)) {
-	return mark;
+		return mark;
 	}
 	// Normalization: when the attach is a revive, we rely on the implicit reviving semantics of the
 	// detach instead of using an explicit revive effect in an AttachAndDetach mark.

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/rebase.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/rebase.test.ts
@@ -963,6 +963,39 @@ export function testRebase() {
 				assertChangesetsEqual(rebased, expected);
 			}));
 
+		it("move and remove ↷ same", () =>
+			withConfig(() => {
+				const moveCellId: SF.CellId = { revision: tag1, localId: brand(0) };
+				const removeCellId: SF.CellId = { revision: tag1, localId: brand(1) };
+				const returnCellId: SF.CellId = { revision: tag2, localId: brand(0) };
+				const moveAndRemove = [
+					{ count: 1 },
+					Mark.attachAndDetach(
+						Mark.returnTo(1, returnCellId, moveCellId),
+						Mark.remove(1, removeCellId),
+					),
+					{ count: 1 },
+					Mark.moveOut(1, returnCellId),
+				];
+				const rebased = rebase(moveAndRemove, moveAndRemove);
+				const expected = [
+					{ count: 1 },
+					Mark.attachAndDetach(
+						Mark.pin(1, returnCellId, {
+							cellId: {
+								...removeCellId,
+								adjacentCells: [{ id: removeCellId.localId, count: 1 }],
+							},
+						}),
+						Mark.remove(1, removeCellId),
+					),
+					{ count: 1 },
+					Mark.tomb(returnCellId.revision, returnCellId.localId),
+				];
+
+				assertChangesetsEqual(rebased, expected);
+			}));
+
 		it("revive ↷ [revive, move]", () =>
 			withConfig(() => {
 				const cellId: ChangeAtomId = { revision: tag1, localId: brand(0) };

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/rebase.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/rebase.test.ts
@@ -980,15 +980,12 @@ export function testRebase() {
 				const rebased = rebase(moveAndRemove, moveAndRemove);
 				const expected = [
 					{ count: 1 },
-					Mark.attachAndDetach(
-						Mark.pin(1, returnCellId, {
-							cellId: {
-								...removeCellId,
-								adjacentCells: [{ id: removeCellId.localId, count: 1 }],
-							},
-						}),
-						Mark.remove(1, removeCellId),
-					),
+					Mark.remove(1, removeCellId, {
+						cellId: {
+							...removeCellId,
+							adjacentCells: [{ id: removeCellId.localId, count: 1 }],
+						},
+					}),
 					{ count: 1 },
 					Mark.tomb(returnCellId.revision, returnCellId.localId),
 				];

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -31,6 +31,7 @@ export const cases: {
 	revive: TestChangeset;
 	pin: TestChangeset;
 	move: TestChangeset;
+	moveAndRemove: TestChangeset;
 	return: TestChangeset;
 	transient_insert: TestChangeset;
 } = {
@@ -50,6 +51,10 @@ export const cases: {
 	revive: createReviveChangeset(2, 2, { revision: tag, localId: brand(0) }),
 	pin: [createPinMark(4, brand(0))],
 	move: createMoveChangeset(1, 2, 4),
+	moveAndRemove: [
+		createMoveOutMark(1, brand(0)),
+		createAttachAndDetachMark(createMoveInMark(1, brand(0)), createRemoveMark(1, brand(1))),
+	],
 	return: createReturnChangeset(1, 3, 0, { revision: tag, localId: brand(0) }),
 	transient_insert: [
 		{ count: 1 },
@@ -181,15 +186,19 @@ function createReviveMark(
 
 function createPinMark(
 	count: number,
-	id: SF.MoveId,
+	id: SF.MoveId | SF.CellId,
 	overrides?: Partial<SF.CellMark<SF.Insert>>,
 ): SF.CellMark<SF.Insert> {
-	return {
+	const cellIdObject: SF.CellId = typeof id === "object" ? id : { localId: id };
+	const mark: SF.CellMark<SF.Insert> = {
 		type: "Insert",
 		count,
-		id,
-		...overrides,
+		id: cellIdObject.localId,
 	};
+	if (cellIdObject.revision !== undefined) {
+		mark.revision = cellIdObject.revision;
+	}
+	return { ...mark, ...overrides };
 }
 
 /**


### PR DESCRIPTION
## Description

1. Fixes `addMovedMarkEffect` to handle the case where a `MoveOut` effect is being added to an `AttachAndDetach` mark.
2. Fixes the `sequenceFieldToDelta` function so that it uses the adequate ID for detached content on an `AttachAndDetach` mark.

Note that, in 1, the intention "pin and detach", are being reduced to the detach intention. I think that is correct/valid because detach intentions overwrite prior intentions for the same content. IOW, we do not support "detach from here" as an intention. The fact that our current implementation needs to keep track of where a node last was before its latest removal is not a motivation to start supporting this kind of intention. At the very least, this PR does no harm in the sense that such intentions were already being reduced in this way.

## Breaking Changes

None