### PR TITLE
refactor(attributable-map): Promote eslint config to `recommended` and fix violations

### DIFF
--- a/examples/apps/attributable-map/.eslintrc.cjs
+++ b/examples/apps/attributable-map/.eslintrc.cjs
@@ -4,9 +4,6 @@
  */
 
 module.exports = {
-	extends: [
-		require.resolve("@fluidframework/eslint-config-fluid/minimal-deprecated"),
-		"prettier",
-	],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
 	rules: {},
 };

--- a/examples/apps/attributable-map/src/app.ts
+++ b/examples/apps/attributable-map/src/app.ts
@@ -40,6 +40,7 @@ async function start(): Promise<void> {
 	}
 
 	// update the browser URL and the window title with the actual container ID
+	// eslint-disable-next-line require-atomic-updates
 	location.hash = id;
 	document.title = id;
 

--- a/examples/apps/attributable-map/src/app.ts
+++ b/examples/apps/attributable-map/src/app.ts
@@ -35,7 +35,7 @@ async function start() {
 		model = createResponse.model;
 		id = await createResponse.attach();
 	} else {
-		id = location.hash.substring(1);
+		id = location.hash.slice(1);
 		model = await tinyliciousModelLoader.loadExisting(id);
 	}
 
@@ -43,7 +43,7 @@ async function start() {
 	location.hash = id;
 	document.title = id;
 
-	const contentDiv = document.getElementById("content") as HTMLDivElement;
+	const contentDiv = document.querySelector("#content") as HTMLDivElement;
 	renderHitCounter(model.hitCounter, model.runtimeAttributor, contentDiv);
 }
 

--- a/examples/apps/attributable-map/src/app.ts
+++ b/examples/apps/attributable-map/src/app.ts
@@ -14,7 +14,7 @@ import { renderHitCounter } from "./view.js";
  *
  * @remarks We wrap this in an async function so we can await Fluid's async calls.
  */
