### PR TITLE
Respect import/no-deprecated for deprecated types

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -23,6 +23,7 @@ import {
 	type LocalReferencePosition,
 	MergeTreeDeltaType,
 	ReferenceType,
+	// eslint-disable-next-line import/no-deprecated
 	SegmentGroup,
 } from "@fluidframework/merge-tree/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
@@ -783,6 +784,7 @@ export class SharedMatrix<T = any>
 					this.submitColMessage(
 						this.cols.regeneratePendingOp(
 							content,
+							// eslint-disable-next-line import/no-deprecated
 							localOpMetadata as SegmentGroup | SegmentGroup[],
 						),
 					);
@@ -791,6 +793,7 @@ export class SharedMatrix<T = any>
 					this.submitRowMessage(
 						this.rows.regeneratePendingOp(
 							content,
+							// eslint-disable-next-line import/no-deprecated
 							localOpMetadata as SegmentGroup | SegmentGroup[],
 						),
 					);

--- a/packages/drivers/odsp-driver/src/test/mockFetch.ts
+++ b/packages/drivers/odsp-driver/src/test/mockFetch.ts
@@ -6,6 +6,7 @@
 import assert from "node:assert";
 
 import * as fetchModule from "node-fetch";
+import { Headers } from "node-fetch";
 import { stub } from "sinon";
 
 /**
@@ -16,7 +17,7 @@ export interface MockResponse {
 	status: number;
 	text: () => Promise<string>;
 	arrayBuffer: () => Promise<unknown>;
-	headers: fetchModule.Headers;
+	headers: Headers;
 	json: () => Promise<unknown>;
 }
 
@@ -29,7 +30,7 @@ export const createResponse = async (
 	status,
 	text: async () => JSON.stringify(response),
 	arrayBuffer: async () => response,
-	headers: headers ? new fetchModule.Headers(headers) : new fetchModule.Headers(),
+	headers: headers ? new Headers(headers) : new Headers(),
 	json: async () => response,
 });
 

--- a/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/baseContainerRuntimeFactory.ts
@@ -12,6 +12,7 @@ import {
 import { type IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { type FluidObject } from "@fluidframework/core-interfaces";
 import {
+	// eslint-disable-next-line import/no-deprecated
 	type RuntimeRequestHandler,
 	// eslint-disable-next-line import/no-deprecated
 	buildRuntimeRequestHandler,
@@ -45,6 +46,7 @@ export interface BaseContainerRuntimeFactoryProps {
 	 * Request handlers for containers produced.
 	 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
 	 */
+	// eslint-disable-next-line import/no-deprecated
 	requestHandlers?: RuntimeRequestHandler[];
 	/**
 	 * The runtime options passed to the ContainerRuntime when instantiating it
@@ -78,6 +80,7 @@ export class BaseContainerRuntimeFactory
 	private readonly registryEntries: NamedFluidDataStoreRegistryEntries;
 	private readonly dependencyContainer?: IFluidDependencySynthesizer;
 	private readonly runtimeOptions?: IContainerRuntimeOptions;
+	// eslint-disable-next-line import/no-deprecated
 	private readonly requestHandlers: RuntimeRequestHandler[];
 	private readonly provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
 

--- a/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/framework/aqueduct/src/container-runtime-factories/containerRuntimeFactoryWithDefaultDataStore.ts
@@ -9,6 +9,7 @@ import {
 } from "@fluidframework/container-runtime/internal";
 import { type IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { type FluidObject, type IRequest, type IResponse } from "@fluidframework/core-interfaces";
+// eslint-disable-next-line import/no-deprecated
 import { type RuntimeRequestHandler } from "@fluidframework/request-handler/internal";
 import {
 	type IFluidDataStoreFactory,
@@ -47,6 +48,7 @@ export interface ContainerRuntimeFactoryWithDefaultDataStoreProps {
 	 * Request handlers for containers produced.
 	 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
 	 */
+	// eslint-disable-next-line import/no-deprecated
 	requestHandlers?: RuntimeRequestHandler[];
 	/**
 	 * The runtime options passed to the ContainerRuntime when instantiating it

--- a/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
+++ b/packages/framework/aqueduct/src/data-object-factories/dataObjectFactory.ts
@@ -9,6 +9,7 @@ import {
 	SharedMap,
 	DirectoryFactory,
 	MapFactory,
+	// eslint-disable-next-line import/no-deprecated
 	SharedDirectory,
 } from "@fluidframework/map/internal";
 import { type NamedFluidDataStoreRegistryEntries } from "@fluidframework/runtime-definitions/internal";
@@ -47,6 +48,7 @@ export class DataObjectFactory<
 
 		if (!sharedObjects.some((factory) => factory.type === DirectoryFactory.Type)) {
 			// User did not register for directory
+			// eslint-disable-next-line import/no-deprecated
 			mergedObjects.push(SharedDirectory.getFactory());
 		}
 

--- a/packages/framework/aqueduct/src/data-objects/dataObject.ts
+++ b/packages/framework/aqueduct/src/data-objects/dataObject.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+// eslint-disable-next-line import/no-deprecated
 import { type ISharedDirectory, MapFactory, SharedDirectory } from "@fluidframework/map/internal";
 
 import { PureDataObject } from "./pureDataObject.js";
@@ -61,6 +62,7 @@ export abstract class DataObject<
 			}
 		} else {
 			// Create a root directory and register it before calling initializingFirstTime
+			// eslint-disable-next-line import/no-deprecated
 			this.internalRoot = SharedDirectory.create(this.runtime, this.rootDirectoryId);
 			this.internalRoot.bindToContext();
 		}

--- a/packages/framework/data-object-base/src/runtimeFactory.ts
+++ b/packages/framework/data-object-base/src/runtimeFactory.ts
@@ -8,6 +8,7 @@ import { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import { type IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { type FluidObject } from "@fluidframework/core-interfaces";
 import {
+	// eslint-disable-next-line import/no-deprecated
 	type RuntimeRequestHandler,
 	// eslint-disable-next-line import/no-deprecated
 	buildRuntimeRequestHandler,
@@ -30,6 +31,7 @@ export interface RuntimeFactoryProps {
 	/**
 	 * @deprecated Will be removed once Loader LTS version is "2.0.0-internal.7.0.0". Migrate all usage of IFluidRouter to the "entryPoint" pattern. Refer to Removing-IFluidRouter.md
 	 */
