### PR TITLE
Fix Signaler use in declarative API

### DIFF
--- a/.changeset/three-doodles-throw.md
+++ b/.changeset/three-doodles-throw.md
@@ -5,4 +5,4 @@
 Fix using Signaler in ContainerSchema.
 
 `Signaler` now implements `SharedObjectKind<ISignaler>`, allowing its use in `ContainerSchema` which was broken when ContainerSchema was made more strict.
-Additionally fewer encapsulated APIs are exposed on Signaler and adn the instance type must now be `ISignalar` (instead of `Signaler`), which has been extended to have an "error" event which was previously missing.
+Additionally fewer encapsulated APIs are exposed on Signaler and the instance type must now be `ISignaler` (instead of `Signaler`), which has been extended to have an "error" event which was previously missing.

--- a/.changeset/three-doodles-throw.md
+++ b/.changeset/three-doodles-throw.md
@@ -1,0 +1,8 @@
+---
+"@fluid-experimental/data-objects": minor
+---
+
+Fix using Signaler in ContainerSchema.
+
+`Signaler` now implements `SharedObjectKind<ISignaler>`, allowing its use in `ContainerSchema` which was broken when ContainerSchema was made more strict.
+Additionally fewer encapsulated APIs are exposed on Signaler and adn the instance type must now be `ISignalar` (instead of `Signaler`), which has been extended to have an "error" event which was previously missing.

--- a/examples/apps/presence-tracker/src/FocusTracker.ts
+++ b/examples/apps/presence-tracker/src/FocusTracker.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Signaler } from "@fluid-experimental/data-objects";
+import { ISignaler } from "@fluid-experimental/data-objects";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type { IAzureAudience } from "@fluidframework/azure-client";
 import { IContainer } from "@fluidframework/container-definitions/internal";
