### PR TITLE
tree: Remove internal export of SharedTreeFactory

### DIFF
--- a/examples/benchmarks/bubblebench/shared-tree-flex-tree/src/bubblebench.ts
+++ b/examples/benchmarks/bubblebench/shared-tree-flex-tree/src/bubblebench.ts
@@ -9,7 +9,7 @@ import {
 	AllowedUpdateType,
 	FlexTreeView,
 	ISharedTree,
-	SharedTreeFactory,
+	SharedTree,
 	fail,
 } from "@fluidframework/tree/internal";
 
@@ -31,7 +31,7 @@ export class Bubblebench extends DataObject {
 	protected async initializingFirstTime() {
 		const tree = this.runtime.createChannel(
 			/* id: */ undefined,
-			new SharedTreeFactory().type,
+			SharedTree.getFactory().type,
 		) as ISharedTree;
 
 		this.initializeTree(tree);
@@ -114,6 +114,6 @@ export class Bubblebench extends DataObject {
 export const BubblebenchInstantiationFactory = new DataObjectFactory(
 	Bubblebench.Name,
 	Bubblebench,
-	[new SharedTreeFactory()], // This is fine for now  but we will have to adjust this API later to allow control of write format
+	[SharedTree.getFactory()], // This is fine for now  but we will have to adjust this API later to allow control of write format
 	{},
 );

--- a/examples/benchmarks/bubblebench/shared-tree/src/bubblebench.ts
+++ b/examples/benchmarks/bubblebench/shared-tree/src/bubblebench.ts
@@ -5,16 +5,13 @@
 
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/internal";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
-import { ISharedTree, SharedTreeFactory, type TreeView, fail } from "@fluidframework/tree/internal";
+import { ISharedTree, SharedTree, type TreeView, fail } from "@fluidframework/tree/internal";
 import { AppState } from "./appState.js";
 import { type App, appTreeConfiguration } from "./schema.js";
 
 // Key used to store/retrieve the SharedTree instance within the root SharedMap.
 const treeKey = "treeKey";
 
-/**
- * @internal
- */
 export class Bubblebench extends DataObject {
 	public static readonly Name = "@fluid-example/bubblebench-simpletree";
 
@@ -24,7 +21,7 @@ export class Bubblebench extends DataObject {
 	protected async initializingFirstTime() {
 		const tree = this.runtime.createChannel(
 			/* id: */ undefined,
-			new SharedTreeFactory().type,
+			SharedTree.getFactory().type,
 		) as ISharedTree;
 
 		this.initializeTree(tree);
@@ -97,6 +94,6 @@ export class Bubblebench extends DataObject {
 export const BubblebenchInstantiationFactory = new DataObjectFactory(
 	Bubblebench.Name,
 	Bubblebench,
-	[new SharedTreeFactory()], // This is fine for now  but we will have to adjust this API later to allow control of write format
+	[SharedTree.getFactory()], // This is fine for now  but we will have to adjust this API later to allow control of write format
 	{},
 );

--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -7,10 +7,6 @@
 import { ErasedType } from '@fluidframework/core-interfaces';
 import { FluidObject } from '@fluidframework/core-interfaces';
 import { IChannel } from '@fluidframework/datastore-definitions';
-import { IChannelAttributes } from '@fluidframework/datastore-definitions';
-import { IChannelFactory } from '@fluidframework/datastore-definitions';
-import { IChannelServices } from '@fluidframework/datastore-definitions';
-import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { ISharedObject } from '@fluidframework/shared-object-base';
@@ -1704,19 +1700,6 @@ export interface SharedTreeContentSnapshot {
     readonly removed: [string | number | undefined, number, JsonableTree][];
     readonly schema: TreeStoredSchema;
     readonly tree: JsonableTree[];
-}
-
-// @internal
-export class SharedTreeFactory implements IChannelFactory<ISharedTree> {
-    constructor(options?: SharedTreeOptions);
-    // (undocumented)
-    readonly attributes: IChannelAttributes;
-    // (undocumented)
-    create(runtime: IFluidDataStoreRuntime, id: string): ISharedTree;
-    // (undocumented)
-    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, channelAttributes: Readonly<IChannelAttributes>): Promise<ISharedTree>;
-    // (undocumented)
-    readonly type: string;
 }
 
 // @internal

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -240,7 +240,6 @@ export {
 	ITreeCheckout,
 	ITransaction,
 	runSynchronous,
-	SharedTreeFactory,
 	SharedTreeOptions,
 	ITreeCheckoutFork,
 	CheckoutEvents,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -407,7 +407,6 @@ export const defaultSharedTreeOptions: Required<SharedTreeOptions> = {
 
 /**
  * A channel factory that creates {@link ISharedTree}s.
- * @internal
  */
 export class SharedTreeFactory implements IChannelFactory<ISharedTree> {
 	public readonly type: string = "https://graph.microsoft.com/types/tree";

--- a/packages/service-clients/azure-client/api-report/azure-client.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.api.md
@@ -68,7 +68,7 @@ export interface AzureContainerVersion {
 
 // @internal @deprecated
 export class AzureFunctionTokenProvider implements ITokenProvider {
-    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "name" | "id" | "additionalDetails"> | undefined);
+    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "id" | "name" | "additionalDetails"> | undefined);
     // (undocumented)
     fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)

--- a/packages/service-clients/azure-client/api-report/azure-client.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.api.md
@@ -68,7 +68,7 @@ export interface AzureContainerVersion {
 
 // @internal @deprecated
 export class AzureFunctionTokenProvider implements ITokenProvider {
-    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "id" | "name" | "additionalDetails"> | undefined);
+    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "name" | "id" | "additionalDetails"> | undefined);
     // (undocumented)
     fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -58,7 +58,7 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 import { SchemaFactory, TreeConfiguration } from "@fluidframework/tree";
-import { ISharedTree, SharedTreeFactory } from "@fluidframework/tree/internal";
+import { ISharedTree, SharedTree } from "@fluidframework/tree/internal";
 
 import { wrapObjectAndOverride } from "../mocking.js";
 
@@ -99,7 +99,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 		[cellId, SharedCell.getFactory()],
 		[counterId, SharedCounter.getFactory()],
 		[directoryId, SharedDirectory.getFactory()],
-		[treeId, new SharedTreeFactory()],
+		[treeId, SharedTree.getFactory()],
 	];
 
 	const testContainerConfig: ITestContainerConfig = {


### PR DESCRIPTION
## Description

Remove internal SharedTreeFactory export. Everything needed from it can be done via SharedTree.getFactory() or configuredSharedTree(...).getFactory.

## Breaking Changes

Users of the internal SharedTreeFactory should migrate to the public SharedTree.getFactory() or internal configuredSharedTree(...).getFactory.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

