### PR TITLE
refactor(matrix): Increase timeout in stress test

### DIFF
--- a/packages/dds/matrix/src/test/matrix.stress.spec.ts
+++ b/packages/dds/matrix/src/test/matrix.stress.spec.ts
@@ -619,7 +619,7 @@ import { expectSize, extract, matrixFactory } from "./utils.js";
 
 				it(`Stress Test With Small Matrix and lots of clients addition`, async function () {
 					// Note: Must use 'function' rather than arrow '() => { .. }' in order to set 'this.timeout(..)'
-					this.timeout(30000);
+					this.timeout(35000);
 
 					const numClients = 2;
 					const numOps = 120;


### PR DESCRIPTION
## Description

In the test stability pipeline this test mostly passes, but occasionally times out after 30s. Normal runtimes seem to average around 27s. So adding another few seconds to make sure it doesn't look like a flaky test.

![image](https://github.com/microsoft/FluidFramework/assets/716334/dfa28cc0-99e2-4471-88db-d5381a85bdd9)

![image](https://github.com/microsoft/FluidFramework/assets/716334/61598064-0f7c-456f-99bd-75a2e4466820)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
