### PR TITLE
Op/Noop telemetry

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -585,8 +585,6 @@ export class Container
 	private setAutoReconnectTime = performance.now();
 
 	private noopHeuristic: NoopHeuristic | undefined;
-	// Number of no-ops sent via this client in the current active connection
-	private noopCount: number = 0;
 
 	private get connectionMode() {
 		return this._deltaManager.connectionManager.connectionMode;
@@ -2119,13 +2117,10 @@ export class Container
 				checkpointSequenceNumber,
 				quorumSize: this._protocolHandler?.quorum.getMembers().size,
 				isDirty: this.isDirty,
-				noopCount: this.noopCount,
 				...this._deltaManager.connectionProps,
 			},
 			reason?.error,
 		);
-		// Reset noop count after it has been logged
-		this.noopCount = 0;
 
 		if (value === ConnectionState.Connected) {
 			this.firstConnection = false;
@@ -2235,9 +2230,7 @@ export class Container
 			this.mc.logger.sendErrorEvent({ eventName: "SubmitMessageWithNoConnection", type });
 			return -1;
 		}
-		if (type === MessageType.NoOp) {
-			this.noopCount++;
-		}
+
 		this.noopHeuristic?.notifyMessageSent();
 		return this._deltaManager.submit(
 			type,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2235,7 +2235,7 @@ export class Container
 			this.mc.logger.sendErrorEvent({ eventName: "SubmitMessageWithNoConnection", type });
 			return -1;
 		}
-		if (type == MessageType.NoOp) {
+		if (type === MessageType.NoOp) {
 			this.noopCount++;
 		}
 		this.noopHeuristic?.notifyMessageSent();

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -326,16 +326,17 @@ class OpPerfTelemetry {
 			});
 		}
 
-		// Count the number of ops submitted by this client.
-		// The value is reset when we log the no-op sampled count
-		this.noOpCount++;
 		if (message.type == MessageType.NoOp) {
-			this.opsLogger.sendPerformanceEvent({
-				eventName: "OpStats",
-				submitOpCount: OpPerfTelemetry.OPS_SAMPLE_RATE,
-				noOpCount: this.noOpCount,
-			});
+			// Count the number of ops submitted by this client.
+			// The value is reset when we log the OpStats samopled event.
+			this.noOpCount++;
 		}
+
+		this.opsLogger.sendPerformanceEvent({
+			eventName: "OpStats",
+			submitOpCount: OpPerfTelemetry.OPS_SAMPLE_RATE,
+			noOpCount: this.noOpCount,
+		});
 	}
 
 	private afterProcessingOp(message: ISequencedDocumentMessage) {

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -251,13 +251,7 @@ class OpPerfTelemetry {
 					latencyStats.opPerfData.lengthInboundQueue = this.deltaManager.inbound.length;
 				}
 			}
-			if (message.contents && isRuntimeMessage(message)) {
-				// This assert will ensure that if/when the 'contents' type changes, we make sure to update the
-				// processedOpSizeForTelemetry calculation below as well.
-				assert(
-					typeof message.contents === "string",
-					"Op's contents are expected to be string",
-				);
+			if (isRuntimeMessage(message) && typeof message.contents === "string") {
 				this.processedOpSizeForTelemetry += message.contents.length;
 			}
 		});

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -327,8 +327,8 @@ class OpPerfTelemetry {
 		}
 
 		if (message.type == MessageType.NoOp) {
-			// Count the number of ops submitted by this client.
-			// The value is reset when we log the OpStats samopled event.
+			// Count the number of no-ops submitted by this client.
+			// The value is reset when we log the OpStats sampled event.
 			this.noOpCount++;
 		}
 

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -149,8 +149,7 @@ class OpPerfTelemetry {
 		// due to complexity of the different asynchronus scenarios of the op message lifecycle.
 		this.opLatencyLogger = createSampledLogger(logger);
 
-		//
-		const submitOpEventSampler: IEventSampler = (() => {
+		const opsEventSampler: IEventSampler = (() => {
 			let eventCount = 0;
 			return {
 				sample: () => {
@@ -166,7 +165,7 @@ class OpPerfTelemetry {
 				},
 			};
 		})();
-		this.opsLogger = createSampledLogger(logger, submitOpEventSampler);
+		this.opsLogger = createSampledLogger(logger, opsEventSampler);
 
 		this.deltaManager.on("pong", (latency) => this.recordPingTime(latency));
 		this.deltaManager.on("submitOp", (message) => this.beforeOpSubmit(message));


### PR DESCRIPTION
[AB#7640](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7640)

Adding some telemetry around observed ops and sent no-ops with following goals in mind:
1. To be able to get average figures on how many ops are sent in a session. (This data would have been useful when FRS reported the issue of large number of ops)
2. To get an estimate of how many no-ops are in ratio of ops-processed in the system. This data will be useful to have if/when we want to update the no-op heuristics.
3. Have a way to estimate the average collab-window that a client maintains on it's end. This too could be useful if/when we update no-op heuristics with content size as one of the control parameters.

In this PR, I am connectionTelemetry utility to observe and processed op counts, no-op counts and the size of the content processed within the sample size logged.

In future `OpStats` event can be further updated to observe other kinds of ops as well/collab-window size related params as well, that might help us refine our heuristics to keep collab window smaller.