### PR TITLE
[RC2] GC: Port recent telemetry changes

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -261,6 +261,9 @@ export interface ContainerRuntimeMessage {
 // @alpha (undocumented)
 export const DefaultSummaryConfiguration: ISummaryConfiguration;
 
+// @alpha
+export const DeletedResponseHeaderKey = "wasDeleted";
+
 // @internal
 export function detectOutboundReferences(envelope: IEnvelope, addedOutboundReference: (fromNodePath: string, toNodePath: string) => void): void;
 

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -780,6 +780,18 @@ export interface RecentlyAddedContainerRuntimeMessageDetails {
 }
 
 // @internal
+export interface RuntimeHeaderData {
+    // (undocumented)
+    allowInactive?: boolean;
+    // (undocumented)
+    allowTombstone?: boolean;
+    // (undocumented)
+    viaHandle?: boolean;
+    // (undocumented)
+    wait?: boolean;
+}
+
+// @internal
 export enum RuntimeHeaders {
     viaHandle = "viaHandle",
     wait = "wait"

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -297,10 +297,10 @@ export type GCFeatureMatrix = {
 
 // @alpha
 export const GCNodeType: {
-    DataStore: string;
-    SubDataStore: string;
-    Blob: string;
-    Other: string;
+    readonly DataStore: "DataStore";
+    readonly SubDataStore: "SubDataStore";
+    readonly Blob: "Blob";
+    readonly Other: "Other";
 };
 
 // @alpha (undocumented)
@@ -460,6 +460,19 @@ export interface IGCMetadata {
     // @deprecated
     readonly sweepEnabled?: boolean;
     readonly tombstoneTimeoutMs?: number;
+}
+
+// @internal
+export interface IGCNodeUpdatedProps {
+    headerData?: RuntimeHeaderData;
+    node: {
+        type: (typeof GCNodeType)["DataStore" | "Blob"];
+        path: string;
+    };
+    packagePath?: readonly string[];
+    reason: "Loaded" | "Changed";
+    request?: IRequest;
+    timestampMs?: number;
 }
 
 // @alpha (undocumented)

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -1243,7 +1243,10 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 				continue;
 			}
 			const dataStoreId = pathParts[1];
-			assert(this.contexts.has(dataStoreId), 0x2d7 /* No data store with specified id */);
+			assert(
+				this.contexts.has(dataStoreId),
+				"updateUnusedRoutes: No data store with specified id",
+			);
 			// Delete the contexts of unused data stores.
 			this.contexts.delete(dataStoreId);
 			// Delete the summarizer node of the unused data stores.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1517,22 +1517,7 @@ export class ContainerRuntime
 			getSummaryForDatastores(baseSnapshot, metadata),
 			parentContext,
 			this.mc.logger,
-			(
-				path: string,
-				reason: "Loaded" | "Changed",
-				timestampMs?: number,
-				packagePath?: readonly string[],
-				request?: IRequest,
-				headerData?: RuntimeHeaderData,
-			) =>
-				this.garbageCollector.nodeUpdated(
-					path,
-					reason,
-					timestampMs,
-					packagePath,
-					request,
-					headerData,
-				),
+			(props) => this.garbageCollector.nodeUpdated(props),
 			(path: string) => this.garbageCollector.isNodeDeleted(path),
 			new Map<string, string>(dataStoreAliasMap),
 			async (runtime: ChannelCollection) => provideEntryPoint,
@@ -1554,7 +1539,11 @@ export class ContainerRuntime
 					);
 				}
 			},
-			(blobPath: string) => this.garbageCollector.nodeUpdated(blobPath, "Loaded"),
+			(blobPath: string) =>
+				this.garbageCollector.nodeUpdated({
+					node: { type: "Blob", path: blobPath },
+					reason: "Loaded",
+				}),
 			(blobPath: string) => this.garbageCollector.isNodeDeleted(blobPath),
 			this,
 			pendingRuntimeState?.pendingAttachmentBlobs,
@@ -2712,12 +2701,11 @@ export class ContainerRuntime
 				"entryPoint must be defined on data store runtime for using getAliasedDataStoreEntryPoint",
 			);
 		}
