### PR TITLE
[rc2] Make ./internal/test exports conditional

### DIFF
--- a/common/build/build-common/README.md
+++ b/common/build/build-common/README.md
@@ -41,7 +41,7 @@ files](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0
 -   tsconfig.node16.json - This config extends base and sets `module: Node16` and `moduleResolution: Node16`. It is intended for all
     builds.
 -   tsconfig.test.node16.json - This config disables some settings that we don't want to use in test code, like `declaration` and
-    `decarationMap`. It also enables the `node` types by default.
+    `decarationMap`. It also enables the `node` types by default, and turns on the "allow-ff-test-exports" [condition](https://nodejs.org/api/packages.html#conditional-exports), which allows imports for test-only indexes used in a few packages.
 
 ### Dual Build Pattern
 

--- a/common/build/build-common/tsconfig.test.node16.json
+++ b/common/build/build-common/tsconfig.test.node16.json
@@ -2,6 +2,7 @@
 	"extends": ["./tsconfig.base.json", "./tsconfig.node16.json"],
 	"compilerOptions": {
 		"composite": false,
+		"customConditions": ["allow-ff-test-exports"],
 		"types": ["node"],
 		"declaration": false,
 		"declarationMap": false,

--- a/packages/dds/merge-tree/package.json
+++ b/packages/dds/merge-tree/package.json
@@ -54,13 +54,15 @@
 			}
 		},
 		"./test": {
-			"import": {
-				"types": "./lib/test/index.d.ts",
-				"default": "./lib/test/index.js"
-			},
-			"require": {
-				"types": "./dist/test/index.d.ts",
-				"default": "./dist/test/index.js"
+			"allow-ff-test-exports": {
+				"import": {
+					"types": "./lib/test/index.d.ts",
+					"default": "./lib/test/index.js"
+				},
+				"require": {
+					"types": "./dist/test/index.d.ts",
+					"default": "./dist/test/index.js"
+				}
 			}
 		}
 	},

--- a/packages/dds/sequence/.eslintrc.cjs
+++ b/packages/dds/sequence/.eslintrc.cjs
@@ -15,4 +15,33 @@ module.exports = {
 		"@typescript-eslint/no-use-before-define": "off",
 		"@typescript-eslint/strict-boolean-expressions": "off",
 	},
+	settings: {
+		"import/extensions": [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
+		"import/parsers": {
+			"@typescript-eslint/parser": [".ts", ".tsx", ".d.ts"],
+		},
+		"import/resolver": {
+			typescript: {
+				extensions: [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
+				conditionNames: [
+					"allow-ff-test-exports",
+
+					// Default condition names below, see https://www.npmjs.com/package/eslint-import-resolver-typescript#conditionnames
+					"types",
+					"import",
+
+					// APF: https://angular.io/guide/angular-package-format
+					"esm2020",
+					"es2020",
+					"es2015",
+
+					"require",
+					"node",
+					"node-addons",
+					"browser",
+					"default",
+				],
+			},
+		},
+	},
 };

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -6,6 +6,7 @@
 /* eslint-disable no-bitwise */
 
 import {
+	// eslint-disable-next-line import/no-deprecated
 	Client,
 	PropertiesManager,
 	PropertySet,
@@ -231,7 +232,7 @@ export interface IIntervalHelpers<TInterval extends ISerializableInterval> {
 		label: string,
 		start: SequencePlace | undefined,
 		end: SequencePlace | undefined,
-
+		// eslint-disable-next-line import/no-deprecated
 		client: Client | undefined,
 		intervalType: IntervalType,
 		op?: ISequencedDocumentMessage,

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -38,7 +38,9 @@ import {
 	ReferencePosition,
 	ReferenceType,
 	MergeTreeRevertibleDriver,
+	// eslint-disable-next-line import/no-deprecated
 	SegmentGroup,
+	// eslint-disable-next-line import/no-deprecated
 	IMergeTreeObliterateMsg,
 	createObliterateRangeOp,
 	SlidingPreference,

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -24,6 +24,7 @@ import {
 	IJSONSegment,
 	IMergeTreeAnnotateMsg,
 	IMergeTreeDeltaOp,
+	// eslint-disable-next-line import/no-deprecated
 	IMergeTreeGroupMsg,
 	IMergeTreeOp,
 	IMergeTreeRemoveMsg,
@@ -187,6 +188,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 				}
 
 				case MergeTreeDeltaType.OBLITERATE: {
+					// eslint-disable-next-line import/no-deprecated
 					const lastRem = ops[ops.length - 1] as IMergeTreeObliterateMsg;
 					if (lastRem?.pos1 === r.position) {
 						assert(
@@ -250,6 +252,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 	/** `Deferred` that triggers once the object is loaded */
 	protected loadedDeferred = new Deferred<void>();
 	// cache out going ops created when partial loading
+	// eslint-disable-next-line import/no-deprecated
 	private readonly loadedDeferredOutgoingOps: [IMergeTreeOp, SegmentGroup | SegmentGroup[]][] =
 		[];
 	// cache incoming ops that arrive when partial loading
@@ -347,6 +350,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 	 * release, as group ops are redundant with the native batching capabilities
 	 * of the runtime
 	 */
+	// eslint-disable-next-line import/no-deprecated
 	public groupOperation(groupOp: IMergeTreeGroupMsg) {
 		this.guardReentrancy(() => this.client.localTransaction(groupOp));
 	}
@@ -661,6 +665,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 				this.submitSequenceMessage(
 					this.client.regeneratePendingOp(
 						content as IMergeTreeOp,
+						// eslint-disable-next-line import/no-deprecated
 						localOpMetadata as SegmentGroup | SegmentGroup[],
 					),
 				);

--- a/packages/dds/sequence/src/sharedString.ts
+++ b/packages/dds/sequence/src/sharedString.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+	// eslint-disable-next-line import/no-deprecated
 	IMergeTreeTextHelper,
 	IRelativePosition,
 	ISegment,
@@ -86,6 +87,7 @@ export class SharedString
 		return this;
 	}
 
+	// eslint-disable-next-line import/no-deprecated
 	private readonly mergeTreeTextHelper: IMergeTreeTextHelper;
 
 	constructor(

--- a/packages/dds/tree/.eslintrc.cjs
+++ b/packages/dds/tree/.eslintrc.cjs
@@ -37,4 +37,33 @@ module.exports = {
 			},
 		},
 	],
+	settings: {
+		"import/extensions": [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
+		"import/parsers": {
+			"@typescript-eslint/parser": [".ts", ".tsx", ".d.ts"],
+		},
+		"import/resolver": {
+			typescript: {
+				extensions: [".ts", ".tsx", ".d.ts", ".js", ".jsx"],
+				conditionNames: [
+					"allow-ff-test-exports",
+
+					// Default condition names below, see https://www.npmjs.com/package/eslint-import-resolver-typescript#conditionnames
+					"types",
+					"import",
+
+					// APF: https://angular.io/guide/angular-package-format
+					"esm2020",
+					"es2020",
+					"es2015",
+
+					"require",
+					"node",
+					"node-addons",
+					"browser",
+					"default",
+				],
+			},
+		},
+	},
 };

--- a/packages/dds/tree/.vscode/settings.json
+++ b/packages/dds/tree/.vscode/settings.json
@@ -12,5 +12,8 @@
 	],
 	"mochaExplorer.configFile": ".mocharc.cjs",
 	"mochaExplorer.timeout": 999999,
+	// This extension appears to invoke mocha programmatically, meaning that the enablement of this option in the common
+	// mocha test config isn't sufficient; it also needs to be enabled here.
+	"mochaExplorer.nodeArgv": ["--conditions", "allow-ff-test-exports"],
 	"cSpell.words": ["deprioritized", "endregion", "insertable", "reentrantly", "unhydrated"],
 }

--- a/packages/dds/tree/src/test/tsconfig.json
+++ b/packages/dds/tree/src/test/tsconfig.json
@@ -10,6 +10,7 @@
 		"module": "Node16",
 		"moduleResolution": "Node16",
 		"types": ["node", "mocha"],
+		"customConditions": ["allow-ff-test-exports"],
 	},
 	"include": ["./**/*"],
 	"references": [

--- a/packages/runtime/id-compressor/package.json
+++ b/packages/runtime/id-compressor/package.json
@@ -54,23 +54,27 @@
 			}
 		},
 		"./test": {
-			"import": {
-				"types": "./lib/test/index.d.ts",
-				"default": "./lib/test/index.js"
-			},
-			"require": {
-				"types": "./dist/test/index.d.ts",
-				"default": "./dist/test/index.js"
+			"allow-ff-test-exports": {
+				"import": {
+					"types": "./lib/test/index.d.ts",
+					"default": "./lib/test/index.js"
+				},
+				"require": {
+					"types": "./dist/test/index.d.ts",
+					"default": "./dist/test/index.js"
+				}
 			}
 		},
 		"./test/idCompressorTestUtilities": {
-			"import": {
-				"types": "./lib/test/idCompressorTestUtilities.d.ts",
-				"default": "./lib/test/idCompressorTestUtilities.js"
-			},
-			"require": {
-				"types": "./dist/test/idCompressorTestUtilities.d.ts",
-				"default": "./dist/test/idCompressorTestUtilities.js"
+			"allow-ff-test-exports": {
+				"import": {
+					"types": "./lib/test/idCompressorTestUtilities.d.ts",
+					"default": "./lib/test/idCompressorTestUtilities.js"
+				},
+				"require": {
+					"types": "./dist/test/idCompressorTestUtilities.d.ts",
+					"default": "./dist/test/idCompressorTestUtilities.js"
+				}
 			}
 		}
 	},

--- a/packages/test/mocha-test-setup/mocharc-common.js
+++ b/packages/test/mocha-test-setup/mocharc-common.js
@@ -51,6 +51,8 @@ function getFluidTestMochaConfig(packageDir, additionalRequiredModules, testRepo
 		"recursive": true,
 		"require": requiredModulePaths,
 		"unhandled-rejections": "strict",
+		// Allow test-only indexes to be imported. Search the FF repo for package.json files with this condition to see example usage.
+		"node-option": "conditions=allow-ff-test-exports",
 		// Performance tests benefit from having access to GC, and memory tests require it.
 		// Exposing it here avoids all packages which do perf testing from having to expose it.
 		"v8-expose-gc": true,

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -41,7 +41,7 @@
 		"test:realsvc:local:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:local --",
 		"test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",
 		"test:realsvc:odsp:report": "npm run test:realsvc:odsp --",
-		"test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=20s --use-openssl-ca",
+		"test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=20s",
 		"test:realsvc:r11s:docker": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=docker --timeout=20s",
 		"test:realsvc:routerlicious": "npm run test:realsvc:r11s",
 		"test:realsvc:routerlicious:report": "npm run test:realsvc:r11s --",

--- a/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
+++ b/packages/test/test-end-to-end-tests/src/test/.mocharc.cjs
@@ -8,4 +8,13 @@
 const packageDir = `${__dirname}/../..`;
 const getFluidTestMochaConfig = require("@fluid-private/test-version-utils/mocharc-common.cjs");
 const config = getFluidTestMochaConfig(packageDir);
+
+// The 'use-openssl-ca' node option used to be passed as a flag in the npm script in package.json, but
+// adding node-option to the base mocharc-common.cjs caused it to be ignored, so we need to append it here.
+if (config["node-option"] === undefined) {
+	config["node-option"] = "use-openssl-ca";
+} else {
+	config["node-option"] += ",use-openssl-ca";
+}
+
 module.exports = config;


### PR DESCRIPTION
## Description

Adjusts the /internal/test exports of merge-tree and id-compressor to be conditional.

Cherry-pick of #20729 into rc2.

This also includes fixes to two follow-up issues this commit introduced, i.e. cherry-picks #20808, and #20827.
