### PR TITLE
[Summarization] Remove trackState option from summarization as it is redundant with fullTree

### DIFF
--- a/experimental/dds/tree/api-report/experimental-tree.api.md
+++ b/experimental/dds/tree/api-report/experimental-tree.api.md
@@ -629,7 +629,7 @@ export class MigrationShim extends EventEmitterWithErrorHandling<IMigrationEvent
     // (undocumented)
     get currentTree(): IChannel & (SharedTree | ITree);
     // (undocumented)
-    getAttachSummary(fullTree?: boolean | undefined, trackState?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined): ISummaryTreeWithStats;
+    getAttachSummary(fullTree?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined): ISummaryTreeWithStats;
     // (undocumented)
     getGCData(fullGC?: boolean | undefined): IGarbageCollectionData;
     // (undocumented)
@@ -645,7 +645,7 @@ export class MigrationShim extends EventEmitterWithErrorHandling<IMigrationEvent
     // (undocumented)
     submitMigrateOp(): void;
     // (undocumented)
-    summarize(fullTree?: boolean | undefined, trackState?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined): Promise<ISummaryTreeWithStats>;
+    summarize(fullTree?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined): Promise<ISummaryTreeWithStats>;
 }
 
 // @internal @sealed
@@ -908,7 +908,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
     get edits(): OrderedEditSet<InternalizedChange>;
     equals(sharedTree: SharedTree): boolean;
     generateNodeId(override?: string): NodeId;
-    getAttachSummary(fullTree?: boolean | undefined, trackState?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined): ISummaryTreeWithStats;
+    getAttachSummary(fullTree?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined): ISummaryTreeWithStats;
     static getFactory(...args: SharedTreeArgs<WriteFormat.v0_0_2>): SharedTreeFactory;
     // (undocumented)
     static getFactory(...args: SharedTreeArgs<WriteFormat.v0_1_1>): SharedTreeFactory;
@@ -1020,7 +1020,7 @@ export class SharedTreeShim implements IShim {
     // (undocumented)
     get currentTree(): ITree & IChannel;
     // (undocumented)
-    getAttachSummary(fullTree?: boolean | undefined, trackState?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined): ISummaryTreeWithStats;
+    getAttachSummary(fullTree?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined): ISummaryTreeWithStats;
     // (undocumented)
     getGCData(fullGC?: boolean | undefined): IGarbageCollectionData;
     // (undocumented)
@@ -1038,7 +1038,7 @@ export class SharedTreeShim implements IShim {
     // (undocumented)
     readonly sharedTreeFactory: IChannelFactory<ITree>;
     // (undocumented)
-    summarize(fullTree?: boolean | undefined, trackState?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined): Promise<ISummaryTreeWithStats>;
+    summarize(fullTree?: boolean | undefined, telemetryContext?: ITelemetryContext | undefined, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined): Promise<ISummaryTreeWithStats>;
 }
 
 // @internal @sealed

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -742,7 +742,6 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	 */
 	public override getAttachSummary(
 		fullTree?: boolean | undefined,
-		trackState?: boolean | undefined,
 		telemetryContext?: ITelemetryContext | undefined
 	): ISummaryTreeWithStats {
 		// If local changes exist, emulate the sequencing of those changes.
@@ -760,7 +759,7 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 			}
 			this.editLog.sequenceLocalEdits();
 		}
-		return super.getAttachSummary(fullTree, trackState, telemetryContext);
+		return super.getAttachSummary(fullTree, telemetryContext);
 	}
 
 	/**

--- a/experimental/dds/tree/src/migration-shim/migrationShim.ts
+++ b/experimental/dds/tree/src/migration-shim/migrationShim.ts
@@ -220,18 +220,16 @@ export class MigrationShim extends EventEmitterWithErrorHandling<IMigrationEvent
 	}
 	public getAttachSummary(
 		fullTree?: boolean | undefined,
-		trackState?: boolean | undefined,
 		telemetryContext?: ITelemetryContext | undefined
 	): ISummaryTreeWithStats {
-		return this.currentTree.getAttachSummary(fullTree, trackState, telemetryContext);
+		return this.currentTree.getAttachSummary(fullTree, telemetryContext);
 	}
 	public async summarize(
 		fullTree?: boolean | undefined,
-		trackState?: boolean | undefined,
 		telemetryContext?: ITelemetryContext | undefined,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined
 	): Promise<ISummaryTreeWithStats> {
-		return this.currentTree.summarize(fullTree, trackState, telemetryContext, incrementalSummaryContext);
+		return this.currentTree.summarize(fullTree, telemetryContext, incrementalSummaryContext);
 	}
 	public isAttached(): boolean {
 		return this.currentTree.isAttached();

--- a/experimental/dds/tree/src/migration-shim/sharedTreeShim.ts
+++ b/experimental/dds/tree/src/migration-shim/sharedTreeShim.ts
@@ -66,18 +66,16 @@ export class SharedTreeShim implements IShim {
 	}
 	public getAttachSummary(
 		fullTree?: boolean | undefined,
-		trackState?: boolean | undefined,
 		telemetryContext?: ITelemetryContext | undefined
 	): ISummaryTreeWithStats {
-		return this.currentTree.getAttachSummary(fullTree, trackState, telemetryContext);
+		return this.currentTree.getAttachSummary(fullTree, telemetryContext);
 	}
 	public async summarize(
 		fullTree?: boolean | undefined,
-		trackState?: boolean | undefined,
 		telemetryContext?: ITelemetryContext | undefined,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined
 	): Promise<ISummaryTreeWithStats> {
-		return this.currentTree.summarize(fullTree, trackState, telemetryContext, incrementalSummaryContext);
+		return this.currentTree.summarize(fullTree, telemetryContext, incrementalSummaryContext);
 	}
 	public isAttached(): boolean {
 		return this.currentTree.isAttached();

--- a/packages/dds/shared-object-base/api-report/shared-object-base.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.api.md
@@ -97,12 +97,12 @@ export function serializeHandles(value: any, serializer: IFluidSerializer, bind:
 // @alpha
 export abstract class SharedObject<TEvent extends ISharedObjectEvents = ISharedObjectEvents> extends SharedObjectCore<TEvent> {
     constructor(id: string, runtime: IFluidDataStoreRuntime, attributes: IChannelAttributes, telemetryContextPrefix: string);
-    getAttachSummary(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    getAttachSummary(fullTree?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): IGarbageCollectionData;
     protected processGCDataCore(serializer: IFluidSerializer): void;
     // (undocumented)
     protected get serializer(): IFluidSerializer;
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
+    summarize(fullTree?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
     protected abstract summarizeCore(serializer: IFluidSerializer, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): ISummaryTreeWithStats;
 }
 
@@ -119,7 +119,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     protected didAttach(): void;
     protected dirty(): void;
     emit(event: EventEmitterEventType, ...args: any[]): boolean;
-    abstract getAttachSummary(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    abstract getAttachSummary(fullTree?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     abstract getGCData(fullGC?: boolean): IGarbageCollectionData;
     readonly handle: IFluidHandleInternal;
     protected handleDecoded(decodedHandle: IFluidHandle): void;
@@ -143,7 +143,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     protected runtime: IFluidDataStoreRuntime;
     protected abstract get serializer(): IFluidSerializer;
     protected submitLocalMessage(content: any, localOpMetadata?: unknown): void;
-    abstract summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
+    abstract summarize(fullTree?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
 }
 
 // @public

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -311,7 +311,6 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
 	 */
 	public abstract getAttachSummary(
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): ISummaryTreeWithStats;
 
