### PR TITLE
fix(api-markdown-documenter): Correctly handle getter/setter properties on interfaces

### DIFF
--- a/tools/api-markdown-documenter/CHANGELOG.md
+++ b/tools/api-markdown-documenter/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   Fixed a bug where pre-escaped text contents (including embedded HTML content) would be incorrectly re-escaped.
 -   Fixed a bug where type parameter information was only being generated for `interface` and `class` items.
 -   Adds "Constraint" and "Default" columns to type parameter tables when any are present among the type parameters.
+-   Fixed a bug where getter/setter properties under interface items did not get documentation generated for them.
 
 ### ⚠ BREAKING CHANGES
 

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
@@ -14,9 +14,9 @@ import {
 	type ApiProperty,
 } from "@microsoft/api-extractor-model";
 
-import { type SectionNode } from "../../documentation-domain/index.js";
+import type { SectionNode } from "../../documentation-domain/index.js";
 import { ApiModifier, isStatic } from "../../utilities/index.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
 import { filterChildMembers } from "../ApiItemTransformUtilities.js";
 
@@ -97,7 +97,7 @@ export function transformApiClass(
 					break;
 				}
 				default: {
-					config.logger?.error(`Unsupported ApiClass child kind: "${child.kind}"`);
+					config.logger?.error(`Unsupported Class child kind: "${child.kind}"`);
 					break;
 				}
 			}

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiClass.ts
@@ -15,7 +15,7 @@ import {
 } from "@microsoft/api-extractor-model";
 
 import { type SectionNode } from "../../documentation-domain/index.js";
-import { ApiModifier, filterByKind, isStatic } from "../../utilities/index.js";
+import { ApiModifier, isStatic } from "../../utilities/index.js";
 import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
 import { filterChildMembers } from "../ApiItemTransformUtilities.js";
