### PR TITLE
tree: Fix reading tree during events (#21172)

### DIFF
--- a/.changeset/tame-hornets-suffer.md
+++ b/.changeset/tame-hornets-suffer.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/tree": minor
+---
+
+Fix bug where reading tree during events could cause issues
+
+Reading the tree inside of NodeChange and TreeChange events could corrupt internal memory structures leading to invalid data in subsequence reads as well as internal errors being thrown. This bug has been fixed.

--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -878,7 +878,6 @@ export const forbiddenFieldKindIdentifier = "Forbidden";
 
 // @internal
 export interface ForestEvents {
-    afterChange(): void;
     afterRootFieldCreated(key: FieldKey): void;
     beforeChange(): void;
 }

--- a/packages/dds/tree/src/core/forest/forest.ts
+++ b/packages/dds/tree/src/core/forest/forest.ts
@@ -43,15 +43,13 @@ export interface ForestEvents {
 
 	/**
 	 * The forest is about to be changed.
-	 * Emitted before the first change in a batch of changes.
+	 * Emitted before each change in a batch of changes.
+	 * @remarks
+	 * This is the last chance for users of the forest to remove cursors from the forest before the edit.
+	 * Removing these cursors is important since they are not allowed to live across edits and
+	 * not clearing them can lead to corruption of in memory structures.
 	 */
 	beforeChange(): void;
-
-	/**
-	 * The forest was just changed.
-	 * Emitted after the last change in a batch of changes.
-	 */
-	afterChange(): void;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -89,7 +89,6 @@ export class ChunkedForest implements IEditableForest {
 			this.activeVisitor === undefined,
 			0x76a /* Must release existing visitor before acquiring another */,
 		);
-		this.events.emit("beforeChange");
 
 		if (this.roots.isShared()) {
 			this.roots = this.roots.clone();
@@ -116,12 +115,13 @@ export class ChunkedForest implements IEditableForest {
 					0x76b /* Multiple free calls for same visitor */,
 				);
 				this.forest.activeVisitor = undefined;
-				this.forest.events.emit("afterChange");
 			},
 			destroy(detachedField: FieldKey, count: number): void {
+				this.forest.events.emit("beforeChange");
 				this.forest.roots.fields.delete(detachedField);
 			},
 			create(content: ProtoNodes, destination: FieldKey): void {
+				this.forest.events.emit("beforeChange");
 				const chunks: TreeChunk[] = content.map((c) => chunkTree(c, this.forest.chunker));
 				this.forest.roots.fields.set(destination, chunks);
 				this.forest.events.emit("afterRootFieldCreated", destination);
@@ -139,6 +139,7 @@ export class ChunkedForest implements IEditableForest {
 			 * @param destination - The index in the current field at which to attach the content.
 			 */
 			attachEdit(source: FieldKey, count: number, destination: PlaceIndex): void {
+				this.forest.events.emit("beforeChange");
 				const sourceField = this.forest.roots.fields.get(source) ?? [];
 				this.forest.roots.fields.delete(source);
 				if (sourceField.length === 0) {
@@ -158,6 +159,7 @@ export class ChunkedForest implements IEditableForest {
 			 * If not specified, the detached range is destroyed.
 			 */
 			detachEdit(source: Range, destination: FieldKey | undefined): void {
+				this.forest.events.emit("beforeChange");
 				const parent = this.getParent();
 				const sourceField = parent.mutableChunk.fields.get(parent.key) ?? [];
 


### PR DESCRIPTION
## Description

Cherry pick of 81a648a9843f7940df318b63258d864d1fa91bc1

Fix bug where reading tree during events could cause issues.

Reading the tree inside of NodeChange and TreeChange events could corrupt internal memory structures leading to invalid data in subsequence reads as well as internal errors being thrown. This bug has been fixed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
