### PR TITLE
fix(odsp-doclib-utils): Re-expose internal APIs through default entrypoint

### DIFF
--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -15,11 +15,11 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./lib/odsp-doclib-utils-public.d.ts",
+				"types": "./lib/index.d.ts",
 				"default": "./lib/index.js"
 			},
 			"require": {
-				"types": "./dist/odsp-doclib-utils-public.d.ts",
+				"types": "./dist/index.d.ts",
 				"default": "./dist/index.js"
 			}
 		},

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -45,7 +45,7 @@
 		}
 	},
 	"main": "dist/index.js",
-	"types": "dist/odsp-doclib-utils-public.d.ts",
+	"types": "dist/index.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
 		"api-extractor:commonjs": "api-extractor run --config ./api-extractor-cjs.json",


### PR DESCRIPTION
The odsp-doclib-utils package was released with API trimming enabled in RC2. This was a mistake. In this change I re-exposed the full API through the default entrypoint. Note that this change does not need to be made in main, since in RC3 and beyond we expect all packages to be API-trimmed, including this one.

The azure-service-utils package was also trimmed in RC2, but that's not known to block anyone, so I have left that out of this change.