### PR TITLE
Incorporate map/matrix tests in test-dds-stress pipeline

### DIFF
--- a/packages/dds/map/package.json
+++ b/packages/dds/map/package.json
@@ -80,6 +80,7 @@
 		"test:mocha:esm": "mocha --recursive \"lib/test/**/*.spec.*js\" --exit",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
 		"test:snapshots:regen": "npm run test:mocha:esm -- --snapshot",
+		"test:stress": "cross-env FUZZ_TEST_COUNT=100 FUZZ_STRESS_RUN=true mocha --ignore \"lib/test/memory/**/*\" --recursive \"lib/test/**/*.spec.js\"",
 		"tsc": "fluid-tsc commonjs --project ./tsconfig.cjs.json && copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist",
 		"typetests:gen": "flub generate typetests --dir . -v --publicFallback",
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"

--- a/packages/dds/matrix/package.json
+++ b/packages/dds/matrix/package.json
@@ -81,6 +81,7 @@
 		"test:mocha:cjs": "mocha  --recursive \"dist/test/**/*.spec.*js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
 		"test:mocha:esm": "mocha  --recursive \"lib/test/**/*.spec.*js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
+		"test:stress": "cross-env FUZZ_TEST_COUNT=100 FUZZ_STRESS_RUN=true mocha --ignore \"lib/test/memory/**/*\" --recursive \"lib/test/**/*.spec.js\"",
 		"tsc": "fluid-tsc commonjs --project ./tsconfig.cjs.json && copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist",
 		"typetests:gen": "flub generate typetests --dir . -v --publicFallback",
 		"typetests:prepare": "flub typetests --dir . --reset --previous --normalize"

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -218,6 +218,7 @@ jobs:
             # logic will be centralized outside of CI in the future.
             echo "@fluid-internal:registry=${{ variables.devFeed }}" >> ./.npmrc
             echo "@fluid-private:registry=${{ variables.devFeed }}" >> ./.npmrc
+            echo "@fluid-tools:registry=${{ variables.devFeed }}" >> ./.npmrc
 
             # This scope must be loaded from the "build" feed
             echo "@ff-internal:registry=$(ado-feeds-build)" >> ./.npmrc

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -248,7 +248,7 @@ jobs:
         # ADO feeds have latency on the order of minutes before packages are available downstream. See:
         # https://learn.microsoft.com/en-us/azure/devops/artifacts/concepts/upstream-sources?view=azure-devops#upstream-sources-health-status
         # This pipeline installs packages which were published very recently relative to its runtime, hence the rather high retry count here.
-        retryCountOnTaskFailure: 5
+        retryCountOnTaskFailure: 10
         inputs:
           command: 'custom'
           workingDir: ${{ parameters.testWorkspace }}
@@ -313,6 +313,7 @@ jobs:
 
         - task: Npm@1
           displayName: 'npm install - extra dependencies for test files'
+          retryCountOnTaskFailure: 10
           inputs:
             command: 'custom'
             workingDir: ${{ parameters.testWorkspace }}

--- a/tools/pipelines/test-dds-stress.yml
+++ b/tools/pipelines/test-dds-stress.yml
@@ -44,4 +44,14 @@ stages:
         - packages/dds/tree
         testFileTarName: tree
         testCommand: test:stress
+      - name: "@fluidframework/map"
+        affectedPaths:
+        - packages/dds/map
+        testFileTarName: map
+        testCommand: test:stress
+      - name: "@fluidframework/matrix"
+        affectedPaths:
+        - packages/dds/matrix
+        testFileTarName: matrix
+        testCommand: test:stress
       testWorkspace: ${{ variables.testWorkspace }}

--- a/tools/pipelines/test-dds-stress.yml
+++ b/tools/pipelines/test-dds-stress.yml
@@ -47,11 +47,13 @@ stages:
       - name: "@fluidframework/map"
         affectedPaths:
         - packages/dds/map
+        - packages/dds/merge-tree
         testFileTarName: map
         testCommand: test:stress
       - name: "@fluidframework/matrix"
         affectedPaths:
         - packages/dds/matrix
+        - packages/dds/merge-tree
         testFileTarName: matrix
         testCommand: test:stress
       testWorkspace: ${{ variables.testWorkspace }}


### PR DESCRIPTION
[AB#3211](https://dev.azure.com/fluidframework/internal/_workitems/edit/3211), [AB#7358](https://dev.azure.com/fluidframework/internal/_workitems/edit/7358), [AB#7360](https://dev.azure.com/fluidframework/internal/_workitems/edit/7360)

1. Added map and matrix stress tests to the test-dds-stress pipeline, verified on the test branch. https://dev.azure.com/fluidframework/internal/_build/results?buildId=266884&view=results
2. Adjusted the retry count for installation steps, as they occasionally failed in other real service pipelines like: https://dev.azure.com/fluidframework/internal/_build/results?buildId=265738&view=logs&j=26483432-40f5-552c-5792-70aed8cde738&t=7e7475d0-c4f0-5e7f-8f9b-69e7ef2f5c89
3. ~The installation of extra dependencies are not robust enough, it is tracked by the work item [AB#7360](https://dev.azure.com/fluidframework/internal/_workitems/edit/7360)~
