### PR TITLE
refactor(versioning-tools): Promote eslint config and fix violations

### DIFF
--- a/build-tools/packages/version-tools/.eslintrc.cjs
+++ b/build-tools/packages/version-tools/.eslintrc.cjs
@@ -4,10 +4,7 @@
  */
 
 module.exports = {
-	extends: [
-		require.resolve("@fluidframework/eslint-config-fluid/minimal-deprecated"),
-		"prettier",
-	],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
 	parserOptions: {
 		project: ["./tsconfig.json", "./src/test/tsconfig.json"],
 	},

--- a/build-tools/packages/version-tools/api-report/version-tools.api.md
+++ b/build-tools/packages/version-tools/api-report/version-tools.api.md
@@ -28,7 +28,11 @@ export function detectBumpType(v1: semver.SemVer | string | null, v2: semver.Sem
 export function detectVersionScheme(rangeOrVersion: string | semver.SemVer): VersionScheme;
 
 // @public
-export function fromInternalScheme(internalVersion: semver.SemVer | string, allowPrereleases?: boolean, allowAnyPrereleaseId?: boolean): [publicVersion: semver.SemVer, internalVersion: semver.SemVer, prereleaseIndentifier: string];
+export function fromInternalScheme(internalVersion: semver.SemVer | string, allowPrereleases?: boolean, allowAnyPrereleaseId?: boolean): [
+publicVersion: semver.SemVer,
+internalVersion: semver.SemVer,
+prereleaseIndentifier: string
+];
 
 // @public
 export function fromVirtualPatchScheme(virtualPatchVersion: semver.SemVer | string): semver.SemVer;

--- a/build-tools/packages/version-tools/api-report/version-tools.api.md
+++ b/build-tools/packages/version-tools/api-report/version-tools.api.md
@@ -28,18 +28,14 @@ export function detectBumpType(v1: semver.SemVer | string | null, v2: semver.Sem
 export function detectVersionScheme(rangeOrVersion: string | semver.SemVer): VersionScheme;
 
 // @public
-export function fromInternalScheme(internalVersion: semver.SemVer | string, allowPrereleases?: boolean, allowAnyPrereleaseId?: boolean): [
-publicVersion: semver.SemVer,
-internalVersion: semver.SemVer,
-prereleaseIndentifier: string
-];
+export function fromInternalScheme(internalVersion: semver.SemVer | string, allowPrereleases?: boolean, allowAnyPrereleaseId?: boolean): [publicVersion: semver.SemVer, internalVersion: semver.SemVer, prereleaseIndentifier: string];
 
 // @public
 export function fromVirtualPatchScheme(virtualPatchVersion: semver.SemVer | string): semver.SemVer;
 
 // Warning: (ae-forgotten-export) The symbol "TagPrefix" needs to be exported by the entry point index.d.ts
 //
-// @public (undocumented)
+// @public
 export function getIsLatest(prefix: TagPrefix, current_version: string, input_tags?: string[], includeInternalVersions?: boolean, log?: boolean): boolean;
 
 // @public
@@ -58,7 +54,7 @@ export function getVersionRange(version: semver.SemVer | string, maxAutomaticBum
 export type InterdependencyRange = WorkspaceRange | RangeOperator | RangeOperatorWithVersion | semver.SemVer;
 
 // @public
-export function isInterdependencyRange(r: any): r is InterdependencyRange;
+export function isInterdependencyRange(r: unknown): r is InterdependencyRange;
 
 // @public
 export function isInternalVersionRange(range: string, allowAnyPrereleaseId?: boolean): boolean;
@@ -70,7 +66,7 @@ export function isInternalVersionScheme(version: semver.SemVer | string | undefi
 export function isPrereleaseVersion(version: string | semver.SemVer | undefined): boolean;
 
 // @public
-export function isRangeOperator(r: any): r is RangeOperator;
+export function isRangeOperator(r: unknown): r is RangeOperator;
 
 // @public
 export function isVersionBumpType(type: VersionChangeType | string | undefined): type is VersionBumpType;
@@ -82,7 +78,7 @@ export function isVersionBumpTypeExtended(type: VersionChangeType | string): typ
 export function isVersionScheme(scheme: string): scheme is VersionScheme;
 
 // @public
-export function isWorkspaceRange(r: any): r is WorkspaceRange;
+export function isWorkspaceRange(r: unknown): r is WorkspaceRange;
 
 // @public
 export type RangeOperator = (typeof RangeOperators)[number];

--- a/build-tools/packages/version-tools/src/bumpTypes.ts
+++ b/build-tools/packages/version-tools/src/bumpTypes.ts
@@ -87,7 +87,7 @@ export type InterdependencyRange =
  * which is good because I don't know how to fix it.
  */
 export function isInterdependencyRange(r: unknown): r is InterdependencyRange {
-	if (semver.valid(r as string | semver.SemVer) !== null) {
+	if ((typeof r === "string" || r instanceof semver.SemVer) && semver.valid(r) !== null) {
 		return true;
 	}
 

--- a/build-tools/packages/version-tools/src/bumpTypes.ts
+++ b/build-tools/packages/version-tools/src/bumpTypes.ts
@@ -95,7 +95,7 @@ export function isInterdependencyRange(r: unknown): r is InterdependencyRange {
 		return true;
 	}
 
-	if (semver.validRange(r as string | semver.Range) === null) {
+	if ((typeof r === "string" || r instanceof semver.Range) && semver.validRange(r) === null) {
 		return false;
 	}
 

--- a/build-tools/packages/version-tools/src/bumpTypes.ts
+++ b/build-tools/packages/version-tools/src/bumpTypes.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { Range, SemVer } from "semver";
 import * as semver from "semver";
 
 /**
@@ -88,7 +87,7 @@ export type InterdependencyRange =
  * which is good because I don't know how to fix it.
  */
 export function isInterdependencyRange(r: unknown): r is InterdependencyRange {
-	if (semver.valid(r as string | SemVer) !== null) {
+	if (semver.valid(r as string | semver.SemVer) !== null) {
 		return true;
 	}
 
@@ -99,7 +98,7 @@ export function isInterdependencyRange(r: unknown): r is InterdependencyRange {
 		return true;
 	}
 
-	if (semver.validRange(r as string | Range) === null) {
+	if (semver.validRange(r as string | semver.Range) === null) {
 		return false;
 	}
 

--- a/build-tools/packages/version-tools/src/bumpTypes.ts
+++ b/build-tools/packages/version-tools/src/bumpTypes.ts
@@ -92,8 +92,8 @@ export function isInterdependencyRange(r: unknown): r is InterdependencyRange {
 	}
 
 	if (
-		RangeOperators.includes(r as RangeOperator) ||
-		WorkspaceRanges.includes(r as WorkspaceRange)
+		isRangeOperator(r) ||
+		isWorkspaceRange(r)
 	) {
 		return true;
 	}
@@ -103,7 +103,7 @@ export function isInterdependencyRange(r: unknown): r is InterdependencyRange {
 	}
 
 	if (typeof r === "string") {
-		return RangeOperators.includes(r[0] as RangeOperator);
+		return isRangeOperator(r[0]);
 	}
 
 	return false;

--- a/build-tools/packages/version-tools/src/bumpTypes.ts
+++ b/build-tools/packages/version-tools/src/bumpTypes.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import type { Range, SemVer } from "semver";
 import * as semver from "semver";
 
 /**
@@ -34,8 +35,8 @@ export type RangeOperator = (typeof RangeOperators)[number];
 /**
  * A typeguard to check if a variable is a {@link RangeOperator}.
  */
-export function isRangeOperator(r: any): r is RangeOperator {
-	return RangeOperators.includes(r);
+export function isRangeOperator(r: unknown): r is RangeOperator {
+	return RangeOperators.includes(r as RangeOperator);
 }
 
 /**
@@ -64,8 +65,8 @@ export type WorkspaceRange = (typeof WorkspaceRanges)[number];
 /**
  * A typeguard to check if a variable is a {@link WorkspaceRange}.
  */
-export function isWorkspaceRange(r: any): r is WorkspaceRange {
-	return WorkspaceRanges.includes(r);
+export function isWorkspaceRange(r: unknown): r is WorkspaceRange {
+	return WorkspaceRanges.includes(r as WorkspaceRange);
 }
 
 /**
@@ -86,21 +87,24 @@ export type InterdependencyRange =
  * excluding non-conforming strings than it does at finding valid ones. This appears to be sufficient for our needs,
  * which is good because I don't know how to fix it.
  */
-export function isInterdependencyRange(r: any): r is InterdependencyRange {
-	if (semver.valid(r) !== null) {
+export function isInterdependencyRange(r: unknown): r is InterdependencyRange {
+	if (semver.valid(r as string | SemVer) !== null) {
 		return true;
 	}
 
-	if (RangeOperators.includes(r) || WorkspaceRanges.includes(r)) {
+	if (
+		RangeOperators.includes(r as RangeOperator) ||
+		WorkspaceRanges.includes(r as WorkspaceRange)
+	) {
 		return true;
 	}
 
-	if (semver.validRange(r) === null) {
+	if (semver.validRange(r as string | Range) === null) {
 		return false;
 	}
 
 	if (typeof r === "string") {
-		return RangeOperators.includes(r[0] as any);
+		return RangeOperators.includes(r[0] as RangeOperator);
 	}
 
 	return false;

--- a/build-tools/packages/version-tools/src/bumpTypes.ts
+++ b/build-tools/packages/version-tools/src/bumpTypes.ts
@@ -91,10 +91,7 @@ export function isInterdependencyRange(r: unknown): r is InterdependencyRange {
 		return true;
 	}
 
-	if (
-		isRangeOperator(r) ||
-		isWorkspaceRange(r)
-	) {
+	if (isRangeOperator(r) || isWorkspaceRange(r)) {
 		return true;
 	}
 

--- a/build-tools/packages/version-tools/src/commands/version.ts
+++ b/build-tools/packages/version-tools/src/commands/version.ts
@@ -151,13 +151,6 @@ export default class VersionCommand extends Command {
 			bumped,
 		};
 
-		const tablify = (scheme: VersionScheme): string => {
-			return table(Object.entries(scheme), {
-				columns: [{ alignment: "left" }, { alignment: "left" }, { alignment: "left" }],
-				singleLine: true,
-			});
-		};
-
 		this.log(`Input string: ${data.input}`);
 		this.log(`Bump type: ${data.bumpType}`);
 
@@ -202,6 +195,13 @@ export default class VersionCommand extends Command {
 			isFluidInternalFormat: isInternalVersionScheme(parsedVersion) === true,
 		};
 	}
+}
+
+function tablify(scheme: VersionScheme): string {
+	return table(Object.entries(scheme), {
+		columns: [{ alignment: "left" }, { alignment: "left" }, { alignment: "left" }],
+		singleLine: true,
+	});
 }
 
 interface ParsedVersion {

--- a/build-tools/packages/version-tools/src/commands/version.ts
+++ b/build-tools/packages/version-tools/src/commands/version.ts
@@ -151,7 +151,7 @@ export default class VersionCommand extends Command {
 			bumped,
 		};
 
-		const tablify = (scheme: VersionScheme) => {
+		const tablify = (scheme: VersionScheme): string => {
 			return table(Object.entries(scheme), {
 				columns: [{ alignment: "left" }, { alignment: "left" }, { alignment: "left" }],
 				singleLine: true,

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -290,7 +290,7 @@ export function isInternalVersionRange(range: string, allowAnyPrereleaseId = fal
 	const singleRangeSet = semverRange.set[0];
 
 	// Prerelease ranges must have comparator operators. This definition expects at least one '>='.
-	if (singleRangeSet.find((comparator) => comparator.operator === ">=") === undefined) {
+	if (!singleRangeSet.some((comparator) => comparator.operator === ">=")) {
 		return false;
 	}
 
@@ -313,12 +313,9 @@ export function isInternalVersionRange(range: string, allowAnyPrereleaseId = fal
 	// For internal version, range should not exceed the scope of single internal version.
 	// There should be a limit spec in range set (has '<' operator) with same prefix.
 	const prereleasePrefix = `${minVer.major}.${minVer.minor}.${minVer.patch}-${minVer.prerelease[0]}.`;
-	return (
-		singleRangeSet.find(
-			(comparator) =>
-				comparator.operator === "<" &&
-				comparator.semver.version.startsWith(prereleasePrefix),
-		) !== undefined
+	return singleRangeSet.some(
+		(comparator) =>
+			comparator.operator === "<" && comparator.semver.version.startsWith(prereleasePrefix),
 	);
 }
 

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -75,7 +75,11 @@ export function fromInternalScheme(
 	internalVersion: semver.SemVer | string,
 	allowPrereleases = false,
 	allowAnyPrereleaseId = false,
-): [publicVersion: semver.SemVer, internalVersion: semver.SemVer, prereleaseIndentifier: string] {
+): [
+	publicVersion: semver.SemVer,
+	internalVersion: semver.SemVer,
+	prereleaseIndentifier: string,
+] {
 	const parsedVersion = semver.parse(internalVersion);
 	validateVersionScheme(
 		parsedVersion,
@@ -153,7 +157,8 @@ export function toInternalScheme(
 	}
 
 	const prereleaseSections = parsedVersion.prerelease;
-	const newPrerelease = prereleaseSections.length > 0 ? `.${prereleaseSections.join(".")}` : "";
+	const newPrerelease =
+		prereleaseSections.length > 0 ? `.${prereleaseSections.join(".")}` : "";
 	const newSemVerString = `${publicVersion}-${prereleaseIdentifier}.${parsedVersion.major}.${parsedVersion.minor}.${parsedVersion.patch}${newPrerelease}`;
 	const newSemVer = semver.parse(newSemVerString);
 	if (newSemVer === null) {
@@ -450,7 +455,9 @@ export function changePreReleaseIdentifier(
  *
  * @internal
  */
-export function detectInternalVersionConstraintType(range: string): "minor" | "patch" | "exact" {
+export function detectInternalVersionConstraintType(
+	range: string,
+): "minor" | "patch" | "exact" {
 	if (semver.validRange(range) === null) {
 		throw new Error(`Invalid range: ${range}`);
 	}

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import * as semver from "semver";
 
 import { VersionBumpTypeExtended } from "./bumpTypes";
@@ -15,10 +15,14 @@ import { detectVersionScheme } from "./schemes";
  */
 export const MINIMUM_PUBLIC_VERSION = "2.0.0";
 
-/** The semver major version of the {@link MINIMUM_PUBLIC_VERSION}. */
+/**
+ * The semver major version of the {@link MINIMUM_PUBLIC_VERSION}.
+ */
 const MINIMUM_PUBLIC_MAJOR = semver.major(MINIMUM_PUBLIC_VERSION);
 
-/** The minimum number of prerelease sections a version should have to be considered a Fluid internal version. */
+/**
+ * The minimum number of prerelease sections a version should have to be considered a Fluid internal version.
+ */
 const MINIMUM_SEMVER_PRERELEASE_SECTIONS = 4;
 
 /**
@@ -146,7 +150,7 @@ export function toInternalScheme(
 		throw new Error(`Couldn't parse ${version} as a semver.`);
 	}
 
-	if (!allowPrereleases && parsedVersion.prerelease.length !== 0) {
+	if (!allowPrereleases && parsedVersion.prerelease.length > 0) {
 		throw new Error(
 			`Input version already has a pre-release component (${parsedVersion.prerelease}), which is not expected.`,
 		);
@@ -256,7 +260,7 @@ export function isInternalVersionScheme(
 
 	try {
 		validateVersionScheme(parsedVersion, allowPrereleases, prereleaseIds);
-	} catch (error) {
+	} catch {
 		return false;
 	}
 
@@ -413,7 +417,7 @@ export function changePreReleaseIdentifier(
 	}
 
 	const pr = ver.prerelease;
-	if (pr.length < 1) {
+	if (pr.length === 0) {
 		throw new Error(`Version has no prerelease section: ${version}`);
 	}
 

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -75,11 +75,7 @@ export function fromInternalScheme(
 	internalVersion: semver.SemVer | string,
 	allowPrereleases = false,
 	allowAnyPrereleaseId = false,
-): [
-	publicVersion: semver.SemVer,
-	internalVersion: semver.SemVer,
-	prereleaseIndentifier: string,
-] {
+): [publicVersion: semver.SemVer, internalVersion: semver.SemVer, prereleaseIndentifier: string] {
 	const parsedVersion = semver.parse(internalVersion);
 	validateVersionScheme(
 		parsedVersion,
@@ -157,8 +153,7 @@ export function toInternalScheme(
 	}
 
 	const prereleaseSections = parsedVersion.prerelease;
-	const newPrerelease =
-		prereleaseSections.length > 0 ? `.${prereleaseSections.join(".")}` : "";
+	const newPrerelease = prereleaseSections.length > 0 ? `.${prereleaseSections.join(".")}` : "";
 	const newSemVerString = `${publicVersion}-${prereleaseIdentifier}.${parsedVersion.major}.${parsedVersion.minor}.${parsedVersion.patch}${newPrerelease}`;
 	const newSemVer = semver.parse(newSemVerString);
 	if (newSemVer === null) {
@@ -192,7 +187,7 @@ export function validateVersionScheme(
 	version: semver.SemVer | string | null,
 	allowPrereleases = false,
 	prereleaseIdentifiers?: readonly string[],
-) {
+): boolean {
 	const parsedVersion = semver.parse(version);
 	if (parsedVersion === null) {
 		throw new Error(`Couldn't parse ${version} as a semver.`);
@@ -321,7 +316,8 @@ export function isInternalVersionRange(range: string, allowAnyPrereleaseId = fal
 	return (
 		singleRangeSet.find(
 			(comparator) =>
-				comparator.operator === "<" && comparator.semver.version.startsWith(prereleasePrefix),
+				comparator.operator === "<" &&
+				comparator.semver.version.startsWith(prereleasePrefix),
 		) !== undefined
 	);
 }
@@ -457,9 +453,7 @@ export function changePreReleaseIdentifier(
  *
  * @internal
  */
-export function detectInternalVersionConstraintType(
-	range: string,
-): "minor" | "patch" | "exact" {
+export function detectInternalVersionConstraintType(range: string): "minor" | "patch" | "exact" {
 	if (semver.validRange(range) === null) {
 		throw new Error(`Invalid range: ${range}`);
 	}

--- a/build-tools/packages/version-tools/src/schemes.ts
+++ b/build-tools/packages/version-tools/src/schemes.ts
@@ -61,7 +61,10 @@ export function detectVersionScheme(rangeOrVersion: string | semver.SemVer): Ver
 		}
 
 		return "semver";
-	} else if (typeof rangeOrVersion === "string" && semver.validRange(rangeOrVersion) !== null) {
+	} else if (
+		typeof rangeOrVersion === "string" &&
+		semver.validRange(rangeOrVersion) !== null
+	) {
 		// Must be a range string
 		if (isInternalVersionRange(rangeOrVersion)) {
 			return "internal";
@@ -156,7 +159,10 @@ export function bumpVersionScheme(
  * only released versions will be returned.
  * @returns The highest version number in the list.
  */
-export function getLatestReleaseFromList(versionList: string[], allowPrereleases = false): string {
+export function getLatestReleaseFromList(
+	versionList: string[],
+	allowPrereleases = false,
+): string {
 	const list = sortVersions(versionList, allowPrereleases);
 	const latest = list[0];
 

--- a/build-tools/packages/version-tools/src/schemes.ts
+++ b/build-tools/packages/version-tools/src/schemes.ts
@@ -61,10 +61,7 @@ export function detectVersionScheme(rangeOrVersion: string | semver.SemVer): Ver
 		}
 
 		return "semver";
-	} else if (
-		typeof rangeOrVersion === "string" &&
-		semver.validRange(rangeOrVersion) !== null
-	) {
+	} else if (typeof rangeOrVersion === "string" && semver.validRange(rangeOrVersion) !== null) {
 		// Must be a range string
 		if (isInternalVersionRange(rangeOrVersion)) {
 			return "internal";
@@ -117,6 +114,7 @@ export function bumpVersionScheme(
 				case "major":
 				case "minor":
 				case "patch": {
+					// eslint-disable-next-line unicorn/no-null
 					return sv?.inc(bumpType) ?? null;
 				}
 				default: {
@@ -159,7 +157,7 @@ export function bumpVersionScheme(
  * only released versions will be returned.
  * @returns The highest version number in the list.
  */
-export function getLatestReleaseFromList(versionList: string[], allowPrereleases = false) {
+export function getLatestReleaseFromList(versionList: string[], allowPrereleases = false): string {
 	const list = sortVersions(versionList, allowPrereleases);
 	const latest = list[0];
 

--- a/build-tools/packages/version-tools/src/schemes.ts
+++ b/build-tools/packages/version-tools/src/schemes.ts
@@ -61,7 +61,10 @@ export function detectVersionScheme(rangeOrVersion: string | semver.SemVer): Ver
 		}
 
 		return "semver";
-	} else if (typeof rangeOrVersion === "string" && semver.validRange(rangeOrVersion) !== null) {
+	} else if (
+		typeof rangeOrVersion === "string" &&
+		semver.validRange(rangeOrVersion) !== null
+	) {
 		// Must be a range string
 		if (isInternalVersionRange(rangeOrVersion)) {
 			return "internal";
@@ -157,7 +160,10 @@ export function bumpVersionScheme(
  * only released versions will be returned.
  * @returns The highest version number in the list.
  */
-export function getLatestReleaseFromList(versionList: string[], allowPrereleases = false): string {
+export function getLatestReleaseFromList(
+	versionList: string[],
+	allowPrereleases = false,
+): string {
 	const list = sortVersions(versionList, allowPrereleases);
 	const latest = list[0];
 

--- a/build-tools/packages/version-tools/src/schemes.ts
+++ b/build-tools/packages/version-tools/src/schemes.ts
@@ -61,10 +61,7 @@ export function detectVersionScheme(rangeOrVersion: string | semver.SemVer): Ver
 		}
 
 		return "semver";
-	} else if (
-		typeof rangeOrVersion === "string" &&
-		semver.validRange(rangeOrVersion) !== null
-	) {
+	} else if (typeof rangeOrVersion === "string" && semver.validRange(rangeOrVersion) !== null) {
 		// Must be a range string
 		if (isInternalVersionRange(rangeOrVersion)) {
 			return "internal";
@@ -139,9 +136,8 @@ export function bumpVersionScheme(
 					throw new Error(
 						`Applying virtual patch failed. The version returned was: ${translatedVersion}`,
 					);
-				} else {
-					return translatedVersion;
 				}
+				return translatedVersion;
 			} else {
 				return sv;
 			}
@@ -160,10 +156,7 @@ export function bumpVersionScheme(
  * only released versions will be returned.
  * @returns The highest version number in the list.
  */
-export function getLatestReleaseFromList(
-	versionList: string[],
-	allowPrereleases = false,
-): string {
+export function getLatestReleaseFromList(versionList: string[], allowPrereleases = false): string {
 	const list = sortVersions(versionList, allowPrereleases);
 	const latest = list[0];
 

--- a/build-tools/packages/version-tools/src/schemes.ts
+++ b/build-tools/packages/version-tools/src/schemes.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import * as semver from "semver";
 
 import { VersionBumpTypeExtended, isVersionBumpType } from "./bumpTypes";
@@ -111,15 +111,18 @@ export function bumpVersionScheme(
 	switch (scheme) {
 		case "semver": {
 			switch (bumpType) {
-				case "current":
+				case "current": {
 					return sv;
+				}
 				case "major":
 				case "minor":
-				case "patch":
+				case "patch": {
 					return sv?.inc(bumpType) ?? null;
-				default:
+				}
+				default: {
 					// If the bump type is an explicit version, just use it.
 					return bumpType;
+				}
 			}
 		}
 		case "internal": {
@@ -131,12 +134,12 @@ export function bumpVersionScheme(
 		case "virtualPatch": {
 			if (isVersionBumpType(bumpType)) {
 				const translatedVersion = bumpVirtualPatchVersion(bumpType, sv);
-				if (!isVersionBumpType(translatedVersion)) {
-					return translatedVersion;
-				} else {
+				if (isVersionBumpType(translatedVersion)) {
 					throw new Error(
 						`Applying virtual patch failed. The version returned was: ${translatedVersion}`,
 					);
+				} else {
+					return translatedVersion;
 				}
 			} else {
 				return sv;

--- a/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
+++ b/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
@@ -149,14 +149,14 @@ describe("internalScheme", () => {
 			[false, "^2.0.0-internal.2.2.1", undefined],
 			[false, "~2.0.0-internal.2.2.1", undefined],
 		];
-		cases.forEach(([isInternal, input, allowAnyPrereleaseId]) => {
+		for (const [isInternal, input, allowAnyPrereleaseId] of cases) {
 			it(`${input} is ${isInternal ? "" : "not "}internal${
 				allowAnyPrereleaseId ? " when allowAnyPrereleaseId is true" : ""
 			}`, () =>
 				(isInternal ? assert.isTrue : assert.isFalse)(
 					isInternalVersionRange(input, allowAnyPrereleaseId),
 				));
-		});
+		}
 	});
 
 	describe("converting FROM internal scheme", () => {

--- a/build-tools/packages/version-tools/src/versions.ts
+++ b/build-tools/packages/version-tools/src/versions.ts
@@ -79,7 +79,9 @@ export function getIsLatest(
 	}
 
 	let versions =
-		input_tags === undefined ? getVersions(prefix) : getVersionsFromStrings(prefix, input_tags);
+		input_tags === undefined
+			? getVersions(prefix)
+			: getVersionsFromStrings(prefix, input_tags);
 	versions = versions.filter((v) => {
 		if (v === undefined) {
 			return false;

--- a/build-tools/packages/version-tools/src/versions.ts
+++ b/build-tools/packages/version-tools/src/versions.ts
@@ -24,10 +24,12 @@ export function getSimpleVersion(
 	argBuildNum: string,
 	argRelease: boolean,
 	simplePatchVersioning: boolean,
-) {
+): string {
 	// Azure DevOp passes in the build number as $(buildNum).$(buildAttempt).
 	// Get the Build number and ignore the attempt number.
-	const buildId = simplePatchVersioning ? Number.parseInt(argBuildNum.split(".")[0], 10) : undefined;
+	const buildId = simplePatchVersioning
+		? Number.parseInt(argBuildNum.split(".")[0], 10)
+		: undefined;
 	let version = fileVersion;
 	if (isInternalVersionScheme(version, /* allowPrereleases */ true)) {
 		if (simplePatchVersioning) {
@@ -54,13 +56,14 @@ export function getSimpleVersion(
 }
 
 /**
+ * Determines if the specified `current_version` is the latest version (higher than the tagged releases _and NOT_ a
+ * pre-release version).
  * @param prefix - The tag prefix to filter the tags by (client, server, etc.).
  * @param current_version - The version to test; that is, the version to check for being the latest build.
  * @param input_tags - If provided, only these tags will be considered. Mostly useful for testing.
  * @param includeInternalVersions - Whether to include Fluid internal builds, which are always
  * @param log - if true, logs to console.
- * @returns true if the current version is to be considered the latest (higher than the tagged releases _and NOT_ a
- * pre-release version).
+ * @returns true if the current version is to be considered the latest.
  */
 export function getIsLatest(
 	prefix: TagPrefix,
@@ -76,9 +79,7 @@ export function getIsLatest(
 	}
 
 	let versions =
-		input_tags === undefined
-			? getVersions(prefix)
-			: getVersionsFromStrings(prefix, input_tags);
+		input_tags === undefined ? getVersions(prefix) : getVersionsFromStrings(prefix, input_tags);
 	versions = versions.filter((v) => {
 		if (v === undefined) {
 			return false;
@@ -112,7 +113,7 @@ function generateSimpleVersion(
 	release_version: string,
 	prerelease_version: string,
 	build_suffix: string,
-) {
+): string {
 	// Generate the full version string
 	if (prerelease_version) {
 		if (build_suffix) {
@@ -128,7 +129,13 @@ function generateSimpleVersion(
 	return release_version;
 }
 
-function parseFileVersion(fileVersion: string, buildId?: number) {
+function parseFileVersion(
+	fileVersion: string,
+	buildId?: number,
+): {
+	releaseVersion: string;
+	prereleaseVersion: string;
+} {
 	const split = fileVersion.split("-");
 	let releaseVersion = split[0];
 	split.shift();
@@ -142,6 +149,7 @@ function parseFileVersion(fileVersion: string, buildId?: number) {
 		const r = releaseVersion.split(".");
 		if (r.length !== 3) {
 			console.error(`ERROR: Invalid format for release version ${releaseVersion}`);
+			// eslint-disable-next-line unicorn/no-process-exit
 			process.exit(9);
 		}
 		r[2] = (Number.parseInt(r[2], 10) + buildId).toString();
@@ -158,7 +166,7 @@ function parseFileVersion(fileVersion: string, buildId?: number) {
  * @param prefix - The tag prefix to filter the tags by (client, server, etc.).
  * @returns An array of versions extracted from the output of `git tag -l`.
  */
-function getVersions(prefix: TagPrefix) {
+function getVersions(prefix: TagPrefix): string[] {
 	const raw_tags = child_process.execSync(`git tag -l`, { encoding: "utf8" });
 	const tags = raw_tags.split(/\s+/g).map((t) => t.trim());
 	return getVersionsFromStrings(prefix, tags);
@@ -171,7 +179,7 @@ function getVersions(prefix: TagPrefix) {
  * @param tags - An array of tags as strings.
  * @returns An array of versions extracted from the provided tags.
  */
-function getVersionsFromStrings(prefix: TagPrefix, tags: string[]) {
+function getVersionsFromStrings(prefix: TagPrefix, tags: string[]): string[] {
 	const versions = tags
 		.filter((v) => v.startsWith(`${prefix}_v`))
 		.map((tag) => tag.slice(`${prefix}_v`.length));

--- a/build-tools/packages/version-tools/src/versions.ts
+++ b/build-tools/packages/version-tools/src/versions.ts
@@ -27,7 +27,7 @@ export function getSimpleVersion(
 ) {
 	// Azure DevOp passes in the build number as $(buildNum).$(buildAttempt).
 	// Get the Build number and ignore the attempt number.
-	const buildId = simplePatchVersioning ? parseInt(argBuildNum.split(".")[0], 10) : undefined;
+	const buildId = simplePatchVersioning ? Number.parseInt(argBuildNum.split(".")[0], 10) : undefined;
 	let version = fileVersion;
 	if (isInternalVersionScheme(version, /* allowPrereleases */ true)) {
 		if (simplePatchVersioning) {
@@ -37,7 +37,7 @@ export function getSimpleVersion(
 		}
 
 		if (!argRelease) {
-			const [, , prereleaseId] = fromInternalScheme(version);
+			const prereleaseId = fromInternalScheme(version)[2];
 			version = changePreReleaseIdentifier(
 				version,
 				// The "internal" prerelease identifier was historically transformed to "dev", so that behavior is preserved
@@ -144,7 +144,7 @@ function parseFileVersion(fileVersion: string, buildId?: number) {
 			console.error(`ERROR: Invalid format for release version ${releaseVersion}`);
 			process.exit(9);
 		}
-		r[2] = (parseInt(r[2], 10) + buildId).toString();
+		r[2] = (Number.parseInt(r[2], 10) + buildId).toString();
 		releaseVersion = r.join(".");
 	}
 
@@ -174,7 +174,7 @@ function getVersions(prefix: TagPrefix) {
 function getVersionsFromStrings(prefix: TagPrefix, tags: string[]) {
 	const versions = tags
 		.filter((v) => v.startsWith(`${prefix}_v`))
-		.map((tag) => tag.substring(`${prefix}_v`.length));
+		.map((tag) => tag.slice(`${prefix}_v`.length));
 	semver.sort(versions);
 	return versions;
 }

--- a/build-tools/packages/version-tools/src/virtualPatchScheme.ts
+++ b/build-tools/packages/version-tools/src/virtualPatchScheme.ts
@@ -18,16 +18,14 @@ const VIRTUAL_PATCH_FORMAT_MULTIPLIER = 1000;
  */
 export function isVirtualPatch(version: semver.SemVer | string): boolean {
 	// If the major is 0 and the patch is >= 1000 assume it's a virtualPatch version
-	if (
-		semver.major(version) === 0 &&
-		semver.patch(version) >= VIRTUAL_PATCH_FORMAT_MULTIPLIER
-	) {
+	if (semver.major(version) === 0 && semver.patch(version) >= VIRTUAL_PATCH_FORMAT_MULTIPLIER) {
 		return true;
 	}
 	return false;
 }
 
 /**
+ * Increments the specified component of the provided version and returns the result.
  * @param versionBump - The bump type to do.
  * @param versionString - The version to bump.
  * @returns The bumped version.
@@ -78,9 +76,7 @@ export function bumpVirtualPatchVersion(
  * @param virtualPatchVersion - A Fluid virtualPatch version.
  * @returns The translated version.
  */
-export function fromVirtualPatchScheme(
-	virtualPatchVersion: semver.SemVer | string,
-): semver.SemVer {
+export function fromVirtualPatchScheme(virtualPatchVersion: semver.SemVer | string): semver.SemVer {
 	const parsedVersion = semver.parse(virtualPatchVersion);
 	assert(parsedVersion !== null, `Parsed as null: ${virtualPatchVersion}`);
 

--- a/build-tools/packages/version-tools/src/virtualPatchScheme.ts
+++ b/build-tools/packages/version-tools/src/virtualPatchScheme.ts
@@ -3,12 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
 import * as semver from "semver";
 
 import { VersionBumpType } from "./bumpTypes";
 
-/** The virtualPatch format uses this value to encode and decode versions in that scheme. */
+/**
+ * The virtualPatch format uses this value to encode and decode versions in that scheme.
+ */
 const VIRTUAL_PATCH_FORMAT_MULTIPLIER = 1000;
 
 /**

--- a/build-tools/packages/version-tools/src/virtualPatchScheme.ts
+++ b/build-tools/packages/version-tools/src/virtualPatchScheme.ts
@@ -18,7 +18,10 @@ const VIRTUAL_PATCH_FORMAT_MULTIPLIER = 1000;
  */
 export function isVirtualPatch(version: semver.SemVer | string): boolean {
 	// If the major is 0 and the patch is >= 1000 assume it's a virtualPatch version
-	if (semver.major(version) === 0 && semver.patch(version) >= VIRTUAL_PATCH_FORMAT_MULTIPLIER) {
+	if (
+		semver.major(version) === 0 &&
+		semver.patch(version) >= VIRTUAL_PATCH_FORMAT_MULTIPLIER
+	) {
 		return true;
 	}
 	return false;
@@ -76,7 +79,9 @@ export function bumpVirtualPatchVersion(
  * @param virtualPatchVersion - A Fluid virtualPatch version.
  * @returns The translated version.
  */
-export function fromVirtualPatchScheme(virtualPatchVersion: semver.SemVer | string): semver.SemVer {
+export function fromVirtualPatchScheme(
+	virtualPatchVersion: semver.SemVer | string,
+): semver.SemVer {
 	const parsedVersion = semver.parse(virtualPatchVersion);
 	assert(parsedVersion !== null, `Parsed as null: ${virtualPatchVersion}`);
 


### PR DESCRIPTION
The minimal config is deprecated and will soon be removed. Promotes the package's config to use the "recommended" config instead, and fixes violations in the code.

[AB#7990](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7990)