### PR TITLE
User summarylogger when emitting summarize telemetry

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3238,7 +3238,7 @@ export class ContainerRuntime
 
 			return { stats, summary };
 		} finally {
-			this.mc.logger.sendTelemetryEvent({
+			summaryLogger.sendTelemetryEvent({
 				eventName: "SummarizeTelemetry",
 				details: telemetryContext.serialize(),
 			});

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -596,13 +596,12 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider) => {
 					runGC: false,
 					fullTree: false,
 					trackState: false,
-					summaryLogger: createChildLogger(),
+					summaryLogger: createChildLogger({ logger: mockLogger }),
 				})
 				.catch(() => {});
 
 			const summarizeTelemetryEvents = mockLogger.events.filter(
-				(event) =>
-					event.eventName === "fluid:telemetry:ContainerRuntime:SummarizeTelemetry",
+				(event) => event.eventName === "SummarizeTelemetry",
 			);
 			assert.strictEqual(
 				summarizeTelemetryEvents.length,


### PR DESCRIPTION
As a part of investigating [AB#7652](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7652)

When trying to link `summarize_end` and `SummarizeTelemetry` events we found via the `summaryNumber`, we could not because the `SummarizeTelemetry` event comes from the root logger. We should use the `summaryLogger`/`summaryNumberLogger` so that the `summaryNumber` and `containerId` can be used to correlate the different summaries together.