### PR TITLE
Revert "fix(id-compressor): Fix resubmission order of ID allocation ops"

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -168,7 +168,6 @@ import {
 	IPendingBatchMessage,
 	IPendingLocalState,
 	PendingStateManager,
-	idAllocationIndicator,
 } from "./pendingStateManager.js";
 import { ScheduleManager } from "./scheduleManager.js";
 import {
@@ -3928,9 +3927,6 @@ export class ContainerRuntime
 				const idAllocationBatchMessage: BatchMessage = {
 					contents: JSON.stringify(idAllocationMessage),
 					referenceSequenceNumber: this.deltaManager.lastSequenceNumber,
-					// tag the id allocation message with the idAllocationIndicator to ensure it is handled
-					// before other op types if a resubmit occurs
-					localOpMetadata: idAllocationIndicator,
 				};
 				this.outbox.submitIdAllocation(idAllocationBatchMessage);
 			}

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -76,11 +76,6 @@ function buildPendingMessageContent(
 }
 
 /**
- * Tag for op local metadata to indicate that the op is an id allocation.
- */
-export const idAllocationIndicator = Symbol("idAllocationIndicator");
-
-/**
  * PendingStateManager is responsible for maintaining the messages that have not been sent or have not yet been
  * acknowledged by the server. It also maintains the batch information for both automatically and manually flushed
  * batches along with the messages.
@@ -386,23 +381,15 @@ export class PendingStateManager implements IDisposable {
 		);
 
 		const initialPendingMessagesCount = this.pendingMessages.length;
-		const messagesToReplay: IPendingMessage[] = [];
-		// The following places all id allocations to the front of the queue while maintaining their
-		// partial order and that of the rest of the ops. Since id allocations are guaranteed to
-		// never be in batches with non-id allocation ops, this code does not need to worry about batch boundaries
-		// as they will naturally be maintained.
-		filterMessagesInto(this.pendingMessages, messagesToReplay, true);
-		filterMessagesInto(this.pendingMessages, messagesToReplay, false);
-		this.pendingMessages.clear();
+		let remainingPendingMessagesCount = this.pendingMessages.length;
 
-		assert(
-			messagesToReplay.length === initialPendingMessagesCount &&
-				this.pendingMessages.isEmpty(),
-			"All messages should be moved to messagesToReplay queue",
-		);
-
-		for (let i = 0; i < messagesToReplay.length; i++) {
-			let pendingMessage = messagesToReplay[i];
+		// Process exactly `pendingMessagesCount` items in the queue as it represents the number of messages that were
+		// pending when we connected. This is important because the `reSubmitFn` might add more items in the queue
+		// which must not be replayed.
+		while (remainingPendingMessagesCount > 0) {
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			let pendingMessage = this.pendingMessages.shift()!;
+			remainingPendingMessagesCount--;
 			assert(
 				pendingMessage.opMetadata?.batch !== false,
 				0x41b /* We cannot process batches in chunks */,