@@ -50,7 +50,7 @@ export class FocusTracker extends TypedEventEmitter<IFocusTrackerEvents> {
 	constructor(
 		container: IContainer,
 		public readonly audience: IAzureAudience,
-		private readonly signaler: Signaler,
+		private readonly signaler: ISignaler,
 	) {
 		super();
 

--- a/examples/apps/presence-tracker/src/MouseTracker.ts
+++ b/examples/apps/presence-tracker/src/MouseTracker.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { Signaler } from "@fluid-experimental/data-objects";
+import { ISignaler } from "@fluid-experimental/data-objects";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import type { IAzureAudience } from "@fluidframework/azure-client";
 import { IEvent } from "@fluidframework/core-interfaces";
@@ -50,7 +50,7 @@ export class MouseTracker extends TypedEventEmitter<IMouseTrackerEvents> {
 
 	constructor(
 		public readonly audience: IAzureAudience,
-		private readonly signaler: Signaler,
+		private readonly signaler: ISignaler,
 	) {
 		super();
 

--- a/examples/apps/presence-tracker/src/containerCode.ts
+++ b/examples/apps/presence-tracker/src/containerCode.ts
@@ -4,7 +4,7 @@
  */
 
 import { ModelContainerRuntimeFactory, getDataStoreEntryPoint } from "@fluid-example/example-utils";
-import { Signaler } from "@fluid-experimental/data-objects";
+import { Signaler, ISignaler } from "@fluid-experimental/data-objects";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
 import { createServiceAudience } from "@fluidframework/fluid-static/internal";
@@ -43,7 +43,7 @@ export class TrackerContainerRuntimeFactory extends ModelContainerRuntimeFactory
 	}
 
 	protected async createModel(runtime: IContainerRuntime, container: IContainer) {
-		const signaler = await getDataStoreEntryPoint<Signaler>(runtime, signalerId);
+		const signaler = await getDataStoreEntryPoint<ISignaler>(runtime, signalerId);
 
 		const audience = createServiceAudience({
 			container,

--- a/experimental/framework/data-objects/api-report/data-objects.api.md
+++ b/experimental/framework/data-objects/api-report/data-objects.api.md
@@ -4,12 +4,13 @@
 
 ```ts
 
-import { DataObject } from '@fluidframework/aqueduct/internal';
-import { DataObjectFactory } from '@fluidframework/aqueduct/internal';
-import { EventEmitter } from '@fluid-internal/client-utils';
 import { IErrorEvent } from '@fluidframework/core-interfaces';
+import { IEventProvider } from '@fluidframework/core-interfaces';
+import type { IFluidDataStoreFactory } from '@fluidframework/runtime-definitions/internal';
 import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
 import { Jsonable } from '@fluidframework/datastore-definitions/internal';
+import type { NamedFluidDataStoreRegistryEntry } from '@fluidframework/runtime-definitions/internal';
+import type { SharedObjectKind } from '@fluidframework/shared-object-base';
 
 // @internal
 export interface IRuntimeSignaler {
@@ -22,31 +23,18 @@ export interface IRuntimeSignaler {
 }
 
 // @internal
-export interface ISignaler {
+export interface ISignaler extends IEventProvider<IErrorEvent> {
     offSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
     onSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
     submitSignal<T>(signalName: string, payload?: Jsonable<T>): any;
 }
 
 // @internal
-export class Signaler extends DataObject<{
-    Events: IErrorEvent;
-}> implements EventEmitter, ISignaler {
-    // (undocumented)
-    static readonly factory: DataObjectFactory<Signaler, {
-        Events: IErrorEvent;
-    }>;
-    // (undocumented)
-    protected hasInitialized(): Promise<void>;
-    // (undocumented)
-    static readonly Name = "@fluid-example/signaler";
-    // (undocumented)
-    offSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
-    // (undocumented)
-    onSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
-    // (undocumented)
-    submitSignal<T>(signalName: string, payload?: Jsonable<T>): void;
-}
+export const Signaler: {
+    readonly factory: IFluidDataStoreFactory & {
+        readonly registryEntry: NamedFluidDataStoreRegistryEntry;
+    };
+} & SharedObjectKind<ISignaler>;
 
 // @internal (undocumented)
 export type SignalListener<T> = (clientId: string, local: boolean, payload: Jsonable<T>) => void;

--- a/experimental/framework/data-objects/package.json
+++ b/experimental/framework/data-objects/package.json
@@ -50,7 +50,8 @@
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",
 		"@fluidframework/map": "workspace:~",
-		"@fluidframework/runtime-definitions": "workspace:~"
+		"@fluidframework/runtime-definitions": "workspace:~",
+		"@fluidframework/shared-object-base": "workspace:~"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5285,6 +5285,7 @@ importers:
       '@fluidframework/eslint-config-fluid': ^5.1.0
       '@fluidframework/map': workspace:~
       '@fluidframework/runtime-definitions': workspace:~
+      '@fluidframework/shared-object-base': workspace:~
       '@microsoft/api-extractor': ^7.43.1
       '@types/node': ^18.19.0
       copyfiles: ^2.4.1
@@ -5301,6 +5302,7 @@ importers:
       '@fluidframework/datastore-definitions': link:../../../packages/runtime/datastore-definitions
       '@fluidframework/map': link:../../../packages/dds/map
       '@fluidframework/runtime-definitions': link:../../../packages/runtime/runtime-definitions
+      '@fluidframework/shared-object-base': link:../../../packages/dds/shared-object-base
     devDependencies:
       '@arethetypeswrong/cli': 0.15.2
       '@biomejs/biome': 1.6.2


### PR DESCRIPTION
## Description

Fix using Signaler in ContainerSchema.

`Signaler` now implements `SharedObjectKind<ISignaler>`, allowing its use in `ContainerSchema` which was broken when ContainerSchema was made more strict.

## Breaking Changes

fewer encapsulated APIs are exposed on Signaler and the instance type must now be `ISignalar` (instead of `Signaler`), which has been extended to have an "error" event which was previously missing.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
