### PR TITLE
Data Virtualization: Fix snapshotTree.id bug in driver

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageServiceBase.ts
@@ -256,6 +256,7 @@ export abstract class OdspDocumentStorageServiceBase implements IDocumentStorage
 			trees: {
 				...hierarchicalAppTree.trees,
 			},
+			id: snapshotTree.id,
 		};
 
 		// The app tree could have a .protocol in that case we want to server protocol to override it.

--- a/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
@@ -628,6 +628,7 @@ describe("Tests for prefetching snapshot", () => {
 				...snapshotTreeWithGroupId.trees[".app"].trees,
 				".protocol": snapshotTreeWithGroupId.trees[".protocol"],
 			},
+			id: "SnapshotId",
 		};
 		beforeEach(async () => {
 			mockLogger = new MockLogger();
@@ -867,6 +868,7 @@ describe("Tests for prefetching snapshot", () => {
 				...snapshotTreeWithGroupId.trees[".app"].trees,
 				".protocol": snapshotTreeWithGroupId.trees[".protocol"],
 			},
+			id: "SnapshotId",
 		};
 		beforeEach(async () => {
 			mockLogger = new MockLogger();


### PR DESCRIPTION
[AB#8050](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8050)

Fix a contract violation detected by the `serializedStateManager`. Essentially, we were not propagating the snapshot.id in the driver. Now the snapshot version will contain the snapshot.id and things will work as expected.