### PR TITLE
Skip(e2e tests): skip "Reconnects while sending and processing compressed batch" and "applies stashed ops with no saved ops" tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -621,6 +621,14 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 					this.skip();
 				}
 
+				// TODO: This test is consistently failing when ran against FRS. See ADO:7944
+				if (
+					provider.driver.type === "routerlicious" &&
+					provider.driver.endpointName === "frs"
+				) {
+					this.skip();
+				}
+
 				await setupContainers(config);
 				// Force the container to reconnect after processing 2 empty ops
 				// which would unroll the original ops from compression
@@ -683,6 +691,14 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 				// This is not supported by the local server. See ADO:2690
 				// This test is flaky on tinylicious. See ADO:2964
 				if (provider.driver.type === "local" || provider.driver.type === "tinylicious") {
+					this.skip();
+				}
+
+				// TODO: This test is consistently failing when ran against FRS. See ADO:7969
+				if (
+					provider.driver.type === "routerlicious" &&
+					provider.driver.endpointName === "frs"
+				) {
 					this.skip();
 				}
 

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1773,6 +1773,10 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 	});
 
 	it("applies stashed ops with no saved ops", async function () {
+		// TODO: This test is consistently failing when ran against FRS. See ADO:7968
+		if (provider.driver.type === "routerlicious" && provider.driver.endpointName === "frs") {
+			this.skip();
+		}
 		// wait for summary
 		await new Promise<void>((resolve) =>
 			container1.on("op", (op) => {


### PR DESCRIPTION
Skip the following tests for consistently failing in FRS;
"Reconnects while sending compressed batch"
"Reconnects while processing compressed batch"
"applies stashed ops with no saved ops"

[AB#6984](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6984)