### PR TITLE
Use ISharedObjectKind for Cell

### DIFF
--- a/.changeset/fancy-frogs-accept.md
+++ b/.changeset/fancy-frogs-accept.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/cell": minor
+---
+
+SharedCell now uses ISharedObjectKind and does not export class
+
+Most users of SHaredCell just need to replace usages of the `SharedCell` type with `ISharedCell`.

--- a/.changeset/fancy-frogs-accept.md
+++ b/.changeset/fancy-frogs-accept.md
@@ -4,4 +4,4 @@
 
 SharedCell now uses ISharedObjectKind and does not export class
 
-Most users of SHaredCell just need to replace usages of the `SharedCell` type with `ISharedCell`.
+Most users of SharedCell just need to replace usages of the `SharedCell` type with `ISharedCell`.

--- a/examples/version-migration/same-container/src/modelVersion1/inventoryList.ts
+++ b/examples/version-migration/same-container/src/modelVersion1/inventoryList.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from "@fluid-example/example-utils";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/internal";
-import { SharedCell } from "@fluidframework/cell/internal";
+import { SharedCell, type ISharedCell } from "@fluidframework/cell/internal";
 import { SharedString } from "@fluidframework/sequence/internal";
 import { v4 as uuid } from "uuid";
 
@@ -32,7 +32,7 @@ class InventoryItem extends EventEmitter implements IInventoryItem {
 	public constructor(
 		private readonly _id: string,
 		private readonly _name: SharedString,
-		private readonly _quantity: SharedCell<number>,
+		private readonly _quantity: ISharedCell<number>,
 	) {
 		super();
 		// this._name.on("sequenceDelta", () =>{
@@ -56,7 +56,7 @@ export class InventoryList extends DataObject implements IInventoryList {
 	public readonly addItem = (name: string, quantity: number) => {
 		const nameString = SharedString.create(this.runtime);
 		nameString.insertText(0, name);
-		const quantityCell: SharedCell<number> = SharedCell.create(this.runtime);
+		const quantityCell: ISharedCell<number> = SharedCell.create(this.runtime);
 		quantityCell.set(quantity);
 		const id = uuid();
 		this.root.set(id, { name: nameString.handle, quantity: quantityCell.handle });

--- a/examples/version-migration/schema-upgrade/src/modelVersion1/inventoryList.ts
+++ b/examples/version-migration/schema-upgrade/src/modelVersion1/inventoryList.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from "@fluid-example/example-utils";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/internal";
-import { SharedCell } from "@fluidframework/cell/internal";
+import { SharedCell, type ISharedCell } from "@fluidframework/cell/internal";
 import { SharedString } from "@fluidframework/sequence/internal";
 import { v4 as uuid } from "uuid";
 
@@ -32,7 +32,7 @@ class InventoryItem extends EventEmitter implements IInventoryItem {
 	public constructor(
 		private readonly _id: string,
 		private readonly _name: SharedString,
-		private readonly _quantity: SharedCell<number>,
+		private readonly _quantity: ISharedCell<number>,
 	) {
 		super();
 		// this._name.on("sequenceDelta", () =>{
@@ -56,7 +56,7 @@ export class InventoryList extends DataObject implements IInventoryList {
 	public readonly addItem = (name: string, quantity: number) => {
 		const nameString = SharedString.create(this.runtime);
 		nameString.insertText(0, name);
-		const quantityCell: SharedCell<number> = SharedCell.create(this.runtime);
+		const quantityCell: ISharedCell<number> = SharedCell.create(this.runtime);
 		quantityCell.set(quantity);
 		const id = uuid();
 		this.root.set(id, { name: nameString.handle, quantity: quantityCell.handle });

--- a/packages/dds/cell/api-report/cell.api.md
+++ b/packages/dds/cell/api-report/cell.api.md
@@ -8,18 +8,14 @@ import { AttributionKey } from '@fluidframework/runtime-definitions/internal';
 import { IChannelAttributes } from '@fluidframework/datastore-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IChannelServices } from '@fluidframework/datastore-definitions';
-import { IChannelStorageService } from '@fluidframework/datastore-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
-import { IFluidSerializer } from '@fluidframework/shared-object-base';
-import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
-import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
+import type { ISharedObjectKind } from '@fluidframework/shared-object-base';
 import { Serializable } from '@fluidframework/datastore-definitions/internal';
-import { SharedObject } from '@fluidframework/shared-object-base/internal';
 
 // @internal @sealed
-export class CellFactory implements IChannelFactory {
+export class CellFactory implements IChannelFactory<ISharedCell> {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;
     get attributes(): IChannelAttributes;
@@ -59,23 +55,6 @@ export interface ISharedCellEvents<T> extends ISharedObjectEvents {
 }
 
 // @internal
-export class SharedCell<T = any> extends SharedObject<ISharedCellEvents<T>> implements ISharedCell<T> {
-    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
-    protected applyStashedOp(content: unknown): void;
-    static create(runtime: IFluidDataStoreRuntime, id?: string): SharedCell;
-    delete(): void;
-    empty(): boolean;
-    get(): Serializable<T> | undefined;
-    // (undocumented)
-    getAttribution(): AttributionKey | undefined;
-    static getFactory(): IChannelFactory;
-    protected initializeLocalCore(): void;
-    protected loadCore(storage: IChannelStorageService): Promise<void>;
-    protected onDisconnect(): void;
-    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
-    protected rollback(content: any, localOpMetadata: unknown): void;
-    set(value: Serializable<T>): void;
-    protected summarizeCore(serializer: IFluidSerializer): ISummaryTreeWithStats;
-}
+export const SharedCell: ISharedObjectKind<ISharedCell>;
 
 ```

--- a/packages/dds/cell/package.json
+++ b/packages/dds/cell/package.json
@@ -128,6 +128,11 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedClassDeclaration_SharedCell": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/dds/cell/src/cell.ts
+++ b/packages/dds/cell/src/cell.ts
@@ -6,7 +6,6 @@
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
 	type IChannelAttributes,
-	type IChannelFactory,
 	type IChannelStorageService,
 	type IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
@@ -18,7 +17,6 @@ import { type AttributionKey } from "@fluidframework/runtime-definitions/interna
 import { type IFluidSerializer } from "@fluidframework/shared-object-base";
 import { SharedObject, createSingleBlobSummary } from "@fluidframework/shared-object-base/internal";
 
-import { CellFactory } from "./cellFactory.js";
 import {
 	type ICellLocalOpMetadata,
 	type ICellOptions,
@@ -55,7 +53,6 @@ const snapshotFileName = "header";
 
 /**
  * {@inheritDoc ISharedCell}
- * @internal
  */
 // TODO: use `unknown` instead (breaking change).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -63,27 +60,6 @@ export class SharedCell<T = any>
 	extends SharedObject<ISharedCellEvents<T>>
 	implements ISharedCell<T>
 {
-	/**
-	 * Create a new `SharedCell`.
-	 *
-	 * @param runtime - The data store runtime to which the `SharedCell` belongs.
-	 * @param id - Unique identifier for the `SharedCell`.
-	 *
-	 * @returns The newly create `SharedCell`. Note that it will not yet be attached.
-	 */
-	public static create(runtime: IFluidDataStoreRuntime, id?: string): SharedCell {
-		return runtime.createChannel(id, CellFactory.Type) as SharedCell;
-	}
-
-	/**
-	 * Gets the factory for the `SharedCell` to register with the data store.
-	 *
-	 * @returns A factory that creates and loads `SharedCell`s.
-	 */
-	public static getFactory(): IChannelFactory {
-		return new CellFactory();
-	}
-
 	/**
 	 * The data held by this cell.
 	 */

--- a/packages/dds/cell/src/cellFactory.ts
+++ b/packages/dds/cell/src/cellFactory.ts
@@ -9,8 +9,10 @@ import {
 	type IChannelServices,
 	type IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
+import type { ISharedObjectKind } from "@fluidframework/shared-object-base";
+import { createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
-import { SharedCell } from "./cell.js";
+import { SharedCell as SharedCellClass } from "./cell.js";
 import { type ISharedCell } from "./interfaces.js";
 import { pkgVersion } from "./packageVersion.js";
 
@@ -21,7 +23,7 @@ import { pkgVersion } from "./packageVersion.js";
  *
  * @internal
  */
-export class CellFactory implements IChannelFactory {
+export class CellFactory implements IChannelFactory<ISharedCell> {
 	/**
 	 * {@inheritDoc CellFactory."type"}
 	 */
@@ -59,7 +61,7 @@ export class CellFactory implements IChannelFactory {
 		services: IChannelServices,
 		attributes: IChannelAttributes,
 	): Promise<ISharedCell> {
-		const cell = new SharedCell(id, runtime, attributes);
+		const cell = new SharedCellClass(id, runtime, attributes);
 		await cell.load(services);
 		return cell;
 	}
@@ -68,8 +70,14 @@ export class CellFactory implements IChannelFactory {
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.create}
 	 */
 	public create(document: IFluidDataStoreRuntime, id: string): ISharedCell {
-		const cell = new SharedCell(id, document, this.attributes);
+		const cell = new SharedCellClass(id, document, this.attributes);
 		cell.initializeLocal();
 		return cell;
 	}
 }
+
+/**
+ * Entrypoint for {@link ISharedCell} creation.
+ * @internal
+ */
+export const SharedCell: ISharedObjectKind<ISharedCell> = createSharedObjectKind(CellFactory);

--- a/packages/dds/cell/src/index.ts
+++ b/packages/dds/cell/src/index.ts
@@ -9,8 +9,7 @@
  * @packageDocumentation
  */
 
-export { SharedCell } from "./cell.js";
-export { CellFactory } from "./cellFactory.js";
+export { CellFactory, SharedCell } from "./cellFactory.js";
 export type {
 	ISharedCell,
 	ISharedCellEvents,

--- a/packages/dds/cell/src/test/types/validateCellPrevious.generated.ts
+++ b/packages/dds/cell/src/test/types/validateCellPrevious.generated.ts
@@ -122,23 +122,11 @@ use_old_InterfaceDeclaration_ISharedCellEvents(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_SharedCell": {"forwardCompat": false}
+* "RemovedClassDeclaration_SharedCell": {"forwardCompat": false}
 */
-declare function get_old_ClassDeclaration_SharedCell():
-    TypeOnly<old.SharedCell>;
-declare function use_current_ClassDeclaration_SharedCell(
-    use: TypeOnly<current.SharedCell>): void;
-use_current_ClassDeclaration_SharedCell(
-    get_old_ClassDeclaration_SharedCell());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "ClassDeclaration_SharedCell": {"backCompat": false}
+* "RemovedClassDeclaration_SharedCell": {"backCompat": false}
 */
-declare function get_current_ClassDeclaration_SharedCell():
-    TypeOnly<current.SharedCell>;
-declare function use_old_ClassDeclaration_SharedCell(
-    use: TypeOnly<old.SharedCell>): void;
-use_old_ClassDeclaration_SharedCell(
-    get_current_ClassDeclaration_SharedCell());

--- a/packages/test/snapshots/src/test/serialized.spec.ts
+++ b/packages/test/snapshots/src/test/serialized.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 import fs from "fs";
 
 import { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
-import { SharedCell } from "@fluidframework/cell/internal";
+import { SharedCell, ISharedCell } from "@fluidframework/cell/internal";
 import { IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import { Loader } from "@fluidframework/container-loader/internal";
 import { SharedCounter } from "@fluidframework/counter/internal";
@@ -68,7 +68,7 @@ describe(`Container Serialization Backwards Compatibility`, () => {
 				await defaultDataStore.getSharedObject<SharedDirectory>(sharedDirectoryId);
 			const sharedString =
 				await defaultDataStore.getSharedObject<SharedString>(sharedStringId);
-			const sharedCell = await defaultDataStore.getSharedObject<SharedCell>(sharedCellId);
+			const sharedCell = await defaultDataStore.getSharedObject<ISharedCell>(sharedCellId);
 			const sharedCounter =
 				await defaultDataStore.getSharedObject<SharedCounter>(sharedCounterId);
 			const crc =
@@ -110,7 +110,7 @@ describe(`Container Serialization Backwards Compatibility`, () => {
 				await defaultDataStore.getSharedObject<SharedDirectory>(sharedDirectoryId);
 			const sharedString =
 				await defaultDataStore.getSharedObject<SharedString>(sharedStringId);
-			const sharedCell = await defaultDataStore.getSharedObject<SharedCell>(sharedCellId);
+			const sharedCell = await defaultDataStore.getSharedObject<ISharedCell>(sharedCellId);
 			const sharedCounter =
 				await defaultDataStore.getSharedObject<SharedCounter>(sharedCounterId);
 			const crc =

--- a/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
@@ -11,7 +11,7 @@ import {
 	enableOnNewFileKey,
 } from "@fluid-experimental/attributor";
 import { describeCompat, itSkipsFailureOnSpecificDrivers } from "@fluid-private/test-version-utils";
-import type { SharedCell } from "@fluidframework/cell/internal";
+import type { ISharedCell } from "@fluidframework/cell/internal";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { AttributionInfo } from "@fluidframework/runtime-definitions/internal";
@@ -25,7 +25,7 @@ import {
 } from "@fluidframework/test-utils/internal";
 
 function assertAttributionMatches(
-	sharedCell: SharedCell,
+	sharedCell: ISharedCell,
 	attributor: IRuntimeAttributor,
 	expected: Partial<AttributionInfo> | "detached" | "local" | undefined,
 ): void {
@@ -92,7 +92,7 @@ describeCompat("Attributor for SharedCell", "NoCompat", (getTestObjectProvider, 
 
 	const sharedCellFromContainer = async (container: IContainer) => {
 		const dataObject = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
-		return dataObject.getSharedObject<SharedCell>(cellId);
+		return dataObject.getSharedObject<ISharedCell>(cellId);
 	};
 
 	const getTestConfig = (runtimeAttributor?: IRuntimeAttributor): ITestContainerConfig => ({

--- a/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellEndToEndTests.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
-import type { ISharedCell, SharedCell } from "@fluidframework/cell/internal";
+import type { ISharedCell } from "@fluidframework/cell/internal";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import { ConfigTypes, IConfigProviderBase, IFluidHandle } from "@fluidframework/core-interfaces";
@@ -48,17 +48,17 @@ describeCompat("SharedCell", "FullCompat", (getTestObjectProvider, apis) => {
 		// Create a Container for the first client.
 		const container1 = await provider.makeTestContainer(testContainerConfig);
 		dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
-		sharedCell1 = await dataObject1.getSharedObject<SharedCell>(cellId);
+		sharedCell1 = await dataObject1.getSharedObject<ISharedCell>(cellId);
 
 		// Load the Container that was created by the first client.
 		const container2 = await provider.loadTestContainer(testContainerConfig);
 		const dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
-		sharedCell2 = await dataObject2.getSharedObject<SharedCell>(cellId);
+		sharedCell2 = await dataObject2.getSharedObject<ISharedCell>(cellId);
 
 		// Load the Container that was created by the first client.
 		const container3 = await provider.loadTestContainer(testContainerConfig);
 		const dataObject3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
-		sharedCell3 = await dataObject3.getSharedObject<SharedCell>(cellId);
+		sharedCell3 = await dataObject3.getSharedObject<ISharedCell>(cellId);
 
 		// Set a starting value in the cell
 		sharedCell1.set(initialCellValue);
@@ -314,7 +314,7 @@ describeCompat("SharedCell orderSequentially", "NoCompat", (getTestObjectProvide
 
 	let container: IContainer;
 	let dataObject: ITestFluidObject;
-	let sharedCell: SharedCell;
+	let sharedCell: ISharedCell;
 	let containerRuntime: ContainerRuntime;
 	let changedEventData: Serializable<unknown>[];
 
@@ -335,7 +335,7 @@ describeCompat("SharedCell orderSequentially", "NoCompat", (getTestObjectProvide
 		};
 		container = await provider.makeTestContainer(configWithFeatureGates);
 		dataObject = (await container.getEntryPoint()) as ITestFluidObject;
-		sharedCell = await dataObject.getSharedObject<SharedCell>(cellId);
+		sharedCell = await dataObject.getSharedObject<ISharedCell>(cellId);
 		containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
 		changedEventData = [];
 		sharedCell.on("valueChanged", (value) => {

--- a/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/deRehydrateContainerTests.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 
 import type { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
 import { describeCompat } from "@fluid-private/test-version-utils";
-import type { SharedCell } from "@fluidframework/cell/internal";
+import type { ISharedCell } from "@fluidframework/cell/internal";
 import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import { Loader } from "@fluidframework/container-loader/internal";
 import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
@@ -437,7 +437,8 @@ describeCompat(
 					await defaultDataStore.getSharedObject<SharedDirectory>(sharedDirectoryId);
 				const sharedString =
 					await defaultDataStore.getSharedObject<SharedString>(sharedStringId);
-				const sharedCell = await defaultDataStore.getSharedObject<SharedCell>(sharedCellId);
+				const sharedCell =
+					await defaultDataStore.getSharedObject<ISharedCell>(sharedCellId);
 				const sharedCounter =
 					await defaultDataStore.getSharedObject<SharedCounter>(sharedCounterId);
 				const crc =
@@ -489,7 +490,8 @@ describeCompat(
 					await defaultDataStore.getSharedObject<SharedDirectory>(sharedDirectoryId);
 				const sharedString =
 					await defaultDataStore.getSharedObject<SharedString>(sharedStringId);
-				const sharedCell = await defaultDataStore.getSharedObject<SharedCell>(sharedCellId);
+				const sharedCell =
+					await defaultDataStore.getSharedObject<ISharedCell>(sharedCellId);
 				const sharedCounter =
 					await defaultDataStore.getSharedObject<SharedCounter>(sharedCounterId);
 				const crc =
@@ -540,7 +542,8 @@ describeCompat(
 					await defaultDataStore.getSharedObject<SharedDirectory>(sharedDirectoryId);
 				const sharedString =
 					await defaultDataStore.getSharedObject<SharedString>(sharedStringId);
-				const sharedCell = await defaultDataStore.getSharedObject<SharedCell>(sharedCellId);
+				const sharedCell =
+					await defaultDataStore.getSharedObject<ISharedCell>(sharedCellId);
 				const sharedCounter =
 					await defaultDataStore.getSharedObject<SharedCounter>(sharedCounterId);
 				const crc =

--- a/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/detachedContainerTests.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 
 import type { SparseMatrix } from "@fluid-experimental/sequence-deprecated";
 import { describeCompat, itExpects } from "@fluid-private/test-version-utils";
-import type { SharedCell } from "@fluidframework/cell/internal";
+import type { ISharedCell } from "@fluidframework/cell/internal";
 import { AttachState } from "@fluidframework/container-definitions";
 import {
 	IContainer,
@@ -643,7 +643,7 @@ describeCompat("Detached Container", "FullCompat", (getTestObjectProvider, apis)
 
 		// Get the root dataStore from the detached container.
 		const dataStore = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
-		const testChannel1 = await dataStore.getSharedObject<SharedCell>(sharedCellId);
+		const testChannel1 = await dataStore.getSharedObject<ISharedCell>(sharedCellId);
 
 		dataStore.context.containerRuntime.on("op", (message, runtimeMessage) => {
 			if (runtimeMessage === false) {

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { ITestDataObject, describeCompat } from "@fluid-private/test-version-utils";
-import type { SharedCell } from "@fluidframework/cell/internal";
+import type { ISharedCell } from "@fluidframework/cell/internal";
 import { AttachState } from "@fluidframework/container-definitions";
 import { IContainer, type IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
 import { Loader } from "@fluidframework/container-loader/internal";
@@ -139,7 +139,7 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		public map!: ISharedMap;
 
 		private readonly sharedCellKey = "sharedCell";
-		public sharedCell!: SharedCell;
+		public sharedCell!: ISharedCell;
 
 		protected async initializingFirstTime() {
 			const sharedMap = SharedMap.create(this.runtime);
@@ -154,7 +154,7 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 			assert(mapHandle !== undefined, "SharedMap not found");
 			this.map = await mapHandle.get();
 
-			const sharedCellHandle = this.root.get<IFluidHandle<SharedCell>>(this.sharedCellKey);
+			const sharedCellHandle = this.root.get<IFluidHandle<ISharedCell>>(this.sharedCellKey);
 			assert(sharedCellHandle !== undefined, "SharedCell not found");
 			this.sharedCell = await sharedCellHandle.get();
 		}
@@ -190,7 +190,7 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 	let sharedMapContainer2: ISharedMap;
 	let sharedMapContainer3: ISharedMap;
 
-	let sharedCellContainer1: SharedCell;
+	let sharedCellContainer1: ISharedCell;
 
 	const createContainer = async (): Promise<IContainer> =>
 		provider.createContainer(runtimeFactory);
@@ -675,7 +675,7 @@ describeCompat("IdCompressor in detached container", "NoCompat", (getTestObjectP
 
 		// Get the root dataStore from the detached container.
 		const dataStore = (await container.getEntryPoint()) as ITestFluidObject;
-		const testChannel1 = await dataStore.getSharedObject<SharedCell>("sharedCell");
+		const testChannel1 = await dataStore.getSharedObject<ISharedCell>("sharedCell");
 
 		// Generate an Id before attaching the container
 		(testChannel1 as any).runtime.idCompressor.generateCompressedId();
@@ -688,7 +688,7 @@ describeCompat("IdCompressor in detached container", "NoCompat", (getTestObjectP
 		const loader2 = provider.makeTestLoader(testConfig) as Loader;
 		const container2 = await loader2.resolve({ url });
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
-		const testChannel2 = await dataStore2.getSharedObject<SharedCell>("sharedCell");
+		const testChannel2 = await dataStore2.getSharedObject<ISharedCell>("sharedCell");
 		// Generate an Id in the second attached container and send an op to send the Ids
 		(testChannel2 as any).runtime.idCompressor.generateCompressedId();
 		testChannel2.set("value");

--- a/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/orderSequentially.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
-import type { SharedCell } from "@fluidframework/cell/internal";
+import type { ISharedCell } from "@fluidframework/cell/internal";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
@@ -53,7 +53,7 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 	let sharedString: SharedString;
 	let sharedString2: SharedString;
 	let sharedDir: SharedDirectory;
-	let sharedCell: SharedCell;
+	let sharedCell: ISharedCell;
 	let sharedMap: ISharedMap;
 	let changedEventData: (IValueChanged | Serializable<unknown>)[];
 	let containerRuntime: ContainerRuntime;
@@ -78,7 +78,7 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 		sharedString = await dataObject.getSharedObject<SharedString>(stringId);
 		sharedString2 = await dataObject.getSharedObject<SharedString>(string2Id);
 		sharedDir = await dataObject.getSharedObject<SharedDirectory>(dirId);
-		sharedCell = await dataObject.getSharedObject<SharedCell>(cellId);
+		sharedCell = await dataObject.getSharedObject<ISharedCell>(cellId);
 		sharedMap = await dataObject.getSharedObject<ISharedMap>(mapId);
 
 		containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
@@ -95,8 +95,8 @@ describeCompat("Multiple DDS orderSequentially", "NoCompat", (getTestObjectProvi
 		sharedCell.on("valueChanged", (value) => {
 			changedEventData.push(value);
 		});
-		sharedCell.on("delete", (value) => {
-			changedEventData.push(value);
+		sharedCell.on("delete", () => {
+			changedEventData.push(undefined);
 		});
 		sharedMap.on("valueChanged", (value) => {
 			changedEventData.push(value);

--- a/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pendingBatchReentry.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
-import type { SharedCell } from "@fluidframework/cell/internal";
+import type { ISharedCell } from "@fluidframework/cell/internal";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import type { SharedCounter } from "@fluidframework/counter/internal";
@@ -52,7 +52,7 @@ describeCompat(
 		let sharedMap: ISharedMap;
 		let sharedString: SharedString;
 		let sharedDirectory: SharedDirectory;
-		let sharedCell: SharedCell;
+		let sharedCell: ISharedCell;
 		let sharedCounter: SharedCounter;
 		let sharedMatrix: SharedMatrix;
 
@@ -70,7 +70,7 @@ describeCompat(
 			sharedMap = await dataObject.getSharedObject<ISharedMap>("map");
 			sharedString = await dataObject.getSharedObject<SharedString>("sharedString");
 			sharedDirectory = await dataObject.getSharedObject<SharedDirectory>("sharedDirectory");
-			sharedCell = await dataObject.getSharedObject<SharedCell>("sharedCell");
+			sharedCell = await dataObject.getSharedObject<ISharedCell>("sharedCell");
 			sharedCounter = await dataObject.getSharedObject<SharedCounter>("sharedCounter");
 			sharedMatrix = await dataObject.getSharedObject<SharedMatrix>("sharedMatrix");
 

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -11,7 +11,7 @@ import {
 	itExpects,
 	itSkipsFailureOnSpecificDrivers,
 } from "@fluid-private/test-version-utils";
-import type { SharedCell } from "@fluidframework/cell/internal";
+import type { ISharedCell } from "@fluidframework/cell/internal";
 import {
 	IContainer,
 	IHostLoader,
@@ -278,7 +278,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 	let container1: IContainerExperimental;
 	let map1: ISharedMap;
 	let string1: SharedString;
-	let cell1: SharedCell;
+	let cell1: ISharedCell;
 	let counter1: SharedCounter;
 	let directory1: ISharedDirectory;
 	let collection1: IIntervalCollection<SequenceInterval>;
@@ -296,7 +296,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		url = await container1.getAbsoluteUrl("");
 		const dataStore1 = (await container1.getEntryPoint()) as ITestFluidObject;
 		map1 = await dataStore1.getSharedObject<ISharedMap>(mapId);
-		cell1 = await dataStore1.getSharedObject<SharedCell>(cellId);
+		cell1 = await dataStore1.getSharedObject<ISharedCell>(cellId);
 		counter1 = await dataStore1.getSharedObject<SharedCounter>(counterId);
 		directory1 = await dataStore1.getSharedObject<SharedDirectory>(directoryId);
 		string1 = await dataStore1.getSharedObject<SharedString>(stringId);
@@ -323,7 +323,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		const pendingOps = await getPendingOps(provider, false, async (c, d) => {
 			const map = await d.getSharedObject<ISharedMap>(mapId);
 			map.set(testKey, testValue);
-			const cell = await d.getSharedObject<SharedCell>(cellId);
+			const cell = await d.getSharedObject<ISharedCell>(cellId);
 			cell.set(testValue);
 			const counter = await d.getSharedObject<SharedCounter>(counterId);
 			counter.increment(testIncrementValue);
@@ -353,7 +353,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		const container2 = await loader.resolve({ url }, pendingOps);
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
 		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
-		const cell2 = await dataStore2.getSharedObject<SharedCell>(cellId);
+		const cell2 = await dataStore2.getSharedObject<ISharedCell>(cellId);
 		const counter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
 		const directory2 = await dataStore2.getSharedObject<SharedDirectory>(directoryId);
 		const string2 = await dataStore2.getSharedObject<SharedString>(stringId);
@@ -390,7 +390,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 			mapCompressedId = (map as any).runtime.idCompressor.generateCompressedId();
 			mapDecompressedId = (map as any).runtime.idCompressor.decompress(mapCompressedId);
 			map.set(mapDecompressedId, testValue);
-			const cell = await d.getSharedObject<SharedCell>(cellId);
+			const cell = await d.getSharedObject<ISharedCell>(cellId);
 			assert((cell as any).runtime.idCompressor !== undefined);
 			cellCompressedId = (cell as any).runtime.idCompressor.generateCompressedId();
 			cellDecompressedId = (cell as any).runtime.idCompressor.decompress(cellCompressedId);
@@ -411,7 +411,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		const container2 = await loader.resolve({ url }, pendingOps);
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
 		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
-		const cell2 = await dataStore2.getSharedObject<SharedCell>(cellId);
+		const cell2 = await dataStore2.getSharedObject<ISharedCell>(cellId);
 		const directory2 = await dataStore2.getSharedObject<SharedDirectory>(directoryId);
 		assert((map2 as any).runtime.idCompressor !== undefined);
 		assert((cell2 as any).runtime.idCompressor !== undefined);
@@ -454,7 +454,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		const pendingOps = await getPendingOps(provider, false, async (c, d) => {
 			const map = await d.getSharedObject<ISharedMap>(mapId);
 			map.set(testKey, testValue);
-			const cell = await d.getSharedObject<SharedCell>(cellId);
+			const cell = await d.getSharedObject<ISharedCell>(cellId);
 			cell.set(testValue);
 			const counter = await d.getSharedObject<SharedCounter>(counterId);
 			counter.increment(testIncrementValue);
@@ -468,7 +468,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		container2.connect();
 		const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
 		const map2 = await dataStore2.getSharedObject<ISharedMap>(mapId);
-		const cell2 = await dataStore2.getSharedObject<SharedCell>(cellId);
+		const cell2 = await dataStore2.getSharedObject<ISharedCell>(cellId);
 		const counter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
 		const directory2 = await dataStore2.getSharedObject<SharedDirectory>(directoryId);
 		await waitForContainerConnection(container2);
@@ -492,7 +492,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 			const pendingOps = await getPendingOps(provider, true, async (c, d) => {
 				const mapPre = await getMap(d);
 				mapPre.set(testKey, "something unimportant");
-				const cell = await d.getSharedObject<SharedCell>(cellId);
+				const cell = await d.getSharedObject<ISharedCell>(cellId);
 				cell.set("something unimportant");
 				const counter = await d.getSharedObject<SharedCounter>(counterId);
 				counter.increment(3);
@@ -510,7 +510,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 			const container2 = await loader.resolve({ url }, pendingOps);
 			const dataStore2 = (await container2.getEntryPoint()) as ITestFluidObject;
 			const map2 = await getMap(dataStore2);
-			const cell2 = await dataStore2.getSharedObject<SharedCell>(cellId);
+			const cell2 = await dataStore2.getSharedObject<ISharedCell>(cellId);
 			const counter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
 			const directory2 = await dataStore2.getSharedObject<SharedDirectory>(directoryId);
 

--- a/packages/test/test-version-utils/api-report/test-version-utils.api.md
+++ b/packages/test/test-version-utils/api-report/test-version-utils.api.md
@@ -84,7 +84,7 @@ export const DataRuntimeApi: {
     FluidDataStoreRuntime: typeof datastore.FluidDataStoreRuntime;
     TestFluidObjectFactory: typeof TestFluidObjectFactory;
     dds: {
-        SharedCell: typeof cell.SharedCell;
+        SharedCell: ISharedObjectKind<cell.ISharedCell<any>>;
         SharedCounter: typeof counter.SharedCounter;
         SharedDirectory: ISharedObjectKind<map.ISharedDirectory>;
         SharedMap: ISharedObjectKind<map.ISharedMap>;

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DefaultEditors.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DefaultEditors.ts
@@ -8,7 +8,7 @@
  * implementations for our DDSs.
  */
 
-import { SharedCell } from "@fluidframework/cell/internal";
+import { SharedCell, type ISharedCell } from "@fluidframework/cell/internal";
 import { SharedCounter } from "@fluidframework/counter/internal";
 import { SharedString } from "@fluidframework/sequence/internal";
 import { type ISharedObject } from "@fluidframework/shared-object-base";
@@ -22,7 +22,7 @@ export const editSharedCell: EditSharedObject = async (
 	sharedObject: ISharedObject,
 	edit: Edit,
 ): Promise<void> => {
-	const sharedCell = sharedObject as SharedCell;
+	const sharedCell = sharedObject as ISharedCell;
 	sharedCell.set(edit.data);
 };
 

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
@@ -8,7 +8,7 @@
  * implementations for our DDSs.
  */
 
-import { SharedCell } from "@fluidframework/cell/internal";
+import { SharedCell, type ISharedCell } from "@fluidframework/cell/internal";
 import { SharedCounter } from "@fluidframework/counter/internal";
 import {
 	type IDirectory,
@@ -47,7 +47,7 @@ export const visualizeSharedCell: VisualizeSharedObject = async (
 	sharedObject: ISharedObject,
 	visualizeChildData: VisualizeChildData,
 ): Promise<FluidObjectNode> => {
-	const sharedCell = sharedObject as SharedCell<unknown>;
+	const sharedCell = sharedObject as ISharedCell<unknown>;
 	const data = sharedCell.get();
 
 	const renderedData = await visualizeChildData(data);

--- a/packages/tools/devtools/devtools-core/src/test/DataVisualizerGraph.spec.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DataVisualizerGraph.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { SharedCell } from "@fluidframework/cell/internal";
+import { SharedCell, type ISharedCell } from "@fluidframework/cell/internal";
 import { type IFluidLoadable } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter/internal";
 import { SharedMap } from "@fluidframework/map/internal";
@@ -163,7 +163,10 @@ describe("DataVisualizerGraph unit tests", () => {
 			SharedCounter.getFactory().attributes,
 		);
 		sharedCounter.increment(42);
-		const sharedCell = new SharedCell("test-cell", runtime, SharedCell.getFactory().attributes);
+		const sharedCell: ISharedCell<string> = SharedCell.getFactory().create(
+			runtime,
+			"test-cell",
+		);
 		sharedCell.set("Hello world");
 
 		const visualizer = new DataVisualizerGraph(

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
@@ -7,7 +7,7 @@
 
 /* eslint-disable unicorn/no-null */
 
-import { SharedCell } from "@fluidframework/cell/internal";
+import { SharedCell, type ISharedCell } from "@fluidframework/cell/internal";
 import { type IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter/internal";
 import { createIdCompressor } from "@fluidframework/id-compressor/internal";
@@ -52,7 +52,10 @@ async function visualizeChildData(data: unknown): Promise<VisualChildNode> {
 describe("DefaultVisualizers unit tests", () => {
 	it("SharedCell (Primitive data)", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
-		const sharedCell = new SharedCell("test-cell", runtime, SharedCell.getFactory().attributes);
+		const sharedCell: ISharedCell<string> = SharedCell.getFactory().create(
+			runtime,
+			"test-cell",
+		);
 
 		const result = await visualizeSharedCell(sharedCell, visualizeChildData);
 
@@ -71,7 +74,10 @@ describe("DefaultVisualizers unit tests", () => {
 
 	it("SharedCell (JSON data)", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
-		const sharedCell = new SharedCell("test-cell", runtime, SharedCell.getFactory().attributes);
+		const sharedCell: ISharedCell<object> = SharedCell.getFactory().create(
+			runtime,
+			"test-cell",
+		);
 
 		sharedCell.set({ test: undefined });
 

--- a/packages/tools/devtools/devtools-example/src/widgets/EmojiButton.tsx
+++ b/packages/tools/devtools/devtools-example/src/widgets/EmojiButton.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Button, Tooltip } from "@fluentui/react-components";
-import { type SharedCell } from "@fluidframework/cell/internal";
+import { type ISharedCell } from "@fluidframework/cell/internal";
 import React from "react";
 
 /**
@@ -12,7 +12,7 @@ import React from "react";
  * @internal
  */
 export interface EmojiButtonProps {
-	emojiCell: SharedCell<boolean>;
+	emojiCell: ISharedCell<boolean>;
 }
 
 /**

--- a/packages/tools/devtools/devtools-example/src/widgets/EmojiGrid.tsx
+++ b/packages/tools/devtools/devtools-example/src/widgets/EmojiGrid.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Spinner } from "@fluentui/react-components";
-import { type SharedCell } from "@fluidframework/cell/internal";
+import { type ISharedCell } from "@fluidframework/cell/internal";
 import { type IFluidHandle } from "@fluidframework/core-interfaces";
 import { type SharedMatrix } from "@fluidframework/matrix/internal";
 import React from "react";
@@ -16,7 +16,7 @@ import { EmojiButton } from "./EmojiButton.js";
  * @internal
  */
 export interface EmojiGridProps {
-	emojiMatrix: SharedMatrix<IFluidHandle<SharedCell<boolean>>>;
+	emojiMatrix: SharedMatrix<IFluidHandle<ISharedCell<boolean>>>;
 }
 
 /**
@@ -32,7 +32,7 @@ export function EmojiGrid(props: EmojiGridProps): React.ReactElement {
 	for (let row = 0; row < rowCount; row++) {
 		const renderedCells: React.ReactElement[] = [];
 		for (let col = 0; col < colCount; col++) {
-			const cellHandle = emojiMatrix.getCell(row, col) as IFluidHandle<SharedCell<boolean>>;
+			const cellHandle = emojiMatrix.getCell(row, col) as IFluidHandle<ISharedCell<boolean>>;
 			renderedCells.push(
 				<CellView key={`emoji-grid-cell-${row}-${col}`} cellHandle={cellHandle} />,
 			);
@@ -44,13 +44,13 @@ export function EmojiGrid(props: EmojiGridProps): React.ReactElement {
 }
 
 interface CellViewProps {
-	cellHandle: IFluidHandle<SharedCell<boolean>>;
+	cellHandle: IFluidHandle<ISharedCell<boolean>>;
 }
 
 function CellView(props: CellViewProps): React.ReactElement {
 	const { cellHandle } = props;
 
-	const [emojiCell, setEmojiCell] = React.useState<SharedCell<boolean> | undefined>();
+	const [emojiCell, setEmojiCell] = React.useState<ISharedCell<boolean> | undefined>();
 
 	React.useEffect(() => {
 		cellHandle.get().then(setEmojiCell, (error) => {


### PR DESCRIPTION
## Description

Update SharedCell to align with our current factory conventions.

## Breaking Changes

SharedCell is internal only, so only internal things should break, and they can be updated to use the ISharedCell for the type and the new factory setup.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
