### PR TITLE
2.0.0-RC3: DocumentSchemaController: Fix 0x950 assert ("time should move forward only")

### DIFF
--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -552,6 +552,7 @@ export class DocumentsSchemaController {
 	 */
 	public maybeSendSchemaMessage(): IDocumentSchemaChangeMessage | undefined {
 		if (this.sendOp && this.futureSchema !== undefined) {
+			this.sendOp = false;
 			assert(
 				this.explicitSchemaControl &&
 					this.futureSchema.runtime.explicitSchemaControl === true,
@@ -562,7 +563,6 @@ export class DocumentsSchemaController {
 				refSeq: this.documentSchema.refSeq,
 			};
 		}
-		this.sendOp = false;
 	}
 
 	/**

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -107,7 +107,7 @@ export function generateRuntimeOptions(
 		chunkSizeInBytes: [204800],
 		enableRuntimeIdCompressor: ["on", undefined, "delayed"],
 		enableGroupedBatching: [true, false],
-		explicitSchemaControl: [false],
+		explicitSchemaControl: [true, false],
 	};
 
 	return generatePairwiseOptions<IContainerRuntimeOptions>(


### PR DESCRIPTION
Scaled down version of https://github.com/microsoft/FluidFramework/pull/20678 from main to be an RC3 patch (without any extra validation). Undos https://github.com/microsoft/FluidFramework/pull/20676 that disabled schema migration testing due to too many errors hit in service tests (due to a bug that this PR fixes)
There is no impact to existing RC3 scenarios here with this change.

However patching code will enable us to enable explicit schema management sooner, including transition to leveraging ID compressor (and short IDs for DDSs & Datastores), In other words, deliver value sooner.

Main already has more strict validation and service tests running green (including all the extra checks in main).