### PR TITLE
tree: Allow removeRange() on empty array node

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -821,7 +821,7 @@ export interface FlexTreeSequenceField<in out TTypes extends FlexAllowedTypes> e
     moveToStart(sourceIndex: number): void;
     moveToStart(sourceIndex: number, source: FlexTreeSequenceField<FlexAllowedTypes>): void;
     removeAt(index: number): void;
-    removeRange(start?: number, end?: number): void;
+    sequenceEditor(): SequenceFieldEditBuilder;
 }
 
 // @internal

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -11,7 +11,7 @@ import {
 	anchorSlot,
 } from "../../core/index.js";
 import { Assume, FlattenKeys } from "../../util/index.js";
-import { FieldKinds } from "../default-schema/index.js";
+import { FieldKinds, SequenceFieldEditBuilder } from "../default-schema/index.js";
 import { FlexFieldKind } from "../modular-schema/index.js";
 import { LocalNodeKey, StableNodeKey } from "../node-key/index.js";
 import { AllowedTypesToFlexInsertableTree, InsertableFlexField } from "../schema-aware/index.js";
@@ -759,6 +759,11 @@ export interface FlexTreeSequenceField<in out TTypes extends FlexAllowedTypes>
 	readonly length: number;
 
 	/**
+	 * Get an editor for this sequence.
+	 */
+	sequenceEditor(): SequenceFieldEditBuilder;
+
+	/**
 	 * Inserts new item(s) at a specified location.
 	 * @param index - The index at which to insert `value`.
 	 * @param value - The content to insert.
@@ -784,16 +789,6 @@ export interface FlexTreeSequenceField<in out TTypes extends FlexAllowedTypes>
 	 * @throws Throws if `index` is not in the range [0, `list.length`).
 	 */
 	removeAt(index: number): void;
-
-	/**
-	 * Removes all items between the specified indices.
-	 * @param start - The starting index of the range to remove (inclusive). Defaults to the start of the sequence.
-	 * @param end - The ending index of the range to remove (exclusive).
-	 * @throws Throws if `start` is not in the range [0, `list.length`).
-	 * @throws Throws if `end` is less than `start`.
-	 * If `end` is not supplied or is greater than the length of the sequence, all items after `start` are deleted.
-	 */
-	removeRange(start?: number, end?: number): void;
 
 	/**
 	 * Moves the specified item to the start of the sequence.

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -763,6 +763,17 @@ export interface FlexTreeSequenceField<in out TTypes extends FlexAllowedTypes>
 	 */
 	sequenceEditor(): SequenceFieldEditBuilder;
 
