### PR TITLE
rc.3 Port: Fix "savedOp" metadata property propagation for grouped ops (#20837)

### DIFF
--- a/packages/runtime/container-runtime/src/metadata.ts
+++ b/packages/runtime/container-runtime/src/metadata.ts
@@ -19,8 +19,8 @@ export interface IBlobMetadata {
 }
 
 /**
- * The IdCompressor needs to know if this is a replayed savedOp as those need to be skipped in stashed ops scenarios.
+ * ContainerRuntime needs to know if this is a replayed savedOp as those need to be skipped in stashed ops scenarios.
  */
-export interface IIdAllocationMetadata {
+export interface ISavedOpMetadata {
 	savedOp?: boolean;
 }


### PR DESCRIPTION
Port of: #20837

Container class will set savedOp property on op before processing stashed ops. Container Runtime uses this information to differentiate ops.

I do not see us propagating savedOp metadata property from grouped ops (as visible in Container) to ungrouped ops. OpGroupingManager.ungroupOp() does not do it as far as I can see. I think we are getting lucky with ID compression ops as they are usually not grouped (there is usually a single ID compression op, as it's part of its own batch). When/if any of those assumptions change, this code would stop working.

Propagate properly this property.
