### PR TITLE
Add OAuthBearer authentication support for rdkafka

### DIFF
--- a/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/alfred/runnerFactory.ts
@@ -99,6 +99,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 			"kafka:lib:producerGlobalAdditionalConfig",
 		);
 		const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
+		const oauthBearerConfig = config.get("kafka:lib:oauthBearerConfig");
 
 		const producer = services.createProducer(
 			kafkaLibrary,
@@ -113,6 +114,7 @@ export class AlfredResourcesFactory implements core.IResourcesFactory<AlfredReso
 			kafkaSslCACertFilePath,
 			eventHubConnString,
 			kafkaProducerGlobalAdditionalConfig,
+			oauthBearerConfig,
 		);
 
 		const redisConfig = config.get("redis");

--- a/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/nexus/runnerFactory.ts
@@ -151,6 +151,7 @@ export class NexusResourcesFactory implements core.IResourcesFactory<NexusResour
 			"kafka:lib:producerGlobalAdditionalConfig",
 		);
 		const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
+		const oauthBearerConfig = config.get("kafka:lib:oauthBearerConfig");
 
 		const producer = services.createProducer(
 			kafkaLibrary,
@@ -165,6 +166,7 @@ export class NexusResourcesFactory implements core.IResourcesFactory<NexusResour
 			kafkaSslCACertFilePath,
 			eventHubConnString,
 			kafkaProducerGlobalAdditionalConfig,
+			oauthBearerConfig,
 		);
 
 		const redisConfig = config.get("redis");

--- a/server/routerlicious/packages/routerlicious/src/deli/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/deli/index.ts
@@ -36,6 +36,7 @@ export async function deliCreate(
 		"kafka:lib:producerGlobalAdditionalConfig",
 	);
 	const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
+	const oauthBearerConfig = config.get("kafka:lib:oauthBearerConfig");
 
 	const kafkaForwardClientId = config.get("deli:kafkaClientId");
 	const kafkaReverseClientId = config.get("alfred:kafkaClientId");
