### PR TITLE
Pipelines: Add retry to npm install tasks

### DIFF
--- a/tools/pipelines/templates/include-telemetry-setup.yml
+++ b/tools/pipelines/templates/include-telemetry-setup.yml
@@ -82,6 +82,7 @@ steps:
 # Install logger package
 - task: Npm@1
   displayName: 'npm install aria logger'
+  retryCountOnTaskFailure: 1
   inputs:
     workingDir: ${{ parameters.pathToTelemetryGenerator }}
     command: 'custom'

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -117,6 +117,7 @@ steps:
 # Install aria-logger
 - task: Npm@1
   displayName: 'npm install aria logger'
+  retryCountOnTaskFailure: 1
   inputs:
     workingDir: ${{ parameters.testWorkspace }}
     command: 'custom'

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -245,6 +245,7 @@ jobs:
       # Install test and logger package
       - task: Npm@1
         displayName: 'npm install'
+        retryCountOnTaskFailure: 1
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}


### PR DESCRIPTION
I'm seeing periodic failures on the npm install tasks in our post ci pipelines. so adding a retry which will hopefully increase reliability due to transient failures.

[retryCountOnTaskFailure](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/tasks?view=azure-devops&tabs=yaml#number-of-retries-if-task-failed)