### PR TITLE
Remove plumbing of app secret for odspdf stress

### DIFF
--- a/packages/test/test-service-load/runLoadTestOnAks.ps1
+++ b/packages/test/test-service-load/runLoadTestOnAks.ps1
@@ -57,7 +57,6 @@ function CreateInfra {
         FLUID_TEST_UID="$TestUid" `
         TEST_PROFILE="$TestProfile" `
         login__microsoft__clientId="$env:ClientId" `
-        login__microsoft__secret="$env:ClientSecret" `
         APPINSIGHTS_INSTRUMENTATIONKEY="$env:InstrumentationKey" `
         BUILD_BUILD_ID="$TestDocFolder"
 

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -74,7 +74,6 @@ stages:
         skipTestResultPublishing: true
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)
-          login__microsoft__secret: $(login-microsoft-secret)
           login__odspdf__test__tenants: $(automation-stress-login-odspdf-test-tenants)
           FLUID_TEST_LOGGER_PKG_SPECIFIER: '@ff-internal/aria-logger' # Contains getTestLogger impl to inject
 


### PR DESCRIPTION
## Description

Removes some extra references for plumbing the environment variable `login__microsoft__secret` in stress tests. Follow-up to #21091.