### PR TITLE
Add e2e test for lastSummary

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -537,7 +537,7 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 							minIdleTime: 60 * 1000,
 							maxIdleTime: 60 * 1000,
 							runtimeOpWeight: 1,
-							nonRuntimeOpWeight: 1,
+							nonRuntimeOpWeight: 0.1,
 							initialSummarizerDelayMs: 0,
 							maxAckWaitTime: 60 * 1000,
 							maxOpsSinceLastSummary: 1000,

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -44,6 +44,7 @@ import {
 	timeoutPromise,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
+import { SinonSandbox, createSandbox } from "sinon";
 
 const flushPromises = async () => new Promise((resolve) => process.nextTick(resolve));
 const testContainerConfig: ITestContainerConfig = {
@@ -120,9 +121,18 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 		}
 	}
 
+	let sandbox: SinonSandbox;
+	before(() => {
+		sandbox = createSandbox();
+	});
+
 	let provider: ITestObjectProvider;
 	beforeEach("getTestObjectProvider", () => {
 		provider = getTestObjectProvider();
+	});
+
+	afterEach(() => {
+		sandbox.restore();
 	});
 
 	it("On demand summaries", async () => {
@@ -505,6 +515,47 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 		assert.strictEqual(sharedString1.getLength(), 203);
 		assert.strictEqual(sharedString2.getLength(), 203);
 	});
+
+	itExpects(
+		"attempt last summary if parent container disconnects",
+		[
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:Summarize_Op",
+				summarizeReason: "lastSummary",
+			},
+		],
+		async function () {
+			const container = await createContainer(provider, {});
+			const { summarizer } = await createSummarizer(provider, container, {
+				runtimeOptions: {
+					summaryOptions: {
+						summaryConfigOverrides: {
+							state: "enabled",
+							minOpsForLastSummaryAttempt: 1, // This is the key setting
+							maxTime: 60 * 1000,
+							maxOps: 1000,
+							minIdleTime: 60 * 1000,
+							maxIdleTime: 60 * 1000,
+							runtimeOpWeight: 1,
+							nonRuntimeOpWeight: 1,
+							initialSummarizerDelayMs: 0,
+							maxAckWaitTime: 60 * 1000,
+							maxOpsSinceLastSummary: 1000,
+						},
+					},
+				},
+			});
+			const containerRuntime = (summarizer as any).runtime as ContainerRuntime;
+			const submitSumarySpy = sandbox.spy(containerRuntime, "submitSummary");
+
+			const prom = summarizer.run("test");
+			summarizer.stop("parentNotConnected");
+			await flushPromises();
+			await prom;
+
+			assert.strictEqual(submitSumarySpy.calledOnce, true, "expect a final summary to run");
+		},
+	);
 });
 
 describeCompat("Summaries", "NoCompat", (getTestObjectProvider) => {

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -548,10 +548,10 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 			const containerRuntime = (summarizer as any).runtime as ContainerRuntime;
 			const submitSumarySpy = sandbox.spy(containerRuntime, "submitSummary");
 
-			const prom = summarizer.run("test");
+			const summarizerRunProm = summarizer.run("test");
 			summarizer.stop("parentNotConnected");
 			await flushPromises();
-			await prom;
+			await summarizerRunProm;
 
 			assert.strictEqual(submitSumarySpy.calledOnce, true, "expect a final summary to run");
 		},

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -548,6 +548,13 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 			const containerRuntime = (summarizer as any).runtime as ContainerRuntime;
 			const submitSumarySpy = sandbox.spy(containerRuntime, "submitSummary");
 
+			const defaultDataStore =
+				await getContainerEntryPointBackCompat<ITestDataObject>(container);
+
+			const directory1 = defaultDataStore._root;
+			directory1.set("key", "value");
+			await provider.ensureSynchronized();
+
 			const summarizerRunProm = summarizer.run("test");
 			summarizer.stop("parentNotConnected");
 			await flushPromises();


### PR DESCRIPTION
We have a lot of unit tests for `"lastSummary"`, but no e2e test.

[AB#6955](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6955)