### PR TITLE
docs(tree): More "editable tree" terminology cleanup

### DIFF
--- a/packages/dds/tree/src/core/forest/README.md
+++ b/packages/dds/tree/src/core/forest/README.md
@@ -4,7 +4,7 @@ An abstraction for representing, editing, and observing collections of trees.
 Forest is focused on allowing the implementation to efficiently be viewed/read and apply deltas,
 while only keeping a subset of the data in memory.
 
-Forest is not supposed to provide a friendly API (See [editable-tree](../../feature-libraries/editable-tree/README.md) for that).
+Forest is not supposed to provide a friendly API (See [flex-tree](../../feature-libraries/flex-tree/README.md) for that).
 Instead, forest provides an abstraction that enables implementing nicer APIs on-top of it as a separate layer while abstracting the actual storage representation.
 This should allow forest implementations to implement compression without having to modify the forest API or its users.
 

--- a/packages/dds/tree/src/feature-libraries/contextuallyTyped.ts
+++ b/packages/dds/tree/src/feature-libraries/contextuallyTyped.ts
@@ -138,7 +138,7 @@ export function getPossibleTypes(
  * A symbol used to define a {@link MarkedArrayLike} interface.
  * @internal
  */
-export const arrayLikeMarkerSymbol: unique symbol = Symbol("editable-tree:arrayLikeMarker");
+export const arrayLikeMarkerSymbol: unique symbol = Symbol("flex-tree:arrayLikeMarker");
 
 /**
  * Can be used to mark a type which works like an array, but is not compatible with `Array.isArray`.

--- a/packages/dds/tree/src/feature-libraries/editableTreeBinder.ts
+++ b/packages/dds/tree/src/feature-libraries/editableTreeBinder.ts
@@ -204,7 +204,7 @@ export interface BindPolicy {
  *
  * @internal
  */
-export const indexSymbol = Symbol("editable-tree-binder:index");
+export const indexSymbol = Symbol("flex-tree-binder:index");
 
 /**
  * A syntax node for the bind language

--- a/packages/dds/tree/src/shared-tree/treeView.ts
+++ b/packages/dds/tree/src/shared-tree/treeView.ts
@@ -43,7 +43,7 @@ export interface FlexTreeView<in out TRoot extends FlexFieldSchema> extends IDis
 	readonly checkout: ITreeCheckout;
 
 	/**
-	 * Get a typed view of the tree content using the editable-tree-2 API.
+	 * Get a typed view of the tree content using the flex-tree API.
 	 */
 	readonly flexTree: FlexTreeTypedField<TRoot>;
 

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/editableTree.identifier.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/editableTree.identifier.spec.ts
@@ -37,7 +37,7 @@ function addKey(view: NodeKeyManager, key: LocalNodeKey): { [nodeKeyFieldKey]: S
 	};
 }
 
-describe("editable-tree: node keys", () => {
+describe("flex-tree: node keys", () => {
 	/** Creates or populates a view with a parent node and two children, each with node keys */
 	function initializeView() {
 		const nodeKeyManager = createMockNodeKeyManager();


### PR DESCRIPTION
## Description

Replaces more uses of "editable tree" with "flex tree" in docs, comments, and a few bits of code.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
