### PR TITLE
improvement(generate:typetests): Fix lint formatting of generated files

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -154,6 +154,7 @@ export default class GenerateTypetestsCommand extends PackageCommand<
 import type * as old from "${previousPackageName}${
 				previousPackageLevel === ApiLevel.public ? "" : `/${previousPackageLevel}`
 			}";
+
 import type * as current from "../../index.js";
 		`.trim(),
 			typeOnly,


### PR DESCRIPTION
New eslint config settings in our 5.3.0 release require the imports be grouped. This small change makes the generated files comply with the rule.