@@ -117,6 +118,7 @@ export async function deliCreate(
 		kafkaSslCACertFilePath,
 		eventHubConnString,
 		kafkaProducerGlobalAdditionalConfig,
+		oauthBearerConfig,
 	);
 	const reverseProducer = services.createProducer(
 		kafkaLibrary,
@@ -131,6 +133,7 @@ export async function deliCreate(
 		kafkaSslCACertFilePath,
 		eventHubConnString,
 		kafkaProducerGlobalAdditionalConfig,
+		oauthBearerConfig,
 	);
 
 	const redisConfig = config.get("redis");

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -48,6 +48,7 @@ export async function scribeCreate(
 		"kafka:lib:producerGlobalAdditionalConfig",
 	);
 	const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
+	const oauthBearerConfig = config.get("kafka:lib:oauthBearerConfig");
 	const sendTopic = config.get("lambdas:deli:topic");
 	const kafkaClientId = config.get("scribe:kafkaClientId");
 	const mongoExpireAfterSeconds = config.get("mongo:expireAfterSeconds") as number;
@@ -142,6 +143,7 @@ export async function scribeCreate(
 		kafkaSslCACertFilePath,
 		eventHubConnString,
 		kafkaProducerGlobalAdditionalConfig,
+		oauthBearerConfig,
 	);
 
 	const externalOrdererUrl = config.get("worker:serverUrl");

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -34,7 +34,7 @@
 		"@fluidframework/server-services-telemetry": "workspace:~",
 		"events_pkg": "npm:events@^3.1.0",
 		"nconf": "^0.12.0",
-		"node-rdkafka": "^2.16.1",
+		"node-rdkafka": "^3.0.1",
 		"sillyname": "^0.1.0"
 	},
 	"devDependencies": {

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/index.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+export { IOauthBearerConfig, IOauthBearerResponse } from "./rdkafkaBase";
 export { IKafkaConsumerOptions, RdkafkaConsumer } from "./rdkafkaConsumer";
 export { IKafkaProducerOptions, RdkafkaProducer } from "./rdkafkaProducer";
 export { IRdkafkaResources, RdkafkaResources, RdkafkaResourcesFactory } from "./resourcesFactory";

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaConsumer.ts
@@ -40,7 +40,6 @@ export interface IKafkaConsumerOptions extends Partial<IKafkaBaseOptions> {
 	 * See https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
 	 */
 	additionalOptions?: kafkaTypes.ConsumerGlobalConfig;
-	eventHubConnString?: string;
 }
 
 /**
@@ -102,7 +101,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 		return this.latestOffsets.get(partitionId);
 	}
 
-	protected connect() {
+	protected async connect() {
 		if (this.closed) {
 			return;
 		}
@@ -170,7 +169,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 
 			this.error(error, { restart: false, errorLabel: "rdkafkaConsumer:connection.failure" });
 
-			this.connect();
+			await this.connect();
 		});
 
 		consumer.on("data", this.processMessage.bind(this));
@@ -319,6 +318,7 @@ export class RdkafkaConsumer extends RdkafkaBase implements IConsumer {
 			Lumberjack.info(`RdKafka consumer: ${event.message}`);
 		});
 
+		await this.setOauthBearerTokenIfNeeded(consumer);
 		consumer.connect();
 	}
 

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaProducer.ts
@@ -46,7 +46,6 @@ export interface IKafkaProducerOptions extends Partial<IKafkaBaseOptions> {
 
 	pollIntervalMs: number;
 	maxMessageSize: number;
-	eventHubConnString?: string;
 }
 
 /**
@@ -108,7 +107,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 	/**
 	 * Creates a connection to Kafka. Will reconnect on failure.
 	 */
-	protected connect() {
+	protected async connect() {
 		// Exit out if we are already connected, are in the process of connecting, or closed
 		if (this.connectedProducer || this.connectingProducer || this.closed) {
 			return;
@@ -158,7 +157,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 					restart: false,
 					errorLabel: "rdkafkaProducer:connection.failure",
 				});
-				this.connect();
+				await this.connect();
 			} catch (err) {
 				Lumberjack.error(
 					"Error encountered when handling producer connection.failure",
@@ -190,6 +189,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 			Lumberjack.info(`RdKafka producer: ${event.message}`);
 		});
 
+		await this.setOauthBearerTokenIfNeeded(producer);
 		producer.connect();
 
 		producer.setPollInterval(this.producerOptions.pollIntervalMs);
@@ -462,7 +462,7 @@ export class RdkafkaProducer extends RdkafkaBase implements IProducer {
 
 		await this.close(true);
 
-		this.connect();
+		await this.connect();
 	}
 
 	/**

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/resourcesFactory.ts
@@ -73,6 +73,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
 		const maxConsumerCommitRetries = config.get("kafka:lib:rdkafkaMaxConsumerCommitRetries");
 		const sslCACertFilePath: string = config.get("kafka:lib:sslCACertFilePath");
 		const eventHubConnString: string = config.get("kafka:lib:eventHubConnString");
+		const oauthBearerConfig = config.get("kafka:lib:oauthBearerConfig");
 		const customRestartOnKafkaErrorCodes = config.get("kafka:customRestartOnKafkaErrorCodes");
 		const consumerGlobalAdditionalConfig = config.get(
 			"kafka:lib:consumerGlobalAdditionalConfig",
@@ -101,6 +102,7 @@ export class RdkafkaResourcesFactory implements IResourcesFactory<RdkafkaResourc
 			sslCACertFilePath,
 			zooKeeperClientConstructor: this.zookeeperClientConstructor,
 			eventHubConnString,
+			oauthBearerConfig,
 			restartOnKafkaErrorCodes: customRestartOnKafkaErrorCodes,
 			additionalOptions: consumerGlobalAdditionalConfig,
 		};

--- a/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
+++ b/server/routerlicious/packages/services/src/kafkaProducerFactory.ts
@@ -32,6 +32,7 @@ export function createProducer(
 	sslCACertFilePath?: string,
 	eventHubConnString?: string,
 	additionalOptions?: object,
+	oauthBearerConfig?: any,
 ): IProducer {
 	let producer: IProducer;
 
@@ -45,6 +46,7 @@ export function createProducer(
 			sslCACertFilePath,
 			eventHubConnString,
 			additionalOptions,
+			oauthBearerConfig,
 		});
 
 		producer.on("error", (error, errorData: IContextErrorData) => {

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -964,7 +964,7 @@ importers:
       eslint: ~8.55.0
       events_pkg: npm:events@^3.1.0
       nconf: ^0.12.0
-      node-rdkafka: ^2.16.1
+      node-rdkafka: ^3.0.1
       prettier: ~3.0.3
       rimraf: ^4.4.0
       sillyname: ^0.1.0
@@ -977,7 +977,7 @@ importers:
       '@fluidframework/server-services-telemetry': link:../services-telemetry
       events_pkg: /events/3.3.0
       nconf: 0.12.0
-      node-rdkafka: 2.16.1
+      node-rdkafka: 3.0.1
       sillyname: 0.1.0
     devDependencies:
       '@fluid-tools/build-cli': 0.38.0_@types+node@18.17.6
@@ -12012,8 +12012,8 @@ packages:
   /nan/2.17.0:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
 
-  /nan/2.18.0:
-    resolution: {integrity: sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==}
+  /nan/2.19.0:
+    resolution: {integrity: sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==}
 
   /nanoid/3.3.3:
     resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
@@ -12166,23 +12166,23 @@ packages:
       - supports-color
     dev: true
 
-  /node-rdkafka/2.16.1:
-    resolution: {integrity: sha512-fiZJGl/w9QnACLhfVTYuS4V4WxSmVSbxhXyxL+B0SgRWEa8kA1NpdiB+gHPG71C3CqjbvYEfTJWhjd/1y0OeSA==}
-    engines: {node: '>=6.0.0'}
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      nan: 2.17.0
-    dev: false
-
   /node-rdkafka/2.18.0:
     resolution: {integrity: sha512-jYkmO0sPvjesmzhv1WFOO4z7IMiAFpThR6/lcnFDWgSPkYL95CtcuVNo/R5PpjujmqSgS22GMkL1qvU4DTAvEQ==}
     engines: {node: '>=6.0.0'}
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      nan: 2.18.0
+      nan: 2.19.0
     dev: true
+
+  /node-rdkafka/3.0.1:
+    resolution: {integrity: sha512-USTFu7ylRj+fEiGz0hA92GWSqmX/hu/xSTqtgmInPPmh5zKhjauTciRjDEG3yK5m6yChwyHKQTIgmr56DfhiaQ==}
+    engines: {node: '>=16'}
+    requiresBuild: true
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.19.0
+    dev: false
 
   /node-releases/2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
@@ -14222,7 +14222,7 @@ packages:
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      nan: 2.18.0
+      nan: 2.19.0
       prebuild-install: 5.3.0
     optional: true
 


### PR DESCRIPTION
## Description

Adds support for OAuthBearer authentication flow for rdkafka client when Kafka server expects/supports it. The 'tokenProvider' is supposed to be set via nconf programatically.

## Breaking Changes

server/routerlicious/packages/services-ordering-rdkafka/src/rdkafkaBase.ts introduces connect() method breaking change by changing its return value from 'void' to 'Promise<void>'. This is needed for tokenProvider's call convenience and overall maintainability/readability of the code.

## Reviewer Guidance

This change has been verified with FRS and three types of Kafka server:

* HDI Kafka w/ SSL auth
* Event Hubs w/ connection string
* Event Hubs w/ managed identity


Another change that is not directly related to the main topic is fix for incorrect node-rdkafka's feature filtering
```
		const rdKafkaHasSSLEnabled = kafka.features.filter((feature) =>
			feature.toLowerCase().includes("ssl"),
		);
```
The `rdKafkaHasSSLEnabled` will have an empty array if `ssl` is not included. Which later would be checked with the following line:
```
		if (!rdKafkaHasSSLEnabled) {
```
The problem with this line is that it will always be false whether `rdKafkaHasSSLEnabled` contains `ssl` entry or it's completely empty. Empty array is still not null/undefined, so the condition will be false.

I've changed it to an array of lower case values from the original one of rdkafka (redundant step, since it always contains lower case features, but to make sure it's always lower case and it doesn't change the previous logic).
```
		const lcKafkaFeatures = kafka.features.map((s) => s.toLowerCase());
```

And new way of checking it traverses this new array and checks it with the `includes()` method:

```
		if (!lcKafkaFeatures.includes("ssl")) {
```
