### PR TITLE
Remove cancelations of connection attempts

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -493,7 +493,7 @@ export class ConnectionManager implements IConnectionManager {
 		}
 	}
 
-	public connect(reason: IConnectionStateChangeReason, connectionMode: ConnectionMode) {
+	public connect(reason: IConnectionStateChangeReason, connectionMode?: ConnectionMode) {
 		this.connectCore(reason, connectionMode).catch((e) => {
 			const normalizedError = normalizeError(e, { props: fatalConnectErrorProp });
 			this.props.closeHandler(normalizedError);
@@ -502,11 +502,11 @@ export class ConnectionManager implements IConnectionManager {
 
 	private async connectCore(
 		reason: IConnectionStateChangeReason,
-		connectionMode: ConnectionMode,
+		connectionMode?: ConnectionMode,
 	): Promise<void> {
 		assert(!this._disposed, 0x26a /* "not closed" */);
 
-		let requestedMode = connectionMode;
+		let requestedMode = connectionMode ?? this.defaultReconnectionMode;
 
 		// if we have any non-acked ops from last connection, reconnect as "write".
 		// without that we would connect in view-only mode, which will result in immediate

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -528,10 +528,10 @@ export class ConnectionManager implements IConnectionManager {
 			// That all said, let's understand better where such mismatches are coming from.
 			const mode = this.connection?.mode ?? this.pendingConnection?.connectionMode;
 			if (mode !== requestedMode) {
-				this.logger.sendErrorEvent({
+				this.logger.sendTelemetryEvent({
 					eventName: "ConnectionModeMismatch",
-					hasConnection: this.connection !== undefined,
-					connectionMode: mode,
+					connected: this.connection !== undefined,
+					mode,
 					requestedMode,
 					stack: generateStack(),
 				});

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -47,6 +47,7 @@ import {
 	GenericError,
 	UsageError,
 	formatTick,
+	generateStack,
 	isFluidError,
 	normalizeError,
 } from "@fluidframework/telemetry-utils/internal";
@@ -492,7 +493,7 @@ export class ConnectionManager implements IConnectionManager {
 		}
 	}
 
-	public connect(reason: IConnectionStateChangeReason, connectionMode?: ConnectionMode) {
+	public connect(reason: IConnectionStateChangeReason, connectionMode: ConnectionMode) {
 		this.connectCore(reason, connectionMode).catch((e) => {
 			const normalizedError = normalizeError(e, { props: fatalConnectErrorProp });
 			this.props.closeHandler(normalizedError);
@@ -501,25 +502,11 @@ export class ConnectionManager implements IConnectionManager {
 
 	private async connectCore(
 		reason: IConnectionStateChangeReason,
-		connectionMode?: ConnectionMode,
+		connectionMode: ConnectionMode,
 	): Promise<void> {
 		assert(!this._disposed, 0x26a /* "not closed" */);
 
-		if (this.connection !== undefined) {
-			return; // Connection attempt already completed successfully
-		}
-
-		let pendingConnectionMode;
-		if (this.pendingConnection !== undefined) {
-			pendingConnectionMode = this.pendingConnection.connectionMode;
-			this.cancelConnection(reason); // Throw out in-progress connection attempt in favor of new attempt
-			assert(
-				this.pendingConnection === undefined,
-				0x344 /* this.pendingConnection should be undefined */,
-			);
-		}
-		// If there is no specified ConnectionMode, try the previous mode, if there is no previous mode use default
-		let requestedMode = connectionMode ?? pendingConnectionMode ?? this.defaultReconnectionMode;
+		let requestedMode = connectionMode;
 
 		// if we have any non-acked ops from last connection, reconnect as "write".
 		// without that we would connect in view-only mode, which will result in immediate
@@ -528,6 +515,28 @@ export class ConnectionManager implements IConnectionManager {
 		// so DDSes will immediately resubmit all pending ops, and some of them will be duplicates, corrupting document
 		if (this.shouldJoinWrite()) {
 			requestedMode = "write";
+		}
+
+		if (this.connection !== undefined || this.pendingConnection !== undefined) {
+			// Connection attempt already completed successfully or is in progress
+			// In general, there should be no issues if the modes do not match:
+			// If at some point it was Ok to connect as "read" (i.e. there were no pending ops we had to track),
+			// then it should be Ok to use "read" connection even if for some reason request came in to connect as "write"
+			// (though that should never happen)
+			// The opposite should be fine as well: we may have had idle "write" connection, and request to reconnect came in,
+			// using default "read" mode.
+			// That all said, let's understand better where such mismatches are coming from.
+			const mode = this.connection?.mode ?? this.pendingConnection?.connectionMode;
+			if (mode !== requestedMode) {
+				this.logger.sendErrorEvent({
+					eventName: "ConnectionModeMismatch",
+					hasConnection: this.connection !== undefined,
+					connectionMode: mode,
+					requestedMode,
+					stack: generateStack(),
+				});
+			}
+			return;
 		}
 
 		const docService = this.serviceProvider();
@@ -789,7 +798,10 @@ export class ConnectionManager implements IConnectionManager {
 		);
 		this.pendingConnection.abort();
 		this.pendingConnection = undefined;
-		this.logger.sendTelemetryEvent({ eventName: "ConnectionCancelReceived" });
+		this.logger.sendTelemetryEvent({
+			eventName: "ConnectionCancelReceived",
+			reason: reason.text,
+		});
 		this.props.cancelConnectionHandler({
 			text: `Cancel Pending Connection due to ${reason.text}`,
 			error: reason.error,

--- a/packages/loader/container-loader/src/test/connectionManager.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionManager.spec.ts
@@ -102,7 +102,7 @@ describe("connectionManager", () => {
 	it("reconnectOnError - exceptions invoke closeHandler", async () => {
 		// Arrange
 		const connectionManager = createConnectionManager();
-		connectionManager.connect({ text: "test:reconnectOnError" });
+		connectionManager.connect({ text: "test:reconnectOnError" }, "write");
 		const connection = await waitForConnection();
 
 		// Monkey patch connection to be undefined to trigger assert in reconnectOnError
@@ -126,7 +126,7 @@ describe("connectionManager", () => {
 	it("reconnectOnError - error, disconnect, and nack handling", async () => {
 		// Arrange
 		const connectionManager = createConnectionManager();
-		connectionManager.connect({ text: "test:reconnectOnError" });
+		connectionManager.connect({ text: "test:reconnectOnError" }, "write");
 		let connection = await waitForConnection();
 
 		// Act I - retryableError
@@ -210,7 +210,7 @@ describe("connectionManager", () => {
 
 	it("reconnectOnError - nack retryAfter", async () => {
 		const connectionManager = createConnectionManager();
-		connectionManager.connect({ text: "test:reconnectOnError" });
+		connectionManager.connect({ text: "test:reconnectOnError" }, "write");
 		let connection = await waitForConnection();
 
 		const nack: Partial<INack> = {
@@ -267,7 +267,7 @@ describe("connectionManager", () => {
 				}
 			},
 		});
-		connectionManager.connect({ text: "Test reconnect" });
+		connectionManager.connect({ text: "Test reconnect" }, "write");
 
 		await clock.tickAsync(retryAfter * 1000 * 10);
 		assert(
@@ -297,7 +297,7 @@ describe("connectionManager", () => {
 			}),
 		);
 		const connectionManager = createConnectionManager();
-		connectionManager.connect({ text: "Test reconnect" });
+		connectionManager.connect({ text: "Test reconnect" }, "write");
 
 		await clock.tickAsync(retryAfter * 1000 * 10);
 		assert(
@@ -357,7 +357,7 @@ describe("connectionManager", () => {
 
 			assert.deepStrictEqual(connectionManager.readOnlyInfo, { readonly: undefined });
 
-			connectionManager.connect({ text: "test" });
+			connectionManager.connect({ text: "test" }, "write");
 			assert.deepStrictEqual(connectionManager.readOnlyInfo, {
 				readonly: true,
 				forced: false,

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -489,28 +489,26 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider) => {
 		);
 	});
 
-	it("can call connect() twice to change the connection mode", async () => {
-		const container = await createConnectedContainer();
+	itExpects(
+		"can call connect() twice",
+		[{ eventName: "fluid:telemetry:ConnectionManager:ConnectionModeMismatch" }],
+		async () => {
+			const container = await createConnectedContainer();
 
-		container.disconnect();
+			container.disconnect();
 
-		container.connect();
-		(container as any).deltaManager.connectionManager.shouldJoinWrite = () => {
-			return true;
-		};
-		container.connect();
+			container.connect();
+			(container as any).deltaManager.connectionManager.shouldJoinWrite = () => {
+				return true;
+			};
+			container.connect();
 
-		await waitForContainerConnection(container, true, {
-			durationMs: timeoutMs,
-			errorMsg: "container connected event timeout",
-		});
-
-		assert.strictEqual(
-			(container as any).connectionMode,
-			"write",
-			"container in read mode after connecting with pending op",
-		);
-	});
+			await waitForContainerConnection(container, true, {
+				durationMs: timeoutMs,
+				errorMsg: "container connected event timeout",
+			});
+		},
+	);
 
 	it("can cancel call connect() twice then cancel with disconnect()", async () => {
 		const container = await createConnectedContainer();


### PR DESCRIPTION
There are plenty of fluid:telemetry:Container:ConnectionStateChange_EstablishingConnection events in telemetry (both Loop production and from E2E tests) suggesting we waste connection attempts by cancelling already inflight connections.

99.9% of those events in production are with Data_containerConnectionState == "EstablishingConnection". That said, it does not tell us much as (for example in Loop) this is usually happens when we call disconnect() while establishing connection, and it's very hard to differentiate if cancelation happens on connect() or disconnect() flow.

Glancing at the code, logic around it, and original motivation, I'm not sure why we are cancelling connections in connectCore().
It feels like code has to be symmetrical about treating already established connection and pending connection - there is not much difference between them, as at some point someone made a call that connection with such mode is acceptable. And that's how code actually worked some time ago (so it's not a new modality I introduce)

That said, I want to have better signal here, and thus adding error telemetry and capturing stack.