### PR TITLE
remove(devtools-core): Deprecated ContainerDevtoolsFeatureFlags flag

### DIFF
--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -71,10 +71,8 @@ export interface ConnectionStateChangeLogEntry extends StateChangeLogEntry<Conta
 
 // @internal
 export interface ContainerDevtoolsFeatureFlags {
-    // @deprecated
-    "container-data"?: boolean;
-    "containerDataEditing"?: boolean;
-    "containerDataVisualization"?: boolean;
+    containerDataEditing?: boolean;
+    containerDataVisualization?: boolean;
 }
 
 // @internal

--- a/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/ContainerDevtools.ts
@@ -535,13 +535,10 @@ export class ContainerDevtools implements IContainerDevtools, HasContainerKey {
 	private getSupportedFeatures(): ContainerDevtoolsFeatureFlags {
 		return {
 			// If no container data was provided to the devtools, we cannot support data visualization.
-			"containerDataVisualization": this.containerData !== undefined,
-
-			// Required for backwards compatibility with the extension through v0.0.3
-			"container-data": this.containerData !== undefined,
+			containerDataVisualization: this.containerData !== undefined,
 
 			// TODO: When ready to enable feature set it to this.containerData !== undefined
-			"containerDataEditing": false,
+			containerDataEditing: false,
 		};
 	}
 

--- a/packages/tools/devtools/devtools-core/src/Features.ts
+++ b/packages/tools/devtools/devtools-core/src/Features.ts
@@ -50,20 +50,10 @@ export interface ContainerDevtoolsFeatureFlags {
 	/**
 	 * Indicates that the Container Devtools supports visualizing the data associated with the Container.
 	 */
-	"containerDataVisualization"?: boolean;
+	containerDataVisualization?: boolean;
 
 	/**
 	 * Indicates that the Container Devtools supports editing the data associated with the Container.
 	 */
-	"containerDataEditing"?: boolean;
-
-	/**
-	 * Indicates that the Container Devtools supports visualizing the data associated with the Container.
-	 *
-	 * @deprecated
-	 *
-	 * This exists for backwards compatibility only.
-	 * Use {@link ContainerDevtoolsFeatureFlags.containerDataVisualization} instead.
-	 */
-	"container-data"?: boolean;
+	containerDataEditing?: boolean;
 }

--- a/packages/tools/devtools/devtools-view/src/components/ContainerDevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerDevtoolsView.tsx
@@ -156,9 +156,7 @@ function _ContainerDevtoolsView(props: _ContainerDevtoolsViewProps): React.React
 	const panelViews = Object.values(PanelView);
 	// Inner view selection
 	const [innerViewSelection, setInnerViewSelection] = React.useState<TabValue>(
-		supportedFeatures.containerDataVisualization === true ||
-			// Backwards compatibility check, needed until we require at least devtools-core/devtools v2.0.0-internal.6.1.0
-			supportedFeatures["container-data"] === true
+		supportedFeatures.containerDataVisualization === true
 			? PanelView.ContainerData
 			: PanelView.ContainerStateHistory,
 	);


### PR DESCRIPTION
Removes a long-obsolete flag that was preserved for backwards compatibility. No customers in the wild should be using the flag, so removal should be safe. 