### PR TITLE
Add createSharedObjectKind utility

### DIFF
--- a/packages/dds/map/api-report/map.api.md
+++ b/packages/dds/map/api-report/map.api.md
@@ -98,7 +98,7 @@ export class MapFactory implements IChannelFactory<ISharedMap> {
     get type(): string;
 }
 
-// @alpha @sealed
+// @alpha
 export const SharedDirectory: ISharedObjectKind<ISharedDirectory>;
 
 // @alpha @deprecated

--- a/packages/dds/map/src/directoryFactory.ts
+++ b/packages/dds/map/src/directoryFactory.ts
@@ -10,6 +10,7 @@ import type {
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
 import type { ISharedObjectKind } from "@fluidframework/shared-object-base";
+import { createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
 import { SharedDirectory as SharedDirectoryInternal } from "./directory.js";
 import type { ISharedDirectory } from "./interfaces.js";
@@ -78,37 +79,10 @@ export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
 
 /**
  * Entrypoint for {@link ISharedDirectory} creation.
- * @sealed
  * @alpha
  */
-export const SharedDirectory: ISharedObjectKind<ISharedDirectory> = {
-	/**
-	 * Create a new shared directory
-	 *
-	 * @param runtime - Data store runtime the new shared directory belongs to
-	 * @param id - Optional name of the shared directory
-	 * @returns Newly create shared directory (but not attached yet)
-	 *
-	 * @example
-	 * To create a `SharedDirectory`, call the static create method:
-	 *
-	 * ```typescript
-	 * const myDirectory = SharedDirectory.create(this.runtime, id);
-	 * ```
-	 */
-	create(runtime: IFluidDataStoreRuntime, id?: string): ISharedDirectory {
-		return runtime.createChannel(id, DirectoryFactory.Type) as ISharedDirectory;
-	},
-
-	/**
-	 * Get a factory for SharedDirectory to register with the data store.
-	 *
-	 * @returns A factory that creates and load SharedDirectory
-	 */
-	getFactory(): IChannelFactory<ISharedDirectory> {
-		return new DirectoryFactory();
-	},
-};
+export const SharedDirectory: ISharedObjectKind<ISharedDirectory> =
+	createSharedObjectKind(DirectoryFactory);
 
 /**
  * Entrypoint for {@link ISharedDirectory} creation.

--- a/packages/dds/map/src/mapFactory.ts
+++ b/packages/dds/map/src/mapFactory.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-/* eslint-disable import/no-deprecated */
-
 import type {
 	IChannelAttributes,
 	IChannelFactory,
@@ -12,6 +10,7 @@ import type {
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
 import type { ISharedObjectKind } from "@fluidframework/shared-object-base";
+import { createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
 import type { ISharedMap } from "./interfaces.js";
 import { SharedMap as SharedMapInternal } from "./map.js";
@@ -82,15 +81,7 @@ export class MapFactory implements IChannelFactory<ISharedMap> {
  * Entrypoint for {@link ISharedMap} creation.
  * @alpha
  */
-export const SharedMap: ISharedObjectKind<ISharedMap> = {
-	getFactory(): IChannelFactory<ISharedMap> {
-		return new MapFactory();
-	},
-
-	create(runtime: IFluidDataStoreRuntime, id?: string): ISharedMap {
-		return runtime.createChannel(id, MapFactory.Type) as ISharedMap;
-	},
-};
+export const SharedMap: ISharedObjectKind<ISharedMap> = createSharedObjectKind(MapFactory);
 
 /**
  * Entrypoint for {@link ISharedMap} creation.

--- a/packages/dds/matrix/src/runtime.ts
+++ b/packages/dds/matrix/src/runtime.ts
@@ -11,6 +11,7 @@ import {
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
 import type { ISharedObjectKind } from "@fluidframework/shared-object-base";
+import { createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
 import { type ISharedMatrix, SharedMatrix as SharedMatrixClass } from "./matrix.js";
 import { pkgVersion } from "./packageVersion.js";
@@ -62,15 +63,8 @@ export class SharedMatrixFactory implements IChannelFactory<ISharedMatrix> {
  * Entrypoint for {@link ISharedMatrix} creation.
  * @alpha
  */
-export const SharedMatrix: ISharedObjectKind<ISharedMatrix> = {
-	getFactory(): IChannelFactory<ISharedMatrix> {
-		return new SharedMatrixFactory();
-	},
-
-	create(runtime: IFluidDataStoreRuntime, id?: string): ISharedMatrix {
-		return runtime.createChannel(id, SharedMatrixFactory.Type) as ISharedMatrix & IChannel;
-	},
-};
+export const SharedMatrix: ISharedObjectKind<ISharedMatrix> =
+	createSharedObjectKind(SharedMatrixFactory);
 
 /**
  * Convenience alias for {@link ISharedMatrix}. Prefer to use {@link ISharedMatrix} when referring to

--- a/packages/dds/shared-object-base/api-report/shared-object-base.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.api.md
@@ -29,6 +29,11 @@ import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
 export function bindHandles(value: any, serializer: IFluidSerializer, bind: IFluidHandle_2): void;
 
 // @internal
+export function createSharedObjectKind<TSharedObject>(factory: (new () => IChannelFactory<TSharedObject>) & {
+    Type: string;
+}): ISharedObjectKind<TSharedObject>;
+
+// @internal
 export function createSingleBlobSummary(key: string, content: string | Uint8Array): ISummaryTreeWithStats;
 
 // @internal

--- a/packages/dds/shared-object-base/src/index.ts
+++ b/packages/dds/shared-object-base/src/index.ts
@@ -4,7 +4,12 @@
  */
 
 export { FluidSerializer, IFluidSerializer } from "./serializer.js";
-export { SharedObject, SharedObjectCore, ISharedObjectKind } from "./sharedObject.js";
+export {
+	SharedObject,
+	SharedObjectCore,
+	ISharedObjectKind,
+	createSharedObjectKind,
+} from "./sharedObject.js";
 export { SummarySerializer } from "./summarySerializer.js";
 export { ISharedObject, ISharedObjectEvents } from "./types.js";
 export {

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -815,3 +815,21 @@ export interface ISharedObjectKind<TSharedObject> {
 	 */
 	create(runtime: IFluidDataStoreRuntime, id?: string): TSharedObject;
 }
+
+/**
+ * Utility for creating ISharedObjectKind instances.
+ * @internal
+ */
+export function createSharedObjectKind<TSharedObject>(
+	factory: (new () => IChannelFactory<TSharedObject>) & { Type: string },
+): ISharedObjectKind<TSharedObject> {
+	return {
+		getFactory(): IChannelFactory<TSharedObject> {
+			return new factory();
+		},
+
+		create(runtime: IFluidDataStoreRuntime, id?: string): TSharedObject {
+			return runtime.createChannel(id, factory.Type) as TSharedObject;
+		},
+	};
+}

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -10,6 +10,7 @@ import {
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
 import { ISharedObjectKind } from "@fluidframework/shared-object-base";
+import { createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
 import { pkgVersion } from "./packageVersion.js";
 import { SharedTree as SharedTreeImpl, SharedTreeOptions } from "./shared-tree/index.js";
@@ -19,14 +20,14 @@ import { ITree } from "./simple-tree/index.js";
  * A channel factory that creates an {@link ITree}.
  */
 export class TreeFactory implements IChannelFactory<ITree> {
-	public static readonly type = "https://graph.microsoft.com/types/tree";
+	public static readonly Type = "https://graph.microsoft.com/types/tree";
 	public static readonly attributes: IChannelAttributes = {
-		type: this.type,
+		type: this.Type,
 		snapshotFormatVersion: "0.0.0",
 		packageVersion: pkgVersion,
 	};
 
-	public readonly type = TreeFactory.type;
+	public readonly type = TreeFactory.Type;
 	public readonly attributes: IChannelAttributes = TreeFactory.attributes;
 
 	public constructor(private readonly options: SharedTreeOptions) {}
@@ -82,14 +83,10 @@ export const SharedTree: ISharedObjectKind<ITree> = configuredSharedTree({});
  * @internal
  */
 export function configuredSharedTree(options: SharedTreeOptions): ISharedObjectKind<ITree> {
-	const factory = new TreeFactory(options);
-	return {
-		getFactory(): IChannelFactory<ITree> {
-			return factory;
-		},
-
-		create(runtime: IFluidDataStoreRuntime, id?: string): ITree {
-			return runtime.createChannel(id, TreeFactory.type) as ITree;
-		},
-	};
+	class ConfiguredFactory extends TreeFactory {
+		public constructor() {
+			super(options);
+		}
+	}
+	return createSharedObjectKind(ConfiguredFactory);
 }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -742,7 +742,7 @@ export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenance
 // @alpha
 export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
 
-// @alpha @sealed
+// @alpha
 export const SharedDirectory: ISharedObjectKind<ISharedDirectory>;
 
 // @alpha @deprecated


### PR DESCRIPTION
## Description

Each DDS exposes a SharedObjectKind which does the same thing. This utility makes doing so easier as well as centralizing the logic to make changes to it easier.

This was done as a cleanup when considering applying ErasedType to IChannelFactory to try and reduce the use of IChannel (and its summary related types it exposes) and IFluidDataStoreRuntime (and the delta types it exposes). Expirments like that will be easier with the refactoring to use createSharedObjectKind  included in this change.

Also removes a `@sealed` on a SharedObjectKind instance, since its a variable not a class (or even interface) it doesn't make sense.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
