### PR TITLE
Add handles to DDS Fuzz Tests in Sequence 

### DIFF
--- a/packages/dds/sequence/src/test/fuzz/fuzzUtils.ts
+++ b/packages/dds/sequence/src/test/fuzz/fuzzUtils.ts
@@ -18,6 +18,7 @@ import {
 	IChannelAttributes,
 	IChannelServices,
 	IFluidDataStoreRuntime,
+	type Serializable,
 } from "@fluidframework/datastore-definitions/internal";
 import { PropertySet } from "@fluidframework/merge-tree/internal";
 
@@ -60,7 +61,7 @@ export interface RemoveRange extends RangeSpec {
 
 export interface AnnotateRange extends RangeSpec {
 	type: "annotateRange";
-	props: { key: string; value?: any }[];
+	props: { key: string; value?: Serializable<any> }[];
 }
 
 export interface ObliterateRange extends RangeSpec {
@@ -323,6 +324,7 @@ export function createSharedStringGeneratorOperations(
 		const key = random.pick(options.propertyNamePool);
 		const value = random.pick([
 			random.string(5),
+			random.handle(),
 			// Bring back after AB#7805, #7806 fixed
 			// undefined
 			null,

--- a/packages/dds/sequence/src/test/fuzz/sharedString.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/fuzz/sharedString.fuzz.spec.ts
@@ -161,7 +161,7 @@ describe("SharedString fuzz testing with annotates", () => {
 		{ ...annotateSharedStringModel, workloadName: "SharedString with annotates" },
 		{
 			...defaultFuzzOptions,
-			skip: [14, 33, 39, 66, 77, 79, 95],
+			skip: [4, 12, 15, 23, 29, 34, 37, 66, 75, 76, 79, 99],
 		},
 	);
 });

--- a/packages/dds/sequence/src/test/intervalCollection.detached.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.detached.spec.ts
@@ -72,7 +72,7 @@ describe("IntervalCollection detached", () => {
 
 			sharedString2.removeText(2, 3);
 			containerRuntimeFactory.processAllMessages();
-			assertEquivalentSharedStrings(sharedString, sharedString2);
+			await assertEquivalentSharedStrings(sharedString, sharedString2);
 		});
 
 		it("can be changed by another client after attaching", async () => {
@@ -84,7 +84,7 @@ describe("IntervalCollection detached", () => {
 			const collection2 = sharedString2.getIntervalCollection("intervals");
 			collection2.change(interval.getIntervalId(), { start: 1, end: 1 });
 			containerRuntimeFactory.processAllMessages();
-			assertEquivalentSharedStrings(sharedString, sharedString2);
+			await assertEquivalentSharedStrings(sharedString, sharedString2);
 		});
 	});
 
@@ -109,7 +109,7 @@ describe("IntervalCollection detached", () => {
 
 			sharedString2.removeText(0, 1);
 			containerRuntimeFactory.processAllMessages();
-			assertEquivalentSharedStrings(sharedString, sharedString2);
+			await assertEquivalentSharedStrings(sharedString, sharedString2);
 		});
 
 		it("can be changed by another client after attaching", async () => {
@@ -122,7 +122,7 @@ describe("IntervalCollection detached", () => {
 			const collection2 = sharedString2.getIntervalCollection("intervals");
 			collection2.change(interval.getIntervalId(), { start: 1, end: 1 });
 			containerRuntimeFactory.processAllMessages();
-			assertEquivalentSharedStrings(sharedString, sharedString2);
+			await assertEquivalentSharedStrings(sharedString, sharedString2);
 		});
 	});
 
@@ -135,7 +135,7 @@ describe("IntervalCollection detached", () => {
 				await attachAndLoadSecondSharedString();
 
 			containerRuntimeFactory.processAllMessages();
-			assertEquivalentSharedStrings(sharedString, sharedString2);
+			await assertEquivalentSharedStrings(sharedString, sharedString2);
 			assert.equal(
 				collection.getIntervalById(interval.getIntervalId())?.properties.foo,
 				"a2",
@@ -153,7 +153,7 @@ describe("IntervalCollection detached", () => {
 			collection2.change(interval.getIntervalId(), { props: { foo: "b1" } });
 			containerRuntimeFactory.processAllMessages();
 
-			assertEquivalentSharedStrings(sharedString, sharedString2);
+			await assertEquivalentSharedStrings(sharedString, sharedString2);
 			assert.equal(
 				collection.getIntervalById(interval.getIntervalId())?.properties.foo,
 				"b1",
@@ -172,7 +172,7 @@ describe("IntervalCollection detached", () => {
 			const collection2 = sharedString2.getIntervalCollection("intervals");
 			assert.equal(Array.from(collection2).length, 0);
 			assert.equal(collection2.getIntervalById(id), undefined);
-			assertEquivalentSharedStrings(sharedString, sharedString2);
+			await assertEquivalentSharedStrings(sharedString, sharedString2);
 		});
 	});
 });

--- a/packages/dds/sequence/src/test/intervalRebasing.spec.ts
+++ b/packages/dds/sequence/src/test/intervalRebasing.spec.ts
@@ -97,67 +97,67 @@ describe("interval rebasing", () => {
 		clients = constructClients(containerRuntimeFactory);
 	});
 
-	it("does not crash for an interval that lies on segment that has been removed locally", () => {
+	it("does not crash for an interval that lies on segment that has been removed locally", async () => {
 		clients[0].sharedString.insertText(0, "A");
 		clients[1].containerRuntime.connected = false;
 		clients[1].sharedString.insertText(0, "01234");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[1].containerRuntime.connected = true;
 		clients[0].sharedString.insertText(0, "012345678901234");
 		clients[0].containerRuntime.connected = false;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		const collection_0 = clients[0].sharedString.getIntervalCollection("comments");
 		collection_0.add({ start: 12, end: 15, props: { intervalId: "id" } });
 		clients[2].sharedString.removeRange(5, 7);
 		clients[0].sharedString.removeRange(3, 5);
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].sharedString.insertText(13, "0123");
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("does not crash when entire string on which interval lies is concurrently removed", () => {
+	it("does not crash when entire string on which interval lies is concurrently removed", async () => {
 		clients[0].sharedString.insertText(0, "a");
 		clients[1].sharedString.insertText(0, "a");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].containerRuntime.connected = false;
 		clients[1].sharedString.removeRange(0, 2);
 		const collection_0 = clients[0].sharedString.getIntervalCollection("comments");
 		collection_0.add({ start: 0, end: 1, props: { intervalId: "id" } });
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].containerRuntime.connected = true;
 	});
 
-	it("does not crash when interval is removed before reconnect when string is concurrently removed", () => {
+	it("does not crash when interval is removed before reconnect when string is concurrently removed", async () => {
 		clients[0].sharedString.insertText(0, "A");
 		clients[1].sharedString.insertText(0, "B");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].containerRuntime.connected = false;
 		clients[1].sharedString.removeRange(0, 2);
 		const collection_0 = clients[0].sharedString.getIntervalCollection("comments");
 		collection_0.add({ start: 0, end: 1, props: { intervalId: "id" } });
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		collection_0.removeIntervalById("id");
 		clients[0].containerRuntime.connected = true;
 	});
 
-	it("does not crash when interval slides off end of string", () => {
+	it("does not crash when interval slides off end of string", async () => {
 		clients[0].sharedString.insertText(0, "012Z45");
 		clients[2].sharedString.insertText(0, "X");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[1].sharedString.insertText(0, "01234567");
 		clients[0].containerRuntime.connected = false;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].sharedString.insertText(0, "ABCDEFGHIJKLMN");
 		const collection_0 = clients[0].sharedString.getIntervalCollection("comments");
 		collection_0.add({
@@ -167,13 +167,13 @@ describe("interval rebasing", () => {
 		});
 		clients[2].sharedString.removeRange(13, 15);
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("handles basic interval sliding for obliterate", () => {
+	it("handles basic interval sliding for obliterate", async () => {
 		// A-(BC)
 
 		clients[0].sharedString.insertText(0, "ABC");
@@ -187,10 +187,10 @@ describe("interval rebasing", () => {
 		});
 		clients[0].sharedString.obliterateRange(1, 3);
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("reference is -1 for obliterated segment", () => {
+	it("reference is -1 for obliterated segment", async () => {
 		// (L-PC-F)
 
 		clients[1].sharedString.insertText(0, "F");
@@ -207,13 +207,13 @@ describe("interval rebasing", () => {
 		clients[1].sharedString.obliterateRange(0, 2);
 
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("slides to correct final destination", () => {
+	it("slides to correct final destination", async () => {
 		clients[0].sharedString.insertText(0, "A");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[2].sharedString.insertText(0, "B");
 		clients[2].sharedString.removeRange(0, 2);
 		clients[0].sharedString.insertText(0, "C");
@@ -226,10 +226,10 @@ describe("interval rebasing", () => {
 		});
 
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("does not slide to invalid position when 0-length interval", () => {
+	it("does not slide to invalid position when 0-length interval", async () => {
 		clients[0].sharedString.insertText(0, "A");
 		const collection_0 = clients[0].sharedString.getIntervalCollection("comments");
 		// A 0-length interval is required here to reproduce this error. If in
@@ -243,7 +243,7 @@ describe("interval rebasing", () => {
 		clients[1].sharedString.insertText(0, "BCD");
 		clients[1].sharedString.removeRange(0, 1);
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[2].sharedString.removeRange(1, 3);
 		clients[1].sharedString.insertText(1, "E");
 		const collection_1 = clients[1].sharedString.getIntervalCollection("comments");
@@ -256,16 +256,16 @@ describe("interval rebasing", () => {
 		});
 
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 
 		assert.equal(clients[0].sharedString.getText(), "CE");
 	});
 
-	it("is consistent for full stickiness", () => {
+	it("is consistent for full stickiness", async () => {
 		clients[0].sharedString.insertText(0, "A");
 		clients[0].sharedString.insertText(0, "BC");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		const collection_1 = clients[1].sharedString.getIntervalCollection("comments");
 		const interval1 = collection_1.add({
 			start: "start",
@@ -278,16 +278,16 @@ describe("interval rebasing", () => {
 		clients[0].sharedString.removeRange(0, 1);
 		clients[1].sharedString.removeRange(0, 3);
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("keeps obliterate segment group the same across multiple reconnects", () => {
+	it("keeps obliterate segment group the same across multiple reconnects", async () => {
 		// A-C
 		// (A-B-C)
 		clients[0].sharedString.insertText(0, "C");
 		clients[0].sharedString.insertText(0, "A");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].sharedString.insertText(1, "B");
 		clients[1].sharedString.obliterateRange(0, 2);
 		clients[1].containerRuntime.connected = false;
@@ -295,30 +295,30 @@ describe("interval rebasing", () => {
 		clients[1].containerRuntime.connected = false;
 		clients[1].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("doesn't crash for empty pending segment group", () => {
+	it("doesn't crash for empty pending segment group", async () => {
 		// A
 		// ((A))-[D]
 		clients[0].sharedString.insertText(0, "A");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[1].sharedString.obliterateRange(0, 1);
 		clients[0].sharedString.insertText(1, "D");
 		clients[0].sharedString.obliterateRange(0, 1);
 		clients[0].sharedString.removeRange(0, 1);
 		clients[0].containerRuntime.connected = false;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].containerRuntime.connected = true;
 
 		assert.equal(clients[0].sharedString.getText(), "");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("zamboni avoids modifying segments with pending interval changes", () => {
+	it("zamboni avoids modifying segments with pending interval changes", async () => {
 		// C-AB
 		// D-C-AB
 		// E-HIJ-FG-D-C-AB
@@ -326,11 +326,11 @@ describe("interval rebasing", () => {
 		clients[2].sharedString.insertText(0, "AB");
 		clients[0].sharedString.insertText(0, "C");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[1].containerRuntime.connected = false;
 		clients[2].sharedString.insertText(0, "D");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[2].sharedString.insertText(0, "E");
 		clients[1].sharedString.insertText(0, "FG");
 		clients[1].sharedString.insertText(0, "HIJ");
@@ -338,7 +338,7 @@ describe("interval rebasing", () => {
 		const collection_0 = clients[1].sharedString.getIntervalCollection("comments");
 		collection_0.add({ start: 0, end: 7 });
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[1].containerRuntime.connected = true;
 	});
 
@@ -363,14 +363,14 @@ describe("interval rebasing", () => {
 		containerRuntimeFactory.processAllMessages();
 		A.containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent([A, B]);
+		await assertConsistent([A, B]);
 	});
 
 	// Reproduction of seed 70. Appears to be some problem with normalization of segments interacting
 	// with sliding logic on reconnect. The ordering of the 22222 and 11 segments is not consistent
 	// across clients even when in the collab window, and the local reference gets put on this segment.
 	// So clients[0] disagrees with the others about where the reference slides.
-	it.skip("AB#6552", () => {
+	it.skip("AB#6552", async () => {
 		// Note: all 3 clients submit edits. When debugging this test, it might be helpful to
 		// add a 4th client that doesn't submit any edits. E.g.:
 		// clients = constructClients(containerRuntimeFactory, 4);
@@ -390,29 +390,29 @@ describe("interval rebasing", () => {
 		clients[1].containerRuntime.connected = true;
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("doesn't create empty segment group when obliterated segment was obliterated by other client during reconnect", () => {
+	it("doesn't create empty segment group when obliterated segment was obliterated by other client during reconnect", async () => {
 		// A
 		// ((A))-[D]
 		clients[0].sharedString.insertText(0, "A");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[1].sharedString.obliterateRange(0, 1);
 		clients[0].sharedString.insertText(1, "D");
 		clients[0].sharedString.obliterateRange(0, 1);
 		clients[0].sharedString.removeRange(0, 1);
 		clients[0].containerRuntime.connected = false;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].containerRuntime.connected = true;
 		clients[0].containerRuntime.connected = false;
 		clients[0].containerRuntime.connected = true;
 
 		assert.equal(clients[0].sharedString.getText(), "");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
 	// todo: a failing obliterate reconnect test. when rebasing the op,
@@ -426,46 +426,46 @@ describe("interval rebasing", () => {
 	// in both cases, it's not clear to me how we detect when we're reconnecting
 	//
 	// ADO#3714
-	it.skip("...", () => {
+	it.skip("...", async () => {
 		// AB
 		// A-C-B
 		clients[0].sharedString.insertText(0, "AB");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].sharedString.insertText(1, "C");
 		clients[1].containerRuntime.connected = false;
 		clients[1].sharedString.obliterateRange(0, 2);
 		clients[1].containerRuntime.connected = true;
 		clients[1].containerRuntime.connected = false;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[1].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
 	// todo: ADO#3714 Failing obliterate reconnect test
-	it.skip("...", () => {
+	it.skip("...", async () => {
 		clients[0].sharedString.insertText(0, "AB");
 		clients[1].sharedString.insertText(0, "CD");
 		clients[1].sharedString.insertText(1, "E");
 		clients[0].sharedString.obliterateRange(0, 1);
 		clients[0].sharedString.insertText(0, "FGHIJK");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].sharedString.insertText(4, "L");
 		clients[2].sharedString.obliterateRange(3, 5);
 		clients[0].containerRuntime.connected = false;
 		clients[0].sharedString.obliterateRange(1, 2);
 		clients[0].sharedString.insertText(7, "M");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("slides two refs on same segment to different segments", () => {
+	it("slides two refs on same segment to different segments", async () => {
 		clients[0].sharedString.insertText(0, "AB");
 		clients[0].sharedString.insertText(0, "C");
 		const collection_1 = clients[0].sharedString.getIntervalCollection("comments");
@@ -478,7 +478,7 @@ describe("interval rebasing", () => {
 		});
 		assert.equal(interval1.stickiness, IntervalStickiness.FULL);
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[2].sharedString.removeRange(1, 2);
 		const collection_2 = clients[1].sharedString.getIntervalCollection("comments");
 		const interval2 = collection_2.add({
@@ -490,13 +490,13 @@ describe("interval rebasing", () => {
 		});
 		assert.equal(interval2.stickiness, IntervalStickiness.FULL);
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("maintains sliding preference on references after ack", () => {
+	it("maintains sliding preference on references after ack", async () => {
 		clients[1].sharedString.insertText(0, "ABC");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].sharedString.removeRange(0, 1);
 		clients[0].sharedString.insertText(0, "D");
 		const collection_1 = clients[1].sharedString.getIntervalCollection("comments");
@@ -509,10 +509,10 @@ describe("interval rebasing", () => {
 		});
 		clients[2].sharedString.removeRange(1, 2);
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("maintains sliding preference on references after reconnect with special endpoint segment", () => {
+	it("maintains sliding preference on references after reconnect with special endpoint segment", async () => {
 		clients[0].sharedString.insertText(0, "D");
 		clients[0].containerRuntime.connected = false;
 		const collection_1 = clients[0].sharedString.getIntervalCollection("comments");
@@ -526,10 +526,10 @@ describe("interval rebasing", () => {
 		assert.equal(interval.stickiness, IntervalStickiness.FULL);
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
-	it("maintains sliding preference on references after reconnect", () => {
+	it("maintains sliding preference on references after reconnect", async () => {
 		clients[0].sharedString.insertText(0, "D");
 		clients[0].containerRuntime.connected = false;
 		const collection_1 = clients[0].sharedString.getIntervalCollection("comments");
@@ -543,7 +543,7 @@ describe("interval rebasing", () => {
 		assert.equal(interval.stickiness, IntervalStickiness.FULL);
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 	});
 
 	// todo: potentially related to AB#7050
@@ -564,18 +564,18 @@ describe("interval rebasing", () => {
 
 		A.sharedString.insertText(0, "UVWXYZ");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent([A, B]);
+		await assertConsistent([A, B]);
 		B.sharedString.insertText(26, "1");
 		A.sharedString.removeRange(0, 1);
 		B.containerRuntime.connected = false;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent([A, B]);
+		await assertConsistent([A, B]);
 		B.containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent([A, B]);
+		await assertConsistent([A, B]);
 	});
 
-	it("slides to correct segment when inserting segment while disconnected after changing interval", () => {
+	it("slides to correct segment when inserting segment while disconnected after changing interval", async () => {
 		// B-A
 		//   ^
 		clients[0].sharedString.insertText(0, "A");
@@ -586,7 +586,7 @@ describe("interval rebasing", () => {
 		clients[0].sharedString.insertText(0, "B");
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 
 		assert.equal(clients[0].sharedString.getText(), "BA");
 
@@ -597,7 +597,7 @@ describe("interval rebasing", () => {
 		);
 	});
 
-	it("changing interval to concurrently deleted segment detaches interval", () => {
+	it("changing interval to concurrently deleted segment detaches interval", async () => {
 		// B-A
 		// ^
 		// (B)-A
@@ -609,20 +609,20 @@ describe("interval rebasing", () => {
 		const collection_0 = clients[2].sharedString.getIntervalCollection("comments");
 		collection_0.add({ start: 0, end: 0, props: { intervalId: "0" } });
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[1].sharedString.removeRange(0, 1);
 		clients[0].containerRuntime.connected = false;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[1].sharedString.removeRange(0, 1);
 		const collection_1 = clients[0].sharedString.getIntervalCollection("comments");
 		collection_1.change("0", { start: 0, end: 0 });
 		clients[2].sharedString.insertText(0, "C");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 
 		assert.equal(clients[0].sharedString.getText(), "C");
 
@@ -633,12 +633,12 @@ describe("interval rebasing", () => {
 		);
 	});
 
-	it("changing interval endpoint while disconnected to segment also inserted while disconnected", () => {
+	it("changing interval endpoint while disconnected to segment also inserted while disconnected", async () => {
 		// AC
 		// A-B-C
 		clients[0].sharedString.insertText(0, "AC");
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 		const collection_0 = clients[0].sharedString.getIntervalCollection("comments");
 		collection_0.add({ start: 0, end: 0, props: { intervalId: "0" } });
 		clients[0].containerRuntime.connected = false;
@@ -646,7 +646,7 @@ describe("interval rebasing", () => {
 		collection_0.change("0", { start: 1, end: 1 });
 		clients[0].containerRuntime.connected = true;
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 
 		assert.equal(clients[0].sharedString.getText(), "ABC");
 
@@ -671,7 +671,7 @@ describe("interval rebasing", () => {
 		clients[0].containerRuntime.connected = true;
 
 		containerRuntimeFactory.processAllMessages();
-		assertConsistent(clients);
+		await assertConsistent(clients);
 
 		assert.equal(clients[0].sharedString.getText(), "x12");
 

--- a/packages/dds/sequence/src/test/intervalTestUtils.ts
+++ b/packages/dds/sequence/src/test/intervalTestUtils.ts
@@ -122,7 +122,7 @@ async function assertPropertiesEqual(a: SharedString, b: SharedString): Promise<
 			bProps === undefined
 				? []
 				: Object.keys(bProps).filter((key) => bProps[key] !== undefined);
-		for (const key of aKeys) {
+		for (const key of aKeys.concat(bKeys)) {
 			const aVal: unknown = aProps[key];
 			const bVal: unknown = bProps[key];
 			if (isObject(aVal) === true) {
@@ -137,18 +137,6 @@ async function assertPropertiesEqual(a: SharedString, b: SharedString): Promise<
 					)} vs ${JSON.stringify(bHandle)}`,
 				);
 			} else {
-				assert.deepEqual(
-					aVal,
-					bVal,
-					`Property sets have different values @${i} for  key ${key}: ${aVal} vs ${bVal}`,
-				);
-			}
-		}
-		if (aKeys.length !== bKeys.length) {
-			for (const key of bKeys) {
-				const aVal: unknown = aProps[key];
-				const bVal: unknown = bProps[key];
-
 				assert.deepEqual(
 					aVal,
 					bVal,


### PR DESCRIPTION
After completing work to add annotates to shared string fuzz tests and fix other related issues, add handles to the sharedString and intervalCollection fuzz tests. 

[AB#7499](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7499), [AB#7500](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7500)