### PR TITLE
Fix Nexus relay user agent parsing

### DIFF
--- a/server/routerlicious/packages/lambdas/src/nexus/index.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/index.ts
@@ -69,9 +69,9 @@ function parseRelayUserAgent(relayUserAgent: string | undefined): Record<string,
 	const propertyKeyValuePairs: string[][] = relayUserAgent
 		.split(";")
 		.map((keyValuePair) => keyValuePair.split(":"));
-	// TODO: would be cleaner with `Object.fromEntries()` but tsconfig needs es2019 lib
 	for (const [key, value] of propertyKeyValuePairs) {
-		map[key] = value;
+		// Trim key and value so that a user agent like "prop1:val1; prop2:val2" is parsed correctly.
+		map[key.trim()] = value.trim();
 	}
 	return map;
 }


### PR DESCRIPTION
## Description

The R11s Driver sends a relayUserAgent string on socket connection like `" driverVersion:1.0"`, but the server parsing does not handle the empty space correctly so we aren't able to log the driverVerison property. `trim`ming the whitespace when parsing the user agent to fix this issue.
