### PR TITLE
feat(build-tools): add --watch support to fluid-tsc

### DIFF
--- a/build-tools/packages/build-tools/src/common/tsCompile.ts
+++ b/build-tools/packages/build-tools/src/common/tsCompile.ts
@@ -18,7 +18,7 @@ interface TsCompileOptions {
 	 */
 	cwd: string;
 	/**
-	 * When specified local package.json will be interpretted as
+	 * When specified, local package.json will be interpreted as
 	 * having "types" property set to this value.
 	 */
 	packageJsonTypeOverride?: "commonjs" | "module";
@@ -70,7 +70,7 @@ export function tsCompile(
 
 	let code = ts.ExitStatus.DiagnosticsPresent_OutputsSkipped;
 	if (commandLine && diagnostics.length === 0) {
-		// When specified overrides current directory's package.json type field so tsc may cleanly
+		// When specified, overrides current directory's package.json type field so tsc may cleanly
 		// transpile .ts files to CommonJS or ESM using compilerOptions.module Node16 or NodeNext.
 		let packageJsonTypeOverrideUsage = "not read" as "not read" | "already present" | "used";
 		const applyPackageJsonTypeOverride = !packageJsonTypeOverride
@@ -80,10 +80,10 @@ export function tsCompile(
 						| tsTypes.CompilerHost
 						| tsTypes.WatchCompilerHostOfConfigFile<tsTypes.EmitAndSemanticDiagnosticsBuilderProgram>,
 				): void => {
-					const origReadFile = host.readFile;
+					const originalReadFile = host.readFile;
 					const packageJsonPath = normalizeSlashes(path.join(cwd, "package.json"));
 					host.readFile = (fileName: string) => {
-						const rawFile = origReadFile(fileName);
+						const rawFile = originalReadFile(fileName);
 						if (fileName === packageJsonPath && rawFile !== undefined) {
 							// Reading local package.json: override type field
 							const packageJson = JSON.parse(rawFile);

--- a/build-tools/packages/build-tools/src/common/tsCompile.ts
+++ b/build-tools/packages/build-tools/src/common/tsCompile.ts
@@ -8,27 +8,57 @@ import type * as tsTypes from "typescript";
 import { defaultLogger } from "./logging.js";
 import { getTscUtils, normalizeSlashes } from "./tscUtils.js";
 
-export function tsCompile({
-	command,
-	cwd,
-	packageJsonTypeOverride,
-}: {
+interface TsCompileOptions {
+	/**
+	 * Complete tsc command line
+	 */
 	command: string;
+	/**
+	 * Working directory
+	 */
 	cwd: string;
+	/**
+	 * When specified local package.json will be interpretted as
+	 * having "types" property set to this value.
+	 */
 	packageJsonTypeOverride?: "commonjs" | "module";
-}): number {
+}
+
+/**
+ * Executes given tsc command line.
+ * If command line includes `--watch`, an error will be thrown.
+ *
+ * @param options - {@link TsCompileOptions}
+ * @returns numeric exit code
+ */
+export function tsCompile(options: TsCompileOptions): number;
+/**
+ * Executes given tsc command line that may include `--watch`.
+ *
+ * @param options - {@link TsCompileOptions}
+ * @returns numeric exit code when completing immediately or undefined when watch has started
+ */
+export function tsCompile(
+	options: TsCompileOptions,
+	allowWatch: "allow-watch",
+): number | undefined;
+export function tsCompile(
+	{ command, cwd, packageJsonTypeOverride }: TsCompileOptions,
+	allowWatch?: "allow-watch",
+): number | undefined {
 	// Load the typescript version that is in the cwd scope
 	const tscUtils = getTscUtils(cwd);
 
 	const ts = tscUtils.tsLib;
 	let commandLine = tscUtils.parseCommandLine(command);
+	let configFileName: string | undefined;
+	const currentDirectorySystem = { ...ts.sys, getCurrentDirectory: () => cwd };
 	const diagnostics: tsTypes.Diagnostic[] = [];
 	if (commandLine) {
-		const configFileName = tscUtils.findConfigFile(cwd, commandLine);
+		configFileName = tscUtils.findConfigFile(cwd, commandLine);
 		if (configFileName) {
 			commandLine = ts.getParsedCommandLineOfConfigFile(configFileName, commandLine.options, {
-				...ts.sys,
-				getCurrentDirectory: () => cwd,
+				...currentDirectorySystem,
 				onUnRecoverableConfigFileDiagnostic: (diagnostic: tsTypes.Diagnostic) => {
 					diagnostics.push(diagnostic);
 				},
@@ -40,31 +70,60 @@ export function tsCompile({
 
 	let code = ts.ExitStatus.DiagnosticsPresent_OutputsSkipped;
 	if (commandLine && diagnostics.length === 0) {
+		// When specified overrides current directory's package.json type field so tsc may cleanly
+		// transpile .ts files to CommonJS or ESM using compilerOptions.module Node16 or NodeNext.
+		let packageJsonTypeOverrideUsage = "not read" as "not read" | "already present" | "used";
+		const applyPackageJsonTypeOverride = !packageJsonTypeOverride
+			? undefined
+			: (
+					host:
+						| tsTypes.CompilerHost
+						| tsTypes.WatchCompilerHostOfConfigFile<tsTypes.EmitAndSemanticDiagnosticsBuilderProgram>,
+				): void => {
+					const origReadFile = host.readFile;
+					const packageJsonPath = normalizeSlashes(path.join(cwd, "package.json"));
+					host.readFile = (fileName: string) => {
+						const rawFile = origReadFile(fileName);
+						if (fileName === packageJsonPath && rawFile !== undefined) {
+							// Reading local package.json: override type field
+							const packageJson = JSON.parse(rawFile);
+							packageJsonTypeOverrideUsage =
+								(packageJson.type ?? "commonjs") !== packageJsonTypeOverride
+									? "used"
+									: "already present";
+							return JSON.stringify({ ...packageJson, type: packageJsonTypeOverride });
+						}
+						return rawFile;
+					};
+				};
+
+		if (commandLine.options.watch) {
+			if (allowWatch !== "allow-watch") {
+				throw new Error(
+					'--watch option requested from command line, but "allow-watch" not specified.',
+				);
+			}
+			if (!configFileName) {
+				throw new Error("A config file is required when --watch option is specified.");
+			}
+
+			const host = ts.createWatchCompilerHost(
+				configFileName,
+				commandLine.options,
+				currentDirectorySystem,
+				ts.createEmitAndSemanticDiagnosticsBuilderProgram,
+			);
+			applyPackageJsonTypeOverride?.(host);
+			ts.createWatchProgram(host);
+			return undefined;
+		}
+
 		const incremental = !!(commandLine.options.incremental || commandLine.options.composite);
 
 		const host = incremental
 			? ts.createIncrementalCompilerHost(commandLine.options)
 			: ts.createCompilerHost(commandLine.options);
-		// When specified overrides current directory's package.json type field so tsc may cleanly
-		// transpile .ts files to CommonJS or ESM using compilerOptions.module Node16 or NodeNext.
-		let packageJsonTypeOverrideUsage = "not read" as "not read" | "already present" | "used";
-		if (packageJsonTypeOverride) {
-			const origReadFile = host.readFile;
-			const packageJsonPath = normalizeSlashes(path.join(cwd, "package.json"));
-			host.readFile = (fileName: string) => {
-				const rawFile = origReadFile(fileName);
-				if (fileName === packageJsonPath && rawFile !== undefined) {
-					// Reading local package.json: override type field
-					const packageJson = JSON.parse(rawFile);
-					packageJsonTypeOverrideUsage =
-						(packageJson.type ?? "commonjs") !== packageJsonTypeOverride
-							? "used"
-							: "already present";
-					return JSON.stringify({ ...packageJson, type: packageJsonTypeOverride });
-				}
-				return rawFile;
-			};
-		}
+		applyPackageJsonTypeOverride?.(host);
 
 		const param = {
 			rootNames: commandLine.fileNames,

--- a/build-tools/packages/build-tools/src/fluidTsc/fluidTsc.ts
+++ b/build-tools/packages/build-tools/src/fluidTsc/fluidTsc.ts
@@ -39,7 +39,14 @@ async function main() {
 	}
 
 	const command = `tsc ${process.argv.slice(3).join(" ")}`;
-	process.exit(tsCompile({ command, cwd: process.cwd(), packageJsonTypeOverride: firstArg }));
+	const result = tsCompile(
+		{ command, cwd: process.cwd(), packageJsonTypeOverride: firstArg },
+		"allow-watch",
+	);
+	// In watch mode, there is no result code and the process must be left to continue running.
+	if (result !== undefined) {
+		process.exit(result);
+	}
 }
 
 main().catch((e) => {


### PR DESCRIPTION
some client packages already use it, but --watch has actually been ignored.

Support patterned after https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#writing-an-incremental-program-watcher