### PR TITLE
fix(generate:typetests): Exit earlier when typetests are disabled

### DIFF
--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -37,3 +37,4 @@ export * as TscUtils from "./common/tscUtils";
 export { typeOnly } from "./typeValidator/compatibility";
 export { type TestCaseTypeData, buildTestCase } from "./typeValidator/testGeneration";
 export { type TypeData, getFullTypeName, getNodeTypeData } from "./typeValidator/typeData";
+export { getTypeTestPreviousPackageDetails } from "./typeValidator/validatorUtils";

--- a/build-tools/packages/build-tools/src/typeValidator/validatorUtils.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/validatorUtils.ts
@@ -3,7 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import path from "node:path";
 import { Project } from "ts-morph";
+import type { Package } from "../common/npmPackage";
 
 let shouldLog = false;
 export function enableLogging(enable: boolean) {
@@ -35,4 +37,26 @@ export interface IValidator {
 	 *      source files
 	 */
 	validate(project: Project, pkgDir: string): BreakingIncrement;
+}
+
+/**
+ * Given a package, returns the name that should be used for the previous version of the package to generate type tests.
+ *
+ * @privateRemarks
+ *
+ * This function is here instead of in build-cli because it is shared between fluid-build's task handler for type test
+ * generation and the generation code that mostly lives in build-cli. Long term this function should move to build-cli
+ * or a third library package and be used by fluid-build and build-cli.
+ */
+export function getTypeTestPreviousPackageDetails(pkg: Package): {
+	name: string;
+	packageJsonPath: string;
+} {
+	const previousPackageName = `${pkg.name}-previous`;
+	const previousBasePath = path.join(pkg.directory, "node_modules", previousPackageName);
+	const previousPackageJsonPath = path.join(previousBasePath, "package.json");
+	return {
+		name: previousPackageName,
+		packageJsonPath: previousPackageJsonPath,
+	};
 }


### PR DESCRIPTION
Includes two major fixes:

1. The type test logic should all be skipped when they're disabled in package.json, so I reordered the code so the skip check happens earlier. This addresses failures because of missing dev dependencies in packages with type tests disabled.
2. I updated the fluid-build task for type testing to include the output files and the package.json of the previous version in the cache key. This should partially address problems people have experienced where CI jobs fail but local incremental jobs succeed. The rest of those problems should be addressed by #20878.