### PR TITLE
devtools-browser-extension: Fix Changeset's version number

### DIFF
--- a/packages/tools/devtools/devtools-browser-extension/EXTENSION_CHANGELOG.md
+++ b/packages/tools/devtools/devtools-browser-extension/EXTENSION_CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fluid Framework Developer Tools
 
-# 0.0.4
+# 0.1.0
 
 -   Updates the Shared Tree Visualizer.
 -   Added the telemetry opt in feature.


### PR DESCRIPTION
#### Description

Fixes changeset's version number from `0.0.4` to `0.1.0`