### PR TITLE
Remove format validation from summary load benchmark

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/summary.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/summary.bench.ts
@@ -17,7 +17,6 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 
 import { AllowedUpdateType } from "../../core/index.js";
-import { typeboxValidator } from "../../external-utilities/index.js";
 import { SharedTreeFactory, TreeContent } from "../../shared-tree/index.js";
 import { makeDeepContent, makeWideContentWithEndValue } from "../scalableTestTrees.js";
 import { TestTreeProviderLite, schematizeFlexTree, testIdCompressor } from "../utils.js";
@@ -72,11 +71,11 @@ describe("Summary benchmarks", () => {
 	describe("load speed of", () => {
 		function runSummaryBenchmark(title: string, content: TreeContent, type: BenchmarkType) {
 			let summaryTree: ITree;
-			const factory = new SharedTreeFactory({ jsonValidator: typeboxValidator });
+			const factory = new SharedTreeFactory();
 			benchmark({
 				title,
 				type,
-				before: async () => {
+				before: () => {
 					summaryTree = convertSummaryTreeToITree(getSummaryTree(content));
 				},
 				benchmarkFnAsync: async () => {


### PR DESCRIPTION
## Description

Looking at the perf benchmarks showed a big increase in summary load performance when updating typebox. This is mostly likely during the optional data validation which we don't expect production users to enable (and don't even provide a stable APi to use).

This change removes this validation from the summary load benchmarks so they should better reflect realistic use.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

