### PR TITLE
NOT TO MERGE: Binary signal payload prototype

### DIFF
--- a/examples/apps/presence-tracker/src/FocusTracker.ts
+++ b/examples/apps/presence-tracker/src/FocusTracker.ts
@@ -70,8 +70,8 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
 		});
 		this.signaler.onSignal(
 			FocusTracker.focusSignalType,
-			(clientId: string, local: boolean, payload: unknown) => {
-				this.onFocusSignalFn(clientId, payload as IFocusSignalPayload);
+			(clientId: string, local: boolean, payload: IFocusSignalPayload) => {
+				this.onFocusSignalFn(clientId, payload);
 			},
 		);
 

--- a/examples/apps/presence-tracker/src/FocusTracker.ts
+++ b/examples/apps/presence-tracker/src/FocusTracker.ts
@@ -70,8 +70,8 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
 		});
 		this.signaler.onSignal(
 			FocusTracker.focusSignalType,
-			(clientId: string, local: boolean, payload: IFocusSignalPayload) => {
-				this.onFocusSignalFn(clientId, payload);
+			(clientId: string, local: boolean, payload: unknown) => {
+				this.onFocusSignalFn(clientId, payload as IFocusSignalPayload);
 			},
 		);
 

--- a/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
+++ b/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import {
 	MockContainerRuntimeFactory,
 	MockFluidDataStoreRuntime,

--- a/experimental/dds/sequence-deprecated/api-report/sequence-deprecated.api.md
+++ b/experimental/dds/sequence-deprecated/api-report/sequence-deprecated.api.md
@@ -9,12 +9,12 @@ import { IChannelAttributes } from '@fluidframework/datastore-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IChannelServices } from '@fluidframework/datastore-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
-import { IFluidHandle } from '@fluidframework/core-interfaces';
+import { IFluidHandle } from '@fluidframework/core-interfaces/internal';
 import { IJSONRunSegment } from '@fluidframework/sequence/internal';
 import { IJSONSegment } from '@fluidframework/merge-tree/internal';
 import { ISegment } from '@fluidframework/merge-tree/internal';
 import { ISharedObject } from '@fluidframework/shared-object-base';
-import { Jsonable } from '@fluidframework/datastore-definitions/internal';
+import { Jsonable } from '@fluidframework/core-interfaces/internal';
 import { PropertySet } from '@fluidframework/merge-tree/internal';
 import { Serializable } from '@fluidframework/datastore-definitions/internal';
 import { SharedSegmentSequence } from '@fluidframework/sequence/internal';
@@ -182,7 +182,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
     static getFactory(): IChannelFactory;
     // (undocumented)
     getItem(row: number, col: number): // The return type is defined explicitly here to prevent TypeScript from generating dynamic imports
-    Jsonable<string | number | boolean | IFluidHandle> | undefined;
+    Jsonable<unknown, IFluidHandle> | undefined;
     // (undocumented)
     getPositionProperties(row: number, col: number): PropertySet | undefined;
     // (undocumented)

--- a/experimental/dds/sequence-deprecated/src/sparsematrix.ts
+++ b/experimental/dds/sequence-deprecated/src/sparsematrix.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { IFluidHandle, Jsonable } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import {
 	IChannelAttributes,
@@ -11,7 +11,6 @@ import {
 	IChannelServices,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
 import {
 	BaseSegment,
 	IJSONSegment,
@@ -294,7 +293,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
 		row: number,
 		col: number,
 	): // The return type is defined explicitly here to prevent TypeScript from generating dynamic imports
-	Jsonable<string | number | boolean | IFluidHandle> | undefined {
+	Jsonable<unknown, IFluidHandle> | undefined {
 		const pos = rowColToPosition(row, col);
 		const { segment, offset } = this.getContainingSegment(pos);
 		if (segment && RunSegment.is(segment)) {

--- a/experimental/framework/data-objects/api-report/data-objects.api.md
+++ b/experimental/framework/data-objects/api-report/data-objects.api.md
@@ -9,7 +9,7 @@ import { DataObjectFactory } from '@fluidframework/aqueduct/internal';
 import { EventEmitter } from '@fluid-internal/client-utils';
 import { IErrorEvent } from '@fluidframework/core-interfaces';
 import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
-import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
+import type { SignalContentType } from '@fluidframework/core-interfaces/internal';
 
 // @internal
 export interface IRuntimeSignaler {
@@ -18,14 +18,14 @@ export interface IRuntimeSignaler {
     // (undocumented)
     on(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): any;
     // (undocumented)
-    submitSignal(type: string, content: JsonableOrBinary): void;
+    submitSignal(type: string, content: SignalContentType): void;
 }
 
 // @internal
 export interface ISignaler {
     offSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
     onSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
-    submitSignal<T>(signalName: string, payload?: JsonableOrBinary<T>): any;
+    submitSignal<T>(signalName: string, payload?: SignalContentType<T>): any;
 }
 
 // @internal
@@ -45,11 +45,11 @@ export class Signaler extends DataObject<{
     // (undocumented)
     onSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
     // (undocumented)
-    submitSignal<T>(signalName: string, payload?: JsonableOrBinary<T>): void;
+    submitSignal<T>(signalName: string, payload?: SignalContentType<T>): void;
 }
 
 // @internal (undocumented)
-export type SignalListener<T> = (clientId: string, local: boolean, payload: JsonableOrBinary<T>) => void;
+export type SignalListener<T> = (clientId: string, local: boolean, payload: SignalContentType<T>) => void;
 
 // (No @packageDocumentation comment for this package)
 

--- a/experimental/framework/data-objects/api-report/data-objects.api.md
+++ b/experimental/framework/data-objects/api-report/data-objects.api.md
@@ -9,7 +9,7 @@ import { DataObjectFactory } from '@fluidframework/aqueduct/internal';
 import { EventEmitter } from '@fluid-internal/client-utils';
 import { IErrorEvent } from '@fluidframework/core-interfaces';
 import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
-import { Jsonable } from '@fluidframework/datastore-definitions/internal';
+import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
 
 // @internal
 export interface IRuntimeSignaler {
@@ -18,14 +18,14 @@ export interface IRuntimeSignaler {
     // (undocumented)
     on(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): any;
     // (undocumented)
-    submitSignal(type: string, content: Jsonable<unknown>): void;
+    submitSignal(type: string, content: JsonableOrBinary): void;
 }
 
 // @internal
 export interface ISignaler {
     offSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
     onSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
-    submitSignal<T>(signalName: string, payload?: Jsonable<T>): any;
+    submitSignal<T>(signalName: string, payload?: JsonableOrBinary<T>): any;
 }
 
 // @internal
@@ -45,11 +45,11 @@ export class Signaler extends DataObject<{
     // (undocumented)
     onSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
     // (undocumented)
-    submitSignal<T>(signalName: string, payload?: Jsonable<T>): void;
+    submitSignal<T>(signalName: string, payload?: JsonableOrBinary<T>): void;
 }
 
 // @internal (undocumented)
-export type SignalListener<T> = (clientId: string, local: boolean, payload: Jsonable<T>) => void;
+export type SignalListener<T> = (clientId: string, local: boolean, payload: JsonableOrBinary<T>) => void;
 
 // (No @packageDocumentation comment for this package)
 

--- a/experimental/framework/data-objects/src/signaler/signaler.ts
+++ b/experimental/framework/data-objects/src/signaler/signaler.ts
@@ -7,7 +7,7 @@ import { EventEmitter, TypedEventEmitter } from "@fluid-internal/client-utils";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/internal";
 import { IErrorEvent } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import type { JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
+import type { SignalContentType } from "@fluidframework/core-interfaces/internal";
 import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 
 // TODO:
@@ -20,7 +20,7 @@ import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 export type SignalListener<T> = (
 	clientId: string,
 	local: boolean,
-	payload: JsonableOrBinary<T>,
+	payload: SignalContentType<T>,
 ) => void;
 
 /**
@@ -51,7 +51,7 @@ export interface ISignaler {
 	 * @param signalName - The name of the signal
 	 * @param payload - The data to send with the signal
 	 */
-	submitSignal<T>(signalName: string, payload?: JsonableOrBinary<T>);
+	submitSignal<T>(signalName: string, payload?: SignalContentType<T>);
 }
 
 /**
@@ -62,7 +62,7 @@ export interface ISignaler {
 export interface IRuntimeSignaler {
 	connected: boolean;
 	on(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void);
-	submitSignal(type: string, content: JsonableOrBinary): void;
+	submitSignal(type: string, content: SignalContentType): void;
 }
 
 /**
@@ -125,7 +125,7 @@ class InternalSignaler extends TypedEventEmitter<IErrorEvent> implements ISignal
 		return this;
 	}
 
-	public submitSignal<T>(signalName: string, payload?: JsonableOrBinary<T>) {
+	public submitSignal<T>(signalName: string, payload?: SignalContentType<T>) {
 		const signalerSignalName = this.getSignalerSignalName(signalName);
 		if (this.signaler.connected) {
 			this.signaler.submitSignal(signalerSignalName, payload);
@@ -171,7 +171,7 @@ export class Signaler
 		return this;
 	}
 
-	public submitSignal<T>(signalName: string, payload?: JsonableOrBinary<T>) {
+	public submitSignal<T>(signalName: string, payload?: SignalContentType<T>) {
 		this.signaler.submitSignal(signalName, payload);
 	}
 }

--- a/experimental/framework/data-objects/src/signaler/signaler.ts
+++ b/experimental/framework/data-objects/src/signaler/signaler.ts
@@ -7,7 +7,7 @@ import { EventEmitter, TypedEventEmitter } from "@fluid-internal/client-utils";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/internal";
 import { IErrorEvent } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
+import type { JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
 import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 
 // TODO:
@@ -17,7 +17,11 @@ import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 /**
  * @internal
  */
-export type SignalListener<T> = (clientId: string, local: boolean, payload: Jsonable<T>) => void;
+export type SignalListener<T> = (
+	clientId: string,
+	local: boolean,
+	payload: JsonableOrBinary<T>,
+) => void;
 
 /**
  * ISignaler defines an interface for working with signals that is similar to the more common
@@ -47,7 +51,7 @@ export interface ISignaler {
 	 * @param signalName - The name of the signal
 	 * @param payload - The data to send with the signal
 	 */
-	submitSignal<T>(signalName: string, payload?: Jsonable<T>);
+	submitSignal<T>(signalName: string, payload?: JsonableOrBinary<T>);
 }
 
 /**
@@ -58,7 +62,7 @@ export interface ISignaler {
 export interface IRuntimeSignaler {
 	connected: boolean;
 	on(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void);
-	submitSignal(type: string, content: Jsonable<unknown>): void;
+	submitSignal(type: string, content: JsonableOrBinary): void;
 }
 
 /**
@@ -121,7 +125,7 @@ class InternalSignaler extends TypedEventEmitter<IErrorEvent> implements ISignal
 		return this;
 	}
 
-	public submitSignal<T>(signalName: string, payload?: Jsonable<T>) {
+	public submitSignal<T>(signalName: string, payload?: JsonableOrBinary<T>) {
 		const signalerSignalName = this.getSignalerSignalName(signalName);
 		if (this.signaler.connected) {
 			this.signaler.submitSignal(signalerSignalName, payload);
@@ -167,7 +171,7 @@ export class Signaler
 		return this;
 	}
 
-	public submitSignal<T>(signalName: string, payload?: Jsonable<T>) {
+	public submitSignal<T>(signalName: string, payload?: JsonableOrBinary<T>) {
 		this.signaler.submitSignal(signalName, payload);
 	}
 }

--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -33,6 +33,7 @@ import { IThrottlingWarning } from '@fluidframework/core-interfaces/internal';
 import type { ITokenClaims } from '@fluidframework/protocol-definitions';
 import { IUsageError } from '@fluidframework/core-interfaces/internal';
 import type { IVersion } from '@fluidframework/protocol-definitions';
+import type { JsonableOrBinary } from '@fluidframework/core-interfaces';
 import type { MessageType } from '@fluidframework/protocol-definitions';
 
 // @public
@@ -188,7 +189,7 @@ export interface IContainerContext {
     // @deprecated (undocumented)
     readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData?: any) => number;
     // (undocumented)
-    readonly submitSignalFn: (contents: unknown, targetClientId?: string) => void;
+    readonly submitSignalFn: (contents: JsonableOrBinary, targetClientId?: string) => void;
     // (undocumented)
     readonly submitSummaryFn: (summaryOp: ISummaryContent, referenceSequenceNumber?: number) => number;
     // (undocumented)

--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -33,8 +33,8 @@ import { IThrottlingWarning } from '@fluidframework/core-interfaces/internal';
 import type { ITokenClaims } from '@fluidframework/protocol-definitions';
 import { IUsageError } from '@fluidframework/core-interfaces/internal';
 import type { IVersion } from '@fluidframework/protocol-definitions';
-import type { JsonableOrBinary } from '@fluidframework/core-interfaces';
 import type { MessageType } from '@fluidframework/protocol-definitions';
+import type { SignalContentType } from '@fluidframework/core-interfaces';
 
 // @public
 export enum AttachState {
@@ -189,7 +189,7 @@ export interface IContainerContext {
     // @deprecated (undocumented)
     readonly submitFn: (type: MessageType, contents: any, batch: boolean, appData?: any) => number;
     // (undocumented)
-    readonly submitSignalFn: (contents: JsonableOrBinary, targetClientId?: string) => void;
+    readonly submitSignalFn: (contents: SignalContentType, targetClientId?: string) => void;
     // (undocumented)
     readonly submitSummaryFn: (summaryOp: ISummaryContent, referenceSequenceNumber?: number) => number;
     // (undocumented)

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -7,6 +7,7 @@ import type {
 	FluidObject,
 	IDisposable,
 	ITelemetryBaseLogger,
+	JsonableOrBinary,
 } from "@fluidframework/core-interfaces";
 import type {
 	IDocumentStorageService,
@@ -126,9 +127,6 @@ export interface IBatchMessage {
  * IContainerContext is fundamentally just the set of things that an IRuntimeFactory (and IRuntime) will consume from the
  * loader layer.  It gets passed into the IRuntimeFactory.instantiateRuntime call.  Only include members on this interface
  * if you intend them to be consumed/called from the runtime layer.
- *
- * TODO: once `@alpha` tag is removed, `unknown` should be removed from submitSignalFn
- * @see {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/7462}
  * @alpha
  */
 export interface IContainerContext {
@@ -158,7 +156,7 @@ export interface IContainerContext {
 		summaryOp: ISummaryContent,
 		referenceSequenceNumber?: number,
 	) => number;
-	readonly submitSignalFn: (contents: unknown, targetClientId?: string) => void;
+	readonly submitSignalFn: (contents: JsonableOrBinary, targetClientId?: string) => void;
 	readonly disposeFn?: (error?: ICriticalContainerError) => void;
 	readonly closeFn: (error?: ICriticalContainerError) => void;
 	readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -7,7 +7,7 @@ import type {
 	FluidObject,
 	IDisposable,
 	ITelemetryBaseLogger,
-	JsonableOrBinary,
+	SignalContentType,
 } from "@fluidframework/core-interfaces";
 import type {
 	IDocumentStorageService,
@@ -156,7 +156,7 @@ export interface IContainerContext {
 		summaryOp: ISummaryContent,
 		referenceSequenceNumber?: number,
 	) => number;
-	readonly submitSignalFn: (contents: JsonableOrBinary, targetClientId?: string) => void;
+	readonly submitSignalFn: (contents: SignalContentType, targetClientId?: string) => void;
 	readonly disposeFn?: (error?: ICriticalContainerError) => void;
 	readonly closeFn: (error?: ICriticalContainerError) => void;
 	readonly deltaManager: IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -362,7 +362,7 @@ export type ISignalEnvelope = {
     clientSignalSequenceNumber: number;
     contents: {
         type: string;
-        content: JsonableOrBinary;
+        content: SignalContentType;
     };
 };
 
@@ -424,6 +424,9 @@ export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
 export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> = L extends any[] ? {
     [K in keyof L]: L[K] extends IEventThisPlaceHolder ? TThis : L[K];
 } : L;
+
+// @public (undocumented)
+export type SignalContentType<T = unknown> = JsonableOrBinary<T>;
 
 // @public
 export interface Tagged<V, T extends string = string> {

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -297,6 +297,12 @@ export interface ILoggingError extends Error {
 }
 
 // @public (undocumented)
+export interface Internal_InterfaceOfJsonableTypesWith<T> {
+    // (undocumented)
+    [index: string | number]: JsonableTypeWith<T>;
+}
+
+// @public (undocumented)
 export interface IProvideFluidHandle {
     // (undocumented)
     readonly [IFluidHandle]: IFluidHandle;
@@ -351,14 +357,14 @@ export interface IResponse {
 }
 
 // @internal (undocumented)
-export interface ISignalEnvelope {
+export type ISignalEnvelope = {
     address?: string;
     clientSignalSequenceNumber: number;
     contents: {
         type: string;
-        content: any;
+        content: JsonableOrBinary;
     };
-}
+};
 
 // @public
 export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
@@ -392,6 +398,17 @@ export interface IThrottlingWarning extends IErrorBase {
 export interface IUsageError extends IErrorBase {
     readonly errorType: typeof FluidErrorTypes.usageError;
 }
+
+// @public
+export type Jsonable<T = unknown, TReplaced = never> = boolean extends (T extends never ? true : false) ? JsonableTypeWith<TReplaced> : unknown extends T ? JsonableTypeWith<TReplaced> : T extends undefined | null | boolean | number | string | TReplaced ? T : Extract<T, Function> extends never ? T extends object ? T extends (infer U)[] ? Jsonable<U, TReplaced>[] : {
+    [K in keyof T]: Extract<K, symbol> extends never ? Jsonable<T[K], TReplaced> : never;
+} : never : never;
+
+// @public (undocumented)
+export type JsonableOrBinary<T = unknown> = Jsonable<T, ArrayBuffer>;
+
+// @public
+export type JsonableTypeWith<T> = undefined | null | boolean | number | string | T | Internal_InterfaceOfJsonableTypesWith<T> | ArrayLike<JsonableTypeWith<T>>;
 
 // @public
 export const LogLevel: {

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -43,3 +43,9 @@ export type { FluidObjectProviderKeys, FluidObject, FluidObjectKeys } from "./pr
 export type { ConfigTypes, IConfigProviderBase } from "./config.js";
 export type { ISignalEnvelope } from "./messages.js";
 export type { ErasedType } from "./erasedType.js";
+export type {
+	Jsonable,
+	JsonableTypeWith,
+	Internal_InterfaceOfJsonableTypesWith,
+	JsonableOrBinary,
+} from "./jsonable.js";

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -41,7 +41,7 @@ export type {
 export { LogLevel } from "./logger.js";
 export type { FluidObjectProviderKeys, FluidObject, FluidObjectKeys } from "./provider.js";
 export type { ConfigTypes, IConfigProviderBase } from "./config.js";
-export type { ISignalEnvelope } from "./messages.js";
+export type { ISignalEnvelope, SignalContentType } from "./messages.js";
 export type { ErasedType } from "./erasedType.js";
 export type {
 	Jsonable,

--- a/packages/common/core-interfaces/src/jsonable.ts
+++ b/packages/common/core-interfaces/src/jsonable.ts
@@ -13,10 +13,11 @@
  *
  * @privateRemarks
  * Perfer using `Jsonable<unknown>` over this type that is an implementation detail.
- * @alpha
+ * @public
  */
 export type JsonableTypeWith<T> =
 	| undefined
+	// eslint-disable-next-line @rushstack/no-new-null
 	| null
 	| boolean
 	| number
@@ -34,7 +35,7 @@ export type JsonableTypeWith<T> =
  * This interface along with ArrayLike above avoids pure type recursion issues, but introduces a limitation on
  * the ability of {@link Jsonable} to detect array-like types that are not handled naively ({@link JSON.stringify}).
  * The TypeOnly filter is not useful for {@link JsonableTypeWith}; so, if type testing improves, this can be removed.
- * @alpha
+ * @public
  */
 export interface Internal_InterfaceOfJsonableTypesWith<T> {
 	[index: string | number]: JsonableTypeWith<T>;
@@ -78,9 +79,9 @@ export interface Internal_InterfaceOfJsonableTypesWith<T> {
  * ```typescript
  * function foo<T>(value: Jsonable<T>) { ... }
  * ```
- * @alpha
+ * @public
  */
-export type Jsonable<T, TReplaced = never> = /* test for 'any' */ boolean extends (
+export type Jsonable<T = unknown, TReplaced = never> = /* test for 'any' */ boolean extends (
 	T extends never ? true : false
 )
 	? /* 'any' => */ JsonableTypeWith<TReplaced>
@@ -88,6 +89,7 @@ export type Jsonable<T, TReplaced = never> = /* test for 'any' */ boolean extend
 	? /* 'unknown' => */ JsonableTypeWith<TReplaced>
 	: /* test for Jsonable primitive types */ T extends
 			| undefined /* is not serialized */
+			// eslint-disable-next-line @rushstack/no-new-null
 			| null
 			| boolean
 			| number
@@ -106,3 +108,8 @@ export type Jsonable<T, TReplaced = never> = /* test for 'any' */ boolean extend
 			  }
 		: /* not an object => */ never
 	: /* function => */ never;
+
+/**
+ * @public
+ */
+export type JsonableOrBinary<T = unknown> = Jsonable<T, ArrayBuffer>;

--- a/packages/common/core-interfaces/src/messages.ts
+++ b/packages/common/core-interfaces/src/messages.ts
@@ -6,6 +6,11 @@
 import type { JsonableOrBinary } from "./jsonable.js";
 
 /**
+ * @public
+ */
+export type SignalContentType<T = unknown> = JsonableOrBinary<T>;
+
+/**
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -25,6 +30,6 @@ export type ISignalEnvelope = {
 	 */
 	contents: {
 		type: string;
-		content: JsonableOrBinary;
+		content: SignalContentType;
 	};
 };

--- a/packages/common/core-interfaces/src/messages.ts
+++ b/packages/common/core-interfaces/src/messages.ts
@@ -3,10 +3,13 @@
  * Licensed under the MIT License.
  */
 
+import type { JsonableOrBinary } from "./jsonable.js";
+
 /**
  * @internal
  */
-export interface ISignalEnvelope {
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type ISignalEnvelope = {
 	/**
 	 * The target for the envelope, undefined for the container
 	 */
@@ -22,7 +25,6 @@ export interface ISignalEnvelope {
 	 */
 	contents: {
 		type: string;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		content: any;
+		content: JsonableOrBinary;
 	};
-}
+};

--- a/packages/common/core-interfaces/src/test/types/jsonable.ts
+++ b/packages/common/core-interfaces/src/test/types/jsonable.ts
@@ -7,6 +7,8 @@ import type { Jsonable } from "../../index.js";
 
 declare function foo<T>(jsonable: Jsonable<T>): void;
 
+/* eslint-disable unicorn/no-null, @typescript-eslint/no-explicit-any, @rushstack/no-new-null, @typescript-eslint/no-unsafe-argument */
+
 // --- ideally wouldn't work but do as we don't know how to just exclude classes
 
 // test simple class.
@@ -65,7 +67,7 @@ declare const json: Json;
 foo(json);
 
 // test "unknown" Jsonable content
-declare const unknownJsonable: Jsonable<unknown>;
+declare const unknownJsonable: Jsonable;
 foo(unknownJsonable);
 
 // test "unknown" cannonical Json content in an interface
@@ -176,7 +178,7 @@ foo(a14);
 
 // test class with function
 class bar {
-	public baz() {}
+	public baz(): void {}
 }
 // @ts-expect-error should not be jsonable
 foo(new bar());
@@ -226,7 +228,7 @@ foo(mayNotBeArray);
  * It is used below to bypass the early "Index signature for type 'string'" issue for interfaces.
  */
 type TypeAliasOf<T> = T extends object
-	? T extends () => any | null
+	? T extends () => any
 		? T
 		: { [K in keyof T]: TypeAliasOf<T[K]> }
 	: T;
@@ -307,7 +309,7 @@ foo<unknown>(selfReferencing as Jsonable<typeof selfReferencing>);
 // Show that cast to Jsonable version of self does compile even if not
 // respecting the limitations. This is a dangerous practice, but can
 // be useful if very careful.
-foo(aUnknown as Jsonable<typeof aUnknown>);
+foo(aUnknown as Jsonable);
 foo(nestedUnknown as Jsonable<typeof nestedUnknown>);
 foo(a11 as Jsonable<typeof a11>);
 foo(a12 as Jsonable<typeof a12>);
@@ -317,3 +319,5 @@ foo(aBar as Jsonable<typeof aBar>);
 foo(mt as Jsonable<typeof mt>);
 foo(nmt as Jsonable<typeof nmt>);
 foo(isym as Jsonable<typeof isym>);
+
+/* eslint-enable unicorn/no-null, @typescript-eslint/no-explicit-any, @rushstack/no-new-null, @typescript-eslint/no-unsafe-argument */

--- a/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
+++ b/packages/common/core-interfaces/src/test/types/validateCoreInterfacesPrevious.generated.ts
@@ -951,13 +951,13 @@ use_old_InterfaceDeclaration_IResponse(
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_ISignalEnvelope": {"forwardCompat": false}
+ * "RemovedInterfaceDeclaration_ISignalEnvelope": {"forwardCompat": false}
  */
 declare function get_old_InterfaceDeclaration_ISignalEnvelope():
     TypeOnly<old.ISignalEnvelope>;
-declare function use_current_InterfaceDeclaration_ISignalEnvelope(
+declare function use_current_RemovedInterfaceDeclaration_ISignalEnvelope(
     use: TypeOnly<current.ISignalEnvelope>): void;
-use_current_InterfaceDeclaration_ISignalEnvelope(
+use_current_RemovedInterfaceDeclaration_ISignalEnvelope(
     get_old_InterfaceDeclaration_ISignalEnvelope());
 
 /*
@@ -965,14 +965,14 @@ use_current_InterfaceDeclaration_ISignalEnvelope(
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_ISignalEnvelope": {"backCompat": false}
+ * "RemovedInterfaceDeclaration_ISignalEnvelope": {"backCompat": false}
  */
-declare function get_current_InterfaceDeclaration_ISignalEnvelope():
+declare function get_current_RemovedInterfaceDeclaration_ISignalEnvelope():
     TypeOnly<current.ISignalEnvelope>;
 declare function use_old_InterfaceDeclaration_ISignalEnvelope(
     use: TypeOnly<old.ISignalEnvelope>): void;
 use_old_InterfaceDeclaration_ISignalEnvelope(
-    get_current_InterfaceDeclaration_ISignalEnvelope());
+    get_current_RemovedInterfaceDeclaration_ISignalEnvelope());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.

--- a/packages/common/driver-definitions/api-report/driver-definitions.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.api.md
@@ -24,6 +24,7 @@ import type { ISummaryTree } from '@fluidframework/protocol-definitions';
 import type { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import type { ITokenClaims } from '@fluidframework/protocol-definitions';
 import type { IVersion } from '@fluidframework/protocol-definitions';
+import type { JsonableOrBinary } from '@fluidframework/core-interfaces';
 
 // @alpha (undocumented)
 export type DriverError = IThrottlingWarning | IGenericNetworkError | IAuthorizationError | ILocationRedirectionError | IDriverBasicError;
@@ -126,7 +127,7 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     serviceConfiguration: IClientConfiguration;
     submit(messages: IDocumentMessage[]): void;
     submitSignal: (content: string, targetClientId?: string) => void;
-    submitSignal2?: (content: any, targetClientId?: string) => void;
+    submitSignal2?: (content: JsonableOrBinary, targetClientId?: string) => void;
     version: string;
 }
 

--- a/packages/common/driver-definitions/api-report/driver-definitions.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.api.md
@@ -126,6 +126,7 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     serviceConfiguration: IClientConfiguration;
     submit(messages: IDocumentMessage[]): void;
     submitSignal: (content: string, targetClientId?: string) => void;
+    submitSignal2?: (content: any, targetClientId?: string) => void;
     version: string;
 }
 

--- a/packages/common/driver-definitions/api-report/driver-definitions.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.api.md
@@ -24,7 +24,7 @@ import type { ISummaryTree } from '@fluidframework/protocol-definitions';
 import type { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import type { ITokenClaims } from '@fluidframework/protocol-definitions';
 import type { IVersion } from '@fluidframework/protocol-definitions';
-import type { JsonableOrBinary } from '@fluidframework/core-interfaces';
+import type { SignalContentType } from '@fluidframework/core-interfaces';
 
 // @alpha (undocumented)
 export type DriverError = IThrottlingWarning | IGenericNetworkError | IAuthorizationError | ILocationRedirectionError | IDriverBasicError;
@@ -127,7 +127,7 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     serviceConfiguration: IClientConfiguration;
     submit(messages: IDocumentMessage[]): void;
     submitSignal: (content: string, targetClientId?: string) => void;
-    submitSignal2?: (content: JsonableOrBinary, targetClientId?: string) => void;
+    submitSignal2?: (content: SignalContentType, targetClientId?: string) => void;
     version: string;
 }
 

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -319,6 +319,8 @@ export interface IDocumentDeltaConnection
 
 	/**
 	 * Submits a new signal to the server
+	 * Content is a JS object. It may container properties of type ArrayBuffer.
+	 * Other than such properties, the content should be serializable using JSON.serialize().
 	 */
 	submitSignal2?: (content: any, targetClientId?: string) => void;
 }

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -9,6 +9,7 @@ import type {
 	IEvent,
 	IEventProvider,
 	ITelemetryBaseLogger,
+	JsonableOrBinary,
 } from "@fluidframework/core-interfaces";
 import type {
 	ConnectionMode,
@@ -322,7 +323,7 @@ export interface IDocumentDeltaConnection
 	 * Content is a JS object. It may container properties of type ArrayBuffer.
 	 * Other than such properties, the content should be serializable using JSON.serialize().
 	 */
-	submitSignal2?: (content: any, targetClientId?: string) => void;
+	submitSignal2?: (content: JsonableOrBinary, targetClientId?: string) => void;
 }
 
 /**

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -9,7 +9,7 @@ import type {
 	IEvent,
 	IEventProvider,
 	ITelemetryBaseLogger,
-	JsonableOrBinary,
+	SignalContentType,
 } from "@fluidframework/core-interfaces";
 import type {
 	ConnectionMode,
@@ -323,7 +323,7 @@ export interface IDocumentDeltaConnection
 	 * Content is a JS object. It may container properties of type ArrayBuffer.
 	 * Other than such properties, the content should be serializable using JSON.serialize().
 	 */
-	submitSignal2?: (content: JsonableOrBinary, targetClientId?: string) => void;
+	submitSignal2?: (content: SignalContentType, targetClientId?: string) => void;
 }
 
 /**

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -314,11 +314,13 @@ export interface IDocumentDeltaConnection
 
 	/**
 	 * Submits a new signal to the server
-	 *
-	 * @privateRemarks
-	 * UnknownShouldBe<string> can be string if {@link IDocumentServiceFactory} becomes internal.
 	 */
 	submitSignal: (content: string, targetClientId?: string) => void;
+
+	/**
+	 * Submits a new signal to the server
+	 */
+	submitSignal2?: (content: any, targetClientId?: string) => void;
 }
 
 /**

--- a/packages/dds/shared-summary-block/api-report/shared-summary-block.api.md
+++ b/packages/dds/shared-summary-block/api-report/shared-summary-block.api.md
@@ -13,7 +13,7 @@ import { IFluidSerializer } from '@fluidframework/shared-object-base';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
-import { Jsonable } from '@fluidframework/datastore-definitions/internal';
+import { Jsonable } from '@fluidframework/core-interfaces';
 import { SharedObject } from '@fluidframework/shared-object-base/internal';
 
 // @alpha

--- a/packages/dds/shared-summary-block/src/interfaces.ts
+++ b/packages/dds/shared-summary-block/src/interfaces.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import { ISharedObject } from "@fluidframework/shared-object-base";
 
 /**

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -9,7 +9,7 @@ import {
 	IChannelStorageService,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
+import type { Jsonable } from "@fluidframework/core-interfaces";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
@@ -26,7 +26,7 @@ const snapshotFileName = "header";
  * Directly used in JSON.stringify, direct result from JSON.parse.
  */
 interface ISharedSummaryBlockDataSerializable {
-	[key: string]: Jsonable<unknown>;
+	[key: string]: Jsonable;
 }
 
 /**
@@ -58,7 +58,7 @@ export class SharedSummaryBlock extends SharedObject implements ISharedSummaryBl
 	/**
 	 * The data held by this object.
 	 */
-	private readonly data = new Map<string, Jsonable<unknown>>();
+	private readonly data = new Map<string, Jsonable>();
 
 	/**
 	 * Constructs a new SharedSummaryBlock. If the object is non-local, an id and service interfaces will

--- a/packages/drivers/local-driver/api-report/local-driver.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.api.md
@@ -61,6 +61,8 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
     nackClient(code: number | undefined, type: NackErrorType | undefined, message: any): void;
     submit(messages: IDocumentMessage[]): void;
     submitSignal(message: string): void;
+    // (undocumented)
+    submitSignal2(message: any): void;
 }
 
 // @internal

--- a/packages/drivers/local-driver/api-report/local-driver.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.api.md
@@ -36,8 +36,8 @@ import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUrlResolver } from '@fluidframework/driver-definitions/internal';
 import { IVersion } from '@fluidframework/protocol-definitions';
 import { IWebSocketServer } from '@fluidframework/server-services-core';
-import type { JsonableOrBinary } from '@fluidframework/core-interfaces';
 import { NackErrorType } from '@fluidframework/protocol-definitions';
+import type { SignalContentType } from '@fluidframework/core-interfaces';
 import type { Socket } from 'socket.io-client';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
@@ -63,7 +63,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
     submit(messages: IDocumentMessage[]): void;
     submitSignal(content: string): void;
     // (undocumented)
-    submitSignal2(content: JsonableOrBinary): void;
+    submitSignal2(content: SignalContentType): void;
 }
 
 // @internal

--- a/packages/drivers/local-driver/api-report/local-driver.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.api.md
@@ -36,6 +36,7 @@ import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUrlResolver } from '@fluidframework/driver-definitions/internal';
 import { IVersion } from '@fluidframework/protocol-definitions';
 import { IWebSocketServer } from '@fluidframework/server-services-core';
+import type { JsonableOrBinary } from '@fluidframework/core-interfaces';
 import { NackErrorType } from '@fluidframework/protocol-definitions';
 import type { Socket } from 'socket.io-client';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
@@ -60,9 +61,9 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
     disconnectClient(disconnectReason: string): void;
     nackClient(code: number | undefined, type: NackErrorType | undefined, message: any): void;
     submit(messages: IDocumentMessage[]): void;
-    submitSignal(message: string): void;
+    submitSignal(content: string): void;
     // (undocumented)
-    submitSignal2(message: any): void;
+    submitSignal2(content: JsonableOrBinary): void;
 }
 
 // @internal

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -147,6 +147,10 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_LocalDocumentDeltaConnection": {
+				"forwardCompat": false
+			}			
+		}
 	}
 }

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -150,7 +150,7 @@
 		"broken": {
 			"ClassDeclaration_LocalDocumentDeltaConnection": {
 				"forwardCompat": false
-			}			
+			}
 		}
 	}
 }

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -84,6 +84,10 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 		this.emitMessages("submitSignal", [[message]]);
 	}
 
+	public submitSignal2(message: any): void {
+		this.emitMessages("submitSignal", [[message]]);
+	}
+
 	/**
 	 * Send a "disconnect" message on the socket.
 	 * @param disconnectReason - The reason of the disconnection.

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -80,12 +80,13 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 	/**
 	 * Submits a new signal to the server
 	 */
-	public submitSignal(message: string): void {
-		this.emitMessages("submitSignal", [[message]]);
+	public submitSignal(content: string): void {
+		this.emitMessages("submitSignal", [[content]]);
 	}
 
-	public submitSignal2(message: any): void {
-		this.emitMessages("submitSignal", [[message]]);
+	public submitSignal2(content: any): void {
+		// TODO: We need different type of serialization in order to support ArrayBuffers
+		this.emitMessages("submitSignal", [[JSON.stringify(content)]]);
 	}
 
 	/**

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import type { ITelemetryBaseLogger, JsonableOrBinary } from "@fluidframework/core-interfaces";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base/internal";
 import {
 	IClient,
@@ -84,7 +84,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 		this.emitMessages("submitSignal", [[content]]);
 	}
 
-	public submitSignal2(content: any): void {
+	public submitSignal2(content: JsonableOrBinary): void {
 		// TODO: We need different type of serialization in order to support ArrayBuffers
 		this.emitMessages("submitSignal", [[JSON.stringify(content)]]);
 	}

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -11,6 +11,7 @@ import {
 	IDocumentMessage,
 	NackErrorType,
 } from "@fluidframework/protocol-definitions";
+import { encodeJsonableOrBinary } from "@fluidframework/driver-utils/internal";
 import { LocalWebSocketServer } from "@fluidframework/server-local-server";
 import { IWebSocketServer } from "@fluidframework/server-services-core";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
@@ -85,8 +86,24 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 	}
 
 	public submitSignal2(content: JsonableOrBinary): void {
-		// TODO: We need different type of serialization in order to support ArrayBuffers
-		this.emitMessages("submitSignal", [[JSON.stringify(content)]]);
+		// WARNING:
+		// This code here is only for demonstration purposes. While driver can do encoding here,
+		// it would need to do symmetrical decoding for "signal" event payloads, as well as this.initialSignals
+		// From efficiency POV, it does not make sense to implement this method if protocol does not support property
+		// binary payloads.
+		// There are two ways to accomplish it:
+		// 1. Leave it as is at socket.io level - it can transfer mixes (JS + binary) messages just fine. On service side,
+		//    likely would need to serialize it into binary blob and pass around binary. Maybe doing encodeJsonableOrBinary
+		//    on service side is fine (saves bandwidth as we do not waste +33% overhead of base64 encoding), but this makes
+		//    service side less efficient (compared if service does some more efficient binary serialization)
+		// 2. Serialize into binary here (in driver), and deserialize back on receiving signals, but service and socket.io
+		//    works only with binary payloads. Likely most efficient, as avoids extra serialization - deserialization at
+		//    socket.io level.
+		// The only reason it works as is - ConnectionManager will do decodeJsonableOrBinary() if it gets a string payload.
+		// But this is wrong, as we should not have any assumptions going across layers on what kind of serialization format
+		// is used - both serialization / deserialization should happen on one layer! (it's Ok to temporarily break this rule
+		//  for staging purpose only)
+		this.emitMessages("submitSignal", [[encodeJsonableOrBinary(content)]]);
 	}
 
 	/**

--- a/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
+++ b/packages/drivers/local-driver/src/localDocumentDeltaConnection.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { ITelemetryBaseLogger, JsonableOrBinary } from "@fluidframework/core-interfaces";
+import type { ITelemetryBaseLogger, SignalContentType } from "@fluidframework/core-interfaces";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base/internal";
 import {
 	IClient,
@@ -85,7 +85,7 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
 		this.emitMessages("submitSignal", [[content]]);
 	}
 
-	public submitSignal2(content: JsonableOrBinary): void {
+	public submitSignal2(content: SignalContentType): void {
 		// WARNING:
 		// This code here is only for demonstration purposes. While driver can do encoding here,
 		// it would need to do symmetrical decoding for "signal" event payloads, as well as this.initialSignals

--- a/packages/drivers/local-driver/src/test/types/validateLocalDriverPrevious.generated.ts
+++ b/packages/drivers/local-driver/src/test/types/validateLocalDriverPrevious.generated.ts
@@ -62,6 +62,7 @@ declare function get_old_ClassDeclaration_LocalDocumentDeltaConnection():
 declare function use_current_ClassDeclaration_LocalDocumentDeltaConnection(
     use: TypeOnly<current.LocalDocumentDeltaConnection>): void;
 use_current_ClassDeclaration_LocalDocumentDeltaConnection(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_LocalDocumentDeltaConnection());
 
 /*

--- a/packages/framework/attributor/src/lz4Encoder.ts
+++ b/packages/framework/attributor/src/lz4Encoder.ts
@@ -4,7 +4,7 @@
  */
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
-import { type Jsonable } from "@fluidframework/datastore-definitions/internal";
+import { type Jsonable } from "@fluidframework/core-interfaces";
 import { compress, decompress } from "lz4js";
 
 import { type Encoder } from "./encoders.js";

--- a/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
+++ b/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
@@ -26,7 +26,7 @@ import {
 	type IChannelServices,
 	type IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
-import { type Jsonable } from "@fluidframework/datastore-definitions/internal";
+import { type Jsonable } from "@fluidframework/core-interfaces";
 import { createInsertOnlyAttributionPolicy } from "@fluidframework/merge-tree/internal";
 import {
 	type ISequencedDocumentMessage,

--- a/packages/framework/attributor/src/test/lz4Encoder.spec.ts
+++ b/packages/framework/attributor/src/test/lz4Encoder.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { type JsonableTypeWith } from "@fluidframework/datastore-definitions/internal";
+import { type JsonableTypeWith } from "@fluidframework/core-interfaces/internal";
 
 import { makeLZ4Encoder } from "../lz4Encoder.js";
 

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -13,7 +13,7 @@ import {
 	IDisposable,
 	ITelemetryBaseProperties,
 	LogLevel,
-	JsonableOrBinary,
+	SignalContentType,
 } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { DriverErrorTypes, IAnyDriverError } from "@fluidframework/driver-definitions";
@@ -1107,7 +1107,7 @@ export class ConnectionManager implements IConnectionManager {
 		};
 	}
 
-	public submitSignal(content: JsonableOrBinary, targetClientId?: string) {
+	public submitSignal(content: SignalContentType, targetClientId?: string) {
 		if (this.connection !== undefined) {
 			// If connection supports sending JS objects as is (submitSignal2 method), use it.
 			// This allows more efficient encoding (as we do not have double sringification of content),

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -30,6 +30,8 @@ import {
 	getRetryDelayFromError,
 	isRuntimeMessage,
 	logNetworkFailure,
+	decodeJsonableOrBinary,
+	encodeJsonableOrBinary,
 } from "@fluidframework/driver-utils/internal";
 import {
 	ConnectionMode,
@@ -1114,7 +1116,7 @@ export class ConnectionManager implements IConnectionManager {
 				this.connection.submitSignal2(content, targetClientId);
 			} else {
 				// This flow does not currently supports binary properties!
-				this.connection.submitSignal(JSON.stringify(content), targetClientId);
+				this.connection.submitSignal(encodeJsonableOrBinary(content), targetClientId);
 			}
 		} else {
 			this.logger.sendErrorEvent({ eventName: "submitSignalDisconnected" });
@@ -1213,7 +1215,7 @@ export class ConnectionManager implements IConnectionManager {
 			// Same if these are synthesized join/clean signals coming from setupNewSuccessfulConnection()
 			// Otherwise it's a string, and it may contain serialized ArrayBuffer's.
 			if (typeof signal.content === "string") {
-				signal.content = JSON.parse(signal.content);
+				signal.content = decodeJsonableOrBinary(signal.content);
 			}
 			this.props.signalHandler(signal);
 		}

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -9,7 +9,12 @@ import {
 	IDeltaQueue,
 	ReadOnlyInfo,
 } from "@fluidframework/container-definitions";
-import { IDisposable, ITelemetryBaseProperties, LogLevel } from "@fluidframework/core-interfaces";
+import {
+	IDisposable,
+	ITelemetryBaseProperties,
+	LogLevel,
+	JsonableOrBinary,
+} from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { DriverErrorTypes, IAnyDriverError } from "@fluidframework/driver-definitions";
 import {
@@ -1100,7 +1105,7 @@ export class ConnectionManager implements IConnectionManager {
 		};
 	}
 
-	public submitSignal(content: unknown, targetClientId?: string) {
+	public submitSignal(content: JsonableOrBinary, targetClientId?: string) {
 		if (this.connection !== undefined) {
 			// If connection supports sending JS objects as is (submitSignal2 method), use it.
 			// This allows more efficient encoding (as we do not have double sringification of content),
@@ -1203,7 +1208,7 @@ export class ConnectionManager implements IConnectionManager {
 	private readonly signalHandler = (signalsArg: ISignalMessage | ISignalMessage[]) => {
 		const signals = Array.isArray(signalsArg) ? signalsArg : [signalsArg];
 		for (const signalArg of signals) {
-			let signal = { ...signalArg }; // make a copy.
+			const signal = { ...signalArg }; // make a copy.
 			// If IDocumentDeltaConnection implements submitSignal2(), then content is coming as JS objects
 			// Same if these are synthesized join/clean signals coming from setupNewSuccessfulConnection()
 			// Otherwise it's a string, and it may contain serialized ArrayBuffer's.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -35,7 +35,6 @@ import {
 	ITelemetryBaseProperties,
 	LogLevel,
 } from "@fluidframework/core-interfaces";
-import { type ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
 import { assert, isPromiseLike, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
 	IDocumentService,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -34,6 +34,7 @@ import {
 	IRequest,
 	ITelemetryBaseProperties,
 	LogLevel,
+	JsonableOrBinary,
 } from "@fluidframework/core-interfaces";
 import { assert, isPromiseLike, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
@@ -2288,8 +2289,7 @@ export class Container
 		this.emit("op", message);
 	}
 
-	// unknown should be removed once `@alpha` tag is removed from IContainerContext
-	private submitSignal(content: unknown, targetClientId?: string) {
+	private submitSignal(content: JsonableOrBinary, targetClientId?: string) {
 		this._deltaManager.submitSignal(content, targetClientId);
 	}
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1517,7 +1517,7 @@ export class Container
 
 	private readonly metadataUpdateHandler = (metadata: Record<string, string>) => {
 		this._containerMetadata = { ...this._containerMetadata, ...metadata };
-		this.emit("metadataUpdate", metadata);
+		this.emit("metadataUpdate", this._containerMetadata);
 	};
 
 	private async createDocumentService(
@@ -2290,8 +2290,8 @@ export class Container
 	}
 
 	// unknown should be removed once `@alpha` tag is removed from IContainerContext
-	private submitSignal(content: unknown | ISignalEnvelope, targetClientId?: string) {
-		this._deltaManager.submitSignal(JSON.stringify(content), targetClientId);
+	private submitSignal(content: unknown, targetClientId?: string) {
+		this._deltaManager.submitSignal(content, targetClientId);
 	}
 
 	private processSignal(message: ISignalMessage) {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -34,7 +34,7 @@ import {
 	IRequest,
 	ITelemetryBaseProperties,
 	LogLevel,
-	JsonableOrBinary,
+	SignalContentType,
 } from "@fluidframework/core-interfaces";
 import { assert, isPromiseLike, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
@@ -2289,7 +2289,7 @@ export class Container
 		this.emit("op", message);
 	}
 
-	private submitSignal(content: JsonableOrBinary, targetClientId?: string) {
+	private submitSignal(content: SignalContentType, targetClientId?: string) {
 		this._deltaManager.submitSignal(content, targetClientId);
 	}
 

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -15,8 +15,7 @@ import {
 	ILoader,
 	ILoaderOptions,
 } from "@fluidframework/container-definitions/internal";
-import { type FluidObject } from "@fluidframework/core-interfaces";
-import { type ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
+import type { FluidObject, JsonableOrBinary } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService, ISnapshot } from "@fluidframework/driver-definitions/internal";
 import {
 	IClientDetails,
@@ -88,13 +87,8 @@ export class ContainerContext implements IContainerContext {
 			referenceSequenceNumber?: number,
 		) => number,
 
-		/**
-		 * `unknown` should be removed once `@alpha` tag is removed from IContainerContext
-		 * @see {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/7462}
-		 * Any changes to submitSignalFn `content` should be checked internally by temporarily changing IContainerContext and removing all `unknown`s
-		 */
 		public readonly submitSignalFn: (
-			content: unknown | ISignalEnvelope,
+			content: JsonableOrBinary,
 			targetClientId?: string,
 		) => void,
 		public readonly disposeFn: (error?: ICriticalContainerError) => void,

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -15,7 +15,7 @@ import {
 	ILoader,
 	ILoaderOptions,
 } from "@fluidframework/container-definitions/internal";
-import type { FluidObject, JsonableOrBinary } from "@fluidframework/core-interfaces";
+import type { FluidObject, SignalContentType } from "@fluidframework/core-interfaces";
 import { IDocumentStorageService, ISnapshot } from "@fluidframework/driver-definitions/internal";
 import {
 	IClientDetails,
@@ -88,7 +88,7 @@ export class ContainerContext implements IContainerContext {
 		) => number,
 
 		public readonly submitSignalFn: (
-			content: JsonableOrBinary,
+			content: SignalContentType,
 			targetClientId?: string,
 		) => void,
 		public readonly disposeFn: (error?: ICriticalContainerError) => void,

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -99,7 +99,7 @@ export interface IConnectionManager {
 	 * Submits signal to relay service.
 	 * Called only when active connection is present.
 	 */
-	submitSignal: (content: string, targetClientId?: string) => void;
+	submitSignal: (content: unknown, targetClientId?: string) => void;
 
 	/**
 	 * Submits messages to relay service.
@@ -135,7 +135,7 @@ export interface IConnectionManagerFactoryArgs {
 	 * Called by connection manager for each incoming signal.
 	 * May be called before connectHandler is called (due to initial signals on socket connection)
 	 */
-	readonly signalHandler: (signals: ISignalMessage[]) => void;
+	readonly signalHandler: (signal: ISignalMessage) => void;
 
 	/**
 	 * Called when connection manager experiences delay in connecting to relay service.

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -10,7 +10,11 @@ import {
 	ReadOnlyInfo,
 } from "@fluidframework/container-definitions";
 import { IFluidCodeDetails, isFluidPackage } from "@fluidframework/container-definitions/internal";
-import { IErrorBase, ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
+import type {
+	IErrorBase,
+	ITelemetryBaseProperties,
+	JsonableOrBinary,
+} from "@fluidframework/core-interfaces";
 import { IContainerPackageInfo } from "@fluidframework/driver-definitions/internal";
 import {
 	ConnectionMode,
@@ -99,7 +103,7 @@ export interface IConnectionManager {
 	 * Submits signal to relay service.
 	 * Called only when active connection is present.
 	 */
-	submitSignal: (content: unknown, targetClientId?: string) => void;
+	submitSignal: (content: JsonableOrBinary, targetClientId?: string) => void;
 
 	/**
 	 * Submits messages to relay service.

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -13,7 +13,7 @@ import { IFluidCodeDetails, isFluidPackage } from "@fluidframework/container-def
 import type {
 	IErrorBase,
 	ITelemetryBaseProperties,
-	JsonableOrBinary,
+	SignalContentType,
 } from "@fluidframework/core-interfaces";
 import { IContainerPackageInfo } from "@fluidframework/driver-definitions/internal";
 import {
@@ -103,7 +103,7 @@ export interface IConnectionManager {
 	 * Submits signal to relay service.
 	 * Called only when active connection is present.
 	 */
-	submitSignal: (content: JsonableOrBinary, targetClientId?: string) => void;
+	submitSignal: (content: SignalContentType, targetClientId?: string) => void;
 
 	/**
 	 * Submits messages to relay service.

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -329,7 +329,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		return message.clientSequenceNumber;
 	}
 
-	public submitSignal(content: string, targetClientId?: string) {
+	public submitSignal(content: unknown, targetClientId?: string) {
 		return this.connectionManager.submitSignal(content, targetClientId);
 	}
 
@@ -428,11 +428,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 					this.close(normalizeError(error));
 				}
 			},
-			signalHandler: (signals: ISignalMessage[]) => {
-				for (const signal of signals) {
-					this._inboundSignal.push(signal);
-				}
-			},
+			signalHandler: (signal: ISignalMessage) => this._inboundSignal.push(signal),
 			reconnectionDelayHandler: (delayMs: number, error: unknown) =>
 				this.emitDelayInfo(this.deltaStreamDelayId, delayMs, error),
 			closeHandler: (error: any) => this.close(error),
@@ -477,7 +473,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			}
 			this.handler.processSignal({
 				clientId: message.clientId,
-				content: JSON.parse(message.content as string),
+				content: message.content,
 			});
 		});
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -16,7 +16,7 @@ import type {
 } from "@fluidframework/core-interfaces";
 import type {
 	IThrottlingWarning,
-	JsonableOrBinary,
+	SignalContentType,
 } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import { DriverErrorTypes } from "@fluidframework/driver-definitions";
@@ -332,7 +332,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		return message.clientSequenceNumber;
 	}
 
-	public submitSignal(content: JsonableOrBinary, targetClientId?: string) {
+	public submitSignal(content: SignalContentType, targetClientId?: string) {
 		return this.connectionManager.submitSignal(content, targetClientId);
 	}
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -9,12 +9,15 @@ import {
 	IDeltaManagerEvents,
 	IDeltaQueue,
 } from "@fluidframework/container-definitions";
-import {
+import type {
 	IEventProvider,
-	type ITelemetryBaseEvent,
+	ITelemetryBaseEvent,
 	ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces";
-import { IThrottlingWarning } from "@fluidframework/core-interfaces/internal";
+import type {
+	IThrottlingWarning,
+	JsonableOrBinary,
+} from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import { DriverErrorTypes } from "@fluidframework/driver-definitions";
 import {
@@ -329,7 +332,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		return message.clientSequenceNumber;
 	}
 
-	public submitSignal(content: unknown, targetClientId?: string) {
+	public submitSignal(content: JsonableOrBinary, targetClientId?: string) {
 		return this.connectionManager.submitSignal(content, targetClientId);
 	}
 

--- a/packages/loader/driver-utils/api-report/driver-utils.api.md
+++ b/packages/loader/driver-utils/api-report/driver-utils.api.md
@@ -38,6 +38,7 @@ import { ITree } from '@fluidframework/protocol-definitions';
 import { ITreeEntry } from '@fluidframework/protocol-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions/internal';
 import { IVersion } from '@fluidframework/protocol-definitions';
+import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
 import { LoaderCachingPolicy } from '@fluidframework/driver-definitions/internal';
 import { LoggingError } from '@fluidframework/telemetry-utils/internal';
 
@@ -121,6 +122,9 @@ export function createGenericNetworkError(message: string, retryInfo: {
 // @internal (undocumented)
 export const createWriteError: (message: string, props: DriverErrorTelemetryProps) => NonRetryableError<"writeError">;
 
+// @internal
+export function decodeJsonableOrBinary(content: string): JsonableOrBinary;
+
 // @internal (undocumented)
 export class DeltaStreamConnectionForbiddenError extends LoggingError implements IDriverErrorBase, IFluidErrorBase {
     constructor(message: string, props: DriverErrorTelemetryProps, storageOnlyReason?: string);
@@ -165,6 +169,9 @@ export type DriverErrorTelemetryProps = ITelemetryBaseProperties & {
 
 // @internal (undocumented)
 export const emptyMessageStream: IStream<ISequencedDocumentMessage[]>;
+
+// @internal
+export function encodeJsonableOrBinary<T>(content: JsonableOrBinary<T>): string;
 
 // @internal
 export class FluidInvalidSchemaError extends LoggingError implements IDriverErrorBase, IFluidErrorBase {

--- a/packages/loader/driver-utils/src/binaryEncoding.ts
+++ b/packages/loader/driver-utils/src/binaryEncoding.ts
@@ -1,0 +1,42 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import type { JsonableOrBinary, Jsonable } from "@fluidframework/core-interfaces/internal";
+import { Uint8ArrayToString, stringToBuffer } from "@fluid-internal/client-utils";
+
+const binaryType = "__fluid_binary__";
+
+/**
+ * Encodes JsonableOrBinary into a string
+ * @param content - content to stringify
+ * @returns string
+ * @internal
+ */
+export function encodeJsonableOrBinary<T>(content: JsonableOrBinary<T>): string {
+	return JSON.stringify(content, (_key: string, value: JsonableOrBinary<T>) => {
+		if (value instanceof ArrayBuffer) {
+			return {
+				type: binaryType,
+				content: Uint8ArrayToString(new Uint8Array(value), "base64"),
+			};
+		}
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return value;
+	});
+}
+
+/**
+ * Decodes string back to JsonableOrBinary
+ * @param content - an encoded string
+ * @returns decoded JS object
+ * @internal
+ */
+export function decodeJsonableOrBinary(content: string): JsonableOrBinary {
+	return JSON.parse(content, (_key: string, value: Jsonable) => {
+		if (value !== null && (value as any).type === binaryType) {
+			return stringToBuffer((value as any).content, "base64");
+		}
+		return value;
+	}) as JsonableOrBinary;
+}

--- a/packages/loader/driver-utils/src/binaryEncoding.ts
+++ b/packages/loader/driver-utils/src/binaryEncoding.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
 import type { JsonableOrBinary, Jsonable } from "@fluidframework/core-interfaces/internal";
 import { Uint8ArrayToString, stringToBuffer } from "@fluid-internal/client-utils";
 

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -55,3 +55,4 @@ export {
 	blobHeadersBlobName,
 } from "./adapters/index.js";
 export { isInstanceOfISnapshot } from "./storageUtils.js";
+export { encodeJsonableOrBinary, decodeJsonableOrBinary } from "./binaryEncoding.js";

--- a/packages/loader/driver-utils/src/test/binaryEncoding.spec.ts
+++ b/packages/loader/driver-utils/src/test/binaryEncoding.spec.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import type { JsonableOrBinary, Jsonable } from "@fluidframework/core-interfaces/internal";
+import { encodeJsonableOrBinary, decodeJsonableOrBinary } from "../binaryEncoding.js";
+
+describe("Binary encoding", () => {
+	function testSameAsJson(content: Jsonable) {
+		const res = JSON.stringify(content);
+		const res2 = encodeJsonableOrBinary(content);
+		assert(res === res2, "not same as JSON.stringify");
+		if (res !== undefined) {
+			assert.deepEqual(
+				JSON.parse(res),
+				decodeJsonableOrBinary(res),
+				"not same as JSON.parse",
+			);
+		}
+	}
+
+	it("test no binary", () => {
+		testSameAsJson(undefined);
+		testSameAsJson(null);
+		testSameAsJson({});
+		testSameAsJson({ a: "test", b: 5 });
+		testSameAsJson({ a: "test", b: { c: "test", d: undefined, e: [5, 6, undefined] } });
+	});
+
+	function testBinaryRoundtrip(content: JsonableOrBinary) {
+		const res = encodeJsonableOrBinary(content);
+		const content2 = decodeJsonableOrBinary(res);
+
+		// This will not compare contents of arrays, only their presence!
+		assert.deepEqual(content, content2);
+		assert(res === encodeJsonableOrBinary(content2));
+	}
+
+	it("test binary conversions", () => {
+		const arr = new Uint8Array([5, 6, 7, 100]);
+		testBinaryRoundtrip({ a: 5, arr: arr.buffer, c: { x: arr.buffer } });
+	});
+});

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -60,10 +60,10 @@ import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
-import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
 import { MessageType } from '@fluidframework/protocol-definitions';
 import { MonitoringContext } from '@fluidframework/telemetry-utils/internal';
 import { NamedFluidDataStoreRegistryEntries } from '@fluidframework/runtime-definitions/internal';
+import type { SignalContentType } from '@fluidframework/core-interfaces/internal';
 import { SummarizeInternalFn } from '@fluidframework/runtime-definitions/internal';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 
@@ -337,7 +337,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     get storage(): IDocumentStorageService;
     // (undocumented)
     submitMessage(type: ContainerMessageType.FluidDataStoreOp | ContainerMessageType.Alias | ContainerMessageType.Attach, contents: any, localOpMetadata?: unknown): void;
-    submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string): void;
+    submitSignal(type: string, content: SignalContentType, targetClientId?: string): void;
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
     summarize(options: {
         fullTree?: boolean;
@@ -564,7 +564,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     readonly storage: IDocumentStorageService;
     // (undocumented)
     submitMessage(type: string, content: any, localOpMetadata: unknown): void;
-    submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string): void;
+    submitSignal(type: string, content: SignalContentType, targetClientId?: string): void;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;
     // (undocumented)
     protected readonly summarizerNode: ISummarizerNodeWithGC;

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -60,6 +60,7 @@ import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
+import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
 import { MessageType } from '@fluidframework/protocol-definitions';
 import { MonitoringContext } from '@fluidframework/telemetry-utils/internal';
 import { NamedFluidDataStoreRegistryEntries } from '@fluidframework/runtime-definitions/internal';
@@ -336,7 +337,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     get storage(): IDocumentStorageService;
     // (undocumented)
     submitMessage(type: ContainerMessageType.FluidDataStoreOp | ContainerMessageType.Alias | ContainerMessageType.Attach, contents: any, localOpMetadata?: unknown): void;
-    submitSignal(type: string, content: unknown, targetClientId?: string): void;
+    submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string): void;
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
     summarize(options: {
         fullTree?: boolean;
@@ -563,7 +564,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     readonly storage: IDocumentStorageService;
     // (undocumented)
     submitMessage(type: string, content: any, localOpMetadata: unknown): void;
-    submitSignal(type: string, content: unknown, targetClientId?: string): void;
+    submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string): void;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;
     // (undocumented)
     protected readonly summarizerNode: ISummarizerNodeWithGC;

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -11,7 +11,7 @@ import {
 	IRequest,
 	IResponse,
 	ITelemetryBaseLogger,
-	JsonableOrBinary,
+	SignalContentType,
 } from "@fluidframework/core-interfaces";
 import { assert, Lazy, LazyPromise } from "@fluidframework/core-utils/internal";
 import { FluidObjectHandle } from "@fluidframework/datastore/internal";
@@ -230,8 +230,8 @@ export function wrapContextForInnerChannel(
 		);
 	};
 
-	context.submitSignal = (type: string, contents: JsonableOrBinary, targetClientId?: string) => {
-		const envelope: IEnvelope<JsonableOrBinary> = {
+	context.submitSignal = (type: string, contents: SignalContentType, targetClientId?: string) => {
+		const envelope: IEnvelope<SignalContentType> = {
 			address: id,
 			contents,
 		};

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -11,6 +11,7 @@ import {
 	IRequest,
 	IResponse,
 	ITelemetryBaseLogger,
+	JsonableOrBinary,
 } from "@fluidframework/core-interfaces";
 import { assert, Lazy, LazyPromise } from "@fluidframework/core-utils/internal";
 import { FluidObjectHandle } from "@fluidframework/datastore/internal";
@@ -229,8 +230,8 @@ export function wrapContextForInnerChannel(
 		);
 	};
 
-	context.submitSignal = (type: string, contents: unknown, targetClientId?: string) => {
-		const envelope: IEnvelope = {
+	context.submitSignal = (type: string, contents: JsonableOrBinary, targetClientId?: string) => {
+		const envelope: IEnvelope<JsonableOrBinary> = {
 			address: id,
 			contents,
 		};

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -33,7 +33,7 @@ import {
 	IResponse,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import type { ISignalEnvelope, JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
+import type { ISignalEnvelope, SignalContentType } from "@fluidframework/core-interfaces/internal";
 import {
 	assert,
 	Deferred,
@@ -1084,7 +1084,7 @@ export class ContainerRuntime
 		summaryOp: ISummaryContent,
 		referenceSequenceNumber?: number,
 	) => number;
-	private readonly submitSignalFn: (content: JsonableOrBinary, targetClientId?: string) => void;
+	private readonly submitSignalFn: (content: SignalContentType, targetClientId?: string) => void;
 	public readonly disposeFn: (error?: ICriticalContainerError) => void;
 	public readonly closeFn: (error?: ICriticalContainerError) => void;
 
@@ -1608,10 +1608,10 @@ export class ContainerRuntime
 		// downstream stores to wrap the signal.
 		parentContext.submitSignal = (
 			type: string,
-			content: JsonableOrBinary,
+			content: SignalContentType,
 			targetClientId?: string,
 		) => {
-			const envelope1 = content as any as IEnvelope<JsonableOrBinary>;
+			const envelope1 = content as any as IEnvelope<SignalContentType>;
 			const envelope2 = this.createNewSignalEnvelope(
 				envelope1.address,
 				type,
@@ -3028,7 +3028,7 @@ export class ContainerRuntime
 	private createNewSignalEnvelope(
 		address: string | undefined,
 		type: string,
-		content: JsonableOrBinary,
+		content: SignalContentType,
 	): ISignalEnvelope {
 		const newSequenceNumber = ++this._perfSignalData.signalSequenceNumber;
 		const newEnvelope: ISignalEnvelope = {
@@ -3055,7 +3055,7 @@ export class ContainerRuntime
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string) {
+	public submitSignal(type: string, content: SignalContentType, targetClientId?: string) {
 		this.verifyNotClosed();
 		const envelope = this.createNewSignalEnvelope(undefined /* address */, type, content);
 		return this.submitSignalFn(envelope, targetClientId);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -33,7 +33,7 @@ import {
 	IResponse,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import { ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
+import type { ISignalEnvelope, JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
 import {
 	assert,
 	Deferred,
@@ -1084,7 +1084,7 @@ export class ContainerRuntime
 		summaryOp: ISummaryContent,
 		referenceSequenceNumber?: number,
 	) => number;
-	private readonly submitSignalFn: (content: ISignalEnvelope, targetClientId?: string) => void;
+	private readonly submitSignalFn: (content: JsonableOrBinary, targetClientId?: string) => void;
 	public readonly disposeFn: (error?: ICriticalContainerError) => void;
 	public readonly closeFn: (error?: ICriticalContainerError) => void;
 
@@ -1606,8 +1606,12 @@ export class ContainerRuntime
 		// Due to a mismatch between different layers in terms of
 		// what is the interface of passing signals, we need the
 		// downstream stores to wrap the signal.
-		parentContext.submitSignal = (type: string, content: unknown, targetClientId?: string) => {
-			const envelope1 = content as IEnvelope;
+		parentContext.submitSignal = (
+			type: string,
+			content: JsonableOrBinary,
+			targetClientId?: string,
+		) => {
+			const envelope1 = content as any as IEnvelope<JsonableOrBinary>;
 			const envelope2 = this.createNewSignalEnvelope(
 				envelope1.address,
 				type,
@@ -3024,7 +3028,7 @@ export class ContainerRuntime
 	private createNewSignalEnvelope(
 		address: string | undefined,
 		type: string,
-		content: any,
+		content: JsonableOrBinary,
 	): ISignalEnvelope {
 		const newSequenceNumber = ++this._perfSignalData.signalSequenceNumber;
 		const newEnvelope: ISignalEnvelope = {
@@ -3051,7 +3055,7 @@ export class ContainerRuntime
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(type: string, content: unknown, targetClientId?: string) {
+	public submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string) {
 		this.verifyNotClosed();
 		const envelope = this.createNewSignalEnvelope(undefined /* address */, type, content);
 		return this.submitSignalFn(envelope, targetClientId);

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -14,7 +14,7 @@ import type {
 	IResponse,
 	ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces";
-import type { JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
+import type { SignalContentType } from "@fluidframework/core-interfaces/internal";
 import { assert, LazyPromise, unreachableCase } from "@fluidframework/core-utils/internal";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import { BlobTreeEntry, readAndParse } from "@fluidframework/driver-utils/internal";
@@ -820,7 +820,7 @@ export abstract class FluidDataStoreContext
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string) {
+	public submitSignal(type: string, content: SignalContentType, targetClientId?: string) {
 		this.verifyNotClosed("submitSignal");
 
 		assert(!!this.channel, 0x147 /* "Channel must exist on submitting signal" */);

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -5,7 +5,7 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { AttachState, IAudience, IDeltaManager } from "@fluidframework/container-definitions";
-import {
+import type {
 	FluidObject,
 	IDisposable,
 	IEvent,
@@ -14,6 +14,7 @@ import {
 	IResponse,
 	ITelemetryBaseProperties,
 } from "@fluidframework/core-interfaces";
+import type { JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
 import { assert, LazyPromise, unreachableCase } from "@fluidframework/core-utils/internal";
 import { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import { BlobTreeEntry, readAndParse } from "@fluidframework/driver-utils/internal";
@@ -88,6 +89,7 @@ function createAttributes(
 		isRootDataStore,
 	};
 }
+
 export function createAttributesBlob(pkg: readonly string[], isRootDataStore: boolean): ITreeEntry {
 	const attributes = createAttributes(pkg, isRootDataStore);
 	return new BlobTreeEntry(dataStoreAttributesBlobName, JSON.stringify(attributes));
@@ -818,7 +820,7 @@ export abstract class FluidDataStoreContext
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(type: string, content: unknown, targetClientId?: string) {
+	public submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string) {
 		this.verifyNotClosed("submitSignal");
 
 		assert(!!this.channel, 0x147 /* "Channel must exist on submitting signal" */);

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -24,6 +24,8 @@ import type { ISequencedDocumentMessage } from '@fluidframework/protocol-definit
 import type { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import type { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import type { ITelemetryContext } from '@fluidframework/runtime-definitions';
+import type { Jsonable } from '@fluidframework/core-interfaces';
+import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
 
 // @public (undocumented)
 export interface IChannel extends IFluidLoadable {
@@ -119,7 +121,7 @@ export interface IFluidDataStoreRuntime extends IEventProvider<IFluidDataStoreRu
     readonly options: Record<string | number, any>;
     // (undocumented)
     readonly rootRoutingContext: IFluidHandleContext;
-    submitSignal: (type: string, content: unknown, targetClientId?: string) => void;
+    submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
     waitAttached(): Promise<void>;
 }
@@ -135,20 +137,6 @@ export interface IFluidDataStoreRuntimeEvents extends IEvent {
     // (undocumented)
     (event: "connected", listener: (clientId: string) => void): any;
 }
-
-// @alpha (undocumented)
-export interface Internal_InterfaceOfJsonableTypesWith<T> {
-    // (undocumented)
-    [index: string | number]: JsonableTypeWith<T>;
-}
-
-// @alpha
-export type Jsonable<T, TReplaced = never> = boolean extends (T extends never ? true : false) ? JsonableTypeWith<TReplaced> : unknown extends T ? JsonableTypeWith<TReplaced> : T extends undefined | null | boolean | number | string | TReplaced ? T : Extract<T, Function> extends never ? T extends object ? T extends (infer U)[] ? Jsonable<U, TReplaced>[] : {
-    [K in keyof T]: Extract<K, symbol> extends never ? Jsonable<T[K], TReplaced> : never;
-} : never : never;
-
-// @alpha
-export type JsonableTypeWith<T> = undefined | null | boolean | number | string | T | Internal_InterfaceOfJsonableTypesWith<T> | ArrayLike<JsonableTypeWith<T>>;
 
 // @alpha
 export type Serializable<T> = Jsonable<T, IFluidHandle>;

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -25,7 +25,7 @@ import type { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions'
 import type { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import type { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import type { Jsonable } from '@fluidframework/core-interfaces';
-import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
+import type { SignalContentType } from '@fluidframework/core-interfaces/internal';
 
 // @public (undocumented)
 export interface IChannel extends IFluidLoadable {
@@ -121,7 +121,7 @@ export interface IFluidDataStoreRuntime extends IEventProvider<IFluidDataStoreRu
     readonly options: Record<string | number, any>;
     // (undocumented)
     readonly rootRoutingContext: IFluidHandleContext;
-    submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
+    submitSignal: (type: string, content: SignalContentType, targetClientId?: string) => void;
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
     waitAttached(): Promise<void>;
 }

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -92,6 +92,18 @@
 		"broken": {
 			"InterfaceDeclaration_IFluidDataStoreRuntime": {
 				"backCompat": false
+			},
+			"RemovedInterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"RemovedTypeAliasDeclaration_Jsonable": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"RemovedTypeAliasDeclaration_JsonableTypeWith": {
+				"forwardCompat": false,
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -20,7 +20,7 @@ import type {
 	ISequencedDocumentMessage,
 } from "@fluidframework/protocol-definitions";
 import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
-import type { JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
+import type { SignalContentType } from "@fluidframework/core-interfaces/internal";
 import type { IChannel } from "./channel.js";
 
 /**
@@ -113,7 +113,7 @@ export interface IFluidDataStoreRuntime
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
+	submitSignal: (type: string, content: SignalContentType, targetClientId?: string) => void;
 
 	/**
 	 * Returns the current quorum.

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -20,7 +20,7 @@ import type {
 	ISequencedDocumentMessage,
 } from "@fluidframework/protocol-definitions";
 import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
-
+import type { JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
 import type { IChannel } from "./channel.js";
 
 /**
@@ -113,7 +113,7 @@ export interface IFluidDataStoreRuntime
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	submitSignal: (type: string, content: unknown, targetClientId?: string) => void;
+	submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
 
 	/**
 	 * Returns the current quorum.

--- a/packages/runtime/datastore-definitions/src/index.ts
+++ b/packages/runtime/datastore-definitions/src/index.ts
@@ -19,10 +19,5 @@ export type {
 	IDeltaHandler,
 } from "./channel.js";
 export type { IFluidDataStoreRuntime, IFluidDataStoreRuntimeEvents } from "./dataStoreRuntime.js";
-export type {
-	Jsonable,
-	JsonableTypeWith,
-	Internal_InterfaceOfJsonableTypesWith,
-} from "./jsonable.js";
 export type { Serializable } from "./serializable.js";
 export type { IChannelAttributes } from "./storage.js";

--- a/packages/runtime/datastore-definitions/src/serializable.ts
+++ b/packages/runtime/datastore-definitions/src/serializable.ts
@@ -3,9 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { IFluidHandle } from "@fluidframework/core-interfaces";
-
-import type { Jsonable } from "./jsonable.js";
+import type { IFluidHandle, Jsonable } from "@fluidframework/core-interfaces";
 
 /**
  * Used to constrain a type 'T' to types that Fluid can intrinsically serialize.  Produces a

--- a/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
@@ -280,84 +280,48 @@ use_old_InterfaceDeclaration_IFluidDataStoreRuntimeEvents(
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith": {"forwardCompat": false}
+ * "RemovedInterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith": {"forwardCompat": false}
  */
-declare function get_old_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith():
-    TypeOnly<old.Internal_InterfaceOfJsonableTypesWith<any>>;
-declare function use_current_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith(
-    use: TypeOnly<current.Internal_InterfaceOfJsonableTypesWith<any>>): void;
-use_current_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith(
-    get_old_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith": {"backCompat": false}
+ * "RemovedInterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith": {"backCompat": false}
  */
-declare function get_current_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith():
-    TypeOnly<current.Internal_InterfaceOfJsonableTypesWith<any>>;
-declare function use_old_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith(
-    use: TypeOnly<old.Internal_InterfaceOfJsonableTypesWith<any>>): void;
-use_old_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith(
-    get_current_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAliasDeclaration_Jsonable": {"forwardCompat": false}
+ * "RemovedTypeAliasDeclaration_Jsonable": {"forwardCompat": false}
  */
-declare function get_old_TypeAliasDeclaration_Jsonable():
-    TypeOnly<old.Jsonable<any>>;
-declare function use_current_TypeAliasDeclaration_Jsonable(
-    use: TypeOnly<current.Jsonable<any>>): void;
-use_current_TypeAliasDeclaration_Jsonable(
-    get_old_TypeAliasDeclaration_Jsonable());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAliasDeclaration_Jsonable": {"backCompat": false}
+ * "RemovedTypeAliasDeclaration_Jsonable": {"backCompat": false}
  */
-declare function get_current_TypeAliasDeclaration_Jsonable():
-    TypeOnly<current.Jsonable<any>>;
-declare function use_old_TypeAliasDeclaration_Jsonable(
-    use: TypeOnly<old.Jsonable<any>>): void;
-use_old_TypeAliasDeclaration_Jsonable(
-    get_current_TypeAliasDeclaration_Jsonable());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAliasDeclaration_JsonableTypeWith": {"forwardCompat": false}
+ * "RemovedTypeAliasDeclaration_JsonableTypeWith": {"forwardCompat": false}
  */
-declare function get_old_TypeAliasDeclaration_JsonableTypeWith():
-    TypeOnly<old.JsonableTypeWith<any>>;
-declare function use_current_TypeAliasDeclaration_JsonableTypeWith(
-    use: TypeOnly<current.JsonableTypeWith<any>>): void;
-use_current_TypeAliasDeclaration_JsonableTypeWith(
-    get_old_TypeAliasDeclaration_JsonableTypeWith());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAliasDeclaration_JsonableTypeWith": {"backCompat": false}
+ * "RemovedTypeAliasDeclaration_JsonableTypeWith": {"backCompat": false}
  */
-declare function get_current_TypeAliasDeclaration_JsonableTypeWith():
-    TypeOnly<current.JsonableTypeWith<any>>;
-declare function use_old_TypeAliasDeclaration_JsonableTypeWith(
-    use: TypeOnly<old.JsonableTypeWith<any>>): void;
-use_old_TypeAliasDeclaration_JsonableTypeWith(
-    get_current_TypeAliasDeclaration_JsonableTypeWith());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.

--- a/packages/runtime/datastore/api-report/datastore.api.md
+++ b/packages/runtime/datastore/api-report/datastore.api.md
@@ -28,6 +28,7 @@ import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions'
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
+import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 import { VisibilityState } from '@fluidframework/runtime-definitions/internal';
 
@@ -115,7 +116,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     setConnectionState(connected: boolean, clientId?: string): void;
     // (undocumented)
     submitMessage(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
-    submitSignal(type: string, content: unknown, targetClientId?: string): void;
+    submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string): void;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
     updateUsedRoutes(usedRoutes: string[]): void;
     // (undocumented)

--- a/packages/runtime/datastore/api-report/datastore.api.md
+++ b/packages/runtime/datastore/api-report/datastore.api.md
@@ -28,7 +28,7 @@ import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions'
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
-import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
+import type { SignalContentType } from '@fluidframework/core-interfaces/internal';
 import { TypedEventEmitter } from '@fluid-internal/client-utils';
 import { VisibilityState } from '@fluidframework/runtime-definitions/internal';
 
@@ -116,7 +116,7 @@ export class FluidDataStoreRuntime extends TypedEventEmitter<IFluidDataStoreRunt
     setConnectionState(connected: boolean, clientId?: string): void;
     // (undocumented)
     submitMessage(type: DataStoreMessageType, content: any, localOpMetadata: unknown): void;
-    submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string): void;
+    submitSignal(type: string, content: SignalContentType, targetClientId?: string): void;
     summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
     updateUsedRoutes(usedRoutes: string[]): void;
     // (undocumented)

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -12,6 +12,7 @@ import {
 	IRequest,
 	IResponse,
 } from "@fluidframework/core-interfaces";
+import type { JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
 import {
 	assert,
 	Deferred,
@@ -958,7 +959,7 @@ export class FluidDataStoreRuntime
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(type: string, content: unknown, targetClientId?: string) {
+	public submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string) {
 		this.verifyNotClosed();
 		return this.dataStoreContext.submitSignal(type, content, targetClientId);
 	}

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -12,7 +12,7 @@ import {
 	IRequest,
 	IResponse,
 } from "@fluidframework/core-interfaces";
-import type { JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
+import type { SignalContentType } from "@fluidframework/core-interfaces/internal";
 import {
 	assert,
 	Deferred,
@@ -959,7 +959,7 @@ export class FluidDataStoreRuntime
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	public submitSignal(type: string, content: JsonableOrBinary, targetClientId?: string) {
+	public submitSignal(type: string, content: SignalContentType, targetClientId?: string) {
 		this.verifyNotClosed();
 		return this.dataStoreContext.submitSignal(type, content, targetClientId);
 	}

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -27,8 +27,8 @@ import type { ISummaryTree } from '@fluidframework/protocol-definitions';
 import type { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import type { ITree } from '@fluidframework/protocol-definitions';
 import type { IUser } from '@fluidframework/protocol-definitions';
-import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
-import type { JsonableOrBinary as JsonableOrBinary_2 } from '@fluidframework/core-interfaces';
+import type { SignalContentType } from '@fluidframework/core-interfaces/internal';
+import type { SignalContentType as SignalContentType_2 } from '@fluidframework/core-interfaces';
 import type { SummaryTree } from '@fluidframework/protocol-definitions';
 import type { TelemetryBaseEventPropertyType } from '@fluidframework/core-interfaces';
 
@@ -140,7 +140,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
     // (undocumented)
     readonly logger: ITelemetryBaseLogger;
     orderSequentially(callback: () => void): void;
-    submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
+    submitSignal: (type: string, content: SignalContentType, targetClientId?: string) => void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 }
@@ -285,7 +285,7 @@ export interface IFluidParentContext extends IProvideFluidHandleContext, Partial
     // (undocumented)
     readonly storage: IDocumentStorageService;
     submitMessage(type: string, content: any, localOpMetadata: unknown): void;
-    submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
+    submitSignal: (type: string, content: SignalContentType, targetClientId?: string) => void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 }
@@ -332,7 +332,7 @@ export interface ISignalEnvelope {
     clientSignalSequenceNumber: number;
     contents: {
         type: string;
-        content: JsonableOrBinary_2;
+        content: SignalContentType_2;
     };
 }
 

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -27,6 +27,8 @@ import type { ISummaryTree } from '@fluidframework/protocol-definitions';
 import type { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import type { ITree } from '@fluidframework/protocol-definitions';
 import type { IUser } from '@fluidframework/protocol-definitions';
+import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
+import type { JsonableOrBinary as JsonableOrBinary_2 } from '@fluidframework/core-interfaces';
 import type { SummaryTree } from '@fluidframework/protocol-definitions';
 import type { TelemetryBaseEventPropertyType } from '@fluidframework/core-interfaces';
 
@@ -138,7 +140,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
     // (undocumented)
     readonly logger: ITelemetryBaseLogger;
     orderSequentially(callback: () => void): void;
-    submitSignal: (type: string, content: unknown, targetClientId?: string) => void;
+    submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 }
@@ -164,10 +166,10 @@ export interface IDataStore {
 }
 
 // @alpha
-export interface IEnvelope {
+export type IEnvelope<T = any> = {
     address: string;
-    contents: any;
-}
+    contents: T;
+};
 
 // @public
 export interface IExperimentalIncrementalSummaryContext {
@@ -283,7 +285,7 @@ export interface IFluidParentContext extends IProvideFluidHandleContext, Partial
     // (undocumented)
     readonly storage: IDocumentStorageService;
     submitMessage(type: string, content: any, localOpMetadata: unknown): void;
-    submitSignal: (type: string, content: unknown, targetClientId?: string) => void;
+    submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
     // (undocumented)
     uploadBlob(blob: ArrayBufferLike, signal?: AbortSignal): Promise<IFluidHandle<ArrayBufferLike>>;
 }
@@ -330,7 +332,7 @@ export interface ISignalEnvelope {
     clientSignalSequenceNumber: number;
     contents: {
         type: string;
-        content: any;
+        content: JsonableOrBinary_2;
     };
 }
 

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -15,6 +15,7 @@ import type {
 	IResponse,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
+import type { JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
 import type { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type {
@@ -186,7 +187,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	submitSignal: (type: string, content: unknown, targetClientId?: string) => void;
+	submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
 
 	/**
 	 * @deprecated 0.16 Issue #1537, #3631
@@ -459,7 +460,7 @@ export interface IFluidParentContext
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	submitSignal: (type: string, content: unknown, targetClientId?: string) => void;
+	submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
 
 	/**
 	 * Called to make the data store locally visible in the container. This happens automatically for root data stores

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -15,7 +15,7 @@ import type {
 	IResponse,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import type { JsonableOrBinary } from "@fluidframework/core-interfaces/internal";
+import type { SignalContentType } from "@fluidframework/core-interfaces/internal";
 import type { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type {
@@ -187,7 +187,7 @@ export interface IContainerRuntimeBase extends IEventProvider<IContainerRuntimeB
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
+	submitSignal: (type: string, content: SignalContentType, targetClientId?: string) => void;
 
 	/**
 	 * @deprecated 0.16 Issue #1537, #3631
@@ -460,7 +460,7 @@ export interface IFluidParentContext
 	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
-	submitSignal: (type: string, content: JsonableOrBinary, targetClientId?: string) => void;
+	submitSignal: (type: string, content: SignalContentType, targetClientId?: string) => void;
 
 	/**
 	 * Called to make the data store locally visible in the container. This happens automatically for root data stores

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -4,12 +4,14 @@
  */
 
 import type { ISignalMessage, ITree } from "@fluidframework/protocol-definitions";
+import type { JsonableOrBinary } from "@fluidframework/core-interfaces";
 
 /**
  * An envelope wraps the contents with the intended target
  * @alpha
  */
-export interface IEnvelope {
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type IEnvelope<T = any> = {
 	/**
 	 * The target for the envelope
 	 */
@@ -18,8 +20,8 @@ export interface IEnvelope {
 	/**
 	 * The contents of the envelope
 	 */
-	contents: any;
-}
+	contents: T;
+};
 
 /**
  * @internal
@@ -41,7 +43,7 @@ export interface ISignalEnvelope {
 	 */
 	contents: {
 		type: string;
-		content: any;
+		content: JsonableOrBinary;
 	};
 }
 

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ISignalMessage, ITree } from "@fluidframework/protocol-definitions";
-import type { JsonableOrBinary } from "@fluidframework/core-interfaces";
+import type { SignalContentType } from "@fluidframework/core-interfaces";
 
 /**
  * An envelope wraps the contents with the intended target
@@ -43,7 +43,7 @@ export interface ISignalEnvelope {
 	 */
 	contents: {
 		type: string;
-		content: JsonableOrBinary;
+		content: SignalContentType;
 	};
 }
 

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -419,13 +419,13 @@ use_old_InterfaceDeclaration_IDataStore(
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_IEnvelope": {"forwardCompat": false}
+ * "RemovedInterfaceDeclaration_IEnvelope": {"forwardCompat": false}
  */
 declare function get_old_InterfaceDeclaration_IEnvelope():
     TypeOnly<old.IEnvelope>;
-declare function use_current_InterfaceDeclaration_IEnvelope(
+declare function use_current_RemovedInterfaceDeclaration_IEnvelope(
     use: TypeOnly<current.IEnvelope>): void;
-use_current_InterfaceDeclaration_IEnvelope(
+use_current_RemovedInterfaceDeclaration_IEnvelope(
     get_old_InterfaceDeclaration_IEnvelope());
 
 /*
@@ -433,14 +433,14 @@ use_current_InterfaceDeclaration_IEnvelope(
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_IEnvelope": {"backCompat": false}
+ * "RemovedInterfaceDeclaration_IEnvelope": {"backCompat": false}
  */
-declare function get_current_InterfaceDeclaration_IEnvelope():
+declare function get_current_RemovedInterfaceDeclaration_IEnvelope():
     TypeOnly<current.IEnvelope>;
 declare function use_old_InterfaceDeclaration_IEnvelope(
     use: TypeOnly<old.IEnvelope>): void;
 use_old_InterfaceDeclaration_IEnvelope(
-    get_current_InterfaceDeclaration_IEnvelope());
+    get_current_RemovedInterfaceDeclaration_IEnvelope());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.

--- a/packages/service-clients/azure-client/api-report/azure-client.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.api.md
@@ -68,7 +68,7 @@ export interface AzureContainerVersion {
 
 // @internal @deprecated
 export class AzureFunctionTokenProvider implements ITokenProvider {
-    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "name" | "id" | "additionalDetails"> | undefined);
+    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "id" | "name" | "additionalDetails"> | undefined);
     // (undocumented)
     fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
@@ -6,9 +6,8 @@
 import type { SignalListener } from "@fluid-experimental/data-objects";
 import { EventEmitter } from "@fluid-internal/client-utils";
 import { DataObject, DataObjectFactory, IDataObjectProps } from "@fluidframework/aqueduct/internal";
-import { type IErrorEvent, IFluidHandle } from "@fluidframework/core-interfaces";
+import { type IErrorEvent, IFluidHandle, Jsonable } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter/internal";
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
 import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 
 export class TestDataObject extends DataObject {


### PR DESCRIPTION
This is a prototype of what it takes to support binary payloads in signals.
Only client changes, with small demonstration of changes up to a driver.

This PR will be broken into pieces, and 95% of it will make it to repo (all refactoring that leads to it).
Actual binary implementation will stay for now in the form of draft...

PRs that were forked / extracted from this PR:
- https://github.com/microsoft/FluidFramework/pull/20953
- https://github.com/microsoft/FluidFramework/pull/20954
- https://github.com/microsoft/FluidFramework/pull/20956
