### PR TITLE
Patch quorum fix server 4.0

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -186,7 +186,10 @@ data:
             "verifyLastOpPersistence": {{ .Values.scribe.verifyLastOpPersistence }},
             "restartOnCheckpointFailure": {{ .Values.scribe.restartOnCheckpointFailure }},
             "disableTransientTenantFiltering": {{ .Values.scribe.disableTransientTenantFiltering }},
-            "maxLogtailLength": {{ .Values.scribe.maxLogtailLength }}
+            "maxLogtailLength": {{ .Values.scribe.maxLogtailLength }},
+            "scrubUserDataInGlobalCheckpoints": {{ .Values.scribe.scrubUserDataInGlobalCheckpoints }},
+            "scrubUserDataInLocalCheckpoints": {{ .Values.scribe.scrubUserDataInLocalCheckpoints }},
+            "scrubUserDataInSummaries": {{ .Values.scribe.scrubUserDataInSummaries }}
         },
         "system": {
             "httpServer": {

--- a/server/routerlicious/kubernetes/routerlicious/values.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/values.yaml
@@ -103,6 +103,9 @@ scribe:
     maxTime: 60000
     maxMessages: 500
   restartOnCheckpointFailure: true
+  scrubUserDataInGlobalCheckpoints: false
+  scrubUserDataInLocalCheckpoints: false
+  scrubUserDataInSummaries: false
 
 riddler:
   name: riddler

--- a/server/routerlicious/packages/lambdas/CHANGELOG.md
+++ b/server/routerlicious/packages/lambdas/CHANGELOG.md
@@ -1,5 +1,48 @@
 # @fluidframework/server-lambdas
 
+## 4.0.1
+
+### Patch Changes
+
+-   Fix: send correct connection scopes for client ([#20312](https://github.com/microsoft/FluidFramework/issues/20312)) [e227db9](https://github.com/microsoft/FluidFramework/commit/e227db94bcab68e05087526c02ea4cca02ee4cea)
+
+    When a client joins in "write" mode with only "read" scopes in their token, the connection message from server will reflect a "read" client mode.
+
+-   Fix: configure user data scrubbing in checkpoints and summaries ([#20150](https://github.com/microsoft/FluidFramework/issues/20150)) [04a2cc9](https://github.com/microsoft/FluidFramework/commit/04a2cc9ee88d4dbfc14bf44320456aa01749990c)
+
+    When scribe boots from a checkpoint, it fails over to the latest summary checkpoint if the quorum is corrupted (i.e. user data is scrubbed).
+    When scribe writes a checkpoint to DB or a summary, it respects new `IScribeServerConfiguration` options (scrubUserDataInSummaries, scrubUserDataInLocalCheckpoints, and scrubUserDataInGlobalCheckpoints) when determining whether to scrub user data in the quorum.
+
+-   Fix: cover edge cases for scrubbed checkpoint users ([#20259](https://github.com/microsoft/FluidFramework/issue/20259)) [6718a9a](https://github.com/microsoft/FluidFramework/commit/6718a9a1707d6a5bcc573acbb2d154b8840c4b72)
+
+    Overhauled how the Scribe lambda handles invalid, missing, or outdated checkpoint data via fallbacks.
+
+    Before:
+
+    ```
+    if (no global checkpoint)
+        use Default checkpoint
+    elsif (global checkpoint was cleared or global checkpoint quorum was scrubbed)
+        use Summary checkpoint
+    else
+        use latest DB checkpoint (local or global)
+    ```
+
+    After:
+
+    ```
+    if (no global and no local checkpoint and no summary checkpoint)
+        use Default checkpoint
+    elsif (
+            global checkpoint was cleared and summary checkpoint ahead of local db checkpoint
+            or latest DB checkpoint quorum was scrubbed
+            or summary checkpoint ahead of latest DB checkpoint
+        )
+        use Summary checkpoint
+    else
+        use latest DB checkpoint (local or global)
+    ```
+
 ## 4.0.0
 
 ### Major Changes

--- a/server/routerlicious/packages/lambdas/src/nexus/index.ts
+++ b/server/routerlicious/packages/lambdas/src/nexus/index.ts
@@ -427,6 +427,7 @@ export function configureWebSocketServices(
 			const isSummarizer = messageClient.details?.type === summarizerClientType;
 			messageClient.user = claims.user;
 			messageClient.scopes = claims.scopes;
+			messageClient.mode = isWriter(claims.scopes, message.mode) ? "write" : "read";
 
 			// 1. Do not give SummaryWrite scope to clients that are not summarizers.
 			// 2. Store connection timestamp for all clients but the summarizer.

--- a/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/checkpointManager.ts
@@ -17,6 +17,7 @@ import {
 } from "@fluidframework/server-services-core";
 import { getLumberBaseProperties, Lumberjack } from "@fluidframework/server-services-telemetry";
 import { ICheckpointManager } from "./interfaces";
+import { isLocalCheckpoint } from "./utils";
 
 /**
  * MongoDB specific implementation of ICheckpointManager
@@ -49,7 +50,7 @@ export class CheckpointManager implements ICheckpointManager {
 		globalCheckpointOnly: boolean,
 		markAsCorrupt: boolean = false,
 	) {
-		const isLocalCheckpoint = !noActiveClients && !globalCheckpointOnly;
+		const isLocal = isLocalCheckpoint(noActiveClients, globalCheckpointOnly);
 		if (this.getDeltasViaAlfred) {
 			if (pending.length > 0 && this.verifyLastOpPersistence) {
 				// Verify that the last pending op has been persisted to op storage
@@ -109,7 +110,7 @@ export class CheckpointManager implements ICheckpointManager {
 				this.tenantId,
 				"scribe",
 				checkpoint,
-				isLocalCheckpoint,
+				isLocal,
 				markAsCorrupt,
 			);
 		} else {
@@ -149,7 +150,7 @@ export class CheckpointManager implements ICheckpointManager {
 				this.tenantId,
 				"scribe",
 				checkpoint,
-				isLocalCheckpoint,
+				isLocal,
 				markAsCorrupt,
 			);
 

--- a/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambda.ts
@@ -48,7 +48,7 @@ import {
 	DocumentCheckpointManager,
 } from "../utils";
 import { ICheckpointManager, IPendingMessageReader, ISummaryWriter } from "./interfaces";
-import { getClientIds, initializeProtocol, sendToDeli } from "./utils";
+import { getClientIds, initializeProtocol, isGlobalCheckpoint, sendToDeli } from "./utils";
 
 /**
  * @internal
@@ -243,6 +243,7 @@ export class ScribeLambda implements IPartitionLambda {
 							try {
 								const scribeCheckpoint = this.generateScribeCheckpoint(
 									this.lastOffset,
+									this.serviceConfiguration.scribe.scrubUserDataInSummaries,
 								);
 								const operation =
 									value.operation as ISequencedDocumentAugmentedMessage;
@@ -358,7 +359,10 @@ export class ScribeLambda implements IPartitionLambda {
 						enableServiceSummaryForTenant
 					) {
 						const operation = value.operation as ISequencedDocumentAugmentedMessage;
-						const scribeCheckpoint = this.generateScribeCheckpoint(this.lastOffset);
+						const scribeCheckpoint = this.generateScribeCheckpoint(
+							this.lastOffset,
+							this.serviceConfiguration.scribe.scrubUserDataInSummaries,
+						);
 						try {
 							const summaryResponse = await this.summaryWriter.writeServiceSummary(
 								operation,
@@ -475,7 +479,15 @@ export class ScribeLambda implements IPartitionLambda {
 		skipKafkaCheckpoint?: boolean,
 	) {
 		// Get checkpoint context
-		const checkpoint = this.generateScribeCheckpoint(message.offset);
+		const checkpoint = this.generateScribeCheckpoint(
+			message.offset,
+			isGlobalCheckpoint(
+				this.documentCheckpointManager.getNoActiveClients(),
+				this.globalCheckpointOnly,
+			)
+				? this.serviceConfiguration.scribe.scrubUserDataInGlobalCheckpoints
+				: this.serviceConfiguration.scribe.scrubUserDataInLocalCheckpoints,
+		);
 		this.documentCheckpointManager.updateCheckpointMessages(message);
 
 		// write the checkpoint with the current up-to-date state
@@ -603,8 +615,8 @@ export class ScribeLambda implements IPartitionLambda {
 		this.pendingMessages = new Deque(pendingOps);
 	}
 
-	private generateScribeCheckpoint(logOffset: number): IScribe {
-		const protocolState = this.protocolHandler.getProtocolState();
+	private generateScribeCheckpoint(logOffset: number, scrubUserData = false): IScribe {
+		const protocolState = this.protocolHandler.getProtocolState(scrubUserData);
 		const checkpoint: IScribe = {
 			lastSummarySequenceNumber: this.lastSummarySequenceNumber,
 			lastClientSummaryHead: this.lastClientSummaryHead,
@@ -822,7 +834,15 @@ export class ScribeLambda implements IPartitionLambda {
 
 	private readonly idleTimeCheckpoint = (initialScribeCheckpointMessage: IQueuedMessage) => {
 		if (initialScribeCheckpointMessage) {
-			const checkpoint = this.generateScribeCheckpoint(initialScribeCheckpointMessage.offset);
+			const checkpoint = this.generateScribeCheckpoint(
+				initialScribeCheckpointMessage.offset,
+				isGlobalCheckpoint(
+					this.documentCheckpointManager.getNoActiveClients(),
+					this.globalCheckpointOnly,
+				)
+					? this.serviceConfiguration.scribe.scrubUserDataInGlobalCheckpoints
+					: this.serviceConfiguration.scribe.scrubUserDataInLocalCheckpoints,
+			);
 			this.checkpointCore(checkpoint, initialScribeCheckpointMessage, this.clearCache);
 			const checkpointResult = `Writing checkpoint. Reason: IdleTime`;
 			const checkpointInfo = this.documentCheckpointManager.getCheckpointInfo();

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -44,7 +44,7 @@ import { CheckpointManager } from "./checkpointManager";
 import { ScribeLambda } from "./lambda";
 import { SummaryReader } from "./summaryReader";
 import { SummaryWriter } from "./summaryWriter";
-import { getClientIds, initializeProtocol, sendToDeli } from "./utils";
+import { getClientIds, initializeProtocol, isCheckpointQuorumScrubbed, sendToDeli } from "./utils";
 import { ILatestSummaryState } from "./interfaces";
 import { PendingMessageReader } from "./pendingMessageReader";
 
@@ -186,15 +186,26 @@ export class ScribeLambdaFactory
 			throw error;
 		}
 
-		if (document.scribe === undefined || document.scribe === null) {
+		const useDefaultCheckpointForNewDocument =
+			document.scribe === undefined || document.scribe === null;
+		const checkpointIsBlank = document.scribe === "";
+		const checkpointQuorumIsScrubbed = isCheckpointQuorumScrubbed(document.scribe);
+		const useLatestSummaryCheckpointForExistingDocument =
+			checkpointIsBlank || checkpointQuorumIsScrubbed;
+
+		if (useDefaultCheckpointForNewDocument) {
 			// Restore scribe state if not present in the cache. Mongodb casts undefined as null so we are checking
 			// both to be safe. Empty sring denotes a cache that was cleared due to a service summary
 			const message = "New document. Setting empty scribe checkpoint";
 			context.log?.info(message, { messageMetaData });
 			Lumberjack.info(message, lumberProperties);
 			lastCheckpoint = DefaultScribe;
-		} else if (document.scribe === "") {
-			const message = "Existing document. Fetching checkpoint from summary";
+		} else if (useLatestSummaryCheckpointForExistingDocument) {
+			const message = `Existing document${
+				!checkpointIsBlank && checkpointQuorumIsScrubbed
+					? " with invalid quorum members"
+					: ""
+			}. Fetching checkpoint from summary`;
 			context.log?.info(message, { messageMetaData });
 			Lumberjack.info(message, lumberProperties);
 			if (!latestSummary.fromSummary) {
@@ -202,6 +213,12 @@ export class ScribeLambdaFactory
 				Lumberjack.error(`Summary can't be fetched`, lumberProperties);
 				lastCheckpoint = DefaultScribe;
 			} else {
+				if (isCheckpointQuorumScrubbed(latestSummary.scribe)) {
+					Lumberjack.error(
+						"Quorum from summary is invalid. Continuing.",
+						lumberProperties,
+					);
+				}
 				lastCheckpoint = JSON.parse(latestSummary.scribe);
 				opMessages = latestSummary.messages;
 				// Since the document was originated elsewhere or cache was cleared, logOffset info is irrelavant.

--- a/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/lambdaFactory.ts
@@ -44,7 +44,12 @@ import { CheckpointManager } from "./checkpointManager";
 import { ScribeLambda } from "./lambda";
 import { SummaryReader } from "./summaryReader";
 import { SummaryWriter } from "./summaryWriter";
-import { getClientIds, initializeProtocol, isCheckpointQuorumScrubbed, sendToDeli } from "./utils";
+import {
+	getClientIds,
+	initializeProtocol,
+	isScribeCheckpointQuorumScrubbed,
+	sendToDeli,
+} from "./utils";
 import { ILatestSummaryState } from "./interfaces";
 import { PendingMessageReader } from "./pendingMessageReader";
 
@@ -102,6 +107,8 @@ export class ScribeLambdaFactory
 		let lastCheckpoint: IScribe;
 		let summaryReader: SummaryReader;
 		let latestSummary: ILatestSummaryState;
+		let latestSummaryCheckpoint: IScribe | undefined;
+		let latestDbCheckpoint: IScribe | undefined;
 		let opMessages: ISequencedDocumentMessage[] = [];
 
 		const { tenantId, documentId } = config;
@@ -116,6 +123,16 @@ export class ScribeLambdaFactory
 			LumberEventName.ScribeSessionResult,
 			this.serviceConfiguration,
 		);
+		const failCreation = async (error: unknown): Promise<void> => {
+			const errorMessage = "Scribe lambda creation failed.";
+			context.log?.error(`${errorMessage} Exception: ${inspect(error)}`, { messageMetaData });
+			Lumberjack.error(errorMessage, lumberProperties, error);
+			await this.sendLambdaStartResult(tenantId, documentId, {
+				lambdaName: LambdaName.Scribe,
+				success: false,
+			});
+			scribeSessionMetric?.error("Scribe lambda creation failed", error);
+		};
 
 		const lumberProperties = getLumberBaseProperties(documentId, tenantId);
 
@@ -173,38 +190,58 @@ export class ScribeLambdaFactory
 				this.enableWholeSummaryUpload,
 			);
 			latestSummary = await summaryReader.readLastSummary();
+			latestSummaryCheckpoint = latestSummary.scribe
+				? JSON.parse(latestSummary.scribe)
+				: undefined;
+			latestDbCheckpoint = (await this.checkpointService.restoreFromCheckpoint(
+				documentId,
+				tenantId,
+				"scribe",
+				document,
+			)) as IScribe;
 		} catch (error) {
-			const errorMessage = "Scribe lambda creation failed.";
-			context.log?.error(`${errorMessage} Exception: ${inspect(error)}`, { messageMetaData });
-			Lumberjack.error(errorMessage, lumberProperties, error);
-			await this.sendLambdaStartResult(tenantId, documentId, {
-				lambdaName: LambdaName.Scribe,
-				success: false,
-			});
-			scribeSessionMetric?.error("Scribe lambda creation failed", error);
-
+			await failCreation(error);
 			throw error;
 		}
 
+		// For a new document, Summary, Global (document) DB and Local DB checkpoints will not exist.
+		// However, it is possible that the global checkpoint was cleared to an empty string
+		// due to a service summary, so specifically check if global is not defined at all.
+		// Lastly, a new document will also not have a summary checkpoint, so if one exists without a DB checkpoint,
+		// we should use the summary checkpoint because there was likely a DB failure.
 		const useDefaultCheckpointForNewDocument =
-			document.scribe === undefined || document.scribe === null;
-		const checkpointIsBlank = document.scribe === "";
-		const checkpointQuorumIsScrubbed = isCheckpointQuorumScrubbed(document.scribe);
+			// Mongodb casts undefined as null so we are checking both to be safe.
+			(document.scribe === undefined || document.scribe === null) &&
+			!latestDbCheckpoint &&
+			!latestSummaryCheckpoint;
+		// Empty string for document DB checkpoint denotes a cache that was cleared due to a service summary.
+		// This will only happen if IServiceConfiguration.scribe.clearCacheAfterServiceSummary is true. Defaults to false.
+		const documentCheckpointIsCleared = document.scribe === "";
+		// It's possible that a local checkpoint is written after global checkpoint was cleared for service summary.
+		// Similarly, it's possible that the summary checkpoint is ahead of the latest db checkpoint due to a failure.
+		const summaryCheckpointAheadOfLatestDbCheckpoint =
+			latestSummaryCheckpoint &&
+			latestSummaryCheckpoint.sequenceNumber > latestDbCheckpoint?.sequenceNumber;
+		// Scrubbed users indicate that the quorum members have been scrubbed for privacy compliance.
+		const dbCheckpointQuorumIsScrubbed = isScribeCheckpointQuorumScrubbed(latestDbCheckpoint);
+		// Only use the summary checkpoint when
+		// 1) summary checkpoint is more recent than any DB checkpoint
+		// 2) the document checkpoint is cleared and there is not a more recent local checkpoint
+		// 3) the latest db checkpoint quorum members are scrubbed for privacy compliance
 		const useLatestSummaryCheckpointForExistingDocument =
-			checkpointIsBlank || checkpointQuorumIsScrubbed;
+			summaryCheckpointAheadOfLatestDbCheckpoint ||
+			(documentCheckpointIsCleared && summaryCheckpointAheadOfLatestDbCheckpoint) ||
+			dbCheckpointQuorumIsScrubbed;
 
 		if (useDefaultCheckpointForNewDocument) {
-			// Restore scribe state if not present in the cache. Mongodb casts undefined as null so we are checking
-			// both to be safe. Empty sring denotes a cache that was cleared due to a service summary
+			// Restore scribe state if not present in the cache.
 			const message = "New document. Setting empty scribe checkpoint";
 			context.log?.info(message, { messageMetaData });
 			Lumberjack.info(message, lumberProperties);
 			lastCheckpoint = DefaultScribe;
 		} else if (useLatestSummaryCheckpointForExistingDocument) {
 			const message = `Existing document${
-				!checkpointIsBlank && checkpointQuorumIsScrubbed
-					? " with invalid quorum members"
-					: ""
+				dbCheckpointQuorumIsScrubbed ? " with invalid quorum members" : ""
 			}. Fetching checkpoint from summary`;
 			context.log?.info(message, { messageMetaData });
 			Lumberjack.info(message, lumberProperties);
@@ -213,13 +250,20 @@ export class ScribeLambdaFactory
 				Lumberjack.error(`Summary can't be fetched`, lumberProperties);
 				lastCheckpoint = DefaultScribe;
 			} else {
-				if (isCheckpointQuorumScrubbed(latestSummary.scribe)) {
+				if (!latestSummaryCheckpoint) {
+					const error = new Error(
+						"Attempted to load from non-existent summary checkpoint.",
+					);
+					await failCreation(error);
+					throw error;
+				}
+				if (isScribeCheckpointQuorumScrubbed(latestSummaryCheckpoint)) {
 					Lumberjack.error(
-						"Quorum from summary is invalid. Continuing.",
+						"Quorum from summary is scrubbed. Continuing.",
 						lumberProperties,
 					);
 				}
-				lastCheckpoint = JSON.parse(latestSummary.scribe);
+				lastCheckpoint = latestSummaryCheckpoint;
 				opMessages = latestSummary.messages;
 				// Since the document was originated elsewhere or cache was cleared, logOffset info is irrelavant.
 				// Currently the lambda checkpoints only after updating the logOffset so setting this to lower
@@ -231,12 +275,12 @@ export class ScribeLambdaFactory
 				Lumberjack.info(checkpointMessage, lumberProperties);
 			}
 		} else {
-			lastCheckpoint = (await this.checkpointService.restoreFromCheckpoint(
-				documentId,
-				tenantId,
-				"scribe",
-				document,
-			)) as IScribe;
+			if (!latestDbCheckpoint) {
+				const error = new Error("Attempted to load from non-existent DB checkpoint.");
+				await failCreation(error);
+				throw error;
+			}
+			lastCheckpoint = latestDbCheckpoint;
 
 			try {
 				opMessages = await this.getOpMessages(documentId, tenantId, lastCheckpoint);

--- a/server/routerlicious/packages/lambdas/src/scribe/utils.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/utils.ts
@@ -77,15 +77,18 @@ export const isGlobalCheckpoint = (noActiveClients: boolean, globalCheckpointOnl
  * Whether the quorum members represented in the checkpoint's protocol state have had their user data scrubbed
  * for privacy compliance.
  */
-export const isCheckpointQuorumScrubbed = (stringifiedCheckpoint: string): boolean => {
-	if (!stringifiedCheckpoint) {
+export const isScribeCheckpointQuorumScrubbed = (
+	checkpoint: string | IScribe | undefined,
+): boolean => {
+	if (!checkpoint) {
 		return false;
 	}
-	const checkpoint: IScribe = JSON.parse(stringifiedCheckpoint);
-	for (const [, sequencedClient] of checkpoint.protocolState.members) {
+	const parsedCheckpoint: IScribe =
+		typeof checkpoint === "string" ? JSON.parse(checkpoint) : checkpoint;
+	for (const [, sequencedClient] of parsedCheckpoint.protocolState.members) {
 		const user: IUser = sequencedClient.client.user;
-		// User information was scrubbed.
 		if (!user.id) {
+			// User information was scrubbed.
 			return true;
 		}
 	}

--- a/server/routerlicious/packages/lambdas/src/scribe/utils.ts
+++ b/server/routerlicious/packages/lambdas/src/scribe/utils.ts
@@ -8,11 +8,13 @@ import {
 	IDocumentMessage,
 	IDocumentSystemMessage,
 	IProtocolState,
+	IUser,
 } from "@fluidframework/protocol-definitions";
 import {
 	IProducer,
 	IRawOperationMessage,
 	RawOperationType,
+	type IScribe,
 } from "@fluidframework/server-services-core";
 
 export const initializeProtocol = (protocolState: IProtocolState): ProtocolOpHandler =>
@@ -50,4 +52,42 @@ export const sendToDeli = (
 
 export const getClientIds = (protocolState: IProtocolState, clientCount: number) => {
 	return protocolState.members.slice(0, clientCount).map((member) => member[0]);
+};
+
+/**
+ * Whether to write checkpoint to local db.
+ * @param noActiveClients - whether there are any active clients
+ * @param globalCheckpointOnly - whether to always write checkpoints to global db
+ * @returns whether to write checkpoint to local db
+ */
+export const isLocalCheckpoint = (noActiveClients: boolean, globalCheckpointOnly: boolean) => {
+	return !isGlobalCheckpoint(noActiveClients, globalCheckpointOnly);
+};
+/**
+ * Whether to write checkpoint to global db.
+ * @param noActiveClients - whether there are any active clients
+ * @param globalCheckpointOnly - whether to always write checkpoints to global db
+ * @returns whether to write checkpoint to global db
+ */
+export const isGlobalCheckpoint = (noActiveClients: boolean, globalCheckpointOnly: boolean) => {
+	return noActiveClients || globalCheckpointOnly;
+};
+
+/**
+ * Whether the quorum members represented in the checkpoint's protocol state have had their user data scrubbed
+ * for privacy compliance.
+ */
+export const isCheckpointQuorumScrubbed = (stringifiedCheckpoint: string): boolean => {
+	if (!stringifiedCheckpoint) {
+		return false;
+	}
+	const checkpoint: IScribe = JSON.parse(stringifiedCheckpoint);
+	for (const [, sequencedClient] of checkpoint.protocolState.members) {
+		const user: IUser = sequencedClient.client.user;
+		// User information was scrubbed.
+		if (!user.id) {
+			return true;
+		}
+	}
+	return false;
 };

--- a/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
+++ b/server/routerlicious/packages/lambdas/src/test/scribe/lambda.spec.ts
@@ -115,6 +115,11 @@ describe("Routerlicious", () => {
 					"getLocalCheckpointEnabled",
 					Sinon.fake.returns(false),
 				);
+				Sinon.replace(
+					testCheckpointService,
+					"restoreFromCheckpoint",
+					Sinon.fake.returns(undefined),
+				);
 
 				testMessageCollection = new TestCollection([]);
 				testKafka = new TestKafka();

--- a/server/routerlicious/packages/protocol-base/CHANGELOG.md
+++ b/server/routerlicious/packages/protocol-base/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @fluidframework/protocol-base
 
+## 4.0.1
+
+### Patch Changes
+
+-   Fix: ensure immutability of quorum snapshot ([#20329](https://github.com/microsoft/FluidFramework/issues/20329)) [f49f533](https://github.com/microsoft/FluidFramework/commit/f49f533a41a7bc1dbbf8b5f79e59b203904f426b)
+
+    Creates a deep-er clone of the quorum members when snapshotting to make sure the snapshot is immutable.
+
+-   Fix: configure user data scrubbing in checkpoints and summaries ([#20150](https://github.com/microsoft/FluidFramework/issues/20150)) [04a2cc9](https://github.com/microsoft/FluidFramework/commit/04a2cc9ee88d4dbfc14bf44320456aa01749990c)
+
+    Added optional param, `scrubUserData`, to `ProtocolOpHandler.getProtocolState()`. When `true`, user data in the quorum is replaced with `{ id: "" }`. Defaults to `false`. Previously was always scrubbed.
+
 ## 4.0.0
 
 Dependency updates only.

--- a/server/routerlicious/packages/protocol-base/api-report/protocol-base.api.md
+++ b/server/routerlicious/packages/protocol-base/api-report/protocol-base.api.md
@@ -76,7 +76,7 @@ export class ProtocolOpHandler implements IProtocolHandler {
     get attributes(): IDocumentAttributes;
     // (undocumented)
     close(): void;
-    getProtocolState(): IScribeProtocolState;
+    getProtocolState(scrubUserData?: boolean): IScribeProtocolState;
     // (undocumented)
     minimumSequenceNumber: number;
     // (undocumented)

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -150,31 +150,30 @@ export class ProtocolOpHandler implements IProtocolHandler {
 
 	/**
 	 * Gets the scribe protocol state
+	 * @param scrubUserData - whether to remove all user data from the quorum members. CAUTION: this will corrupt the quorum if used in a summary.
 	 */
-	public getProtocolState(): IScribeProtocolState {
+	public getProtocolState(scrubUserData = false): IScribeProtocolState {
 		// return a new object every time
 		// this ensures future state changes will not affect outside callers
-
 		const snapshot = this._quorum.snapshot();
 
-		const quorumMembers = snapshot.members;
-
-		// Removing any identifying client information
-		quorumMembers.forEach((member) => {
-			member[1] = {
-				...member[1],
-				client: {
-					...member[1].client,
-					user: { id: "" },
-				},
-			};
-		});
+		if (scrubUserData) {
+			// In place, remove any identifying client information
+			snapshot.members.forEach((member) => {
+				member[1] = {
+					...member[1],
+					client: {
+						...member[1].client,
+						user: { id: "" },
+					},
+				};
+			});
+		}
 
 		return {
 			sequenceNumber: this.sequenceNumber,
 			minimumSequenceNumber: this.minimumSequenceNumber,
-			...this._quorum.snapshot(),
-			members: quorumMembers,
+			...snapshot,
 		};
 	}
 }

--- a/server/routerlicious/packages/protocol-base/src/protocol.ts
+++ b/server/routerlicious/packages/protocol-base/src/protocol.ts
@@ -159,15 +159,16 @@ export class ProtocolOpHandler implements IProtocolHandler {
 
 		if (scrubUserData) {
 			// In place, remove any identifying client information
-			snapshot.members.forEach((member) => {
-				member[1] = {
-					...member[1],
+			snapshot.members = snapshot.members.map(([id, sequencedClient]) => [
+				id,
+				{
+					...sequencedClient,
 					client: {
-						...member[1].client,
+						...sequencedClient.client,
 						user: { id: "" },
 					},
-				};
-			});
+				},
+			]);
 		}
 
 		return {

--- a/server/routerlicious/packages/protocol-base/src/test/protocol.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/protocol.spec.ts
@@ -1,0 +1,235 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import {
+	MessageType,
+	type ISequencedDocumentMessage,
+	type ISequencedDocumentSystemMessage,
+	type IClientJoin,
+	type IClientDetails,
+	type IUser,
+} from "@fluidframework/protocol-definitions";
+import { ProtocolOpHandler } from "../protocol";
+
+describe("Protocol", () => {
+	let protocolOpHandler: ProtocolOpHandler;
+
+	beforeEach(() => {
+		protocolOpHandler = new ProtocolOpHandler(
+			0 /* minimumSequenceNumber */,
+			0 /* sequenceNumber */,
+			[] /* members */,
+			[] /* proposals */,
+			[] /* values */,
+			() => {
+				return 0;
+			} /* sendProposal */,
+		);
+	});
+
+	describe("ProtocolOpHandler", () => {
+		it("tracks sequence numbers", () => {
+			const messages: ISequencedDocumentMessage[] = [
+				{
+					sequenceNumber: 1,
+					minimumSequenceNumber: 1,
+					clientSequenceNumber: 1,
+					type: MessageType.Operation,
+					clientId: "test",
+					referenceSequenceNumber: 0,
+					contents: "test content",
+					timestamp: 0,
+				},
+				{
+					sequenceNumber: 2,
+					minimumSequenceNumber: 1,
+					clientSequenceNumber: 2,
+					type: MessageType.Operation,
+					clientId: "test-2",
+					referenceSequenceNumber: 0,
+					contents: "test content",
+					timestamp: 1,
+				},
+			];
+			messages.forEach((message) => {
+				assert.doesNotThrow(() => protocolOpHandler.processMessage(message, false));
+			});
+			assert.strictEqual(protocolOpHandler.attributes.sequenceNumber, 2);
+		});
+
+		it("throws when state not moving sequentially", () => {
+			const messages: ISequencedDocumentMessage[] = [
+				{
+					sequenceNumber: 1,
+					minimumSequenceNumber: 1,
+					clientSequenceNumber: 1,
+					type: MessageType.Operation,
+					clientId: "test",
+					referenceSequenceNumber: 0,
+					contents: "test content",
+					timestamp: 0,
+				},
+				{
+					sequenceNumber: 3,
+					minimumSequenceNumber: 1,
+					clientSequenceNumber: 2,
+					type: MessageType.Operation,
+					clientId: "test-2",
+					referenceSequenceNumber: 0,
+					contents: "test content",
+					timestamp: 1,
+				},
+			];
+			assert.doesNotThrow(() => protocolOpHandler.processMessage(messages[0], false));
+			assert.throws(() => protocolOpHandler.processMessage(messages[1], false));
+		});
+
+		it("scrubs user data from protocol state quorum", () => {
+			const clientJoin1: IClientJoin = {
+				clientId: "test",
+				detail: {
+					mode: "write",
+					details: {} as IClientDetails,
+					permission: [],
+					user: {
+						id: "test-user",
+						name: "Test User",
+						additionalDetails: { favoriteColor: "red" },
+					} as IUser,
+					scopes: [],
+					timestamp: 0,
+				},
+			};
+			const clientJoin2: IClientJoin = {
+				clientId: "test-2",
+				detail: {
+					mode: "write",
+					details: {} as IClientDetails,
+					permission: [],
+					user: {
+						id: "test-user-2",
+						name: "Test User2",
+						additionalDetails: { favoriteColor: "blue" },
+					} as IUser,
+					scopes: [],
+					timestamp: 0,
+				},
+			};
+			const messages: ISequencedDocumentSystemMessage[] = [
+				{
+					sequenceNumber: 1,
+					minimumSequenceNumber: 1,
+					clientSequenceNumber: 1,
+					type: MessageType.ClientJoin,
+					clientId: null,
+					referenceSequenceNumber: 0,
+					contents: "test content",
+					timestamp: 0,
+					data: JSON.stringify(clientJoin1),
+				},
+				{
+					sequenceNumber: 2,
+					minimumSequenceNumber: 1,
+					clientSequenceNumber: 2,
+					type: MessageType.ClientJoin,
+					clientId: null,
+					referenceSequenceNumber: 0,
+					contents: "test content",
+					timestamp: 1,
+					data: JSON.stringify(clientJoin2),
+				},
+			];
+			messages.forEach((message) => {
+				assert.doesNotThrow(() => protocolOpHandler.processMessage(message, false));
+			});
+			assert.strictEqual(protocolOpHandler.attributes.sequenceNumber, 2);
+
+			const scrubbedProtocolState = protocolOpHandler.getProtocolState(true);
+			scrubbedProtocolState.members.forEach(([, member]) => {
+				assert(!member.client.user.id, "user id should be empty");
+				assert(
+					!(member.client.user as unknown as any).name,
+					"user name should not be present",
+				);
+				assert(
+					!(member.client.user as unknown as any).additionalDetails?.favoriteColor,
+					"user additional details should not be present",
+				);
+			});
+		});
+
+		it("does not scrub user data from protocol state quorum", () => {
+			const clientJoin1: IClientJoin = {
+				clientId: "test",
+				detail: {
+					mode: "write",
+					details: {} as IClientDetails,
+					permission: [],
+					user: {
+						id: "test-user",
+						name: "Test User",
+						additionalDetails: { favoriteColor: "red" },
+					} as IUser,
+					scopes: [],
+					timestamp: 0,
+				},
+			};
+			const clientJoin2: IClientJoin = {
+				clientId: "test-2",
+				detail: {
+					mode: "write",
+					details: {} as IClientDetails,
+					permission: [],
+					user: {
+						id: "test-user-2",
+						name: "Test User2",
+						additionalDetails: { favoriteColor: "blue" },
+					} as IUser,
+					scopes: [],
+					timestamp: 0,
+				},
+			};
+			const messages: ISequencedDocumentSystemMessage[] = [
+				{
+					sequenceNumber: 1,
+					minimumSequenceNumber: 1,
+					clientSequenceNumber: 1,
+					type: MessageType.ClientJoin,
+					clientId: null,
+					referenceSequenceNumber: 0,
+					contents: "test content",
+					timestamp: 0,
+					data: JSON.stringify(clientJoin1),
+				},
+				{
+					sequenceNumber: 2,
+					minimumSequenceNumber: 1,
+					clientSequenceNumber: 2,
+					type: MessageType.ClientJoin,
+					clientId: null,
+					referenceSequenceNumber: 0,
+					contents: "test content",
+					timestamp: 1,
+					data: JSON.stringify(clientJoin2),
+				},
+			];
+			messages.forEach((message) => {
+				assert.doesNotThrow(() => protocolOpHandler.processMessage(message, false));
+			});
+			assert.strictEqual(protocolOpHandler.attributes.sequenceNumber, 2);
+
+			const protocolState = protocolOpHandler.getProtocolState();
+			protocolState.members.forEach(([, member]) => {
+				assert(member.client.user.id, "user id should be present");
+				assert((member.client.user as unknown as any).name, "user name should be present");
+				assert(
+					(member.client.user as unknown as any).additionalDetails?.favoriteColor,
+					"user additional details should be present",
+				);
+			});
+		});
+	});
+});

--- a/server/routerlicious/packages/protocol-base/src/test/protocol.spec.ts
+++ b/server/routerlicious/packages/protocol-base/src/test/protocol.spec.ts
@@ -221,6 +221,18 @@ describe("Protocol", () => {
 			});
 			assert.strictEqual(protocolOpHandler.attributes.sequenceNumber, 2);
 
+			const scrubbedProtocolState = protocolOpHandler.getProtocolState(true);
+			scrubbedProtocolState.members.forEach(([, member]) => {
+				assert(!member.client.user.id, "user id should be empty");
+				assert(
+					!(member.client.user as unknown as any).name,
+					"user name should not be present",
+				);
+				assert(
+					!(member.client.user as unknown as any).additionalDetails?.favoriteColor,
+					"user additional details should not be present",
+				);
+			});
 			const protocolState = protocolOpHandler.getProtocolState();
 			protocolState.members.forEach(([, member]) => {
 				assert(member.client.user.id, "user id should be present");

--- a/server/routerlicious/packages/routerlicious/CHANGELOG.md
+++ b/server/routerlicious/packages/routerlicious/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @fluidframework/server-routerlicious
 
+## 4.0.1
+
+### Patch Changes
+
+-   Fix: configure user data scrubbing in checkpoints and summaries ([#20150](https://github.com/microsoft/FluidFramework/issues/20150)) [04a2cc9](https://github.com/microsoft/FluidFramework/commit/04a2cc9ee88d4dbfc14bf44320456aa01749990c)
+
+    Added the following configuration options for `IScribeServerConfiguration`: scrubUserDataInSummaries, scrubUserDataInLocalCheckpoints, and scrubUserDataInGlobalCheckpoints. All default to `false`.
+
 ## 4.0.0
 
 ### Major Changes

--- a/server/routerlicious/packages/routerlicious/config/config.json
+++ b/server/routerlicious/packages/routerlicious/config/config.json
@@ -201,7 +201,10 @@
 		"verifyLastOpPersistence": false,
 		"restartOnCheckpointFailure": true,
 		"disableTransientTenantFiltering": true,
-		"maxLogtailLength": 2000
+		"maxLogtailLength": 2000,
+		"scrubUserDataInGlobalCheckpoints": false,
+		"scrubUserDataInLocalCheckpoints": false,
+		"scrubUserDataInSummaries": false
 	},
 	"system": {
 		"httpServer": {

--- a/server/routerlicious/packages/routerlicious/src/scribe/index.ts
+++ b/server/routerlicious/packages/routerlicious/src/scribe/index.ts
@@ -140,10 +140,25 @@ export async function scribeCreate(
 
 	const externalOrdererUrl = config.get("worker:serverUrl");
 	const enforceDiscoveryFlow: boolean = config.get("worker:enforceDiscoveryFlow");
+	const scrubUserDataInGlobalCheckpoints: boolean =
+		config.get("scribe:scrubUserDataInGlobalCheckpoints") ??
+		DefaultServiceConfiguration.scribe.scrubUserDataInGlobalCheckpoints;
+	const scrubUserDataInLocalCheckpoints: boolean =
+		config.get("scribe:scrubUserDataInLocalCheckpoints") ??
+		DefaultServiceConfiguration.scribe.scrubUserDataInLocalCheckpoints;
+	const scrubUserDataInSummaries: boolean =
+		config.get("scribe:scrubUserDataInSummaries") ??
+		DefaultServiceConfiguration.scribe.scrubUserDataInSummaries;
 	const serviceConfiguration: IServiceConfiguration = {
 		...DefaultServiceConfiguration,
 		externalOrdererUrl,
 		enforceDiscoveryFlow,
+		scribe: {
+			...DefaultServiceConfiguration.scribe,
+			scrubUserDataInGlobalCheckpoints,
+			scrubUserDataInLocalCheckpoints,
+			scrubUserDataInSummaries,
+		},
 	};
 
 	const checkpointService = new core.CheckpointService(

--- a/server/routerlicious/packages/services-core/CHANGELOG.md
+++ b/server/routerlicious/packages/services-core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @fluidframework/server-services-core
 
+## 4.0.1
+
+### Patch Changes
+
+-   Fix: configure user data scrubbing in checkpoints and summaries ([#20150](https://github.com/microsoft/FluidFramework/issues/20150)) [04a2cc9](https://github.com/microsoft/FluidFramework/commit/04a2cc9ee88d4dbfc14bf44320456aa01749990c)
+
+    Added the following configuration options for `IScribeServerConfiguration`: scrubUserDataInSummaries, scrubUserDataInLocalCheckpoints, and scrubUserDataInGlobalCheckpoints. All default to `false`.
+
+-   Fix: cover edge cases for scrubbed checkpoint users ([#20259](https://github.com/microsoft/FluidFramework/issue/20259)) [6718a9a](https://github.com/microsoft/FluidFramework/commit/6718a9a1707d6a5bcc573acbb2d154b8840c4b72)
+
+    Updated `CheckpointService` with additional fallback logic for loading a checkpoint from local or global DB depending on whether the quorum information in the checkpoint is valid (i.e. does not contain scrubbed users).
+
 ## 4.0.0
 
 Dependency updates only.

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -79,6 +79,9 @@
 			"InterfaceDeclaration_IServiceConfiguration": {
 				"forwardCompat": false
 			},
+			"InterfaceDeclaration_IScribeServerConfiguration": {
+				"forwardCompat": false
+			},
 			"InterfaceDeclaration_IDeliServerConfiguration": {
 				"forwardCompat": false,
 				"backCompat": true

--- a/server/routerlicious/packages/services-core/src/checkpointService.ts
+++ b/server/routerlicious/packages/services-core/src/checkpointService.ts
@@ -14,7 +14,7 @@ import {
 	Lumberjack,
 } from "@fluidframework/server-services-telemetry";
 import { ICheckpointRepository, IDocumentRepository } from "./database";
-import { IDeliState, IDocument, IScribe } from "./document";
+import { IDeliState, IDocument, IScribe, type ICheckpoint } from "./document";
 
 type DocumentLambda = "deli" | "scribe";
 
@@ -204,46 +204,73 @@ export class CheckpointService implements ICheckpointService {
 		service: DocumentLambda,
 		document: IDocument,
 	) {
-		let checkpoint;
-		let lastCheckpoint: IDeliState | IScribe;
+		let lastCheckpoint: IDeliState | IScribe | undefined;
 		let isLocalCheckpoint = false;
-		let localLogOffset;
-		let globalLogOffset;
-		let localSequenceNumber;
-		let globalSequenceNumber;
+		let localLogOffset: number | undefined;
+		let globalLogOffset: number | undefined;
+		let localSequenceNumber: number | undefined;
+		let globalSequenceNumber: number | undefined;
+		let checkpointSource = "notFound";
 
 		const restoreFromCheckpointMetric = Lumberjack.newLumberMetric(
 			LumberEventName.RestoreFromCheckpoint,
 		);
-		let checkpointSource = "defaultGlobalCollection";
+		const parseCheckpointString = (
+			checkpointString: string | undefined,
+		): IDeliState | IScribe | undefined =>
+			checkpointString ? (JSON.parse(checkpointString) as IDeliState | IScribe) : undefined;
 
 		try {
 			if (!this.localCheckpointEnabled || !this.checkpointRepository) {
 				// If we cannot checkpoint locally, use document
-				lastCheckpoint = JSON.parse(document[service]);
+				lastCheckpoint = parseCheckpointString(document[service]);
 				globalLogOffset = lastCheckpoint.logOffset;
 				globalSequenceNumber = lastCheckpoint.sequenceNumber;
+				checkpointSource = "defaultGlobalCollection";
 			} else {
 				// Search checkpoints collection for checkpoint
-				try {
-					checkpoint = await this.checkpointRepository.getCheckpoint(
-						documentId,
-						tenantId,
+				const checkpoint: ICheckpoint | undefined = await this.checkpointRepository
+					.getCheckpoint(documentId, tenantId)
+					.catch((error) => {
+						Lumberjack.error(
+							`Error retrieving local checkpoint`,
+							getLumberBaseProperties(documentId, tenantId),
+						);
+						return undefined;
+					});
+
+				const localCheckpoint: IDeliState | IScribe | undefined = parseCheckpointString(
+					checkpoint?.[service],
+				);
+				const globalCheckpoint: IDeliState | IScribe | undefined = parseCheckpointString(
+					document[service],
+				);
+				localLogOffset = localCheckpoint?.logOffset;
+				globalLogOffset = globalCheckpoint?.logOffset;
+				localSequenceNumber = localCheckpoint?.sequenceNumber;
+				globalSequenceNumber = globalCheckpoint?.sequenceNumber;
+
+				if (localCheckpoint && !globalCheckpoint) {
+					// If checkpoint does not exist in document (global), use local
+					Lumberjack.info(
+						`Global checkpoint not found.`,
+						getLumberBaseProperties(documentId, tenantId),
 					);
-				} catch (error) {
-					checkpoint = undefined;
-					Lumberjack.error(
-						`Error retrieving local checkpoint`,
+					lastCheckpoint = localCheckpoint;
+					checkpointSource = "notFoundInGlobalCollection";
+					isLocalCheckpoint = true;
+				} else if (!localCheckpoint && globalCheckpoint) {
+					// If checkpoint does not exist in local, use document (global)
+					Lumberjack.info(
+						`Local checkpoint not found.`,
 						getLumberBaseProperties(documentId, tenantId),
 					);
 					checkpointSource = "notFoundInLocalCollection";
-				}
-
-				if (checkpoint?.[service]) {
-					const localCheckpoint: IDeliState | IScribe = JSON.parse(checkpoint[service]);
-					const globalCheckpoint: IDeliState | IScribe = JSON.parse(document[service]);
-
-					// Compare local and global checkpoints to use latest version
+					lastCheckpoint = globalCheckpoint;
+					isLocalCheckpoint = false;
+				} else if (localCheckpoint && globalCheckpoint) {
+					// If both checkpoints exist,
+					// compare local and global checkpoints to use latest version
 					if (localCheckpoint.sequenceNumber < globalCheckpoint.sequenceNumber) {
 						// if local checkpoint is behind global, use global
 						lastCheckpoint = globalCheckpoint;
@@ -254,20 +281,6 @@ export class CheckpointService implements ICheckpointService {
 						checkpointSource = "latestFoundInLocalCollection";
 						isLocalCheckpoint = true;
 					}
-					localLogOffset = localCheckpoint.logOffset;
-					globalLogOffset = globalCheckpoint.logOffset;
-					localSequenceNumber = localCheckpoint.sequenceNumber;
-					globalSequenceNumber = globalCheckpoint.sequenceNumber;
-				} else {
-					// If checkpoint does not exist, use document
-					Lumberjack.info(
-						`Local checkpoint not found.`,
-						getLumberBaseProperties(documentId, tenantId),
-					);
-					checkpointSource = "notFoundInLocalCollection";
-					lastCheckpoint = JSON.parse(document[service]);
-					globalLogOffset = lastCheckpoint.logOffset;
-					globalSequenceNumber = lastCheckpoint.sequenceNumber;
 				}
 			}
 			restoreFromCheckpointMetric.setProperties({

--- a/server/routerlicious/packages/services-core/src/configuration.ts
+++ b/server/routerlicious/packages/services-core/src/configuration.ts
@@ -133,6 +133,15 @@ export interface IScribeServerConfiguration {
 
 	// Controls how often scribe should checkpoint
 	checkpointHeuristics: ICheckpointHeuristicsServerConfiguration;
+
+	// Enables scrubbing user data from protocol state quorum in Summaries
+	scrubUserDataInSummaries: boolean;
+
+	// Enables scrubbing user data from protocol state quorum in local checkpoints
+	scrubUserDataInLocalCheckpoints: boolean;
+
+	// Enables scrubbing user data from protocol state quorum in global checkpoints
+	scrubUserDataInGlobalCheckpoints: boolean;
 }
 
 /**
@@ -274,6 +283,9 @@ export const DefaultServiceConfiguration: IServiceConfiguration = {
 			maxTime: 1 * 60 * 1000,
 			maxMessages: 500,
 		},
+		scrubUserDataInSummaries: false,
+		scrubUserDataInLocalCheckpoints: false,
+		scrubUserDataInGlobalCheckpoints: false,
 	},
 	moira: {
 		enable: false,

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -1982,6 +1982,7 @@ declare function get_old_InterfaceDeclaration_IScribeServerConfiguration():
 declare function use_current_InterfaceDeclaration_IScribeServerConfiguration(
     use: TypeOnly<current.IScribeServerConfiguration>): void;
 use_current_InterfaceDeclaration_IScribeServerConfiguration(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IScribeServerConfiguration());
 
 /*


### PR DESCRIPTION
## Description

T9s v4 doesn't have the Quorum scrubbed users fix, and is also missing the fix for correct Read/Write scopes on socket connection. Cherry-picking some commits:

---

### server: cover edge cases for scrubbed checkpoint users (microsoft#20259)

6718a9a

---

### server: provided user was not an azure user fixes (microsoft#20150)

786abfa

---

### server: fix mutable quorum snapshot (microsoft#20329)

5de9472

---

### fix: send correct connection scopes for client (microsoft#20312)

7d07fc5

