### PR TITLE
Make several driver related types no longer public

### DIFF
--- a/.changeset/mighty-pigs-cheer.md
+++ b/.changeset/mighty-pigs-cheer.md
@@ -1,0 +1,17 @@
+---
+"@fluidframework/driver-definitions": minor
+"fluid-framework": minor
+---
+
+Make several driver types no longer public
+
+Move the following types from `@public` to `@alpha`:
+
+-   ITokenClaims
+-   IDocumentMessage
+-   IClientConfiguration
+-   IAnyDriverError
+-   IDriverErrorBase
+-   DriverErrorTypes
+
+`DriverErrorTypes` is no longer exported from the `fluid-framework` package.

--- a/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
+++ b/common/lib/protocol-definitions/api-report/protocol-definitions.api.md
@@ -65,7 +65,7 @@ export interface IClient {
     user: IUser;
 }
 
-// @public
+// @alpha
 export interface IClientConfiguration {
     blockSize: number;
     maxMessageSize: number;
@@ -142,7 +142,7 @@ export interface IDocumentAttributes {
     sequenceNumber: number;
 }
 
-// @public
+// @alpha
 export interface IDocumentMessage {
     clientSequenceNumber: number;
     compression?: string;
@@ -455,7 +455,7 @@ export interface ISummaryTree {
     unreferenced?: true;
 }
 
-// @public
+// @alpha
 export interface ITokenClaims {
     documentId: string;
     exp: number;

--- a/common/lib/protocol-definitions/src/config.ts
+++ b/common/lib/protocol-definitions/src/config.ts
@@ -5,7 +5,7 @@
 
 /**
  * Key value store of service configuration properties provided to the client as part of connection.
- * @public
+ * @alpha
  */
 export interface IClientConfiguration {
 	/**

--- a/common/lib/protocol-definitions/src/protocol.ts
+++ b/common/lib/protocol-definitions/src/protocol.ts
@@ -134,7 +134,7 @@ export interface INack {
 
 /**
  * Document-specific message.
- * @public
+ * @alpha
  */
 export interface IDocumentMessage {
 	/**

--- a/common/lib/protocol-definitions/src/tokens.ts
+++ b/common/lib/protocol-definitions/src/tokens.ts
@@ -9,7 +9,7 @@ import { IUser } from "./users.js";
  * {@link https://jwt.io/introduction/ | JSON Web Token (JWT)} Claims
  *
  * See {@link https://datatracker.ietf.org/doc/html/rfc7519#section-4}
- * @public
+ * @alpha
  */
 export interface ITokenClaims {
 	/**

--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 import type { FluidObject } from '@fluidframework/core-interfaces';
-import type { IAnyDriverError } from '@fluidframework/driver-definitions';
+import type { IAnyDriverError } from '@fluidframework/driver-definitions/internal';
 import type { IClient } from '@fluidframework/protocol-definitions';
 import type { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import type { IClientDetails } from '@fluidframework/protocol-definitions';

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -10,7 +10,7 @@ import type {
 	IEvent,
 	IEventProvider,
 } from "@fluidframework/core-interfaces";
-import type { IAnyDriverError } from "@fluidframework/driver-definitions";
+import type { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import type {
 	IClientConfiguration,
 	IClientDetails,

--- a/packages/common/driver-definitions/api-report/driver-definitions.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.api.md
@@ -28,7 +28,7 @@ import type { IVersion } from '@fluidframework/protocol-definitions';
 // @alpha (undocumented)
 export type DriverError = IThrottlingWarning | IGenericNetworkError | IAuthorizationError | ILocationRedirectionError | IDriverBasicError;
 
-// @public
+// @alpha
 export const DriverErrorTypes: {
     readonly genericNetworkError: "genericNetworkError";
     readonly authorizationError: "authorizationError";
@@ -50,7 +50,7 @@ export const DriverErrorTypes: {
     readonly usageError: "usageError";
 };
 
-// @public
+// @alpha
 export type DriverErrorTypes = (typeof DriverErrorTypes)[keyof typeof DriverErrorTypes];
 
 // @alpha
@@ -78,7 +78,7 @@ export enum FetchSource {
 // @alpha (undocumented)
 export type FiveDaysMs = 432000000;
 
-// @public
+// @alpha
 export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
     // (undocumented)
     readonly errorType: string;
@@ -206,7 +206,7 @@ export interface IDriverBasicError extends IDriverErrorBase {
     readonly statusCode?: number;
 }
 
-// @public
+// @alpha
 export interface IDriverErrorBase {
     canRetry: boolean;
     endpointReached?: boolean;

--- a/packages/common/driver-definitions/src/driverError.ts
+++ b/packages/common/driver-definitions/src/driverError.ts
@@ -13,7 +13,7 @@ const { dataCorruptionError, dataProcessingError, ...FluidErrorTypesExceptDataTy
 
 /**
  * Different error types the Driver may report out to the Host.
- * @public
+ * @alpha
  */
 export const DriverErrorTypes = {
 	// Inherit base error types
@@ -107,7 +107,7 @@ export const DriverErrorTypes = {
 } as const;
 /**
  * {@inheritDoc (DriverErrorTypes:variable)}
- * @public
+ * @alpha
  */
 export type DriverErrorTypes = (typeof DriverErrorTypes)[keyof typeof DriverErrorTypes];
 
@@ -121,7 +121,7 @@ export type DriverErrorTypes = (typeof DriverErrorTypes)[keyof typeof DriverErro
  * "Any" in the interface name is a nod to the fact that errorType has lost its type constraint.
  * It will be either {@link @fluidframework/driver-definitions#(DriverErrorTypes:variable)} or the specific driver's specialized error type enum,
  * but we can't reference a specific driver's error type enum in this code.
- * @public
+ * @alpha
  */
 export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
 	readonly errorType: string;
@@ -134,7 +134,7 @@ export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
 
 /**
  * Base interface for all errors and warnings
- * @public
+ * @alpha
  */
 export interface IDriverErrorBase {
 	/**

--- a/packages/drivers/driver-base/api-report/driver-base.api.md
+++ b/packages/drivers/driver-base/api-report/driver-base.api.md
@@ -6,7 +6,7 @@
 
 import { ConnectionMode } from '@fluidframework/protocol-definitions';
 import { EventEmitterWithErrorHandling } from '@fluidframework/telemetry-utils/internal';
-import { IAnyDriverError } from '@fluidframework/driver-definitions';
+import { IAnyDriverError } from '@fluidframework/driver-definitions/internal';
 import { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import { IConnect } from '@fluidframework/protocol-definitions';
 import { IConnected } from '@fluidframework/protocol-definitions';

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -5,8 +5,8 @@
 
 import { IDisposable, ITelemetryBaseProperties, LogLevel } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { IAnyDriverError } from "@fluidframework/driver-definitions";
 import {
+	IAnyDriverError,
 	IDocumentDeltaConnection,
 	IDocumentDeltaConnectionEvents,
 } from "@fluidframework/driver-definitions/internal";

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
@@ -6,7 +6,7 @@
 
 import { DriverError } from '@fluidframework/driver-definitions/internal';
 import { FiveDaysMs } from '@fluidframework/driver-definitions/internal';
-import { IDriverErrorBase } from '@fluidframework/driver-definitions';
+import { IDriverErrorBase } from '@fluidframework/driver-definitions/internal';
 import { IResolvedUrl } from '@fluidframework/driver-definitions/internal';
 
 // @alpha (undocumented)

--- a/packages/drivers/odsp-driver-definitions/src/errors.ts
+++ b/packages/drivers/odsp-driver-definitions/src/errors.ts
@@ -3,8 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { DriverErrorTypes, IDriverErrorBase } from "@fluidframework/driver-definitions";
-import { DriverError } from "@fluidframework/driver-definitions/internal";
+import {
+	DriverErrorTypes,
+	IDriverErrorBase,
+	DriverError,
+} from "@fluidframework/driver-definitions/internal";
 
 /**
  * ODSP Error types.

--- a/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentDeltaConnection.ts
@@ -7,7 +7,7 @@ import { TypedEventEmitter, performance } from "@fluid-internal/client-utils";
 import { IEvent } from "@fluidframework/core-interfaces";
 import { assert, Deferred } from "@fluidframework/core-utils/internal";
 import { DocumentDeltaConnection } from "@fluidframework/driver-base/internal";
-import { IAnyDriverError } from "@fluidframework/driver-definitions";
+import { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import { createGenericNetworkError } from "@fluidframework/driver-utils/internal";
 import { OdspError } from "@fluidframework/odsp-driver-definitions/internal";
 import {

--- a/packages/drivers/odsp-driver/src/test/socketTests/socketMock.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/socketMock.ts
@@ -5,7 +5,7 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { IEvent } from "@fluidframework/core-interfaces";
-import { IAnyDriverError } from "@fluidframework/driver-definitions";
+import { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import { createGenericNetworkError } from "@fluidframework/driver-utils/internal";
 import { IConnect, IConnected, ScopeType } from "@fluidframework/protocol-definitions";
 import { v4 as uuid } from "uuid";

--- a/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { IAnyDriverError } from "@fluidframework/driver-definitions";
+import { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import { createOdspNetworkError } from "@fluidframework/odsp-doclib-utils/internal";
 import { IOdspResolvedUrl, OdspErrorTypes } from "@fluidframework/odsp-driver-definitions/internal";
 import { IClient } from "@fluidframework/protocol-definitions";

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -4,8 +4,10 @@
  */
 
 import { DocumentDeltaConnection } from "@fluidframework/driver-base/internal";
-import { IAnyDriverError } from "@fluidframework/driver-definitions";
-import { IDocumentDeltaConnection } from "@fluidframework/driver-definitions/internal";
+import {
+	IDocumentDeltaConnection,
+	IAnyDriverError,
+} from "@fluidframework/driver-definitions/internal";
 import { IClient, IConnect } from "@fluidframework/protocol-definitions";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import type { io as SocketIOClientStatic } from "socket.io-client";

--- a/packages/drivers/routerlicious-driver/src/errorUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/errorUtils.ts
@@ -3,8 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { DriverErrorTypes, IDriverErrorBase } from "@fluidframework/driver-definitions";
-import { DriverError } from "@fluidframework/driver-definitions/internal";
+import {
+	DriverError,
+	DriverErrorTypes,
+	IDriverErrorBase,
+} from "@fluidframework/driver-definitions/internal";
 import {
 	AuthorizationError,
 	GenericNetworkError,

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -149,31 +149,6 @@ export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
 export const disposeSymbol: unique symbol;
 
 // @public
-export const DriverErrorTypes: {
-    readonly genericNetworkError: "genericNetworkError";
-    readonly authorizationError: "authorizationError";
-    readonly fileNotFoundOrAccessDeniedError: "fileNotFoundOrAccessDeniedError";
-    readonly offlineError: "offlineError";
-    readonly unsupportedClientProtocolVersion: "unsupportedClientProtocolVersion";
-    readonly writeError: "writeError";
-    readonly fetchFailure: "fetchFailure";
-    readonly fetchTokenError: "fetchTokenError";
-    readonly incorrectServerResponse: "incorrectServerResponse";
-    readonly fileOverwrittenInStorage: "fileOverwrittenInStorage";
-    readonly deltaStreamConnectionForbidden: "deltaStreamConnectionForbidden";
-    readonly locationRedirection: "locationRedirection";
-    readonly fluidInvalidSchema: "fluidInvalidSchema";
-    readonly fileIsLocked: "fileIsLocked";
-    readonly outOfStorageError: "outOfStorageError";
-    readonly genericError: "genericError";
-    readonly throttlingError: "throttlingError";
-    readonly usageError: "usageError";
-};
-
-// @public
-export type DriverErrorTypes = (typeof DriverErrorTypes)[keyof typeof DriverErrorTypes];
-
-// @public
 export type Events<E> = {
     [P in (string | symbol) & keyof E as IsEvent<E[P]> extends true ? P : never]: E[P];
 };

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -15,7 +15,6 @@ export type {
 	ICriticalContainerError,
 } from "@fluidframework/container-definitions";
 export { AttachState } from "@fluidframework/container-definitions";
-export { DriverErrorTypes } from "@fluidframework/driver-definitions";
 export { ConnectionState } from "@fluidframework/container-loader";
 export type {
 	ContainerAttachProps,

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -11,11 +11,12 @@ import {
 } from "@fluidframework/container-definitions/internal";
 import { IDisposable, ITelemetryBaseProperties, LogLevel } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { DriverErrorTypes, IAnyDriverError } from "@fluidframework/driver-definitions";
 import {
 	IDocumentDeltaConnection,
 	IDocumentDeltaConnectionEvents,
 	IDocumentService,
+	DriverErrorTypes,
+	IAnyDriverError,
 } from "@fluidframework/driver-definitions/internal";
 import {
 	calculateMaxWaitTime,

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -6,7 +6,7 @@
 import { IDeltaManager } from "@fluidframework/container-definitions/internal";
 import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
 import { assert, Timer } from "@fluidframework/core-utils/internal";
-import { IAnyDriverError } from "@fluidframework/driver-definitions";
+import { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import { IClient, ISequencedClient } from "@fluidframework/protocol-definitions";
 import {
 	type TelemetryEventCategory,

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -16,10 +16,10 @@ import {
 } from "@fluidframework/core-interfaces";
 import { IThrottlingWarning } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
 import {
 	IDocumentDeltaStorageService,
 	IDocumentService,
+	DriverErrorTypes,
 } from "@fluidframework/driver-definitions/internal";
 import {
 	MessageType2,

--- a/packages/loader/container-loader/src/location-redirection-utilities/resolveWithLocationRedirection.ts
+++ b/packages/loader/container-loader/src/location-redirection-utilities/resolveWithLocationRedirection.ts
@@ -4,10 +4,10 @@
  */
 
 import { IRequest, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
 import {
 	ILocationRedirectionError,
 	IUrlResolver,
+	DriverErrorTypes,
 } from "@fluidframework/driver-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 

--- a/packages/loader/container-loader/src/test/connectionManager.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionManager.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 import { stub, useFakeTimers } from "sinon";
 import { MockDocumentDeltaConnection, MockDocumentService } from "@fluid-private/test-loader-utils";
 import { Deferred } from "@fluidframework/core-utils/internal";
-import { DriverErrorTypes, IAnyDriverError } from "@fluidframework/driver-definitions";
+import { DriverErrorTypes, IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import { IDocumentService } from "@fluidframework/driver-definitions/internal";
 import { NonRetryableError, RetryableError } from "@fluidframework/driver-utils/internal";
 import { IClient, INack, NackErrorType } from "@fluidframework/protocol-definitions";

--- a/packages/loader/container-loader/src/test/locationRedirectionTests.spec.ts
+++ b/packages/loader/container-loader/src/test/locationRedirectionTests.spec.ts
@@ -6,8 +6,11 @@
 import { strict as assert } from "assert";
 
 import { IRequest } from "@fluidframework/core-interfaces";
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
-import { IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions/internal";
+import {
+	IResolvedUrl,
+	IUrlResolver,
+	DriverErrorTypes,
+} from "@fluidframework/driver-definitions/internal";
 
 import { resolveWithLocationRedirectionHandling } from "../location-redirection-utilities/index.js";
 

--- a/packages/loader/container-loader/src/utils.ts
+++ b/packages/loader/container-loader/src/utils.ts
@@ -5,7 +5,7 @@
 
 import { Uint8ArrayToString, bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
 import { assert, compareArrays, unreachableCase } from "@fluidframework/core-utils/internal";
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
+import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import {
 	IDocumentStorageService,
 	type ISnapshot,

--- a/packages/loader/driver-utils/api-report/driver-utils.api.md
+++ b/packages/loader/driver-utils/api-report/driver-utils.api.md
@@ -16,7 +16,7 @@ import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IDocumentServiceFactory } from '@fluidframework/driver-definitions/internal';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions/internal';
 import { IDocumentStorageServicePolicies } from '@fluidframework/driver-definitions/internal';
-import { IDriverErrorBase } from '@fluidframework/driver-definitions';
+import { IDriverErrorBase } from '@fluidframework/driver-definitions/internal';
 import { IFluidErrorBase } from '@fluidframework/telemetry-utils/internal';
 import { ILocationRedirectionError } from '@fluidframework/driver-definitions/internal';
 import { IRequest } from '@fluidframework/core-interfaces';

--- a/packages/loader/driver-utils/src/error.ts
+++ b/packages/loader/driver-utils/src/error.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { DriverErrorTypes, IDriverErrorBase } from "@fluidframework/driver-definitions";
+import { DriverErrorTypes, IDriverErrorBase } from "@fluidframework/driver-definitions/internal";
 import { IFluidErrorBase, LoggingError } from "@fluidframework/telemetry-utils/internal";
 
 /**

--- a/packages/loader/driver-utils/src/network.ts
+++ b/packages/loader/driver-utils/src/network.ts
@@ -4,12 +4,13 @@
  */
 
 import { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
-import { DriverErrorTypes, IDriverErrorBase } from "@fluidframework/driver-definitions";
 import {
 	IAuthorizationError,
 	ILocationRedirectionError,
 	IResolvedUrl,
 	IThrottlingWarning,
+	DriverErrorTypes,
+	IDriverErrorBase,
 } from "@fluidframework/driver-definitions/internal";
 import { IFluidErrorBase, LoggingError } from "@fluidframework/telemetry-utils/internal";
 

--- a/packages/loader/driver-utils/src/runWithRetry.ts
+++ b/packages/loader/driver-utils/src/runWithRetry.ts
@@ -5,7 +5,7 @@
 
 import { performance } from "@fluid-internal/client-utils";
 import { delay } from "@fluidframework/core-utils/internal";
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
+import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import { ITelemetryLoggerExt, isFluidError } from "@fluidframework/telemetry-utils/internal";
 
 import { NonRetryableError, canRetryOnError, getRetryDelayFromError } from "./network.js";

--- a/packages/loader/driver-utils/src/test/runWithRetry.spec.ts
+++ b/packages/loader/driver-utils/src/test/runWithRetry.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "assert";
 
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
+import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { runWithRetry } from "../runWithRetry.js";

--- a/packages/loader/test-loader-utils/api-report/test-loader-utils.api.md
+++ b/packages/loader/test-loader-utils/api-report/test-loader-utils.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 import { ConnectionMode } from '@fluidframework/protocol-definitions';
-import { IAnyDriverError } from '@fluidframework/driver-definitions';
+import { IAnyDriverError } from '@fluidframework/driver-definitions/internal';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import { IDisposable } from '@fluidframework/core-interfaces';

--- a/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
+++ b/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
@@ -5,10 +5,10 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { IDisposable } from "@fluidframework/core-interfaces";
-import { IAnyDriverError } from "@fluidframework/driver-definitions";
 import {
 	IDocumentDeltaConnection,
 	IDocumentDeltaConnectionEvents,
+	IAnyDriverError,
 } from "@fluidframework/driver-definitions/internal";
 import {
 	ConnectionMode,

--- a/packages/runtime/container-runtime/src/deltaManagerProxies.ts
+++ b/packages/runtime/container-runtime/src/deltaManagerProxies.ts
@@ -13,7 +13,7 @@ import type {
 	ReadOnlyInfo,
 } from "@fluidframework/container-definitions/internal";
 import type { IErrorBase } from "@fluidframework/core-interfaces";
-import type { IAnyDriverError } from "@fluidframework/driver-definitions";
+import type { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import {
 	IClientConfiguration,
 	IClientDetails,

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -6,7 +6,7 @@
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { IDisposable, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert, Deferred, PromiseTimer, delay } from "@fluidframework/core-utils/internal";
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
+import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
 import {
 	MonitoringContext,

--- a/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
@@ -11,7 +11,7 @@ import {
 	IPromiseTimerResult,
 	Timer,
 } from "@fluidframework/core-utils/internal";
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
+import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import { getRetryDelaySecondsFromError } from "@fluidframework/driver-utils/internal";
 import { MessageType } from "@fluidframework/protocol-definitions";
 import {

--- a/packages/runtime/container-runtime/src/summary/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryManager.ts
@@ -11,7 +11,7 @@ import {
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
+import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import {
 	ITelemetryLoggerExt,
 	PerformanceEvent,

--- a/packages/service-clients/azure-client/api-report/azure-client.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.api.md
@@ -67,7 +67,7 @@ export interface AzureContainerVersion {
 
 // @internal @deprecated
 export class AzureFunctionTokenProvider implements ITokenProvider {
-    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "name" | "id" | "additionalDetails"> | undefined);
+    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "name" | "additionalDetails" | "id"> | undefined);
     // (undocumented)
     fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)

--- a/packages/service-clients/azure-client/api-report/azure-client.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.api.md
@@ -67,7 +67,7 @@ export interface AzureContainerVersion {
 
 // @internal @deprecated
 export class AzureFunctionTokenProvider implements ITokenProvider {
-    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "name" | "additionalDetails" | "id"> | undefined);
+    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "name" | "id" | "additionalDetails"> | undefined);
     // (undocumented)
     fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -35,7 +35,7 @@ import {
 	IRequestHeader,
 } from "@fluidframework/core-interfaces";
 import { Deferred } from "@fluidframework/core-utils/internal";
-import { DriverErrorTypes, IAnyDriverError } from "@fluidframework/driver-definitions";
+import { DriverErrorTypes, IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import {
 	FiveDaysMs,
 	IDocumentServiceFactory,

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -6,7 +6,6 @@
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { IDisposable, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert, Deferred } from "@fluidframework/core-utils/internal";
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
 import {
 	IDocumentDeltaConnection,
 	IDocumentDeltaConnectionEvents,
@@ -17,6 +16,7 @@ import {
 	IDocumentStorageService,
 	IResolvedUrl,
 	ISnapshotFetchOptions,
+	DriverErrorTypes,
 } from "@fluidframework/driver-definitions/internal";
 import {
 	IClient,

--- a/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
@@ -5,7 +5,7 @@
 
 import child_process from "child_process";
 
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
+import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import {
 	IClientConfig,
 	IOdspAuthRequestInfo,

--- a/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspErrorUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
+import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import {
 	AuthorizationError,
 	DriverErrorTelemetryProps,

--- a/packages/utils/odsp-doclib-utils/src/test/odspErrorUtils.spec.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/odspErrorUtils.spec.ts
@@ -5,10 +5,10 @@
 
 import { strict as assert } from "assert";
 
-import { DriverErrorTypes } from "@fluidframework/driver-definitions";
 import {
 	IGenericNetworkError,
 	IThrottlingWarning,
+	DriverErrorTypes,
 } from "@fluidframework/driver-definitions/internal";
 import { GenericNetworkError, createWriteError } from "@fluidframework/driver-utils/internal";
 import {


### PR DESCRIPTION
## Description

Follow-up to https://github.com/microsoft/FluidFramework/pull/21003 making more types non-public.

The only public API referencing these types were the delta manager ones which are now alpha.

## Breaking Changes

Move the following types from `@public` to `@alpha`:

-   ITokenClaims
-   IDocumentMessage
-   IClientConfiguration
-   IAnyDriverError
-   IDriverErrorBase
-   DriverErrorTypes

`DriverErrorTypes` is no longer exported from the `fluid-framework` package.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I'm unclear on if DriverErrorTypes (maybe just the constant not the type?) is intended to be part of the declarative API or not, and thus maybe it should be kept in fluid-framework and public?