@@ -320,7 +319,6 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
 	 */
 	public abstract summarize(
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats>;
 
@@ -675,7 +673,6 @@ export abstract class SharedObject<
 	 */
 	public getAttachSummary(
 		fullTree: boolean = false,
-		trackState: boolean = false,
 		telemetryContext?: ITelemetryContext,
 	): ISummaryTreeWithStats {
 		const result = this.summarizeCore(this.serializer, telemetryContext);
@@ -697,7 +694,6 @@ export abstract class SharedObject<
 	 */
 	public async summarize(
 		fullTree: boolean = false,
-		trackState: boolean = false,
 		telemetryContext?: ITelemetryContext,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): Promise<ISummaryTreeWithStats> {

--- a/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
+++ b/packages/dds/shared-object-base/src/test/sharedObject.spec.ts
@@ -80,13 +80,10 @@ class MySharedObjectCore extends SharedObjectCore {
 	protected applyStashedOp(content: any): unknown {
 		throw new Error("Method not implemented.");
 	}
-	public getAttachSummary(fullTree?: boolean, trackState?: boolean): ISummaryTreeWithStats {
+	public getAttachSummary(fullTree?: boolean): ISummaryTreeWithStats {
 		throw new Error("Method not implemented.");
 	}
-	public async summarize(
-		fullTree?: boolean,
-		trackState?: boolean,
-	): Promise<ISummaryTreeWithStats> {
+	public async summarize(fullTree?: boolean): Promise<ISummaryTreeWithStats> {
 		throw new Error("Method not implemented.");
 	}
 	public getGCData(fullGC?: boolean): IGarbageCollectionData {

--- a/packages/dds/tree/src/feature-libraries/detachedFieldIndexSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/detachedFieldIndexSummarizer.ts
@@ -36,7 +36,6 @@ export class DetachedFieldIndexSummarizer implements Summarizable {
 	public getAttachSummary(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): ISummaryTreeWithStats {
 		const data = this.detachedFieldIndex.encode();
@@ -46,10 +45,9 @@ export class DetachedFieldIndexSummarizer implements Summarizable {
 	public async summarize(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats> {
-		return this.getAttachSummary(stringify, fullTree, trackState, telemetryContext);
+		return this.getAttachSummary(stringify, fullTree, telemetryContext);
 	}
 
 	public getGCData(fullGC?: boolean): IGarbageCollectionData {

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -98,7 +98,6 @@ export class ForestSummarizer implements Summarizable {
 	public getAttachSummary(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): ISummaryTreeWithStats {
 		return createSingleBlobSummary(treeBlobKey, this.getTreeString(stringify));
@@ -107,7 +106,6 @@ export class ForestSummarizer implements Summarizable {
 	public async summarize(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats> {
 		return createSingleBlobSummary(treeBlobKey, this.getTreeString(stringify));

--- a/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/schema-index/schemaSummarizer.ts
@@ -59,7 +59,6 @@ export class SchemaSummarizer implements Summarizable {
 	public getAttachSummary(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined,
 	): ISummaryTreeWithStats {
@@ -84,7 +83,6 @@ export class SchemaSummarizer implements Summarizable {
 	public async summarize(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined,
 	): Promise<ISummaryTreeWithStats> {

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -47,7 +47,6 @@ export class EditManagerSummarizer<TChangeset> implements Summarizable {
 	public getAttachSummary(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): ISummaryTreeWithStats {
 		return this.summarizeCore(stringify);
@@ -56,7 +55,6 @@ export class EditManagerSummarizer<TChangeset> implements Summarizable {
 	public async summarize(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats> {
 		return this.summarizeCore(stringify);

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -209,7 +209,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 				s.getAttachSummary(
 					(contents) => serializer.stringify(contents, this.handle),
 					undefined,
-					undefined,
 					telemetryContext,
 					incrementalSummaryContext,
 				),
@@ -410,7 +409,6 @@ export interface Summarizable {
 	getAttachSummary(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): ISummaryTreeWithStats;
@@ -422,7 +420,6 @@ export interface Summarizable {
 	summarize(
 		stringify: SummaryElementStringifier,
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats>;
 

--- a/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -493,7 +493,6 @@ describe("SharedTreeCore", () => {
 		public getAttachSummary(
 			stringify: SummaryElementStringifier,
 			fullTree?: boolean | undefined,
-			trackState?: boolean | undefined,
 			telemetryContext?: ITelemetryContext | undefined,
 		): ISummaryTreeWithStats {
 			this.emit("summarizeAttached");
@@ -503,7 +502,6 @@ describe("SharedTreeCore", () => {
 		public async summarize(
 			stringify: SummaryElementStringifier,
 			fullTree?: boolean | undefined,
-			trackState?: boolean | undefined,
 			telemetryContext?: ITelemetryContext | undefined,
 		): Promise<ISummaryTreeWithStats> {
 			this.emit("summarizeAsync");

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -474,7 +474,6 @@ describe("SharedTree", () => {
 				const summaryTree = await tree2.summarize(
 					undefined,
 					undefined,
-					undefined,
 					incrementalSummaryContext,
 				);
 				containerRuntimeFactory.processAllMessages();

--- a/packages/framework/attributor/src/mixinAttributor.ts
+++ b/packages/framework/attributor/src/mixinAttributor.ts
@@ -224,10 +224,9 @@ export const mixinAttributor = (
 		protected addContainerStateToSummary(
 			summaryTree: ISummaryTreeWithStats,
 			fullTree: boolean,
-			trackState: boolean,
 			telemetryContext?: ITelemetryContext,
 		): void {
-			super.addContainerStateToSummary(summaryTree, fullTree, trackState, telemetryContext);
+			super.addContainerStateToSummary(summaryTree, fullTree, telemetryContext);
 			const attributorSummary = this.runtimeAttributor?.summarize();
 			if (attributorSummary) {
 				addSummarizeResultToSummary(summaryTree, attributorTreeName, attributorSummary);

--- a/packages/framework/attributor/src/test/mixinAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/mixinAttributor.spec.ts
@@ -135,7 +135,6 @@ describe("mixinAttributor", () => {
 		(context.deltaManager as MockDeltaManager).emit("op", op);
 		const { summary } = await containerRuntime.summarize({
 			fullTree: true,
-			trackState: false,
 			runGC: false,
 		});
 
@@ -269,7 +268,6 @@ describe("mixinAttributor", () => {
 
 				const { summary } = await containerRuntime.summarize({
 					fullTree: true,
-					trackState: false,
 					runGC: false,
 				});
 				assert(summary.tree[".attributor"] === undefined);

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -342,6 +342,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
     summarize(options: {
         fullTree?: boolean;
+        trackState?: boolean;
         summaryLogger?: ITelemetryLoggerExt;
         runGC?: boolean;
         fullGC?: boolean;

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -152,7 +152,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
     // (undocumented)
     protected submitAttachChannelOp(localContext: LocalFluidDataStoreContext): void;
     // (undocumented)
-    summarize(fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
+    summarize(fullTree: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
     updateStateBeforeGC(): Promise<void>;
     updateTombstonedRoutes(tombstonedRoutes: readonly string[]): void;
     updateUsedRoutes(usedRoutes: readonly string[]): void;
@@ -211,7 +211,7 @@ export enum ContainerMessageType {
 export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents & ISummarizerEvents> implements IContainerRuntime, IRuntime, ISummarizerRuntime, ISummarizerInternalsProvider, IProvideFluidHandleContext {
     protected constructor(context: IContainerContext, registry: IFluidDataStoreRegistry, metadata: IContainerRuntimeMetadata | undefined, electedSummarizerData: ISerializedElection | undefined, chunks: [string, string[]][], dataStoreAliasMap: [string, string][], runtimeOptions: Readonly<Required<IContainerRuntimeOptions>>, containerScope: FluidObject, baseLogger: ITelemetryBaseLogger, existing: boolean, blobManagerSnapshot: IBlobManagerLoadInfo, _storage: IDocumentStorageService, createIdCompressor: () => Promise<IIdCompressor & IIdCompressorCore>, documentsSchemaController: DocumentsSchemaController, featureGatesForTelemetry: Record<string, boolean | number | undefined>, provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>, requestHandler?: ((request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>) | undefined, summaryConfiguration?: ISummaryConfiguration);
     // (undocumented)
-    protected addContainerStateToSummary(summaryTree: ISummaryTreeWithStats, fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext): void;
+    protected addContainerStateToSummary(summaryTree: ISummaryTreeWithStats, fullTree: boolean, telemetryContext?: ITelemetryContext): void;
     addedGCOutboundReference(srcHandle: {
         absolutePath: string;
     }, outboundHandle: {
@@ -342,7 +342,6 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
     summarize(options: {
         fullTree?: boolean;
-        trackState?: boolean;
         summaryLogger?: ITelemetryLoggerExt;
         runGC?: boolean;
         fullGC?: boolean;
@@ -566,7 +565,7 @@ export abstract class FluidDataStoreContext extends TypedEventEmitter<IFluidData
     // (undocumented)
     submitMessage(type: string, content: any, localOpMetadata: unknown): void;
     submitSignal(type: string, content: unknown, targetClientId?: string): void;
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;
+    summarize(fullTree?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;
     // (undocumented)
     protected readonly summarizerNode: ISummarizerNodeWithGC;
     // (undocumented)

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -1094,7 +1094,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 
 	public async summarize(
 		fullTree: boolean,
-		trackState: boolean,
+		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats> {
 		const summaryBuilder = new SummaryTreeBuilder();
@@ -1117,11 +1117,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 					return context.attachState === AttachState.Attached;
 				})
 				.map(async ([contextId, context]) => {
-					const contextSummary = await context.summarize(
-						fullTree,
-						trackState,
-						telemetryContext,
-					);
+					const contextSummary = await context.summarize(fullTree, telemetryContext);
 					summaryBuilder.addWithStats(contextId, contextSummary);
 				}),
 		);

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -372,9 +372,8 @@ export abstract class FluidDataStoreContext
 
 		const thisSummarizeInternal = async (
 			fullTree: boolean,
-			trackState: boolean,
 			telemetryContext?: ITelemetryContext,
-		) => this.summarizeInternal(fullTree, trackState, telemetryContext);
+		) => this.summarizeInternal(fullTree, telemetryContext);
 
 		this.summarizerNode = props.createSummarizerNodeFn(
 			thisSummarizeInternal,
@@ -607,20 +606,17 @@ export abstract class FluidDataStoreContext
 	/**
 	 * Returns a summary at the current sequence number.
 	 * @param fullTree - true to bypass optimizations and force a full summary tree
-	 * @param trackState - This tells whether we should track state from this summary.
 	 * @param telemetryContext - summary data passed through the layers for telemetry purposes
 	 */
 	public async summarize(
 		fullTree: boolean = false,
-		trackState: boolean = true,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummarizeResult> {
-		return this.summarizerNode.summarize(fullTree, trackState, telemetryContext);
+		return this.summarizerNode.summarize(fullTree, telemetryContext);
 	}
 
 	private async summarizeInternal(
 		fullTree: boolean,
-		trackState: boolean,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummarizeInternalResult> {
 		await this.realize();
@@ -628,7 +624,7 @@ export abstract class FluidDataStoreContext
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const summarizeResult = await this.channel!.summarize(
 			fullTree,
-			trackState,
+			true /* trackState */,
 			telemetryContext,
 		);
 

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -846,7 +846,6 @@ export class GarbageCollector implements IGarbageCollector {
 	 */
 	public summarize(
 		fullTree: boolean,
-		trackState: boolean,
 		telemetryContext?: ITelemetryContext,
 	): ISummarizeResult | undefined {
 		if (!this.shouldRunGC || this.gcDataFromLastRun === undefined) {
@@ -863,7 +862,7 @@ export class GarbageCollector implements IGarbageCollector {
 		}
 
 		return this.summaryStateTracker.summarize(
-			trackState && !fullTree,
+			!fullTree,
 			gcState,
 			this.deletedNodes,
 			this.tombstones,

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -354,7 +354,6 @@ export interface IGarbageCollector {
 	/** Summarizes the GC data and returns it as a summary tree. */
 	summarize(
 		fullTree: boolean,
-		trackState: boolean,
 		telemetryContext?: ITelemetryContext,
 	): ISummarizeResult | undefined;
 	/** Returns the garbage collector specific metadata to be written into the summary. */

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -162,7 +162,6 @@ export class SummarizerNode implements IRootSummarizerNode {
 
 	public async summarize(
 		fullTree: boolean,
-		trackState: boolean = true,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummarizeResult> {
 		assert(
@@ -214,7 +213,6 @@ export class SummarizerNode implements IRootSummarizerNode {
 
 		const result = await this.summarizeInternalFn(
 			fullTree,
-			true,
 			telemetryContext,
 			incrementalSummaryContext,
 		);

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -1491,10 +1491,7 @@ describe("Garbage Collection Tests", () => {
 
 			await garbageCollector.collectGarbage({});
 			// Summarize with fullTree as true so that the deleted nodes are written as a blob and can be validated.
-			const summaryTree = garbageCollector.summarize(
-				true /* fullTree */,
-				true /* trackState */,
-			);
+			const summaryTree = garbageCollector.summarize(true /* fullTree */);
 			assert(summaryTree?.summary.type === SummaryType.Tree, "The summary should be a tree");
 
 			// Get the deleted node ids from summary and validate that its the same as the one GC loaded from.
@@ -1540,10 +1537,7 @@ describe("Garbage Collection Tests", () => {
 
 			// Run GC and summarize. The summary should contain the deleted nodes.
 			await garbageCollector.collectGarbage({});
-			const gcSummary = garbageCollector.summarize(
-				false /* fullTree */,
-				true /* trackState */,
-			);
+			const gcSummary = garbageCollector.summarize(false /* fullTree */);
 			assert(gcSummary?.summary.type === SummaryType.Tree, "The summary should be a tree");
 
 			// Get the deleted node ids from summary and validate that its the same as the one GC loaded from.
@@ -1560,10 +1554,7 @@ describe("Garbage Collection Tests", () => {
 
 			// Run GC and summarize again. The whole GC summary should now be a summary handle.
 			await garbageCollector.collectGarbage({});
-			const gcSummary2 = garbageCollector.summarize(
-				false /* fullTree */,
-				true /* trackState */,
-			);
+			const gcSummary2 = garbageCollector.summarize(false /* fullTree */);
 			assert(
 				gcSummary2?.summary.type === SummaryType.Handle,
 				"The summary should be a handle",
@@ -1630,7 +1621,7 @@ describe("Garbage Collection Tests", () => {
 
 			await garbageCollector.collectGarbage({});
 
-			const summaryTree = garbageCollector.summarize(true, false)?.summary;
+			const summaryTree = garbageCollector.summarize(true)?.summary;
 			assert(summaryTree !== undefined, "Nothing to summarize after running GC");
 			assert(summaryTree.type === SummaryType.Tree, "Expecting a summary tree!");
 
@@ -2121,7 +2112,6 @@ describe("Garbage Collection Tests", () => {
 
 	describe("No changes to GC between summaries", () => {
 		const fullTree = false;
-		const trackState = true;
 		let garbageCollector: IGarbageCollector;
 
 		beforeEach(() => {
@@ -2146,7 +2136,7 @@ describe("Garbage Collection Tests", () => {
 			garbageCollector = createGarbageCollector();
 
 			await garbageCollector.collectGarbage({});
-			const tree1 = garbageCollector.summarize(fullTree, trackState);
+			const tree1 = garbageCollector.summarize(fullTree);
 
 			checkGCSummaryType(tree1, SummaryType.Tree, "first");
 
@@ -2155,7 +2145,7 @@ describe("Garbage Collection Tests", () => {
 				isSummaryNewer: true,
 			});
 			await garbageCollector.collectGarbage({});
-			const tree2 = garbageCollector.summarize(fullTree, trackState);
+			const tree2 = garbageCollector.summarize(fullTree);
 
 			checkGCSummaryType(tree2, SummaryType.Handle, "second");
 		});

--- a/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcSummaryStateTracker.spec.ts
@@ -86,7 +86,7 @@ describe("GCSummaryStateTracker tests", () => {
 			// Summarize with the same GC state, tombstone state and deleted nodes as in the initial state.
 			// The GC data should be summarized as a summary handle.
 			const summary = summaryStateTracker.summarize(
-				true /* trackState */,
+				false /* fullTree */,
 				initialGCState,
 				initialDeletedNodes,
 				initialTombstones,
@@ -104,7 +104,7 @@ describe("GCSummaryStateTracker tests", () => {
 				},
 			};
 			const summary = summaryStateTracker.summarize(
-				true /* trackState */,
+				false /* fullTree */,
 				newGCState,
 				initialDeletedNodes,
 				initialTombstones,
@@ -129,7 +129,7 @@ describe("GCSummaryStateTracker tests", () => {
 			// state. The tombstone state should be summarized as a summary handle.
 			const newTombstones: string[] = Array.from([...initialTombstones, nodes[2]]);
 			const summary = summaryStateTracker.summarize(
-				true /* trackState */,
+				false /* fullTree */,
 				initialGCState,
 				initialDeletedNodes,
 				newTombstones,
@@ -154,7 +154,7 @@ describe("GCSummaryStateTracker tests", () => {
 			// state. The deleted nodes should be summarized as a summary handle.
 			const newDeletedNodes: Set<string> = new Set(...initialDeletedNodes, nodes[2]);
 			const summary = summaryStateTracker.summarize(
-				true /* trackState */,
+				false /* fullTree */,
 				initialGCState,
 				newDeletedNodes,
 				initialTombstones,
@@ -214,7 +214,7 @@ describe("GCSummaryStateTracker tests", () => {
 		// Call summarize but do not refresh latest summary. This mimics scenarios where summary generation fails
 		// sometime after summarize. This means updatedDSCountSinceLastSummary should be updated incrementally
 		// without resetting it.
-		summaryStateTracker.summarize(true /* trackState */, { gcNodes: {} }, new Set(), []);
+		summaryStateTracker.summarize(false /* fullTree */, { gcNodes: {} }, new Set(), []);
 
 		// Update the stat from GC state again mimicking a GC run after a failed summary.
 		expectedUpdatedDataStoreCount += updatedDataStoreCount;
@@ -227,7 +227,7 @@ describe("GCSummaryStateTracker tests", () => {
 
 		// Call summarize and refresh latest summary. This mimics a successful summary after a failed one. After
 		// this, updatedDSCountSinceLastSummary should be reset to 0.
-		summaryStateTracker.summarize(true /* trackState */, { gcNodes: {} }, new Set(), []);
+		summaryStateTracker.summarize(false /* fullTree */, { gcNodes: {} }, new Set(), []);
 
 		await summaryStateTracker.refreshLatestSummary({
 			isSummaryTracked: true,

--- a/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
@@ -94,10 +94,7 @@ describe("SummarizerNodeWithGC Tests", () => {
 		};
 	});
 
-	async function summarizeInternal(
-		fullTree: boolean,
-		trackState: boolean,
-	): Promise<ISummarizeInternalResult> {
+	async function summarizeInternal(fullTree: boolean): Promise<ISummarizeInternalResult> {
 		const stats = mergeStats();
 		stats.treeNodeCount++;
 		return {

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -29,11 +29,11 @@ export interface IChannel extends IFluidLoadable {
     // (undocumented)
     readonly attributes: IChannelAttributes;
     connect(services: IChannelServices): void;
-    getAttachSummary(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
+    getAttachSummary(fullTree?: boolean, telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): IGarbageCollectionData;
     readonly id: string;
     isAttached(): boolean;
-    summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
+    summarize(fullTree?: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext): Promise<ISummaryTreeWithStats>;
 }
 
 // @alpha

--- a/packages/runtime/datastore-definitions/src/channel.ts
+++ b/packages/runtime/datastore-definitions/src/channel.ts
@@ -44,24 +44,12 @@ export interface IChannel extends IFluidLoadable {
 	 *
 	 * Default: `false`
 	 *
-	 * @param trackState - An optimization for tracking state of objects across summaries. If the state
-	 * of an object did not change since last successful summary, an
-	 * {@link @fluidframework/protocol-definitions#ISummaryHandle} can be used
-	 * instead of re-summarizing it. If this is `false`, the expectation is that you should never
-	 * send an `ISummaryHandle`, since you are not expected to track state.
-	 *
-	 * Note: The goal is to remove the trackState and automatically decided whether the
-	 * handles will be used or not: {@link https://github.com/microsoft/FluidFramework/issues/10455}
-	 *
-	 * Default: `false`
-	 *
 	 * @param telemetryContext - See {@link @fluidframework/runtime-definitions#ITelemetryContext}.
 	 *
 	 * @returns A summary capturing the current state of the channel.
 	 */
 	getAttachSummary(
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): ISummaryTreeWithStats;
 
@@ -75,24 +63,12 @@ export interface IChannel extends IFluidLoadable {
 	 *
 	 * Default: `false`
 	 *
-	 * @param trackState - An optimization for tracking state of objects across summaries. If the state
-	 * of an object did not change since last successful summary, an
-	 * {@link @fluidframework/protocol-definitions#ISummaryHandle} can be used
-	 * instead of re-summarizing it. If this is `false`, the expectation is that you should never
-	 * send an `ISummaryHandle`, since you are not expected to track state.
-	 *
-	 * Default: `false`
-	 *
-	 * Note: The goal is to remove the trackState and automatically decided whether the
-	 * handles will be used or not: {@link https://github.com/microsoft/FluidFramework/issues/10455}
-	 *
 	 * @param telemetryContext - See {@link @fluidframework/runtime-definitions#ITelemetryContext}.
 	 *
 	 * @returns A summary capturing the current state of the channel.
 	 */
 	summarize(
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): Promise<ISummaryTreeWithStats>;

--- a/packages/runtime/datastore/src/channelContext.ts
+++ b/packages/runtime/datastore/src/channelContext.ts
@@ -41,11 +41,7 @@ export interface IChannelContext {
 
 	processOp(message: ISequencedDocumentMessage, local: boolean, localOpMetadata?: unknown): void;
 
-	summarize(
-		fullTree?: boolean,
-		trackState?: boolean,
-		telemetryContext?: ITelemetryContext,
-	): Promise<ISummarizeResult>;
+	summarize(fullTree?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;
 
 	reSubmit(content: any, localOpMetadata: unknown): void;
 
@@ -104,10 +100,9 @@ export function createChannelServiceEndpoints(
 export function summarizeChannel(
 	channel: IChannel,
 	fullTree: boolean = false,
-	trackState: boolean = false,
 	telemetryContext?: ITelemetryContext,
 ): ISummaryTreeWithStats {
-	const summarizeResult = channel.getAttachSummary(fullTree, trackState, telemetryContext);
+	const summarizeResult = channel.getAttachSummary(fullTree, telemetryContext);
 
 	// Add the channel attributes to the returned result.
 	addBlobToSummary(summarizeResult, attributesBlobKey, JSON.stringify(channel.attributes));
@@ -117,13 +112,11 @@ export function summarizeChannel(
 export async function summarizeChannelAsync(
 	channel: IChannel,
 	fullTree: boolean = false,
-	trackState: boolean = false,
 	telemetryContext?: ITelemetryContext,
 	incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 ): Promise<ISummaryTreeWithStats> {
 	const summarizeResult = await channel.summarize(
 		fullTree,
-		trackState,
 		telemetryContext,
 		incrementalSummaryContext,
 	);

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -854,11 +854,7 @@ export class FluidDataStoreRuntime
 					return isAttached;
 				})
 				.map(async ([contextId, context]) => {
-					const contextSummary = await context.summarize(
-						fullTree,
-						trackState,
-						telemetryContext,
-					);
+					const contextSummary = await context.summarize(fullTree, telemetryContext);
 					summaryBuilder.addWithStats(contextId, contextSummary);
 				}),
 		);
@@ -997,11 +993,7 @@ export class FluidDataStoreRuntime
 			0x2d0 /* "Data store should be globally visible to attach channels." */,
 		);
 
-		const summarizeResult = summarizeChannel(
-			channel,
-			true /* fullTree */,
-			false /* trackState */,
-		);
+		const summarizeResult = summarizeChannel(channel, true /* fullTree */);
 
 		// We need to include the channel's GC Data so remote clients can learn of this channel's outbound routes
 		const gcData = channel.getGCData(/* fullGC: */ true);

--- a/packages/runtime/datastore/src/localChannelContext.ts
+++ b/packages/runtime/datastore/src/localChannelContext.ts
@@ -112,16 +112,14 @@ export abstract class LocalChannelContextBase implements IChannelContext {
 	/**
 	 * Returns a summary at the current sequence number.
 	 * @param fullTree - true to bypass optimizations and force a full summary tree
-	 * @param trackState - This tells whether we should track state from this summary.
 	 * @param telemetryContext - summary data passed through the layers for telemetry purposes
 	 */
 	public async summarize(
 		fullTree: boolean = false,
-		trackState: boolean = false,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummarizeResult> {
 		const channel = await this.getChannel();
-		return summarizeChannelAsync(channel, fullTree, trackState, telemetryContext);
+		return summarizeChannelAsync(channel, fullTree, telemetryContext);
 	}
 
 	/**
@@ -134,12 +132,7 @@ export abstract class LocalChannelContextBase implements IChannelContext {
 			this._channel !== undefined,
 			0x18d /* "Channel should be loaded to take snapshot" */,
 		);
-		return summarizeChannel(
-			this._channel,
-			true /* fullTree */,
-			false /* trackState */,
-			telemetryContext,
-		);
+		return summarizeChannel(this._channel, true /* fullTree */, telemetryContext);
 	}
 
 	/**

--- a/packages/runtime/datastore/src/remoteChannelContext.ts
+++ b/packages/runtime/datastore/src/remoteChannelContext.ts
@@ -121,16 +121,9 @@ export class RemoteChannelContext implements IChannelContext {
 
 		const thisSummarizeInternal = async (
 			fullTree: boolean,
-			trackState: boolean,
 			telemetryContext?: ITelemetryContext,
 			incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
-		) =>
-			this.summarizeInternal(
-				fullTree,
-				trackState,
-				telemetryContext,
-				incrementalSummaryContext,
-			);
+		) => this.summarizeInternal(fullTree, telemetryContext, incrementalSummaryContext);
 
 		this.summarizerNode = createSummarizerNode(
 			thisSummarizeInternal,
@@ -194,20 +187,17 @@ export class RemoteChannelContext implements IChannelContext {
 	/**
 	 * Returns a summary at the current sequence number.
 	 * @param fullTree - true to bypass optimizations and force a full summary tree
-	 * @param trackState - This tells whether we should track state from this summary.
 	 * @param telemetryContext - summary data passed through the layers for telemetry purposes
 	 */
 	public async summarize(
 		fullTree: boolean = false,
-		trackState: boolean = true,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummarizeResult> {
-		return this.summarizerNode.summarize(fullTree, trackState, telemetryContext);
+		return this.summarizerNode.summarize(fullTree, telemetryContext);
 	}
 
 	private async summarizeInternal(
 		fullTree: boolean,
-		trackState: boolean,
 		telemetryContext?: ITelemetryContext,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 	): Promise<ISummarizeInternalResult> {
@@ -215,7 +205,6 @@ export class RemoteChannelContext implements IChannelContext {
 		const summarizeResult = await summarizeChannelAsync(
 			channel,
 			fullTree,
-			trackState,
 			telemetryContext,
 			incrementalSummaryContext,
 		);

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -364,7 +364,7 @@ export interface ISummarizerNode {
     isSummaryInProgress?(): boolean;
     recordChange(op: ISequencedDocumentMessage): void;
     readonly referenceSequenceNumber: number;
-    summarize(fullTree: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;
+    summarize(fullTree: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;
     updateBaseSummaryState(snapshot: ISnapshotTree): void;
 }
 
@@ -444,7 +444,7 @@ export interface OpAttributionKey {
 }
 
 // @alpha (undocumented)
-export type SummarizeInternalFn = (fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext) => Promise<ISummarizeInternalResult>;
+export type SummarizeInternalFn = (fullTree: boolean, telemetryContext?: ITelemetryContext, incrementalSummaryContext?: IExperimentalIncrementalSummaryContext) => Promise<ISummarizeInternalResult>;
 
 // @internal (undocumented)
 export const totalBlobSizePropertyName = "TotalBlobSize";

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -319,6 +319,10 @@ export interface IFluidDataStoreChannel extends IDisposable {
 	 */
 	summarize(
 		fullTree?: boolean,
+		/**
+		 * @deprecated - This has no effect and is redundant with fullTree. Please use fullTree = true
+		 * instead of trackState = false to re-summarize all nodes and vice-versa.
+		 */
 		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats>;

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -115,7 +115,6 @@ export interface IExperimentalIncrementalSummaryContext {
  */
 export type SummarizeInternalFn = (
 	fullTree: boolean,
-	trackState: boolean,
 	telemetryContext?: ITelemetryContext,
 	incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 ) => Promise<ISummarizeInternalResult>;
@@ -182,14 +181,9 @@ export interface ISummarizerNode {
 	/**
 	 * Calls the internal summarize function and handles internal state tracking.
 	 * @param fullTree - true to skip optimizations and always generate the full tree
-	 * @param trackState - indicates whether the summarizer node should track the state of the summary or not
 	 * @param telemetryContext - summary data passed through the layers for telemetry purposes
 	 */
-	summarize(
-		fullTree: boolean,
-		trackState?: boolean,
-		telemetryContext?: ITelemetryContext,
-	): Promise<ISummarizeResult>;
+	summarize(fullTree: boolean, telemetryContext?: ITelemetryContext): Promise<ISummarizeResult>;
 	/**
 	 * Checks if there are any additional path parts for children that need to
 	 * be loaded from the base summary. Additional path parts represent parts
@@ -241,9 +235,6 @@ export interface ISummarizerNode {
  * `usedRoutes`: The routes in this node that are currently in use.
  *
  * `getGCData`: A new API that can be used to get the garbage collection data for this node.
- *
- * `summarize`: Added a trackState flag which indicates whether the summarizer node should track the state of the
- * summary or not.
  *
  * `createChild`: Added the following params:
  *

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
@@ -58,7 +58,6 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 				const { stats, summary } = await containerRuntime.summarize({
 					runGC: false,
 					fullTree: false,
-					trackState: false,
 				});
 
 				// Validate stats

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
@@ -57,7 +57,6 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 			const { stats, summary } = await containerRuntime.summarize({
 				runGC: false,
 				fullTree: false,
-				trackState: false,
 			});
 
 			// Validate stats

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -61,7 +61,6 @@ describeCompat("Garbage collection of blobs", "NoCompat", (getTestObjectProvider
 			const { summary } = await summarizerRuntime.summarize({
 				runGC: true,
 				fullTree: true,
-				trackState: false,
 			});
 
 			const gcState = getGCStateFromSummary(summary);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -39,7 +39,6 @@ describeCompat("GC Data Store Aliased Full Compat", "FullCompat", (getTestObject
 		const dataStore = await getContainerEntryPointBackCompat<ITestDataObject>(container);
 		return (dataStore._context.containerRuntime as ContainerRuntime).summarize({
 			runGC: true,
-			trackState: false,
 		});
 	}
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDeleteObjectsInTestMode.spec.ts
@@ -48,7 +48,6 @@ async function validateNodeStateInGCSummaryTree(
 	const { summary } = await summarizerContainerRuntime.summarize({
 		runGC: true,
 		fullTree: true,
-		trackState: false,
 		summaryLogger: createChildLogger(),
 	});
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -128,7 +128,6 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 		return containerRuntime.summarize({
 			runGC: true,
 			fullTree: true,
-			trackState: false,
 		});
 	}
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcReferenceUpdatesInSummary.spec.ts
@@ -123,7 +123,6 @@ describeCompat(
 			const { summary } = await containerRuntime.summarize({
 				runGC: true,
 				fullTree: true,
-				trackState: false,
 				summaryLogger: createChildLogger(),
 			});
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -180,7 +180,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		const gcStats = await summarizerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		const summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		const summarizeResult = await summarizerRuntime.summarize({});
 		assert.strictEqual(
 			summarizeResult.stats.unreferencedBlobSize,
 			0,
@@ -249,7 +249,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		gcStats = await summarizerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		let summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		let summarizeResult = await summarizerRuntime.summarize({});
 		let unrefDataStoreStats = getDataStoreSummaryStats(summarizeResult.summary, [
 			dataStore1._context.id,
 		]);
@@ -276,7 +276,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		gcStats = await summarizerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		summarizeResult = await summarizerRuntime.summarize({});
 		unrefDataStoreStats = getDataStoreSummaryStats(summarizeResult.summary, [
 			dataStore1._context.id,
 			dataStore2._context.id,
@@ -379,7 +379,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		const gcStats = await summarizerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		const summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		const summarizeResult = await summarizerRuntime.summarize({});
 		assert.strictEqual(
 			summarizeResult.stats.unreferencedBlobSize,
 			0,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
@@ -78,7 +78,7 @@ describeCompat("GC unknown handles", "FullCompat", (getTestObjectProvider) => {
 	 */
 	async function getGCNodesFromSummary() {
 		await provider.ensureSynchronized();
-		const { summary } = await summarizerRuntime.summarize({ runGC: true, trackState: false });
+		const { summary } = await summarizerRuntime.summarize({ runGC: true });
 		const gcState = getGCStateFromSummary(summary);
 		assert(gcState !== undefined, "GC tree is not available in the summary");
 		return new Set(Object.keys(gcState));

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -243,7 +243,6 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 		const { stats, summary } = await containerRuntime.summarize({
 			runGC: false,
 			fullTree: false,
-			trackState: false,
 			summaryLogger: createChildLogger(),
 		});
 
@@ -595,7 +594,6 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider) => {
 				.summarize({
 					runGC: false,
 					fullTree: false,
-					trackState: false,
 					summaryLogger: createChildLogger({ logger: mockLogger }),
 				})
 				.catch(() => {});

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -213,7 +213,6 @@ export async function uploadSummary(container: IContainer) {
 	assert(runtime !== undefined, 0x5a7 /* ContainerRuntime entryPoint was not initialized */);
 	const summaryResult = await runtime.summarize({
 		fullTree: true,
-		trackState: false,
 		fullGC: true,
 	});
 	return runtime.storage.uploadSummaryWithContext(summaryResult.summary, {

--- a/packages/tools/replay-tool/src/unknownChannel.ts
+++ b/packages/tools/replay-tool/src/unknownChannel.ts
@@ -48,7 +48,6 @@ class UnknownChannel implements IChannel {
 
 	public getAttachSummary(
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): ISummaryTreeWithStats {
 		return {
@@ -68,10 +67,9 @@ class UnknownChannel implements IChannel {
 
 	public async summarize(
 		fullTree?: boolean,
-		trackState?: boolean,
 		telemetryContext?: ITelemetryContext,
 	): Promise<ISummaryTreeWithStats> {
-		return this.getAttachSummary(fullTree, trackState, telemetryContext);
+		return this.getAttachSummary(fullTree, telemetryContext);
 	}
 
 	public isAttached() {


### PR DESCRIPTION
## Description
The `trackState` option in summaries is not used and is redundant with `fullTree`. Basically, `trackState = false` has the same effect as `fullTree = true` and vice-versa.
It was added as a means to tell summarizer nodes to not track state for doing incremental summaries. Over time, summarization has simplified by some extent and these two options provide the same functionality. `trackState` isn't used anywhere except in tests and those usages can be updated to use `fullTree`

This PR removes `trackState` in favor of `fullTree`. It does the following to maintain backwards compatibility:
- Keeps the `trackState` option in `ContainerRuntime::summarize` but deprecates it. This is used in some UTs by some partners. It will be removed later.
- Keeps the `trackState` option in `IFluidDataStoreChannel::summarize` but deprecates it. This is needed for N/N-1 compat across the container runtime / data store runtime boundary. However, the option is not used and is removed from layers above data store context and below data store runtime.

## Reviewer guidance
It's a big change due to lot of files touched. However, the interesting changes are in `IFluidDataStoreChannel::summarize`, `FluidDataStoreRuntime::summarize`, `FluidDataStoreContext::summarizeInternal` and `ContainerRuntime::summarize`
where the option is still kept due to back-compat.

[AB#8059](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8059)