### PR TITLE
refactor(telemetry-context): Provide internal used telemetry context interface

### DIFF
--- a/.changeset/old-olives-eat.md
+++ b/.changeset/old-olives-eat.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/runtime-definitions": major
+---
+
+Remove deprecated 'get' and 'serialize' members on the ITelemetryContext interface
+
+The `ITelemetryContext` interface was not intended to allow getting properties that had been added to it, so it is now "write-only". Internal usage within FluidFramework should use the new `ITelemetryContextExt`.

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -30,6 +30,7 @@ import type { ITree } from '@fluidframework/protocol-definitions';
 import type { IUser } from '@fluidframework/protocol-definitions';
 import type { SummaryTree } from '@fluidframework/protocol-definitions';
 import type { TelemetryBaseEventPropertyType } from '@fluidframework/core-interfaces';
+import type { TelemetryEventPropertyTypeExt } from '@fluidframework/telemetry-utils/internal';
 
 // @alpha
 export type AliasResult = "Success" | "Conflict" | "AlreadyAliased";
@@ -417,12 +418,14 @@ export interface ISummaryTreeWithStats {
 
 // @alpha
 export interface ITelemetryContext {
-    // @deprecated
-    get(prefix: string, property: string): TelemetryBaseEventPropertyType;
-    // @deprecated
-    serialize(): string;
     set(prefix: string, property: string, value: TelemetryBaseEventPropertyType): void;
     setMultiple(prefix: string, property: string, values: Record<string, TelemetryBaseEventPropertyType>): void;
+}
+
+// @internal
+export interface ITelemetryContextExt {
+    set(prefix: string, property: string, value: TelemetryEventPropertyTypeExt): void;
+    setMultiple(prefix: string, property: string, values: Record<string, TelemetryEventPropertyTypeExt>): void;
 }
 
 // @alpha

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -77,7 +77,8 @@
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/id-compressor": "workspace:~",
-		"@fluidframework/protocol-definitions": "^3.2.0"
+		"@fluidframework/protocol-definitions": "^3.2.0",
+		"@fluidframework/telemetry-utils": "workspace:~"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.15.2",
@@ -111,6 +112,9 @@
 			},
 			"InterfaceDeclaration_IFluidParentContext": {
 				"forwardCompat": false,
+				"backCompat": false
+			},
+			"InterfaceDeclaration_ITelemetryContext": {
 				"backCompat": false
 			},
 			"RemovedInterfaceDeclaration_IFluidDataStoreContextEvents": {

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -61,6 +61,7 @@ export type {
 	ISummaryStats,
 	ISummaryTreeWithStats,
 	ITelemetryContext,
+	ITelemetryContextExt,
 	SummarizeInternalFn,
 } from "./summary.js";
 export {

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -12,6 +12,7 @@ import type {
 	SummaryTree,
 } from "@fluidframework/protocol-definitions";
 
+import type { TelemetryEventPropertyTypeExt } from "@fluidframework/telemetry-utils/internal";
 import type {
 	IGarbageCollectionData,
 	IGarbageCollectionDetailsBase,
@@ -322,6 +323,33 @@ export const channelsTreeName = ".channels";
 
 /**
  * Contains telemetry data relevant to summarization workflows.
+ * This object, in contrast to ITelemetryContext, is expected to be modified directly by various summarize methods.
+ * @internal
+ */
+export interface ITelemetryContextExt {
+	/**
+	 * Sets value for telemetry data being tracked.
+	 * @param prefix - unique prefix to tag this data with (ex: "fluid:map:")
+	 * @param property - property name of the telemetry data being tracked (ex: "DirectoryCount")
+	 * @param value - value to attribute to this summary telemetry data
+	 */
+	set(prefix: string, property: string, value: TelemetryEventPropertyTypeExt): void;
+
+	/**
+	 * Sets multiple values for telemetry data being tracked.
+	 * @param prefix - unique prefix to tag this data with (ex: "fluid:summarize:")
+	 * @param property - property name of the telemetry data being tracked (ex: "Options")
+	 * @param values - A set of values to attribute to this summary telemetry data.
+	 */
+	setMultiple(
+		prefix: string,
+		property: string,
+		values: Record<string, TelemetryEventPropertyTypeExt>,
+	): void;
+}
+
+/**
+ * Contains telemetry data relevant to summarization workflows.
  * This object is expected to be modified directly by various summarize methods.
  * @alpha
  */
@@ -345,26 +373,6 @@ export interface ITelemetryContext {
 		property: string,
 		values: Record<string, TelemetryBaseEventPropertyType>,
 	): void;
-
-	/**
-	 * Get the telemetry data being tracked
-	 *
-	 * @deprecated This interface should only be used for instrumenting, not for attempting to read already-set telemetry data.
-	 *
-	 * @param prefix - unique prefix for this data (ex: "fluid:map:")
-	 * @param property - property name of the telemetry data being tracked (ex: "DirectoryCount")
-	 * @returns undefined if item not found
-	 */
-	get(prefix: string, property: string): TelemetryBaseEventPropertyType;
-
-	/**
-	 * Returns a serialized version of all the telemetry data.
-	 * Should be used when logging in telemetry events.
-	 *
-	 * @deprecated This interface should only be used for instrumenting. A concrete implementation will likely have a serialize function
-	 * but this functionality should not be used by other code being given an ITelemetryContext.
-	 */
-	serialize(): string;
 }
 
 /**

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -1139,6 +1139,7 @@ declare function get_current_InterfaceDeclaration_ITelemetryContext():
 declare function use_old_InterfaceDeclaration_ITelemetryContext(
     use: TypeOnly<old.ITelemetryContext>): void;
 use_old_InterfaceDeclaration_ITelemetryContext(
+    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ITelemetryContext());
 
 /*

--- a/packages/runtime/runtime-utils/api-report/runtime-utils.api.md
+++ b/packages/runtime/runtime-utils/api-report/runtime-utils.api.md
@@ -33,10 +33,11 @@ import { ISummaryStats } from '@fluidframework/runtime-definitions/internal';
 import { ISummaryTree } from '@fluidframework/protocol-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions/internal';
+import { ITelemetryContextExt } from '@fluidframework/runtime-definitions/internal';
 import { ITree } from '@fluidframework/protocol-definitions';
 import { SummaryObject } from '@fluidframework/protocol-definitions';
 import { SummaryType } from '@fluidframework/protocol-definitions';
-import type { TelemetryBaseEventPropertyType } from '@fluidframework/core-interfaces';
+import type { TelemetryEventPropertyTypeExt } from '@fluidframework/telemetry-utils/internal';
 
 // @internal (undocumented)
 export function addBlobToSummary(summary: ISummaryTreeWithStats, key: string, content: string | Uint8Array): void;
@@ -224,11 +225,11 @@ export class SummaryTreeBuilder implements ISummaryTreeWithStats {
 }
 
 // @internal (undocumented)
-export class TelemetryContext implements ITelemetryContext {
-    get(prefix: string, property: string): TelemetryBaseEventPropertyType;
+export class TelemetryContext implements ITelemetryContext, ITelemetryContextExt {
+    get(prefix: string, property: string): TelemetryEventPropertyTypeExt;
     serialize(): string;
-    set(prefix: string, property: string, value: TelemetryBaseEventPropertyType): void;
-    setMultiple(prefix: string, property: string, values: Record<string, TelemetryBaseEventPropertyType>): void;
+    set(prefix: string, property: string, value: TelemetryEventPropertyTypeExt): void;
+    setMultiple(prefix: string, property: string, values: Record<string, TelemetryEventPropertyTypeExt>): void;
 }
 
 // @internal

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -10,7 +10,7 @@ import {
 	fromBase64ToUtf8,
 } from "@fluid-internal/client-utils";
 import { ISnapshotTreeWithBlobContents } from "@fluidframework/container-definitions/internal";
-import type { TelemetryBaseEventPropertyType } from "@fluidframework/core-interfaces";
+import type { TelemetryEventPropertyTypeExt } from "@fluidframework/telemetry-utils/internal";
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
 	AttachmentTreeEntry,
@@ -32,6 +32,7 @@ import {
 	ITelemetryContext,
 	IGarbageCollectionData,
 	ISummarizeResult,
+	ITelemetryContextExt,
 } from "@fluidframework/runtime-definitions/internal";
 
 /**
@@ -412,13 +413,13 @@ export function processAttachMessageGCData(
 /**
  * @internal
  */
-export class TelemetryContext implements ITelemetryContext {
-	private readonly telemetry = new Map<string, TelemetryBaseEventPropertyType>();
+export class TelemetryContext implements ITelemetryContext, ITelemetryContextExt {
+	private readonly telemetry = new Map<string, TelemetryEventPropertyTypeExt>();
 
 	/**
 	 * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.set}
 	 */
-	set(prefix: string, property: string, value: TelemetryBaseEventPropertyType): void {
+	set(prefix: string, property: string, value: TelemetryEventPropertyTypeExt): void {
 		this.telemetry.set(`${prefix}${property}`, value);
 	}
 
@@ -428,7 +429,7 @@ export class TelemetryContext implements ITelemetryContext {
 	setMultiple(
 		prefix: string,
 		property: string,
-		values: Record<string, TelemetryBaseEventPropertyType>,
+		values: Record<string, TelemetryEventPropertyTypeExt>,
 	): void {
 		// Set the values individually so that they are logged as a flat list along with other properties.
 		for (const key of Object.keys(values)) {
@@ -439,7 +440,7 @@ export class TelemetryContext implements ITelemetryContext {
 	/**
 	 * {@inheritDoc @fluidframework/runtime-definitions#ITelemetryContext.get}
 	 */
-	get(prefix: string, property: string): TelemetryBaseEventPropertyType {
+	get(prefix: string, property: string): TelemetryEventPropertyTypeExt {
 		return this.telemetry.get(`${prefix}${property}`);
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8998,6 +8998,7 @@ importers:
       '@fluidframework/id-compressor': workspace:~
       '@fluidframework/protocol-definitions': ^3.2.0
       '@fluidframework/runtime-definitions-previous': npm:@fluidframework/runtime-definitions@2.0.0-rc.4.0.0
+      '@fluidframework/telemetry-utils': workspace:~
       '@microsoft/api-extractor': ^7.43.1
       copyfiles: ^2.4.1
       eslint: ~8.55.0
@@ -9011,6 +9012,7 @@ importers:
       '@fluidframework/driver-definitions': link:../../common/driver-definitions
       '@fluidframework/id-compressor': link:../id-compressor
       '@fluidframework/protocol-definitions': 3.2.0
+      '@fluidframework/telemetry-utils': link:../../utils/telemetry-utils
     devDependencies:
       '@arethetypeswrong/cli': 0.15.2
       '@biomejs/biome': 1.6.2


### PR DESCRIPTION
## Description

> Deprecating `get` and `serialize` on the interface, it should just be a write-only interface for instrumentation (like logger.sendEvent).  Then containerRuntime has the concrete implementation (`TelemetryContext`) which has `serialize` (and perhaps no one would ever really need `get`)

> Providing internal used telemetry context interface
