### PR TITLE
Use post-creation resolved URL to handle discovery pattern

### DIFF
--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -47,8 +47,8 @@ export class FaultInjectionDocumentServiceFactory implements IDocumentServiceFac
 			clientIsSummarizer,
 		);
 		const ds = new FaultInjectionDocumentService(internal);
-		assert(!this._documentServices.has(resolvedUrl), "one ds per resolved url instance");
-		this._documentServices.set(resolvedUrl, ds);
+		assert(!this._documentServices.has(ds.resolvedUrl), "one ds per resolved url instance");
+		this._documentServices.set(ds.resolvedUrl, ds);
 		return ds;
 	}
 	async createContainer(


### PR DESCRIPTION
FRS/FRSCanary stress tests have been timing out in the pipelines.  I determined this is because the spawned clients were getting stuck waiting to catch up ([here](https://github.com/microsoft/FluidFramework/blob/main/packages/test/test-service-load/src/loadTestDataStore.ts#L87)).  All the clients join in "read" mode and therefore don't generate a "join" op, and so the "op" event will never fire and the containers will never realize they are caught up.  This logic should be improved, but that's not what this PR does.

Instead, I looked into why only FRS was failing in the pipeline - why were the other services able to progress, since they should be doing the same thing?  It turns out that the other services also get stuck too!  However, they also participate in fault injection, including NACK injection.  When one of the clients gets a NACK injected, they reconnect in write mode, thereby generating a "join" op and getting everyone unstuck.  Depending upon the NACK was surely not the intended way to kick off the stress tests, but it does work.

But FRS is also supposed to be participating in fault injection per its config ([here](https://github.com/microsoft/FluidFramework/blob/main/packages/test/test-service-load/testConfig.json#L63)).  So why wasn't FRS also NACK-ing its way out of the stuck state?

The fault injection flow can silently exit for a number of reasons, and in this case the interesting one is finding the IDocumentService on the FaultInjectionDocumentServiceFactory ([here](https://github.com/microsoft/FluidFramework/blob/main/packages/test/test-service-load/src/runner.ts#L373)).  On FRS, the retrieval failed to find the connection because it was using the discovery URL when storing the connection in its map, but then looking for it using the container.resolvedUrl (which is post-discovery).  So even though the connection was there, it wasn't being found - and so fault injection would silently exit without injecting any faults.  We really shouldn't silently exit - this seems like an unexpected situation that should blow up.  But that's not what this PR does.

Instead this PR just uses the post-discovery resolved url to store the connection, so it can be properly found later.  This allows FRS to start injecting NACKs same as the other services, and get unstuck in the same way too.  Being able to successfully find the connection would have also caused failure in scheduled offline ([here](https://github.com/microsoft/FluidFramework/blob/main/packages/test/test-service-load/src/runner.ts#L506)), but FRS doesn't schedule offline yet.

I'm not sure why this would have started failing when it did - I didn't see any suspicious changes coinciding with it offhand.  But this change should get FRS running again, and we can also consider fixing the other issues I mentioned above afterwards.