### PR TITLE
refactor(test-version-utils): More verbose output in case of error

### DIFF
--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -249,11 +249,13 @@ export async function ensureInstalled(
 					options,
 					(error, stdout, stderr) => {
 						if (error) {
+							const errorString =
+								error instanceof Error
+									? `${error.message}\n${error.stack}`
+									: JSON.stringify(error);
 							reject(
 								new Error(
-									`Failed to initialize install directory ${modulePath}\nError:${JSON.stringify(
-										error,
-									)}\nStdout:${stdout}\nStdErr:${stderr}`,
+									`Failed to initialize install directory ${modulePath}\nError:${errorString}\nStdOut:${stdout}\nStdErr:${stderr}`,
 								),
 							);
 						}
@@ -275,11 +277,13 @@ export async function ensureInstalled(
 					options,
 					(error, stdout, stderr) => {
 						if (error) {
+							const errorString =
+								error instanceof Error
+									? `${error.message}\n${error.stack}`
+									: JSON.stringify(error);
 							reject(
 								new Error(
-									`Failed to install in ${modulePath}\nError:${JSON.stringify(
-										error,
-									)}\nStdout:${stdout}\nStdErr:${stderr}`,
+									`Failed to install in ${modulePath}\nError:${errorString}\nStdOut:${stdout}\nStdErr:${stderr}`,
 								),
 							);
 						}

--- a/packages/test/test-version-utils/src/versionUtils.ts
+++ b/packages/test/test-version-utils/src/versionUtils.ts
@@ -251,7 +251,9 @@ export async function ensureInstalled(
 						if (error) {
 							reject(
 								new Error(
-									`Failed to initialize install directory ${modulePath}\n${stderr}`,
+									`Failed to initialize install directory ${modulePath}\nError:${JSON.stringify(
+										error,
+									)}\nStdout:${stdout}\nStdErr:${stderr}`,
 								),
 							);
 						}
@@ -273,7 +275,13 @@ export async function ensureInstalled(
 					options,
 					(error, stdout, stderr) => {
 						if (error) {
-							reject(new Error(`Failed to install in ${modulePath}\n${stderr}`));
+							reject(
+								new Error(
+									`Failed to install in ${modulePath}\nError:${JSON.stringify(
+										error,
+									)}\nStdout:${stdout}\nStdErr:${stderr}`,
+								),
+							);
 						}
 						resolve();
 					},


### PR DESCRIPTION
## Description

I saw an error running `npm init` [during a recent pipeline run](https://dev.azure.com/fluidframework/public/_build/results?buildId=259682&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=5cfe65a4-d7cb-5934-e953-1c67617821f4&l=18380)

The output still has no good information about what the problem is, so adding more bits of the error/output to the logged message.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
