### PR TITLE
benchmark-test(shared-tree): Implement read/write execution time benchmark

### DIFF
--- a/packages/dds/tree/src/test/simple-tree/benchmarkUtilities.ts
+++ b/packages/dds/tree/src/test/simple-tree/benchmarkUtilities.ts
@@ -1,0 +1,114 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+import {
+	SchemaFactory,
+	type NodeFromSchema,
+	type Unhydrated,
+	type ValidateRecursiveSchema,
+} from "../../simple-tree/index.js";
+import { hydrate } from "./utils.js";
+import { Tree } from "../../shared-tree/index.js";
+
+const schemaFactory = new SchemaFactory("test");
+
+/**
+ * A recursive tree node with a single leaf value
+ */
+export class DeepTreeNode extends schemaFactory.objectRecursive("deep-tree-node", {
+	node: [() => DeepTreeNode, schemaFactory.number],
+}) {}
+{
+	type _check = ValidateRecursiveSchema<typeof DeepTreeNode>;
+}
+
+/**
+ * A wide tree node with all leaves having the same value
+ */
+export const WideTreeNode = schemaFactory.array(schemaFactory.number);
+export type WideTreeNode = NodeFromSchema<typeof WideTreeNode>;
+
+/**
+ * Make an unhydrated deep tree with a single leaf value
+ */
+function makeDeepTree(depth: number, leafValue: number): Unhydrated<DeepTreeNode> {
+	return new DeepTreeNode({ node: depth === 1 ? leafValue : makeDeepTree(depth - 1, leafValue) });
+}
+
+/**
+ * generate a deep tree with a single leaf value
+ */
+export function generateDeepSimpleTree(depth: number, leafValue: number): DeepTreeNode {
+	assert(Number.isSafeInteger(depth));
+	assert(depth > 0);
+
+	return hydrate(DeepTreeNode, makeDeepTree(depth, leafValue));
+}
+
+/**
+ * read the deep tree and return the depth and value of the leaf node
+ */
+export function readDeepSimpleTree(tree: DeepTreeNode): {
+	depth: number;
+	value: number;
+} {
+	let currentNode: DeepTreeNode | number = tree;
+	let depth = 0;
+
+	while (Tree.is(currentNode, DeepTreeNode)) {
+		depth += 1;
+		currentNode = currentNode.node;
+	}
+
+	return { depth, value: currentNode };
+}
+
+/**
+ * Update the deep tree with a new leaf value deep in the tree
+ */
+export function writeDeepTree(tree: DeepTreeNode, newValue: number): void {
+	let currentNode: DeepTreeNode = tree;
+
+	while (Tree.is(currentNode.node, DeepTreeNode)) {
+		currentNode = currentNode.node;
+	}
+
+	currentNode.node = newValue;
+}
+
+/**
+ * generate a wide tree with a single layer
+ */
+export function generateWideSimpleTree(length: number, leafValue: number): WideTreeNode {
+	return hydrate(
+		WideTreeNode,
+		Array.from({ length }, () => leafValue),
+	);
+}
+
+/**
+ * Reads the whole wide tree and returns the width and the sum of all value in the leaf node.
+ */
+export function readWideSimpleTree(tree: WideTreeNode): {
+	nodesCount: number;
+	sum: number;
+} {
+	const nodesCount = tree.length;
+	const sum = tree.reduce((a, b) => a + b, 0);
+	return { nodesCount, sum };
+}
+
+/**
+ * Update the input index value for the wide tree.
+ */
+export function writeWideSimpleTreeNewValue(
+	tree: WideTreeNode,
+	newValue: number,
+	index: number,
+): void {
+	tree.insertAt(index, newValue);
+	tree.removeAt(index + 1);
+}

--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -177,8 +177,8 @@ describe("SimpleTree benchmarks", () => {
 					tree.moveToIndex(tree.length - 2, tree.length - 1);
 				},
 				after: () => {
-					const actual = tree[tree.length - 1];
-					assert.equal(actual, changedLeafValue);
+					if (!isInPerformanceTestingMode)
+						assert.equal(tree[tree.length - 1], changedLeafValue);
 				},
 			});
 		}

