### PR TITLE
Fix SharedTree identifier field output typing

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -136,7 +136,7 @@ export const Any: "Any";
 export type Any = typeof Any;
 
 // @public
-export type ApplyKind<T, Kind extends FieldKind> = Kind extends FieldKind.Required ? T : undefined | T;
+export type ApplyKind<T, Kind extends FieldKind> = Kind extends FieldKind.Required ? T : Kind extends FieldKind.Identifier ? T : undefined | T;
 
 // @internal
 export type ApplyMultiplicity<TMultiplicity extends Multiplicity, TypedChild> = {
@@ -977,6 +977,9 @@ export interface InitializeAndSchematizeConfiguration<TRoot extends FlexFieldSch
 // @internal
 export type _InlineTrick = 0;
 
+// @public
+export type InsertableApplyKind<T, Kind extends FieldKind> = Kind extends FieldKind.Required ? T : undefined | T;
+
 // @internal
 export type InsertableFlexField<TField extends FlexFieldSchema> = [
 ApplyMultiplicity<TField["kind"]["multiplicity"], AllowedTypesToFlexInsertableTree<TField["allowedTypes"]>>
@@ -998,10 +1001,10 @@ export type InsertableObjectFromSchemaRecordUnsafe<T extends Unenforced<Restrict
 };
 
 // @public
-export type InsertableTreeFieldFromImplicitField<TSchema extends ImplicitFieldSchema = FieldSchema> = TSchema extends FieldSchema<infer Kind, infer Types> ? ApplyKind<InsertableTreeNodeFromImplicitAllowedTypes<Types>, Kind> : TSchema extends ImplicitAllowedTypes ? InsertableTreeNodeFromImplicitAllowedTypes<TSchema> : unknown;
+export type InsertableTreeFieldFromImplicitField<TSchema extends ImplicitFieldSchema = FieldSchema> = TSchema extends FieldSchema<infer Kind, infer Types> ? InsertableApplyKind<InsertableTreeNodeFromImplicitAllowedTypes<Types>, Kind> : TSchema extends ImplicitAllowedTypes ? InsertableTreeNodeFromImplicitAllowedTypes<TSchema> : unknown;
 
 // @public
-export type InsertableTreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<ImplicitFieldSchema>> = TSchema extends FieldSchemaUnsafe<infer Kind, infer Types> ? ApplyKind<InsertableTreeNodeFromImplicitAllowedTypesUnsafe<Types>, Kind> : InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema>;
+export type InsertableTreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<ImplicitFieldSchema>> = TSchema extends FieldSchemaUnsafe<infer Kind, infer Types> ? InsertableApplyKind<InsertableTreeNodeFromImplicitAllowedTypesUnsafe<Types>, Kind> : InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema>;
 
 // @public
 export type InsertableTreeNodeFromImplicitAllowedTypes<TSchema extends ImplicitAllowedTypes = TreeNodeSchema> = TSchema extends TreeNodeSchema ? InsertableTypedNode<TSchema> : TSchema extends AllowedTypes ? InsertableTypedNode<FlexListToUnion<TSchema>> : never;
@@ -1602,7 +1605,7 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
     }, false, T>;
     readonly boolean: TreeNodeSchema<"com.fluidframework.leaf.boolean", NodeKind.Leaf, boolean, boolean>;
     readonly handle: TreeNodeSchema<"com.fluidframework.leaf.handle", NodeKind.Leaf, IFluidHandle<FluidObject & IFluidLoadable>, IFluidHandle<FluidObject & IFluidLoadable>>;
