### PR TITLE
Package Seal: magically make an interface sealed when it leaves the package!

### DIFF
--- a/examples/data-objects/inventory-app/src/schema.ts
+++ b/examples/data-objects/inventory-app/src/schema.ts
@@ -2,8 +2,15 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
-
-import { SchemaFactory, TreeConfiguration } from "@fluidframework/tree";
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+	SchemaFactory,
+	TreeConfiguration,
+	type ITree2,
+	type ImplicitFieldSchema,
+	type TreeView,
+} from "@fluidframework/tree";
 
 const builder = new SchemaFactory("com.contoso.app.inventory");
 
@@ -31,3 +38,40 @@ export const treeConfiguration = new TreeConfiguration(
 			],
 		}),
 );
+
+// This it outside the package so it fails to build since implementing this interface is blocked.
+const bad: ITree2 = {
+	schematize<TRoot extends ImplicitFieldSchema>(
+		config: TreeConfiguration<TRoot>,
+	): TreeView<TRoot> {
+		throw new Error("Function not implemented.");
+	},
+	id: "",
+	attributes: undefined as any,
+	getAttachSummary(
+		fullTree?: boolean | undefined,
+		trackState?: boolean | undefined,
+		telemetryContext?: any | undefined,
+	): any {
+		throw new Error("Function not implemented.");
+	},
+	async summarize(
+		fullTree?: boolean | undefined,
+		trackState?: boolean | undefined,
+		telemetryContext?: any | undefined,
+		incrementalSummaryContext?: any | undefined,
+	): Promise<any> {
+		throw new Error("Function not implemented.");
+	},
+	isAttached(): boolean {
+		throw new Error("Function not implemented.");
+	},
+	connect(services: any): void {
+		throw new Error("Function not implemented.");
+	},
+	getGCData(fullGC?: boolean | undefined): any {
+		throw new Error("Function not implemented.");
+	},
+	handle: undefined as any,
+	IFluidLoadable: undefined as any,
+};

