### PR TITLE
Use SharedTreeFormatVersion.v2 by default

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -25,13 +25,7 @@ import {
 } from "../util/index.js";
 
 import { SummaryData } from "./editManager.js";
-import {
-	Commit,
-	EncodedCommit,
-	EncodedEditManager,
-	SequencedCommit,
-	version,
-} from "./editManagerFormat.js";
+import { Commit, EncodedCommit, EncodedEditManager, SequencedCommit } from "./editManagerFormat.js";
 
 export interface EditManagerEncodingContext {
 	readonly schema?: SchemaAndPolicy;
@@ -68,12 +62,12 @@ export function makeEditManagerCodecs<TChangeset>(
 	options: ICodecOptions,
 ): ICodecFamily<SummaryData<TChangeset>, EditManagerEncodingContext> {
 	return makeCodecFamily([
-		[1, makeV1Codec(changeCodecs.resolve(1), revisionTagCodec, options)],
-		[2, makeV1Codec(changeCodecs.resolve(2), revisionTagCodec, options)],
+		[1, makeV1CodecWithVersion(changeCodecs.resolve(1), revisionTagCodec, options, 1)],
+		[2, makeV1CodecWithVersion(changeCodecs.resolve(2), revisionTagCodec, options, 2)],
 	]);
 }
 
-function makeV1Codec<TChangeset>(
+function makeV1CodecWithVersion<TChangeset>(
 	changeCodec: IMultiFormatCodec<
 		TChangeset,
 		JsonCompatibleReadOnly,
@@ -87,6 +81,7 @@ function makeV1Codec<TChangeset>(
 		ChangeEncodingContext
 	>,
 	options: ICodecOptions,
+	version: EncodedEditManager<TChangeset>["version"],
 ): IJsonCodec<
 	SummaryData<TChangeset>,
 	JsonCompatibleReadOnly,

--- a/packages/dds/tree/src/shared-tree-core/editManagerFormat.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerFormat.ts
@@ -94,15 +94,13 @@ const SummarySessionBranch = <ChangeSchema extends TSchema>(tChange: ChangeSchem
 export interface EncodedEditManager<TChangeset> {
 	readonly trunk: readonly Readonly<SequencedCommit<TChangeset>>[];
 	readonly branches: readonly [SessionId, Readonly<EncodedSummarySessionBranch<TChangeset>>][];
-	readonly version: typeof version;
+	readonly version: 1 | 2;
 }
-
-export const version = 1.0;
 
 export const EncodedEditManager = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
 	Type.Object(
 		{
-			version: Type.Literal(version),
+			version: Type.Union([Type.Literal(1), Type.Literal(2)]),
 			trunk: Type.Array(SequencedCommit(tChange)),
 			branches: Type.Array(Type.Tuple([SessionIdSchema, SummarySessionBranch(tChange)])),
 		},

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -62,16 +62,21 @@ export function makeMessageCodecs<TChangeset>(
 	>,
 	options: ICodecOptions,
 ): ICodecFamily<DecodedMessage<TChangeset>, MessageEncodingContext> {
-	const v1Codec = makeV1Codec(changeCodecs.resolve(1).json, revisionTagCodec, options);
+	const v1Codec = makeV1CodecWithVersion(
+		changeCodecs.resolve(1).json,
+		revisionTagCodec,
+		options,
+		1,
+	);
 	return makeCodecFamily([
 		// Back-compat: messages weren't always written with an explicit version field.
 		[undefined, v1Codec],
 		[1, v1Codec],
-		[2, makeV1Codec(changeCodecs.resolve(2).json, revisionTagCodec, options)],
+		[2, makeV1CodecWithVersion(changeCodecs.resolve(2).json, revisionTagCodec, options, 2)],
 	]);
 }
 
-function makeV1Codec<TChangeset>(
+function makeV1CodecWithVersion<TChangeset>(
 	changeCodec: ChangeFamilyCodec<TChangeset>,
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
@@ -80,6 +85,7 @@ function makeV1Codec<TChangeset>(
 		ChangeEncodingContext
 	>,
 	options: ICodecOptions,
+	version: 1 | 2,
 ): IJsonCodec<
 	DecodedMessage<TChangeset>,
 	JsonCompatibleReadOnly,
@@ -106,7 +112,7 @@ function makeV1Codec<TChangeset>(
 						originatorId,
 						schema: context.schema,
 					}),
-					version: 1,
+					version,
 				};
 				return message as unknown as JsonCompatibleReadOnly;
 			},

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -386,7 +386,7 @@ export const defaultSharedTreeOptions: Required<SharedTreeOptions> = {
 	jsonValidator: noopValidator,
 	forest: ForestType.Reference,
 	treeEncodeType: TreeCompressionStrategy.Compressed,
-	formatVersion: SharedTreeFormatVersion.v1,
+	formatVersion: SharedTreeFormatVersion.v2,
 };
 
 /**

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -313,6 +313,9 @@ export class SharedTree
 export const SharedTreeFormatVersion = {
 	/**
 	 * Requires \@fluidframework/tree \>= 2.0.0.
+	 *
+	 * @deprecated - FF does not currently plan on supporting this format long-term.
+	 * Do not write production documents using this format, as they may not be loadable in the future.
 	 */
 	v1: 1,
 
@@ -362,7 +365,7 @@ export interface SharedTreeFormatOptions {
 	 * To be safe, application authors should verify that they have saturated this version
 	 * of \@fluidframework/tree in their ecosystem before changing the format version.
 	 *
-	 * This option defaults to SharedTreeFormatVersion.v1.
+	 * This option defaults to SharedTreeFormatVersion.v2.
 	 */
 	formatVersion: SharedTreeFormatVersion[keyof SharedTreeFormatVersion];
 }

--- a/packages/dds/tree/src/test/snapshots/opFormat.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/opFormat.spec.ts
@@ -11,9 +11,9 @@ import {
 	MockFluidDataStoreRuntime,
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
-import { SharedTree } from "../../treeFactory.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "./snapshotTools.js";
 import { ITree, SchemaFactory } from "../../simple-tree/index.js";
+import { SharedTreeFactory, SharedTreeFormatVersion } from "../../shared-tree/index.js";
 
 /**
  * This suite provides some e2e snapshot coverage for how SharedTree ops look.
@@ -42,7 +42,7 @@ describe("SharedTree op format snapshots", () => {
 	let tree: ITree;
 
 	beforeEach(() => {
-		const factory = SharedTree.getFactory();
+		const factory = new SharedTreeFactory({ formatVersion: SharedTreeFormatVersion.v1 });
 		const containerRuntimeFactory = new MockContainerRuntimeFactory();
 		const sessionId = "00000000-0000-4000-b000-000000000000" as SessionId;
 		const runtime = new MockFluidDataStoreRuntime({

--- a/packages/dds/tree/src/test/snapshots/testTrees.ts
+++ b/packages/dds/tree/src/test/snapshots/testTrees.ts
@@ -34,10 +34,12 @@ import {
 	ITreeCheckout,
 	InitializeAndSchematizeConfiguration,
 	SharedTreeFactory,
+	SharedTreeOptions,
+	SharedTreeFormatVersion,
 	runSynchronous,
 } from "../../shared-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
-import { SharedTreeOptions, defaultSharedTreeOptions } from "../../shared-tree/sharedTree.js";
+import { defaultSharedTreeOptions } from "../../shared-tree/sharedTree.js";
 import { brand } from "../../util/index.js";
 import {
 	TestTreeProviderLite,
@@ -138,12 +140,13 @@ function generateTreeRecursively(
 // TODO: The generated test trees should eventually be updated to use the chunked-forest.
 export function generateTestTrees(useUncompressedEncode?: boolean) {
 	const testEncodeType = useUncompressedEncode === true ? "uncompressed" : "default-compression";
-	const factoryOptions = {
+	const factoryOptions: SharedTreeOptions = {
 		jsonValidator: typeboxValidator,
 		treeEncodeType:
 			useUncompressedEncode === true
 				? TreeCompressionStrategy.Uncompressed
 				: defaultSharedTreeOptions.treeEncodeType,
+		formatVersion: SharedTreeFormatVersion.v1,
 	};
 	const factory = new SharedTreeFactory(factoryOptions);
 	const testTrees: {


### PR DESCRIPTION
## Description

Fixes logic around writing `version: 2` in the right places for `SharedTreeFormatVersion.v2` and makes `SharedTreeFormatVersion.v2` the default value.

Writing `version: 2` for messages and edit manager's summary blob should have been handled by #20615, but was missed.

This is a breaking change in the sense that it breaks collaboration with versions of SharedTree before v2 format was implemented (i.e. anything rc-2 and earlier).

We are leveraging the fact that SharedTree doesn't yet have as strong of compatibility guarantees as other DDSes with current production usage.
