### PR TITLE
Cleanup Container loading code

### DIFF
--- a/examples/utils/example-utils/src/modelLoader/modelLoader.ts
+++ b/examples/utils/example-utils/src/modelLoader/modelLoader.ts
@@ -114,7 +114,6 @@ export class ModelLoader<ModelType> implements IModelLoader<ModelType> {
 			this.loader,
 			{
 				url: id,
-				headers: {},
 			},
 			sequenceNumber,
 		);

--- a/examples/utils/example-utils/src/modelLoader/modelLoader.ts
+++ b/examples/utils/example-utils/src/modelLoader/modelLoader.ts
@@ -8,7 +8,11 @@ import {
 	type IHostLoader,
 	LoaderHeader,
 } from "@fluidframework/container-definitions/internal";
-import { ILoaderProps, Loader } from "@fluidframework/container-loader/internal";
+import {
+	ILoaderProps,
+	Loader,
+	loadContainerPaused,
+} from "@fluidframework/container-loader/internal";
 import type { IRequest } from "@fluidframework/core-interfaces";
 
 import type { IDetachedModel, IModelLoader } from "./interfaces.js";
@@ -106,16 +110,14 @@ export class ModelLoader<ModelType> implements IModelLoader<ModelType> {
 	}
 
 	public async loadExistingPaused(id: string, sequenceNumber: number): Promise<ModelType> {
-		const container = await this.loader.resolve({
-			url: id,
-			headers: {
-				[LoaderHeader.loadMode]: {
-					opsBeforeReturn: "sequenceNumber",
-					pauseAfterLoad: true,
-				},
-				[LoaderHeader.sequenceNumber]: sequenceNumber,
+		const container = await loadContainerPaused(
+			this.loader,
+			{
+				url: id,
+				headers: {},
 			},
-		});
+			sequenceNumber,
+		);
 		const model = await this.getModelFromContainer(container);
 		return model;
 	}

--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -221,8 +221,7 @@ export interface IContainerLoadMode {
     // (undocumented)
     deltaConnection?: "none" | "delayed" | undefined;
     // (undocumented)
-    opsBeforeReturn?: undefined | "sequenceNumber" | "cached" | "all";
-    pauseAfterLoad?: boolean;
+    opsBeforeReturn?: undefined | "cached" | "all";
 }
 
 // @public
@@ -400,7 +399,6 @@ export interface ILoaderHeader {
     [LoaderHeader.clientDetails]: IClientDetails;
     // (undocumented)
     [LoaderHeader.reconnect]: boolean;
-    [LoaderHeader.sequenceNumber]: number;
     // (undocumented)
     [LoaderHeader.loadMode]: IContainerLoadMode;
     // (undocumented)

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -127,6 +127,9 @@
 			},
 			"InterfaceDeclaration_IBatchMessage": {
 				"backCompat": false
+			},
+			"InterfaceDeclaration_ILoaderHeader": {
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -653,11 +653,6 @@ export interface IContainerLoadMode {
 	 */
 	| undefined
 		/*
-		 * Only fetch and apply trailing ops up until (and including) the specified sequence number.
-		 * Requires `ILoaderHeader["fluid-sequence-number"]` to also be defined.
-		 */
-		| "sequenceNumber"
-		/*
 		 * Only cached trailing ops are applied before returning container.
 		 * Caching is optional and could be implemented by the driver.
 		 * If driver does not implement any kind of local caching strategy, this is same as above.
@@ -690,11 +685,6 @@ export interface IContainerLoadMode {
 		 * Default value.
 		 */
 		| undefined;
-
-	/**
-	 * If set to true, will indefinitely pause all incoming and outgoing after the container is loaded.
-	 */
-	pauseAfterLoad?: boolean;
 }
 
 /**
@@ -708,11 +698,6 @@ export interface ILoaderHeader {
 	[LoaderHeader.cache]: boolean;
 	[LoaderHeader.clientDetails]: IClientDetails;
 	[LoaderHeader.loadMode]: IContainerLoadMode;
-	/**
-	 * Loads the container to at least the specified sequence number.
-	 * If not defined, behavior will fall back to `IContainerLoadMode.opsBeforeReturn`.
-	 */
-	[LoaderHeader.sequenceNumber]: number;
 	[LoaderHeader.reconnect]: boolean;
 	[LoaderHeader.version]: string | undefined;
 }

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -664,6 +664,8 @@ export interface IContainerLoadMode {
 		 * This mode might have significant impact on boot speed (depends on storage perf characteristics)
 		 * Also there might be a lot of trailing ops and applying them might take time, so hosts are
 		 * recommended to have some progress UX / cancellation built into loading flow when using this option.
+		 * WARNING: This is the only option that may result in unbound wait. If machine is offline or hits some other
+		 * errors (like 429s), it may get into inifinite retry loop, with no ability to observe or cancel that process.
 		 */
 		| "all";
 

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -1002,6 +1002,7 @@ declare function get_current_InterfaceDeclaration_ILoaderHeader():
 declare function use_old_InterfaceDeclaration_ILoaderHeader(
     use: TypeOnly<old.ILoaderHeader>): void;
 use_old_InterfaceDeclaration_ILoaderHeader(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ILoaderHeader());
 
 /*

--- a/packages/loader/container-loader/api-report/container-loader.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.api.md
@@ -109,7 +109,7 @@ export interface IProtocolHandler extends IProtocolHandler_2 {
 export function isLocationRedirectionError(error: any): error is ILocationRedirectionError;
 
 // @internal
-export function loadContainerPaused(loader: ILoader, request: IRequest, loadToSequenceNumber?: number): Promise<IContainer>;
+export function loadContainerPaused(loader: ILoader, request: IRequest, loadToSequenceNumber?: number, signal?: AbortSignal): Promise<IContainer>;
 
 // @alpha
 export class Loader implements IHostLoader {

--- a/packages/loader/container-loader/api-report/container-loader.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.api.md
@@ -15,6 +15,7 @@ import { IDocumentStorageService } from '@fluidframework/driver-definitions/inte
 import { IFluidCodeDetails } from '@fluidframework/container-definitions/internal';
 import { IFluidModule } from '@fluidframework/container-definitions/internal';
 import { IHostLoader } from '@fluidframework/container-definitions/internal';
+import { ILoader } from '@fluidframework/container-definitions/internal';
 import { ILoaderOptions as ILoaderOptions_2 } from '@fluidframework/container-definitions/internal';
 import { ILocationRedirectionError } from '@fluidframework/driver-definitions/internal';
 import { IProtocolHandler as IProtocolHandler_2 } from '@fluidframework/protocol-base';
@@ -106,6 +107,9 @@ export interface IProtocolHandler extends IProtocolHandler_2 {
 
 // @internal
 export function isLocationRedirectionError(error: any): error is ILocationRedirectionError;
+
+// @internal
+export function loadContainerPaused(loader: ILoader, request: IRequest, loadToSequenceNumber?: number): Promise<IContainer>;
 
 // @alpha
 export class Loader implements IHostLoader {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -164,11 +164,6 @@ export interface IContainerLoadProps {
 	 * The pending state serialized from a pervious container instance
 	 */
 	readonly pendingLocalState?: IPendingContainerState;
-
-	/**
-	 * Load the container to at least this sequence number.
-	 */
-	readonly loadToSequenceNumber?: number;
 }
 
 /**
@@ -362,8 +357,7 @@ export class Container
 		loadProps: IContainerLoadProps,
 		createProps: IContainerCreateProps,
 	): Promise<Container> {
-		const { version, pendingLocalState, loadMode, resolvedUrl, loadToSequenceNumber } =
-			loadProps;
+		const { version, pendingLocalState, loadMode, resolvedUrl } = loadProps;
 
 		const container = new Container(createProps, loadProps);
 
@@ -392,7 +386,7 @@ export class Container
 					container.on("closed", onClosed);
 
 					container
-						.load(version, mode, resolvedUrl, pendingLocalState, loadToSequenceNumber)
+						.load(version, mode, resolvedUrl, pendingLocalState)
 						.finally(() => {
 							container.removeListener("closed", onClosed);
 						})
@@ -1514,7 +1508,6 @@ export class Container
 		loadMode: IContainerLoadMode,
 		resolvedUrl: IResolvedUrl,
 		pendingLocalState: IPendingContainerState | undefined,
-		loadToSequenceNumber: number | undefined,
 	) {
 		const timings: Record<string, number> = { phase1: performance.now() };
 		this.service = await this.createDocumentService(async () =>
@@ -1571,57 +1564,6 @@ export class Container
 			attributes.sequenceNumber;
 		let opsBeforeReturnP: Promise<void> | undefined;
 
-		if (loadMode.pauseAfterLoad === true) {
-			// If we are trying to pause at a specific sequence number, ensure the latest snapshot is not newer than the desired sequence number.
-			if (loadMode.opsBeforeReturn === "sequenceNumber") {
-				assert(
-					loadToSequenceNumber !== undefined,
-					0x727 /* sequenceNumber should be defined */,
-				);
-				// Note: It is possible that we think the latest snapshot is newer than the specified sequence number
-				// due to saved ops that may be replayed after the snapshot.
-				// https://dev.azure.com/fluidframework/internal/_workitems/edit/5055
-				if (lastProcessedSequenceNumber > loadToSequenceNumber) {
-					throw new Error(
-						"Cannot satisfy request to pause the container at the specified sequence number. Most recent snapshot is newer than the specified sequence number.",
-					);
-				}
-			}
-
-			// Force readonly mode - this will ensure we don't receive an error for the lack of join op
-			this.forceReadonly(true);
-
-			// We need to setup a listener to stop op processing once we reach the desired sequence number (if specified).
-			const opHandler = () => {
-				if (loadToSequenceNumber === undefined) {
-					// If there is no specified sequence number, pause after the inbound queue is empty.
-					if (this.deltaManager.inbound.length !== 0) {
-						return;
-					}
-				} else {
-					// If there is a specified sequence number, keep processing until we reach it.
-					if (this.deltaManager.lastSequenceNumber < loadToSequenceNumber) {
-						return;
-					}
-				}
-
-				// Pause op processing once we have processed the desired number of ops.
-				void this.deltaManager.inbound.pause();
-				void this.deltaManager.outbound.pause();
-				this.off("op", opHandler);
-			};
-			if (
-				(loadToSequenceNumber === undefined && this.deltaManager.inbound.length === 0) ||
-				this.deltaManager.lastSequenceNumber === loadToSequenceNumber
-			) {
-				// If we have already reached the desired sequence number, call opHandler() to pause immediately.
-				opHandler();
-			} else {
-				// If we have not yet reached the desired sequence number, setup a listener to pause once we reach it.
-				this.on("op", opHandler);
-			}
-		}
-
 		// Attach op handlers to finish initialization and be able to start processing ops
 		// Kick off any ops fetching if required.
 		switch (loadMode.opsBeforeReturn) {
@@ -1634,7 +1576,6 @@ export class Container
 					lastProcessedSequenceNumber,
 				);
 				break;
