### PR TITLE
build(fluid-framework): fix missing API trim for CJS

### DIFF
--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -19,7 +19,7 @@
 				"default": "./lib/index.js"
 			},
 			"require": {
-				"types": "./dist/index.d.ts",
+				"types": "./dist/public.d.ts",
 				"default": "./dist/index.js"
 			}
 		},


### PR DESCRIPTION
CJS for 'fluid-framework' should point to 'public.d.ts'.