### PR TITLE
skip(test-e2e): Skip Payload size check test for failing on routerlicious and FRS

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -511,6 +511,13 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 								this.skip();
 							}
 
+							// This test is flaky on routerlicious. See ADO:7883 and ADO:7924
+							if (
+								provider.driver.type === "routerlicious"
+							) {
+								this.skip();
+							}
+
 							await setup();
 
 							for (let i = 0; i < config.messagesInBatch; i++) {

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -512,9 +512,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 							}
 
 							// This test is flaky on routerlicious. See ADO:7883 and ADO:7924
-							if (
-								provider.driver.type === "routerlicious"
-							) {
+							if (provider.driver.type === "routerlicious") {
 								this.skip();
 							}
 


### PR DESCRIPTION
This test is failing on routerlicious and FRS, created Issue to track and skipping it
[AB#7883](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7883)
[AB#7924](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7924)