--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -1,0 +1,186 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { BenchmarkType, benchmark, isInPerformanceTestingMode } from "@fluid-tools/benchmark";
+import {
+	DeepTreeNode,
+	generateDeepSimpleTree,
+	generateWideSimpleTree,
+	readDeepSimpleTree,
+	readWideSimpleTree,
+	writeDeepTree,
+	writeWideSimpleTreeNewValue,
+	type WideTreeNode,
+} from "./benchmarkUtilities.js";
+
+// number of nodes in test for wide trees
+const nodesCountWide = [
+	[10, BenchmarkType.Measurement],
+	[100, BenchmarkType.Perspective],
+	[500, BenchmarkType.Measurement],
+];
+// number of nodes in test for deep trees
+const nodesCountDeep = [
+	[1, BenchmarkType.Measurement],
+	[10, BenchmarkType.Perspective],
+	[100, BenchmarkType.Measurement],
+];
+
+describe("SimpleTree benchmarks", () => {
+	describe("Read SimpleTree", () => {
+		const leafValue = 1;
+		for (const [numberOfNodes, benchmarkType] of nodesCountDeep) {
+			let tree: DeepTreeNode;
+			let actualDepth = 0;
+			let actualValue = 0;
+
+			benchmark({
+				type: benchmarkType,
+				title: `Deep Tree as SimpleTree: reads with ${numberOfNodes} nodes`,
+				before: () => {
+					// Setup
+					tree = generateDeepSimpleTree(numberOfNodes, leafValue);
+				},
+				benchmarkFn: () => {
+					const { depth, value } = readDeepSimpleTree(tree);
+					actualDepth = depth;
+					actualValue = value;
+				},
+				after() {
+					//  Assert read values
+					assert.equal(actualDepth, numberOfNodes);
+					assert.equal(actualValue, leafValue);
+				},
+			});
+		}
+		for (const [numberOfNodes, benchmarkType] of nodesCountWide) {
+			let tree: WideTreeNode;
+			const expected = numberOfNodes * leafValue;
+			let actualNodesCount = 0;
+			let actualSum = 0;
+			benchmark({
+				type: benchmarkType,
+				title: `Wide Tree as SimpleTree: reads with ${numberOfNodes} nodes`,
+				before: () => {
+					// Setup
+					tree = generateWideSimpleTree(numberOfNodes, leafValue);
+				},
+				benchmarkFn: () => {
+					const { nodesCount, sum } = readWideSimpleTree(tree);
+					actualNodesCount = nodesCount;
+					actualSum = sum;
+				},
+				after() {
+					assert.equal(actualNodesCount, numberOfNodes);
+					assert.equal(actualSum, expected);
+				},
+			});
+		}
+	});
+
+	describe(`Edit SimpleTree`, () => {
+		const leafValue = 1;
+		const changedLeafValue = -1;
+		for (const [numberOfNodes, benchmarkType] of nodesCountDeep) {
+			let tree: DeepTreeNode;
+			benchmark({
+				type: benchmarkType,
+				title: `Update value at leaf of ${numberOfNodes} deep tree`,
+				before: () => {
+					// Setup
+					tree = generateDeepSimpleTree(numberOfNodes, leafValue);
+				},
+				benchmarkFn: () => {
+					writeDeepTree(tree, changedLeafValue);
+				},
+				after: () => {
+					const expected = generateDeepSimpleTree(numberOfNodes, changedLeafValue);
+					assert.deepEqual(tree, expected);
+				},
+			});
+		}
+
+		for (const [numberOfNodes, benchmarkType] of nodesCountWide) {
+			let tree: WideTreeNode;
+			benchmark({
+				type: benchmarkType,
+				title: `Remove and insert end value at leaf of ${numberOfNodes} Wide tree`,
+				before: () => {
+					// Setup
+					tree = generateWideSimpleTree(numberOfNodes, leafValue);
+				},
+				benchmarkFn: () => {
+					writeWideSimpleTreeNewValue(tree, changedLeafValue, tree.length - 1);
+				},
+				after: () => {
+					const actual = tree[tree.length - 1];
+					assert.equal(actual, changedLeafValue);
+				},
+			});
+		}
+
+		for (const [numberOfNodes, benchmarkType] of nodesCountWide) {
+			let tree: WideTreeNode;
+			benchmark({
+				type: benchmarkType,
+				title: `Remove and insert first value at leaf of ${numberOfNodes} Wide tree`,
+				before: () => {
+					// Setup
+					tree = generateWideSimpleTree(numberOfNodes, leafValue);
+				},
+				benchmarkFn: () => {
+					writeWideSimpleTreeNewValue(tree, changedLeafValue, 0);
+				},
+				after: () => {
+					const actual = tree[0];
+					assert.equal(actual, changedLeafValue);
+				},
+			});
+		}
+
+		for (const [numberOfNodes, benchmarkType] of nodesCountWide) {
+			let tree: WideTreeNode;
+			benchmark({
+				type: benchmarkType,
+				title: `Move second leaf to begining of ${numberOfNodes} Wide tree`,
+				before: () => {
+					// Setup
+					tree = generateWideSimpleTree(numberOfNodes, leafValue);
+					writeWideSimpleTreeNewValue(tree, changedLeafValue, 1);
+				},
+				benchmarkFn: () => {
+					tree.moveToIndex(0, 1);
+				},
+				after: () => {
+					// Even number of iterations cancel out, so this validation only works after odd numbers of iterations.
+					// Correctness mode always does a single iteration, so just validate that case.
+					if (!isInPerformanceTestingMode) assert.equal(tree[0], changedLeafValue);
+				},
+			});
+		}
+
+		for (const [numberOfNodes, benchmarkType] of nodesCountWide) {
+			let tree: WideTreeNode;
+			benchmark({
+				type: benchmarkType,
+				title: `Move next-to-last leaf to end of ${numberOfNodes} Wide tree`,
+				before: () => {
+					// Setup
+					tree = generateWideSimpleTree(numberOfNodes, leafValue);
+					writeWideSimpleTreeNewValue(tree, changedLeafValue, tree.length - 2);
+				},
+				benchmarkFn: () => {
+					tree.moveToIndex(tree.length - 2, tree.length - 1);
+				},
+				after: () => {
+					const actual = tree[tree.length - 1];
+					assert.equal(actual, changedLeafValue);
+				},
+			});
+		}
+	});
+});