-		this.garbageCollector.nodeUpdated(
-			`/${internalId}`,
-			"Loaded",
-			undefined /* timestampMs */,
-			context.packagePath,
-		);
+		this.garbageCollector.nodeUpdated({
+			node: { type: "DataStore", path: `/${internalId}` },
+			reason: "Loaded",
+			packagePath: context.packagePath,
+		});
 		return channel.entryPoint;
 	}
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -467,6 +467,11 @@ export interface IContainerRuntimeOptions {
 }
 
 /**
+ * Error responses when requesting a deleted object will have this header set to true
+ * @alpha
+ */
+export const DeletedResponseHeaderKey = "wasDeleted";
+/**
  * Tombstone error responses will have this header set to true
  * @alpha
  */

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -484,6 +484,7 @@ export const InactiveResponseHeaderKey = "isInactive";
 
 /**
  * The full set of parsed header data that may be found on Runtime requests
+ * @internal
  */
 export interface RuntimeHeaderData {
 	wait?: boolean;

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -230,8 +230,20 @@ export abstract class FluidDataStoreContext
 	 * 2. is root as part of the base snapshot that the datastore loaded from
 	 * @returns whether a datastore is root
 	 */
-	public async isRoot(): Promise<boolean> {
-		return this.isInMemoryRoot() || (await this.getInitialSnapshotDetails()).isRootDataStore;
+	public async isRoot(aliasedDataStores?: Set<string>): Promise<boolean> {
+		if (this.isInMemoryRoot()) {
+			return true;
+		}
+
+		// This if is a performance optimization.
+		// We know that if the base snapshot is omitted, then the isRootDataStore flag is not set.
+		// That means we can skip the expensive call to getInitialSnapshotDetails for virtualized datastores,
+		// and get the information from the alias map directly.
+		if (aliasedDataStores !== undefined && this.baseSnapshot?.omitted === true) {
+			return aliasedDataStores.has(this.id);
+		}
+
+		return (await this.getInitialSnapshotDetails()).isRootDataStore;
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -80,7 +80,19 @@ export class DataStoreContexts implements Iterable<[string, FluidDataStoreContex
 	public delete(id: string): boolean {
 		this.deferredContexts.delete(id);
 		this.notBoundContexts.delete(id);
+
+		// Stash the context here in case it's requested in this session, we can log some details about it
+		const context = this._contexts.get(id);
+		this._recentlyDeletedContexts.set(id, context);
+
 		return this._contexts.delete(id);
+	}
+
+	private readonly _recentlyDeletedContexts: Map<string, FluidDataStoreContext | undefined> =
+		new Map();
+
+	public getRecentlyDeletedContext(id: string) {
+		return this._recentlyDeletedContexts.get(id);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -23,11 +23,7 @@ import {
 	tagCodeArtifacts,
 } from "@fluidframework/telemetry-utils";
 import { BlobManager } from "../blobManager.js";
-import {
-	InactiveResponseHeaderKey,
-	RuntimeHeaderData,
-	TombstoneResponseHeaderKey,
-} from "../containerRuntime.js";
+import { InactiveResponseHeaderKey, TombstoneResponseHeaderKey } from "../containerRuntime.js";
 import { ClientSessionExpiredError } from "../error.js";
 import { ContainerMessageType, ContainerRuntimeGCMessage } from "../messageTypes.js";
 import { IRefreshSummaryResult } from "../summary/index.js";
@@ -47,12 +43,15 @@ import {
 	GarbageCollectionMessage,
 	GarbageCollectionMessageType,
 	disableAutoRecoveryKey,
+	type IGCNodeUpdatedProps,
 } from "./gcDefinitions.js";
 import {
 	cloneGCData,
 	compatBehaviorAllowsGCMessageType,
 	concatGarbageCollectionData,
+	dataStoreNodePathOnly,
 	getGCDataFromSnapshot,
+	urlToGCNodePath,
 } from "./gcHelpers.js";
 import { runGarbageCollection } from "./gcReferenceGraphAlgorithm.js";
 import { IGarbageCollectionSnapshotData, IGarbageCollectionState } from "./gcSummaryDefinitions.js";
@@ -987,30 +986,30 @@ export class GarbageCollector implements IGarbageCollector {
 	/**
 	 * Called when a node with the given id is updated. If the node is inactive or tombstoned, this will log an error
 	 * or throw an error if failing on incorrect usage is configured.
-	 * @param nodePath - The path of the node that changed.
-	 * @param reason - Whether the node was loaded or changed.
-	 * @param timestampMs - The timestamp when the node changed.
-	 * @param packagePath - The package path of the node. This may not be available if the node hasn't been loaded yet.
-	 * @param request - The original request for loads to preserve it in telemetry.
-	 * @param requestHeaders - If the node was loaded via request path, the headers in the request.
+	 * @param IGCNodeUpdatedProps - Details about the node and how it was updated
 	 */
-	public nodeUpdated(
-		nodePath: string,
-		reason: "Loaded" | "Changed",
-		timestampMs?: number,
-		packagePath?: readonly string[],
-		request?: IRequest,
-		headerData?: RuntimeHeaderData,
-	) {
+	public nodeUpdated({
+		node,
+		reason,
+		timestampMs,
+		packagePath,
+		request,
+		headerData,
+	}: IGCNodeUpdatedProps) {
 		if (!this.configs.shouldRunGC) {
 			return;
 		}
 
-		const isTombstoned = this.tombstones.includes(nodePath);
+		// trackedId will be either DataStore or Blob ID (not sub-DataStore ID, since some of those are unrecognized by GC)
+		const trackedId = node.path;
+		const isTombstoned = this.tombstones.includes(trackedId);
+		const isInactive = this.unreferencedNodesState.get(trackedId)?.state === "Inactive";
+
+		const fullPath = request !== undefined ? urlToGCNodePath(request.url) : trackedId;
 
 		// This will log if appropriate
-		this.telemetryTracker.nodeUsed({
-			id: nodePath,
+		this.telemetryTracker.nodeUsed(trackedId, {
+			id: fullPath,
 			usageType: reason,
 			currentReferenceTimestampMs:
 				timestampMs ?? this.runtime.getCurrentReferenceTimestampMs(),
@@ -1019,6 +1018,8 @@ export class GarbageCollector implements IGarbageCollector {
 			isTombstoned,
 			lastSummaryTime: this.getLastSummaryTimestampMs(),
 			headers: headerData,
+			requestUrl: request?.url,
+			requestHeaders: JSON.stringify(request?.headers),
 		});
 
 		// Any time we log a Tombstone Loaded error (via Telemetry Tracker),
@@ -1027,17 +1028,20 @@ export class GarbageCollector implements IGarbageCollector {
 		// to be loaded by the Summarizer, and auto-recovery will be triggered then.
 		if (isTombstoned && reason === "Loaded") {
 			// Note that when a DataStore and its DDS are all loaded, each will trigger AutoRecovery for itself.
-			this.triggerAutoRecovery(nodePath);
+			this.triggerAutoRecovery(fullPath);
 		}
 
-		const nodeType = this.runtime.getNodeType(nodePath);
+		const nodeType = this.runtime.getNodeType(fullPath);
 
 		// Unless this is a Loaded event for a Blob or DataStore, we're done after telemetry tracking
-		if (reason !== "Loaded" || ![GCNodeType.Blob, GCNodeType.DataStore].includes(nodeType)) {
+		const loadedBlobOrDataStore =
+			reason === "Loaded" &&
+			(nodeType === GCNodeType.Blob || nodeType === GCNodeType.DataStore);
+		if (!loadedBlobOrDataStore) {
 			return;
 		}
 
-		const errorRequest: IRequest = request ?? { url: nodePath };
+		const errorRequest: IRequest = request ?? { url: fullPath };
 		if (isTombstoned && this.throwOnTombstoneLoad && headerData?.allowTombstone !== true) {
 			// The requested data store is removed by gc. Create a 404 gc response exception.
 			throw responseToException(
@@ -1049,7 +1053,7 @@ export class GarbageCollector implements IGarbageCollector {
 		}
 
 		// If the object is inactive and inactive enforcement is configured, throw an error.
-		if (this.unreferencedNodesState.get(nodePath)?.state === "Inactive") {
+		if (isInactive) {
 			const shouldThrowOnInactiveLoad =
 				!this.isSummarizerClient &&
 				this.configs.throwOnInactiveLoad === true &&
@@ -1121,22 +1125,30 @@ export class GarbageCollector implements IGarbageCollector {
 		outboundRoutes.push(toNodePath);
 		this.newReferencesSinceLastRun.set(fromNodePath, outboundRoutes);
 
-		this.telemetryTracker.nodeUsed({
+		// GC won't recognize some subDataStore paths that we encounter (e.g. a path suited for a custom request handler)
+		// So for subDataStore paths we need to check the parent dataStore for current tombstone/inactive status.
+		const trackedId =
+			this.runtime.getNodeType(toNodePath) === "SubDataStore"
+				? dataStoreNodePathOnly(toNodePath)
+				: toNodePath;
+		this.telemetryTracker.nodeUsed(trackedId, {
 			id: toNodePath,
+			fromId: fromNodePath,
 			usageType: "Revived",
 			currentReferenceTimestampMs: this.runtime.getCurrentReferenceTimestampMs(),
 			packagePath: undefined,
 			completedGCRuns: this.completedRuns,
-			isTombstoned: this.tombstones.includes(toNodePath),
+			isTombstoned: this.tombstones.includes(trackedId),
 			lastSummaryTime: this.getLastSummaryTimestampMs(),
-			fromId: fromNodePath,
 			autorecovery,
 		});
 
-		// This node is referenced - Clear its unreferenced state
+		// This node is referenced - Clear its unreferenced state if present
 		// But don't delete the node id from the map yet.
 		// When generating GC stats, the set of nodes in here is used as the baseline for
 		// what was unreferenced in the last GC run.
+		// NOTE: We use toNodePath not trackedId even though it may be an unrecognized subDataStore route (hence no-op),
+		// because a reference to such a path is not sufficient to consider the DataStore referenced.
 		this.unreferencedNodesState.get(toNodePath)?.stopTracking();
 	}
 

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -245,7 +245,7 @@ export const GCNodeType = {
 	Blob: "Blob",
 	// Nodes that are neither of the above. For example, root node.
 	Other: "Other",
-};
+} as const;
 
 /**
  * @alpha
@@ -372,14 +372,7 @@ export interface IGarbageCollector {
 	 * Called when a node with the given path is updated. If the node is inactive or tombstoned, this will log an error
 	 * or throw an error if failing on incorrect usage is configured.
 	 */
-	nodeUpdated(
-		nodePath: string,
-		reason: "Loaded" | "Changed",
-		timestampMs?: number,
-		packagePath?: readonly string[],
-		request?: IRequest,
-		headerData?: RuntimeHeaderData,
-	): void;
+	nodeUpdated(props: IGCNodeUpdatedProps): void;
 	/** Called when a reference is added to a node. Used to identify nodes that were referenced between summaries. */
 	addedOutboundReference(fromNodePath: string, toNodePath: string, autorecovery?: true): void;
 	/** Called to process a garbage collection message. */
@@ -388,6 +381,25 @@ export interface IGarbageCollector {
 	isNodeDeleted(nodePath: string): boolean;
 	setConnectionState(connected: boolean, clientId?: string): void;
 	dispose(): void;
+}
+
+/**
+ * Info needed by GC when notified that a node was updated (loaded or changed)
+ * @internal
+ */
+export interface IGCNodeUpdatedProps {
+	/** Type and path of the updated node */
+	node: { type: (typeof GCNodeType)["DataStore" | "Blob"]; path: string };
+	/** Whether the node (or a subpath) was loaded or changed. */
+	reason: "Loaded" | "Changed";
+	/** The op-based timestamp when the node changed, if applicable */
+	timestampMs?: number;
+	/** The package path of the node. This may not be available if the node hasn't been loaded yet */
+	packagePath?: readonly string[];
+	/** The original request for loads to preserve it in telemetry */
+	request?: IRequest;
+	/** If the node was loaded via request path, the header data. May be modified from the original request */
+	headerData?: RuntimeHeaderData;
 }
 
 /** Parameters necessary for creating a GarbageCollector. */

--- a/packages/runtime/container-runtime/src/gc/gcHelpers.ts
+++ b/packages/runtime/container-runtime/src/gc/gcHelpers.ts
@@ -263,8 +263,21 @@ export function unpackChildNodesGCDetails(gcDetails: IGarbageCollectionDetailsBa
  * @param str - A string that may contain leading and / or trailing slashes.
  * @returns A new string without leading and trailing slashes.
  */
-export function trimLeadingAndTrailingSlashes(str: string) {
+function trimLeadingAndTrailingSlashes(str: string) {
 	return str.replace(/^\/+|\/+$/g, "");
+}
+
+/** Reformats a request URL to match expected format for a GC node path */
+export function urlToGCNodePath(url: string): string {
+	return `/${trimLeadingAndTrailingSlashes(url.split("?")[0])}`;
+}
+
+/**
+ * Pulls out the first path segment and formats it as a GC Node path
+ * e.g. "/dataStoreId/ddsId" yields "/dataStoreId"
+ */
+export function dataStoreNodePathOnly(subDataStorePath: string): string {
+	return `/${subDataStorePath.split("/")[1]}`;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -11,6 +11,7 @@ import {
 	tagCodeArtifacts,
 	type ITelemetryGenericEventExt,
 } from "@fluidframework/telemetry-utils";
+import type { Tagged } from "@fluidframework/core-interfaces";
 import { RuntimeHeaderData } from "../containerRuntime.js";
 import { ICreateContainerMetadata } from "../summary/index.js";
 import {
@@ -38,11 +39,12 @@ interface ICommonProps {
 
 /** The event that is logged when unreferenced node is used after a certain time. */
 interface IUnreferencedEventProps extends ICreateContainerMetadata, ICommonProps {
+	/** The id that GC uses to track the node. May or may not match id */
+	trackedId: string;
 	state: UnreferencedState;
-	id: {
-		value: string;
-		tag: string;
-	};
+	/** The full path (in GC Path format) to the node in question */
+	id: Tagged<string>;
+	fromId?: Tagged<string>;
 	type: GCNodeType;
 	unrefTime: number;
 	age: number;
@@ -51,19 +53,24 @@ interface IUnreferencedEventProps extends ICreateContainerMetadata, ICommonProps
 		[K in keyof GCFeatureMatrix]: GCFeatureMatrix[K];
 	};
 	timeout?: number;
-	fromId?: {
-		value: string;
-		tag: string;
-	};
 }
 
 /** Properties passed to nodeUsed function when a node is used. */
 interface INodeUsageProps extends ICommonProps {
+	/** The full path (in GC Path format) to the node in question */
 	id: string;
+	/** Latest timestamp received from the server, as a baseline for computing GC state/age */
 	currentReferenceTimestampMs: number | undefined;
+	/** The package path of the node. This may not be available if the node hasn't been loaded yet */
 	packagePath: readonly string[] | undefined;
+	/** In case of Revived - what node added the reference? */
 	fromId?: string;
+	/** In case of Revived - was it revived due to autorecovery? */
 	autorecovery?: true;
+	/** URL (including query string) if this usage came from a request */
+	requestUrl?: string;
+	/** Original request headers if this usage came from a request or handle.get */
+	requestHeaders?: string;
 }
 
 /**
@@ -138,18 +145,34 @@ export class GCTelemetryTracker {
 	}
 
 	/**
-	 * Called when a node is used. If the node is not active or tombstoned, log telemetry indicating object is used
+	 * Called when a node is used. If the node is inactive or tombstoned, log telemetry indicating object is used
 	 * when it should not have been.
+	 * @param trackedId - The id that GC uses to track the node. For SubDataStore nodes, this should be the DataStore ID.
+	 * @param INodeUsageProps - All kind of details about this event to be logged
 	 */
-	public nodeUsed(nodeUsageProps: INodeUsageProps) {
+	public nodeUsed(
+		trackedId: string,
+		{
+			usageType,
+			currentReferenceTimestampMs,
+			packagePath,
+			id: untaggedId,
+			fromId: untaggedFromId,
+			isTombstoned,
+			...otherNodeUsageProps
+		}: INodeUsageProps,
+	) {
 		// If there is no reference timestamp to work with, no ops have been processed after creation. If so, skip
 		// logging as nothing interesting would have happened worth logging.
-		if (nodeUsageProps.currentReferenceTimestampMs === undefined) {
+		if (currentReferenceTimestampMs === undefined) {
 			return;
 		}
 
-		const nodeStateTracker = this.getNodeStateTracker(nodeUsageProps.id);
-		const nodeType = this.getNodeType(nodeUsageProps.id);
+		// Note: For SubDataStore Load usage, trackedId will be the DataStore's id, not the full path in question.
+		// This is necessary because the SubDataStore path may be unrecognized by GC (if suited for a custom request handler)
+		const nodeStateTracker = this.getNodeStateTracker(trackedId);
+		const nodeType = this.getNodeType(untaggedId);
+
 		const timeout = (() => {
 			switch (nodeStateTracker?.state) {
 				case UnreferencedState.Inactive:
@@ -165,33 +188,27 @@ export class GCTelemetryTracker {
 					return undefined;
 			}
 		})();
-		const {
-			usageType,
-			currentReferenceTimestampMs,
-			packagePath,
-			id: untaggedId,
-			fromId: untaggedFromId,
-			...propsToLog
-		} = nodeUsageProps;
 		const { persistedGcFeatureMatrix, ...configs } = this.configs;
-		const unrefEventProps: Omit<IUnreferencedEventProps, "state" | "usageType"> = {
+		const unrefEventProps = {
+			trackedId,
 			type: nodeType,
 			unrefTime: nodeStateTracker?.unreferencedTimestampMs ?? -1,
 			age:
 				nodeStateTracker !== undefined
-					? nodeUsageProps.currentReferenceTimestampMs -
-					  nodeStateTracker.unreferencedTimestampMs
+					? currentReferenceTimestampMs - nodeStateTracker.unreferencedTimestampMs
 					: -1,
 			timeout,
+			isTombstoned,
 			...tagCodeArtifacts({ id: untaggedId, fromId: untaggedFromId }),
-			...propsToLog,
+			...otherNodeUsageProps,
 			...this.createContainerMetadata,
 			gcConfigs: { ...configs, ...persistedGcFeatureMatrix },
-		};
+		} satisfies Omit<IUnreferencedEventProps, "state" | "usageType"> &
+			typeof otherNodeUsageProps;
 
 		// If the node that is used is tombstoned, log a tombstone telemetry.
-		if (nodeUsageProps.isTombstoned) {
-			this.logTombstoneUsageTelemetry(nodeUsageProps, unrefEventProps, nodeType, usageType);
+		if (isTombstoned) {
+			this.logTombstoneUsageTelemetry(unrefEventProps, nodeType, usageType, packagePath);
 		}
 
 		// After logging tombstone telemetry, if the node's unreferenced state is not tracked, there is nothing
@@ -201,16 +218,9 @@ export class GCTelemetryTracker {
 		}
 
 		const state = nodeStateTracker.state;
-		const uniqueEventId = `${state}-${nodeUsageProps.id}-${nodeUsageProps.usageType}`;
+		const uniqueEventId = `${state}-${untaggedId}-${usageType}`;
 
-		if (
-			!this.shouldLogNonActiveEvent(
-				nodeType,
-				nodeUsageProps.usageType,
-				nodeStateTracker,
-				uniqueEventId,
-			)
-		) {
+		if (!this.shouldLogNonActiveEvent(nodeType, usageType, nodeStateTracker, uniqueEventId)) {
 			return;
 		}
 
@@ -224,8 +234,8 @@ export class GCTelemetryTracker {
 		// SweepReady errors are usages of Objects that will be deleted by GC Sweep!
 		if (this.isSummarizerClient) {
 			this.pendingEventsQueue.push({
-				...unrefEventProps,
-				usageType: nodeUsageProps.usageType,
+				...unrefEventProps, // Note: Contains some properties from INodeUsageProps as well
+				usageType,
 				state,
 			});
 		} else {
@@ -233,11 +243,11 @@ export class GCTelemetryTracker {
 			// summarizer clients if they are based off of user actions (such as scrolling to content for these objects)
 			// Events generated:
 			// InactiveObject_Loaded, SweepReadyObject_Loaded
-			if (nodeUsageProps.usageType === "Loaded") {
+			if (usageType === "Loaded") {
 				const { id, fromId, headers, gcConfigs, ...detailedProps } = unrefEventProps;
 				const event = {
-					eventName: `${state}Object_${nodeUsageProps.usageType}`,
-					...tagCodeArtifacts({ pkg: nodeUsageProps.packagePath?.join("/") }),
+					eventName: `${state}Object_${usageType}`,
+					...tagCodeArtifacts({ pkg: packagePath?.join("/") }),
 					stack: generateStack(),
 					id,
 					fromId,
@@ -257,10 +267,10 @@ export class GCTelemetryTracker {
 	 * Logs telemetry when a tombstoned object is changed, revived or loaded.
 	 */
 	private logTombstoneUsageTelemetry(
-		nodeUsageProps: INodeUsageProps,
 		unrefEventProps: Omit<IUnreferencedEventProps, "state" | "usageType">,
 		nodeType: GCNodeType,
 		usageType: NodeUsageType,
+		packagePath?: readonly string[],
 	) {
 		// This will log the following events:
 		// GC_Tombstone_DataStore_Requested, GC_Tombstone_DataStore_Changed, GC_Tombstone_DataStore_Revived
@@ -270,12 +280,12 @@ export class GCTelemetryTracker {
 		const eventUsageName = usageType === "Loaded" ? "Requested" : usageType;
 		const event = {
 			eventName: `GC_Tombstone_${nodeType}_${eventUsageName}`,
-			pkg: tagCodeArtifacts({ pkg: nodeUsageProps.packagePath?.join("/") }).pkg,
+			...tagCodeArtifacts({ pkg: packagePath?.join("/") }),
 			stack: generateStack(),
 			id,
 			fromId,
 			headers: { ...headers },
-			details: detailedProps,
+			details: detailedProps, // Also includes some properties from INodeUsageProps type
 			gcConfigs,
 			tombstoneFlags: {
 				DisableTombstone: this.mc.config.getBoolean(disableTombstoneKey),
@@ -367,7 +377,6 @@ export class GCTelemetryTracker {
 		// InactiveObject_Loaded, InactiveObject_Changed, InactiveObject_Revived
 		// SweepReadyObject_Loaded, SweepReadyObject_Changed, SweepReadyObject_Revived
 		for (const eventProps of this.pendingEventsQueue) {
-			// const { usageType, state, id, fromId, ...propsToLog } = eventProps;
 			const { usageType, state, id, fromId, headers, gcConfigs, ...detailedProps } =
 				eventProps;
 			/**
@@ -376,7 +385,7 @@ export class GCTelemetryTracker {
 			 * Loaded and Changed events are logged only if the node is not active. If the node is active, it was
 			 * revived and a Revived event will be logged for it.
 			 */
-			const nodeStateTracker = this.getNodeStateTracker(eventProps.id.value);
+			const nodeStateTracker = this.getNodeStateTracker(detailedProps.trackedId); // Note: This is never SubDataStore path
 			const active =
 				nodeStateTracker === undefined ||
 				nodeStateTracker.state === UnreferencedState.Active;

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -23,6 +23,7 @@ export {
 	IGarbageCollectorCreateParams,
 	IGCMetadata,
 	IGCMetadata_Deprecated,
+	IGCNodeUpdatedProps,
 	IGCResult,
 	IGCRuntimeOptions,
 	IMarkPhaseStats,
@@ -45,8 +46,8 @@ export {
 export {
 	cloneGCData,
 	concatGarbageCollectionStates,
-	trimLeadingAndTrailingSlashes,
 	unpackChildNodesGCDetails,
+	urlToGCNodePath,
 } from "./gcHelpers.js";
 export { runGarbageCollection } from "./gcReferenceGraphAlgorithm.js";
 export {

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -47,6 +47,7 @@ export {
 	IGCRuntimeOptions,
 	IMarkPhaseStats,
 	ISweepPhaseStats,
+	IGCNodeUpdatedProps,
 	IGCStats,
 } from "./gc/index.js";
 export {

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -14,6 +14,7 @@ export {
 	RuntimeMessage,
 	agentSchedulerId,
 	ContainerRuntime,
+	DeletedResponseHeaderKey,
 	TombstoneResponseHeaderKey,
 	InactiveResponseHeaderKey,
 	ISummaryConfiguration,

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -21,6 +21,7 @@ export {
 	DefaultSummaryConfiguration,
 	ICompressionRuntimeOptions,
 	CompressionAlgorithms,
+	RuntimeHeaderData,
 } from "./containerRuntime.js";
 export {
 	ContainerMessageType,

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -128,6 +128,22 @@ describe("Garbage Collection Tests", () => {
 		return sweepReadyRoutes;
 	}
 
+	/** More concise signature for calling IGarbageCollector.nodeUpdated */
+	function nodeUpdated(
+		garbageCollector: IGarbageCollector,
+		path: string,
+		reason: "Loaded" | "Changed",
+		timestampMs?: number,
+		packagePath?: readonly string[],
+	) {
+		garbageCollector.nodeUpdated({
+			node: { type: "DataStore", path },
+			reason,
+			timestampMs,
+			packagePath,
+		});
+	}
+
 	function createGarbageCollector(
 		params: {
 			createParams?: Partial<IGarbageCollectorCreateParams>;
@@ -471,7 +487,7 @@ describe("Garbage Collection Tests", () => {
 			assert.deepEqual(gc.tombstones, [nodes[0]], "node 0 should be in the Tombstones list");
 
 			// Simulate usage to trigger TombstoneLoaded op.
-			gc.nodeUpdated(nodes[0], "Loaded");
+			nodeUpdated(gc, nodes[0], "Loaded");
 			const [gcTombstoneLoadedMessage] = spies.gc.submitMessage.args[0];
 			assert.deepEqual(
 				gcTombstoneLoadedMessage,
@@ -534,8 +550,8 @@ describe("Garbage Collection Tests", () => {
 		// Mock node loaded and changed activity for all the nodes in the graph.
 		async function mockNodeChangesAndRunGC(garbageCollector: IGarbageCollector) {
 			nodes.forEach((nodeId) => {
-				garbageCollector.nodeUpdated(nodeId, "Loaded", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodeId, "Changed", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodeId, "Loaded", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodeId, "Changed", Date.now(), testPkgPath);
 			});
 			await garbageCollector.collectGarbage({});
 		}
@@ -698,8 +714,8 @@ describe("Garbage Collection Tests", () => {
 
 				// Expire the timeout and validate that only revived event is generated for node 2.
 				clock.tick(1);
-				garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodes[2], "Loaded", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodes[2], "Changed", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodes[2], "Loaded", Date.now(), testPkgPath);
 				garbageCollector.addedOutboundReference(nodes[1], nodes[2]);
 				await garbageCollector.collectGarbage({});
 
@@ -811,8 +827,8 @@ describe("Garbage Collection Tests", () => {
 				// Run GC to trigger loading the GC details from the base summary. Will also generate Delete logs
 				await garbageCollector.collectGarbage({});
 				// Validate that all events are logged as expected.
-				garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodes[3], "Loaded", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodes[3], "Changed", Date.now(), testPkgPath);
 				await garbageCollector.collectGarbage({});
 				mockLogger.assertMatch(
 					[
@@ -890,8 +906,8 @@ describe("Garbage Collection Tests", () => {
 				await garbageCollector.initializeBaseState();
 
 				// Simulate sending op and loading the node in unreferenced state.
-				garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodes[3], "Loaded", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodes[3], "Changed", Date.now(), testPkgPath);
 
 				// Log pending events explicitly. This is needed because summarizer clients don't log these events
 				// until the next GC run which calls this function.
@@ -975,8 +991,8 @@ describe("Garbage Collection Tests", () => {
 				await garbageCollector.collectGarbage({});
 
 				// Validate that no events are generated since none of the timeouts have passed
-				garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodes[3], "Changed", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodes[3], "Loaded", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodes[3], "Changed", Date.now(), testPkgPath);
 				await garbageCollector.collectGarbage({});
 				mockLogger.assertMatchNone(
 					[
@@ -1069,9 +1085,9 @@ describe("Garbage Collection Tests", () => {
 				await garbageCollector.collectGarbage({});
 
 				// Validate that all events are logged as expected.
-				garbageCollector.nodeUpdated(nodes[3], "Loaded", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodes[1], "Changed", Date.now(), testPkgPath);
-				garbageCollector.nodeUpdated(nodes[2], "Changed", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodes[3], "Loaded", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodes[1], "Changed", Date.now(), testPkgPath);
+				nodeUpdated(garbageCollector, nodes[2], "Changed", Date.now(), testPkgPath);
 				await garbageCollector.collectGarbage({});
 				mockLogger.assertMatch(
 					[

--- a/packages/runtime/container-runtime/src/test/gc/gcHelpers.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcHelpers.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { GCFeatureMatrix } from "../../gc/index.js";
 // eslint-disable-next-line import/no-internal-modules
-import { shouldAllowGcSweep } from "../../gc/gcHelpers.js";
+import { dataStoreNodePathOnly, shouldAllowGcSweep, urlToGCNodePath } from "../../gc/gcHelpers.js";
 
 describe("Garbage Collection Helpers Tests", () => {
 	describe("[TEMP] shouldAllowGcTombstoneEnforcement - Show behavior change as it's replaced by shouldAllowGcSweep", () => {
@@ -115,6 +115,82 @@ describe("Garbage Collection Helpers Tests", () => {
 			it(`persisted=${JSON.stringify(persisted)}, current=${current}`, () => {
 				const shouldAllow = shouldAllowGcSweep(persisted, current);
 				assert.equal(shouldAllow, expectedShouldAllowValue);
+			});
+		});
+	});
+
+	describe("dataStoreNodePathOnly", () => {
+		const testCases: {
+			path: string;
+			expected: string;
+		}[] = [
+			{
+				path: "/",
+				expected: "/",
+			},
+			{
+				path: "/a",
+				expected: "/a",
+			},
+			{
+				path: "/a/b",
+				expected: "/a",
+			},
+			{
+				path: "/a/b/c",
+				expected: "/a",
+			},
+		];
+		testCases.forEach(({ path, expected }) => {
+			it(`path=${path}`, () => {
+				const result = dataStoreNodePathOnly(path);
+				assert.equal(result, expected);
+			});
+		});
+	});
+
+	describe("urlToGCNodePath", () => {
+		const testCases: {
+			url: string;
+			expected: string;
+		}[] = [
+			{
+				url: "/a",
+				expected: "/a",
+			},
+			{
+				url: "/a/",
+				expected: "/a",
+			},
+			{
+				url: "/a/b",
+				expected: "/a/b",
+			},
+			{
+				url: "/a/b/",
+				expected: "/a/b",
+			},
+			{
+				url: "/a?x=1",
+				expected: "/a",
+			},
+			{
+				url: "/a/?x=1",
+				expected: "/a",
+			},
+			{
+				url: "/a/b?x=1",
+				expected: "/a/b",
+			},
+			{
+				url: "/a/b/?x=1",
+				expected: "/a/b",
+			},
+		];
+		testCases.forEach(({ url, expected }) => {
+			it(`url=${url}`, () => {
+				const result = urlToGCNodePath(url);
+				assert.equal(result, expected);
 			});
 		});
 	});

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -122,7 +122,7 @@ describe("GC Telemetry Tracker", () => {
 	// Mock node loaded and changed activity for the given nodes.
 	function mockNodeChanges(nodeIds: string[]) {
 		nodeIds.forEach((id) => {
-			telemetryTracker.nodeUsed({
+			telemetryTracker.nodeUsed(id, {
 				id,
 				usageType: "Loaded",
 				currentReferenceTimestampMs: Date.now(),
@@ -130,7 +130,7 @@ describe("GC Telemetry Tracker", () => {
 				completedGCRuns: 0,
 				isTombstoned: false,
 			});
-			telemetryTracker.nodeUsed({
+			telemetryTracker.nodeUsed(id, {
 				id,
 				usageType: "Changed",
 				currentReferenceTimestampMs: Date.now(),
@@ -143,7 +143,7 @@ describe("GC Telemetry Tracker", () => {
 
 	// Mock node revived activity for the given nodes.
 	function reviveNode(fromId: string, toId: string, isTombstoned = false) {
-		telemetryTracker.nodeUsed({
+		telemetryTracker.nodeUsed(toId, {
 			id: toId,
 			usageType: "Revived",
 			currentReferenceTimestampMs: Date.now(),
@@ -444,6 +444,37 @@ describe("GC Telemetry Tracker", () => {
 					],
 					"revived event not as expected",
 				);
+			});
+
+			it("generates events properly for untracked subDataStore paths", async () => {
+				// Mark node 1 as unreferenced.
+				markNodesUnreferenced([nodes[1]]);
+
+				// We'll mock a Loaded event for this path, passing the DataStore path as trackedId to ensure coverage
+				const subDataStorePath = `${nodes[1]}/something`;
+
+				// Expire the timeout, update nodes and validate that all events for node 1 are logged.
+				clock.tick(timeout);
+				telemetryTracker.nodeUsed(nodes[1], {
+					id: subDataStorePath,
+					usageType: "Loaded",
+					currentReferenceTimestampMs: Date.now(),
+					packagePath: testPkgPath,
+					completedGCRuns: 0,
+					isTombstoned: false,
+				});
+				await simulateGCToTriggerEvents(isSummarizerClient);
+				const expectedEvents: Omit<ITelemetryBaseEvent, "category">[] = [];
+				expectedEvents.push({
+					eventName: loadedEventName,
+					timeout,
+					...tagCodeArtifacts({ id: subDataStorePath, pkg: testPkgPath.join("/") }),
+					createContainerRuntimeVersion: pkgVersion,
+					isTombstoned: false,
+					trackedId: nodes[1],
+					type: "SubDataStore",
+				});
+				assertMatchEvents(expectedEvents, "all events not as expected");
 			});
 
 			it("generates events once per node", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDataVirtualization.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDataVirtualization.spec.ts
@@ -1,0 +1,219 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+	createTestConfigProvider,
+	createSummarizer,
+	ITestContainerConfig,
+	ITestObjectProvider,
+	summarizeNow,
+	waitForContainerConnection,
+} from "@fluidframework/test-utils/internal";
+import {
+	describeCompat,
+	ITestDataObject,
+	TestDataObjectType,
+} from "@fluid-private/test-version-utils";
+import {
+	ISummaryTree,
+	SummaryType,
+	type ISnapshotTree,
+} from "@fluidframework/protocol-definitions";
+import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
+import type { ISnapshot } from "@fluidframework/driver-definitions/internal";
+import { getGCStateFromSummary } from "./gcTestSummaryUtils.js";
+
+const interceptResult = <T>(
+	parent: any,
+	fn: (...args: any[]) => Promise<T>,
+	intercept: (result: T) => void,
+) => {
+	const interceptFn = async (...args: any[]) => {
+		const val = await fn.apply(parent, args);
+		intercept(val);
+		return val as T;
+	};
+	parent[fn.name] = interceptFn;
+	interceptFn.bind(parent);
+	return fn;
+};
+
+const assertOmittedTree = (
+	snapshotTree: ISnapshotTree,
+	groupId: string | undefined,
+	message: string,
+) => {
+	assert(snapshotTree.omitted, message);
+	assert(snapshotTree.groupId === groupId, message);
+	assert(Object.entries(snapshotTree.trees).length === 0, message);
+	assert(Object.entries(snapshotTree.blobs).length === 0, message);
+};
+
+/**
+ * Validates that an unreferenced datastore goes through all the GC phases without overlapping.
+ */
+describeCompat("GC & Data Virtualization", "NoCompat", (getTestObjectProvider) => {
+	const configProvider = createTestConfigProvider();
+	configProvider.set("Fluid.Container.UseLoadingGroupIdForSnapshotFetch", true);
+	const testContainerConfig: ITestContainerConfig = {
+		runtimeOptions: {
+			summaryOptions: {
+				summaryConfigOverrides: {
+					state: "disabled",
+				},
+			},
+		},
+		loaderProps: { configProvider },
+	};
+
+	let provider: ITestObjectProvider;
+
+	const loadSummarizer = async (container: IContainer, summaryVersion?: string) => {
+		return createSummarizer(
+			provider,
+			container,
+			{
+				loaderProps: { configProvider },
+			},
+			summaryVersion,
+		);
+	};
+
+	function getDataStoreInSummaryTree(summaryTree: ISummaryTree, dataStoreId: string) {
+		const channelsTree = summaryTree.tree[".channels"];
+		assert(channelsTree !== undefined, "Expected a .channels tree");
+		assert(channelsTree.type === SummaryType.Tree, "Expected a tree");
+		return channelsTree.tree[dataStoreId];
+	}
+
+	async function isDataStoreInSummaryTree(summaryTree: ISummaryTree, dataStoreId: string) {
+		return getDataStoreInSummaryTree(summaryTree, dataStoreId) !== undefined;
+	}
+
+	beforeEach("setup", async function () {
+		provider = getTestObjectProvider({ syncSummarizer: true });
+
+		// Data virtualization only works with local
+		// TODO: enable for ODSP, AB#7508
+		if (provider.driver.type !== "local") {
+			this.skip();
+		}
+	});
+
+	it("Virtualized datastore has same gc state even when not downloaded", async () => {
+		// Intercept snapshot call so we can get call count and the snapshot
+		let snapshotCaptured: ISnapshot | undefined;
+		let callCount = 0;
+		const documentServiceFactory = provider.documentServiceFactory;
+		interceptResult(
+			documentServiceFactory,
+			documentServiceFactory.createDocumentService,
+			(documentService) => {
+				interceptResult(documentService, documentService.connectToStorage, (storage) => {
+					assert(storage.getSnapshot !== undefined, "Test can't run without getSnapshot");
+					interceptResult(storage, storage.getSnapshot, (snapshot) => {
+						snapshotCaptured = snapshot;
+						callCount++;
+					});
+				});
+			},
+		);
+
+		// create container and summarizer
+		const mainContainer = await provider.makeTestContainer(testContainerConfig);
+		const mainDataStore = (await mainContainer.getEntryPoint()) as ITestDataObject;
+		await waitForContainerConnection(mainContainer);
+		callCount = 0;
+		const { container, summarizer } = await loadSummarizer(mainContainer);
+		assert(callCount === 1, "Expected one snapshot call");
+
+		// create datastore A and B
+		const dataStoreA = await mainDataStore._context.containerRuntime.createDataStore(
+			TestDataObjectType,
+			"group",
+		);
+		const dataStoreB =
+			await mainDataStore._context.containerRuntime.createDataStore(TestDataObjectType);
+		const handleA = dataStoreA.entryPoint;
+		const handleB = dataStoreB.entryPoint;
+		assert(handleA !== undefined, "Expected a handle when creating a datastoreA");
+		assert(handleB !== undefined, "Expected a handle when creating a datastoreB");
+		const dataObjectA = (await handleA.get()) as ITestDataObject;
+		const dataStoreId = dataObjectA._context.id;
+
+		// reference datastore A and B
+		mainDataStore._root.set("dataStoreA", handleA);
+		mainDataStore._root.set("dataStoreB", handleB);
+
+		// unreference datastore A
+		mainDataStore._root.delete("dataStoreA");
+
+		// Summarize and verify datastore A is unreferenced
+		await provider.ensureSynchronized();
+		callCount = 0;
+		const { summaryTree, summaryVersion } = await summarizeNow(summarizer);
+
+		// Validate GC state datastoreA should be unreferenced
+		assert(callCount === 0, "Expected no snapshot call");
+		const gcState = getGCStateFromSummary(summaryTree);
+		assert(gcState !== undefined, "Expected GC state to be generated");
+		const gcNodeA = gcState.gcNodes[handleA.absolutePath];
+		assert(gcNodeA !== undefined, "Data Store should exist on gc graph");
+		const unreferencedTimestampMs = gcNodeA.unreferencedTimestampMs;
+		assert(unreferencedTimestampMs !== undefined, "Data Store should be unreferenced");
+		// DataStoreA should be in the summary
+		assert(
+			isDataStoreInSummaryTree(summaryTree, dataStoreId),
+			"Data Store should be in the summary!",
+		);
+
+		// Load new container
+		const mainContainer2 = await provider.loadTestContainer(testContainerConfig, {
+			[LoaderHeader.version]: summaryVersion,
+		});
+		const mainDataStore2 = (await mainContainer2.getEntryPoint()) as ITestDataObject;
+
+		// Close the old summarizer and container so that we can summarize th new container.
+		summarizer.close();
+		container.close();
+		mainContainer.close();
+
+		// Unreference datastore B
+		mainDataStore2._root.delete("dataStoreB");
+
+		// Load new summarizer
+		snapshotCaptured = undefined;
+		callCount = 0;
+		const { summarizer: summarizer2 } = await loadSummarizer(mainContainer2, summaryVersion);
+		assert(callCount === 1, "Expected one snapshot call");
+		assert(snapshotCaptured !== undefined, "Expected snapshot to be captured");
+
+		// Validate that we loaded the snapshot without datastoreA on the snapshot
+		const tree = (snapshotCaptured as ISnapshot).snapshotTree.trees[".channels"].trees;
+		const datastoreATree = tree[dataStoreId];
+		assert(datastoreATree !== undefined, "DataStoreA should be in the snapshot");
+		assertOmittedTree(datastoreATree, "group", "DataStoreA should be omitted");
+
+		// Summarize and verify datastoreA is still unreferenced
+		await provider.ensureSynchronized();
+		callCount = 0;
+		const { summaryTree: summaryTree2 } = await summarizeNow(summarizer2);
+
+		// Validate GC state (dataStoreA should be unreferenced with the same timestamp as the previous summary)
+		assert(callCount === 0, "Expected no snapshot call");
+		const gcState2 = getGCStateFromSummary(summaryTree2);
+		assert(gcState2 !== undefined, "Expected GC state to be generated");
+		const gcNodeA2 = gcState2.gcNodes[handleA.absolutePath];
+		assert(gcNodeA2 !== undefined, "DataStoreA should exist on gc graph");
+		assert(
+			gcNodeA2.unreferencedTimestampMs === unreferencedTimestampMs,
+			"DataStoreA should be unreferenced the same",
+		);
+		// Validate summary state (dataStoreA should be a summary handle)
+		const dataStoreTreeA = getDataStoreInSummaryTree(summaryTree2, dataStoreId);
+		assert(dataStoreTreeA?.type === SummaryType.Handle, "DataStoreA should not have changed!");
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -222,15 +222,38 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 				await summarize(summarizerRuntime);
 				validateNoInactiveEvents();
 
-				// Revive the inactive data store and validate that we get the revivedEvent event.
+				// Revive the inactive data store (via both DDS reference and DataStore reference) and validate that we get the revivedEvent events.
+				defaultDataStore._root.set("dataStore_root", dataObject._root.handle);
 				defaultDataStore._root.set("dataStore1", dataObject.handle);
 				await summarize(summarizerRuntime);
 				mockLogger.assertMatch(
 					[
+						// For DDS
 						{
 							eventName: revivedEvent,
 							timeout: inactiveTimeoutMs,
-							id: { value: url, tag: TelemetryDataTag.CodeArtifact },
+							trackedId: url,
+							type: "SubDataStore",
+							id: {
+								value: dataObject._root.handle.absolutePath,
+								tag: TelemetryDataTag.CodeArtifact,
+							},
+							pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
+							fromId: {
+								value: defaultDataStore._root.handle.absolutePath,
+								tag: TelemetryDataTag.CodeArtifact,
+							},
+						},
+						// For DataStore
+						{
+							eventName: revivedEvent,
+							timeout: inactiveTimeoutMs,
+							trackedId: url,
+							type: "DataStore",
+							id: {
+								value: url,
+								tag: TelemetryDataTag.CodeArtifact,
+							},
 							pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
 							fromId: {
 								value: defaultDataStore._root.handle.absolutePath,
@@ -238,7 +261,7 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 							},
 						},
 					],
-					"revived event not generated as expected",
+					"revived events not generated as expected",
 					true /* inlineDetailsProp */,
 				);
 			},
@@ -338,6 +361,7 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 				const dataObject = await createNewDataObject();
 				const dataStoreUrl = dataObject.handle.absolutePath;
 				const ddsUrl = dataObject._root.handle.absolutePath;
+				const untrackedUrl = `${dataStoreUrl}/unrecognizedSubPath`;
 
 				defaultDataStore._root.set("dataStore1", dataObject.handle);
 				await provider.ensureSynchronized();
@@ -358,12 +382,18 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 				// Make changes to the inactive data store and validate that we get the changedEvent.
 				dataObject._root.set("key", "value");
 				await provider.ensureSynchronized();
-				// Load the DDS and validate that we get loadedEvent.
-				const response = await summarizerRuntime.resolveHandle({ url: ddsUrl });
+				// Load the DDS and untracked subDataStore path and validate that we get loadedEvents.
+				const response1 = await summarizerRuntime.resolveHandle({ url: ddsUrl });
 				assert.equal(
-					response.status,
+					response1.status,
 					200,
 					"Loading the inactive object should succeed on summarizer despite throwOnInactiveLoad option",
+				);
+				const response2 = await summarizerRuntime.resolveHandle({ url: untrackedUrl });
+				assert.equal(
+					response2.status,
+					404,
+					"404 would fall back to custom request handler (not implemented here)",
 				);
 				await summarize(summarizerRuntime);
 				mockLogger.assertMatch(
@@ -373,12 +403,23 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 							timeout: inactiveTimeoutMs,
 							id: { value: dataStoreUrl, tag: TelemetryDataTag.CodeArtifact },
 							pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
+							type: "DataStore",
 						},
 						{
 							eventName: loadedEvent,
 							timeout: inactiveTimeoutMs,
 							id: { value: ddsUrl, tag: TelemetryDataTag.CodeArtifact },
 							pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
+							trackedId: dataStoreUrl,
+							type: "SubDataStore",
+						},
+						{
+							eventName: loadedEvent,
+							timeout: inactiveTimeoutMs,
+							id: { value: untrackedUrl, tag: TelemetryDataTag.CodeArtifact },
+							pkg: { value: TestDataObjectType, tag: TelemetryDataTag.CodeArtifact },
+							trackedId: dataStoreUrl,
+							type: "SubDataStore",
 						},
 					],
 					"changed and loaded events not generated as expected",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -11,7 +11,7 @@ import {
 	IOnDemandSummarizeOptions,
 	ISummarizeEventProps,
 	ISummarizer,
-	TombstoneResponseHeaderKey,
+	DeletedResponseHeaderKey,
 } from "@fluidframework/container-runtime";
 import { ISummaryTree, SummaryType } from "@fluidframework/protocol-definitions";
 import { channelsTreeName, gcTreeKey } from "@fluidframework/runtime-definitions";
@@ -39,6 +39,7 @@ import {
 } from "@fluidframework/container-runtime/test/summary";
 // eslint-disable-next-line import/no-internal-modules
 import { ISweepMessage } from "@fluidframework/container-runtime/test/gc";
+import { MockLogger, tagCodeArtifacts } from "@fluidframework/telemetry-utils/internal";
 import {
 	getGCDeletedStateFromSummary,
 	getGCStateFromSummary,
@@ -122,23 +123,26 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 	const tombstoneTimeoutMs = 200;
 	const sweepGracePeriodMs = 0; // Skip Tombstone, these tests focus on Sweep
 	const sweepTimeoutMs = tombstoneTimeoutMs + sweepGracePeriodMs;
-	const gcOptions: IGCRuntimeOptions = {
+	const newGCOptions: () => IGCRuntimeOptions = () => ({
 		inactiveTimeoutMs: 0,
 		enableGCSweep: true,
 		sweepGracePeriodMs,
-	};
+	});
+	const mockLogger = new MockLogger();
 	const configProvider = createTestConfigProvider();
-	const testContainerConfig: ITestContainerConfig = {
+	const newTestContainerConfig: () => ITestContainerConfig = () => ({
 		runtimeOptions: {
 			summaryOptions: {
 				summaryConfigOverrides: {
 					state: "disabled",
 				},
 			},
-			gcOptions,
+			gcOptions: newGCOptions(),
 		},
-		loaderProps: { configProvider },
-	};
+		loaderProps: { configProvider, logger: mockLogger },
+	});
+
+	const testContainerConfig: ITestContainerConfig = newTestContainerConfig();
 
 	let provider: ITestObjectProvider;
 
@@ -154,6 +158,7 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 	});
 
 	afterEach(() => {
+		mockLogger.clear();
 		configProvider.clear();
 	});
 
@@ -171,7 +176,7 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 			provider,
 			container,
 			{
-				runtimeOptions: { gcOptions },
+				runtimeOptions: { gcOptions: newGCOptions() },
 				loaderProps: { configProvider },
 			},
 			summaryVersion,
@@ -250,6 +255,10 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 			"Send ops fails for swept datastores in summarizing container loaded before tombstone timeout",
 			[
 				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_DeletingLoadedDataStore",
+					clientType: "noninteractive/summarizer", // summarizationWithUnreferencedDataStoreAfterTime has a summarizer spanning before/after the delete
+				},
+				{
 					eventName: "fluid:telemetry:FluidDataStoreContext:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
 					callSite: "submitMessage",
@@ -279,6 +288,10 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 		itExpects(
 			"Send signals fails for swept datastores in summarizing container loaded before tombstone timeout",
 			[
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_DeletingLoadedDataStore",
+					clientType: "noninteractive/summarizer", // summarizationWithUnreferencedDataStoreAfterTime has a summarizer spanning before/after the delete
+				},
 				{
 					eventName: "fluid:telemetry:FluidDataStoreContext:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
@@ -312,6 +325,17 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 			"Requesting swept datastores not allowed",
 			[
 				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_DeletingLoadedDataStore",
+					clientType: "noninteractive/summarizer", // summarizationWithUnreferencedDataStoreAfterTime has a summarizer spanning before/after the delete
+				},
+				// DataStore
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+					clientType: "interactive",
+					callSite: "getDataStore",
+				},
+				// Sub-DataStore
+				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
 					clientType: "interactive",
 					callSite: "getDataStore",
@@ -331,12 +355,15 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 				const { summaryVersion } = await ensureSynchronizedAndSummarize(summarizer);
 				const container = await loadContainer(summaryVersion);
 
+				mockLogger.clear();
+
 				// This request fails since the datastore is swept
 				const entryPoint = (await container.getEntryPoint()) as ITestDataObject;
 				const errorResponse = await (
 					entryPoint._context.containerRuntime as any
 				).resolveHandle({
 					url: unreferencedId,
+					headers: { viaHandle: true },
 				});
 				assert.equal(
 					errorResponse.status,
@@ -349,10 +376,67 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 					"Expected the Sweep error message",
 				);
 				assert.equal(
-					errorResponse.headers?.[TombstoneResponseHeaderKey],
-					undefined,
-					"DID NOT Expect tombstone header to be set on the response",
+					errorResponse.headers?.[DeletedResponseHeaderKey],
+					true,
+					"Expected 'deleted' header to be set on the response",
 				);
+
+				// Flush microtask queue to get PathInfo event logged
+				await delay(0);
+				mockLogger.assertMatch([
+					{
+						eventName:
+							"fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+						...tagCodeArtifacts({ id: `/${unreferencedId}` }),
+					},
+					{
+						eventName: "fluid:telemetry:ContainerRuntime:GC_DeletedDataStore_PathInfo",
+						...tagCodeArtifacts({
+							id: `/${unreferencedId}`,
+							pkg: "@fluid-example/test-dataStore",
+						}),
+					},
+				]);
+
+				// Request for child fails too since the datastore is swept
+				const childErrorResponse = await (
+					entryPoint._context.containerRuntime as any
+				).resolveHandle({
+					url: `${unreferencedId}/some-child-id`, // child id can be anything to test this case
+					headers: { viaHandle: true },
+				});
+				assert.equal(
+					childErrorResponse.status,
+					404,
+					"Should not be able to retrieve a swept datastore loading from a non-summarizer client",
+				);
+				assert.equal(
+					childErrorResponse.value,
+					`DataStore was deleted: ${unreferencedId}/some-child-id`,
+					"Expected the Sweep error message",
+				);
+				assert.equal(
+					childErrorResponse.headers?.[DeletedResponseHeaderKey],
+					true,
+					"Expected 'deleted' header to be set on the response",
+				);
+
+				// Flush microtask queue to get PathInfo event logged
+				await delay(0);
+				mockLogger.assertMatch([
+					{
+						eventName:
+							"fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Requested",
+						...tagCodeArtifacts({ id: `/${unreferencedId}/some-child-id` }),
+					},
+					{
+						eventName: "fluid:telemetry:ContainerRuntime:GC_DeletedDataStore_PathInfo",
+						...tagCodeArtifacts({
+							id: `/${unreferencedId}/some-child-id`,
+							pkg: "@fluid-example/test-dataStore",
+						}),
+					},
+				]);
 
 				// This request fails since the datastore is swept
 				const summarizerResponse = await (summarizer as any).runtime.resolveHandle({
@@ -369,9 +453,9 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 					"Expected the Sweep error message",
 				);
 				assert.equal(
-					summarizerResponse.headers?.[TombstoneResponseHeaderKey],
-					undefined,
-					"DID NOT Expect tombstone header to be set on the response",
+					errorResponse.headers?.[DeletedResponseHeaderKey],
+					true,
+					"Expected 'deleted' header to be set on the response",
 				);
 			},
 		);
@@ -379,6 +463,14 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 		itExpects(
 			"Ops for swept data stores is ignored but logs an error",
 			[
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_DeletingLoadedDataStore",
+					clientType: "noninteractive/summarizer", // summarizationWithUnreferencedDataStoreAfterTime has a summarizer spanning before/after the delete
+				},
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_DeletingLoadedDataStore",
+					clientType: "interactive", // For this test, the interactive client is set up to receive the delete op and send ops concurrently
+				},
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
@@ -447,6 +539,10 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 			"Signals for swept datastores are ignored but logs an error",
 			[
 				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_DeletingLoadedDataStore",
+					clientType: "noninteractive/summarizer", // summarizationWithUnreferencedDataStoreAfterTime has a summarizer spanning before/after the delete
+				},
+				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
 					clientType: "noninteractive/summarizer",
 					callSite: "processSignal",
@@ -455,6 +551,10 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
 					clientType: "interactive",
 					callSite: "processSignal",
+				},
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_DeletingLoadedDataStore",
+					clientType: "interactive", // For this test, the interactive client is set up to receive the delete op and send ops concurrently
 				},
 				{
 					eventName: "fluid:telemetry:ContainerRuntime:GC_Deleted_DataStore_Changed",
@@ -517,26 +617,35 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 	});
 
 	describe("Deleted data stores in summary", () => {
-		it("updates deleted data store state in the summary", async () => {
-			const { unreferencedId, summarizer } =
-				await summarizationWithUnreferencedDataStoreAfterTime();
-			const sweepReadyDataStoreNodePath = `/${unreferencedId}`;
+		itExpects(
+			"updates deleted data store state in the summary",
+			[
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_DeletingLoadedDataStore",
+					clientType: "noninteractive/summarizer", // summarizationWithUnreferencedDataStoreAfterTime has a summarizer spanning before/after the delete
+				},
+			],
+			async () => {
+				const { unreferencedId, summarizer } =
+					await summarizationWithUnreferencedDataStoreAfterTime();
+				const sweepReadyDataStoreNodePath = `/${unreferencedId}`;
 
-			// Summarize. In this summary, the gc op will be sent with the deleted data store id. The data store
-			// will be removed in the subsequent summary.
-			await ensureSynchronizedAndSummarize(summarizer);
+				// Summarize. In this summary, the gc op will be sent with the deleted data store id. The data store
+				// will be removed in the subsequent summary.
+				await ensureSynchronizedAndSummarize(summarizer);
 
-			// Summarize again so that the sweep ready blobs are now deleted from the GC data.
-			const summary3 = await ensureSynchronizedAndSummarize(summarizer);
+				// Summarize again so that the sweep ready blobs are now deleted from the GC data.
+				const summary3 = await ensureSynchronizedAndSummarize(summarizer);
 
-			// Validate that the deleted data store's state is correct in the summary.
-			validateDataStoreStateInSummary(
-				summary3.summaryTree,
-				sweepReadyDataStoreNodePath,
-				true /* expectDelete */,
-				false /* expectGCStateHandle */,
-			);
-		});
+				// Validate that the deleted data store's state is correct in the summary.
+				validateDataStoreStateInSummary(
+					summary3.summaryTree,
+					sweepReadyDataStoreNodePath,
+					true /* expectDelete */,
+					false /* expectGCStateHandle */,
+				);
+			},
+		);
 
 		it("disableDatastoreSweep true - Tombstones the SweepReady data store state in the summary", async () => {
 			configProvider.set("Fluid.GarbageCollection.DisableDataStoreSweep", true);
@@ -573,23 +682,32 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 			configProvider.set("Fluid.Summarizer.ValidateSummaryBeforeUpload", true);
 		});
 
-		it("can run sweep without failing summaries due to local changes", async () => {
-			const { summarizer } = await summarizationWithUnreferencedDataStoreAfterTime();
+		itExpects(
+			"can run sweep without failing summaries due to local changes",
+			[
+				{
+					eventName: "fluid:telemetry:ContainerRuntime:GC_DeletingLoadedDataStore",
+					clientType: "noninteractive/summarizer", // summarizationWithUnreferencedDataStoreAfterTime has a summarizer spanning before/after the delete
+				},
+			],
+			async () => {
+				const { summarizer } = await summarizationWithUnreferencedDataStoreAfterTime();
 
-			// Summarize. In this summary, the gc op will be sent with the deleted data store id. Validate that
-			// the GC op does not fail summary due to local changes.
-			await assert.doesNotReject(
-				async () => ensureSynchronizedAndSummarize(summarizer),
-				"Summary and GC should succeed in presence of GC op",
-			);
+				// Summarize. In this summary, the gc op will be sent with the deleted data store id. Validate that
+				// the GC op does not fail summary due to local changes.
+				await assert.doesNotReject(
+					async () => ensureSynchronizedAndSummarize(summarizer),
+					"Summary and GC should succeed in presence of GC op",
+				);
 
-			// Summarize again so that the sweep ready blobs are now deleted from the GC data. Validate that
-			// summarize and GC succeed.
-			await assert.doesNotReject(
-				async () => ensureSynchronizedAndSummarize(summarizer),
-				"Summary and GC should succeed with deleted data store",
-			);
-		});
+				// Summarize again so that the sweep ready blobs are now deleted from the GC data. Validate that
+				// summarize and GC succeed.
+				await assert.doesNotReject(
+					async () => ensureSynchronizedAndSummarize(summarizer),
+					"Summary and GC should succeed with deleted data store",
+				);
+			},
+		);
 	});
 
 	describe("Sweep with summarize failures and retries", () => {
@@ -786,9 +904,7 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 					// Load a container from the above summary, process all ops (including any GC ops) and validate that
 					// the deleted data store cannot be retrieved.
 					// We load with GC Disabled to confirm that the GC Op is processed regardless of such settings
-					const config_gcSweepDisabled = JSON.parse(
-						JSON.stringify(testContainerConfig),
-					) as ITestContainerConfig;
+					const config_gcSweepDisabled = newTestContainerConfig();
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					config_gcSweepDisabled.runtimeOptions!.gcOptions!.enableGCSweep = undefined;
 					const container2 = await loadContainer(
@@ -807,12 +923,14 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 					await assert.rejects(
 						async () => handle.get(),
 						(error: any) => {
+							// (see non-exported error interface IResponseException)
 							const correctErrorType = error.code === 404;
-							const correctErrorMessage = error.message as string;
-							return (
-								correctErrorType &&
-								correctErrorMessage.startsWith("DataStore was deleted:")
+							const correctErrorMessage = (error.message as string).startsWith(
+								"DataStore was deleted:",
 							);
+							const correctHeaders =
+								error.underlyingResponseHeaders[DeletedResponseHeaderKey] === true;
+							return correctErrorType && correctErrorMessage && correctHeaders;
 						},
 						`Should not be able to get deleted data store`,
 					);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -480,6 +480,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
 					headers: expectedHeadersLogged.request,
 					clientType: "interactive",
+					category: "error",
 				},
 				// Interactive client's request w/ allowTombstone
 				{
@@ -487,6 +488,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
 					headers: expectedHeadersLogged.request_allowTombstone,
 					clientType: "interactive",
+					category: "generic",
 				},
 				// Summarizer client's request
 				{
@@ -494,6 +496,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
 					headers: expectedHeadersLogged.request,
 					clientType: "noninteractive/summarizer",
+					category: "generic",
 				},
 			],
 			async () => {
@@ -556,9 +559,9 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 					[
 						// request WITHOUT allowTombsone
 						{
-							category: "error",
 							eventName:
 								"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
+							error: "GC_Tombstone_DataStore_Requested",
 							clientType: "interactive",
 							headers: expectedHeadersLogged.request,
 							id: { value: `/${unreferencedId}`, tag: TelemetryDataTag.CodeArtifact },
@@ -566,7 +569,6 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 						},
 						// request WITH allowTombsone
 						{
-							category: "generic",
 							eventName:
 								"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
 							headers: expectedHeadersLogged.request_allowTombstone,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -47,6 +47,11 @@ import { MockLogger, TelemetryDataTag } from "@fluidframework/telemetry-utils";
 import { FluidSerializer, parseHandles } from "@fluidframework/shared-object-base";
 import type { ISharedMap } from "@fluidframework/map";
 import {
+	getGCStateFromSummary,
+	getGCTombstoneStateFromSummary,
+	manufactureHandle,
+} from "./gcTestSummaryUtils";
+
 type ExpectedTombstoneError = Error & {
 	code: number;
 	underlyingResponseHeaders?: { [TombstoneResponseHeaderKey]: boolean };

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -50,7 +50,7 @@ import {
 	getGCStateFromSummary,
 	getGCTombstoneStateFromSummary,
 	manufactureHandle,
-} from "./gcTestSummaryUtils";
+} from "./gcTestSummaryUtils.js";
 
 type ExpectedTombstoneError = Error & {
 	code: number;

--- a/packages/test/test-utils/src/testContainerRuntimeFactory.ts
+++ b/packages/test/test-utils/src/testContainerRuntimeFactory.ts
@@ -89,7 +89,7 @@ export const createTestContainerRuntimeFactory = (
 			const rootContext =
 				"createDetachedRootDataStore" in runtime
 					? (runtime as any).createDetachedRootDataStore([this.type], "default")
-					: runtime.createDetachedDataStore([this.type], "default");
+					: runtime.createDetachedDataStore([this.type]);
 
 			const rootRuntime = await this.dataStoreFactory.instantiateDataStore(
 				rootContext,

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -66,7 +66,7 @@ export class MockLogger implements ITelemetryBaseLogger {
 	): void {
 		const actualEvents = this.events;
 		if (!this.matchEvents(expectedEvents, inlineDetailsProp)) {
-			throw new Error(`${message}
+			throw new Error(`${message ?? "Logs don't match"}
 expected:
 ${JSON.stringify(expectedEvents)}
 
@@ -105,7 +105,7 @@ ${JSON.stringify(actualEvents)}`);
 	): void {
 		const actualEvents = this.events;
 		if (!this.matchAnyEvent(expectedEvents, inlineDetailsProp)) {
-			throw new Error(`${message}
+			throw new Error(`${message ?? "Logs don't match"}
 expected:
 ${JSON.stringify(expectedEvents)}
 
@@ -142,7 +142,7 @@ ${JSON.stringify(actualEvents)}`);
 	): void {
 		const actualEvents = this.events;
 		if (!this.matchEventStrict(expectedEvents, inlineDetailsProp)) {
-			throw new Error(`${message}
+			throw new Error(`${message ?? "Logs don't match"}
 expected:
 ${JSON.stringify(expectedEvents)}
 
@@ -161,7 +161,7 @@ ${JSON.stringify(actualEvents)}`);
 	): void {
 		const actualEvents = this.events;
 		if (this.matchAnyEvent(disallowedEvents, inlineDetailsProp)) {
-			throw new Error(`${message}
+			throw new Error(`${message ?? "Logs don't match"}
 disallowed events:
 ${JSON.stringify(disallowedEvents)}
 


### PR DESCRIPTION
Port the following commits to RC2 branch:

* f2b744a7f92e52fe40ec2e66bcb824bd3ac14cd9
* 60112cda222d7d628c358be1abdd70437209a824
* 059fc1896bbb11419e62e1351c50a2c23f1d3d1c
* 68e6f921898cfa5b8210eb72304cdc89259c44de

Our GC early adopters are seeing a handful (less than 10) docs that are somehow trying to load deleted objects.  The changes being ported here will aid in that analysis, helping to confirm or refute some assumptions we're having to make based on the current data.

The risk of these changes is low - it's scoped to GC plus some heavily-tested ContainerRuntime codepaths, and is mostly logging changes or light refactoring.