### PR TITLE
fix(build-cli): PackageCommands should error if any of the child processes fail

### DIFF
--- a/build-tools/packages/build-cli/src/commands/test-only-filter.ts
+++ b/build-tools/packages/build-cli/src/commands/test-only-filter.ts
@@ -45,8 +45,9 @@ export default class FilterCommand extends PackageCommand<typeof FilterCommand> 
 		// do nothing
 	}
 
-	protected async processPackages(packages: PackageWithKind[]): Promise<void> {
+	protected async processPackages(packages: PackageWithKind[]): Promise<string[]> {
 		// do nothing
+		return [];
 	}
 
 	public async run(): Promise<FilterCommandResult> {


### PR DESCRIPTION
The PackageCommand base class was exiting with no errors even when child processes failed. This is especially problematic when running a PackageCommand with the `--dir .` flag to run on a single package. If that single package failed, the command still succeeded.

The implementation now collects and returns error strings from subprocesses, and if any errors are returned the command will exit with a non-zero exit code.

This should fix several problems people have experienced with commands based on PackageCommand where builds report success but fail downstream during testing or otherwise.