### PR TITLE
Fix various compression flaky tests

### DIFF
--- a/packages/runtime/container-runtime/src/test/opLifecycle/opCompressor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opCompressor.spec.ts
@@ -44,7 +44,7 @@ describe("OpCompressor", () => {
 			// small batch with small messages
 			createBatch(10, 100 * 1024),
 			// small batch with large messages
-			createBatch(2, 100 * 1024 * 1024),
+			createBatch(2, 2 * 1024 * 1024),
 			// large batch with small messages
 			createBatch(1000, 100 * 1024),
 		].forEach((batch) => {


### PR DESCRIPTION
As these features have been "battle tested" for about a year, it is safe to decrease the aggressiveness of these tests by decreasing the limits in the ContainerRuntime options and have the tests trigger them by using smaller payloads.

[AB#6430](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6430)
[AB#6510](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6510)
[AB#6506](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6506)