### PR TITLE
test various connection modes

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -881,13 +881,10 @@ export class Container
 					const mode = this.connectionMode;
 					// We get here when socket does not receive any ops on "write" connection, including
 					// its own join op.
-					// Report issues only if we already loaded container - op processing is paused while container is loading,
-					// so we always time-out processing of join op in cases where fetching snapshot takes a minute.
-					// It's not a problem with op processing itself - such issues should be tracked as part of boot perf monitoring instead.
 					this._deltaManager.logConnectionIssue({
 						eventName,
 						mode,
-						category: this._lifecycleState === "loading" ? "generic" : category,
+						category,
 						duration:
 							performance.now() -
 							this.connectionTransitionTimes[ConnectionState.CatchingUp],

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -28,17 +28,12 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
-						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
-						"Fluid.Summarizer.UseDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
-					}
-				},
-				"odsp-odsp-df": {
-					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
 						"Fluid.Summarizer.UseDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false],
+						"Fluid.Container.DisableCatchUpBeforeDeclaringConnected": [true, false],
+						"Fluid.Container.DisableJoinSignalWait": [true, false]
 					}
 				},
 				"tinylicious": {
@@ -202,20 +197,6 @@
 			},
 			"totalBlobCount": 300,
 			"blobSize": 256
-		},
-		"binarySnapshotFormat": {
-			"opRatePerMin": 60,
-			"progressIntervalMs": 5000,
-			"numClients": 4,
-			"totalSendCount": 150,
-			"readWriteCycleMs": 10000,
-			"optionOverrides": {
-				"odsp": {
-					"configurations": {
-						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2]
-					}
-				}
-			}
 		},
 		"scale_with_signals": {
 			"opRatePerMin": 7,


### PR DESCRIPTION
Thanks to https://github.com/microsoft/FluidFramework/pull/20752, we no longer have a timer running that triggers NoJoinOp error events while container is loading - we wait until container is fully loaded before starting to measure how long it takes to get connected / process join ops. As such, cleanup a bit code.

Also add feature gates controlling how we raise "connected" events to a test suite, such that we continue to test "old way" of doing things, in case we have to engage kill-bit switches in production - we better have confidence that old workflows continue to work correctly.