### PR TITLE
Make tree's test tsconfig extend from base node16 test config

### DIFF
--- a/package.json
+++ b/package.json
@@ -361,10 +361,12 @@
 			"codemirror and marked overrides are because simplemde use * versions, and the fully up to date versions of its deps do not work. packageExtensions was tried to fix this, but did not work.",
 			"Fixing the @oclif/core version avoids a large number of peer dep errors since 2.6 adds a prod dep on ts-node and thus a peer dep on @types/node",
 			"sharp <0.32.6 has a vulnerability that Component Governance flags (https://github.com/advisories/GHSA-54xq-cgqr-rpm3). It's a transitive dependency through jssm-viz-cli, which hasn't updated to a version with the fix",
-			"@fluentui/react-positioning's dependency on @floating-ui/dom causes a peer dependency violation, so overriding it forces a version that meets peer dependency requirements is installed."
+			"@fluentui/react-positioning's dependency on @floating-ui/dom causes a peer dependency violation, so overriding it forces a version that meets peer dependency requirements is installed.",
+			"get-tsconfig has bug below 4.7.3 which causes eslint to fail to resolve typescript configurations. See https://github.com/privatenumber/get-tsconfig/issues/67"
 		],
 		"overrides": {
 			"@types/node@<18": "^18.19.0",
+			"get-tsconfig": "^4.7.3",
 			"node-fetch": "^2.6.9",
 			"good-fences>nodegit": "npm:empty-npm-package@1.0.0",
 			"qs": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -362,7 +362,7 @@
 			"Fixing the @oclif/core version avoids a large number of peer dep errors since 2.6 adds a prod dep on ts-node and thus a peer dep on @types/node",
 			"sharp <0.32.6 has a vulnerability that Component Governance flags (https://github.com/advisories/GHSA-54xq-cgqr-rpm3). It's a transitive dependency through jssm-viz-cli, which hasn't updated to a version with the fix",
 			"@fluentui/react-positioning's dependency on @floating-ui/dom causes a peer dependency violation, so overriding it forces a version that meets peer dependency requirements is installed.",
-			"get-tsconfig has bug below 4.7.3 which causes eslint to fail to resolve typescript configurations. See https://github.com/privatenumber/get-tsconfig/issues/67"
+			"get-tsconfig has a bug below 4.7.3 which causes eslint to fail to resolve typescript configurations. See https://github.com/privatenumber/get-tsconfig/issues/67"
 		],
 		"overrides": {
 			"@types/node@<18": "^18.19.0",

--- a/packages/dds/tree/src/test/tsconfig.json
+++ b/packages/dds/tree/src/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
 	"compilerOptions": {
 		"lib": ["ES2019", "ES2018.Promise", "DOM", "DOM.Iterable"],
 		"noImplicitAny": true,
@@ -7,8 +7,6 @@
 		"noImplicitOverride": true,
 		"rootDir": "./",
 		"outDir": "../../lib/test",
-		"module": "Node16",
-		"moduleResolution": "Node16",
 		"types": ["node", "mocha"],
 	},
 	"include": ["./**/*"],

--- a/packages/dds/tree/src/test/tsconfig.json
+++ b/packages/dds/tree/src/test/tsconfig.json
@@ -8,7 +8,6 @@
 		"rootDir": "./",
 		"outDir": "../../lib/test",
 		"types": ["node", "mocha"],
-		"customConditions": ["allow-ff-test-exports"],
 	},
 	"include": ["./**/*"],
 	"references": [

--- a/packages/service-clients/end-to-end-tests/azure-client/.eslintrc.cjs
+++ b/packages/service-clients/end-to-end-tests/azure-client/.eslintrc.cjs
@@ -8,9 +8,6 @@ module.exports = {
 	rules: {
 		"prefer-arrow-callback": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
-
-		// This rule causes linting to crash with a "Error: Circularity detected while resolving configuration: /common/build/build-common/tsconfig.base.json"
-		"import/namespace": "off",
 	},
 	parserOptions: {
 		project: ["./src/test/tsconfig.json"],

--- a/packages/test/local-server-tests/.eslintrc.cjs
+++ b/packages/test/local-server-tests/.eslintrc.cjs
@@ -11,9 +11,6 @@ module.exports = {
 	rules: {
 		"@typescript-eslint/strict-boolean-expressions": "off", // requires strictNullChecks=true in tsconfig
 		"import/no-nodejs-modules": "off",
-
-		// This rule causes linting to crash with a "Error: Circularity detected while resolving configuration: /common/build/build-common/tsconfig.base.json"
-		"import/namespace": "off",
 	},
 	parserOptions: {
 		project: ["./src/test/tsconfig.json"],

--- a/packages/test/test-driver-definitions/.eslintrc.cjs
+++ b/packages/test/test-driver-definitions/.eslintrc.cjs
@@ -12,10 +12,7 @@ module.exports = {
 		{
 			// Rules only for test files
 			files: ["*.spec.ts", "src/test/**"],
-			rules: {
-				// This rule causes linting to crash with a "Error: Circularity detected while resolving configuration: /common/build/build-common/tsconfig.base.json"
-				"import/namespace": "off",
-			},
+			rules: {},
 		},
 	],
 };

--- a/packages/test/test-end-to-end-tests/.eslintrc.cjs
+++ b/packages/test/test-end-to-end-tests/.eslintrc.cjs
@@ -40,9 +40,6 @@ module.exports = {
 			},
 		],
 
-		// This rule causes linting to crash with a "Error: Circularity detected while resolving configuration: /common/build/build-common/tsconfig.base.json"
-		"import/namespace": "off",
-
 		/*
 			This rule causes the following errors, so is temporarily disabled.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 overrides:
   '@types/node@<18': ^18.19.0
+  get-tsconfig: ^4.7.3
   node-fetch: ^2.6.9
   good-fences>nodegit: npm:empty-npm-package@1.0.0
   qs: ^6.11.0
@@ -29128,7 +29129,7 @@ packages:
       eslint-module-utils: 2.8.0_j7h7oj6rrhtikhzta4fgkou42e
       eslint-plugin-import: /eslint-plugin-i/2.29.0_j7h7oj6rrhtikhzta4fgkou42e
       fast-glob: 3.3.2
-      get-tsconfig: 4.7.2
+      get-tsconfig: 4.7.3
       is-core-module: 2.13.1
       is-glob: 4.0.3
     transitivePeerDependencies:
@@ -29243,7 +29244,7 @@ packages:
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.8.0_762h3b5esehr7f4s6pbg6xsz7q
-      get-tsconfig: 4.7.2
+      get-tsconfig: 4.7.3
       is-glob: 4.0.3
       minimatch: 3.1.2
       resolve: 1.22.8
@@ -30800,8 +30801,8 @@ packages:
       get-intrinsic: 1.2.2
     dev: true
 
-  /get-tsconfig/4.7.2:
-    resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
+  /get-tsconfig/4.7.3:
+    resolution: {integrity: sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==}
     dependencies:
       resolve-pkg-maps: 1.0.0
     dev: true


### PR DESCRIPTION
## Description

Make tree's test tsconfig extend from base node16 test config. To do so, I needed to bump the version of get-tsconfig to allow tree's lint script to pass. This was the same bug affecting some other test packages / tsconfigs which allows re-enabling that lint rule.