### PR TITLE
Soft delete on deli close for ec containers

### DIFF
--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -24,7 +24,6 @@ import {
 	LambdaCloseType,
 	MongoManager,
 	requestWithRetry,
-	runWithRetry,
 } from "@fluidframework/server-services-core";
 import { defaultHash, IGitManager } from "@fluidframework/server-services-client";
 import {
@@ -229,6 +228,7 @@ export class DeliLambdaFactory
 		);
 
 		deliLambda.on("close", (closeType) => {
+			const baseLumberjackProperties = getLumberBaseProperties(documentId, tenantId);
 			const handler = async () => {
 				if (
 					closeType === LambdaCloseType.ActivityTimeout ||
@@ -240,38 +240,42 @@ export class DeliLambdaFactory
 							await requestWithRetry(
 								async () => gitManager.deleteSummary(false),
 								"deliLambda_onClose" /* callName */,
-								getLumberBaseProperties(
-									documentId,
-									tenantId,
-								) /* telemetryProperties */,
+								baseLumberjackProperties /* telemetryProperties */,
 								(error) => true /* shouldRetry */,
 								3 /* maxRetries */,
 							);
 						}
 
-						// Delete the document metadata
-						await runWithRetry(
-							async () =>
-								this.documentRepository.deleteOne({
-									documentId,
-									tenantId,
-								}),
-							"deleteDocMetadata",
-							3 /* maxRetries */,
-							1000 /* retryAfterMs */,
-							getLumberBaseProperties(documentId, tenantId),
-							(error) =>
-								error.code === 11000 ||
-								error.message?.toString()?.indexOf("E11000 duplicate key") >=
-									0 /* shouldIgnoreError */,
-							(error) => true /* shouldRetry */,
-						);
+						// Delete the document metadata, soft or hard depending on the configuration
+						const deletionFilter = {
+							documentId,
+							tenantId,
+						};
+						if (
+							this.serviceConfiguration.deli.ephemeralContainerSoftDeleteTimeInMs >= 0
+						) {
+							const scheduledDeletionTime = new Date(
+								Date.now() +
+									this.serviceConfiguration.deli
+										.ephemeralContainerSoftDeleteTimeInMs,
+							);
+							await this.documentRepository.updateOne(
+								deletionFilter,
+								{ scheduledDeletionTime: scheduledDeletionTime.toJSON() },
+								null,
+							);
+							Lumberjack.info(
+								`Successfully scheduled to clean up ephemeral container`,
+								baseLumberjackProperties,
+							);
+						} else {
+							await this.documentRepository.deleteOne(deletionFilter);
 
-						Lumberjack.info(
-							`Successfully cleaned up ephemeral container`,
-							getLumberBaseProperties(documentId, tenantId),
-						);
-
+							Lumberjack.info(
+								`Successfully cleaned up ephemeral container`,
+								baseLumberjackProperties,
+							);
+						}
 						return;
 					}
 					const filter = { documentId, tenantId, session: { $exists: true } };
@@ -297,7 +301,7 @@ export class DeliLambdaFactory
 						} catch (error) {
 							Lumberjack.error(
 								"Failed to get cluster draining status",
-								getLumberBaseProperties(documentId, tenantId),
+								baseLumberjackProperties,
 								error,
 							);
 						}
@@ -308,13 +312,13 @@ export class DeliLambdaFactory
                         ${JSON.stringify(closeType)}`;
 
 					context.log?.info(message, { messageMetaData });
-					Lumberjack.info(message, getLumberBaseProperties(documentId, tenantId));
+					Lumberjack.info(message, baseLumberjackProperties);
 				}
 			};
 			handler().catch((e) => {
 				const message = `Failed to handle session alive and active with exception ${e}`;
 				context.log?.error(message, { messageMetaData });
-				Lumberjack.error(message, getLumberBaseProperties(documentId, tenantId), e);
+				Lumberjack.error(message, baseLumberjackProperties, e);
 			});
 		});
 

--- a/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/deli/lambdaFactory.ts
@@ -254,19 +254,22 @@ export class DeliLambdaFactory
 						if (
 							this.serviceConfiguration.deli.ephemeralContainerSoftDeleteTimeInMs >= 0
 						) {
-							const scheduledDeletionTime = new Date(
+							const scheduledDeletionTimeStr = new Date(
 								Date.now() +
 									this.serviceConfiguration.deli
 										.ephemeralContainerSoftDeleteTimeInMs,
-							);
+							).toJSON();
 							await this.documentRepository.updateOne(
 								deletionFilter,
-								{ scheduledDeletionTime: scheduledDeletionTime.toJSON() },
+								{ scheduledDeletionTime: scheduledDeletionTimeStr },
 								null,
 							);
 							Lumberjack.info(
 								`Successfully scheduled to clean up ephemeral container`,
-								baseLumberjackProperties,
+								{
+									...baseLumberjackProperties,
+									scheduledDeletionTime: scheduledDeletionTimeStr,
+								},
 							);
 						} else {
 							await this.documentRepository.deleteOne(deletionFilter);

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -73,8 +73,7 @@ export async function deliCreate(
 		enableEphemeralContainerSummaryCleanup;
 
 	const ephemeralContainerSoftDeleteTimeInMs =
-		(config.get("deli:ephemeralContainerSoftDeleteTimeInMs") as number | undefined) ??
-		5 * 24 * 60 * 60 * 1000;
+		(config.get("deli:ephemeralContainerSoftDeleteTimeInMs") as number | undefined) ?? -1; // -1 means not soft deletion but hard deletion directly
 	core.DefaultServiceConfiguration.deli.ephemeralContainerSoftDeleteTimeInMs =
 		ephemeralContainerSoftDeleteTimeInMs;
 

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -72,6 +72,12 @@ export async function deliCreate(
 	core.DefaultServiceConfiguration.deli.enableEphemeralContainerSummaryCleanup =
 		enableEphemeralContainerSummaryCleanup;
 
+	const ephemeralContainerSoftDeleteTimeInMs =
+		(config.get("deli:ephemeralContainerSoftDeleteTimeInMs") as number | undefined) ??
+		5 * 24 * 60 * 60 * 1000;
+	core.DefaultServiceConfiguration.deli.ephemeralContainerSoftDeleteTimeInMs =
+		ephemeralContainerSoftDeleteTimeInMs;
+
 	let globalDb: core.IDb;
 	if (globalDbEnabled) {
 		const globalDbReconnect = (config.get("mongo:globalDbReconnect") as boolean) ?? false;

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -79,6 +79,9 @@
 			},
 			"InterfaceDeclaration_IScribe": {
 				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IDeliServerConfiguration": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -29,6 +29,9 @@ export interface IDeliServerConfiguration {
 	// Enables ephemeral container summary deletion on deli close
 	enableEphemeralContainerSummaryCleanup: boolean;
 
+	// Time to wait before deleting ephemeral container summaries
+	ephemeralContainerSoftDeleteTimeInMs: number;
+
 	// Enables deli to maintain batches as it produces them to the next lambdas
 	maintainBatches: boolean;
 
@@ -233,6 +236,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
 		enableOpHashing: true,
 		enableAutoDSNUpdate: false,
 		enableEphemeralContainerSummaryCleanup: true,
+		ephemeralContainerSoftDeleteTimeInMs: 24 * 60 * 60 * 1000,
 		checkForIdleClientsOnStartup: false,
 		maintainBatches: false,
 		enableWriteClientSignals: false,

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -236,7 +236,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
 		enableOpHashing: true,
 		enableAutoDSNUpdate: false,
 		enableEphemeralContainerSummaryCleanup: true,
-		ephemeralContainerSoftDeleteTimeInMs: 24 * 60 * 60 * 1000,
+		ephemeralContainerSoftDeleteTimeInMs: -1,
 		checkForIdleClientsOnStartup: false,
 		maintainBatches: false,
 		enableWriteClientSignals: false,

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -800,6 +800,7 @@ declare function get_old_InterfaceDeclaration_IDeliServerConfiguration():
 declare function use_current_InterfaceDeclaration_IDeliServerConfiguration(
     use: TypeOnly<current.IDeliServerConfiguration>): void;
 use_current_InterfaceDeclaration_IDeliServerConfiguration(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IDeliServerConfiguration());
 
 /*


### PR DESCRIPTION
## Description

We cleanup op metadata using doc purge for soft deleted documents. If document is hard deleted here directly, the ops from EC containers will accumulate and casing storage cost in db due to partition split. Added a new config to config soft delete.

