### PR TITLE
fix(azure-end-to-end-tests): Include AzureClient e2e tests in ci:test:realsvc:tinylicious

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
 		"checks:fix": "fluid-build --task checks:fix",
 		"ci:build": "fluid-build --task ci:build",
 		"ci:build:docs": "fluid-build --task ci:build:docs",
-		"ci:test:azureclient:tinylicious": "pnpm run -r --no-sort --stream --no-bail test:azureclient:tinylicious:report",
-		"ci:test:azureclient:tinylicious:coverage": "c8 --no-clean pnpm run -r --no-sort --stream --no-bail test:azureclient:tinylicious:report",
 		"ci:test:jest": "npm run test:jest:report",
 		"ci:test:jest:coverage": "c8 --no-clean npm run test:jest:report",
 		"ci:test:mocha": "npm run test:mocha",

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -26,13 +26,13 @@
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"start:tinylicious:test": "PORT=7071 tinylicious > tinylicious.log 2>&1",
 		"test": "npm run test:realsvc",
-		"test:azureclient:tinylicious:report": "npm run test:realsvc:tinylicious",
 		"test:coverage": "c8 npm test",
 		"test:realsvc": "npm run test:realsvc:tinylicious",
 		"test:realsvc:azure": "cross-env FLUID_CLIENT=azure npm run test:realsvc:azure:run",
 		"test:realsvc:azure:run": "mocha --recursive \"lib/test/**/*.spec.*js\" --exit --timeout 20000 --config src/test/.mocharc.cjs",
 		"test:realsvc:run": "mocha lib/test --config src/test/.mocharc.cjs",
 		"test:realsvc:tinylicious": "start-server-and-test start:tinylicious:test 7071 test:realsvc:azure:run",
+		"test:realsvc:tinylicious:report": "npm run test:realsvc:tinylicious",
 		"test:realsvc:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:realsvc"
 	},
 	"c8": {

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -156,7 +156,6 @@ extends:
     - webpack
     - ci:test:mocha
     - ci:test:jest
-    - ci:test:azureclient:tinylicious
     - ci:test:realsvc:local
     - ci:test:realsvc:tinylicious
     - ci:test:stress:tinylicious


### PR DESCRIPTION
## Description

This PR makes it so AzureClient e2e tests are ran as part of the `ci:test:realsvc:tinylicious` command instead of having its own phase.

