### PR TITLE
Port RC4: Store handles in detached DDS before attaching  (#21132)

### DIFF
--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -952,13 +952,27 @@ export class FluidDataStoreRuntime
 		//  "The data store should be locally visible when generating attach summary",
 		// );
 
-		for (const [contextId, context] of this.contexts) {
-			if (!(context instanceof LocalChannelContextBase)) {
-				throw new LoggingError("Should only be called with local channel handles");
-			}
+		const visitedContexts = new Set<string>();
+		let visitedLength = -1;
+		while (visitedLength !== visitedContexts.size) {
+			// detect changes in the visitedContexts set, as on visiting a context
+			// it could could make contexts available by removing other contexts
+			// from the notBoundedChannelContextSet, so we need to ensure those get processed as well.
+			// only once the loop can run with no new contexts added to the visitedContexts set do we
+			// know for sure all possible contexts have been visited.
+			visitedLength = visitedContexts.size;
+			for (const [contextId, context] of this.contexts) {
+				if (!(context instanceof LocalChannelContextBase)) {
+					throw new LoggingError("Should only be called with local channel handles");
+				}
 
-			if (!this.notBoundedChannelContextSet.has(contextId)) {
-				visitor(contextId, context);
+				if (
+					!visitedContexts.has(contextId) &&
+					!this.notBoundedChannelContextSet.has(contextId)
+				) {
+					visitor(contextId, context);
+					visitedContexts.add(contextId);
+				}
 			}
 		}
 	}

--- a/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
@@ -4,10 +4,12 @@
  */
 
 import assert from "assert";
-import { describeCompat } from "@fluid-private/test-version-utils";
-import type { ISharedCell } from "@fluidframework/cell/internal";
+import {
+	describeCompat,
+	type CompatApis,
+	type ITestObjectProviderOptions,
+} from "@fluid-private/test-version-utils";
 import { IFluidHandle, type FluidObject } from "@fluidframework/core-interfaces";
-import { ISharedDirectory, type ISharedMap } from "@fluidframework/map/internal";
 import {
 	ChannelFactoryRegistry,
 	ITestContainerConfig,
@@ -16,23 +18,27 @@ import {
 	ITestFluidObject,
 	type ITestObjectProvider,
 } from "@fluidframework/test-utils/internal";
-import type { ISharedMatrix } from "@fluidframework/matrix/internal";
-import { type IConsensusRegisterCollection } from "@fluidframework/register-collection/internal";
+import { SharedMatrixFactory, type ISharedMatrix } from "@fluidframework/matrix/internal";
 import {
-	ConsensusResult,
-	type ConsensusCallback,
-	type IConsensusOrderedCollection,
-} from "@fluidframework/ordered-collection/internal";
-import {
-	ISharedTree,
 	SharedTree,
 	SchemaFactory,
 	TreeConfiguration,
 	type TreeView,
+	type ISharedTree,
 } from "@fluidframework/tree/internal";
 import { isObject } from "@fluidframework/core-utils/internal";
 import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
+import type {
+	IChannel,
+	IFluidDataStoreRuntime,
+} from "@fluidframework/datastore-definitions/internal";
+import { ISharedMap, type ISharedDirectory } from "@fluidframework/map/internal";
+import { ISharedCell } from "@fluidframework/cell/internal";
 import type { SharedString } from "@fluidframework/sequence/internal";
+import {
+	ConsensusRegisterCollectionFactory,
+	type IConsensusRegisterCollection,
+} from "@fluidframework/register-collection/internal";
 
 const mapId = "map";
 const stringId = "sharedString";
@@ -60,7 +66,10 @@ function treeSetup(dds) {
 	return treeView;
 }
 
-async function setup(getTestObjectProvider, apis) {
+async function setup(
+	getTestObjectProvider: (options?: ITestObjectProviderOptions) => ITestObjectProvider,
+	apis: CompatApis,
+) {
 	const {
 		SharedMap,
 		SharedDirectory,
@@ -120,203 +129,249 @@ async function setup(getTestObjectProvider, apis) {
 	};
 }
 
-const handleFns: {
+interface aDDSType {
+	id: string;
+	storeHandle(handle: IFluidHandle): Promise<void>;
+	readHandle(): Promise<unknown>;
+	handle: IFluidHandle;
+}
+
+interface aDDSFactory {
+	id: string;
 	type: string;
-	storeHandle: (defaultDataStore: ITestFluidObject, handle: IFluidHandle) => Promise<void>;
-	readHandle: (defaultDataStore: ITestFluidObject) => Promise<unknown>;
-}[] = [
-	{
-		type: mapId,
-		storeHandle: async (defaultDataStore, handle) => {
-			const mapRoot = await defaultDataStore.getSharedObject<ISharedMap>(mapId);
-			mapRoot.set("B", handle);
-		},
-		readHandle: async (defaultDataStore) => {
-			const mapRoot = await defaultDataStore.getSharedObject<ISharedMap>(mapId);
-			return mapRoot.get("B");
-		},
-	},
-	{
-		type: cellId,
-		storeHandle: async (defaultDataStore, handle) => {
-			const cellRoot = await defaultDataStore.getSharedObject<ISharedCell>(cellId);
-			cellRoot.set(handle);
-		},
-		readHandle: async (defaultDataStore) => {
-			const cellRoot = await defaultDataStore.getSharedObject<ISharedCell>(cellId);
-			return cellRoot.get();
-		},
-	},
-	{
-		type: directoryId,
-		storeHandle: async (defaultDataStore, handle) => {
-			const dirRoot = await defaultDataStore.getSharedObject<ISharedDirectory>(directoryId);
-			dirRoot.set("B", handle);
-		},
-		readHandle: async (defaultDataStore) => {
-			const dirRoot = await defaultDataStore.getSharedObject<ISharedDirectory>(directoryId);
-			return dirRoot.get("B");
-		},
-	},
-	{
-		type: stringId,
-		storeHandle: async (defaultDataStore, handle) => {
-			const stringRoot = await defaultDataStore.getSharedObject<SharedString>(stringId);
-			stringRoot.insertText(0, "hello");
-			stringRoot.annotateRange(0, 1, { B: handle });
-		},
-		readHandle: async (defaultDataStore) => {
-			const stringRoot = await defaultDataStore.getSharedObject<SharedString>(stringId);
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-			return stringRoot.getPropertiesAtPosition(0)?.B;
-		},
-	},
-	{
-		type: matrixId,
-		storeHandle: async (defaultDataStore, handle) => {
-			const matrixRoot = await defaultDataStore.getSharedObject<ISharedMatrix>(matrixId);
-			matrixRoot.insertRows(0, 1);
-			matrixRoot.insertCols(0, 1);
-			matrixRoot.setCell(0, 0, handle);
-		},
-		readHandle: async (defaultDataStore) => {
-			const matrixRoot = await defaultDataStore.getSharedObject<ISharedMatrix>(matrixId);
-			return matrixRoot.getCell(0, 0);
-		},
-	},
-	{
-		type: treeId,
-		storeHandle: async (defaultDataStore, handle) => {
-			const treeRoot = await defaultDataStore.getSharedObject<ISharedTree>(treeId);
-			const treeView = treeSetup(treeRoot);
-			treeView.root.h = handle;
-		},
-		readHandle: async (defaultDataStore) => {
-			const treeRoot = await defaultDataStore.getSharedObject<ISharedTree>(treeId);
-			const treeView = treeSetup(treeRoot);
-			return treeView.root.h;
-		},
-	},
-	// {
-	// 	type: legacyTreeId,
-	// 	storeHandle: async (defaultDataStore, handle) => {
-	// 		const treeRoot = await defaultDataStore.getSharedObject<LegacySharedTree>(legacyTreeId);
-	// 		const legacyNodeId: TraitLabel = "inventory" as TraitLabel;
+	createDDS(runtime: IFluidDataStoreRuntime, apis: CompatApis): aDDSType;
+	downCast(channel: IChannel): aDDSType;
+	getDDS(dataStore: ITestFluidObject): Promise<aDDSType>;
+}
 
-	// 		const handleNode: BuildNode = {
-	// 			definition: legacyNodeId,
-	// 			traits: {
-	// 				handle,
-	// 			},
-	// 		};
-	// 		treeRoot.applyEdit(
-	// 			Change.insertTree(
-	// 				handleNode,
-	// 				StablePlace.atStartOf({
-	// 					parent: treeRoot.currentView.root,
-	// 					label: legacyNodeId,
-	// 				}),
-	// 			),
-	// 		);
-
-	// 		const rootNode = treeRoot.currentView.getViewNode(treeRoot.currentView.root);
-	// 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	// 		const nodeId = rootNode.traits.get(legacyNodeId)![0];
-	// 		const change: Change = Change.setPayload(nodeId, handle);
-	// 		treeRoot.applyEdit(change);
-	// 	},
-	// },
+const ddsTypes: aDDSFactory[] = [
 	{
-		type: registerId,
-		storeHandle: async (defaultDataStore, handle) => {
-			const registerRoot =
-				await defaultDataStore.getSharedObject<IConsensusRegisterCollection<FluidObject>>(
-					registerId,
-				);
-			await registerRoot.write("B", handle);
+		id: mapId,
+		type: "https://graph.microsoft.com/types/map",
+		createDDS(runtime, apis) {
+			const { SharedMap } = apis.dds;
+			const map = runtime.createChannel(undefined, SharedMap.getFactory().type);
+			return this.downCast(map);
 		},
-		readHandle: async (defaultDataStore) => {
-			const registerRoot =
-				await defaultDataStore.getSharedObject<IConsensusRegisterCollection<FluidObject>>(
-					registerId,
-				);
-			return registerRoot.read("B");
-		},
-	},
-	{
-		type: queueId,
-		storeHandle: async (defaultDataStore, handle) => {
-			const queueRoot =
-				await defaultDataStore.getSharedObject<IConsensusOrderedCollection>(queueId);
-			await queueRoot.add(handle);
-		},
-		readHandle: async (defaultDataStore) => {
-			let handle2: unknown;
-			const queueRoot =
-				await defaultDataStore.getSharedObject<IConsensusOrderedCollection>(queueId);
-			const callback: ConsensusCallback<IFluidHandle> = async (value) => {
-				handle2 = value;
-				return ConsensusResult.Complete;
+		downCast(channel): aDDSType {
+			const map = channel as ISharedMap;
+			return {
+				id: map.id,
+				async storeHandle(handle: IFluidHandle) {
+					map.set("B", handle);
+				},
+				async readHandle(): Promise<unknown> {
+					return map.get("B");
+				},
+				handle: map.handle,
 			};
-			await queueRoot.waitAndAcquire(callback);
-			return handle2;
+		},
+		async getDDS(dataStore) {
+			const map = await dataStore.getSharedObject<ISharedMap>(mapId);
+			return this.downCast(map);
 		},
 	},
-	// {
-	// 	type: migrationShimId,
-	// 	storeHandle: async (defaultDataStore, handle) => {
-	// 		const migrationShimRoot = await defaultDataStore.getSharedObject<MigrationShim>(migrationShimId);
-	// 		const tree = migrationShimRoot.currentTree as LegacySharedTree;
-	// 		const legacyNodeId: TraitLabel = "inventory" as TraitLabel;
+	{
+		id: cellId,
+		type: "https://graph.microsoft.com/types/cell",
+		createDDS(runtime, apis) {
+			const { SharedCell } = apis.dds;
+			const cell = runtime.createChannel(undefined, SharedCell.getFactory().type);
+			return this.downCast(cell);
+		},
+		downCast(channel): aDDSType {
+			const cell = channel as ISharedCell;
+			return {
+				id: cell.id,
+				async storeHandle(handle: IFluidHandle) {
+					cell.set(handle);
+				},
+				async readHandle(): Promise<unknown> {
+					return cell.get();
+				},
+				handle: cell.handle,
+			};
+		},
+		async getDDS(dataStore) {
+			const cell = await dataStore.getSharedObject<ISharedCell>(cellId);
+			return this.downCast(cell);
+		},
+	},
+	{
+		id: directoryId,
+		type: "https://graph.microsoft.com/types/directory",
+		createDDS(runtime, apis) {
+			const { SharedDirectory } = apis.dds;
+			const directory = runtime.createChannel(undefined, SharedDirectory.getFactory().type);
+			return this.downCast(directory);
+		},
+		downCast(channel): aDDSType {
+			const directory = channel as ISharedDirectory;
+			return {
+				id: directory.id,
+				async storeHandle(handle: IFluidHandle) {
+					directory.set("B", handle);
+				},
+				async readHandle(): Promise<unknown> {
+					return directory.get("B");
+				},
+				handle: directory.handle,
+			};
+		},
+		async getDDS(dataStore) {
+			const directory = await dataStore.getSharedObject<ISharedDirectory>(directoryId);
+			return this.downCast(directory);
+		},
+	},
+	{
+		id: stringId,
+		type: "https://graph.microsoft.com/types/mergeTree",
+		createDDS(runtime, apis) {
+			const { SharedString } = apis.dds;
+			const string = runtime.createChannel(undefined, SharedString.getFactory().type);
+			return this.downCast(string);
+		},
+		downCast(channel): aDDSType {
+			const string = channel as SharedString;
+			return {
+				id: string.id,
+				async storeHandle(handle: IFluidHandle) {
+					string.insertText(0, "hello");
+					string.annotateRange(0, 1, { B: handle });
+				},
+				async readHandle(): Promise<unknown> {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+					return string.getPropertiesAtPosition(0)?.B;
+				},
+				handle: string.handle,
+			};
+		},
+		async getDDS(dataStore) {
+			const string = await dataStore.getSharedObject<SharedString>(stringId);
+			return this.downCast(string);
+		},
+	},
+	{
+		id: matrixId,
+		type: SharedMatrixFactory.Type,
+		createDDS(runtime, apis) {
+			const { SharedMatrix } = apis.dds;
+			const matrix = runtime.createChannel(undefined, SharedMatrix.getFactory().type);
+			return this.downCast(matrix);
+		},
+		downCast(channel): aDDSType {
+			const matrix = channel as ISharedMatrix;
+			return {
+				id: matrix.id,
+				async storeHandle(handle: IFluidHandle) {
+					matrix.insertRows(0, 1);
+					matrix.insertCols(0, 1);
+					matrix.setCell(0, 0, handle);
+				},
+				async readHandle(): Promise<unknown> {
+					return matrix.getCell(0, 0);
+				},
+				handle: matrix.handle,
+			};
+		},
+		async getDDS(dataStore) {
+			const matrix = await dataStore.getSharedObject<ISharedMatrix>(matrixId);
+			return this.downCast(matrix);
+		},
+	},
+	{
+		id: treeId,
+		type: SharedTree.getFactory().type,
+		createDDS(runtime, apis) {
+			const tree = runtime.createChannel(undefined, SharedTree.getFactory().type);
+			return this.downCast(tree);
+		},
+		downCast(channel): aDDSType {
+			const tree = channel as ISharedTree;
+			const treeView = treeSetup(tree);
 
-	// 		const handleNode: BuildNode = {
-	// 			definition: legacyNodeId,
-	// 			traits: {
-	// 				handle,
-	// 			},
-	// 		};
-	// 		tree.applyEdit(
-	// 			Change.insertTree(
-	// 				handleNode,
-	// 				StablePlace.atStartOf({
-	// 					parent: tree.currentView.root,
-	// 					label: legacyNodeId,
-	// 				}),
-	// 			),
-	// 		);
-
-	// 		const rootNode = tree.currentView.getViewNode(tree.currentView.root);
-	// 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	// 		const nodeId = rootNode.traits.get(legacyNodeId)![0];
-	// 		const change = Change.setPayload(nodeId, handle);
-	// 		tree.applyEdit(change);
-	// 	},
-	// },
+			return {
+				id: tree.id,
+				async storeHandle(handle: IFluidHandle) {
+					treeView.root.h = handle;
+				},
+				async readHandle(): Promise<unknown> {
+					return treeView.root.h;
+				},
+				handle: tree.handle,
+			};
+		},
+		async getDDS(dataStore) {
+			const tree = await dataStore.getSharedObject<ISharedTree>(treeId);
+			return this.downCast(tree);
+		},
+	},
+	{
+		id: registerId,
+		type: ConsensusRegisterCollectionFactory.Type,
+		createDDS(runtime, apis) {
+			const { ConsensusRegisterCollection } = apis.dds;
+			const register = runtime.createChannel(
+				undefined,
+				ConsensusRegisterCollection.getFactory().type,
+			);
+			return this.downCast(register);
+		},
+		downCast(channel): aDDSType {
+			const register = channel as IConsensusRegisterCollection<FluidObject>;
+			return {
+				id: register.id,
+				async storeHandle(handle: IFluidHandle) {
+					await register.write("B", handle);
+				},
+				async readHandle(): Promise<unknown> {
+					return register.read("B");
+				},
+				handle: register.handle,
+			};
+		},
+		async getDDS(dataStore) {
+			const register =
+				await dataStore.getSharedObject<IConsensusRegisterCollection<FluidObject>>(
+					registerId,
+				);
+			return this.downCast(register);
+		},
+	},
 ];
 
+const ddsFactoriesByType = new Map<string, aDDSFactory>(
+	ddsTypes.map((factory) => [factory.type, factory]),
+);
+
+async function getReferencedDDS(handle: IFluidHandle): Promise<aDDSType> {
+	const channel = (await handle.get()) as IChannel;
+	const factory = ddsFactoriesByType.get(channel.attributes.type);
+	assert(factory !== undefined);
+	return factory.downCast(channel);
+}
+
 describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) => {
-	for (const handle of handleFns) {
-		it(`store handle in dds: ${handle.type}`, async () => {
+	for (const handle of ddsTypes) {
+		it(`store handle in dds: ${handle.id}`, async () => {
 			const { container1, provider, testContainerConfig } = await setup(
 				getTestObjectProvider,
 				apis,
 			);
-			let idA: string;
-			let seq: number;
-			{
-				const defaultDataStore = (await container1.getEntryPoint()) as ITestFluidObject;
-				const runtime = defaultDataStore.context.containerRuntime;
-				idA = defaultDataStore.context.id;
 
-				const dataStoreB = await runtime.createDataStore(["default"]);
-				const dataObjectB = (await dataStoreB.entryPoint.get()) as ITestFluidObject;
+			const defaultDataStore = (await container1.getEntryPoint()) as ITestFluidObject;
+			const runtime = defaultDataStore.context.containerRuntime;
+			const idA = defaultDataStore.context.id;
 
-				await handle.storeHandle(defaultDataStore, dataObjectB.handle);
+			const dataStoreB = await runtime.createDataStore(["default"]);
+			const dataObjectB = (await dataStoreB.entryPoint.get()) as ITestFluidObject;
+			const dds = handle.createDDS(defaultDataStore.runtime, apis);
 
-				await provider.ensureSynchronized();
-				seq = container1.deltaManager.lastSequenceNumber;
-				container1.dispose();
-			}
+			await dds.storeHandle(dataObjectB.handle);
+
+			await provider.ensureSynchronized();
+			const seq = container1.deltaManager.lastSequenceNumber;
+			container1.dispose();
 
 			const container2 = await provider.loadTestContainer(testContainerConfig);
 			if (container2.deltaManager.lastSequenceNumber < seq) {
@@ -333,9 +388,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 				});
 			}
 
-			const default2 = (await container2.getEntryPoint()) as ITestFluidObject;
-
-			const actualVal = await handle.readHandle(default2);
+			const actualVal = await dds.readHandle();
 			assert(isFluidHandle(actualVal), `not a handle: ${actualVal}`);
 
 			const actualObject = await actualVal.get();
@@ -344,5 +397,203 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 			const actualId: FluidObject<ITestFluidObject> = actualObject;
 			assert(actualId.ITestFluidObject?.context.id, idA);
 		});
+	}
+
+	for (const detachedDds1Utils of ddsTypes) {
+		for (const detachedDds2Utils of ddsTypes) {
+			for (const attachedDdsUtils of ddsTypes) {
+				it(`stores ${detachedDds1Utils.id} handle in ${detachedDds2Utils.id} and attaches by storing in ${attachedDdsUtils.id}`, async () => {
+					/**
+					 * setup required for all portions of the test
+					 */
+					const { container1, provider, testContainerConfig } = await setup(
+						getTestObjectProvider,
+						apis,
+					);
+
+					const attachedDataStore =
+						(await container1.getEntryPoint()) as ITestFluidObject;
+					await provider.ensureSynchronized();
+
+					/**
+					 * create the first detached dds
+					 */
+					const createdDds1 = detachedDds1Utils.createDDS(
+						attachedDataStore.runtime,
+						apis,
+					);
+
+					/**
+					 * create the second detached dds and store a handle to the first dds in it
+					 */
+					const createdDds2 = detachedDds2Utils.createDDS(
+						attachedDataStore.runtime,
+						apis,
+					);
+					await createdDds2.storeHandle(createdDds1.handle);
+
+					/**
+					 * get the attached dds
+					 */
+					const attachedDds = await attachedDdsUtils.getDDS(attachedDataStore);
+
+					/**
+					 * store handle to dds2 in attached dds (which will attach ddss 1 and 2)
+					 */
+					await attachedDds.storeHandle(createdDds2.handle);
+
+					/**
+					 * close container, get sequence number and sync
+					 */
+					await provider.ensureSynchronized(container1);
+					const seq = container1.deltaManager.lastSequenceNumber;
+					container1.dispose();
+
+					const container2 = await provider.loadTestContainer(testContainerConfig);
+					if (container2.deltaManager.lastSequenceNumber < seq) {
+						await new Promise<void>((resolve, reject) => {
+							const func = (op) => {
+								if (container2.deltaManager.lastSequenceNumber >= seq) {
+									container2.deltaManager.off("op", func);
+									container2.off("closed", reject);
+									resolve();
+								}
+								console.log(op);
+							};
+							container2.deltaManager.on("op", func);
+							container2.once("closed", reject);
+						});
+					}
+					await provider.ensureSynchronized(container2);
+
+					const default2 = (await container2.getEntryPoint()) as ITestFluidObject;
+					const attached2 = await attachedDdsUtils.getDDS(default2);
+					/**
+					 * validation
+					 */
+					const handleFromAttached = await attached2.readHandle();
+					assert(
+						isFluidHandle(handleFromAttached),
+						`not a handle: ${handleFromAttached}`,
+					);
+
+					const refToDetached2 = await getReferencedDDS(handleFromAttached);
+					assert(
+						refToDetached2.id === createdDds2.id,
+						`ids do not match: ${refToDetached2.id}, ${createdDds2.id}`,
+					);
+					const handleFromDetached2 = await refToDetached2.readHandle();
+					assert(
+						isFluidHandle(handleFromDetached2),
+						`not a handle: ${handleFromDetached2}`,
+					);
+
+					const refToDetached1 = await getReferencedDDS(handleFromDetached2);
+					assert(
+						refToDetached1.id === createdDds1.id,
+						`ids do not match: ${refToDetached1.id}, ${createdDds1.id}`,
+					);
+				});
+			}
+		}
+	}
+
+	for (const detachedDds1Utils of ddsTypes) {
+		for (const detachedDds2Utils of ddsTypes) {
+			for (const attachedDdsUtils of ddsTypes) {
+				it(`stores ${detachedDds1Utils.id} handle in ${detachedDds2Utils.id} and attaches by storing in ${attachedDdsUtils.id} with new data store`, async () => {
+					/**
+					 * setup required for all portions of the test
+					 */
+					const { container1, provider, testContainerConfig } = await setup(
+						getTestObjectProvider,
+						apis,
+					);
+
+					const attachedDataStore =
+						(await container1.getEntryPoint()) as ITestFluidObject;
+
+					const dataStoreB =
+						await attachedDataStore.context.containerRuntime.createDataStore([
+							"default",
+						]);
+					const dataObjectB = (await dataStoreB.entryPoint.get()) as ITestFluidObject;
+					await provider.ensureSynchronized();
+
+					/**
+					 * create the first detached dds
+					 */
+					const createdDds1 = detachedDds1Utils.createDDS(dataObjectB.runtime, apis);
+
+					/**
+					 * create the second detached dds and store a handle to the first dds in it
+					 */
+					const createdDds2 = detachedDds2Utils.createDDS(dataObjectB.runtime, apis);
+					await createdDds2.storeHandle(createdDds1.handle);
+
+					/**
+					 * get the attached dds
+					 */
+					const attachedDds = await attachedDdsUtils.getDDS(attachedDataStore);
+
+					/**
+					 * store handle to dds2 in attached dds (which will attach ddss 1 and 2)
+					 */
+					await attachedDds.storeHandle(createdDds2.handle);
+
+					/**
+					 * close container, get sequence number and sync
+					 */
+					await provider.ensureSynchronized(container1);
+					const seq = container1.deltaManager.lastSequenceNumber;
+					container1.dispose();
+
+					const container2 = await provider.loadTestContainer(testContainerConfig);
+					if (container2.deltaManager.lastSequenceNumber < seq) {
+						await new Promise<void>((resolve, reject) => {
+							const func = (op) => {
+								if (container2.deltaManager.lastSequenceNumber >= seq) {
+									container2.deltaManager.off("op", func);
+									container2.off("closed", reject);
+									resolve();
+								}
+								console.log(op);
+							};
+							container2.deltaManager.on("op", func);
+							container2.once("closed", reject);
+						});
+					}
+					await provider.ensureSynchronized(container2);
+
+					const default2 = (await container2.getEntryPoint()) as ITestFluidObject;
+					const attached2 = await attachedDdsUtils.getDDS(default2);
+					/**
+					 * validation
+					 */
+					const handleFromAttached = await attached2.readHandle();
+					assert(
+						isFluidHandle(handleFromAttached),
+						`not a handle: ${handleFromAttached}`,
+					);
+
+					const refToDetached2 = await getReferencedDDS(handleFromAttached);
+					assert(
+						refToDetached2.id === createdDds2.id,
+						`ids do not match: ${refToDetached2.id}, ${createdDds2.id}`,
+					);
+					const handleFromDetached2 = await refToDetached2.readHandle();
+					assert(
+						isFluidHandle(handleFromDetached2),
+						`not a handle: ${handleFromDetached2}`,
+					);
+
+					const refToDetached1 = await getReferencedDDS(handleFromDetached2);
+					assert(
+						refToDetached1.id === createdDds1.id,
+						`ids do not match: ${refToDetached1.id}, ${createdDds1.id}`,
+					);
+				});
+			}
+		}
 	}
 });


### PR DESCRIPTION
Add more tests that involve handles stored in a detached DDS attaching due to the storing of a handle of one of the detached DDSs in an attached DDS. In addition, fixes a bug where some of the contexts were not bound based on the ordering of contexts in the context list.
Port of #21132 
[AB#8009](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8009)

