### PR TITLE
Increase retry count on npm install step for real service tests

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -245,7 +245,10 @@ jobs:
       # Install test and logger package
       - task: Npm@1
         displayName: 'npm install'
-        retryCountOnTaskFailure: 1
+        # ADO feeds have latency on the order of minutes before packages are available downstream. See:
+        # https://learn.microsoft.com/en-us/azure/devops/artifacts/concepts/upstream-sources?view=azure-devops#upstream-sources-health-status
+        # This pipeline installs packages which were published very recently relative to its runtime, hence the rather high retry count here.
+        retryCountOnTaskFailure: 5
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}


### PR DESCRIPTION
## Description

A recent test-service-clients run failed on this step despite the single retry. Given we know why that happens and it should resolve itself on the order of minutes, this bumps the retry count for the install step to 5.