### PR TITLE
tree: Use runtime ID compressor for revision tags in TestSharedTreeCore

### DIFF
--- a/packages/dds/tree/src/test/shared-tree-core/utils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/utils.ts
@@ -7,7 +7,7 @@ import { IChannelAttributes, IFluidDataStoreRuntime } from "@fluidframework/data
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import { ICodecOptions } from "../../codec/index.js";
-import { TreeStoredSchemaRepository } from "../../core/index.js";
+import { RevisionTagCodec, TreeStoredSchemaRepository } from "../../core/index.js";
 import { typeboxValidator } from "../../external-utilities/index.js";
 import {
 	DefaultChangeFamily,
@@ -20,7 +20,7 @@ import {
 	makeModularChangeCodecFamily,
 } from "../../feature-libraries/index.js";
 import { SharedTreeBranch, SharedTreeCore, Summarizable } from "../../shared-tree-core/index.js";
-import { testRevisionTagCodec } from "../utils.js";
+import { testIdCompressor } from "../utils.js";
 
 /**
  * A `SharedTreeCore` with
@@ -47,7 +47,7 @@ export class TestSharedTreeCore extends SharedTreeCore<DefaultEditBuilder, Defau
 		const formatVersions = { editManager: 1, message: 1, fieldBatch: 1 };
 		const codec = makeModularChangeCodecFamily(
 			fieldKindConfigurations,
-			testRevisionTagCodec,
+			new RevisionTagCodec(runtime.idCompressor ?? testIdCompressor),
 			makeFieldBatchCodec(codecOptions, formatVersions.fieldBatch),
 			codecOptions,
 			chunkCompressionStrategy,

--- a/packages/dds/tree/src/test/shared-tree-core/utils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/utils.ts
@@ -21,6 +21,7 @@ import {
 } from "../../feature-libraries/index.js";
 import { SharedTreeBranch, SharedTreeCore, Summarizable } from "../../shared-tree-core/index.js";
 import { testIdCompressor } from "../utils.js";
+import { strict as assert } from "assert";
 
 /**
  * A `SharedTreeCore` with
@@ -35,19 +36,22 @@ export class TestSharedTreeCore extends SharedTreeCore<DefaultEditBuilder, Defau
 	};
 
 	public constructor(
-		runtime: IFluidDataStoreRuntime = new MockFluidDataStoreRuntime(),
+		runtime: IFluidDataStoreRuntime = new MockFluidDataStoreRuntime({
+			idCompressor: testIdCompressor,
+		}),
 		id = "TestSharedTreeCore",
 		summarizables: readonly Summarizable[] = [],
 		schema: TreeStoredSchemaRepository = new TreeStoredSchemaRepository(),
 		chunkCompressionStrategy: TreeCompressionStrategy = TreeCompressionStrategy.Uncompressed,
 	) {
+		assert(runtime.idCompressor !== undefined, "The runtime must provide an ID compressor");
 		const codecOptions: ICodecOptions = {
 			jsonValidator: typeboxValidator,
 		};
 		const formatVersions = { editManager: 1, message: 1, fieldBatch: 1 };
 		const codec = makeModularChangeCodecFamily(
 			fieldKindConfigurations,
-			new RevisionTagCodec(runtime.idCompressor ?? testIdCompressor),
+			new RevisionTagCodec(runtime.idCompressor),
 			makeFieldBatchCodec(codecOptions, formatVersions.fieldBatch),
 			codecOptions,
 			chunkCompressionStrategy,


### PR DESCRIPTION
## Description

Changed TestSharedTreeCore to create a RevisionTagCodec from the runtime's ID compressor when possible instead of always using testRevisionTagCodec which uses a static test ID compressor.