### PR TITLE
fix(generate:typetests): Load source instead of type declarations for current package version

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -82,7 +82,7 @@ export default class GenerateTypetestsCommand extends PackageCommand<
 			this.verbose(`Deleted file: ${typeTestOutputFile}`);
 
 			// Early exit; no error.
-			this.exit(0);
+			return;
 		}
 
 		ensureDevDependencyExists(currentPackageJson, previousPackageName);
@@ -110,7 +110,18 @@ export default class GenerateTypetestsCommand extends PackageCommand<
 			`Found ${previousPackageLevel} type definitions for ${previousPackageJson.name}: ${previousTypesPath}`,
 		);
 
-		const currentFile = loadTypesSourceFile(currentTypesPath);
+		// For the current version, we load the package-local tsconfig and return index.ts as the source file. This ensures
+		// we don't need to build before running type test generation. It's tempting to load the .d.ts files and use the
+		// same code path as is used below for th previous version (loadTypesSourceFile()), but that approach requires that
+		// the local project be built.
+		//
+		// One drawback to this approach is that it will always enumerate the full (internal) API for the current version.
+		// There's no way to scope it to just alpha, beta, etc. for example. If that capability is eventually needed we can
+		// revisit this.
+		const currentFile = new Project({
+			skipFileDependencyResolution: true,
+			tsConfigFilePath: path.join(pkg.directory, "tsconfig.json"),
+		}).getSourceFileOrThrow("index.ts");
 		this.verbose(
 			`Loaded source file for current version (${pkg.version}): ${currentFile.getFilePath()}`,
 		);

--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -112,7 +112,7 @@ export default class GenerateTypetestsCommand extends PackageCommand<
 
 		// For the current version, we load the package-local tsconfig and return index.ts as the source file. This ensures
 		// we don't need to build before running type test generation. It's tempting to load the .d.ts files and use the
-		// same code path as is used below for th previous version (loadTypesSourceFile()), but that approach requires that
+		// same code path as is used below for the previous version (loadTypesSourceFile()), but that approach requires that
 		// the local project be built.
 		//
 		// One drawback to this approach is that it will always enumerate the full (internal) API for the current version.


### PR DESCRIPTION
Fixes the build ordering problem introduced by unifying the code paths for loading files to extract types. I added a lengthy comment explaining why the code is different and its limitations. This is essentially reverting the code to what it is in the current type test generator. I had refactored it when porting it to build-cli, so I introduced the bug.

I also noticed that oclif apparently still returns some sort of error when you call exit from a command, so I used an early return instead.