### PR TITLE
bugfix: Audience to be populated when loading from snapshot.

### DIFF
--- a/packages/loader/container-loader/src/protocol.ts
+++ b/packages/loader/container-loader/src/protocol.ts
@@ -61,6 +61,10 @@ export class ProtocolHandler extends ProtocolOpHandler implements IProtocolHandl
 			sendProposal,
 		);
 
+		for (const [clientId, member] of this.quorum.getMembers()) {
+			audience.addMember(clientId, member.client);
+		}
+
 		// Join / leave signals are ignored for "write" clients in favor of join / leave ops
 		this.quorum.on("addMember", (clientId, details) =>
 			audience.addMember(clientId, details.client),


### PR DESCRIPTION
Some time ago I made Audience a superset of quorum. I.e. join / leave signals for "write" clients are ignored by Audience, and instead when join / leave op for such client shows up and quorum updates, such update is replicated into Audience.
No more conditions where user might show up in audience and quorum at random time in those structures.

What I've missed is loading from snapshot flow - we do not populate audience from quorum. Thanks @jatgarg for asking the right question!
