### PR TITLE
feat(benchmark-tool): Proof of concept for custom benchmarks

### DIFF
--- a/tools/benchmark/api-report/benchmark.api.md
+++ b/tools/benchmark/api-report/benchmark.api.md
@@ -23,6 +23,9 @@ export interface BenchmarkAsyncFunction extends BenchmarkOptions {
     benchmarkFnAsync: () => Promise<unknown>;
 }
 
+// @alpha
+export function benchmarkCustom(options: CustomBenchmarkOptions): Test;
+
 // @public
 export interface BenchmarkData {
     readonly elapsedSeconds: number;
@@ -109,6 +112,16 @@ export interface CustomBenchmark extends BenchmarkTimingOptions {
 // @public (undocumented)
 export type CustomBenchmarkArguments = MochaExclusiveOptions & CustomBenchmark & BenchmarkDescription;
 
+// @alpha
+export interface CustomBenchmarkOptions {
+    // (undocumented)
+    only: boolean;
+    // (undocumented)
+    runBenchmark: (reporter: IMeasurementReporter) => Promise<void>;
+    // (undocumented)
+    title: string;
+}
+
 // @public
 export function geometricMean(values: number[]): number;
 
@@ -120,6 +133,11 @@ export interface HookArguments {
 
 // @public
 export type HookFunction = () => void | Promise<unknown>;
+
+// @alpha
+export interface IMeasurementReporter {
+    addMeasurement(key: string, value: number): void;
+}
 
 // @public (undocumented)
 export interface IMemoryTestObject extends MemoryTestObjectProps {

--- a/tools/benchmark/src/MochaCustomOutputReporter.ts
+++ b/tools/benchmark/src/MochaCustomOutputReporter.ts
@@ -1,0 +1,188 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// This file is a reporter used with node, so depending on node is fine.
+/* eslint-disable import/no-nodejs-modules */
+/* eslint-disable unicorn/prefer-module */
+
+import * as path from "node:path";
+import * as fs from "node:fs";
+import Table from "easy-table";
+import { Runner, Suite, Test } from "mocha";
+import chalk from "chalk";
+import { isChildProcess } from "./Configuration";
+import { pad, getName } from "./ReporterUtilities";
+// eslint-disable-next-line import/no-internal-modules
+import { getSuiteName } from "./mocha/mochaReporterUtilities";
+// eslint-disable-next-line import/no-internal-modules
+import type { CustomBenchmarkResults } from "./mocha/customOutputRunner";
+
+/**
+ * Custom mocha reporter for benchmarks that provide their own measurements.
+ *
+ * @remarks
+ * It can be used by passing the JavaScript version of this file to mocha's --reporter option.
+ *
+ * This reporter takes output from mocha events and prints a user-friendly version of the results, in addition
+ * to writing them to a file.
+ * The path of the output file can be controlled with --reporterOptions reportDir=<path>.
+ *
+ * This reporter is coupled to customOutputRunner.ts, and depends on how it emits the actual benchmark data.
+ *
+ * See https://mochajs.org/api/tutorial-custom-reporter.html for more information about custom mocha reporters.
+ */
+class MochaCustomBenchmarkReporter {
+	private readonly inProgressSuites: Map<string, [string, CustomBenchmarkResults][]> = new Map();
+	private readonly outputDirectory: string;
+
+	public constructor(runner: Runner, options?: { reporterOptions?: { reportDir?: string } }) {
+		// If changing this or the result file logic in general,
+		// be sure to update the glob used to look for output files in the perf pipeline.
+		const reportDir = options?.reporterOptions?.reportDir ?? "";
+		this.outputDirectory =
+			reportDir === "" ? path.join(__dirname, ".output") : path.resolve(reportDir);
+
+		fs.mkdirSync(this.outputDirectory, { recursive: true });
+
+		const data: Map<Test, CustomBenchmarkResults> = new Map();
+
+		runner
+			.on(Runner.constants.EVENT_TEST_BEGIN, (test: Test) => {
+				// Forward results from `benchmark end` to BenchmarkReporter.
+				test.on("benchmark end", (benchmarkResults: CustomBenchmarkResults) => {
+					// There are (at least) two ways a benchmark can fail:
+					// The actual benchmark part of the test aborts for some reason OR
+					// the mocha test fails (ex: validation after the benchmark reports an issue).
+					// So instead of reporting the data now, wait until the mocha test ends so we can confirm the
+					// test passed.
+					data.set(test, benchmarkResults);
+				});
+			})
+			.on(Runner.constants.EVENT_TEST_FAIL, (test, err) => {
+				console.info(chalk.red(`Test ${test.fullTitle()} failed with error: `, err));
+			})
+			.on(Runner.constants.EVENT_TEST_END, (test: Test) => {
+				// Type signature for `Test.state` indicates it will never be 'pending',
+				// but that is incorrect: skipped tests have state 'pending' here.
+				// See: https://github.com/mochajs/mocha/issues/4079
+				if (test.state === ("pending" as string)) {
+					return; // Test was skipped.
+				}
+
+				const suite = test.parent ? getSuiteName(test.parent) : "root suite";
+				const benchmarkResults = data.get(test);
+				if (benchmarkResults === undefined) {
+					// Mocha test completed without reporting data. This is an error, so report it as such.
+					console.error(
+						chalk.red(
+							`Test ${test.title} in ${suite} completed with status '${test.state}' without reporting any data.`,
+						),
+					);
+					return;
+				}
+				if (test.state !== "passed") {
+					// The mocha test failed after reporting benchmark data.
+					// This may indicate the benchmark did not measure what was intended, so mark as aborted.
+					console.info(
+						chalk.red(
+							`Test ${test.title} in ${suite} completed with status '${test.state}' after reporting data.`,
+						),
+					);
+					benchmarkResults.aborted = true;
+				}
+
+				if (isChildProcess) {
+					// Write the data to stdout so the parent process can collect it.
+					console.info(JSON.stringify(benchmarkResults));
+				} else {
+					let suiteData = this.inProgressSuites.get(suite);
+					if (suiteData === undefined) {
+						suiteData = [];
+						this.inProgressSuites.set(suite, suiteData);
+					}
+					suiteData.push([getName(test.title), benchmarkResults]);
+				}
+			})
+			.on(Runner.constants.EVENT_SUITE_END, (suite: Suite) => {
+				if (!isChildProcess) {
+					const suiteName = getSuiteName(suite);
+					const suiteData = this.inProgressSuites.get(suiteName);
+					if (suiteData === undefined) {
+						return;
+					}
+					console.log(`\n${chalk.bold(suiteName)}`);
+
+					const table = new Table();
+					const failedTests = new Array<[string, CustomBenchmarkResults]>();
+
+					for (const [testName, testData] of suiteData) {
+						if (testData.aborted) {
+							table.cell("status", `${pad(4)}${chalk.red("×")}`);
+							failedTests.push([testName, testData]);
+						} else {
+							table.cell("status", `${pad(4)}${chalk.green("✔")}`);
+						}
+						table.cell("name", chalk.italic(testName));
+						if (!testData.aborted) {
+							for (const [key, value] of Object.entries(
+								testData.customMeasurements,
+							)) {
+								table.cell(key, value.toString(), Table.padLeft);
+							}
+						}
+						table.newRow();
+					}
+
+					console.log(`${table.toString()}`);
+					if (failedTests.length > 0) {
+						console.log(
+							"------------------------------------------------------",
+							`\n${chalk.red("ERRORS:")}`,
+						);
+						for (const [testName, testData] of failedTests) {
+							console.log(`\n${chalk.red(testName)}`, "\n", testData.error);
+						}
+					}
+
+					this.writeCompletedBenchmarks(suiteName);
+					this.inProgressSuites.delete(suiteName);
+				}
+			})
+			.once(Runner.constants.EVENT_RUN_END, () => {});
+	}
+
+	private writeCompletedBenchmarks(suiteName: string): string {
+		const outputFriendlyBenchmarks: unknown[] = [];
+		const suiteData = this.inProgressSuites.get(suiteName);
+		if (suiteData !== undefined) {
+			for (const [testName, testData] of suiteData) {
+				if (testData.aborted) {
+					break;
+				}
+				outputFriendlyBenchmarks.push({
+					testName,
+					testData,
+				});
+			}
+		}
+
+		// Use the suite name as a filename, but first replace non-alphanumerics with underscores
+		const suiteNameEscaped: string = suiteName.replace(/[^\da-z]/gi, "_");
+		const outputContentString: string = JSON.stringify(
+			{ suiteName, tests: outputFriendlyBenchmarks },
+			undefined,
+			4,
+		);
+
+		// If changing this or the result file logic in general,
+		// be sure to update the glob used to look for output files in the perf pipeline.
+		const outputFilename = `${suiteNameEscaped}_CustomBenchmarkResult.json`;
+		const fullPath: string = path.join(this.outputDirectory, outputFilename);
+		fs.writeFileSync(fullPath, outputContentString);
+		return fullPath;
+	}
+}
+
+module.exports = MochaCustomBenchmarkReporter;

--- a/tools/benchmark/src/index.ts
+++ b/tools/benchmark/src/index.ts
@@ -38,7 +38,15 @@ export {
 	BenchmarkTimer,
 	CustomBenchmarkArguments,
 } from "./Configuration";
-export { benchmark, benchmarkMemory, IMemoryTestObject, MemoryTestObjectProps } from "./mocha";
+export {
+	benchmark,
+	benchmarkMemory,
+	benchmarkCustom,
+	IMemoryTestObject,
+	MemoryTestObjectProps,
+	CustomBenchmarkOptions,
+	IMeasurementReporter,
+} from "./mocha";
 export { prettyNumber, geometricMean, Stats } from "./ReporterUtilities";
 export { BenchmarkReporter } from "./Reporter";
 export {

--- a/tools/benchmark/src/mocha/customOutputRunner.ts
+++ b/tools/benchmark/src/mocha/customOutputRunner.ts
@@ -1,0 +1,88 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Test } from "mocha";
+import { timer } from "../timer";
+
+/**
+ * Options to configure a benchmark that reports custom measurements.
+ *
+ * @alpha
+ */
+export interface CustomBenchmarkOptions {
+	only: boolean;
+	title: string;
+	runBenchmark: (reporter: IMeasurementReporter) => Promise<void>;
+}
+/**
+ * This is a wrapper for Mocha's `it` function which runs the specified function `options.runBenchmark`
+ * and gives it full control over the measurements that will be reported as benchmark output.
+ *
+ * @remarks
+ * Tests created with this function get tagged with '\@CustomBenchmark', so mocha's --grep/--fgrep
+ * options can be used to only run this type of tests by filtering on that value.
+ *
+ * @alpha
+ */
+export function benchmarkCustom(options: CustomBenchmarkOptions): Test {
+	const itFunction = options.only === true ? it.only : it;
+	const test = itFunction(`${options.title} @CustomBenchmark`, async () => {
+		const customMeasurements: Record<string, number> = {};
+		const reporter: IMeasurementReporter = {
+			addMeasurement: (key: string, value: number) => {
+				if (key in customMeasurements) {
+					throw new Error(`Measurement key '${key}' was already used.`);
+				}
+				customMeasurements[key] = value;
+			},
+		};
+
+		const startTime = timer.now();
+		await options.runBenchmark(reporter);
+
+		const results: CustomBenchmarkResults = {
+			aborted: false,
+			totalRunTimeMs: timer.toSeconds(startTime, timer.now()) * 1000,
+			customMeasurements,
+		};
+
+		test.emit("benchmark end", results);
+	});
+	return test;
+}
+
+/**
+ * Allows the benchmark code to report custom measurements.
+ *
+ * @alpha
+ */
+export interface IMeasurementReporter {
+	/**
+	 * Adds a custom measurement to the benchmark output.
+	 * @param key - Key to uniquely identify the measurement.
+	 * @param value - Measurement value.
+	 *
+	 * @remarks
+	 * A given key should be used only once per benchmark.
+	 * Trying to add a measurement with a key that was already used will throw an error.
+	 */
+	addMeasurement(key: string, value: number): void;
+}
+
+/**
+ * Contains the result data for a benchmark with custom measurements.
+ */
+export interface CustomBenchmarkResults {
+	// TODO: aborted, error, and totalRunTimeMs apply to any kind of benchmark (runtime, memory, custom)
+	// so they could go in a base interface
+	aborted: boolean;
+	error?: Error;
+	totalRunTimeMs: number;
+
+	/**
+	 * Custom measurements that represent the result of the benchmark.
+	 */
+	customMeasurements: Record<string, number>;
+}

--- a/tools/benchmark/src/mocha/index.ts
+++ b/tools/benchmark/src/mocha/index.ts
@@ -5,3 +5,8 @@
 
 export { benchmark } from "./runner";
 export { benchmarkMemory, IMemoryTestObject, MemoryTestObjectProps } from "./memoryTestRunner";
+export {
+	benchmarkCustom,
+	CustomBenchmarkOptions,
+	IMeasurementReporter,
+} from "./customOutputRunner";


### PR DESCRIPTION
## Description

This is a proof of concept adding a feature to the benchmark-tool, so we can use it to write benchmarks that report their own custom measurements.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Now with a third kind of benchmark (execution time, memory usage, custom outputs) some patterns where we could be reusing code across all kinds become clear but I didn't try to refactor in that direction for the proof of concept.

Interested in feedback about the new feature, if the API seems good enough, where we might need more flexibility, etc.