### PR TITLE
[RC.4] Port #21102 (Make handle parsing/decoding functions idempotent)

### DIFF
--- a/packages/dds/shared-object-base/src/serializer.ts
+++ b/packages/dds/shared-object-base/src/serializer.ts
@@ -167,9 +167,9 @@ export class FluidSerializer implements IFluidSerializer {
 		// is a non-null object.
 		const maybeReplaced = replacer(input, context);
 
-		// If the replacer made a substitution there is no need to decscend further. IFluidHandles are always
-		// leaves in the object graph.
-		if (maybeReplaced !== input) {
+		// If either input or the replaced result is a Fluid Handle, there is no need to descend further.
+		// IFluidHandles are always leaves in the object graph, and the code below cannot deal with IFluidHandle's structure.
+		if (isFluidHandle(input) || isFluidHandle(maybeReplaced)) {
 			return maybeReplaced;
 		}
 

--- a/packages/dds/shared-object-base/src/test/serializer.spec.ts
+++ b/packages/dds/shared-object-base/src/test/serializer.spec.ts
@@ -9,6 +9,7 @@ import { IFluidHandle } from "@fluidframework/core-interfaces";
 
 import { RemoteFluidObjectHandle } from "../remoteObjectHandle.js";
 import { FluidSerializer } from "../serializer.js";
+import { makeHandlesSerializable, parseHandles } from "../utils.js";
 
 import { MockHandleContext, makeJson } from "./utils.js";
 
@@ -167,41 +168,55 @@ describe("FluidSerializer", () => {
 			url: "/root",
 		};
 
-		function check(input, expected) {
-			it(`${printHandle(input)} -> ${JSON.stringify(expected)}`, () => {
-				const replaced = serializer.encode(input, handle);
+		function check(decodedForm, encodedForm) {
+			it(`${printHandle(decodedForm)} -> ${JSON.stringify(encodedForm)}`, () => {
+				const replaced = serializer.encode(decodedForm, handle);
 				assert.notStrictEqual(
 					replaced,
-					input,
+					decodedForm,
 					"encode() must shallow-clone rather than mutate original object.",
 				);
-				assert.deepStrictEqual(replaced, expected, "encode() must return expected output.");
+				assert.deepStrictEqual(
+					replaced,
+					encodedForm,
+					"encode() must return expected output.",
+				);
 
-				const decoded = serializer.decode(replaced);
+				const replacedTwice = serializer.encode(replaced, handle);
+				assert.deepStrictEqual(replacedTwice, replaced, "encode should be idempotent");
+
+				const decodedRoundTrip = serializer.decode(replaced);
 				assert.notStrictEqual(
-					decoded,
-					input,
+					decodedRoundTrip,
+					decodedForm,
 					"decode() must shallow-clone rather than mutate original object.",
 				);
 				assert.deepStrictEqual(
-					decoded,
-					input,
+					decodedRoundTrip,
+					decodedForm,
 					"input must round-trip through encode()/decode().",
 				);
 
-				const stringified = serializer.stringify(input, handle);
+				const decodedTwice = serializer.decode(decodedRoundTrip);
+				assert.deepStrictEqual(
+					decodedTwice,
+					decodedRoundTrip,
+					"decode should be idempotent",
+				);
+
+				const stringified = serializer.stringify(decodedForm, handle);
 
 				// Note that we're using JSON.parse() in this test, so the handles remained serialized.
 				assert.deepStrictEqual(
 					JSON.parse(stringified),
-					expected,
+					encodedForm,
 					"Round-trip through stringify()/JSON.parse() must produce the same output as encode()",
 				);
 
 				const parsed = serializer.parse(stringified);
 				assert.deepStrictEqual(
 					parsed,
-					input,
+					decodedForm,
 					"input must round-trip through stringify()/parse().",
 				);
 			});
@@ -305,6 +320,42 @@ describe("FluidSerializer", () => {
 				parsedHandle.routeContext.absolutePath,
 				"",
 				"Parsed handle's route context should be the root context",
+			);
+		});
+	});
+
+	describe("Utils", () => {
+		const serializer = new FluidSerializer(new MockHandleContext(), () => {});
+		it("makeSerializable is idempotent", () => {
+			const bind = new RemoteFluidObjectHandle("/", new MockHandleContext());
+			const handle = new RemoteFluidObjectHandle("/okay", new MockHandleContext());
+			const input = { x: handle, y: 123 };
+			const serializedOnce = makeHandlesSerializable(input, serializer, bind);
+			assert(
+				serializedOnce.x.type === "__fluid_handle__",
+				"Serialized handle should be a handle",
+			);
+			const serializedTwice = makeHandlesSerializable(serializedOnce, serializer, bind);
+			assert(
+				serializedTwice.x.type === "__fluid_handle__",
+				"Twice-Serialized handle should be a handle",
+			);
+		});
+		it("parseHandles is idempotent", () => {
+			const serializedHandle = {
+				type: "__fluid_handle__",
+				url: "/root",
+			};
+			const input = { x: serializedHandle, y: 123 };
+			const parsedOnce = parseHandles(input, serializer);
+			assert(
+				parsedOnce.x instanceof RemoteFluidObjectHandle,
+				"Parsed handle should be an instance of RemoteFluidObjectHandle",
+			);
+			const parsedTwice = parseHandles(parsedOnce, serializer);
+			assert(
+				parsedTwice.x instanceof RemoteFluidObjectHandle,
+				"Twice-Parsed handle should be an instance of RemoteFluidObjectHandle",
 			);
 		});
 	});

--- a/packages/dds/shared-object-base/src/test/utils.ts
+++ b/packages/dds/shared-object-base/src/test/utils.ts
@@ -13,6 +13,10 @@ export class MockHandleContext implements IFluidHandleContext {
 		return this;
 	}
 
+	// In real scenarios, the handle context is ContainerFluidHandleContext which has a circular reference to ContainerRuntime.
+	// This has caused trouble with traversing an object with handles, so include it in the mock as well.
+	public circular = this;
+
 	constructor(
 		public readonly absolutePath = "",
 		public readonly routeContext?: IFluidHandleContext,

--- a/packages/dds/shared-object-base/src/utils.ts
+++ b/packages/dds/shared-object-base/src/utils.ts
@@ -53,6 +53,7 @@ export function makeHandlesSerializable(
 /**
  * Given a fully-plain object that may have serializable-form handles within, will return the mostly-plain object
  * with handle objects created instead.
+ * @remarks Idempotent when called multiple times.
  * @param value - The fully-plain object
  * @param serializer - The serializer that knows how to convert serializable-form handles into handle objects
  * @param context - The handle context for the container
@@ -61,7 +62,7 @@ export function makeHandlesSerializable(
  */
 export function parseHandles(value: any, serializer: IFluidSerializer) {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-	return value !== undefined ? serializer.parse(JSON.stringify(value)) : value;
+	return serializer.decode(value);
 }
 
 /**


### PR DESCRIPTION
Port #21102 to `release/client/2.0.0-rc.4.0`

For anyone implementing their own DDS, when upgrading from `2.0.0-rc.2.0` to `2.0.0-rc.3.0` or later, they will likely be in a position where handles are going through `parseHandles` or `serializer.decode` twice.  Without this fix, those functions are not idempotent and will hit a fatal error being called twice.

Note that `parseHandles` may return the same object unmodified now, whereas before it would always clone (via `JSON.stringify` roundtrip)
