### PR TITLE
tools(common-utils): Remove use of deprecated eslint config base

### DIFF
--- a/common/lib/common-utils/.eslintrc.cjs
+++ b/common/lib/common-utils/.eslintrc.cjs
@@ -4,10 +4,7 @@
  */
 
 module.exports = {
-	extends: [
-		require.resolve("@fluidframework/eslint-config-fluid/minimal-deprecated"),
-		"prettier",
-	],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
 	parserOptions: {
 		project: [
 			"./tsconfig.json",
@@ -26,6 +23,14 @@ module.exports = {
 		// This package uses node's events APIs.
 		// This should probably be reconsidered, but until then we will leave an exception for it here.
 		"import/no-nodejs-modules": ["error", { allow: ["events"] }],
+
+		// This package has been deprecated. The following rules have a significant number of violations
+		// that will not be fixed here.
+		"unicorn/prefer-node-protocol": "off",
+		"@typescript-eslint/no-explicit-any": "off",
+		"@typescript-eslint/no-unsafe-argument": "off",
+		"@typescript-eslint/no-unsafe-member-access": "off",
+		"@typescript-eslint/no-unsafe-call": "off",
 	},
 	overrides: [
 		{
@@ -33,6 +38,9 @@ module.exports = {
 			rules: {
 				// It's fine for tests to use node.js modules.
 				"import/no-nodejs-modules": "off",
+
+				// It's fine for tests to use `__dirname`, etc.
+				"unicorn/prefer-module": "off",
 			},
 		},
 	],

--- a/common/lib/common-utils/.eslintrc.cjs
+++ b/common/lib/common-utils/.eslintrc.cjs
@@ -26,11 +26,15 @@ module.exports = {
 
 		// This package has been deprecated. The following rules have a significant number of violations
 		// that will not be fixed here.
-		"unicorn/prefer-node-protocol": "off",
 		"@typescript-eslint/no-explicit-any": "off",
 		"@typescript-eslint/no-unsafe-argument": "off",
 		"@typescript-eslint/no-unsafe-member-access": "off",
 		"@typescript-eslint/no-unsafe-call": "off",
+		"@typescript-eslint/no-unsafe-assignment": "off",
+		"@typescript-eslint/explicit-module-boundary-types": "off",
+		"unicorn/text-encoding-identifier-case": "off",
+		"unicorn/prefer-node-protocol": "off",
+		"unicorn/prefer-code-point": "off",
 	},
 	overrides: [
 		{

--- a/common/lib/common-utils/src/base64Encoding.ts
+++ b/common/lib/common-utils/src/base64Encoding.ts
@@ -37,7 +37,6 @@ export const fromUtf8ToBase64 = (input: string): string =>
 export const toUtf8 = (input: string, encoding: string): string => {
 	switch (encoding) {
 		case "utf8":
-		// eslint-disable-next-line unicorn/text-encoding-identifier-case
 		case "utf-8": {
 			return input;
 		}

--- a/common/lib/common-utils/src/base64Encoding.ts
+++ b/common/lib/common-utils/src/base64Encoding.ts
@@ -37,9 +37,12 @@ export const fromUtf8ToBase64 = (input: string): string =>
 export const toUtf8 = (input: string, encoding: string): string => {
 	switch (encoding) {
 		case "utf8":
-		case "utf-8":
+		// eslint-disable-next-line unicorn/text-encoding-identifier-case
+		case "utf-8": {
 			return input;
-		default:
+		}
+		default: {
 			return IsoBuffer.from(input, encoding).toString();
+		}
 	}
 };

--- a/common/lib/common-utils/src/bufferBrowser.ts
+++ b/common/lib/common-utils/src/bufferBrowser.ts
@@ -100,6 +100,7 @@ export class IsoBuffer extends Uint8Array {
 	}
 
 	/**
+	 * Deprecated
 	 * @param value - (string | ArrayBuffer)
 	 * @param encodingOrOffset - (string | number)
 	 * @param length - (number)
@@ -116,6 +117,7 @@ export class IsoBuffer extends Uint8Array {
 		} else if (isArrayBuffer(value)) {
 			return IsoBuffer.fromArrayBuffer(value, encodingOrOffset as number | undefined, length);
 		} else {
+			// eslint-disable-next-line unicorn/error-message
 			throw new TypeError();
 		}
 	}
@@ -133,6 +135,7 @@ export class IsoBuffer extends Uint8Array {
 			validLength < 0 ||
 			validLength + offset > arrayBuffer.byteLength
 		) {
+			// eslint-disable-next-line unicorn/error-message
 			throw new RangeError();
 		}
 

--- a/common/lib/common-utils/src/heap.ts
+++ b/common/lib/common-utils/src/heap.ts
@@ -127,7 +127,7 @@ export class Heap<T> {
 		// Move the node we want to remove to the end of the array
 		const position = node.position;
 		this.swap(node.position, this.L.length - 1);
-		this.L.splice(this.L.length - 1);
+		this.L.splice(-1);
 
 		// Update the swapped node assuming we didn't remove the end of the list
 		if (position !== this.L.length) {

--- a/common/lib/common-utils/src/idleTaskScheduler.ts
+++ b/common/lib/common-utils/src/idleTaskScheduler.ts
@@ -17,8 +17,8 @@ export async function scheduleIdleTask<T>(callback: () => T, timeout: number): P
 		const doLowPriorityTask = (): any => {
 			try {
 				resolve(callback());
-			} catch (err: any) {
-				reject(err);
+			} catch (error: any) {
+				reject(error);
 			}
 		};
 

--- a/common/lib/common-utils/src/promiseCache.ts
+++ b/common/lib/common-utils/src/promiseCache.ts
@@ -28,9 +28,13 @@ export type PromiseCacheExpiry =
  * @internal
  */
 export interface PromiseCacheOptions {
-	/** Common expiration policy for all items added to this cache */
+	/**
+	 * Common expiration policy for all items added to this cache
+	 */
 	expiry?: PromiseCacheExpiry;
-	/** If the stored Promise is rejected with a particular error, should the given key be removed? */
+	/**
+	 * If the stored Promise is rejected with a particular error, should the given key be removed?
+	 */
 	removeOnError?: (e: any) => boolean;
 }
 

--- a/common/lib/common-utils/src/promises.ts
+++ b/common/lib/common-utils/src/promises.ts
@@ -80,6 +80,7 @@ export class LazyPromise<T> implements Promise<T> {
 
 	constructor(private readonly execute: () => Promise<T>) {}
 
+	// eslint-disable-next-line unicorn/no-thenable
 	public async then<TResult1 = T, TResult2 = never>(
 		// eslint-disable-next-line @rushstack/no-new-null
 		onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null | undefined,

--- a/common/lib/common-utils/src/safeParser.ts
+++ b/common/lib/common-utils/src/safeParser.ts
@@ -19,7 +19,7 @@ export function safelyParseJSON(json: string): any | undefined {
 	let parsed;
 	try {
 		parsed = JSON.parse(json);
-	} catch (error) {
+	} catch {
 		return undefined;
 	}
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/common/lib/common-utils/src/safeParser.ts
+++ b/common/lib/common-utils/src/safeParser.ts
@@ -14,7 +14,6 @@
  * @deprecated Moved to the `@fluidframework/core-utils` package.
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function safelyParseJSON(json: string): any | undefined {
 	let parsed;
 	try {
@@ -22,6 +21,5 @@ export function safelyParseJSON(json: string): any | undefined {
 	} catch {
 		return undefined;
 	}
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 	return parsed;
 }

--- a/common/lib/common-utils/src/test/jest/buffer.spec.ts
+++ b/common/lib/common-utils/src/test/jest/buffer.spec.ts
@@ -14,8 +14,8 @@ describe("Buffer isomorphism", () => {
 			"比特币", // non-ascii range
 			"😂💁🏼‍♂️💁🏼‍💁‍♂", // surrogate pairs with glyph modifiers
 			"\u0080\u0080", // invalid sequence of utf-8 continuation codes
-			"\ud800", // single utf-16 surrogate without pair
-			"\u2962\u0000\uffff\uaaaa", // garbage
+			"\uD800", // single utf-16 surrogate without pair
+			"\u2962\u0000\uFFFF\uAAAA", // garbage
 		];
 
 		for (const item of testArray) {

--- a/common/lib/common-utils/src/test/jest/gitHash.spec.ts
+++ b/common/lib/common-utils/src/test/jest/gitHash.spec.ts
@@ -54,7 +54,7 @@ async function evaluateBrowserHash(
 			const fileUint8 = Uint8Array.from(fileCharCodes);
 
 			// eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-			const hashFn = Function(`"use strict"; return ( ${fn} );`);
+			const hashFn = new Function(`"use strict"; return ( ${fn} );`);
 			const pageHashArray = await (hashFn()(fileUint8, alg) as Promise<Uint8Array>);
 
 			// Similarly, return the hash array as a string instead of a Uint8Array

--- a/common/lib/common-utils/src/test/mocha/assert.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/assert.spec.ts
@@ -12,9 +12,9 @@ describe("Assert", () => {
 		for (const shortCode of ["0x000", "0x03a", "0x200", "0x4321"]) {
 			try {
 				assert(false, Number.parseInt(shortCode, 16));
-			} catch (e: any) {
-				strict(e instanceof Error, "not an error");
-				strict.strictEqual(e.message, shortCode, "incorrect short code format");
+			} catch (error: any) {
+				strict(error instanceof Error, "not an error");
+				strict.strictEqual(error.message, shortCode, "incorrect short code format");
 			}
 		}
 	});

--- a/common/lib/common-utils/src/test/mocha/idleTaskScheduler.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/idleTaskScheduler.spec.ts
@@ -51,8 +51,8 @@ describe("Idle task scheduler", () => {
 						someTask(5);
 					}, 1000);
 				});
-			} catch (e) {
-				reject(e);
+			} catch (error) {
+				reject(error);
 			}
 		}).then(() => {
 			success = true;

--- a/common/lib/common-utils/src/test/mocha/promiseCache.spec.ts
+++ b/common/lib/common-utils/src/test/mocha/promiseCache.spec.ts
@@ -35,6 +35,7 @@ describe("PromiseCache", () => {
 			assert.equal(get_WhenPresent, "one");
 
 			const addOrGet_WhenPresent = await pc.addOrGet(1, async () => {
+				// eslint-disable-next-line unicorn/error-message
 				throw new Error();
 			});
 			assert.equal(addOrGet_WhenPresent, "one");
@@ -63,6 +64,7 @@ describe("PromiseCache", () => {
 			assert.equal(add_WhenAbsent, true);
 
 			const add_WhenPresent = pc.add(1, async () => {
+				// eslint-disable-next-line unicorn/error-message
 				throw new Error();
 			});
 			assert.equal(add_WhenPresent, false);

--- a/common/lib/common-utils/src/typedEventEmitter.ts
+++ b/common/lib/common-utils/src/typedEventEmitter.ts
@@ -26,7 +26,7 @@ export interface IEvent {
 	 *
 	 * @eventProperty
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	(event: string, listener: (...args: any[]) => void);
 }
 
@@ -47,7 +47,7 @@ export interface IErrorEvent extends IEvent {
 	 * @eventProperty
 	 *
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 	(event: "error", listener: (message: any) => void);
 }
 
@@ -111,7 +111,7 @@ export type IEventThisPlaceHolder = { thisPlaceHolder: "thisPlaceHolder" };
  * We need it here because TypedEventEmitter lives here, but otherwise should be removed in favor of the one in
  * core-interfaces.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> = L extends any[]
 	? { [K in keyof L]: L[K] extends IEventThisPlaceHolder ? TThis : L[K] }
 	: L;
@@ -127,7 +127,7 @@ export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> = L extends any
  * We need it here because TypedEventEmitter lives here, but otherwise should be removed in favor of the one in
  * core-interfaces.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 export type TransformedEvent<TThis, E, A extends any[]> = (
 	event: E,
 	listener: (...args: ReplaceIEventThisPlaceHolder<A, TThis>) => void,
@@ -165,7 +165,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 	(event: infer E12, listener: (...args: infer A12) => void);
 	(event: infer E13, listener: (...args: infer A13) => void);
 	(event: infer E14, listener: (...args: infer A14) => void);
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	(event: string, listener: (...args: any[]) => void);
 }
 	? TransformedEvent<TThis, E0, A0> &
@@ -198,7 +197,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E11, listener: (...args: infer A11) => void);
 			(event: infer E12, listener: (...args: infer A12) => void);
 			(event: infer E13, listener: (...args: infer A13) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -229,7 +227,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E10, listener: (...args: infer A10) => void);
 			(event: infer E11, listener: (...args: infer A11) => void);
 			(event: infer E12, listener: (...args: infer A12) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -258,7 +255,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E9, listener: (...args: infer A9) => void);
 			(event: infer E10, listener: (...args: infer A10) => void);
 			(event: infer E11, listener: (...args: infer A11) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -285,7 +281,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E8, listener: (...args: infer A8) => void);
 			(event: infer E9, listener: (...args: infer A9) => void);
 			(event: infer E10, listener: (...args: infer A10) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -310,7 +305,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E7, listener: (...args: infer A7) => void);
 			(event: infer E8, listener: (...args: infer A8) => void);
 			(event: infer E9, listener: (...args: infer A9) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -333,7 +327,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E6, listener: (...args: infer A6) => void);
 			(event: infer E7, listener: (...args: infer A7) => void);
 			(event: infer E8, listener: (...args: infer A8) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -354,7 +347,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E5, listener: (...args: infer A5) => void);
 			(event: infer E6, listener: (...args: infer A6) => void);
 			(event: infer E7, listener: (...args: infer A7) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -373,7 +365,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E4, listener: (...args: infer A4) => void);
 			(event: infer E5, listener: (...args: infer A5) => void);
 			(event: infer E6, listener: (...args: infer A6) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -390,7 +381,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E3, listener: (...args: infer A3) => void);
 			(event: infer E4, listener: (...args: infer A4) => void);
 			(event: infer E5, listener: (...args: infer A5) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -405,7 +395,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E2, listener: (...args: infer A2) => void);
 			(event: infer E3, listener: (...args: infer A3) => void);
 			(event: infer E4, listener: (...args: infer A4) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -418,7 +407,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E1, listener: (...args: infer A1) => void);
 			(event: infer E2, listener: (...args: infer A2) => void);
 			(event: infer E3, listener: (...args: infer A3) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -429,7 +418,6 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 			(event: infer E0, listener: (...args: infer A0) => void);
 			(event: infer E1, listener: (...args: infer A1) => void);
 			(event: infer E2, listener: (...args: infer A2) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> &
@@ -438,18 +426,15 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 	: TEvent extends {
 			(event: infer E0, listener: (...args: infer A0) => void);
 			(event: infer E1, listener: (...args: infer A1) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0> & TransformedEvent<TThis, E1, A1>
 	: TEvent extends {
 			(event: infer E0, listener: (...args: infer A0) => void);
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(event: string, listener: (...args: any[]) => void);
 	  }
 	? TransformedEvent<TThis, E0, A0>
-	: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-	  TransformedEvent<TThis, string, any[]>;
+	: TransformedEvent<TThis, string, any[]>;
 
 /**
  * The event emitter polyfill and the node event emitter have different event types:


### PR DESCRIPTION
Migrated from `minimal-deprecated` to default (`recommended`).

Since this package is deprecated in its entirety, minimal effort was made to fix errors. Instead, many rules were disabled. The main goal here is to get packages off of `minimal-deprecated` so we can remove it. The only actual code changes made here are the ones eslint could auto-fix.

[AB#2898](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2898)