### PR TITLE
Fixed visualization bug to show newlines

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
@@ -47,7 +47,7 @@ const getStyles = makeStyles({
 		verticalAlign: "middle",
 	},
 	inlineValue: {
-		whiteSpace: "pre-line",
+		whiteSpace: "pre-wrap",
 	},
 });
 

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
@@ -46,6 +46,9 @@ const getStyles = makeStyles({
 		paddingBottom: "2px",
 		verticalAlign: "middle",
 	},
+	inlineValue: {
+		whiteSpace: "pre-line",
+	},
 });
 
 /**
@@ -94,7 +97,9 @@ export function TreeHeader(props: TreeHeaderProps): React.ReactElement {
 					<Info20Regular className={styles.iconContainer} />
 				</Tooltip>
 			)}
-			{inlineValue !== undefined && <span>: {inlineValue}</span>}
+			{inlineValue !== undefined && (
+				<span className={styles.inlineValue}>: {inlineValue}</span>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
[AB#5068](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5068)

## Description

This PR add styling to the span used to display the inline value of the SharedString text.

<img width="1007" alt="Screenshot 2024-04-11 at 3 55 08 PM" src="https://github.com/microsoft/FluidFramework/assets/23732584/e8590699-bd34-43c8-af18-f27c129ed2cc">


### Reviewer Guidance

Should there be a conditional `<br/>` added so that if the text is multiline, it gets displayed in a neat block instead of the first line being inline?