### PR TITLE
Wait for container connection in service load test

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -662,7 +662,10 @@ async function setupOpsMetrics(
 	};
 }
 
-async function waitForContainerConnectionWithTimeout(container: IContainer, timeout = 5000): Promise<void> {
+async function waitForContainerConnectionWithTimeout(
+	container: IContainer,
+	timeout = 5000,
+): Promise<void> {
 	if (container.connectionState !== ConnectionState.Connected) {
 		let timer: NodeJS.Timeout;
 		const timeoutP = new Promise<void>((resolve) => {


### PR DESCRIPTION
Tinylicious is seeing lots of `"OpRoundtripTime"` errors around the time of initialization. We should wait until we connect to start sending the ops.

[AB#7819](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7819)