### PR TITLE
Add readme to Example folder

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Fluid Framework Examples
+
+**Note: These examples are for internal consumption only and should not be used to build Fluid Framework apps.**
+
+This repository contains a collection of examples that are intended for internal use and serve as a reference for developers working on the Fluid Framework. Many of the APIs used in these examples are NOT part of the public API surface and the coding patterns here do not represent the recommended ways to use Fluid Framework. Go to [microsoft/FluidExamples](https://github.com/microsoft/fluidexamples) for examples of how to use Fluid Framework.
+
+## License
+
+This repository is licensed under the [MIT License](LICENSE). However, please note that the examples provided here are for internal use only and should not be used to build Fluid Framework apps.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,8 +2,12 @@
 
 **Note: These examples are for internal consumption only and should not be used to build Fluid Framework apps.**
 
-This repository contains a collection of examples that are intended for internal use and serve as a reference for developers working on the Fluid Framework. Many of the APIs used in these examples are NOT part of the public API surface and the coding patterns here do not represent the recommended ways to use Fluid Framework. Go to [microsoft/FluidExamples](https://github.com/microsoft/fluidexamples) for examples of how to use Fluid Framework.
+This repository contains a collection of examples that are intended for internal use and serve as a
+reference for developers working on the Fluid Framework. Many of the APIs used in these examples are NOT part
+of the public API surface and the coding patterns here do not represent the recommended ways to use Fluid Framework.
+Go to [microsoft/FluidExamples](https://github.com/microsoft/fluidexamples) for examples of how to use Fluid Framework.
 
 ## License
 
-This repository is licensed under the [MIT License](LICENSE). However, please note that the examples provided here are for internal use only and should not be used to build Fluid Framework apps.
+This repository is licensed under the [MIT License](LICENSE). However, please note that the examples provided
+here are for internal use only and should not be used to build Fluid Framework apps.


### PR DESCRIPTION
Adding a readme file that warns people not to use these examples as examples of how to use Fluid Framework.