### PR TITLE
devtools-browser-extension: Publish new version of the devtools browser extension

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/EXTENSION_CHANGELOG.md
+++ b/packages/tools/devtools/devtools-browser-extension/EXTENSION_CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -   Updates the Shared Tree Visualizer.
 -   Added the telemetry opt in feature.
+-   Added button to toggle unsampled telemetry
 
 # 0.0.3
 

--- a/packages/tools/devtools/devtools-browser-extension/EXTENSION_CHANGELOG.md
+++ b/packages/tools/devtools/devtools-browser-extension/EXTENSION_CHANGELOG.md
@@ -1,5 +1,10 @@
 # Fluid Framework Developer Tools
 
+# 0.0.4
+
+-   Updates the Shared Tree Visualizer.
+-   Added the telemetry opt in feature.
+
 # 0.0.3
 
 -   Fixed a number of styling and accessibility issues.

--- a/packages/tools/devtools/devtools-browser-extension/public/manifest.json
+++ b/packages/tools/devtools/devtools-browser-extension/public/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Fluid Framework Developer Tools (Preview)",
 	"description": "Devtools extension for viewing live data about your Fluid application.",
 	"author": "Microsoft",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"action": {
 		"default_icon": {
 			"16": "icons/icon_16.png",

--- a/packages/tools/devtools/devtools-browser-extension/public/manifest.json
+++ b/packages/tools/devtools/devtools-browser-extension/public/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Fluid Framework Developer Tools (Preview)",
 	"description": "Devtools extension for viewing live data about your Fluid application.",
 	"author": "Microsoft",
-	"version": "0.0.4",
+	"version": "0.1.0",
 	"action": {
 		"default_icon": {
 			"16": "icons/icon_16.png",


### PR DESCRIPTION
### Description 

[7645](https://dev.azure.com/fluidframework/internal/_workitems/edit/7645/)

This PR publishes a new version of `fluid-framework/devtools-browser-extension`. 