### PR TITLE
Hide the SharedMatrix class

### DIFF
--- a/.changeset/icy-sloths-double.md
+++ b/.changeset/icy-sloths-double.md
@@ -1,0 +1,16 @@
+---
+"@fluidframework/matrix": minor
+---
+
+SharedMatrix class hidden
+
+The `SharedMatrix` class has been hidden from the alpha API.
+In its place:
+
+-   The constant `SharedMatrix` is exposed as the entrypoint for `SharedMatrix` creation. See documentation on `ISharedObjectKind`.
+-   The type `SharedMatrix` is aliased to `ISharedMatrix`, which contains matrix's public API. This API has no semantic changes from previous versions.
+
+Additionally, `SharedMatrixFactory` has been deprecated. Rather than construct the factory directly, use `SharedMatrix.getFactory()` (e.g. for usage in `DataObject` registries).
+
+This change is part of a larger effort to clean up the API surface of various DDSes we have to leak less implementation details. See e.g. #20030.
+Most code which uses `SharedMatrix` should continue to function without changes.

--- a/packages/dds/matrix/api-report/matrix.api.md
+++ b/packages/dds/matrix/api-report/matrix.api.md
@@ -27,7 +27,7 @@ export interface IRevertible {
 }
 
 // @alpha (undocumented)
