### PR TITLE
[Summarization] Refactor summary in progress validation during summarize

### DIFF
--- a/packages/framework/attributor/src/test/mixinAttributor.spec.ts
+++ b/packages/framework/attributor/src/test/mixinAttributor.spec.ts
@@ -135,7 +135,6 @@ describe("mixinAttributor", () => {
 		(context.deltaManager as MockDeltaManager).emit("op", op);
 		const { summary } = await containerRuntime.summarize({
 			fullTree: true,
-			trackState: false,
 			runGC: false,
 		});
 
@@ -269,7 +268,6 @@ describe("mixinAttributor", () => {
 
 				const { summary } = await containerRuntime.summarize({
 					fullTree: true,
-					trackState: false,
 					runGC: false,
 				});
 				assert(summary.tree[".attributor"] === undefined);

--- a/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNode.spec.ts
@@ -376,14 +376,25 @@ describe("Runtime", () => {
 			});
 
 			describe("Summarize", () => {
-				it("Should fail summarize if startSummary is not called", async () => {
+				it("Should fail completeSummary if startSummary is not called", async () => {
 					createRoot();
 					await expectReject(
-						async () => rootNode.summarize(false),
+						async () => rootNode.completeSummary("handle"),
 						"summarize",
 						"no wip referenceSequenceNumber or logger",
-						"0x1a1",
-						"0x1a2",
+						"0x1a4",
+					);
+					assertSummarizeCalls(0, 0, 0);
+				});
+
+				it("Should fail validateSummary if startSummary is not called", async () => {
+					createRoot();
+					await expectReject(
+						async () => rootNode.validateSummary(),
+						"summarize",
+						"no wip referenceSequenceNumber or logger",
+						"0x6fc",
+						"0x6fd",
 					);
 					assertSummarizeCalls(0, 0, 0);
 				});

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.memory.spec.ts
@@ -57,8 +57,7 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 
 				const { stats, summary } = await containerRuntime.summarize({
 					runGC: false,
-					fullTree: false,
-					trackState: false,
+					fullTree: true,
 				});
 
 				// Validate stats

--- a/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/summarization.time.spec.ts
@@ -56,8 +56,7 @@ describeCompat("Summarization - runtime benchmarks", "NoCompat", (getTestObjectP
 
 			const { stats, summary } = await containerRuntime.summarize({
 				runGC: false,
-				fullTree: false,
-				trackState: false,
+				fullTree: true,
 			});
 
 			// Validate stats

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcAttachmentBlobs.spec.ts
@@ -61,7 +61,6 @@ describeCompat("Garbage collection of blobs", "NoCompat", (getTestObjectProvider
 			const { summary } = await summarizerRuntime.summarize({
 				runGC: true,
 				fullTree: true,
-				trackState: false,
 			});
 
 			const gcState = getGCStateFromSummary(summary);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcDatastoreAliased.spec.ts
@@ -40,6 +40,7 @@ describeCompat("GC Data Store Aliased Full Compat", "FullCompat", (getTestObject
 		return (dataStore._context.containerRuntime as ContainerRuntime).summarize({
 			runGC: true,
 			trackState: false,
+			fullTree: true,
 		});
 	}
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcInactiveNodes.spec.ts
@@ -128,7 +128,6 @@ describeCompat("GC inactive nodes tests", "NoCompat", (getTestObjectProvider, ap
 		return containerRuntime.summarize({
 			runGC: true,
 			fullTree: true,
-			trackState: false,
 		});
 	}
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -180,7 +180,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		const gcStats = await summarizerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		const summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		const summarizeResult = await summarizerRuntime.summarize({ fullTree: true });
 		assert.strictEqual(
 			summarizeResult.stats.unreferencedBlobSize,
 			0,
@@ -249,7 +249,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		gcStats = await summarizerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		let summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		let summarizeResult = await summarizerRuntime.summarize({ fullTree: true });
 		let unrefDataStoreStats = getDataStoreSummaryStats(summarizeResult.summary, [
 			dataStore1._context.id,
 		]);
@@ -276,7 +276,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		gcStats = await summarizerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		summarizeResult = await summarizerRuntime.summarize({ fullTree: true });
 		unrefDataStoreStats = getDataStoreSummaryStats(summarizeResult.summary, [
 			dataStore1._context.id,
 			dataStore2._context.id,
@@ -379,7 +379,7 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		const gcStats = await summarizerRuntime.collectGarbage({});
 		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
 
-		const summarizeResult = await summarizerRuntime.summarize({ trackState: false });
+		const summarizeResult = await summarizerRuntime.summarize({ fullTree: true });
 		assert.strictEqual(
 			summarizeResult.stats.unreferencedBlobSize,
 			0,

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcUnknownHandles.spec.ts
@@ -78,7 +78,11 @@ describeCompat("GC unknown handles", "FullCompat", (getTestObjectProvider) => {
 	 */
 	async function getGCNodesFromSummary() {
 		await provider.ensureSynchronized();
-		const { summary } = await summarizerRuntime.summarize({ runGC: true, trackState: false });
+		const { summary } = await summarizerRuntime.summarize({
+			runGC: true,
+			trackState: false,
+			fullTree: true,
+		});
 		const gcState = getGCStateFromSummary(summary);
 		assert(gcState !== undefined, "GC tree is not available in the summary");
 		return new Set(Object.keys(gcState));

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -242,8 +242,7 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider, apis) => {
 
 		const { stats, summary } = await containerRuntime.summarize({
 			runGC: false,
-			fullTree: false,
-			trackState: false,
+			fullTree: true,
 			summaryLogger: createChildLogger(),
 		});
 
@@ -594,8 +593,7 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider) => {
 			await containerRuntime
 				.summarize({
 					runGC: false,
-					fullTree: false,
-					trackState: false,
+					fullTree: true,
 					summaryLogger: createChildLogger({ logger: mockLogger }),
 				})
 				.catch(() => {});

--- a/packages/tools/replay-tool/src/helpers.ts
+++ b/packages/tools/replay-tool/src/helpers.ts
@@ -213,7 +213,6 @@ export async function uploadSummary(container: IContainer) {
 	assert(runtime !== undefined, 0x5a7 /* ContainerRuntime entryPoint was not initialized */);
 	const summaryResult = await runtime.summarize({
 		fullTree: true,
-		trackState: false,
 		fullGC: true,
 	});
 	return runtime.storage.uploadSummaryWithContext(summaryResult.summary, {


### PR DESCRIPTION
This is a pre-cursor to https://github.com/microsoft/FluidFramework/pull/21186 which removes `trackState`.

In `SummarizerNode::summarize`, removed the validation that a summary in progress. This validation exists to ensure that `startSummary` was called before `summarize` so that we can track state for incremental summaries. 
However, this may not be the case in tests where `ContainerRuntime::summarize` is called directly. Currently, these tests set `trackState` to false to indicate that it is just interested in the summary tree without the tracking for incremental summary. The same can be achieved by setting `fullTree` to true and we can remove the redundant `trackState` option.

The scenario where this validation is still useful is when `fullTree` is true in the regular summarization flow via `ContainerRuntime::submitSummary`. In this scenario, the validation will still happen in `SummarizerNode::validateSummary` for single-commit summaries and in `SummarizerNode::completeSummary` for two-commit summaries. Added unit tests to validate this.