### PR TITLE
refactor(e2e tests): Move e2e perf test telemetry to ffengineering table

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/DocumentCreator.ts
@@ -68,6 +68,7 @@ export function createDocument(props: IDocumentCreatorProps): IDocumentLoaderAnd
 		logger: getTestLogger?.(),
 		properties: {
 			all: {
+				namespace: "FFEngineering",
 				driverType: props.provider.driver.type,
 				driverEndpointName: props.provider.driver.endpointName,
 				benchmarkType: props.benchmarkType,


### PR DESCRIPTION
## Description

Following up on what https://github.com/microsoft/FluidFramework/pull/19768 did, this moves the telemetry produced by our e2e perf tests to the `ffengineering_*` tables.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