### PR DESCRIPTION
## Description

> We want to have execution time benchmark tests for read and write speed on the simple-tree layer (for now) of SharedTree. Look at packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts for inspiration. That file covers some of the scenarios that we want to benchmark.

## Sample
~~~
  SimpleTree benchmarks
spec.js:54
    Direct SimpleTree
spec.js:54
      ✔ @Benchmark @Measurement @ExecutionTime Deep Tree as SimpleTree: reads with 1 nodes
spec.js:76
      ✔ @Benchmark @Perspective @ExecutionTime Deep Tree as SimpleTree: reads with 10 nodes
spec.js:76
      ✔ @Benchmark @Measurement @ExecutionTime Deep Tree as SimpleTree: reads with 100 nodes
spec.js:76
      ✔ @Benchmark @Measurement @ExecutionTime Wide Tree as SimpleTree: reads with 1 nodes
spec.js:76
      ✔ @Benchmark @Perspective @ExecutionTime Wide Tree as SimpleTree: reads with 100 nodes
spec.js:76
      ✔ @Benchmark @Measurement @ExecutionTime Wide Tree as SimpleTree: reads with 500 nodes
spec.js:76
      Edit SimpleTree
spec.js:54
        ✔ @Benchmark @Measurement @ExecutionTime Update value at leaf of 1 deep tree
spec.js:76
        ✔ @Benchmark @Perspective @ExecutionTime Update value at leaf of 10 deep tree
spec.js:76
        ✔ @Benchmark @Measurement @ExecutionTime Update value at leaf of 100 deep tree
spec.js:76
        ✔ @Benchmark @Measurement @ExecutionTime Update value at leaf of 1 Wide tree
spec.js:76
        ✔ @Benchmark @Perspective @ExecutionTime Update value at leaf of 100 Wide tree
spec.js:76
        ✔ @Benchmark @Measurement @ExecutionTime Update value at leaf of 500 Wide tree
spec.js:76
  12 passing (150ms)
~~~

~~~
SimpleTree benchmarks Read SimpleTree
Results file: /home/tong/workspace/FluidFramework/node_modules/.pnpm/@fluid-tools+benchmark@0.48.0/node_modules/@fluid-tools/benchmark/dist/.output/SimpleTree_benchmarks_Read_SimpleTree_perfresult.json
status  name                                           period (ns/op)  relative margin of error  iterations per batch  batch count  total time (s)
------  ---------------------------------------------  --------------  ------------------------  --------------------  -----------  --------------
    ✔   Deep Tree as SimpleTree: reads with 1 nodes          3,842.93                    ±9.83%                16,384           80            5.11
    ✔   Deep Tree as SimpleTree: reads with 10 nodes        92,774.94                   ±18.97%                 1,024           53            5.12
    ✔   Deep Tree as SimpleTree: reads with 100 nodes    2,106,151.86                    ±4.65%                    32           74            5.07
    ✔   Wide Tree as SimpleTree: reads with 1 nodes         29,892.08                   ±16.84%                 4,096           40            5.01
    ✔   Wide Tree as SimpleTree: reads with 100 nodes      885,287.25                   ±16.88%                    64           87            5.01
    ✔   Wide Tree as SimpleTree: reads with 500 nodes    3,800,340.77                    ±7.98%                    16           81            5.00
 
 
