### PR TITLE
build(build-tools): Move all pnpm config to workspace root

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -112,6 +112,14 @@
 			"json5@>=2.0.0 <2.2.2": "^2.2.2",
 			"qs": "^6.11.0",
 			"sharp": "^0.33.2"
+		},
+		"updateConfig": {
+			"ignoreDependencies": [
+				"latest-version",
+				"read-pkg-up",
+				"type-fest",
+				"typescript"
+			]
 		}
 	}
 }

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -192,15 +192,5 @@
 				"description": "Release commands are used to manage the Fluid release process."
 			}
 		}
-	},
-	"pnpm": {
-		"updateConfig": {
-			"ignoreDependencies": [
-				"latest-version",
-				"read-pkg-up",
-				"type-fest",
-				"typescript"
-			]
-		}
 	}
 }

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -86,10 +86,5 @@
 	},
 	"engines": {
 		"node": ">=14.17.0"
-	},
-	"pnpm": {
-		"updateConfig": {
-			"ignoreDependencies": ["type-fest", "typescript"]
-		}
 	}
 }

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -75,10 +75,5 @@
 		"plugins": [],
 		"repositoryPrefix": "<%- repo %>/blob/main/build-tools/packages/readme-command/<%- commandPath %>",
 		"topicSeparator": " "
-	},
-	"pnpm": {
-		"updateConfig": {
-			"ignoreDependencies": ["typescript"]
-		}
 	}
 }


### PR DESCRIPTION
pnpm only loads config from the root workspace package.json, so the settings in the individual packages are ignored. I moved a superset of the individual package configs to the root.