### PR TITLE
Adding comma to the end of line for config

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -201,7 +201,7 @@ data:
         },
         "usage": {
             "clientConnectivityCountingEnabled": "{{ .Values.usage.clientConnectivityCountingEnabled }}",
-            "signalUsageCountingEnabled": {{ .Values.usage.signalUsageCountingEnabled }}
+            "signalUsageCountingEnabled": {{ .Values.usage.signalUsageCountingEnabled }},
             "httpUsageCountingEnabled": {{ .Values.usage.httpUsageCountingEnabled }}
         },
         "shared": {


### PR DESCRIPTION
Fix for adding comma to the config line so that it does not break deployments