### PR TITLE
fix(build-tools): Update broken tests

### DIFF
--- a/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
@@ -15,6 +15,10 @@ const test_tags = [
 	"client_v2.0.0-rc.1.0.0",
 	"client_v2.0.0-rc.1.0.1",
 	"client_v2.0.0-rc.2.0.0",
+	"client_v2.0.0-rc.3.0.0",
+	"client_v2.0.0-rc.4.0.0",
+	"client_v2.0.0-rc.5.0.0",
+	"client_v2.0.0-rc.6.0.0",
 	"build-tools_v0.5.2002",
 	"build-tools_v0.4.2001",
 	"build-tools_v0.4.2000",
@@ -421,12 +425,12 @@ describe("generate:buildVersion", () => {
 		.command([
 			"generate:buildVersion",
 			"--fileVersion",
-			"2.0.0-rc.3.0.0",
+			"2.0.0-rc.7.0.0",
 			"--tags",
 			...test_tags,
 		])
 		.it("RC version, release", (ctx) => {
-			expect(ctx.stdout).to.contain("version=2.0.0-rc.3.0.0");
+			expect(ctx.stdout).to.contain("version=2.0.0-rc.7.0.0");
 			expect(ctx.stdout).to.contain("isLatest=false");
 		});
 });

--- a/build-tools/packages/build-cli/test/filter.test.ts
+++ b/build-tools/packages/build-cli/test/filter.test.ts
@@ -172,8 +172,7 @@ describe("selectAndFilterPackages", async () => {
 		expect(names).to.be.containingAllOf([
 			"@fluidframework/build-common",
 			"@fluidframework/eslint-config-fluid",
-			"@fluidframework/common-definitions",
-			"@fluidframework/common-utils",
+			"@fluid-internal/eslint-plugin-fluid",
 			"@fluidframework/protocol-definitions",
 			"@fluid-tools/api-markdown-documenter",
 			"@fluid-tools/benchmark",


### PR DESCRIPTION
Some build-tools tests end up examining the repo state, since the build-tools typically work with the repo and very little is easily mockable. This does make some of the tests brittle and susceptible to breaks due to changes elsewhere in the repo.

In this case, the common-definitions package was deleted which caused a package filtering test to start failing, and the RC3 version number was used in a test case but it no longer works for that purpose because we have released that version.