### PR TITLE
fix(ci): Fix routerlicious e2e tests

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -42,7 +42,7 @@
 		"test:realsvc:local:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:local --",
 		"test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",
 		"test:realsvc:odsp:report": "npm run test:realsvc:odsp --",
-		"test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=20s --use-openssl-ca",
+		"test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=20s",
 		"test:realsvc:r11s:docker": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=docker --timeout=20s",
 		"test:realsvc:routerlicious": "npm run test:realsvc:r11s",
 		"test:realsvc:routerlicious:report": "npm run test:realsvc:r11s --",

--- a/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
+++ b/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
@@ -8,4 +8,13 @@
 const packageDir = `${__dirname}/../..`;
 const getFluidTestMochaConfig = require("@fluid-private/test-version-utils/mocharc-common");
 const config = getFluidTestMochaConfig(packageDir);
+
+// The 'use-openssl-ca' node option used to be passed as a flag in the npm script in package.json, but
+// adding node-option to the base mocharc-common.cjs caused it to be ignored, so we need to append it here.
+if (config["node-option"] === undefined) {
+	config["node-option"] = "use-openssl-ca";
+} else {
+	config["node-option"] += ",use-openssl-ca";
+}
+
 module.exports = config;


### PR DESCRIPTION
## Description

Fixes the routerlicious e2e tests. In https://github.com/microsoft/FluidFramework/pull/20729 we introduced `node-option` in the common mocha configuration file, and that apparently caused the `--use-openssl-ca` flag that we were passing at invocation time when running routerlicious e2e tests to be ignored.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
