### PR TITLE
Remove creating new Lazy Promise every time in FileLogger

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -12,7 +12,7 @@ import { makeRandom } from "@fluid-private/stochastic-test-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
 import { ConnectionState } from "@fluidframework/container-loader";
 import { IContainerExperimental, Loader } from "@fluidframework/container-loader/internal";
-import { IRequestHeader, LogLevel } from "@fluidframework/core-interfaces";
+import { IRequestHeader } from "@fluidframework/core-interfaces";
 import { assert, delay } from "@fluidframework/core-utils/internal";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions/internal";
@@ -104,16 +104,12 @@ async function main() {
 	// this makes runners repeatable, but ensures each runner
 	// will get its own set of randoms
 	const random = makeRandom(seed, runId);
-	const logger = await createLogger(
-		{
-			runId,
-			driverType: driver,
-			driverEndpointName: endpoint,
-			profile: profileName,
-		},
-		// Turn on verbose events for ALL stress test runs.
-		random.pick([LogLevel.verbose]),
-	);
+	const logger = await createLogger({
+		runId,
+		driverType: driver,
+		driverEndpointName: endpoint,
+		profile: profileName,
+	});
 
 	// this will enabling capturing the full stack for errors
 	// since this is test capturing the full stack is worth it

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -77,11 +77,9 @@ class FileLogger implements ITelemetryBufferedLogger {
 	private error: boolean = false;
 	private readonly schema = new Map<string, number>();
 	private logs: ITelemetryBaseEvent[] = [];
+	public readonly minLogLevel: LogLevel = LogLevel.verbose;
 
-	private constructor(
-		private readonly baseLogger?: ITelemetryBufferedLogger,
-		public readonly minLogLevel: LogLevel = LogLevel.verbose,
-	) {}
+	private constructor(private readonly baseLogger?: ITelemetryBufferedLogger) {}
 
 	async flush(runInfo?: { url: string; runId?: number }): Promise<void> {
 		const baseFlushP = this.baseLogger?.flush();

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -45,30 +45,25 @@ import { ILoadTestConfig, ITestConfig } from "./testConfigFile.js";
 const packageName = `${pkgName}@${pkgVersion}`;
 
 class FileLogger implements ITelemetryBufferedLogger {
-	private static readonly loggerP = (minLogLevel?: LogLevel) =>
-		new LazyPromise<FileLogger>(async () => {
-			if (process.env.FLUID_TEST_LOGGER_PKG_SPECIFIER !== undefined) {
-				await import(process.env.FLUID_TEST_LOGGER_PKG_SPECIFIER);
-				const logger = getTestLogger?.();
-				assert(logger !== undefined, "Expected getTestLogger to return something");
-				return new FileLogger(logger, minLogLevel);
-			} else {
-				return new FileLogger(undefined, minLogLevel);
-			}
-		});
+	private static readonly loggerP = new LazyPromise<FileLogger>(async () => {
+		if (process.env.FLUID_TEST_LOGGER_PKG_SPECIFIER !== undefined) {
+			await import(process.env.FLUID_TEST_LOGGER_PKG_SPECIFIER);
+			const logger = getTestLogger?.();
+			assert(logger !== undefined, "Expected getTestLogger to return something");
+			return new FileLogger(logger);
+		} else {
+			return new FileLogger(undefined);
+		}
+	});
 
-	public static async createLogger(
-		dimensions: {
-			driverType: string;
-			driverEndpointName: string | undefined;
-			profile: string;
-			runId: number | undefined;
-		},
-		minLogLevel: LogLevel = LogLevel.default,
-	) {
-		const logger = await this.loggerP(minLogLevel);
+	public static async createLogger(dimensions: {
+		driverType: string;
+		driverEndpointName: string | undefined;
+		profile: string;
+		runId: number | undefined;
+	}) {
 		return createChildLogger({
-			logger,
+			logger: await this.loggerP,
 			properties: {
 				all: dimensions,
 			},
@@ -76,7 +71,7 @@ class FileLogger implements ITelemetryBufferedLogger {
 	}
 
 	public static async flushLogger(runInfo?: { url: string; runId?: number }) {
-		await (await this.loggerP()).flush(runInfo);
+		await (await this.loggerP).flush(runInfo);
 	}
 
 	private error: boolean = false;
@@ -85,7 +80,7 @@ class FileLogger implements ITelemetryBufferedLogger {
 
 	private constructor(
 		private readonly baseLogger?: ITelemetryBufferedLogger,
-		public readonly minLogLevel?: LogLevel,
+		public readonly minLogLevel: LogLevel = LogLevel.verbose,
 	) {}
 
 	async flush(runInfo?: { url: string; runId?: number }): Promise<void> {
@@ -188,16 +183,12 @@ export async function initialize(
 		generateConfigurations(seed, optionsOverride?.configurations),
 	);
 
-	const minLogLevel = random.pick([LogLevel.verbose, LogLevel.default]);
-	const logger = await createLogger(
-		{
-			driverType: testDriver.type,
-			driverEndpointName: testDriver.endpointName,
-			profile: profileName,
-			runId: undefined,
-		},
-		minLogLevel,
-	);
+	const logger = await createLogger({
+		driverType: testDriver.type,
+		driverEndpointName: testDriver.endpointName,
+		profile: profileName,
+		runId: undefined,
+	});
 
 	logger.sendTelemetryEvent({
 		eventName: "RunConfigOptions",
@@ -205,7 +196,6 @@ export async function initialize(
 			loaderOptions,
 			containerOptions,
 			configurations: { ...globalConfigurations, ...configurations },
-			logLevel: minLogLevel,
 		}),
 	});
 


### PR DESCRIPTION
## Description

ADO Task: [Link](https://dev.azure.com/fluidframework/internal/_workitems/edit/7741)
Remove creating new Lazy Promise every time in FileLogger. Just use Verbose for local stress test runs.