### PR TITLE
[rc2] Use public client auth for odsp e2e flows (#21091)

### DIFF
--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
@@ -22,7 +22,6 @@ export interface IOdspLoginCredentials {
  */
 export interface IOdspCredentials extends IOdspLoginCredentials {
 	clientId: string;
-	clientSecret: string;
 }
 
 /**
@@ -37,7 +36,6 @@ export function createOdspClient(
 	const siteUrl = process.env.odsp__client__siteUrl as string;
 	const driveId = process.env.odsp__client__driveId as string;
 	const clientId = process.env.odsp__client__clientId as string;
-	const clientSecret = process.env.odsp__client__clientSecret as string;
 	if (siteUrl === "" || siteUrl === undefined) {
 		throw new Error("site url is missing");
 	}
@@ -49,17 +47,12 @@ export function createOdspClient(
 		throw new Error("client id is missing");
 	}
 
-	if (clientSecret === "" || clientSecret === undefined) {
-		throw new Error("client secret is missing");
-	}
-
 	if (creds.username === undefined || creds.password === undefined) {
 		throw new Error("username or password is missing for login account");
 	}
 
 	const credentials: IOdspCredentials = {
 		clientId,
-		clientSecret,
 		...creds,
 	};
 

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspTokenFactory.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspTokenFactory.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { TokenResponse } from "@fluidframework/odsp-driver-definitions";
 import {
-	IClientConfig,
+	IPublicClientConfig,
 	TokenRequestCredentials,
 	getFetchTokenUrl,
 	unauthPostAsync,
@@ -50,9 +50,8 @@ export class OdspTestTokenProvider implements IOdspTokenProvider {
 		refreshToken: string;
 	}> {
 		const server = new URL(siteUrl).host;
-		const clientConfig: IClientConfig = {
+		const clientConfig: IPublicClientConfig = {
 			clientId: this.creds.clientId,
-			clientSecret: this.creds.clientSecret,
 		};
 		const credentials: TokenRequestCredentials = {
 			grant_type: "password",
@@ -62,7 +61,6 @@ export class OdspTestTokenProvider implements IOdspTokenProvider {
 		const body = {
 			scope,
 			client_id: clientConfig.clientId,
-			client_secret: clientConfig.clientSecret,
 			...credentials,
 		};
 		const response = await unauthPostAsync(getFetchTokenUrl(server), new URLSearchParams(body));

--- a/packages/service-clients/odsp-client/src/test/odspClient.spec.ts
+++ b/packages/service-clients/odsp-client/src/test/odspClient.spec.ts
@@ -18,7 +18,6 @@ import { OdspTestTokenProvider } from "./odspTestTokenProvider.js";
  */
 export interface OdspTestCredentials {
 	clientId: string;
-	clientSecret: string;
 	username: string;
 	password: string;
 }
@@ -28,7 +27,6 @@ export interface OdspTestCredentials {
  */
 const clientCreds: OdspTestCredentials = {
 	clientId: "<client_id>",
-	clientSecret: "<client_secret>",
 	username: "<email_id>",
 	password: "<password>",
 };

--- a/packages/service-clients/odsp-client/src/test/odspTestTokenProvider.ts
+++ b/packages/service-clients/odsp-client/src/test/odspTestTokenProvider.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/core-utils";
 import { TokenResponse } from "@fluidframework/odsp-driver-definitions";
 import {
-	IClientConfig,
+	IPublicClientConfig,
 	TokenRequestCredentials,
 	getFetchTokenUrl,
 	unauthPostAsync,
@@ -50,9 +50,8 @@ export class OdspTestTokenProvider implements IOdspTokenProvider {
 		refreshToken?: string;
 	}> {
 		const server = new URL(siteUrl).host;
-		const clientConfig: IClientConfig = {
+		const clientConfig: IPublicClientConfig = {
 			clientId: this.creds.clientId,
-			clientSecret: this.creds.clientSecret,
 		};
 		const credentials: TokenRequestCredentials = {
 			grant_type: "password",
@@ -62,7 +61,6 @@ export class OdspTestTokenProvider implements IOdspTokenProvider {
 		const body = {
 			scope,
 			client_id: clientConfig.clientId,
-			client_secret: clientConfig.clientSecret,
 			...credentials,
 		};
 		const response = await unauthPostAsync(getFetchTokenUrl(server), new URLSearchParams(body));

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -21,7 +21,7 @@ import {
 import {
 	getDriveId,
 	getDriveItemByRootFileName,
-	IClientConfig,
+	IPublicClientConfig,
 } from "@fluidframework/odsp-doclib-utils/internal";
 import { ITestDriver, OdspEndpoint } from "@fluidframework/test-driver-definitions";
 import { OdspDriverApiType, OdspDriverApi } from "./odspDriverApi";
@@ -39,7 +39,7 @@ interface IOdspTestLoginInfo {
 	supportsBrowserAuth?: boolean;
 }
 
-type TokenConfig = IOdspTestLoginInfo & IClientConfig;
+type TokenConfig = IOdspTestLoginInfo & IPublicClientConfig;
 
 interface IOdspTestDriverConfig extends TokenConfig {
 	directory: string;
@@ -263,7 +263,7 @@ export class OdspTestDriver implements ITestDriver {
 
 	private static async getStorageToken(
 		options: OdspResourceTokenFetchOptions & { useBrowserAuth?: boolean },
-		config: IOdspTestLoginInfo & IClientConfig,
+		config: IOdspTestLoginInfo & IPublicClientConfig,
 	) {
 		const host = new URL(options.siteUrl).host;
 

--- a/packages/test/test-service-load/runLoadTestOnAks.ps1
+++ b/packages/test/test-service-load/runLoadTestOnAks.ps1
@@ -57,7 +57,6 @@ function CreateInfra {
         FLUID_TEST_UID="$TestUid" `
         TEST_PROFILE="$TestProfile" `
         login__microsoft__clientId="$env:ClientId" `
-        login__microsoft__secret="$env:ClientSecret" `
         APPINSIGHTS_INSTRUMENTATIONKEY="$env:InstrumentationKey" `
         BUILD_BUILD_ID="$TestDocFolder"
 

--- a/packages/tools/fetch-tool/README.md
+++ b/packages/tools/fetch-tool/README.md
@@ -1,7 +1,7 @@
 # @fluid-tools/fetch-tool
 
 Connection using ODSP or routerlicious driver to dump the messages or snapshot information on the server.
-In order to connect to ODSP, the clientID and clientSecret must be set as environment variables `login__microsoft__clientId` and `login__microsoft__secret`, respectively. If you have access to the keyvault this can be done by running [this tool](../../../tools/getkeys).
+In order to connect to ODSP, the clientID must be set as the environment variable `login__microsoft__clientId`. If you have access to the keyvault this can be done by running [this tool](../../../tools/getkeys).
 Beware that to use fetch-tool on documents in the Microsoft tenant, you will need to follow the fetch tool usage instructions on the "Debugging Tools" page of the internal Fluid wiki.
 
 ## Usage

--- a/packages/tools/fetch-tool/src/fluidFetchInit.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchInit.ts
@@ -5,7 +5,10 @@
 
 import { IRequest } from "@fluidframework/core-interfaces";
 import { IResolvedUrl } from "@fluidframework/driver-definitions";
-import { IClientConfig, IOdspAuthRequestInfo } from "@fluidframework/odsp-doclib-utils/internal";
+import {
+	IPublicClientConfig,
+	IOdspAuthRequestInfo,
+} from "@fluidframework/odsp-doclib-utils/internal";
 import * as odsp from "@fluidframework/odsp-driver";
 import {
 	IOdspResolvedUrl,
@@ -24,7 +27,7 @@ export let connectionInfo: any;
 async function initializeODSPCore(
 	odspResolvedUrl: IOdspResolvedUrl,
 	server: string,
-	clientConfig: IClientConfig,
+	clientConfig: IPublicClientConfig,
 ) {
 	const { driveId, itemId } = odspResolvedUrl;
 

--- a/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
@@ -9,7 +9,7 @@ import {
 	getChildrenByDriveItem,
 	getDriveItemByServerRelativePath,
 	getDriveItemFromDriveAndItem,
-	IClientConfig,
+	IPublicClientConfig,
 	IOdspDriveItem,
 	getOdspRefreshTokenFn,
 	IOdspAuthRequestInfo,
@@ -26,7 +26,7 @@ import { getForceTokenReauth } from "./fluidFetchArgs";
 export async function resolveWrapper<T>(
 	callback: (authRequestInfo: IOdspAuthRequestInfo) => Promise<T>,
 	server: string,
-	clientConfig: IClientConfig,
+	clientConfig: IPublicClientConfig,
 	forceTokenReauth = false,
 	forToken = false,
 ): Promise<T> {
@@ -70,7 +70,7 @@ export async function resolveWrapper<T>(
 async function resolveDriveItemByServerRelativePath(
 	server: string,
 	serverRelativePath: string,
-	clientConfig: IClientConfig,
+	clientConfig: IPublicClientConfig,
 ) {
 	return resolveWrapper<IOdspDriveItem>(
 		// eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -84,7 +84,7 @@ async function resolveDriveItemByServerRelativePath(
 async function resolveChildrenByDriveItem(
 	server: string,
 	folderDriveItem: IOdspDriveItem,
-	clientConfig: IClientConfig,
+	clientConfig: IPublicClientConfig,
 ) {
 	return resolveWrapper<IOdspDriveItem[]>(
 		// eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/packages/utils/odsp-doclib-utils/api-report/odsp-doclib-utils.api.md
+++ b/packages/utils/odsp-doclib-utils/api-report/odsp-doclib-utils.api.md
@@ -24,7 +24,7 @@ export function enrichOdspError(error: IFluidErrorBase & OdspError, response?: R
 export const fetchIncorrectResponse = 712;
 
 // @internal
-export function fetchTokens(server: string, scope: string, clientConfig: IClientConfig, credentials: TokenRequestCredentials): Promise<IOdspTokens>;
+export function fetchTokens(server: string, scope: string, clientConfig: IPublicClientConfig, credentials: TokenRequestCredentials): Promise<IOdspTokens>;
 
 // @internal (undocumented)
 export function getAadTenant(server: string): string;
@@ -54,19 +54,19 @@ export function getDriveItemFromDriveAndItem(server: string, drive: string, item
 export function getFetchTokenUrl(server: string): string;
 
 // @internal (undocumented)
-export function getLoginPageUrl(server: string, clientConfig: IClientConfig, scope: string, odspAuthRedirectUri: string): string;
+export function getLoginPageUrl(server: string, clientConfig: IPublicClientConfig, scope: string, odspAuthRedirectUri: string): string;
 
 // @internal (undocumented)
-export const getOdspRefreshTokenFn: (server: string, clientConfig: IClientConfig, tokens: IOdspTokens) => () => Promise<string>;
+export const getOdspRefreshTokenFn: (server: string, clientConfig: IPublicClientConfig, tokens: IOdspTokens) => () => Promise<string>;
 
 // @alpha (undocumented)
 export const getOdspScope: (server: string) => string;
 
 // @internal (undocumented)
-export const getPushRefreshTokenFn: (server: string, clientConfig: IClientConfig, tokens: IOdspTokens) => () => Promise<string>;
+export const getPushRefreshTokenFn: (server: string, clientConfig: IPublicClientConfig, tokens: IOdspTokens) => () => Promise<string>;
 
 // @internal (undocumented)
-export const getRefreshTokenFn: (scope: string, server: string, clientConfig: IClientConfig, tokens: IOdspTokens) => () => Promise<string>;
+export const getRefreshTokenFn: (scope: string, server: string, clientConfig: IPublicClientConfig, tokens: IOdspTokens) => () => Promise<string>;
 
 // @internal (undocumented)
 export function getServer(tenantId: string): string;
@@ -81,14 +81,6 @@ export function getSPOAndGraphRequestIdsFromResponse(headers: {
 
 // @internal (undocumented)
 export function hasFacetCodes(x: any): x is Pick<IOdspErrorAugmentations, "facetCodes">;
-
-// @internal (undocumented)
-export interface IClientConfig {
-    // (undocumented)
-    clientId: string;
-    // (undocumented)
-    clientSecret: string;
-}
 
 // @alpha (undocumented)
 export interface IOdspAuthRequestInfo {
@@ -118,6 +110,12 @@ export interface IOdspTokens {
     readonly accessToken: string;
     // (undocumented)
     readonly refreshToken: string;
+}
+
+// @internal
+export interface IPublicClientConfig {
+    // (undocumented)
+    clientId: string;
 }
 
 // @internal (undocumented)
@@ -169,7 +167,7 @@ export const pushScope = "offline_access https://pushchannel.1drv.ms/PushChannel
 export function putAsync(url: string, authRequestInfo: IOdspAuthRequestInfo): Promise<Response>;
 
 // @internal
-export function refreshTokens(server: string, scope: string, clientConfig: IClientConfig, tokens: IOdspTokens): Promise<IOdspTokens>;
+export function refreshTokens(server: string, scope: string, clientConfig: IPublicClientConfig, tokens: IOdspTokens): Promise<IOdspTokens>;
 
 // @internal
 export function throwOdspNetworkError(errorMessage: string, statusCode: number, response: Response, responseText?: string, props?: ITelemetryBaseProperties): never;

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -146,6 +146,11 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedInterfaceDeclaration_IClientConfig": {
+				"backCompat": false,
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/utils/odsp-doclib-utils/src/index.ts
+++ b/packages/utils/odsp-doclib-utils/src/index.ts
@@ -12,7 +12,7 @@ export {
 	getOdspScope,
 	getPushRefreshTokenFn,
 	getRefreshTokenFn,
-	IClientConfig,
+	IPublicClientConfig,
 	IOdspAuthRequestInfo,
 	IOdspTokens,
 	pushScope,

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -18,11 +18,11 @@ export interface IOdspTokens {
 }
 
 /**
+ * Configuration for a public client.
  * @internal
  */
-export interface IClientConfig {
+export interface IPublicClientConfig {
 	clientId: string;
-	clientSecret: string;
 }
 
 /**
@@ -54,7 +54,6 @@ export type TokenRequestCredentials =
 
 type TokenRequestBody = TokenRequestCredentials & {
 	client_id: string;
-	client_secret: string;
 	scope: string;
 };
 
@@ -80,7 +79,7 @@ export function getFetchTokenUrl(server: string): string {
  */
 export function getLoginPageUrl(
 	server: string,
-	clientConfig: IClientConfig,
+	clientConfig: IPublicClientConfig,
 	scope: string,
 	odspAuthRedirectUri: string,
 ) {
@@ -98,7 +97,7 @@ export function getLoginPageUrl(
  */
 export const getOdspRefreshTokenFn = (
 	server: string,
-	clientConfig: IClientConfig,
+	clientConfig: IPublicClientConfig,
 	tokens: IOdspTokens,
 ) => getRefreshTokenFn(getOdspScope(server), server, clientConfig, tokens);
 /**
@@ -106,14 +105,14 @@ export const getOdspRefreshTokenFn = (
  */
 export const getPushRefreshTokenFn = (
 	server: string,
-	clientConfig: IClientConfig,
+	clientConfig: IPublicClientConfig,
 	tokens: IOdspTokens,
 ) => getRefreshTokenFn(pushScope, server, clientConfig, tokens);
 /**
  * @internal
  */
 export const getRefreshTokenFn =
-	(scope: string, server: string, clientConfig: IClientConfig, tokens: IOdspTokens) =>
+	(scope: string, server: string, clientConfig: IPublicClientConfig, tokens: IOdspTokens) =>
 	async () => {
 		const newTokens = await refreshTokens(server, scope, clientConfig, tokens);
 		return newTokens.accessToken;
@@ -130,13 +129,12 @@ export const getRefreshTokenFn =
 export async function fetchTokens(
 	server: string,
 	scope: string,
-	clientConfig: IClientConfig,
+	clientConfig: IPublicClientConfig,
 	credentials: TokenRequestCredentials,
 ): Promise<IOdspTokens> {
 	const body: TokenRequestBody = {
 		scope,
 		client_id: clientConfig.clientId,
-		client_secret: clientConfig.clientSecret,
 		...credentials,
 	};
 	const response = await unauthPostAsync(
@@ -205,7 +203,7 @@ function isAccessTokenError(parsedResponse: any): parsedResponse is AadOauth2Tok
 export async function refreshTokens(
 	server: string,
 	scope: string,
-	clientConfig: IClientConfig,
+	clientConfig: IPublicClientConfig,
 	tokens: IOdspTokens,
 ): Promise<IOdspTokens> {
 	// Clear out the old tokens while awaiting the new tokens

--- a/packages/utils/odsp-doclib-utils/src/test/types/validateOdspDoclibUtilsPrevious.generated.ts
+++ b/packages/utils/odsp-doclib-utils/src/test/types/validateOdspDoclibUtilsPrevious.generated.ts
@@ -24,26 +24,14 @@ type TypeOnly<T> = T extends number
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IClientConfig": {"forwardCompat": false}
+* "RemovedInterfaceDeclaration_IClientConfig": {"forwardCompat": false}
 */
-declare function get_old_InterfaceDeclaration_IClientConfig():
-    TypeOnly<old.IClientConfig>;
-declare function use_current_InterfaceDeclaration_IClientConfig(
-    use: TypeOnly<current.IClientConfig>): void;
-use_current_InterfaceDeclaration_IClientConfig(
-    get_old_InterfaceDeclaration_IClientConfig());
 
 /*
 * Validate back compat by using current type in place of old type
 * If breaking change required, add in package.json under typeValidation.broken:
-* "InterfaceDeclaration_IClientConfig": {"backCompat": false}
+* "RemovedInterfaceDeclaration_IClientConfig": {"backCompat": false}
 */
-declare function get_current_InterfaceDeclaration_IClientConfig():
-    TypeOnly<current.IClientConfig>;
-declare function use_old_InterfaceDeclaration_IClientConfig(
-    use: TypeOnly<old.IClientConfig>): void;
-use_old_InterfaceDeclaration_IClientConfig(
-    get_current_InterfaceDeclaration_IClientConfig());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/packages/utils/tool-utils/api-report/tool-utils.api.md
+++ b/packages/utils/tool-utils/api-report/tool-utils.api.md
@@ -4,15 +4,15 @@
 
 ```ts
 
-import { IClientConfig } from '@fluidframework/odsp-doclib-utils/internal';
 import { IOdspTokens } from '@fluidframework/odsp-doclib-utils/internal';
+import { IPublicClientConfig } from '@fluidframework/odsp-doclib-utils/internal';
 import { ITree } from '@fluidframework/protocol-definitions';
 
 // @internal
 export const gcBlobPrefix = "__gc";
 
 // @internal (undocumented)
-export const getMicrosoftConfiguration: () => IClientConfig;
+export const getMicrosoftConfiguration: () => IPublicClientConfig;
 
 // @internal
 export function getNormalizedSnapshot(snapshot: ITree, config?: ISnapshotNormalizerConfig): ITree;
@@ -77,9 +77,9 @@ export type OdspTokenConfig = {
 export class OdspTokenManager {
     constructor(tokenCache?: IAsyncCache<IOdspTokenManagerCacheKey, IOdspTokens> | undefined);
     // (undocumented)
-    getOdspTokens(server: string, clientConfig: IClientConfig, tokenConfig: OdspTokenConfig, forceRefresh?: boolean, forceReauth?: boolean): Promise<IOdspTokens>;
+    getOdspTokens(server: string, clientConfig: IPublicClientConfig, tokenConfig: OdspTokenConfig, forceRefresh?: boolean, forceReauth?: boolean): Promise<IOdspTokens>;
     // (undocumented)
-    getPushTokens(server: string, clientConfig: IClientConfig, tokenConfig: OdspTokenConfig, forceRefresh?: boolean, forceReauth?: boolean): Promise<IOdspTokens>;
+    getPushTokens(server: string, clientConfig: IPublicClientConfig, tokenConfig: OdspTokenConfig, forceRefresh?: boolean, forceReauth?: boolean): Promise<IOdspTokens>;
     // (undocumented)
     updateTokensCache(key: IOdspTokenManagerCacheKey, value: IOdspTokens): Promise<void>;
 }

--- a/packages/utils/tool-utils/src/odspTokenManager.ts
+++ b/packages/utils/tool-utils/src/odspTokenManager.ts
@@ -6,7 +6,7 @@
 import { unreachableCase } from "@fluidframework/core-utils";
 import {
 	IOdspTokens,
-	IClientConfig,
+	IPublicClientConfig,
 	fetchTokens,
 	refreshTokens,
 	getOdspScope,
@@ -27,20 +27,12 @@ const odspAuthRedirectUri = new URL("/auth/callback", odspAuthRedirectOrigin).hr
 /**
  * @internal
  */
-export const getMicrosoftConfiguration = (): IClientConfig => ({
+export const getMicrosoftConfiguration = (): IPublicClientConfig => ({
 	get clientId() {
 		if (!process.env.login__microsoft__clientId) {
 			throw new Error("Client ID environment variable not set: login__microsoft__clientId.");
 		}
 		return process.env.login__microsoft__clientId;
-	},
-	get clientSecret() {
-		if (!process.env.login__microsoft__secret) {
-			throw new Error(
-				"Client Secret environment variable not set: login__microsoft__secret.",
-			);
-		}
-		return process.env.login__microsoft__secret;
 	},
 });
 
@@ -108,21 +100,23 @@ export class OdspTokenManager {
 
 	public async getOdspTokens(
 		server: string,
-		clientConfig: IClientConfig,
+		clientConfig: IPublicClientConfig,
 		tokenConfig: OdspTokenConfig,
 		forceRefresh = false,
 		forceReauth = false,
 	): Promise<IOdspTokens> {
+		debug("Getting odsp tokens");
 		return this.getTokens(false, server, clientConfig, tokenConfig, forceRefresh, forceReauth);
 	}
 
 	public async getPushTokens(
 		server: string,
-		clientConfig: IClientConfig,
+		clientConfig: IPublicClientConfig,
 		tokenConfig: OdspTokenConfig,
 		forceRefresh = false,
 		forceReauth = false,
 	): Promise<IOdspTokens> {
+		debug("Getting push tokens");
 		return this.getTokens(true, server, clientConfig, tokenConfig, forceRefresh, forceReauth);
 	}
 
@@ -156,7 +150,7 @@ export class OdspTokenManager {
 	private async getTokens(
 		isPush: boolean,
 		server: string,
-		clientConfig: IClientConfig,
+		clientConfig: IPublicClientConfig,
 		tokenConfig: OdspTokenConfig,
 		forceRefresh: boolean,
 		forceReauth: boolean,
@@ -198,7 +192,7 @@ export class OdspTokenManager {
 	private async getTokensCore(
 		isPush: boolean,
 		server: string,
-		clientConfig: IClientConfig,
+		clientConfig: IPublicClientConfig,
 		tokenConfig: OdspTokenConfig,
 		forceRefresh,
 		forceReauth,
@@ -261,7 +255,7 @@ export class OdspTokenManager {
 	private async acquireTokensWithPassword(
 		server: string,
 		scope: string,
-		clientConfig: IClientConfig,
+		clientConfig: IPublicClientConfig,
 		username: string,
 		password: string,
 	): Promise<IOdspTokens> {
@@ -276,7 +270,7 @@ export class OdspTokenManager {
 	private async acquireTokensViaBrowserLogin(
 		loginPageUrl: string,
 		server: string,
-		clientConfig: IClientConfig,
+		clientConfig: IPublicClientConfig,
 		scope: string,
 		navigator: (url: string) => void,
 		redirectUriCallback?: (tokens: IOdspTokens) => Promise<string>,

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -408,7 +408,6 @@ stages:
             FLUID_ENDPOINTNAME: ${{ endpointObject.endpointName }}
             FLUID_LOGGER_PROPS: '{ "hostName": "Benchmark" }'
             login__microsoft__clientId: $(login-microsoft-clientId)
-            login__microsoft__secret: $(login-microsoft-secret)
             ${{ if eq( endpointObject.endpointName, 'odsp' ) }}:
               login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
             ${{ if eq( endpointObject.endpointName, 'frs' ) }}:

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -72,7 +72,6 @@ stages:
         testCommand: start:odspdf
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)
-          login__microsoft__secret: $(login-microsoft-secret)
           login__odspdf__test__tenants: $(automation-stress-login-odspdf-test-tenants)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -51,7 +51,6 @@ stages:
         testCommand: start:odsp
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)
-          login__microsoft__secret: $(login-microsoft-secret)
           login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -163,7 +163,6 @@ stages:
             flags: --compatVersion=V2_INT_3 --tenantIndex=3
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)
-          login__microsoft__secret: $(login-microsoft-secret)
           login__odsp__test__tenants: $(automation-e2e-login-odsp-test-tenants)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -66,7 +66,7 @@ stages:
           # Disable colorization for tinylicious logs (not useful when printing to a file)
           logger__colorize: "false" # Need to pass it as string so ADO doesn't convert it into False (capital F) which doesn't work
           logger__morganFormat: tiny
-  
+
   - stage: e2e_odsp_client_odsp_server
     displayName: e2e - odsp client with odsp service
     dependsOn: []
@@ -81,7 +81,6 @@ stages:
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
           odsp__client__clientId: $(odsp-client-clientId)
-          odsp__client__clientSecret: $(odsp-client-clientSecret)
           odsp__client__siteUrl: $(odsp-client-siteUrl)
           odsp__client__driveId: $(odsp-client-driveId)
           odsp__client__login__username: $(odsp-client-login-username)


### PR DESCRIPTION
## Description

Currently, we use the ropc flow with a confidential client to authenticate in our e2e/stress tests against odsp. This is less appropriate than using a public client flow, since our application registration really only needs to have delegated permissions.
This PR adjusts things to use a public flow--I've updated the relevant app registrations to allow both forms of auth already.

Using a public flow also means our infrastructure setup here aligns exactly with [this relatively recent MSFT guidance](https://learn.microsoft.com/en-us/entra/identity-platform/test-automate-integration-testing?tabs=dotnet).

Cherry-pick of #21091. This change needs to be in every branch we plan on maintaining real service tests against odsp for, as I plan on removing the application configuration enabling confidential client auth.