### PR TITLE
GC: Include fullGC flag in gcUnknownOutboundReferences event

### DIFF
--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -576,7 +576,7 @@ export class GarbageCollector implements IGarbageCollector {
 		const gcResult = runGarbageCollection(gcData.gcNodes, ["/"]);
 		// Get all referenced nodes - References in this run + references between the previous and current runs.
 		const allReferencedNodeIds =
-			this.findAllNodesReferencedBetweenGCs(gcData, this.gcDataFromLastRun, logger) ??
+			this.findAllNodesReferencedBetweenGCs(gcData, this.gcDataFromLastRun, fullGC, logger) ??
 			gcResult.referencedNodeIds;
 
 		// 2. Get the mark phase stats based on the previous / current GC state.
@@ -778,6 +778,7 @@ export class GarbageCollector implements IGarbageCollector {
 	private findAllNodesReferencedBetweenGCs(
 		currentGCData: IGarbageCollectionData,
 		previousGCData: IGarbageCollectionData | undefined,
+		fullGC: boolean,
 		logger: ITelemetryLoggerExt,
 	): string[] | undefined {
 		// If we haven't run GC before there is nothing to do.
@@ -794,6 +795,7 @@ export class GarbageCollector implements IGarbageCollector {
 			currentGCData,
 			previousGCData,
 			this.newReferencesSinceLastRun,
+			fullGC,
 			logger,
 		);
 

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -323,11 +323,14 @@ export class GCTelemetryTracker {
 	 * @param currentGCData - The GC data (reference graph) from the current GC run.
 	 * @param previousGCData - The GC data (reference graph) from the previous GC run.
 	 * @param explicitReferences - New references added explicity between the previous and the current run.
+	 * @param fullGC - Whether this is a full GC run or not, for logging
+	 * @param logger - The logger to use for logging the telemetry events.
 	 */
 	public logIfMissingExplicitReferences(
 		currentGCData: IGarbageCollectionData,
 		previousGCData: IGarbageCollectionData,
 		explicitReferences: Map<string, string[]>,
+		fullGC: boolean,
 		logger: ITelemetryLoggerExt,
 	) {
 		for (const [nodeId, currentOutboundRoutes] of Object.entries(currentGCData.gcNodes)) {
@@ -364,6 +367,7 @@ export class GCTelemetryTracker {
 						id: nodeId,
 						routes: JSON.stringify(missingExplicitRoutes),
 					}),
+					details: { fullGC },
 				});
 			}
 		}

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -643,6 +643,7 @@ describe("GC Telemetry Tracker", () => {
 				currentGCData,
 				previousGCData,
 				explicitReferences,
+				false /* fullGC */,
 				mc.logger,
 			);
 
@@ -665,6 +666,7 @@ describe("GC Telemetry Tracker", () => {
 				currentGCData,
 				previousGCData,
 				explicitReferences,
+				false /* fullGC */,
 				mc.logger,
 			);
 
@@ -673,12 +675,15 @@ describe("GC Telemetry Tracker", () => {
 					{
 						eventName: unknownReferenceEventName,
 						...tagCodeArtifacts({ id, routes: JSON.stringify(routes) }),
+						fullGC: false, // from details
 					},
 				],
 				"gcUnknownOutboundReferences event not logged as expected",
+				true /* inlineDetailsProp */,
 			);
 		});
 
+		// Also tests passing fullGC true
 		it("logs gcUnknownOutboundReferences when there are multiple unknown data store references", async () => {
 			const id1 = nodes[0];
 			const routes1 = [nodes[2], nodes[3]];
@@ -691,6 +696,7 @@ describe("GC Telemetry Tracker", () => {
 				currentGCData,
 				previousGCData,
 				explicitReferences,
+				true /* fullGC */,
 				mc.logger,
 			);
 
@@ -699,13 +705,16 @@ describe("GC Telemetry Tracker", () => {
 					{
 						eventName: unknownReferenceEventName,
 						...tagCodeArtifacts({ id: id1, routes: JSON.stringify(routes1) }),
+						fullGC: true, // from details
 					},
 					{
 						eventName: unknownReferenceEventName,
 						...tagCodeArtifacts({ id: id2, routes: JSON.stringify(routes2) }),
+						fullGC: true, // from details
 					},
 				],
 				"gcUnknownOutboundReferences event not logged as expected",
+				true /* inlineDetailsProp */,
 			);
 		});
 
@@ -719,6 +728,7 @@ describe("GC Telemetry Tracker", () => {
 				currentGCData,
 				previousGCData,
 				explicitReferences,
+				false /* fullGC */,
 				mc.logger,
 			);
 
@@ -743,6 +753,7 @@ describe("GC Telemetry Tracker", () => {
 				currentGCData,
 				previousGCData,
 				explicitReferences,
+				false /* fullGC */,
 				mc.logger,
 			);
 
@@ -766,6 +777,7 @@ describe("GC Telemetry Tracker", () => {
 				currentGCData,
 				previousGCData,
 				explicitReferences,
+				false /* fullGC */,
 				mc.logger,
 			);
 
@@ -789,6 +801,7 @@ describe("GC Telemetry Tracker", () => {
 				currentGCData,
 				previousGCData,
 				explicitReferences,
+				false /* fullGC */,
 				mc.logger,
 			);
 


### PR DESCRIPTION
## Description

We've observed a likely correlation between gcUnknownOutboundReferences and running fullGC, but it's hard to draw an exact conclusion because that bit isn't logged in that event.  This PR plumbs it through.
