### PR TITLE
Make MapTree immutable

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -1255,7 +1255,9 @@ export class MapNodeStoredSchema extends TreeNodeStoredSchema {
 // @internal
 export interface MapTree extends NodeData {
     // (undocumented)
-    fields: Map<FieldKey, MapTree[]>;
+    readonly fields: ReadonlyMap<FieldKey, readonly MapTree[]>;
+    // (undocumented)
+    readonly value?: NodeData["value"];
 }
 
 // @internal

--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -1256,8 +1256,6 @@ export class MapNodeStoredSchema extends TreeNodeStoredSchema {
 export interface MapTree extends NodeData {
     // (undocumented)
     readonly fields: ReadonlyMap<FieldKey, readonly MapTree[]>;
-    // (undocumented)
-    readonly value?: NodeData["value"];
 }
 
 // @internal
@@ -1300,7 +1298,7 @@ export type NodeBuilderDataUnsafe<T extends Unenforced<TreeNodeSchema>> = T exte
 // @internal
 export interface NodeData {
     readonly type: TreeNodeSchemaIdentifier;
-    value?: TreeValue;
+    readonly value?: TreeValue;
 }
 
 // @internal (undocumented)

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -43,7 +43,6 @@ export {
 	mapCursorField,
 	mapCursorFields,
 	iterateCursorField,
-	getMapTreeField,
 	MapTree,
 	detachedFieldAsKey,
 	keyAsDetachedField,

--- a/packages/dds/tree/src/core/tree/index.ts
+++ b/packages/dds/tree/src/core/tree/index.ts
@@ -43,7 +43,7 @@ export {
 	DetachedNodeRename as DeltaDetachedNodeRename,
 	FieldChanges as DeltaFieldChanges,
 } from "./delta.js";
-export { getMapTreeField, MapTree } from "./mapTree.js";
+export { MapTree } from "./mapTree.js";
 export {
 	clonePath,
 	topDownPath,

--- a/packages/dds/tree/src/core/tree/mapTree.ts
+++ b/packages/dds/tree/src/core/tree/mapTree.ts
@@ -17,6 +17,5 @@ import { NodeData } from "./types.js";
  * @internal
  */
 export interface MapTree extends NodeData {
-	readonly value?: NodeData["value"];
 	readonly fields: ReadonlyMap<FieldKey, readonly MapTree[]>;
 }

--- a/packages/dds/tree/src/core/tree/mapTree.ts
+++ b/packages/dds/tree/src/core/tree/mapTree.ts
@@ -17,22 +17,6 @@ import { NodeData } from "./types.js";
  * @internal
  */
 export interface MapTree extends NodeData {
-	fields: Map<FieldKey, MapTree[]>;
-}
-
-/**
- * Get a field from `node`, optionally modifying the tree to create it if missing.
- */
-export function getMapTreeField(node: MapTree, key: FieldKey, createIfMissing: boolean): MapTree[] {
-	const field = node.fields.get(key);
-	if (field !== undefined) {
-		return field;
-	}
-	// Handle missing field:
-	if (createIfMissing === false) {
-		return [];
-	}
-	const newField: MapTree[] = [];
-	node.fields.set(key, newField);
-	return newField;
+	readonly value?: NodeData["value"];
+	readonly fields: ReadonlyMap<FieldKey, readonly MapTree[]>;
 }

--- a/packages/dds/tree/src/core/tree/types.ts
+++ b/packages/dds/tree/src/core/tree/types.ts
@@ -148,12 +148,8 @@ export type Value = undefined | TreeValue;
 export interface NodeData {
 	/**
 	 * A payload of arbitrary serializable data.
-	 *
-	 * TODO: clarify rules for mutating this value.
-	 * For now, avoid mutating the TreeValue itself.
-	 * For example, if its an object, make a modified copy of the object instead of mutating it.
 	 */
-	value?: TreeValue;
+	readonly value?: TreeValue;
 
 	/**
 	 * The meaning of this node.

--- a/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
@@ -12,7 +12,6 @@ import {
 	MapNodeStoredSchema,
 	Multiplicity,
 	type SchemaAndPolicy,
-	getMapTreeField,
 } from "../../core/index.js";
 import { allowsValue } from "../valueUtilities.js";
 import { fail } from "../../util/index.js";
@@ -55,7 +54,7 @@ export function isNodeInSchema(
 		}
 		const uncheckedFieldsFromNode = new Set(node.fields.keys());
 		for (const [fieldKey, fieldSchema] of schema.objectNodeFields) {
-			const nodeField = getMapTreeField(node, fieldKey, false);
+			const nodeField = node.fields.get(fieldKey) ?? [];
 			const fieldInSchemaResult = isFieldInSchema(nodeField, fieldSchema, schemaAndPolicy);
 			if (fieldInSchemaResult !== SchemaValidationErrors.NoError) {
 				return fieldInSchemaResult;
@@ -84,7 +83,7 @@ export function isNodeInSchema(
 }
 
 export function isFieldInSchema(
-	childNodes: MapTree[],
+	childNodes: readonly MapTree[],
 	schema: TreeFieldStoredSchema,
 	schemaAndPolicy: SchemaAndPolicy,
 ): SchemaValidationErrors {

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -44,7 +44,7 @@ import {
 import { cursorForMapTreeNode, mapTreeFromCursor } from "../mapTreeCursor.js";
 import { CursorWithNode, SynchronousCursor } from "../treeCursorUtils.js";
 
-/** A `MapTree` with a mutable value and mutable fields */
+/** A `MapTree` with mutable fields */
 interface MutableMapTree extends MapTree {
 	readonly fields: Map<FieldKey, MutableMapTree[]>;
 }
@@ -61,8 +61,6 @@ function getOrCreateField(mapTree: MutableMapTree, key: FieldKey): MutableMapTre
 	return newField;
 }
 
-// TODO: this references the existing TreeValues instead of copying them:
-// they are assumed to be copy on write. See TODO on NodeData.
 function deepCopyMapTree(mapTree: MapTree): MutableMapTree {
 	return {
 		...mapTree,

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -31,7 +31,6 @@ import {
 	UpPath,
 	Value,
 	aboveRootPlaceholder,
-	getMapTreeField,
 } from "../../core/index.js";
 import { createEmitter } from "../../events/index.js";
 import {
@@ -40,14 +39,39 @@ import {
 	assertValidRange,
 	brand,
 	fail,
+	mapIterable,
 } from "../../util/index.js";
 import { cursorForMapTreeNode, mapTreeFromCursor } from "../mapTreeCursor.js";
 import { CursorWithNode, SynchronousCursor } from "../treeCursorUtils.js";
 
-function makeRoot(): MapTree {
+/** A `MapTree` with a mutable value and mutable fields */
+interface MutableMapTree extends MapTree {
+	readonly fields: Map<FieldKey, MutableMapTree[]>;
+}
+
+/** Get a field from a `MutableMapTree`, optionally modifying the tree to create it if missing. */
+function getOrCreateField(mapTree: MutableMapTree, key: FieldKey): MutableMapTree[] {
+	const field = mapTree.fields.get(key);
+	if (field !== undefined) {
+		return field;
+	}
+
+	const newField: MutableMapTree[] = [];
+	mapTree.fields.set(key, newField);
+	return newField;
+}
+
+// TODO: this references the existing TreeValues instead of copying them:
+// they are assumed to be copy on write. See TODO on NodeData.
+function deepCopyMapTree(mapTree: MapTree): MutableMapTree {
 	return {
-		type: aboveRootPlaceholder,
-		fields: new Map(),
+		...mapTree,
+		fields: new Map(
+			mapIterable(mapTree.fields.entries(), ([key, field]) => [
+				key,
+				field.map(deepCopyMapTree),
+			]),
+		),
 	};
 }
 
@@ -60,14 +84,28 @@ function makeRoot(): MapTree {
 export class ObjectForest implements IEditableForest {
 	private activeVisitor?: DeltaVisitor;
 
-	public readonly roots: MapTree = makeRoot();
-
 	// All cursors that are in the "Current" state. Must be empty when editing.
 	public readonly currentCursors: Set<Cursor> = new Set();
 
 	private readonly events = createEmitter<ForestEvents>();
 
-	public constructor(public readonly anchors: AnchorSet = new AnchorSet()) {}
+	readonly #roots: MutableMapTree;
+	public get roots(): MapTree {
+		return this.#roots;
+	}
+
+	public constructor(
+		public readonly anchors: AnchorSet = new AnchorSet(),
+		roots?: MapTree,
+	) {
+		this.#roots =
+			roots !== undefined
+				? deepCopyMapTree(roots)
+				: {
+						type: aboveRootPlaceholder,
+						fields: new Map(),
+				  };
+	}
 
 	public get isEmpty(): boolean {
 		return this.roots.fields.size === 0;
@@ -78,17 +116,7 @@ export class ObjectForest implements IEditableForest {
 	}
 
 	public clone(_: TreeStoredSchemaSubscription, anchors: AnchorSet): ObjectForest {
-		const forest = new ObjectForest(anchors);
-		// Deep copy the trees.
-		for (const [key, value] of this.roots.fields) {
-			// TODO: this references the existing TreeValues instead of copying them:
-			// they are assumed to be copy on write. See TODO on NodeData.
-			forest.roots.fields.set(
-				key,
-				value.map((v) => mapTreeFromCursor(cursorForMapTreeNode(v))),
-			);
-		}
-		return forest;
+		return new ObjectForest(anchors, this.roots);
 	}
 
 	public forgetAnchor(anchor: Anchor): void {
@@ -168,9 +196,9 @@ export class ObjectForest implements IEditableForest {
 					parent !== this.forest.roots || key !== source,
 					0x7b6 /* Attach source field must be different from current field */,
 				);
-				const currentField = getMapTreeField(parent, key, true);
+				const currentField = getOrCreateField(parent, key);
 				assertValidIndex(destination, currentField, true);
-				const sourceField = getMapTreeField(this.forest.roots, source, false);
+				const sourceField = this.forest.#roots.fields.get(source) ?? [];
 				assert(sourceField !== undefined, 0x7b7 /* Attach source field must exist */);
 				assert(
 					sourceField.length === count,
@@ -196,7 +224,7 @@ export class ObjectForest implements IEditableForest {
 						key !== destination,
 					0x7b9 /* Detach destination field must be different from current field */,
 				);
-				const currentField = getMapTreeField(parent, key, true);
+				const currentField = getOrCreateField(parent, key);
 				assertValidRange(source, currentField);
 				const content = currentField.splice(source.start, source.end - source.start);
 				if (destination !== undefined) {
@@ -245,19 +273,19 @@ export class ObjectForest implements IEditableForest {
 	}
 
 	private add(nodes: Iterable<ITreeCursor>, key: FieldKey): void {
-		const field: ObjectField = Array.from(nodes, mapTreeFromCursor);
+		const field = Array.from(nodes, mapTreeFromCursor) as MutableMapTree[];
 		this.addFieldAsDetached(field, key);
 	}
 
-	private addFieldAsDetached(field: ObjectField, key: FieldKey): void {
+	private addFieldAsDetached(field: MutableMapTree[], key: FieldKey): void {
 		assert(!this.roots.fields.has(key), 0x370 /* new range must not already exist */);
 		if (field.length > 0) {
-			this.roots.fields.set(key, field);
+			this.#roots.fields.set(key, field);
 		}
 	}
 
 	private delete(field: FieldKey): void {
-		this.roots.fields.delete(field);
+		this.#roots.fields.delete(field);
 	}
 
 	public allocateCursor(): Cursor {
@@ -330,8 +358,6 @@ export class ObjectForest implements IEditableForest {
 	}
 }
 
-type ObjectField = MapTree[];
-
 /**
  * Cursor implementation for ObjectForest.
  */
@@ -344,7 +370,7 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 	 */
 	public constructor(
 		public readonly forest: ObjectForest,
-		private innerCursor?: CursorWithNode<MapTree>,
+		private innerCursor?: CursorWithNode<MutableMapTree>,
 	) {
 		super();
 		if (innerCursor === undefined) {
@@ -465,16 +491,19 @@ class Cursor extends SynchronousCursor implements ITreeSubscriptionCursor {
 		);
 		this.clear();
 		this.state = ITreeSubscriptionCursorState.Current;
-		this.innerCursor = cursorForMapTreeNode(this.forest.roots);
+		// Cast to a cursor of _mutable_ trees to allow direct manipulation of the tree data which is more efficient than doing immutable copies.
+		this.innerCursor = cursorForMapTreeNode(
+			this.forest.roots,
+		) as CursorWithNode<MutableMapTree>;
 		this.forest.currentCursors.add(this);
 	}
 
-	public getNode(): MapTree {
+	public getNode(): MutableMapTree {
 		assert(this.innerCursor !== undefined, 0x33e /* Cursor must be current to be used */);
 		return this.innerCursor.getNode();
 	}
 
-	public getParent(): [MapTree, FieldKey] {
+	public getParent(): [MutableMapTree, FieldKey] {
 		assert(this.innerCursor !== undefined, 0x441 /* Cursor must be current to be used */);
 		// This could be optimized to skip moving it accessing internals of cursor.
 		const key = this.innerCursor.getFieldKey();

--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -90,13 +90,17 @@ export const adapter: CursorAdapter<JsonableTree> = {
  */
 export function jsonableTreeFromCursor(cursor: ITreeCursor): JsonableTree {
 	assert(cursor.mode === CursorLocationType.Nodes, 0x3ba /* must start at node */);
-	const node: JsonableTree = {
-		type: cursor.type,
-	};
+	const node: JsonableTree =
+		cursor.value !== undefined
+			? {
+					type: cursor.type,
+					value: cursor.value,
+			  }
+			: {
+					type: cursor.type,
+			  };
+
 	// Normalize object by only including fields that are required.
-	if (cursor.value !== undefined) {
-		node.value = cursor.value;
-	}
 	for (let inFields = cursor.firstField(); inFields; inFields = cursor.nextField()) {
 		const field: JsonableTree[] = mapCursorField(cursor, jsonableTreeFromCursor);
 		setGenericTreeField(node, cursor.getFieldKey(), field);

--- a/packages/dds/tree/src/test/feature-libraries/default-schema/schemaChecker.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-schema/schemaChecker.spec.ts
@@ -164,9 +164,14 @@ describe("schema validation", () => {
 				const { node, schema } = createLeafNode("myNumberNode", 1, ValueSchema.Number);
 				const stringNode = createLeafNode("myStringNode", "string", ValueSchema.String);
 				const schemaAndPolicy = createSchemaAndPolicy(new Map([[node.type, schema]]));
-				node.fields.set(brand("prop1"), [stringNode.node]);
+				const outOfSchemaNode: MapTree = {
+					type: node.type,
+					value: node.value,
+					fields: new Map([[brand("prop1"), [stringNode.node]]]),
+				};
+
 				assert.equal(
-					isNodeInSchema(node, schemaAndPolicy),
+					isNodeInSchema(outOfSchemaNode, schemaAndPolicy),
 					SchemaValidationErrors.LeafNode_FieldsNotAllowed,
 				);
 			});
@@ -183,7 +188,10 @@ describe("schema validation", () => {
 				]);
 				const mapNode = createNonLeafNode(
 					"myUnionMapNode",
-					new Map(),
+					new Map([
+						[brand("prop1"), [numberNode.node]],
+						[brand("prop2"), [stringNode.node]],
+					]),
 					new MapNodeStoredSchema(fieldSchema),
 				);
 				const schemaAndPolicy = createSchemaAndPolicy(
@@ -195,8 +203,6 @@ describe("schema validation", () => {
 					new Map([[fieldSchema.kind, FieldKinds.required]]),
 				);
 
-				mapNode.node.fields.set(brand("prop1"), [numberNode.node]);
-				mapNode.node.fields.set(brand("prop2"), [stringNode.node]);
 				assert.equal(
 					isNodeInSchema(mapNode.node, schemaAndPolicy),
 					SchemaValidationErrors.NoError,
@@ -231,7 +237,6 @@ describe("schema validation", () => {
 					new Map([[brand("prop1"), [numberNode.node]]]),
 					new MapNodeStoredSchema(fieldSchema),
 				);
-				mapNode.node.value = "something that's not undefined";
 
 				const schemaAndPolicy = createSchemaAndPolicy(
 					new Map([
@@ -241,8 +246,14 @@ describe("schema validation", () => {
 					new Map([[fieldSchema.kind, FieldKinds.required]]),
 				);
 
+				const outOfSchemaNode: MapTree = {
+					type: mapNode.node.type,
+					value: "something that's not undefined",
+					fields: mapNode.node.fields,
+				};
+
 				assert.equal(
-					isNodeInSchema(mapNode.node, schemaAndPolicy),
+					isNodeInSchema(outOfSchemaNode, schemaAndPolicy),
 					SchemaValidationErrors.NonLeafNode_ValueNotAllowed,
 				);
 			});
@@ -350,7 +361,6 @@ describe("schema validation", () => {
 					new Map([[brand("prop1"), [numberNode.node]]]),
 					new ObjectNodeStoredSchema(new Map([[brand("requiredProp"), fieldSchema]])),
 				);
-				objectNode.node.value = "something that's not undefined";
 
 				const schemaAndPolicy = createSchemaAndPolicy(
 					new Map([
@@ -360,8 +370,14 @@ describe("schema validation", () => {
 					new Map([[fieldSchema.kind, FieldKinds.required]]),
 				);
 
+				const outOfSchemaNode: MapTree = {
+					type: objectNode.node.type,
+					value: "something that's not undefined",
+					fields: objectNode.node.fields,
+				};
+
 				assert.equal(
-					isNodeInSchema(objectNode.node, schemaAndPolicy),
+					isNodeInSchema(outOfSchemaNode, schemaAndPolicy),
 					SchemaValidationErrors.NonLeafNode_ValueNotAllowed,
 				);
 			});


### PR DESCRIPTION
## Description

Make the internal types `NodeData` and `MapTree` immutable. With the exception of `ObjectForest` and a couple of other small usages, consumers of `NodeData` and `MapTree` already tolerate them being immutable. Making them immutable adds some type safety in scenarios where multiple owners share the same `MapTree`. `ObjectForest` has been given mutable access to its `MapTree` to preserve its existing behavior (the alternative would be to have it clone every subtree that changes which would be less efficient). This PR also does some small related cleanup in `ObjectForest`.  