@@ -415,14 +402,14 @@ export class PendingStateManager implements IDisposable {
 			 */
 			if (pendingMessage.opMetadata?.batch) {
 				assert(
-					i < messagesToReplay.length - 1,
+					remainingPendingMessagesCount > 0,
 					0x554 /* Last pending message cannot be a batch begin */,
 				);
 
 				const batch: IPendingBatchMessage[] = [];
 
-				// batch end may be last pending message
-				while (i < messagesToReplay.length) {
+				// check is >= because batch end may be last pending message
+				while (remainingPendingMessagesCount >= 0) {
 					batch.push({
 						content: pendingMessage.content,
 						localOpMetadata: pendingMessage.localOpMetadata,
@@ -432,8 +419,11 @@ export class PendingStateManager implements IDisposable {
 					if (pendingMessage.opMetadata?.batch === false) {
 						break;
 					}
-					assert(i < messagesToReplay.length - 1, 0x555 /* No batch end found */);
-					pendingMessage = messagesToReplay[++i];
+					assert(remainingPendingMessagesCount > 0, 0x555 /* No batch end found */);
+
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					pendingMessage = this.pendingMessages.shift()!;
+					remainingPendingMessagesCount--;
 					assert(
 						pendingMessage.opMetadata?.batch !== true,
 						0x556 /* Batch start needs a corresponding batch end */,
@@ -462,20 +452,6 @@ export class PendingStateManager implements IDisposable {
 				count: initialPendingMessagesCount,
 				clientId: this.stateHandler.clientId(),
 			});
-		}
-	}
-}
-
-function filterMessagesInto(
-	src: Deque<IPendingMessage>,
-	dst: IPendingMessage[],
-	addIdAllocations: boolean,
-): void {
-	for (let i = 0; i < src.length; i++) {
-		const pendingMessage = src.get(i);
-		assert(pendingMessage !== undefined, "pendingMessage should be in queue");
-		if ((pendingMessage?.localOpMetadata === idAllocationIndicator) === addIdAllocations) {
-			dst.push(pendingMessage);
 		}
 	}
 }

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -6,11 +6,7 @@
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import {
-	ITelemetryLoggerExt,
-	LoggingError,
-	createChildLogger,
-} from "@fluidframework/telemetry-utils/internal";
+import { ITelemetryLoggerExt, createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { FinalSpace } from "./finalSpace.js";
 import { FinalCompressedId, LocalCompressedId, NumericUuid, isFinalId } from "./identifiers.js";
@@ -60,13 +56,6 @@ import {
  * This should not be changed without careful consideration to compatibility.
  */
 const currentWrittenVersion = 2.0;
-
-function rangeFinalizationError(expectedStart: number, actualStart: number): LoggingError {
-	return new LoggingError("Ranges finalized out of order", {
-		expectedStart,
-		actualStart,
-	});
-}
 
 /**
  * See {@link IIdCompressor} and {@link IIdCompressorCore}
@@ -271,7 +260,7 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 		if (lastCluster === undefined) {
 			// This is the first cluster in the session space
 			if (rangeBaseLocal !== -1) {
-				throw rangeFinalizationError(-1, rangeBaseLocal);
+				throw new Error("Ranges finalized out of order.");
 			}
 			lastCluster = this.addEmptyCluster(session, requestedClusterSize + count);
 			if (isLocal) {
@@ -284,10 +273,7 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 
 		const remainingCapacity = lastCluster.capacity - lastCluster.count;
 		if (lastCluster.baseLocalId - lastCluster.count !== rangeBaseLocal) {
-			throw rangeFinalizationError(
-				lastCluster.baseLocalId - lastCluster.count + 1,
-				rangeBaseLocal,
-			);
+			throw new Error("Ranges finalized out of order.");
 		}
 
 		if (remainingCapacity >= count) {

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -379,10 +379,7 @@ describe("IdCompressor", () => {
 			compressor.finalizeCreationRange(batchRange);
 			assert.throws(
 				() => compressor.finalizeCreationRange(batchRange),
-				(e: Error) =>
-					e.message === "Ranges finalized out of order" &&
-					(e as any).expectedStart === -3 &&
-					(e as any).actualStart === -1,
+				(e: Error) => e.message === "Ranges finalized out of order.",
 			);
 		});
 
@@ -394,10 +391,7 @@ describe("IdCompressor", () => {
 			const secondRange = compressor.takeNextCreationRange();
 			assert.throws(
 				() => compressor.finalizeCreationRange(secondRange),
-				(e: Error) =>
-					e.message === "Ranges finalized out of order" &&
-					(e as any).expectedStart === -1 &&
-					(e as any).actualStart === -2,
+				(e: Error) => e.message === "Ranges finalized out of order.",
 			);
 		});
 

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -33,8 +33,6 @@ import {
 	summarizeNow,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
-import { delay } from "@fluidframework/core-utils/internal";
-import { generatePairwiseOptions } from "@fluid-private/test-pairwise-generator";
 
 function getIdCompressor(dds: IChannel): IIdCompressor {
 	return (dds as any).runtime.idCompressor as IIdCompressor;
@@ -555,64 +553,42 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		assert.strictEqual(sharedMapContainer1.get(sharedMapDecompressedId), "value");
 	});
 
-	const sharedPoints = [0, 1, 2];
-	const testConfigs = generatePairwiseOptions({
-		preOfflineChanges: sharedPoints,
-		postOfflineChanges: sharedPoints,
-		allocateDuringResubmitStride: [1, 2, 3],
-		delayBetweenOfflineChanges: [true, false],
+	it("Ids generated when disconnected are correctly resubmitted", async () => {
+		// Disconnect the first container
+		container1.disconnect();
+
+		const idPairs: [SessionSpaceCompressedId, IIdCompressor][] = [];
+		// Generate a new Id in the disconnected container
+		const id1 = getIdCompressor(sharedMapContainer1).generateCompressedId();
+		idPairs.push([id1, getIdCompressor(sharedMapContainer1)]);
+
+		// Trigger Id submission
+		sharedMapContainer1.set("key", "value");
+
+		const superResubmit = (sharedMapContainer1 as any).reSubmitCore.bind(sharedMapContainer1);
+		(sharedMapContainer1 as any).reSubmitCore = (
+			content: unknown,
+			localOpMetadata: unknown,
+		) => {
+			// Simulate a DDS that generates IDs as part of the resubmit path (e.g. SharedTree)
+			// This will test that ID allocation ops are correctly sorted into a separate batch in the outbox
+			const id = getIdCompressor(sharedMapContainer1).generateCompressedId();
+			idPairs.push([id, getIdCompressor(sharedMapContainer1)]);
+			superResubmit(content, localOpMetadata);
+		};
+
+		// Generate ids in a connected container but don't send them yet
+		const id2 = getIdCompressor(sharedMapContainer2).generateCompressedId();
+		idPairs.push([id2, getIdCompressor(sharedMapContainer2)]);
+		const id3 = getIdCompressor(sharedMapContainer2).generateCompressedId();
+		idPairs.push([id3, getIdCompressor(sharedMapContainer2)]);
+
+		// Reconnect the first container
+		// IdRange should be resubmitted and reflected in all compressors
+		container1.connect();
+		await waitForContainerConnection(container1);
+		await assureAlignment([sharedMapContainer1, sharedMapContainer2], idPairs);
 	});
-
-	for (const testConfig of testConfigs) {
-		it(`Ids generated across batches are correctly resubmitted: ${JSON.stringify(
-			testConfig,
-		)}`, async () => {
-			const idPairs: [SessionSpaceCompressedId, IIdCompressor][] = [];
-
-			const simulateAllocation = (map: ISharedMap) => {
-				const idCompressor = getIdCompressor(map);
-				const id = idCompressor.generateCompressedId();
-				idPairs.push([id, idCompressor]);
-			};
-
-			for (let i = 0; i < testConfig.preOfflineChanges; i++) {
-				simulateAllocation(sharedMapContainer1);
-				sharedMapContainer1.set("key", i); // Trigger Id submission
-			}
-
-			container1.disconnect();
-
-			for (let i = 0; i < testConfig.postOfflineChanges; i++) {
-				simulateAllocation(sharedMapContainer1);
-				sharedMapContainer1.set("key", i); // Trigger Id submission
-
-				if (testConfig.delayBetweenOfflineChanges) {
-					await delay(100); // Trigger Id submission
-				}
-			}
-
-			let invokedCount = 0;
-			const superResubmit = (sharedMapContainer1 as any).reSubmitCore.bind(
-				sharedMapContainer1,
-			);
-			(sharedMapContainer1 as any).reSubmitCore = (
-				content: unknown,
-				localOpMetadata: unknown,
-			) => {
-				invokedCount++;
-				if (invokedCount % testConfig.allocateDuringResubmitStride === 0) {
-					// Simulate a DDS that generates IDs as part of the resubmit path (e.g. SharedTree)
-					// This will test that ID allocation ops are correctly sorted into a separate batch in the outbox
-					simulateAllocation(sharedMapContainer1);
-				}
-				superResubmit(content, localOpMetadata);
-			};
-
-			container1.connect();
-			await waitForContainerConnection(container1);
-			await assureAlignment([sharedMapContainer1, sharedMapContainer2], idPairs);
-		});
-	}
 
 	// IdCompressor is at container runtime level, which means that individual DDSs
 	// in the same container and different DataStores should have the same underlying compressor state


### PR DESCRIPTION
Reverts microsoft/FluidFramework#21016

2nd stress run after this was checked in exhibited a number of "Runtime detected too many reconnects with no progress syncing local ops.", which has otherwise never been hit by stress in the last 6 months. This PR is a likely culprit as it touches container-runtime's resubmit flow.