### PR TITLE
Wait for container connection before submitting ops

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/batching.spec.ts
@@ -26,6 +26,7 @@ import {
 	ITestObjectProvider,
 	getContainerEntryPointBackCompat,
 	timeoutPromise,
+	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 
 const map1Id = "map1Key";
@@ -130,12 +131,14 @@ describeCompat("Flushing ops", "NoCompat", (getTestObjectProvider, apis) => {
 		dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
 		dataObject1map1 = await dataObject1.getSharedObject<ISharedMap>(map1Id);
 		dataObject1map2 = await dataObject1.getSharedObject<ISharedMap>(map2Id);
+		await waitForContainerConnection(container1);
 
 		// Load the Container that was created by the first client.
 		const container2 = await provider.loadTestContainer(configCopy);
 		dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
 		dataObject2map1 = await dataObject2.getSharedObject<ISharedMap>(map1Id);
 		dataObject2map2 = await dataObject2.getSharedObject<ISharedMap>(map2Id);
+		await waitForContainerConnection(container2);
 
 		// To precisely control batch boundary, we need to force the container into write mode upfront
 		// So that the first flush doesn't result in reconnect to write mode and cause batches

--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -26,6 +26,7 @@ import {
 	ITestFluidObject,
 	ITestObjectProvider,
 	getContainerEntryPointBackCompat,
+	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 
 import { pkgVersion } from "../packageVersion.js";
@@ -59,11 +60,13 @@ const compressionSuite = (getProvider) => {
 			localDataObject =
 				await getContainerEntryPointBackCompat<ITestFluidObject>(localContainer);
 			localMap = await localDataObject.getSharedObject<ISharedMap>("mapKey");
+			await waitForContainerConnection(localContainer);
 
 			const remoteContainer = await provider.loadTestContainer(containerConfig);
 			const remoteDataObject =
 				await getContainerEntryPointBackCompat<ITestFluidObject>(remoteContainer);
 			remoteMap = await remoteDataObject.getSharedObject<ISharedMap>("mapKey");
+			await waitForContainerConnection(remoteContainer);
 		}
 
 		afterEach(() => {

--- a/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/containerRuntime.spec.ts
@@ -12,6 +12,7 @@ import {
 	type ITestContainerConfig,
 	ITestObjectProvider,
 	getContainerEntryPointBackCompat,
+	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 
 describeCompat("ContainerRuntime Document Schema", "FullCompat", (getTestObjectProvider, apis) => {
@@ -122,6 +123,7 @@ describeCompat("ContainerRuntime Document Schema", "FullCompat", (getTestObjectP
 		};
 		const container = await provider.makeTestContainer(options);
 		entry = await getEntryPoint(container);
+		await waitForContainerConnection(container);
 
 		assert(entry);
 		entry.root.set("key", generateStringOfSize(10000));
@@ -135,6 +137,7 @@ describeCompat("ContainerRuntime Document Schema", "FullCompat", (getTestObjectP
 
 		const container2 = await loadContainer(options);
 		const entry2 = await getEntryPoint(container2);
+		await waitForContainerConnection(container2);
 		assert(entry.root.get("key").length === 10000);
 
 		entry2.root.set("key2", generateStringOfSize(5000));
@@ -146,6 +149,7 @@ describeCompat("ContainerRuntime Document Schema", "FullCompat", (getTestObjectP
 
 		const container3 = await loadContainer(options);
 		const entry3 = await getEntryPoint(container3);
+		await waitForContainerConnection(container3);
 		await provider.ensureSynchronized();
 
 		assert.equal(crash, container.closed);


### PR DESCRIPTION
We are seeing a large number of "SubmitMessageWithNoConnection" errors for some tests. Some waits have been added to see if the flakiness is fixed.

[AB#7808](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7808)