### PR TITLE
Better telemetry for disconnect events: record pendingClientId

### DIFF
--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -660,9 +660,6 @@ class ConnectionStateHandler implements IConnectionStateHandler {
 			}
 			this._clientId = this.pendingClientId;
 		} else if (value === ConnectionState.Disconnected) {
-			// Clear pending state immediately to prepare for reconnect
-			this._pendingClientId = undefined;
-
 			if (this.joinTimer.hasTimer) {
 				this.stopjoinTimer();
 			}
@@ -691,8 +688,15 @@ class ConnectionStateHandler implements IConnectionStateHandler {
 			}
 		}
 
-		// Report transition before we propagate event across layers
+		// Report transition
 		this.handler.connectionStateChanged(this._connectionState, oldState, reason);
+
+		// Clear pending state immediately to prepare for reconnect
+		// Do it after calling connectionStateChanged() above, such that our telemetry contains pendingClientId on disconnect events
+		// and we can pair attempts to connect with disconnects (that's the only ID we have if connection did not move far enough before being disconnected)
+		if (value === ConnectionState.Disconnected) {
+			this._pendingClientId = undefined;
+		}
 	}
 
 	protected get membership(): IMembership | undefined {


### PR DESCRIPTION
When connection does not move far enough (does not get to "Connected" state), we do not have good mechanism to pair "establishing connection" events with "disconnect" events (unless complex join queries are involved), as clientId can't be used for such pairing. We need pendingClientId for that, but it's reset on disconnect before telemetry event fires.

This change moves the time when we reset it, such that it gets into telemetry.