### PR TITLE
Specify mochaExplorer.nodeArgv in tree workspace

### DIFF
--- a/packages/dds/tree/.vscode/settings.json
+++ b/packages/dds/tree/.vscode/settings.json
@@ -12,5 +12,8 @@
 	],
 	"mochaExplorer.configFile": ".mocharc.cjs",
 	"mochaExplorer.timeout": 999999,
+	// This extension appears to invoke mocha programmatically, meaning that the enablement of this option in the common
+	// mocha test config isn't sufficient; it also needs to be enabled here.
+	"mochaExplorer.nodeArgv": ["--conditions", "allow-ff-test-exports"],
 	"cSpell.words": ["deprioritized", "endregion", "insertable", "reentrantly", "unhydrated"],
 }


### PR DESCRIPTION
## Description

Follow-up to #20729.
This allows the test explorer to load tree tests again.
