### PR TITLE
improvement(eslint-config-fluid): relax @fluid-experimental imports

### DIFF
--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -10,6 +10,9 @@ const permittedImports = [
 	// Within Fluid Framework allow import of '/internal' from other FF packages.
 	"@fluidframework/*/internal",
 
+	// Experimental packages are frankly unknown, so allow any imports from them.
+	"@fluid-experimental/**",
+
 	// Allow imports from sibling and ancestral sibling directories,
 	// but not from cousin directories. Parent is allowed but only
 	// because there isn't a known way to deny it.

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -10,7 +10,7 @@ const permittedImports = [
 	// Within Fluid Framework allow import of '/internal' from other FF packages.
 	"@fluidframework/*/internal",
 
-	// Experimental packages are frankly unknown, so allow any imports from them.
+	// Experimental package APIs and exports are unknown, so allow any imports from them.
 	"@fluid-experimental/**",
 
 	// Allow imports from sibling and ancestral sibling directories,

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -603,6 +603,7 @@
             {
                 "allow": [
                     "@fluidframework/*/internal",
+                    "@fluid-experimental/**",
                     "*/index.js"
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -596,6 +596,7 @@
             {
                 "allow": [
                     "@fluidframework/*/internal",
+                    "@fluid-experimental/**",
                     "*/index.js"
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -605,6 +605,7 @@
             {
                 "allow": [
                     "@fluidframework/*/internal",
+                    "@fluid-experimental/**",
                     "*/index.js"
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -603,6 +603,7 @@
             {
                 "allow": [
                     "@fluidframework/*/internal",
+                    "@fluid-experimental/**",
                     "*/index.js"
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -619,6 +619,7 @@
             {
                 "allow": [
                     "@fluidframework/*/internal",
+                    "@fluid-experimental/**",
                     "*/index.js"
                 ]
             }

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -605,6 +605,7 @@
                     "@fluid*/*/test*",
                     "@fluid*/*/internal/test*",
                     "@fluidframework/*/internal",
+                    "@fluid-experimental/**",
                     "*/index.js"
                 ]
             }


### PR DESCRIPTION
experimental packages are free to experiment with export paths and thus imports need not be restricted.