### PR TITLE
refactor(server): Update default TTL for MongoDB

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -137,7 +137,7 @@ mongodb:
   operationsDbEndpoint: mongodb_url
   globalDbEndpoint: mongoglobaldb_url
   globalDbEnabled: false
-  expireAfterSeconds: -1
+  expireAfterSeconds: 9000 # Note: CosmosDB supports -1 to disable TTL but MongoDB does not
   createCosmosDBIndexes: false
   directConnection: true
   softDeletionRetentionPeriodMs: 2592000000

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -28,7 +28,7 @@
 		"operationsDbEndpoint": "mongodb://mongodb:27017",
 		"globalDbEndpoint": "mongodb://mongodb:27017",
 		"globalDbEnabled": false,
-		"expireAfterSeconds": -1,
+		"expireAfterSeconds": 9000,
 		"createCosmosDBIndexes": false,
 		"directConnection": true,
 		"softDeletionRetentionPeriodMs": 2592000000,


### PR DESCRIPTION
## Description

Updates the default TTL value for MongoDB indices from -1 to 9000. MongoDB does not support -1 to disable TTL in its indices, like CosmosDB does. This is causing our internal routerlicious instance to log errors like the following:

```
{
  "eventName":"LogMessage",
  "exception":{
    "code":67,
    "codeName":"CannotCreateIndex",
    "isGlobalDb":false,
    "message":"TTL index 'expireAfterSeconds' option cannot be less than 0. Index spec: { expireAfterSeconds: -1, name: \"_ts_1\", key: { _ts: 1 } }",
    "name":"MongoServerError",
    "ok":0,
    ...
  }
}
```

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
