### PR TITLE
Make sure ContainerStateHandler overwrites could be used (not crash)

### DIFF
--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -11,8 +11,8 @@ import { IClient, ISequencedClient } from "@fluidframework/driver-definitions";
 import {
 	type TelemetryEventCategory,
 	ITelemetryLoggerExt,
+	MonitoringContext,
 	PerformanceEvent,
-	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 
 import { CatchUpMonitor, ICatchUpMonitor } from "./catchUpMonitor.js";
@@ -31,6 +31,7 @@ const JoinSignalTimeoutMs = 10000;
 /** Constructor parameter type for passing in dependencies needed by the ConnectionStateHandler */
 export interface IConnectionStateHandlerInputs {
 	logger: ITelemetryLoggerExt;
+	mc: MonitoringContext;
 	/** Log to telemetry any change in state, included to Connecting */
 	connectionStateChanged: (
 		value: ConnectionState,
@@ -92,10 +93,10 @@ export function createConnectionStateHandler(
 	deltaManager: IDeltaManager<any, any>,
 	clientId?: string,
 ) {
-	const mc = loggerToMonitoringContext(inputs.logger);
+	const config = inputs.mc.config;
 	return createConnectionStateHandlerCore(
-		mc.config.getBoolean("Fluid.Container.DisableCatchUpBeforeDeclaringConnected") !== true, // connectedRaisedWhenCaughtUp
-		mc.config.getBoolean("Fluid.Container.DisableJoinSignalWait") !== true, // readClientsWaitForJoinSignal
+		config.getBoolean("Fluid.Container.DisableCatchUpBeforeDeclaringConnected") !== true, // connectedRaisedWhenCaughtUp
+		config.getBoolean("Fluid.Container.DisableJoinSignalWait") !== true, // readClientsWaitForJoinSignal
 		inputs,
 		deltaManager,
 		clientId,
@@ -188,6 +189,9 @@ class ConnectionStateHandlerPassThrough
 
 	public get logger() {
 		return this.inputs.logger;
+	}
+	public get mc() {
+		return this.inputs.mc;
 	}
 	public connectionStateChanged(
 		value: ConnectionState,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -92,6 +92,7 @@ import {
 	normalizeError,
 	raiseConnectedEvent,
 	wrapError,
+	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 import structuredClone from "@ungap/structured-clone";
 import { v4 as uuid } from "uuid";
@@ -864,6 +865,9 @@ export class Container
 		this.connectionStateHandler = createConnectionStateHandler(
 			{
 				logger: this.mc.logger,
+				// WARNING: logger on this context should not including getters like containerConnectionState above (on this.subLogger),
+				// as that will result in attempt to dereference this.connectionStateHandler from this call while it's still undefined.
+				mc: loggerToMonitoringContext(subLogger),
 				connectionStateChanged: (value, oldState, reason) => {
 					this.logConnectionStateChangeTelemetry(value, oldState, reason);
 					if (this.loaded) {

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -13,6 +13,7 @@ import { IClientConfiguration, ITokenClaims } from "@fluidframework/driver-defin
 import {
 	TelemetryEventCategory,
 	createChildLogger,
+	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
 
@@ -141,6 +142,7 @@ describe("ConnectionStateHandler Tests", () => {
 			(clientId: string) => false, // shouldClientHaveLeft
 		);
 		shouldClientJoinWrite = false;
+		const logger = createChildLogger();
 		handlerInputs = {
 			maxClientLeaveWaitTime: expectedTimeout,
 			shouldClientJoinWrite: () => shouldClientJoinWrite,
@@ -152,7 +154,8 @@ describe("ConnectionStateHandler Tests", () => {
 				throw new Error(`logConnectionIssue: ${eventName} ${JSON.stringify(details)}`);
 			},
 			connectionStateChanged: () => {},
-			logger: createChildLogger(),
+			logger,
+			mc: loggerToMonitoringContext(logger),
 			clientShouldHaveLeft: (clientId: string) => {},
 			onCriticalError: (error) => {
 				// eslint-disable-next-line @typescript-eslint/no-throw-literal

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -19,10 +19,18 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 import { SummaryType } from "@fluidframework/driver-definitions";
 import { isFluidError } from "@fluidframework/telemetry-utils/internal";
+import {
+	MockLogger,
+	wrapConfigProviderWithDefaults,
+	mixinMonitoringContext,
+	createChildLogger,
+} from "@fluidframework/telemetry-utils/internal";
+
 import { v4 as uuid } from "uuid";
 
 import { IDetachedBlobStorage, Loader } from "../loader.js";
 import type { IPendingDetachedContainerState } from "../serializedStateManager.js";
+import { Container } from "../container.js";
 
 import { failProxy, failSometimeProxy } from "./failProxy.js";
 
@@ -217,5 +225,38 @@ describe("loader unit test", () => {
 		assert.strictEqual(Object.keys(parsedState.snapshotBlobs).length, 4);
 		assert.ok(parsedState.baseSnapshot);
 		await loader.rehydrateDetachedContainerFromSnapshot(detachedContainerState);
+	});
+
+	it("ConnectionStateHandler overwrites", () => {
+		const configProvider = wrapConfigProviderWithDefaults(
+			undefined, // original provider
+			{
+				"Fluid.Container.DisableCatchUpBeforeDeclaringConnected": true,
+				"Fluid.Container.DisableJoinSignalWait": true,
+			},
+		);
+
+		const logger = mixinMonitoringContext(
+			createChildLogger({ logger: new MockLogger() }),
+			configProvider,
+		);
+
+		// Ensure that this call does not crash due to potential reentrnacy:
+		// - Container.constructor
+		// - ConnectionStateHandler.constructor
+		// - fetching overwrites from config
+		// - logs event about fetching config
+		// - calls property getters on logger setup by Container.constructor
+		// - containerConnectionState getter
+		// - Container.connectionState getter
+		// - Container.connectionStateHandler.connectionState - crash, as Container.connectionStateHandler is undefined (not setup yet).
+		new Container({
+			urlResolver: failProxy(),
+			documentServiceFactory: failProxy(),
+			codeLoader,
+			options: {},
+			scope: {},
+			subLogger: logger.logger,
+		});
 	});
 });

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -227,7 +227,7 @@ describe("loader unit test", () => {
 		await loader.rehydrateDetachedContainerFromSnapshot(detachedContainerState);
 	});
 
-	it("ConnectionStateHandler overwrites", () => {
+	it("ConnectionStateHandler feature gate overrides", () => {
 		const configProvider = wrapConfigProviderWithDefaults(
 			undefined, // original provider
 			{


### PR DESCRIPTION
When ContainerStateHandler overrides are used, we get into recursive call into Container that is not fully initialized, causing a crash.
This is due to a config provider logging events (using logger) as part of retrieving config.
This PR breaks this cycle.

UT and [internal chat](https://teams.microsoft.com/l/message/19:10ccb94cae324ec2aabcd6b6322b1a25@thread.skype/1715387179369?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=9ce27575-2f82-4689-abdb-bcff07e8063b&parentMessageId=1715387179369&teamName=Fluid%20Framework&channelName=General&createdTime=1715387179369) have more details.

The alternative (and simpler) fix is to fix Container.connectionState (and other methods / getters that use this.connectionStateHandler) to be this:
```ts
	public get connectionState(): ConnectionState {
		return this.connectionStateHandler === undefined ? ConnectionState.Disconnected : this.connectionStateHandler.connectionState;
	}
```

The issue with that - it may not be enough, as the same issue could be hit for other members that are initialized in ctor, so it feels like we are better off using config that completely prevents these issues.
