### PR TITLE
Skip ops logging when sampling is disabled.

### DIFF
--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -95,6 +95,13 @@ class OpPerfTelemetry {
 	private readonly deltaLatencyLogger: ISampledTelemetryLogger;
 
 	private static readonly PROCESSED_OPS_SAMPLE_RATE = 500;
+
+	/**
+	 * A sampled logger to log Ops that have been processed by the current client, the NoOp sent and the
+	 * size of the ops processed within one sampling window of this log event.
+	 * The data from this logger will be used to monitor the efficiency of NoOp-heuristics or to get approximate collab window size.
+	 * Note: no log events are sent when sampling is disabled, because logging at every op will be too noisy.
+	 */
 	private readonly opsLogger: ISampledTelemetryLogger;
 
 	/**
@@ -167,7 +174,11 @@ class OpPerfTelemetry {
 				},
 			};
 		})();
-		this.opsLogger = createSampledLogger(logger, opsEventSampler);
+		this.opsLogger = createSampledLogger(
+			logger,
+			opsEventSampler,
+			true /* skipLoggingWhenSamplingIsDisabled */,
+		);
 
 		this.deltaManager.on("pong", (latency) => this.recordPingTime(latency));
 		this.deltaManager.on("submitOp", (message) => this.beforeOpSubmit(message));

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -41,7 +41,7 @@ export function createChildMonitoringContext(props: Parameters<typeof createChil
 export function createMultiSinkLogger(props: MultiSinkLoggerProperties): ITelemetryLoggerExt;
 
 // @internal
-export function createSampledLogger(logger: ITelemetryLoggerExt, eventSampler?: IEventSampler): ISampledTelemetryLogger;
+export function createSampledLogger(logger: ITelemetryLoggerExt, eventSampler?: IEventSampler, shouldSampleWhenSamplingDisabled?: boolean): ISampledTelemetryLogger;
 
 // @internal
 export class DataCorruptionError extends LoggingError implements IErrorBase, IFluidErrorBase {

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.api.md
@@ -41,7 +41,7 @@ export function createChildMonitoringContext(props: Parameters<typeof createChil
 export function createMultiSinkLogger(props: MultiSinkLoggerProperties): ITelemetryLoggerExt;
 
 // @internal
-export function createSampledLogger(logger: ITelemetryLoggerExt, eventSampler?: IEventSampler, shouldSampleWhenSamplingDisabled?: boolean): ISampledTelemetryLogger;
+export function createSampledLogger(logger: ITelemetryLoggerExt, eventSampler?: IEventSampler, skipLoggingWhenSamplingIsDisabled?: boolean): ISampledTelemetryLogger;
 
 // @internal
 export class DataCorruptionError extends LoggingError implements IErrorBase, IFluidErrorBase {

--- a/packages/utils/telemetry-utils/src/test/utils.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/utils.spec.ts
@@ -172,7 +172,7 @@ describe("Sampling", () => {
 		);
 	});
 
-	it("Events are not logged if DisableSampling telemetry flag is set to true but doNotLogWhenSamplingIsDisabled is provided as true", () => {
+	it("Events are not logged if DisableSampling telemetry flag is set to true but skipLoggingWhenSamplingIsDisabled is provided as false", () => {
 		const injectedSettings = {
 			"Fluid.Telemetry.DisableSampling": true,
 		};
@@ -181,11 +181,12 @@ describe("Sampling", () => {
 		const loggerWithoutSampling = createSampledLogger(
 			logger,
 			createSystematicEventSampler({ samplingRate: 1 }),
-			true, // doNotLogWhenSamplingIsDisabled
+			true, // skipLoggingWhenSamplingIsDisabled
 		);
 		const loggerWithEvery5Sampling = createSampledLogger(
 			logger,
 			createSystematicEventSampler({ samplingRate: 5 }),
+			true, // skipLoggingWhenSamplingIsDisabled
 		);
 
 		const totalEventCount = 15;
@@ -193,8 +194,16 @@ describe("Sampling", () => {
 			loggerWithoutSampling.send({ category: "generic", eventName: "noSampling" });
 			loggerWithEvery5Sampling.send({ category: "generic", eventName: "oneEveryFive" });
 		}
-		assert.equal(events.length, 0);
-		assert.equal(events.length, 0);
+		assert.equal(
+			events.filter((event) => event.eventName === "noSampling").length,
+			0,
+			"skipLoggingWhenSamplingIsDisabled flag was not honored by loggerWithoutSampling",
+		);
+		assert.equal(
+			events.filter((event) => event.eventName === "oneEveryFive").length,
+			0,
+			"skipLoggingWhenSamplingIsDisabled flag was not honored by loggerWithEvery5Sampling",
+		);
 	});
 
 	it("Systematic Sampling works as expected", () => {

--- a/packages/utils/telemetry-utils/src/test/utils.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/utils.spec.ts
@@ -172,7 +172,7 @@ describe("Sampling", () => {
 		);
 	});
 
-	it("Events are not logged if DisableSampling telemetry flag is set to true but skipLoggingWhenSamplingIsDisabled is provided as false", () => {
+	it("Events are not logged if DisableSampling telemetry flag is set to true but skipLoggingWhenSamplingIsDisabled is provided as true", () => {
 		const injectedSettings = {
 			"Fluid.Telemetry.DisableSampling": true,
 		};

--- a/packages/utils/telemetry-utils/src/test/utils.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/utils.spec.ts
@@ -172,6 +172,31 @@ describe("Sampling", () => {
 		);
 	});
 
+	it("Events are not logged if DisableSampling telemetry flag is set to true but doNotLogWhenSamplingIsDisabled is provided as true", () => {
+		const injectedSettings = {
+			"Fluid.Telemetry.DisableSampling": true,
+		};
+		const logger = getMockLoggerExtWithConfig(injectedSettings);
+
+		const loggerWithoutSampling = createSampledLogger(
+			logger,
+			createSystematicEventSampler({ samplingRate: 1 }),
+			true, // doNotLogWhenSamplingIsDisabled
+		);
+		const loggerWithEvery5Sampling = createSampledLogger(
+			logger,
+			createSystematicEventSampler({ samplingRate: 5 }),
+		);
+
+		const totalEventCount = 15;
+		for (let i = 0; i < totalEventCount; i++) {
+			loggerWithoutSampling.send({ category: "generic", eventName: "noSampling" });
+			loggerWithEvery5Sampling.send({ category: "generic", eventName: "oneEveryFive" });
+		}
+		assert.equal(events.length, 0);
+		assert.equal(events.length, 0);
+	});
+
 	it("Systematic Sampling works as expected", () => {
 		const injectedSettings = {
 			"Fluid.Telemetry.DisableSampling": false,

--- a/packages/utils/telemetry-utils/src/utils.ts
+++ b/packages/utils/telemetry-utils/src/utils.ts
@@ -56,7 +56,7 @@ export interface ISampledTelemetryLogger extends ITelemetryLoggerExt {
 export function createSampledLogger(
 	logger: ITelemetryLoggerExt,
 	eventSampler?: IEventSampler,
-	doNotLogWhenSamplingIsDisabled?: boolean,
+	skipLoggingWhenSamplingIsDisabled?: boolean,
 ): ISampledTelemetryLogger {
 	const monitoringContext = loggerToMonitoringContext(logger);
 	const isSamplingDisabled =
@@ -67,39 +67,35 @@ export function createSampledLogger(
 			// The sampler uses the following logic for sending events:
 			// 1. If isSamplingDisabled is true, then this means events should be unsampled. Therefore we send the event without any checks.
 			// 2. If isSamplingDisabled is false, then event should be sampled using the event sampler, if the sampler is not defined just send all events, other use the eventSampler.sample() method.
-			// 3. If doNotLogWhenSamplingIsDisabled is false, then no event is sent.
-			if (
-				(isSamplingDisabled && !doNotLogWhenSamplingIsDisabled) ||
-				eventSampler === undefined ||
-				eventSampler.sample()
-			) {
+			// 3. If skipLoggingWhenSamplingIsDisabled is true, then no event is sent.
+			if (isSamplingDisabled || eventSampler === undefined || eventSampler.sample()) {
+				if (isSamplingDisabled && skipLoggingWhenSamplingIsDisabled) {
+					return;
+				}
 				logger.send(event);
 			}
 		},
 		sendTelemetryEvent: (event: ITelemetryGenericEventExt): void => {
-			if (
-				(isSamplingDisabled && !doNotLogWhenSamplingIsDisabled) ||
-				eventSampler === undefined ||
-				eventSampler.sample()
-			) {
+			if (isSamplingDisabled || eventSampler === undefined || eventSampler.sample()) {
+				if (isSamplingDisabled && skipLoggingWhenSamplingIsDisabled) {
+					return;
+				}
 				logger.sendTelemetryEvent(event);
 			}
 		},
 		sendErrorEvent: (event: ITelemetryGenericEventExt): void => {
-			if (
-				(isSamplingDisabled && !doNotLogWhenSamplingIsDisabled) ||
-				eventSampler === undefined ||
-				eventSampler.sample()
-			) {
+			if (isSamplingDisabled || eventSampler === undefined || eventSampler.sample()) {
+				if (isSamplingDisabled && skipLoggingWhenSamplingIsDisabled) {
+					return;
+				}
 				logger.sendErrorEvent(event);
 			}
 		},
 		sendPerformanceEvent: (event: ITelemetryGenericEventExt): void => {
-			if (
-				(isSamplingDisabled && !doNotLogWhenSamplingIsDisabled) ||
-				eventSampler === undefined ||
-				eventSampler.sample()
-			) {
+			if (isSamplingDisabled || eventSampler === undefined || eventSampler.sample()) {
+				if (isSamplingDisabled && skipLoggingWhenSamplingIsDisabled) {
+					return;
+				}
 				logger.sendPerformanceEvent(event);
 			}
 		},

--- a/packages/utils/telemetry-utils/src/utils.ts
+++ b/packages/utils/telemetry-utils/src/utils.ts
@@ -56,6 +56,7 @@ export interface ISampledTelemetryLogger extends ITelemetryLoggerExt {
 export function createSampledLogger(
 	logger: ITelemetryLoggerExt,
 	eventSampler?: IEventSampler,
+	doNotLogWhenSamplingIsDisabled?: boolean,
 ): ISampledTelemetryLogger {
 	const monitoringContext = loggerToMonitoringContext(logger);
 	const isSamplingDisabled =
@@ -66,22 +67,39 @@ export function createSampledLogger(
 			// The sampler uses the following logic for sending events:
 			// 1. If isSamplingDisabled is true, then this means events should be unsampled. Therefore we send the event without any checks.
 			// 2. If isSamplingDisabled is false, then event should be sampled using the event sampler, if the sampler is not defined just send all events, other use the eventSampler.sample() method.
-			if (isSamplingDisabled || eventSampler === undefined || eventSampler.sample()) {
+			// 3. If doNotLogWhenSamplingIsDisabled is false, then no event is sent.
+			if (
+				(isSamplingDisabled && !doNotLogWhenSamplingIsDisabled) ||
+				eventSampler === undefined ||
+				eventSampler.sample()
+			) {
 				logger.send(event);
 			}
 		},
 		sendTelemetryEvent: (event: ITelemetryGenericEventExt): void => {
-			if (isSamplingDisabled || eventSampler === undefined || eventSampler.sample()) {
+			if (
+				(isSamplingDisabled && !doNotLogWhenSamplingIsDisabled) ||
+				eventSampler === undefined ||
+				eventSampler.sample()
+			) {
 				logger.sendTelemetryEvent(event);
 			}
 		},
 		sendErrorEvent: (event: ITelemetryGenericEventExt): void => {
-			if (isSamplingDisabled || eventSampler === undefined || eventSampler.sample()) {
+			if (
+				(isSamplingDisabled && !doNotLogWhenSamplingIsDisabled) ||
+				eventSampler === undefined ||
+				eventSampler.sample()
+			) {
 				logger.sendErrorEvent(event);
 			}
 		},
 		sendPerformanceEvent: (event: ITelemetryGenericEventExt): void => {
-			if (isSamplingDisabled || eventSampler === undefined || eventSampler.sample()) {
+			if (
+				(isSamplingDisabled && !doNotLogWhenSamplingIsDisabled) ||
+				eventSampler === undefined ||
+				eventSampler.sample()
+			) {
 				logger.sendPerformanceEvent(event);
 			}
 		},


### PR DESCRIPTION
- Add a new option in `createSampledLogger` utility to disallow logging when sampling is disabled.
- Disable sampling for ops in connectionTelemetry, because they are too frequent.