### PR TITLE
refactor: Add explicit schema types for Array, Object, and Map nodes

### DIFF
--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -29,7 +29,6 @@ import {
 	type ImplicitAllowedTypes,
 	type InsertableTreeNodeFromImplicitAllowedTypes,
 	type TreeNodeFromImplicitAllowedTypes,
-	ImplicitFieldSchema,
 	TreeNodeSchemaClass,
 	WithType,
 	TreeNodeSchema,
@@ -232,6 +231,22 @@ export const TreeArrayNode = {
 };
 
 /**
+ * {@link TreeNodeSchemaClass} for {@link TreeArrayNode}s.
+ */
+export type ArrayNodeSchema<
+	TName extends string = string,
+	T extends ImplicitAllowedTypes = ImplicitAllowedTypes,
+	ImplicitlyConstructable extends boolean = boolean,
+> = TreeNodeSchemaClass<
+	TName,
+	NodeKind.Array,
+	TreeArrayNode<T> & WithType<TName>,
+	Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>,
+	ImplicitlyConstructable,
+	T
+>;
+
+/**
  * Package internal construction API.
  * Use {@link (TreeArrayNode:variable).spread} to create an instance of this type instead.
  */
@@ -317,12 +332,12 @@ const arrayNodePrototypeProperties: PropertyDescriptorMap = {
 
 			const content = contextualizeInsertedArrayContent(value, sequenceField);
 
-			const simpleNodeSchema = getSimpleNodeSchema(sequenceNode.schema);
+			const simpleNodeSchema = getSimpleNodeSchema(sequenceNode.schema) as ArrayNodeSchema;
 			assert(simpleNodeSchema.kind === NodeKind.Array, 0x912 /* Expected array schema */);
 
 			const simpleFieldSchema = getSimpleFieldSchema(
 				sequenceField.schema,
-				simpleNodeSchema.info as ImplicitFieldSchema,
+				simpleNodeSchema.info,
 			);
 
 			sequenceField.insertAt(index, cursorFromFieldData(content, simpleFieldSchema));
@@ -338,12 +353,12 @@ const arrayNodePrototypeProperties: PropertyDescriptorMap = {
 
 			const content = contextualizeInsertedArrayContent(value, sequenceField);
 
-			const simpleNodeSchema = getSimpleNodeSchema(sequenceNode.schema);
+			const simpleNodeSchema = getSimpleNodeSchema(sequenceNode.schema) as ArrayNodeSchema;
 			assert(simpleNodeSchema.kind === NodeKind.Array, 0x913 /* Expected array schema */);
 
 			const simpleFieldSchema = getSimpleFieldSchema(
 				sequenceField.schema,
-				simpleNodeSchema.info as ImplicitFieldSchema,
+				simpleNodeSchema.info,
 			);
 
 			sequenceField.insertAtStart(cursorFromFieldData(content, simpleFieldSchema));
@@ -359,12 +374,12 @@ const arrayNodePrototypeProperties: PropertyDescriptorMap = {
 
 			const content = contextualizeInsertedArrayContent(value, sequenceField);
 
-			const simpleNodeSchema = getSimpleNodeSchema(sequenceNode.schema);
+			const simpleNodeSchema = getSimpleNodeSchema(sequenceNode.schema) as ArrayNodeSchema;
 			assert(simpleNodeSchema.kind === NodeKind.Array, 0x914 /* Expected array schema */);
 
 			const simpleFieldSchema = getSimpleFieldSchema(
 				sequenceField.schema,
-				simpleNodeSchema.info as ImplicitFieldSchema,
+				simpleNodeSchema.info,
 			);
 
 			sequenceField.insertAtEnd(cursorFromFieldData(content, simpleFieldSchema));
@@ -756,14 +771,7 @@ export function arraySchema<
 	// Setup array functionality
 	Object.defineProperties(schema.prototype, arrayNodePrototypeProperties);
 
-	return schema as typeof base as TreeNodeSchemaClass<
-		TName,
-		NodeKind.Array,
-		TreeArrayNode<T> & WithType<TName>,
-		Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>,
-		ImplicitlyConstructable,
-		T
-	>;
+	return schema as typeof base as ArrayNodeSchema<TName, T, ImplicitlyConstructable>;
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -82,6 +82,22 @@ const handler: ProxyHandler<TreeMapNode> = {
 };
 
 /**
+ * {@link TreeNodeSchemaClass} for {@link TreeMapNode}s.
+ */
+export type MapNodeSchema<
+	TName extends string = string,
+	T extends ImplicitAllowedTypes = never,
+	ImplicitlyConstructable extends boolean = boolean,
+> = TreeNodeSchemaClass<
+	TName,
+	NodeKind.Map,
+	TreeMapNode<T> & WithType<TName>,
+	Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>,
+	ImplicitlyConstructable,
+	T
+>;
+
+/**
  * Define a {@link TreeNodeSchema} for a {@link (TreeArrayNode:interface)}.
  *
  * @param base - base schema type to extend.
@@ -163,8 +179,12 @@ export function mapSchema<
 				node.context.forest,
 			);
 
-			const classSchema = getSimpleNodeSchema(node.schema);
-			const cursor = cursorFromNodeData(content, classSchema.info as ImplicitAllowedTypes);
+			const classSchema = getSimpleNodeSchema(node.schema) as MapNodeSchema<
+				TName,
+				T,
+				ImplicitlyConstructable
+			>;
+			const cursor = cursorFromNodeData(content, classSchema.info);
 
 			node.set(key, cursor);
 			return this;
@@ -193,14 +213,7 @@ export function mapSchema<
 		}
 		// TODO: add `clear` once we have established merge semantics for it.
 	}
-	const schemaErased: TreeNodeSchemaClass<
-		TName,
-		NodeKind.Map,
-		TreeMapNode<T> & WithType<TName>,
-		Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>,
-		ImplicitlyConstructable,
-		T
-	> = schema;
+	const schemaErased: MapNodeSchema<TName, T, ImplicitlyConstructable> = schema;
 	return schemaErased;
 }
 

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -223,7 +223,10 @@ export function setField(
 	}
 }
 
-type ObjectNodeSchema<
+/**
+ * {@link TreeNodeSchemaClass} for {@link TreeObjectNode}s.
+ */
+export type ObjectNodeSchema<
 	TName extends string = string,
 	T extends RestrictiveReadonlyRecord<string, ImplicitFieldSchema> = RestrictiveReadonlyRecord<
 		string,
@@ -233,7 +236,7 @@ type ObjectNodeSchema<
 > = TreeNodeSchemaClass<
 	TName,
 	NodeKind.Object,
-	TreeNode & WithType<TName>,
+	TreeObjectNode<T, TName>,
 	InsertableObjectFromSchemaRecord<T>,
 	ImplicitlyConstructable,
 	T
@@ -249,7 +252,16 @@ export function objectSchema<
 	TName extends string,
 	const T extends RestrictiveReadonlyRecord<string, ImplicitFieldSchema>,
 	const ImplicitlyConstructable extends boolean,
->(base: ObjectNodeSchema<TName, T, ImplicitlyConstructable>) {
+>(
+	base: TreeNodeSchemaClass<
+		TName,
+		NodeKind.Object,
+		TreeNode & WithType<TName>,
+		InsertableObjectFromSchemaRecord<T>,
+		ImplicitlyConstructable,
+		T
+	>,
+) {
 	// Ensure no collisions between final set of view keys, and final set of stored keys (including those
 	// implicitly derived from view keys)
 	assertUniqueKeys(base.identifier, base.info);
@@ -342,14 +354,7 @@ export function objectSchema<
 		}
 	}
 
-	return CustomObjectNode as TreeNodeSchemaClass<
-		TName,
-		NodeKind.Object,
-		TreeObjectNode<T, TName>,
-		object & InsertableObjectFromSchemaRecord<T>,
-		true,
-		T
-	>;
+	return CustomObjectNode as ObjectNodeSchema<TName, T, true>;
 }
 
 const targetToProxy: WeakMap<object, TreeNode> = new WeakMap();

--- a/packages/dds/tree/src/simple-tree/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/schemaFactory.ts
@@ -40,10 +40,10 @@ import {
 	type FieldProps,
 	createFieldSchema,
 } from "./schemaTypes.js";
-import { TreeArrayNode, arraySchema } from "./arrayNode.js";
+import { TreeArrayNode, arraySchema, type ArrayNodeSchema } from "./arrayNode.js";
 import { TreeNode } from "./types.js";
 import { InsertableObjectFromSchemaRecord, TreeObjectNode, objectSchema } from "./objectNode.js";
-import { TreeMapNode, mapSchema } from "./mapNode.js";
+import { TreeMapNode, mapSchema, type MapNodeSchema } from "./mapNode.js";
 import {
 	InsertableObjectFromSchemaRecordUnsafe,
 	InsertableTreeNodeFromImplicitAllowedTypesUnsafe,
@@ -406,14 +406,7 @@ export class SchemaFactory<
 		allowedTypes: T,
 		customizable: boolean,
 		implicitlyConstructable: ImplicitlyConstructable,
-	): TreeNodeSchemaClass<
-		ScopedSchemaName<TScope, Name>,
-		NodeKind.Map,
-		TreeMapNode<T> & WithType<ScopedSchemaName<TScope, Name>>,
-		Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>,
-		ImplicitlyConstructable,
-		T
-	> {
+	): MapNodeSchema<ScopedSchemaName<TScope, Name>, T, ImplicitlyConstructable> {
 		return mapSchema(
 			this.nodeSchema(name, NodeKind.Map, allowedTypes, implicitlyConstructable),
 			// The current policy is customizable nodes don't get fake prototypes.
@@ -535,14 +528,7 @@ export class SchemaFactory<
 		allowedTypes: T,
 		customizable: boolean,
 		implicitlyConstructable: ImplicitlyConstructable,
-	): TreeNodeSchemaClass<
-		ScopedSchemaName<TScope, Name>,
-		NodeKind.Array,
-		TreeArrayNode<T> & WithType<ScopedSchemaName<TScope, string>>,
-		Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>,
-		ImplicitlyConstructable,
-		T
-	> {
+	): ArrayNodeSchema<ScopedSchemaName<TScope, Name>, T, ImplicitlyConstructable> {
 		return arraySchema(
 			this.nodeSchema(name, NodeKind.Array, allowedTypes, implicitlyConstructable),
 			customizable,

--- a/packages/dds/tree/src/simple-tree/toFlexSchema.ts
+++ b/packages/dds/tree/src/simple-tree/toFlexSchema.ts
@@ -44,6 +44,9 @@ import {
 } from "./schemaTypes.js";
 import { cursorFromNodeData } from "./toMapTree.js";
 import { TreeConfiguration } from "./tree.js";
+import type { MapNodeSchema } from "./mapNode.js";
+import type { ArrayNodeSchema } from "./arrayNode.js";
+import type { ObjectNodeSchema } from "./objectNode.js";
 
 /**
  * Returns a cursor (in nodes mode) for the root node.
@@ -202,7 +205,7 @@ export function convertNodeSchema(
 				return cached;
 			}
 			case NodeKind.Map: {
-				const fieldInfo = schema.info as ImplicitAllowedTypes;
+				const fieldInfo: ImplicitAllowedTypes = (schema as MapNodeSchema).info;
 				const field = FlexFieldSchema.create(
 					FieldKinds.optional,
 					convertAllowedTypes(schemaMap, fieldInfo),
@@ -213,7 +216,7 @@ export function convertNodeSchema(
 				break;
 			}
 			case NodeKind.Array: {
-				const fieldInfo = schema.info as ImplicitAllowedTypes;
+				const fieldInfo: ImplicitFieldSchema = (schema as ArrayNodeSchema).info;
 				const field = FlexFieldSchema.create(
 					FieldKinds.sequence,
 					convertAllowedTypes(schemaMap, fieldInfo),
@@ -224,7 +227,7 @@ export function convertNodeSchema(
 				break;
 			}
 			case NodeKind.Object: {
-				const info = schema.info as Record<string, ImplicitFieldSchema>;
+				const info: Record<string, ImplicitFieldSchema> = (schema as ObjectNodeSchema).info;
 				const fields: Record<string, FlexFieldSchema> = Object.create(null);
 				for (const [viewKey, implicitFieldSchema] of Object.entries(info)) {
 					// If a `stored key` was provided, use it as the key in the flex schema.


### PR DESCRIPTION
The refactoring is primarily aimed at slightly improving the way consumers access node-kind-specific `Info` data, but it also resulted in some nice type-cleanup.