### PR TITLE
fix(build-common): Update `bundledPackages` glob patterns to support sub-root import patterns (e.g. /internal)

### DIFF
--- a/common/build/build-common/api-extractor-lint.json
+++ b/common/build/build-common/api-extractor-lint.json
@@ -52,10 +52,10 @@
 	},
 	// Bundle local dependencies so we can validate cross-package relationships
 	"bundledPackages": [
-		"@fluidframework/*",
-		"@fluid-internal/*",
-		"@fluid-experimental/*",
-		"@fluid-private/*",
-		"@fluid-tools/*"
+		"@fluidframework/**",
+		"@fluid-internal/**",
+		"@fluid-experimental/**",
+		"@fluid-private/**",
+		"@fluid-tools/**"
 	]
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"bundle-analysis:run": "flub run bundleStats --dangerfile build-tools/packages/build-cli/lib/library/dangerfile.js",
 		"changeset": "flub changeset add --releaseGroup client",
 		"check:are-the-types-wrong": "fluid-build --task check:are-the-types-wrong",
+		"check:release-tags": "fluid-build --task check:release-tags",
 		"check:versions": "flub check buildVersion -g client --path .",
 		"check:versions:fix": "flub check buildVersion -g client --path . --fix",
 		"checks": "fluid-build --task checks",

--- a/packages/framework/fluid-framework/api-extractor.json
+++ b/packages/framework/fluid-framework/api-extractor.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "../../../common/build/build-common/api-extractor-base.esm.primary.json",
-	"bundledPackages": ["@fluidframework/*"],
+	"bundledPackages": ["@fluidframework/**"],
 	"messages": {
 		"extractorMessageReporting": {
 			// TODO: Fix violations and set logLevel to "error"


### PR DESCRIPTION
When the bundledPackages settings were configured, we were strictly importing from package roots. We have since migrated to using trimmed entrypoints via `/internal`, `/beta`, etc. The glob patterns needed to be updated to support this.