### PR TITLE
server: Replace missing cluster draining logic in Nexus

### DIFF
--- a/server/routerlicious/packages/lambdas/src/nexus/connect.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/connect.ts
@@ -273,6 +273,36 @@ async function checkToken(
 	}
 }
 
+async function checkClusterDraining(
+	{ clusterDrainingChecker }: INexusLambdaDependencies,
+	message: IConnect,
+	properties: Record<string, any>,
+) {
+	if (!clusterDrainingChecker) {
+		return;
+	}
+	let clusterInDraining = false;
+	try {
+		clusterInDraining = await clusterDrainingChecker.isClusterDraining();
+	} catch (error) {
+		Lumberjack.error(
+			"Failed to get cluster draining status. Will allow requests to proceed.",
+			properties,
+			error,
+		);
+		clusterInDraining = false;
+	}
+
+	if (clusterInDraining) {
+		// TODO: add a new error class
+		Lumberjack.info("Reject connect document request because cluster is draining.", {
+			...properties,
+			tenantId: message.tenantId,
+		});
+		throw new NetworkError(503, "Cluster is not available. Please retry later.");
+	}
+}
+
 async function joinRoomAndSubscribeToChannel(
 	socket: IWebSocket,
 	tenantId: string,
@@ -486,6 +516,8 @@ export async function connectDocument(
 		tenantId = claims.tenantId;
 		documentId = claims.documentId;
 		connectionTrace.stampStage(ConnectDocumentStage.TokenVerified);
+
+		await checkClusterDraining(lambdaDependencies, message, properties);
 
 		const [clientId, room] = await joinRoomAndSubscribeToChannel(
 			socket,

--- a/server/routerlicious/packages/services-core/src/tokenRevocationManager.ts
+++ b/server/routerlicious/packages/services-core/src/tokenRevocationManager.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { NetworkError, INetworkErrorDetails } from "@fluidframework/server-services-client";
+import {
+	NetworkError,
+	INetworkErrorDetails,
+	isNetworkError,
+} from "@fluidframework/server-services-client";
 
 /**
  * @internal
@@ -72,6 +76,13 @@ export class TokenRevocationError extends NetworkError {
 			...super.toJSON(),
 		};
 	}
+}
+
+/**
+ * @internal
+ */
+export function isTokenRevokedError(error: unknown): error is TokenRevokedError {
+	return isNetworkError(error) && (error as TokenRevokedError).errorType === "TokenRevoked";
 }
 
 /**


### PR DESCRIPTION
## Description

Cluster draining logic in Nexus was lost to merge conflicts in #19906. This adds it back.

Also added basic unit tests for Token Revoker and Cluster Draining Checker.