### PR TITLE
Tree: Align tree tsconfigs with repo conventions

### DIFF
--- a/packages/dds/tree/src/test/tsconfig.json
+++ b/packages/dds/tree/src/test/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
 	"compilerOptions": {
-		"lib": ["ES2019", "ES2018.Promise", "DOM", "DOM.Iterable"],
 		"noImplicitAny": true,
 		"noUnusedLocals": false,
 		"noImplicitOverride": true,

--- a/packages/dds/tree/tsconfig.json
+++ b/packages/dds/tree/tsconfig.json
@@ -1,20 +1,16 @@
 {
-	"extends": "@fluidframework/build-common/ts-common-config.json",
+	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"module": "Node16",
-		"moduleResolution": "Node16",
 		"noImplicitAny": true,
-		"composite": true,
 		"preserveConstEnums": true,
 		// Allow unused locals.
 		// This is needed for type assertions using the TypeCheck library.
 		// Linter is used to enforce "_" prefix for unused locals to prevent accidentally having unused locals.
 		"noUnusedLocals": false,
 		"noImplicitOverride": true,
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
 	},
-	"include": ["src/**/*"],
 }


### PR DESCRIPTION
## Description

Update how tree consumes our base configs (based on how the cell backed does it as it seems like a clean up to date example).
Remove redundant options not needed due to values from base config.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).