### PR TITLE
tree(fix): Remove accidentally exposed identifier API

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -463,7 +463,6 @@ export type FieldKey = Brand<string, "tree.FieldKey">;
 
 // @public
 export enum FieldKind {
-    Identifier = 2,
     Optional = 0,
     Required = 1
 }
@@ -1586,7 +1585,6 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
     }, false, T>;
     readonly boolean: TreeNodeSchema<"com.fluidframework.leaf.boolean", NodeKind.Leaf, boolean, boolean>;
     readonly handle: TreeNodeSchema<"com.fluidframework.leaf.handle", NodeKind.Leaf, IFluidHandle<FluidObject & IFluidLoadable>, IFluidHandle<FluidObject & IFluidLoadable>>;
-    get identifier(): FieldSchema<FieldKind.Identifier>;
     map<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchema<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, `Map<${string}>`>>, Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>, true, T>;
     map<Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, Name>>, Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>, true, T>;
     mapRecursive<Name extends TName, const T extends Unenforced<ImplicitAllowedTypes>>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>>, {
@@ -1917,7 +1915,6 @@ export interface TreeNodeApi {
     on<K extends keyof TreeChangeEvents>(node: TreeNode, eventName: K, listener: TreeChangeEvents[K]): () => void;
     parent(node: TreeNode): TreeNode | undefined;
     schema<T extends TreeNode | TreeLeafValue>(node: T): TreeNodeSchema<string, NodeKind, unknown, T>;
-    shortId(node: TreeNode): number | undefined;
     readonly status: (node: TreeNode) => TreeStatus;
 }
 

--- a/packages/dds/tree/src/simple-tree/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/schemaFactory.ts
@@ -577,12 +577,13 @@ export class SchemaFactory<
 		return new FieldSchema(FieldKind.Required, t, props);
 	}
 
-	/**
-	 * Make a field of type identifier instead of the default which is required.
-	 */
-	public get identifier(): FieldSchema<FieldKind.Identifier> {
-		return new FieldSchema(FieldKind.Identifier, this.string);
-	}
+	// TODO:#7734,7736: Re-enable when persisted document format is optimized
+	// /**
+	//  * Make a field of type identifier instead of the default which is required.
+	//  */
+	// public get identifier(): FieldSchema<FieldKind.Identifier> {
+	// 	return createFieldSchema(FieldKind.Identifier, this.string);
+	// }
 
 	/**
 	 * {@link SchemaFactory.object} except tweaked to work better for recursive types.

--- a/packages/dds/tree/src/simple-tree/schemaTypes.ts
+++ b/packages/dds/tree/src/simple-tree/schemaTypes.ts
@@ -139,12 +139,13 @@ export enum FieldKind {
 	 * Only allows exactly one child.
 	 */
 	Required,
-	/**
-	 * A special field used for node identifiers.
-	 * @remarks
-	 * Only allows exactly one child.
-	 */
-	Identifier,
+	// TODO:#7734,7736: Re-enable when persisted document format is optimized
+	// /**
+	//  * A special field used for node identifiers.
+	//  * @remarks
+	//  * Only allows exactly one child.
+	//  */
+	// Identifier,
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/toFlexSchema.ts
+++ b/packages/dds/tree/src/simple-tree/toFlexSchema.ts
@@ -147,7 +147,8 @@ export function convertField(schemaMap: SchemaMap, schema: ImplicitFieldSchema):
 const convertFieldKind = new Map<FieldKind, FlexFieldKind>([
 	[FieldKind.Optional, FieldKinds.optional],
 	[FieldKind.Required, FieldKinds.required],
-	[FieldKind.Identifier, FieldKinds.identifier],
+	// TODO:#7734,7736: Re-enable when persisted document format is optimized
+	// [FieldKind.Identifier, FieldKinds.identifier],
 ]);
 
 /**

--- a/packages/dds/tree/src/simple-tree/treeApi.ts
+++ b/packages/dds/tree/src/simple-tree/treeApi.ts
@@ -7,14 +7,12 @@ import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 
 import { Multiplicity, rootFieldKey } from "../core/index.js";
 import {
-	FieldKinds,
 	LeafNodeSchema,
-	StableNodeKey,
 	TreeStatus,
 	isTreeValue,
 	valueSchemaAllows,
 } from "../feature-libraries/index.js";
-import { fail, extractFromOpaque } from "../util/index.js";
+import { fail } from "../util/index.js";
 
 import { getOrCreateNodeProxy } from "./proxies.js";
 import { getFlexNode, tryGetFlexNode } from "./proxyBinding.js";
@@ -94,11 +92,12 @@ export interface TreeNodeApi {
 	 */
 	readonly status: (node: TreeNode) => TreeStatus;
 
