### PR TITLE
Add errorLabel after resourceFactory.customize call

### DIFF
--- a/server/routerlicious/packages/services-shared/src/runner.ts
+++ b/server/routerlicious/packages/services-shared/src/runner.ts
@@ -29,7 +29,10 @@ export async function run<T extends IResources>(
 	logger: ILogger | undefined,
 ) {
 	const customizations = await (resourceFactory.customize
-		? resourceFactory.customize(config)
+		? resourceFactory.customize(config).catch((error) => {
+				prefixErrorLabel(error, "resourceFactory:customize");
+				throw error;
+		  })
 		: undefined);
 	const resources = await resourceFactory.create(config, customizations).catch((error) => {
 		prefixErrorLabel(error, "resourceFactory:create");


### PR DESCRIPTION
## Description

Recently I added errorLabel to the RunService metric properties so that it's easier to identify exceptions/restarts during initial setup vs during runtime (https://github.com/microsoft/FluidFramework/pull/20695)

Adding the same to resourceFactory.customize call as well since that was missed during original PR.