### PR TITLE
Added option to disable local ids for attachment blobs for 1.x compat

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -732,6 +732,7 @@ export interface IContainerRuntimeOptions {
     readonly gcOptions?: IGCRuntimeOptions;
     readonly loadSequenceNumberVerification?: "close" | "log" | "bypass";
     readonly maxBatchSizeInBytes?: number;
+    readonly noLocalIdsForAttachmentBlobs?: boolean;
     // (undocumented)
     readonly summaryOptions?: ISummaryRuntimeOptions;
 }

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -478,6 +478,14 @@ export interface IContainerRuntimeOptions {
 	 * are engaged as they become available, without giving legacy clients any chance to fail predictably.
 	 */
 	readonly explicitSchemaControl?: boolean;
+
+	/**
+	 * When this property is set to true, the blob manager will not return local ids for attachment
+	 * blobs that it uploads. It will instead return the id returned by storage after the blob has
+	 * been uploaded. This is added to ensure that clients running versions 1.x and older can read blobs
+	 * created by clients running versions 2.x. 1.x didn't support local ids for attachment blobs.
+	 */
+	readonly noLocalIdsForAttachmentBlobs?: boolean;
 }
 
 /**
@@ -801,6 +809,7 @@ export class ContainerRuntime
 			chunkSizeInBytes = defaultChunkSizeInBytes,
 			enableGroupedBatching = true,
 			explicitSchemaControl = false,
+			noLocalIdsForAttachmentBlobs = false,
 		} = runtimeOptions;
 
 		const registry = new FluidDataStoreRegistry(registryEntries);
@@ -1007,6 +1016,7 @@ export class ContainerRuntime
 				enableRuntimeIdCompressor: enableRuntimeIdCompressor as "on" | "delayed",
 				enableGroupedBatching,
 				explicitSchemaControl,
+				noLocalIdsForAttachmentBlobs,
 			},
 			containerScope,
 			logger,
@@ -1694,6 +1704,7 @@ export class ContainerRuntime
 			runtime: this,
 			stashedBlobs: pendingRuntimeState?.pendingAttachmentBlobs,
 			closeContainer: (error?: ICriticalContainerError) => this.closeFn(error),
+			noLocalIds: runtimeOptions.noLocalIdsForAttachmentBlobs,
 		});
 
 		this.scheduleManager = new ScheduleManager(

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -480,10 +480,10 @@ export interface IContainerRuntimeOptions {
 	readonly explicitSchemaControl?: boolean;
 
 	/**
-	 * When this property is set to true, the blob manager will not return local ids for attachment
-	 * blobs that it uploads. It will instead return the id returned by storage after the blob has
-	 * been uploaded. This is added to ensure that clients running versions 1.x and older can read blobs
-	 * created by clients running versions 2.x. 1.x didn't support local ids for attachment blobs.
+	 * When this property is set to true, the blob manager will not return local ids for attachment blobs that it
+	 * uploads. It will instead return the id returned by storage after the blob has been uploaded. 1.x didn't support
+	 * local ids for attachment blobs so this will ensure that clients running versions 1.x and older can read blobs
+	 * created by clients running versions 2.x and newer versions.
 	 */
 	readonly noLocalIdsForAttachmentBlobs?: boolean;
 }
@@ -1614,6 +1614,7 @@ export class ContainerRuntime
 			readAndParseBlob: async <T>(id: string) => readAndParse<T>(this.storage, id),
 			submitMessage: (message: ContainerRuntimeGCMessage) => this.submit(message),
 			sessionExpiryTimerStarted: pendingRuntimeState?.sessionExpiryTimerStarted,