-	/**
-	 * If the given node has an identifier specified by a field of kind "identifier" then this returns the compressed form of that identifier.
-	 * Otherwise returns undefined.
-	 */
-	shortId(node: TreeNode): number | undefined;
+	// TODO:#7734,7736: Re-enable when persisted document format is optimized
+	// /**
+	//  * If the given node has an identifier specified by a field of kind "identifier" then this returns the compressed form of that identifier.
+	//  * Otherwise returns undefined.
+	//  */
+	// shortId(node: TreeNode): number | undefined;
 }
 
 /**
@@ -189,19 +188,20 @@ export const treeNodeApi: TreeNodeApi = {
 			T
 		>;
 	},
-	shortId(node: TreeNode): number | undefined {
-		const flexNode = getFlexNode(node);
-		for (const field of flexNode.boxedIterator()) {
-			if (field.schema.kind === FieldKinds.identifier) {
-				const identifier = field.boxedAt(0);
-				assert(identifier !== undefined, 0x927 /* The identifier must exist */);
+	// TODO:#7734,7736: Re-enable when persisted document format is optimized
+	// shortId(node: TreeNode): number | undefined {
+	// 	const flexNode = getFlexNode(node);
+	// 	for (const field of flexNode.boxedIterator()) {
+	// 		if (field.schema.kind === FieldKinds.identifier) {
+	// 			const identifier = field.boxedAt(0);
+	// 			assert(identifier !== undefined, 0x927 /* The identifier must exist */);
 
