### PR TITLE
fix(id-compressor): Fix resubmission order of ID allocation ops

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -168,6 +168,7 @@ import {
 	IPendingBatchMessage,
 	IPendingLocalState,
 	PendingStateManager,
+	idAllocationIndicator,
 } from "./pendingStateManager.js";
 import { ScheduleManager } from "./scheduleManager.js";
 import {
@@ -3927,6 +3928,9 @@ export class ContainerRuntime
 				const idAllocationBatchMessage: BatchMessage = {
 					contents: JSON.stringify(idAllocationMessage),
 					referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
+					// tag the id allocation message with the idAllocationIndicator to ensure it is handled
+					// before other op types if a resubmit occurs
+					localOpMetadata: idAllocationIndicator,
 				};
 				this.outbox.submitIdAllocation(idAllocationBatchMessage);
 			}

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -393,11 +393,13 @@ export class PendingStateManager implements IDisposable {
 		// as they will naturally be maintained.
 		filterMessagesInto(this.pendingMessages, messagesToReplay, true);
 		filterMessagesInto(this.pendingMessages, messagesToReplay, false);
-		assert(
-			messagesToReplay.length === initialPendingMessagesCount,
-			"All messages should be dequeued",
-		);
 		this.pendingMessages.clear();
+
+		assert(
+			messagesToReplay.length === initialPendingMessagesCount &&
+				this.pendingMessages.isEmpty(),
+			"All messages should be moved to messagesToReplay queue",
+		);
 
 		for (let i = 0; i < messagesToReplay.length; i++) {
 			let pendingMessage = messagesToReplay[i];
@@ -431,9 +433,7 @@ export class PendingStateManager implements IDisposable {
 						break;
 					}
 					assert(i < messagesToReplay.length - 1, 0x555 /* No batch end found */);
-					i++;
-
-					pendingMessage = messagesToReplay[i];
+					pendingMessage = messagesToReplay[++i];
 					assert(
 						pendingMessage.opMetadata?.batch !== true,
 						0x556 /* Batch start needs a corresponding batch end */,

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -260,7 +260,9 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 		if (lastCluster === undefined) {
 			// This is the first cluster in the session space
 			if (rangeBaseLocal !== -1) {
-				throw new Error("Ranges finalized out of order.");
+				throw new Error(
+					`Ranges finalized out of order, expected range starting with -1, got one starting at ${rangeBaseLocal}.`,
+				);
 			}
 			lastCluster = this.addEmptyCluster(session, requestedClusterSize + count);
 			if (isLocal) {
@@ -273,7 +275,11 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 
 		const remainingCapacity = lastCluster.capacity - lastCluster.count;
 		if (lastCluster.baseLocalId - lastCluster.count !== rangeBaseLocal) {
-			throw new Error("Ranges finalized out of order.");
+			throw new Error(
+				`Ranges finalized out of order, expected range starting with ${
+					lastCluster.baseLocalId - lastCluster.count + 1
+				}, got one starting at ${rangeBaseLocal}.`,
+			);
 		}
 
 		if (remainingCapacity >= count) {

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -379,7 +379,7 @@ describe("IdCompressor", () => {
 			compressor.finalizeCreationRange(batchRange);
 			assert.throws(
 				() => compressor.finalizeCreationRange(batchRange),
-				(e: Error) => e.message === "Ranges finalized out of order.",
+				(e: Error) => e.message === "Ranges finalized out of order, expected range starting with -3, got one starting at -1.",
 			);
 		});
 
@@ -391,7 +391,7 @@ describe("IdCompressor", () => {
 			const secondRange = compressor.takeNextCreationRange();
 			assert.throws(
 				() => compressor.finalizeCreationRange(secondRange),
-				(e: Error) => e.message === "Ranges finalized out of order.",
+				(e: Error) => e.message === "Ranges finalized out of order, expected range starting with -1, got one starting at -2.",
 			);
 		});
 

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -379,7 +379,9 @@ describe("IdCompressor", () => {
 			compressor.finalizeCreationRange(batchRange);
 			assert.throws(
 				() => compressor.finalizeCreationRange(batchRange),
-				(e: Error) => e.message === "Ranges finalized out of order, expected range starting with -3, got one starting at -1.",
+				(e: Error) =>
+					e.message ===
+					"Ranges finalized out of order, expected range starting with -3, got one starting at -1.",
 			);
 		});
 
@@ -391,7 +393,9 @@ describe("IdCompressor", () => {
 			const secondRange = compressor.takeNextCreationRange();
 			assert.throws(
 				() => compressor.finalizeCreationRange(secondRange),
-				(e: Error) => e.message === "Ranges finalized out of order, expected range starting with -1, got one starting at -2.",
+				(e: Error) =>
+					e.message ===
+					"Ranges finalized out of order, expected range starting with -1, got one starting at -2.",
 			);
 		});
 

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -380,8 +380,9 @@ describe("IdCompressor", () => {
 			assert.throws(
 				() => compressor.finalizeCreationRange(batchRange),
 				(e: Error) =>
-					e.message ===
-					"Ranges finalized out of order, expected range starting with -3, got one starting at -1.",
+					e.message === "Ranges finalized out of order" &&
+					(e as any).expectedStart === -3 &&
+					(e as any).actualStart === -1,
 			);
 		});
 
@@ -394,8 +395,9 @@ describe("IdCompressor", () => {
 			assert.throws(
 				() => compressor.finalizeCreationRange(secondRange),
 				(e: Error) =>
-					e.message ===
-					"Ranges finalized out of order, expected range starting with -1, got one starting at -2.",
+					e.message === "Ranges finalized out of order" &&
+					(e as any).expectedStart === -1 &&
+					(e as any).actualStart === -2,
 			);
 		});
 

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -555,17 +555,17 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		assert.strictEqual(sharedMapContainer1.get(sharedMapDecompressedId), "value");
 	});
 
-	const sharedPoints = [0, 1, 3, 5];
+	const sharedPoints = [0, 1, 2];
 	const testConfigs = generatePairwiseOptions({
-		preOfflineChanges: [...sharedPoints],
-		postOfflineChanges: [...sharedPoints],
-		allocateDuringResubmitStride: [1, 2, 3, 4],
+		preOfflineChanges: sharedPoints,
+		postOfflineChanges: sharedPoints,
+		allocateDuringResubmitStride: [1, 2, 3],
 		delayBetweenOfflineChanges: [true, false],
 	});
 
 	for (const testConfig of testConfigs) {
 		it(`Ids generated across batches are correctly resubmitted: ${JSON.stringify(
-			testConfig ?? "undefined",
+			testConfig,
 		)}`, async () => {
 			const idPairs: [SessionSpaceCompressedId, IIdCompressor][] = [];
 


### PR DESCRIPTION
## Description

This PR makes the runtime correctly resubmit ID allocation ops; specifically, any pending allocations are resubmitted before any other ops because the resubmission of non-allocation ops can cause allocations (which would then be resubmitted before earlier allocation ops, causing the "Ranges finalized out of order." exception).

This PR also differentiates exception messages in the compressor for this failure case.