### PR TITLE
feat(build-tools): `generate entrypoints` per package.json with Node10 option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ nyc
 *.log
 .DS_Store
 
+# Generated Node10 module resolution compatibility files
+beta.d.ts
+internal.d.ts
+
 # TypeScript incremental build cache
 *.tsbuildinfo
 

--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -214,15 +214,17 @@ _See code: [src/commands/generate/changeset.ts](https://github.com/microsoft/Flu
 
 ## `flub generate entrypoints`
 
-Generates type declaration entrypoints for Fluid Framework API levels (/alpha, /beta. etc.)
+Generates type declaration entrypoints for Fluid Framework API levels (/alpha, /beta. etc.) as found in package.json "exports"
 
 ```
 USAGE
-  $ flub generate entrypoints [-v | --quiet] [--mainEntrypoint <value>] [--outDir <value>] [--outFileAlpha <value>]
-    [--outFileBeta <value>] [--outFilePublic <value>] [--outFilePrefix <value>] [--outFileSuffix <value>]
+  $ flub generate entrypoints [-v | --quiet] [--mainEntrypoint <value>] [--outDir <value>] [--outFilePrefix <value>]
+    [--outFileAlpha <value>] [--outFileBeta <value>] [--outFilePublic <value>] [--outFileSuffix <value>]
+    [--node10TypeCompat]
 
 FLAGS
   --mainEntrypoint=<value>  [default: ./src/index.ts] Main entrypoint file containing all untrimmed exports.
+  --node10TypeCompat        Optional generation of Node10 resolution compatible type entrypoints matching others.
   --outDir=<value>          [default: ./lib] Directory to emit entrypoint declaration files.
   --outFileAlpha=<value>    [default: alpha] Base file name for alpha entrypoint declaration files.
   --outFileBeta=<value>     [default: beta] Base file name for beta entrypoint declaration files.
@@ -238,7 +240,8 @@ LOGGING FLAGS
       --quiet    Disable all logging.
 
 DESCRIPTION
-  Generates type declaration entrypoints for Fluid Framework API levels (/alpha, /beta. etc.)
+  Generates type declaration entrypoints for Fluid Framework API levels (/alpha, /beta. etc.) as found in package.json
+  "exports"
 ```
 
 _See code: [src/commands/generate/entrypoints.ts](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/src/commands/generate/entrypoints.ts)_

--- a/build-tools/packages/build-cli/src/commands/generate/entrypoints.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/entrypoints.ts
@@ -404,6 +404,7 @@ async function generateEntrypoints(
 		if (namedExports.length > 0) {
 			sourceFile.insertText(0, generatedHeader);
 			sourceFile.addExportDeclaration({
+				leadingTrivia: "\n",
 				moduleSpecifier: `./${mainSourceFile
 					.getBaseName()
 					.replace(/\.(?:d\.)?([cm]?)ts$/, ".$1js")}`,
@@ -439,8 +440,8 @@ async function generateNode10TypeEntrypoints(
 			fs.writeFile(
 				outFile,
 				isTypeOnly
-					? `${generatedHeader}\nexport type * from "${relPath}";\n`
-					: `${generatedHeader}\nexport * from "${jsImport}";\n`,
+					? `${generatedHeader}export type * from "${relPath}";\n`
+					: `${generatedHeader}export * from "${jsImport}";\n`,
 				"utf8",
 			),
 		);

--- a/experimental/framework/last-edited/package.json
+++ b/experimental/framework/last-edited/package.json
@@ -27,9 +27,6 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
-		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib",
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
 		"build:compile:min": "npm run build:compile",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -33,9 +33,6 @@
 	},
 	"types": "dist/indexNode.d.ts",
 	"scripts": {
-		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib",
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",

--- a/packages/loader/test-loader-utils/package.json
+++ b/packages/loader/test-loader-utils/package.json
@@ -27,9 +27,6 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
-		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib",
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",

--- a/packages/test/stochastic-test-utils/package.json
+++ b/packages/test/stochastic-test-utils/package.json
@@ -37,9 +37,6 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
-		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib",
 		"bench": "mocha --recursive dist/test --timeout 999999 --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js",
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",

--- a/packages/test/test-drivers/package.json
+++ b/packages/test/test-drivers/package.json
@@ -27,9 +27,6 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
-		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib",
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
 		"build:compile:min": "npm run build:compile",

--- a/packages/test/test-pairwise-generator/package.json
+++ b/packages/test/test-pairwise-generator/package.json
@@ -27,9 +27,6 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
-		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib",
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -24,8 +24,6 @@
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
 	"scripts": {
-		"api": "fluid-build . --task api",
-		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib",
 		"build": "fluid-build . --task build",
 		"build:compile": "fluid-build . --task compile",
 		"build:docs": "api-extractor run --local",

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -28,9 +28,6 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"scripts": {
-		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib",
 		"build": "fluid-build . --task build",
 		"build-and-test-mocha": "npm run build && npm run test:mocha:verbose",
 		"build:compile": "fluid-build . --task compile",


### PR DESCRIPTION
## package.json "exports" coordination
- Only generates where there is presence in "exports".
- Error is generated if there are no matches.
- Requested outputs that are not in "exports" are skipped, with any prior file being deleted.
- Will now generate an empty export when there are no exports at level assuming that package.json "exports" are as intended and useless paths are okay. Will warn (though general build seems to eat most error/warning logs).
- Removed unused API tasks (can be restored once used)

## Node10 Type Compatibility option
- Node10 types compat stub files are now generated based on package.json exports and the generated entrypoint files
- Preset from .gitignores

Tested Node10 build compat with a ESNext+Node10 package in FF.