### PR TITLE
Update tools packages to use fluid-internal mocha-test-setup package

### DIFF
--- a/tools/api-markdown-documenter/.mocharc.cjs
+++ b/tools/api-markdown-documenter/.mocharc.cjs
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common");
+const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const packageDir = __dirname;
 const config = getFluidTestMochaConfig(packageDir);

--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -80,11 +80,11 @@
 		"hastscript": "^9.0.0"
 	},
 	"devDependencies": {
+		"@fluid-internal/mocha-test-setup": "~2.0.0-rc.3.0.3",
 		"@fluid-tools/markdown-magic": "file:../markdown-magic",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.37.0",
 		"@fluidframework/eslint-config-fluid": "^5.1.0",
-		"@fluidframework/mocha-test-setup": "~2.0.0-internal.6.2.0",
 		"@microsoft/api-extractor": "^7.42.3",
 		"@types/chai": "^4.3.4",
 		"@types/hast": "^3.0.4",

--- a/tools/api-markdown-documenter/pnpm-lock.yaml
+++ b/tools/api-markdown-documenter/pnpm-lock.yaml
@@ -7,11 +7,11 @@ importers:
 
   .:
     specifiers:
+      '@fluid-internal/mocha-test-setup': ~2.0.0-rc.3.0.3
       '@fluid-tools/markdown-magic': file:../markdown-magic
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/build-tools': ^0.37.0
       '@fluidframework/eslint-config-fluid': ^5.1.0
-      '@fluidframework/mocha-test-setup': ~2.0.0-internal.6.2.0
       '@microsoft/api-extractor': ^7.42.3
       '@microsoft/api-extractor-model': ~7.28.2
       '@microsoft/tsdoc': ^0.14.2
@@ -49,11 +49,11 @@ importers:
       hast-util-raw: 9.0.2
       hastscript: 9.0.0
     devDependencies:
+      '@fluid-internal/mocha-test-setup': 2.0.0-rc.3.0.3
       '@fluid-tools/markdown-magic': file:../markdown-magic_@types+node@18.15.11
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/build-tools': 0.37.0_@types+node@18.15.11
       '@fluidframework/eslint-config-fluid': 5.2.0_bpztyfltmpuv6lhsgzfwtmxhte
-      '@fluidframework/mocha-test-setup': 2.0.0-internal.6.2.0
       '@microsoft/api-extractor': 7.42.3_@types+node@18.15.11
       '@types/chai': 4.3.4
       '@types/hast': 3.0.4
@@ -175,6 +175,23 @@ packages:
       - typescript
     dev: true
 
+  /@fluid-internal/mocha-test-setup/2.0.0-rc.3.0.3:
+    resolution: {integrity: sha512-QhmRb2dwAylu7SNzm5xVn2LDrLAHb5g2nJWuAT0LMkbiJYt8QyKGWmwM+ap8AgIrqi0tu30WC4igLMs+9JuMZA==}
+    dependencies:
+      '@fluid-internal/test-driver-definitions': 2.0.0-rc.3.0.3
+      '@fluidframework/core-interfaces': 2.0.0-rc.3.0.3
+      mocha: 10.2.0
+      source-map-support: 0.5.21
+    dev: true
+
+  /@fluid-internal/test-driver-definitions/2.0.0-rc.3.0.3:
+    resolution: {integrity: sha512-hCI1gDwzzP/4SfvOgA81GX1vbMtfI1mClR+CRQ0M+uDQCrxP31D2dIoll+RSNNI9MwS3+ymAcVJLarNDrXaPYw==}
+    dependencies:
+      '@fluidframework/core-interfaces': 2.0.0-rc.3.0.3
+      '@fluidframework/driver-definitions': 2.0.0-rc.3.0.3
+      '@fluidframework/protocol-definitions': 3.2.0
+    dev: true
+
   /@fluid-tools/version-tools/0.37.0:
     resolution: {integrity: sha512-hPUJUxl8rZQAgWCpnEL5MxXRYZkdXhqusVUyJa3Wbu6f6BuaxKofOLOCB88rVkGiCgyZui8Mo5M2Q4GqLGYWIQ==}
     engines: {node: '>=14.17.0'}
@@ -256,19 +273,15 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/common-definitions/0.20.1:
-    resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
+  /@fluidframework/core-interfaces/2.0.0-rc.3.0.3:
+    resolution: {integrity: sha512-lndP37QUE9r/Eot3yX9WIGlR0hMSC0FLxg0TQNUOJYCAbr4+4VNlDIzTRlMFqISiPgDNhpZEVx6vr8O1HxCtzg==}
     dev: true
 
-  /@fluidframework/core-interfaces/2.0.0-internal.6.2.0:
-    resolution: {integrity: sha512-VsIoxjv1c132k9mZJbMUXRxASaen1MGffYnnPyq/pwuPk20PrlDlzZtBpnCqp0KVVO9W5EK54S7z8DupmBhy0A==}
-    dev: true
-
-  /@fluidframework/driver-definitions/2.0.0-internal.6.2.0:
-    resolution: {integrity: sha512-3aIpoG2cHkPzpI05bcYllaCsK9bL81kw4uCjHMBnrUcMHHUvsdYnby4NCczsS9lSpsyRGVceFfVafUTyRj+I0w==}
+  /@fluidframework/driver-definitions/2.0.0-rc.3.0.3:
+    resolution: {integrity: sha512-Rrp49H/0PSFBKFtgt1l7QKQ/FR8fX0qLmCtp+mDiY2ubwQIYnn+3nxDY8sTO4S0vzqOcd6qiwzSf1QTwVmlNIw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.2.0
-      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/core-interfaces': 2.0.0-rc.3.0.3
+      '@fluidframework/protocol-definitions': 3.2.0
     dev: true
 
   /@fluidframework/eslint-config-fluid/5.2.0_bpztyfltmpuv6lhsgzfwtmxhte:
@@ -300,27 +313,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/mocha-test-setup/2.0.0-internal.6.2.0:
-    resolution: {integrity: sha512-v5S45oGYDxMy9aQn4maoFhwwdSweA/02P3UVvjLosjzO68GZ1/3tflsNCYSM27ludmOaYQqEiWtk6qX3O8vZsw==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.2.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.6.2.0
-      mocha: 10.2.0
-    dev: true
-
-  /@fluidframework/protocol-definitions/1.2.0:
-    resolution: {integrity: sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-    dev: true
-
-  /@fluidframework/test-driver-definitions/2.0.0-internal.6.2.0:
-    resolution: {integrity: sha512-Z9nHMke74S0l6i7szNpSNdn+4ae4WF9o4+HyAS3RUeYEoWzPWA5pcEDyHpLnThMbcIKICLd3DGSTh9uSU2Gprg==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.2.0
-      '@fluidframework/protocol-definitions': 1.2.0
-      uuid: 9.0.0
+  /@fluidframework/protocol-definitions/3.2.0:
+    resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
     dev: true
 
   /@gitbeaker/core/35.8.1:
@@ -6404,11 +6398,6 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: true
-
-  /uuid/9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
-    hasBin: true
     dev: true
 
   /v8-to-istanbul/9.1.0:

--- a/tools/benchmark/.mocharc.cjs
+++ b/tools/benchmark/.mocharc.cjs
@@ -5,7 +5,7 @@
 
 "use strict";
 
-const getFluidTestMochaConfig = require("@fluidframework/mocha-test-setup/mocharc-common");
+const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const packageDir = __dirname;
 const config = getFluidTestMochaConfig(packageDir);

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -27,7 +27,7 @@
 		"format": "npm run prettier:fix",
 		"lint": "npm run prettier && npm run eslint",
 		"lint:fix": "npm run prettier:fix && npm run eslint:fix",
-		"perf": "mocha --config ./.mocharc.cjs --v8-expose-gc --timeout 999999 -r node_modules/@fluidframework/mocha-test-setup --perfMode --fgrep @Benchmark --reporter ./dist/MochaReporter.js \"./dist/**/*.tests.js\"",
+		"perf": "mocha --config ./.mocharc.cjs --v8-expose-gc --timeout 999999 -r node_modules/@fluid-internal/mocha-test-setup --perfMode --fgrep @Benchmark --reporter ./dist/MochaReporter.js \"./dist/**/*.tests.js\"",
 		"prettier": "prettier --check . --cache --ignore-path ../../.prettierignore",
 		"prettier:fix": "prettier --write . --cache --ignore-path ../../.prettierignore",
 		"test": "npm run test:mocha",
@@ -45,9 +45,9 @@
 		"moment": "^2.21.0"
 	},
 	"devDependencies": {
+		"@fluid-internal/mocha-test-setup": "~2.0.0-rc.3.0.3",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/eslint-config-fluid": "^4.0.0",
-		"@fluidframework/mocha-test-setup": "~2.0.0-internal.6.2.0",
 		"@microsoft/api-extractor": "^7.42.3",
 		"@types/benchmark": "^2.1.0",
 		"@types/chai": "^4.3.4",

--- a/tools/benchmark/pnpm-lock.yaml
+++ b/tools/benchmark/pnpm-lock.yaml
@@ -4,9 +4,9 @@ importers:
 
   .:
     specifiers:
+      '@fluid-internal/mocha-test-setup': ~2.0.0-rc.3.0.3
       '@fluidframework/build-common': ^2.0.3
       '@fluidframework/eslint-config-fluid': ^4.0.0
-      '@fluidframework/mocha-test-setup': ~2.0.0-internal.6.2.0
       '@microsoft/api-extractor': ^7.42.3
       '@types/benchmark': ^2.1.0
       '@types/chai': ^4.3.4
@@ -36,9 +36,9 @@ importers:
       mocha-multi-reporters: 1.5.1_mocha@10.2.0
       moment: 2.29.4
     devDependencies:
+      '@fluid-internal/mocha-test-setup': 2.0.0-rc.3.0.3
       '@fluidframework/build-common': 2.0.3
       '@fluidframework/eslint-config-fluid': 4.0.0_bpztyfltmpuv6lhsgzfwtmxhte
-      '@fluidframework/mocha-test-setup': 2.0.0-internal.6.2.0
       '@microsoft/api-extractor': 7.42.3_@types+node@14.18.38
       '@types/benchmark': 2.1.2
       '@types/chai': 4.3.11
@@ -134,24 +134,37 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@fluid-internal/mocha-test-setup/2.0.0-rc.3.0.3:
+    resolution: {integrity: sha512-QhmRb2dwAylu7SNzm5xVn2LDrLAHb5g2nJWuAT0LMkbiJYt8QyKGWmwM+ap8AgIrqi0tu30WC4igLMs+9JuMZA==}
+    dependencies:
+      '@fluid-internal/test-driver-definitions': 2.0.0-rc.3.0.3
+      '@fluidframework/core-interfaces': 2.0.0-rc.3.0.3
+      mocha: 10.2.0
+      source-map-support: 0.5.21
+    dev: true
+
+  /@fluid-internal/test-driver-definitions/2.0.0-rc.3.0.3:
+    resolution: {integrity: sha512-hCI1gDwzzP/4SfvOgA81GX1vbMtfI1mClR+CRQ0M+uDQCrxP31D2dIoll+RSNNI9MwS3+ymAcVJLarNDrXaPYw==}
+    dependencies:
+      '@fluidframework/core-interfaces': 2.0.0-rc.3.0.3
+      '@fluidframework/driver-definitions': 2.0.0-rc.3.0.3
+      '@fluidframework/protocol-definitions': 3.2.0
+    dev: true
+
   /@fluidframework/build-common/2.0.3:
     resolution: {integrity: sha512-1LU/2uyCeMxf63z5rhFOFEBvFyBogZ7ZXwzXLxyBhSgq/fGiq8PLjBW7uX++r0LcVCdaWyopf7w060eJpANYdg==}
     hasBin: true
     dev: true
 
-  /@fluidframework/common-definitions/0.20.1:
-    resolution: {integrity: sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g==}
+  /@fluidframework/core-interfaces/2.0.0-rc.3.0.3:
+    resolution: {integrity: sha512-lndP37QUE9r/Eot3yX9WIGlR0hMSC0FLxg0TQNUOJYCAbr4+4VNlDIzTRlMFqISiPgDNhpZEVx6vr8O1HxCtzg==}
     dev: true
 
-  /@fluidframework/core-interfaces/2.0.0-internal.6.2.0:
-    resolution: {integrity: sha512-VsIoxjv1c132k9mZJbMUXRxASaen1MGffYnnPyq/pwuPk20PrlDlzZtBpnCqp0KVVO9W5EK54S7z8DupmBhy0A==}
-    dev: true
-
-  /@fluidframework/driver-definitions/2.0.0-internal.6.2.0:
-    resolution: {integrity: sha512-3aIpoG2cHkPzpI05bcYllaCsK9bL81kw4uCjHMBnrUcMHHUvsdYnby4NCczsS9lSpsyRGVceFfVafUTyRj+I0w==}
+  /@fluidframework/driver-definitions/2.0.0-rc.3.0.3:
+    resolution: {integrity: sha512-Rrp49H/0PSFBKFtgt1l7QKQ/FR8fX0qLmCtp+mDiY2ubwQIYnn+3nxDY8sTO4S0vzqOcd6qiwzSf1QTwVmlNIw==}
     dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.2.0
-      '@fluidframework/protocol-definitions': 1.2.0
+      '@fluidframework/core-interfaces': 2.0.0-rc.3.0.3
+      '@fluidframework/protocol-definitions': 3.2.0
     dev: true
 
   /@fluidframework/eslint-config-fluid/4.0.0_bpztyfltmpuv6lhsgzfwtmxhte:
@@ -182,27 +195,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/mocha-test-setup/2.0.0-internal.6.2.0:
-    resolution: {integrity: sha512-v5S45oGYDxMy9aQn4maoFhwwdSweA/02P3UVvjLosjzO68GZ1/3tflsNCYSM27ludmOaYQqEiWtk6qX3O8vZsw==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.2.0
-      '@fluidframework/test-driver-definitions': 2.0.0-internal.6.2.0
-      mocha: 10.2.0
-    dev: true
-
-  /@fluidframework/protocol-definitions/1.2.0:
-    resolution: {integrity: sha512-2/GoupA8mjHD8gcjyn4SedqJStKlQAZxga5PtDBoh+xHsuugQRhsAHJCX+8tdqbSK4ZOo9z8iq/vWKVLUi5Dzw==}
-    dependencies:
-      '@fluidframework/common-definitions': 0.20.1
-    dev: true
-
-  /@fluidframework/test-driver-definitions/2.0.0-internal.6.2.0:
-    resolution: {integrity: sha512-Z9nHMke74S0l6i7szNpSNdn+4ae4WF9o4+HyAS3RUeYEoWzPWA5pcEDyHpLnThMbcIKICLd3DGSTh9uSU2Gprg==}
-    dependencies:
-      '@fluidframework/core-interfaces': 2.0.0-internal.6.2.0
-      '@fluidframework/driver-definitions': 2.0.0-internal.6.2.0
-      '@fluidframework/protocol-definitions': 1.2.0
-      uuid: 9.0.0
+  /@fluidframework/protocol-definitions/3.2.0:
+    resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
     dev: true
 
   /@humanwhocodes/config-array/0.11.14:
@@ -800,6 +794,10 @@ packages:
 
   /browser-stdout/1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
+  /buffer-from/1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
 
   /builtin-modules/3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -3033,6 +3031,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /source-map-support/0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: true
+
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -3355,11 +3360,6 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: true
-
-  /uuid/9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
-    hasBin: true
     dev: true
 
   /validate-npm-package-license/3.0.4:


### PR DESCRIPTION
I moved mocha-test-setup to fluid-internal in #19759, but forgot to include it in the list of published packages (corrected in #20204).  Now that it's published, we can use it in the remaining non-client packages (the tools).

[AB#7295](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7295)