### PR TITLE
improvement(eslint-config-fluid): Enable `allowExpressions` exception in `@typescript-eslint/explicit-function-return-type` rule config

### DIFF
--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -116,7 +116,7 @@
         "@typescript-eslint/explicit-function-return-type": [
             "error",
             {
-                "allowExpressions": false,
+                "allowExpressions": true,
                 "allowTypedFunctionExpressions": true,
                 "allowHigherOrderFunctions": true,
                 "allowDirectConstAssertionInArrowFunctions": true,

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -118,7 +118,7 @@
         "@typescript-eslint/explicit-function-return-type": [
             "error",
             {
-                "allowExpressions": false,
+                "allowExpressions": true,
                 "allowTypedFunctionExpressions": true,
                 "allowHigherOrderFunctions": true,
                 "allowDirectConstAssertionInArrowFunctions": true,

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -116,7 +116,7 @@
         "@typescript-eslint/explicit-function-return-type": [
             "error",
             {
-                "allowExpressions": false,
+                "allowExpressions": true,
                 "allowTypedFunctionExpressions": true,
                 "allowHigherOrderFunctions": true,
                 "allowDirectConstAssertionInArrowFunctions": true,

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -122,7 +122,7 @@
         "@typescript-eslint/explicit-function-return-type": [
             "error",
             {
-                "allowExpressions": false,
+                "allowExpressions": true,
                 "allowTypedFunctionExpressions": true,
                 "allowHigherOrderFunctions": true,
                 "allowDirectConstAssertionInArrowFunctions": true,

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -116,7 +116,7 @@
         "@typescript-eslint/explicit-function-return-type": [
             "error",
             {
-                "allowExpressions": false,
+                "allowExpressions": true,
                 "allowTypedFunctionExpressions": true,
                 "allowHigherOrderFunctions": true,
                 "allowDirectConstAssertionInArrowFunctions": true,

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -36,7 +36,7 @@ module.exports = {
 		"@typescript-eslint/explicit-function-return-type": [
 			"error",
 			{
-				allowExpressions: false,
+				allowExpressions: true,
 				allowTypedFunctionExpressions: true,
 				allowHigherOrderFunctions: true,
 				allowDirectConstAssertionInArrowFunctions: true,


### PR DESCRIPTION
Enables inline use of lambdas with omitted return type when assigning to a typed parameter (where a return type is very commonly redundant).

See: https://typescript-eslint.io/rules/explicit-function-return-type/#allowexpressions