### PR TITLE
AttributableMap uses ISharedObjectKind

### DIFF
--- a/examples/apps/attributable-map/src/dataObject.ts
+++ b/examples/apps/attributable-map/src/dataObject.ts
@@ -4,7 +4,7 @@
  */
 
 import type { EventEmitter } from "@fluid-example/example-utils";
-import { AttributableMap } from "@fluid-experimental/attributable-map";
+import { AttributableMap, ISharedMap } from "@fluid-experimental/attributable-map";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 
@@ -27,7 +27,7 @@ export interface IHitCounter extends EventEmitter {
 	/**
 	 * The attributable map to store timestamp key and value
 	 */
-	readonly map: AttributableMap | undefined;
+	readonly map: ISharedMap | undefined;
 
 	/**
 	 * Inrement the hit count. Will cause a "hit" event to be emitted.
@@ -42,7 +42,7 @@ export interface IHitCounter extends EventEmitter {
 
 export class HitCounter extends DataObject implements IHitCounter {
 	private readonly mapKey = "mapKey";
-	private _map: AttributableMap | undefined;
+	private _map: ISharedMap | undefined;
 
 	public get map() {
 		if (this._map === undefined) {
@@ -75,7 +75,7 @@ export class HitCounter extends DataObject implements IHitCounter {
 
 	protected async hasInitialized() {
 		// Store the content if we are loading the first time or loading from existing
-		this._map = await this.root.get<IFluidHandle<AttributableMap>>(this.mapKey)?.get();
+		this._map = await this.root.get<IFluidHandle<ISharedMap>>(this.mapKey)?.get();
 		this.map.on("valueChanged", () => {
 			this.emit("hit");
 		});

--- a/experimental/dds/attributable-map/api-report/attributable-map.api.md
+++ b/experimental/dds/attributable-map/api-report/attributable-map.api.md
@@ -5,48 +5,15 @@
 ```ts
 
 import { AttributionKey } from '@fluidframework/runtime-definitions/internal';
-import { IChannelAttributes } from '@fluidframework/datastore-definitions';
-import { IChannelFactory } from '@fluidframework/datastore-definitions';
-import { IChannelServices } from '@fluidframework/datastore-definitions';
-import { IChannelStorageService } from '@fluidframework/datastore-definitions';
 import { IEventThisPlaceHolder } from '@fluidframework/core-interfaces';
-import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidSerializer } from '@fluidframework/shared-object-base';
-import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
-import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
-import { ITelemetryContext } from '@fluidframework/runtime-definitions';
-import { SharedObject } from '@fluidframework/shared-object-base/internal';
+import { ISharedObjectKind } from '@fluidframework/shared-object-base';
 
 // @internal
-export class AttributableMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
-    [Symbol.iterator](): IterableIterator<[string, any]>;
-    readonly [Symbol.toStringTag]: string;
-    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
-    protected applyStashedOp(content: unknown): void;
-    clear(): void;
-    static create(runtime: IFluidDataStoreRuntime, id?: string): AttributableMap;
-    delete(key: string): boolean;
-    entries(): IterableIterator<[string, any]>;
-    forEach(callbackFn: (value: any, key: string, map: Map<string, any>) => void): void;
-    get<T = any>(key: string): T | undefined;
-    getAllAttribution(): Map<string, AttributionKey> | undefined;
-    getAttribution(key: string): AttributionKey | undefined;
-    static getFactory(): IChannelFactory;
-    has(key: string): boolean;
-    keys(): IterableIterator<string>;
-    protected loadCore(storage: IChannelStorageService): Promise<void>;
-    protected onDisconnect(): void;
-    protected processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): void;
-    protected reSubmitCore(content: unknown, localOpMetadata: unknown): void;
-    protected rollback(content: unknown, localOpMetadata: unknown): void;
-    set(key: string, value: unknown): this;
-    get size(): number;
-    protected summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
-    values(): IterableIterator<any>;
-}
+export const AttributableMap: ISharedObjectKind<ISharedMap>;
 
 // @internal
 export interface ILocalValue {
@@ -72,6 +39,8 @@ export interface ISerializedValue {
 // @internal
 export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string, any> {
     get<T = any>(key: string): T | undefined;
+    getAllAttribution(): Map<string, AttributionKey> | undefined;
+    getAttribution(key: string): AttributionKey | undefined;
     set<T = unknown>(key: string, value: T): this;
 }
 
@@ -92,16 +61,6 @@ export class LocalValueMaker {
     constructor();
     fromInMemory(value: unknown): ILocalValue;
     fromSerializable(serializable: ISerializableValue, serializer: IFluidSerializer, bind: IFluidHandle): ILocalValue;
-}
-
-// @internal @sealed
-export class MapFactory implements IChannelFactory {
-    static readonly Attributes: IChannelAttributes;
-    get attributes(): IChannelAttributes;
-    create(runtime: IFluidDataStoreRuntime, id: string): ISharedMap;
-    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, attributes: IChannelAttributes): Promise<ISharedMap>;
-    static readonly Type = "https://graph.microsoft.com/types/map";
-    get type(): string;
 }
 
 ```

--- a/experimental/dds/attributable-map/src/index.ts
+++ b/experimental/dds/attributable-map/src/index.ts
@@ -21,4 +21,4 @@ export {
 	IValueChanged,
 } from "./interfaces.js";
 export { LocalValueMaker, ILocalValue } from "./localValues.js";
-export { MapFactory, AttributableMap } from "./map.js";
+export { AttributableMap } from "./map.js";

--- a/experimental/dds/attributable-map/src/interfaces.ts
+++ b/experimental/dds/attributable-map/src/interfaces.ts
@@ -86,6 +86,19 @@ export interface ISharedMap extends ISharedObject<ISharedMapEvents>, Map<string,
 	 * @returns The {@link ISharedMap} itself
 	 */
 	set<T = unknown>(key: string, value: T): this;
+
+	/**
+	 * Get the attribution of one entry through its key
+	 * @param key - Key to track
+	 * @returns The attribution of related entry
+	 */
+	getAttribution(key: string): AttributionKey | undefined;
+
+	/**
+	 * Get all attribution of the map
+	 * @returns All attribution in the map
+	 */
+	getAllAttribution(): Map<string, AttributionKey> | undefined;
 }
 
 /**

--- a/experimental/dds/attributable-map/src/map.ts
+++ b/experimental/dds/attributable-map/src/map.ts
@@ -16,7 +16,7 @@ import { ISummaryTreeWithStats, ITelemetryContext } from "@fluidframework/runtim
 import { AttributionKey } from "@fluidframework/runtime-definitions/internal";
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils/internal";
 import { IFluidSerializer } from "@fluidframework/shared-object-base";
-import { SharedObject } from "@fluidframework/shared-object-base/internal";
+import { SharedObject, createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
 import { ISharedMap, ISharedMapEvents } from "./interfaces.js";
 import { AttributableMapKernel, IMapDataObjectSerializable, IMapOperation } from "./mapKernel.js";
@@ -33,7 +33,6 @@ const snapshotFileName = "header";
  * {@link @fluidframework/datastore-definitions#IChannelFactory} for {@link AttributableMap}.
  *
  * @sealed
- * @internal
  */
 export class MapFactory implements IChannelFactory {
 	/**
@@ -73,7 +72,7 @@ export class MapFactory implements IChannelFactory {
 		services: IChannelServices,
 		attributes: IChannelAttributes,
 	): Promise<ISharedMap> {
-		const map = new AttributableMap(id, runtime, attributes);
+		const map = new AttributableMapClass(id, runtime, attributes);
 		await map.load(services);
 
 		return map;
@@ -83,7 +82,7 @@ export class MapFactory implements IChannelFactory {
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.create}
 	 */
 	public create(runtime: IFluidDataStoreRuntime, id: string): ISharedMap {
-		const map = new AttributableMap(id, runtime, MapFactory.Attributes);
+		const map = new AttributableMapClass(id, runtime, MapFactory.Attributes);
 		map.initializeLocal();
 
 		return map;
@@ -94,35 +93,12 @@ export class MapFactory implements IChannelFactory {
  * {@inheritDoc ISharedMap}
  * @internal
  */
-export class AttributableMap extends SharedObject<ISharedMapEvents> implements ISharedMap {
-	/**
-	 * Create a new attributable map.
-	 *
-	 * @param runtime - The data store runtime that the new attributable map belongs to.
-	 * @param id - Optional name of the attributable map.
-	 *
-	 * @returns Newly created attributable map.
-	 *
-	 * @example
-	 *
-	 * To create a `AttributableMap`, call the static create method:
-	 *
-	 * ```typescript
-	 * const myMap = AttributableMap.create(this.runtime, id);
-	 * ```
-	 */
-	public static create(runtime: IFluidDataStoreRuntime, id?: string): AttributableMap {
-		return runtime.createChannel(id, MapFactory.Type) as AttributableMap;
-	}
+export const AttributableMap = createSharedObjectKind(MapFactory);
 
-	/**
-	 * Get a factory for AttributableMap to register with the data store.
-	 * @returns A factory that creates AttributableMap's and loads them from storage.
-	 */
-	public static getFactory(): IChannelFactory {
-		return new MapFactory();
-	}
-
+/**
+ * {@inheritDoc ISharedMap}
+ */
+export class AttributableMapClass extends SharedObject<ISharedMapEvents> implements ISharedMap {
 	/**
 	 * String representation for the class.
 	 */

--- a/experimental/dds/attributable-map/src/test/memory/map.spec.ts
+++ b/experimental/dds/attributable-map/src/test/memory/map.spec.ts
@@ -6,10 +6,11 @@
 import { IMemoryTestObject, benchmarkMemory } from "@fluid-tools/benchmark";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
-import { AttributableMap, MapFactory } from "../../map.js";
+import { AttributableMapClass, MapFactory } from "../../map.js";
+import type { ISharedMap } from "../../interfaces.js";
 
-function createLocalMap(id: string): AttributableMap {
-	const map: AttributableMap = new AttributableMap(
+function createLocalMap(id: string): ISharedMap {
+	const map: ISharedMap = new AttributableMapClass(
 		id,
 		new MockFluidDataStoreRuntime(),
 		MapFactory.Attributes,
@@ -41,7 +42,7 @@ describe("SharedMap memory usage", () => {
 			public readonly title = "Create empty map";
 			public readonly minSampleCount = 500;
 
-			private map: AttributableMap = createLocalMap("testMap");
+			private map: ISharedMap = createLocalMap("testMap");
 
 			public async run(): Promise<void> {
 				this.map = createLocalMap("testMap");
@@ -55,7 +56,7 @@ describe("SharedMap memory usage", () => {
 		benchmarkMemory(
 			new (class implements IMemoryTestObject {
 				public readonly title = `Add ${x} integers to a local map`;
-				private map: AttributableMap = createLocalMap("testMap");
+				private map: ISharedMap = createLocalMap("testMap");
 
 				public async run(): Promise<void> {
 					for (let i = 0; i < x; i++) {
@@ -72,7 +73,7 @@ describe("SharedMap memory usage", () => {
 		benchmarkMemory(
 			new (class implements IMemoryTestObject {
 				public readonly title = `Add ${x} integers to a local map, clear it`;
-				private map: AttributableMap = createLocalMap("testMap");
+				private map: ISharedMap = createLocalMap("testMap");
 
 				public async run(): Promise<void> {
 					for (let i = 0; i < x; i++) {

--- a/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
+++ b/experimental/dds/attributable-map/src/test/mocha/map.spec.ts
@@ -24,7 +24,7 @@ import {
 	IMapSetOperation,
 	MapLocalOpMetadata,
 } from "../../internalInterfaces.js";
-import { AttributableMap, MapFactory } from "../../map.js";
+import { AttributableMapClass, MapFactory } from "../../map.js";
 import { IMapOperation } from "../../mapKernel.js";
 
 function createConnectedMap(id: string, runtimeFactory: MockContainerRuntimeFactory): TestMap {
@@ -47,7 +47,7 @@ function createDetachedMap(id: string): TestMap {
 	return map;
 }
 
-class TestMap extends AttributableMap {
+class TestMap extends AttributableMapClass {
 	private lastMetadata?: MapLocalOpMetadata;
 	public testApplyStashedOp(content: IMapOperation): MapLocalOpMetadata | undefined {
 		this.lastMetadata = undefined;

--- a/experimental/dds/attributable-map/src/test/mocha/reconnection.spec.ts
+++ b/experimental/dds/attributable-map/src/test/mocha/reconnection.spec.ts
@@ -12,15 +12,16 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { AttributableMap, MapFactory } from "../../map.js";
+import { AttributableMapClass, MapFactory } from "../../map.js";
+import type { ISharedMap } from "../../interfaces.js";
 
 describe("Reconnection", () => {
 	describe("SharedMap", () => {
 		let containerRuntimeFactory: MockContainerRuntimeFactoryForReconnection;
 		let containerRuntime1: MockContainerRuntimeForReconnection;
 		let containerRuntime2: MockContainerRuntimeForReconnection;
-		let map1: AttributableMap;
-		let map2: AttributableMap;
+		let map1: ISharedMap;
+		let map2: ISharedMap;
 
 		beforeEach(async () => {
 			containerRuntimeFactory = new MockContainerRuntimeFactoryForReconnection();
@@ -32,7 +33,11 @@ describe("Reconnection", () => {
 				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
-			map1 = new AttributableMap("shared-map-1", dataStoreRuntime1, MapFactory.Attributes);
+			map1 = new AttributableMapClass(
+				"shared-map-1",
+				dataStoreRuntime1,
+				MapFactory.Attributes,
+			);
 			map1.connect(services1);
 
 			// Create the second SharedMap.
@@ -42,7 +47,11 @@ describe("Reconnection", () => {
 				deltaConnection: dataStoreRuntime2.createDeltaConnection(),
 				objectStorage: new MockStorage(),
 			};
-			map2 = new AttributableMap("shared-map-2", dataStoreRuntime2, MapFactory.Attributes);
+			map2 = new AttributableMapClass(
+				"shared-map-2",
+				dataStoreRuntime2,
+				MapFactory.Attributes,
+			);
 			map2.connect(services2);
 		});
 


### PR DESCRIPTION
## Description

AttributableMap now uses ISharedObjectKind and does not export the class.

## Breaking Changes

AttributableMap is internal and experimental so this change should not break any external users. If any do exist, they can update to use the interface.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

