### PR TITLE
Upload manifest file for release branch

### DIFF
--- a/build-tools/packages/build-cli/docs/release.md
+++ b/build-tools/packages/build-cli/docs/release.md
@@ -217,9 +217,12 @@ Creates a release report for an unreleased build (one that is not published to n
 
 ```
 USAGE
-  $ flub release report-unreleased --version <value> --outDir <value> --fullReportFilePath <value> [-v | --quiet]
+  $ flub release report-unreleased --version <value> --outDir <value> --fullReportFilePath <value> --branchName <value> [-v |
+    --quiet]
 
 FLAGS
+  --branchName=<value>          (required) Branch name. For release branches, the manifest file is uplaoded by build
+                                number and not by current date.
   --fullReportFilePath=<value>  (required) Path to a report file in the 'full' format.
   --outDir=<value>              (required) Release report output directory
   --version=<value>             (required) Version to generate a report for. Typically, this version is the version of a

--- a/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
@@ -184,18 +184,10 @@ async function updateReportVersions(
  * @example
  * Returns 260312
  * extractBuildNumber("2.0.0-dev-rc.4.0.0.260312");
- *
- * @example
- * Returns 259575
- * extractBuildNumber("0.0.0-259575-test");
  */
 
 function extractBuildNumber(version: string): number {
-	const devVersion: boolean = version.includes("dev");
-	const versionParts: string[] = devVersion ? version.split(".") : version.split("-");
-
-	// Extract the last part of the version, which is the build number
-	return devVersion
-		? Number.parseInt(versionParts[versionParts.length - 1], 10)
-		: Number.parseInt(versionParts[1], 10);
+	const versionParts: string[] = version.split(".");
+	// Extract the last part of the version, which is the number you're looking for
+	return Number.parseInt(versionParts[versionParts.length - 1], 10);
 }

--- a/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
@@ -184,10 +184,18 @@ async function updateReportVersions(
  * @example
  * Returns 260312
  * extractBuildNumber("2.0.0-dev-rc.4.0.0.260312");
+ *
+ * @example
+ * Returns 259575
+ * extractBuildNumber("0.0.0-259575-test");
  */
 
 function extractBuildNumber(version: string): number {
-	const versionParts: string[] = version.split(".");
-	// Extract the last part of the version, which is the number you're looking for
-	return Number.parseInt(versionParts[versionParts.length - 1], 10);
+	const devVersion: boolean = version.includes("dev");
+	const versionParts: string[] = devVersion ? version.split(".") : version.split("-");
+
+	// Extract the last part of the version, which is the build number
+	return devVersion
+		? Number.parseInt(versionParts[versionParts.length - 1], 10)
+		: Number.parseInt(versionParts[1], 10);
 }

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -584,7 +584,7 @@ extends:
 
                 # This condition should be kept in sync with the one in include-set-package-version, which decides if
                 # upload-dev-manifest.yml should be included or not.
-                - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(parameters.tagName, 'client')) }}:
+                - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), eq(parameters.tagName, 'client')) }}:
                   - output: pipelineArtifact
                     displayName: Publish Artifact - release_reports
                     targetPath: $(Build.ArtifactStagingDirectory)/release_reports

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -584,7 +584,7 @@ extends:
 
                 # This condition should be kept in sync with the one in include-set-package-version, which decides if
                 # upload-dev-manifest.yml should be included or not.
-                - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), eq(parameters.tagName, 'client')) }}:
+                - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.tagName, 'client'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
                   - output: pipelineArtifact
                     displayName: Publish Artifact - release_reports
                     targetPath: $(Build.ArtifactStagingDirectory)/release_reports

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -148,7 +148,7 @@ steps:
 # Only generate manifest files for runs in the internal project (i.e. CI runs, not PR run), for the main and release branch, and
 # for the build of the client release group (we don't need manifests for anything else).
 # Enabling this template for every PR run risks overwriting existing manifest files uploaded to Azure blobs. Therefore, it's crucial to restrict this template to commits merged into the main and release branch.
-- ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), eq(parameters.tagName, 'client')) }}:
+- ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.tagName, 'client'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
   - template: /tools/pipelines/templates/upload-dev-manifest.yml
     parameters:
       buildDirectory: '${{ parameters.buildDirectory }}'

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -145,15 +145,16 @@ steps:
     workingDirectory: ${{ parameters.buildDirectory }}
     filePath: $(Build.SourcesDirectory)/scripts/update-package-version.sh
 
-# Only generate manifest files for runs in the internal project (i.e. CI runs, not PR run), for the main branch, and
+# Only generate manifest files for runs in the internal project (i.e. CI runs, not PR run), for the main and release branch, and
 # for the build of the client release group (we don't need manifests for anything else).
-# Enabling this template for every PR run risks overwriting existing manifest files uploaded to Azure blobs. Therefore, it's crucial to restrict this template to commits merged into the main branch.
-- ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(parameters.tagName, 'client')) }}:
+# Enabling this template for every PR run risks overwriting existing manifest files uploaded to Azure blobs. Therefore, it's crucial to restrict this template to commits merged into the main and release branch.
+- ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), eq(parameters.tagName, 'client')) }}:
   - template: /tools/pipelines/templates/upload-dev-manifest.yml
     parameters:
       buildDirectory: '${{ parameters.buildDirectory }}'
       STORAGE_ACCOUNT: '${{ parameters.STORAGE_ACCOUNT }}'
       STORAGE_KEY: '${{ parameters.STORAGE_KEY }}'
+      branchName: ${{ variables['Build.SourceBranch'] }}
 
 # This task is a last-minute verification that no Fluid internal versions show up with caret dependencies. This is to
 # help find and prevent bugs in the version bumping tools.

--- a/tools/pipelines/templates/include-set-package-version.yml
+++ b/tools/pipelines/templates/include-set-package-version.yml
@@ -154,7 +154,6 @@ steps:
       buildDirectory: '${{ parameters.buildDirectory }}'
       STORAGE_ACCOUNT: '${{ parameters.STORAGE_ACCOUNT }}'
       STORAGE_KEY: '${{ parameters.STORAGE_KEY }}'
-      branchName: ${{ variables['Build.SourceBranch'] }}
 
 # This task is a last-minute verification that no Fluid internal versions show up with caret dependencies. This is to
 # help find and prevent bugs in the version bumping tools.

--- a/tools/pipelines/templates/upload-dev-manifest.yml
+++ b/tools/pipelines/templates/upload-dev-manifest.yml
@@ -11,6 +11,9 @@ parameters:
 - name: STORAGE_KEY
   type: string
 
+- name: branchName
+  type: string
+
 steps:
 - task: Bash@3
   displayName: Generate release reports
@@ -28,7 +31,7 @@ steps:
     workingDirectory: ${{ parameters.buildDirectory }}
     script: |
       mkdir upload_release_reports
-      flub release report-unreleased --version $(SetVersion.version) --fullReportFilePath generate_release_reports/manifest.full.json --outDir upload_release_reports
+      flub release report-unreleased --version $(SetVersion.version) --fullReportFilePath generate_release_reports/manifest.full.json --outDir upload_release_reports --branchName ${{ parameters.branchName }}
 
 - task: CopyFiles@2
   displayName: Copy release reports

--- a/tools/pipelines/templates/upload-dev-manifest.yml
+++ b/tools/pipelines/templates/upload-dev-manifest.yml
@@ -11,9 +11,6 @@ parameters:
 - name: STORAGE_KEY
   type: string
 
-- name: branchName
-  type: string
-
 steps:
 - task: Bash@3
   displayName: Generate release reports
@@ -31,7 +28,7 @@ steps:
     workingDirectory: ${{ parameters.buildDirectory }}
     script: |
       mkdir upload_release_reports
-      flub release report-unreleased --version $(SetVersion.version) --fullReportFilePath generate_release_reports/manifest.full.json --outDir upload_release_reports --branchName ${{ parameters.branchName }}
+      flub release report-unreleased --version $(SetVersion.version) --fullReportFilePath generate_release_reports/manifest.full.json --outDir upload_release_reports --branchName '$(Build.SourceBranch)'
 
 - task: CopyFiles@2
   displayName: Copy release reports


### PR DESCRIPTION
The manifest file is uploaded by date and build number for main branch. This change extends the functionality for release branches too. 
 
For release branches, the manifest file is uploaded based on the build number, rather than the date. This approach prevents it from overriding the one uploaded from the main branch.
 
Once this PR is merged in main, I can port the change to release branches. 