-async function start() {
+async function start(): Promise<void> {
 	/**
 	 * Manually enable the attribution config,
 	 */
@@ -47,4 +47,8 @@ async function start() {
 	renderHitCounter(model.hitCounter, model.runtimeAttributor, contentDiv);
 }
 
-start().catch((error) => console.error(error));
+try {
+	await start();
+} catch (error) {
+	console.error(error);
+}

--- a/examples/apps/attributable-map/src/containerCode.ts
+++ b/examples/apps/attributable-map/src/containerCode.ts
@@ -36,7 +36,7 @@ export class HitCounterContainerRuntimeFactory extends ModelContainerRuntimeFact
 	/**
 	 * {@inheritDoc ModelContainerRuntimeFactory.containerInitializingFirstTime}
 	 */
-	protected async containerInitializingFirstTime(runtime: IContainerRuntime) {
+	protected async containerInitializingFirstTime(runtime: IContainerRuntime): Promise<void> {
 		const hitCounter = await runtime.createDataStore(HitCounter.getFactory().type);
 		await hitCounter.trySetAlias(hitCounterId);
 	}
@@ -44,7 +44,10 @@ export class HitCounterContainerRuntimeFactory extends ModelContainerRuntimeFact
 	/**
 	 * {@inheritDoc ModelContainerRuntimeFactory.createModel}
 	 */
-	protected async createModel(runtime: IContainerRuntime, container: IContainer) {
+	protected async createModel(
+		runtime: IContainerRuntime,
+		container: IContainer,
+	): Promise<HitCounterAppModel> {
 		const hitCounter = await getDataStoreEntryPoint<HitCounter>(runtime, hitCounterId);
 		const maybeProvidesAttributor: FluidObject<IProvideRuntimeAttributor> = runtime.scope;
 		const runtimeAttributor = maybeProvidesAttributor.IRuntimeAttributor;

--- a/examples/apps/attributable-map/src/dataObject.ts
+++ b/examples/apps/attributable-map/src/dataObject.ts
@@ -30,7 +30,7 @@ export interface IHitCounter extends EventEmitter {
 	readonly map: ISharedMap | undefined;
 
 	/**
-	 * Inrement the hit count. Will cause a "hit" event to be emitted.
+	 * Increment the hit count. Will cause a "hit" event to be emitted.
 	 */
 	hit: (color: string) => void;
 
@@ -44,7 +44,7 @@ export class HitCounter extends DataObject implements IHitCounter {
 	private readonly mapKey = "mapKey";
 	private _map: ISharedMap | undefined;
 
-	public get map() {
+	public get map(): ISharedMap {
 		if (this._map === undefined) {
 			throw new Error("The AttributableMap was not initialized correctly");
 		}
@@ -60,11 +60,11 @@ export class HitCounter extends DataObject implements IHitCounter {
 		{},
 	);
 
-	public static getFactory() {
+	public static getFactory(): DataObjectFactory<HitCounter> {
 		return this.factory;
 	}
 
-	protected async initializingFirstTime() {
+	protected async initializingFirstTime(): Promise<void> {
 		// Create the AttributableMap and store the handle in our root SharedDirectory
 		const map = AttributableMap.create(this.runtime);
 		// set the initial value
@@ -73,7 +73,7 @@ export class HitCounter extends DataObject implements IHitCounter {
 		this.root.set(this.mapKey, map.handle);
 	}
 
-	protected async hasInitialized() {
+	protected async hasInitialized(): Promise<void> {
 		// Store the content if we are loading the first time or loading from existing
 		this._map = await this.root.get<IFluidHandle<ISharedMap>>(this.mapKey)?.get();
 		this.map.on("valueChanged", () => {
@@ -81,7 +81,8 @@ export class HitCounter extends DataObject implements IHitCounter {
 		});
 	}
 
-	public readonly hit = (color) => {
+	public readonly hit = (color: string): void => {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		const oldValue = this.map.get(color);
 		const newValue = Number(oldValue) + 1;
 		this.map?.set(color, newValue);

--- a/examples/apps/attributable-map/src/modelContainerRuntimeFactoryWithAttribution.ts
+++ b/examples/apps/attributable-map/src/modelContainerRuntimeFactoryWithAttribution.ts
@@ -27,7 +27,7 @@ const containerRuntimeWithAttribution = mixinAttributor(ContainerRuntime);
 export abstract class ModelContainerRuntimeFactoryWithAttribution<ModelType>
 	implements IRuntimeFactory
 {
-	public get IRuntimeFactory() {
+	public get IRuntimeFactory(): IRuntimeFactory {
 		return this;
 	}
 

--- a/examples/apps/attributable-map/src/view.ts
+++ b/examples/apps/attributable-map/src/view.ts
@@ -6,6 +6,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { IRuntimeAttributor } from "@fluid-experimental/attributor";
+import type { AttributionKey } from "@fluidframework/runtime-definitions/internal";
 
 import { IHitCounter, ITinyliciousUser, greenKey, redKey } from "./dataObject.js";
 
@@ -16,8 +17,10 @@ export function renderHitCounter(
 ): void {
 	const redCounterContainerDiv = document.querySelector("#red-counter-container-div")!;
 	const greenCounterContainerDiv = document.querySelector("#green-counter-container-div")!;
-	const redAttributionContainerDiv = document.querySelector("#red-attribution-container-div");
-	const greenAttributionContainerDiv = document.querySelector("#green-attribution-container-div");
+	const redAttributionContainerDiv = document.querySelector("#red-attribution-container-div")!;
+	const greenAttributionContainerDiv = document.querySelector(
+		"#green-attribution-container-div",
+	)!;
 
 	const redButton = document.querySelector("#red-button")!;
 	redButton.addEventListener("click", () => {
@@ -29,37 +32,45 @@ export function renderHitCounter(
 		hitCounter.hit("green");
 	});
 
+	// update the attribution text
+	const updateAttributionDisplay = (
+		attributionKey: AttributionKey | undefined,
+		containerDiv: Element,
+	): void => {
+		/**
+		 * A production application would manage detached and local attribution key types as well.
+		 * The current example and attributor will concentrate solely on handling the attribution of the Op-stream type.
+		 */
+		if (attributionKey !== undefined && attributionKey.type === "op") {
+			const attribution = runtimeAttributor?.get(attributionKey);
+			const userString = JSON.stringify(attribution?.user);
+			const user = JSON.parse(userString) as ITinyliciousUser;
+			// eslint-disable-next-line unicorn/no-null
+			const timestamp = new Date(attribution?.timestamp ?? JSON.stringify(null));
+			containerDiv.textContent = `Last updated by ${
+				user.name
+			}\non ${timestamp.toLocaleString()}`;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+			(containerDiv as any).style.display = "block";
+		} else {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+			(containerDiv as any).style.display = "none";
+		}
+	};
+
 	// Function to update counter value and attribution text
-	const updateView = () => {
-		const greenValue = hitCounter.map?.get(greenKey);
-		const redValue = hitCounter.map?.get(redKey);
+	const updateView = (): void => {
+		const greenValue: number | undefined = hitCounter.map?.get(greenKey);
+		const redValue: number | undefined = hitCounter.map?.get(redKey);
 
 		// update the counter value
-		redCounterContainerDiv.textContent = redValue.toString();
-		greenCounterContainerDiv.textContent = greenValue.toString();
+		// eslint-disable-next-line unicorn/no-null
+		redCounterContainerDiv.textContent = redValue?.toString() ?? null;
+		// eslint-disable-next-line unicorn/no-null
+		greenCounterContainerDiv.textContent = greenValue?.toString() ?? null;
 
 		const greenAttributionKey = hitCounter.map?.getAttribution(greenKey);
 		const redAttributionKey = hitCounter.map?.getAttribution(redKey);
-
-		// update the attribution text
-		const updateAttributionDisplay = (attributionKey, containerDiv) => {
-			/**
-			 * A production application would manage detached and local attribution key types as well.
-			 * The current example and attributor will concentrate solely on handling the attribution of the Op-stream type.
-			 */
-			if (attributionKey !== undefined && attributionKey.type === "op") {
-				const attribution = runtimeAttributor?.get(attributionKey);
-				const userString = JSON.stringify(attribution?.user);
-				const user = JSON.parse(userString) as ITinyliciousUser;
-				const timestamp = new Date(attribution?.timestamp ?? JSON.stringify(null));
-				containerDiv.textContent = `Last updated by ${
-					user.name
-				}\non ${timestamp.toLocaleString()}`;
-				containerDiv.style.display = "block";
-			} else {
-				containerDiv.style.display = "none";
-			}
-		};
 
 		updateAttributionDisplay(redAttributionKey, redAttributionContainerDiv);
 		updateAttributionDisplay(greenAttributionKey, greenAttributionContainerDiv);

--- a/examples/apps/attributable-map/src/view.ts
+++ b/examples/apps/attributable-map/src/view.ts
@@ -13,18 +13,18 @@ export function renderHitCounter(
 	hitCounter: IHitCounter,
 	runtimeAttributor: IRuntimeAttributor | undefined,
 	div: HTMLDivElement,
-) {
-	const redCounterContainerDiv = document.getElementById("red-counter-container-div")!;
-	const greenCounterContainerDiv = document.getElementById("green-counter-container-div")!;
-	const redAttributionContainerDiv = document.getElementById("red-attribution-container-div");
-	const greenAttributionContainerDiv = document.getElementById("green-attribution-container-div");
+): void {
+	const redCounterContainerDiv = document.querySelector("#red-counter-container-div")!;
+	const greenCounterContainerDiv = document.querySelector("#green-counter-container-div")!;
+	const redAttributionContainerDiv = document.querySelector("#red-attribution-container-div");
+	const greenAttributionContainerDiv = document.querySelector("#green-attribution-container-div");
 
-	const redButton = document.getElementById("red-button")!;
+	const redButton = document.querySelector("#red-button")!;
 	redButton.addEventListener("click", () => {
 		hitCounter.hit("red");
 	});
 
-	const greenButton = document.getElementById("green-button")!;
+	const greenButton = document.querySelector("#green-button")!;
 	greenButton.addEventListener("click", () => {
 		hitCounter.hit("green");
 	});


### PR DESCRIPTION
The minimal eslint config is deprecated and should not be used. This PR upgrades the config in `attributable-map` to use our recommended base config instead and fixes violations in the code.

[AB#4987](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4987)