### PR TITLE
[LTS] Use public client auth for odsp e2e flows (#21091)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -34,7 +34,6 @@ services:
             - NODE_ENV=development
             - IS_FLUID_SERVER=true
             - login__microsoft__clientId
-            - login__microsoft__secret
             - login__accounts
         restart: always
     alfred:

--- a/api-report/tool-utils.api.md
+++ b/api-report/tool-utils.api.md
@@ -4,15 +4,15 @@
 
 ```ts
 
-import { IClientConfig } from '@fluidframework/odsp-doclib-utils';
 import { IOdspTokens } from '@fluidframework/odsp-doclib-utils';
+import { IPublicClientConfig } from '@fluidframework/odsp-doclib-utils';
 import { ITree } from '@fluidframework/protocol-definitions';
 
 // @public
 export const gcBlobPrefix = "__gc";
 
 // @public (undocumented)
-export const getMicrosoftConfiguration: () => IClientConfig;
+export const getMicrosoftConfiguration: () => IPublicClientConfig;
 
 // @public
 export function getNormalizedSnapshot(snapshot: ITree, config?: ISnapshotNormalizerConfig): ITree;
@@ -77,9 +77,9 @@ export type OdspTokenConfig = {
 export class OdspTokenManager {
     constructor(tokenCache?: IAsyncCache<IOdspTokenManagerCacheKey, IOdspTokens> | undefined);
     // (undocumented)
-    getOdspTokens(server: string, clientConfig: IClientConfig, tokenConfig: OdspTokenConfig, forceRefresh?: boolean, forceReauth?: boolean): Promise<IOdspTokens>;
+    getOdspTokens(server: string, clientConfig: IPublicClientConfig, tokenConfig: OdspTokenConfig, forceRefresh?: boolean, forceReauth?: boolean): Promise<IOdspTokens>;
     // (undocumented)
-    getPushTokens(server: string, clientConfig: IClientConfig, tokenConfig: OdspTokenConfig, forceRefresh?: boolean, forceReauth?: boolean): Promise<IOdspTokens>;
+    getPushTokens(server: string, clientConfig: IPublicClientConfig, tokenConfig: OdspTokenConfig, forceRefresh?: boolean, forceReauth?: boolean): Promise<IOdspTokens>;
     // (undocumented)
     updateTokensCache(key: IOdspTokenManagerCacheKey, value: IOdspTokens): Promise<void>;
 }

--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -21,7 +21,7 @@ import {
 import {
     getDriveId,
     getDriveItemByRootFileName,
-    IClientConfig,
+    IPublicClientConfig,
 } from "@fluidframework/odsp-doclib-utils";
 import { ITestDriver, OdspEndpoint } from "@fluidframework/test-driver-definitions";
 import { OdspDriverApiType, OdspDriverApi } from "./odspDriverApi";
@@ -39,7 +39,7 @@ interface IOdspTestLoginInfo {
     supportsBrowserAuth?: boolean;
 }
 
-type TokenConfig = IOdspTestLoginInfo & IClientConfig;
+type TokenConfig = IOdspTestLoginInfo & IPublicClientConfig;
 
 interface IOdspTestDriverConfig extends TokenConfig {
     directory: string;
@@ -252,7 +252,7 @@ export class OdspTestDriver implements ITestDriver {
 
     private static async getStorageToken(
         options: OdspResourceTokenFetchOptions & { useBrowserAuth?: boolean; },
-        config: IOdspTestLoginInfo & IClientConfig,
+        config: IOdspTestLoginInfo & IPublicClientConfig,
     ) {
         const host = new URL(options.siteUrl).host;
 

--- a/packages/test/test-service-load/runLoadTestOnAks.ps1
+++ b/packages/test/test-service-load/runLoadTestOnAks.ps1
@@ -57,7 +57,6 @@ function CreateInfra {
         FLUID_TEST_UID="$TestUid" `
         TEST_PROFILE="$TestProfile" `
         login__microsoft__clientId="$env:ClientId" `
-        login__microsoft__secret="$env:ClientSecret" `
         APPINSIGHTS_INSTRUMENTATIONKEY="$env:InstrumentationKey" `
         BUILD_BUILD_ID="$TestDocFolder"
 

--- a/packages/tools/fetch-tool/README.md
+++ b/packages/tools/fetch-tool/README.md
@@ -1,7 +1,7 @@
 # @fluid-tools/fetch-tool
 
 Connection using ODSP or routerlicious driver to dump the messages or snapshot information on the server.
-In order to connect to ODSP, the clientID and clientSecret must be set as environment variables login__microsoft__clientId and login__microsoft__secret, respectively. If you have access to the keyvault this can be done by running [this tool](../../../tools/getkeys).
+In order to connect to ODSP, the clientID must be set as the environment variable `login__microsoft__clientId`. If you have access to the keyvault this can be done by running [this tool](../../../tools/getkeys).
 
 ## Usage
 
@@ -41,7 +41,6 @@ In order to connect to ODSP, the clientID and clientSecret must be set as enviro
     leave                                                                    |    16       3810
     ----------------------------------------------------------------------------------------------------
     Total                                                                    |   105      38605
-
 
 **--stat:dataType**
 
@@ -102,6 +101,7 @@ If you would like to debug fetch-tool, you can create a unit test. Remember to a
 In the unit test, you can use `setArguments()` from fluidFetchArgs to pass in arguments you want to test. Then call the methods you want to run and you will be able to set breakpoints in vscode.
 
 **Example**
+
 ```js
 describe("fetch tool", () => {
     it("can fetch messages", async () => {
@@ -111,4 +111,3 @@ describe("fetch tool", () => {
     });
 });
 ```
-

--- a/packages/tools/fetch-tool/src/fluidFetchInit.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchInit.ts
@@ -8,7 +8,7 @@ import child_process from "child_process";
 import { IFluidResolvedUrl, IResolvedUrl, IUrlResolver } from "@fluidframework/driver-definitions";
 import { configurableUrlResolver } from "@fluidframework/driver-utils";
 import { FluidAppOdspUrlResolver } from "@fluid-tools/fluidapp-odsp-urlresolver";
-import { IClientConfig, IOdspAuthRequestInfo } from "@fluidframework/odsp-doclib-utils";
+import { IPublicClientConfig, IOdspAuthRequestInfo } from "@fluidframework/odsp-doclib-utils";
 import * as odsp from "@fluidframework/odsp-driver";
 import { IOdspResolvedUrl, OdspResourceTokenFetchOptions } from "@fluidframework/odsp-driver-definitions";
 import { OdspUrlResolver } from "@fluidframework/odsp-urlresolver";
@@ -33,7 +33,7 @@ export const fluidFetchWebNavigator = (url: string) => {
 async function initializeODSPCore(
     odspResolvedUrl: IOdspResolvedUrl,
     server: string,
-    clientConfig: IClientConfig,
+    clientConfig: IPublicClientConfig,
 ) {
     const { driveId, itemId } = odspResolvedUrl;
 

--- a/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchSharePoint.ts
@@ -8,7 +8,7 @@ import {
     getChildrenByDriveItem,
     getDriveItemByServerRelativePath,
     getDriveItemFromDriveAndItem,
-    IClientConfig,
+    IPublicClientConfig,
     IOdspDriveItem,
     getOdspRefreshTokenFn,
     IOdspAuthRequestInfo,
@@ -26,7 +26,7 @@ import { getForceTokenReauth } from "./fluidFetchArgs";
 export async function resolveWrapper<T>(
     callback: (authRequestInfo: IOdspAuthRequestInfo) => Promise<T>,
     server: string,
-    clientConfig: IClientConfig,
+    clientConfig: IPublicClientConfig,
     forceTokenReauth = false,
     forToken = false,
 ): Promise<T> {
@@ -68,7 +68,7 @@ export async function resolveWrapper<T>(
 export async function resolveDriveItemByServerRelativePath(
     server: string,
     serverRelativePath: string,
-    clientConfig: IClientConfig,
+    clientConfig: IPublicClientConfig,
 ) {
     return resolveWrapper<IOdspDriveItem>(
         // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -84,7 +84,7 @@ export async function resolveDriveItemByServerRelativePath(
 async function resolveChildrenByDriveItem(
     server: string,
     folderDriveItem: IOdspDriveItem,
-    clientConfig: IClientConfig,
+    clientConfig: IPublicClientConfig,
 ) {
     return resolveWrapper<IOdspDriveItem[]>(
         // eslint-disable-next-line @typescript-eslint/promise-function-async

--- a/packages/utils/odsp-doclib-utils/package.json
+++ b/packages/utils/odsp-doclib-utils/package.json
@@ -88,6 +88,13 @@
     "version": "1.4.0",
     "baselineRange": "~1.3.0",
     "baselineVersion": "1.3.1",
-    "broken": {}
+    "broken": {
+      "broken": {
+        "RemovedInterfaceDeclaration_IClientConfig": {
+          "backCompat": false,
+          "forwardCompat": false
+        }
+      }
+    }
   }
 }

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -20,6 +20,11 @@ export interface IPublicClientConfig {
 	clientId: string;
 }
 
+export interface IClientConfig {
+    clientId: string;
+    clientSecret: string;
+}
+
 export interface IOdspAuthRequestInfo {
     accessToken: string;
     refreshTokenFn?: () => Promise<string>;
@@ -68,7 +73,12 @@ export const getOdspRefreshTokenFn = (server: string, clientConfig: IPublicClien
     getRefreshTokenFn(getOdspScope(server), server, clientConfig, tokens);
 export const getPushRefreshTokenFn = (server: string, clientConfig: IPublicClientConfig, tokens: IOdspTokens) =>
     getRefreshTokenFn(pushScope, server, clientConfig, tokens);
-export const getRefreshTokenFn = (scope: string, server: string, clientConfig: IPublicClientConfig, tokens: IOdspTokens) =>
+export const getRefreshTokenFn = (
+    scope: string,
+    server: string,
+    clientConfig: IPublicClientConfig,
+    tokens: IOdspTokens,
+) =>
     async () => {
         const newTokens = await refreshTokens(server, scope, clientConfig, tokens);
         return newTokens.accessToken;

--- a/packages/utils/odsp-doclib-utils/src/odspAuth.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspAuth.ts
@@ -13,9 +13,11 @@ export interface IOdspTokens {
     readonly refreshToken: string;
 }
 
-export interface IClientConfig {
-    clientId: string;
-    clientSecret: string;
+/**
+ * Configuration for a public client.
+ */
+export interface IPublicClientConfig {
+	clientId: string;
 }
 
 export interface IOdspAuthRequestInfo {
@@ -39,7 +41,6 @@ export type TokenRequestCredentials = {
 type TokenRequestBody =
     TokenRequestCredentials & {
         client_id: string;
-        client_secret: string;
         scope: string;
     };
 
@@ -52,7 +53,7 @@ export function getFetchTokenUrl(server: string): string {
 
 export function getLoginPageUrl(
     server: string,
-    clientConfig: IClientConfig,
+    clientConfig: IPublicClientConfig,
     scope: string,
     odspAuthRedirectUri: string,
 ) {
@@ -63,11 +64,11 @@ export function getLoginPageUrl(
         + `&redirect_uri=${odspAuthRedirectUri}`;
 }
 
-export const getOdspRefreshTokenFn = (server: string, clientConfig: IClientConfig, tokens: IOdspTokens) =>
+export const getOdspRefreshTokenFn = (server: string, clientConfig: IPublicClientConfig, tokens: IOdspTokens) =>
     getRefreshTokenFn(getOdspScope(server), server, clientConfig, tokens);
-export const getPushRefreshTokenFn = (server: string, clientConfig: IClientConfig, tokens: IOdspTokens) =>
+export const getPushRefreshTokenFn = (server: string, clientConfig: IPublicClientConfig, tokens: IOdspTokens) =>
     getRefreshTokenFn(pushScope, server, clientConfig, tokens);
-export const getRefreshTokenFn = (scope: string, server: string, clientConfig: IClientConfig, tokens: IOdspTokens) =>
+export const getRefreshTokenFn = (scope: string, server: string, clientConfig: IPublicClientConfig, tokens: IOdspTokens) =>
     async () => {
         const newTokens = await refreshTokens(server, scope, clientConfig, tokens);
         return newTokens.accessToken;
@@ -83,13 +84,12 @@ export const getRefreshTokenFn = (scope: string, server: string, clientConfig: I
 export async function fetchTokens(
     server: string,
     scope: string,
-    clientConfig: IClientConfig,
+    clientConfig: IPublicClientConfig,
     credentials: TokenRequestCredentials,
 ): Promise<IOdspTokens> {
     const body: TokenRequestBody = {
         scope,
         client_id: clientConfig.clientId,
-        client_secret: clientConfig.clientSecret,
         ...credentials,
     };
     const result = await unauthPostAsync(
@@ -122,7 +122,7 @@ export async function fetchTokens(
 export async function refreshTokens(
     server: string,
     scope: string,
-    clientConfig: IClientConfig,
+    clientConfig: IPublicClientConfig,
     tokens: IOdspTokens,
 ): Promise<IOdspTokens> {
     // Clear out the old tokens while awaiting the new tokens

--- a/packages/utils/tool-utils/src/odspTokenManager.ts
+++ b/packages/utils/tool-utils/src/odspTokenManager.ts
@@ -91,7 +91,7 @@ export class OdspTokenManager {
         forceRefresh = false,
         forceReauth = false,
     ): Promise<IOdspTokens> {
-        debug('Getting odsp tokens');
+        debug("Getting odsp tokens");
         return this.getTokens(
             false,
             server,
@@ -109,7 +109,7 @@ export class OdspTokenManager {
         forceRefresh = false,
         forceReauth = false,
     ): Promise<IOdspTokens> {
-        debug('Getting push tokens');
+        debug("Getting push tokens");
         return this.getTokens(
             true,
             server,

--- a/packages/utils/tool-utils/src/odspTokenManager.ts
+++ b/packages/utils/tool-utils/src/odspTokenManager.ts
@@ -6,7 +6,7 @@
 import { unreachableCase } from "@fluidframework/common-utils";
 import {
     IOdspTokens,
-    IClientConfig,
+    IPublicClientConfig,
     fetchTokens,
     refreshTokens,
     getOdspScope,
@@ -24,18 +24,12 @@ const odspAuthRedirectPort = 7000;
 const odspAuthRedirectOrigin = `http://localhost:${odspAuthRedirectPort}`;
 const odspAuthRedirectUri = new URL("/auth/callback", odspAuthRedirectOrigin).href;
 
-export const getMicrosoftConfiguration = (): IClientConfig => ({
+export const getMicrosoftConfiguration = (): IPublicClientConfig => ({
     get clientId() {
         if (!process.env.login__microsoft__clientId) {
             throw new Error("Client ID environment variable not set: login__microsoft__clientId.");
         }
         return process.env.login__microsoft__clientId;
-    },
-    get clientSecret() {
-        if (!process.env.login__microsoft__secret) {
-            throw new Error("Client Secret environment variable not set: login__microsoft__secret.");
-        }
-        return process.env.login__microsoft__secret;
     },
 });
 
@@ -92,11 +86,12 @@ export class OdspTokenManager {
 
     public async getOdspTokens(
         server: string,
-        clientConfig: IClientConfig,
+        clientConfig: IPublicClientConfig,
         tokenConfig: OdspTokenConfig,
         forceRefresh = false,
         forceReauth = false,
     ): Promise<IOdspTokens> {
+        debug('Getting odsp tokens');
         return this.getTokens(
             false,
             server,
@@ -109,11 +104,12 @@ export class OdspTokenManager {
 
     public async getPushTokens(
         server: string,
-        clientConfig: IClientConfig,
+        clientConfig: IPublicClientConfig,
         tokenConfig: OdspTokenConfig,
         forceRefresh = false,
         forceReauth = false,
     ): Promise<IOdspTokens> {
+        debug('Getting push tokens');
         return this.getTokens(
             true,
             server,
@@ -153,7 +149,7 @@ export class OdspTokenManager {
     private async getTokens(
         isPush: boolean,
         server: string,
-        clientConfig: IClientConfig,
+        clientConfig: IPublicClientConfig,
         tokenConfig: OdspTokenConfig,
         forceRefresh: boolean,
         forceReauth: boolean,
@@ -194,7 +190,7 @@ export class OdspTokenManager {
     private async getTokensCore(
         isPush: boolean,
         server: string,
-        clientConfig: IClientConfig,
+        clientConfig: IPublicClientConfig,
         tokenConfig: OdspTokenConfig,
         forceRefresh,
         forceReauth,
@@ -257,7 +253,7 @@ export class OdspTokenManager {
     private async acquireTokensWithPassword(
         server: string,
         scope: string,
-        clientConfig: IClientConfig,
+        clientConfig: IPublicClientConfig,
         username: string,
         password: string,
     ): Promise<IOdspTokens> {
@@ -272,7 +268,7 @@ export class OdspTokenManager {
     private async acquireTokensViaBrowserLogin(
         loginPageUrl: string,
         server: string,
-        clientConfig: IClientConfig,
+        clientConfig: IPublicClientConfig,
         scope: string,
         navigator: (url: string) => void,
         redirectUriCallback?: (tokens: IOdspTokens) => Promise<string>,

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -75,7 +75,6 @@ stages:
         testCommand: start:odspdf
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)
-          login__microsoft__secret: $(login-microsoft-secret)
           login__odspdf__test__tenants: $(automation-stress-login-odspdf-test-tenants)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 

--- a/tools/pipelines/test-real-service-stress.yml
+++ b/tools/pipelines/test-real-service-stress.yml
@@ -53,7 +53,6 @@ stages:
         testCommand: start:odsp
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)
-          login__microsoft__secret: $(login-microsoft-secret)
           login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -149,6 +149,5 @@ stages:
             flags: --compatVersion=LTS --tenantIndex=3
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)
-          login__microsoft__secret: $(login-microsoft-secret)
           login__odsp__test__tenants: $(automation-e2e-login-odsp-test-tenants)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject


### PR DESCRIPTION
## Description

Currently, we use the ropc flow with a confidential client to authenticate in our e2e/stress tests against odsp. This is less appropriate than using a public client flow, since our application registration really only needs to have delegated permissions.
This PR adjusts things to use a public flow--I've updated the relevant app registrations to allow both forms of auth already.

Using a public flow also means our infrastructure setup here aligns exactly with [this relatively recent MSFT guidance](https://learn.microsoft.com/en-us/entra/identity-platform/test-automate-integration-testing?tabs=dotnet).

Cherry-pick of #21091. This change needs to be in every branch we plan on maintaining real service tests against odsp for, as I plan on removing the application configuration enabling confidential client auth.