### PR TITLE
More public API refinement

### DIFF
--- a/.changeset/public-cases-press.md
+++ b/.changeset/public-cases-press.md
@@ -9,4 +9,4 @@ Declarative API cleanup
 Make `IDisposable` `@beta` since it's most public use is `IDevtools` which is `@beta`.
 Make `IInboundSignalMessage` `@alpha` since its not used in the declarative API.
 
-Cleanup `fluid-framework` legacy exports toi remove no longer required types.
+Cleanup `fluid-framework` legacy exports to remove no longer required types.

--- a/.changeset/public-cases-press.md
+++ b/.changeset/public-cases-press.md
@@ -1,0 +1,12 @@
+---
+"@fluidframework/core-interfaces": minor
+"fluid-framework": minor
+"@fluidframework/runtime-definitions": minor
+---
+
+Declarative API cleanup
+
+Make `IDisposable` `@beta` since it's most public use is `IDevtools` which is `@beta`.
+Make `IInboundSignalMessage` `@alpha` since its not used in the declarative API.
+
+Cleanup `fluid-framework` legacy exports toi remove no longer required types.

--- a/examples/data-objects/codemirror/src/presence.ts
+++ b/examples/data-objects/codemirror/src/presence.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from "@fluid-example/example-utils";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 import CodeMirror from "codemirror";
 
 interface IPresenceInfo {

--- a/experimental/dds/tree/api-report/experimental-tree.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.api.md
@@ -10,7 +10,7 @@ import { IChannelAttributes } from '@fluidframework/datastore-definitions/intern
 import { IChannelFactory } from '@fluidframework/datastore-definitions/internal';
 import { IChannelServices } from '@fluidframework/datastore-definitions/internal';
 import { IChannelStorageService } from '@fluidframework/datastore-definitions/internal';
-import { IDisposable } from '@fluidframework/core-interfaces';
+import { IDisposable } from '@fluidframework/core-interfaces/internal';
 import { IErrorEvent } from '@fluidframework/core-interfaces';
 import { IEvent } from '@fluidframework/core-interfaces';
 import { IExperimentalIncrementalSummaryContext } from '@fluidframework/runtime-definitions/internal';

--- a/experimental/dds/tree/src/Checkout.ts
+++ b/experimental/dds/tree/src/Checkout.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable, IErrorEvent, ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
+import { IErrorEvent, ITelemetryBaseProperties } from '@fluidframework/core-interfaces';
+import { IDisposable } from '@fluidframework/core-interfaces/internal';
 import { assert } from '@fluidframework/core-utils/internal';
 import {
 	ITelemetryLoggerExt,

--- a/experimental/framework/data-objects/api-report/data-objects.api.md
+++ b/experimental/framework/data-objects/api-report/data-objects.api.md
@@ -8,7 +8,7 @@ import { DataObject } from '@fluidframework/aqueduct/internal';
 import { DataObjectFactory } from '@fluidframework/aqueduct/internal';
 import { EventEmitter } from '@fluid-internal/client-utils';
 import { IErrorEvent } from '@fluidframework/core-interfaces';
-import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
+import { IInboundSignalMessage } from '@fluidframework/runtime-definitions/internal';
 import { Jsonable } from '@fluidframework/datastore-definitions/internal';
 
 // @internal

--- a/experimental/framework/data-objects/src/signaler/signaler.ts
+++ b/experimental/framework/data-objects/src/signaler/signaler.ts
@@ -8,7 +8,7 @@ import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/internal
 import { IErrorEvent } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { Jsonable } from "@fluidframework/datastore-definitions/internal";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 
 // TODO:
 // add way to mark with current sequence number for ordering signals relative to ops

--- a/packages/common/container-definitions/api-report/container-definitions.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.api.md
@@ -9,7 +9,7 @@ import type { IAnyDriverError } from '@fluidframework/driver-definitions/interna
 import type { IClient } from '@fluidframework/protocol-definitions';
 import type { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import type { IClientDetails } from '@fluidframework/protocol-definitions';
-import type { IDisposable } from '@fluidframework/core-interfaces';
+import type { IDisposable } from '@fluidframework/core-interfaces/internal';
 import type { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import type { IDocumentStorageService } from '@fluidframework/driver-definitions/internal';
 import { IErrorBase } from '@fluidframework/core-interfaces/internal';

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -4,12 +4,12 @@
  */
 
 import type {
-	IDisposable,
 	IErrorBase,
 	IErrorEvent,
 	IEvent,
 	IEventProvider,
 } from "@fluidframework/core-interfaces";
+import type { IDisposable } from "@fluidframework/core-interfaces/internal";
 import type { IAnyDriverError } from "@fluidframework/driver-definitions/internal";
 import type {
 	IClientConfiguration,

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -3,11 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import type {
-	FluidObject,
-	IDisposable,
-	ITelemetryBaseLogger,
-} from "@fluidframework/core-interfaces";
+import type { FluidObject, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import type { IDisposable } from "@fluidframework/core-interfaces/internal";
 import type {
 	IDocumentStorageService,
 	ISnapshot,

--- a/packages/common/core-interfaces/api-report/core-interfaces.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.api.md
@@ -47,7 +47,7 @@ export interface IConfigProviderBase {
     getRawConfig(name: string): ConfigTypes;
 }
 
-// @public
+// @beta
 export interface IDisposable {
     dispose(error?: Error): void;
     readonly disposed: boolean;

--- a/packages/common/core-interfaces/src/disposable.ts
+++ b/packages/common/core-interfaces/src/disposable.ts
@@ -5,7 +5,7 @@
 
 /**
  * Base interface for objects that require lifetime management via explicit disposal.
- * @public
+ * @beta
  */
 export interface IDisposable {
 	/**

--- a/packages/common/driver-definitions/api-report/driver-definitions.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.api.md
@@ -8,7 +8,7 @@ import type { ConnectionMode } from '@fluidframework/protocol-definitions';
 import type { IClient } from '@fluidframework/protocol-definitions';
 import type { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import type { ICreateBlobResponse } from '@fluidframework/protocol-definitions';
-import type { IDisposable } from '@fluidframework/core-interfaces';
+import type { IDisposable } from '@fluidframework/core-interfaces/internal';
 import type { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import type { IErrorEvent } from '@fluidframework/core-interfaces';
 import type { IEvent } from '@fluidframework/core-interfaces';

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -4,12 +4,12 @@
  */
 
 import type {
-	IDisposable,
 	IErrorEvent,
 	IEvent,
 	IEventProvider,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
+import type { IDisposable } from "@fluidframework/core-interfaces/internal";
 import type {
 	ConnectionMode,
 	IClient,

--- a/packages/dds/map/api-report/map.api.md
+++ b/packages/dds/map/api-report/map.api.md
@@ -7,7 +7,7 @@
 import type { IChannelAttributes } from '@fluidframework/datastore-definitions/internal';
 import type { IChannelFactory } from '@fluidframework/datastore-definitions/internal';
 import type { IChannelServices } from '@fluidframework/datastore-definitions/internal';
-import type { IDisposable } from '@fluidframework/core-interfaces';
+import type { IDisposable } from '@fluidframework/core-interfaces/internal';
 import type { IEvent } from '@fluidframework/core-interfaces';
 import type { IEventProvider } from '@fluidframework/core-interfaces';
 import type { IEventThisPlaceHolder } from '@fluidframework/core-interfaces';

--- a/packages/dds/map/src/interfaces.ts
+++ b/packages/dds/map/src/interfaces.ts
@@ -4,11 +4,11 @@
  */
 
 import type {
-	IDisposable,
 	IEvent,
 	IEventProvider,
 	IEventThisPlaceHolder,
 } from "@fluidframework/core-interfaces";
+import type { IDisposable } from "@fluidframework/core-interfaces/internal";
 import type {
 	ISharedObject,
 	ISharedObjectEvents,

--- a/packages/drivers/driver-base/api-report/driver-base.api.md
+++ b/packages/drivers/driver-base/api-report/driver-base.api.md
@@ -10,7 +10,7 @@ import { IAnyDriverError } from '@fluidframework/driver-definitions/internal';
 import { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import { IConnect } from '@fluidframework/protocol-definitions';
 import { IConnected } from '@fluidframework/protocol-definitions';
-import { IDisposable } from '@fluidframework/core-interfaces';
+import { IDisposable } from '@fluidframework/core-interfaces/internal';
 import { IDocumentDeltaConnection } from '@fluidframework/driver-definitions/internal';
 import { IDocumentDeltaConnectionEvents } from '@fluidframework/driver-definitions/internal';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';

--- a/packages/drivers/driver-base/src/documentDeltaConnection.ts
+++ b/packages/drivers/driver-base/src/documentDeltaConnection.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable, ITelemetryBaseProperties, LogLevel } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties, LogLevel } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import {
 	IAnyDriverError,

--- a/packages/drivers/file-driver/api-report/file-driver.api.md
+++ b/packages/drivers/file-driver/api-report/file-driver.api.md
@@ -8,7 +8,7 @@ import * as api from '@fluidframework/protocol-definitions';
 import { ConnectionMode } from '@fluidframework/protocol-definitions';
 import { IClientConfiguration } from '@fluidframework/protocol-definitions';
 import { IConnected } from '@fluidframework/protocol-definitions';
-import { IDisposable } from '@fluidframework/core-interfaces';
+import { IDisposable } from '@fluidframework/core-interfaces/internal';
 import { IDocumentDeltaConnection } from '@fluidframework/driver-definitions/internal';
 import { IDocumentDeltaConnectionEvents } from '@fluidframework/driver-definitions/internal';
 import { IDocumentDeltaStorageService } from '@fluidframework/driver-definitions/internal';

--- a/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
+++ b/packages/drivers/file-driver/src/fileDocumentDeltaConnection.ts
@@ -4,7 +4,7 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IDisposable } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import {
 	IDocumentDeltaConnection,
 	IDocumentDeltaConnectionEvents,

--- a/packages/drivers/odsp-driver/src/retryErrorsStorageAdapter.ts
+++ b/packages/drivers/odsp-driver/src/retryErrorsStorageAdapter.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import {
 	FetchSource,
 	IDocumentStorageService,

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -4,7 +4,7 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IDisposable } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { delay } from "@fluidframework/core-utils/internal";
 import {
 	IDocumentDeltaConnection,

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -6,26 +6,14 @@
 
 import { Client } from '@fluidframework/merge-tree/internal';
 import { ErasedType } from '@fluidframework/core-interfaces';
-import { EventEmitterEventType } from '@fluid-internal/client-utils';
-import { EventEmitterWithErrorHandling } from '@fluidframework/telemetry-utils/internal';
 import { IChannel } from '@fluidframework/datastore-definitions/internal';
-import { IChannelAttributes } from '@fluidframework/datastore-definitions/internal';
-import type { IChannelFactory } from '@fluidframework/datastore-definitions/internal';
-import { IChannelServices } from '@fluidframework/datastore-definitions/internal';
-import { IChannelStorageService } from '@fluidframework/datastore-definitions/internal';
-import type { IClientConfiguration } from '@fluidframework/protocol-definitions';
-import type { IClientDetails } from '@fluidframework/protocol-definitions';
-import type { IDisposable as IDisposable_2 } from '@fluidframework/core-interfaces';
-import { IDocumentMessage } from '@fluidframework/protocol-definitions';
+import type { IDisposable as IDisposable_2 } from '@fluidframework/core-interfaces/internal';
 import type { IErrorBase } from '@fluidframework/core-interfaces';
 import { IErrorEvent } from '@fluidframework/core-interfaces';
 import { IEvent } from '@fluidframework/core-interfaces';
 import { IEventProvider } from '@fluidframework/core-interfaces';
 import { IEventThisPlaceHolder } from '@fluidframework/core-interfaces';
-import { IExperimentalIncrementalSummaryContext } from '@fluidframework/runtime-definitions/internal';
-import { IFluidDataStoreRuntime } from '@fluidframework/datastore-definitions/internal';
 import { IFluidHandle } from '@fluidframework/core-interfaces';
-import { IFluidHandleInternal } from '@fluidframework/core-interfaces/internal';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions/internal';
 import { IJSONSegment } from '@fluidframework/merge-tree/internal';
@@ -38,11 +26,6 @@ import { ISegment } from '@fluidframework/merge-tree/internal';
 import { ISegmentAction } from '@fluidframework/merge-tree/internal';
 import { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import { ISharedObjectKind } from '@fluidframework/shared-object-base/internal';
-import type { ISignalMessage } from '@fluidframework/protocol-definitions';
-import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/internal';
-import { ITelemetryContext } from '@fluidframework/runtime-definitions/internal';
-import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
-import type { ITokenClaims } from '@fluidframework/protocol-definitions';
 import { LocalReferencePosition } from '@fluidframework/merge-tree/internal';
 import { Marker } from '@fluidframework/merge-tree/internal';
 import { MergeTreeDeltaOperationType } from '@fluidframework/merge-tree/internal';
@@ -110,19 +93,6 @@ export type ConnectionStateType = ConnectionStateType.Disconnected | ConnectionS
 // @public
 export type ContainerAttachProps<T = unknown> = T;
 
-// @alpha
-export const ContainerErrorTypes: {
-    readonly clientSessionExpiredError: "clientSessionExpiredError";
-    readonly genericError: "genericError";
-    readonly throttlingError: "throttlingError";
-    readonly dataCorruptionError: "dataCorruptionError";
-    readonly dataProcessingError: "dataProcessingError";
-    readonly usageError: "usageError";
-};
-
-// @alpha
-export type ContainerErrorTypes = (typeof ContainerErrorTypes)[keyof typeof ContainerErrorTypes];
-
 // @public
 export interface ContainerSchema {
     readonly dynamicObjectTypes?: readonly SharedObjectKind[];
@@ -136,43 +106,8 @@ export interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldP
 // @alpha (undocumented)
 export type DeserializeCallback = (properties: PropertySet) => void;
 
-// @alpha @sealed
-export class DirectoryFactory implements IChannelFactory<ISharedDirectory> {
-    static readonly Attributes: IChannelAttributes;
-    get attributes(): IChannelAttributes;
-    create(runtime: IFluidDataStoreRuntime, id: string): ISharedDirectory;
-    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, attributes: IChannelAttributes): Promise<ISharedDirectory>;
-    static readonly Type = "https://graph.microsoft.com/types/directory";
-    get type(): string;
-}
-
 // @public
 export const disposeSymbol: unique symbol;
-
-// @alpha
-export const DriverErrorTypes: {
-    readonly genericNetworkError: "genericNetworkError";
-    readonly authorizationError: "authorizationError";
-    readonly fileNotFoundOrAccessDeniedError: "fileNotFoundOrAccessDeniedError";
-    readonly offlineError: "offlineError";
-    readonly unsupportedClientProtocolVersion: "unsupportedClientProtocolVersion";
-    readonly writeError: "writeError";
-    readonly fetchFailure: "fetchFailure";
-    readonly fetchTokenError: "fetchTokenError";
-    readonly incorrectServerResponse: "incorrectServerResponse";
-    readonly fileOverwrittenInStorage: "fileOverwrittenInStorage";
-    readonly deltaStreamConnectionForbidden: "deltaStreamConnectionForbidden";
-    readonly locationRedirection: "locationRedirection";
-    readonly fluidInvalidSchema: "fluidInvalidSchema";
-    readonly fileIsLocked: "fileIsLocked";
-    readonly outOfStorageError: "outOfStorageError";
-    readonly genericError: "genericError";
-    readonly throttlingError: "throttlingError";
-    readonly usageError: "usageError";
-};
-
-// @alpha
-export type DriverErrorTypes = (typeof DriverErrorTypes)[keyof typeof DriverErrorTypes];
 
 // @public
 export type Events<E> = {
@@ -217,97 +152,14 @@ export type FlexList<Item = unknown> = readonly LazyItem<Item>[];
 // @public
 export type FlexListToUnion<TList extends FlexList> = ExtractItemType<TList[number]>;
 
-// @alpha
-export interface IAnyDriverError extends Omit<IDriverErrorBase, "errorType"> {
-    // (undocumented)
-    readonly errorType: string;
-    scenarioName?: string;
-}
-
 // @public
 export interface IConnection {
     readonly id: string;
     readonly mode: "write" | "read";
 }
 
-// @alpha
-export interface IConnectionDetails {
-    checkpointSequenceNumber: number | undefined;
-    // (undocumented)
-    claims: ITokenClaims;
-    clientId: string;
-    // (undocumented)
-    serviceConfiguration: IClientConfiguration;
-}
-
 // @public
 export type ICriticalContainerError = IErrorBase;
-
-// @alpha @sealed
-export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>, IDeltaSender {
-    readonly active: boolean;
-    readonly clientDetails: IClientDetails;
-    readonly hasCheckpointSequenceNumber: boolean;
-    // @deprecated
-    readonly inbound: IDeltaQueue<T>;
-    readonly inboundSignal: IDeltaQueue<ISignalMessage>;
-    readonly initialSequenceNumber: number;
-    readonly lastKnownSeqNumber: number;
-    readonly lastMessage: ISequencedDocumentMessage | undefined;
-    readonly lastSequenceNumber: number;
-    readonly maxMessageSize: number;
-    readonly minimumSequenceNumber: number;
-    // @deprecated
-    readonly outbound: IDeltaQueue<U[]>;
-    // (undocumented)
-    readonly readOnlyInfo: ReadOnlyInfo;
-    readonly serviceConfiguration: IClientConfiguration | undefined;
-    submitSignal(content: any, targetClientId?: string): void;
-    readonly version: string;
-}
-
-// @alpha @sealed
-export interface IDeltaManagerEvents extends IEvent {
-    // @deprecated (undocumented)
-    (event: "prepareSend", listener: (messageBuffer: any[]) => void): any;
-    // @deprecated (undocumented)
-    (event: "submitOp", listener: (message: IDocumentMessage) => void): any;
-    (event: "op", listener: (message: ISequencedDocumentMessage, processingTime: number) => void): any;
-    (event: "pong", listener: (latency: number) => void): any;
-    (event: "connect", listener: (details: IConnectionDetails, opsBehind?: number) => void): any;
-    (event: "disconnect", listener: (reason: string, error?: IAnyDriverError) => void): any;
-    (event: "readonly", listener: (readonly: boolean, readonlyConnectionReason?: {
-        reason: string;
-        error?: IErrorBase;
-    }) => void): any;
-}
-
-// @alpha @sealed
-export interface IDeltaQueue<T> extends IEventProvider<IDeltaQueueEvents<T>>, IDisposable_2 {
-    idle: boolean;
-    length: number;
-    pause(): Promise<void>;
-    paused: boolean;
-    peek(): T | undefined;
-    resume(): void;
-    toArray(): T[];
-    waitTillProcessingDone(): Promise<{
-        count: number;
-        duration: number;
-    }>;
-}
-
-// @alpha @sealed
-export interface IDeltaQueueEvents<T> extends IErrorEvent {
-    (event: "push", listener: (task: T) => void): any;
-    (event: "op", listener: (task: T) => void): any;
-    (event: "idle", listener: (count: number, duration: number) => void): any;
-}
-
-// @alpha @sealed
-export interface IDeltaSender {
-    flush(): void;
-}
 
 // @alpha
 export interface IDirectory extends Map<string, any>, IEventProvider<IDirectoryEvents>, Partial<IDisposable_2> {
@@ -342,15 +194,6 @@ export interface IDisposable {
     [disposeSymbol](): void;
 }
 
-// @alpha
-export interface IDriverErrorBase {
-    canRetry: boolean;
-    endpointReached?: boolean;
-    readonly errorType: DriverErrorTypes;
-    readonly message: string;
-    online?: string;
-}
-
 // @public @sealed
 export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
     attach(props?: ContainerAttachProps): Promise<string>;
@@ -372,14 +215,6 @@ export interface IFluidContainerEvents extends IEvent {
     (event: "saved", listener: () => void): void;
     (event: "dirty", listener: () => void): void;
     (event: "disposed", listener: (error?: ICriticalContainerError) => void): any;
-}
-
-// @alpha (undocumented)
-export interface IFluidSerializer {
-    decode(input: any): any;
-    encode(value: any, bind: IFluidHandle): any;
-    parse(value: string): any;
-    stringify(value: any, bind: IFluidHandle): string;
 }
 
 // @alpha
@@ -729,16 +564,6 @@ export type LazyItem<Item = unknown> = Item | (() => Item);
 export interface MakeNominal {
 }
 
-// @alpha @sealed
-export class MapFactory implements IChannelFactory<ISharedMap> {
-    static readonly Attributes: IChannelAttributes;
-    get attributes(): IChannelAttributes;
-    create(runtime: IFluidDataStoreRuntime, id: string): ISharedMap;
-    load(runtime: IFluidDataStoreRuntime, id: string, services: IChannelServices, attributes: IChannelAttributes): Promise<ISharedMap>;
-    static readonly Type = "https://graph.microsoft.com/types/map";
-    get type(): string;
-}
-
 // @public
 export type MemberChangedListener<M extends IMember> = (clientId: string, member: M) => void;
 
@@ -783,17 +608,6 @@ export type ObjectFromSchemaRecord<T extends RestrictiveReadonlyRecord<string, I
 // @public
 export type ObjectFromSchemaRecordUnsafe<T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>> = {
     -readonly [Property in keyof T]: TreeFieldFromImplicitFieldUnsafe<T[Property]>;
-};
-
-// @alpha (undocumented)
-export type ReadOnlyInfo = {
-    readonly readonly: false | undefined;
-} | {
-    readonly readonly: true;
-    readonly forced: boolean;
-    readonly permissions: boolean | undefined;
-    readonly storageOnly: boolean;
-    readonly storageOnlyReason?: string;
 };
 
 // @public
@@ -958,58 +772,6 @@ export const SharedMap: ISharedObjectKind<ISharedMap> & SharedObjectKind_2<IShar
 
 // @alpha
 export type SharedMap = ISharedMap;
-
-// @alpha
-export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends SharedObjectCore<TEvent> {
-    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes, telemetryContextPrefix: string);
-    getAttachSummary(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
-    getGCData(fullGC?: boolean): IGarbageCollectionData;
-    protected processGCDataCore(serializer: IFluidSerializer): void;
-    // (undocumented)
-    protected get serializer(): IFluidSerializer;
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
-    protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): ISummaryTreeWithStats;
-}
-
-// @alpha
-export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends EventEmitterWithErrorHandling<TEvent> implements ISharedObject<TEvent> {
-    constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes);
-    protected abstract applyStashedOp(content: any): void;
-    // (undocumented)
-    readonly attributes: IChannelAttributes;
-    bindToContext(): void;
-    connect(services: IChannelServices): void;
-    get connected(): boolean;
-    protected get deltaManager(): IDeltaManager<ISequencedDocumentMessage, IDocumentMessage>;
-    protected didAttach(): void;
-    protected dirty(): void;
-    emit(event: EventEmitterEventType, ...args: any[]): boolean;
-    abstract getAttachSummary(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
-    abstract getGCData(fullGC?: boolean): IGarbageCollectionData;
-    readonly handle: IFluidHandleInternal;
-    protected handleDecoded(decodedHandle: IFluidHandle): void;
-    // (undocumented)
-    id: string;
-    // (undocumented)
-    get IFluidLoadable(): this;
-    initializeLocal(): void;
-    protected initializeLocalCore(): void;
-    isAttached(): boolean;
-    load(services: IChannelServices): Promise<void>;
-    protected abstract loadCore(services: IChannelStorageService): Promise<void>;
-    protected readonly logger: ITelemetryLoggerExt;
-    protected newAckBasedPromise<T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
-    protected onConnect(): void;
-    protected abstract onDisconnect(): any;
-    protected abstract processCore(message: ISequencedDocumentMessage, local: boolean, localOpMetadata: unknown): any;
-    protected reSubmitCore(content: any, localOpMetadata: unknown): void;
-    protected rollback(content: any, localOpMetadata: unknown): void;
-    // (undocumented)
-    protected runtime: IFluidDataStoreRuntime;
-    protected abstract get serializer(): IFluidSerializer;
-    protected submitLocalMessage(content: any, localOpMetadata?: unknown): void;
-    abstract summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
-}
 
 // @public
 export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -58,23 +58,6 @@ export const SharedTree: SharedObjectKind<ITree> = OriginalSharedTree;
 // ===============================================================
 // Legacy exports
 
-export {
-	ContainerErrorTypes,
-	type IDeltaManager,
-	type IDeltaManagerEvents,
-	type IDeltaSender,
-	type IDeltaQueue,
-	type ReadOnlyInfo,
-	type IConnectionDetails,
-	type IDeltaQueueEvents,
-} from "@fluidframework/container-definitions/internal";
-
-export type {
-	IAnyDriverError,
-	IDriverErrorBase,
-	DriverErrorTypes,
-} from "@fluidframework/driver-definitions/internal";
-
 export type {
 	IDirectory,
 	IDirectoryEvents,
@@ -86,12 +69,7 @@ export type {
 	IValueChanged,
 } from "@fluidframework/map/internal";
 
-export {
-	DirectoryFactory,
-	MapFactory,
-	SharedDirectory,
-	SharedMap,
-} from "@fluidframework/map/internal";
+export { SharedDirectory, SharedMap } from "@fluidframework/map/internal";
 
 export type {
 	DeserializeCallback,
@@ -110,6 +88,7 @@ export type {
 	SequencePlace,
 	SharedStringSegment,
 	Side,
+	ISharedSegmentSequence,
 } from "@fluidframework/sequence/internal";
 
 export {
@@ -119,13 +98,9 @@ export {
 	SequenceInterval,
 	SequenceMaintenanceEvent,
 	SharedString,
-	type ISharedSegmentSequence,
 } from "@fluidframework/sequence/internal";
 
 export type {
-	SharedObject,
-	IFluidSerializer,
-	SharedObjectCore,
 	ISharedObject,
 	ISharedObjectEvents,
 } from "@fluidframework/shared-object-base/internal";

--- a/packages/loader/container-loader/src/catchUpMonitor.ts
+++ b/packages/loader/container-loader/src/catchUpMonitor.ts
@@ -4,7 +4,7 @@
  */
 
 import { IDeltaManager } from "@fluidframework/container-definitions/internal";
-import { IDisposable } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -6,7 +6,8 @@
 import { TypedEventEmitter, performance } from "@fluid-internal/client-utils";
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
 import { IDeltaQueue, ReadOnlyInfo } from "@fluidframework/container-definitions/internal";
-import { IDisposable, ITelemetryBaseProperties, LogLevel } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseProperties, LogLevel } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import {
 	IDocumentDeltaConnection,

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -5,7 +5,7 @@
 
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
 import { ISnapshotTreeWithBlobContents } from "@fluidframework/container-definitions/internal";
-import { IDisposable } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import {
 	FetchSource,

--- a/packages/loader/container-loader/src/disposal.ts
+++ b/packages/loader/container-loader/src/disposal.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 
 /**
  * Returns a wrapper around the provided function, which will only invoke the inner function if the provided

--- a/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import {
 	IDocumentStorageService,
 	ISummaryContext,

--- a/packages/loader/container-loader/src/retriableDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/retriableDocumentStorageService.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import {
 	FetchSource,

--- a/packages/loader/test-loader-utils/api-report/test-loader-utils.api.md
+++ b/packages/loader/test-loader-utils/api-report/test-loader-utils.api.md
@@ -8,7 +8,7 @@ import { ConnectionMode } from '@fluidframework/protocol-definitions';
 import { IAnyDriverError } from '@fluidframework/driver-definitions/internal';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IClientConfiguration } from '@fluidframework/protocol-definitions';
-import { IDisposable } from '@fluidframework/core-interfaces';
+import { IDisposable } from '@fluidframework/core-interfaces/internal';
 import { IDocumentDeltaConnection } from '@fluidframework/driver-definitions/internal';
 import { IDocumentDeltaConnectionEvents } from '@fluidframework/driver-definitions/internal';
 import { IDocumentDeltaStorageService } from '@fluidframework/driver-definitions/internal';

--- a/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
+++ b/packages/loader/test-loader-utils/src/mockDocumentDeltaConnection.ts
@@ -4,7 +4,7 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IDisposable } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import {
 	IDocumentDeltaConnection,
 	IDocumentDeltaConnectionEvents,

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -21,7 +21,7 @@ import { IContainerRuntimeEvents } from '@fluidframework/container-runtime-defin
 import { ICriticalContainerError } from '@fluidframework/container-definitions';
 import { IDataStore } from '@fluidframework/runtime-definitions/internal';
 import { IDeltaManager } from '@fluidframework/container-definitions/internal';
-import { IDisposable } from '@fluidframework/core-interfaces';
+import { IDisposable } from '@fluidframework/core-interfaces/internal';
 import { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import { IDocumentStorageService } from '@fluidframework/driver-definitions/internal';
 import { IEnvelope } from '@fluidframework/runtime-definitions/internal';
@@ -41,7 +41,7 @@ import { IGarbageCollectionDetailsBase } from '@fluidframework/runtime-definitio
 import { IGetPendingLocalStateProps } from '@fluidframework/container-definitions/internal';
 import type { IIdCompressor } from '@fluidframework/id-compressor';
 import type { IIdCompressorCore } from '@fluidframework/id-compressor/internal';
-import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
+import { IInboundSignalMessage } from '@fluidframework/runtime-definitions/internal';
 import { IProvideFluidHandleContext } from '@fluidframework/core-interfaces/internal';
 import { IQuorumClients } from '@fluidframework/protocol-definitions';
 import { IRequest } from '@fluidframework/core-interfaces';

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -6,12 +6,12 @@
 import { AttachState } from "@fluidframework/container-definitions";
 import {
 	FluidObject,
-	IDisposable,
 	IRequest,
 	IResponse,
 	ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
 import type { IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert, Lazy, LazyPromise } from "@fluidframework/core-utils/internal";
 import { FluidObjectHandle } from "@fluidframework/datastore/internal";
 import {
@@ -21,7 +21,6 @@ import {
 } from "@fluidframework/driver-utils/internal";
 import type { ISnapshot } from "@fluidframework/driver-definitions/internal";
 import { ISequencedDocumentMessage, ISnapshotTree } from "@fluidframework/protocol-definitions";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import {
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -40,6 +39,7 @@ import {
 	InboundAttachMessage,
 	NamedFluidDataStoreRegistryEntries,
 	channelsTreeName,
+	IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	GCDataBuilder,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -8,8 +8,8 @@ import {
 	AttachState,
 	IAudience,
 	ISelf,
-	ICriticalContainerError,
 	type IAudienceEvents,
+	ICriticalContainerError,
 } from "@fluidframework/container-definitions";
 import {
 	IBatchMessage,
@@ -70,7 +70,6 @@ import {
 	MessageType,
 	SummaryType,
 } from "@fluidframework/protocol-definitions";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import {
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -88,6 +87,7 @@ import {
 	SummarizeInternalFn,
 	channelsTreeName,
 	gcTreeKey,
+	IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	GCDataBuilder,

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -8,13 +8,12 @@ import { AttachState, IAudience } from "@fluidframework/container-definitions";
 import { IDeltaManager } from "@fluidframework/container-definitions/internal";
 import {
 	FluidObject,
-	IDisposable,
 	IRequest,
 	IResponse,
 	ITelemetryBaseProperties,
 	type IEvent,
 } from "@fluidframework/core-interfaces";
-import { type IFluidHandleInternal } from "@fluidframework/core-interfaces/internal";
+import { type IFluidHandleInternal, IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert, LazyPromise, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
 	IDocumentStorageService,
@@ -34,7 +33,6 @@ import {
 	ISnapshotTree,
 	ITreeEntry,
 } from "@fluidframework/protocol-definitions";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import {
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -57,6 +55,7 @@ import {
 	SummarizeInternalFn,
 	channelsTreeName,
 	gcDataBlobKey,
+	IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	addBlobToSummary,

--- a/packages/runtime/container-runtime/src/dataStoreContexts.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContexts.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { IDisposable, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert, Deferred, Lazy } from "@fluidframework/core-utils/internal";
 import { ITelemetryLoggerExt, createChildLogger } from "@fluidframework/telemetry-utils/internal";
 

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -4,7 +4,7 @@
  */
 
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
-import { IDisposable } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert, Lazy } from "@fluidframework/core-utils/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import {

--- a/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
+++ b/packages/runtime/container-runtime/src/summary/runningSummarizer.ts
@@ -4,7 +4,8 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IDisposable, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert, Deferred, PromiseTimer, delay } from "@fluidframework/core-utils/internal";
 import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import { ISequencedDocumentMessage, MessageType } from "@fluidframework/protocol-definitions";

--- a/packages/runtime/container-runtime/src/summary/summaryCollection.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryCollection.ts
@@ -5,7 +5,8 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { IDeltaManager } from "@fluidframework/container-definitions/internal";
-import { IDisposable, IEvent } from "@fluidframework/core-interfaces";
+import { IEvent } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert, Deferred } from "@fluidframework/core-utils/internal";
 import {
 	IDocumentMessage,

--- a/packages/runtime/container-runtime/src/summary/summaryManager.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryManager.ts
@@ -4,12 +4,8 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import {
-	IDisposable,
-	IEvent,
-	IEventProvider,
-	ITelemetryBaseLogger,
-} from "@fluidframework/core-interfaces";
+import { IEvent, IEventProvider, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 import { DriverErrorTypes } from "@fluidframework/driver-definitions/internal";
 import {

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -8,7 +8,7 @@ import type { AttachState } from '@fluidframework/container-definitions';
 import type { ErasedType } from '@fluidframework/core-interfaces';
 import type { FluidObject } from '@fluidframework/core-interfaces';
 import type { IAudience } from '@fluidframework/container-definitions';
-import type { IDisposable } from '@fluidframework/core-interfaces';
+import type { IDisposable } from '@fluidframework/core-interfaces/internal';
 import type { IEvent } from '@fluidframework/core-interfaces';
 import type { IEventProvider } from '@fluidframework/core-interfaces';
 import type { IExperimentalIncrementalSummaryContext } from '@fluidframework/runtime-definitions/internal';
@@ -17,7 +17,7 @@ import type { IFluidHandleContext } from '@fluidframework/core-interfaces/intern
 import type { IFluidLoadable } from '@fluidframework/core-interfaces';
 import type { IGarbageCollectionData } from '@fluidframework/runtime-definitions/internal';
 import type { IIdCompressor } from '@fluidframework/id-compressor';
-import type { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
+import type { IInboundSignalMessage } from '@fluidframework/runtime-definitions/internal';
 import type { IQuorumClients } from '@fluidframework/protocol-definitions';
 import type { ISequencedDocumentMessage } from '@fluidframework/protocol-definitions';
 import type { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/internal';

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -7,19 +7,18 @@ import type { AttachState, IAudience } from "@fluidframework/container-definitio
 import type {
 	IFluidHandle,
 	FluidObject,
-	IDisposable,
 	IEvent,
 	IEventProvider,
 	ITelemetryBaseLogger,
 	ErasedType,
 } from "@fluidframework/core-interfaces";
-import type { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
+import type { IFluidHandleContext, IDisposable } from "@fluidframework/core-interfaces/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type {
 	IQuorumClients,
 	ISequencedDocumentMessage,
 } from "@fluidframework/protocol-definitions";
-import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 
 import type { IChannel } from "./channel.js";
 

--- a/packages/runtime/datastore/api-report/datastore.api.md
+++ b/packages/runtime/datastore/api-report/datastore.api.md
@@ -23,7 +23,7 @@ import { IFluidHandleContext } from '@fluidframework/core-interfaces/internal';
 import type { IFluidHandleInternal } from '@fluidframework/core-interfaces/internal';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions/internal';
 import { IIdCompressor } from '@fluidframework/id-compressor';
-import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
+import { IInboundSignalMessage } from '@fluidframework/runtime-definitions/internal';
 import { IQuorumClients } from '@fluidframework/protocol-definitions';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResponse } from '@fluidframework/core-interfaces';

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -34,7 +34,6 @@ import {
 	ISummaryTree,
 	SummaryType,
 } from "@fluidframework/protocol-definitions";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import {
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -47,6 +46,7 @@ import {
 	IFluidDataStoreContext,
 	VisibilityState,
 	gcDataBlobKey,
+	IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	GCDataBuilder,

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -9,7 +9,7 @@ import type { FluidObject } from '@fluidframework/core-interfaces';
 import type { IAudience } from '@fluidframework/container-definitions';
 import type { IClientDetails } from '@fluidframework/protocol-definitions';
 import type { IDeltaManager } from '@fluidframework/container-definitions/internal';
-import type { IDisposable } from '@fluidframework/core-interfaces';
+import type { IDisposable } from '@fluidframework/core-interfaces/internal';
 import type { IDocumentMessage } from '@fluidframework/protocol-definitions';
 import type { IDocumentStorageService } from '@fluidframework/driver-definitions/internal';
 import type { IEvent } from '@fluidframework/core-interfaces';
@@ -302,7 +302,7 @@ export interface IGarbageCollectionDetailsBase {
     usedRoutes?: string[];
 }
 
-// @public
+// @alpha
 export interface IInboundSignalMessage extends ISignalMessage {
     // (undocumented)
     type: string;

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -7,7 +7,6 @@ import type { AttachState, IAudience } from "@fluidframework/container-definitio
 import type { IDeltaManager } from "@fluidframework/container-definitions/internal";
 import type {
 	FluidObject,
-	IDisposable,
 	IEvent,
 	IEventProvider,
 	IFluidHandle,
@@ -18,6 +17,7 @@ import type {
 import type {
 	IFluidHandleInternal,
 	IProvideFluidHandleContext,
+	IDisposable,
 } from "@fluidframework/core-interfaces/internal";
 import type { IDocumentStorageService } from "@fluidframework/driver-definitions/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
@@ -14,7 +14,7 @@ import {
 import { type IErrorEvent, IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter/internal";
 import { Jsonable } from "@fluidframework/datastore-definitions/internal";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 
 class TestDataObjectClass extends DataObject {
 	public static readonly Name = "@fluid-example/test-data-object";

--- a/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 import {
 	DataObjectFactoryType,
 	ITestContainerConfig,

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -4,7 +4,8 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { IDisposable, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import { IDisposable } from "@fluidframework/core-interfaces/internal";
 import { assert, Deferred } from "@fluidframework/core-utils/internal";
 import {
 	IDocumentDeltaConnection,

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -17,7 +17,7 @@ import { assert, delay } from "@fluidframework/core-utils/internal";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions/internal";
 import { getRetryDelayFromError } from "@fluidframework/driver-utils/internal";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 import { GenericError, ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import commander from "commander";
 

--- a/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
+++ b/packages/tools/devtools/devtools-core/api-report/devtools-core.api.md
@@ -8,7 +8,7 @@ import { AttachState } from '@fluidframework/container-definitions';
 import { ConnectionState } from '@fluidframework/container-loader';
 import { IClient } from '@fluidframework/protocol-definitions';
 import { IContainer } from '@fluidframework/container-definitions/internal';
-import { IDisposable } from '@fluidframework/core-interfaces';
+import { IDisposable } from '@fluidframework/core-interfaces/internal';
 import { IEvent } from '@fluidframework/core-interfaces';
 import { IEventProvider } from '@fluidframework/core-interfaces';
 import { IFluidLoadable } from '@fluidframework/core-interfaces';

--- a/packages/tools/devtools/devtools-core/src/IContainerDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/IContainerDevtools.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type IDisposable } from "@fluidframework/core-interfaces";
+import { type IDisposable } from "@fluidframework/core-interfaces/internal";
 
 import { type HasContainerKey } from "./CommonInterfaces.js";
 import { type AudienceChangeLogEntry, type ConnectionStateChangeLogEntry } from "./Logs.js";

--- a/packages/tools/devtools/devtools-core/src/IFluidDevtools.ts
+++ b/packages/tools/devtools/devtools-core/src/IFluidDevtools.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { type IDisposable } from "@fluidframework/core-interfaces";
+import { type IDisposable } from "@fluidframework/core-interfaces/internal";
 
 import { type ContainerKey } from "./CommonInterfaces.js";
 import { type ContainerDevtoolsProps } from "./ContainerDevtools.js";

--- a/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/DataVisualization.ts
@@ -8,12 +8,14 @@
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import {
-	type IDisposable,
 	type IEvent,
 	type IFluidHandle,
 	type IFluidLoadable,
 } from "@fluidframework/core-interfaces";
-import { type IProvideFluidHandle } from "@fluidframework/core-interfaces/internal";
+import {
+	type IProvideFluidHandle,
+	type IDisposable,
+} from "@fluidframework/core-interfaces/internal";
 import { type ISharedObject } from "@fluidframework/shared-object-base/internal";
 
 import { type FluidObjectId } from "../CommonInterfaces.js";

--- a/packages/tools/devtools/devtools/api-report/devtools.api.md
+++ b/packages/tools/devtools/devtools/api-report/devtools.api.md
@@ -8,7 +8,7 @@ import { ContainerKey } from '@fluidframework/devtools-core/internal';
 import { createDevtoolsLogger } from '@fluidframework/devtools-core/internal';
 import { HasContainerKey } from '@fluidframework/devtools-core/internal';
 import { IDevtoolsLogger } from '@fluidframework/devtools-core/internal';
-import { IDisposable } from '@fluidframework/core-interfaces';
+import { IDisposable } from '@fluidframework/core-interfaces/internal';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 
 // @beta

--- a/packages/tools/devtools/devtools/src/index.ts
+++ b/packages/tools/devtools/devtools/src/index.ts
@@ -19,7 +19,8 @@
  */
 
 import { type IContainer } from "@fluidframework/container-definitions/internal";
-import { type IDisposable, type IFluidLoadable } from "@fluidframework/core-interfaces";
+import { type IFluidLoadable } from "@fluidframework/core-interfaces";
+import { type IDisposable } from "@fluidframework/core-interfaces/internal";
 import {
 	type ContainerDevtoolsProps as ContainerDevtoolsPropsBase,
 	type HasContainerKey,

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -8,7 +8,7 @@ import { ConfigTypes } from '@fluidframework/core-interfaces';
 import type { EventEmitter } from '@fluid-internal/client-utils';
 import { EventEmitterEventType } from '@fluid-internal/client-utils';
 import { IConfigProviderBase } from '@fluidframework/core-interfaces';
-import type { IDisposable } from '@fluidframework/core-interfaces';
+import type { IDisposable } from '@fluidframework/core-interfaces/internal';
 import { IErrorBase } from '@fluidframework/core-interfaces';
 import { IEvent } from '@fluidframework/core-interfaces';
 import { IGenericError } from '@fluidframework/core-interfaces/internal';

--- a/packages/utils/telemetry-utils/src/sampledTelemetryHelper.ts
+++ b/packages/utils/telemetry-utils/src/sampledTelemetryHelper.ts
@@ -4,8 +4,8 @@
  */
 
 import { performance } from "@fluid-internal/client-utils";
-import type { IDisposable, ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
-
+import type { ITelemetryBaseProperties } from "@fluidframework/core-interfaces";
+import type { IDisposable } from "@fluidframework/core-interfaces/internal";
 import {
 	type ITelemetryGenericEventExt,
 	ITelemetryLoggerExt,


### PR DESCRIPTION
## Description

Remove a couple more public APIs, and cleanout no longer needed legacy exports from fluid-framework (these used to be reachable from the exports there we do care about, but no longer are)

## Breaking Changes

Make `IDisposable` `@beta` since it's most public use is `IDevtools` which is `@beta`.
Make `IInboundSignalMessage` `@alpha` since its not used in the declarative API.

Cleanup `fluid-framework` legacy exports to remove no longer required types.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

