### PR TITLE
fix(ci): Update condition to publish release_manifests artifact

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -582,7 +582,9 @@ extends:
                       sbomEnabled: false
                       publishLocation: pipeline
 
-                - ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+                # This condition should be kept in sync with the one in include-set-package-version, which decides if
+                # upload-dev-manifest.yml should be included or not.
+                - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(parameters.tagName, 'client')) }}:
                   - output: pipelineArtifact
                     displayName: Publish Artifact - release_reports
                     targetPath: $(Build.ArtifactStagingDirectory)/release_reports


### PR DESCRIPTION
## Description

Follow up to https://github.com/microsoft/FluidFramework/pull/21000, updating the condition in another place where it was relevant. Now the pipelines shouldn't attempt to publish an artifact that wasn't generated.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).