### PR TITLE
Revert "test various connection modes (#20879)"

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -875,10 +875,13 @@ export class Container
 					const mode = this.connectionMode;
 					// We get here when socket does not receive any ops on "write" connection, including
 					// its own join op.
+					// Report issues only if we already loaded container - op processing is paused while container is loading,
+					// so we always time-out processing of join op in cases where fetching snapshot takes a minute.
+					// It's not a problem with op processing itself - such issues should be tracked as part of boot perf monitoring instead.
 					this._deltaManager.logConnectionIssue({
 						eventName,
 						mode,
-						category,
+						category: this._lifecycleState === "loading" ? "generic" : category,
 						duration:
 							performance.now() -
 							this.connectionTransitionTimes[ConnectionState.CatchingUp],

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -28,12 +28,17 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
+						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
+						"Fluid.Summarizer.UseDynamicRetries": [true, false],
+						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+					}
+				},
+				"odsp-odsp-df": {
+					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
 						"Fluid.Summarizer.UseDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false],
-						"Fluid.Container.DisableCatchUpBeforeDeclaringConnected": [true, false],
-						"Fluid.Container.DisableJoinSignalWait": [true, false]
+						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
 					}
 				},
 				"tinylicious": {
@@ -197,6 +202,20 @@
 			},
 			"totalBlobCount": 300,
 			"blobSize": 256
+		},
+		"binarySnapshotFormat": {
+			"opRatePerMin": 60,
+			"progressIntervalMs": 5000,
+			"numClients": 4,
+			"totalSendCount": 150,
+			"readWriteCycleMs": 10000,
+			"optionOverrides": {
+				"odsp": {
+					"configurations": {
+						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2]
+					}
+				}
+			}
 		},
 		"scale_with_signals": {
 			"opRatePerMin": 7,


### PR DESCRIPTION
This reverts commit 33d84312ead3cd9551c451923aac03bedf84833d.

This was due to it causing the stress tests pipelines to fail immediately when ran against ODSP services.