### PR TITLE
Throw error if snapshot response is empty

### DIFF
--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -375,17 +375,31 @@ async function fetchLatestSnapshotCore(
 					case "application/json": {
 						let text: string;
 						[text, receiveContentTime] = await measureP(async () =>
-							odspResponse.content.text().catch((error) =>
-								// Parsing can fail and message could contain full request URI, including
-								// tokens, etc. So do not log error object itself.
-								throwOdspNetworkError(
-									"Error while parsing fetch response",
-									fetchIncorrectResponse,
-									odspResponse.content, // response
-									undefined, // response text
-									propsToLog,
+							odspResponse.content
+								.text()
+								.then((res) => {
+									if (res.length === 0) {
+										throwOdspNetworkError(
+											"Response from browser is empty",
+											fetchIncorrectResponse,
+											odspResponse.content, // response
+											undefined, // response text
+											propsToLog,
+										);
+									}
+									return res;
+								})
+								.catch((error) =>
+									// Parsing can fail and message could contain full request URI, including
+									// tokens, etc. So do not log error object itself.
+									throwOdspNetworkError(
+										"Error while parsing fetch response",
+										fetchIncorrectResponse,
+										odspResponse.content, // response
+										undefined, // response text
+										propsToLog,
+									),
 								),
-							),
 						);
 						propsToLog.bodySize = text.length;
 						let content: IOdspSnapshot;
@@ -405,17 +419,31 @@ async function fetchLatestSnapshotCore(
 					case "application/ms-fluid": {
 						let content: ArrayBuffer;
 						[content, receiveContentTime] = await measureP(async () =>
-							odspResponse.content.arrayBuffer().catch((error) =>
-								// Parsing can fail and message could contain full request URI, including
-								// tokens, etc. So do not log error object itself.
-								throwOdspNetworkError(
-									"Error while parsing fetch response",
-									fetchIncorrectResponse,
-									odspResponse.content, // response
-									undefined, // response text
-									propsToLog,
+							odspResponse.content
+								.arrayBuffer()
+								.then((res) => {
+									if (res.byteLength === 0) {
+										throwOdspNetworkError(
+											"Response from browser is empty",
+											fetchIncorrectResponse,
+											odspResponse.content, // response
+											undefined, // response text
+											propsToLog,
+										);
+									}
+									return res;
+								})
+								.catch((error) =>
+									// Parsing can fail and message could contain full request URI, including
+									// tokens, etc. So do not log error object itself.
+									throwOdspNetworkError(
+										"Error while parsing fetch response",
+										fetchIncorrectResponse,
+										odspResponse.content, // response
+										undefined, // response text
+										propsToLog,
+									),
 								),
-							),
 						);
 						propsToLog.bodySize = content.byteLength;
 						let snapshotContents: ISnapshotContentsWithProps;


### PR DESCRIPTION
## Description

Throw error if snapshot response is empty from the browser. 