### PR TITLE
Change container to wait for being caught up before raising "connected" event when using "read" connections.

### DIFF
--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -94,8 +94,7 @@ export function createConnectionStateHandler(
 ) {
 	const mc = loggerToMonitoringContext(inputs.logger);
 	return createConnectionStateHandlerCore(
-		// mc.config.getBoolean("Fluid.Container.DisableCatchUpBeforeDeclaringConnected") !== true, // connectedRaisedWhenCaughtUp
-		mc.config.getBoolean("Fluid.Container.CatchUpBeforeDeclaringConnected") === true, // connectedRaisedWhenCaughtUp
+		mc.config.getBoolean("Fluid.Container.DisableCatchUpBeforeDeclaringConnected") !== true, // connectedRaisedWhenCaughtUp
 		mc.config.getBoolean("Fluid.Container.DisableJoinSignalWait") !== true, // readClientsWaitForJoinSignal
 		inputs,
 		deltaManager,


### PR DESCRIPTION
Enable Audience to have same behavior for "read" and "write" clients:
- "connected" event raised when we caught up on ops.

For deeper description of work in this space, please see first PR below.

This is continuation of this work:
- https://github.com/microsoft/FluidFramework/pull/20703
- https://github.com/microsoft/FluidFramework/pull/20752
- https://github.com/microsoft/FluidFramework/pull/20704
- https://github.com/microsoft/FluidFramework/pull/20745
- https://github.com/microsoft/FluidFramework/pull/20766
- https://github.com/microsoft/FluidFramework/pull/20817

And active PRs (do not block this PR, but make whole story more consistent for serialized / rehydrated containers):
- https://github.com/microsoft/FluidFramework/pull/20767

Changeset added in previous PR in the same version (part of it should have been included in this PR, but made it earlier by accident):
[.changeset/cruel-trees-dance.md](https://github.com/microsoft/FluidFramework/pull/20215/files#diff-8f706b3e769f698985bea8fbf9bb3fb0a0a8798de53ad3f51cbace1dd3d1d2b2)
