### PR TITLE
Tree: Fix TreeViewEvents.afterBatch

### DIFF
--- a/.changeset/salty-poets-melt.md
+++ b/.changeset/salty-poets-melt.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/tree": minor
+---
+
+Fix AfterBatch event
+
+`TreeViewEvents.afterBatch` is now triggered when appropriate instead of never firing.

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -170,6 +170,7 @@ export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitField
 						lastRoot = this.root;
 						this.events.emit("rootChanged");
 					}
+					this.events.emit("afterBatch");
 				});
 				break;
 			}

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -102,8 +102,7 @@ describe("SchematizingSimpleTreeView", () => {
 
 		assert.deepEqual(log, [
 			["rootChanged", 6],
-			// This checkout editing setup does not produce batch events.
-			// ["afterBatch", 6],
+			["afterBatch", 6],
 		]);
 	});
 


### PR DESCRIPTION
## Description

`TreeViewEvents.afterBatch` is now triggered when appropriate instead of never firing.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