+	/*
+	 * TODO:
+	 * Remove these editing methods and replace their use with use of `sequenceEditor`.
+	 * These editing methods replicate the API exposed by simple-tree, but using flex-tree types.
+	 * As these methods just re-abstract the lower level SequenceFieldEditBuilder API, they add little value.
+	 * Migrating the logic implementing them to simple-tree (and having it just use `sequenceEditor` directly)
+	 * avoids duplicating the API surface (and documentation), as well as makes it simpler to implement the desired user facing validation and errors
+	 * since simple-tree becomes responsible for all the validation and can produce usage errors in terms of the public package API.
+	 */
+	// #region Editing Methods
+
 	/**
 	 * Inserts new item(s) at a specified location.
 	 * @param index - The index at which to insert `value`.
@@ -911,6 +922,8 @@ export interface FlexTreeSequenceField<in out TTypes extends FlexAllowedTypes>
 		sourceEnd: number,
 		source: FlexTreeSequenceField<FlexAllowedTypes>,
 	): void;
+
+	// #endregion
 
 	boxedIterator(): IterableIterator<FlexTreeTypedNodeUnion<TTypes>>;
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -298,7 +298,7 @@ export class LazySequence<TTypes extends FlexAllowedTypes>
 		return this.map((x) => x);
 	}
 
-	private sequenceEditor(): SequenceFieldEditBuilder {
+	public sequenceEditor(): SequenceFieldEditBuilder {
 		const fieldPath = this.getFieldPathForEditing();
 		const fieldEditor = this.context.editor.sequenceField(fieldPath);
 		return fieldEditor;
@@ -329,15 +329,6 @@ export class LazySequence<TTypes extends FlexAllowedTypes>
 	public removeAt(index: number): void {
 		const fieldEditor = this.sequenceEditor();
 		fieldEditor.remove(index, 1);
-	}
-
-	public removeRange(start?: number, end?: number): void {
-		const fieldEditor = this.sequenceEditor();
-		const { length } = this;
-		const removeStart = start ?? 0;
-		const removeEnd = Math.min(length, end ?? length);
-		assertValidRangeIndices(removeStart, removeEnd, this);
-		fieldEditor.remove(removeStart, removeEnd - removeStart);
 	}
 
 	public moveToStart(sourceIndex: number): void;

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -659,7 +659,7 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		validatePositiveIndex(removeStart);
 		validatePositiveIndex(removeEnd);
 		if (removeEnd < removeStart) {
-			// This catches both the case where start is > array.length and when end is > array.length.
+			// This catches both the case where start is > array.length and when start is > end.
 			throw new UsageError('Too large of "start" value passed to TreeArrayNode.removeRange.');
 		}
 		fieldEditor.remove(removeStart, removeEnd - removeStart);

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -159,7 +159,9 @@ function applySequenceFieldEdit(
 			break;
 		}
 		case "remove": {
-			field.removeRange(change.range.first, change.range.last + 1);
+			field
+				.sequenceEditor()
+				.remove(change.range.first, change.range.last + 1 - change.range.first);
 			break;
 		}
 		case "intraFieldMove": {

--- a/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
@@ -5,22 +5,22 @@
 
 import { strict as assert } from "assert";
 import { SchemaFactory } from "../../simple-tree/index.js";
-import { hydrate } from "./utils.js";
+import { hydrate, validateUsageError } from "./utils.js";
 import { Mutable } from "../../util/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { asIndex } from "../../simple-tree/arrayNode.js";
 
 const schemaFactory = new SchemaFactory("ArrayNodeTest");
-const structuralArray = schemaFactory.array(schemaFactory.number);
-const classBasedArray = schemaFactory.array("Array", schemaFactory.number);
+const PojoEmulationNumberArray = schemaFactory.array(schemaFactory.number);
+const CustomizableNumberArray = schemaFactory.array("Array", schemaFactory.number);
 
 describe("ArrayNode", () => {
 	describe("created in pojo-emulation mode", () => {
-		testArrayFromSchemaType(structuralArray);
+		testArrayFromSchemaType(PojoEmulationNumberArray);
 	});
 
 	describe("created in customizable mode", () => {
-		testArrayFromSchemaType(classBasedArray);
+		testArrayFromSchemaType(CustomizableNumberArray);
 
 		it("doesn't stringify extra properties", () => {
 			class ExtraArray extends schemaFactory.array("ArrayWithExtra", schemaFactory.number) {
@@ -35,9 +35,9 @@ describe("ArrayNode", () => {
 		});
 	});
 
-	// Tests which should behave the same for both "structural" and "class-based" arrays can be added in this function to avoid duplication.
+	// Tests which should behave the same for both "structurally named" "POJO emulation mode" arrays and "customizable" arrays can be added in this function to avoid duplication.
 	function testArrayFromSchemaType(
-		schemaType: typeof structuralArray | typeof classBasedArray,
+		schemaType: typeof PojoEmulationNumberArray | typeof CustomizableNumberArray,
 	): void {
 		it("fails at runtime if attempting to set content via index assignment", () => {
 			const array = hydrate(schemaType, [0]);
@@ -52,6 +52,76 @@ describe("ArrayNode", () => {
 			const jsArray = [0, 1, 2];
 			const array = hydrate(schemaType, jsArray);
 			assert.equal(JSON.stringify(array), JSON.stringify(jsArray));
+		});
+
+		it("removeAt()", () => {
+			const array = hydrate(schemaType, [0, 1, 2]);
+			array.removeAt(1);
+			assert.deepEqual([...array], [0, 2]);
+		});
+
+		describe("removeRange", () => {
+			it("no arguments", () => {
+				const jsArray = [0, 1, 2];
+				const array = hydrate(schemaType, jsArray);
+				assert.equal(array.length, 3);
+				array.removeRange();
+				assert.equal(array.length, 0);
+				assert.deepEqual([...array], []);
+			});
+
+			it("empty array no arguments", () => {
+				const array = hydrate(schemaType, []);
+				array.removeRange();
+			});
+
+			it("middle", () => {
+				const list = hydrate(schemaType, [0, 1, 2, 3]);
+				list.removeRange(/* start: */ 1, /* end: */ 3);
+				assert.deepEqual([...list], [0, 3]);
+			});
+
+			it("all", () => {
+				const list = hydrate(schemaType, [0, 1, 2, 3]);
+				list.removeRange(0, 4);
+				assert.deepEqual([...list], []);
+			});
+
+			it("past end", () => {
+				const list = hydrate(schemaType, [0, 1, 2, 3]);
+				list.removeRange(1, Infinity);
+				assert.deepEqual([...list], [0]);
+			});
+
+			it("empty range", () => {
+				const list = hydrate(schemaType, [0, 1, 2, 3]);
+				list.removeRange(2, 2);
+				assert.deepEqual([...list], [0, 1, 2, 3]);
+			});
+
+			it("empty range - at start", () => {
+				const list = hydrate(schemaType, [0, 1, 2, 3]);
+				list.removeRange(0, 0);
+				assert.deepEqual([...list], [0, 1, 2, 3]);
+			});
+
+			it("empty range - at end", () => {
+				const list = hydrate(schemaType, [0, 1, 2, 3]);
+				list.removeRange(4, 4);
+				assert.deepEqual([...list], [0, 1, 2, 3]);
+			});
+
+			it("invalid", () => {
+				const list = hydrate(schemaType, [0, 1, 2, 3]);
+				// Past end
+				assert.throws(() => list.removeRange(5, 6), validateUsageError(/Too large/));
+				// start after end
+				assert.throws(() => list.removeRange(3, 2), validateUsageError(/Too large/));
+				// negative index
+				assert.throws(() => list.removeRange(-1, 2), validateUsageError(/index/));
+				// non-integer index
+				assert.throws(() => list.removeRange(1.5, 2), validateUsageError(/integer/));
+			});
 		});
 	}
 

