### PR TITLE
fix(client): BREAKING CHANGE - Jsonable tightening

### DIFF
--- a/packages/runtime/datastore-definitions/src/exposedUtilityTypes.ts
+++ b/packages/runtime/datastore-definitions/src/exposedUtilityTypes.ts
@@ -1,0 +1,72 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Returns non-symbol keys for optional properties of an object type.
+ *
+ * @beta
+ */
+export type NonSymbolWithOptionalPropertyOf<T extends object> = Exclude<
+	{
+		[K in keyof T]: T extends Record<K, T[K]> ? never : K;
+	}[keyof T],
+	undefined | symbol
+>;
+
+/**
+ * Returns non-symbol keys for required properties of an object type.
+ *
+ * @beta
+ */
+export type NonSymbolWithRequiredPropertyOf<T extends object> = Exclude<
+	{
+		[K in keyof T]: T extends Record<K, T[K]> ? K : never;
+	}[keyof T],
+	undefined | symbol
+>;
+
+/**
+ * Checks for a type that is simple class of number and string indexed types to numbers and strings.
+ *
+ * @beta
+ */
+export type IsEnumLike<T extends object> = T extends readonly (infer _)[]
+	? /* array => */ false
+	: T extends {
+			// all numerical indices should refer to a string
+			readonly [i: number]: string;
+			// string indices may be string or number
+			readonly [p: string]: number | string;
+	  }
+	? /* test for a never or any property */ true extends {
+			[K in keyof T]: T[K] extends never ? true : never;
+	  }[keyof T]
+		? false
+		: true
+	: false;
+
+/**
+ * Checks for that type is exactly `object`.
+ *
+ * @beta
+ */
+export type IsExactlyObject<T extends object> =
+	/* test for more than type with all optional properties */ object extends Required<T>
+		? /* test for `{}` */ false extends T
+			? /* `{}` => */ false
+			: /* `object` => */ true
+		: /* optional or required properties => */ false;
+
+/**
+ * Creates a simple object type from an intersection of multiple.
+ * @privateRemarks `T extends Record` encourages tsc to process intersections within unions.
+ *
+ * @beta
+ */
+export type FlattenIntersection<T> = T extends Record<any, any>
+	? {
+			[K in keyof T]: T[K];
+	  }
+	: T;

--- a/packages/runtime/datastore-definitions/src/index.ts
+++ b/packages/runtime/datastore-definitions/src/index.ts
@@ -19,10 +19,9 @@ export type {
 	IDeltaHandler,
 } from "./channel.js";
 export type { IFluidDataStoreRuntime, IFluidDataStoreRuntimeEvents } from "./dataStoreRuntime.js";
-export type {
-	Jsonable,
-	JsonableTypeWith,
-	Internal_InterfaceOfJsonableTypesWith,
-} from "./jsonable.js";
+export type { Internal_JsonableForArrayItem, Jsonable, JsonableTypeWith } from "./jsonable.js";
 export type { Serializable } from "./serializable.js";
 export type { IChannelAttributes } from "./storage.js";
+
+import type * as InternalUtilityTypes from "./exposedUtilityTypes.js";
+export { InternalUtilityTypes };

--- a/packages/runtime/datastore-definitions/src/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/jsonable.ts
@@ -3,6 +3,14 @@
  * Licensed under the MIT License.
  */
 
+import type {
+	FlattenIntersection,
+	IsEnumLike,
+	IsExactlyObject,
+	NonSymbolWithOptionalPropertyOf,
+	NonSymbolWithRequiredPropertyOf,
+} from "./exposedUtilityTypes.js";
+
 /**
  * Type constraint for types that are likely serializable as JSON or have a custom
  * alternate type.
@@ -16,29 +24,50 @@
  * @alpha
  */
 export type JsonableTypeWith<T> =
-	| undefined
+	// eslint-disable-next-line @rushstack/no-new-null
 	| null
 	| boolean
 	| number
 	| string
 	| T
-	| Internal_InterfaceOfJsonableTypesWith<T>
-	| ArrayLike<JsonableTypeWith<T>>;
+	| { [key: string | number]: JsonableTypeWith<T> }
+	| JsonableTypeWith<T>[];
 
 /**
- * @remarks
- * This type is a kludge and not intended for general use.
+ * Filters a type `T` to types for undefined that is not viable in an array (or tuple) that
+ * must go through JSON serialization.
+ * If `T` is `undefined`, then an error literal string type is returned with hopes of being
+ * informative. When result is unioned with `string`, then the error string will be eclipsed
+ * by the union. In that case undefined will still not be an option, but source of the error
+ * may be harder to discover.
  *
- * @privateRemarks
- * Internal type testing for compatibility uses TypeOnly filter which cannot handle recursive "pure" types.
- * This interface along with ArrayLike above avoids pure type recursion issues, but introduces a limitation on
- * the ability of {@link Jsonable} to detect array-like types that are not handled naively ({@link JSON.stringify}).
- * The TypeOnly filter is not useful for {@link JsonableTypeWith}; so, if type testing improves, this can be removed.
+ * @remarks As a special case to deal with infinite recursion, if give T is exactly the same
+ * type as its parent (containing) type, then just use the parent type as-is. It is assumed
+ * that any unsupported aspects will be flagged in other branches of Jsonable filtering.
+ *
  * @alpha
  */
