### PR TITLE
fix: Handle SharedTree events subscriptions with the same listener

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -1066,7 +1066,7 @@ export function isNeverField(policy: FullSchemaPolicy, originalData: TreeStoredS
 
 // @public
 export interface ISubscribable<E extends Events<E>> {
-    on<K extends keyof Events<E>>(eventName: K, listener: E[K]): () => void;
+    on<K extends keyof Events<E>>(eventName: K, listener: E[K]): Off;
 }
 
 // @public
@@ -1378,6 +1378,9 @@ export class ObjectNodeStoredSchema extends TreeNodeStoredSchema {
     // (undocumented)
     readonly objectNodeFields: ReadonlyMap<FieldKey, TreeFieldStoredSchema>;
 }
+
+// @public
+export type Off = () => void;
 
 // @internal
 export function oneFromSet<T>(set: ReadonlySet<T> | undefined): T | undefined;

--- a/packages/dds/tree/src/events/events.ts
+++ b/packages/dds/tree/src/events/events.ts
@@ -95,11 +95,19 @@ export interface ISubscribable<E extends Events<E>> {
 	 * Register an event listener.
 	 * @param eventName - the name of the event
 	 * @param listener - the handler to run when the event is fired by the emitter
-	 * @returns a function which will deregister the listener when run. This function has undefined behavior
-	 * if called more than once.
+	 * @returns a {@link Off | function} which will deregister the listener when called.
+	 * This function has undefined behavior if called more than once.
 	 */
-	on<K extends keyof Events<E>>(eventName: K, listener: E[K]): () => void;
+	on<K extends keyof Events<E>>(eventName: K, listener: E[K]): Off;
 }
+
+/**
+ * A function that, when called, will deregister an event listener subscription that was previously registered.
+ * @remarks
+ * It is returned by the {@link ISubscribable.on | event registration function} when event registration occurs.
+ * @public
+ */
+export type Off = () => void;
 
 /**
  * Interface for an event emitter that can emit typed events to subscribed listeners.
@@ -193,19 +201,14 @@ export interface HasListeners<E extends Events<E>> {
  *     this.events.emit("loaded");
  *   }
  *
- *   public on<K extends keyof MyEvents>(eventName: K, listener: MyEvents[K]): () => void {
+ *   public on<K extends keyof MyEvents>(eventName: K, listener: MyEvents[K]): Off {
  *     return this.events.on(eventName, listener);
  *   }
  * }
  * ```
  */
 export class EventEmitter<E extends Events<E>> implements ISubscribable<E>, HasListeners<E> {
-	// TODO: because the inner data-structure here is a set, adding the same callback twice does not error,
-	// but only calls it once, and unsubscribing will stop calling it all together.
-	// This is surprising since it makes subscribing and unsubscribing not inverses (but instead both idempotent).
-	// This might be desired, but if so the documentation should indicate it.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	private readonly listeners = new Map<keyof E, Set<(...args: unknown[]) => any>>();
+	private readonly listeners = new Map<keyof E, Map<Off, (...args: any[]) => E[keyof E]>>();
 
 	// Because this is protected and not public, calling this externally (not from a subclass) makes sending events to the constructed instance impossible.
 	// Instead, use the static `create` function to get an instance which allows emitting events.
@@ -216,9 +219,9 @@ export class EventEmitter<E extends Events<E>> implements ISubscribable<E>, HasL
 		if (listeners !== undefined) {
 			const argArray: unknown[] = args; // TODO: Current TS (4.5.5) cannot spread `args` into `listener()`, but future versions (e.g. 4.8.4) can.
 			// This explicitly copies listeners so that new listeners added during this call to emit will not receive this event.
-			for (const listener of [...listeners]) {
+			for (const [off, listener] of [...listeners]) {
 				// If listener has been unsubscribed while invoking other listeners, skip it.
-				if (listeners.has(listener)) {
+				if (listeners.has(off)) {
 					listener(...argArray);
 				}
 			}
@@ -233,7 +236,7 @@ export class EventEmitter<E extends Events<E>> implements ISubscribable<E>, HasL
 		if (listeners !== undefined) {
 			const argArray: unknown[] = args;
 			const resultArray: ReturnType<E[K]>[] = [];
-			for (const listener of listeners.values()) {
+			for (const listener of [...listeners.values()]) {
 				resultArray.push(listener(...argArray));
 			}
 			return resultArray;
@@ -252,26 +255,25 @@ export class EventEmitter<E extends Events<E>> implements ISubscribable<E>, HasL
 	 * invoking the returned callback can error even if its only called once if the same listener was provided to two calls to "on".
 	 * This behavior is not documented and its unclear if its a bug or not: see note on listeners.
 	 */
-	public on<K extends keyof Events<E>>(eventName: K, listener: E[K]): () => void {
-		getOrCreate(this.listeners, eventName, () => new Set()).add(listener);
-		return () => this.off(eventName, listener);
-	}
-
-	private off<K extends keyof Events<E>>(eventName: K, listener: E[K]): void {
-		const listeners =
-			this.listeners.get(eventName) ??
-			// TODO: consider making this (and assert below) a usage error since it can be triggered by users of the public API: maybe separate those use cases somehow?
-			fail(
-				"Event has no listeners. Event deregistration functions may only be invoked once.",
+	public on<K extends keyof Events<E>>(eventName: K, listener: E[K]): Off {
+		const off: Off = () => {
+			const listeners =
+				this.listeners.get(eventName) ??
+				// TODO: consider making this (and assert below) a usage error since it can be triggered by users of the public API: maybe separate those use cases somehow?
+				fail(
+					"Event has no listeners. Event deregistration functions may only be invoked once.",
+				);
+			assert(
+				listeners.delete(off),
+				0x4c1 /* Listener does not exist. Event deregistration functions may only be invoked once. */,
 			);
-		assert(
-			listeners.delete(listener),
-			0x4c1 /* Listener does not exist. Event deregistration functions may only be invoked once. */,
-		);
-		if (listeners.size === 0) {
-			this.listeners.delete(eventName);
-			this.noListeners?.(eventName);
-		}
+			if (listeners.size === 0) {
+				this.listeners.delete(eventName);
+				this.noListeners?.(eventName);
+			}
+		};
+		getOrCreate(this.listeners, eventName, () => new Map()).set(off, listener);
+		return off;
 	}
 
 	public hasListeners(eventName?: keyof Events<E>): boolean {

--- a/packages/dds/tree/src/events/index.ts
+++ b/packages/dds/tree/src/events/index.ts
@@ -8,6 +8,7 @@ export {
 	EventEmitter,
 	Events,
 	ISubscribable,
+	Off,
 	IsEvent,
 	TransformEvents,
 	UnionToIntersection,

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -90,10 +90,7 @@ export function makeTree(context: Context, cursor: ITreeSubscriptionCursor): Laz
 		return cached as LazyTreeNode;
 	}
 	const schema = context.schema.nodeSchema.get(cursor.type) ?? fail("missing schema");
-	const output = buildSubclass(context, schema, cursor, anchorNode, anchor);
-	anchorNode.slots.set(flexTreeSlot, output);
-	anchorNode.on("afterDestroy", cleanupTree);
-	return output;
+	return buildSubclass(context, schema, cursor, anchorNode, anchor);
 }
 
 function cleanupTree(anchor: AnchorNode): void {

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -123,6 +123,7 @@ export {
 	Events,
 	IsEvent,
 	ISubscribable,
+	Off,
 	createEmitter,
 	IEmitter,
 	NoListenersCallback,

--- a/packages/dds/tree/src/test/events/eventEmitter.spec.ts
+++ b/packages/dds/tree/src/test/events/eventEmitter.spec.ts
@@ -99,20 +99,26 @@ describe("EventEmitter", () => {
 		assert(!closed);
 	});
 
-	// TODO: this behavior is questionable due to how it relates to unregister events.
-	// If events registered twice stop firing when unregistered once, that seems odd.
-	// Also if two place (that don't know about each-other) add some callback for the same event,
-	// it seems off that the behavior, and how they have to handle un-registration depends on if the functions they provided
-	// happen to compare equal (ex: two calls to a logger or fail could hit this).
-	it("ignores duplicate events", () => {
+	it("allows duplicate event listeners", () => {
 		const emitter = createEmitter<TestEvents>();
-		let count = 0;
+		let count: number;
 		const listener = () => (count += 1);
-		emitter.on("open", listener);
-		emitter.on("open", listener);
+		const off1 = emitter.on("open", listener);
+		const off2 = emitter.on("open", listener);
+
+		count = 0;
 		emitter.emit("open");
-		// Count should be 1, not 2, even though `listener` was registered twice
+		assert.strictEqual(count, 2); // Listener should be fired twice
+
+		count = 0;
+		off1();
+		emitter.emit("open");
 		assert.strictEqual(count, 1);
+
+		count = 0;
+		off2();
+		emitter.emit("open");
+		assert.strictEqual(count, 0);
 	});
 
 	it("fails on duplicate deregistrations", () => {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -533,7 +533,7 @@ export interface ISharedString extends ISharedSegmentSequence<SharedStringSegmen
 
 // @public
 export interface ISubscribable<E extends Events<E>> {
-    on<K extends keyof Events<E>>(eventName: K, listener: E[K]): () => void;
+    on<K extends keyof Events<E>>(eventName: K, listener: E[K]): Off;
 }
 
 // @public
@@ -609,6 +609,9 @@ export type ObjectFromSchemaRecord<T extends RestrictiveReadonlyRecord<string, I
 export type ObjectFromSchemaRecordUnsafe<T extends Unenforced<RestrictiveReadonlyRecord<string, ImplicitFieldSchema>>> = {
     -readonly [Property in keyof T]: TreeFieldFromImplicitFieldUnsafe<T[Property]>;
 };
+
+// @public
+export type Off = () => void;
 
 // @public
 export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {


### PR DESCRIPTION
## Description

This fixes a bug in which the deregister function returned from the event registration function `on` would deregister multiple events if the same event listener object was registered multiple times. Each deregistration function now correctly deregisters only the registration that produced it, regardless of the object identity of the listener function. The new `Off` type is added for clarity since it is used as a map key, and it also helps document the return value for customers.

This also removes an unnecessary event subscription for LazyTree that was never getting cleaned up (and accidentally relied on the previous deregister behavior to get deregistered alongside a duplicate registration).
