### PR TITLE
Data virtualization: run e2e tests against odsp df

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -25,6 +25,8 @@ import {
 	summarizeNow,
 } from "@fluidframework/test-utils/internal";
 import { getSnapshotTree } from "@fluidframework/driver-utils/internal";
+import { TestSnapshotCache } from "./testSnapshotCache.js";
+import { supportsDataVirtualization } from "./utils.js";
 
 const interceptResult = <T>(
 	parent: any,
@@ -88,11 +90,20 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 	const assertOmittedTree = (
 		snapshotTree: ISnapshotTree,
 		groupId: string | undefined,
+		blobContents: Map<string, ArrayBuffer>,
 		message: string,
 	) => {
+		// Only local driver supports consistently omitting data from snapshots
+		if (provider.driver.type !== "local") {
+			return;
+		}
 		assert(snapshotTree.groupId === groupId, message);
-		assert(Object.entries(snapshotTree.trees).length === 0, message);
-		assert(Object.entries(snapshotTree.blobs).length === 0, message);
+		for (const tree of Object.values(snapshotTree.trees)) {
+			assertOmittedTree(tree, groupId, blobContents, message);
+		}
+		for (const id of Object.values(snapshotTree.blobs)) {
+			assert(!blobContents.has(id), `${message}: ${id}`);
+		}
 	};
 
 	const assertOmittedBlobContents = (
@@ -101,6 +112,10 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		blobContents: Map<string, ArrayBuffer>,
 		message: string,
 	) => {
+		// Only local driver supports consistently omitting data from snapshots
+		if (provider.driver.type !== "local") {
+			return;
+		}
 		const snapshotTree = getSnapshotTree(snapshot);
 		assert(snapshotTree.groupId === groupId, message);
 		assert(assertOmittedBlobContentsCore(snapshotTree, groupId, blobContents), message);
@@ -157,12 +172,17 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 	let dataObjectB = {} as unknown as TestDataObject;
 	let dataObjectC = {} as unknown as TestDataObject;
 	let dataObjectD = {} as unknown as TestDataObject;
+	const persistedCache = new TestSnapshotCache();
 	beforeEach("setup", async () => {
-		provider = getTestObjectProvider();
+		provider = getTestObjectProvider({ persistedCache });
 		dataObjectA = {} as unknown as TestDataObject;
 		dataObjectB = {} as unknown as TestDataObject;
 		dataObjectC = {} as unknown as TestDataObject;
 		dataObjectD = {} as unknown as TestDataObject;
+	});
+
+	afterEach("teardown", async () => {
+		persistedCache.reset();
 	});
 
 	const noId = undefined;
@@ -228,11 +248,19 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		const { summaryVersion, summaryTree } = await summarizeNow(summarizer);
 		const channelsTree = summaryTree.tree[".channels"];
 		assert(channelsTree.type === SummaryType.Tree, "channels should be a tree");
-		const dataObjectTree = channelsTree.tree[dataObjectA.id];
-		assert(dataObjectTree !== undefined, "dataObjectTree should exist");
-		assert(dataObjectTree.type === SummaryType.Tree, "dataObjectTree should be a tree");
-		assert(dataObjectTree.groupId === loadingGroupId, "GroupId should be on the summary tree");
+		const dataObjectTreeA = channelsTree.tree[dataObjectA.id];
+		const dataObjectTreeB = channelsTree.tree[dataObjectB.id];
+		assert(dataObjectTreeA !== undefined, "dataObjectTree should exist");
+		assert(dataObjectTreeA.type === SummaryType.Tree, "dataObjectTree should be a tree");
+		assert(dataObjectTreeA.groupId === loadingGroupId, "GroupId missing from A summary tree");
+		assert(dataObjectTreeB !== undefined, "dataObjectTree should exist");
+		assert(dataObjectTreeB.type === SummaryType.Tree, "dataObjectTree should be a tree");
+		assert(dataObjectTreeB.groupId === loadingGroupId, "GroupId missing from B summary tree");
 
+		// TODO enable for prod odsp
+		if (provider.driver.endpointName === "odsp-df") {
+			persistedCache.clearCache();
+		}
 		const container2 = await provider.loadContainer(
 			runtimeFactory,
 			{
@@ -241,6 +269,7 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 				}),
 			},
 			{
+				// For ODSP this technically doesn't work, but the cache is cleared so we get the "latest"
 				[LoaderHeader.version]: summaryVersion,
 			},
 		);