SimpleTree benchmarks Edit SimpleTree
Results file: /home/tong/workspace/FluidFramework/node_modules/.pnpm/@fluid-tools+benchmark@0.48.0/node_modules/@fluid-tools/benchmark/dist/.output/SimpleTree_benchmarks_Edit_SimpleTree_perfresult.json
status  name                                   period (ns/op)  relative margin of error  iterations per batch  batch count  total time (s)
------  -------------------------------------  --------------  ------------------------  --------------------  -----------  --------------
    ✔   Update value at leaf of 1 deep tree         48,345.98                    ±5.36%                   512          199            5.01
    ✔   Update value at leaf of 10 deep tree       167,054.64                    ±5.29%                   256          115            5.02
    ✔   Update value at leaf of 100 deep tree    2,462,559.79                    ±6.66%                    32           63            5.09
    ✔   Update value at leaf of 1 Wide tree        125,448.51                    ±4.68%                   256          153            5.02
    ✔   Update value at leaf of 100 Wide tree      122,261.31                    ±4.46%                   256          157            5.02
    ✔   Update value at leaf of 500 Wide tree      136,890.41                    ±5.31%                   256          140            5.01
~~~

## Compare

~~~
SharedTree benchmarks FlexTree bench
Results file: /home/tong/workspace/FluidFramework/node_modules/.pnpm/@fluid-tools+benchmark@0.48.0/node_modules/@fluid-tools/benchmark/dist/.output/SharedTree_benchmarks_FlexTree_bench_perfresult.json
status  name                                            period (ns/op)  relative margin of error  iterations per batch  batch count  total time (s)
------  ----------------------------------------------  --------------  ------------------------  --------------------  -----------  --------------
    ✔   Deep Tree with Flex Tree: reads with 1 nodes            613.67                    ±0.99%               131,072           13            1.15
    ✔   Deep Tree with Flex Tree: reads with 10 nodes         4,713.16                    ±0.97%                16,384           32            2.57
    ✔   Deep Tree with Flex Tree: reads with 100 nodes      199,981.85                    ±0.97%                   256           11            0.63
    ✔   Wide Tree with Flex Tree: reads with 1 nodes          4,098.05                    ±8.55%                16,384           74            5.05
    ✔   Wide Tree with Flex Tree: reads with 100 nodes        8,127.00                    ±5.20%                 8,192           74            5.01
    ✔   Wide Tree with Flex Tree: reads with 500 nodes       24,592.14                    ±1.66%                 2,048           98            5.01
 
 
SharedTree benchmarks Edit with editor
Results file: /home/tong/workspace/FluidFramework/node_modules/.pnpm/@fluid-tools+benchmark@0.48.0/node_modules/@fluid-tools/benchmark/dist/.output/SharedTree_benchmarks_Edit_with_editor_perfresult.json
status  name                                             period (ns/op)  relative margin of error  iterations per batch  batch count  total time (s)
------  -----------------------------------------------  --------------  ------------------------  --------------------  -----------  --------------
    ✔   Update value at leaf of 1 deep tree 100 times      3,201,278.34                    ±1.96%                     1          779            5.00
    ✔   Update value at leaf of 10 deep tree 100 times     6,223,620.41                    ±1.95%                     1          514            5.00
    ✔   Update value at leaf of 100 deep tree 100 times   55,436,297.43                    ±3.72%                     1           83            5.05
    ✔   Update value at leaf of 1 wide tree 100 times      5,090,486.90                    ±2.52%                     1          585            5.01
    ✔   Update value at leaf of 100 wide tree 100 times    5,538,222.80                    ±2.52%                     1          547            5.00
    ✔   Update value at leaf of 500 wide tree 100 times    5,526,472.70                    ±2.62%                     1          521            5.01
~~~