### PR TITLE
[Port rc.3.0] [Service load test] Force some connections to be write mode for Tinyl…

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -45,7 +45,8 @@
 					"configurations": {
 						"Fluid.Summarizer.ValidateSummaryBeforeUpload": [true, false],
 						"Fluid.Summarizer.UseDynamicRetries": [true, false],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false],
+						"Fluid.Container.ForceWriteConnection": [true, false]
 					}
 				}
 			},


### PR DESCRIPTION
We are seeing a large number of "OpRoundtripTime" errors for Tinylicious runs, largely caused by replaying ops at the beginning of the run. Forcing some of these 120 clients to be in write mode from the start should help alleviate some of the load.

https://github.com/microsoft/FluidFramework/pull/21136