### PR TITLE
Stress cleanup disposed handling

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -41,8 +41,10 @@ export interface IRunConfig {
 
 export interface ILoadTest {
 	run(config: IRunConfig, reset: boolean): Promise<boolean>;
-	detached(config: Omit<IRunConfig, "runId" | "profileName">): Promise<LoadTestDataStoreModel>;
-	getRuntime(): Promise<IFluidDataStoreRuntime>;
+	detached(
+		config: Omit<IRunConfig, "runId" | "profileName">,
+	): Promise<LoadTestDataStoreModel | undefined>;
+	getRuntime(): Promise<IFluidDataStoreRuntime | undefined>;
 }
 
 const taskManagerKey = "taskManager";
@@ -60,52 +62,41 @@ const defaultBlobSize = 1024;
  * via task picking.
  */
 export class LoadTestDataStoreModel {
-	private static async waitForCatchup(runtime: IFluidDataStoreRuntime): Promise<void> {
-		if (!runtime.connected) {
-			await new Promise<void>((resolve, reject) => {
-				const connectListener = () => {
-					runtime.off("dispose", disposeListener);
+	private static async waitForCatchupOrDispose(runtime: IFluidDataStoreRuntime): Promise<void> {
+		await new Promise<void>((resolve) => {
+			const resolveIfConnectedOrDisposed = () => {
+				if (runtime.connected || runtime.disposed) {
+					runtime.off("dispose", resolveIfConnectedOrDisposed);
+					runtime.off("connected", resolveIfConnectedOrDisposed);
 					resolve();
-				};
-				const disposeListener = () => {
-					runtime.off("connected", connectListener);
-					reject(new Error("disposed"));
-				};
+				}
+			};
 
-				runtime.once("connected", connectListener);
-				runtime.once("dispose", disposeListener);
-			});
-		}
+			resolveIfConnectedOrDisposed();
+
+			runtime.once("connected", resolveIfConnectedOrDisposed);
+			runtime.once("dispose", resolveIfConnectedOrDisposed);
+		});
+
 		const lastKnownSeq = runtime.deltaManager.lastKnownSeqNumber;
 		assert(
 			runtime.deltaManager.lastSequenceNumber <= lastKnownSeq,
 			"lastKnownSeqNumber should never be below last processed sequence number",
 		);
-		if (runtime.deltaManager.lastSequenceNumber === lastKnownSeq) {
-			return;
-		}
 
-		return new Promise<void>((resolve, reject) => {
-			if (runtime.disposed) {
-				reject(new Error("disposed"));
-			}
-
-			const opListener = (op: ISequencedDocumentMessage) => {
-				if (lastKnownSeq <= op.sequenceNumber) {
-					runtime.deltaManager.off("op", opListener);
-					runtime.off("dispose", disposeListener);
+		await new Promise<void>((resolve) => {
+			const resolveIfDisposedOrCaughtUp = (op?: ISequencedDocumentMessage) => {
+				if (runtime.disposed || (op !== undefined && lastKnownSeq <= op.sequenceNumber)) {
+					runtime.deltaManager.off("op", resolveIfDisposedOrCaughtUp);
+					runtime.off("dispose", resolveIfDisposedOrCaughtUp);
 					resolve();
 				}
 			};
 
-			const disposeListener = () => {
-				runtime.deltaManager.off("op", opListener);
-				runtime.off("dispose", disposeListener);
-				reject(new Error("disposed"));
-			};
+			resolveIfDisposedOrCaughtUp();
 
-			runtime.deltaManager.on("op", opListener);
-			runtime.on("dispose", disposeListener);
+			runtime.deltaManager.on("op", resolveIfDisposedOrCaughtUp);
+			runtime.once("dispose", resolveIfDisposedOrCaughtUp);
 		});
 	}
 
@@ -153,7 +144,10 @@ export class LoadTestDataStoreModel {
 		runtime: IFluidDataStoreRuntime,
 		containerRuntime: IContainerRuntimeBase,
 	) {
-		await LoadTestDataStoreModel.waitForCatchup(runtime);
+		await LoadTestDataStoreModel.waitForCatchupOrDispose(runtime);
+		if (runtime.disposed) {
+			return;
+		}
 
 		if (!root.hasSubDirectory(config.runId.toString())) {
 			root.createSubDirectory(config.runId.toString());
@@ -200,7 +194,7 @@ export class LoadTestDataStoreModel {
 		);
 
 		if (reset) {
-			await LoadTestDataStoreModel.waitForCatchup(runtime);
+			await LoadTestDataStoreModel.waitForCatchupOrDispose(runtime);
 			runDir.set(startTimeKey, Date.now());
 			runDir.delete(taskTimeKey);
 			counter.increment(-1 * counter.value);
@@ -208,6 +202,9 @@ export class LoadTestDataStoreModel {
 			if (partnerCounter !== undefined && partnerCounter.value > 0) {
 				partnerCounter.increment(-1 * partnerCounter.value);
 			}
+		}
+		if (runtime.disposed) {
+			return;
 		}
 		return dataModel;
 	}
@@ -521,6 +518,9 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 			this.runtime,
 			this.context.containerRuntime,
 		);
+		if (dataModel === undefined) {
+			return false;
+		}
 
 		// At every moment, we want half the client to be concurrent writers, and start and stop
 		// in a rotation fashion for every cycle.
@@ -551,7 +551,9 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 	}
 
 	async getRuntime() {
-		return this.runtime;
+		if (!this.runtime.disposed) {
+			return this.runtime;
+		}
 	}
 
 	async sendOps(dataModel: LoadTestDataStoreModel, config: IRunConfig) {

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -91,7 +91,6 @@ export class LoadTestDataStoreModel {
 				}
 			};
 
-			resolveIfDisposedOrCaughtUp();
 
 			runtime.deltaManager.on("op", resolveIfDisposedOrCaughtUp);
 			runtime.once("dispose", resolveIfDisposedOrCaughtUp);

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -94,6 +94,8 @@ export class LoadTestDataStoreModel {
 
 			runtime.deltaManager.on("op", resolveIfDisposedOrCaughtUp);
 			runtime.once("dispose", resolveIfDisposedOrCaughtUp);
+			resolveIfDisposedOrCaughtUp();
+
 		});
 	}
 

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -71,11 +71,9 @@ export class LoadTestDataStoreModel {
 					resolve();
 				}
 			};
-
-			resolveIfConnectedOrDisposed();
-
 			runtime.once("connected", resolveIfConnectedOrDisposed);
 			runtime.once("dispose", resolveIfConnectedOrDisposed);
+			resolveIfConnectedOrDisposed();
 		});
 
 		const lastKnownSeq = runtime.deltaManager.lastKnownSeqNumber;

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -91,11 +91,9 @@ export class LoadTestDataStoreModel {
 				}
 			};
 
-
 			runtime.deltaManager.on("op", resolveIfDisposedOrCaughtUp);
 			runtime.once("dispose", resolveIfDisposedOrCaughtUp);
 			resolveIfDisposedOrCaughtUp();
-
 		});
 	}
 

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -263,12 +263,14 @@ async function runnerProcess(
 
 			if (enableOpsMetrics) {
 				const testRuntime = await test.getRuntime();
-				metricsCleanup = await setupOpsMetrics(
-					container,
-					runConfig.logger,
-					runConfig.testConfig.progressIntervalMs,
-					testRuntime,
-				);
+				if (testRuntime !== undefined) {
+					metricsCleanup = await setupOpsMetrics(
+						container,
+						runConfig.logger,
+						runConfig.testConfig.progressIntervalMs,
+						testRuntime,
+					);
+				}
 			}
 
 			// Control fault injection period through config.


### PR DESCRIPTION
This change improves the handling of the disposed state of the runtime in the stress test. Previously a runtime disposal would result in error being thrown from the test and logged into the test harness. This leads to unnecessary noise in the stress logs as if the container is disposed there was likely already an error logged. Additionally, we improve how the runner manages the container such that all faults have errors, which the test knows now to ignore, and all closures expect an error except for the final disposal which is the only expected, non-fault, close/dispose.

fixes [AB#7811](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7811)