### PR TITLE
fix(matrix): Convert reentrancy detection to a usage error

### DIFF
--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -476,7 +476,6 @@ export class SharedMatrix<T = any>
 			// Validate that applications don't submit edits in response to matrix change notifications. This is unsupported.
 			throw new UsageError("Reentrancy detected in SharedMatrix.");
 		}
-		assert(this.reentrantCount === 0, 0x85d /* reentrant code */);
 		this.reentrantCount++;
 		try {
 			callback();

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -472,10 +472,17 @@ export class SharedMatrix<T = any>
 	 * @param callback - code that needs to protected against reentrancy.
 	 */
 	private protectAgainstReentrancy(callback: () => void) {
+		if (this.reentrantCount !== 0) {
+			// Validate that applications don't submit edits in response to matrix change notifications. This is unsupported.
+			throw new UsageError("Reentrancy detected in SharedMatrix.");
+		}
 		assert(this.reentrantCount === 0, 0x85d /* reentrant code */);
 		this.reentrantCount++;
-		callback();
-		this.reentrantCount--;
+		try {
+			callback();
+		} finally {
+			this.reentrantCount--;
+		}
 		assert(this.reentrantCount === 0, 0x85e /* reentrant code on exit */);
 	}
 

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -482,7 +482,10 @@ export class SharedMatrix<T = any>
 		} finally {
 			this.reentrantCount--;
 		}
-		assert(this.reentrantCount === 0, 0x85e /* reentrant code on exit */);
+		assert(
+			this.reentrantCount === 0,
+			0x85e /* indicates a problem with the reentrancy tracking code. */,
+		);
 	}
 
 	private submitVectorMessage(

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1317,7 +1317,7 @@ export const shortCodeMap = {
 	"0x85a": "newMark should have cell ID",
 	"0x85b": "Expected cells to have the same revision",
 	"0x85d": "reentrant code",
-	"0x85e": "reentrant code on exit",
+	"0x85e": "indicates a problem with the reentrancy tracking code.",
 	"0x85f": "should be in Fww mode when calling this method",
 	"0x860": "clientId should not be null",
 	"0x861": "clientId should not be null!!",


### PR DESCRIPTION
## Description

This error should not be an assert, as it validates applications don't make matrix edits in response to matrix changes.

I also added a try-finally on the validation, as otherwise `callback` can throw an error and result in the method permanently throwing whenever it's called. This was the case for some telemetry I looked at recently, where an application did *not* have reentrant code, but they *did* have some improperly disposed processes which attempted to submit ops on a closed container. The first one failed with a reasonable error (validation against "runtime is closed"), but subsequent ones claimed reentrancy.