### PR TITLE
Remove unnecessary parameter from `treeStatusFromAnchorCache`

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -250,7 +250,7 @@ export abstract class LazyField<TKind extends FlexFieldKind, TTypes extends Flex
 
 		// As the "parentAnchor === undefined" case is handled above, parentAnchorNode should exist.
 		assert(parentAnchorNode !== undefined, 0x77e /* parentAnchorNode must exist. */);
-		return treeStatusFromAnchorCache(this.context.forest.anchors, parentAnchorNode);
+		return treeStatusFromAnchorCache(parentAnchorNode);
 	}
 
 	public getFieldPath(): FieldUpPath {

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -266,7 +266,7 @@ export abstract class LazyTreeNode<TSchema extends FlexTreeNodeSchema = FlexTree
 		if (this[isFreedSymbol]()) {
 			return TreeStatus.Deleted;
 		}
-		return treeStatusFromAnchorCache(this.context.forest.anchors, this.anchorNode);
+		return treeStatusFromAnchorCache(this.anchorNode);
 	}
 
 	public on<K extends keyof FlexTreeNodeEvents>(

--- a/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
@@ -5,7 +5,6 @@
 
 import {
 	AnchorNode,
-	AnchorSet,
 	DetachedField,
 	anchorSlot,
 	getDetachedFieldContainingPath,
@@ -32,22 +31,22 @@ export function treeStatusFromDetachedField(detachedField: DetachedField): TreeS
  * @param anchorNode - the {@link AnchorNode} to get the {@link TreeStatus} of.
  * @returns - the {@link TreeStatus} of the anchorNode provided.
  */
-export function treeStatusFromAnchorCache(anchors: AnchorSet, anchorNode: AnchorNode): TreeStatus {
+export function treeStatusFromAnchorCache(anchorNode: AnchorNode): TreeStatus {
 	const cache = anchorNode.slots.get(detachedFieldSlot);
+	const { generationNumber } = anchorNode.anchorSet;
 	if (cache === undefined) {
 		// If the cache is undefined, set the cache and return the treeStatus based on the detached field.
 		return treeStatusFromDetachedField(
-			getCachedUpdatedDetachedField(anchorNode, anchors.generationNumber),
+			getCachedUpdatedDetachedField(anchorNode, generationNumber),
 		);
 	} else {
 		// If the cache is up to date, return the treeStatus based on the cached detached field.
-		const currentGenerationNumber = anchors.generationNumber;
-		if (cache.generationNumber === currentGenerationNumber) {
+		if (cache.generationNumber === generationNumber) {
 			return treeStatusFromDetachedField(cache.detachedField);
 		}
 		// If the cache is not up to date, update the cache and return the treeStatus based on the updated detached field.
 		return treeStatusFromDetachedField(
-			getCachedUpdatedDetachedField(anchorNode, currentGenerationNumber),
+			getCachedUpdatedDetachedField(anchorNode, generationNumber),
 		);
 	}
 }

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/utilities.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/utilities.spec.ts
@@ -30,7 +30,7 @@ describe("flex-tree utilities", () => {
 			assert(anchorNode0 !== undefined);
 
 			// Checks that treeStatusFromAnchorCache returns the correct TreeStatus.
-			assert(treeStatusFromAnchorCache(anchors, anchorNode0) === TreeStatus.InDocument);
+			assert(treeStatusFromAnchorCache(anchorNode0) === TreeStatus.InDocument);
 		});
 
 		it("non-root detachedField returns TreeStatus.Removed", () => {
@@ -46,7 +46,7 @@ describe("flex-tree utilities", () => {
 			assert(anchorNode0 !== undefined);
 
 			// Checks that treeStatusFromAnchorCache returns the correct TreeStatus.
-			assert(treeStatusFromAnchorCache(anchors, anchorNode0) === TreeStatus.Removed);
+			assert(treeStatusFromAnchorCache(anchorNode0) === TreeStatus.Removed);
 		});
 
 		it("uses cached field only when cache is not stale", () => {
@@ -61,7 +61,7 @@ describe("flex-tree utilities", () => {
 			assert(anchorNode0 !== undefined);
 
 			// Checks that treeStatus is TreeStatus.InDocument
-			assert(treeStatusFromAnchorCache(anchors, anchorNode0) === TreeStatus.InDocument);
+			assert(treeStatusFromAnchorCache(anchorNode0) === TreeStatus.InDocument);
 
 			// Manually set cache to a non-root detachedField to check if it's being used.
 			const testFieldKey: FieldKey = brand("testFieldKey");
@@ -69,12 +69,12 @@ describe("flex-tree utilities", () => {
 				generationNumber: 0,
 				detachedField: keyAsDetachedField(testFieldKey),
 			});
-			assert(treeStatusFromAnchorCache(anchors, anchorNode0) === TreeStatus.Removed);
+			assert(treeStatusFromAnchorCache(anchorNode0) === TreeStatus.Removed);
 
 			// Applies a dummy delta to increment anchorSet generationNumber.
 			applyTestDelta(new Map([]), anchors);
 			// Checks that the treeStatus is no longer being read from stale cache.
-			assert(treeStatusFromAnchorCache(anchors, anchorNode0) === TreeStatus.InDocument);
+			assert(treeStatusFromAnchorCache(anchorNode0) === TreeStatus.InDocument);
 		});
 
 		it("correctly sets and updates cache", () => {
@@ -97,7 +97,7 @@ describe("flex-tree utilities", () => {
 			};
 
 			// Checks that the cache is updated to the expected value after calling treeStatusFromAnchorCache.
-			treeStatusFromAnchorCache(anchors, anchorNode0);
+			treeStatusFromAnchorCache(anchorNode0);
 			assert.deepEqual(anchorNode0.slots.get(detachedFieldSlot), expectedCache);
 
 			// Applies a dummy delta to increment anchorSet generationNumber.
@@ -114,7 +114,7 @@ describe("flex-tree utilities", () => {
 				detachedField: keyAsDetachedField(rootFieldKey),
 			};
 			// Calls treeStatusFromAnchorCache and checks if cache is updated.
-			treeStatusFromAnchorCache(anchors, anchorNode0);
+			treeStatusFromAnchorCache(anchorNode0);
 			assert.deepEqual(anchorNode0.slots.get(detachedFieldSlot), expectedUpdatedCache);
 		});
 	});


### PR DESCRIPTION
Now that the `AnchorSet` can be retrieved via an `AnchorNode`, there is no need to pass in both arguments to `treeStatusFromAnchorCache`.