### PR TITLE
api(tags) - missed or new APIs consumed by partners

### DIFF
--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -94,7 +94,7 @@ export type ICommittedProposal = {
     commitSequenceNumber: number;
 } & IApprovedProposal;
 
-// @internal
+// @alpha
 export interface IConnect {
     client: IClient;
     driverVersion?: string;

--- a/common/lib/protocol-definitions/src/sockets.ts
+++ b/common/lib/protocol-definitions/src/sockets.ts
@@ -10,7 +10,7 @@ import { ITokenClaims } from "./tokens.js";
 
 /**
  * Message sent to connect to the given document.
- * @internal
+ * @alpha
  */
 export interface IConnect {
 	/**

--- a/packages/dds/merge-tree/api-report/merge-tree.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.api.md
@@ -909,7 +909,7 @@ export function refHasTileLabels(refPos: ReferencePosition): boolean;
 // @internal (undocumented)
 export function refTypeIncludesFlag(refPosOrType: ReferencePosition | ReferenceType, flags: ReferenceType): boolean;
 
-// @internal
+// @alpha
 export const reservedMarkerIdKey = "markerId";
 
 // @internal (undocumented)

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -692,9 +692,10 @@ export abstract class BaseSegment implements ISegment {
  *
  * @remarks In general, marker ids should be accessed using the inherent method
  * {@link Marker.getId}. Marker ids should not be updated after creation.
- * @internal
+ * @alpha
  */
 export const reservedMarkerIdKey = "markerId";
+
 /**
  * @internal
  */

--- a/packages/dds/task-manager/api-report/task-manager.api.md
+++ b/packages/dds/task-manager/api-report/task-manager.api.md
@@ -15,7 +15,7 @@ import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base/internal';
 
-// @internal
+// @alpha
 export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
     abandon(taskId: string): void;
     assigned(taskId: string): boolean;
@@ -27,7 +27,7 @@ export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
     volunteerForTask(taskId: string): Promise<boolean>;
 }
 
-// @internal
+// @alpha
 export interface ITaskManagerEvents extends ISharedObjectEvents {
     // @eventProperty
     (event: "assigned", listener: TaskEventListener): any;
@@ -37,10 +37,10 @@ export interface ITaskManagerEvents extends ISharedObjectEvents {
     (event: "lost", listener: TaskEventListener): any;
 }
 
-// @internal
+// @alpha
 export type TaskEventListener = (taskId: string) => void;
 
-// @internal @sealed
+// @alpha @sealed
 export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITaskManager {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
     abandon(taskId: string): void;

--- a/packages/dds/task-manager/package.json
+++ b/packages/dds/task-manager/package.json
@@ -23,6 +23,16 @@
 				"default": "./dist/index.js"
 			}
 		},
+		"./legacy": {
+			"import": {
+				"types": "./lib/legacy.d.ts",
+				"default": "./lib/index.js"
+			},
+			"require": {
+				"types": "./dist/legacy.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
 		"./internal": {
 			"import": {
 				"types": "./lib/index.d.ts",

--- a/packages/dds/task-manager/src/interfaces.ts
+++ b/packages/dds/task-manager/src/interfaces.ts
@@ -9,13 +9,13 @@ import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-objec
  * Describes the event listener format for {@link ITaskManagerEvents} events.
  *
  * @param taskId - The unique identifier of the related task.
- * @internal
+ * @alpha
  */
 export type TaskEventListener = (taskId: string) => void;
 
 /**
  * Events emitted by {@link TaskManager}.
- * @internal
+ * @alpha
  */
 export interface ITaskManagerEvents extends ISharedObjectEvents {
 	/**
@@ -133,7 +133,7 @@ export interface ITaskManagerEvents extends ISharedObjectEvents {
  * when using {@link ITaskManager.subscribeToTask}.
  *
  * See {@link ITaskManagerEvents} for more details.
- * @internal
+ * @alpha
  */
 export interface ITaskManager extends ISharedObject<ITaskManagerEvents> {
 	/**

--- a/packages/dds/task-manager/src/taskManager.ts
+++ b/packages/dds/task-manager/src/taskManager.ts
@@ -60,7 +60,7 @@ const placeholderClientId = "placeholder";
  * {@inheritDoc ITaskManager}
  *
  * @sealed
- * @internal
+ * @alpha
  */
 export class TaskManager extends SharedObject<ITaskManagerEvents> implements ITaskManager {
 	/**

--- a/packages/loader/container-loader/api-report/container-loader.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.api.md
@@ -88,7 +88,7 @@ export interface ILoaderServices {
     readonly urlResolver: IUrlResolver;
 }
 
-// @internal
+// @alpha
 export interface IParsedUrl {
     id: string;
     path: string;
@@ -132,7 +132,7 @@ export type ProtocolHandlerBuilder = (attributes: IDocumentAttributes, snapshot:
 // @alpha
 export function resolveWithLocationRedirectionHandling<T>(api: (request: IRequest) => Promise<T>, request: IRequest, urlResolver: IUrlResolver, logger?: ITelemetryBaseLogger): Promise<T>;
 
-// @internal
+// @alpha
 export function tryParseCompatibleResolvedUrl(url: string): IParsedUrl | undefined;
 
 // @alpha

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -43,7 +43,7 @@ export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
  * Interface to represent the parsed parts of IResolvedUrl.url to help
  * in getting info about different parts of the url.
  * May not be compatible or relevant for any Url Resolver
- * @internal
+ * @alpha
  */
 export interface IParsedUrl {
 	/**
@@ -72,7 +72,7 @@ export interface IParsedUrl {
  * with urls of type: protocol://<string>/.../..?<querystring>
  * @param url - This is the IResolvedUrl.url part of the resolved url.
  * @returns The IParsedUrl representing the input URL, or undefined if the format was not supported
- * @internal
+ * @alpha
  */
 export function tryParseCompatibleResolvedUrl(url: string): IParsedUrl | undefined {
 	const parsed = new URL(url);
@@ -163,7 +163,6 @@ function convertSummaryToSnapshotAndBlobs(summary: ISummaryTree): SnapshotWithBl
 				throw new LoggingError(
 					"No handles should be there in summary in detached container!!",
 				);
-				break;
 			default: {
 				unreachableCase(summaryObject, `Unknown tree type ${(summaryObject as any).type}`);
 			}

--- a/packages/runtime/datastore/api-report/datastore.api.md
+++ b/packages/runtime/datastore/api-report/datastore.api.md
@@ -150,7 +150,7 @@ export interface ISharedObjectRegistry {
     get(name: string): IChannelFactory | undefined;
 }
 
-// @internal
+// @alpha
 export const mixinRequestHandler: (requestHandler: (request: IRequest, runtime: FluidDataStoreRuntime) => Promise<IResponse>, Base?: typeof FluidDataStoreRuntime) => typeof FluidDataStoreRuntime;
 
 // @alpha

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1267,7 +1267,7 @@ export class FluidDataStoreRuntime
  * Request handler is only called when data store can't resolve request, i.e. for custom requests.
  * @param Base - base class, inherits from FluidDataStoreRuntime
  * @param requestHandler - request handler to mix in
- * @internal
+ * @alpha
  */
 export const mixinRequestHandler = (
 	requestHandler: (request: IRequest, runtime: FluidDataStoreRuntime) => Promise<IResponse>,

--- a/packages/runtime/runtime-utils/api-report/runtime-utils.api.md
+++ b/packages/runtime/runtime-utils/api-report/runtime-utils.api.md
@@ -51,7 +51,7 @@ export function convertToSummaryTree(snapshot: ITree, fullTree?: boolean): ISumm
 // @alpha
 export function convertToSummaryTreeWithStats(snapshot: ITree, fullTree?: boolean): ISummaryTreeWithStats;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const create404Response: (request: IRequest) => IResponse;
 
 // @internal (undocumented)

--- a/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
+++ b/packages/runtime/runtime-utils/src/dataStoreHelpers.ts
@@ -72,7 +72,7 @@ export function responseToException(response: IResponse, request: IRequest): Err
 }
 
 /**
- * @internal
+ * @alpha
  */
 export const create404Response = (request: IRequest) =>
 	createResponseError(404, "not found", request);

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -266,7 +266,7 @@ export class LoggingError extends Error implements ILoggingError, Omit<IFluidErr
 // @internal
 export function mixinMonitoringContext<L extends ITelemetryBaseLogger = ITelemetryLoggerExt>(logger: L, ...configs: (IConfigProviderBase | undefined)[]): MonitoringContext<L>;
 
-// @internal
+// @alpha
 export class MockLogger implements ITelemetryBaseLogger {
     constructor(minLogLevel?: LogLevel | undefined);
     assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean): void;

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -17,7 +17,7 @@ import { ITelemetryLoggerExt, ITelemetryPropertiesExt } from "./telemetryTypes.j
  * The MockLogger records events sent to it, and then can walk back over those events
  * searching for a set of expected events to match against the logged events.
  *
- * @internal
+ * @alpha
  */
 export class MockLogger implements ITelemetryBaseLogger {
 	events: ITelemetryBaseEvent[] = [];


### PR DESCRIPTION
Add alpha tags to APIs required for partners.

Not sure if we missed these API, or if the usages are new.  (Probably a bit of both.)