### PR TITLE
[main>rc1]: build: Narrow workspace definitions

### DIFF
--- a/build-tools/pnpm-workspace.yaml
+++ b/build-tools/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
+# This is the workspace definition for the build-tools release group. See https://pnpm.io/pnpm-workspace_yaml for more
+# information about the format.
+#
+# Guidelines for updating this file:
+#
+# 1. Keep the entries alphabetical wherever possible.
+# 2. DO NOT end a glob with "**". E.g. "packages/**". Doing so can include unexpected packages. This is especially true
+#    of packages for which we build ESM and CJS. Such packages sometimes have package.json files in their source or
+#    output directories during compilation.
+
 packages:
-  - "packages/**"
+  - "packages/*"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,20 @@
+# This is the workspace definition for the client release group. See https://pnpm.io/pnpm-workspace_yaml for more
+# information about the format.
+#
+# Guidelines for updating this file:
+#
+# 1. Keep the entries alphabetical wherever possible.
+# 2. Be careful when using globs that end with "**". E.g. "packages/**". Doing so can include unexpected packages. This
+#    is especially true of packages for which we build ESM and CJS. Such packages sometimes have package.json files in
+#    their source or output directories during compilation.
+
 packages:
   - "azure/packages/**"
   - "examples/**"
   - "experimental/**"
   - "packages/**"
+
+  # exclude any package.json files that are inside src or output directories
+  - "!**/dist/**"
+  - "!**/lib/**"
+  - "!**/src/**"

--- a/server/gitrest/pnpm-workspace.yaml
+++ b/server/gitrest/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
+# This is the workspace definition for the gitrest release group. See https://pnpm.io/pnpm-workspace_yaml for more
+# information about the format.
+#
+# Guidelines for updating this file:
+#
+# 1. Keep the entries alphabetical wherever possible.
+# 2. DO NOT end a glob with "**". E.g. "packages/**". Doing so can include unexpected packages. This is especially true
+#    of packages for which we build ESM and CJS. Such packages sometimes have package.json files in their source or
+#    output directories during compilation.
+
 packages:
-  - "packages/**"
+  - "packages/*"

--- a/server/historian/pnpm-workspace.yaml
+++ b/server/historian/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
+# This is the workspace definition for the hisorian release group. See https://pnpm.io/pnpm-workspace_yaml for more
+# information about the format.
+#
+# Guidelines for updating this file:
+#
+# 1. Keep the entries alphabetical wherever possible.
+# 2. DO NOT end a glob with "**". E.g. "packages/**". Doing so can include unexpected packages. This is especially true
+#    of packages for which we build ESM and CJS. Such packages sometimes have package.json files in their source or
+#    output directories during compilation.
+
 packages:
-  - "packages/**"
+  - "packages/*"

--- a/server/routerlicious/pnpm-workspace.yaml
+++ b/server/routerlicious/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
+# This is the workspace definition for the server (routerlicious) release group. See https://pnpm.io/pnpm-workspace_yaml
+# for more information about the format.
+#
+# Guidelines for updating this file:
+#
+# 1. Keep the entries alphabetical wherever possible.
+# 2. DO NOT end a glob with "**". E.g. "packages/**". Doing so can include unexpected packages. This is especially true
+#    of packages for which we build ESM and CJS. Such packages sometimes have package.json files in their source or
+#    output directories during compilation.
+
 packages:
-  - "packages/**"
+  - "packages/*"


### PR DESCRIPTION
_This ports #19047 from main the RC1 release branch to improve the dev experience when switching between branches._

Our workspace definitions are including projects that shouldn't be included, especially when using temporary package.json files to control the compilation of ESM/CJS in dual-emit packages.

This change updates the definitions to be narrower. For the client workspace in particular, the results are more verbose because we have packages at arbitrary depths in the tree. We should address this over time by reorganizing the repo. For the server-related release groups the change is much smaller because they're small and follow conventions.