### PR TITLE
Fix connection transitions

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -536,6 +536,8 @@ export class ConnectionManager implements IConnectionManager {
 		let connection: IDocumentDeltaConnection | undefined;
 
 		if (docService.policies?.storageOnly === true) {
+			// go through all steps
+			this.props.establishConnectionHandler(reason);
 			connection = new NoDeltaStream();
 			this.setupNewSuccessfulConnection(connection, "read", reason);
 			assert(this.pendingConnection === undefined, 0x2b3 /* "logic error" */);

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -533,11 +533,11 @@ export class ConnectionManager implements IConnectionManager {
 		const docService = this.serviceProvider();
 		assert(docService !== undefined, 0x2a7 /* "Container is not attached" */);
 
+		this.props.establishConnectionHandler(reason);
+
 		let connection: IDocumentDeltaConnection | undefined;
 
 		if (docService.policies?.storageOnly === true) {
-			// go through all steps
-			this.props.establishConnectionHandler(reason);
 			connection = new NoDeltaStream();
 			this.setupNewSuccessfulConnection(connection, "read", reason);
 			assert(this.pendingConnection === undefined, 0x2b3 /* "logic error" */);
@@ -558,7 +558,6 @@ export class ConnectionManager implements IConnectionManager {
 			connectionMode: requestedMode,
 		};
 
-		this.props.establishConnectionHandler(reason);
 		// This loop will keep trying to connect until successful, with a delay between each iteration.
 		while (connection === undefined) {
 			if (this._disposed) {


### PR DESCRIPTION
This is one-liner extraction from https://github.com/microsoft/FluidFramework/pull/20215 that ensures we go through the same transitions steps on reconnection flow. Currently we skip "establishingConnection" step that translated to ConnectionState.EstablishingConnection in Container. This would result in 0x3e3 assert being triggered when we are using connectedRaisedWhenCaughtUp flat with createConnectionStateHandler.

Making this one-linder change will allow me to start experimenting with feature gates in Loop code base before full PR above shows up / checked in, thus reducing risk and proving direction before big changes hit main.
