### PR TITLE
Improve doc on ISharedObjectKind.create and implement and use MockFluidDataStoreRuntime.createChannel 

### DIFF
--- a/experimental/dds/ot/ot/src/test/ot.stress.spec.ts
+++ b/experimental/dds/ot/ot/src/test/ot.stress.spec.ts
@@ -94,7 +94,7 @@ describe("SharedOT", () => {
 						objectStorage: new MockStorage(),
 					};
 
-					const docN = SharedDelta.getFactory().create(dataStoreRuntimeN, `doc-${i}`);
+					const docN = dataStoreRuntimeN.create(SharedDelta, `doc-${i}`);
 					docN.connect(servicesN);
 
 					docs.push(docN);

--- a/experimental/dds/ot/ot/src/test/ot.stress.spec.ts
+++ b/experimental/dds/ot/ot/src/test/ot.stress.spec.ts
@@ -86,7 +86,9 @@ describe("SharedOT", () => {
 
 				// Create docs for this stress run.
 				for (let i = 0; i < numClients; i++) {
-					const dataStoreRuntimeN = new MockFluidDataStoreRuntime();
+					const dataStoreRuntimeN = new MockFluidDataStoreRuntime({
+						registry: [SharedDelta.getFactory()],
+					});
 					const containerRuntimeN =
 						containerRuntimeFactory.createContainerRuntime(dataStoreRuntimeN);
 					const servicesN: IChannelServices = {
@@ -94,7 +96,7 @@ describe("SharedOT", () => {
 						objectStorage: new MockStorage(),
 					};
 
-					const docN = dataStoreRuntimeN.create(SharedDelta, `doc-${i}`);
+					const docN = SharedDelta.create(dataStoreRuntimeN, `doc-${i}`);
 					docN.connect(servicesN);
 
 					docs.push(docN);

--- a/experimental/dds/tree/src/test/utilities/SharedTreeVersioningTests.ts
+++ b/experimental/dds/tree/src/test/utilities/SharedTreeVersioningTests.ts
@@ -58,7 +58,7 @@ export function runSharedTreeVersioningTests(
 		};
 
 		it('defaults to latest version if no version is specified when creating factory', () => {
-			const sharedTree = SharedTree.getFactory().create(new MockFluidDataStoreRuntime(), 'SharedTree');
+			const sharedTree = new MockFluidDataStoreRuntime().create(SharedTree, 'SharedTree');
 			const writeFormats = Object.values(WriteFormat);
 			expect(sharedTree.getWriteFormat()).to.equal(writeFormats[writeFormats.length - 1]);
 		});

--- a/experimental/dds/tree/src/test/utilities/SharedTreeVersioningTests.ts
+++ b/experimental/dds/tree/src/test/utilities/SharedTreeVersioningTests.ts
@@ -58,7 +58,10 @@ export function runSharedTreeVersioningTests(
 		};
 
 		it('defaults to latest version if no version is specified when creating factory', () => {
-			const sharedTree = new MockFluidDataStoreRuntime().create(SharedTree, 'SharedTree');
+			const sharedTree = SharedTree.create(
+				new MockFluidDataStoreRuntime({ registry: [SharedTree.getFactory()] }),
+				'SharedTree'
+			);
 			const writeFormats = Object.values(WriteFormat);
 			expect(sharedTree.getWriteFormat()).to.equal(writeFormats[writeFormats.length - 1]);
 		});

--- a/packages/dds/cell/src/cellFactory.ts
+++ b/packages/dds/cell/src/cellFactory.ts
@@ -78,6 +78,9 @@ export class CellFactory implements IChannelFactory<ISharedCell> {
 
 /**
  * Entrypoint for {@link ISharedCell} creation.
+ *
+ * This does not control the type of the content of the cell:
+ * it is up to the user of this to ensure the cell's content types align.
  * @internal
  */
 export const SharedCell: ISharedObjectKind<ISharedCell> = createSharedObjectKind(CellFactory);

--- a/packages/dds/map/src/test/memory/directory.spec.ts
+++ b/packages/dds/map/src/test/memory/directory.spec.ts
@@ -9,7 +9,10 @@ import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/in
 import { ISharedDirectory, SharedDirectory } from "../../index.js";
 
 function createLocalDirectory(id: string): ISharedDirectory {
-	const directory = new MockFluidDataStoreRuntime().create(SharedDirectory, id);
+	const directory = SharedDirectory.create(
+		new MockFluidDataStoreRuntime({ registry: [SharedDirectory.getFactory()] }),
+		id,
+	);
 	return directory;
 }
 

--- a/packages/dds/map/src/test/memory/directory.spec.ts
+++ b/packages/dds/map/src/test/memory/directory.spec.ts
@@ -9,7 +9,7 @@ import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/in
 import { ISharedDirectory, SharedDirectory } from "../../index.js";
 
 function createLocalDirectory(id: string): ISharedDirectory {
-	const directory = SharedDirectory.getFactory().create(new MockFluidDataStoreRuntime(), id);
+	const directory = new MockFluidDataStoreRuntime().create(SharedDirectory, id);
 	return directory;
 }
 

--- a/packages/dds/map/src/test/memory/map.spec.ts
+++ b/packages/dds/map/src/test/memory/map.spec.ts
@@ -9,7 +9,10 @@ import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/in
 import { ISharedMap, SharedMap } from "../../index.js";
 
 function createLocalMap(id: string): ISharedMap {
-	const map = new MockFluidDataStoreRuntime().create(SharedMap, id);
+	const map = SharedMap.create(
+		new MockFluidDataStoreRuntime({ registry: [SharedMap.getFactory()] }),
+		id,
+	);
 	return map;
 }
 

--- a/packages/dds/map/src/test/memory/map.spec.ts
+++ b/packages/dds/map/src/test/memory/map.spec.ts
@@ -9,7 +9,7 @@ import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/in
 import { ISharedMap, SharedMap } from "../../index.js";
 
 function createLocalMap(id: string): ISharedMap {
-	const map = SharedMap.getFactory().create(new MockFluidDataStoreRuntime(), id);
+	const map = new MockFluidDataStoreRuntime().create(SharedMap, id);
 	return map;
 }
 

--- a/packages/dds/map/src/test/mocha/directory.order.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.order.spec.ts
@@ -33,7 +33,7 @@ function createConnectedDirectory(
 		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
-	const directory = SharedDirectory.getFactory().create(dataStoreRuntime, id);
+	const directory = dataStoreRuntime.create(SharedDirectory, id);
 	directory.connect(services);
 	return directory;
 }
@@ -88,7 +88,7 @@ describe("Directory Iteration Order", () => {
 
 		beforeEach("createDirectory", async () => {
 			dataStoreRuntime = new MockFluidDataStoreRuntime({ attachState: AttachState.Detached });
-			directory = SharedDirectory.getFactory().create(dataStoreRuntime, "directory");
+			directory = dataStoreRuntime.create(SharedDirectory, "directory");
 		});
 
 		it("create subdirectories", () => {

--- a/packages/dds/map/src/test/mocha/directory.order.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.order.spec.ts
@@ -27,13 +27,15 @@ function createConnectedDirectory(
 	id: string,
 	runtimeFactory: MockContainerRuntimeFactory,
 ): ISharedDirectory {
-	const dataStoreRuntime = new MockFluidDataStoreRuntime();
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({
+		registry: [SharedDirectory.getFactory()],
+	});
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
 		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
-	const directory = dataStoreRuntime.create(SharedDirectory, id);
+	const directory = SharedDirectory.create(dataStoreRuntime, id);
 	directory.connect(services);
 	return directory;
 }
@@ -87,8 +89,11 @@ describe("Directory Iteration Order", () => {
 		let dataStoreRuntime: MockFluidDataStoreRuntime;
 
 		beforeEach("createDirectory", async () => {
-			dataStoreRuntime = new MockFluidDataStoreRuntime({ attachState: AttachState.Detached });
-			directory = dataStoreRuntime.create(SharedDirectory, "directory");
+			dataStoreRuntime = new MockFluidDataStoreRuntime({
+				attachState: AttachState.Detached,
+				registry: [SharedDirectory.getFactory()],
+			});
+			directory = SharedDirectory.create(dataStoreRuntime, "directory");
 		});
 
 		it("create subdirectories", () => {

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -33,13 +33,15 @@ export function createConnectedDirectory(
 	id: string,
 	runtimeFactory: MockContainerRuntimeFactory,
 ): ISharedDirectory {
-	const dataStoreRuntime = new MockFluidDataStoreRuntime();
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({
+		registry: [SharedDirectory.getFactory()],
+	});
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
 		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
-	const directory = dataStoreRuntime.create(SharedDirectory, id);
+	const directory = SharedDirectory.create(dataStoreRuntime, id);
 	directory.connect(services);
 	return directory;
 }
@@ -111,8 +113,11 @@ describe("Directory", () => {
 		let dataStoreRuntime: MockFluidDataStoreRuntime;
 
 		beforeEach("createDirectory", async () => {
-			dataStoreRuntime = new MockFluidDataStoreRuntime({ attachState: AttachState.Detached });
-			directory = dataStoreRuntime.create(SharedDirectory, "directory");
+			dataStoreRuntime = new MockFluidDataStoreRuntime({
+				attachState: AttachState.Detached,
+				registry: [SharedDirectory.getFactory()],
+			});
+			directory = SharedDirectory.create(dataStoreRuntime, "directory");
 		});
 
 		describe("API", () => {

--- a/packages/dds/map/src/test/mocha/directory.spec.ts
+++ b/packages/dds/map/src/test/mocha/directory.spec.ts
@@ -39,7 +39,7 @@ export function createConnectedDirectory(
 		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
-	const directory = SharedDirectory.getFactory().create(dataStoreRuntime, id);
+	const directory = dataStoreRuntime.create(SharedDirectory, id);
 	directory.connect(services);
 	return directory;
 }
@@ -112,7 +112,7 @@ describe("Directory", () => {
 
 		beforeEach("createDirectory", async () => {
 			dataStoreRuntime = new MockFluidDataStoreRuntime({ attachState: AttachState.Detached });
-			directory = SharedDirectory.getFactory().create(dataStoreRuntime, "directory");
+			directory = dataStoreRuntime.create(SharedDirectory, "directory");
 		});
 
 		describe("API", () => {

--- a/packages/dds/map/src/test/mocha/map.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.spec.ts
@@ -39,13 +39,13 @@ export function createConnectedMap(
 		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
-	const map = SharedMap.getFactory().create(dataStoreRuntime, id);
+	const map = dataStoreRuntime.create(SharedMap, id);
 	map.connect(services);
 	return map;
 }
 
 function createLocalMap(id: string): ISharedMap {
-	const map = SharedMap.getFactory().create(new MockFluidDataStoreRuntime(), id);
+	const map = new MockFluidDataStoreRuntime().create(SharedMap, id);
 	return map;
 }
 

--- a/packages/dds/map/src/test/mocha/map.spec.ts
+++ b/packages/dds/map/src/test/mocha/map.spec.ts
@@ -33,19 +33,20 @@ export function createConnectedMap(
 	id: string,
 	runtimeFactory: MockContainerRuntimeFactory,
 ): ISharedMap {
-	const dataStoreRuntime = new MockFluidDataStoreRuntime();
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({ registry: [SharedMap.getFactory()] });
 	const containerRuntime = runtimeFactory.createContainerRuntime(dataStoreRuntime);
 	const services = {
 		deltaConnection: dataStoreRuntime.createDeltaConnection(),
 		objectStorage: new MockStorage(),
 	};
-	const map = dataStoreRuntime.create(SharedMap, id);
+	const map = SharedMap.create(dataStoreRuntime, id);
 	map.connect(services);
 	return map;
 }
 
 function createLocalMap(id: string): ISharedMap {
-	const map = new MockFluidDataStoreRuntime().create(SharedMap, id);
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({ registry: [SharedMap.getFactory()] });
+	const map = SharedMap.create(dataStoreRuntime, id);
 	return map;
 }
 

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -804,12 +804,12 @@ export interface ISharedObjectKind<TSharedObject> {
 	 * const myTree = SharedTree.create(this.runtime, id);
 	 * ```
 	 * @remarks
+	 * The created object is local (detached): insert a handle to it into an attached object to share (attach) it.
 	 * If using `@fluidframework/fluid-static` (for example via `@fluidframework/azure-client`), use {@link @fluidframework/fluid-static#IFluidContainer.create} instead of calling this directly.
 	 *
 	 * @privateRemarks
 	 * TODO:
-	 * This returns null when used with MockFluidDataStoreRuntime, so its unclear how tests should create DDS instances unless using `RootDataObject.create` (which most tests shouldn't to minimize dependencies).
-	 * In practice tests either avoid mock runtimes, use getFactory(), or call the DDS constructor directly. It is unclear (from docs) how getFactory().create differs but it does not rely on runtime.createChannel so it works with mock runtimes.
+	 * This returns null when used with `MockFluidDataStoreRuntime`: instead tests can use `MockFluidDataStoreRuntime.create`.
 	 * TODO:
 	 * See note on ISharedObjectKind.getFactory.
 	 */

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -782,12 +782,6 @@ export interface ISharedObjectKind<TSharedObject> {
 	 * - {@link @fluidframework/fluid-static#IFluidContainer.create} if using `@fluidframework/fluid-static`, for example via `@fluidframework/azure-client`.
 	 *
 	 * - {@link ISharedObjectKind.create} if using a custom container definitions (and thus not using {@link @fluidframework/fluid-static#IFluidContainer}).
-	 *
-	 * @privateRemarks
-	 * TODO:
-	 * Many tests use this and can't use {@link ISharedObjectKind.create}.
-	 * The docs should make it clear why that's ok, and why {@link ISharedObjectKind.create} isn't in such a way that when reading non app code (like tests in this package)
-	 * someone can tell if the wrong one is being used without running it and seeing if it works.
 	 */
 	getFactory(): IChannelFactory<TSharedObject>;
 
@@ -808,10 +802,7 @@ export interface ISharedObjectKind<TSharedObject> {
 	 * If using `@fluidframework/fluid-static` (for example via `@fluidframework/azure-client`), use {@link @fluidframework/fluid-static#IFluidContainer.create} instead of calling this directly.
 	 *
 	 * @privateRemarks
-	 * TODO:
-	 * This returns null when used with `MockFluidDataStoreRuntime`: instead tests can use `MockFluidDataStoreRuntime.create`.
-	 * TODO:
-	 * See note on ISharedObjectKind.getFactory.
+	 * This can only be used with a `MockFluidDataStoreRuntime` when that mock is created with a `registry` containing a factory for this shared object.
 	 */
 	create(runtime: IFluidDataStoreRuntime, id?: string): TSharedObject;
 }

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -97,6 +97,15 @@ const DebugSharedTree = configuredSharedTree({
 	forest: ForestType.Reference,
 }) as ISharedObjectKind<SharedTree>;
 
+class MockSharedTreeRuntime extends MockFluidDataStoreRuntime {
+	public constructor() {
+		super({
+			idCompressor: createIdCompressor(),
+			registry: [DebugSharedTree.getFactory()],
+		});
+	}
+}
+
 describe("SharedTree", () => {
 	describe("schematize", () => {
 		const builder = new SchemaBuilderBase(FieldKinds.optional, {
@@ -143,9 +152,7 @@ describe("SharedTree", () => {
 		});
 
 		it("noop upgrade", () => {
-			const tree = new MockFluidDataStoreRuntime({
-				idCompressor: createIdCompressor(),
-			}).create(DebugSharedTree);
+			const tree = DebugSharedTree.create(new MockSharedTreeRuntime());
 			tree.checkout.updateSchema(storedSchema);
 
 			// No op upgrade with AllowedUpdateType.None does not error
@@ -159,9 +166,7 @@ describe("SharedTree", () => {
 		});
 
 		it("incompatible upgrade errors", () => {
-			const tree = new MockFluidDataStoreRuntime({
-				idCompressor: createIdCompressor(),
-			}).create(DebugSharedTree);
+			const tree = DebugSharedTree.create(new MockSharedTreeRuntime());
 			tree.checkout.updateSchema(storedSchemaGeneralized);
 			assert.throws(() => {
 				schematizeFlexTree(tree, {
@@ -173,9 +178,7 @@ describe("SharedTree", () => {
 		});
 
 		it("upgrade schema", () => {
-			const tree = new MockFluidDataStoreRuntime({
-				idCompressor: createIdCompressor(),
-			}).create(DebugSharedTree);
+			const tree = DebugSharedTree.create(new MockSharedTreeRuntime());
 			tree.checkout.updateSchema(storedSchema);
 			const schematized = schematizeFlexTree(tree, {
 				allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
@@ -188,9 +191,7 @@ describe("SharedTree", () => {
 
 		// TODO: ensure unhydrated initialTree input is correctly hydrated.
 		it.skip("unhydrated tree input", () => {
-			const tree = new MockFluidDataStoreRuntime({
-				idCompressor: createIdCompressor(),
-			}).create(DebugSharedTree);
+			const tree = DebugSharedTree.create(new MockSharedTreeRuntime());
 			const sb = new SchemaFactory("test-factory");
 			class Foo extends sb.object("Foo", {}) {}
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -89,14 +89,16 @@ import {
 	validateTreeContent,
 	validateViewConsistency,
 } from "../utils.js";
+import { configuredSharedTree } from "../../treeFactory.js";
+import { ISharedObjectKind } from "@fluidframework/shared-object-base";
+
+const DebugSharedTree = configuredSharedTree({
+	jsonValidator: typeboxValidator,
+	forest: ForestType.Reference,
+}) as ISharedObjectKind<SharedTree>;
 
 describe("SharedTree", () => {
 	describe("schematize", () => {
-		const factory = new SharedTreeFactory({
-			jsonValidator: typeboxValidator,
-			forest: ForestType.Reference,
-		});
-
 		const builder = new SchemaBuilderBase(FieldKinds.optional, {
 			libraries: [leaf.library],
 			scope: "test",
@@ -141,10 +143,9 @@ describe("SharedTree", () => {
 		});
 
 		it("noop upgrade", () => {
-			const tree = factory.create(
-				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-				"the tree",
-			) as SharedTree;
+			const tree = new MockFluidDataStoreRuntime({
+				idCompressor: createIdCompressor(),
+			}).create(DebugSharedTree);
 			tree.checkout.updateSchema(storedSchema);
 
 			// No op upgrade with AllowedUpdateType.None does not error
@@ -158,10 +159,9 @@ describe("SharedTree", () => {
 		});
 
 		it("incompatible upgrade errors", () => {
-			const tree = factory.create(
-				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-				"the tree",
-			) as SharedTree;
+			const tree = new MockFluidDataStoreRuntime({
+				idCompressor: createIdCompressor(),
+			}).create(DebugSharedTree);
 			tree.checkout.updateSchema(storedSchemaGeneralized);
 			assert.throws(() => {
 				schematizeFlexTree(tree, {
@@ -173,10 +173,9 @@ describe("SharedTree", () => {
 		});
 
 		it("upgrade schema", () => {
-			const tree = factory.create(
-				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
-				"the tree",
-			) as SharedTree;
+			const tree = new MockFluidDataStoreRuntime({
+				idCompressor: createIdCompressor(),
+			}).create(DebugSharedTree);
 			tree.checkout.updateSchema(storedSchema);
 			const schematized = schematizeFlexTree(tree, {
 				allowedSchemaModifications: AllowedUpdateType.SchemaCompatible,
@@ -189,7 +188,9 @@ describe("SharedTree", () => {
 
 		// TODO: ensure unhydrated initialTree input is correctly hydrated.
 		it.skip("unhydrated tree input", () => {
-			const tree = factory.create(new MockFluidDataStoreRuntime(), "the tree") as SharedTree;
+			const tree = new MockFluidDataStoreRuntime({
+				idCompressor: createIdCompressor(),
+			}).create(DebugSharedTree);
 			const sb = new SchemaFactory("test-factory");
 			class Foo extends sb.object("Foo", {}) {}
 

--- a/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
+++ b/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
@@ -249,7 +249,10 @@ function createSharedString(
 	let serializer: Encoder<IAttributor, string> | undefined;
 	const initialState: FuzzTestState = {
 		clients: clientIds.map((clientId, index) => {
-			const dataStoreRuntime = new MockFluidDataStoreRuntime({ clientId });
+			const dataStoreRuntime = new MockFluidDataStoreRuntime({
+				clientId,
+				registry: [SharedString.getFactory()],
+			});
 			dataStoreRuntime.options = {
 				attribution: {
 					track: makeSerializer !== undefined,
@@ -257,7 +260,7 @@ function createSharedString(
 				},
 			};
 			const { deltaManager } = dataStoreRuntime;
-			const sharedString = SharedString.getFactory().create(
+			const sharedString = SharedString.create(
 				dataStoreRuntime, // eslint-disable-next-line unicorn/prefer-code-point
 				String.fromCharCode(index + 65),
 			);

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -97,8 +97,10 @@ describe("Shared Directory with Interception", () => {
 		}
 
 		beforeEach(() => {
-			const dataStoreRuntime = new MockFluidDataStoreRuntime();
-			sharedDirectory = dataStoreRuntime.create(SharedDirectory, documentId);
+			const dataStoreRuntime = new MockFluidDataStoreRuntime({
+				registry: [SharedDirectory.getFactory()],
+			});
+			sharedDirectory = SharedDirectory.create(dataStoreRuntime, documentId);
 
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 			dataStoreContext = {

--- a/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedDirectoryWithInterception.spec.ts
@@ -98,7 +98,7 @@ describe("Shared Directory with Interception", () => {
 
 		beforeEach(() => {
 			const dataStoreRuntime = new MockFluidDataStoreRuntime();
-			sharedDirectory = SharedDirectory.getFactory().create(dataStoreRuntime, documentId);
+			sharedDirectory = dataStoreRuntime.create(SharedDirectory, documentId);
 
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 			dataStoreContext = {

--- a/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
@@ -33,8 +33,10 @@ describe("Shared Map with Interception", () => {
 		}
 
 		beforeEach(() => {
-			const dataStoreRuntime = new MockFluidDataStoreRuntime();
-			sharedMap = dataStoreRuntime.create(SharedMap, documentId);
+			const dataStoreRuntime = new MockFluidDataStoreRuntime({
+				registry: [SharedMap.getFactory()],
+			});
+			sharedMap = SharedMap.create(dataStoreRuntime, documentId);
 
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 			dataStoreContext = {

--- a/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedMapWithInterception.spec.ts
@@ -34,7 +34,7 @@ describe("Shared Map with Interception", () => {
 
 		beforeEach(() => {
 			const dataStoreRuntime = new MockFluidDataStoreRuntime();
-			sharedMap = SharedMap.getFactory().create(dataStoreRuntime, documentId);
+			sharedMap = dataStoreRuntime.create(SharedMap, documentId);
 
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 			dataStoreContext = {

--- a/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
+++ b/packages/framework/dds-interceptions/src/test/sharedStringWithInterception.spec.ts
@@ -51,8 +51,10 @@ describe("Shared String with Interception", () => {
 		}
 
 		beforeEach(() => {
-			const dataStoreRuntime = new MockFluidDataStoreRuntime();
-			sharedString = SharedString.getFactory().create(dataStoreRuntime, documentId);
+			const dataStoreRuntime = new MockFluidDataStoreRuntime({
+				registry: [SharedString.getFactory()],
+			});
+			sharedString = SharedString.create(dataStoreRuntime, documentId);
 
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 			dataStoreContext = {

--- a/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
+++ b/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
@@ -50,7 +50,9 @@ describe("SharedSegmentSequenceUndoRedoHandler", () => {
 	let undoRedoStack: UndoRedoStackManager;
 
 	beforeEach(() => {
-		const dataStoreRuntime = new MockFluidDataStoreRuntime();
+		const dataStoreRuntime = new MockFluidDataStoreRuntime({
+			registry: [SharedString.getFactory()],
+		});
 
 		containerRuntimeFactory = new MockContainerRuntimeFactory();
 		containerRuntimeFactory.createContainerRuntime(dataStoreRuntime);
@@ -59,7 +61,7 @@ describe("SharedSegmentSequenceUndoRedoHandler", () => {
 			objectStorage: new MockStorage(undefined),
 		};
 
-		sharedString = SharedString.getFactory().create(dataStoreRuntime, documentId);
+		sharedString = SharedString.create(dataStoreRuntime, documentId);
 		sharedString.initializeLocal();
 		sharedString.bindToContext();
 		sharedString.connect(services);

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -450,6 +450,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
         logger?: ITelemetryBaseLogger;
         idCompressor?: IIdCompressor & IIdCompressorCore;
         attachState?: AttachState;
+        registry?: readonly IChannelFactory[];
     });
     // (undocumented)
     get absolutePath(): string;
@@ -481,7 +482,7 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
         getFactory(): IChannelFactory<T>;
     }, id?: string): T & IChannel;
     // (undocumented)
-    createChannel(id: string, type: string): IChannel;
+    createChannel(id: string | undefined, type: string): IChannel;
     // (undocumented)
     createDeltaConnection(): MockDeltaConnection;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -14,6 +14,7 @@ import { IAudience } from '@fluidframework/container-definitions';
 import { IAudienceEvents } from '@fluidframework/container-definitions';
 import { IAudienceOwner } from '@fluidframework/container-definitions/internal';
 import { IChannel } from '@fluidframework/datastore-definitions';
+import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IChannelServices } from '@fluidframework/datastore-definitions';
 import { IChannelStorageService } from '@fluidframework/datastore-definitions';
 import type { IClient } from '@fluidframework/protocol-definitions';
@@ -476,6 +477,9 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     readonly connected = true;
     // (undocumented)
     containerRuntime?: MockContainerRuntime;
+    create<T>(factory: {
+        getFactory(): IChannelFactory<T>;
+    }, id?: string): T & IChannel;
     // (undocumented)
     createChannel(id: string, type: string): IChannel;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.api.md
@@ -478,9 +478,6 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     readonly connected = true;
     // (undocumented)
     containerRuntime?: MockContainerRuntime;
-    create<T>(factory: {
-        getFactory(): IChannelFactory<T>;
-    }, id?: string): T & IChannel;
     // (undocumented)
     createChannel(id: string | undefined, type: string): IChannel;
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -1087,17 +1087,6 @@ export class MockFluidDataStoreRuntime
 	public rollback?(message: any, localOpMetadata: unknown): void {
 		return;
 	}
-
-	/**
-	 * Test utility to help create shared object instances from a {@link @fluidframework/shared-object-base#ISharedObjectKind}.
-	 * @remarks
-	 * This is an alternative to {@link @fluidframework/shared-object-base#ISharedObjectKind.create} that avoids its incompatibility with {@link MockFluidDataStoreRuntime}.
-	 *
-	 * If an `id` is not provided, a random UUID is used.
-	 */
-	public create<T>(factory: { getFactory(): IChannelFactory<T> }, id?: string): T & IChannel {
-		return factory.getFactory().create(this, id ?? uuid());
-	}
 }
 
 /**

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -1074,9 +1074,9 @@ export class MockFluidDataStoreRuntime
 	}
 
 	/**
-	 * Test utility to help shared object instances from a {@link @fluidframework/shared-object-base#ISharedObjectKind}.
+	 * Test utility to help create shared object instances from a {@link @fluidframework/shared-object-base#ISharedObjectKind}.
 	 * @remarks
-	 * This is an alternative to {@link @fluidframework/shared-object-base#ISharedObjectKind.create} that avoids it's incompatibility with {@link MockFluidDataStoreRuntime}.
+	 * This is an alternative to {@link @fluidframework/shared-object-base#ISharedObjectKind.create} that avoids its incompatibility with {@link MockFluidDataStoreRuntime}.
 	 *
 	 * If an `id` is not provided, a random UUID is used.
 	 */

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -29,6 +29,7 @@ import {
 	IDeltaConnection,
 	IDeltaHandler,
 	IFluidDataStoreRuntime,
+	IChannelFactory,
 } from "@fluidframework/datastore-definitions";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type { IIdCompressorCore, IdCreationRange } from "@fluidframework/id-compressor/internal";
@@ -1070,6 +1071,17 @@ export class MockFluidDataStoreRuntime
 
 	public rollback?(message: any, localOpMetadata: unknown): void {
 		return;
+	}
+
+	/**
+	 * Test utility to help shared object instances from a {@link @fluidframework/shared-object-base#ISharedObjectKind}.
+	 * @remarks
+	 * This is an alternative to {@link @fluidframework/shared-object-base#ISharedObjectKind.create} that avoids it's incompatibility with {@link MockFluidDataStoreRuntime}.
+	 *
+	 * If an `id` is not provided, a random UUID is used.
+	 */
+	public create<T>(factory: { getFactory(): IChannelFactory<T> }, id?: string): T & IChannel {
+		return factory.getFactory().create(this, id ?? uuid());
 	}
 }
 

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/PasTable.all.spec.ts
@@ -13,18 +13,18 @@ import {
 
 import { IBenchmarkParameters, benchmarkAll } from "./DocumentCreator.js";
 
-const matrixFactory = SharedMatrix.getFactory();
-
 function createLocalMatrix(id: string, dataStoreRuntime: MockFluidDataStoreRuntime) {
-	return matrixFactory.create(dataStoreRuntime, id);
+	return SharedMatrix.create(dataStoreRuntime, id);
 }
 
 function createString(id: string, dataStoreRuntime: MockFluidDataStoreRuntime) {
-	return SharedString.getFactory().create(dataStoreRuntime, id);
+	return SharedString.create(dataStoreRuntime, id);
 }
 
 describeCompat("PAS Test", "NoCompat", () => {
-	const dataStoreRuntime = new MockFluidDataStoreRuntime();
+	const dataStoreRuntime = new MockFluidDataStoreRuntime({
+		registry: [SharedMatrix.getFactory(), SharedString.getFactory()],
+	});
 	const rowSize = 6;
 	const columnSize = 5;
 

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -589,7 +589,10 @@ describeCompat(
 
 		it("addChannel should add the channel successfully to the runtime", async () => {
 			// Create a new map in local (detached) state.
-			const newSharedMap1 = SharedMap.create(dataObject1.runtime, "newSharedMapId");
+			const newSharedMap1 = SharedMap.getFactory().create(
+				dataObject1.runtime,
+				"newSharedMapId",
+			);
 
 			// Set a value while in local state.
 			newSharedMap1.set("newKey", "newValue");
@@ -611,7 +614,10 @@ describeCompat(
 
 		it("should create error when channel created with different runtime is added to different runtime", async () => {
 			// Create a new map in local (detached) state.
-			const newSharedMap1 = SharedMap.create(dataObject1.runtime, "newSharedMapId");
+			const newSharedMap1 = SharedMap.getFactory().create(
+				dataObject1.runtime,
+				"newSharedMapId",
+			);
 
 			// Set a value while in local state.
 			newSharedMap1.set("newKey", "newValue");

--- a/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mapEndToEndTests.spec.ts
@@ -589,10 +589,7 @@ describeCompat(
 
 		it("addChannel should add the channel successfully to the runtime", async () => {
 			// Create a new map in local (detached) state.
-			const newSharedMap1 = SharedMap.getFactory().create(
-				dataObject1.runtime,
-				"newSharedMapId",
-			);
+			const newSharedMap1 = SharedMap.create(dataObject1.runtime, "newSharedMapId");
 
 			// Set a value while in local state.
 			newSharedMap1.set("newKey", "newValue");
@@ -614,10 +611,7 @@ describeCompat(
 
 		it("should create error when channel created with different runtime is added to different runtime", async () => {
 			// Create a new map in local (detached) state.
-			const newSharedMap1 = SharedMap.getFactory().create(
-				dataObject1.runtime,
-				"newSharedMapId",
-			);
+			const newSharedMap1 = SharedMap.create(dataObject1.runtime, "newSharedMapId");
 
 			// Set a value while in local state.
 			newSharedMap1.set("newKey", "newValue");

--- a/packages/tools/devtools/devtools-core/src/test/DataVisualizerGraph.spec.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DataVisualizerGraph.spec.ts
@@ -23,8 +23,8 @@ import {
 
 describe("DataVisualizerGraph unit tests", () => {
 	it("Single root DDS (SharedCounter)", async () => {
-		const runtime = new MockFluidDataStoreRuntime();
-		const sharedCounter = runtime.create(SharedCounter, "test-counter");
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedCounter.getFactory()] });
+		const sharedCounter = SharedCounter.create(runtime, "test-counter");
 
 		const visualizer = new DataVisualizerGraph(
 			{
@@ -65,10 +65,9 @@ describe("DataVisualizerGraph unit tests", () => {
 	});
 
 	it("Single root DDS (SharedMap)", async () => {
-		const runtime = new MockFluidDataStoreRuntime();
-
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedCounter.getFactory()] });
 		// Create SharedMap
-		const sharedMap = runtime.create(SharedMap, "test-map");
+		const sharedMap = SharedMap.create(runtime, "test-map");
 
 		const visualizer = new DataVisualizerGraph(
 			{
@@ -100,7 +99,7 @@ describe("DataVisualizerGraph unit tests", () => {
 			b: "2",
 			c: true,
 		});
-		const sharedCounter = runtime.create(SharedCounter, "test-counter");
+		const sharedCounter = SharedCounter.create(runtime, "test-counter");
 		sharedMap.set("test-handle", sharedCounter.handle);
 
 		const childTreeAfterEdit = await visualizer.render(sharedMap.id);
@@ -147,11 +146,11 @@ describe("DataVisualizerGraph unit tests", () => {
 	});
 
 	it("Multiple root DDS_s", async () => {
-		const runtime = new MockFluidDataStoreRuntime();
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedCounter.getFactory()] });
 
-		const sharedCounter = runtime.create(SharedCounter, "test-counter");
+		const sharedCounter = SharedCounter.create(runtime, "test-counter");
 		sharedCounter.increment(42);
-		const sharedCell: ISharedCell<string> = runtime.create(SharedCell, "test-cell");
+		const sharedCell = SharedCell.create(runtime, "test-cell") as ISharedCell<string>;
 		sharedCell.set("Hello world");
 
 		const visualizer = new DataVisualizerGraph(

--- a/packages/tools/devtools/devtools-core/src/test/DataVisualizerGraph.spec.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DataVisualizerGraph.spec.ts
@@ -65,7 +65,9 @@ describe("DataVisualizerGraph unit tests", () => {
 	});
 
 	it("Single root DDS (SharedMap)", async () => {
-		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedCounter.getFactory()] });
+		const runtime = new MockFluidDataStoreRuntime({
+			registry: [SharedMap.getFactory(), SharedCounter.getFactory()],
+		});
 		// Create SharedMap
 		const sharedMap = SharedMap.create(runtime, "test-map");
 
@@ -146,7 +148,9 @@ describe("DataVisualizerGraph unit tests", () => {
 	});
 
 	it("Multiple root DDS_s", async () => {
-		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedCounter.getFactory()] });
+		const runtime = new MockFluidDataStoreRuntime({
+			registry: [SharedCounter.getFactory(), SharedCell.getFactory()],
+		});
 
 		const sharedCounter = SharedCounter.create(runtime, "test-counter");
 		sharedCounter.increment(42);

--- a/packages/tools/devtools/devtools-core/src/test/DataVisualizerGraph.spec.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DataVisualizerGraph.spec.ts
@@ -24,7 +24,7 @@ import {
 describe("DataVisualizerGraph unit tests", () => {
 	it("Single root DDS (SharedCounter)", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
-		const sharedCounter = SharedCounter.getFactory().create(runtime, "test-counter");
+		const sharedCounter = runtime.create(SharedCounter, "test-counter");
 
 		const visualizer = new DataVisualizerGraph(
 			{
@@ -68,7 +68,7 @@ describe("DataVisualizerGraph unit tests", () => {
 		const runtime = new MockFluidDataStoreRuntime();
 
 		// Create SharedMap
-		const sharedMap = SharedMap.getFactory().create(runtime, "test-map");
+		const sharedMap = runtime.create(SharedMap, "test-map");
 
 		const visualizer = new DataVisualizerGraph(
 			{
@@ -100,7 +100,7 @@ describe("DataVisualizerGraph unit tests", () => {
 			b: "2",
 			c: true,
 		});
-		const sharedCounter = SharedCounter.getFactory().create(runtime, "test-counter");
+		const sharedCounter = runtime.create(SharedCounter, "test-counter");
 		sharedMap.set("test-handle", sharedCounter.handle);
 
 		const childTreeAfterEdit = await visualizer.render(sharedMap.id);
@@ -149,12 +149,9 @@ describe("DataVisualizerGraph unit tests", () => {
 	it("Multiple root DDS_s", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
 
-		const sharedCounter = SharedCounter.getFactory().create(runtime, "test-counter");
+		const sharedCounter = runtime.create(SharedCounter, "test-counter");
 		sharedCounter.increment(42);
-		const sharedCell: ISharedCell<string> = SharedCell.getFactory().create(
-			runtime,
-			"test-cell",
-		);
+		const sharedCell: ISharedCell<string> = runtime.create(SharedCell, "test-cell");
 		sharedCell.set("Hello world");
 
 		const visualizer = new DataVisualizerGraph(

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
@@ -115,7 +115,7 @@ describe("DefaultVisualizers unit tests", () => {
 	});
 
 	it("SharedDirectory", async () => {
-		const runtime = new MockFluidDataStoreRuntime();
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedDirectory.getFactory()] });
 		const sharedDirectory = SharedDirectory.create(runtime, "test-directory");
 
 		sharedDirectory.set("foo", 37);

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
@@ -52,10 +52,7 @@ async function visualizeChildData(data: unknown): Promise<VisualChildNode> {
 describe("DefaultVisualizers unit tests", () => {
 	it("SharedCell (Primitive data)", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
-		const sharedCell: ISharedCell<string> = SharedCell.getFactory().create(
-			runtime,
-			"test-cell",
-		);
+		const sharedCell: ISharedCell<string> = runtime.create(SharedCell, "test-cell");
 
 		const result = await visualizeSharedCell(sharedCell, visualizeChildData);
 
@@ -74,10 +71,7 @@ describe("DefaultVisualizers unit tests", () => {
 
 	it("SharedCell (JSON data)", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
-		const sharedCell: ISharedCell<object> = SharedCell.getFactory().create(
-			runtime,
-			"test-cell",
-		);
+		const sharedCell: ISharedCell<object> = runtime.create(SharedCell, "test-cell");
 
 		sharedCell.set({ test: undefined });
 
@@ -104,7 +98,7 @@ describe("DefaultVisualizers unit tests", () => {
 
 	it("SharedCounter", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
-		const sharedCounter = SharedCounter.getFactory().create(runtime, "test-counter");
+		const sharedCounter = runtime.create(SharedCounter, "test-counter");
 		sharedCounter.increment(37);
 
 		const result = await visualizeSharedCounter(sharedCounter, visualizeChildData);
@@ -122,7 +116,7 @@ describe("DefaultVisualizers unit tests", () => {
 
 	it("SharedDirectory", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
-		const sharedDirectory = SharedDirectory.getFactory().create(runtime, "test-directory");
+		const sharedDirectory = runtime.create(SharedDirectory, "test-directory");
 
 		sharedDirectory.set("foo", 37);
 		sharedDirectory.set("bar", false);
@@ -232,7 +226,7 @@ describe("DefaultVisualizers unit tests", () => {
 
 	it("SharedMap", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
-		const sharedMap = SharedMap.getFactory().create(runtime, "test-map");
+		const sharedMap = runtime.create(SharedMap, "test-map");
 		sharedMap.set("foo", 42);
 		sharedMap.set("bar", true);
 		sharedMap.set("baz", {
@@ -290,7 +284,7 @@ describe("DefaultVisualizers unit tests", () => {
 
 	it("SharedMatrix", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
-		const sharedMatrix = SharedMatrix.getFactory().create(runtime, "test-matrix");
+		const sharedMatrix = runtime.create(SharedMatrix, "test-matrix");
 		sharedMatrix.insertRows(0, 2);
 		sharedMatrix.insertCols(0, 3);
 		sharedMatrix.setCell(0, 0, "Hello");

--- a/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
+++ b/packages/tools/devtools/devtools-core/src/test/DefaultVisualizers.spec.ts
@@ -51,8 +51,8 @@ async function visualizeChildData(data: unknown): Promise<VisualChildNode> {
 
 describe("DefaultVisualizers unit tests", () => {
 	it("SharedCell (Primitive data)", async () => {
-		const runtime = new MockFluidDataStoreRuntime();
-		const sharedCell: ISharedCell<string> = runtime.create(SharedCell, "test-cell");
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedCell.getFactory()] });
+		const sharedCell = SharedCell.create(runtime, "test-cell") as ISharedCell<string>;
 
 		const result = await visualizeSharedCell(sharedCell, visualizeChildData);
 
@@ -70,8 +70,8 @@ describe("DefaultVisualizers unit tests", () => {
 	});
 
 	it("SharedCell (JSON data)", async () => {
-		const runtime = new MockFluidDataStoreRuntime();
-		const sharedCell: ISharedCell<object> = runtime.create(SharedCell, "test-cell");
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedCell.getFactory()] });
+		const sharedCell = SharedCell.create(runtime, "test-cell") as ISharedCell<object>;
 
 		sharedCell.set({ test: undefined });
 
@@ -97,8 +97,8 @@ describe("DefaultVisualizers unit tests", () => {
 	});
 
 	it("SharedCounter", async () => {
-		const runtime = new MockFluidDataStoreRuntime();
-		const sharedCounter = runtime.create(SharedCounter, "test-counter");
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedCounter.getFactory()] });
+		const sharedCounter = SharedCounter.create(runtime, "test-counter");
 		sharedCounter.increment(37);
 
 		const result = await visualizeSharedCounter(sharedCounter, visualizeChildData);
@@ -116,7 +116,7 @@ describe("DefaultVisualizers unit tests", () => {
 
 	it("SharedDirectory", async () => {
 		const runtime = new MockFluidDataStoreRuntime();
-		const sharedDirectory = runtime.create(SharedDirectory, "test-directory");
+		const sharedDirectory = SharedDirectory.create(runtime, "test-directory");
 
 		sharedDirectory.set("foo", 37);
 		sharedDirectory.set("bar", false);
@@ -225,8 +225,8 @@ describe("DefaultVisualizers unit tests", () => {
 	});
 
 	it("SharedMap", async () => {
-		const runtime = new MockFluidDataStoreRuntime();
-		const sharedMap = runtime.create(SharedMap, "test-map");
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedMap.getFactory()] });
+		const sharedMap = SharedMap.create(runtime, "test-map");
 		sharedMap.set("foo", 42);
 		sharedMap.set("bar", true);
 		sharedMap.set("baz", {
@@ -283,8 +283,8 @@ describe("DefaultVisualizers unit tests", () => {
 	});
 
 	it("SharedMatrix", async () => {
-		const runtime = new MockFluidDataStoreRuntime();
-		const sharedMatrix = runtime.create(SharedMatrix, "test-matrix");
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedMatrix.getFactory()] });
+		const sharedMatrix = SharedMatrix.create(runtime, "test-matrix");
 		sharedMatrix.insertRows(0, 2);
 		sharedMatrix.insertCols(0, 3);
 		sharedMatrix.setCell(0, 0, "Hello");
@@ -365,8 +365,8 @@ describe("DefaultVisualizers unit tests", () => {
 	});
 
 	it("SharedString", async () => {
-		const runtime = new MockFluidDataStoreRuntime();
-		const sharedString = SharedString.getFactory().create(runtime, "test-string");
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedString.getFactory()] });
+		const sharedString = SharedString.create(runtime, "test-string");
 		sharedString.insertText(0, "Hello World!");
 
 		const result = await visualizeSharedString(sharedString, visualizeChildData);
@@ -819,14 +819,14 @@ describe("DefaultVisualizers unit tests", () => {
 	it("SharedTree: Handle at the root", async () => {
 		const factory = SharedTree.getFactory();
 		const builder = new SchemaFactory("shared-tree-test");
-		const runtime = new MockFluidDataStoreRuntime();
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedString.getFactory()] });
 
 		const sharedTree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"test",
 		);
 
-		const sharedString = SharedString.getFactory().create(runtime, "test-string");
+		const sharedString = SharedString.create(runtime, "test-string");
 		sharedString.insertText(0, "Hello World!");
 
 		sharedTree.schematize(new TreeConfiguration(builder.handle, () => sharedString.handle));
@@ -859,14 +859,14 @@ describe("DefaultVisualizers unit tests", () => {
 	it("SharedTree: Handle", async () => {
 		const factory = SharedTree.getFactory();
 		const builder = new SchemaFactory("shared-tree-test");
-		const runtime = new MockFluidDataStoreRuntime();
+		const runtime = new MockFluidDataStoreRuntime({ registry: [SharedString.getFactory()] });
 
 		const sharedTree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"test",
 		);
 
-		const sharedString = SharedString.getFactory().create(runtime, "test-string");
+		const sharedString = SharedString.create(runtime, "test-string");
 		sharedString.insertText(0, "Hello World!");
 
 		class RootNodeSchema extends builder.object("root-item", {


### PR DESCRIPTION
## Description

Clarify localness of ISharedObjectKind,create, and add MockFluidDataStoreRuntime.createChannel implementation for use in tests.

Migrate away from `getFactory().create` pattern as real production app code should not call methods on the channel factory, and they may get made more hidden soon.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
