### PR TITLE
refactor(ci): Use runs of the main branch for Build - client packages in the AFR perf tests pipeline

### DIFF
--- a/tools/pipelines/fluid-afr-perf-test.yml
+++ b/tools/pipelines/fluid-afr-perf-test.yml
@@ -21,6 +21,7 @@ resources:
   pipelines:
     - pipeline: client
       source: Build - client packages
+      branch: main # Default branch for manual/scheduled triggers if none is selected
 
 variables:
   - group: fluid-afr-perf-test-keys


### PR DESCRIPTION
## Description

In its last 4 runs, the AFR perf tests pipeline has happened to use a run of the `Build - client packages` pipeline that was using a test/ branch, and thus has been trying to download package versions that it won't be able to. Since we run the pipeline on a schedule, it should default to using runs of `Build - client packages` for the main branch. This PR updates it so it does that.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Last 4 failed runs:

![image](https://github.com/microsoft/FluidFramework/assets/716334/5df45439-1d93-4afb-b14a-68d4685d1d1c)
