### PR TITLE
fix(fluid-build): Always consider semantic errors in incremental tsc

### DIFF
--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -124,13 +124,21 @@ export class TscTask extends LeafTask {
 		}
 
 		const program = tsBuildInfo.program;
+		const noEmit = config.options.noEmit ?? false;
+		const hasChangedFiles = (program.changeFileSet?.length ?? 0) > 0;
+		const hasEmitErrorsOrPending =
+			(program.affectedFilesPendingEmit?.length ??
+				program.emitDiagnosticsPerFile?.length ??
+				0) > 0;
+		const hasSemanticErrors =
+			program.semanticDiagnosticsPerFile?.some((item) => Array.isArray(item)) ?? false;
+
+		const previousBuildError = noEmit
+			? hasChangedFiles || hasEmitErrorsOrPending || hasSemanticErrors
+			: hasChangedFiles || hasSemanticErrors;
+
 		// Check previous build errors
-		if (
-			program.changeFileSet?.length ||
-			(!config.options.noEmit
-				? program.affectedFilesPendingEmit?.length || program.emitDiagnosticsPerFile?.length
-				: program.semanticDiagnosticsPerFile?.some((item) => Array.isArray(item)))
-		) {
+		if (previousBuildError) {
 			this.traceTrigger("previous build error");
 			return false;
 		}

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -134,8 +134,8 @@ export class TscTask extends LeafTask {
 			program.semanticDiagnosticsPerFile?.some((item) => Array.isArray(item)) ?? false;
 
 		const previousBuildError = noEmit
-			? hasChangedFiles || hasEmitErrorsOrPending || hasSemanticErrors
-			: hasChangedFiles || hasSemanticErrors;
+			? hasChangedFiles || hasSemanticErrors
+			: hasChangedFiles || hasSemanticErrors || hasEmitErrorsOrPending;
 
 		// Check previous build errors
 		if (previousBuildError) {

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -127,9 +127,8 @@ export class TscTask extends LeafTask {
 		const noEmit = config.options.noEmit ?? false;
 		const hasChangedFiles = (program.changeFileSet?.length ?? 0) > 0;
 		const hasEmitErrorsOrPending =
-			(program.affectedFilesPendingEmit?.length ??
-				program.emitDiagnosticsPerFile?.length ??
-				0) > 0;
+			(program.affectedFilesPendingEmit?.length ?? 0) > 0 ||
+			(program.emitDiagnosticsPerFile?.length ?? 0) > 0;
 		const hasSemanticErrors =
 			program.semanticDiagnosticsPerFile?.some((item) => Array.isArray(item)) ?? false;
 


### PR DESCRIPTION
fluid-build was not considering semantic errors as failures in some cases. This caused fluid-build to skip tasks that were in fact not up to date. I fixed that flaw and also made the boolean logic more explicit. It's more verbose, but I think it clarifies the cases. Had the code been written this way originally, I don't think the bug would have been written.