-				return extractFromOpaque(
-					identifier.context.nodeKeys.localize(identifier.value as StableNodeKey),
-				);
-			}
-		}
-	},
+	// 			return extractFromOpaque(
+	// 				identifier.context.nodeKeys.localize(identifier.value as StableNodeKey),
+	// 			);
+	// 		}
+	// 	}
+	// },
 };
 
 /**

--- a/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
@@ -7,19 +7,12 @@ import { strict as assert } from "assert";
 
 import { MockHandle } from "@fluidframework/test-runtime-utils/internal";
 
-import {
-	NodeFromSchema,
-	SchemaFactory,
-	TreeArrayNode,
-	TreeConfiguration,
-} from "../../simple-tree/index.js";
+import { NodeFromSchema, SchemaFactory, TreeArrayNode } from "../../simple-tree/index.js";
 // TODO: test other things from "proxies" file.
 // eslint-disable-next-line import/no-internal-modules
 import { isTreeNode } from "../../simple-tree/proxies.js";
 
 import { hydrate, pretty } from "./utils.js";
-import { getView } from "../utils.js";
-import { createMockNodeKeyManager } from "../../feature-libraries/index.js";
 
 describe("simple-tree proxies", () => {
 	const sb = new SchemaFactory("test");
@@ -169,19 +162,20 @@ describe("SharedTreeObject", () => {
 		assert.equal(root.optional, undefined);
 	});
 
-	it("returns the stable id under the identifier field kind.", () => {
-		const schemaWithIdentifier = sb.object("parent", {
-			identifier: sb.identifier,
-		});
-		const nodeKeyManager = createMockNodeKeyManager();
-		const id = nodeKeyManager.stabilizeNodeKey(nodeKeyManager.generateLocalNodeKey());
-		const config = new TreeConfiguration(schemaWithIdentifier, () => ({
-			identifier: id,
-		}));
+	// TODO:#7734,7736: Re-enable when persisted document format is optimized
+	// it("returns the stable id under the identifier field kind.", () => {
+	// 	const schemaWithIdentifier = sb.object("parent", {
+	// 		identifier: sb.identifier,
+	// 	});
+	// 	const nodeKeyManager = createMockNodeKeyManager();
+	// 	const id = nodeKeyManager.stabilizeNodeKey(nodeKeyManager.generateLocalNodeKey());
+	// 	const config = new TreeConfiguration(schemaWithIdentifier, () => ({
+	// 		identifier: id,
+	// 	}));
 
-		const root = getView(config, nodeKeyManager).root;
-		assert.equal(root.identifier, id);
-	});
+	// 	const root = getView(config, nodeKeyManager).root;
+	// 	assert.equal(root.identifier, id);
+	// });
 });
 
 describe("ArrayNode Proxy", () => {

--- a/packages/dds/tree/src/test/simple-tree/treeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeApi.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "node:assert";
 import { type TreeChangeEvents } from "../../../dist/index.js";
 import { rootFieldKey } from "../../core/index.js";
-import { TreeStatus, createMockNodeKeyManager } from "../../feature-libraries/index.js";
+import { TreeStatus } from "../../feature-libraries/index.js";
 import {
 	NodeFromSchema,
 	SchemaFactory,
@@ -123,32 +123,33 @@ describe("treeApi", () => {
 		// TODO: test Deleted status.
 	});
 
-	describe("shortID", () => {
-		it("returns local id when an identifier fieldkind exists.", () => {
-			const schemaWithIdentifier = schema.object("parent", {
-				identifier: schema.identifier,
-			});
-			const nodeKeyManager = createMockNodeKeyManager();
-			const id = nodeKeyManager.stabilizeNodeKey(nodeKeyManager.generateLocalNodeKey());
-			const config = new TreeConfiguration(schemaWithIdentifier, () => ({
-				identifier: id,
-			}));
+	// TODO:#7734,7736: Re-enable when persisted document format is optimized
+	// describe("shortId", () => {
+	// 	it("returns local id when an identifier fieldkind exists.", () => {
+	// 		const schemaWithIdentifier = schema.object("parent", {
+	// 			identifier: schema.identifier,
+	// 		});
+	// 		const nodeKeyManager = createMockNodeKeyManager();
+	// 		const id = nodeKeyManager.stabilizeNodeKey(nodeKeyManager.generateLocalNodeKey());
+	// 		const config = new TreeConfiguration(schemaWithIdentifier, () => ({
+	// 			identifier: id,
+	// 		}));
 
-			const root = getView(config, nodeKeyManager).root;
+	// 		const root = getView(config, nodeKeyManager).root;
 
-			assert.equal(Tree.shortId(root), nodeKeyManager.localizeNodeKey(id));
-		});
-		it("returns undefined when an identifier fieldkind does not exist.", () => {
-			const schemaWithIdentifier = schema.object("parent", {
-				identifier: schema.string,
-			});
-			const config = new TreeConfiguration(schemaWithIdentifier, () => ({
-				identifier: "testID",
-			}));
-			const root = getView(config).root;
-			assert.equal(Tree.shortId(root), undefined);
-		});
-	});
+	// 		assert.equal(Tree.shortId(root), nodeKeyManager.localizeNodeKey(id));
+	// 	});
+	// 	it("returns undefined when an identifier fieldkind does not exist.", () => {
+	// 		const schemaWithIdentifier = schema.object("parent", {
+	// 			identifier: schema.string,
+	// 		});
+	// 		const config = new TreeConfiguration(schemaWithIdentifier, () => ({
+	// 			identifier: "testID",
+	// 		}));
+	// 		const root = getView(config).root;
+	// 		assert.equal(Tree.shortId(root), undefined);
+	// 	});
+	// });
 
 	describe("on", () => {
 		describe("object node", () => {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -176,7 +176,6 @@ export type ExtractItemType<Item extends LazyItem> = Item extends () => infer Re
 
 // @public
 export enum FieldKind {
-    Identifier = 2,
     Optional = 0,
     Required = 1
 }
@@ -648,7 +647,6 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
     }, false, T>;
     readonly boolean: TreeNodeSchema<"com.fluidframework.leaf.boolean", NodeKind.Leaf, boolean, boolean>;
     readonly handle: TreeNodeSchema<"com.fluidframework.leaf.handle", NodeKind.Leaf, IFluidHandle<FluidObject & IFluidLoadable>, IFluidHandle<FluidObject & IFluidLoadable>>;
-    get identifier(): FieldSchema<FieldKind.Identifier>;
     map<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchema<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, `Map<${string}>`>>, Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>, true, T>;
     map<Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, Name>>, Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>, true, T>;
     mapRecursive<Name extends TName, const T extends Unenforced<ImplicitAllowedTypes>>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>>, {
@@ -968,7 +966,6 @@ export interface TreeNodeApi {
     on<K extends keyof TreeChangeEvents>(node: TreeNode, eventName: K, listener: TreeChangeEvents[K]): () => void;
     parent(node: TreeNode): TreeNode | undefined;
     schema<T extends TreeNode | TreeLeafValue>(node: T): TreeNodeSchema<string, NodeKind, unknown, T>;
-    shortId(node: TreeNode): number | undefined;
     readonly status: (node: TreeNode) => TreeStatus;
 }
 


### PR DESCRIPTION
## Description

[This is a patch of PR 20718](https://github.com/microsoft/FluidFramework/pull/20718)

This bug fix removes an accidentally-exposed API in tree. The API in question, identifiers, is exposed in schema creation but is not usable in the current state and thus this change will not have any customer impact. The API will be re-added in the future when it functions.