### PR TITLE
Partner Ask: Re-add Removed Exports

### DIFF
--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -216,7 +216,7 @@ export interface IContainerEvents extends IEvent {
     (event: "metadataUpdate", listener: (metadata: Record<string, string>) => void): any;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IContainerLoadMode {
     // (undocumented)
     deltaConnection?: "none" | "delayed" | undefined;

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -644,7 +644,7 @@ export enum LoaderHeader {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface IContainerLoadMode {
 	opsBeforeReturn?: /*

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -300,7 +300,7 @@ export interface IGenericError extends IErrorBase {
     readonly errorType: typeof FluidErrorTypes.genericError;
 }
 
-// @internal
+// @alpha
 export interface ILoggingError extends Error {
     getTelemetryProperties(): ITelemetryBaseProperties;
 }

--- a/packages/common/core-interfaces/src/logger.ts
+++ b/packages/common/core-interfaces/src/logger.ts
@@ -91,7 +91,7 @@ export interface ITelemetryErrorEvent extends ITelemetryBaseProperties {
 
 /**
  * An error object that supports exporting its properties to be logged to telemetry
- * @internal
+ * @alpha
  */
 export interface ILoggingError extends Error {
 	/**

--- a/packages/dds/map/api-report/map.api.md
+++ b/packages/dds/map/api-report/map.api.md
@@ -26,6 +26,12 @@ export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
     get type(): string;
 }
 
+// @alpha @deprecated
+export interface ICreateInfo {
+    ccIds: string[];
+    csn: number;
+}
+
 // @alpha
 export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryEvents>, Partial<IDisposable> {
     readonly absolutePath: string;
@@ -40,6 +46,13 @@ export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryE
     subdirectories(): IterableIterator<[string, IDirectory]>;
 }
 
+// @alpha @deprecated
+export interface IDirectoryDataObject {
+    ci?: ICreateInfo;
+    storage?: Record<string, ISerializableValue>;
+    subdirectories?: Record<string, IDirectoryDataObject>;
+}
+
 // @alpha
 export interface IDirectoryEvents extends IEvent {
     (event: "containedValueChanged", listener: (changed: IValueChanged, local: boolean, target: IEventThisPlaceHolder) => void): any;
@@ -49,9 +62,21 @@ export interface IDirectoryEvents extends IEvent {
     (event: "undisposed", listener: (target: IEventThisPlaceHolder) => void): any;
 }
 
+// @alpha @deprecated
+export interface IDirectoryNewStorageFormat {
+    blobs: string[];
+    content: IDirectoryDataObject;
+}
+
 // @alpha
 export interface IDirectoryValueChanged extends IValueChanged {
     path: string;
+}
+
+// @alpha @deprecated
+export interface ISerializableValue {
+    type: string;
+    value: any;
 }
 
 // @alpha

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -204,7 +204,7 @@ export type IDirectoryOperation = IDirectoryStorageOperation | IDirectorySubDire
 /**
  * Create info for the subdirectory.
  *
- * @deprecated - This interface will no longer be exported in the future.
+ * @deprecated - This interface will no longer be exported in the future(AB#8004).
  *
  * @alpha
  */
@@ -228,7 +228,7 @@ export interface ICreateInfo {
  * | JSON.stringify}, direct result from
  * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse | JSON.parse}.
  *
- * @deprecated - This interface will no longer be exported in the future.
+ * @deprecated - This interface will no longer be exported in the future(AB#8004).
  *
  * @alpha
  */
@@ -257,7 +257,7 @@ export interface IDirectoryDataObject {
 /**
  * {@link IDirectory} storage format.
  *
- * @deprecated - This interface will no longer be exported in the future.
+ * @deprecated - This interface will no longer be exported in the future(AB#8004).
  *
  * @alpha
  */

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -203,6 +203,9 @@ export type IDirectoryOperation = IDirectoryStorageOperation | IDirectorySubDire
 
 /**
  * Create info for the subdirectory.
+ *
+ * @deprecated - This interface will no longer be exported in the future.
+ *
  * @alpha
  */
 export interface ICreateInfo {
@@ -224,6 +227,9 @@ export interface ICreateInfo {
  * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
  * | JSON.stringify}, direct result from
  * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse | JSON.parse}.
+ *
+ * @deprecated - This interface will no longer be exported in the future.
+ *
  * @alpha
  */
 export interface IDirectoryDataObject {
@@ -251,7 +257,9 @@ export interface IDirectoryDataObject {
 /**
  * {@link IDirectory} storage format.
  *
- * @internal
+ * @deprecated - This interface will no longer be exported in the future.
+ *
+ * @alpha
  */
 export interface IDirectoryNewStorageFormat {
 	/**

--- a/packages/dds/map/src/index.ts
+++ b/packages/dds/map/src/index.ts
@@ -27,3 +27,5 @@ export type {
 } from "./interfaces.js";
 export { MapFactory, SharedMap } from "./mapFactory.js";
 export { DirectoryFactory, SharedDirectory } from "./directoryFactory.js";
+export type { ICreateInfo, IDirectoryNewStorageFormat, IDirectoryDataObject } from "./directory.js";
+export type { ISerializableValue } from "./internalInterfaces.js";

--- a/packages/dds/map/src/internalInterfaces.ts
+++ b/packages/dds/map/src/internalInterfaces.ts
@@ -136,7 +136,7 @@ export type MapLocalOpMetadata = IMapClearLocalOpMetadata | MapKeyLocalOpMetadat
  * If type is Shared, then the in-memory value will just be a reference to the SharedObject.  Its value will be a
  * channel ID.
  *
- * @deprecated This type is legacy and deprecated.
+ * @deprecated This type is legacy and deprecated(AB#8004).
  * @alpha
  */
 export interface ISerializableValue {

--- a/packages/dds/merge-tree/api-report/merge-tree.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.api.md
@@ -893,10 +893,10 @@ export enum ReferenceType {
     Transient = 256
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const refGetTileLabels: (refPos: ReferencePosition) => string[] | undefined;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export function refHasTileLabel(refPos: ReferencePosition, label: string): boolean;
 
 // @internal (undocumented)

--- a/packages/dds/merge-tree/src/referencePositions.ts
+++ b/packages/dds/merge-tree/src/referencePositions.ts
@@ -30,7 +30,7 @@ export function refTypeIncludesFlag(
 }
 
 /**
- * @internal
+ * @alpha
  */
 export const refGetTileLabels = (refPos: ReferencePosition): string[] | undefined =>
 	refTypeIncludesFlag(refPos, ReferenceType.Tile) && refPos.properties
@@ -38,7 +38,7 @@ export const refGetTileLabels = (refPos: ReferencePosition): string[] | undefine
 		: undefined;
 
 /**
- * @internal
+ * @alpha
  */
 export function refHasTileLabel(refPos: ReferencePosition, label: string): boolean {
 	const tileLabels = refGetTileLabels(refPos);

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -791,6 +791,33 @@ export interface IEnqueueSummarizeOptions extends IOnDemandSummarizeOptions {
     readonly override?: boolean;
 }
 
+// @alpha @deprecated (undocumented)
+export interface IFluidDataStoreAttributes0 {
+    readonly isRootDataStore?: boolean;
+    // (undocumented)
+    pkg: string;
+    // (undocumented)
+    readonly snapshotFormatVersion?: undefined;
+    // (undocumented)
+    readonly summaryFormatVersion?: undefined;
+}
+
+// @alpha @deprecated (undocumented)
+export interface IFluidDataStoreAttributes1 extends OmitAttributesVersions<IFluidDataStoreAttributes0> {
+    // (undocumented)
+    readonly snapshotFormatVersion: "0.1";
+    // (undocumented)
+    readonly summaryFormatVersion?: undefined;
+}
+
+// @alpha @deprecated (undocumented)
+export interface IFluidDataStoreAttributes2 extends OmitAttributesVersions<IFluidDataStoreAttributes1> {
+    readonly disableIsolatedChannels?: true;
+    readonly snapshotFormatVersion?: undefined;
+    // (undocumented)
+    readonly summaryFormatVersion: 2;
+}
+
 // @internal (undocumented)
 export interface IFluidDataStoreContextEvents extends IEvent_2 {
     // (undocumented)
@@ -1198,11 +1225,17 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
 // @internal
 export const neverCancelledSummaryToken: ISummaryCancellationToken;
 
+// @alpha @deprecated (undocumented)
+export type OmitAttributesVersions<T> = Omit<T, "snapshotFormatVersion" | "summaryFormatVersion">;
+
 // @alpha (undocumented)
 export type OpActionEventListener = (op: ISequencedDocumentMessage) => void;
 
 // @alpha (undocumented)
 export type OpActionEventName = MessageType.Summarize | MessageType.SummaryAck | MessageType.SummaryNack | "default";
+
+// @alpha @deprecated
+export type ReadFluidDataStoreAttributes = IFluidDataStoreAttributes0 | IFluidDataStoreAttributes1 | IFluidDataStoreAttributes2;
 
 // @internal
 export interface RecentlyAddedContainerRuntimeMessageDetails {

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -77,6 +77,7 @@ import {
 
 import { detectOutboundRoutesViaDDSKey, sendGCUnexpectedUsageEvent } from "./gc/index.js";
 import {
+	// eslint-disable-next-line import/no-deprecated
 	ReadFluidDataStoreAttributes,
 	WriteFluidDataStoreAttributes,
 	dataStoreAttributesBlobName,
@@ -1099,7 +1100,7 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 		}
 	}
 
-	/* 
+	/*
 	This API should not be called for RemoteFluidDataStoreContext. But here is one scenario where it's not the case:
 	The scenario (hit by stashedOps.spec.ts, "resends attach op" UT is the following (as far as I understand):
 	1. data store is being attached in attached container
@@ -1141,6 +1142,7 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 
 		if (!!tree && tree.blobs[dataStoreAttributesBlobName] !== undefined) {
 			// Need to get through snapshot and use that to populate extraBlobs
+			// eslint-disable-next-line import/no-deprecated
 			const attributes = await readAndParse<ReadFluidDataStoreAttributes>(
 				this.storage,
 				tree.blobs[dataStoreAttributesBlobName],
@@ -1317,6 +1319,7 @@ export class LocalFluidDataStoreContextBase extends FluidDataStoreContext {
 
 	private readonly initialSnapshotDetailsP = new LazyPromise<ISnapshotDetails>(async () => {
 		let snapshot = this.snapshotTree;
+		// eslint-disable-next-line import/no-deprecated
 		let attributes: ReadFluidDataStoreAttributes;
 		let isRootDataStore = false;
 		if (snapshot !== undefined) {

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -107,6 +107,11 @@ export {
 	DocumentsSchemaController,
 	IDocumentSchemaChangeMessage,
 	IDocumentSchemaFeatures,
+	ReadFluidDataStoreAttributes,
+	IFluidDataStoreAttributes0,
+	IFluidDataStoreAttributes1,
+	IFluidDataStoreAttributes2,
+	OmitAttributesVersions,
 } from "./summary/index.js";
 export { IChunkedOp, unpackRuntimeMessage } from "./opLifecycle/index.js";
 export { ChannelCollection } from "./channelCollection.js";

--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -98,6 +98,10 @@ export {
 	WriteFluidDataStoreAttributes,
 	wrapSummaryInChannelsTree,
 	idCompressorBlobName,
+	IFluidDataStoreAttributes0,
+	IFluidDataStoreAttributes1,
+	IFluidDataStoreAttributes2,
+	OmitAttributesVersions,
 } from "./summaryFormat.js";
 export {
 	IdCompressorMode,

--- a/packages/runtime/container-runtime/src/summary/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryFormat.ts
@@ -22,13 +22,13 @@ import { IGCMetadata } from "../gc/index.js";
 import { IDocumentSchema } from "./documentSchema.js";
 
 /**
- * @deprecated - This interface will no longer be exported in the future.
+ * @deprecated - This interface will no longer be exported in the future(AB#8004).
  * @alpha
  */
 export type OmitAttributesVersions<T> = Omit<T, "snapshotFormatVersion" | "summaryFormatVersion">;
 
 /**
- * @deprecated - This interface will no longer be exported in the future.
+ * @deprecated - This interface will no longer be exported in the future(AB#8004).
  * @alpha
  */
 export interface IFluidDataStoreAttributes0 {
@@ -44,7 +44,7 @@ export interface IFluidDataStoreAttributes0 {
 }
 
 /**
- * @deprecated - This interface will no longer be exported in the future.
+ * @deprecated - This interface will no longer be exported in the future(AB#8004).
  * @alpha
  */
 export interface IFluidDataStoreAttributes1
@@ -54,7 +54,7 @@ export interface IFluidDataStoreAttributes1
 }
 
 /**
- * @deprecated - This interface will no longer be exported in the future.
+ * @deprecated - This interface will no longer be exported in the future(AB#8004).
  * @alpha
  */
 export interface IFluidDataStoreAttributes2
@@ -75,7 +75,7 @@ export interface IFluidDataStoreAttributes2
  * store like the package, snapshotFormatVersion to take different decisions based on a particular
  * snapshotFormatVersion.
  *
- * @deprecated - This interface will no longer be exported in the future.
+ * @deprecated - This interface will no longer be exported in the future(AB#8004).
  *
  * @alpha
  *

--- a/packages/runtime/container-runtime/src/summary/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryFormat.ts
@@ -21,8 +21,17 @@ import { IGCMetadata } from "../gc/index.js";
 
 import { IDocumentSchema } from "./documentSchema.js";
 
-type OmitAttributesVersions<T> = Omit<T, "snapshotFormatVersion" | "summaryFormatVersion">;
-interface IFluidDataStoreAttributes0 {
+/**
+ * @deprecated - This interface will no longer be exported in the future.
+ * @alpha
+ */
+export type OmitAttributesVersions<T> = Omit<T, "snapshotFormatVersion" | "summaryFormatVersion">;
+
+/**
+ * @deprecated - This interface will no longer be exported in the future.
+ * @alpha
+ */
+export interface IFluidDataStoreAttributes0 {
 	readonly snapshotFormatVersion?: undefined;
 	readonly summaryFormatVersion?: undefined;
 	pkg: string;
@@ -33,11 +42,23 @@ interface IFluidDataStoreAttributes0 {
 	 */
 	readonly isRootDataStore?: boolean;
 }
-interface IFluidDataStoreAttributes1 extends OmitAttributesVersions<IFluidDataStoreAttributes0> {
+
+/**
+ * @deprecated - This interface will no longer be exported in the future.
+ * @alpha
+ */
+export interface IFluidDataStoreAttributes1
+	extends OmitAttributesVersions<IFluidDataStoreAttributes0> {
 	readonly snapshotFormatVersion: "0.1";
 	readonly summaryFormatVersion?: undefined;
 }
-interface IFluidDataStoreAttributes2 extends OmitAttributesVersions<IFluidDataStoreAttributes1> {
+
+/**
+ * @deprecated - This interface will no longer be exported in the future.
+ * @alpha
+ */
+export interface IFluidDataStoreAttributes2
+	extends OmitAttributesVersions<IFluidDataStoreAttributes1> {
 	/** Switch from snapshotFormatVersion to summaryFormatVersion */
 	readonly snapshotFormatVersion?: undefined;
 	readonly summaryFormatVersion: 2;
@@ -53,6 +74,11 @@ interface IFluidDataStoreAttributes2 extends OmitAttributesVersions<IFluidDataSt
  * Added IFluidDataStoreAttributes similar to IChannelAttributes which will tell the attributes of a
  * store like the package, snapshotFormatVersion to take different decisions based on a particular
  * snapshotFormatVersion.
+ *
+ * @deprecated - This interface will no longer be exported in the future.
+ *
+ * @alpha
+ *
  */
 export type ReadFluidDataStoreAttributes =
 	| IFluidDataStoreAttributes0


### PR DESCRIPTION
We're received feedback that our current RC releases are missing exports one of our partners depends on. Some of these are legitimate misses, where other represent coupling we do not want. The bad couplings have been marked as deprecated, and we have a plan with the partner to move off those types, but we need this change to unblock integrations.

related to [AB#8004](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8004)