@@ -263,11 +292,11 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		// TODO: Enable this portion in tinylicious
 		// This allows us to test against services without groupId enabled.
 		// Round tripping of groupId only works for local driver, regardless the rest should just work as intended
-		if (provider.driver.type === "local") {
+		if (supportsDataVirtualization(provider)) {
 			assert.equal(dataObjectA2.loadingGroupId, loadingGroupId, "A groupId not set");
 			assert.equal(dataObjectB2.loadingGroupId, loadingGroupId, "B groupId not set");
-			assert.equal(dataObjectC2.loadingGroupId, loadingGroupId2, "B groupId not set");
-			assert.equal(dataObjectD2.loadingGroupId, loadingGroupId2, "B groupId not set");
+			assert.equal(dataObjectC2.loadingGroupId, loadingGroupId2, "C groupId not set");
+			assert.equal(dataObjectD2.loadingGroupId, loadingGroupId2, "D groupId not set");
 		}
 	});
 
@@ -279,8 +308,7 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		await createDataObjectsWithGroupIds(mainObject, containerRuntime);
 
 		await provider.attachDetachedContainer(container);
-		// TODO: Enable this portion in tinylicious
-		if (provider.driver.type === "local") {
+		if (supportsDataVirtualization(provider)) {
 			const container2 = await provider.loadContainer(runtimeFactory, {
 				configProvider: configProvider({
 					"Fluid.Container.UseLoadingGroupIdForSnapshotFetch": true,
@@ -309,7 +337,7 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 	});
 
 	it("Excludes dataStores with loadingGroupId from summary", async () => {
-		if (provider.driver.type !== "local") {
+		if (!supportsDataVirtualization(provider)) {
 			return;
 		}
 		// Load basic container stuff
@@ -358,6 +386,11 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			},
 		);
 
+		// TODO enable for prod odsp
+		if (provider.driver.endpointName === "odsp-df") {
+			persistedCache.clearCache();
+		}
+
 		// Load from the summary
 		const container2 = await provider.loadContainer(
 			runtimeFactory,
@@ -380,8 +413,8 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
 		const runtime2 = mainObject2.containerRuntime;
 		assert(runtime2.storage.getSnapshot !== undefined, "getSnapshot should be defined");
-		assert(callCount === 1, "Should have only called getSnapshot once");
-		assert(loadingSnapshot.sequenceNumber === summaryRefSeq, "Loaded from wrong snapshot");
+		assert.equal(callCount, 1, "Should have only called getSnapshot once");
+		assert.equal(loadingSnapshot.sequenceNumber, summaryRefSeq, "Loaded from wrong snapshot");
 
 		// Snapshot validation (a snapshot call with NO loadingGroupIds)
 		const channelsTree = loadingSnapshot.snapshotTree.trees[".channels"];
@@ -492,7 +525,7 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		const dataObjectCTree2 = channelsTree2.trees[dataObjectC.id];
 		const dataObjectDTree2 = channelsTree2.trees[dataObjectD.id];
 
-		assertOmittedTree(mainObjectTree2, noId, "mainObject tree incorrect");
+		assertOmittedTree(mainObjectTree2, noId, blobContents, "mainObject tree incorrect");
 		assertPopulatedTree(
 			dataObjectATree2,
 			loadingGroupId,
@@ -505,8 +538,8 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			blobContents,
 			"Incorrect tree for B2",
 		);
-		assertOmittedTree(dataObjectCTree2, loadingGroupId2, "Incorrect tree for C2");
-		assertOmittedTree(dataObjectDTree2, loadingGroupId2, "Incorrect tree for D2");
+		assertOmittedTree(dataObjectCTree2, loadingGroupId2, blobContents, "Incorrect tree for C2");
+		assertOmittedTree(dataObjectDTree2, loadingGroupId2, blobContents, "Incorrect tree for D2");
 
 		const handleC2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectC");
 		// This call realizes the data object
@@ -529,9 +562,19 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		const dataObjectC2Tree2 = channels2Tree2.trees[dataObjectC.id];
 		const dataObjectD2Tree2 = channels2Tree2.trees[dataObjectD.id];
 
-		assertOmittedTree(mainObject2Tree2, noId, "Not omitted tree for mainObject");
-		assertOmittedTree(dataObjectA2Tree2, loadingGroupId, "Not omitted tree for A2");
-		assertOmittedTree(dataObjectB2Tree2, loadingGroupId, "Not omitted tree for B2");
+		assertOmittedTree(mainObject2Tree2, noId, blobContents, "Not omitted tree for mainObject");
+		assertOmittedTree(
+			dataObjectA2Tree2,
+			loadingGroupId,
+			blobContents,
+			"Not omitted tree for A2",
+		);
+		assertOmittedTree(
+			dataObjectB2Tree2,
+			loadingGroupId,
+			blobContents,
+			"Not omitted tree for B2",
+		);
 		assertPopulatedTree(
 			dataObjectC2Tree2,
 			loadingGroupId2,

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
@@ -19,9 +19,9 @@ import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 import type { IContainerExperimental } from "@fluidframework/container-loader/internal";
 import { LoaderHeader } from "@fluidframework/container-definitions/internal";
-import { clearCacheIfOdsp, supportsDataVirtualization } from "./utils.js";
-import { TestSnapshotCache } from "./testSnapshotCache.js";
 import type { ISnapshot } from "@fluidframework/driver-definitions/internal";
+import { TestSnapshotCache } from "./testSnapshotCache.js";
+import { clearCacheIfOdsp, supportsDataVirtualization } from "./utils.js";
 
 const interceptResult = <T>(
 	parent: any,

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
@@ -19,6 +19,9 @@ import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 import type { IContainerExperimental } from "@fluidframework/container-loader/internal";
 import { LoaderHeader } from "@fluidframework/container-definitions/internal";
+import { clearCacheIfOdsp, supportsDataVirtualization } from "./utils.js";
+import { TestSnapshotCache } from "./testSnapshotCache.js";
+import type { ISnapshot } from "@fluidframework/driver-definitions/internal";
 
 const interceptResult = <T>(
 	parent: any,
@@ -78,9 +81,14 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 
 	let provider: ITestObjectProvider;
 	let callCount = 0;
+	let latestSnapshot: ISnapshot | undefined;
+	const persistedCache = new TestSnapshotCache();
+	beforeEach("setup", async function () {
+		provider = getTestObjectProvider({ persistedCache });
+		if (!supportsDataVirtualization(provider)) {
+			this.skip();
+		}
 
-	beforeEach("setup", async () => {
-		provider = getTestObjectProvider();
 		const documentServiceFactory = provider.documentServiceFactory;
 		interceptResult(
 			documentServiceFactory,
@@ -89,6 +97,7 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 				interceptResult(documentService, documentService.connectToStorage, (storage) => {
 					assert(storage.getSnapshot !== undefined, "Test can't run without getSnapshot");
 					interceptResult(storage, storage.getSnapshot, (snapshot) => {
+						latestSnapshot = snapshot;
 						callCount++;
 					});
 				});
@@ -96,12 +105,13 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 		);
 	});
 
+	afterEach("teardown", async () => {
+		persistedCache.reset();
+	});
+
 	const loadingGroupId = "loadingGroupId";
 
 	it("GroupId offline regular flow", async () => {
-		if (provider.driver.type !== "local") {
-			return;
-		}
 		// Load basic container stuff
 		const container = (await provider.createContainer(runtimeFactory, {
 			configProvider,
@@ -164,9 +174,6 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 	});
 
 	it("GroupId offline with older snapshot", async () => {
-		if (provider.driver.type !== "local") {
-			return;
-		}
 		// Load basic container stuff
 		const container = await provider.createContainer(runtimeFactory, {
 			configProvider,
@@ -204,6 +211,7 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 		);
 
 		const { summaryVersion } = await summarizeNow(summarizer);
+		clearCacheIfOdsp(provider, persistedCache);
 
 		const container2 = (await provider.loadContainer(
 			runtimeFactory,
@@ -258,9 +266,6 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 	});
 
 	it("GroupId offline with refresh", async () => {
-		if (provider.driver.type !== "local") {
-			return;
-		}
 		// Load basic container stuff
 		const container = (await provider.createContainer(runtimeFactory, {
 			configProvider,
@@ -295,10 +300,12 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 			undefined,
 			configProvider,
 		);
-
-		await provider.ensureSynchronized();
+		const initialSummaryVersion = latestSnapshot?.snapshotTree.id;
+		assert(initialSummaryVersion !== undefined, "Initial summary version should be defined");
 		const { summaryVersion } = await summarizeNow(summarizer);
 		await provider.ensureSynchronized();
+
+		clearCacheIfOdsp(provider, persistedCache);
 
 		const container2 = (await provider.loadContainer(
 			runtimeFactory,
@@ -334,6 +341,8 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 				};
 			}
 		).serializedStateManager;
+		clearCacheIfOdsp(provider, persistedCache);
+
 		await serializedStateManager.refreshLatestSnapshot(true);
 
 		// Update the latestSequenceNumber so that the reference sequence number is beyond the snapshot

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
@@ -26,6 +26,8 @@ import {
 	createSummarizerFromFactory,
 	summarizeNow,
 } from "@fluidframework/test-utils/internal";
+import { clearCacheIfOdsp, supportsDataVirtualization } from "./utils.js";
+import { TestSnapshotCache } from "./testSnapshotCache.js";
 
 const interceptResult = <T>(
 	parent: any,
@@ -116,15 +118,19 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		}
 	};
 
-	beforeEach("setup", async () => {
-		provider = getTestObjectProvider();
+	const persistedCache = new TestSnapshotCache();
+	beforeEach("setup", async function () {
+		provider = getTestObjectProvider({ persistedCache });
+		if (!supportsDataVirtualization(provider)) {
+			this.skip();
+		}
+	});
+	afterEach(async () => {
+		persistedCache.reset();
 	});
 
 	const loadingGroupId = "loadingGroupId";
 	it("Load datastore via groupId with snapshot in the future, with seq < all the ops", async () => {
-		if (provider.driver.type !== "local") {
-			return;
-		}
 		// Load basic container stuff
 		const container = await provider.createContainer(runtimeFactory, {
 			configProvider: configProvider({
@@ -160,7 +166,7 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			}),
 		);
 		const { summaryVersion } = await summarizeNow(summarizer);
-
+		clearCacheIfOdsp(provider, persistedCache);
 		const container2 = await provider.loadContainer(
 			runtimeFactory,
 			{
@@ -209,9 +215,6 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 	});
 
 	it("Load datastore via groupId with snapshot in the future, with seq > some ops", async () => {
-		if (provider.driver.type !== "local") {
-			return;
-		}
 		// Load basic container stuff
 		const container = await provider.createContainer(runtimeFactory, {
 			configProvider: configProvider({
@@ -257,6 +260,8 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		const handleAS = mainObjectS._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
 		assert(handleAS !== undefined, "handleA2 should not be undefined");
 		const dataObjectAS = await handleAS.get();
+
+		clearCacheIfOdsp(provider, persistedCache);
 
 		const container2 = await provider.loadContainer(
 			runtimeFactory,
@@ -318,14 +323,6 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			},
 		],
 		async () => {
-			if (provider.driver.type !== "local") {
-				provider.logger?.send({
-					category: "error",
-					eventName: "fluid:telemetry:FluidDataStoreContext:RealizeError",
-					error: "Summarizer client behind, loaded newer snapshot with loadingGroupId",
-				});
-				return;
-			}
 			// Load basic container stuff
 			const container = await provider.createContainer(runtimeFactory, {
 				configProvider: configProvider({
@@ -364,19 +361,19 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 			dataObjectA._root.set("B", "B");
 			summarizer.close();
 
-			const { summarizer: summarizer1, container: container1 } =
-				await createSummarizerFromFactory(
-					provider,
-					container,
-					dataObjectFactory,
-					summaryVersion,
-					undefined,
-					undefined,
-					undefined,
-					configProvider({
-						"Fluid.Container.UseLoadingGroupIdForSnapshotFetch": true,
-					}),
-				);
+			clearCacheIfOdsp(provider, persistedCache);
+			const { summarizer: summarizer1 } = await createSummarizerFromFactory(
+				provider,
+				container,
+				dataObjectFactory,
+				summaryVersion,
+				undefined,
+				undefined,
+				undefined,
+				configProvider({
+					"Fluid.Container.UseLoadingGroupIdForSnapshotFetch": true,
+				}),
+			);
 
 			const { summarizer: summarizer2, container: container2 } =
 				await createSummarizerFromFactory(
@@ -410,6 +407,9 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 
 			// Make sure that summarizer1 gets the op
 			const waitForOp = new Deferred<void>();
+			if (dataObjectA1._root.get("C") === "C") {
+				waitForOp.resolve();
+			}
 			dataObjectA1._root.on("valueChanged", (changed) => {
 				if (changed.key === "C") {
 					waitForOp.resolve();
@@ -443,9 +443,6 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 	);
 
 	it("Load datastore via groupId getting a snapshot older than snapshot we loaded from", async () => {
-		if (provider.driver.type !== "local") {
-			return;
-		}
 		// Load basic container stuff
 		const container = await provider.createContainer(runtimeFactory, {
 			configProvider: configProvider({
@@ -482,12 +479,17 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		// Summarize
 		await provider.ensureSynchronized();
 		const { summaryVersion: summaryVersion1 } = await summarizeNow(summarizer);
-
+		clearCacheIfOdsp(provider, persistedCache);
+		const olderSnapshot = await containerRuntime.storage.getSnapshot?.({
+			versionId: summaryVersion1,
+			loadingGroupIds: [loadingGroupId],
+		});
 		dataObjectA._root.set("B", "B");
 
 		await provider.ensureSynchronized();
 		const { summaryVersion: summaryVersion2 } = await summarizeNow(summarizer);
 
+		clearCacheIfOdsp(provider, persistedCache);
 		// Load the container with the second summary
 		const container2 = await provider.loadContainer(
 			runtimeFactory,
@@ -505,10 +507,6 @@ describeCompat("Create data store with group id", "NoCompat", (getTestObjectProv
 		assert(dataObjectA2Handle !== undefined, "dataObjectA2Handle should not be undefined");
 
 		assert(runtime2.storage.getSnapshot !== undefined, "getSnapshot not defined for runtime2");
-		const olderSnapshot = await runtime2.storage.getSnapshot({
-			versionId: summaryVersion1,
-			loadingGroupIds: [loadingGroupId],
-		});
 		overrideResult(runtime2.storage, runtime2.storage.getSnapshot, olderSnapshot);
 		// TODO: update when this assert changes to a hex.
 		await assert.rejects(

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/utils.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/utils.ts
@@ -1,0 +1,18 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { ITestObjectProvider } from "@fluidframework/test-utils/internal";
+import type { TestSnapshotCache } from "./testSnapshotCache.js";
+
+export function supportsDataVirtualization(provider: ITestObjectProvider) {
+	return provider.driver.type === "local" || provider.driver.endpointName === "odsp-df";
+}
+
+// TODO: enable for Odsp Prod endpoint
+export function clearCacheIfOdsp(provider: ITestObjectProvider, persistedCache: TestSnapshotCache) {
+	if (provider.driver.endpointName === "odsp-df") {
+		persistedCache.clearCache();
+	}
+}


### PR DESCRIPTION
[AB#7508](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7508)

Enable data virtualization tests to run against odsp-df so that we get better test coverage of a live service.