-export interface ISharedMatrix<T = any> extends IEventProvider<ISharedMatrixEvents<T>>, IMatrixProducer<MatrixItem<T>>, IMatrixReader<MatrixItem<T>>, IMatrixWriter<MatrixItem<T>> {
+export interface ISharedMatrix<T = any> extends IEventProvider<ISharedMatrixEvents<T>>, IMatrixProducer<MatrixItem<T>>, IMatrixReader<MatrixItem<T>>, IMatrixWriter<MatrixItem<T>>, IChannel {
     insertCols(colStart: number, count: number): void;
     insertRows(rowStart: number, count: number): void;
     isSetCellConflictResolutionPolicyFWW(): boolean;

--- a/packages/dds/matrix/api-report/matrix.api.md
+++ b/packages/dds/matrix/api-report/matrix.api.md
@@ -8,22 +8,15 @@ import { IChannel } from '@fluidframework/datastore-definitions';
 import { IChannelAttributes } from '@fluidframework/datastore-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IChannelServices } from '@fluidframework/datastore-definitions';
-import { IChannelStorageService } from '@fluidframework/datastore-definitions';
 import { IEvent } from '@fluidframework/core-interfaces';
 import { IEventProvider } from '@fluidframework/core-interfaces';
 import { IEventThisPlaceHolder } from '@fluidframework/core-interfaces';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
-import { IFluidSerializer } from '@fluidframework/shared-object-base';
-import { IJSONSegment } from '@fluidframework/merge-tree/internal';
-import { IMatrixConsumer } from '@tiny-calc/nano';
 import { IMatrixProducer } from '@tiny-calc/nano';
 import { IMatrixReader } from '@tiny-calc/nano';
 import { IMatrixWriter } from '@tiny-calc/nano';
-import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
-import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
-import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
+import type { ISharedObjectKind } from '@fluidframework/shared-object-base';
 import { Serializable } from '@fluidframework/datastore-definitions/internal';
-import { SharedObject } from '@fluidframework/shared-object-base/internal';
 
 // @alpha (undocumented)
 export interface IRevertible {
@@ -35,16 +28,14 @@ export interface IRevertible {
 
 // @alpha (undocumented)
 export interface ISharedMatrix<T = any> extends IEventProvider<ISharedMatrixEvents<T>>, IMatrixProducer<MatrixItem<T>>, IMatrixReader<MatrixItem<T>>, IMatrixWriter<MatrixItem<T>> {
-    // (undocumented)
     insertCols(colStart: number, count: number): void;
-    // (undocumented)
     insertRows(rowStart: number, count: number): void;
-    // (undocumented)
+    isSetCellConflictResolutionPolicyFWW(): boolean;
     openUndo(consumer: IUndoConsumer): void;
-    // (undocumented)
     removeCols(colStart: number, count: number): void;
-    // (undocumented)
     removeRows(rowStart: number, count: number): void;
+    setCells(rowStart: number, colStart: number, colCount: number, values: readonly MatrixItem<T>[]): void;
+    switchSetCellPolicy(): void;
 }
 
 // @alpha
@@ -62,67 +53,12 @@ export interface IUndoConsumer {
 export type MatrixItem<T> = Serializable<Exclude<T, null>> | undefined;
 
 // @alpha
-export class SharedMatrix<T = any> extends SharedObject<ISharedMatrixEvents<T> & ISharedObjectEvents> implements ISharedMatrix<T> {
-    constructor(runtime: IFluidDataStoreRuntime, id: string, attributes: IChannelAttributes, _isSetCellConflictResolutionPolicyFWW?: boolean);
-    protected applyStashedOp(_content: unknown): void;
-    // (undocumented)
-    closeMatrix(consumer: IMatrixConsumer<MatrixItem<T>>): void;
-    // (undocumented)
-    get colCount(): number;
-    static create<T>(runtime: IFluidDataStoreRuntime, id?: string): SharedMatrix<T>;
-    // (undocumented)
-    protected didAttach(): void;
-    // (undocumented)
-    getCell(row: number, col: number): MatrixItem<T>;
-    // (undocumented)
-    static getFactory(): SharedMatrixFactory;
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    insertCols(colStart: number, count: number): void;
-    // (undocumented)
-    insertRows(rowStart: number, count: number): void;
-    // (undocumented)
-    isSetCellConflictResolutionPolicyFWW(): boolean;
-    protected loadCore(storage: IChannelStorageService): Promise<void>;
-    // (undocumented)
-    get matrixProducer(): IMatrixProducer<MatrixItem<T>>;
-    // (undocumented)
-    protected onConnect(): void;
-    // (undocumented)
-    protected onDisconnect(): void;
-    // (undocumented)
-    openMatrix(consumer: IMatrixConsumer<MatrixItem<T>>): IMatrixReader<MatrixItem<T>>;
-    openUndo(consumer: IUndoConsumer): void;
-    // (undocumented)
-    protected processCore(msg: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
-    protected processGCDataCore(serializer: IFluidSerializer): void;
-    // (undocumented)
-    removeCols(colStart: number, count: number): void;
-    // (undocumented)
-    removeRows(rowStart: number, count: number): void;
-    // (undocumented)
-    protected reSubmitCore(incoming: unknown, localOpMetadata: unknown): void;
-    // (undocumented)
-    get rowCount(): number;
-    // (undocumented)
-    setCell(row: number, col: number, value: MatrixItem<T>): void;
-    // (undocumented)
-    setCells(rowStart: number, colStart: number, colCount: number, values: readonly MatrixItem<T>[]): void;
-    // (undocumented)
-    protected submitLocalMessage(message: any, localOpMetadata?: any): void;
-    // (undocumented)
-    protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats;
-    switchSetCellPolicy(): void;
-    // (undocumented)
-    toString(): string;
-    // (undocumented)
-    _undoRemoveCols(colStart: number, spec: IJSONSegment): void;
-    // (undocumented)
-    _undoRemoveRows(rowStart: number, spec: IJSONSegment): void;
-}
+export const SharedMatrix: ISharedObjectKind<ISharedMatrix>;
 
 // @alpha
+export type SharedMatrix<T = any> = ISharedMatrix<T>;
+
+// @alpha @deprecated
 export class SharedMatrixFactory implements IChannelFactory<ISharedMatrix> {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -153,6 +153,10 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedClassDeclaration_SharedMatrix": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/dds/matrix/src/index.ts
+++ b/packages/dds/matrix/src/index.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-export { ISharedMatrixEvents, SharedMatrix, ISharedMatrix } from "./matrix.js";
+export { ISharedMatrixEvents, ISharedMatrix } from "./matrix.js";
 export { MatrixItem } from "./ops.js";
-export { SharedMatrixFactory } from "./runtime.js";
+export { SharedMatrixFactory, SharedMatrix } from "./runtime.js";
 
 // TODO: We temporarily duplicate these contracts from 'framework/undo-redo' to unblock development
 //       of SharedMatrix undo while we decide on the correct layering for undo.

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -40,7 +40,6 @@ import {
 } from "./ops.js";
 import { PermutationVector, reinsertSegmentIntoVector } from "./permutationvector.js";
 import { ensureRange } from "./range.js";
-import { SharedMatrixFactory } from "./runtime.js";
 import { deserializeBlob } from "./serialization.js";
 import { SparseArray2D } from "./sparsearray2d.js";
 import { IUndoConsumer } from "./types.js";
@@ -77,7 +76,7 @@ export interface ISharedMatrixEvents<T> extends IEvent {
 	 *
 	 * - `conflictingValue` - The value that this client tried to set in the cell and got ignored due to conflict.
 	 *
-	 * - `target` - The {@link SharedMatrix} itself.
+	 * - `target` - The {@link ISharedMatrix} itself.
 	 */
 	(
 		event: "conflict",
@@ -105,12 +104,79 @@ export interface ISharedMatrix<T = any>
 		IMatrixProducer<MatrixItem<T>>,
 		IMatrixReader<MatrixItem<T>>,
 		IMatrixWriter<MatrixItem<T>> {
+	/**
+	 * Inserts columns into the matrix.
+	 * @param colStart - Index of the first column to insert.
+	 * @param count - Number of columns to insert.
+	 * @remarks
+	 * Inserting 0 columns is a noop.
+	 */
 	insertCols(colStart: number, count: number): void;
+	/**
+	 * Removes columns from the matrix.
+	 * @param colStart - Index of the first column to remove.
+	 * @param count - Number of columns to remove.
+	 * @remarks
+	 * Removing 0 columns is a noop.
+	 */
 	removeCols(colStart: number, count: number): void;
+	/**
+	 * Inserts rows into the matrix.
+	 * @param rowStart - Index of the first row to insert.
+	 * @param count - Number of rows to insert.
+	 * @remarks
+	 * Inserting 0 rows is a noop.
+	 */
 	insertRows(rowStart: number, count: number): void;
+	/**
+	 * Removes rows from the matrix.
+	 * @param rowStart - Index of the first row to remove.
+	 * @param count - Number of rows to remove.
+	 * @remarks
+	 * Removing 0 rows is a noop.
+	 */
 	removeRows(rowStart: number, count: number): void;
 
+	/**
+	 * Sets a range of cells in the matrix.
+	 * Cells are set in consecutive columns between `colStart` and `colStart + colCount - 1`.
+	 * When `values` has larger size than `colCount`, the extra values are inserted in subsequent rows
+	 * a la text-wrapping.
+	 * @param rowStart - Index of the row to start setting cells.
+	 * @param colStart - Index of the column to start setting cells.
+	 * @param colCount - Number of columns to set before wrapping to subsequent rows (if `values` has more items)
+	 * @param values - Values to insert.
+	 * @remarks
+	 * This is not currently more efficient than calling `setCell` for each cell.
+	 */
+	setCells(
+		rowStart: number,
+		colStart: number,
+		colCount: number,
+		values: readonly MatrixItem<T>[],
+	): void;
+
+	/**
+	 * Attach an {@link IUndoConsumer} to the matrix.
+	 * @param consumer - Undo consumer which will receive revertibles from the matrix.
+	 */
 	openUndo(consumer: IUndoConsumer): void;
+
+	/**
+	 * Whether the current conflict resolution policy is first-write win (FWW).
+	 * See {@link ISharedMatrix.switchSetCellPolicy} for more details.
+	 */
+	isSetCellConflictResolutionPolicyFWW(): boolean;
+
+	/**
+	 * Change the conflict resolution policy for setCell operations to first-write win (FWW).
+	 *
+	 * This API only switches from LWW to FWW and not from FWW to LWW.
+	 *
+	 * @privateRemarks
+	 * The next SetOp which is sent will communicate this policy to other clients.
+	 */
+	switchSetCellPolicy(): void;
 }
 
 /**
@@ -131,10 +197,6 @@ export class SharedMatrix<T = any>
 	implements ISharedMatrix<T>
 {
 	private readonly consumers = new Set<IMatrixConsumer<MatrixItem<T>>>();
-
-	public static getFactory() {
-		return new SharedMatrixFactory();
-	}
 
 	/**
 	 * Note: this field only provides a lower-bound on the reference sequence numbers for in-flight ops.
@@ -172,12 +234,10 @@ export class SharedMatrix<T = any>
 		runtime: IFluidDataStoreRuntime,
 		public id: string,
 		attributes: IChannelAttributes,
-		_isSetCellConflictResolutionPolicyFWW?: boolean,
 	) {
 		super(id, runtime, attributes, "fluid_matrix_");
 
-		this.setCellLwwToFwwPolicySwitchOpSeqNumber =
-			_isSetCellConflictResolutionPolicyFWW === true ? 0 : -1;
+		this.setCellLwwToFwwPolicySwitchOpSeqNumber = -1;
 		const getMinInFlightRefSeq = () => this.inFlightRefSeqs.get(0);
 		this.rows = new PermutationVector(
 			SnapshotPath.rows,
@@ -219,13 +279,6 @@ export class SharedMatrix<T = any>
 	}
 	private get colHandles() {
 		return this.cols.handleCache;
-	}
-
-	/**
-	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.create}
-	 */
-	public static create<T>(runtime: IFluidDataStoreRuntime, id?: string) {
-		return runtime.createChannel(id, SharedMatrixFactory.Type) as SharedMatrix<T>;
 	}
 
 	// #region IMatrixProducer
@@ -975,10 +1028,6 @@ export class SharedMatrix<T = any>
 		}
 	};
 
-	/**
-	 * Api to switch Set Op policy from Last Writer Win to First Writer Win. It only switches from LWW to FWW
-	 * and not from FWW to LWW. The next SetOp which is sent will communicate this policy to other clients.
-	 */
 	public switchSetCellPolicy() {
 		if (this.setCellLwwToFwwPolicySwitchOpSeqNumber === -1) {
 			if (this.isAttached()) {

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -3,12 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { IEvent, IEventProvider, IEventThisPlaceHolder } from "@fluidframework/core-interfaces";
+import {
+	IEvent,
+	IEventThisPlaceHolder,
+	type IEventProvider,
+} from "@fluidframework/core-interfaces";
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
 	IChannelAttributes,
 	IChannelStorageService,
 	IFluidDataStoreRuntime,
+	type IChannel,
 } from "@fluidframework/datastore-definitions";
 import {
 	// eslint-disable-next-line import/no-deprecated
@@ -103,7 +108,8 @@ export interface ISharedMatrix<T = any>
 	extends IEventProvider<ISharedMatrixEvents<T>>,
 		IMatrixProducer<MatrixItem<T>>,
 		IMatrixReader<MatrixItem<T>>,
-		IMatrixWriter<MatrixItem<T>> {
+		IMatrixWriter<MatrixItem<T>>,
+		IChannel {
 	/**
 	 * Inserts columns into the matrix.
 	 * @param colStart - Index of the first column to insert.

--- a/packages/dds/matrix/src/runtime.ts
+++ b/packages/dds/matrix/src/runtime.ts
@@ -10,13 +10,15 @@ import {
 	IChannelServices,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
+import type { ISharedObjectKind } from "@fluidframework/shared-object-base";
 
-import { type ISharedMatrix, SharedMatrix } from "./matrix.js";
+import { type ISharedMatrix, SharedMatrix as SharedMatrixClass } from "./matrix.js";
 import { pkgVersion } from "./packageVersion.js";
 
 /**
- * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link SharedMatrix}.
+ * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link ISharedMatrix}.
  * @alpha
+ * @deprecated - Use `SharedMatrix.getFactory` instead.
  */
 export class SharedMatrixFactory implements IChannelFactory<ISharedMatrix> {
 	public static Type = "https://graph.microsoft.com/types/sharedmatrix";
@@ -44,14 +46,37 @@ export class SharedMatrixFactory implements IChannelFactory<ISharedMatrix> {
 		services: IChannelServices,
 		attributes: IChannelAttributes,
 	): Promise<ISharedMatrix & IChannel> {
-		const matrix = new SharedMatrix(runtime, id, attributes);
+		const matrix = new SharedMatrixClass(runtime, id, attributes);
 		await matrix.load(services);
 		return matrix;
 	}
 
 	public create(document: IFluidDataStoreRuntime, id: string): ISharedMatrix & IChannel {
-		const matrix = new SharedMatrix(document, id, this.attributes);
+		const matrix = new SharedMatrixClass(document, id, this.attributes);
 		matrix.initializeLocal();
 		return matrix;
 	}
 }
+
+/**
+ * Entrypoint for {@link ISharedMatrix} creation.
+ * @alpha
+ */
+export const SharedMatrix: ISharedObjectKind<ISharedMatrix> = {
+	getFactory(): IChannelFactory<ISharedMatrix> {
+		return new SharedMatrixFactory();
+	},
+
+	create(runtime: IFluidDataStoreRuntime, id?: string): ISharedMatrix {
+		return runtime.createChannel(id, SharedMatrixFactory.Type) as ISharedMatrix & IChannel;
+	},
+};
+
+/**
+ * Convenience alias for {@link ISharedMatrix}. Prefer to use {@link ISharedMatrix} when referring to
+ * SharedMatrix as a type.
+ * @alpha
+ * @privateRemarks
+ * This alias is for legacy compat from when the SharedMatrix class was exported as public.
+ */
+export type SharedMatrix<T = any> = ISharedMatrix<T>;

--- a/packages/dds/matrix/src/test/matrix.applyStashedOp.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.applyStashedOp.spec.ts
@@ -14,9 +14,9 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { SharedMatrix, SharedMatrixFactory } from "../index.js";
+import { SharedMatrix } from "../matrix.js";
 
-import { extract } from "./utils.js";
+import { extract, matrixFactory } from "./utils.js";
 
 async function createMatrixForReconnection(
 	id: string,
@@ -37,12 +37,14 @@ async function createMatrixForReconnection(
 			summary !== undefined ? MockStorage.createFromSummary(summary) : new MockStorage(),
 	};
 
-	const matrix = new SharedMatrix(dataStoreRuntime, id, SharedMatrixFactory.Attributes);
+	let matrix: SharedMatrix;
 	if (summary !== undefined) {
-		await matrix.load(services);
+		matrix = await matrixFactory.load(dataStoreRuntime, id, services, matrixFactory.attributes);
 	} else {
+		matrix = matrixFactory.create(dataStoreRuntime, id);
 		matrix.connect(services);
 	}
+
 	return {
 		matrix,
 		containerRuntime,

--- a/packages/dds/matrix/src/test/matrix.applyStashedOp.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.applyStashedOp.spec.ts
@@ -14,7 +14,7 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { SharedMatrix } from "../matrix.js";
+import { SharedMatrix } from "../index.js";
 
 import { extract, matrixFactory } from "./utils.js";
 

--- a/packages/dds/matrix/src/test/matrix.big.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.big.spec.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "assert";
+
 import { AttachState } from "@fluidframework/container-definitions";
 import { IChannelServices } from "@fluidframework/datastore-definitions";
 import {
@@ -12,9 +14,10 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { SharedMatrix, SharedMatrixFactory } from "../index.js";
+import { SharedMatrix } from "../index.js";
+import { SharedMatrix as SharedMatrixClass } from "../matrix.js";
 
-import { checkCorners, expectSize, setCorners } from "./utils.js";
+import { checkCorners, expectSize, setCorners, matrixFactory } from "./utils.js";
 
 const enum Const {
 	// https://support.office.com/en-us/article/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3
@@ -24,29 +27,28 @@ const enum Const {
 
 // Summarizes the given `SharedMatrix`, loads the summary into a 2nd SharedMatrix, vets that the two are
 // equivalent, and then returns the 2nd matrix.
-async function summarize<T>(matrix: SharedMatrix<T>) {
+async function summarize<T>(matrix: SharedMatrix<T>): Promise<SharedMatrix<T>> {
+	assert(matrix instanceof SharedMatrixClass);
 	// Create a summary
 	const objectStorage = MockStorage.createFromSummary(matrix.getAttachSummary().summary);
 
 	// Create a local DataStoreRuntime since we only want to load the summary for a local client.
 	const dataStoreRuntime = new MockFluidDataStoreRuntime({ attachState: AttachState.Detached });
 
-	// Load the summary into a newly created 2nd SharedMatrix.
-	const matrix2 = new SharedMatrix<T>(
+	const matrix2 = await matrixFactory.load(
 		dataStoreRuntime,
 		`load(${matrix.id})`,
-		SharedMatrixFactory.Attributes,
-		matrix.isSetCellConflictResolutionPolicyFWW(),
+		{
+			deltaConnection: new MockEmptyDeltaConnection(),
+			objectStorage,
+		},
+		matrixFactory.attributes,
 	);
-	await matrix2.load({
-		deltaConnection: new MockEmptyDeltaConnection(),
-		objectStorage,
-	});
 
 	// Vet that the 2nd matrix is equivalent to the original.
 	expectSize(matrix2, matrix.rowCount, matrix.colCount);
 
-	return matrix2;
+	return matrix2 as SharedMatrix<T>;
 }
 
 [false, true].forEach((isSetCellPolicyFWW: boolean) => {
@@ -54,8 +56,8 @@ async function summarize<T>(matrix: SharedMatrix<T>) {
 		this.timeout(10000);
 
 		describe(`Excel-size matrix (${Const.excelMaxRows}x${Const.excelMaxCols})`, () => {
-			let matrix1: SharedMatrix;
-			let matrix2: SharedMatrix;
+			let matrix1: SharedMatrixClass;
+			let matrix2: SharedMatrixClass;
 			let dataStoreRuntime1: MockFluidDataStoreRuntime;
 			let containerRuntimeFactory: MockContainerRuntimeFactory;
 
@@ -70,12 +72,11 @@ async function summarize<T>(matrix: SharedMatrix<T>) {
 					deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
-				matrix1 = new SharedMatrix(
-					dataStoreRuntime1,
-					"matrix1",
-					SharedMatrixFactory.Attributes,
-					isSetCellPolicyFWW,
-				);
+
+				matrix1 = matrixFactory.create(dataStoreRuntime1, "matrix1");
+				if (isSetCellPolicyFWW) {
+					matrix1.switchSetCellPolicy();
+				}
 				matrix1.connect(services1);
 
 				// Create and connect the second SharedMatrix.
@@ -86,12 +87,10 @@ async function summarize<T>(matrix: SharedMatrix<T>) {
 					deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 					objectStorage: new MockStorage(),
 				};
-				matrix2 = new SharedMatrix(
-					dataStoreRuntime2,
-					"matrix2",
-					SharedMatrixFactory.Attributes,
-					isSetCellPolicyFWW,
-				);
+				matrix2 = matrixFactory.create(dataStoreRuntime2, "matrix2");
+				if (isSetCellPolicyFWW) {
+					matrix2.switchSetCellPolicy();
+				}
 				matrix2.connect(services2);
 			});
 
@@ -215,12 +214,10 @@ async function summarize<T>(matrix: SharedMatrix<T>) {
 				const dataStoreRuntime = new MockFluidDataStoreRuntime({
 					attachState: AttachState.Detached,
 				});
-				matrix = new SharedMatrix(
-					dataStoreRuntime,
-					"matrix1",
-					SharedMatrixFactory.Attributes,
-					isSetCellPolicyFWW,
-				);
+				matrix = matrixFactory.create(dataStoreRuntime, "matrix1");
+				if (isSetCellPolicyFWW) {
+					matrix.switchSetCellPolicy();
+				}
 			});
 
 			it("summarize", async () => {

--- a/packages/dds/matrix/src/test/matrix.big.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.big.spec.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
-
 import { AttachState } from "@fluidframework/container-definitions";
 import { IChannelServices } from "@fluidframework/datastore-definitions";
 import {
@@ -15,7 +13,6 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 
 import { SharedMatrix } from "../index.js";
-import { SharedMatrix as SharedMatrixClass } from "../matrix.js";
 
 import { checkCorners, expectSize, setCorners, matrixFactory } from "./utils.js";
 
@@ -28,7 +25,6 @@ const enum Const {
 // Summarizes the given `SharedMatrix`, loads the summary into a 2nd SharedMatrix, vets that the two are
 // equivalent, and then returns the 2nd matrix.
 async function summarize<T>(matrix: SharedMatrix<T>): Promise<SharedMatrix<T>> {
-	assert(matrix instanceof SharedMatrixClass);
 	// Create a summary
 	const objectStorage = MockStorage.createFromSummary(matrix.getAttachSummary().summary);
 
@@ -48,7 +44,7 @@ async function summarize<T>(matrix: SharedMatrix<T>): Promise<SharedMatrix<T>> {
 	// Vet that the 2nd matrix is equivalent to the original.
 	expectSize(matrix2, matrix.rowCount, matrix.colCount);
 
-	return matrix2 as SharedMatrix<T>;
+	return matrix2;
 }
 
 [false, true].forEach((isSetCellPolicyFWW: boolean) => {
@@ -56,8 +52,8 @@ async function summarize<T>(matrix: SharedMatrix<T>): Promise<SharedMatrix<T>> {
 		this.timeout(10000);
 
 		describe(`Excel-size matrix (${Const.excelMaxRows}x${Const.excelMaxCols})`, () => {
-			let matrix1: SharedMatrixClass;
-			let matrix2: SharedMatrixClass;
+			let matrix1: SharedMatrix;
+			let matrix2: SharedMatrix;
 			let dataStoreRuntime1: MockFluidDataStoreRuntime;
 			let containerRuntimeFactory: MockContainerRuntimeFactory;
 

--- a/packages/dds/matrix/src/test/matrix.reconnect.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.reconnect.spec.ts
@@ -11,9 +11,9 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { SharedMatrix } from "../matrix.js";
+import { SharedMatrix } from "../runtime.js";
 
-import { extract } from "./utils.js";
+import { extract, matrixFactory } from "./utils.js";
 
 describe("SharedMatrix reconnect", () => {
 	/**
@@ -25,20 +25,19 @@ describe("SharedMatrix reconnect", () => {
 	 * make sure positions are rebased appropriately).
 	 */
 	it("rebase setCell in inserted column with overlapping remove", () => {
-		const factory = SharedMatrix.getFactory();
 		const containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 		const dataRuntime1 = new MockFluidDataStoreRuntime();
 		containerRuntimeFactory.createContainerRuntime(dataRuntime1);
 		const dataRuntime2 = new MockFluidDataStoreRuntime();
 		const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataRuntime2);
 
-		const matrix1 = factory.create(dataRuntime1, "A") as SharedMatrix<number>;
+		const matrix1 = matrixFactory.create(dataRuntime1, "A");
 		matrix1.connect({
 			deltaConnection: dataRuntime1.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		});
 
-		const matrix2 = factory.create(dataRuntime2, "B") as SharedMatrix<number>;
+		const matrix2 = matrixFactory.create(dataRuntime2, "B");
 		matrix2.connect({
 			deltaConnection: dataRuntime2.createDeltaConnection(),
 			objectStorage: new MockStorage(),
@@ -78,20 +77,19 @@ describe("SharedMatrix reconnect", () => {
 	});
 
 	it("discards setCell in removed column", () => {
-		const factory = SharedMatrix.getFactory();
 		const containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 		const dataRuntime1 = new MockFluidDataStoreRuntime();
 		containerRuntimeFactory.createContainerRuntime(dataRuntime1);
 		const dataRuntime2 = new MockFluidDataStoreRuntime();
 		const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataRuntime2);
 
-		const matrix1 = factory.create(dataRuntime1, "A") as SharedMatrix<number>;
+		const matrix1 = matrixFactory.create(dataRuntime1, "A");
 		matrix1.connect({
 			deltaConnection: dataRuntime1.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		});
 
-		const matrix2 = factory.create(dataRuntime2, "B") as SharedMatrix<number>;
+		const matrix2 = matrixFactory.create(dataRuntime2, "B");
 		matrix2.connect({
 			deltaConnection: dataRuntime2.createDeltaConnection(),
 			objectStorage: new MockStorage(),
@@ -140,12 +138,12 @@ describe("SharedMatrix reconnect", () => {
 		const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataRuntime1);
 		const dataRuntime2 = new MockFluidDataStoreRuntime();
 		const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataRuntime2);
-		const matrix1 = factory.create(dataRuntime1, "A") as SharedMatrix<number>;
+		const matrix1 = matrixFactory.create(dataRuntime1, "A");
 		matrix1.connect({
 			deltaConnection: dataRuntime1.createDeltaConnection(),
 			objectStorage: new MockStorage(),
 		});
-		const matrix2 = factory.create(dataRuntime2, "B") as SharedMatrix<number>;
+		const matrix2 = matrixFactory.create(dataRuntime2, "B");
 		matrix2.connect({
 			deltaConnection: dataRuntime2.createDeltaConnection(),
 			objectStorage: new MockStorage(),
@@ -180,7 +178,6 @@ describe("SharedMatrix reconnect", () => {
 	// account in-flight ops.
 	// See "client.applyMsg updates minSeq" in merge-tree's test suite for a lower-level unit test of some relevant behavior.
 	it("avoids zamboni of information required to resubmit", async () => {
-		const factory = SharedMatrix.getFactory();
 		const containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
 		const dataRuntime1 = new MockFluidDataStoreRuntime();
 		const containerRuntime1 = containerRuntimeFactory.createContainerRuntime(dataRuntime1);
@@ -188,7 +185,7 @@ describe("SharedMatrix reconnect", () => {
 		const containerRuntime2 = containerRuntimeFactory.createContainerRuntime(dataRuntime2);
 		const dataRuntime3 = new MockFluidDataStoreRuntime();
 		const containerRuntime3 = containerRuntimeFactory.createContainerRuntime(dataRuntime3);
-		const matrix1 = factory.create(dataRuntime1, "A") as SharedMatrix<number>;
+		const matrix1 = matrixFactory.create(dataRuntime1, "A");
 
 		matrix1.insertCols(0, 2);
 		const { summary } = matrix1.getAttachSummary();
@@ -197,24 +194,24 @@ describe("SharedMatrix reconnect", () => {
 			objectStorage: new MockStorage(),
 		});
 
-		const matrix2 = (await factory.load(
+		const matrix2 = await matrixFactory.load(
 			dataRuntime2,
 			"B",
 			{
 				deltaConnection: dataRuntime2.createDeltaConnection(),
 				objectStorage: MockStorage.createFromSummary(summary),
 			},
-			factory.attributes,
-		)) as SharedMatrix<number>;
-		const matrix3 = (await factory.load(
+			matrixFactory.attributes,
+		);
+		const matrix3 = await matrixFactory.load(
 			dataRuntime3,
 			"C",
 			{
 				deltaConnection: dataRuntime3.createDeltaConnection(),
 				objectStorage: MockStorage.createFromSummary(summary),
 			},
-			factory.attributes,
-		)) as SharedMatrix<number>;
+			matrixFactory.attributes,
+		);
 
 		containerRuntime3.connected = false;
 		containerRuntime1.connected = false;

--- a/packages/dds/matrix/src/test/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.spec.ts
@@ -82,7 +82,6 @@ describe("Matrix1", () => {
 				// Summarizes the given `SharedMatrix`, loads the summarize into a 2nd SharedMatrix, vets that the two are
 				// equivalent, and then returns the 2nd matrix.
 				async function summarize<T>(matrix: SharedMatrix<T>) {
-					assert(matrix instanceof SharedMatrixClass);
 					// Create a summary
 					const objectStorage = MockStorage.createFromSummary(
 						matrix.getAttachSummary().summary,
@@ -124,10 +123,7 @@ describe("Matrix1", () => {
 				}
 
 				beforeEach("createMatrix", async () => {
-					matrix = matrixFactory.create(
-						new MockFluidDataStoreRuntime(),
-						"matrix1",
-					) as SharedMatrix<number>;
+					matrix = matrixFactory.create(new MockFluidDataStoreRuntime(), "matrix1");
 					if (isSetCellPolicyFWW) {
 						matrix.switchSetCellPolicy();
 					}
@@ -1068,22 +1064,27 @@ describe("Matrix1", () => {
 					private colCount = 0;
 					private subMatrixCount = 0;
 					private _expectedRoutes: string[] = [];
+					// The GC test harness requires a SharedObject, not just ISharedObject.
 					private readonly matrix1: SharedMatrixClass;
 					private readonly matrix2: SharedMatrixClass;
 					private readonly containerRuntimeFactory: MockContainerRuntimeFactory;
 
 					constructor() {
 						this.containerRuntimeFactory = new MockContainerRuntimeFactory();
-						this.matrix1 = createConnectedMatrix(
+						const matrix1 = createConnectedMatrix(
 							"matrix1",
 							this.containerRuntimeFactory,
 							isSetCellPolicyFWW,
 						);
-						this.matrix2 = createConnectedMatrix(
+						assert(matrix1 instanceof SharedMatrixClass);
+						this.matrix1 = matrix1;
+						const matrix2 = createConnectedMatrix(
 							"matrix2",
 							this.containerRuntimeFactory,
 							isSetCellPolicyFWW,
 						);
+						assert(matrix2 instanceof SharedMatrixClass);
+						this.matrix2 = matrix2;
 						// Insert a row into the matrix where we will set cells.
 						this.matrix1.insertRows(0, 1);
 					}
@@ -1224,7 +1225,6 @@ describe("Matrix1", () => {
 				containerRuntime: MockContainerRuntimeForReconnection;
 				consumer: TestConsumer;
 			}> {
-				assert(matrix instanceof SharedMatrixClass);
 				// Create a summary
 				const objectStorage = MockStorage.createFromSummary(
 					matrix.getAttachSummary().summary,
@@ -1299,8 +1299,7 @@ describe("Matrix1", () => {
 					assert(col === 0, "col should be correct");
 					assert(currentVal === "A", "currentVal should be correct");
 					assert(rejectedVal === "B", "rejectedVal should be correct");
-					assert(instance instanceof SharedMatrixClass);
-					assert((instance.id = "matrix2"), "matrix should be correct");
+					assert(instance.id === "matrix2", "matrix should be correct");
 					eventRaised = true;
 				});
 
@@ -1371,8 +1370,7 @@ describe("Matrix1", () => {
 					assert(col === 0, "col should be correct");
 					assert(currentVal === "A", "currentVal should be correct");
 					assert(rejectedVal === "B", "rejectedVal should be correct");
-					assert(instance instanceof SharedMatrixClass);
-					assert((instance.id = "matrix2"), "matrix should be correct");
+					assert(instance.id === "matrix2", "matrix should be correct");
 					eventRaised = true;
 				});
 
@@ -1492,8 +1490,7 @@ describe("Matrix1", () => {
 						rejectedVal === (eventRaisedCount === 0 ? "4th" : "1st"),
 						"rejectedVal should be correct",
 					);
-					assert(instance instanceof SharedMatrixClass);
-					assert((instance.id = "matrix2"), "matrix should be correct");
+					assert(instance.id === "matrix2", "matrix should be correct");
 					eventRaisedCount++;
 				});
 
@@ -1529,8 +1526,7 @@ describe("Matrix1", () => {
 				matrix2.on("conflict", (row, col, currentVal, rejectedVal, instance) => {
 					assert(row === 0, "row should be correct");
 					assert(col === 0, "col should be correct");
-					assert(instance instanceof SharedMatrixClass);
-					assert((instance.id = "matrix2"), "matrix should be correct");
+					assert(instance.id === "matrix2", "matrix should be correct");
 					eventRaisedCount++;
 				});
 

--- a/packages/dds/matrix/src/test/matrix.stress.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.stress.spec.ts
@@ -104,12 +104,12 @@ import { expectSize, extract, matrixFactory } from "./utils.js";
 						undoProbability === 0 ? undefined : [];
 
 					containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
-					let summarizer: SharedMatrixClass | undefined;
+					let summarizer: SharedMatrix | undefined;
 
 					// Summarizes the given `SharedMatrix`, loads the summarize into a 2nd SharedMatrix, vets that the two are
 					// equivalent, and then returns the 2nd matrix.
 					const createNewClientFromSummary = async function summarize<T>(
-						summarizer: SharedMatrixClass<T>,
+						summarizer: SharedMatrix<T>,
 					) {
 						// Create a summary
 						const objectStorage = MockStorage.createFromSummary(

--- a/packages/dds/matrix/src/test/matrix.stress.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.stress.spec.ts
@@ -14,10 +14,11 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 import { Random } from "best-random";
 
-import { SharedMatrix, SharedMatrixFactory } from "../index.js";
+import { SharedMatrix } from "../index.js";
+import { SharedMatrix as SharedMatrixClass } from "../matrix.js";
 
 import { UndoRedoStackManager } from "./undoRedoStackManager.js";
-import { expectSize, extract } from "./utils.js";
+import { expectSize, extract, matrixFactory } from "./utils.js";
 
 /**
  * 0 means use LWW.
@@ -31,6 +32,12 @@ import { expectSize, extract } from "./utils.js";
 			let runtimes: MockContainerRuntimeForReconnection[] = [];
 			let trace: string[]; // Repro steps to be printed if a failure is encountered.
 			let matrixTrace: string[];
+
+			const logMatrix = (matrix: SharedMatrix) => {
+				// This avoids @typescript-eslint/no-base-to-string.
+				assert(matrix instanceof SharedMatrixClass);
+				matrixTrace.push(matrix.toString());
+			};
 
 			/**
 			 * Drains the queue of pending ops for each client and vets that all matrices converged on the same state.
@@ -97,12 +104,12 @@ import { expectSize, extract } from "./utils.js";
 						undoProbability === 0 ? undefined : [];
 
 					containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
-					let summarizer: SharedMatrix | undefined;
+					let summarizer: SharedMatrixClass | undefined;
 
 					// Summarizes the given `SharedMatrix`, loads the summarize into a 2nd SharedMatrix, vets that the two are
 					// equivalent, and then returns the 2nd matrix.
 					const createNewClientFromSummary = async function summarize<T>(
-						summarizer: SharedMatrix<T>,
+						summarizer: SharedMatrixClass<T>,
 					) {
 						// Create a summary
 						const objectStorage = MockStorage.createFromSummary(
@@ -120,13 +127,12 @@ import { expectSize, extract } from "./utils.js";
 							objectStorage,
 						};
 
-						const matrixN = new SharedMatrix(
+						const matrixN = await matrixFactory.load(
 							dataStoreRuntime,
 							`matrix-${matrices.length}`,
-							SharedMatrixFactory.Attributes,
+							servicesN,
+							matrixFactory.attributes,
 						);
-						await matrixN.load(servicesN);
-						matrixN.connect(servicesN);
 						if (undoRedoStacks) {
 							const undoRedo = new UndoRedoStackManager();
 							matrixN.openUndo(undoRedo);
@@ -155,12 +161,14 @@ import { expectSize, extract } from "./utils.js";
 							objectStorage: new MockStorage(),
 						};
 
-						const matrixN = new SharedMatrix(
+						const matrixN = matrixFactory.create(
 							dataStoreRuntimeN,
 							i === numClients ? "summarizer" : `matrix-${i}`,
-							SharedMatrixFactory.Attributes,
-							isSetCellPolicyFWW === 1 ? true : false,
 						);
+						if (isSetCellPolicyFWW === 1) {
+							matrixN.switchSetCellPolicy();
+						}
+
 						matrixN.connect(servicesN);
 						if (i < numClients) {
 							if (undoRedoStacks) {
@@ -239,9 +247,10 @@ import { expectSize, extract } from "./utils.js";
 
 					assert(summarizer !== undefined);
 					for (const m of matrices) {
-						matrixTrace.push(m.toString());
-						matrixTrace.push(summarizer.toString());
+						logMatrix(m);
 					}
+					logMatrix(summarizer);
+
 					// Loop for the prescribed number of iterations, randomly mutating one of matrices with one
 					// of the following operations:
 					//
@@ -415,9 +424,9 @@ import { expectSize, extract } from "./utils.js";
 							await expect();
 							matrixTrace = [];
 							for (const m of matrices) {
-								matrixTrace.push(m.toString());
-								matrixTrace.push(summarizer.toString());
+								logMatrix(m);
 							}
+							logMatrix(summarizer);
 						}
 					}
 
@@ -435,6 +444,7 @@ import { expectSize, extract } from "./utils.js";
 					}
 
 					for (const m of matrices) {
+						assert(m instanceof SharedMatrixClass);
 						console.log(
 							`Matrix id=${
 								m.id
@@ -444,6 +454,7 @@ import { expectSize, extract } from "./utils.js";
 
 					// Also dump the current state of the matrices.
 					for (const m of matrices) {
+						// eslint-disable-next-line @typescript-eslint/no-base-to-string
 						console.log(m.toString());
 					}
 
@@ -655,6 +666,7 @@ import { expectSize, extract } from "./utils.js";
 					);
 
 					// Note: Mocha reporter intercepts 'console.log()' so use 'process.stdout.write' instead.
+					// eslint-disable-next-line @typescript-eslint/no-base-to-string
 					process.stdout.write(matrices[0].toString());
 
 					process.stdout.write(

--- a/packages/dds/matrix/src/test/matrix.undo.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.undo.spec.ts
@@ -13,11 +13,12 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { MatrixItem, SharedMatrix, SharedMatrixFactory } from "../index.js";
+import { MatrixItem } from "../index.js";
+import { SharedMatrix } from "../matrix.js";
 
 import { TestConsumer } from "./testconsumer.js";
 import { UndoRedoStackManager } from "./undoRedoStackManager.js";
-import { expectSize, extract } from "./utils.js";
+import { expectSize, extract, matrixFactory } from "./utils.js";
 
 [false, true].forEach((isSetCellPolicyFWW: boolean) => {
 	describe(`Matrix isSetCellPolicyFWW=${isSetCellPolicyFWW}`, () => {
@@ -419,16 +420,15 @@ import { expectSize, extract } from "./utils.js";
 					});
 
 					// Load the summary into a newly created 2nd SharedMatrix.
-					const matrix2 = new SharedMatrix<T>(
+					const matrix2 = await matrixFactory.load(
 						dataStoreRuntime,
 						`load(${matrix.id})`,
-						SharedMatrixFactory.Attributes,
-						isSetCellPolicyFWW,
+						{
+							deltaConnection: new MockEmptyDeltaConnection(),
+							objectStorage,
+						},
+						matrixFactory.attributes,
 					);
-					await matrix2.load({
-						deltaConnection: new MockEmptyDeltaConnection(),
-						objectStorage,
-					});
 
 					// Vet that the 2nd matrix is equivalent to the original.
 					//
@@ -458,12 +458,10 @@ import { expectSize, extract } from "./utils.js";
 
 				beforeEach("createMatrix", async () => {
 					dataStoreRuntime = new MockFluidDataStoreRuntime();
-					matrix1 = new SharedMatrix(
-						dataStoreRuntime,
-						"matrix1",
-						SharedMatrixFactory.Attributes,
-						isSetCellPolicyFWW,
-					);
+					matrix1 = matrixFactory.create(dataStoreRuntime, "matrix1");
+					if (isSetCellPolicyFWW) {
+						matrix1.switchSetCellPolicy();
+					}
 
 					// Attach a new IMatrixConsumer
 					consumer1 = new TestConsumer(matrix1);
@@ -528,12 +526,11 @@ import { expectSize, extract } from "./utils.js";
 
 					// Create and connect the first SharedMatrix.
 					const dataStoreRuntime1 = new MockFluidDataStoreRuntime();
-					matrix1 = new SharedMatrix(
-						dataStoreRuntime1,
-						"matrix1",
-						SharedMatrixFactory.Attributes,
-						isSetCellPolicyFWW,
-					);
+					matrix1 = matrixFactory.create(dataStoreRuntime1, "matrix1");
+					if (isSetCellPolicyFWW) {
+						matrix1.switchSetCellPolicy();
+					}
+
 					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
 					matrix1.connect({
 						deltaConnection: dataStoreRuntime1.createDeltaConnection(),
@@ -545,12 +542,11 @@ import { expectSize, extract } from "./utils.js";
 
 					// Create and connect the second SharedMatrix.
 					const dataStoreRuntime2 = new MockFluidDataStoreRuntime();
-					matrix2 = new SharedMatrix(
-						dataStoreRuntime2,
-						"matrix2",
-						SharedMatrixFactory.Attributes,
-						isSetCellPolicyFWW,
-					);
+					matrix2 = matrixFactory.create(dataStoreRuntime2, "matrix2");
+					if (isSetCellPolicyFWW) {
+						matrix2.switchSetCellPolicy();
+					}
+
 					containerRuntimeFactory.createContainerRuntime(dataStoreRuntime2);
 					matrix2.connect({
 						deltaConnection: dataStoreRuntime2.createDeltaConnection(),

--- a/packages/dds/matrix/src/test/matrix.undo.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.undo.spec.ts
@@ -13,8 +13,7 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { MatrixItem } from "../index.js";
-import { SharedMatrix } from "../matrix.js";
+import { MatrixItem, SharedMatrix } from "../index.js";
 
 import { TestConsumer } from "./testconsumer.js";
 import { UndoRedoStackManager } from "./undoRedoStackManager.js";

--- a/packages/dds/matrix/src/test/memory/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/matrix.spec.ts
@@ -7,9 +7,10 @@ import { IMemoryTestObject, benchmarkMemory } from "@fluid-tools/benchmark";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import { SharedMatrix, SharedMatrixFactory } from "../../index.js";
+import { SharedMatrix as SharedMatrixClass } from "../../matrix.js";
 
 function createLocalMatrix(id: string) {
-	return new SharedMatrix(
+	return new SharedMatrixClass(
 		new MockFluidDataStoreRuntime(),
 		"matrix1",
 		SharedMatrixFactory.Attributes,

--- a/packages/dds/matrix/src/test/memory/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/matrix.spec.ts
@@ -6,15 +6,11 @@
 import { IMemoryTestObject, benchmarkMemory } from "@fluid-tools/benchmark";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
-import { SharedMatrix, SharedMatrixFactory } from "../../index.js";
-import { SharedMatrix as SharedMatrixClass } from "../../matrix.js";
+import { SharedMatrix } from "../../index.js";
+import { matrixFactory } from "../utils.js";
 
 function createLocalMatrix(id: string) {
-	return new SharedMatrixClass(
-		new MockFluidDataStoreRuntime(),
-		"matrix1",
-		SharedMatrixFactory.Attributes,
-	);
+	return matrixFactory.create(new MockFluidDataStoreRuntime(), id);
 }
 
 describe("Matrix memory usage", () => {

--- a/packages/dds/matrix/src/test/types/validateMatrixPrevious.generated.ts
+++ b/packages/dds/matrix/src/test/types/validateMatrixPrevious.generated.ts
@@ -122,26 +122,20 @@ use_old_TypeAliasDeclaration_MatrixItem(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_SharedMatrix": {"forwardCompat": false}
+* "RemovedClassDeclaration_SharedMatrix": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_SharedMatrix():
     TypeOnly<old.SharedMatrix>;
-declare function use_current_ClassDeclaration_SharedMatrix(
+declare function use_current_RemovedClassDeclaration_SharedMatrix(
     use: TypeOnly<current.SharedMatrix>): void;
-use_current_ClassDeclaration_SharedMatrix(
+use_current_RemovedClassDeclaration_SharedMatrix(
     get_old_ClassDeclaration_SharedMatrix());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_SharedMatrix": {"backCompat": false}
+* "RemovedClassDeclaration_SharedMatrix": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_SharedMatrix():
-    TypeOnly<current.SharedMatrix>;
-declare function use_old_ClassDeclaration_SharedMatrix(
-    use: TypeOnly<old.SharedMatrix>): void;
-use_old_ClassDeclaration_SharedMatrix(
-    get_current_ClassDeclaration_SharedMatrix());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/dds/matrix/src/test/utils.ts
+++ b/packages/dds/matrix/src/test/utils.ts
@@ -6,43 +6,13 @@
 import { strict as assert } from "assert";
 
 import { IMatrixConsumer, IMatrixProducer, IMatrixReader, IMatrixWriter } from "@tiny-calc/nano";
-import type {
-	IFluidDataStoreRuntime,
-	IChannelServices,
-	IChannelAttributes,
-	IChannel,
-} from "@fluidframework/datastore-definitions";
 
-import { SharedMatrix, SharedMatrixFactory } from "../index.js";
-import { SharedMatrix as SharedMatrixClass } from "../matrix.js";
-
-class TestMatrixFactory extends SharedMatrixFactory {
-	public async load(
-		runtime: IFluidDataStoreRuntime,
-		id: string,
-		services: IChannelServices,
-		attributes: IChannelAttributes,
-	): Promise<SharedMatrixClass & IChannel> {
-		const result = await super.load(runtime, id, services, attributes);
-		assert(result instanceof SharedMatrixClass);
-		return result;
-	}
-
-	public create(runtime: IFluidDataStoreRuntime, id: string): SharedMatrixClass {
-		const result = super.create(runtime, id);
-		assert(result instanceof SharedMatrixClass);
-		return result;
-	}
-}
+import { SharedMatrix } from "../index.js";
 
 /**
- * A factory for creating SharedMatrix instances.
- *
- * Unlike the production factory, this factory is typed to return the concrete SharedMatrix class.
- * This allows unit testing aspects of the DDS that aren't exposed to FF consumers without additional casting,
- * like summarization and the load/attach flow.
+ * Convenience export of SharedMatrix's factory for usage in tests.
  */
-export const matrixFactory = new TestMatrixFactory();
+export const matrixFactory = SharedMatrix.getFactory();
 
 export type IMatrix<T> = IMatrixReader<T> & IMatrixWriter<T>;
 

--- a/packages/dds/matrix/src/test/utils.ts
+++ b/packages/dds/matrix/src/test/utils.ts
@@ -6,8 +6,43 @@
 import { strict as assert } from "assert";
 
 import { IMatrixConsumer, IMatrixProducer, IMatrixReader, IMatrixWriter } from "@tiny-calc/nano";
+import type {
+	IFluidDataStoreRuntime,
+	IChannelServices,
+	IChannelAttributes,
+	IChannel,
+} from "@fluidframework/datastore-definitions";
 
-import { SharedMatrix } from "../index.js";
+import { SharedMatrix, SharedMatrixFactory } from "../index.js";
+import { SharedMatrix as SharedMatrixClass } from "../matrix.js";
+
+class TestMatrixFactory extends SharedMatrixFactory {
+	public async load(
+		runtime: IFluidDataStoreRuntime,
+		id: string,
+		services: IChannelServices,
+		attributes: IChannelAttributes,
+	): Promise<SharedMatrixClass & IChannel> {
+		const result = await super.load(runtime, id, services, attributes);
+		assert(result instanceof SharedMatrixClass);
+		return result;
+	}
+
+	public create(runtime: IFluidDataStoreRuntime, id: string): SharedMatrixClass {
+		const result = super.create(runtime, id);
+		assert(result instanceof SharedMatrixClass);
+		return result;
+	}
+}
+
+/**
+ * A factory for creating SharedMatrix instances.
+ *
+ * Unlike the production factory, this factory is typed to return the concrete SharedMatrix class.
+ * This allows unit testing aspects of the DDS that aren't exposed to FF consumers without additional casting,
+ * like summarization and the load/attach flow.
+ */
+export const matrixFactory = new TestMatrixFactory();
 
 export type IMatrix<T> = IMatrixReader<T> & IMatrixWriter<T>;
 

--- a/packages/framework/undo-redo/src/test/matrix.spec.ts
+++ b/packages/framework/undo-redo/src/test/matrix.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 
-import { SharedMatrix, SharedMatrixFactory } from "@fluidframework/matrix/internal";
+import { SharedMatrix } from "@fluidframework/matrix/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import { UndoRedoStackManager } from "../undoRedoStackManager.js";
@@ -21,7 +21,8 @@ describe("Matrix", () => {
 
 	beforeEach(async () => {
 		dataStoreRuntime = new MockFluidDataStoreRuntime();
-		matrix = new SharedMatrix(dataStoreRuntime, "matrix1", SharedMatrixFactory.Attributes);
+		const matrixFactory = SharedMatrix.getFactory();
+		matrix = matrixFactory.create(dataStoreRuntime, "matrix1");
 
 		undo = new UndoRedoStackManager();
 		matrix.openUndo(undo);

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { describeCompat } from "@fluid-private/test-version-utils";
-import { SharedMatrix, SharedMatrixFactory } from "@fluidframework/matrix/internal";
+import { SharedMatrix } from "@fluidframework/matrix/internal";
 import { SharedString, SharedStringFactory } from "@fluidframework/sequence/internal";
 import {
 	MockContainerRuntimeFactory,
@@ -13,12 +13,10 @@ import {
 
 import { IBenchmarkParameters, benchmarkAll } from "./DocumentCreator.js";
 
+const matrixFactory = SharedMatrix.getFactory();
+
 function createLocalMatrix(id: string, dataStoreRuntime: MockFluidDataStoreRuntime) {
-	return new SharedMatrix<SharedString["handle"]>(
-		dataStoreRuntime,
-		"matrix1",
-		SharedMatrixFactory.Attributes,
-	);
+	return matrixFactory.create(dataStoreRuntime, id);
 }
 
 function createString(id: string, dataStoreRuntime: MockFluidDataStoreRuntime) {

--- a/packages/test/test-version-utils/api-report/test-version-utils.api.md
+++ b/packages/test/test-version-utils/api-report/test-version-utils.api.md
@@ -88,7 +88,7 @@ export const DataRuntimeApi: {
         SharedCounter: typeof counter.SharedCounter;
         SharedDirectory: ISharedObjectKind<map.ISharedDirectory>;
         SharedMap: ISharedObjectKind<map.ISharedMap>;
-        SharedMatrix: typeof matrix.SharedMatrix;
+        SharedMatrix: ISharedObjectKind<matrix.ISharedMatrix<any>>;
         ConsensusQueue: typeof orderedCollection.ConsensusQueue;
         ConsensusRegisterCollection: typeof registerCollection.ConsensusRegisterCollection;
         SharedString: typeof sequence.SharedString;

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
@@ -203,7 +203,7 @@ export const visualizeSharedMatrix: VisualizeSharedObject = async (
 	sharedObject: ISharedObject,
 	visualizeChildData: VisualizeChildData,
 ): Promise<FluidObjectTreeNode> => {
-	const sharedMatrix = sharedObject as SharedMatrix;
+	const sharedMatrix = sharedObject as unknown as SharedMatrix;
 
 	const { rowCount, colCount: columnCount, id: fluidObjectId } = sharedMatrix;
 

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
@@ -288,11 +288,7 @@ describe("DefaultVisualizers unit tests", () => {
 
 	it("SharedMatrix", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
-		const sharedMatrix = new SharedMatrix(
-			runtime,
-			"test-matrix",
-			SharedMatrix.getFactory().attributes,
-		);
+		const sharedMatrix = SharedMatrix.getFactory().create(runtime, "test-matrix");
 		sharedMatrix.insertRows(0, 2);
 		sharedMatrix.insertCols(0, 3);
 		sharedMatrix.setCell(0, 0, "Hello");
@@ -306,7 +302,10 @@ describe("DefaultVisualizers unit tests", () => {
 			c: false,
 		});
 
-		const result = await visualizeSharedMatrix(sharedMatrix, visualizeChildData);
+		const result = await visualizeSharedMatrix(
+			sharedMatrix as unknown as ISharedObject,
+			visualizeChildData,
+		);
 
 		const expected: FluidObjectTreeNode = {
 			fluidObjectId: "test-matrix",

--- a/packages/tools/replay-tool/src/replayMessages.ts
+++ b/packages/tools/replay-tool/src/replayMessages.ts
@@ -910,15 +910,16 @@ async function assertDdsEqual(
 
 	async function newMatrix(summary: ISummaryTree): Promise<SharedMatrix> {
 		const objectStorage = MockStorage.createFromSummary(summary);
-		const matrix = new SharedMatrix(
-			dataStoreRuntime as any,
+		const matrixFactory = SharedMatrix.getFactory();
+		const matrix = await matrixFactory.load(
+			dataStoreRuntime,
 			"1",
-			SharedMatrixFactory.Attributes,
+			{
+				deltaConnection,
+				objectStorage,
+			},
+			matrixFactory.attributes,
 		);
-		await matrix.load({
-			deltaConnection,
-			objectStorage,
-		});
 		return matrix;
 	}
 


### PR DESCRIPTION
## Description

Makes `@fluidframework/matrix` follow the pattern we've been moving our DDSes toward: expose an interface consisting of the DDS's public API, hide the implementation class from the API surface, and instead expose a constant `SharedMatrix` implementing `ISharedObjectKind` (which powers end-user usage through code like `SharedMatrix.create` or `SharedMatrix.getFactory()`) as well as the type `SharedMatrix` (which is how existing code leveraging `SharedMatrix` declared its variable types).

In doing so, I discovered a few places where `ISharedMatrix` was lacking:

- Some of the newer APIs weren't added to it
- It didn't extend `IChannel`, which means idiomatic Fluid use like storing `matrix.handle` in another DDS wouldn't have worked
- Lots of missing API docs which I've added where appropriate.

I ended up cleaning up a lot of `SharedMatrix`'s tests to operate in terms of the public API surface. This should also serve as a nice reference for users trying to migrate off APIs we don't want them using.

## Breaking Changes

Idiomatic usage of `SharedMatrix` should be unaffected by this PR, except perhaps needing to replace direct instantiation of the factory (i.e. `new SharedMatrixFactory()`) with `SharedMatrix.getFactory()`. The factory is still exported to give some time to migrate, but is deprecated.

Code which meaningfully used implementation details of the `SharedMatrix` class (e.g. by extending it and accessing protected members) is explicitly no longer supported.
