### PR TITLE
Respect the odspEndpoint argument if supplied in e2e tests.

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -41,6 +41,7 @@
 		"test:realsvc:local:report": "npm run test:realsvc:local --",
 		"test:realsvc:local:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:local --",
 		"test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",
+		"test:realsvc:odsp-df": "npm run test:realsvc:run -- --driver=odsp --odspEndpointName=odsp-df --timeout=20s",
 		"test:realsvc:odsp:report": "npm run test:realsvc:odsp --",
 		"test:realsvc:r11s": "npm run test:realsvc:run -- --driver=r11s --timeout=20s",
 		"test:realsvc:r11s:docker": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=docker --timeout=20s",

--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -21,6 +21,7 @@ import {
 	r11sEndpointName,
 	tenantIndex,
 	reinstall,
+	odspEndpointName,
 } from "./compatOptions.js";
 import { pkgVersion } from "./packageVersion.js";
 import { ensurePackageInstalled } from "./testApi.js";
@@ -317,6 +318,7 @@ export const configList = new Lazy<readonly CompatConfig[]>(() => {
 	}
 	process.env.fluid__test__driver = driver;
 	process.env.fluid__test__r11sEndpointName = r11sEndpointName;
+	process.env.fluid__test__odspEndpointName = odspEndpointName;
 	process.env.fluid__test__tenantIndex = tenantIndex.toString();
 	process.env.fluid__test__baseVersion = baseVersion;
 

--- a/packages/test/test-version-utils/src/compatOptions.ts
+++ b/packages/test/test-version-utils/src/compatOptions.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+	OdspEndpoint,
 	RouterliciousEndpoint,
 	TestDriverTypes,
 } from "@fluid-internal/test-driver-definitions";
@@ -74,6 +75,9 @@ const options = {
 	r11sEndpointName: {
 		type: "string",
 	},
+	odspEndpointName: {
+		type: "string",
+	},
 	tenantIndex: {
 		type: "number",
 	},
@@ -100,6 +104,7 @@ nconf
 			"fluid__test__backCompat",
 			"fluid__test__driver",
 			"fluid__test__r11sEndpointName",
+			"fluid__test__odspEndpointName",
 			"fluid__test__baseVersion",
 		],
 		transform: (obj: { key: string; value: string }) => {
@@ -148,6 +153,10 @@ export const compatVersions = nconf.get("fluid:test:compatVersion") as string[] 
  * @internal
  */
 export const driver = nconf.get("fluid:test:driver") as TestDriverTypes;
+/**
+ * @internal
+ */
+export const odspEndpointName = nconf.get("fluid:test:odspEndpointName") as OdspEndpoint;
 /**
  * @internal
  */

--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -17,7 +17,13 @@ import {
 	isCompatVersionBelowMinVersion,
 	mochaGlobalSetup,
 } from "./compatConfig.js";
-import { CompatKind, driver, r11sEndpointName, tenantIndex } from "./compatOptions.js";
+import {
+	CompatKind,
+	driver,
+	odspEndpointName,
+	r11sEndpointName,
+	tenantIndex,
+} from "./compatOptions.js";
 import {
 	getVersionedTestObjectProviderFromApis,
 	getCompatVersionedTestObjectProviderFromApis,
@@ -70,14 +76,14 @@ function createCompatSuite(
 										type: driver,
 										config: {
 											r11s: { r11sEndpointName },
-											odsp: { tenantIndex },
+											odsp: { tenantIndex, odspEndpointName },
 										},
 								  })
 								: await getVersionedTestObjectProviderFromApis(apis, {
 										type: driver,
 										config: {
 											r11s: { r11sEndpointName },
-											odsp: { tenantIndex },
+											odsp: { tenantIndex, odspEndpointName },
 										},
 								  });
 					} catch (error) {

--- a/packages/test/test-version-utils/src/describeE2eDocs.ts
+++ b/packages/test/test-version-utils/src/describeE2eDocs.ts
@@ -15,7 +15,13 @@ import {
 
 import { testBaseVersion } from "./baseVersion.js";
 import { configList } from "./compatConfig.js";
-import { CompatKind, driver, r11sEndpointName, tenantIndex } from "./compatOptions.js";
+import {
+	CompatKind,
+	driver,
+	odspEndpointName,
+	r11sEndpointName,
+	tenantIndex,
+} from "./compatOptions.js";
 import { getVersionedTestObjectProviderFromApis } from "./compatUtils.js";
 import { ITestObjectProviderOptions } from "./describeCompat.js";
 import {
@@ -372,7 +378,7 @@ function createE2EDocCompatSuite(
 								type: driver,
 								config: {
 									r11s: { r11sEndpointName },
-									odsp: { tenantIndex },
+									odsp: { tenantIndex, odspEndpointName },
 								},
 							});
 						} catch (error) {

--- a/packages/test/test-version-utils/src/describeWithVersions.ts
+++ b/packages/test/test-version-utils/src/describeWithVersions.ts
@@ -9,7 +9,7 @@ import {
 	TestObjectProvider,
 } from "@fluidframework/test-utils/internal";
 
-import { driver, r11sEndpointName, tenantIndex } from "./compatOptions.js";
+import { driver, odspEndpointName, r11sEndpointName, tenantIndex } from "./compatOptions.js";
 import { getVersionedTestObjectProvider } from "./compatUtils.js";
 import { ITestObjectProviderOptions } from "./describeCompat.js";
 import { pkgVersion } from "./packageVersion.js";
@@ -88,7 +88,7 @@ function createTestSuiteWithInstalledVersion(
 					version: pkgVersion,
 					config: {
 						r11s: { r11sEndpointName },
-						odsp: { tenantIndex },
+						odsp: { tenantIndex, odspEndpointName },
 					},
 				}, // driverConfig
 				pkgVersion, // runtimeVersion


### PR DESCRIPTION
## Description

E2E test does not respect the odspEndpointName argument is supplied. If not supplied, they run against odsp PROD. Fix it to respect the argument. 