### PR TITLE
refactor(telemetry-generator): Upgrade eslint config to "recommended" and fix violations in code

### DIFF
--- a/tools/telemetry-generator/.eslintrc.cjs
+++ b/tools/telemetry-generator/.eslintrc.cjs
@@ -4,10 +4,7 @@
  */
 
 module.exports = {
-	extends: [
-		require.resolve("@fluidframework/eslint-config-fluid/minimal-deprecated"),
-		"prettier",
-	],
+	extends: [require.resolve("@fluidframework/eslint-config-fluid"), "prettier"],
 	parserOptions: {
 		project: ["./tsconfig.json"],
 	},

--- a/tools/telemetry-generator/.eslintrc.cjs
+++ b/tools/telemetry-generator/.eslintrc.cjs
@@ -16,6 +16,7 @@ module.exports = {
 		"@typescript-eslint/no-unsafe-call": "off",
 		"@typescript-eslint/no-unsafe-member-access": "off",
 		"@typescript-eslint/no-unsafe-argument": "off",
+		"unicorn/prefer-module": "off",
 
 		// This package is exclusively used in a Node.js context
 		"import/no-nodejs-modules": "off",

--- a/tools/telemetry-generator/.eslintrc.cjs
+++ b/tools/telemetry-generator/.eslintrc.cjs
@@ -12,6 +12,10 @@ module.exports = {
 		// TODO: remove these overrides and fix violations
 		"@typescript-eslint/ban-ts-comment": "off",
 		"@typescript-eslint/no-non-null-assertion": "off",
+		"@typescript-eslint/no-unsafe-assignment": "off",
+		"@typescript-eslint/no-unsafe-call": "off",
+		"@typescript-eslint/no-unsafe-member-access": "off",
+		"@typescript-eslint/no-unsafe-argument": "off",
 
 		// This package is exclusively used in a Node.js context
 		"import/no-nodejs-modules": "off",

--- a/tools/telemetry-generator/src/commands/appInsights.ts
+++ b/tools/telemetry-generator/src/commands/appInsights.ts
@@ -45,7 +45,7 @@ export class EntryPoint extends Command {
 		},
 	];
 
-	async run() {
+	async run(): Promise<void> {
 		const { flags } = await this.parse(EntryPoint);
 
 		let handler;
@@ -106,7 +106,8 @@ export class EntryPoint extends Command {
 	}
 }
 
-function exitWithError(errorMessage: string) {
+function exitWithError(errorMessage: string): void {
 	console.error(errorMessage);
+	// eslint-disable-next-line unicorn/no-process-exit
 	process.exit(1);
 }

--- a/tools/telemetry-generator/src/commands/appInsights.ts
+++ b/tools/telemetry-generator/src/commands/appInsights.ts
@@ -53,6 +53,7 @@ export class EntryPoint extends Command {
 			// Note: we expect the path to the handler module to be absolute. Relative paths technically work, but
 			// one needs to be very familiar with Node's module resolution strategy and understand exactly which file
 			// is the one getting executed at runtime (since that's where the relative path will be resolved from).
+			// eslint-disable-next-line unicorn/no-await-expression-member
 			handler = (await import(flags.handlerModule)).default;
 		} catch (error) {
 			exitWithError(`Unexpected error importing specified handler module.\n${error}`);
@@ -97,8 +98,12 @@ export class EntryPoint extends Command {
 				console.log(`Processing file '${fullPath}'`);
 				const data = JSON.parse(fs.readFileSync(fullPath, "utf8"));
 				handler(data, telemetryClient);
-			} catch (error: any) {
-				console.error(`Unexpected error processing file '${fullPath}'.\n${error.stack}`);
+			} catch (error: unknown) {
+				console.error(
+					`Unexpected error processing file '${fullPath}'.\n${
+						(error as Partial<Error>).stack
+					}`,
+				);
 			}
 		}
 

--- a/tools/telemetry-generator/src/commands/index.ts
+++ b/tools/telemetry-generator/src/commands/index.ts
@@ -12,6 +12,7 @@ import { Command, Flags } from "@oclif/core";
 import { ConsoleLogger } from "../logger";
 
 // Allow for dynamic injection of a logger. Leveraged in internal CI pipelines.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _global: any = global;
 let logger: ITelemetryBufferedLogger = _global.getTestLogger?.({
 	// The telemetry libraries have issues with reporting synchronous flush completion.
@@ -58,7 +59,7 @@ export class EntryPoint extends Command {
 		},
 	];
 
-	async run() {
+	async run(): Promise<void> {
 		const { flags } = await this.parse(EntryPoint);
 
 		let handler;
@@ -121,5 +122,6 @@ export class EntryPoint extends Command {
 
 function exitWithError(errorMessage: string): void {
 	console.error(errorMessage);
+	// eslint-disable-next-line unicorn/no-process-exit
 	process.exit(1);
 }

--- a/tools/telemetry-generator/src/commands/index.ts
+++ b/tools/telemetry-generator/src/commands/index.ts
@@ -67,6 +67,7 @@ export class EntryPoint extends Command {
 			// Note: we expect the path to the handler module to be absolute. Relative paths technically work, but
 			// one needs to be very familiar with Node's module resolution strategy and understand exactly which file
 			// is the one getting executed at runtime (since that's where the relative path will be resolved from).
+			// eslint-disable-next-line unicorn/no-await-expression-member
 			handler = (await import(flags.handlerModule)).default;
 		} catch (error) {
 			exitWithError(`Unexpected error importing specified handler module.\n${error}`);
@@ -111,7 +112,9 @@ export class EntryPoint extends Command {
 				handler(data, logger);
 			} catch (error: unknown) {
 				console.error(
-					`Unexpected error processing file '${fullPath}'.\n${(error as Error).stack}`,
+					`Unexpected error processing file '${fullPath}'.\n${
+						(error as Partial<Error>).stack
+					}`,
 				);
 			}
 		}

--- a/tools/telemetry-generator/src/handlers/appInsightsExecutionTimeTestHandler.ts
+++ b/tools/telemetry-generator/src/handlers/appInsightsExecutionTimeTestHandler.ts
@@ -11,7 +11,7 @@ import { TelemetryClient } from "applicationinsights";
  */
 module.exports = function handler(fileData, telemetryClient: TelemetryClient): void {
 	console.log(`Found ${fileData.benchmarks.length} total benchmark tests to emit`);
-	fileData.benchmarks.forEach(async (testData) => {
+	for (const testData of fileData.benchmarks) {
 		const arithmeticMeanMetricName = `${fileData.suiteName}_${testData.benchmarkName}_arithmeticMean`;
 		try {
 			console.log(
@@ -58,5 +58,5 @@ module.exports = function handler(fileData, telemetryClient: TelemetryClient): v
 		} catch (error) {
 			console.error(`failed to emit metric ${marginOfErrorMetricName}`, error);
 		}
-	});
+	}
 };

--- a/tools/telemetry-generator/src/handlers/appInsightsExecutionTimeTestHandler.ts
+++ b/tools/telemetry-generator/src/handlers/appInsightsExecutionTimeTestHandler.ts
@@ -9,7 +9,7 @@ import { TelemetryClient } from "applicationinsights";
  * This handler emits metrics to the Azure App Insights instance configured by the telemetryClient provided to this handler.
  * This handler expects the 'telemetryClient' arg to be TelemetryClient class from the 'applicationinsights' Azure package.
  */
-module.exports = function handler(fileData, telemetryClient: TelemetryClient) {
+module.exports = function handler(fileData, telemetryClient: TelemetryClient): void {
 	console.log(`Found ${fileData.benchmarks.length} total benchmark tests to emit`);
 	fileData.benchmarks.forEach(async (testData) => {
 		const arithmeticMeanMetricName = `${fileData.suiteName}_${testData.benchmarkName}_arithmeticMean`;

--- a/tools/telemetry-generator/src/handlers/appInsightsMemoryUsageTestHandler.ts
+++ b/tools/telemetry-generator/src/handlers/appInsightsMemoryUsageTestHandler.ts
@@ -9,7 +9,7 @@ import { TelemetryClient } from "applicationinsights";
  * This handler emits metrics to the Azure App Insights instance configured by the telemetryClient provided to this handler.
  * This handler expects the 'telemetryClient' arg to be TelemetryClient class from the 'applicationinsights' Azure package.
  */
-module.exports = function handler(fileData, telemetryClient: TelemetryClient) {
+module.exports = function handler(fileData, telemetryClient: TelemetryClient): void {
 	console.log(`Found ${fileData.tests.length} total benchmark tests to emit`);
 	fileData.tests.forEach(async (testData) => {
 		const heapUsedAvgMetricName = `${fileData.suiteName}_${testData.testName}_heapUsedAvg`;

--- a/tools/telemetry-generator/src/handlers/appInsightsMemoryUsageTestHandler.ts
+++ b/tools/telemetry-generator/src/handlers/appInsightsMemoryUsageTestHandler.ts
@@ -11,7 +11,7 @@ import { TelemetryClient } from "applicationinsights";
  */
 module.exports = function handler(fileData, telemetryClient: TelemetryClient): void {
 	console.log(`Found ${fileData.tests.length} total benchmark tests to emit`);
-	fileData.tests.forEach(async (testData) => {
+	for (const testData of fileData.tests) {
 		const heapUsedAvgMetricName = `${fileData.suiteName}_${testData.testName}_heapUsedAvg`;
 		try {
 			console.log(
@@ -57,5 +57,5 @@ module.exports = function handler(fileData, telemetryClient: TelemetryClient): v
 		} catch (error) {
 			console.error(`failed to emit metric ${heapUsedStdDevMetricName}`, error);
 		}
-	});
+	}
 };

--- a/tools/telemetry-generator/src/handlers/bundleSizeHandler.ts
+++ b/tools/telemetry-generator/src/handlers/bundleSizeHandler.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-module.exports = function handler(fileData, logger) {
+module.exports = function handler(fileData, logger): void {
 	// - fileData is a JSON object obtained by calling JSON.parse() on the contents of a file.
 	// - logger is an ITelemetryBufferedLogger. Call its send() method to write the output telemetry
 	//   events.

--- a/tools/telemetry-generator/src/handlers/executionTimeTestHandler.ts
+++ b/tools/telemetry-generator/src/handlers/executionTimeTestHandler.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-module.exports = function handler(fileData, logger) {
+module.exports = function handler(fileData, logger): void {
 	if (process.env.FLUID_ENDPOINTNAME === undefined) {
 		console.log("ENDPOINTNAME not defined using local as default.");
 	} else {

--- a/tools/telemetry-generator/src/handlers/executionTimeTestHandler.ts
+++ b/tools/telemetry-generator/src/handlers/executionTimeTestHandler.ts
@@ -4,13 +4,13 @@
  */
 
 module.exports = function handler(fileData, logger) {
-	if (process.env.FLUID_ENDPOINTNAME !== undefined) {
-		console.log("ENDPOINTNAME", process.env.FLUID_ENDPOINTNAME);
-	} else {
+	if (process.env.FLUID_ENDPOINTNAME === undefined) {
 		console.log("ENDPOINTNAME not defined using local as default.");
+	} else {
+		console.log("ENDPOINTNAME", process.env.FLUID_ENDPOINTNAME);
 	}
 
-	fileData.benchmarks.forEach((testData) => {
+	for (const testData of fileData.benchmarks) {
 		logger.send({
 			namespace: "FFEngineering", // Transfer the telemetry associated with tests performance measurement to namespace "FFEngineering"
 			category: "performance",
@@ -22,5 +22,5 @@ module.exports = function handler(fileData, logger) {
 			marginOfError: testData.stats.marginOfError,
 			driverEndpointName: process.env.FLUID_ENDPOINTNAME ?? "",
 		});
-	});
+	}
 };

--- a/tools/telemetry-generator/src/handlers/memoryUsageTestHandler.ts
+++ b/tools/telemetry-generator/src/handlers/memoryUsageTestHandler.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-module.exports = function handler(fileData, logger) {
+module.exports = function handler(fileData, logger): void {
 	if (process.env.FLUID_ENDPOINTNAME === undefined) {
 		console.log("ENDPOINTNAME not defined using local as default.");
 	} else {

--- a/tools/telemetry-generator/src/handlers/memoryUsageTestHandler.ts
+++ b/tools/telemetry-generator/src/handlers/memoryUsageTestHandler.ts
@@ -4,13 +4,13 @@
  */
 
 module.exports = function handler(fileData, logger) {
-	if (process.env.FLUID_ENDPOINTNAME !== undefined) {
-		console.log("ENDPOINTNAME", process.env.FLUID_ENDPOINTNAME);
-	} else {
+	if (process.env.FLUID_ENDPOINTNAME === undefined) {
 		console.log("ENDPOINTNAME not defined using local as default.");
+	} else {
+		console.log("ENDPOINTNAME", process.env.FLUID_ENDPOINTNAME);
 	}
 
-	fileData.tests.forEach((testData) => {
+	for (const testData of fileData.tests) {
 		logger.send({
 			namespace: "FFEngineering", // Transfer the telemetry associated with tests performance measurement to namespace "FFEngineering"
 			category: "performance",
@@ -22,5 +22,5 @@ module.exports = function handler(fileData, logger) {
 			heapUsedStdDev: testData.testData.stats.standardDeviation,
 			driverEndpointName: process.env.FLUID_ENDPOINTNAME ?? "",
 		});
-	});
+	}
 };

--- a/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
+++ b/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
@@ -3,7 +3,9 @@
  * Licensed under the MIT License.
  */
 
-/** Interface to make it easier to parse json returned from the timeline REST API */
+/**
+ * Interface to make it easier to parse json returned from the timeline REST API
+ */
 interface ParsedJob {
 	stageName: string;
 	startTime: number;
@@ -22,10 +24,10 @@ module.exports = function handler(fileData, logger) {
 	if (fileData.records?.length === undefined || fileData.records?.length === 0) {
 		console.log(`could not locate records info`);
 	}
-	if (process.env.BUILD_ID !== undefined) {
-		console.log("BUILD_ID", process.env.BUILD_ID);
-	} else {
+	if (process.env.BUILD_ID === undefined) {
 		console.log("BUILD_ID not defined.");
+	} else {
+		console.log("BUILD_ID", process.env.BUILD_ID);
 	}
 
 	// Note: type == "Task" would include tasks from the stages in the result set. It might be interesting in the future - for now we will only collect stages.

--- a/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
+++ b/tools/telemetry-generator/src/handlers/stageTimingRetriever.ts
@@ -15,7 +15,7 @@ interface ParsedJob {
 	result: string;
 }
 
-module.exports = function handler(fileData, logger) {
+module.exports = function handler(fileData, logger): void {
 	// - fileData is a JSON object obtained by calling JSON.parse() on the contents of a file.
 	// In this particular handler, we are using the timeline REST API to retrieve the status of the pipeline:
 	// Ex. https://dev.azure.com/fluidframework/internal/_apis/build/builds/<buildId>/timeline?api-version=6.0-preview.1

--- a/tools/telemetry-generator/src/handlers/template.ts
+++ b/tools/telemetry-generator/src/handlers/template.ts
@@ -7,7 +7,7 @@
  * This is a template for how to define a handler file that can be passed to this tool to process
  * arbitrary JSON files.
  */
-module.exports = function handler(fileData, logger) {
+module.exports = function handler(fileData, logger): void {
 	// - fileData is a JSON object obtained by calling JSON.parse() on the contents of a file.
 	// - logger is an ITelemetryBufferedLogger. Call its send() method to write the output telemetry
 	//   events.

--- a/tools/telemetry-generator/src/handlers/testPassRate.ts
+++ b/tools/telemetry-generator/src/handlers/testPassRate.ts
@@ -11,7 +11,8 @@
  * @param logger - An ITelemetryBufferedLogger. Call its send() method to write the output telemetry events.
  */
 module.exports = function handler(fileData, logger): void {
-	if (fileData.resultSummary === undefined) {
+	// eslint-disable-next-line @rushstack/no-new-null -- External API can return an actual null
+	if (fileData.resultSummary === null || fileData.resultSummary === undefined) {
 		console.log(`Could not locate test result info.`);
 		return;
 	}

--- a/tools/telemetry-generator/src/handlers/testPassRate.ts
+++ b/tools/telemetry-generator/src/handlers/testPassRate.ts
@@ -11,14 +11,14 @@
  * @param logger - An ITelemetryBufferedLogger. Call its send() method to write the output telemetry events.
  */
 module.exports = function handler(fileData, logger) {
-	if (fileData.resultSummary == null) {
+	if (fileData.resultSummary == undefined) {
 		console.log(`Could not locate test result info.`);
 		return;
 	}
-	if (process.env.BUILD_ID !== undefined) {
-		console.log("BUILD_ID", process.env.BUILD_ID);
-	} else {
+	if (process.env.BUILD_ID === undefined) {
 		console.log("BUILD_ID not defined.");
+	} else {
+		console.log("BUILD_ID", process.env.BUILD_ID);
 	}
 	const resultSummary = fileData.resultSummary.resultSummaryByRunState.Completed;
 	console.log(resultSummary);
@@ -26,7 +26,7 @@ module.exports = function handler(fileData, logger) {
 	const passedTests: number = resultSummary.aggregatedResultDetailsByOutcome.Passed?.count ?? 0;
 	const failedTests: number = resultSummary.aggregatedResultDetailsByOutcome.Failed?.count ?? 0;
 	const totalTests = passedTests + failedTests;
-	const passRate = totalTests !== 0 ? passedTests / totalTests : 0;
+	const passRate = totalTests === 0 ? 0 : passedTests / totalTests;
 	console.log(passRate);
 
 	logger.send({

--- a/tools/telemetry-generator/src/handlers/testPassRate.ts
+++ b/tools/telemetry-generator/src/handlers/testPassRate.ts
@@ -10,8 +10,8 @@
  * @param fileData - A JSON object obtained by calling JSON.parse() on the contents of a file.
  * @param logger - An ITelemetryBufferedLogger. Call its send() method to write the output telemetry events.
  */
-module.exports = function handler(fileData, logger) {
-	if (fileData.resultSummary == undefined) {
+module.exports = function handler(fileData, logger): void {
+	if (fileData.resultSummary === undefined) {
 		console.log(`Could not locate test result info.`);
 		return;
 	}


### PR DESCRIPTION
This package was using the `minimal-deprecated` configuration, which is scheduled for deletion. Upgrades the package's config to the `recommended` base and fixes violations in the code.

This PR disables some of the `recommended` rules due to the sheer number of violations. These can and should be removed and fixed in the future. For now, the primary goal here is to remove usages of the deprecated config.

[AB#2900](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2900)