@@ -69,13 +69,39 @@ export function transformApiClass(
 	const filteredChildren = filterChildMembers(apiClass, config);
 	if (filteredChildren.length > 0) {
 		// Accumulate child items
-		const constructors = filterByKind(apiClass.members, [ApiItemKind.Constructor]).map(
-			(apiItem) => apiItem as ApiConstructor,
-		);
-
-		const allProperties = filterByKind(apiClass.members, [ApiItemKind.Property]).map(
-			(apiItem) => apiItem as ApiProperty,
-		);
+		const constructors: ApiConstructor[] = [];
+		const allProperties: ApiProperty[] = [];
+		const callSignatures: ApiCallSignature[] = [];
+		const indexSignatures: ApiIndexSignature[] = [];
+		const allMethods: ApiMethod[] = [];
+		for (const child of filteredChildren) {
+			switch (child.kind) {
+				case ApiItemKind.Constructor: {
+					constructors.push(child as ApiConstructor);
+					break;
+				}
+				case ApiItemKind.Property: {
+					allProperties.push(child as ApiProperty);
+					break;
+				}
+				case ApiItemKind.CallSignature: {
+					callSignatures.push(child as ApiCallSignature);
+					break;
+				}
+				case ApiItemKind.IndexSignature: {
+					indexSignatures.push(child as ApiIndexSignature);
+					break;
+				}
+				case ApiItemKind.Method: {
+					allMethods.push(child as ApiMethod);
+					break;
+				}
+				default: {
+					config.logger?.error(`Unsupported ApiClass child kind: "${child.kind}"`);
+					break;
+				}
+			}
+		}
 
 		// Split properties into event properties and non-event properties
 		const standardProperties = allProperties.filter(
@@ -95,18 +121,6 @@ export function transformApiClass(
 		);
 		const nonStaticEventProperties = eventProperties.filter(
 			(apiProperty) => !isStatic(apiProperty),
-		);
-
-		const callSignatures = filterByKind(apiClass.members, [ApiItemKind.CallSignature]).map(
-			(apiItem) => apiItem as ApiCallSignature,
-		);
-
-		const indexSignatures = filterByKind(apiClass.members, [ApiItemKind.IndexSignature]).map(
-			(apiItem) => apiItem as ApiIndexSignature,
-		);
-
-		const allMethods = filterByKind(apiClass.members, [ApiItemKind.Method]).map(
-			(apiItem) => apiItem as ApiMethod,
 		);
 
 		// Split methods into static and non-static methods

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiEnum.ts
@@ -10,9 +10,8 @@ import {
 	ApiItemKind,
 } from "@microsoft/api-extractor-model";
 
-import { type DocumentationNode, type SectionNode } from "../../documentation-domain/index.js";
-import { filterByKind } from "../../utilities/index.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { DocumentationNode, SectionNode } from "../../documentation-domain/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createMemberTables, wrapInSection } from "../helpers/index.js";
 import { filterChildMembers } from "../ApiItemTransformUtilities.js";
 
@@ -29,9 +28,19 @@ export function transformApiEnum(
 	const filteredChildren = filterChildMembers(apiEnum, config);
 	if (filteredChildren.length > 0) {
 		// Accumulate child items
-		const flags = filterByKind(apiEnum.members, [ApiItemKind.EnumMember]).map(
-			(apiItem) => apiItem as ApiEnumMember,
-		);
+		const flags: ApiEnumMember[] = [];
+		for (const child of filteredChildren) {
+			switch (child.kind) {
+				case ApiItemKind.EnumMember: {
+					flags.push(child as ApiEnumMember);
+					break;
+				}
+				default: {
+					config.logger?.error(`Unsupported Enum child kind: "${child.kind}"`);
+					break;
+				}
+			}
+		}
 
 		// Render summary tables
 		const memberTableSections = createMemberTables(

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
@@ -14,8 +14,8 @@ import {
 	type ApiPropertySignature,
 } from "@microsoft/api-extractor-model";
 
-import { type SectionNode } from "../../documentation-domain/index.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { SectionNode } from "../../documentation-domain/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
 import { filterChildMembers } from "../ApiItemTransformUtilities.js";
 
@@ -90,7 +90,7 @@ export function transformApiInterface(
 					break;
 				}
 				default: {
-					config.logger?.error(`Unsupported ApiInterface child kind: "${child.kind}"`);
+					config.logger?.error(`Unsupported Interface child kind: "${child.kind}"`);
 					break;
 				}
 			}

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
@@ -11,7 +11,7 @@ import {
 	type ApiItem,
 	ApiItemKind,
 	type ApiMethodSignature,
-	type ApiPropertySignature,
+	type ApiPropertyItem,
 } from "@microsoft/api-extractor-model";
 
 import type { SectionNode } from "../../documentation-domain/index.js";
@@ -63,7 +63,7 @@ export function transformApiInterface(
 	if (filteredChildren.length > 0) {
 		// Accumulate child items
 		const constructSignatures: ApiConstructSignature[] = [];
-		const allProperties: ApiPropertySignature[] = [];
+		const allProperties: ApiPropertyItem[] = [];
 		const callSignatures: ApiCallSignature[] = [];
 		const indexSignatures: ApiIndexSignature[] = [];
 		const methods: ApiMethodSignature[] = [];
@@ -73,8 +73,9 @@ export function transformApiInterface(
 					constructSignatures.push(child as ApiConstructSignature);
 					break;
 				}
+				case ApiItemKind.Property:
 				case ApiItemKind.PropertySignature: {
-					allProperties.push(child as ApiPropertySignature);
+					allProperties.push(child as ApiPropertyItem);
 					break;
 				}
 				case ApiItemKind.CallSignature: {

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiInterface.ts
@@ -15,7 +15,6 @@ import {
 } from "@microsoft/api-extractor-model";
 
 import { type SectionNode } from "../../documentation-domain/index.js";
-import { filterByKind } from "../../utilities/index.js";
 import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
 import { filterChildMembers } from "../ApiItemTransformUtilities.js";
@@ -63,31 +62,45 @@ export function transformApiInterface(
 	const filteredChildren = filterChildMembers(apiInterface, config);
 	if (filteredChildren.length > 0) {
 		// Accumulate child items
-		const constructSignatures = filterByKind(apiInterface.members, [
-			ApiItemKind.ConstructSignature,
-		]).map((apiItem) => apiItem as ApiConstructSignature);
-
-		const allProperties = filterByKind(apiInterface.members, [
-			ApiItemKind.PropertySignature,
-		]).map((apiItem) => apiItem as ApiPropertySignature);
+		const constructSignatures: ApiConstructSignature[] = [];
+		const allProperties: ApiPropertySignature[] = [];
+		const callSignatures: ApiCallSignature[] = [];
+		const indexSignatures: ApiIndexSignature[] = [];
+		const methods: ApiMethodSignature[] = [];
+		for (const child of filteredChildren) {
+			switch (child.kind) {
+				case ApiItemKind.ConstructSignature: {
+					constructSignatures.push(child as ApiConstructSignature);
+					break;
+				}
+				case ApiItemKind.PropertySignature: {
+					allProperties.push(child as ApiPropertySignature);
+					break;
+				}
+				case ApiItemKind.CallSignature: {
+					callSignatures.push(child as ApiCallSignature);
+					break;
+				}
+				case ApiItemKind.IndexSignature: {
+					indexSignatures.push(child as ApiIndexSignature);
+					break;
+				}
+				case ApiItemKind.MethodSignature: {
+					methods.push(child as ApiMethodSignature);
+					break;
+				}
+				default: {
+					config.logger?.error(`Unsupported ApiInterface child kind: "${child.kind}"`);
+					break;
+				}
+			}
+		}
 
 		// Split properties into event properties and non-event properties
 		const standardProperties = allProperties.filter(
 			(apiProperty) => !apiProperty.isEventProperty,
 		);
 		const eventProperties = allProperties.filter((apiProperty) => apiProperty.isEventProperty);
-
-		const callSignatures = filterByKind(apiInterface.members, [ApiItemKind.CallSignature]).map(
-			(apiItem) => apiItem as ApiCallSignature,
-		);
-
-		const indexSignatures = filterByKind(apiInterface.members, [
-			ApiItemKind.IndexSignature,
-		]).map((apiItem) => apiItem as ApiIndexSignature);
-
-		const methods = filterByKind(apiInterface.members, [ApiItemKind.MethodSignature]).map(
-			(apiItem) => apiItem as ApiMethodSignature,
-		);
 
 		// Render summary tables
 		const renderedMemberTables = createMemberTables(

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiModuleLike.ts
@@ -15,9 +15,9 @@ import {
 	type ApiVariable,
 } from "@microsoft/api-extractor-model";
 
-import { type SectionNode } from "../../documentation-domain/index.js";
-import { type ApiModuleLike, filterByKind } from "../../utilities/index.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { SectionNode } from "../../documentation-domain/index.js";
+import type { ApiModuleLike } from "../../utilities/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { createChildDetailsSection, createMemberTables } from "../helpers/index.js";
 import { filterItems } from "../ApiItemTransformUtilities.js";
 
@@ -68,33 +68,49 @@ export function transformApiModuleLike(
 	const filteredChildren = filterItems(apiItem.members, config);
 	if (filteredChildren.length > 0) {
 		// Accumulate child items
-		const interfaces = filterByKind(filteredChildren, [ApiItemKind.Interface]).map(
-			(_apiItem) => _apiItem as ApiInterface,
-		);
-
-		const classes = filterByKind(filteredChildren, [ApiItemKind.Class]).map(
-			(_apiItem) => _apiItem as ApiClass,
-		);
-
-		const namespaces = filterByKind(filteredChildren, [ApiItemKind.Namespace]).map(
-			(_apiItem) => _apiItem as ApiNamespace,
-		);
-
-		const types = filterByKind(filteredChildren, [ApiItemKind.TypeAlias]).map(
-			(_apiItem) => _apiItem as ApiTypeAlias,
-		);
-
-		const functions = filterByKind(filteredChildren, [ApiItemKind.Function]).map(
-			(_apiItem) => _apiItem as ApiFunction,
-		);
-
-		const enums = filterByKind(filteredChildren, [ApiItemKind.Enum]).map(
-			(_apiItem) => _apiItem as ApiEnum,
-		);
-
-		const variables = filterByKind(filteredChildren, [ApiItemKind.Variable]).map(
-			(_apiItem) => _apiItem as ApiVariable,
-		);
+		const interfaces: ApiInterface[] = [];
+		const classes: ApiClass[] = [];
+		const namespaces: ApiNamespace[] = [];
+		const types: ApiTypeAlias[] = [];
+		const functions: ApiFunction[] = [];
+		const enums: ApiEnum[] = [];
+		const variables: ApiVariable[] = [];
+		for (const child of filteredChildren) {
+			switch (child.kind) {
+				case ApiItemKind.Interface: {
+					interfaces.push(child as ApiInterface);
+					break;
+				}
+				case ApiItemKind.Class: {
+					classes.push(child as ApiClass);
+					break;
+				}
+				case ApiItemKind.Namespace: {
+					namespaces.push(child as ApiNamespace);
+					break;
+				}
+				case ApiItemKind.TypeAlias: {
+					types.push(child as ApiTypeAlias);
+					break;
+				}
+				case ApiItemKind.Function: {
+					functions.push(child as ApiFunction);
+					break;
+				}
+				case ApiItemKind.Enum: {
+					enums.push(child as ApiEnum);
+					break;
+				}
+				case ApiItemKind.Variable: {
+					variables.push(child as ApiVariable);
+					break;
+				}
+				default: {
+					config.logger?.error(`Unsupported ${apiItem.kind} child kind: "${child.kind}"`);
+					break;
+				}
+			}
+		}
 
 		// Render summary tables
 		const memberTableSections = createMemberTables(

--- a/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiNamespace.ts
+++ b/tools/api-markdown-documenter/src/api-item-transforms/default-implementations/TransformApiNamespace.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { type ApiItem, type ApiNamespace } from "@microsoft/api-extractor-model";
+import type { ApiItem, ApiNamespace } from "@microsoft/api-extractor-model";
 
-import { type SectionNode } from "../../documentation-domain/index.js";
-import { type ApiItemTransformationConfiguration } from "../configuration/index.js";
+import type { SectionNode } from "../../documentation-domain/index.js";
+import type { ApiItemTransformationConfiguration } from "../configuration/index.js";
 import { transformApiModuleLike } from "./TransformApiModuleLike.js";
 
 /**

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/simple-suite-test/testclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/simple-suite-test/testclass-class.html
@@ -250,13 +250,13 @@
                 <a href='./simple-suite-test/testclass-class#testclassgetterproperty-property'>testClassGetterProperty</a>
               </td>
               <td>
-                <code>readonly</code>, <code>virtual</code>
+                <code>virtual</code>
               </td>
               <td>
                 <span>number</span>
               </td>
               <td>
-                Test class getter-only property
+                Test class property with both a getter and a setter.
               </td>
             </tr>
             <tr>
@@ -502,7 +502,7 @@
           </h3>
           <section>
             <p>
-              Test class getter-only property
+              Test class property with both a getter and a setter.
             </p>
           </section>
           <section>
@@ -513,6 +513,10 @@
               /** @virtual */
               <br>
               get testClassGetterProperty(): number;
+              <br>
+              <br>
+              <br>
+              set testClassGetterProperty(newValue: number);
             </code>
           </section>
           <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/simple-suite-test/testinterface-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/default-config/simple-suite-test/testinterface-interface.html
@@ -134,6 +134,37 @@
           <tbody>
             <tr>
               <td>
+                <a href='./simple-suite-test/testinterface-interface#getterproperty-property'>getterProperty</a>
+              </td>
+              <td>
+                <code>readonly</code>
+              </td>
+              <td>
+              </td>
+              <td>
+                <span>boolean</span>
+              </td>
+              <td>
+                A test getter-only interface property.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href='./simple-suite-test/testinterface-interface#setterproperty-property'>setterProperty</a>
+              </td>
+              <td>
+              </td>
+              <td>
+              </td>
+              <td>
+                <span>boolean</span>
+              </td>
+              <td>
+                A test property with a getter and a setter.
+              </td>
+            </tr>
+            <tr>
+              <td>
                 <a href='./simple-suite-test/testinterface-interface#testinterfaceproperty-propertysignature'>testInterfaceProperty</a>
               </td>
               <td>
@@ -301,6 +332,46 @@
         <h2>
           Property Details
         </h2>
+        <section>
+          <h3 id="getterproperty-property">
+            getterProperty
+          </h3>
+          <section>
+            <p>
+              A test getter-only interface property.
+            </p>
+          </section>
+          <section>
+            <h4 id="getterproperty-signature">
+              Signature
+            </h4>
+            <code>
+              get getterProperty(): boolean;
+            </code>
+          </section>
+        </section>
+        <section>
+          <h3 id="setterproperty-property">
+            setterProperty
+          </h3>
+          <section>
+            <p>
+              A test property with a getter and a setter.
+            </p>
+          </section>
+          <section>
+            <h4 id="setterproperty-signature">
+              Signature
+            </h4>
+            <code>
+              get setterProperty(): boolean;
+              <br>
+              <br>
+              <br>
+              set setterProperty(newValue: boolean);
+            </code>
+          </section>
+        </section>
         <section>
           <h3 id="testinterfaceproperty-propertysignature">
             testInterfaceProperty

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/simple-suite-test.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/simple-suite-test.html
@@ -1787,13 +1787,13 @@
                   <a href='docs/simple-suite-test#testclass-testclassgetterproperty-property'>testClassGetterProperty</a>
                 </td>
                 <td>
-                  <code>readonly</code>, <code>virtual</code>
+                  <code>virtual</code>
                 </td>
                 <td>
                   <span>number</span>
                 </td>
                 <td>
-                  Test class getter-only property
+                  Test class property with both a getter and a setter.
                 </td>
               </tr>
               <tr>
@@ -2039,7 +2039,7 @@
             </h4>
             <section>
               <p>
-                Test class getter-only property
+                Test class property with both a getter and a setter.
               </p>
             </section>
             <section>
@@ -2050,6 +2050,10 @@
                 /** @virtual */
                 <br>
                 get testClassGetterProperty(): number;
+                <br>
+                <br>
+                <br>
+                set testClassGetterProperty(newValue: number);
               </code>
             </section>
             <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/simple-suite-test.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/flat-config/simple-suite-test.html
@@ -525,6 +525,37 @@
             <tbody>
               <tr>
                 <td>
+                  <a href='docs/simple-suite-test#testinterface-getterproperty-property'>getterProperty</a>
+                </td>
+                <td>
+                  <code>readonly</code>
+                </td>
+                <td>
+                </td>
+                <td>
+                  <span>boolean</span>
+                </td>
+                <td>
+                  A test getter-only interface property.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a href='docs/simple-suite-test#testinterface-setterproperty-property'>setterProperty</a>
+                </td>
+                <td>
+                </td>
+                <td>
+                </td>
+                <td>
+                  <span>boolean</span>
+                </td>
+                <td>
+                  A test property with a getter and a setter.
+                </td>
+              </tr>
+              <tr>
+                <td>
                   <a href='docs/simple-suite-test#testinterface-testinterfaceproperty-propertysignature'>testInterfaceProperty</a>
                 </td>
                 <td>
@@ -692,6 +723,46 @@
           <h3>
             Property Details
           </h3>
+          <section>
+            <h4 id="testinterface-getterproperty-property">
+              getterProperty
+            </h4>
+            <section>
+              <p>
+                A test getter-only interface property.
+              </p>
+            </section>
+            <section>
+              <h5 id="getterproperty-signature">
+                Signature
+              </h5>
+              <code>
+                get getterProperty(): boolean;
+              </code>
+            </section>
+          </section>
+          <section>
+            <h4 id="testinterface-setterproperty-property">
+              setterProperty
+            </h4>
+            <section>
+              <p>
+                A test property with a getter and a setter.
+              </p>
+            </section>
+            <section>
+              <h5 id="setterproperty-signature">
+                Signature
+              </h5>
+              <code>
+                get setterProperty(): boolean;
+                <br>
+                <br>
+                <br>
+                set setterProperty(newValue: boolean);
+              </code>
+            </section>
+          </section>
           <section>
             <h4 id="testinterface-testinterfaceproperty-propertysignature">
               testInterfaceProperty

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/simple-suite-test/testclass-class.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/simple-suite-test/testclass-class.html
@@ -244,13 +244,13 @@
                 <a href='docs/simple-suite-test/testclass-testclassgetterproperty-property'>testClassGetterProperty</a>
               </td>
               <td>
-                <code>readonly</code>, <code>virtual</code>
+                <code>virtual</code>
               </td>
               <td>
                 <span>number</span>
               </td>
               <td>
-                Test class getter-only property
+                Test class property with both a getter and a setter.
               </td>
             </tr>
             <tr>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/simple-suite-test/testclass-testclassgetterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/simple-suite-test/testclass-testclassgetterproperty-property.html
@@ -10,7 +10,7 @@
       </h2>
       <section>
         <p>
-          Test class getter-only property
+          Test class property with both a getter and a setter.
         </p>
       </section>
       <section>
@@ -21,6 +21,10 @@
           /** @virtual */
           <br>
           get testClassGetterProperty(): number;
+          <br>
+          <br>
+          <br>
+          set testClassGetterProperty(newValue: number);
         </code>
       </section>
       <section>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/simple-suite-test/testinterface-getterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/simple-suite-test/testinterface-getterproperty-property.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <section>
+      <h2>
+        getterProperty
+      </h2>
+      <section>
+        <p>
+          A test getter-only interface property.
+        </p>
+      </section>
+      <section>
+        <h3 id="getterproperty-signature">
+          Signature
+        </h3>
+        <code>
+          get getterProperty(): boolean;
+        </code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/simple-suite-test/testinterface-interface.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/simple-suite-test/testinterface-interface.html
@@ -128,6 +128,37 @@
           <tbody>
             <tr>
               <td>
+                <a href='docs/simple-suite-test/testinterface-getterproperty-property'>getterProperty</a>
+              </td>
+              <td>
+                <code>readonly</code>
+              </td>
+              <td>
+              </td>
+              <td>
+                <span>boolean</span>
+              </td>
+              <td>
+                A test getter-only interface property.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href='docs/simple-suite-test/testinterface-setterproperty-property'>setterProperty</a>
+              </td>
+              <td>
+              </td>
+              <td>
+              </td>
+              <td>
+                <span>boolean</span>
+              </td>
+              <td>
+                A test property with a getter and a setter.
+              </td>
+            </tr>
+            <tr>
+              <td>
                 <a href='docs/simple-suite-test/testinterface-testinterfaceproperty-propertysignature'>testInterfaceProperty</a>
               </td>
               <td>

--- a/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/simple-suite-test/testinterface-setterproperty-property.html
+++ b/tools/api-markdown-documenter/src/test/snapshots/html/simple-suite-test/sparse-config/simple-suite-test/testinterface-setterproperty-property.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <section>
+      <h2>
+        setterProperty
+      </h2>
+      <section>
+        <p>
+          A test property with a getter and a setter.
+        </p>
+      </section>
+      <section>
+        <h3 id="setterproperty-signature">
+          Signature
+        </h3>
+        <code>
+          get setterProperty(): boolean;
+          <br>
+          <br>
+          <br>
+          set setterProperty(newValue: boolean);
+        </code>
+      </section>
+    </section>
+  </body>
+</html>

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/simple-suite-test/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/simple-suite-test/testclass-class.md
@@ -54,7 +54,7 @@ Here are some remarks about the class
 | Property | Modifiers | Type | Description |
 | --- | --- | --- | --- |
 | [abstractPropertyGetter](./simple-suite-test/testclass-class#abstractpropertygetter-property) | `readonly` | [TestMappedType](./simple-suite-test#testmappedtype-typealias) | A test abstract getter property. |
-| [testClassGetterProperty](./simple-suite-test/testclass-class#testclassgetterproperty-property) | `readonly`, `virtual` | number | Test class getter-only property |
+| [testClassGetterProperty](./simple-suite-test/testclass-class#testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](./simple-suite-test/testclass-class#testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
 
 ## Methods
@@ -120,13 +120,14 @@ get abstractPropertyGetter(): TestMappedType;
 
 ### testClassGetterProperty {#testclassgetterproperty-property}
 
-Test class getter-only property
+Test class property with both a getter and a setter.
 
 #### Signature {#testclassgetterproperty-signature}
 
 ```typescript
 /** @virtual */
 get testClassGetterProperty(): number;
+set testClassGetterProperty(newValue: number);
 ```
 
 #### Remarks {#testclassgetterproperty-remarks}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/simple-suite-test/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/default-config/simple-suite-test/testinterface-interface.md
@@ -32,6 +32,8 @@ Here are some remarks about the interface
 
 | Property | Modifiers | Default Value | Type | Description |
 | --- | --- | --- | --- | --- |
+| [getterProperty](./simple-suite-test/testinterface-interface#getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
+| [setterProperty](./simple-suite-test/testinterface-interface#setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
 | [testInterfaceProperty](./simple-suite-test/testinterface-interface#testinterfaceproperty-propertysignature) |  |  | number | Test interface property |
 | [testOptionalInterfaceProperty](./simple-suite-test/testinterface-interface#testoptionalinterfaceproperty-propertysignature) | `optional` | 0 | number | Test optional property |
 
@@ -81,6 +83,27 @@ readonly testClassEventProperty: () => void;
 Here are some remarks about the event property
 
 ## Property Details
+
+### getterProperty {#getterproperty-property}
+
+A test getter-only interface property.
+
+#### Signature {#getterproperty-signature}
+
+```typescript
+get getterProperty(): boolean;
+```
+
+### setterProperty {#setterproperty-property}
+
+A test property with a getter and a setter.
+
+#### Signature {#setterproperty-signature}
+
+```typescript
+get setterProperty(): boolean;
+set setterProperty(newValue: boolean);
+```
 
 ### testInterfaceProperty {#testinterfaceproperty-propertysignature}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/simple-suite-test.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/simple-suite-test.md
@@ -564,7 +564,7 @@ Here are some remarks about the class
 | Property | Modifiers | Type | Description |
 | --- | --- | --- | --- |
 | [abstractPropertyGetter](docs/simple-suite-test#testclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/simple-suite-test#testmappedtype-typealias) | A test abstract getter property. |
-| [testClassGetterProperty](docs/simple-suite-test#testclass-testclassgetterproperty-property) | `readonly`, `virtual` | number | Test class getter-only property |
+| [testClassGetterProperty](docs/simple-suite-test#testclass-testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](docs/simple-suite-test#testclass-testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
 
 ### Methods
@@ -630,13 +630,14 @@ get abstractPropertyGetter(): TestMappedType;
 
 #### testClassGetterProperty {#testclass-testclassgetterproperty-property}
 
-Test class getter-only property
+Test class property with both a getter and a setter.
 
 ##### Signature {#testclassgetterproperty-signature}
 
 ```typescript
 /** @virtual */
 get testClassGetterProperty(): number;
+set testClassGetterProperty(newValue: number);
 ```
 
 ##### Remarks {#testclassgetterproperty-remarks}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/simple-suite-test.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/flat-config/simple-suite-test.md
@@ -132,6 +132,8 @@ Here are some remarks about the interface
 
 | Property | Modifiers | Default Value | Type | Description |
 | --- | --- | --- | --- | --- |
+| [getterProperty](docs/simple-suite-test#testinterface-getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
+| [setterProperty](docs/simple-suite-test#testinterface-setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
 | [testInterfaceProperty](docs/simple-suite-test#testinterface-testinterfaceproperty-propertysignature) |  |  | number | Test interface property |
 | [testOptionalInterfaceProperty](docs/simple-suite-test#testinterface-testoptionalinterfaceproperty-propertysignature) | `optional` | 0 | number | Test optional property |
 
@@ -181,6 +183,27 @@ readonly testClassEventProperty: () => void;
 Here are some remarks about the event property
 
 ### Property Details
+
+#### getterProperty {#testinterface-getterproperty-property}
+
+A test getter-only interface property.
+
+##### Signature {#getterproperty-signature}
+
+```typescript
+get getterProperty(): boolean;
+```
+
+#### setterProperty {#testinterface-setterproperty-property}
+
+A test property with a getter and a setter.
+
+##### Signature {#setterproperty-signature}
+
+```typescript
+get setterProperty(): boolean;
+set setterProperty(newValue: boolean);
+```
 
 #### testInterfaceProperty {#testinterface-testinterfaceproperty-propertysignature}
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/simple-suite-test/testclass-class.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/simple-suite-test/testclass-class.md
@@ -50,7 +50,7 @@ Here are some remarks about the class
 | Property | Modifiers | Type | Description |
 | --- | --- | --- | --- |
 | [abstractPropertyGetter](docs/simple-suite-test/testclass-abstractpropertygetter-property) | `readonly` | [TestMappedType](docs/simple-suite-test/testmappedtype-typealias) | A test abstract getter property. |
-| [testClassGetterProperty](docs/simple-suite-test/testclass-testclassgetterproperty-property) | `readonly`, `virtual` | number | Test class getter-only property |
+| [testClassGetterProperty](docs/simple-suite-test/testclass-testclassgetterproperty-property) | `virtual` | number | Test class property with both a getter and a setter. |
 | [testClassProperty](docs/simple-suite-test/testclass-testclassproperty-property) | `readonly` | TTypeParameterB | Test class property |
 
 ### Methods

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/simple-suite-test/testclass-testclassgetterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/simple-suite-test/testclass-testclassgetterproperty-property.md
@@ -1,12 +1,13 @@
 ## testClassGetterProperty
 
-Test class getter-only property
+Test class property with both a getter and a setter.
 
 ### Signature {#testclassgetterproperty-signature}
 
 ```typescript
 /** @virtual */
 get testClassGetterProperty(): number;
+set testClassGetterProperty(newValue: number);
 ```
 
 ### Remarks {#testclassgetterproperty-remarks}

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/simple-suite-test/testinterface-getterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/simple-suite-test/testinterface-getterproperty-property.md
@@ -1,0 +1,9 @@
+## getterProperty
+
+A test getter-only interface property.
+
+### Signature {#getterproperty-signature}
+
+```typescript
+get getterProperty(): boolean;
+```

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/simple-suite-test/testinterface-interface.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/simple-suite-test/testinterface-interface.md
@@ -28,6 +28,8 @@ Here are some remarks about the interface
 
 | Property | Modifiers | Default Value | Type | Description |
 | --- | --- | --- | --- | --- |
+| [getterProperty](docs/simple-suite-test/testinterface-getterproperty-property) | `readonly` |  | boolean | A test getter-only interface property. |
+| [setterProperty](docs/simple-suite-test/testinterface-setterproperty-property) |  |  | boolean | A test property with a getter and a setter. |
 | [testInterfaceProperty](docs/simple-suite-test/testinterface-testinterfaceproperty-propertysignature) |  |  | number | Test interface property |
 | [testOptionalInterfaceProperty](docs/simple-suite-test/testinterface-testoptionalinterfaceproperty-propertysignature) | `optional` | 0 | number | Test optional property |
 

--- a/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/simple-suite-test/testinterface-setterproperty-property.md
+++ b/tools/api-markdown-documenter/src/test/snapshots/markdown/simple-suite-test/sparse-config/simple-suite-test/testinterface-setterproperty-property.md
@@ -1,0 +1,10 @@
+## setterProperty
+
+A test property with a getter and a setter.
+
+### Signature {#setterproperty-signature}
+
+```typescript
+get setterProperty(): boolean;
+set setterProperty(newValue: boolean);
+```

--- a/tools/api-markdown-documenter/src/test/test-data/simple-suite-test.json
+++ b/tools/api-markdown-documenter/src/test/test-data/simple-suite-test.json
@@ -1,7 +1,7 @@
 {
 	"metadata": {
 		"toolPackage": "@microsoft/api-extractor",
-		"toolVersion": "7.39.4",
+		"toolVersion": "7.42.3",
 		"schemaVersion": 1011,
 		"oldestForwardsCompatibleVersion": 1001,
 		"tsdocConfig": {
@@ -620,7 +620,7 @@
 						{
 							"kind": "Property",
 							"canonicalReference": "simple-suite-test!TestClass#testClassGetterProperty:member",
-							"docComment": "/**\n * Test class getter-only property\n *\n * @remarks\n *\n * Here are some remarks about the getter-only property\n *\n * @virtual\n */\n",
+							"docComment": "/**\n * Test class property with both a getter and a setter.\n *\n * @remarks\n *\n * Here are some remarks about the getter-only property\n *\n * @virtual\n */\n",
 							"excerptTokens": [
 								{
 									"kind": "Content",
@@ -632,10 +632,10 @@
 								},
 								{
 									"kind": "Content",
-									"text": ";"
+									"text": ";\n\nset testClassGetterProperty(newValue: number);"
 								}
 							],
-							"isReadonly": true,
+							"isReadonly": false,
 							"isOptional": false,
 							"releaseTag": "Public",
 							"name": "testClassGetterProperty",

--- a/tools/api-markdown-documenter/src/test/test-data/simple-suite-test.json
+++ b/tools/api-markdown-documenter/src/test/test-data/simple-suite-test.json
@@ -1357,6 +1357,66 @@
 							"parameters": []
 						},
 						{
+							"kind": "Property",
+							"canonicalReference": "simple-suite-test!TestInterface#getterProperty:member",
+							"docComment": "/**\n * A test getter-only interface property.\n */\n",
+							"excerptTokens": [
+								{
+									"kind": "Content",
+									"text": "get getterProperty(): "
+								},
+								{
+									"kind": "Content",
+									"text": "boolean"
+								},
+								{
+									"kind": "Content",
+									"text": ";"
+								}
+							],
+							"isReadonly": true,
+							"isOptional": false,
+							"releaseTag": "Public",
+							"name": "getterProperty",
+							"propertyTypeTokenRange": {
+								"startIndex": 1,
+								"endIndex": 2
+							},
+							"isStatic": false,
+							"isProtected": false,
+							"isAbstract": false
+						},
+						{
+							"kind": "Property",
+							"canonicalReference": "simple-suite-test!TestInterface#setterProperty:member",
+							"docComment": "/**\n * A test property with a getter and a setter.\n */\n",
+							"excerptTokens": [
+								{
+									"kind": "Content",
+									"text": "get setterProperty(): "
+								},
+								{
+									"kind": "Content",
+									"text": "boolean"
+								},
+								{
+									"kind": "Content",
+									"text": ";\n\nset setterProperty(newValue: boolean);"
+								}
+							],
+							"isReadonly": false,
+							"isOptional": false,
+							"releaseTag": "Public",
+							"name": "setterProperty",
+							"propertyTypeTokenRange": {
+								"startIndex": 1,
+								"endIndex": 2
+							},
+							"isStatic": false,
+							"isProtected": false,
+							"isAbstract": false
+						},
+						{
 							"kind": "PropertySignature",
 							"canonicalReference": "simple-suite-test!TestInterface#testClassEventProperty:member",
 							"docComment": "/**\n * Test interface event property\n *\n * @remarks\n *\n * Here are some remarks about the event property\n *\n * @eventProperty\n */\n",


### PR DESCRIPTION
Getter and setter properties are processed as properties rather than property signatures on interfaces. The code was previously assuming that only signatures could appear on interfaces. Updates test assets with test cases for this.

Also refactors the pattern used for iterating child items to help detect cases like this in the future.

[AB#7743](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7743)