### PR TITLE
Revert "Remove attach batch from container runtime"

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2827,9 +2827,9 @@ export class ContainerRuntime
 		let checkpoint: IBatchCheckpoint | undefined;
 		let result: T;
 		if (this.mc.config.getBoolean("Fluid.ContainerRuntime.EnableRollback")) {
-			// Note: we are not touching any batches other than mainBatch here, for two reasons:
-			// 1. It would not help, as other batches are flushed independently from main batch.
-			// 2. There is no way to undo process of data store creation, blob creation, ID compressor ops, or other things tracked by other batches.
+			// Note: we are not touching this.pendingAttachBatch here, for two reasons:
+			// 1. It would not help, as we flush attach ops as they become available.
+			// 2. There is no way to undo process of data store creation.
 			checkpoint = this.outbox.checkpoint().mainBatch;
 		}
 		try {
@@ -3952,7 +3952,33 @@ export class ContainerRuntime
 					});
 				}
 
-				if (type === ContainerMessageType.BlobAttach) {
+				// If this is attach message for new data store, and we are in a batch, send this op out of order
+				// Is it safe:
+				//    Yes, this should be safe reordering. Newly created data stores are not visible through API surface.
+				//    They become visible only when aliased, or handle to some sub-element of newly created datastore
+				//    is stored in some DDS, i.e. only after some other op.
+				// Why:
+				//    Attach ops are large, and expensive to process. Plus there are scenarios where a lot of new data
+				//    stores are created, causing issues like relay service throttling (too many ops) and catastrophic
+				//    failure (batch is too large). Pushing them earlier and outside of main batch should alleviate
+				//    these issues.
+				// Cons:
+				//    1. With large batches, relay service may throttle clients. Clients may disconnect while throttled.
+				//    This change creates new possibility of a lot of newly created data stores never being referenced
+				//    because client died before it had a change to submit the rest of the ops. This will create more
+				//    garbage that needs to be collected leveraging GC (Garbage Collection) feature.
+				//    2. Sending ops out of order means they are excluded from rollback functionality. This is not an issue
+				//    today as rollback can't undo creation of data store. To some extent not sending them is a bigger
+				//    issue than sending.
+				// Please note that this does not change file format, so it can be disabled in the future if this
+				// optimization no longer makes sense (for example, batch compression may make it less appealing).
+				if (
+					this.currentlyBatching() &&
+					type === ContainerMessageType.Attach &&
+					this.disableAttachReorder !== true
+				) {
+					this.outbox.submitAttach(message);
+				} else if (type === ContainerMessageType.BlobAttach) {
 					// BlobAttach ops must have their metadata visible and cannot be grouped (see opGroupingManager.ts)
 					this.outbox.submitBlobAttach(message);
 				} else {

--- a/packages/runtime/container-runtime/src/opLifecycle/README.md
+++ b/packages/runtime/container-runtime/src/opLifecycle/README.md
@@ -339,19 +339,19 @@ stateDiagram-v2
 	state "Store original (uncompressed, unchunked, ungrouped) batch locally" as store
     state if_compression <<choice>>
 	[*] --> ContainerRuntime.submit
-	ContainerRuntime.submit --> outbox.submitIdAllocation
+	ContainerRuntime.submit --> outbox.submitAttach
 	ContainerRuntime.submit --> outbox.submitBlobAttach
 	ContainerRuntime.submit --> outbox.submit
 	outbox.submit --> scheduleFlush
-	outbox.submitIdAllocation --> scheduleFlush
+	outbox.submitAttach --> scheduleFlush
 	outbox.submitBlobAttach --> scheduleFlush
 	scheduleFlush --> jsTurn
 	jsTurn --> flush
 	flush --> outbox.flushInternalMain
-	flush --> outbox.flushInternalIdAllocation
+	flush --> outbox.flushInternalAttach
 	flush --> outbox.flushInternalBlobAttach
 	outbox.flushInternalMain --> flushInternal
-	outbox.flushInternalIdAllocation --> flushInternal
+	outbox.flushInternalAttach --> flushInternal
 	outbox.flushInternalBlobAttach --> flushInternal
 	flushInternal --> ContainerRuntime.reSubmit: if batch has reentrant ops and should group
 	ContainerRuntime.reSubmit --> flushInternal

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -9,6 +9,7 @@ import { BatchMessage, IBatch, IBatchCheckpoint } from "./definitions.js";
 
 export interface IBatchManagerOptions {
 	readonly hardLimit: number;
+	readonly softLimit?: number;
 	readonly compressionOptions?: ICompressionRuntimeOptions;
 }
 
@@ -70,6 +71,19 @@ export class BatchManager {
 		// Not taking it into account, as compression work should help there - compressed payload will be
 		// initially stored as base64, and that requires only 2 extra escape characters.
 		const socketMessageSize = contentSize + opOverhead * opCount;
+
+		// If we were provided soft limit, check for exceeding it.
+		// But only if we have any ops, as the intention here is to flush existing ops (on exceeding this limit)
+		// and start over. That's not an option if we have no ops.
+		// If compression is enabled, the soft and hard limit are ignored and the message will be pushed anyways.
+		// Cases where the message is still too large will be handled by the maxConsecutiveReconnects path.
+		if (
+			this.options.softLimit !== undefined &&
+			this.length > 0 &&
+			socketMessageSize >= this.options.softLimit
+		) {
+			return false;
+		}
 
 		if (socketMessageSize >= this.options.hardLimit) {
 			return false;

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -89,9 +89,11 @@ export function getLongStack<T>(action: () => T, length: number = 50): T {
 
 export class Outbox {
 	private readonly mc: MonitoringContext;
+	private readonly attachFlowBatch: BatchManager;
 	private readonly mainBatch: BatchManager;
 	private readonly blobAttachBatch: BatchManager;
 	private readonly idAllocationBatch: BatchManager;
+	private readonly defaultAttachFlowSoftLimitInBytes = 320 * 1024;
 	private batchRebasesToReport = 5;
 	private rebasing = false;
 
@@ -111,14 +113,21 @@ export class Outbox {
 			Number.POSITIVE_INFINITY;
 		// We need to allow infinite size batches if we enable compression
 		const hardLimit = isCompressionEnabled ? Infinity : this.params.config.maxBatchSizeInBytes;
+		const softLimit = isCompressionEnabled ? Infinity : this.defaultAttachFlowSoftLimitInBytes;
 
+		this.attachFlowBatch = new BatchManager({ hardLimit, softLimit });
 		this.mainBatch = new BatchManager({ hardLimit });
 		this.blobAttachBatch = new BatchManager({ hardLimit });
 		this.idAllocationBatch = new BatchManager({ hardLimit });
 	}
 
 	public get messageCount(): number {
-		return this.mainBatch.length + this.blobAttachBatch.length + this.idAllocationBatch.length;
+		return (
+			this.attachFlowBatch.length +
+			this.mainBatch.length +
+			this.blobAttachBatch.length +
+			this.idAllocationBatch.length
+		);
 	}
 
 	public get isEmpty(): boolean {
@@ -133,11 +142,13 @@ export class Outbox {
 	 */
 	private maybeFlushPartialBatch() {
 		const mainBatchSeqNums = this.mainBatch.sequenceNumbers;
+		const attachFlowBatchSeqNums = this.attachFlowBatch.sequenceNumbers;
 		const blobAttachSeqNums = this.blobAttachBatch.sequenceNumbers;
 		const idAllocSeqNums = this.idAllocationBatch.sequenceNumbers;
 		assert(
 			this.params.config.disablePartialFlush ||
-				(sequenceNumbersMatch(mainBatchSeqNums, blobAttachSeqNums) &&
+				(sequenceNumbersMatch(mainBatchSeqNums, attachFlowBatchSeqNums) &&
+					sequenceNumbersMatch(mainBatchSeqNums, blobAttachSeqNums) &&
 					sequenceNumbersMatch(mainBatchSeqNums, idAllocSeqNums)),
 			0x58d /* Reference sequence numbers from both batches must be in sync */,
 		);
@@ -146,6 +157,7 @@ export class Outbox {
 
 		if (
 			sequenceNumbersMatch(mainBatchSeqNums, currentSequenceNumbers) &&
+			sequenceNumbersMatch(attachFlowBatchSeqNums, currentSequenceNumbers) &&
 			sequenceNumbersMatch(blobAttachSeqNums, currentSequenceNumbers) &&
 			sequenceNumbersMatch(idAllocSeqNums, currentSequenceNumbers)
 		) {
@@ -160,6 +172,8 @@ export class Outbox {
 					eventName: "ReferenceSequenceNumberMismatch",
 					mainReferenceSequenceNumber: mainBatchSeqNums.referenceSequenceNumber,
 					mainClientSequenceNumber: mainBatchSeqNums.clientSequenceNumber,
+					attachReferenceSequenceNumber: attachFlowBatchSeqNums.referenceSequenceNumber,
+					attachClientSequenceNumber: attachFlowBatchSeqNums.clientSequenceNumber,
 					blobAttachReferenceSequenceNumber: blobAttachSeqNums.referenceSequenceNumber,
 					blobAttachClientSequenceNumber: blobAttachSeqNums.clientSequenceNumber,
 					currentReferenceSequenceNumber: currentSequenceNumbers.referenceSequenceNumber,
@@ -178,6 +192,37 @@ export class Outbox {
 		this.maybeFlushPartialBatch();
 
 		this.addMessageToBatchManager(this.mainBatch, message);
+	}
+
+	public submitAttach(message: BatchMessage) {
+		this.maybeFlushPartialBatch();
+
+		if (
+			!this.attachFlowBatch.push(
+				message,
+				this.isContextReentrant(),
+				this.params.getCurrentSequenceNumbers().clientSequenceNumber,
+			)
+		) {
+			// BatchManager has two limits - soft limit & hard limit. Soft limit is only engaged
+			// when queue is not empty.
+			// Flush queue & retry. Failure on retry would mean - single message is bigger than hard limit
+			this.flushInternal(this.attachFlowBatch);
+
+			this.addMessageToBatchManager(this.attachFlowBatch, message);
+		}
+
+		// If compression is enabled, we will always successfully receive
+		// attach ops and compress then send them at the next JS turn, regardless
+		// of the overall size of the accumulated ops in the batch.
+		// However, it is more efficient to flush these ops faster, preferably
+		// after they reach a size which would benefit from compression.
+		if (
+			this.attachFlowBatch.contentSizeInBytes >=
+			this.params.config.compressionOptions.minimumBatchSizeInBytes
+		) {
+			this.flushInternal(this.attachFlowBatch);
+		}
 	}
 
 	public submitBlobAttach(message: BatchMessage) {
@@ -258,6 +303,7 @@ export class Outbox {
 
 	private flushAll() {
 		this.flushInternal(this.idAllocationBatch);
+		this.flushInternal(this.attachFlowBatch);
 		this.flushInternal(this.blobAttachBatch, true /* disableGroupedBatching */);
 		this.flushInternal(this.mainBatch);
 	}
@@ -433,6 +479,7 @@ export class Outbox {
 		const mainBatch: IBatchCheckpoint = this.mainBatch.checkpoint();
 		return {
 			mainBatch,
+			attachFlowBatch: this.attachFlowBatch.checkpoint(),
 			blobAttachBatch: this.blobAttachBatch.checkpoint(),
 		};
 	}

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -9,6 +9,7 @@ import { ContainerMessageType } from "../../messageTypes.js";
 import { BatchManager, BatchMessage, estimateSocketSize } from "../../opLifecycle/index.js";
 
 describe("BatchManager", () => {
+	const softLimit = 1024;
 	const hardLimit = 950 * 1024;
 	const smallMessageSize = 10;
 
@@ -21,8 +22,119 @@ describe("BatchManager", () => {
 			type: ContainerMessageType.FluidDataStoreOp,
 		}) as any as BatchMessage;
 
+	it("BatchManager's soft limit: a bunch of small messages", () => {
+		const message = { contents: generateStringOfSize(softLimit / 2) } as any as BatchMessage;
+		const batchManager = new BatchManager({ hardLimit, softLimit });
+
+		// Can push one large message
+		assert.equal(batchManager.push(message, /* reentrant */ false), true);
+		assert.equal(batchManager.length, 1);
+
+		// Can't push another large message
+		assert.equal(batchManager.push(message, /* reentrant */ false), false);
+		assert.equal(batchManager.length, 1);
+
+		// But can push one small message
+		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), true);
+		assert.equal(batchManager.length, 2);
+
+		// Pop and check batch
+		const batch = batchManager.popBatch();
+		assert.equal(batch.content.length, 2);
+		assert.equal(batch.contentSizeInBytes, softLimit / 2 + smallMessageSize);
+
+		// Validate that can push large message again
+		assert.equal(batchManager.push(message, /* reentrant */ false), true);
+		assert.equal(batchManager.length, 1);
+
+		assert.equal(batchManager.push(message, /* reentrant */ false), false);
+		assert.equal(batchManager.length, 1);
+	});
+
+	it("BatchManager's soft limit: single large message", () => {
+		const message = { contents: generateStringOfSize(softLimit * 2) } as any as BatchMessage;
+		const batchManager = new BatchManager({ hardLimit, softLimit });
+
+		// Can push one large message, even above soft limit
+		assert.equal(batchManager.push(message, /* reentrant */ false), true);
+		assert.equal(batchManager.length, 1);
+
+		// Can't push another small message
+		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), false);
+		assert.equal(batchManager.length, 1);
+
+		// Pop and check batch
+		const batch = batchManager.popBatch();
+		assert.equal(batch.content.length, 1);
+		assert.equal(batch.contentSizeInBytes, softLimit * 2);
+
+		// Validate that we can't push large message above soft limit if we have already at least one message.
+		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), true);
+		assert.equal(batchManager.length, 1);
+
+		assert.equal(batchManager.push(message, /* reentrant */ false), false);
+		assert.equal(batchManager.length, 1);
+	});
+
+	it("BatchManager: no soft limit", () => {
+		const batchManager = new BatchManager({ hardLimit });
+		const third = Math.floor(hardLimit / 3) + 1;
+		const message = { contents: generateStringOfSize(third) } as any as BatchMessage;
+
+		// Can push one large message, even above soft limit
+		assert.equal(batchManager.push(message, /* reentrant */ false), true);
+		assert.equal(batchManager.length, 1);
+
+		// Can push second large message, even above soft limit
+		assert.equal(batchManager.push(message, /* reentrant */ false), true);
+		assert.equal(batchManager.length, 2);
+
+		// Can't push another message
+		assert.equal(batchManager.push(message, /* reentrant */ false), false);
+		assert.equal(batchManager.length, 2);
+
+		// Pop and check batch
+		const batch = batchManager.popBatch();
+		assert.equal(batch.content.length, 2);
+
+		// Can push messages again
+		assert.equal(batchManager.push(message, /* reentrant */ false), true);
+		assert.equal(batchManager.length, 1);
+
+		assert.equal(batchManager.push(message, /* reentrant */ false), true);
+		assert.equal(batchManager.length, 2);
+
+		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), true);
+		assert.equal(batchManager.length, 3);
+	});
+
+	it("BatchManager: soft limit is higher than hard limit", () => {
+		const batchManager = new BatchManager({ hardLimit, softLimit: hardLimit * 2 });
+		const twoThird = Math.floor((hardLimit * 2) / 3);
+		const message = { contents: generateStringOfSize(twoThird) } as any as BatchMessage;
+		const largeMessage = {
+			contents: generateStringOfSize(hardLimit + 1),
+		} as any as BatchMessage;
+
+		// Can't push very large message, above hard limit
+		assert.equal(batchManager.push(largeMessage, /* reentrant */ false), false);
+		assert.equal(batchManager.length, 0);
+
+		// Can push one message
+		assert.equal(batchManager.push(message, /* reentrant */ false), true);
+		assert.equal(batchManager.length, 1);
+
+		// Can't push second message
+		assert.equal(batchManager.push(message, /* reentrant */ false), false);
+		assert.equal(batchManager.length, 1);
+
+		// Pop and check batch
+		const batch = batchManager.popBatch();
+		assert.equal(batch.content.length, 1);
+	});
+
 	it("BatchManager: 'infinity' hard limit allows everything", () => {
-		const message = { contents: generateStringOfSize(1024) } as any as BatchMessage;
+		const message = { contents: generateStringOfSize(softLimit) } as any as BatchMessage;
 		const batchManager = new BatchManager({ hardLimit: Infinity });
 
 		for (let i = 1; i <= 10; i++) {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -251,16 +251,16 @@ describe("Outbox", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
-			createMessage(ContainerMessageType.IdAllocation, "3"),
+			createMessage(ContainerMessageType.Attach, "2"),
+			createMessage(ContainerMessageType.Attach, "3"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "4"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "5"),
 		];
 
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
-		outbox.submitIdAllocation(messages[3]);
+		outbox.submitAttach(messages[2]);
+		outbox.submitAttach(messages[3]);
 
 		outbox.flush();
 
@@ -330,13 +330,13 @@ describe("Outbox", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
+			createMessage(ContainerMessageType.Attach, "2"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
 		];
 
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
+		outbox.submitAttach(messages[2]);
 		outbox.submit(messages[3]);
 
 		outbox.flush();
@@ -368,13 +368,13 @@ describe("Outbox", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
+			createMessage(ContainerMessageType.Attach, "2"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
 		];
 
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
+		outbox.submitAttach(messages[2]);
 		outbox.submit(messages[3]);
 
 		outbox.flush();
@@ -423,13 +423,13 @@ describe("Outbox", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
+			createMessage(ContainerMessageType.Attach, "2"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
 		];
 
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
+		outbox.submitAttach(messages[2]);
 		outbox.submit(messages[3]);
 
 		outbox.flush();
@@ -462,7 +462,7 @@ describe("Outbox", () => {
 		);
 	});
 
-	it("Compress and send (only) ID allocation ops if compression is enabled and their size exceed the compression threshold", () => {
+	it("Compress and send (only) attachment ops if compression is enabled and their size exceed the compression threshold", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
@@ -470,57 +470,55 @@ describe("Outbox", () => {
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
-			createMessage(ContainerMessageType.IdAllocation, "3"),
-			createMessage(ContainerMessageType.IdAllocation, "4"),
-			createMessage(ContainerMessageType.IdAllocation, "5"),
-			createMessage(ContainerMessageType.IdAllocation, "6"),
-			createMessage(ContainerMessageType.IdAllocation, "7"),
+			createMessage(ContainerMessageType.Attach, "2"),
+			createMessage(ContainerMessageType.Attach, "3"),
+			createMessage(ContainerMessageType.Attach, "4"),
+			createMessage(ContainerMessageType.Attach, "5"),
+			createMessage(ContainerMessageType.Attach, "6"),
+			createMessage(ContainerMessageType.Attach, "7"),
 		];
 
-		const idAllocationMessages = messages.filter(
-			(x) => typeFromBatchedOp(x) === ContainerMessageType.IdAllocation,
+		const attachMessages = messages.filter(
+			(x) => typeFromBatchedOp(x) === ContainerMessageType.Attach,
 		);
-		assert.ok(
-			idAllocationMessages.length > 0 && idAllocationMessages[0].contents !== undefined,
-		);
+		assert.ok(attachMessages.length > 0 && attachMessages[0].contents !== undefined);
 		const outbox = getOutbox({
 			context: getMockContext() as IContainerContext,
 			compressionOptions: {
-				minimumBatchSizeInBytes: idAllocationMessages[0].contents.length * 3,
+				minimumBatchSizeInBytes: attachMessages[0].contents.length * 3,
 				compressionAlgorithm: CompressionAlgorithms.lz4,
 			},
 		});
 
 		for (const message of messages) {
-			if (typeFromBatchedOp(message) === ContainerMessageType.IdAllocation) {
-				outbox.submitIdAllocation(message);
+			if (typeFromBatchedOp(message) === ContainerMessageType.Attach) {
+				outbox.submitAttach(message);
 			} else {
 				outbox.submit(message);
 			}
 		}
 
-		// Although there was no explicit flush, the Id allocation messages will get flushed
+		// Although there was no explicit flush, the attach messages will get flushed
 		// as their size have exceeded the compression threshold.
-		assert.equal(state.opsSubmitted, idAllocationMessages.length);
+		assert.equal(state.opsSubmitted, attachMessages.length);
 		assert.equal(state.batchesSubmitted.length, 2); // 6 messages in 2 batches
 		assert.equal(state.individualOpsSubmitted.length, 0);
 		assert.equal(state.deltaManagerFlushCalls, 0);
 		assert.deepEqual(state.batchesCompressed, [
-			toBatch(idAllocationMessages.slice(0, 3)),
-			toBatch(idAllocationMessages.slice(3)),
+			toBatch(attachMessages.slice(0, 3)),
+			toBatch(attachMessages.slice(3)),
 		]);
 		assert.deepEqual(
 			state.batchesSubmitted.map((x) => x.messages),
 			[
-				toBatch(idAllocationMessages.slice(0, 3)).content.map((x) => batchedMessage(x)),
-				toBatch(idAllocationMessages.slice(3)).content.map((x) => batchedMessage(x)),
+				toBatch(attachMessages.slice(0, 3)).content.map((x) => batchedMessage(x)),
+				toBatch(attachMessages.slice(3)).content.map((x) => batchedMessage(x)),
 			],
 		);
 
 		assert.deepEqual(
 			state.pendingOpContents,
-			idAllocationMessages.map((message) => ({
+			attachMessages.map((message) => ({
 				content: message.contents,
 				referenceSequenceNumber: message.referenceSequenceNumber,
 				opMetadata: message.metadata,
@@ -570,13 +568,13 @@ describe("Outbox", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
+			createMessage(ContainerMessageType.Attach, "2"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
 		];
 
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
+		outbox.submitAttach(messages[2]);
 		outbox.submit(messages[3]);
 
 		outbox.flush();
@@ -626,13 +624,13 @@ describe("Outbox", () => {
 		const messages = [
 			createMessage(ContainerMessageType.FluidDataStoreOp, "0"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "1"),
-			createMessage(ContainerMessageType.IdAllocation, "2"),
+			createMessage(ContainerMessageType.Attach, "2"),
 			createMessage(ContainerMessageType.FluidDataStoreOp, "3"),
 		];
 
 		outbox.submit(messages[0]);
 		outbox.submit(messages[1]);
-		outbox.submitIdAllocation(messages[2]);
+		outbox.submitAttach(messages[2]);
 		outbox.submit(messages[3]);
 
 		outbox.flush();
@@ -654,7 +652,7 @@ describe("Outbox", () => {
 		);
 	});
 
-	it("Throws at submit, when compression is enabled and the compressed batch is still larger than the threshold", () => {
+	it("Throws at submit, when compression is enabled and the attached compressed batch is still larger than the threshold", () => {
 		const outbox = getOutbox({
 			context: getMockContext() as IContainerContext,
 			maxBatchSize: 1,
@@ -664,9 +662,9 @@ describe("Outbox", () => {
 			},
 		});
 
-		const messages = [createMessage(ContainerMessageType.IdAllocation, "0")];
+		const messages = [createMessage(ContainerMessageType.Attach, "0")];
 
-		assert.throws(() => outbox.submitIdAllocation(messages[0]));
+		assert.throws(() => outbox.submitAttach(messages[0]));
 		// The batch is compressed
 		assert.deepEqual(state.batchesCompressed, [toBatch(messages)]);
 		// The batch is not persisted
@@ -724,11 +722,11 @@ describe("Outbox", () => {
 	[
 		[
 			{
-				...createMessage(ContainerMessageType.IdAllocation, "0"),
+				...createMessage(ContainerMessageType.Attach, "0"),
 				referenceSequenceNumber: 0,
 			},
 			{
-				...createMessage(ContainerMessageType.IdAllocation, "0"),
+				...createMessage(ContainerMessageType.Attach, "0"),
 				referenceSequenceNumber: 0,
 			},
 			{
@@ -746,7 +744,7 @@ describe("Outbox", () => {
 				referenceSequenceNumber: 0,
 			},
 			{
-				...createMessage(ContainerMessageType.IdAllocation, "0"),
+				...createMessage(ContainerMessageType.Attach, "0"),
 				referenceSequenceNumber: 1,
 			},
 		],
@@ -755,8 +753,8 @@ describe("Outbox", () => {
 			const outbox = getOutbox({ context: getMockContext() as IContainerContext });
 			for (const op of ops) {
 				currentSeqNumbers.referenceSequenceNumber = op.referenceSequenceNumber;
-				if (typeFromBatchedOp(op) === ContainerMessageType.IdAllocation) {
-					outbox.submitIdAllocation(op);
+				if (typeFromBatchedOp(op) === ContainerMessageType.Attach) {
+					outbox.submitAttach(op);
 				} else {
 					outbox.submit(op);
 				}
@@ -797,19 +795,19 @@ describe("Outbox", () => {
 				referenceSequenceNumber: 2,
 			},
 			{
-				...createMessage(ContainerMessageType.IdAllocation, "1"),
+				...createMessage(ContainerMessageType.Attach, "1"),
 				referenceSequenceNumber: 3,
 			},
 			{
-				...createMessage(ContainerMessageType.IdAllocation, "1"),
+				...createMessage(ContainerMessageType.Attach, "1"),
 				referenceSequenceNumber: 3,
 			},
 		];
 
 		for (const message of messages) {
 			currentSeqNumbers.referenceSequenceNumber = message.referenceSequenceNumber;
-			if (typeFromBatchedOp(message) === ContainerMessageType.IdAllocation) {
-				outbox.submitIdAllocation(message);
+			if (typeFromBatchedOp(message) === ContainerMessageType.Attach) {
+				outbox.submitAttach(message);
 			} else {
 				outbox.submit(message);
 			}


### PR DESCRIPTION
Reverts microsoft/FluidFramework#20603

I suspect this is causing 0x294, as we begin seeing this error around this change, and it is the only recent change in the area of the code base where the assert comes from:

Data_eventName | Data_error | Data_errorType | Data_message | count_ | min_Event_Time | max_Event_Time | Data_stack | set_Data_messageType
-- | -- | -- | -- | -- | -- | -- | -- | --
RunnerFailed | 0x294 | dataProcessingError | 0x294 | 2 | 2024-04-17 06:02:36.2470000 | 2024-04-17 06:02:42.3880000 | Errorat assert (/mnt/vss/_work/1/test/node_modules/@fluidframework/core-utils/dist/assert.js:21:15)at ScheduleManagerCore.afterOpProcessing (/mnt/vss/_work/1/test/node_modules/@fluidframework/container-runtime/dist/scheduleManager.js:122:31)at DeltaManager.<anonymous> (/mnt/vss/_work/1/test/node_modules/@fluidframework/container-runtime/dist/scheduleManager.js:115:54)at DeltaManager.emit (/mnt/vss/_work/1/test/node_modules/events_pkg/events.js:158:7)at DeltaManager.processInboundMessage (/mnt/vss/_work/1/test/node_modules/@fluidframework/container-loader/dist/deltaManager.js:768:14)at DeltaQueue.worker (/mnt/vss/_work/1/test/node_modules/@fluidframework/container-loader/dist/deltaManager.js:270:18)at DeltaQueue.processDeltas (/mnt/vss/_work/1/test/node_modules/@fluidframework/container-loader/dist/deltaQueue.js:127:18)at /mnt/vss/_work/1/test/node_modules/@fluidframework/container-loader/dist/deltaQueue.js:92:37at process.processTicksAndRejections (node:internal/process/task_queues:95:5) | [ ""]