+	// eslint-disable-next-line import/no-deprecated
 	requestHandlers?: RuntimeRequestHandler[];
 	provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
 }
@@ -41,6 +43,7 @@ export class RuntimeFactory extends RuntimeFactoryHelper {
 	private readonly registry: NamedFluidDataStoreRegistryEntries;
 
 	private readonly defaultStoreFactory: IFluidDataStoreFactory;
+	// eslint-disable-next-line import/no-deprecated
 	private readonly requestHandlers: RuntimeRequestHandler[];
 	private readonly provideEntryPoint: (runtime: IContainerRuntime) => Promise<FluidObject>;
 

--- a/packages/test/test-utils/src/testContainerRuntimeFactory.ts
+++ b/packages/test/test-utils/src/testContainerRuntimeFactory.ts
@@ -18,6 +18,7 @@ import {
 } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import {
+	// eslint-disable-next-line import/no-deprecated
 	RuntimeRequestHandler,
 	// eslint-disable-next-line import/no-deprecated
 	buildRuntimeRequestHandler,
@@ -81,6 +82,7 @@ export const createTestContainerRuntimeFactory = (
 					},
 				},
 			},
+			// eslint-disable-next-line import/no-deprecated
 			public requestHandlers: RuntimeRequestHandler[] = [],
 		) {
 			super();

--- a/packages/test/test-utils/src/testContainerRuntimeFactoryWithDefaultDataStore.ts
+++ b/packages/test/test-utils/src/testContainerRuntimeFactoryWithDefaultDataStore.ts
@@ -7,6 +7,7 @@ import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqu
 import { IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { FluidObject } from "@fluidframework/core-interfaces";
+// eslint-disable-next-line import/no-deprecated
 import { RuntimeRequestHandler } from "@fluidframework/request-handler/internal";
 import {
 	IFluidDataStoreFactory,
@@ -31,6 +32,7 @@ export const createContainerRuntimeFactoryWithDefaultDataStore = (
 		defaultFactory: IFluidDataStoreFactory;
 		registryEntries: NamedFluidDataStoreRegistryEntries;
 		dependencyContainer?: any;
+		// eslint-disable-next-line import/no-deprecated
 		requestHandlers?: RuntimeRequestHandler[];
 		runtimeOptions?: IContainerRuntimeOptions;
 		provideEntryPoint?: (runtime: IContainerRuntime) => Promise<FluidObject>;

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DefaultVisualizers.ts
@@ -12,9 +12,11 @@ import { SharedCell } from "@fluidframework/cell/internal";
 import { SharedCounter } from "@fluidframework/counter/internal";
 import {
 	type IDirectory,
-	SharedDirectory,
 	type ISharedMap,
 	SharedMap,
+	type ISharedDirectory,
+	// eslint-disable-next-line import/no-deprecated
+	SharedDirectory,
 } from "@fluidframework/map/internal";
 import { SharedMatrix } from "@fluidframework/matrix/internal";
 import { SharedString } from "@fluidframework/sequence/internal";
@@ -123,7 +125,7 @@ export const visualizeSharedDirectory: VisualizeSharedObject = async (
 	sharedObject: ISharedObject,
 	visualizeChildData: VisualizeChildData,
 ): Promise<FluidObjectTreeNode> => {
-	const sharedDirectory = sharedObject as SharedDirectory;
+	const sharedDirectory = sharedObject as ISharedDirectory;
 	const renderedChildData = await visualizeDirectory(sharedDirectory, visualizeChildData);
 	return {
 		fluidObjectId: sharedDirectory.id,
@@ -304,6 +306,7 @@ export const visualizeUnknownSharedObject: VisualizeSharedObject = async (
 export const defaultVisualizers: Record<string, VisualizeSharedObject> = {
 	[SharedCell.getFactory().type]: visualizeSharedCell,
 	[SharedCounter.getFactory().type]: visualizeSharedCounter,
+	// eslint-disable-next-line import/no-deprecated
 	[SharedDirectory.getFactory().type]: visualizeSharedDirectory,
 	[SharedMap.getFactory().type]: visualizeSharedMap,
 	[SharedMatrix.getFactory().type]: visualizeSharedMatrix,


### PR DESCRIPTION
## Description

#20858 fixes an issue where import/no-deprecated did not properly lint against imports for deprecated types.

This change preps the repo for adopting that change by correctly ignoring or updating such imports as makes sense (ignoring is more appropriate for types which we intend to make \@internal or have APIs left around for compatibility).
