### PR TITLE
Mark TypedEventEmitter as alpha

### DIFF
--- a/packages/common/client-utils/api-report/client-utils.api.md
+++ b/packages/common/client-utils/api-report/client-utils.api.md
@@ -24,7 +24,7 @@ export const bufferToString: (blob: ArrayBufferLike, encoding: "utf8" | "utf-8" 
 
 export { EventEmitter }
 
-// @public
+// @alpha
 export type EventEmitterEventType = string;
 
 // @internal
@@ -78,7 +78,7 @@ export class Trace {
     trace(): ITraceEvent;
 }
 
-// @public
+// @alpha
 export class TypedEventEmitter<TEvent> extends EventEmitter implements IEventProvider<TEvent & IEvent> {
     constructor();
     // (undocumented)
@@ -97,7 +97,7 @@ export class TypedEventEmitter<TEvent> extends EventEmitter implements IEventPro
     readonly removeListener: TypedEventTransform<this, TEvent>;
 }
 
-// @public (undocumented)
+// @alpha (undocumented)
 export type TypedEventTransform<TThis, TEvent> = TransformedEvent<TThis, "newListener" | "removeListener", Parameters<(event: string, listener: (...args: any[]) => void) => void>> & IEventTransformer<TThis, TEvent & IEvent> & TransformedEvent<TThis, EventEmitterEventType, any[]>;
 
 // @internal

--- a/packages/common/client-utils/src/typedEventEmitter.ts
+++ b/packages/common/client-utils/src/typedEventEmitter.ts
@@ -17,12 +17,12 @@ import { EventEmitter } from "./eventEmitter.cjs";
  * string | symbol vs. string | number
  *
  * The polyfill is now always used, but string is the only event type preferred.
- * @public
+ * @alpha
  */
 export type EventEmitterEventType = string;
 
 /**
- * @public
+ * @alpha
  */
 export type TypedEventTransform<TThis, TEvent> =
 	// Event emitter supports some special events for the emitter itself to use
@@ -42,8 +42,10 @@ export type TypedEventTransform<TThis, TEvent> =
 		TransformedEvent<TThis, EventEmitterEventType, any[]>;
 
 /**
- * Event Emitter helper class the supports emitting typed events
- * @public
+ * Event Emitter helper class the supports emitting typed events.
+ * @privateRemarks
+ * This should become internal once the classes extending it become internal.
+ * @alpha
  */
 export class TypedEventEmitter<TEvent>
 	extends EventEmitter


### PR DESCRIPTION
## Description

Mark `TypedEventEmitter`, `EventEmitterEventType` and `TypedEventTransform` from `@fluid-internal/client-utils` as `alpha`.

This was left over after the concreate DDS classes were moved from public to alpha.

## Breaking Changes

These types from a @fluid-internal package are no longer exported as public.
Externals users of them should not use @fluid-internal packages.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
