### PR TITLE
tree: Remove TestChangeset type alias

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.test.ts
@@ -19,7 +19,7 @@ import { NodeId, SequenceField as SF } from "../../../feature-libraries/index.js
 import { brand } from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 import { TestNodeId } from "../../testNodeId.js";
-import { cases, ChangeMaker as Change, MarkMaker as Mark, TestChangeset } from "./testEdits.js";
+import { cases, ChangeMaker as Change, MarkMaker as Mark } from "./testEdits.js";
 import {
 	areComposable,
 	assertChangesetsEqual,
@@ -525,7 +525,7 @@ export function testCompose() {
 				const revive = [Mark.revive(1, detachEvent, { changes })];
 				const deletion = [Mark.remove(2, brand(0))];
 				const actual = shallowCompose([tagChange(revive, tag2), tagChange(deletion, tag3)]);
-				const expected: TestChangeset = [
+				const expected: SF.Changeset = [
 					Mark.remove(
 						1,
 						{ localId: brand(0), revision: tag3 },

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
@@ -23,7 +23,7 @@ import {
 	withOrderingMethod,
 	assertChangesetsEqual,
 } from "./utils.js";
-import { ChangeMaker as Change, MarkMaker as Mark, TestChangeset } from "./testEdits.js";
+import { ChangeMaker as Change, MarkMaker as Mark } from "./testEdits.js";
 
 function invert(change: SF.Changeset, tag?: RevisionTag): SF.Changeset {
 	return invertChange(tagChange(change, tag ?? tag1));
@@ -43,16 +43,16 @@ export function testInvert() {
 		const withConfig = (fn: () => void) => withOrderingMethod(config.cellOrdering, fn);
 		it("no changes", () =>
 			withConfig(() => {
-				const input: TestChangeset = [];
-				const expected: TestChangeset = [];
+				const input: SF.Changeset = [];
+				const expected: SF.Changeset = [];
 				const actual = invert(input);
 				assertChangesetsEqual(actual, expected);
 			}));
 
 		it("tombstones", () =>
 			withConfig(() => {
-				const input: TestChangeset = [Mark.tomb(tag1, brand(0))];
-				const expected: TestChangeset = [Mark.tomb(tag1, brand(0))];
+				const input: SF.Changeset = [Mark.tomb(tag1, brand(0))];
+				const expected: SF.Changeset = [Mark.tomb(tag1, brand(0))];
 				const actual = invert(input);
 				assertChangesetsEqual(actual, expected);
 			}));
@@ -136,7 +136,7 @@ export function testInvert() {
 					type: SF.DetachIdOverrideType.Redetach,
 					id: { revision: tag2, localId: brand(0) },
 				};
-				const input: TestChangeset = [Mark.remove(2, brand(5), { idOverride })];
+				const input: SF.Changeset = [Mark.remove(2, brand(5), { idOverride })];
 				const expected = [Mark.revive(2, idOverride.id, { id: brand(5) })];
 				const actual = invert(input);
 				assertChangesetsEqual(actual, expected);
@@ -154,7 +154,7 @@ export function testInvert() {
 					type: SF.DetachIdOverrideType.Redetach,
 					id: cellId,
 				};
-				const expected: TestChangeset = [Mark.remove(2, brand(0), { idOverride })];
+				const expected: SF.Changeset = [Mark.remove(2, brand(0), { idOverride })];
 				const actual = invert(input);
 				assertChangesetsEqual(actual, expected);
 			}));
@@ -219,7 +219,7 @@ export function testInvert() {
 					type: SF.DetachIdOverrideType.Redetach,
 					id: cellId,
 				};
-				const expected: TestChangeset = [
+				const expected: SF.Changeset = [
 					Mark.returnTo(2, brand(42), { revision: tag1, localId: brand(42) }),
 					{ count: 3 },
 					Mark.moveOut(1, brand(42), {
@@ -237,7 +237,7 @@ export function testInvert() {
 		it("pin live nodes => skip", () =>
 			withConfig(() => {
 				const input = [Mark.pin(1, brand(0), { changes: childChange1 })];
-				const expected: TestChangeset = [Mark.modify(childChange1)];
+				const expected: SF.Changeset = [Mark.modify(childChange1)];
 				const actual = invert(input);
 				assertChangesetsEqual(actual, expected);
 			}));
@@ -246,7 +246,7 @@ export function testInvert() {
 			withConfig(() => {
 				const cellId: ChangeAtomId = { revision: tag1, localId: brand(0) };
 				const input = [Mark.pin(1, brand(0), { cellId, changes: childChange1 })];
-				const expected: TestChangeset = [
+				const expected: SF.Changeset = [
 					Mark.remove(1, brand(0), {
 						idOverride: {
 							type: SF.DetachIdOverrideType.Redetach,

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/rebase.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/rebase.test.ts
@@ -23,7 +23,7 @@ import {
 	withOrderingMethod,
 	withoutTombstones,
 } from "./utils.js";
-import { ChangeMaker as Change, MarkMaker as Mark, TestChangeset, cases } from "./testEdits.js";
+import { ChangeMaker as Change, MarkMaker as Mark, cases } from "./testEdits.js";
 import { brand } from "../../../index.js";
 import { TestChange } from "../../testChange.js";
 
@@ -32,11 +32,11 @@ const tag2: RevisionTag = mintRevisionTag();
 const tag3: RevisionTag = mintRevisionTag();
 
 function rebase(
-	change: TestChangeset,
-	base: TestChangeset,
+	change: SF.Changeset,
+	base: SF.Changeset,
 	baseRev?: RevisionTag,
 	config?: RebaseConfig,
-): TestChangeset {
+): SF.Changeset {
 	return rebaseI(change, tagChange(base, baseRev ?? tag1), config);
 }
 
@@ -1213,7 +1213,7 @@ export function testRebase() {
 		describe("Over composition", () => {
 			it("insert ↷ [remove, remove]", () =>
 				withConfig(() => {
-					const removes: TestChangeset = shallowCompose([
+					const removes: SF.Changeset = shallowCompose([
 						tagChange(Change.remove(1, 2), tag1),
 						tagChange(Change.remove(0, 2), tag2),
 					]);
@@ -1246,7 +1246,7 @@ export function testRebase() {
 
 			it("modify ↷ [remove, remove]", () =>
 				withConfig(() => {
-					const removes: TestChangeset = shallowCompose([
+					const removes: SF.Changeset = shallowCompose([
 						tagChange(Change.remove(1, 3), tag1),
 						tagChange(Change.remove(0, 2), tag2),
 					]);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/relevantRemovedRoots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/relevantRemovedRoots.test.ts
@@ -15,7 +15,7 @@ import { NodeId, SequenceField as SF } from "../../../feature-libraries/index.js
 import { brand } from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 import { TestNodeId } from "../../testNodeId.js";
-import { TestChangeset, MarkMaker as Mark } from "./testEdits.js";
+import { MarkMaker as Mark } from "./testEdits.js";
 import { mintRevisionTag } from "../../utils.js";
 
 const tag = mintRevisionTag();
@@ -36,43 +36,43 @@ export function testRelevantRemovedRoots() {
 	describe("relevantRemovedRoots", () => {
 		describe("does not include", () => {
 			it("a tree that remains in-doc", () => {
-				const input: TestChangeset = [{ count: 1 }];
+				const input: SF.Changeset = [{ count: 1 }];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, []);
 			});
 			it("a tree with child changes that remains in-doc", () => {
-				const input: TestChangeset = [Mark.modify(childChange)];
+				const input: SF.Changeset = [Mark.modify(childChange)];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, []);
 			});
 			it("a tree that remains removed", () => {
-				const input: TestChangeset = [{ count: 1, cellId: atomId }];
+				const input: SF.Changeset = [{ count: 1, cellId: atomId }];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, []);
 			});
 			it("a tree being removed", () => {
-				const input: TestChangeset = [Mark.remove(1, atomId)];
+				const input: SF.Changeset = [Mark.remove(1, atomId)];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, []);
 			});
 			it("a tree with child changes being removed", () => {
-				const input: TestChangeset = [Mark.remove(1, atomId, { changes: childChange })];
+				const input: SF.Changeset = [Mark.remove(1, atomId, { changes: childChange })];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, []);
 			});
 			it("a tree being moved", () => {
-				const input: TestChangeset = [Mark.moveOut(1, atomId), Mark.moveIn(1, atomId)];
+				const input: SF.Changeset = [Mark.moveOut(1, atomId), Mark.moveIn(1, atomId)];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, []);
 			});
 			it("a tree with child changes being moved", () => {
-				const input: TestChangeset = [
+				const input: SF.Changeset = [
 					Mark.moveOut(1, atomId, { changes: childChange }),
 					Mark.moveIn(1, atomId),
 				];
@@ -81,7 +81,7 @@ export function testRelevantRemovedRoots() {
 				assert.deepEqual(array, []);
 			});
 			it("a live tree being pinned", () => {
-				const input: TestChangeset = [Mark.pin(1, brand(0))];
+				const input: SF.Changeset = [Mark.pin(1, brand(0))];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, []);
@@ -89,13 +89,13 @@ export function testRelevantRemovedRoots() {
 		});
 		describe("does include", () => {
 			it("a tree being inserted", () => {
-				const input: TestChangeset = [Mark.insert(1, atomId)];
+				const input: SF.Changeset = [Mark.insert(1, atomId)];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, [deltaId]);
 			});
 			it("a tree being transiently inserted", () => {
-				const input: TestChangeset = [
+				const input: SF.Changeset = [
 					Mark.attachAndDetach(Mark.insert(1, atomId), Mark.remove(1, atomId)),
 				];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
@@ -103,7 +103,7 @@ export function testRelevantRemovedRoots() {
 				assert.deepEqual(array, [deltaId]);
 			});
 			it("a tree being transiently inserted and moved out", () => {
-				const input: TestChangeset = [
+				const input: SF.Changeset = [
 					Mark.attachAndDetach(Mark.insert(1, atomId), Mark.moveOut(1, atomId)),
 				];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
@@ -111,49 +111,49 @@ export function testRelevantRemovedRoots() {
 				assert.deepEqual(array, [deltaId]);
 			});
 			it("relevant roots from nested changes under a tree that remains in-doc", () => {
-				const input: TestChangeset = [Mark.modify(childChange)];
+				const input: SF.Changeset = [Mark.modify(childChange)];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), oneTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, [relevantNestedTree]);
 			});
 			it("relevant roots from nested changes under a tree that remains removed", () => {
-				const input: TestChangeset = [Mark.modify(childChange, atomId)];
+				const input: SF.Changeset = [Mark.modify(childChange, atomId)];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), oneTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, [deltaId, relevantNestedTree]);
 			});
 			it("a removed tree with nested changes", () => {
-				const input: TestChangeset = [Mark.modify(childChange, atomId)];
+				const input: SF.Changeset = [Mark.modify(childChange, atomId)];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, [deltaId]);
 			});
 			it("a tree being restored by revive", () => {
-				const input: TestChangeset = [Mark.revive(1, atomId)];
+				const input: SF.Changeset = [Mark.revive(1, atomId)];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, [deltaId]);
 			});
 			it("a tree being restored by pin", () => {
-				const input: TestChangeset = [Mark.pin(1, brand(0), { cellId: atomId })];
+				const input: SF.Changeset = [Mark.pin(1, brand(0), { cellId: atomId })];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, [deltaId]);
 			});
 			it("a tree being transiently restored", () => {
-				const input: TestChangeset = [Mark.remove(1, brand(0), { cellId: atomId })];
+				const input: SF.Changeset = [Mark.remove(1, brand(0), { cellId: atomId })];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), noTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, [deltaId]);
 			});
 			it("relevant roots from nested changes under a tree being restored by revive", () => {
-				const input: TestChangeset = [Mark.revive(1, atomId, { changes: childChange })];
+				const input: SF.Changeset = [Mark.revive(1, atomId, { changes: childChange })];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), oneTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, [deltaId, relevantNestedTree]);
 			});
 			it("relevant roots from nested changes under a tree being restored by pin", () => {
-				const input: TestChangeset = [
+				const input: SF.Changeset = [
 					Mark.pin(1, brand(0), { cellId: atomId, changes: childChange }),
 				];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), oneTreeDelegate);
@@ -161,19 +161,19 @@ export function testRelevantRemovedRoots() {
 				assert.deepEqual(array, [deltaId, relevantNestedTree]);
 			});
 			it("relevant roots from nested changes under a tree being removed", () => {
-				const input: TestChangeset = [Mark.remove(1, atomId, { changes: childChange })];
+				const input: SF.Changeset = [Mark.remove(1, atomId, { changes: childChange })];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), oneTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, [relevantNestedTree]);
 			});
 			it("relevant roots from nested changes under a tree being inserted", () => {
-				const input: TestChangeset = [Mark.insert(1, atomId, { changes: childChange })];
+				const input: SF.Changeset = [Mark.insert(1, atomId, { changes: childChange })];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), oneTreeDelegate);
 				const array = Array.from(actual);
 				assert.deepEqual(array, [deltaId, relevantNestedTree]);
 			});
 			it("relevant roots from nested changes under a tree being moved", () => {
-				const input: TestChangeset = [
+				const input: SF.Changeset = [
 					Mark.moveOut(1, atomId, { changes: childChange }),
 					Mark.moveIn(1, atomId),
 				];
@@ -182,7 +182,7 @@ export function testRelevantRemovedRoots() {
 				assert.deepEqual(array, [relevantNestedTree]);
 			});
 			it("relevant roots from nested changes under a tree being transiently inserted", () => {
-				const input: TestChangeset = [
+				const input: SF.Changeset = [
 					Mark.attachAndDetach(Mark.insert(1, atomId), Mark.remove(1, atomId), {
 						changes: childChange,
 					}),
@@ -192,7 +192,7 @@ export function testRelevantRemovedRoots() {
 				assert.deepEqual(array, [deltaId, relevantNestedTree]);
 			});
 			it("relevant roots from nested changes under a tree being transiently restored", () => {
-				const input: TestChangeset = [
+				const input: SF.Changeset = [
 					Mark.remove(1, brand(0), { cellId: atomId, changes: childChange }),
 				];
 				const actual = SF.relevantRemovedRoots(makeAnonChange(input), oneTreeDelegate);
@@ -200,7 +200,7 @@ export function testRelevantRemovedRoots() {
 				assert.deepEqual(array, [deltaId, relevantNestedTree]);
 			});
 			it("relevant roots from nested changes under a tree being transiently inserted and moved out", () => {
-				const input: TestChangeset = [
+				const input: SF.Changeset = [
 					Mark.attachAndDetach(Mark.insert(1, atomId), Mark.moveOut(1, atomId), {
 						changes: childChange,
 					}),
@@ -211,7 +211,7 @@ export function testRelevantRemovedRoots() {
 			});
 		});
 		it("uses passed down revision", () => {
-			const input: TestChangeset = [Mark.modify(childChange, { localId: brand(42) })];
+			const input: SF.Changeset = [Mark.modify(childChange, { localId: brand(42) })];
 			const actual = SF.relevantRemovedRoots(tagChange(input, tag), noTreeDelegate);
 			const array = Array.from(actual);
 			assert.deepEqual(array, [{ major: tag, minor: 42 }]);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEditor.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldEditor.test.ts
@@ -10,7 +10,7 @@ import { SequenceField as SF } from "../../../feature-libraries/index.js";
 import { brand } from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 import { TestNodeId } from "../../testNodeId.js";
-import { TestChangeset, MarkMaker as Mark } from "./testEdits.js";
+import { MarkMaker as Mark } from "./testEdits.js";
 import { deepFreeze } from "../../utils.js";
 
 const id: ChangesetLocalId = brand(0);
@@ -21,7 +21,7 @@ export function testEditor() {
 			const childChange = TestNodeId.create({ localId: brand(0) }, TestChange.mint([0], 1));
 			deepFreeze(childChange);
 			const actual = SF.sequenceFieldEditor.buildChildChange(42, childChange);
-			const expected: TestChangeset = [{ count: 42 }, Mark.modify(childChange)];
+			const expected: SF.Changeset = [{ count: 42 }, Mark.modify(childChange)];
 			assert.deepEqual(actual, expected);
 		});
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldToDelta.test.ts
@@ -22,7 +22,7 @@ import { brand } from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 import { assertFieldChangesEqual, deepFreeze, mintRevisionTag } from "../../utils.js";
 import { TestNodeId } from "../../testNodeId.js";
-import { ChangeMaker as Change, MarkMaker as Mark, TestChangeset } from "./testEdits.js";
+import { ChangeMaker as Change, MarkMaker as Mark } from "./testEdits.js";
 import { toDelta } from "./utils.js";
 
 const moveId = brand<ChangesetLocalId>(4242);
@@ -34,7 +34,7 @@ const fooField = brand<FieldKey>("foo");
 const cellId = { revision: tag1, localId: brand<ChangesetLocalId>(0) };
 const deltaNodeId: DeltaDetachedNodeId = { major: cellId.revision, minor: cellId.localId };
 
-function toDeltaShallow(change: TestChangeset): DeltaFieldChanges {
+function toDeltaShallow(change: SF.Changeset): DeltaFieldChanges {
 	deepFreeze(change);
 	return SF.sequenceFieldToDelta(makeAnonChange(change), () =>
 		fail("Unexpected call to child ToDelta"),
@@ -220,7 +220,7 @@ export function testToDelta() {
 		});
 
 		it("multiple changes", () => {
-			const changeset: TestChangeset = [
+			const changeset: SF.Changeset = [
 				Mark.remove(10, brand(42)),
 				{ count: 3 },
 				Mark.insert(1, brand(52)),

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/testEdits.ts
@@ -16,24 +16,21 @@ import { ChangeAtomId } from "../../../core/index.js";
 
 const tag: RevisionTag = mintRevisionTag();
 
-// TODO: Remove this
-export type TestChangeset = SF.Changeset;
-
 const nodeId1: NodeId = { localId: brand(1) };
 const nodeId2: NodeId = { localId: brand(2) };
 
 export const cases: {
-	no_change: TestChangeset;
-	insert: TestChangeset;
-	modify: TestChangeset;
-	modify_insert: TestChangeset;
-	remove: TestChangeset;
-	revive: TestChangeset;
-	pin: TestChangeset;
-	move: TestChangeset;
-	moveAndRemove: TestChangeset;
-	return: TestChangeset;
-	transient_insert: TestChangeset;
+	no_change: SF.Changeset;
+	insert: SF.Changeset;
+	modify: SF.Changeset;
+	modify_insert: SF.Changeset;
+	remove: SF.Changeset;
+	revive: SF.Changeset;
+	pin: SF.Changeset;
+	move: SF.Changeset;
+	moveAndRemove: SF.Changeset;
+	return: SF.Changeset;
+	transient_insert: SF.Changeset;
 } = {
 	no_change: [],
 	insert: createInsertChangeset(1, 2, brand(1)),

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -67,7 +67,6 @@ import {
 	defaultRevisionMetadataFromChanges,
 } from "../../utils.js";
 
-import { TestChangeset } from "./testEdits.js";
 import { ChangesetWrapper } from "../../changesetWrapper.js";
 import { TestNodeId } from "../../testNodeId.js";
 
@@ -170,9 +169,9 @@ export function composeDeep(
 }
 
 export function composeNoVerify(
-	changes: TaggedChange<TestChangeset>[],
+	changes: TaggedChange<SF.Changeset>[],
 	revInfos?: RevisionInfo[],
-): TestChangeset {
+): SF.Changeset {
 	return composeI(changes, (id1, id2) => TestNodeId.composeChild(id1, id2, false), revInfos);
 }
 
@@ -184,10 +183,10 @@ export function composeShallow(changes: TaggedChange<SF.Changeset>[]): SF.Change
 }
 
 export function compose(
-	changes: TaggedChange<TestChangeset>[],
+	changes: TaggedChange<SF.Changeset>[],
 	revInfos?: RevisionInfo[] | RevisionMetadataSource,
 	childComposer?: (change1: NodeId | undefined, change2: NodeId | undefined) => NodeId,
-): TestChangeset {
+): SF.Changeset {
 	return composeI(changes, childComposer ?? TestNodeId.composeChild, revInfos);
 }
 
@@ -196,9 +195,9 @@ export function pruneDeep(change: WrappedChange): WrappedChange {
 }
 
 export function prune(
-	change: TestChangeset,
+	change: SF.Changeset,
 	childPruner?: (child: NodeId) => NodeId | undefined,
-): TestChangeset {
+): SF.Changeset {
 	return SF.sequenceFieldChangeRebaser.prune(change, childPruner ?? ((child: NodeId) => child));
 }
 
@@ -271,10 +270,10 @@ export interface RebaseConfig {
 }
 
 export function rebase(
-	change: TestChangeset,
-	base: TaggedChange<TestChangeset>,
+	change: SF.Changeset,
+	base: TaggedChange<SF.Changeset>,
 	config: RebaseConfig = {},
-): TestChangeset {
+): SF.Changeset {
 	const cleanChange = purgeUnusedCellOrderingInfo(change);
 	const cleanBase = { ...base, change: purgeUnusedCellOrderingInfo(base.change) };
 	deepFreeze(cleanChange);
@@ -313,17 +312,17 @@ export function rebase(
 }
 
 export function rebaseTagged(
-	change: TaggedChange<TestChangeset>,
-	baseChange: TaggedChange<TestChangeset>,
-): TaggedChange<TestChangeset> {
+	change: TaggedChange<SF.Changeset>,
+	baseChange: TaggedChange<SF.Changeset>,
+): TaggedChange<SF.Changeset> {
 	return rebaseOverChanges(change, [baseChange]);
 }
 
 export function rebaseOverChanges(
-	change: TaggedChange<TestChangeset>,
-	baseChanges: TaggedChange<TestChangeset>[],
+	change: TaggedChange<SF.Changeset>,
+	baseChanges: TaggedChange<SF.Changeset>[],
 	revInfos?: RevisionInfo[],
-): TaggedChange<TestChangeset> {
+): TaggedChange<SF.Changeset> {
 	let currChange = change;
 	const revisionInfo = revInfos ?? defaultRevInfosFromChanges(baseChanges);
 	for (const base of baseChanges) {
@@ -339,10 +338,10 @@ export function rebaseOverChanges(
 }
 
 export function rebaseOverComposition(
-	change: TestChangeset,
-	base: TestChangeset,
+	change: SF.Changeset,
+	base: SF.Changeset,
 	metadata: RebaseRevisionMetadata,
-): TestChangeset {
+): SF.Changeset {
 	return rebase(change, makeAnonChange(base), { metadata });
 }
 
@@ -406,11 +405,11 @@ export function invert(change: TaggedChange<SF.Changeset>): SF.Changeset {
 	return inverted;
 }
 
-export function checkDeltaEquality(actual: TestChangeset, expected: TestChangeset) {
+export function checkDeltaEquality(actual: SF.Changeset, expected: SF.Changeset) {
 	assertFieldChangesEqual(toDelta(actual), toDelta(expected));
 }
 
-export function toDelta(change: TestChangeset, revision?: RevisionTag): DeltaFieldChanges {
+export function toDelta(change: SF.Changeset, revision?: RevisionTag): DeltaFieldChanges {
 	deepFreeze(change);
 	return SF.sequenceFieldToDelta(tagChange(change, revision), TestNodeId.deltaFromChild);
 }


### PR DESCRIPTION
## Description

`TestChangeset` was originally an alias for sequence field `Changeset<TestChange>`, but `Changeset`'s generic parameter has been removed so the alias is no longer useful.