### PR TITLE
Added support for custom tenant key generators

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -133,6 +133,9 @@
 		"broken": {
 			"ClassDeclaration_NexusResources": {
 				"backCompat": false
+			},
+			"ClassDeclaration_RiddlerResources": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/api.ts
@@ -13,7 +13,7 @@ import {
 } from "@fluidframework/server-services-core";
 import { handleResponse } from "@fluidframework/server-services";
 import { Router } from "express";
-import { getParam } from "@fluidframework/server-services-utils";
+import { getParam, ITenantKeyGenerator } from "@fluidframework/server-services-utils";
 import { decode } from "jsonwebtoken";
 import { ITokenClaims } from "@fluidframework/protocol-definitions";
 import { getGlobalTelemetryContext } from "@fluidframework/server-services-telemetry";
@@ -28,6 +28,7 @@ export function create(
 	secretManager: ISecretManager,
 	fetchTenantKeyMetricInterval: number,
 	riddlerStorageRequestMetricInterval: number,
+	tenantKeyGenerator: ITenantKeyGenerator,
 	cache?: ICache,
 ): Router {
 	const router: Router = Router();
@@ -39,6 +40,7 @@ export function create(
 		secretManager,
 		fetchTenantKeyMetricInterval,
 		riddlerStorageRequestMetricInterval,
+		tenantKeyGenerator,
 		cache,
 	);
 

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/app.ts
@@ -12,6 +12,7 @@ import {
 	bindCorrelationId,
 	bindTelemetryContext,
 	jsonMorganLoggerMiddleware,
+	ITenantKeyGenerator,
 } from "@fluidframework/server-services-utils";
 import { catch404, getTenantIdFromRequest, handleError } from "../utils";
 import * as api from "./api";
@@ -26,6 +27,7 @@ export function create(
 	secretManager: ISecretManager,
 	fetchTenantKeyMetricInterval: number,
 	riddlerStorageRequestMetricInterval: number,
+	tenantKeyGenerator: ITenantKeyGenerator,
 	cache?: ICache,
 ) {
 	// Express app configuration
@@ -61,6 +63,7 @@ export function create(
 			secretManager,
 			fetchTenantKeyMetricInterval,
 			riddlerStorageRequestMetricInterval,
+			tenantKeyGenerator,
 			cache,
 		),
 	);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/customizations.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/customizations.ts
@@ -3,7 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { IRedisClientConnectionManager } from "@fluidframework/server-services-utils";
+import {
+	IRedisClientConnectionManager,
+	ITenantKeyGenerator,
+} from "@fluidframework/server-services-utils";
 import { ITenantRepository } from "./mongoTenantRepository";
 
 /**
@@ -12,4 +15,5 @@ import { ITenantRepository } from "./mongoTenantRepository";
 export interface IRiddlerResourcesCustomizations {
 	tenantRepository?: ITenantRepository;
 	redisClientConnectionManagerForTenantCache?: IRedisClientConnectionManager;
+	tenantKeyGenerator?: ITenantKeyGenerator;
 }

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runner.ts
@@ -15,6 +15,7 @@ import {
 import { LumberEventName, Lumberjack } from "@fluidframework/server-services-telemetry";
 import { runnerHttpServerStop } from "@fluidframework/server-services-shared";
 import { Provider } from "nconf";
+import type { ITenantKeyGenerator } from "@fluidframework/server-services-utils";
 import * as app from "./app";
 import { ITenantRepository } from "./mongoTenantRepository";
 
@@ -38,6 +39,7 @@ export class RiddlerRunner implements IRunner {
 		private readonly secretManager: ISecretManager,
 		private readonly fetchTenantKeyMetricInterval: number,
 		private readonly riddlerStorageRequestMetricInterval: number,
+		private readonly tenantKeyGenerator: ITenantKeyGenerator,
 		private readonly cache?: ICache,
 		private readonly config?: Provider,
 	) {}
@@ -61,6 +63,7 @@ export class RiddlerRunner implements IRunner {
 				this.secretManager,
 				this.fetchTenantKeyMetricInterval,
 				this.riddlerStorageRequestMetricInterval,
+				this.tenantKeyGenerator,
 				this.cache,
 			);
 			riddler.set("port", this.port);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -45,6 +45,7 @@ export class RiddlerResources implements IResources {
 		public readonly secretManager: ISecretManager,
 		public readonly fetchTenantKeyMetricIntervalMs: number,
 		public readonly riddlerStorageRequestMetricIntervalMs: number,
+		public readonly tenantKeyGenerator: utils.ITenantKeyGenerator,
 		public readonly cache: RedisCache,
 	) {
 		const httpServerConfig: services.IHttpServerConfig = config.get("system:httpServer");
@@ -158,6 +159,9 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
 		const riddlerStorageRequestMetricIntervalMs = config.get(
 			"apiCounters:riddlerStorageRequestMetricMs",
 		);
+		const tenantKeyGenerator = customizations?.tenantKeyGenerator
+			? customizations.tenantKeyGenerator
+			: new utils.TenantKeyGenerator();
 
 		return new RiddlerResources(
 			config,
@@ -172,6 +176,7 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
 			secretManager,
 			fetchTenantKeyMetricIntervalMs,
 			riddlerStorageRequestMetricIntervalMs,
+			tenantKeyGenerator,
 			cache,
 		);
 	}
@@ -193,6 +198,7 @@ export class RiddlerRunnerFactory implements IRunnerFactory<RiddlerResources> {
 			resources.secretManager,
 			resources.fetchTenantKeyMetricIntervalMs,
 			resources.riddlerStorageRequestMetricIntervalMs,
+			resources.tenantKeyGenerator,
 			resources.cache,
 			resources.config,
 		);

--- a/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/riddler/runnerFactory.ts
@@ -20,7 +20,6 @@ import * as utils from "@fluidframework/server-services-utils";
 import { Provider } from "nconf";
 import * as winston from "winston";
 import { RedisCache } from "@fluidframework/server-services";
-import { RedisClientConnectionManager } from "@fluidframework/server-services-utils";
 import { RiddlerRunner } from "./runner";
 import { ITenantDocument } from "./tenantManager";
 import { IRiddlerResourcesCustomizations } from "./customizations";
@@ -90,7 +89,7 @@ export class RiddlerResourcesFactory implements IResourcesFactory<RiddlerResourc
 			const redisClientConnectionManagerForTenantCache =
 				customizations?.redisClientConnectionManagerForTenantCache
 					? customizations.redisClientConnectionManagerForTenantCache
-					: new RedisClientConnectionManager(
+					: new utils.RedisClientConnectionManager(
 							undefined,
 							redisConfig,
 							redisConfig.enableClustering,

--- a/server/routerlicious/packages/routerlicious-base/src/test/riddler/api.spec.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/riddler/api.spec.ts
@@ -16,6 +16,7 @@ import {
 import * as riddlerApp from "../../riddler/app";
 import Sinon from "sinon";
 import { ITenantDocument } from "../../riddler";
+import { TenantKeyGenerator } from "@fluidframework/server-services-utils";
 
 const documentsCollectionName = "testDocuments";
 const deltasCollectionName = "testDeltas";
@@ -89,6 +90,7 @@ describe("Routerlicious", () => {
 					Sinon.useFakeTimers();
 					const testFetchTenantKeyMetricIntervalMs = 60000;
 					const testRiddlerStorageRequestMetricIntervalMs = 60000;
+					const tenantKeyGenerator = new TenantKeyGenerator();
 
 					app = riddlerApp.create(
 						defaultTenantsCollection,
@@ -99,6 +101,7 @@ describe("Routerlicious", () => {
 						testSecretManager,
 						testFetchTenantKeyMetricIntervalMs,
 						testRiddlerStorageRequestMetricIntervalMs,
+						tenantKeyGenerator,
 					);
 					supertest = request(app);
 				});

--- a/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
@@ -512,6 +512,7 @@ declare function get_old_ClassDeclaration_RiddlerResources():
 declare function use_current_ClassDeclaration_RiddlerResources(
     use: TypeOnly<current.RiddlerResources>): void;
 use_current_ClassDeclaration_RiddlerResources(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_RiddlerResources());
 
 /*

--- a/server/routerlicious/packages/services-utils/src/index.ts
+++ b/server/routerlicious/packages/services-utils/src/index.ts
@@ -60,3 +60,4 @@ export {
 	RedisClientConnectionManager,
 	IRedisClientConnectionManager,
 } from "./redisClientConnectionManager";
+export { ITenantKeyGenerator, TenantKeyGenerator } from "./tenantKeyGenerator";

--- a/server/routerlicious/packages/services-utils/src/tenantKeyGenerator.ts
+++ b/server/routerlicious/packages/services-utils/src/tenantKeyGenerator.ts
@@ -1,0 +1,17 @@
+import * as crypto from "crypto";
+
+/**
+ * Interface for generating tenant keys.
+ */
+export interface ITenantKeyGenerator {
+	/**
+	 * Generates a tenant key.
+	 */
+	generateTenantKey(): string;
+}
+
+export class TenantKeyGenerator implements ITenantKeyGenerator {
+	public generateTenantKey(): string {
+		return crypto.randomBytes(16).toString("hex");
+	}
+}

--- a/server/routerlicious/packages/services-utils/src/tenantKeyGenerator.ts
+++ b/server/routerlicious/packages/services-utils/src/tenantKeyGenerator.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import * as crypto from "crypto";
 
 /**


### PR DESCRIPTION
## Description

This PR adds support for customizations for generating `tenantKeys`. This would allow customized ways of creating `tenantKeys`. This is needed to migrate to HIS credentials for Azure. On the FRS side, we would need to implement the `ITenantKeyGenerator` interface with our tenantKey genereation logic.

The change was tested on a dev cluster.

## Breaking Changes

This change breaks backward compatibility for `RiddlerResources` as it introduces a new arg for `ITenantKeyGenerator`.