-    get identifier(): FieldSchema<FieldKind.Identifier>;
+    get identifier(): FieldSchema<FieldKind.Identifier, typeof SchemaFactory.string>;
     map<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchema<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, `Map<${string}>`>>, Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>, true, T>;
     map<Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, Name>>, Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>, true, T>;
     mapRecursive<Name extends TName, const T extends Unenforced<ImplicitAllowedTypes>>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>>, {

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -290,6 +290,7 @@ export {
 	WithType,
 	AllowedTypes,
 	ApplyKind,
+	InsertableApplyKind,
 	FieldKind,
 	FieldSchema,
 	ImplicitAllowedTypes,

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -21,6 +21,7 @@ export {
 	WithType,
 	AllowedTypes,
 	ApplyKind,
+	InsertableApplyKind,
 	FieldKind,
 	FieldSchema,
 	InsertableTreeFieldFromImplicitField,

--- a/packages/dds/tree/src/simple-tree/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/schemaFactory.ts
@@ -539,7 +539,7 @@ export class SchemaFactory<
 	/**
 	 * Make a field of type identifier instead of the default which is required.
 	 */
-	public get identifier(): FieldSchema<FieldKind.Identifier> {
+	public get identifier(): FieldSchema<FieldKind.Identifier, typeof this.string> {
 		return createFieldSchema(FieldKind.Identifier, this.string);
 	}
 

--- a/packages/dds/tree/src/simple-tree/schemaTypes.ts
+++ b/packages/dds/tree/src/simple-tree/schemaTypes.ts
@@ -392,22 +392,32 @@ export type TreeFieldFromImplicitField<TSchema extends ImplicitFieldSchema = Fie
 export type InsertableTreeFieldFromImplicitField<
 	TSchema extends ImplicitFieldSchema = FieldSchema,
 > = TSchema extends FieldSchema<infer Kind, infer Types>
-	? ApplyKind<InsertableTreeNodeFromImplicitAllowedTypes<Types>, Kind>
+	? InsertableApplyKind<InsertableTreeNodeFromImplicitAllowedTypes<Types>, Kind>
 	: TSchema extends ImplicitAllowedTypes
 	? InsertableTreeNodeFromImplicitAllowedTypes<TSchema>
 	: unknown;
 
 /**
  * Suitable for output.
- * For input must error on side of excluding undefined instead.
+ * @privateRemarks Special cases identifier fields to be required (as opposed to input, when they are optional).
  * @public
  */
 export type ApplyKind<T, Kind extends FieldKind> = Kind extends FieldKind.Required
 	? T
+	: Kind extends FieldKind.Identifier
+	? T
 	: undefined | T;
 
 /**
- * Type of of tree node for a field of the given schema.
+ * Suitable for input.
+ * @public
+ */
+export type InsertableApplyKind<T, Kind extends FieldKind> = Kind extends FieldKind.Required
+	? T
+	: undefined | T;
+
+/**
+ * Type of tree node for a field of the given schema.
  * @public
  */
 export type TreeNodeFromImplicitAllowedTypes<

--- a/packages/dds/tree/src/simple-tree/typesUnsafe.ts
+++ b/packages/dds/tree/src/simple-tree/typesUnsafe.ts
@@ -18,6 +18,7 @@ import {
 	TreeNodeFromImplicitAllowedTypes,
 	TreeNodeSchema,
 	WithType,
+	InsertableApplyKind,
 } from "./schemaTypes.js";
 import { TreeArrayNodeBase, TreeArrayNode } from "./arrayNode.js";
 import { TreeNode, Unhydrated } from "./types.js";
@@ -166,7 +167,7 @@ export type InsertableObjectFromSchemaRecordUnsafe<
 export type InsertableTreeFieldFromImplicitFieldUnsafe<
 	TSchema extends Unenforced<ImplicitFieldSchema>,
 > = TSchema extends FieldSchemaUnsafe<infer Kind, infer Types>
-	? ApplyKind<InsertableTreeNodeFromImplicitAllowedTypesUnsafe<Types>, Kind>
+	? InsertableApplyKind<InsertableTreeNodeFromImplicitAllowedTypesUnsafe<Types>, Kind>
 	: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema>;
 
 /**

--- a/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
@@ -20,6 +20,7 @@ import { isTreeNode } from "../../simple-tree/proxies.js";
 import { hydrate, pretty } from "./utils.js";
 import { getView } from "../utils.js";
 import { createMockNodeKeyManager } from "../../feature-libraries/index.js";
+import { requireAssignableTo } from "../../util/index.js";
 
 describe("simple-tree proxies", () => {
 	const sb = new SchemaFactory("test");
@@ -180,6 +181,7 @@ describe("SharedTreeObject", () => {
 		}));
 
 		const root = getView(config, nodeKeyManager).root;
+		type _ = requireAssignableTo<typeof root.identifier, string>;
 		assert.equal(root.identifier, id);
 	});
 });

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -55,7 +55,7 @@ import { TypedEventEmitter } from '@fluid-internal/client-utils';
 export type AllowedTypes = readonly LazyItem<TreeNodeSchema>[];
 
 // @public
-export type ApplyKind<T, Kind extends FieldKind> = Kind extends FieldKind.Required ? T : undefined | T;
+export type ApplyKind<T, Kind extends FieldKind> = Kind extends FieldKind.Required ? T : Kind extends FieldKind.Identifier ? T : undefined | T;
 
 // @public
 export enum AttachState {
@@ -353,6 +353,9 @@ export type InitialObjects<T extends ContainerSchema> = {
 };
 
 // @public
+export type InsertableApplyKind<T, Kind extends FieldKind> = Kind extends FieldKind.Required ? T : undefined | T;
+
+// @public
 export type InsertableObjectFromSchemaRecord<T extends RestrictiveReadonlyRecord<string, ImplicitFieldSchema>> = {
     readonly [Property in keyof T]: InsertableTreeFieldFromImplicitField<T[Property]>;
 };
@@ -363,10 +366,10 @@ export type InsertableObjectFromSchemaRecordUnsafe<T extends Unenforced<Restrict
 };
 
 // @public
-export type InsertableTreeFieldFromImplicitField<TSchema extends ImplicitFieldSchema = FieldSchema> = TSchema extends FieldSchema<infer Kind, infer Types> ? ApplyKind<InsertableTreeNodeFromImplicitAllowedTypes<Types>, Kind> : TSchema extends ImplicitAllowedTypes ? InsertableTreeNodeFromImplicitAllowedTypes<TSchema> : unknown;
+export type InsertableTreeFieldFromImplicitField<TSchema extends ImplicitFieldSchema = FieldSchema> = TSchema extends FieldSchema<infer Kind, infer Types> ? InsertableApplyKind<InsertableTreeNodeFromImplicitAllowedTypes<Types>, Kind> : TSchema extends ImplicitAllowedTypes ? InsertableTreeNodeFromImplicitAllowedTypes<TSchema> : unknown;
 
 // @public
-export type InsertableTreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<ImplicitFieldSchema>> = TSchema extends FieldSchemaUnsafe<infer Kind, infer Types> ? ApplyKind<InsertableTreeNodeFromImplicitAllowedTypesUnsafe<Types>, Kind> : InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema>;
+export type InsertableTreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<ImplicitFieldSchema>> = TSchema extends FieldSchemaUnsafe<infer Kind, infer Types> ? InsertableApplyKind<InsertableTreeNodeFromImplicitAllowedTypesUnsafe<Types>, Kind> : InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TSchema>;
 
 // @public
 export type InsertableTreeNodeFromImplicitAllowedTypes<TSchema extends ImplicitAllowedTypes = TreeNodeSchema> = TSchema extends TreeNodeSchema ? InsertableTypedNode<TSchema> : TSchema extends AllowedTypes ? InsertableTypedNode<FlexListToUnion<TSchema>> : never;
@@ -678,7 +681,7 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
     }, false, T>;
     readonly boolean: TreeNodeSchema<"com.fluidframework.leaf.boolean", NodeKind.Leaf, boolean, boolean>;
     readonly handle: TreeNodeSchema<"com.fluidframework.leaf.handle", NodeKind.Leaf, IFluidHandle<FluidObject & IFluidLoadable>, IFluidHandle<FluidObject & IFluidLoadable>>;
-    get identifier(): FieldSchema<FieldKind.Identifier>;
+    get identifier(): FieldSchema<FieldKind.Identifier, typeof SchemaFactory.string>;
     map<const T extends TreeNodeSchema | readonly TreeNodeSchema[]>(allowedTypes: T): TreeNodeSchema<ScopedSchemaName<TScope, `Map<${string}>`>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, `Map<${string}>`>>, Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>, true, T>;
     map<Name extends TName, const T extends ImplicitAllowedTypes>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNode<T> & WithType<ScopedSchemaName<TScope, Name>>, Iterable<[string, InsertableTreeNodeFromImplicitAllowedTypes<T>]>, true, T>;
     mapRecursive<Name extends TName, const T extends Unenforced<ImplicitAllowedTypes>>(name: Name, allowedTypes: T): TreeNodeSchemaClass<ScopedSchemaName<TScope, Name>, NodeKind.Map, TreeMapNodeUnsafe<T> & WithType<ScopedSchemaName<TScope, Name>>, {


### PR DESCRIPTION
Currently, reading an identifier field of a SharedTree node produces the type `unknown`. This PR changes it to return `string`. 

Note that the input type (the type provided when supplying an identifier) is still `string | undefined`. This is accomplished by special casing identifiers in the `ApplyKind` type helper. This is the first instance in which we have data whose input type is optional but whose output type is not.

This PR should go in _after_ identifiers have been giving defaulting behavior, so that the input type can indeed be optional while still guaranteeing a valid output type later.