### PR TITLE
fix(tree): throw UsageError on invalid move

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { ICodecFamily } from "../../codec/index.js";
 import {
@@ -266,11 +266,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 					if (attachAncestorIndex < sourceIndex) {
 						// The attach path runs through a node located before the detached nodes.
 						// No need to adjust the attach path.
-					} else {
-						assert(
-							sourceIndex + count <= attachAncestorIndex,
-							0x801 /* Invalid move: the destination is below one of the moved elements. */,
-						);
+					} else if (sourceIndex + count <= attachAncestorIndex) {
 						// The attach path runs through a node located after the detached nodes.
 						// adjust the index for the node at that depth of the path, so that it is interpreted correctly
 						// in the composition performed by `submitChanges`.
@@ -288,6 +284,10 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 							};
 						}
 						adjustedAttachField = { parent, field: destinationField.field };
+					} else {
+						throw new UsageError(
+							"Invalid move operation: the destination is located under one of the moved elements.",
+						);
 					}
 				}
 			}

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -286,7 +286,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 						adjustedAttachField = { parent, field: destinationField.field };
 					} else {
 						throw new UsageError(
-							"Invalid move operation: the destination is located under one of the moved elements.",
+							"Invalid move operation: the destination is located under one of the moved elements. Consider using the Tree.contains API to detect this.",
 						);
 					}
 				}

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 
 import { unreachableCase } from "@fluidframework/core-utils/internal";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
 	AnchorNode,
@@ -33,6 +32,7 @@ import {
 	insert,
 	makeTreeFromJson,
 	remove,
+	validateUsageError,
 } from "../utils.js";
 
 const rootField: FieldUpPath = {
@@ -1765,7 +1765,9 @@ describe("Editing", () => {
 						{ parent: fooPath, field: brand("bar") },
 						0,
 					),
-				/Invalid move operation: the destination is located under one of the moved elements./,
+				validateUsageError(
+					/Invalid move operation: the destination is located under one of the moved elements/,
+				),
 			);
 		});
 

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -6,6 +6,7 @@
 import { strict as assert } from "assert";
 
 import { unreachableCase } from "@fluidframework/core-utils/internal";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
 	AnchorNode,
@@ -1755,14 +1756,16 @@ describe("Editing", () => {
 				parentField: brand("foo"),
 				parentIndex: 0,
 			};
-			assert.throws(() =>
-				tree.editor.move(
-					{ parent: rootNode, field: brand("foo") },
-					0,
-					1,
-					{ parent: fooPath, field: brand("bar") },
-					0,
-				),
+			assert.throws(
+				() =>
+					tree.editor.move(
+						{ parent: rootNode, field: brand("foo") },
+						0,
+						1,
+						{ parent: fooPath, field: brand("bar") },
+						0,
+					),
+				/Invalid move operation: the destination is located under one of the moved elements./,
 			);
 		});
 

--- a/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
@@ -5,10 +5,11 @@
 
 import { strict as assert } from "assert";
 import { SchemaFactory } from "../../simple-tree/index.js";
-import { hydrate, validateUsageError } from "./utils.js";
+import { hydrate } from "./utils.js";
 import { Mutable } from "../../util/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { asIndex } from "../../simple-tree/arrayNode.js";
+import { validateUsageError } from "../utils.js";
 
 const schemaFactory = new SchemaFactory("ArrayNodeTest");
 const PojoEmulationNumberArray = schemaFactory.array(schemaFactory.number);

--- a/packages/dds/tree/src/test/simple-tree/types.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/types.spec.ts
@@ -17,7 +17,7 @@ import { RawTreeNode } from "../../simple-tree/rawNode.js";
 import { numberSchema } from "../../simple-tree/leafNodeSchema.js";
 // eslint-disable-next-line import/no-internal-modules
 import { getFlexSchema } from "../../simple-tree/toFlexSchema.js";
-import { validateUsageError } from "./utils.js";
+import { validateUsageError } from "../utils.js";
 
 describe("simple-tree types", () => {
 	describe("TreeNode", () => {

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -3,9 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "node:assert";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
-
 import { NodeKeyManager, createMockNodeKeyManager } from "../../feature-libraries/index.js";
 import {
 	ImplicitFieldSchema,
@@ -45,20 +42,4 @@ export function pretty(arg: unknown): number | string {
 		return arg;
 	}
 	return JSON.stringify(arg);
-}
-
-export function validateUsageError(expectedErrorMsg: string | RegExp): (error: Error) => true {
-	return (error: Error) => {
-		assert(error instanceof UsageError);
-		if (
-			typeof expectedErrorMsg === "string"
-				? error.message !== expectedErrorMsg
-				: !expectedErrorMsg.test(error.message)
-		) {
-			throw new Error(
-				`Unexpected assertion thrown\nActual: ${error.message}\nExpected: ${expectedErrorMsg}`,
-			);
-		}
-		return true;
-	};
 }

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
+import { strict as assert } from "node:assert";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { makeRandom } from "@fluid-private/stochastic-test-utils";
 import { LocalServerTestDriver } from "@fluid-private/test-drivers";
@@ -1241,4 +1242,20 @@ export class MockTreeCheckout implements ITreeCheckout {
 	public locate(anchor: Anchor): AnchorNode | undefined {
 		throw new Error("Method 'locate' not implemented in MockTreeCheckout.");
 	}
+}
+
+export function validateUsageError(expectedErrorMsg: string | RegExp): (error: Error) => true {
+	return (error: Error) => {
+		assert(error instanceof UsageError);
+		if (
+			typeof expectedErrorMsg === "string"
+				? error.message !== expectedErrorMsg
+				: !expectedErrorMsg.test(error.message)
+		) {
+			throw new Error(
+				`Unexpected assertion thrown\nActual: ${error.message}\nExpected: ${expectedErrorMsg}`,
+			);
+		}
+		return true;
+	};
 }


### PR DESCRIPTION
## Description

Change an assert into a throw of a UsageError with a clear error message. This improves the user experience for ST users since an error message is clearer an assert hex code.

## Breaking Changes

None