### PR TITLE
Add rdkafka producer/consumer additional config, rdkafka logs to the Lumberjack

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -95,6 +95,9 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 		const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
 		const kafkaMaxBatchSize = config.get("kafka:lib:maxBatchSize");
 		const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
+		const kafkaProducerGlobalAdditionalConfig = config.get(
+			"kafka:lib:producerGlobalAdditionalConfig",
+		);
 		const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
 
 		const producer = services.createProducer(
@@ -109,6 +112,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 			kafkaMaxBatchSize,
 			kafkaSslCACertFilePath,
 			eventHubConnString,
+			kafkaProducerGlobalAdditionalConfig,
 		);
 
 		const redisConfig = config.get("redis");

--- a/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
@@ -147,6 +147,9 @@ export class NexusResourcesFactory implements core.IResourcesFactory<NexusResour
 		const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
 		const kafkaMaxBatchSize = config.get("kafka:lib:maxBatchSize");
 		const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
+		const kafkaProducerGlobalAdditionalConfig = config.get(
+			"kafka:lib:producerGlobalAdditionalConfig",
+		);
 		const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
 
 		const producer = services.createProducer(
@@ -161,6 +164,7 @@ export class NexusResourcesFactory implements core.IResourcesFactory<NexusResour
 			kafkaMaxBatchSize,
 			kafkaSslCACertFilePath,
 			eventHubConnString,
+			kafkaProducerGlobalAdditionalConfig,
 		);
 
 		const redisConfig = config.get("redis");

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -32,6 +32,9 @@ export async function deliCreate(
 	const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
 	const kafkaMaxBatchSize = config.get("kafka:lib:maxBatchSize");
 	const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
+	const kafkaProducerGlobalAdditionalConfig = config.get(
+		"kafka:lib:producerGlobalAdditionalConfig",
+	);
 	const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
 
 	const kafkaForwardClientId = config.get("deli:kafkaClientId");
@@ -110,6 +113,7 @@ export async function deliCreate(
 		kafkaMaxBatchSize,
 		kafkaSslCACertFilePath,
 		eventHubConnString,
+		kafkaProducerGlobalAdditionalConfig,
 	);
 	const reverseProducer = services.createProducer(
 		kafkaLibrary,
@@ -123,6 +127,7 @@ export async function deliCreate(
 		kafkaMaxBatchSize,
 		kafkaSslCACertFilePath,
 		eventHubConnString,
+		kafkaProducerGlobalAdditionalConfig,
 	);
 
 	const redisConfig = config.get("redis");

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -44,6 +44,9 @@ export async function scribeCreate(
 	const kafkaReplicationFactor = config.get("kafka:lib:replicationFactor");
 	const kafkaMaxBatchSize = config.get("kafka:lib:maxBatchSize");
 	const kafkaSslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
+	const kafkaProducerGlobalAdditionalConfig = config.get(
+		"kafka:lib:producerGlobalAdditionalConfig",
+	);
 	const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
 	const sendTopic = config.get("lambdas:deli:topic");
 	const kafkaClientId = config.get("scribe:kafkaClientId");
@@ -138,6 +141,7 @@ export async function scribeCreate(
 		kafkaMaxBatchSize,
 		kafkaSslCACertFilePath,
 		eventHubConnString,
+		kafkaProducerGlobalAdditionalConfig,
 	);
 
 	const externalOrdererUrl = config.get("worker:serverUrl");

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -13,6 +13,7 @@ import {
 	IZookeeperClient,
 	ZookeeperClientConstructor,
 } from "@fluidframework/server-services-core";
+import { Lumberjack } from "@fluidframework/server-services-telemetry";
 import { IKafkaBaseOptions, IKafkaEndpoints, RdkafkaBase } from "./rdkafkaBase";
 
 /**
@@ -315,6 +316,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 
 		consumer.on("event.log", (event) => {
 			this.emit("log", event);
+			Lumberjack.info(`RdKafka consumer: ${event.message}`);
 		});
 
 		consumer.connect();

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -187,6 +187,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 
 		producer.on("event.log", (event) => {
 			this.emit("log", event);
+			Lumberjack.info(`RdKafka producer: ${event.message}`);
 		});
 
 		producer.connect();

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -74,6 +74,9 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
 		const sslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
 		const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
 		const customRestartOnKafkaErrorCodes = config.get("kafka:customRestartOnKafkaErrorCodes");
+		const consumerGlobalAdditionalConfig = config.get(
+			"kafka:lib:consumerGlobalAdditionalConfig",
+		);
 
 		// Receive topic and group - for now we will assume an entry in config mapping
 		// to the given name. Later though the lambda config will likely be split from the stream config
@@ -99,6 +102,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
 			zooKeeperClientConstructor: this.zookeeperClientConstructor,
 			eventHubConnString,
 			restartOnKafkaErrorCodes: customRestartOnKafkaErrorCodes,
+			additionalOptions: consumerGlobalAdditionalConfig,
 		};
 
 		const consumer = new RdkafkaConsumer(endpoints, clientId, receiveTopic, groupId, options);

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -31,6 +31,7 @@ export function createProducer(
 	maxBatchSize?: number,
 	sslCACertFilePath?: string,
 	eventHubConnString?: string,
+	additionalOptions?: object,
 ): IProducer {
 	let producer: IProducer;
 
@@ -43,6 +44,7 @@ export function createProducer(
 			maxMessageSize: MaxKafkaMessageSize,
 			sslCACertFilePath,
 			eventHubConnString,
+			additionalOptions,
 		});
 
 		producer.on("error", (error, errorData: IContextErrorData) => {


### PR DESCRIPTION
## Description

This change adds additional global configuration for rdkafka producers and consumers from nconf needed for FRS as  dynamic override or addition of any config combination but ssl ones. 

## Reviewer Guidance

For this PR I wasn't sure about adding Lumberjack logging directly within rdkafka producer and consumer for FRS needs. Any piece of advise on where it might be more beneficial is appreciated :)