--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -242,7 +242,7 @@ export interface CommitMetadata {
 export function compareLocalNodeKeys(a: LocalNodeKey, b: LocalNodeKey): -1 | 0 | 1;
 
 // @internal
-export function configuredSharedTree(options: SharedTreeOptions): ISharedObjectKind<ITree>;
+export function configuredSharedTree(options: SharedTreeOptions): ISharedObjectKind<ITree2>;
 
 // @internal
 export type ContextuallyTypedFieldData = ContextuallyTypedNodeData | undefined;
@@ -983,6 +983,13 @@ export interface InitializeAndSchematizeConfiguration<TRoot extends FlexFieldSch
 // @internal
 export type _InlineTrick = 0;
 
+// @public
+export type InPackage = InPackageTester<1> extends InPackageTester<2> ? false : true;
+
+// @public
+export class InPackageTester<T> {
+}
+
 // @internal
 export type InsertableFlexField<TField extends FlexFieldSchema> = [
 ApplyMultiplicity<TField["kind"]["multiplicity"], AllowedTypesToFlexInsertableTree<TField["allowedTypes"]>>
@@ -1086,6 +1093,9 @@ export interface ITransaction {
 export interface ITree extends IChannel {
     schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TRoot>;
 }
+
+// @public (undocumented)
+export type ITree2 = PackageSeal<ITree>;
 
 // @internal
 export interface ITreeCheckout extends AnchorLocator {
@@ -1396,6 +1406,9 @@ export type OptionalFields<T> = [
 }
 ][_InlineTrick];
 
+// @public
+export type PackageSeal<T> = InPackage extends true ? T : T & ErasedType<readonly ["PackageSeal", T]>;
+
 // @internal
 export interface PathRootPrefix {
     indexOffset?: number;
@@ -1692,7 +1705,7 @@ export interface SequenceFieldEditBuilder {
 }
 
 // @public
-export const SharedTree: ISharedObjectKind<ITree>;
+export const SharedTree: ISharedObjectKind<ITree2>;
 
 // @internal
 export interface SharedTreeContentSnapshot {

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -307,6 +307,11 @@ export {
 	DefaultProvider,
 	type FieldProps,
 	type InternalTreeNode,
+	// Test
+	ITree2,
+	PackageSeal,
+	InPackageTester,
+	InPackage,
 
 	// Recursive Schema APIs
 	type ValidateRecursiveSchema,

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -3,7 +3,17 @@
  * Licensed under the MIT License.
  */
 
-export { ITree, TreeView, TreeViewEvents, TreeConfiguration, SchemaIncompatible } from "./tree.js";
+export {
+	ITree,
+	TreeView,
+	TreeViewEvents,
+	TreeConfiguration,
+	SchemaIncompatible,
+	ITree2,
+	PackageSeal,
+	InPackageTester,
+	InPackage,
+} from "./tree.js";
 export {
 	TreeNodeSchema,
 	NodeFromSchema,

--- a/packages/dds/tree/src/simple-tree/tree.ts
+++ b/packages/dds/tree/src/simple-tree/tree.ts
@@ -15,6 +15,7 @@ import {
 	InsertableTreeFieldFromImplicitField,
 	TreeFieldFromImplicitField,
 } from "./schemaTypes.js";
+import { ErasedType } from "@fluidframework/core-interfaces";
 
 /**
  * Channel for a Fluid Tree DDS.
@@ -63,6 +64,33 @@ export interface ITree extends IChannel {
 		config: TreeConfiguration<TRoot>,
 	): TreeView<TRoot>;
 }
+
+/**
+ * This type parameter is covariant from within the package, but has no impact on assignability from outside the package since the type of private members are dropped.
+ * @public
+ */
+export class InPackageTester<T> {
+	private readonly test!: T;
+}
+
+/**
+ * True when use within this package, false from outside it.
+ * @public
+ */
+export type InPackage = InPackageTester<1> extends InPackageTester<2> ? false : true;
+
+/**
+ * Adapt an interface to be "sealed" making it non-constructable and non implementable, but only from outside the package.
+ * @public
+ */
+export type PackageSeal<T> = InPackage extends true
+	? T
+	: T & ErasedType<readonly ["PackageSeal", T]>;
+
+/**
+ * @public
+ */
+export type ITree2 = PackageSeal<ITree>;
 
 /**
  * Configuration for how to {@link ITree.schematize|schematize} a tree.

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -66,7 +66,13 @@ import {
 // eslint-disable-next-line import/no-internal-modules
 import { requireSchema } from "../../shared-tree/schematizingTreeView.js";
 import { EditManager } from "../../shared-tree-core/index.js";
-import { SchemaFactory, TreeConfiguration } from "../../simple-tree/index.js";
+import {
+	ITree2,
+	ImplicitFieldSchema,
+	SchemaFactory,
+	TreeConfiguration,
+	TreeView,
+} from "../../simple-tree/index.js";
 import { brand, disposeSymbol, fail } from "../../util/index.js";
 import {
 	ConnectionSetter,
@@ -90,11 +96,55 @@ import {
 } from "../utils.js";
 import { configuredSharedTree } from "../../treeFactory.js";
 import { ISharedObjectKind } from "@fluidframework/shared-object-base";
+import { IChannelServices } from "@fluidframework/datastore-definitions";
+import {
+	ITelemetryContext,
+	ISummaryTreeWithStats,
+	IExperimentalIncrementalSummaryContext,
+	IGarbageCollectionData,
+} from "@fluidframework/runtime-definitions";
+
+// This it outside the package (for TSC, not for intellisense) so it fails to build since implementing this interface is blocked.
+const bad: ITree2 = {
+	schematize<TRoot extends ImplicitFieldSchema>(
+		config: TreeConfiguration<TRoot>,
+	): TreeView<TRoot> {
+		throw new Error("Function not implemented.");
+	},
+	id: "",
+	attributes: undefined as any,
+	getAttachSummary(
+		fullTree?: boolean | undefined,
+		trackState?: boolean | undefined,
+		telemetryContext?: ITelemetryContext | undefined,
+	): ISummaryTreeWithStats {
+		throw new Error("Function not implemented.");
+	},
+	async summarize(
+		fullTree?: boolean | undefined,
+		trackState?: boolean | undefined,
+		telemetryContext?: ITelemetryContext | undefined,
+		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined,
+	): Promise<ISummaryTreeWithStats> {
+		throw new Error("Function not implemented.");
+	},
+	isAttached(): boolean {
+		throw new Error("Function not implemented.");
+	},
+	connect(services: IChannelServices): void {
+		throw new Error("Function not implemented.");
+	},
+	getGCData(fullGC?: boolean | undefined): IGarbageCollectionData {
+		throw new Error("Function not implemented.");
+	},
+	handle: undefined as any,
+	IFluidLoadable: undefined as any,
+};
 
 const DebugSharedTree = configuredSharedTree({
 	jsonValidator: typeboxValidator,
 	forest: ForestType.Reference,
-}) as ISharedObjectKind<SharedTree>;
+}) as unknown as ISharedObjectKind<SharedTree>;
 
 class MockSharedTreeRuntime extends MockFluidDataStoreRuntime {
 	public constructor() {

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -14,7 +14,7 @@ import { createSharedObjectKind } from "@fluidframework/shared-object-base/inter
 
 import { pkgVersion } from "./packageVersion.js";
 import { SharedTree as SharedTreeImpl, SharedTreeOptions } from "./shared-tree/index.js";
-import { ITree } from "./simple-tree/index.js";
+import { ITree, ITree2 } from "./simple-tree/index.js";
 
 /**
  * A channel factory that creates an {@link ITree}.
@@ -55,7 +55,7 @@ export class TreeFactory implements IChannelFactory<ITree> {
  * of objects, arrays, and other data types.
  * @public
  */
-export const SharedTree: ISharedObjectKind<ITree> = configuredSharedTree({});
+export const SharedTree: ISharedObjectKind<ITree2> = configuredSharedTree({});
 
 /**
  * {@link SharedTree} but allowing a non-default configuration.
@@ -82,7 +82,7 @@ export const SharedTree: ISharedObjectKind<ITree> = configuredSharedTree({});
  * Maybe as part of a test utils or dev-tool package?
  * @internal
  */
-export function configuredSharedTree(options: SharedTreeOptions): ISharedObjectKind<ITree> {
+export function configuredSharedTree(options: SharedTreeOptions): ISharedObjectKind<ITree2> {
 	class ConfiguredFactory extends TreeFactory {
 		public constructor() {
 			super(options);

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -361,6 +361,13 @@ export type InitialObjects<T extends ContainerSchema> = {
 };
 
 // @public
+export type InPackage = InPackageTester<1> extends InPackageTester<2> ? false : true;
+
+// @public
+export class InPackageTester<T> {
+}
+
+// @public
 export type InsertableObjectFromSchemaRecord<T extends RestrictiveReadonlyRecord<string, ImplicitFieldSchema>> = {
     readonly [Property in keyof T]: InsertableTreeFieldFromImplicitField<T[Property]>;
 };
@@ -559,6 +566,9 @@ export interface ITree extends IChannel {
     schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TRoot>;
 }
 
+// @public (undocumented)
+export type ITree2 = PackageSeal<ITree>;
+
 // @alpha @sealed
 export interface IValueChanged {
     readonly key: string;
@@ -633,6 +643,9 @@ export type ObjectFromSchemaRecord<T extends RestrictiveReadonlyRecord<string, I
 export type ObjectFromSchemaRecordUnsafe<T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>> = {
     -readonly [Property in keyof T]: TreeFieldFromImplicitFieldUnsafe<T[Property]>;
 };
+
+// @public
+export type PackageSeal<T> = InPackage extends true ? T : T & ErasedType<readonly ["PackageSeal", T]>;
 
 // @public
 export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
@@ -865,7 +878,7 @@ export type SharedString = ISharedString;
 export type SharedStringSegment = TextSegment | Marker;
 
 // @public
-export const SharedTree: ISharedObjectKind<ITree>;
+export const SharedTree: ISharedObjectKind<ITree2>;
 
 // @alpha
 export enum Side {


### PR DESCRIPTION
## Description

TypeScript has different type checking within a compilation unit vs when using the d.ts files generated by that compilation. This can be used to modify a type when viewed from outside the package, allowing building the package to type check with one version, but for users to get a different version.

This is probably a bad idea, and very confusing, but it is possible.

It can be used to make a branded version of an interface that is not implementable, but leave it implementable when inside the package to avoid needing to cast to the non-implementable type when outputting instance via the public API.

In this case the branding is done by intersecting with ErasedType which is a non-implementable non constructable token type we already have laying around, but a different approach could be used if desired.
More advanced API transformations could be performed as well, like removing all members ending in "internal" or swapping the interface for some base interface with less members. This could be combined with the branding to make it relatively type safe.

These same approaches can be done across without the in package detection trick, and just for an explicit cast everywhere a value is exposed in the public API: that may be needed for repo instead of package scoped cases.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

If you think this might be useful, let me know.