--- a/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
@@ -89,7 +89,7 @@ describe("ArrayNode", () => {
 
 			it("past end", () => {
 				const list = hydrate(schemaType, [0, 1, 2, 3]);
-				list.removeRange(1, Infinity);
+				list.removeRange(1, Number.POSITIVE_INFINITY);
 				assert.deepEqual([...list], [0]);
 			});
 
@@ -122,6 +122,21 @@ describe("ArrayNode", () => {
 				// non-integer index
 				assert.throws(() => list.removeRange(1.5, 2), validateUsageError(/integer/));
 			});
+
+			it("invalid empty range", () => {
+				// If someday someone optimized empty ranges to no op earlier, they still need to error in these cases:
+				const list = hydrate(schemaType, [0, 1, 2, 3]);
+				// Past end
+				assert.throws(() => list.removeRange(5, 5), validateUsageError(/Too large/));
+				// negative index
+				assert.throws(() => list.removeRange(-1, -1), validateUsageError(/index/));
+				// non-integer index
+				assert.throws(
+					() => list.removeRange(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY),
+					validateUsageError(/safe integer/),
+				);
+				assert.throws(() => list.removeRange(1.5, 1.5), validateUsageError(/integer/));
+			});
 		});
 	}
 
@@ -146,5 +161,6 @@ describe("ArrayNode", () => {
 		assert.equal(asIndex("0x1", Number.POSITIVE_INFINITY), undefined);
 		assert.equal(asIndex(" 1", Number.POSITIVE_INFINITY), undefined);
 		assert.equal(asIndex("1.0", Number.POSITIVE_INFINITY), undefined);
+		assert.equal(asIndex("1 ", Number.POSITIVE_INFINITY), undefined);
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
@@ -425,56 +425,6 @@ describe("ArrayNode Proxy", () => {
 		});
 	});
 
