### PR TITLE
tree: Update more shared objects to new factory pattern

### DIFF
--- a/experimental/PropertyDDS/packages/property-dds/api-report/property-dds.api.md
+++ b/experimental/PropertyDDS/packages/property-dds/api-report/property-dds.api.md
@@ -11,6 +11,7 @@ import { IChannelStorageService } from '@fluidframework/datastore-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidSerializer } from '@fluidframework/shared-object-base';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
+import { ISharedObjectKind } from '@fluidframework/shared-object-base/internal';
 import { IsoBuffer } from '@fluid-internal/client-utils';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { NodeProperty } from '@fluid-experimental/property-properties';
@@ -166,7 +167,7 @@ export const enum OpKind {
 }
 
 // @internal
-export class PropertyTreeFactory implements IChannelFactory {
+export class PropertyTreeFactory implements IChannelFactory<SharedPropertyTree> {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;
     // (undocumented)
@@ -257,6 +258,9 @@ export class SharedPropertyTree extends SharedObject {
     // (undocumented)
     useMH: boolean;
 }
+
+// @internal
+export const SharedPropertyTreeKind: ISharedObjectKind<SharedPropertyTree>;
 
 // @internal (undocumented)
 export interface SharedPropertyTreeOptions {

--- a/experimental/PropertyDDS/packages/property-dds/src/index.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/index.ts
@@ -21,4 +21,4 @@ export {
 	DeflatedPropertyTreeFactory,
 	LZ4PropertyTreeFactory,
 } from "./propertyTreeExtFactories.js";
-export { PropertyTreeFactory } from "./propertyTreeFactory.js";
+export { PropertyTreeFactory, SharedPropertyTreeKind } from "./propertyTreeFactory.js";

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTree.ts
@@ -147,16 +147,7 @@ const defaultEncDec: ISharedPropertyTreeEncDec = {
 };
 
 /**
- * Silly DDS example that models a six sided die.
- *
- * Unlike the typical 'Dice Roller' example where clients clobber each other's last roll in a
- * SharedMap, this 'SharedDie' DDS works by advancing an internal PRNG each time it sees a 'roll'
- * operation.
- *
- * Because all clients are using the same PRNG starting in the same state, they arrive at
- * consensus by simply applying the same number of rolls.  (A fun addition would be logging
- * who received which roll, which would need to change as clients learn how races are resolved
- * in the total order)
+ * DDS that models a tree made of objects with properties under string keys.
  * @internal
  */
 export class SharedPropertyTree extends SharedObject {

--- a/experimental/PropertyDDS/packages/property-dds/src/propertyTreeFactory.ts
+++ b/experimental/PropertyDDS/packages/property-dds/src/propertyTreeFactory.ts
@@ -9,14 +9,19 @@ import {
 	IChannelServices,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
+import { createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
 import { SharedPropertyTree, SharedPropertyTreeOptions } from "./propertyTree.js";
 
 /**
- * The factory that defines the map
+ * The factory for SharedPropertyTree.
+ * @privateRemarks
+ * TODO:
+ * This class should not be package exported.
+ * For now its being kept exported for compatibility, which is helpful since its actual users are not internal despite how it's tagged.
  * @internal
  */
-export class PropertyTreeFactory implements IChannelFactory {
+export class PropertyTreeFactory implements IChannelFactory<SharedPropertyTree> {
 	public static readonly Type = "PropertyTree:01EP5J4Y6C284JR6ATVPPHRJ4E";
 
 	public static readonly Attributes: IChannelAttributes = {
@@ -69,3 +74,12 @@ export class PropertyTreeFactory implements IChannelFactory {
 		return cell;
 	}
 }
+
+/**
+ * The factory for SharedProperty.
+ * @privateRemarks
+ * TODO: There should be an interface implemented by SharedPropertyTree which this exposes rather than exposing the class.
+ * TODO: as PropertyDDS is published for use outside the Fluid Framework repo, it should not be `@internal`.
+ * @internal
+ */
+export const SharedPropertyTreeKind = createSharedObjectKind(PropertyTreeFactory);

--- a/packages/dds/register-collection/api-report/register-collection.api.md
+++ b/packages/dds/register-collection/api-report/register-collection.api.md
@@ -13,16 +13,21 @@ import { IFluidSerializer } from '@fluidframework/shared-object-base';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base';
+import { ISharedObjectKind } from '@fluidframework/shared-object-base/internal';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { SharedObject } from '@fluidframework/shared-object-base/internal';
 
 // @alpha
-export class ConsensusRegisterCollection<T> extends SharedObject<IConsensusRegisterCollectionEvents> implements IConsensusRegisterCollection<T> {
+export const ConsensusRegisterCollection: ISharedObjectKind<IConsensusRegisterCollection<any>>;
+
+// @alpha
+export type ConsensusRegisterCollection<T> = IConsensusRegisterCollection<T>;
+
+// @alpha
+export class ConsensusRegisterCollectionClass<T> extends SharedObject<IConsensusRegisterCollectionEvents> implements IConsensusRegisterCollection<T> {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
     // (undocumented)
     protected applyStashedOp(): void;
-    static create<T>(runtime: IFluidDataStoreRuntime, id?: string): ConsensusRegisterCollection<T>;
-    static getFactory(): ConsensusRegisterCollectionFactory;
     // (undocumented)
     keys(): string[];
     protected loadCore(storage: IChannelStorageService): Promise<void>;
@@ -39,7 +44,7 @@ export class ConsensusRegisterCollection<T> extends SharedObject<IConsensusRegis
 }
 
 // @alpha
-export class ConsensusRegisterCollectionFactory implements IConsensusRegisterCollectionFactory {
+export class ConsensusRegisterCollectionFactory implements IChannelFactory<IConsensusRegisterCollection> {
     // (undocumented)
     static readonly Attributes: IChannelAttributes;
     // (undocumented)
@@ -67,12 +72,8 @@ export interface IConsensusRegisterCollectionEvents extends ISharedObjectEvents 
     (event: "atomicChanged" | "versionChanged", listener: (key: string, value: any, local: boolean) => void): any;
 }
 
-// @alpha
-export interface IConsensusRegisterCollectionFactory extends IChannelFactory {
-    // (undocumented)
-    create(document: IFluidDataStoreRuntime, id: string): IConsensusRegisterCollection;
-    load(document: IFluidDataStoreRuntime, id: string, services: IChannelServices, attributes: IChannelAttributes): Promise<IConsensusRegisterCollection>;
-}
+// @alpha @deprecated
+export type IConsensusRegisterCollectionFactory = IChannelFactory<IConsensusRegisterCollection>;
 
 // @alpha
 export enum ReadPolicy {

--- a/packages/dds/register-collection/package.json
+++ b/packages/dds/register-collection/package.json
@@ -138,6 +138,10 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_ConsensusRegisterCollection": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -15,7 +15,6 @@ import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
 import { IFluidSerializer } from "@fluidframework/shared-object-base";
 import { SharedObject, createSingleBlobSummary } from "@fluidframework/shared-object-base/internal";
 
-import { ConsensusRegisterCollectionFactory } from "./consensusRegisterCollectionFactory.js";
 import {
 	IConsensusRegisterCollection,
 	IConsensusRegisterCollectionEvents,
@@ -108,29 +107,6 @@ export class ConsensusRegisterCollection<T>
 	extends SharedObject<IConsensusRegisterCollectionEvents>
 	implements IConsensusRegisterCollection<T>
 {
-	/**
-	 * Create a new consensus register collection
-	 *
-	 * @param runtime - data store runtime the new consensus register collection belongs to
-	 * @param id - optional name of the consensus register collection
-	 * @returns newly create consensus register collection (but not attached yet)
-	 */
-	public static create<T>(runtime: IFluidDataStoreRuntime, id?: string) {
-		return runtime.createChannel(
-			id,
-			ConsensusRegisterCollectionFactory.Type,
-		) as ConsensusRegisterCollection<T>;
-	}
-
-	/**
-	 * Get a factory for ConsensusRegisterCollection to register with the data store.
-	 *
-	 * @returns a factory that creates and load ConsensusRegisterCollection
-	 */
-	public static getFactory() {
-		return new ConsensusRegisterCollectionFactory();
-	}
-
 	private readonly data = new Map<string, ILocalData<T>>();
 
 	/**

--- a/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
@@ -7,17 +7,21 @@ import {
 	IChannelAttributes,
 	IChannelServices,
 	IFluidDataStoreRuntime,
+	type IChannelFactory,
 } from "@fluidframework/datastore-definitions";
+import { createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
-import { ConsensusRegisterCollection } from "./consensusRegisterCollection.js";
-import { IConsensusRegisterCollection, IConsensusRegisterCollectionFactory } from "./interfaces.js";
+import { ConsensusRegisterCollection as ConsensusRegisterCollectionClass } from "./consensusRegisterCollection.js";
+import { IConsensusRegisterCollection } from "./interfaces.js";
 import { pkgVersion } from "./packageVersion.js";
 
 /**
  * The factory that defines the consensus queue.
  * @alpha
  */
-export class ConsensusRegisterCollectionFactory implements IConsensusRegisterCollectionFactory {
+export class ConsensusRegisterCollectionFactory
+	implements IChannelFactory<IConsensusRegisterCollection>
+{
 	public static Type = "https://graph.microsoft.com/types/consensus-register-collection";
 
 	public static readonly Attributes: IChannelAttributes = {
@@ -43,13 +47,13 @@ export class ConsensusRegisterCollectionFactory implements IConsensusRegisterCol
 		services: IChannelServices,
 		attributes: IChannelAttributes,
 	): Promise<IConsensusRegisterCollection> {
-		const collection = new ConsensusRegisterCollection(id, runtime, attributes);
+		const collection = new ConsensusRegisterCollectionClass(id, runtime, attributes);
 		await collection.load(services);
 		return collection;
 	}
 
 	public create(document: IFluidDataStoreRuntime, id: string): IConsensusRegisterCollection {
-		const collection = new ConsensusRegisterCollection(
+		const collection = new ConsensusRegisterCollectionClass(
 			id,
 			document,
 			ConsensusRegisterCollectionFactory.Attributes,
@@ -58,3 +62,16 @@ export class ConsensusRegisterCollectionFactory implements IConsensusRegisterCol
 		return collection;
 	}
 }
+
+/**
+ * {@inheritdoc IConsensusRegisterCollection}
+ * @alpha
+ */
+export const ConsensusRegisterCollection = createSharedObjectKind(
+	ConsensusRegisterCollectionFactory,
+);
+/**
+ * Compatibility alias for {@link IConsensusRegisterCollection}.
+ * @alpha
+ */
+export type ConsensusRegisterCollection<T> = IConsensusRegisterCollection<T>;

--- a/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollectionFactory.ts
@@ -64,7 +64,7 @@ export class ConsensusRegisterCollectionFactory
 }
 
 /**
- * {@inheritdoc IConsensusRegisterCollection}
+ * {@inheritDoc IConsensusRegisterCollection}
  * @alpha
  */
 export const ConsensusRegisterCollection = createSharedObjectKind(

--- a/packages/dds/register-collection/src/index.ts
+++ b/packages/dds/register-collection/src/index.ts
@@ -3,8 +3,11 @@
  * Licensed under the MIT License.
  */
 
-export { ConsensusRegisterCollection } from "./consensusRegisterCollection.js";
-export { ConsensusRegisterCollectionFactory } from "./consensusRegisterCollectionFactory.js";
+export { ConsensusRegisterCollection as ConsensusRegisterCollectionClass } from "./consensusRegisterCollection.js";
+export {
+	ConsensusRegisterCollectionFactory,
+	ConsensusRegisterCollection,
+} from "./consensusRegisterCollectionFactory.js";
 export {
 	IConsensusRegisterCollection,
 	IConsensusRegisterCollectionEvents,

--- a/packages/dds/register-collection/src/interfaces.ts
+++ b/packages/dds/register-collection/src/interfaces.ts
@@ -12,7 +12,7 @@ import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-objec
  * Extends the base IChannelFactory to return a more definite type of IConsensusRegisterCollection
  * Use for the runtime to create and load distributed data structure by type name of each channel.
  * @alpha
- * @deprecated Use IChannelFactory<IConsensusRegisterCollection>.
+ * @deprecated Use `IChannelFactory<IConsensusRegisterCollection>`.
  */
 export type IConsensusRegisterCollectionFactory = IChannelFactory<IConsensusRegisterCollection>;
 

--- a/packages/dds/register-collection/src/interfaces.ts
+++ b/packages/dds/register-collection/src/interfaces.ts
@@ -3,12 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	IChannelAttributes,
-	IChannelFactory,
-	IChannelServices,
-	IFluidDataStoreRuntime,
-} from "@fluidframework/datastore-definitions";
+import { IChannelFactory } from "@fluidframework/datastore-definitions";
 import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-object-base";
 
 /**
@@ -17,20 +12,9 @@ import { ISharedObject, ISharedObjectEvents } from "@fluidframework/shared-objec
  * Extends the base IChannelFactory to return a more definite type of IConsensusRegisterCollection
  * Use for the runtime to create and load distributed data structure by type name of each channel.
  * @alpha
+ * @deprecated Use IChannelFactory<IConsensusRegisterCollection>.
  */
-export interface IConsensusRegisterCollectionFactory extends IChannelFactory {
-	/**
-	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.load}
-	 */
-	load(
-		document: IFluidDataStoreRuntime,
-		id: string,
-		services: IChannelServices,
-		attributes: IChannelAttributes,
-	): Promise<IConsensusRegisterCollection>;
-
-	create(document: IFluidDataStoreRuntime, id: string): IConsensusRegisterCollection;
-}
+export type IConsensusRegisterCollectionFactory = IChannelFactory<IConsensusRegisterCollection>;
 
 /**
  * Events emitted by {@link IConsensusRegisterCollection}.

--- a/packages/dds/register-collection/src/test/types/validateRegisterCollectionPrevious.generated.ts
+++ b/packages/dds/register-collection/src/test/types/validateRegisterCollectionPrevious.generated.ts
@@ -48,6 +48,7 @@ declare function get_current_ClassDeclaration_ConsensusRegisterCollection():
 declare function use_old_ClassDeclaration_ConsensusRegisterCollection(
     use: TypeOnly<old.ConsensusRegisterCollection<any>>): void;
 use_old_ClassDeclaration_ConsensusRegisterCollection(
+    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_ConsensusRegisterCollection());
 
 /*
@@ -139,13 +140,13 @@ use_old_InterfaceDeclaration_IConsensusRegisterCollectionEvents(
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_IConsensusRegisterCollectionFactory": {"forwardCompat": false}
+ * "RemovedInterfaceDeclaration_IConsensusRegisterCollectionFactory": {"forwardCompat": false}
  */
 declare function get_old_InterfaceDeclaration_IConsensusRegisterCollectionFactory():
     TypeOnly<old.IConsensusRegisterCollectionFactory>;
-declare function use_current_InterfaceDeclaration_IConsensusRegisterCollectionFactory(
+declare function use_current_RemovedInterfaceDeclaration_IConsensusRegisterCollectionFactory(
     use: TypeOnly<current.IConsensusRegisterCollectionFactory>): void;
-use_current_InterfaceDeclaration_IConsensusRegisterCollectionFactory(
+use_current_RemovedInterfaceDeclaration_IConsensusRegisterCollectionFactory(
     get_old_InterfaceDeclaration_IConsensusRegisterCollectionFactory());
 
 /*
@@ -153,14 +154,14 @@ use_current_InterfaceDeclaration_IConsensusRegisterCollectionFactory(
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_IConsensusRegisterCollectionFactory": {"backCompat": false}
+ * "RemovedInterfaceDeclaration_IConsensusRegisterCollectionFactory": {"backCompat": false}
  */
-declare function get_current_InterfaceDeclaration_IConsensusRegisterCollectionFactory():
+declare function get_current_RemovedInterfaceDeclaration_IConsensusRegisterCollectionFactory():
     TypeOnly<current.IConsensusRegisterCollectionFactory>;
 declare function use_old_InterfaceDeclaration_IConsensusRegisterCollectionFactory(
     use: TypeOnly<old.IConsensusRegisterCollectionFactory>): void;
 use_old_InterfaceDeclaration_IConsensusRegisterCollectionFactory(
-    get_current_InterfaceDeclaration_IConsensusRegisterCollectionFactory());
+    get_current_RemovedInterfaceDeclaration_IConsensusRegisterCollectionFactory());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.

--- a/packages/test/test-end-to-end-tests/src/test/summarizeIncrementallySubDds.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarizeIncrementallySubDds.spec.ts
@@ -30,7 +30,7 @@ import {
 import { channelsTreeName } from "@fluidframework/runtime-definitions/internal";
 import { SummaryTreeBuilder } from "@fluidframework/runtime-utils/internal";
 import { IFluidSerializer } from "@fluidframework/shared-object-base";
-import { SharedObject } from "@fluidframework/shared-object-base/internal";
+import { SharedObject, createSharedObjectKind } from "@fluidframework/shared-object-base/internal";
 import {
 	ITestFluidObject,
 	ITestObjectProvider,
@@ -190,7 +190,7 @@ class TestIncrementalSummaryBlobDDS extends SharedObject {
 }
 
 // Test DDS factory for the tree dds
-class TestTreeDDSFactory implements IChannelFactory {
+class TestTreeDDSFactory implements IChannelFactory<TestIncrementalSummaryTreeDDS> {
 	public static readonly Type = "incrementalTreeDDS";
 
 	public static readonly Attributes: IChannelAttributes = {
@@ -213,7 +213,7 @@ class TestTreeDDSFactory implements IChannelFactory {
 		services: IChannelServices,
 		attributes: IChannelAttributes,
 	): Promise<TestIncrementalSummaryTreeDDS> {
-		const sharedObject = new TestIncrementalSummaryTreeDDS(
+		const sharedObject = new TestIncrementalSummaryTreeDDSClass(
 			id,
 			runtime,
 			attributes,
@@ -227,7 +227,7 @@ class TestTreeDDSFactory implements IChannelFactory {
 	 * {@inheritDoc @fluidframework/datastore-definitions#IChannelFactory.create}
 	 */
 	public create(document: IFluidDataStoreRuntime, id: string): TestIncrementalSummaryTreeDDS {
-		return new TestIncrementalSummaryTreeDDS(id, document, this.attributes, "TestTreeDDS");
+		return new TestIncrementalSummaryTreeDDSClass(id, document, this.attributes, "TestTreeDDS");
 	}
 }
 
@@ -249,17 +249,16 @@ interface ICreateTreeNodeOp {
 	type: "treeOp";
 }
 
+const TestIncrementalSummaryTreeDDS = createSharedObjectKind(TestTreeDDSFactory);
+export type TestIncrementalSummaryTreeDDS = TestIncrementalSummaryTreeDDSClass;
+
 // Creates trees that can be incrementally summarized
 // Each op creates a new child node for any node in the tree.
 // The data of the tree is stored in the node's header blob
 // Any node and its subsequent children that do not change are summarized as a summary handle
 // This tree is written in a simple recursive structure.
 // The test below should indicate how the DDS can be used.
-class TestIncrementalSummaryTreeDDS extends SharedObject {
-	static getFactory(): IChannelFactory {
-		return new TestTreeDDSFactory();
-	}
-
+class TestIncrementalSummaryTreeDDSClass extends SharedObject {
 	public readonly rootNodeName = "rootNode";
 	private readonly root: ITreeNode = {
 		children: [],

--- a/packages/test/test-version-utils/api-report/test-version-utils.api.md
+++ b/packages/test/test-version-utils/api-report/test-version-utils.api.md
@@ -90,7 +90,7 @@ export const DataRuntimeApi: {
         SharedMap: ISharedObjectKind<map.ISharedMap>;
         SharedMatrix: ISharedObjectKind<matrix.ISharedMatrix<any>>;
         ConsensusQueue: typeof orderedCollection.ConsensusQueue;
-        ConsensusRegisterCollection: typeof registerCollection.ConsensusRegisterCollection;
+        ConsensusRegisterCollection: ISharedObjectKind<registerCollection.IConsensusRegisterCollection<any>>;
         SharedString: ISharedObjectKind<sequence.ISharedString>;
         SparseMatrix: typeof sequenceDeprecated.SparseMatrix;
     };


### PR DESCRIPTION
## Description

Update more shared objects to new factory pattern.

## Breaking Changes

None of the impacted code is public, and the API should remain mostly the same, but some code creating internal and alpha shared objects might need minor adjustment to use the interfaces and SharedObjectKind instead of the concrete class and factories.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