+			noLocalIdsForBlobs: runtimeOptions.noLocalIdsForAttachmentBlobs,
 		});
 
 		const loadedFromSequenceNumber = this.deltaManager.initialSequenceNumber;

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -186,7 +186,7 @@ export class GarbageCollector implements IGarbageCollector {
 		this.configs = generateGCConfigs(this.mc, createParams);
 
 		// If session expiry is enabled, we need to close the container when the session expiry timeout expires.
-		if (this.configs.sessionExpiryTimeoutMs !== undefined) {
+		if (this.configs.gcEnabled && this.configs.sessionExpiryTimeoutMs !== undefined) {
 			// If Test Override config is set, override Session Expiry timeout.
 			const overrideSessionExpiryTimeoutMs = this.mc.config.getNumber(
 				"Fluid.GarbageCollection.TestOverride.SessionExpiryMs",

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -42,6 +42,8 @@ import { getGCVersion, getGCVersionInEffect, shouldAllowGcSweep } from "./gcHelp
  * gcOptions - The garbage collector runtime options.
  * metadata - The container runtime's createParams.metadata.
  * existing - Whether the container is new or an existing one.
+ * isSummarizerClient - Whether this is a summarizer client.
+ * noLocalIdsForBlobs - Whether local ids for attachment blobs is supported.
  * @returns The garbage collector configurations.
  */
 export function generateGCConfigs(
@@ -51,6 +53,7 @@ export function generateGCConfigs(
 		metadata: IContainerRuntimeMetadata | undefined;
 		existing: boolean;
 		isSummarizerClient: boolean;
+		noLocalIdsForBlobs?: boolean;
 	},
 ): IGarbageCollectorConfigs {
 	let gcEnabled: boolean = true;
@@ -97,6 +100,15 @@ export function generateGCConfigs(
 		if (gcGeneration !== undefined) {
 			persistedGcFeatureMatrix = { gcGeneration };
 		}
+	}
+
+	/**
+	 * If local ids for attachment blobs isn't supported, turn GC off for this container permanently. GC for attachment
+	 * blobs doesn't work correctly when local id isn't used. The "noLocalIdsForBlobs" option is only used in back
+	 * compat scenarios when upgrading from 1.x to a newer version. For these documents, GC won't run.
+	 */
+	if (createParams.noLocalIdsForBlobs) {
+		gcEnabled = false;
 	}
 
 	// The persisted GC generation must indicate Sweep is allowed for this document,

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -412,6 +412,8 @@ export interface IGarbageCollectorCreateParams {
 	readonly readAndParseBlob: ReadAndParseBlob;
 	readonly submitMessage: (message: ContainerRuntimeGCMessage) => void;
 	readonly sessionExpiryTimerStarted?: number | undefined;
+	/** If local ids for blobs is turned on, GC will be disabled for this container permanently. */
+	readonly noLocalIdsForBlobs?: boolean;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/test/blobManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/blobManager.spec.ts
@@ -94,6 +94,7 @@ export class MockRuntime
 			runtime: this,
 			stashedBlobs: stashed[1],
 			closeContainer: () => (this.closed = true),
+			noLocalIds: false,
 		});
 	}
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -1449,6 +1449,7 @@ describe("Runtime", () => {
 				enableRuntimeIdCompressor: undefined,
 				enableGroupedBatching: false,
 				explicitSchemaControl: false,
+				noLocalIdsForAttachmentBlobs: false,
 			} satisfies IContainerRuntimeOptions;
 			const mergedRuntimeOptions = { ...defaultRuntimeOptions, ...runtimeOptions };
 

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -105,6 +105,7 @@ export function generateRuntimeOptions(
 		enableRuntimeIdCompressor: ["on", undefined, "delayed"],
 		enableGroupedBatching: [true, false],
 		explicitSchemaControl: [true, false],
+		noLocalIdsForAttachmentBlobs: [undefined],
 	};
 
 	return generatePairwiseOptions<IContainerRuntimeOptions>(

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -105,7 +105,7 @@ export function generateRuntimeOptions(
 		enableRuntimeIdCompressor: ["on", undefined, "delayed"],
 		enableGroupedBatching: [true, false],
 		explicitSchemaControl: [true, false],
-		noLocalIdsForAttachmentBlobs: [undefined],
+		noLocalIdsForAttachmentBlobs: [true, false],
 	};
 
 	return generatePairwiseOptions<IContainerRuntimeOptions>(


### PR DESCRIPTION
## Bug
When a blob is uploaded, blob manager does the following:
1. Generates a "local id" and once the blob is uploaded and storage returns a "storage id", creates a mapping from "local id" -> "storage id".
2. It sends the local id and storage id in a blob attach op so other clients can create the mapping.
3. It returns the "local id" as the result of blob upload in a BlobHandle. Other clients use this BlobHandle with local id to retrieve the blob - Blob manager looks up the storage id and fetches the blob from storage.
However, version 1.x and older didn't support local ids for blobs uploaded in attached state. It always returned "storage id" on blob creation and only created a "storage id" -> "storage id" mapping on receving the blob attach op.
So, during 1.x -> 2.x upgrade, when a 1.x client and 2.x client run in parallel, blobs created by a 2.x client won't be retrievable by a 1.x client because it won't understand the local id used by 2.x client.

## Fix
- This change adds a container runtime option `noLocalIdsForAttachmentBlobs` that will disable returning a "local id" when a blob is uploaded. It will return the "storage id" instead. This will ensure that blobs uploaded by 2.x client can be retrieved by a 1.x client.
- When this option is enabled, GC will be disabled permanently for this document because GC will not work correctly if blob manager returns storage ids (See #13486 for details on the issue with GC). Given that there are hardly any scenarios where GC and attachment blobs intersect pre 2.0, this is the cheapest solution.

## Usage
When upgrading from 1.x -> 2.x, the `noLocalIdsForAttachmentBlobs` option should be set to true for 2.x clients. Once the upgrade is complete, the option can be removed.

 
[AB#6286](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6286)