### PR TITLE
RedisClientConnectionManager logging enrichment and consolidation (R11S)

### DIFF
--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -216,12 +216,15 @@ export function create(
 	socketIoConfig?: any,
 	ioSetup?: (io: Server) => void,
 ): core.IWebSocketServer {
-	redisClientConnectionManagerForPub.getRedisClient().on("error", (err) => {
-		Lumberjack.error("Error with Redis pub connection", undefined, err);
-	});
-	redisClientConnectionManagerForSub.getRedisClient().on("error", (err) => {
-		Lumberjack.error("Error with Redis sub connection", undefined, err);
-	});
+	redisClientConnectionManagerForPub.addErrorHandler(
+		undefined, // lumber properties
+		"Error with Redis pub connection", // error message
+	);
+
+	redisClientConnectionManagerForSub.addErrorHandler(
+		undefined, // lumber properties
+		"Error with Redis sub connection", // error message
+	);
 
 	let adapter: (nsp: Namespace) => Adapter;
 	if (socketIoAdapterConfig?.enableCustomSocketIoAdapter) {

--- a/server/routerlicious/packages/services-utils/src/redisClientConnectionManager.ts
+++ b/server/routerlicious/packages/services-utils/src/redisClientConnectionManager.ts
@@ -191,8 +191,8 @@ export class RedisClientConnectionManager implements IRedisClientConnectionManag
 			const commandName: string | undefined =
 				error.command.name ?? error.lastNodeError?.command.name;
 			const args: string[] = error.command?.args ?? error.lastNodeError?.command.args ?? [];
-			// Grab only the lengths of each arg, to avoid logging sensitive information
-			if (commandName === "exec" && error.previousErrors) {
+
+			if (error.previousErrors) {
 				// Internally redact the previous errors of an exec command
 				lumberProperties.previousErrors = [];
 				error.previousErrors?.forEach((prevError) => {

--- a/server/routerlicious/packages/services-utils/src/redisClientConnectionManager.ts
+++ b/server/routerlicious/packages/services-utils/src/redisClientConnectionManager.ts
@@ -150,7 +150,10 @@ export class RedisClientConnectionManager implements IRedisClientConnectionManag
 					redisClusteringOptions,
 			  )
 			: new Redis.default(this.redisOptions);
-		Lumberjack.info("Redis client created", {["constructorOptions"]: stringifiedOptions, ["clusteringEnabled"]: this.enableClustering});
+		Lumberjack.info("Redis client created", {
+			["constructorOptions"]: stringifiedOptions,
+			["clusteringEnabled"]: this.enableClustering,
+		});
 	}
 
 	public getRedisClient(): Redis.default | Redis.Cluster {

--- a/server/routerlicious/packages/services-utils/src/redisClientConnectionManager.ts
+++ b/server/routerlicious/packages/services-utils/src/redisClientConnectionManager.ts
@@ -179,7 +179,15 @@ export class RedisClientConnectionManager implements IRedisClientConnectionManag
 				error.commandName ?? error.lastNodeError?.commandName;
 			const args: string[] = error.args ?? error.lastNodeError?.args ?? [];
 			// Grab only the lengths of each arg, to avoid logging sensitive information
-			const argSizes: number[] = args.map((arg) => arg.length);
+			const argSizes: string[] = args.map((arg, ind) => {
+				// For some commands argument 0 is the key, meaning we can safely log it
+				const safeCommands: string[] = ["get", "set", "del", "hget", "hset", "hdel"];
+				if (ind === 0 && safeCommands.includes(commandName?.toLowerCase() ?? "")) {
+					return arg;
+				}
+
+				return arg.length.toString();
+			});
 
 			// Set additional logging info in lumberProperties
 			lumberProperties.commandName = commandName;

--- a/server/routerlicious/packages/services-utils/src/redisClientConnectionManager.ts
+++ b/server/routerlicious/packages/services-utils/src/redisClientConnectionManager.ts
@@ -144,17 +144,13 @@ export class RedisClientConnectionManager implements IRedisClientConnectionManag
 			? JSON.stringify(loggableClusteringOptions)
 			: JSON.stringify(loggableRedisOptions);
 
-		Lumberjack.verbose(
-			`Creating a redis client with the following configs: ${stringifiedOptions}`,
-		);
-
 		this.client = this.enableClustering
 			? new Redis.Cluster(
 					[{ port: this.redisOptions.port, host: this.redisOptions.host }],
 					redisClusteringOptions,
 			  )
 			: new Redis.default(this.redisOptions);
-		Lumberjack.info("Redis client created");
+		Lumberjack.info("Redis client created", {["constructorOptions"]: stringifiedOptions, ["clusteringEnabled"]: this.enableClustering});
 	}
 
 	public getRedisClient(): Redis.default | Redis.Cluster {

--- a/server/routerlicious/packages/services/src/redis.ts
+++ b/server/routerlicious/packages/services/src/redis.ts
@@ -29,9 +29,10 @@ export class RedisCache implements ICache {
 			this.prefix = parameters.prefix;
 		}
 
-		redisClientConnectionManager.getRedisClient().on("error", (err) => {
-			Lumberjack.error("Error with Redis", undefined, err);
-		});
+		redisClientConnectionManager.addErrorHandler(
+			undefined, // lumber properties
+			"Error with Redis", // error message
+		);
 	}
 	public async delete(key: string): Promise<boolean> {
 		try {

--- a/server/routerlicious/packages/services/src/redisClientManager.ts
+++ b/server/routerlicious/packages/services/src/redisClientManager.ts
@@ -10,7 +10,6 @@ import {
 	IRedisParameters,
 	IRedisClientConnectionManager,
 } from "@fluidframework/server-services-utils";
-import { Lumberjack } from "@fluidframework/server-services-telemetry";
 
 // Manages the set of connected clients in redis hashes with an expiry of 'expireAfterSeconds'.
 /**
@@ -32,9 +31,10 @@ export class ClientManager implements IClientManager {
 			this.prefix = parameters.prefix;
 		}
 
-		redisClientConnectionManager.getRedisClient().on("error", (error) => {
-			Lumberjack.error("Client Manager Redis Error", undefined, error);
-		});
+		redisClientConnectionManager.addErrorHandler(
+			undefined, // lumber properties
+			"Client Manager Redis Error", // error message
+		);
 	}
 
 	public async addClient(

--- a/server/routerlicious/packages/services/src/redisThrottleAndUsageStorageManager.ts
+++ b/server/routerlicious/packages/services/src/redisThrottleAndUsageStorageManager.ts
@@ -40,13 +40,10 @@ export class RedisThrottleAndUsageStorageManager implements IThrottleAndUsageSto
 			this.prefix = parameters.prefix;
 		}
 
-		redisClientConnectionManager.getRedisClient().on("error", (error) => {
-			Lumberjack.error(
-				"Throttle Manager Redis Error",
-				{ [CommonProperties.telemetryGroupName]: "throttling" },
-				error,
-			);
-		});
+		redisClientConnectionManager.addErrorHandler(
+			{ [CommonProperties.telemetryGroupName]: "throttling" }, // lumber properties
+			"Throttle Manager Redis Error", // error message
+		);
 	}
 
 	public async setThrottlingMetric(

--- a/server/routerlicious/packages/services/src/socketIoRedisPublisher.ts
+++ b/server/routerlicious/packages/services/src/socketIoRedisPublisher.ts
@@ -32,9 +32,14 @@ export class SocketIoRedisPublisher implements core.IPublisher {
 		this.redisClientConnectionManager = redisClientConnectionManager;
 		this.io = new SocketIoEmitter(redisClientConnectionManager.getRedisClient());
 
-		redisClientConnectionManager.getRedisClient().on("error", (error) => {
-			this.events.emit("error", error);
-		});
+		redisClientConnectionManager.addErrorHandler(
+			undefined, // lumber properties
+			"Error with SocketIoRedisPublisher", // error message
+			(error) => {
+				this.events.emit("error", error);
+				return false;
+			},
+		);
 	}
 
 	public on(event: string, listener: (...args: any[]) => void) {

--- a/server/routerlicious/packages/test-utils/src/testRedisClientConnectionManager.ts
+++ b/server/routerlicious/packages/test-utils/src/testRedisClientConnectionManager.ts
@@ -27,4 +27,12 @@ export class TestRedisClientConnectionManager implements IRedisClientConnectionM
 			: new RedisMock();
 		return mockRedisClient;
 	}
+
+	public addErrorHandler(
+		lumberProperties?: Map<string, any> | Record<string, any> | undefined,
+		errorMessage: string = "Error with Redis",
+		additionalLoggingFunctionality?: (error: Error) => boolean,
+	): void {
+		// Do nothing
+	}
 }


### PR DESCRIPTION
## Description

- Consolidates Redis logging/error handling into a method of redisClientConnectionManager 
- Adds logging for the params passed into the Redis or Redis.Cluster constructors (sanitized to remove the password)
- Adds logging for the redis command that failed, as well as the lengths of each argument passed to the command
- Argument lengths are used instead of the raw values, because command arguments can contain sensitive info (like the value being assigned to a key)
- New consolidated method for handling redis errors still allows for custom error handling, custom message, and lumber logging props

## Reviewer Guidance

- Most of the changes made are in: server/routerlicious/packages/services-utils/src/redisClientConnectionManager.ts
- Changes in other files are primarily to use the new method exposed by redisClientConnectionManager.ts
- This PR will be followed with another PR to use the r11s changes in historian