### PR TITLE
skip(test-e2e): Skip "Newly connected container synchronizes from summary" for failing on FRS

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -805,7 +805,11 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider) => 
 		assert(summaryStats.clusterCount === 1, "Should have a local cluster as all ids are ack'd");
 	});
 
-	it("Newly connected container synchronizes from summary", async () => {
+	it("Newly connected container synchronizes from summary", async function () {
+		// This test is flaky on FRS. See ADO:7931
+		if (provider.driver.type === "routerlicious" && provider.driver.endpointName === "frs") {
+			this.skip();
+		}
 		const container = await createContainer(enabledConfig);
 		const defaultDataStore = (await container.getEntryPoint()) as ITestDataObject;
 		const idCompressor: IIdCompressor = (defaultDataStore._root as any).runtime.idCompressor;


### PR DESCRIPTION
This test is failing on FRS, created Issue to track and skipping it
[AB#7931](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7931)