-	describe("removing items", () => {
-		const _ = new SchemaFactory("test");
-		const schema = _.array(_.number);
-
-		it("removeAt()", () => {
-			const list = hydrate(schema, [0, 1, 2]);
-			assert.deepEqual(list, [0, 1, 2]);
-			list.removeAt(1);
-			assert.deepEqual(list, [0, 2]);
-		});
-
-		it("removeRange()", () => {
-			const list = hydrate(schema, [0, 1, 2, 3]);
-			assert.deepEqual(list, [0, 1, 2, 3]);
-			list.removeRange(/* start: */ 1, /* end: */ 3);
-			assert.deepEqual(list, [0, 3]);
-		});
-
-		it("removeRange() - all", () => {
-			const list = hydrate(schema, [0, 1, 2, 3]);
-			assert.deepEqual(list, [0, 1, 2, 3]);
-			list.removeRange(/* start: */ 1, /* end: */ 3);
-			assert.deepEqual(list, [0, 3]);
-			list.removeRange();
-			assert.deepEqual(list, []);
-		});
-
-		it("removeRange() - past end", () => {
-			const list = hydrate(schema, [0, 1, 2, 3]);
-			assert.deepEqual(list, [0, 1, 2, 3]);
-			list.removeRange(/* start: */ 1, /* end: */ 3);
-			assert.deepEqual(list, [0, 3]);
-			list.removeRange(1, Infinity);
-			assert.deepEqual(list, [0]);
-		});
-
-		it("removeRange() - empty range", () => {
-			const list = hydrate(schema, [0, 1, 2, 3]);
-			assert.deepEqual(list, [0, 1, 2, 3]);
-			list.removeRange(2, 2);
-			assert.deepEqual(list, [0, 1, 2, 3]);
-		});
-
-		it("removeRange() - empty list", () => {
-			const list = hydrate(schema, []);
-			assert.deepEqual(list, []);
-			assert.throws(() => list.removeRange());
-		});
-	});
-
 	describe("moving items", () => {
 		describe("within the same list", () => {
 			const _ = new SchemaFactory("test");

--- a/packages/dds/tree/src/test/simple-tree/types.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/types.spec.ts
@@ -4,7 +4,6 @@
  */
 
 import { strict as assert } from "node:assert";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 // eslint-disable-next-line import/no-internal-modules
@@ -18,6 +17,7 @@ import { RawTreeNode } from "../../simple-tree/rawNode.js";
 import { numberSchema } from "../../simple-tree/leafNodeSchema.js";
 // eslint-disable-next-line import/no-internal-modules
 import { getFlexSchema } from "../../simple-tree/toFlexSchema.js";
+import { validateUsageError } from "./utils.js";
 
 describe("simple-tree types", () => {
 	describe("TreeNode", () => {
@@ -239,19 +239,3 @@ describe("simple-tree types", () => {
 		});
 	});
 });
-
-export function validateUsageError(expectedErrorMsg: string | RegExp): (error: Error) => true {
-	return (error: Error) => {
-		assert(error instanceof UsageError);
-		if (
-			typeof expectedErrorMsg === "string"
-				? error.message !== expectedErrorMsg
-				: !expectedErrorMsg.test(error.message)
-		) {
-			throw new Error(
-				`Unexpected assertion thrown\nActual: ${error.message}\nExpected: ${expectedErrorMsg}`,
-			);
-		}
-		return true;
-	};
-}

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "node:assert";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
+
 import {
 	ImplicitFieldSchema,
 	InsertableTreeFieldFromImplicitField,
@@ -40,4 +43,20 @@ export function pretty(arg: unknown): number | string {
 		return arg;
 	}
 	return JSON.stringify(arg);
+}
+
+export function validateUsageError(expectedErrorMsg: string | RegExp): (error: Error) => true {
+	return (error: Error) => {
+		assert(error instanceof UsageError);
+		if (
+			typeof expectedErrorMsg === "string"
+				? error.message !== expectedErrorMsg
+				: !expectedErrorMsg.test(error.message)
+		) {
+			throw new Error(
+				`Unexpected assertion thrown\nActual: ${error.message}\nExpected: ${expectedErrorMsg}`,
+			);
+		}
+		return true;
+	};
 }


### PR DESCRIPTION
## Description

Before this change calling node.removeRange() on an empty array node would throw.

More generally removing any empty range at the end of the array would throw due to the start equaling the length.

This seems inconsistent and has been changed to allow this case (which is a no-op, just like other empty range removals).

Errors due to invalid input into removeRange now throw UsageErrros not asserts.

This change also makes it easier for simple-tree tests to check for usage errors.

This also starts a refactor to FlexTreeSequenceField to avoid requiring an extra intermediate flex tree API between SequenceFieldEditBuilder and ArrayNode for edits. This continues our trend toward reducing complexity in flex-tree which does not add value given the existing of the new package public (simple-tree) api.

## Breaking Changes

ArrayNode.removeRange no longer throws when the start equals the length.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
