### PR TITLE
[Summarization] Added type for the error thrown during summarization

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -631,7 +631,7 @@ export interface IAckSummaryResult {
 
 // @alpha
 export interface IBaseSummarizeResult {
-    readonly error: IRetriableFailureResult | undefined;
+    readonly error: IRetriableFailureError | undefined;
     // (undocumented)
     readonly minimumSequenceNumber: number;
     readonly referenceSequenceNumber: number;
@@ -973,7 +973,7 @@ export interface IRefreshSummaryAckOptions {
 }
 
 // @alpha
-export interface IRetriableFailureResult extends Error {
+export interface IRetriableFailureError extends Error {
     // (undocumented)
     readonly retryAfterSeconds?: number;
 }
@@ -1300,7 +1300,7 @@ export type SummarizeResultPart<TSuccess, TFailure = undefined> = {
     success: false;
     data: TFailure | undefined;
     message: string;
-    error: IRetriableFailureResult;
+    error: IRetriableFailureError;
 };
 
 // @alpha (undocumented)

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -631,7 +631,7 @@ export interface IAckSummaryResult {
 
 // @alpha
 export interface IBaseSummarizeResult {
-    readonly error: Error | undefined;
+    readonly error: IRetriableFailureResult | undefined;
     // (undocumented)
     readonly minimumSequenceNumber: number;
     readonly referenceSequenceNumber: number;
@@ -948,7 +948,7 @@ export interface IMarkPhaseStats {
 }
 
 // @alpha (undocumented)
-export interface INackSummaryResult extends IRetriableFailureResult {
+export interface INackSummaryResult {
     // (undocumented)
     readonly ackNackDuration: number;
     // (undocumented)
@@ -973,7 +973,7 @@ export interface IRefreshSummaryAckOptions {
 }
 
 // @alpha
-export interface IRetriableFailureResult {
+export interface IRetriableFailureResult extends Error {
     // (undocumented)
     readonly retryAfterSeconds?: number;
 }
@@ -1260,7 +1260,7 @@ export enum RuntimeHeaders {
 }
 
 // @alpha
-export interface SubmitSummaryFailureData extends IRetriableFailureResult {
+export interface SubmitSummaryFailureData {
     // (undocumented)
     stage: SummaryStage;
 }
@@ -1300,7 +1300,7 @@ export type SummarizeResultPart<TSuccess, TFailure = undefined> = {
     success: false;
     data: TFailure | undefined;
     message: string;
-    error: any;
+    error: IRetriableFailureResult;
 };
 
 // @alpha (undocumented)

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -263,7 +263,8 @@
 				"backCompat": false,
 				"forwardCompat": false
 			},
-			"InterfaceDeclaration_IRetriableFailureResult": {
+			"RemovedInterfaceDeclaration_IRetriableFailureResult": {
+				"backCompat": false,
 				"forwardCompat": false
 			}
 		}

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -262,6 +262,9 @@
 			"InterfaceDeclaration_ISummarizerRuntime": {
 				"backCompat": false,
 				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IRetriableFailureResult": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -97,7 +97,7 @@ export {
 	ICancellableSummarizerController,
 	SubmitSummaryFailureData,
 	SummaryStage,
-	IRetriableFailureResult,
+	IRetriableFailureError,
 	ISummarizeEventProps,
 	IdCompressorMode,
 	IDocumentSchema,

--- a/packages/runtime/container-runtime/src/summary/index.ts
+++ b/packages/runtime/container-runtime/src/summary/index.ts
@@ -63,7 +63,7 @@ export {
 	SummarizeResultPart,
 	SubmitSummaryFailureData,
 	SummaryStage,
-	IRetriableFailureResult,
+	IRetriableFailureError,
 	ISummarizeEventProps,
 } from "./summarizerTypes.js";
 export {

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -38,7 +38,7 @@ import {
 	ISummaryCancellationToken,
 	SubmitSummaryResult,
 	SummarizerStopReason,
-	type IRetriableFailureResult,
+	type IRetriableFailureError,
 } from "./summarizerTypes.js";
 import { IAckedSummary, IClientSummaryWatcher, SummaryCollection } from "./summaryCollection.js";
 import {
@@ -686,7 +686,7 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 		let done = false;
 		let status: "success" | "failure" | "canceled" = "success";
 		let results: ISummarizeResults | undefined;
-		let error: IRetriableFailureResult | undefined;
+		let error: IRetriableFailureError | undefined;
 		do {
 			currentAttempt++;
 			if (this.cancellationToken.cancelled) {
@@ -736,7 +736,7 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 			if (retryAfterSeconds !== undefined && retryAfterSeconds > 0) {
 				this.mc.logger.sendPerformanceEvent({
 					eventName: "SummarizeAttemptDelay",
-					duration: retryAfterSeconds,
+					duration: retryAfterSeconds * 1000,
 					stage: submitSummaryResult.data?.stage,
 					...attemptResult.summarizeProps,
 				});

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -717,7 +717,7 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 			// Emit "summarize" event for this failed attempt.
 			status = "failure";
 			error = ackNackResult.error;
-			retryAfterSeconds = error?.retryAfterSeconds;
+			retryAfterSeconds = error.retryAfterSeconds;
 			const eventProps: ISummarizeEventProps = {
 				result: status,
 				currentAttempt,
@@ -737,6 +737,7 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 				this.mc.logger.sendPerformanceEvent({
 					eventName: "SummarizeAttemptDelay",
 					duration: retryAfterSeconds * 1000,
+					summaryNackDelay: ackNackResult.data !== undefined, // This will only be defined only for nack failures.
 					stage: submitSummaryResult.data?.stage,
 					...attemptResult.summarizeProps,
 				});

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -8,7 +8,6 @@ import { IDisposable, ITelemetryBaseLogger } from "@fluidframework/core-interfac
 import { assert, Deferred, PromiseTimer, delay } from "@fluidframework/core-utils/internal";
 import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";
-import { getRetryDelaySecondsFromError } from "@fluidframework/driver-utils/internal";
 import {
 	MonitoringContext,
 	UsageError,
@@ -39,9 +38,11 @@ import {
 	ISummaryCancellationToken,
 	SubmitSummaryResult,
 	SummarizerStopReason,
+	type IRetriableFailureResult,
 } from "./summarizerTypes.js";
 import { IAckedSummary, IClientSummaryWatcher, SummaryCollection } from "./summaryCollection.js";
 import {
+	RetriableSummaryError,
 	SummarizeReason,
 	SummarizeResultBuilder,
 	SummaryGenerator,
@@ -685,7 +686,7 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 		let done = false;
 		let status: "success" | "failure" | "canceled" = "success";
 		let results: ISummarizeResults | undefined;
-		let error: Error | undefined;
+		let error: IRetriableFailureResult | undefined;
 		do {
 			currentAttempt++;
 			if (this.cancellationToken.cancelled) {
@@ -705,25 +706,18 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 				break;
 			}
 
-			// Update max attempts and retry params from the failure result.
-			// If submit summary failed, use the params from "summarySubmitted" result. Else, use the params
-			// from "receivedSummaryAckOrNack" result.
+			// Update max attempts from the failure result.
+			// If submit summary failed, use maxAttemptsForSubmitFailures. Else use the defaultMaxAttempts.
 			// Note: Check "summarySubmitted" result first because if it fails, ack nack would fail as well.
 			const submitSummaryResult = await results.summarySubmitted;
-			if (!submitSummaryResult.success) {
-				maxAttempts = this.maxAttemptsForSubmitFailures;
-				retryAfterSeconds = submitSummaryResult.data?.retryAfterSeconds;
-			} else {
-				maxAttempts = defaultMaxAttempts;
-				retryAfterSeconds = ackNackResult.data?.retryAfterSeconds;
-			}
+			maxAttempts = !submitSummaryResult.success
+				? this.maxAttemptsForSubmitFailures
+				: defaultMaxAttempts;
 
 			// Emit "summarize" event for this failed attempt.
 			status = "failure";
 			error = ackNackResult.error;
-			// If retryAfterSeconds is available in the failure results, use it. Otherwise, attempt to get
-			// it from the error.
-			retryAfterSeconds = retryAfterSeconds ?? getRetryDelaySecondsFromError(error);
+			retryAfterSeconds = error?.retryAfterSeconds;
 			const eventProps: ISummarizeEventProps = {
 				result: status,
 				currentAttempt,
@@ -743,7 +737,6 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 				this.mc.logger.sendPerformanceEvent({
 					eventName: "SummarizeAttemptDelay",
 					duration: retryAfterSeconds,
-					summaryNackDelay: ackNackResult.data?.retryAfterSeconds !== undefined,
 					stage: submitSummaryResult.data?.stage,
 					...attemptResult.summarizeProps,
 				});
@@ -802,7 +795,10 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 	) {
 		const results = await this.trySummarizeWithRetries(reason);
 		if (results === undefined) {
-			resultsBuilder.fail("Summarization was canceled", undefined);
+			resultsBuilder.fail(
+				"Summarization was canceled",
+				new RetriableSummaryError("Summarization was canceled"),
+			);
 			return resultsBuilder.build();
 		}
 		const submitResult = await results.summarySubmitted;
@@ -820,7 +816,10 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 		resultsBuilder: SummarizeResultBuilder = new SummarizeResultBuilder(),
 	): ISummarizeResults {
 		if (this.stopping) {
-			resultsBuilder.fail("RunningSummarizer stopped or disposed", undefined);
+			resultsBuilder.fail(
+				"RunningSummarizer stopped or disposed",
+				new RetriableSummaryError("RunningSummarizer stopped or disposed"),
+			);
 			return resultsBuilder.build();
 		}
 		// Check for concurrent summary attempts. If one is found,
@@ -858,7 +857,9 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 			// Override existing enqueued summarize attempt.
 			this.enqueuedSummary.resultsBuilder.fail(
 				"Aborted; overridden by another enqueue summarize attempt",
-				undefined,
+				new RetriableSummaryError(
+					"Summary was overridden by another enqueue summarize attempt",
+				),
 			);
 			this.enqueuedSummary = undefined;
 			overridden = true;
@@ -909,7 +910,7 @@ export class RunningSummarizer extends TypedEventEmitter<ISummarizerEvents> impl
 		if (this.enqueuedSummary !== undefined) {
 			this.enqueuedSummary.resultsBuilder.fail(
 				"RunningSummarizer stopped or disposed",
-				undefined,
+				new RetriableSummaryError("RunningSummarizer stopped or disposed"),
 			);
 			this.enqueuedSummary = undefined;
 		}

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -185,7 +185,7 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
  * Type for summarization failures that are retriable.
  * @alpha
  */
-export interface IRetriableFailureResult extends Error {
+export interface IRetriableFailureError extends Error {
 	readonly retryAfterSeconds?: number;
 }
 
@@ -196,7 +196,7 @@ export interface IRetriableFailureResult extends Error {
 export interface IBaseSummarizeResult {
 	readonly stage: "base";
 	/** Retriable error object related to failed summarize attempt. */
-	readonly error: IRetriableFailureResult | undefined;
+	readonly error: IRetriableFailureError | undefined;
 	/** Reference sequence number as of the generate summary attempt. */
 	readonly referenceSequenceNumber: number;
 	readonly minimumSequenceNumber: number;
@@ -315,7 +315,7 @@ export type SummarizeResultPart<TSuccess, TFailure = undefined> =
 			success: false;
 			data: TFailure | undefined;
 			message: string;
-			error: IRetriableFailureResult;
+			error: IRetriableFailureError;
 	  };
 
 /**

--- a/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerTypes.ts
@@ -182,13 +182,21 @@ export interface IGeneratedSummaryStats extends ISummaryStats {
 }
 
 /**
+ * Type for summarization failures that are retriable.
+ * @alpha
+ */
+export interface IRetriableFailureResult extends Error {
+	readonly retryAfterSeconds?: number;
+}
+
+/**
  * Base results for all submitSummary attempts.
  * @alpha
  */
 export interface IBaseSummarizeResult {
 	readonly stage: "base";
-	/** Error object related to failed summarize attempt. */
-	readonly error: Error | undefined;
+	/** Retriable error object related to failed summarize attempt. */
+	readonly error: IRetriableFailureResult | undefined;
 	/** Reference sequence number as of the generate summary attempt. */
 	readonly referenceSequenceNumber: number;
 	readonly minimumSequenceNumber: number;
@@ -264,18 +272,10 @@ export type SubmitSummaryResult =
 export type SummaryStage = SubmitSummaryResult["stage"] | "unknown";
 
 /**
- * Type for summarization failures that are retriable.
- * @alpha
- */
-export interface IRetriableFailureResult {
-	readonly retryAfterSeconds?: number;
-}
-
-/**
  * The data in summarizer result when submit summary stage fails.
  * @alpha
  */
-export interface SubmitSummaryFailureData extends IRetriableFailureResult {
+export interface SubmitSummaryFailureData {
 	stage: SummaryStage;
 }
 
@@ -298,7 +298,7 @@ export interface IAckSummaryResult {
 /**
  * @alpha
  */
-export interface INackSummaryResult extends IRetriableFailureResult {
+export interface INackSummaryResult {
 	readonly summaryNackOp: ISummaryNackMessage;
 	readonly ackNackDuration: number;
 }
@@ -315,7 +315,7 @@ export type SummarizeResultPart<TSuccess, TFailure = undefined> =
 			success: false;
 			data: TFailure | undefined;
 			message: string;
-			error: any;
+			error: IRetriableFailureResult;
 	  };
 
 /**

--- a/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
@@ -35,7 +35,7 @@ import {
 	SubmitSummaryResult,
 	SummarizeResultPart,
 	SummaryGeneratorTelemetry,
-	type IRetriableFailureResult,
+	type IRetriableFailureError,
 } from "./summarizerTypes.js";
 import { IClientSummaryWatcher } from "./summaryCollection.js";
 
@@ -153,7 +153,7 @@ export class SummarizeResultBuilder {
 	 */
 	public fail(
 		message: string,
-		error: IRetriableFailureResult,
+		error: IRetriableFailureError,
 		submitFailureResult?: SubmitSummaryFailureData,
 		nackSummaryResult?: INackSummaryResult,
 	) {
@@ -187,7 +187,7 @@ export class SummarizeResultBuilder {
 /**
  * Errors type for errors hit during summary that may be retriable.
  */
-export class RetriableSummaryError extends LoggingError implements IRetriableFailureResult {
+export class RetriableSummaryError extends LoggingError implements IRetriableFailureError {
 	constructor(
 		message: string,
 		public readonly retryAfterSeconds?: number,
@@ -275,7 +275,7 @@ export class SummaryGenerator {
 		 */
 		const fail = (
 			errorCode: SummarizeErrorCode,
-			error: IRetriableFailureResult,
+			error: IRetriableFailureError,
 			properties?: SummaryGeneratorTelemetry,
 			submitFailureResult?: SubmitSummaryFailureData,
 			nackSummaryResult?: INackSummaryResult,
@@ -297,7 +297,7 @@ export class SummaryGenerator {
 					category,
 					retryAfterSeconds: error.retryAfterSeconds,
 				},
-				error ?? reason,
+				error,
 			); // disconnect & summaryAckTimeout do not have proper error.
 
 			resultsBuilder.fail(reason, error, submitFailureResult, nackSummaryResult);

--- a/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryGenerator.ts
@@ -35,6 +35,7 @@ import {
 	SubmitSummaryResult,
 	SummarizeResultPart,
 	SummaryGeneratorTelemetry,
+	type IRetriableFailureResult,
 } from "./summarizerTypes.js";
 import { IClientSummaryWatcher } from "./summaryCollection.js";
 
@@ -127,8 +128,10 @@ const summarizeErrors = {
 	disconnect: "Summary cancelled due to summarizer or main client disconnect",
 } as const;
 
+export type SummarizeErrorCode = keyof typeof summarizeErrors;
+
 // Helper functions to report failures and return.
-export const getFailMessage = (errorCode: keyof typeof summarizeErrors) =>
+export const getFailMessage = (errorCode: SummarizeErrorCode) =>
 	`${errorCode}: ${summarizeErrors[errorCode]}`;
 
 export class SummarizeResultBuilder {
@@ -150,7 +153,7 @@ export class SummarizeResultBuilder {
 	 */
 	public fail(
 		message: string,
-		error: any,
+		error: IRetriableFailureResult,
 		submitFailureResult?: SubmitSummaryFailureData,
 		nackSummaryResult?: INackSummaryResult,
 	) {
@@ -184,7 +187,7 @@ export class SummarizeResultBuilder {
 /**
  * Errors type for errors hit during summary that may be retriable.
  */
-export class RetriableSummaryError extends LoggingError {
+export class RetriableSummaryError extends LoggingError implements IRetriableFailureResult {
 	constructor(
 		message: string,
 		public readonly retryAfterSeconds?: number,
@@ -271,8 +274,8 @@ export class SummaryGenerator {
 		 * be provided. For op broadcast failures, only errors / properties should be provided.
 		 */
 		const fail = (
-			errorCode: keyof typeof summarizeErrors,
-			error?: Error,
+			errorCode: SummarizeErrorCode,
+			error: IRetriableFailureResult,
 			properties?: SummaryGeneratorTelemetry,
 			submitFailureResult?: SubmitSummaryFailureData,
 			nackSummaryResult?: INackSummaryResult,
@@ -292,10 +295,7 @@ export class SummaryGenerator {
 					...properties,
 					reason,
 					category,
-					retryAfterSeconds:
-						submitFailureResult?.retryAfterSeconds ??
-						nackSummaryResult?.retryAfterSeconds ??
-						getRetryDelaySecondsFromError(error),
+					retryAfterSeconds: error.retryAfterSeconds,
 				},
 				error ?? reason,
 			); // disconnect & summaryAckTimeout do not have proper error.
@@ -329,9 +329,11 @@ export class SummaryGenerator {
 			);
 
 			if (summaryData.stage !== "submit") {
-				return fail("submitSummaryFailure", summaryData.error, summarizeTelemetryProps, {
+				const errorCode: SummarizeErrorCode = "submitSummaryFailure";
+				const retriableError =
+					summaryData.error ?? new RetriableSummaryError(getFailMessage(errorCode));
+				return fail(errorCode, retriableError, summarizeTelemetryProps, {
 					stage: summaryData.stage,
-					retryAfterSeconds: getRetryDelaySecondsFromError(summaryData.error),
 				});
 			}
 
@@ -395,14 +397,16 @@ export class SummaryGenerator {
 				cancellationToken,
 			);
 			if (waitBroadcastResult.result === "cancelled") {
-				return fail("disconnect");
+				const errorCode: SummarizeErrorCode = "disconnect";
+				return fail(errorCode, new RetriableSummaryError(getFailMessage(errorCode)));
 			}
 			if (waitBroadcastResult.result !== "done") {
 				// The summary op may not have been received within the timeout due to a transient error. So,
 				// fail with a retriable error to re-attempt the summary if possible.
+				const errorCode: SummarizeErrorCode = "summaryOpWaitTimeout";
 				return fail(
-					"summaryOpWaitTimeout",
-					new RetriableSummaryError("Summary op wait timeout", 0 /* retryAfterSeconds */),
+					errorCode,
+					new RetriableSummaryError(getFailMessage(errorCode), 0 /* retryAfterSeconds */),
 				);
 			}
 			const summarizeOp = waitBroadcastResult.value;
@@ -429,17 +433,16 @@ export class SummaryGenerator {
 				cancellationToken,
 			);
 			if (waitAckNackResult.result === "cancelled") {
-				return fail("disconnect");
+				const errorCode: SummarizeErrorCode = "disconnect";
+				return fail(errorCode, new RetriableSummaryError(getFailMessage(errorCode)));
 			}
 			if (waitAckNackResult.result !== "done") {
+				const errorCode: SummarizeErrorCode = "summaryAckWaitTimeout";
 				// The summary ack may not have been received within the timeout due to a transient error. So,
 				// fail with a retriable error to re-attempt the summary if possible.
 				return fail(
-					"summaryAckWaitTimeout",
-					new RetriableSummaryError(
-						"Summary ack wait timeout",
-						0 /* retryAfterSeconds */,
-					),
+					errorCode,
+					new RetriableSummaryError(getFailMessage(errorCode), 0 /* retryAfterSeconds */),
 				);
 			}
 			const ackNackOp = waitAckNackResult.value;
@@ -484,10 +487,16 @@ export class SummaryGenerator {
 				const errorMessage = summaryNack?.message;
 				const retryAfterSeconds = summaryNack?.retryAfter;
 
+				const errorCode: SummarizeErrorCode = "summaryNack";
+
 				// pre-0.58 error message prefix: summaryNack
-				const error = new RetriableSummaryError(`Received summaryNack`, retryAfterSeconds, {
-					errorMessage,
-				});
+				const error = new RetriableSummaryError(
+					getFailMessage(errorCode),
+					retryAfterSeconds,
+					{
+						errorMessage,
+					},
+				);
 
 				assert(
 					getRetryDelaySecondsFromError(error) === retryAfterSeconds,
@@ -495,11 +504,11 @@ export class SummaryGenerator {
 				);
 				// This will only set resultsBuilder.receivedSummaryAckOrNack, as other promises are already set.
 				return fail(
-					"summaryNack",
+					errorCode,
 					error,
 					{ ...summarizeTelemetryProps, nackRetryAfter: retryAfterSeconds },
 					undefined /* submitFailureResult */,
-					{ summaryNackOp: ackNackOp, ackNackDuration, retryAfterSeconds },
+					{ summaryNackOp: ackNackOp, ackNackDuration },
 				);
 			}
 		} finally {

--- a/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/runningSummarizer.spec.ts
@@ -633,7 +633,7 @@ describe("Runtime", () => {
 						expectedEvents.push({
 							eventName: "Running:SummarizeAttemptDelay",
 							...retryProps1,
-							duration: retryAfterSeconds,
+							duration: retryAfterSeconds ? retryAfterSeconds * 1000 : undefined,
 						});
 					}
 					mockLogger.assertMatch(

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -1555,29 +1555,16 @@ use_old_InterfaceDeclaration_IRefreshSummaryAckOptions(
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_IRetriableFailureResult": {"forwardCompat": false}
+ * "RemovedInterfaceDeclaration_IRetriableFailureResult": {"forwardCompat": false}
  */
-declare function get_old_InterfaceDeclaration_IRetriableFailureResult():
-    TypeOnly<old.IRetriableFailureResult>;
-declare function use_current_InterfaceDeclaration_IRetriableFailureResult(
-    use: TypeOnly<current.IRetriableFailureResult>): void;
-use_current_InterfaceDeclaration_IRetriableFailureResult(
-    // @ts-expect-error compatibility expected to be broken
-    get_old_InterfaceDeclaration_IRetriableFailureResult());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_IRetriableFailureResult": {"backCompat": false}
+ * "RemovedInterfaceDeclaration_IRetriableFailureResult": {"backCompat": false}
  */
-declare function get_current_InterfaceDeclaration_IRetriableFailureResult():
-    TypeOnly<current.IRetriableFailureResult>;
-declare function use_old_InterfaceDeclaration_IRetriableFailureResult(
-    use: TypeOnly<old.IRetriableFailureResult>): void;
-use_old_InterfaceDeclaration_IRetriableFailureResult(
-    get_current_InterfaceDeclaration_IRetriableFailureResult());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -1562,6 +1562,7 @@ declare function get_old_InterfaceDeclaration_IRetriableFailureResult():
 declare function use_current_InterfaceDeclaration_IRetriableFailureResult(
     use: TypeOnly<current.IRetriableFailureResult>): void;
 use_current_InterfaceDeclaration_IRetriableFailureResult(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IRetriableFailureResult());
 
 /*


### PR DESCRIPTION
The error thrown during summarization go through multiple layers - container runtime -> summary generator -> running summarizer. Currently, the error type is `Error` and it gets lost while is moves through these layers.

This change fixes this by improving the types of the summarizer errors through these layers. It does the following:
- Renames `IRetriableFailureResult` -> `IRetriableFailureResult` and uses it consistently as the error type throughtout all these layers.
- In SummaryGenerator / RunningSummarizer, ensures that all failures have an error associated with them.
- Removes the error from the failure results which was a duplicate of the error in the base result. 