### PR TITLE
Make guestDisplayname unnecessary in join session request

### DIFF
--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -20,7 +20,7 @@ import { runWithRetry } from "./retryUtils.js";
 
 interface IJoinSessionBody {
 	requestSocketToken: boolean;
-	guestDisplayName: string;
+	guestDisplayName?: string;
 }
 
 /**
@@ -83,12 +83,14 @@ export async function fetchJoinSession(
 				postBody += `prefer: FluidRemoveCheckAccess\r\n`;
 			}
 			postBody += `_post: 1\r\n`;
-			// Name should be there when socket token is requested and vice-versa.
-			if (requestSocketToken && guestDisplayName !== undefined) {
+
+			if (requestSocketToken) {
 				const body: IJoinSessionBody = {
 					requestSocketToken: true,
-					guestDisplayName,
 				};
+				if (guestDisplayName !== undefined) {
+					body.guestDisplayName = guestDisplayName;
+				}
 				postBody += `\r\n${JSON.stringify(body)}\r\n`;
 			}
 			postBody += `\r\n--${formBoundary}--`;


### PR DESCRIPTION
## Description

[Task](https://dev.azure.com/fluidframework/internal/_workitems/edit/7614)

fetchJoinSession allows requestSocketToken argument which can be set to true to instruct /joinSession backend to fetch access token for Push service and return it back as part of joinSession response payload. Current implementation sends such instruction only if guestDisplayName argument value is not undefined. That used to be required by joinSession implementation, but it is no longer the case. In fact, requestSocketToken is set to true in MSA case and the caller is forced to specify guestDisplayName which does not make sense in case of MSA user (it is not guest scenario).