### PR TITLE
fix(core-utils): Fix LazyPromise getter (#21207)

### DIFF
--- a/packages/common/core-utils/src/lazy.ts
+++ b/packages/common/core-utils/src/lazy.ts
@@ -44,8 +44,9 @@ export class Lazy<T> {
  * @alpha
  */
 export class LazyPromise<T> implements Promise<T> {
+	// eslint-disable-next-line @typescript-eslint/class-literal-property-style
 	public get [Symbol.toStringTag](): string {
-		return this.getPromise()[Symbol.toStringTag];
+		return "[object LazyPromise]";
 	}
 
 	private result: Promise<T> | undefined;


### PR DESCRIPTION
## Description

Port of https://github.com/microsoft/FluidFramework/commit/cf447da257a44728b705e74cae95d9a8da65ed69

This PR modifies the getter function for `LazyPromise` to prevent it from invoking the callback - that is quite an unexpected side effect of running toString.

We found a case where the events_pkg polyfill was logging the target of an "addListener" call - happened to be ContainerRuntime - and Node's console.warn implementation formats the args to print them out. This eventually cascaded down to calling toString on a LazyPromise which triggered its callback, but the objects in question had not been initialized properly so it asserted.

