### PR TITLE
fix(tree): remove support for implicit revisions in updateRefreshers

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1290,7 +1290,7 @@ function* relevantRemovedRootsFromFields(
  * Can be retrieved by calling {@link relevantRemovedRoots}.
  */
 export function updateRefreshers(
-	{ change, revision }: TaggedChange<ModularChangeset>,
+	change: ModularChangeset,
 	getDetachedNode: (id: DeltaDetachedNodeId) => TreeChunk | undefined,
 	removedRoots: Iterable<DeltaDetachedNodeId>,
 ): ModularChangeset {
@@ -1308,9 +1308,7 @@ export function updateRefreshers(
 
 	for (const root of removedRoots) {
 		if (change.builds !== undefined) {
-			const major = root.major === revision ? undefined : root.major;
-			const lengthTree = chunkLengths.get(major);
-
+			const lengthTree = chunkLengths.get(root.major);
 			if (lengthTree !== undefined) {
 				const lengthPair = lengthTree.getPairOrNextLower(root.minor);
 				if (lengthPair !== undefined) {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -1352,7 +1352,7 @@ describe("ModularChangeFamily", () => {
 				refreshers: new Map([[aMajor, new Map([[brand(2), node2Chunk]])]]),
 			};
 
-			const withBuilds = updateRefreshers(makeAnonChange(input), getDetachedNode, [a2]);
+			const withBuilds = updateRefreshers(input, getDetachedNode, [a2]);
 			assert.deepEqual(withBuilds, expected);
 		});
 
@@ -1377,7 +1377,7 @@ describe("ModularChangeFamily", () => {
 				fieldChanges: new Map([]),
 			};
 
-			const filtered = updateRefreshers(makeAnonChange(input), getDetachedNode, []);
+			const filtered = updateRefreshers(input, getDetachedNode, []);
 			assert.deepEqual(filtered, expected);
 		});
 
@@ -1395,7 +1395,7 @@ describe("ModularChangeFamily", () => {
 				builds: new Map([[aMajor, new Map([[brand(3), nodesChunk]])]]),
 			};
 
-			const withBuilds = updateRefreshers(makeAnonChange(input), getDetachedNode, [
+			const withBuilds = updateRefreshers(input, getDetachedNode, [
 				{ major: aMajor, minor: 4 },
 			]);
 			assert.deepEqual(withBuilds, expected);
@@ -1423,11 +1423,7 @@ describe("ModularChangeFamily", () => {
 					]),
 				};
 
-				const withBuilds = updateRefreshers(makeAnonChange(input), getDetachedNode, [
-					a1,
-					a2,
-					b1,
-				]);
+				const withBuilds = updateRefreshers(input, getDetachedNode, [a1, a2, b1]);
 				assert.deepEqual(withBuilds, expected);
 			});
 
@@ -1460,7 +1456,7 @@ describe("ModularChangeFamily", () => {
 					]),
 				};
 
-				const filtered = updateRefreshers(makeAnonChange(input), getDetachedNode, [a1, a2]);
+				const filtered = updateRefreshers(input, getDetachedNode, [a1, a2]);
 				assert.deepEqual(filtered, expected);
 			});
 
@@ -1495,11 +1491,7 @@ describe("ModularChangeFamily", () => {
 					]),
 				};
 
-				const withBuilds = updateRefreshers(makeAnonChange(input), getDetachedNode, [
-					a1,
-					a2,
-					b1,
-				]);
+				const withBuilds = updateRefreshers(input, getDetachedNode, [a1, a2, b1]);
 				assert.deepEqual(withBuilds, expected);
 			});
 
@@ -1509,38 +1501,7 @@ describe("ModularChangeFamily", () => {
 					fieldChanges: new Map([]),
 				};
 
-				assert.throws(() =>
-					updateRefreshers(makeAnonChange(input), getDetachedNode, [{ minor: 2 }]),
-				);
-			});
-		});
-
-		describe("handles implicit and explicit build revision representations", () => {
-			it("explicit builds", () => {
-				const explicitBuild: ModularChangeset = {
-					nodeChanges: new Map(),
-					fieldChanges: new Map([]),
-					builds: new Map([[tag1, new Map([[brand(1), node1Chunk]])]]),
-				};
-				const withBuilds = updateRefreshers(
-					makeAnonChange(explicitBuild),
-					getDetachedNode,
-					[{ major: tag1, minor: 1 }],
-				);
-				assert.deepEqual(withBuilds, explicitBuild);
-			});
-			it("implicit builds", () => {
-				const implicitBuild: ModularChangeset = {
-					nodeChanges: new Map(),
-					fieldChanges: new Map([]),
-					builds: new Map([[undefined, new Map([[brand(1), node1Chunk]])]]),
-				};
-				const withBuilds = updateRefreshers(
-					tagChange(implicitBuild, tag1),
-					getDetachedNode,
-					[{ major: tag1, minor: 1 }],
-				);
-				assert.deepEqual(withBuilds, implicitBuild);
+				assert.throws(() => updateRefreshers(input, getDetachedNode, [{ minor: 2 }]));
 			});
 		});
 	});


### PR DESCRIPTION
This function used to assume that undefined revision tags in `ChangeAtomsId`s should be interpreted as equivalent to the changeset's top-level revision. This should no longer be the case because changesets no longer support such implicit revisions.