### PR TITLE
Vscode settings to handle trailing whitespace and newlines

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,6 +70,12 @@
 	"[typescript]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode",
 	},
+	// Handle trailing whitespace and newlines for all files, in a way that matches how we configure the repo-wide formatter.
+	// They're specified here so they apply to files we don't format explicitly (e.g. yml files).
+	// Note they don't affect indentation, so they shouldn't inadvertently break yml files like other formatter rules might.
+	"files.insertFinalNewline": true,
+	"files.trimFinalNewlines": true,
+	"files.trimTrailingWhitespace": true,
 
 	// Customizations for VSCode search results.
 	// These entries should probably be kept more or less in sync with the .gitignore file.


### PR DESCRIPTION
## Description

Most files in the repo are taken care of by the formatters (prettier/biome). However, we don't auto-format yaml files (to prevent accidentally breaking them with indentation changes or similar). The new rules should help since they will apply to yaml files as well (for people using VSCode to work on the repo) and they are safe because they won't touch the indentation.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
