### PR TITLE
fix(ci): Fix stage dependencies for stage that uploads telemetry to Kusto

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -581,8 +581,8 @@ extends:
                       artifactName: _api-extractor-temp
                       sbomEnabled: false
                       publishLocation: pipeline
-                
-                - ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}: 
+
+                - ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
                   - output: pipelineArtifact
                     displayName: Publish Artifact - release_reports
                     targetPath: $(Build.ArtifactStagingDirectory)/release_reports
@@ -628,7 +628,7 @@ extends:
             # conditions *and exact stage names* that exist there. At some point it might be preferable to always create the
             # stages, control their execution with 'condition:', and update this stage to always depend on all previous
             # stages (while still running if some of the dependencies were skipped).
-            - ${{ if eq(variables.publish, true) }}:
+            - ${{ if eq(parameters.publish, true) }}:
               - ${{ if eq(variables['testBuild'], true) }}:
                 - publish_npm_internal_test
               - ${{ if eq(variables['testBuild'], false) }}:


### PR DESCRIPTION
## Description

Fixes the build-npm-package template so the stage that uploads telemetry to Kusto runs after all other stages, not just the build stage.

This used to work but a bug was introduced by mistake in https://github.com/microsoft/FluidFramework/pull/20056.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Note a pre-existing correct use of `parameters.publish` in line 613.