-export interface Internal_InterfaceOfJsonableTypesWith<T> {
-	[index: string | number]: JsonableTypeWith<T>;
-}
+export type Internal_JsonableForArrayItem<T, TReplaced, TParent> =
+	// Some initial filtering must be provided before a test for undefined.
+	// These tests are expected to match those in JsonEncodable/JsonDecodable.
+	/* test for 'any' */ boolean extends (T extends never ? true : false)
+		? /* 'any' => */ JsonableTypeWith<TReplaced>
+		: /* test for 'unknown' */ unknown extends T
+		? /* 'unknown' => */ JsonableTypeWith<TReplaced>
+		: /* test for Jsonable primitive types */ T extends  // eslint-disable-next-line @rushstack/no-new-null
+				| null
+				| boolean
+				| number
+				| string
+				| TReplaced
+		? /* primitive types => */ T
+		: /* test for undefined possibility */ undefined extends T
+		? /* undefined | ... => */ "error-array-or-tuple-may-not-allow-undefined-value-consider-null"
+		: /* test for identical parent */ (<G>() => G extends T ? 1 : 2) extends <
+				G,
+		  >() => G extends TParent ? 1 : 2
+		? /* identical */ TParent
+		: /* different */ Jsonable<T, TReplaced>;
 
 /**
  * Used to constrain a type `T` to types that are serializable as JSON.
@@ -58,11 +87,7 @@ export interface Internal_InterfaceOfJsonableTypesWith<T> {
  *
  * Note that `Jsonable<T>` does not protect against the following pitfalls when serializing with JSON.stringify():
  *
- * - `undefined` properties on objects are omitted (i.e., properties become undefined instead of equal to undefined).
- *
- * - When `undefined` appears as the root object or as an array element it is coerced to `null`.
- *
- * - Non-finite numbers (`NaN`, `+/-Infinity`) are also coerced to `null`.
+ * - Non-finite numbers (`NaN`, `+/-Infinity`) are coerced to `null`.
  *
  * - prototypes and non-enumerable properties are lost.
  *
@@ -86,8 +111,7 @@ export type Jsonable<T, TReplaced = never> = /* test for 'any' */ boolean extend
 	? /* 'any' => */ JsonableTypeWith<TReplaced>
 	: /* test for 'unknown' */ unknown extends T
 	? /* 'unknown' => */ JsonableTypeWith<TReplaced>
-	: /* test for Jsonable primitive types */ T extends
-			| undefined /* is not serialized */
+	: /* test for JSON Encodable primitive types or given alternate */ T extends  // eslint-disable-next-line @rushstack/no-new-null
 			| null
 			| boolean
 			| number
@@ -96,13 +120,33 @@ export type Jsonable<T, TReplaced = never> = /* test for 'any' */ boolean extend
 	? /* primitive types => */ T
 	: // eslint-disable-next-line @typescript-eslint/ban-types
 	/* test for not a function */ Extract<T, Function> extends never
-	? /* not a function =>  => test for object */ T extends object
-		? /* object => test for array */ T extends (infer U)[] // prefer ArrayLike test to catch non-array array-like types
-			? /* array => */ Jsonable<U, TReplaced>[]
-			: /* property bag => */ {
-					[K in keyof T]: Extract<K, symbol> extends never
-						? Jsonable<T[K], TReplaced>
-						: never;
+	? /* not a function => test for object */ T extends object
+		? /* object => test for array */ T extends readonly (infer _)[]
+			? /* array => */ {
+					/* array items may not not allow undefined */
+					/* use homomorphic mapped type to preserve tuple type */
+					[K in keyof T]: Internal_JsonableForArrayItem<T[K], TReplaced, T>;
 			  }
+			: /* not an array => test for exactly `object` */ IsExactlyObject<T> extends true
+			? /* `object` => */ JsonableTypeWith<TReplaced>
+			: /* test for enum like types */ IsEnumLike<T> extends true
+			? /* enum or similar simple type (return as-is) => */ T
+			: /* property bag => */ FlattenIntersection<
+					{
+						/* required properties are recursed and may not have undefined values. */
+						[K in NonSymbolWithRequiredPropertyOf<T>]-?: undefined extends T[K]
+							? "error-required-property-may-not-allow-undefined-value"
+							: Jsonable<T[K], TReplaced>;
+					} & {
+						/* optional properties are recursed and allowed to preserve undefined value type. */
+						[K in NonSymbolWithOptionalPropertyOf<T>]?: Jsonable<
+							T[K],
+							TReplaced | undefined
+						>;
+					} & {
+						/* symbol properties are rejected */
+						[K in keyof T & symbol]: never;
+					}
+			  >
 		: /* not an object => */ never
 	: /* function => */ never;

--- a/packages/runtime/datastore-definitions/src/test/types/jsonable.ts
+++ b/packages/runtime/datastore-definitions/src/test/types/jsonable.ts
@@ -32,7 +32,6 @@ foo(new getter());
 // test plain types
 foo(1);
 foo("");
-foo(undefined);
 foo(null);
 foo(true);
 foo([]);
@@ -130,6 +129,9 @@ declare const selfReferencing: SelfReferencing;
 foo(selfReferencing);
 
 // --- should not work
+
+// @ts-expect-error undefined should not be jsonable
+foo(undefined);
 
 // test unknown
 declare const aUnknown: unknown;


### PR DESCRIPTION
overlay of proposed new "Jsonable" type over the existing one. There are breaks in client making this change that are not addressed. One common case is not allowing `undefined`, which is not encodable.