-			case "sequenceNumber":
 			case "cached":
 			case "all":
 				opsBeforeReturnP = this.attachDeltaManagerOpHandler(
@@ -1713,22 +1654,6 @@ export class Container
 				loadMode.deltaConnection,
 				pendingLocalState !== undefined,
 			);
-		}
-
-		// If we have not yet reached `loadToSequenceNumber`, we will wait for ops to arrive until we reach it
-		if (
-			loadToSequenceNumber !== undefined &&
-			this.deltaManager.lastSequenceNumber < loadToSequenceNumber
-		) {
-			await new Promise<void>((resolve, reject) => {
-				const opHandler = (message: ISequencedDocumentMessage) => {
-					if (message.sequenceNumber >= loadToSequenceNumber) {
-						resolve();
-						this.off("op", opHandler);
-					}
-				};
-				this.on("op", opHandler);
-			});
 		}
 
 		// Safety net: static version of Container.load() should have learned about it through "closed" handler.
@@ -2068,7 +1993,7 @@ export class Container
 
 	private async attachDeltaManagerOpHandler(
 		attributes: IDocumentAttributes,
-		prefetchType?: "sequenceNumber" | "cached" | "all" | "none",
+		prefetchType?: "cached" | "all" | "none",
 		lastProcessedSequenceNumber?: number,
 	) {
 		return this._deltaManager.attachOpHandler(

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -557,7 +557,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		minSequenceNumber: number,
 		snapshotSequenceNumber: number,
 		handler: IDeltaHandlerStrategy,
-		prefetchType: "sequenceNumber" | "cached" | "all" | "none" = "none",
+		prefetchType: "cached" | "all" | "none" = "none",
 		lastProcessedSequenceNumber: number = snapshotSequenceNumber,
 	) {
 		this.initSequenceNumber = snapshotSequenceNumber;

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -13,6 +13,7 @@ export {
 	ILoaderProps,
 	ILoaderServices,
 	Loader,
+	loadContainerPaused,
 } from "./loader.js";
 export {
 	isLocationRedirectionError,

--- a/packages/loader/container-loader/src/index.ts
+++ b/packages/loader/container-loader/src/index.ts
@@ -13,8 +13,8 @@ export {
 	ILoaderProps,
 	ILoaderServices,
 	Loader,
-	loadContainerPaused,
 } from "./loader.js";
+export { loadContainerPaused } from "./loadPaused.js";
 export {
 	isLocationRedirectionError,
 	resolveWithLocationRedirectionHandling,

--- a/packages/loader/container-loader/src/loadPaused.ts
+++ b/packages/loader/container-loader/src/loadPaused.ts
@@ -5,93 +5,114 @@
 
 import { ILoader, LoaderHeader } from "@fluidframework/container-definitions/internal";
 import { IRequest } from "@fluidframework/core-interfaces";
-import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+
+/* eslint-disable jsdoc/check-indentation */
 
 /**
- * Loads container and leaves it in a state where it does not process any ops
+ * Loads container and leaves it in a state where it does not process any ops.
+ * Container instance returned by this function is in special mode where some functionality that is available in normal use will not work correctly
+ * with instance of container returned by this function. Some examples:
+ * 1. calling IContainer.connect() will have very little impact on this container as it will not process ops.
+ * 2. functionality like waitContainerToCatchUp() or waiting for ops in any other way would hand infinitely, as this container is not processing ops
+ * 3. No changes can be made to this container - they will be lost.
+ *
  * If sequence number is provided, loads up to this sequence number and stops there, otherwise stops immediately after loading snapshot.
+ * In all cases, container is returned disconnected & paused, or an exception is thrown
+ * Notes:
+ * 1. Ignores LoaderHeader.loadMode headers. Container is always returned with ops applied upt to provided sequence number,
+ *    or no ops applied at all (if sequence number is not provided)
+ * 2. This call can hang infinitately if disconnected from internet (or hit some other conditions, like 429 storm).
+ *    Compare to Container.load() experience (with default settings) - it either returns failure right away, or succeeds, with
+ *    ops fetching / delta connection happening in parallel / after container load flow, and thus providing an object (Container instance) to observe
+ *    network connectivity issues / ability to cancel (IContainer.disconnect) or close container (IContainer.close)
+ *    This flow needs to fetch ops (potentially connecting to delta connection), and any retriable errors on this path result in infinite retry.
+ *    If you need to cancel that process, consider supplying AbortSignal parameter.
+ * @param loader - loader instance to use to load container
+ * @param request - request identifying container instance / load parameters. LoaderHeader.loadMode headers are ignored (see above)
+ * @param loadToSequenceNumber - optional sequence number. If provided, ops are processed up to this sequence number.
+ * @param signal - optional abort signal that can be used to cancel waiting for the ops.
+ * @returns IContainer instance
+ *
  * @internal
- * */
+ */
 export async function loadContainerPaused(
 	loader: ILoader,
 	request: IRequest,
 	loadToSequenceNumber?: number,
+	signal?: AbortSignal,
 ) {
 	const container = await loader.resolve({
 		url: request.url,
 		headers: {
 			...request.headers,
-			// ensure we do not process any ops.
+			// ensure we do not process any ops, such that we can examine container before ops starts to flow.
 			[LoaderHeader.loadMode]: { opsBeforeReturn: undefined, deltaConnection: "none" },
 		},
 	});
 
-	// If we are trying to pause at a specific sequence number, ensure the latest snapshot is not newer than the desired sequence number.
-	if (loadToSequenceNumber !== undefined) {
-		const lastProcessedSequenceNumber = container.deltaManager.initialSequenceNumber;
-		if (lastProcessedSequenceNumber > loadToSequenceNumber) {
-			throw new Error(
-				"Cannot satisfy request to pause the container at the specified sequence number. Most recent snapshot is newer than the specified sequence number.",
-			);
-		}
-	}
-
 	// Force readonly mode - this will ensure we don't receive an error for the lack of join op
 	container.forceReadonly?.(true);
 
-	// We need to setup a listener to stop op processing once we reach the desired sequence number (if specified).
-	const opHandler = () => {
-		if (loadToSequenceNumber === undefined) {
-			// If there is no specified sequence number, pause after the inbound queue is empty.
-			if (container.deltaManager.inbound.length !== 0) {
-				return;
-			}
-		} else {
-			// If there is a specified sequence number, keep processing until we reach it.
-			if (container.deltaManager.lastSequenceNumber < loadToSequenceNumber) {
-				return;
-			}
-		}
+	const dm = container.deltaManager;
 
-		// Pause op processing once we have processed the desired number of ops.
-		void container.deltaManager.inbound.pause();
-		void container.deltaManager.outbound.pause();
-		container.off("op", opHandler);
-	};
-	if (
-		(loadToSequenceNumber === undefined && container.deltaManager.inbound.length === 0) ||
-		container.deltaManager.lastSequenceNumber === loadToSequenceNumber
-	) {
-		// If we have already reached the desired sequence number, call opHandler() to pause immediately.
-		opHandler();
-	} else {
-		// If we have not yet reached the desired sequence number, setup a listener to pause once we reach it.
-		container.on("op", opHandler);
-	}
+	const promise = new Promise<void>((resolve, reject) => {
+		const pauseAndResolve = () => {
+			void dm.inbound.pause();
+			void dm.outbound.pause();
+			signal?.removeEventListener("abort", reject);
+			resolve();
+		};
+
+		// We need to setup a listener to stop op processing once we reach the desired sequence number (if specified).
+		const opHandler = () => {
+			// If there is a specified sequence number, keep processing until we reach it.
+			if (
+				loadToSequenceNumber !== undefined &&
+				dm.lastSequenceNumber >= loadToSequenceNumber
+			) {
+				// Pause op processing once we have processed the desired number of ops.
+				pauseAndResolve();
+				container.off("op", opHandler);
+			}
+		};
+
+		const lastProcessedSequenceNumber = dm.initialSequenceNumber;
+
+		if (
+			loadToSequenceNumber === undefined ||
+			lastProcessedSequenceNumber === loadToSequenceNumber
+		) {
+			// If we have already reached the desired sequence number, call opHandler() to pause immediately.
+			pauseAndResolve();
+		} else if (lastProcessedSequenceNumber > loadToSequenceNumber) {
+			// If we are trying to pause at a specific sequence number, ensure the latest snapshot is not newer than the desired sequence number.
+			throw new Error(
+				"Cannot satisfy request to pause the container at the specified sequence number. Most recent snapshot is newer than the specified sequence number.",
+			);
+		} else {
+			// If we have not yet reached the desired sequence number, setup a listener to pause once we reach it.
+			signal?.addEventListener("abort", reject);
+			container.on("op", opHandler);
+		}
+	});
 
 	// There are no guarantees on when ops will land in storage.
 	// No guarantees that driver implements ops caching (i.e. ops observed in previous session can be served from cache)
 	// or that browser will provide caching capabilities / keep the data (localStorage).
-	// So we have to ensure we connect to delta storage in order to make forward progress with ops.
+	// Thus, we have to ensure we connect to delta storage in order to make forward progress with ops.
 	// We also instructed not to fetch / apply any ops from storage above (to be able to install callback above before ops are processed),
 	// connect() call will fetch ops as needed.
 	container.connect();
 
-	// If we have not yet reached `loadToSequenceNumber`, we will wait for ops to arrive until we reach it
-	if (
-		loadToSequenceNumber !== undefined &&
-		container.deltaManager.lastSequenceNumber < loadToSequenceNumber
-	) {
-		await new Promise<void>((resolve, reject) => {
-			const opHandler2 = (message: ISequencedDocumentMessage) => {
-				if (message.sequenceNumber >= loadToSequenceNumber) {
-					resolve();
-					container.off("op", opHandler2);
-				}
-			};
-			container.on("op", opHandler2);
-		});
-	}
+	// Wait for the ops to be processed.
+	await promise.finally(() => {
+		// There is not much value in leaving delta connection on. We are not processing ops, we also can't advance to "connected" state because of it.
+		// We are not sending ops (due to forceReadonly() call above). We are holding collab window and any consensus-based processes.
+		// It's better not to have connection in such case, as there are only nagatives, and no positives.
+		container.disconnect();
+	});
 
 	return container;
 }
+
+/* eslint-enable jsdoc/check-indentation */

--- a/packages/loader/container-loader/src/loadPaused.ts
+++ b/packages/loader/container-loader/src/loadPaused.ts
@@ -68,7 +68,7 @@ export async function loadContainerPaused(
 		loadToSequenceNumber === undefined ||
 		lastProcessedSequenceNumber === loadToSequenceNumber
 	) {
-		// If we have already reached the desired sequence number, call opHandler() to pause immediately.
+		// If we have already reached the desired sequence number, call pauseContainer() to pause immediately.
 		pauseContainer();
 		return container;
 	}

--- a/packages/loader/container-loader/src/loadPaused.ts
+++ b/packages/loader/container-loader/src/loadPaused.ts
@@ -1,0 +1,97 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ILoader, LoaderHeader } from "@fluidframework/container-definitions/internal";
+import { IRequest } from "@fluidframework/core-interfaces";
+import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+
+/**
+ * Loads container and leaves it in a state where it does not process any ops
+ * If sequence number is provided, loads up to this sequence number and stops there, otherwise stops immediately after loading snapshot.
+ * @internal
+ * */
+export async function loadContainerPaused(
+	loader: ILoader,
+	request: IRequest,
+	loadToSequenceNumber?: number,
+) {
+	const container = await loader.resolve({
+		url: request.url,
+		headers: {
+			...request.headers,
+			// ensure we do not process any ops.
+			[LoaderHeader.loadMode]: { opsBeforeReturn: undefined, deltaConnection: "none" },
+		},
+	});
+
+	// If we are trying to pause at a specific sequence number, ensure the latest snapshot is not newer than the desired sequence number.
+	if (loadToSequenceNumber !== undefined) {
+		const lastProcessedSequenceNumber = container.deltaManager.initialSequenceNumber;
+		if (lastProcessedSequenceNumber > loadToSequenceNumber) {
+			throw new Error(
+				"Cannot satisfy request to pause the container at the specified sequence number. Most recent snapshot is newer than the specified sequence number.",
+			);
+		}
+	}
+
+	// Force readonly mode - this will ensure we don't receive an error for the lack of join op
+	container.forceReadonly?.(true);
+
+	// We need to setup a listener to stop op processing once we reach the desired sequence number (if specified).
+	const opHandler = () => {
+		if (loadToSequenceNumber === undefined) {
+			// If there is no specified sequence number, pause after the inbound queue is empty.
+			if (container.deltaManager.inbound.length !== 0) {
+				return;
+			}
+		} else {
+			// If there is a specified sequence number, keep processing until we reach it.
+			if (container.deltaManager.lastSequenceNumber < loadToSequenceNumber) {
+				return;
+			}
+		}
+
+		// Pause op processing once we have processed the desired number of ops.
+		void container.deltaManager.inbound.pause();
+		void container.deltaManager.outbound.pause();
+		container.off("op", opHandler);
+	};
+	if (
+		(loadToSequenceNumber === undefined && container.deltaManager.inbound.length === 0) ||
+		container.deltaManager.lastSequenceNumber === loadToSequenceNumber
+	) {
+		// If we have already reached the desired sequence number, call opHandler() to pause immediately.
+		opHandler();
+	} else {
+		// If we have not yet reached the desired sequence number, setup a listener to pause once we reach it.
+		container.on("op", opHandler);
+	}
+
+	// There are no guarantees on when ops will land in storage.
+	// No guarantees that driver implements ops caching (i.e. ops observed in previous session can be served from cache)
+	// or that browser will provide caching capabilities / keep the data (localStorage).
+	// So we have to ensure we connect to delta storage in order to make forward progress with ops.
+	// We also instructed not to fetch / apply any ops from storage above (to be able to install callback above before ops are processed),
+	// connect() call will fetch ops as needed.
+	container.connect();
+
+	// If we have not yet reached `loadToSequenceNumber`, we will wait for ops to arrive until we reach it
+	if (
+		loadToSequenceNumber !== undefined &&
+		container.deltaManager.lastSequenceNumber < loadToSequenceNumber
+	) {
+		await new Promise<void>((resolve, reject) => {
+			const opHandler2 = (message: ISequencedDocumentMessage) => {
+				if (message.sequenceNumber >= loadToSequenceNumber) {
+					resolve();
+					container.off("op", opHandler2);
+				}
+			};
+			container.on("op", opHandler2);
+		});
+	}
+
+	return container;
+}

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -25,7 +25,7 @@ import {
 	IResolvedUrl,
 	IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
-import { IClientDetails, ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
+import { IClientDetails } from "@fluidframework/protocol-definitions";
 import {
 	ITelemetryLoggerExt,
 	MonitoringContext,
@@ -391,93 +391,4 @@ export class Loader implements IHostLoader {
 			},
 		);
 	}
-}
-
-/**
- * Loads container and leaves it in a state where it does not process any ops
- * If sequence number is provided, loads up to this sequence number and stops there, otherwise stops immediately after loading snapshot.
- * @internal
- * */
-export async function loadContainerPaused(
-	loader: ILoader,
-	request: IRequest,
-	loadToSequenceNumber?: number,
-) {
-	const container = await loader.resolve({
-		url: request.url,
-		headers: {
-			...request.headers,
-			// ensure we do not process any ops.
-			[LoaderHeader.loadMode]: { opsBeforeReturn: undefined, deltaConnection: "none" },
-		},
-	});
-
-	// If we are trying to pause at a specific sequence number, ensure the latest snapshot is not newer than the desired sequence number.
-	if (loadToSequenceNumber !== undefined) {
-		const lastProcessedSequenceNumber = container.deltaManager.initialSequenceNumber;
-		if (lastProcessedSequenceNumber > loadToSequenceNumber) {
-			throw new Error(
-				"Cannot satisfy request to pause the container at the specified sequence number. Most recent snapshot is newer than the specified sequence number.",
-			);
-		}
-	}
-
-	// Force readonly mode - this will ensure we don't receive an error for the lack of join op
-	container.forceReadonly?.(true);
-
-	// We need to setup a listener to stop op processing once we reach the desired sequence number (if specified).
-	const opHandler = () => {
-		if (loadToSequenceNumber === undefined) {
-			// If there is no specified sequence number, pause after the inbound queue is empty.
-			if (container.deltaManager.inbound.length !== 0) {
-				return;
-			}
-		} else {
-			// If there is a specified sequence number, keep processing until we reach it.
-			if (container.deltaManager.lastSequenceNumber < loadToSequenceNumber) {
-				return;
-			}
-		}
-
-		// Pause op processing once we have processed the desired number of ops.
-		void container.deltaManager.inbound.pause();
-		void container.deltaManager.outbound.pause();
-		container.off("op", opHandler);
-	};
-	if (
-		(loadToSequenceNumber === undefined && container.deltaManager.inbound.length === 0) ||
-		container.deltaManager.lastSequenceNumber === loadToSequenceNumber
-	) {
-		// If we have already reached the desired sequence number, call opHandler() to pause immediately.
-		opHandler();
-	} else {
-		// If we have not yet reached the desired sequence number, setup a listener to pause once we reach it.
-		container.on("op", opHandler);
-	}
-
-	// There are no guarantees on when ops will land in storage.
-	// No guarantees that driver implements ops caching (i.e. ops observed in previous session can be served from cache)
-	// or that browser will provide caching capabilities / keep the data (localStorage).
-	// So we have to ensure we connect to delta storage in order to make forward progress with ops.
-	// We also instructed not to fetch / apply any ops from storage above (to be able to install callback above before ops are processed),
-	// connect() call will fetch ops as needed.
-	container.connect();
-
-	// If we have not yet reached `loadToSequenceNumber`, we will wait for ops to arrive until we reach it
-	if (
-		loadToSequenceNumber !== undefined &&
-		container.deltaManager.lastSequenceNumber < loadToSequenceNumber
-	) {
-		await new Promise<void>((resolve, reject) => {
-			const opHandler2 = (message: ISequencedDocumentMessage) => {
-				if (message.sequenceNumber >= loadToSequenceNumber) {
-					resolve();
-					container.off("op", opHandler2);
-				}
-			};
-			container.on("op", opHandler2);
-		});
-	}
-
-	return container;
 }

--- a/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/SummarizerWithSearch.spec.ts
@@ -60,7 +60,6 @@ interface SearchContent extends ProvideSearchContent {
 async function loadSummarizer(
 	provider: ITestObjectProvider,
 	runtimeFactory: IRuntimeFactory,
-	sequenceNumber: number,
 	summaryVersion?: string,
 	loaderProps?: Partial<ILoaderProps>,
 ) {
@@ -72,10 +71,6 @@ async function loadSummarizer(
 		},
 		[DriverHeader.summarizingClient]: true,
 		[LoaderHeader.reconnect]: false,
-		[LoaderHeader.loadMode]: {
-			opsBeforeReturn: "sequenceNumber",
-		},
-		[LoaderHeader.sequenceNumber]: sequenceNumber,
 		[LoaderHeader.version]: summaryVersion,
 	};
 	const summarizerContainer = await provider.loadContainer(
@@ -296,12 +291,7 @@ describeCompat(
 		};
 
 		const getNewSummarizer = async (summaryVersion?: string) => {
-			return loadSummarizer(
-				provider,
-				runtimeFactory,
-				mainContainer.deltaManager.lastSequenceNumber,
-				summaryVersion,
-			);
+			return loadSummarizer(provider, runtimeFactory, summaryVersion);
 		};
 
 		/**

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTreeSummaryHandles.spec.ts
@@ -46,7 +46,6 @@ import { wrapObjectAndOverride } from "../../mocking.js";
 async function loadSummarizer(
 	provider: ITestObjectProvider,
 	runtimeFactory: IRuntimeFactory,
-	sequenceNumber: number,
 	summaryVersion?: string,
 	loaderProps?: Partial<ILoaderProps>,
 ) {
@@ -58,10 +57,6 @@ async function loadSummarizer(
 		},
 		[DriverHeader.summarizingClient]: true,
 		[LoaderHeader.reconnect]: false,
-		[LoaderHeader.loadMode]: {
-			opsBeforeReturn: "sequenceNumber",
-		},
-		[LoaderHeader.sequenceNumber]: sequenceNumber,
 		[LoaderHeader.version]: summaryVersion,
 	};
 	const summarizerContainer = await provider.loadContainer(
@@ -237,12 +232,7 @@ describeCompat(
 		};
 
 		const getNewSummarizer = async (summaryVersion?: string) => {
-			return loadSummarizer(
-				provider,
-				runtimeFactory,
-				mainContainer.deltaManager.lastSequenceNumber,
-				summaryVersion,
-			);
+			return loadSummarizer(provider, runtimeFactory, summaryVersion);
 		};
 
 		/**


### PR DESCRIPTION
There is a bunch of logic in Container.load() that can be easily implemented as a layer on top of core layer, not as part of core layer.

This change removes such concepts as 
- IContainerLoadMode.opsBeforeReturn ===  "sequenceNumber"
- IContainerLoadMode.pauseAfterLoad
- LoaderHeader.sequenceNumber

**Improvements:**
- There is no more overlap with pending state options - it was possible (before) to ask to load from pending state, and up to sequence number - that would not work correctly.
- It was possible before to ask for non-paused, but loaded up to some sequence number Container - it would happily return container loaded from snapshot that has higher sequence number than the one where we needed to stop. This combo is no longer possible.
- Our E2E tests were covering some combination that do not matter and that should not have been existed.
- No need for a bunch of checks in Loader layer around non-valid combos or types.
- There is reference to https://dev.azure.com/fluidframework/internal/_workitems/edit/5055 in the code. That issue should be resolved with this PR, as we set op handler before we process any ops (including cached ops) with this PR.
- This logic could hang if container gets disposed while processing ops - adding checks for that.
- Logic around checking container.deltaManager.inbound.length looks fishy - removed
- Added ability to provide AbortSignal, as this process can hang (as explained in comments).