### PR TITLE
RC4 Port: Add an in-memory and default implementation of detached blob storage

### DIFF
--- a/.changeset/early-melons-bathe.md
+++ b/.changeset/early-melons-bathe.md
@@ -1,0 +1,12 @@
+---
+"@fluidframework/container-loader": minor
+---
+
+IDetachedBlobStorage is deprecated and replaced with a default in memory store for detached blobs
+
+IDetachedBlobStorage will be removed in a future release without a replacement.
+
+When applications load a container without specifying ILoaderServices.detachedBlobStorage, an implementation which stores the blobs in memory will be injected by Fluid.
+
+IDetachedBlobStorage as well as application-defined implementations of it are deprecated and support will be removed for them in a future update.
+Applications are recommended to stop providing this property on ILoaderServices.

--- a/packages/loader/container-loader/api-report/container-loader.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.api.md
@@ -46,10 +46,11 @@ export interface IContainerExperimental extends IContainer {
     getPendingLocalState?(): Promise<string>;
 }
 
-// @alpha
+// @alpha @deprecated
 export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | "readBlob"> & {
     size: number;
     getBlobIds(): string[];
+    dispose?(): void;
 };
 
 // @alpha @deprecated (undocumented)
@@ -80,6 +81,7 @@ export interface ILoaderProps {
 // @alpha
 export interface ILoaderServices {
     readonly codeLoader: ICodeDetailsLoader;
+    // @deprecated
     readonly detachedBlobStorage?: IDetachedBlobStorage;
     readonly documentServiceFactory: IDocumentServiceFactory;
     readonly options: ILoaderOptions;

--- a/packages/loader/container-loader/src/attachment.ts
+++ b/packages/loader/container-loader/src/attachment.ts
@@ -9,6 +9,7 @@ import { IDocumentStorageService } from "@fluidframework/driver-definitions/inte
 import { CombinedAppAndProtocolSummary } from "@fluidframework/driver-utils/internal";
 import { ISummaryTree } from "@fluidframework/protocol-definitions";
 
+// eslint-disable-next-line import/no-deprecated
 import { IDetachedBlobStorage } from "./loader.js";
 import type { SnapshotWithBlobs } from "./serializedStateManager.js";
 import { getSnapshotTreeAndBlobsFromSerializedContainer } from "./utils.js";
@@ -110,6 +111,7 @@ export interface AttachProcessProps {
 	/**
 	 * The detached blob storage if it exists.
 	 */
+	// eslint-disable-next-line import/no-deprecated
 	readonly detachedBlobStorage?: Pick<IDetachedBlobStorage, "getBlobIds" | "readBlob" | "size">;
 
 	/**

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -111,6 +111,7 @@ import {
 	getPackageName,
 } from "./contracts.js";
 import { DeltaManager, IConnectionArgs } from "./deltaManager.js";
+// eslint-disable-next-line import/no-deprecated
 import { IDetachedBlobStorage, ILoaderOptions, RelativeLoader } from "./loader.js";
 import { NoopHeuristic } from "./noopHeuristic.js";
 import { pkgVersion } from "./packageVersion.js";
@@ -136,6 +137,11 @@ import {
 	getSnapshotTreeAndBlobsFromSerializedContainer,
 	runSingle,
 } from "./utils.js";
+import {
+	serializeMemoryDetachedBlobStorage,
+	createMemoryDetachedBlobStorage,
+	tryInitializeMemoryDetachedBlobStorage,
+} from "./memoryBlobStorage.js";
 
 const detachedContainerRefSeqNumber = 0;
 
@@ -218,6 +224,7 @@ export interface IContainerCreateProps {
 	/**
 	 * Blobs storage for detached containers.
 	 */
+	// eslint-disable-next-line import/no-deprecated
 	readonly detachedBlobStorage?: IDetachedBlobStorage;
 
 	/**
@@ -465,7 +472,8 @@ export class Container
 	private readonly options: ILoaderOptions;
 	private readonly scope: FluidObject;
 	private readonly subLogger: ITelemetryLoggerExt;
-	private readonly detachedBlobStorage: IDetachedBlobStorage | undefined;
+	// eslint-disable-next-line import/no-deprecated
+	private readonly detachedBlobStorage: IDetachedBlobStorage;
 	private readonly protocolHandlerBuilder: ProtocolHandlerBuilder;
 	private readonly client: IClient;
 
@@ -767,7 +775,7 @@ export class Container
 		// Tracking alternative ways to handle this in AB#4129.
 		this.options = { ...options };
 		this.scope = scope;
-		this.detachedBlobStorage = detachedBlobStorage;
+		this.detachedBlobStorage = detachedBlobStorage ?? createMemoryDetachedBlobStorage();
 		this.protocolHandlerBuilder =
 			protocolHandlerBuilder ??
 			((
@@ -944,7 +952,7 @@ export class Container
 			options.summarizeProtocolTree;
 
 		this.storageAdapter = new ContainerStorageAdapter(
-			detachedBlobStorage,
+			this.detachedBlobStorage,
 			this.mc.logger,
 			pendingLocalState?.snapshotBlobs,
 			pendingLocalState?.loadedGroupIdSnapshots,
@@ -1208,7 +1216,8 @@ export class Container
 			baseSnapshot,
 			snapshotBlobs,
 			pendingRuntimeState,
-			hasAttachmentBlobs: !!this.detachedBlobStorage && this.detachedBlobStorage.size > 0,
+			hasAttachmentBlobs: this.detachedBlobStorage.size > 0,
+			attachmentBlobs: serializeMemoryDetachedBlobStorage(this.detachedBlobStorage),
 		};
 		return JSON.stringify(detachedContainerState);
 	}
@@ -1328,6 +1337,7 @@ export class Container
 					this.serializedStateManager.setInitialSnapshot(snapshotWithBlobs);
 
 					if (!this.closed) {
+						this.detachedBlobStorage.dispose?.();
 						this.handleDeltaConnectionArg(attachProps?.deltaConnection, {
 							fetchOpsFromStorage: false,
 							reason: { text: "createDetached" },
@@ -1760,11 +1770,15 @@ export class Container
 		baseSnapshot,
 		snapshotBlobs,
 		hasAttachmentBlobs,
+		attachmentBlobs,
 		pendingRuntimeState,
 	}: IPendingDetachedContainerState) {
 		if (hasAttachmentBlobs) {
+			if (attachmentBlobs !== undefined) {
+				tryInitializeMemoryDetachedBlobStorage(this.detachedBlobStorage, attachmentBlobs);
+			}
 			assert(
-				!!this.detachedBlobStorage && this.detachedBlobStorage.size > 0,
+				this.detachedBlobStorage.size > 0,
 				0x250 /* "serialized container with attachment blobs must be rehydrated with detached blob storage" */,
 			);
 		}

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -26,6 +26,7 @@ import {
 } from "@fluidframework/protocol-definitions";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
+// eslint-disable-next-line import/no-deprecated
 import { IDetachedBlobStorage } from "./loader.js";
 import { ProtocolTreeStorageService } from "./protocolTreeDocumentStorageService.js";
 import { RetriableDocumentStorageService } from "./retriableDocumentStorageService.js";
@@ -79,6 +80,7 @@ export class ContainerStorageAdapter
 	 * @param forceEnableSummarizeProtocolTree - Enforce uploading a protocol summary regardless of the service's policy
 	 */
 	public constructor(
+		// eslint-disable-next-line import/no-deprecated
 		detachedBlobStorage: IDetachedBlobStorage | undefined,
 		private readonly logger: ITelemetryLoggerExt,
 		/**
@@ -233,6 +235,7 @@ export class ContainerStorageAdapter
  */
 class BlobOnlyStorage implements IDocumentStorageService {
 	constructor(
+		// eslint-disable-next-line import/no-deprecated
 		private readonly detachedStorage: IDetachedBlobStorage | undefined,
 		private readonly logger: ITelemetryLoggerExt,
 	) {}
@@ -245,6 +248,7 @@ class BlobOnlyStorage implements IDocumentStorageService {
 		return this.verifyStorage().readBlob(blobId);
 	}
 
+	// eslint-disable-next-line import/no-deprecated
 	private verifyStorage(): IDetachedBlobStorage {
 		if (this.detachedStorage === undefined) {
 			throw new UsageError("Real storage calls not allowed in Unattached container");

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -227,6 +227,7 @@ export interface ILoaderServices {
 
 	/**
 	 * Blobs storage for detached containers.
+	 * @deprecated - IDetachedBlobStorage will be removed in a future release without a replacement. Blobs created while detached will be stored in memory to align with attached container behavior. AB#8049
 	 */
 	readonly detachedBlobStorage?: IDetachedBlobStorage;
 
@@ -241,6 +242,8 @@ export interface ILoaderServices {
  * Subset of IDocumentStorageService which only supports createBlob() and readBlob(). This is used to support
  * blobs in detached containers.
  * @alpha
+ *
+ * @deprecated - IDetachedBlobStorage will be removed in a future release without a replacement. Blobs created while detached will be stored in memory to align with attached container behavior. AB#8049
  */
 export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | "readBlob"> & {
 	size: number;
@@ -248,6 +251,11 @@ export type IDetachedBlobStorage = Pick<IDocumentStorageService, "createBlob" | 
 	 * Return an array of all blob IDs present in storage
 	 */
 	getBlobIds(): string[];
+
+	/**
+	 * After the container is attached, the detached blob storage is no longer needed and will be disposed.
+	 */
+	dispose?(): void;
 };
 
 /**

--- a/packages/loader/container-loader/src/memoryBlobStorage.ts
+++ b/packages/loader/container-loader/src/memoryBlobStorage.ts
@@ -1,0 +1,79 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { ICreateBlobResponse } from "@fluidframework/protocol-definitions";
+import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
+import { assert, isObject } from "@fluidframework/core-utils/internal";
+// eslint-disable-next-line import/no-deprecated
+import type { IDetachedBlobStorage } from "./loader.js";
+
+const MemoryDetachedBlobStorageIdentifier = Symbol();
+
+// eslint-disable-next-line import/no-deprecated
+interface MemoryDetachedBlobStorage extends IDetachedBlobStorage {
+	[MemoryDetachedBlobStorageIdentifier]: typeof MemoryDetachedBlobStorageIdentifier;
+	initialize(attachmentBlobs: string[]): void;
+	serialize(): string | undefined;
+}
+
+function isMemoryDetachedBlobStorage(
+	// eslint-disable-next-line import/no-deprecated
+	detachedStorage: IDetachedBlobStorage,
+): detachedStorage is MemoryDetachedBlobStorage {
+	return (
+		isObject(detachedStorage) &&
+		MemoryDetachedBlobStorageIdentifier in detachedStorage &&
+		detachedStorage[MemoryDetachedBlobStorageIdentifier] === MemoryDetachedBlobStorageIdentifier
+	);
+}
+
+export function serializeMemoryDetachedBlobStorage(
+	// eslint-disable-next-line import/no-deprecated
+	detachedStorage: IDetachedBlobStorage,
+): string | undefined {
+	if (detachedStorage.size > 0 && isMemoryDetachedBlobStorage(detachedStorage)) {
+		return detachedStorage.serialize();
+	}
+}
+
+export function tryInitializeMemoryDetachedBlobStorage(
+	// eslint-disable-next-line import/no-deprecated
+	detachedStorage: IDetachedBlobStorage,
+	attachmentBlobs: string,
+) {
+	if (!isMemoryDetachedBlobStorage(detachedStorage)) {
+		throw new Error(
+			"DetachedBlobStorage was not provided to the loader during serialize so cannot be provided during rehydrate.",
+		);
+	}
+
+	assert(detachedStorage.size === 0, "Blob storage already initialized");
+	const maybeAttachmentBlobs = JSON.parse(attachmentBlobs);
+	assert(Array.isArray(maybeAttachmentBlobs), "Invalid attachmentBlobs");
+
+	detachedStorage.initialize(maybeAttachmentBlobs);
+}
+
+// eslint-disable-next-line import/no-deprecated
+export function createMemoryDetachedBlobStorage(): IDetachedBlobStorage {
+	const blobs: ArrayBufferLike[] = [];
+	const storage: MemoryDetachedBlobStorage = {
+		[MemoryDetachedBlobStorageIdentifier]: MemoryDetachedBlobStorageIdentifier,
+		createBlob: async (file: ArrayBufferLike): Promise<ICreateBlobResponse> => ({
+			id: `${blobs.push(file) - 1}`,
+		}),
+		readBlob: async (id: string): Promise<ArrayBufferLike> =>
+			blobs[Number(id)] ?? Promise.reject(new Error(`Blob not found: ${id}`)),
+		get size() {
+			return blobs.length;
+		},
+		getBlobIds: (): string[] => blobs.map((_, i) => `${i}`),
+		dispose: () => blobs.splice(0),
+		serialize: () => JSON.stringify(blobs.map((b) => bufferToString(b, "utf-8"))),
+		initialize: (attachmentBlobs: string[]) =>
+			blobs.push(...attachmentBlobs.map((maybeBlob) => stringToBuffer(maybeBlob, "utf-8"))),
+	};
+	return storage;
+}

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -93,6 +93,8 @@ export interface IPendingDetachedContainerState extends SnapshotWithBlobs {
 	attached: false;
 	/** Indicates whether we expect the rehydrated container to have non-empty Detached Blob Storage */
 	hasAttachmentBlobs: boolean;
+	/** Used by the memory blob storage to persisted attachment blobs */
+	attachmentBlobs?: string;
 	/**
 	 * Runtime-specific state that will be needed to properly rehydrate
 	 * (it's included in ContainerContext passed to instantiateRuntime)

--- a/packages/loader/container-loader/src/test/memoryBlobStorage.spec.ts
+++ b/packages/loader/container-loader/src/test/memoryBlobStorage.spec.ts
@@ -1,0 +1,147 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { stringToBuffer } from "@fluid-internal/client-utils";
+import {
+	createMemoryDetachedBlobStorage,
+	serializeMemoryDetachedBlobStorage,
+	tryInitializeMemoryDetachedBlobStorage,
+} from "../memoryBlobStorage.js";
+import type { IDetachedBlobStorage } from "../loader.js";
+
+describe("MemoryBlobStorage", () => {
+	it("Can create and read blobs", async () => {
+		const blobContent = stringToBuffer("test content", "utf-8"); // Add the encoding argument
+
+		const storage = createMemoryDetachedBlobStorage();
+		const blobResponse = await storage.createBlob(blobContent);
+
+		const readContent = await storage.readBlob(blobResponse.id);
+		assert.deepStrictEqual(
+			readContent,
+			blobContent,
+			"Read content does not match written content",
+		);
+	});
+
+	it("Throws error when reading non-existent blob", async () => {
+		const storage = createMemoryDetachedBlobStorage();
+
+		await assert.rejects(async () => {
+			await storage.readBlob("non-existent-id");
+		}, "Expected an error when reading non-existent blob");
+	});
+
+	it("Can handle multiple blobs", async () => {
+		const blobContent1 = stringToBuffer("test content 1", "utf-8");
+		const blobContent2 = stringToBuffer("test content 2", "utf-8");
+
+		const storage = createMemoryDetachedBlobStorage();
+		const blobResponse1 = await storage.createBlob(blobContent1);
+		const blobResponse2 = await storage.createBlob(blobContent2);
+
+		const readContent1 = await storage.readBlob(blobResponse1.id);
+		const readContent2 = await storage.readBlob(blobResponse2.id);
+
+		assert.deepStrictEqual(
+			readContent1,
+			blobContent1,
+			"Read content does not match written content for blob 1",
+		);
+
+		assert.deepStrictEqual(
+			readContent2,
+			blobContent2,
+			"Read content does not match written content for blob 2",
+		);
+	});
+
+	it("Can serialize and initialize blob storage", async () => {
+		const blobContent = stringToBuffer("test content", "utf-8");
+
+		// Create and populate blob storage
+		const storage = createMemoryDetachedBlobStorage();
+		const blobResponse = await storage.createBlob(blobContent);
+
+		// Serialize the storage
+		const serializedStorage = serializeMemoryDetachedBlobStorage(storage);
+		assert(serializedStorage !== undefined, "Serialized storage is undefined");
+
+		const newStorage = createMemoryDetachedBlobStorage();
+		// Initialize a new storage from the serialized one
+		tryInitializeMemoryDetachedBlobStorage(newStorage, serializedStorage);
+
+		// Check that the new storage has the same blobs
+		const readContent = await newStorage.readBlob(blobResponse.id);
+		assert.deepStrictEqual(
+			readContent,
+			blobContent,
+			"Read content does not match written content",
+		);
+	});
+
+	it("Throws error when initializing from invalid serialized storage", async () => {
+		const newStorage = createMemoryDetachedBlobStorage();
+		const invalidSerializedStorage = "invalid serialized storage";
+
+		assert.throws(() => {
+			tryInitializeMemoryDetachedBlobStorage(newStorage, invalidSerializedStorage);
+		}, "Expected an error when initializing from invalid serialized storage");
+	});
+
+	it("Throws error when tryInitializeMemoryDetachedBlobStorage is called on storage with existing blobs", async () => {
+		const blobContent = stringToBuffer("test content", "utf-8");
+
+		// Create and populate blob storage
+		const storage = createMemoryDetachedBlobStorage();
+		await storage.createBlob(blobContent);
+
+		// Serialize the storage
+		const serializedStorage = serializeMemoryDetachedBlobStorage(storage);
+
+		assert(serializedStorage !== undefined, "Serialized storage is undefined");
+
+		const newStorage = createMemoryDetachedBlobStorage();
+		// Add another blob to the storage
+		await newStorage.createBlob(stringToBuffer("another test content", "utf-8"));
+		assert.throws(() => {
+			tryInitializeMemoryDetachedBlobStorage(newStorage, serializedStorage);
+		}, "Expected an error when initializing storage that already has blobs");
+	});
+
+	it("Throws error when tryInitializeMemoryDetachedBlobStorage is called on non-MemoryBlobStorage", () => {
+		const notMemoryBlobStorage: IDetachedBlobStorage = {
+			size: 0,
+			createBlob: async () => {
+				throw new Error("createBlob not implemented");
+			},
+			readBlob: async () => {
+				throw new Error("readBlob not implemented");
+			},
+			getBlobIds: () => {
+				throw new Error("getBlobIds not implemented");
+			},
+			dispose: () => {
+				throw new Error("dispose not implemented");
+			},
+		};
+
+		assert.throws(() => {
+			tryInitializeMemoryDetachedBlobStorage(notMemoryBlobStorage, "");
+		}, "Expected an error when initializing non-MemoryBlobStorage");
+	});
+
+	it("Returns undefined when serializing empty storage", () => {
+		const storage = createMemoryDetachedBlobStorage();
+		const serializedStorage = serializeMemoryDetachedBlobStorage(storage);
+		assert.strictEqual(
+			serializedStorage,
+			undefined,
+			"Expected undefined when serializing empty storage",
+		);
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
@@ -258,7 +258,7 @@ describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, api
 			detachedDataStore.root.set("map", map.handle);
 			map.set("my blob", blobHandle);
 			await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-			detachedBlobStorage.blobs.clear();
+			detachedBlobStorage.dispose();
 			checkForAttachedHandles(map);
 		});
 
@@ -266,7 +266,7 @@ describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, api
 			detachedDataStore.root.set(directoryId, directory.handle);
 			directory.set("my blob", blobHandle);
 			await container.attach(provider.driver.createCreateNewRequest(provider.documentId));
-			detachedBlobStorage.blobs.clear();
+			detachedBlobStorage.dispose();
 			checkForAttachedHandles(directory);
 		});
 
@@ -283,7 +283,7 @@ describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, api
 				false,
 				"blob should be detached in a detached dds and attached container",
 			);
-			detachedBlobStorage.blobs.clear();
+			detachedBlobStorage.dispose();
 			detachedDataStore.root.set(mapId, map.handle);
 			assert.strictEqual(
 				map.handle.isAttached,
@@ -310,7 +310,7 @@ describeCompat("blob handle isAttached", "NoCompat", (getTestObjectProvider, api
 				false,
 				"blob should be detached in a detached dds and attached container",
 			);
-			detachedBlobStorage.blobs.clear();
+			detachedBlobStorage.dispose();
 			detachedDataStore.root.set(directoryId, directory.handle);
 			assert.strictEqual(
 				directory.handle.isAttached,

--- a/packages/test/test-end-to-end-tests/src/test/mockDetachedBlobStorage.ts
+++ b/packages/test/test-end-to-end-tests/src/test/mockDetachedBlobStorage.ts
@@ -13,7 +13,7 @@ import { ICreateBlobResponse } from "@fluidframework/protocol-definitions";
 import { ITestObjectProvider } from "@fluidframework/test-utils/internal";
 
 export class MockDetachedBlobStorage implements IDetachedBlobStorage {
-	public readonly blobs = new Map<string, ArrayBufferLike>();
+	private readonly blobs = new Map<string, ArrayBufferLike>();
 
 	public get size() {
 		return this.blobs.size;
@@ -33,6 +33,10 @@ export class MockDetachedBlobStorage implements IDetachedBlobStorage {
 		const blob = this.blobs.get(blobId);
 		assert(blob);
 		return blob;
+	}
+
+	dispose(): void {
+		this.blobs.clear();
 	}
 }
 


### PR DESCRIPTION
port of #21144

Based on feedback from partners, the current story around blobs is overly complicated, and hard to work with. The existing detached blob storage interface is difficult to work with as it applies to the whole loader, and not a specific container, additionally it is decoupled from the serialization flow which make coordination difficult, lastly the need to supply detached blob storage when not using serialization is burdensome.

To address these issues, this change creates a default in memory detached blob storage which also support serialization and deserialization, so that detached, serialization and rehydration can be used in the presence of blobs without the need to pass a custom storage mechanism which doesn't align with our existing surface area.

For testing I've refactored our existing detached blob storage to support testing with both a custom detached blob storage specified, and an undefined detached blob storage which will result in using the new in memory storage. These test cover attaching, serializing, and deserializing with blobs.

Lastly IDetachedBlobStorage is deprecated and replaced with a default in memory store for detached blobs. IDetachedBlobStorage will be removed in a future release without a replacement. Blobs created while detached will be stored in memory to align with attached container behavior.


[AB#8049](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8049)

[AB#5179](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/5179)
