### PR TITLE
Remove PublishPipelineArtifact task 

### DIFF
--- a/tools/pipelines/templates/upload-dev-manifest.yml
+++ b/tools/pipelines/templates/upload-dev-manifest.yml
@@ -29,13 +29,6 @@ steps:
     script: |
       mkdir upload_release_reports
       flub release report-unreleased --version $(SetVersion.version) --fullReportFilePath generate_release_reports/manifest.full.json --outDir upload_release_reports
-
-- task: PublishPipelineArtifact@1
-  displayName: Publish release reports
-  continueOnError: true
-  inputs:
-    targetPath: ${{ parameters.buildDirectory }}/upload_release_reports
-    artifactName: 'release_reports'
       
 - task: AzureCLI@2
   displayName: Upload release reports


### PR DESCRIPTION
The `PublishPipelineArtifact` step fails: https://dev.azure.com/fluidframework/internal/_build/results?buildId=261558&view=results. This PR removes the step from `upload-dev-manifest.yml`.

Rest of the changes made in https://github.com/microsoft/FluidFramework/pull/20722 are functional - [Pipeline run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=261584&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=bfe27d5f-9219-57c0-0d67-1b2946a32921)