### PR TITLE
Move Jsonable types into core-interfaces

### DIFF
--- a/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
+++ b/experimental/dds/ot/sharejs/json1/src/test/json1.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import {
 	MockContainerRuntimeFactory,
 	MockFluidDataStoreRuntime,

--- a/experimental/dds/sequence-deprecated/api-report/sequence-deprecated.api.md
+++ b/experimental/dds/sequence-deprecated/api-report/sequence-deprecated.api.md
@@ -9,12 +9,12 @@ import { IChannelAttributes } from '@fluidframework/datastore-definitions';
 import { IChannelFactory } from '@fluidframework/datastore-definitions';
 import { IChannelServices } from '@fluidframework/datastore-definitions';
 import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions';
-import { IFluidHandle } from '@fluidframework/core-interfaces';
+import { IFluidHandle } from '@fluidframework/core-interfaces/internal';
 import { IJSONRunSegment } from '@fluidframework/sequence/internal';
 import { IJSONSegment } from '@fluidframework/merge-tree/internal';
 import { ISegment } from '@fluidframework/merge-tree/internal';
 import { ISharedObject } from '@fluidframework/shared-object-base';
-import { Jsonable } from '@fluidframework/datastore-definitions/internal';
+import { Jsonable } from '@fluidframework/core-interfaces/internal';
 import { PropertySet } from '@fluidframework/merge-tree/internal';
 import { Serializable } from '@fluidframework/datastore-definitions/internal';
 import { SharedSegmentSequence } from '@fluidframework/sequence/internal';
@@ -182,7 +182,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
     static getFactory(): IChannelFactory;
     // (undocumented)
     getItem(row: number, col: number): // The return type is defined explicitly here to prevent TypeScript from generating dynamic imports
-    Jsonable<string | number | boolean | IFluidHandle> | undefined;
+    Jsonable<unknown, IFluidHandle> | undefined;
     // (undocumented)
     getPositionProperties(row: number, col: number): PropertySet | undefined;
     // (undocumented)

--- a/experimental/dds/sequence-deprecated/src/sparsematrix.ts
+++ b/experimental/dds/sequence-deprecated/src/sparsematrix.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidHandle } from "@fluidframework/core-interfaces";
+import { IFluidHandle, Jsonable } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import {
 	IChannelAttributes,
@@ -11,7 +11,6 @@ import {
 	IChannelServices,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
 import {
 	BaseSegment,
 	IJSONSegment,
@@ -294,7 +293,7 @@ export class SparseMatrix extends SharedSegmentSequence<MatrixSegment> {
 		row: number,
 		col: number,
 	): // The return type is defined explicitly here to prevent TypeScript from generating dynamic imports
-	Jsonable<string | number | boolean | IFluidHandle> | undefined {
+	Jsonable<unknown, IFluidHandle> | undefined {
 		const pos = rowColToPosition(row, col);
 		const { segment, offset } = this.getContainingSegment(pos);
 		if (segment && RunSegment.is(segment)) {

--- a/experimental/framework/data-objects/api-report/data-objects.api.md
+++ b/experimental/framework/data-objects/api-report/data-objects.api.md
@@ -9,7 +9,7 @@ import { DataObjectFactory } from '@fluidframework/aqueduct/internal';
 import { EventEmitter } from '@fluid-internal/client-utils';
 import { IErrorEvent } from '@fluidframework/core-interfaces';
 import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
-import { Jsonable } from '@fluidframework/datastore-definitions/internal';
+import { Jsonable } from '@fluidframework/core-interfaces/internal';
 
 // @internal
 export interface IRuntimeSignaler {
@@ -18,7 +18,7 @@ export interface IRuntimeSignaler {
     // (undocumented)
     on(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void): any;
     // (undocumented)
-    submitSignal(type: string, content: Jsonable<unknown>): void;
+    submitSignal(type: string, content: Jsonable): void;
 }
 
 // @internal

--- a/experimental/framework/data-objects/src/signaler/signaler.ts
+++ b/experimental/framework/data-objects/src/signaler/signaler.ts
@@ -58,7 +58,7 @@ export interface ISignaler {
 export interface IRuntimeSignaler {
 	connected: boolean;
 	on(event: "signal", listener: (message: IInboundSignalMessage, local: boolean) => void);
-	submitSignal(type: string, content: Jsonable<unknown>): void;
+	submitSignal(type: string, content: Jsonable): void;
 }
 
 /**

--- a/experimental/framework/data-objects/src/signaler/signaler.ts
+++ b/experimental/framework/data-objects/src/signaler/signaler.ts
@@ -7,7 +7,7 @@ import { EventEmitter, TypedEventEmitter } from "@fluid-internal/client-utils";
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/internal";
 import { IErrorEvent } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
+import { Jsonable } from "@fluidframework/core-interfaces/internal";
 import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 
 // TODO:

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -297,6 +297,12 @@ export interface ILoggingError extends Error {
 }
 
 // @public (undocumented)
+export interface Internal_InterfaceOfJsonableTypesWith<T> {
+    // (undocumented)
+    [index: string | number]: JsonableTypeWith<T>;
+}
+
+// @public (undocumented)
 export interface IProvideFluidHandle {
     // (undocumented)
     readonly [IFluidHandle]: IFluidHandle;
@@ -394,6 +400,17 @@ export interface IUsageError extends IErrorBase {
 }
 
 // @public
+export type Jsonable<T = unknown, TReplaced = never> = boolean extends (T extends never ? true : false) ? JsonableTypeWith<TReplaced> : unknown extends T ? JsonableTypeWith<TReplaced> : T extends undefined | null | boolean | number | string | TReplaced ? T : Extract<T, Function> extends never ? T extends object ? T extends (infer U)[] ? Jsonable<U, TReplaced>[] : {
+    [K in keyof T]: Extract<K, symbol> extends never ? Jsonable<T[K], TReplaced> : never;
+} : never : never;
+
+// @public (undocumented)
+export type JsonableOrBinary<T = unknown> = Jsonable<T, ArrayBuffer>;
+
+// @public
+export type JsonableTypeWith<T> = undefined | null | boolean | number | string | T | Internal_InterfaceOfJsonableTypesWith<T> | ArrayLike<JsonableTypeWith<T>>;
+
+// @public
 export const LogLevel: {
     readonly verbose: 10;
     readonly default: 20;
@@ -407,6 +424,9 @@ export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
 export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> = L extends any[] ? {
     [K in keyof L]: L[K] extends IEventThisPlaceHolder ? TThis : L[K];
 } : L;
+
+// @public (undocumented)
+export type SignalContentType<T = unknown> = JsonableOrBinary<T>;
 
 // @public
 export interface Tagged<V, T extends string = string> {

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -404,9 +404,6 @@ export type Jsonable<T = unknown, TReplaced = never> = boolean extends (T extend
     [K in keyof T]: Extract<K, symbol> extends never ? Jsonable<T[K], TReplaced> : never;
 } : never : never;
 
-// @public (undocumented)
-export type JsonableOrBinary<T = unknown> = Jsonable<T, ArrayBuffer>;
-
 // @public
 export type JsonableTypeWith<T> = undefined | null | boolean | number | string | T | Internal_InterfaceOfJsonableTypesWith<T> | ArrayLike<JsonableTypeWith<T>>;
 
@@ -424,9 +421,6 @@ export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
 export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> = L extends any[] ? {
     [K in keyof L]: L[K] extends IEventThisPlaceHolder ? TThis : L[K];
 } : L;
-
-// @public (undocumented)
-export type SignalContentType<T = unknown> = JsonableOrBinary<T>;
 
 // @public
 export interface Tagged<V, T extends string = string> {

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -43,3 +43,8 @@ export type { FluidObjectProviderKeys, FluidObject, FluidObjectKeys } from "./pr
 export type { ConfigTypes, IConfigProviderBase } from "./config.js";
 export type { ISignalEnvelope } from "./messages.js";
 export type { ErasedType } from "./erasedType.js";
+export type {
+	Jsonable,
+	JsonableTypeWith,
+	Internal_InterfaceOfJsonableTypesWith,
+} from "./jsonable.js";

--- a/packages/common/core-interfaces/src/jsonable.ts
+++ b/packages/common/core-interfaces/src/jsonable.ts
@@ -13,10 +13,11 @@
  *
  * @privateRemarks
  * Perfer using `Jsonable<unknown>` over this type that is an implementation detail.
- * @alpha
+ * @public
  */
 export type JsonableTypeWith<T> =
 	| undefined
+	// eslint-disable-next-line @rushstack/no-new-null
 	| null
 	| boolean
 	| number
@@ -34,7 +35,7 @@ export type JsonableTypeWith<T> =
  * This interface along with ArrayLike above avoids pure type recursion issues, but introduces a limitation on
  * the ability of {@link Jsonable} to detect array-like types that are not handled naively ({@link JSON.stringify}).
  * The TypeOnly filter is not useful for {@link JsonableTypeWith}; so, if type testing improves, this can be removed.
- * @alpha
+ * @public
  */
 export interface Internal_InterfaceOfJsonableTypesWith<T> {
 	[index: string | number]: JsonableTypeWith<T>;
@@ -78,9 +79,9 @@ export interface Internal_InterfaceOfJsonableTypesWith<T> {
  * ```typescript
  * function foo<T>(value: Jsonable<T>) { ... }
  * ```
- * @alpha
+ * @public
  */
-export type Jsonable<T, TReplaced = never> = /* test for 'any' */ boolean extends (
+export type Jsonable<T = unknown, TReplaced = never> = /* test for 'any' */ boolean extends (
 	T extends never ? true : false
 )
 	? /* 'any' => */ JsonableTypeWith<TReplaced>
@@ -88,6 +89,7 @@ export type Jsonable<T, TReplaced = never> = /* test for 'any' */ boolean extend
 	? /* 'unknown' => */ JsonableTypeWith<TReplaced>
 	: /* test for Jsonable primitive types */ T extends
 			| undefined /* is not serialized */
+			// eslint-disable-next-line @rushstack/no-new-null
 			| null
 			| boolean
 			| number

--- a/packages/common/core-interfaces/src/test/types/jsonable.ts
+++ b/packages/common/core-interfaces/src/test/types/jsonable.ts
@@ -7,6 +7,8 @@ import type { Jsonable } from "../../index.js";
 
 declare function foo<T>(jsonable: Jsonable<T>): void;
 
+/* eslint-disable unicorn/no-null, @typescript-eslint/no-explicit-any, @rushstack/no-new-null, @typescript-eslint/no-unsafe-argument */
+
 // --- ideally wouldn't work but do as we don't know how to just exclude classes
 
 // test simple class.
@@ -65,7 +67,7 @@ declare const json: Json;
 foo(json);
 
 // test "unknown" Jsonable content
-declare const unknownJsonable: Jsonable<unknown>;
+declare const unknownJsonable: Jsonable;
 foo(unknownJsonable);
 
 // test "unknown" cannonical Json content in an interface
@@ -176,7 +178,7 @@ foo(a14);
 
 // test class with function
 class bar {
-	public baz() {}
+	public baz(): void {}
 }
 // @ts-expect-error should not be jsonable
 foo(new bar());
@@ -226,7 +228,7 @@ foo(mayNotBeArray);
  * It is used below to bypass the early "Index signature for type 'string'" issue for interfaces.
  */
 type TypeAliasOf<T> = T extends object
-	? T extends () => any | null
+	? T extends () => any
 		? T
 		: { [K in keyof T]: TypeAliasOf<T[K]> }
 	: T;
@@ -307,7 +309,7 @@ foo<unknown>(selfReferencing as Jsonable<typeof selfReferencing>);
 // Show that cast to Jsonable version of self does compile even if not
 // respecting the limitations. This is a dangerous practice, but can
 // be useful if very careful.
-foo(aUnknown as Jsonable<typeof aUnknown>);
+foo(aUnknown as Jsonable);
 foo(nestedUnknown as Jsonable<typeof nestedUnknown>);
 foo(a11 as Jsonable<typeof a11>);
 foo(a12 as Jsonable<typeof a12>);
@@ -317,3 +319,5 @@ foo(aBar as Jsonable<typeof aBar>);
 foo(mt as Jsonable<typeof mt>);
 foo(nmt as Jsonable<typeof nmt>);
 foo(isym as Jsonable<typeof isym>);
+
+/* eslint-enable unicorn/no-null, @typescript-eslint/no-explicit-any, @rushstack/no-new-null, @typescript-eslint/no-unsafe-argument */

--- a/packages/dds/shared-summary-block/api-report/shared-summary-block.api.md
+++ b/packages/dds/shared-summary-block/api-report/shared-summary-block.api.md
@@ -13,7 +13,7 @@ import { IFluidSerializer } from '@fluidframework/shared-object-base';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISharedObject } from '@fluidframework/shared-object-base';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
-import { Jsonable } from '@fluidframework/datastore-definitions/internal';
+import { Jsonable } from '@fluidframework/core-interfaces';
 import { SharedObject } from '@fluidframework/shared-object-base/internal';
 
 // @alpha

--- a/packages/dds/shared-summary-block/src/interfaces.ts
+++ b/packages/dds/shared-summary-block/src/interfaces.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
+import { Jsonable } from "@fluidframework/core-interfaces";
 import { ISharedObject } from "@fluidframework/shared-object-base";
 
 /**

--- a/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
+++ b/packages/dds/shared-summary-block/src/sharedSummaryBlock.ts
@@ -9,7 +9,7 @@ import {
 	IChannelStorageService,
 	IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
+import type { Jsonable } from "@fluidframework/core-interfaces";
 import { readAndParse } from "@fluidframework/driver-utils/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ISummaryTreeWithStats } from "@fluidframework/runtime-definitions";
@@ -26,7 +26,7 @@ const snapshotFileName = "header";
  * Directly used in JSON.stringify, direct result from JSON.parse.
  */
 interface ISharedSummaryBlockDataSerializable {
-	[key: string]: Jsonable<unknown>;
+	[key: string]: Jsonable;
 }
 
 /**
@@ -58,7 +58,7 @@ export class SharedSummaryBlock extends SharedObject implements ISharedSummaryBl
 	/**
 	 * The data held by this object.
 	 */
-	private readonly data = new Map<string, Jsonable<unknown>>();
+	private readonly data = new Map<string, Jsonable>();
 
 	/**
 	 * Constructs a new SharedSummaryBlock. If the object is non-local, an id and service interfaces will

--- a/packages/framework/attributor/src/lz4Encoder.ts
+++ b/packages/framework/attributor/src/lz4Encoder.ts
@@ -4,7 +4,7 @@
  */
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
-import { type Jsonable } from "@fluidframework/datastore-definitions/internal";
+import { type Jsonable } from "@fluidframework/core-interfaces";
 import { compress, decompress } from "lz4js";
 
 import { type Encoder } from "./encoders.js";

--- a/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
+++ b/packages/framework/attributor/src/test/attribution/sharedString.attribution.spec.ts
@@ -26,7 +26,7 @@ import {
 	type IChannelServices,
 	type IFluidDataStoreRuntime,
 } from "@fluidframework/datastore-definitions";
-import { type Jsonable } from "@fluidframework/datastore-definitions/internal";
+import { type Jsonable } from "@fluidframework/core-interfaces";
 import { createInsertOnlyAttributionPolicy } from "@fluidframework/merge-tree/internal";
 import {
 	type ISequencedDocumentMessage,

--- a/packages/framework/attributor/src/test/lz4Encoder.spec.ts
+++ b/packages/framework/attributor/src/test/lz4Encoder.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { type JsonableTypeWith } from "@fluidframework/datastore-definitions/internal";
+import { type JsonableTypeWith } from "@fluidframework/core-interfaces/internal";
 
 import { makeLZ4Encoder } from "../lz4Encoder.js";
 

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -24,6 +24,7 @@ import type { ISequencedDocumentMessage } from '@fluidframework/protocol-definit
 import type { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions';
 import type { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import type { ITelemetryContext } from '@fluidframework/runtime-definitions';
+import type { Jsonable } from '@fluidframework/core-interfaces';
 
 // @public (undocumented)
 export interface IChannel extends IFluidLoadable {
@@ -135,20 +136,6 @@ export interface IFluidDataStoreRuntimeEvents extends IEvent {
     // (undocumented)
     (event: "connected", listener: (clientId: string) => void): any;
 }
-
-// @alpha (undocumented)
-export interface Internal_InterfaceOfJsonableTypesWith<T> {
-    // (undocumented)
-    [index: string | number]: JsonableTypeWith<T>;
-}
-
-// @alpha
-export type Jsonable<T, TReplaced = never> = boolean extends (T extends never ? true : false) ? JsonableTypeWith<TReplaced> : unknown extends T ? JsonableTypeWith<TReplaced> : T extends undefined | null | boolean | number | string | TReplaced ? T : Extract<T, Function> extends never ? T extends object ? T extends (infer U)[] ? Jsonable<U, TReplaced>[] : {
-    [K in keyof T]: Extract<K, symbol> extends never ? Jsonable<T[K], TReplaced> : never;
-} : never : never;
-
-// @alpha
-export type JsonableTypeWith<T> = undefined | null | boolean | number | string | T | Internal_InterfaceOfJsonableTypesWith<T> | ArrayLike<JsonableTypeWith<T>>;
 
 // @alpha
 export type Serializable<T> = Jsonable<T, IFluidHandle>;

--- a/packages/runtime/datastore-definitions/package.json
+++ b/packages/runtime/datastore-definitions/package.json
@@ -92,6 +92,18 @@
 		"broken": {
 			"InterfaceDeclaration_IFluidDataStoreRuntime": {
 				"backCompat": false
+			},
+			"RemovedInterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"RemovedTypeAliasDeclaration_Jsonable": {
+				"forwardCompat": false,
+				"backCompat": false
+			},
+			"RemovedTypeAliasDeclaration_JsonableTypeWith": {
+				"forwardCompat": false,
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/runtime/datastore-definitions/src/index.ts
+++ b/packages/runtime/datastore-definitions/src/index.ts
@@ -19,10 +19,5 @@ export type {
 	IDeltaHandler,
 } from "./channel.js";
 export type { IFluidDataStoreRuntime, IFluidDataStoreRuntimeEvents } from "./dataStoreRuntime.js";
-export type {
-	Jsonable,
-	JsonableTypeWith,
-	Internal_InterfaceOfJsonableTypesWith,
-} from "./jsonable.js";
 export type { Serializable } from "./serializable.js";
 export type { IChannelAttributes } from "./storage.js";

--- a/packages/runtime/datastore-definitions/src/serializable.ts
+++ b/packages/runtime/datastore-definitions/src/serializable.ts
@@ -3,9 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { IFluidHandle } from "@fluidframework/core-interfaces";
-
-import type { Jsonable } from "./jsonable.js";
+import type { IFluidHandle, Jsonable } from "@fluidframework/core-interfaces";
 
 /**
  * Used to constrain a type 'T' to types that Fluid can intrinsically serialize.  Produces a

--- a/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/validateDatastoreDefinitionsPrevious.generated.ts
@@ -280,84 +280,48 @@ use_old_InterfaceDeclaration_IFluidDataStoreRuntimeEvents(
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith": {"forwardCompat": false}
+ * "RemovedInterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith": {"forwardCompat": false}
  */
-declare function get_old_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith():
-    TypeOnly<old.Internal_InterfaceOfJsonableTypesWith<any>>;
-declare function use_current_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith(
-    use: TypeOnly<current.Internal_InterfaceOfJsonableTypesWith<any>>): void;
-use_current_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith(
-    get_old_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith": {"backCompat": false}
+ * "RemovedInterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith": {"backCompat": false}
  */
-declare function get_current_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith():
-    TypeOnly<current.Internal_InterfaceOfJsonableTypesWith<any>>;
-declare function use_old_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith(
-    use: TypeOnly<old.Internal_InterfaceOfJsonableTypesWith<any>>): void;
-use_old_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith(
-    get_current_InterfaceDeclaration_Internal_InterfaceOfJsonableTypesWith());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAliasDeclaration_Jsonable": {"forwardCompat": false}
+ * "RemovedTypeAliasDeclaration_Jsonable": {"forwardCompat": false}
  */
-declare function get_old_TypeAliasDeclaration_Jsonable():
-    TypeOnly<old.Jsonable<any>>;
-declare function use_current_TypeAliasDeclaration_Jsonable(
-    use: TypeOnly<current.Jsonable<any>>): void;
-use_current_TypeAliasDeclaration_Jsonable(
-    get_old_TypeAliasDeclaration_Jsonable());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAliasDeclaration_Jsonable": {"backCompat": false}
+ * "RemovedTypeAliasDeclaration_Jsonable": {"backCompat": false}
  */
-declare function get_current_TypeAliasDeclaration_Jsonable():
-    TypeOnly<current.Jsonable<any>>;
-declare function use_old_TypeAliasDeclaration_Jsonable(
-    use: TypeOnly<old.Jsonable<any>>): void;
-use_old_TypeAliasDeclaration_Jsonable(
-    get_current_TypeAliasDeclaration_Jsonable());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAliasDeclaration_JsonableTypeWith": {"forwardCompat": false}
+ * "RemovedTypeAliasDeclaration_JsonableTypeWith": {"forwardCompat": false}
  */
-declare function get_old_TypeAliasDeclaration_JsonableTypeWith():
-    TypeOnly<old.JsonableTypeWith<any>>;
-declare function use_current_TypeAliasDeclaration_JsonableTypeWith(
-    use: TypeOnly<current.JsonableTypeWith<any>>): void;
-use_current_TypeAliasDeclaration_JsonableTypeWith(
-    get_old_TypeAliasDeclaration_JsonableTypeWith());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAliasDeclaration_JsonableTypeWith": {"backCompat": false}
+ * "RemovedTypeAliasDeclaration_JsonableTypeWith": {"backCompat": false}
  */
-declare function get_current_TypeAliasDeclaration_JsonableTypeWith():
-    TypeOnly<current.JsonableTypeWith<any>>;
-declare function use_old_TypeAliasDeclaration_JsonableTypeWith(
-    use: TypeOnly<old.JsonableTypeWith<any>>): void;
-use_old_TypeAliasDeclaration_JsonableTypeWith(
-    get_current_TypeAliasDeclaration_JsonableTypeWith());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
@@ -6,9 +6,8 @@
 import type { SignalListener } from "@fluid-experimental/data-objects";
 import { EventEmitter } from "@fluid-internal/client-utils";
 import { DataObject, DataObjectFactory, IDataObjectProps } from "@fluidframework/aqueduct/internal";
-import { type IErrorEvent, IFluidHandle } from "@fluidframework/core-interfaces";
+import { type IErrorEvent, IFluidHandle, Jsonable } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter/internal";
-import { Jsonable } from "@fluidframework/datastore-definitions/internal";
 import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 
 export class TestDataObject extends DataObject {


### PR DESCRIPTION
Split from https://github.com/microsoft/FluidFramework/pull/20952

Also
- Add unknown as default generics argument - it means "all JSONable types"
- Fix some incorrect usages of Jsonable.
- Make it public. I'll need it to annotate submitSignal payload type, and these APIs are public, so Jsonable has to be public too.