### PR TITLE
Make ./internal/test exports conditional

### DIFF
--- a/common/build/build-common/README.md
+++ b/common/build/build-common/README.md
@@ -36,7 +36,7 @@ files](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0
 -   tsconfig.node16.json - This config extends base and sets `module: Node16` and `moduleResolution: Node16`. It is intended for all
     builds.
 -   tsconfig.test.node16.json - This config disables some settings that we don't want to use in test code, like `declaration` and
-    `decarationMap`. It also enables the `node` types by default.
+    `decarationMap`. It also enables the `node` types by default, and turns on the "allow-ff-test-exports" [condition](https://nodejs.org/api/packages.html#conditional-exports), which allows imports for test-only indexes used in a few packages.
 
 ### Dual Build Pattern
 

--- a/common/build/build-common/tsconfig.test.node16.json
+++ b/common/build/build-common/tsconfig.test.node16.json
@@ -2,6 +2,7 @@
 	"extends": ["./tsconfig.base.json", "./tsconfig.node16.json"],
 	"compilerOptions": {
 		"composite": false,
+		"customConditions": ["allow-ff-test-exports"],
 		"types": ["node"],
 		"declaration": false,
 		"declarationMap": false,

--- a/common/build/eslint-config-fluid/base.js
+++ b/common/build/eslint-config-fluid/base.js
@@ -349,24 +349,6 @@ module.exports = {
 		"import/resolver": {
 			typescript: {
 				extensions: [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
-				conditionNames: [
-					"allow-ff-test-exports",
-
-					// Default condition names below, see https://www.npmjs.com/package/eslint-import-resolver-typescript#conditionnames
-					"types",
-					"import",
-
-					// APF: https://angular.io/guide/angular-package-format
-					"esm2020",
-					"es2020",
-					"es2015",
-
-					"require",
-					"node",
-					"node-addons",
-					"browser",
-					"default",
-				],
 			},
 		},
 	},

--- a/common/build/eslint-config-fluid/base.js
+++ b/common/build/eslint-config-fluid/base.js
@@ -349,6 +349,24 @@ module.exports = {
 		"import/resolver": {
 			typescript: {
 				extensions: [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
+				conditionNames: [
+					"allow-ff-test-exports",
+
+					// Default condition names below, see https://www.npmjs.com/package/eslint-import-resolver-typescript#conditionnames
+					"types",
+					"import",
+
+					// APF: https://angular.io/guide/angular-package-format
+					"esm2020",
+					"es2020",
+					"es2015",
+
+					"require",
+					"node",
+					"node-addons",
+					"browser",
+					"default",
+				],
 			},
 		},
 	},

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -44,13 +44,15 @@
 			}
 		},
 		"./internal/test": {
-			"import": {
-				"types": "./lib/test/index.d.ts",
-				"default": "./lib/test/index.js"
-			},
-			"require": {
-				"types": "./dist/test/index.d.ts",
-				"default": "./dist/test/index.js"
+			"allow-ff-test-exports": {
+				"import": {
+					"types": "./lib/test/index.d.ts",
+					"default": "./lib/test/index.js"
+				},
+				"require": {
+					"types": "./dist/test/index.d.ts",
+					"default": "./dist/test/index.js"
+				}
 			}
 		}
 	},

--- a/packages/dds/sequence/.eslintrc.cjs
+++ b/packages/dds/sequence/.eslintrc.cjs
@@ -15,4 +15,33 @@ module.exports = {
 		"@typescript-eslint/no-use-before-define": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
 	},
+	settings: {
+		"import/extensions": [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
+		"import/parsers": {
+			"@typescript-eslint/parser": [".ts", ".tsx", ".d.ts"],
+		},
+		"import/resolver": {
+			typescript: {
+				extensions: [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
+				conditionNames: [
+					"allow-ff-test-exports",
+
+					// Default condition names below, see https://www.npmjs.com/package/eslint-import-resolver-typescript#conditionnames
+					"types",
+					"import",
+
+					// APF: https://angular.io/guide/angular-package-format
+					"esm2020",
+					"es2020",
+					"es2015",
+
+					"require",
+					"node",
+					"node-addons",
+					"browser",
+					"default",
+				],
+			},
+		},
+	},
 };

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -12,7 +12,7 @@ import {
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
 import {
-	// eslint-disable-next-line import/no-deprecated
+	/* eslint-disable import/no-deprecated */
 	Client,
 	IJSONSegment,
 	IMergeTreeAnnotateMsg,
@@ -32,12 +32,13 @@ import {
 	ReferenceType,
 	SegmentGroup,
 	SlidingPreference,
-	createAnnotateRangeOp, // eslint-disable-next-line import/no-deprecated
+	createAnnotateRangeOp,
 	createGroupOp,
 	createInsertOp,
 	createObliterateRangeOp,
 	createRemoveRangeOp,
 	matchProperties,
+	/* eslint-enable import/no-deprecated */
 } from "@fluidframework/merge-tree/internal";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import { ISummaryTreeWithStats, ITelemetryContext } from "@fluidframework/runtime-definitions";
@@ -180,6 +181,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 				}
 
 				case MergeTreeDeltaType.OBLITERATE: {
+					// eslint-disable-next-line import/no-deprecated
 					const lastRem = ops[ops.length - 1] as IMergeTreeObliterateMsg;
 					if (lastRem?.pos1 === r.position) {
 						assert(
@@ -243,6 +245,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 	/** `Deferred` that triggers once the object is loaded */
 	protected loadedDeferred = new Deferred<void>();
 	// cache out going ops created when partial loading
+	// eslint-disable-next-line import/no-deprecated
 	private readonly loadedDeferredOutgoingOps: [IMergeTreeOp, SegmentGroup | SegmentGroup[]][] =
 		[];
 	// cache incoming ops that arrive when partial loading
@@ -340,6 +343,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 	 * release, as group ops are redundant with the native batching capabilities
 	 * of the runtime
 	 */
+	// eslint-disable-next-line import/no-deprecated
 	public groupOperation(groupOp: IMergeTreeGroupMsg) {
 		this.guardReentrancy(() => this.client.localTransaction(groupOp));
 	}
@@ -654,6 +658,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 				this.submitSequenceMessage(
 					this.client.regeneratePendingOp(
 						content as IMergeTreeOp,
+						// eslint-disable-next-line import/no-deprecated
 						localOpMetadata as SegmentGroup | SegmentGroup[],
 					),
 				);

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -42,7 +42,6 @@ import {
 	createObliterateRangeOp,
 	createRemoveRangeOp,
 	matchProperties,
-	/* eslint-enable import/no-deprecated */
 } from "@fluidframework/merge-tree/internal";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import { ISummaryTreeWithStats, ITelemetryContext } from "@fluidframework/runtime-definitions";

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -12,12 +12,14 @@ import {
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
 import {
-	/* eslint-disable import/no-deprecated */
+	// eslint-disable-next-line import/no-deprecated
 	Client,
 	IJSONSegment,
 	IMergeTreeAnnotateMsg,
 	IMergeTreeDeltaOp,
+	// eslint-disable-next-line import/no-deprecated
 	IMergeTreeGroupMsg,
+	// eslint-disable-next-line import/no-deprecated
 	IMergeTreeObliterateMsg,
 	IMergeTreeOp,
 	IMergeTreeRemoveMsg,
@@ -30,9 +32,11 @@ import {
 	PropertySet,
 	ReferencePosition,
 	ReferenceType,
+	// eslint-disable-next-line import/no-deprecated
 	SegmentGroup,
 	SlidingPreference,
 	createAnnotateRangeOp,
+	// eslint-disable-next-line import/no-deprecated
 	createGroupOp,
 	createInsertOp,
 	createObliterateRangeOp,

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -5,6 +5,7 @@
 
 import { IChannelAttributes, IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import {
+	// eslint-disable-next-line import/no-deprecated
 	IMergeTreeTextHelper,
 	IRelativePosition,
 	ISegment,
@@ -87,6 +88,7 @@ export class SharedString
 		return this;
 	}
 
+	// eslint-disable-next-line import/no-deprecated
 	private readonly mergeTreeTextHelper: IMergeTreeTextHelper;
 
 	constructor(

--- a/packages/dds/sequence/src/test/generateSharedStrings.ts
+++ b/packages/dds/sequence/src/test/generateSharedStrings.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line import/no-internal-modules
 import { SnapshotLegacy as Snapshot } from "@fluidframework/merge-tree/internal/test";
 import * as mocks from "@fluidframework/test-runtime-utils/internal";
 import { MersenneTwister19937, Random } from "random-js";

--- a/packages/dds/sequence/src/test/intervalRebasing.spec.ts
+++ b/packages/dds/sequence/src/test/intervalRebasing.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 
 import { IChannelServices } from "@fluidframework/datastore-definitions";
-// eslint-disable-next-line import/no-internal-modules
 import { useStrictPartialLengthChecks } from "@fluidframework/merge-tree/internal/test";
 import {
 	MockContainerRuntimeFactoryForReconnection,

--- a/packages/dds/sequence/src/test/sequenceDeltaEvent.spec.ts
+++ b/packages/dds/sequence/src/test/sequenceDeltaEvent.spec.ts
@@ -14,7 +14,6 @@ import {
 	createInsertSegmentOp,
 	createRemoveRangeOp,
 } from "@fluidframework/merge-tree/internal";
-// eslint-disable-next-line import/no-internal-modules
 import { TestClient } from "@fluidframework/merge-tree/internal/test";
 
 import { SequenceDeltaEvent } from "../sequenceDeltaEvent.js";

--- a/packages/dds/sequence/src/test/subSequence.spec.ts
+++ b/packages/dds/sequence/src/test/subSequence.spec.ts
@@ -10,7 +10,6 @@ import {
 	createInsertSegmentOp,
 	createRemoveRangeOp,
 } from "@fluidframework/merge-tree/internal";
-// eslint-disable-next-line import/no-internal-modules
 import { TestClient } from "@fluidframework/merge-tree/internal/test";
 
 import { SubSequence } from "../sharedSequence.js";

--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -39,4 +39,33 @@ module.exports = {
 			},
 		},
 	],
+	settings: {
+		"import/extensions": [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
+		"import/parsers": {
+			"@typescript-eslint/parser": [".ts", ".tsx", ".d.ts"],
+		},
+		"import/resolver": {
+			typescript: {
+				extensions: [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
+				conditionNames: [
+					"allow-ff-test-exports",
+
+					// Default condition names below, see https://www.npmjs.com/package/eslint-import-resolver-typescript#conditionnames
+					"types",
+					"import",
+
+					// APF: https://angular.io/guide/angular-package-format
+					"esm2020",
+					"es2020",
+					"es2015",
+
+					"require",
+					"node",
+					"node-addons",
+					"browser",
+					"default",
+				],
+			},
+		},
+	},
 };

--- a/packages/dds/tree/src/test/tsconfig.json
+++ b/packages/dds/tree/src/test/tsconfig.json
@@ -10,6 +10,7 @@
 		"module": "Node16",
 		"moduleResolution": "Node16",
 		"types": ["node", "mocha"],
+		"customConditions": ["allow-ff-test-exports"],
 	},
 	"include": ["./**/*"],
 	"references": [

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -44,13 +44,15 @@
 			}
 		},
 		"./internal/test-utils": {
-			"import": {
-				"types": "./lib/test/index.d.ts",
-				"default": "./lib/test/index.js"
-			},
-			"require": {
-				"types": "./dist/test/index.d.ts",
-				"default": "./dist/test/index.js"
+			"allow-ff-test-exports": {
+				"import": {
+					"types": "./lib/test/index.d.ts",
+					"default": "./lib/test/index.js"
+				},
+				"require": {
+					"types": "./dist/test/index.d.ts",
+					"default": "./dist/test/index.js"
+				}
 			}
 		}
 	},

--- a/packages/test/mocha-test-setup/mocharc-common.cjs
+++ b/packages/test/mocha-test-setup/mocharc-common.cjs
@@ -51,6 +51,7 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 		"recursive": true,
 		"require": requiredModulePaths,
 		"unhandled-rejections": "strict",
+		// Allow test-only indexes to be imported. Search the FF repo for package.json files with this condition to see example usage.
 		"node-option": "conditions=allow-ff-test-exports",
 		// Performance tests benefit from having access to GC, and memory tests require it.
 		// Exposing it here avoids all packages which do perf testing from having to expose it.

--- a/packages/test/mocha-test-setup/mocharc-common.cjs
+++ b/packages/test/mocha-test-setup/mocharc-common.cjs
@@ -51,6 +51,7 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 		"recursive": true,
 		"require": requiredModulePaths,
 		"unhandled-rejections": "strict",
+		"node-option": "conditions=allow-ff-test-exports",
 		// Performance tests benefit from having access to GC, and memory tests require it.
 		// Exposing it here avoids all packages which do perf testing from having to expose it.
 		"v8-expose-gc": true,


### PR DESCRIPTION
## Description

Makes the test-only index package exports of merge-tree and id-compressor conditional. This effectively hides them from usage outside FF, including tooling that uses metadata from package.json. This should reduce noise for consumers using such tooling, which we've recently gotten some reports of.