### PR TITLE
server: Limit max length of validParentSummaries

### DIFF
--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -759,6 +759,12 @@ export class ScribeLambda implements IPartitionLambda {
 			this.validParentSummaries = [];
 		}
 		this.validParentSummaries.push(summaryHandle);
+		if (
+			this.validParentSummaries.length >
+			this.serviceConfiguration.scribe.maxTrackedServiceSummaryVersionsSinceLastClientSummary
+		) {
+			this.validParentSummaries.shift();
+		}
 	}
 
 	private async sendSummaryAck(contents: ISummaryAck) {

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -763,8 +763,14 @@ export class ScribeLambda implements IPartitionLambda {
 			this.validParentSummaries.length -
 			this.serviceConfiguration.scribe.maxTrackedServiceSummaryVersionsSinceLastClientSummary;
 		if (countOverLimit === 1) {
+			// Remove the oldest handle if we have one over the limit.
+			// This is the most common case once a limit is enforced, and we only need to remove one,
+			// so we use shift() because it is over 2x more performant than splice()
+			// even when removing 2 elements: https://www.measurethat.net/Benchmarks/Show/12324/0/slice-vs-splice-vs-shift
 			this.validParentSummaries.shift();
 		} else if (countOverLimit > 1) {
+			// Older documents from before the limit was enforced can have many more handles than the limit.
+			// Use splice in this case to remove all but the last limit number of handles.
 			this.validParentSummaries.splice(0, countOverLimit);
 		}
 	}

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -759,11 +759,13 @@ export class ScribeLambda implements IPartitionLambda {
 			this.validParentSummaries = [];
 		}
 		this.validParentSummaries.push(summaryHandle);
-		if (
-			this.validParentSummaries.length >
-			this.serviceConfiguration.scribe.maxTrackedServiceSummaryVersionsSinceLastClientSummary
-		) {
+		const countOverLimit =
+			this.validParentSummaries.length -
+			this.serviceConfiguration.scribe.maxTrackedServiceSummaryVersionsSinceLastClientSummary;
+		if (countOverLimit === 1) {
 			this.validParentSummaries.shift();
+		} else if (countOverLimit > 1) {
+			this.validParentSummaries.splice(0, countOverLimit);
 		}
 	}
 

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -145,6 +145,11 @@ export interface IScribeServerConfiguration {
 
 	// Enables scrubbing user data from protocol state quorum in global checkpoints
 	scrubUserDataInGlobalCheckpoints: boolean;
+
+	// Limits the number of service summary versions to track as "valid parent summaries"
+	// since the last client summary. If the list grows beyond this limit, the oldest
+	// service summary version is removed.
+	maxTrackedServiceSummaryVersionsSinceLastClientSummary: number;
 }
 
 /**
@@ -290,6 +295,7 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
 		scrubUserDataInSummaries: false,
 		scrubUserDataInLocalCheckpoints: false,
 		scrubUserDataInGlobalCheckpoints: false,
+		maxTrackedServiceSummaryVersionsSinceLastClientSummary: 10,
 	},
 	moira: {
 		enable: false,


### PR DESCRIPTION
## Description

If a document has a lot of service summaries but no client summaries, the list of validParentSummaries grows extremely long. Older service summaries become more unlikely to be used as parent summaries as more summaries are generated, so we can just shift the list by 1 when the length is too long.

To fix old docs loaded from a large checkpoint, this will remove elements down to the limit when the gap is greater than 1.

## Reviewer Guidance

The configuration is not bubbled up to service level configs yet. I don't think it's necessary.
