### PR TITLE
Skip document corruption if partition is closed

### DIFF
--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -161,6 +161,13 @@ export class DocumentPartition {
 	 * Future messages will be checkpointed but no real processing will happen
 	 */
 	private markAsCorrupt(error: any, message?: IQueuedMessage) {
+		if (this.closed) {
+			Lumberjack.info(
+				"Skipping marking document as corrupt as the document partition is already closed",
+				{ ...getLumberBaseProperties(this.documentId, this.tenantId), error },
+			);
+			return;
+		}
 		this.corrupt = true;
 		this.context.log?.error(`Marking document as corrupted due to error: ${inspect(error)}`, {
 			messageMetaData: {

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -163,7 +163,7 @@ export class DocumentPartition {
 	private markAsCorrupt(error: any, message?: IQueuedMessage) {
 		if (this.closed) {
 			Lumberjack.info(
-				"Skipping marking document as corrupt as the document partition is already closed",
+				"Skipping marking document as corrupt since the document partition is already closed",
 				{ ...getLumberBaseProperties(this.documentId, this.tenantId), error },
 			);
 			return;

--- a/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
+++ b/server/routerlicious/packages/lambdas-driver/src/document-router/documentPartition.ts
@@ -164,7 +164,10 @@ export class DocumentPartition {
 		if (this.closed) {
 			Lumberjack.info(
 				"Skipping marking document as corrupt since the document partition is already closed",
-				{ ...getLumberBaseProperties(this.documentId, this.tenantId), error },
+				{
+					...getLumberBaseProperties(this.documentId, this.tenantId),
+					error: error.toString(),
+				},
 			);
 			return;
 		}


### PR DESCRIPTION
## Description

Adding a check in doc corruption logic to skip marking the doc as corrupted if the doc partition is already closed (eg: if the session is paused)

This will help reduce unnecessary doc corruptions in case of paused sessions as well as reduce uncaught exception restarts due to emitting error for a paused session.