### PR TITLE
Skip GC attachment blob tests for services that don't support them

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -83,26 +83,6 @@ describeCompat("Garbage collection of blobs", "NoCompat", (getTestObjectProvider
 		}
 
 		/**
-		 * Retrieves the storage Id from the given reference map of blobIds. Note that this only works if the given
-		 * localId blobs are mapped to the same storageId.
-		 */
-		function getStorageIdFromReferenceMap(
-			referenceNodeStateMap: Map<string, "referenced" | "unreferenced">,
-			localBlobIds: string[],
-		): string {
-			let storageId: string | undefined;
-			referenceNodeStateMap.forEach((state, nodePath) => {
-				if (localBlobIds.includes(nodePath)) {
-					return;
-				}
-				assert(storageId === undefined, "Unexpected blob node in reference state map");
-				storageId = nodePath;
-			});
-			assert(storageId !== undefined, "No storage id node in reference state map");
-			return storageId;
-		}
-
-		/**
 		 * Loads a container from the itemId of the container. We need to do this instead of loading a container
 		 * normally because - When a detached container is attached after attachment blobs have been added, a .tmp
 		 * extension is added to the end of the filename. Since the ODSP test driver assumes the filename will always
@@ -125,6 +105,7 @@ describeCompat("Garbage collection of blobs", "NoCompat", (getTestObjectProvider
 
 		beforeEach("setup", async function () {
 			provider = getTestObjectProvider();
+			// Skip these tests for drivers / services that do not support attachment blobs.
 			if (!driverSupportsBlobs(provider.driver)) {
 				this.skip();
 			}

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -189,6 +189,10 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 
 	beforeEach("setup", async function () {
 		provider = getTestObjectProvider({ syncSummarizer: true });
+		// Skip these tests for drivers / services that do not support attachment blobs.
+		if (!driverSupportsBlobs(provider.driver)) {
+			this.skip();
+		}
 
 		configProvider.set(
 			"Fluid.GarbageCollection.TestOverride.TombstoneTimeoutMs",
@@ -201,12 +205,6 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 	});
 
 	describe("Attachment blobs in attached container", () => {
-		beforeEach("skipNonLocal", async function () {
-			if (provider.driver.type !== "local") {
-				this.skip();
-			}
-		});
-
 		itExpects(
 			"fails retrieval of deleted attachment blobs",
 			[
@@ -454,12 +452,6 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 			const mainDataStore = (await mainContainer.getEntryPoint()) as ITestDataObject;
 			return { mainContainer, mainDataStore };
 		}
-
-		beforeEach("conditionalSkip", async function () {
-			if (!driverSupportsBlobs(provider.driver)) {
-				this.skip();
-			}
-		});
 
 		itExpects(
 			"deletes blobs uploaded in detached container",
@@ -801,12 +793,6 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 			return { summarizer, summarizerContainer };
 		}
 
-		beforeEach("skipNonLocal", async function () {
-			if (provider.driver.type !== "local") {
-				this.skip();
-			}
-		});
-
 		itExpects(
 			"deletes blobs uploaded in disconnected container",
 			[
@@ -1094,12 +1080,6 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 	});
 
 	describe("Deleted blob in summary", () => {
-		beforeEach("skipNonLocal", async function () {
-			if (provider.driver.type !== "local") {
-				this.skip();
-			}
-		});
-
 		[true, undefined].forEach((disableDatastoreSweep) =>
 			it(`updates deleted blob state in the summary [disableDatastoreSweep=${disableDatastoreSweep}]`, async () => {
 				configProvider.set(disableDatastoreSweepKey, disableDatastoreSweep);
@@ -1147,15 +1127,6 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 	});
 
 	describe("Sweep with summarize failures and retries", () => {
-		beforeEach("setup", async function () {
-			// TODO: This test is consistently failing when ran against FRS. See ADO:7922 and ADO:7923
-			if (
-				provider.driver.type === "routerlicious" &&
-				provider.driver.endpointName === "frs"
-			) {
-				this.skip();
-			}
-		});
 		const summarizeErrorMessage = "SimulatedTestFailure";
 		/**
 		 * This function does the following:

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -66,6 +66,9 @@ describeCompat("GC attachment blob tombstone tests", "NoCompat", (getTestObjectP
 
 	beforeEach("setup", async function () {
 		provider = getTestObjectProvider({ syncSummarizer: true });
+		if (!driverSupportsBlobs(provider.driver)) {
+			this.skip();
+		}
 		configProvider.set(
 			"Fluid.GarbageCollection.TestOverride.TombstoneTimeoutMs",
 			tombstoneTimeoutMs,
@@ -93,12 +96,6 @@ describeCompat("GC attachment blob tombstone tests", "NoCompat", (getTestObjectP
 
 			return { dataStore, summarizer };
 		}
-
-		beforeEach("skipNonLocal", async function () {
-			if (provider.driver.type !== "local") {
-				this.skip();
-			}
-		});
 
 		itExpects(
 			"fails retrieval of tombstones attachment blobs",
@@ -472,12 +469,6 @@ describeCompat("GC attachment blob tombstone tests", "NoCompat", (getTestObjectP
 			return { mainContainer, mainDataStore };
 		}
 
-		beforeEach("conditionalSkip", async function () {
-			if (!driverSupportsBlobs(provider.driver)) {
-				this.skip();
-			}
-		});
-
 		itExpects(
 			"tombstones blobs uploaded in detached container",
 			[
@@ -825,12 +816,6 @@ describeCompat("GC attachment blob tombstone tests", "NoCompat", (getTestObjectP
 			await summarizeNow(summarizer);
 			return summarizer;
 		}
-
-		beforeEach("skipNonLocal", async function () {
-			if (provider.driver.type !== "local") {
-				this.skip();
-			}
-		});
 
 		itExpects(
 			"tombstones blobs uploaded in disconnected container",


### PR DESCRIPTION
Attachment blobs are currently supported by local server and ODSP. This PR skips the GC attachment blob related tests for other services. This was causing the test to fail for these services.
Plus, some small cleanups - centralized the logic to skip tests for unsupported services and removed an unused function.

[AB#7922](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7922) and [AB#7923](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7923)