### PR TITLE
Add additional properties to summarizer and GC logs

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3392,10 +3392,15 @@ export class ContainerRuntime
 		// The summary number for this summary. This will be updated during the summary process, so get it now and
 		// use it for all events logged during this summary.
 		const summaryNumber = this.nextSummaryNumber;
+		let summaryRefSeqNum: number | undefined;
 		const summaryNumberLogger = createChildLogger({
 			logger: summaryLogger,
 			properties: {
-				all: { summaryNumber },
+				all: {
+					summaryNumber,
+					summaryReferenceSequenceNumber: () => summaryRefSeqNum,
+					initialSequenceNumber: this.deltaManager.initialSequenceNumber,
+				},
 			},
 		});
 
@@ -3463,8 +3468,6 @@ export class ContainerRuntime
 			this.mc.config.getBoolean(
 				"Fluid.ContainerRuntime.SubmitSummary.shouldValidatePreSummaryState",
 			) === true;
-
-		let summaryRefSeqNum: number | undefined;
 
 		try {
 			await this.deltaManager.inbound.pause();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1865,6 +1865,7 @@ export class ContainerRuntime
 			}),
 			telemetryDocumentId: this.telemetryDocumentId,
 			groupedBatchingEnabled: this.groupedBatchingEnabled,
+			initialSequenceNumber: this.deltaManager.initialSequenceNumber,
 		});
 
 		ReportOpPerfTelemetry(this.clientId, this.deltaManager, this, this.logger);
@@ -3399,7 +3400,6 @@ export class ContainerRuntime
 				all: {
 					summaryNumber,
 					summaryReferenceSequenceNumber: () => summaryRefSeqNum,
-					initialSequenceNumber: this.deltaManager.initialSequenceNumber,
 				},
 			},
 		});

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3399,7 +3399,7 @@ export class ContainerRuntime
 			properties: {
 				all: {
 					summaryNumber,
-					summaryReferenceSequenceNumber: () => summaryRefSeqNum,
+					referenceSequenceNumber: () => summaryRefSeqNum,
 				},
 			},
 		});


### PR DESCRIPTION
We need better correlation of summary events across all summarizers in a document. The sequence number we loaded from and current summary's referenceSequenceNumber should add enough information.

[AB#6970](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6970)
[AB#6971](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6971)