### PR TITLE
Disable logger throttling for perf data upload

### DIFF
--- a/tools/telemetry-generator/src/commands/index.ts
+++ b/tools/telemetry-generator/src/commands/index.ts
@@ -10,9 +10,18 @@ import { ITelemetryBufferedLogger } from "@fluidframework/test-driver-definition
 import { ConsoleLogger } from "../logger";
 
 // Allow for dynamic injection of a logger. Leveraged in internal CI pipelines.
-// The parameter to getTestLogger() is a delay to apply after flushing the buffer.
 const _global: any = global;
-let logger: ITelemetryBufferedLogger = _global.getTestLogger?.(5_000);
+let logger: ITelemetryBufferedLogger = _global.getTestLogger?.({
+	// The telemetry libraries have issues with reporting synchronous flush completion.
+	// If the process exits too early, some telemetry may be lost. 5s here is likely a bit
+	// paranoid, but not much in the grand scheme of the pipeline.
+	afterFlushDelayMs: 5_000,
+	// This strategy of emitting an event with summary stats from each benchmark generates many telemetry
+	// events in a small window of time.
+	// The default test logger has client-side throttling (which is useful for contexts like e2e tests,
+	// where bugs may result in overlogging), which is not applicable here.
+	throttleLogging: false,
+});
 
 if (logger === undefined) {
 	logger = new ConsoleLogger();


### PR DESCRIPTION
## Description

We're missing perf data from some benchmarks in our kusto instance. The current theory is that the logger which sends events for each benchmark is throttling and dropping events past the first 100 benchmarks due to some configuration that makes sense for e2e/stress tests but doesn't for telemetry upload.

This theory is backed up by telemetry showing each build seems to cap at 100:

office_fluid_ffengineering_performance
| where Data_eventName has "Benchmark"
| where Data_branch == "refs/heads/main"
| where Event_Time > ago(3d)
| summarize count() by bin(Event_Time, 1s), Data_buildId
| render timechart

![image](https://github.com/microsoft/FluidFramework/assets/5222607/81e5d99e-a1b4-469e-ad31-ba200b066732)
