### PR TITLE
Stress tests: Turn off explicit schema testing

### DIFF
--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -107,7 +107,7 @@ export function generateRuntimeOptions(
 		chunkSizeInBytes: [204800],
 		enableRuntimeIdCompressor: ["on", undefined, "delayed"],
 		enableGroupedBatching: [true, false],
-		explicitSchemaControl: [true, false],
+		explicitSchemaControl: [false],
 	};
 
 	return generatePairwiseOptions<IContainerRuntimeOptions>(


### PR DESCRIPTION
This change should turn off workflows that are hitting 0x950 assert (see https://dev.azure.com/fluidframework/internal/_workitems/edit/7759/) and make pipeline less noisy, such that we can see any other failures that it might be hiding.

There are no production scenarios at the moment that are changing schemas, and this this assert should not be hit in production.
A PR will follow with more logging and enabling this testing back to diagnose it further and fix the issue is finds.

Some info about assert:
It asserts that the sequence number of previous schema change should be below latest sequence number that attempts to change schema. That should never happen in real life, but I can't figure out why it does happen. It happens only when schema changes, which results in schema change op being sent. An assert fires on validation of that op.

My attempt to reconstruct stress test in smaller environment did not lead to any results - everything works fine, including running service tests locally.