### PR TITLE
Re-enables test that was commented out

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
@@ -257,7 +257,7 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 		await provider.ensureSynchronized();
 	});
 
-	it.skip("GroupId offline with refresh", async () => {
+	it("GroupId offline with refresh", async () => {
 		if (provider.driver.type !== "local") {
 			return;
 		}


### PR DESCRIPTION
[AB#7996](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7996)

In the comment referenced: https://github.com/microsoft/FluidFramework/pull/21025#discussion_r1595534588, the test was failing.

I enabled the test and it started passing. I ran it in both local and tinylicious and it passed on my machine.