### PR TITLE
Use quorum to get client in attributor instead of audience

### DIFF
--- a/packages/framework/attributor/api-report/attributor.api.md
+++ b/packages/framework/attributor/api-report/attributor.api.md
@@ -7,9 +7,9 @@
 import { AttributionInfo } from '@fluidframework/runtime-definitions/internal';
 import { AttributionKey } from '@fluidframework/runtime-definitions/internal';
 import { ContainerRuntime } from '@fluidframework/container-runtime/internal';
-import { IAudience } from '@fluidframework/container-definitions';
 import { IDeltaManager } from '@fluidframework/container-definitions';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
+import { IQuorumClients } from '@fluidframework/protocol-definitions';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 
 // @internal
@@ -63,7 +63,7 @@ export const mixinAttributor: (Base?: typeof ContainerRuntime) => typeof Contain
 
 // @internal
 export class OpStreamAttributor extends Attributor implements IAttributor {
-    constructor(deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, audience: IAudience, initialEntries?: Iterable<[number, AttributionInfo]>);
+    constructor(deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, quorumClients: IQuorumClients, initialEntries?: Iterable<[number, AttributionInfo]>);
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/framework/attributor/api-report/attributor.api.md
+++ b/packages/framework/attributor/api-report/attributor.api.md
@@ -7,22 +7,6 @@
 import { AttributionInfo } from '@fluidframework/runtime-definitions/internal';
 import { AttributionKey } from '@fluidframework/runtime-definitions/internal';
 import { ContainerRuntime } from '@fluidframework/container-runtime/internal';
-import { IDeltaManager } from '@fluidframework/container-definitions';
-import { IDocumentMessage } from '@fluidframework/protocol-definitions';
-import { IQuorumClients } from '@fluidframework/protocol-definitions';
-import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
-
-// @internal
-export class Attributor implements IAttributor {
-    constructor(initialEntries?: Iterable<[number, AttributionInfo]>);
-    // (undocumented)
-    entries(): IterableIterator<[number, AttributionInfo]>;
-    getAttributionInfo(key: number): AttributionInfo;
-    // (undocumented)
-    protected readonly keyToInfo: Map<number, AttributionInfo>;
-    // (undocumented)
-    tryGetAttributionInfo(key: number): AttributionInfo | undefined;
-}
 
 // @internal
 export function createRuntimeAttributor(): IRuntimeAttributor;
@@ -60,11 +44,6 @@ export interface IRuntimeAttributor extends IProvideRuntimeAttributor {
 
 // @internal
 export const mixinAttributor: (Base?: typeof ContainerRuntime) => typeof ContainerRuntime;
-
-// @internal
-export class OpStreamAttributor extends Attributor implements IAttributor {
-    constructor(deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>, quorumClients: IQuorumClients, initialEntries?: Iterable<[number, AttributionInfo]>);
-}
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/framework/attributor/src/attributor.ts
+++ b/packages/framework/attributor/src/attributor.ts
@@ -42,7 +42,6 @@ export interface IAttributor {
 
 /**
  * {@inheritdoc IAttributor}
- * @internal
  */
 export class Attributor implements IAttributor {
 	protected readonly keyToInfo: Map<number, AttributionInfo>;
@@ -83,7 +82,6 @@ export class Attributor implements IAttributor {
 /**
  * Attributor which listens to an op stream and records entries for each op.
  * Sequence numbers are used as attribution keys.
- * @internal
  */
 export class OpStreamAttributor extends Attributor implements IAttributor {
 	public constructor(

--- a/packages/framework/attributor/src/index.ts
+++ b/packages/framework/attributor/src/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { Attributor, type IAttributor, OpStreamAttributor } from "./attributor.js";
+export { type IAttributor } from "./attributor.js";
 export {
 	createRuntimeAttributor,
 	enableOnNewFileKey,

--- a/packages/framework/attributor/src/mixinAttributor.ts
+++ b/packages/framework/attributor/src/mixinAttributor.ts
@@ -4,7 +4,7 @@
  */
 
 import { bufferToString } from "@fluid-internal/client-utils";
-import { type IAudience, type IDeltaManager } from "@fluidframework/container-definitions";
+import { type IDeltaManager } from "@fluidframework/container-definitions";
 import { type IContainerContext } from "@fluidframework/container-definitions/internal";
 import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import type { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
@@ -13,6 +13,7 @@ import { type FluidObject, type IRequest, type IResponse } from "@fluidframework
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
 	type IDocumentMessage,
+	type IQuorumClients,
 	type ISequencedDocumentMessage,
 	type ISnapshotTree,
 } from "@fluidframework/protocol-definitions";
@@ -152,10 +153,10 @@ export const mixinAttributor = (
 			const baseSnapshot: ISnapshotTree | undefined =
 				pendingRuntimeState?.baseSnapshot ?? context.baseSnapshot;
 
-			const { audience, deltaManager, taggedLogger } = context;
+			const { quorum, deltaManager, taggedLogger } = context;
 			assert(
-				audience !== undefined,
-				0x508 /* Audience must exist when instantiating attribution-providing runtime */,
+				quorum !== undefined,
+				"quorum must exist when instantiating attribution-providing runtime",
 			);
 
 			const mc = loggerToMonitoringContext(taggedLogger);
@@ -197,7 +198,7 @@ export const mixinAttributor = (
 				async (event) => {
 					await runtime.runtimeAttributor?.initialize(
 						deltaManager,
-						audience,
+						quorum,
 						baseSnapshot,
 						async (id) => runtime.storage.readBlob(id),
 						shouldTrackAttribution,
@@ -279,7 +280,7 @@ class RuntimeAttributor implements IRuntimeAttributor {
 
 	public async initialize(
 		deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>,
-		audience: IAudience,
+		quorum: IQuorumClients,
 		baseSnapshot: ISnapshotTree | undefined,
 		readBlob: (id: string) => Promise<ArrayBufferLike>,
 		shouldAddAttributorOnNewFile: boolean,
@@ -299,14 +300,14 @@ class RuntimeAttributor implements IRuntimeAttributor {
 		this.isEnabled = true;
 		this.encoder = chain(
 			new AttributorSerializer(
-				(entries) => new OpStreamAttributor(deltaManager, audience, entries),
+				(entries) => new OpStreamAttributor(deltaManager, quorum, entries),
 				deltaEncoder,
 			),
 			makeLZ4Encoder(),
 		);
 
 		if (attributorTree === undefined) {
-			this.opAttributor = new OpStreamAttributor(deltaManager, audience);
+			this.opAttributor = new OpStreamAttributor(deltaManager, quorum);
 		} else {
 			const id = attributorTree.blobs[opBlobName];
 			assert(

--- a/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
+++ b/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
@@ -22,7 +22,6 @@ import {
 	performFuzzActions,
 	take,
 } from "@fluid-private/stochastic-test-utils";
-import { type IAudience } from "@fluidframework/container-definitions";
 import {
 	type IChannelServices,
 	type IFluidDataStoreRuntime,
@@ -30,10 +29,11 @@ import {
 import { type Jsonable } from "@fluidframework/datastore-definitions/internal";
 import { createInsertOnlyAttributionPolicy } from "@fluidframework/merge-tree/internal";
 import {
-	type IClient,
 	type ISequencedDocumentMessage,
 	type ISummaryTree,
 	SummaryType,
+	type IQuorumClients,
+	type ISequencedClient,
 } from "@fluidframework/protocol-definitions";
 import { SharedString, SharedStringFactory } from "@fluidframework/sequence/internal";
 import {
@@ -41,6 +41,7 @@ import {
 	type MockContainerRuntimeForReconnection,
 	MockFluidDataStoreRuntime,
 	MockStorage,
+	MockQuorumClients,
 } from "@fluidframework/test-runtime-utils/internal";
 
 import { type IAttributor, OpStreamAttributor } from "../../attributor.js";
@@ -54,8 +55,8 @@ import { makeLZ4Encoder } from "../../lz4Encoder.js";
 
 import { _dirname } from "./dirname.cjs";
 
-function makeMockAudience(clientIds: string[]): IAudience {
-	const clients = new Map<string, IClient>();
+function makeMockQuorum(clientIds: string[]): IQuorumClients {
+	const clients = new Map<string, ISequencedClient>();
 	for (const [index, clientId] of clientIds.entries()) {
 		// eslint-disable-next-line unicorn/prefer-code-point
 		const stringId = String.fromCharCode(index + 65);
@@ -68,19 +69,17 @@ function makeMockAudience(clientIds: string[]): IAudience {
 			email,
 		};
 		clients.set(clientId, {
-			mode: "write",
-			details: { capabilities: { interactive: true } },
-			permission: [],
-			user,
-			scopes: [],
+			client: {
+				mode: "write",
+				details: { capabilities: { interactive: true } },
+				permission: [],
+				user,
+				scopes: [],
+			},
+			sequenceNumber: 0,
 		});
 	}
-	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-	return {
-		getMember: (clientId: string): IClient | undefined => {
-			return clients.get(clientId);
-		},
-	} as IAudience;
+	return new MockQuorumClients(...clients.entries());
 }
 
 type PropertySet = Record<string, unknown>;
@@ -244,7 +243,7 @@ function createSharedString(
 ): FuzzTestState {
 	const numClients = 3;
 	const clientIds = Array.from({ length: numClients }, () => random.uuid4());
-	const audience = makeMockAudience(clientIds);
+	const quorum = makeMockQuorum(clientIds);
 	const containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 	let attributor: IAttributor | undefined;
 	let serializer: Encoder<IAttributor, string> | undefined;
@@ -266,17 +265,17 @@ function createSharedString(
 			);
 
 			if (index === 0 && makeSerializer !== undefined) {
-				attributor = new OpStreamAttributor(deltaManager, audience);
+				attributor = new OpStreamAttributor(deltaManager, quorum);
 				serializer = makeSerializer(dataStoreRuntime);
 				// DeltaManager mock doesn't have high fidelity but attribution requires DataStoreRuntime implements
-				// audience / op emission.
+				// quorum / op emission.
 				let opIndex = 0;
 				sharedString.on("op", (message) => {
 					opIndex++;
 					message.timestamp = getTimestamp(opIndex);
 					deltaManager.emit("op", message);
 				});
-				dataStoreRuntime.getAudience = (): IAudience => audience;
+				dataStoreRuntime.getQuorum = (): IQuorumClients => quorum;
 			}
 
 			const containerRuntime =
@@ -633,7 +632,7 @@ describe("SharedString Attribution", () => {
 								(entries) =>
 									new OpStreamAttributor(
 										runtime.deltaManager,
-										runtime.getAudience(),
+										runtime.getQuorum(),
 										entries,
 									),
 								noopEncoder,
@@ -652,7 +651,7 @@ describe("SharedString Attribution", () => {
 								(entries) =>
 									new OpStreamAttributor(
 										runtime.deltaManager,
-										runtime.getAudience(),
+										runtime.getQuorum(),
 										entries,
 									),
 								noopEncoder,
@@ -671,7 +670,7 @@ describe("SharedString Attribution", () => {
 								(entries) =>
 									new OpStreamAttributor(
 										runtime.deltaManager,
-										runtime.getAudience(),
+										runtime.getQuorum(),
 										entries,
 									),
 								deltaEncoder,

--- a/packages/framework/attributor/src/test/mixinAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/mixinAttributor.spec.ts
@@ -17,7 +17,7 @@ import {
 	SummaryType,
 } from "@fluidframework/protocol-definitions";
 import { MockLogger, sessionStorageConfigProvider } from "@fluidframework/telemetry-utils/internal";
-import { MockDeltaManager, MockQuorumClients } from "@fluidframework/test-runtime-utils/internal";
+import { MockDeltaManager } from "@fluidframework/test-runtime-utils/internal";
 
 import { Attributor } from "../attributor.js";
 import { AttributorSerializer, chain, deltaEncoder } from "../encoders.js";
@@ -29,7 +29,7 @@ import {
 	mixinAttributor,
 } from "../mixinAttributor.js";
 
-import { makeMockAudience } from "./utils.js";
+import { makeMockAudience, makeMockQuorum } from "./utils.js";
 
 type Mutable<T> = {
 	-readonly [P in keyof T]: T[P];
@@ -42,7 +42,7 @@ describe("mixinAttributor", () => {
 			audience: makeMockAudience([clientId]),
 			attachState: AttachState.Attached,
 			deltaManager: new MockDeltaManager(),
-			quorum: new MockQuorumClients(),
+			quorum: makeMockQuorum([clientId]),
 			taggedLogger: new MockLogger(),
 			clientDetails: { capabilities: { interactive: true } },
 			closeFn: (error?: ICriticalContainerError): void => {

--- a/packages/framework/attributor/src/test/opStreamAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/opStreamAttributor.spec.ts
@@ -10,10 +10,10 @@ import { MockDeltaManager } from "@fluidframework/test-runtime-utils/internal";
 
 import { OpStreamAttributor } from "../attributor.js";
 
-import { makeMockAudience } from "./utils.js";
+import { makeMockQuorum } from "./utils.js";
 
 const clientIds = ["A", "B", "C"];
-const defaultAudience = makeMockAudience(clientIds);
+const defaultQuorumClients = makeMockQuorum(clientIds);
 
 class OpFactory {
 	private seq = 0;
@@ -43,13 +43,13 @@ describe("OpStreamAttributor", () => {
 
 	it("can retrieve user information from ops submitted during the current session", () => {
 		const deltaManager = new MockDeltaManager();
-		const attributor = new OpStreamAttributor(deltaManager, defaultAudience);
+		const attributor = new OpStreamAttributor(deltaManager, defaultQuorumClients);
 		const clientId = clientIds[1];
 		const timestamp = 50;
 		const op = opFactory.makeOp({ timestamp, clientId });
 		deltaManager.emit("op", op);
 		assert.deepEqual(attributor.getAttributionInfo(op.sequenceNumber), {
-			user: defaultAudience.getMember(clientId)?.user,
+			user: defaultQuorumClients.getMember(clientId)?.client.user,
 			timestamp,
 		});
 	});

--- a/packages/framework/attributor/src/test/utils.ts
+++ b/packages/framework/attributor/src/test/utils.ts
@@ -3,8 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { type IAudience } from "@fluidframework/container-definitions";
-import { type IClient } from "@fluidframework/protocol-definitions";
+import type { IAudience } from "@fluidframework/container-definitions";
+import {
+	type IClient,
+	type IQuorumClients,
+	type ISequencedClient,
+} from "@fluidframework/protocol-definitions";
+import { MockQuorumClients } from "@fluidframework/test-runtime-utils/internal";
 
 /**
  * Creates a mock {@link @fluidframework/container-definitions#IAudience} for testing.
@@ -36,4 +41,34 @@ export function makeMockAudience(clientIds: string[]): IAudience {
 			return clients.get(clientId);
 		},
 	} as IAudience;
+}
+
+/**
+ * Creates a mock {@link @fluidframework/protocol-definitions#IQuorumClients} for testing.
+ */
+export function makeMockQuorum(clientIds: string[]): IQuorumClients {
+	const clients = new Map<string, ISequencedClient>();
+	for (const [index, clientId] of clientIds.entries()) {
+		// eslint-disable-next-line unicorn/prefer-code-point
+		const stringId = String.fromCharCode(index + 65);
+		const name = stringId.repeat(10);
+		const userId = `${name}@microsoft.com`;
+		const email = userId;
+		const user = {
+			id: userId,
+			name,
+			email,
+		};
+		clients.set(clientId, {
+			client: {
+				mode: "write",
+				details: { capabilities: { interactive: true } },
+				permission: [],
+				user,
+				scopes: [],
+			},
+			sequenceNumber: 0,
+		});
+	}
+	return new MockQuorumClients(...clients.entries());
 }


### PR DESCRIPTION
## Description

[Task Link](https://dev.azure.com/fluidframework/internal/_workitems/edit/7710)

Use quorum to get client in attributor instead of audience. Quorum contains all the clients until they leave the session with a leave op, so we will not run into problems where client is not present, and we receive an op from it.
Also remove export of Attributor and OpStreamAttributor from index.js as not required anymore.