### PR TITLE
Add performance events for test-service-load client election

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1774,6 +1774,9 @@ export class ContainerRuntime
 				orderedClientCollection,
 				electedSummarizerData ?? this.innerDeltaManager.lastSequenceNumber,
 				SummarizerClientElection.isClientEligible,
+				this.mc.config.getBoolean(
+					"Fluid.ContainerRuntime.OrderedClientElection.EnablePerformanceEvents",
+				),
 			);
 
 			this.summarizerClientElection = new SummarizerClientElection(

--- a/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
+++ b/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
@@ -543,7 +543,11 @@ export class OrderedClientElection
 					if (this._electedClient.client.details.type !== summarizerClientType) {
 						throw new UsageError("Elected client should be a summarizer client 1");
 					}
-					this.tryElectingClient(this._electedParent, sequenceNumber, "RemoveSummarizerClient");
+					this.tryElectingClient(
+						this._electedParent,
+						sequenceNumber,
+						"RemoveSummarizerClient",
+					);
 				} else {
 					// 2. The _electedClient is an interactive client that has left the quorum.
 					// Automatically shift to next oldest client.

--- a/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
+++ b/packages/runtime/container-runtime/src/summary/orderedClientElection.ts
@@ -543,7 +543,7 @@ export class OrderedClientElection
 					if (this._electedClient.client.details.type !== summarizerClientType) {
 						throw new UsageError("Elected client should be a summarizer client 1");
 					}
-					this.tryElectingClient(this._electedParent, sequenceNumber, "RemoveClient");
+					this.tryElectingClient(this._electedParent, sequenceNumber, "RemoveSummarizerClient");
 				} else {
 					// 2. The _electedClient is an interactive client that has left the quorum.
 					// Automatically shift to next oldest client.

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -305,6 +305,7 @@ export const globalConfigurations: Record<string, ConfigTypes> = {
 	"Fluid.SharedObject.DdsCallbacksTelemetrySampling": 10000,
 	"Fluid.SharedObject.OpProcessingTelemetrySampling": 10000,
 	"Fluid.Driver.ReadBlobTelemetrySampling": 100,
+	"Fluid.ContainerRuntime.OrderedClientElection.EnablePerformanceEvents": true,
 };
 
 /**


### PR DESCRIPTION
We are seeing weird gaps in summarizer in test-service-load runs. This PR adds optional performance events (only enabled in test-service-load) to track adding, removing, and electing clients.