### PR TITLE
Promote AttributionInfo to alpha

### DIFF
--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -33,7 +33,7 @@ import type { TelemetryBaseEventPropertyType } from '@fluidframework/core-interf
 // @alpha
 export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
 
-// @internal
+// @alpha
 export interface AttributionInfo {
     timestamp: number;
     user: IUser;

--- a/packages/runtime/runtime-definitions/src/attribution.ts
+++ b/packages/runtime/runtime-definitions/src/attribution.ts
@@ -64,7 +64,7 @@ export type AttributionKey = OpAttributionKey | DetachedAttributionKey | LocalAt
 
 /**
  * Attribution information associated with a change.
- * @internal
+ * @alpha
  */
 export interface AttributionInfo {
 	/**


### PR DESCRIPTION
## Description

Other attribution-related types were already promoted to alpha due to transitive reference via merge-tree. This makes the export of the attribution API surface consistent (documentation for those types references `AttributionInfo`, which is reasonable).
