### PR TITLE
fix(ci): Try workaround for Credscan failures (#20104)

### DIFF
--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -47,6 +47,9 @@ extends:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022
         os: windows
+      # Tentative workaround for the occasional Credscan failures
+      credscan:
+        batchSize: 4
     # Skip tagging if Github PR coming from a fork
     settings:
       skipBuildTagsForGitHubPullRequests: true

--- a/tools/pipelines/templates/1ES/build-docker-service.yml
+++ b/tools/pipelines/templates/1ES/build-docker-service.yml
@@ -129,6 +129,9 @@ extends:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022
         os: windows
+      # Tentative workaround for the occasional Credscan failures
+      credscan:
+          batchSize: 4
     # Skip tagging if Github PR coming from a fork;  This skips Microsoft security checks that won't work on forks.
     settings:
       skipBuildTagsForGitHubPullRequests: true

--- a/tools/pipelines/templates/1ES/build-npm-package.yml
+++ b/tools/pipelines/templates/1ES/build-npm-package.yml
@@ -166,6 +166,9 @@ extends:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022
         os: windows
+      # Tentative workaround for the occasional Credscan failures
+      credscan:
+        batchSize: 4
     # Skip tagging if Github PR coming from a fork;  This skips Microsoft security checks that won't work on forks.
     settings:
       skipBuildTagsForGitHubPullRequests: true


### PR DESCRIPTION
Cherry-pick of https://github.com/microsoft/FluidFramework/pull/20104

## Description

We've had a few instances of the auto-injected CredScan task failing during CI runs. Support told us to try this workaround.