### PR TITLE
Introduction of JsonableOrBinary

### DIFF
--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -394,6 +394,8 @@ export interface IUsageError extends IErrorBase {
 }
 
 // @public
+export type JsonableOrBinary<T = unknown> = Jsonable<T, ArrayBuffer>;
+
 export const LogLevel: {
     readonly verbose: 10;
     readonly default: 20;

--- a/packages/common/core-interfaces/src/index.ts
+++ b/packages/common/core-interfaces/src/index.ts
@@ -43,3 +43,9 @@ export type { FluidObjectProviderKeys, FluidObject, FluidObjectKeys } from "./pr
 export type { ConfigTypes, IConfigProviderBase } from "./config.js";
 export type { ISignalEnvelope } from "./messages.js";
 export type { ErasedType } from "./erasedType.js";
+export type {
+	Jsonable,
+	JsonableTypeWith,
+	Internal_InterfaceOfJsonableTypesWith,
+	JsonableOrBinary,
+} from "./jsonable.js";

--- a/packages/common/core-utils/src/binaryEncoding.ts
+++ b/packages/common/core-utils/src/binaryEncoding.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import type { JsonableOrBinary, Jsonable } from "@fluidframework/core-interfaces/internal";
+import { Uint8ArrayToString } from "@fluid-internal/client-utils";
+
+/**
+ * Encodes JsonableOrBinary into a string. Binary payloads will be base64 encoded
+ * Please note that output of this API can be used in various protocols or document format.
+ * As such, serialization format can not change. It could only be extended IF JsonableOrBinary type is extended.
+ * @param content - content to stringify
+ * @returns string
+ * @internal
+ */
+export function encodeJsonableOrBinary<T>(content: JsonableOrBinary<T>): string {
+	return JSON.stringify(content, (_key: string, value: JsonableOrBinary<T>) => {
+		if (value instanceof ArrayBuffer) {
+			
+			Uint8ArrayToString(new Uint8Array(value), "base64");
+			return value;
+		}
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return value;
+	});
+}
+
+/**
+ * Decodes string back to JsonableOrBinary.
+ * Can be called only for content that was produced by encodeJsonableOrBinary()
+ * @param content - an encoded string
+ * @returns decoded JS object
+ */
+export function decodeJsonableOrBinary(content: string): JsonableOrBinary {
+	return JSON.parse(content, (key: string, value: Jsonable) => {
+		// stringToBuffer(value, "base64")
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return value;
+	}) as JsonableOrBinary;
+}

--- a/packages/loader/driver-utils/api-report/driver-utils.api.md
+++ b/packages/loader/driver-utils/api-report/driver-utils.api.md
@@ -38,6 +38,7 @@ import { ITree } from '@fluidframework/protocol-definitions';
 import { ITreeEntry } from '@fluidframework/protocol-definitions';
 import { IUrlResolver } from '@fluidframework/driver-definitions/internal';
 import { IVersion } from '@fluidframework/protocol-definitions';
+import type { JsonableOrBinary } from '@fluidframework/core-interfaces/internal';
 import { LoaderCachingPolicy } from '@fluidframework/driver-definitions/internal';
 import { LoggingError } from '@fluidframework/telemetry-utils/internal';
 
@@ -121,6 +122,9 @@ export function createGenericNetworkError(message: string, retryInfo: {
 // @internal (undocumented)
 export const createWriteError: (message: string, props: DriverErrorTelemetryProps) => NonRetryableError<"writeError">;
 
+// @internal
+export function decodeJsonableOrBinary(content: string): JsonableOrBinary;
+
 // @internal (undocumented)
 export class DeltaStreamConnectionForbiddenError extends LoggingError implements IDriverErrorBase, IFluidErrorBase {
     constructor(message: string, props: DriverErrorTelemetryProps, storageOnlyReason?: string);
@@ -165,6 +169,9 @@ export type DriverErrorTelemetryProps = ITelemetryBaseProperties & {
 
 // @internal (undocumented)
 export const emptyMessageStream: IStream<ISequencedDocumentMessage[]>;
+
+// @internal
+export function encodeJsonableOrBinary<T>(content: JsonableOrBinary<T>): string;
 
 // @internal
 export class FluidInvalidSchemaError extends LoggingError implements IDriverErrorBase, IFluidErrorBase {

--- a/packages/loader/driver-utils/src/binaryEncoding.ts
+++ b/packages/loader/driver-utils/src/binaryEncoding.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { JsonableOrBinary, Jsonable } from "@fluidframework/core-interfaces/internal";
+import { Uint8ArrayToString, stringToBuffer } from "@fluid-internal/client-utils";
+
+const binaryType = "__fluid_binary__";
+
+/**
+ * Encodes JsonableOrBinary into a string
+ * @param content - content to stringify
+ * @returns string
+ * @internal
+ */
+export function encodeJsonableOrBinary<T>(content: JsonableOrBinary<T>): string {
+	return JSON.stringify(content, (_key: string, value: JsonableOrBinary<T>) => {
+		if (value instanceof ArrayBuffer) {
+			return {
+				type: binaryType,
+				content: Uint8ArrayToString(new Uint8Array(value), "base64"),
+			};
+		}
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return value;
+	});
+}
+
+/**
+ * Decodes string back to JsonableOrBinary
+ * @param content - an encoded string
+ * @returns decoded JS object
+ * @internal
+ */
+export function decodeJsonableOrBinary(content: string): JsonableOrBinary {
+	return JSON.parse(content, (_key: string, value: Jsonable) => {
+		if (value !== null && (value as any).type === binaryType) {
+			return stringToBuffer((value as any).content, "base64");
+		}
+		return value;
+	}) as JsonableOrBinary;
+}

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -55,3 +55,4 @@ export {
 	blobHeadersBlobName,
 } from "./adapters/index.js";
 export { isInstanceOfISnapshot } from "./storageUtils.js";
+export { encodeJsonableOrBinary, decodeJsonableOrBinary } from "./binaryEncoding.js";

--- a/packages/loader/driver-utils/src/test/binaryEncoding.spec.ts
+++ b/packages/loader/driver-utils/src/test/binaryEncoding.spec.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import type { JsonableOrBinary, Jsonable } from "@fluidframework/core-interfaces/internal";
+import { encodeJsonableOrBinary, decodeJsonableOrBinary } from "../binaryEncoding.js";
+
+describe("Binary encoding", () => {
+	function testSameAsJson(content: Jsonable) {
+		const res = JSON.stringify(content);
+		const res2 = encodeJsonableOrBinary(content);
+		assert(res === res2, "not same as JSON.stringify");
+		if (res !== undefined) {
+			assert.deepEqual(
+				JSON.parse(res),
+				decodeJsonableOrBinary(res),
+				"not same as JSON.parse",
+			);
+		}
+	}
+
+	it("test no binary", () => {
+		testSameAsJson(undefined);
+		testSameAsJson(null);
+		testSameAsJson({});
+		testSameAsJson({ a: "test", b: 5 });
+		testSameAsJson({ a: "test", b: { c: "test", d: undefined, e: [5, 6, undefined] } });
+	});
+
+	function testBinaryRoundtrip(content: JsonableOrBinary) {
+		const res = encodeJsonableOrBinary(content);
+		const content2 = decodeJsonableOrBinary(res);
+
+		// This will not compare contents of arrays, only their presence!
+		assert.deepEqual(content, content2);
+		assert(res === encodeJsonableOrBinary(content2));
+	}
+
+	it("test binary conversions", () => {
+		const arr = new Uint8Array([5, 6, 7, 100]);
+		testBinaryRoundtrip({ a: 5, arr: arr.buffer, c: { x: arr.buffer } });
+	});
+});

--- a/packages/runtime/datastore-definitions/src/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/jsonable.ts
@@ -106,3 +106,14 @@ export type Jsonable<T, TReplaced = never> = /* test for 'any' */ boolean extend
 			  }
 		: /* not an object => */ never
 	: /* function => */ never;
+
+/**
+ * This is similar to Jsonable<T> type, but allows leaf nodes to be of type ArrayBuffer.
+ * It's assumed that {@link encodeJsonableOrBinary} & {@link decodeJsonableOrBinary} functions would be used
+ * with such content to envode and decode into string, however other types of serializaitons are possible, for
+ * example, it can be serialized into binary format.
+ * Templated argument <T> can be used to scope type. But default, it allows all seriazable types.
+ * Please see {@link Jsonable} for more information and caveats of using this type (and JSON serialization limitations).
+ * @public
+ */
+export type JsonableOrBinary<T = unknown> = Jsonable<T, ArrayBuffer>;


### PR DESCRIPTION
Split from https://github.com/microsoft/FluidFramework/pull/20952
This PR will not compile, it depends on #20953 being merged first.

Introduces new type JsonableOrBinary<T> that allows mixing in ArrayBuffer into Jsonable, and provides serialization / deserialization APIs.

Name is likely not great and needs to be changed - feedback is welcome.
