### PR TITLE
fix(generate:typetests): Format imports in generated tests

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -154,6 +154,7 @@ export default class GenerateTypetestsCommand extends PackageCommand<
 import type * as old from "${previousPackageName}${
 				previousPackageLevel === ApiLevel.public ? "" : `/${previousPackageLevel}`
 			}";
+
 import type * as current from "../../index.js";
 		`.trim(),
 			typeOnly,


### PR DESCRIPTION
The import sorting rules in our upcoming shared eslint config release (5.3.0) require exports to be grouped. The generated type tests are not compliant; with this change, they are.