### PR TITLE
tree: Remove revision from FieldChange

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeTypes.ts
@@ -10,7 +10,6 @@ import {
 	FieldKey,
 	FieldKindIdentifier,
 	RevisionInfo,
-	RevisionTag,
 } from "../../core/index.js";
 import { Brand } from "../../util/index.js";
 import { TreeChunk } from "../chunked-forest/index.js";
@@ -72,15 +71,6 @@ export type FieldChangeMap = Map<FieldKey, FieldChange>;
  */
 export interface FieldChange {
 	fieldKind: FieldKindIdentifier;
-
-	/**
-	 * If defined, `change` is part of the specified revision.
-	 * Undefined in the following cases:
-	 * A) A revision is specified on an ancestor of this `FieldChange`, in which case `change` is part of that revision.
-	 * B) `change` is composed of multiple revisions.
-	 * C) `change` is part of an anonymous revision.
-	 */
-	revision?: RevisionTag;
 	change: FieldChangeset;
 }
 


### PR DESCRIPTION
## Description

Removed the revision field from FieldChange as it is no longer used.