### PR TITLE
fix(build): Add ci:test:azureclient:tinylicious:coverage command

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"ci:build": "fluid-build --task ci:build",
 		"ci:build:docs": "fluid-build --task ci:build:docs",
 		"ci:test:azureclient:tinylicious": "pnpm run -r --no-sort --stream --no-bail test:azureclient:tinylicious:report",
+		"ci:test:azureclient:tinylicious:coverage": "c8 --no-clean pnpm run -r --no-sort --stream --no-bail test:azureclient:tinylicious:report",
 		"ci:test:jest": "npm run test:jest:report",
 		"ci:test:jest:coverage": "c8 --no-clean npm run test:jest:report",
 		"ci:test:mocha": "npm run test:mocha",


### PR DESCRIPTION
## Description

Add missing command for AzureClient e2e tests when running post check-in build.
