### PR TITLE
skip(test-e2e): Skip "load version validates unreferenced timestamp from summary by create version" test for failing on FRS

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcContainerRuntimeCompat.spec.ts
@@ -158,6 +158,13 @@ describeCompat(
 		 * be read by older / newer versions of the container runtime.
 		 */
 		it("load version validates unreferenced timestamp from summary by create version", async function () {
+			// This test is flaky on FRS. See ADO:7865
+			if (
+				provider.driver.type === "routerlicious" &&
+				provider.driver.endpointName === "frs"
+			) {
+				this.skip();
+			}
 			// Create a new summarizer running version 1 runtime. This client will generate a summary which will be used to load
 			// a new client using the runtime factory version 2.
 			const summarizer1 = await createSummarizer(version1Apis);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -1252,14 +1252,7 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 						clientType: "interactive",
 					},
 				],
-				async function () {
-					// This test is flaky on FRS. See ADO:7922 and ADO:7923
-					if (
-						provider.driver.type === "routerlicious" &&
-						provider.driver.endpointName === "frs"
-					) {
-						this.skip();
-					}
+				async () => {
 					const { dataStore: mainDataStore, summarizer } =
 						await createDataStoreAndSummarizer();
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -1252,7 +1252,14 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 						clientType: "interactive",
 					},
 				],
-				async () => {
+				async function () {
+					// This test is flaky on FRS. See ADO:7922 and ADO:7923
+					if (
+						provider.driver.type === "routerlicious" &&
+						provider.driver.endpointName === "frs"
+					) {
+						this.skip();
+					}
 					const { dataStore: mainDataStore, summarizer } =
 						await createDataStoreAndSummarizer();
 


### PR DESCRIPTION
This test is failing on FRS, created Issue to track and skipping it
[AB#7865](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7865)