### PR TITLE
build(test-end-to-end-tests): Add eslint rule to check for incorrect describeCompat pattern

### DIFF
--- a/packages/test/test-end-to-end-tests/.eslintrc.cjs
+++ b/packages/test/test-end-to-end-tests/.eslintrc.cjs
@@ -67,10 +67,11 @@ module.exports = {
 			[
 				{
 					id: "invalidDescribeCompat",
-					message: "Invalid describeCompat usage. The inner describeCompat block should have have arguments defined. Using the TestObjectProvider from the outer block inside the inner block may lead to unexpected behavior.",
+					message:
+						"Invalid describeCompat usage. The inner describeCompat block should have have arguments defined. Using the TestObjectProvider from the outer block inside the inner block may lead to unexpected behavior.",
 					regex: `.*describeCompat\\(".*?",\\s+".*?",\\s+\\(.*?\\)\\s+=>\\s+\\{\\s+describeCompat\\(".*?",\\s+".*?",\\s+\\(\\)\\s+=>\\s+\\{.*`,
 					files: {
-						ignore: "^(?!.*\.spec\.ts).*$",
+						ignore: "^(?!.*.spec.ts).*$",
 					},
 				},
 			],

--- a/packages/test/test-end-to-end-tests/.eslintrc.cjs
+++ b/packages/test/test-end-to-end-tests/.eslintrc.cjs
@@ -11,6 +11,7 @@ module.exports = {
 	parserOptions: {
 		project: ["./src/test/tsconfig.json"],
 	},
+	plugins: ["regex"],
 	rules: {
 		"prefer-arrow-callback": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
@@ -61,6 +62,19 @@ module.exports = {
 			@fluid-private/test-end-to-end-tests:     at ExportMap.get (/home/tylerbu/code/release-1/node_modules/.pnpm/eslint-plugin-i@2.29.0_j7h7oj6rrhtikhzta4fgkou42e/node_modules/eslint-plugin-i/lib/ExportMap.js:792:465)
 		 */
 		"import/no-deprecated": "off",
+		"regex/invalid-error": [
+			"error",
+			[
+				{
+					id: "invalidDescribeCompat",
+					message: "Invalid describeCompat usage. The inner describeCompat block should have have arguments defined. Using the TestObjectProvider from the outer block inside the inner block may lead to unexpected behavior.",
+					regex: `.*describeCompat\\(".*?",\\s+".*?",\\s+\\(.*?\\)\\s+=>\\s+\\{\\s+describeCompat\\(".*?",\\s+".*?",\\s+\\(\\)\\s+=>\\s+\\{.*`,
+					files: {
+						ignore: "^(?!.*\.spec\.ts).*$",
+					},
+				},
+			],
+		],
 	},
 	overrides: [
 		{

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -139,6 +139,7 @@
 		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"eslint": "~8.55.0",
+		"eslint-plugin-regex": "1.10.0",
 		"mocha-json-output-reporter": "^2.0.1",
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.21.0",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -139,7 +139,7 @@
 		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",
 		"eslint": "~8.55.0",
-		"eslint-plugin-regex": "1.10.0",
+		"eslint-plugin-regex": "~1.10.0",
 		"mocha-json-output-reporter": "^2.0.1",
 		"mocha-multi-reporters": "^1.5.1",
 		"moment": "^2.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10084,6 +10084,7 @@ importers:
       c8: ^8.0.1
       cross-env: ^7.0.3
       eslint: ~8.55.0
+      eslint-plugin-regex: 1.10.0
       mocha: ^10.2.0
       mocha-json-output-reporter: ^2.0.1
       mocha-multi-reporters: ^1.5.1
@@ -10162,6 +10163,7 @@ importers:
       '@types/uuid': 9.0.7
       c8: 8.0.1
       eslint: 8.55.0
+      eslint-plugin-regex: 1.10.0_eslint@8.55.0
       mocha-json-output-reporter: 2.1.0_mocha@10.2.0+moment@2.29.4
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
       moment: 2.29.4
@@ -29365,6 +29367,15 @@ packages:
       resolve: 2.0.0-next.5
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
+    dev: true
+
+  /eslint-plugin-regex/1.10.0_eslint@8.55.0:
+    resolution: {integrity: sha512-C8/qYKkkbIb0epxKzaz4aw7oVAOmm19fJpR/moUrUToq/vc4xW4sEKMlTQqH6EtNGpvLjYsbbZRlWNWwQGeTSA==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      eslint: '>=4.0.0'
+    dependencies:
+      eslint: 8.55.0
     dev: true
 
   /eslint-plugin-tsdoc/0.2.17:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10084,7 +10084,7 @@ importers:
       c8: ^8.0.1
       cross-env: ^7.0.3
       eslint: ~8.55.0
-      eslint-plugin-regex: 1.10.0
+      eslint-plugin-regex: ~1.10.0
       mocha: ^10.2.0
       mocha-json-output-reporter: ^2.0.1
       mocha-multi-reporters: ^1.5.1


### PR DESCRIPTION
## Description

This PR adds an eslint rule to check for incorrect usage of `describeCompat`. The following pattern can lead to unexpected/incorrect behavior:
```ts
describeCompat("Outer Block", "NoCompat", (getTestObjectProvider, apis) => {
	describeCompat("Inner Block", "FullCompat", () => {
		// Tests...
	});
});
```
Attempting to use `getTestObjectProvider` with this pattern will lead to unexpected behavior. For instance, when running CrossVersion tests, the same API version will be used for both N and N-1.

## Reviewer Guidance

- Should this be a lint error or warning? I would suggest error, because it will better catch devs attention, and because you can always add `// eslint-disable-next-line regex/invalid-error` to disable the build error. Additionally, I don't think this pattern is ever something we "want" devs to use.
- Suggestions for the error wording
