### PR TITLE
Mark IInboundSignalMessage as alpha and readonly

### DIFF
--- a/.changeset/twelve-chairs-learn.md
+++ b/.changeset/twelve-chairs-learn.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/runtime-definitions": minor
+---
+
+Make IInboundSignalMessage alpha and readonly
+
+Users of `IInboundSignalMessage` will need to import it from the `/legacy` scope and should not mutate it.
+Only users of existing `@alpha` APIs like `IFluidDataStoreRuntime` should be able to use this type, so it should not introduce new `/legacy` usage.

--- a/examples/data-objects/codemirror/src/presence.ts
+++ b/examples/data-objects/codemirror/src/presence.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from "@fluid-example/example-utils";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 import CodeMirror from "codemirror";
 
 interface IPresenceInfo {

--- a/experimental/framework/data-objects/api-report/data-objects.api.md
+++ b/experimental/framework/data-objects/api-report/data-objects.api.md
@@ -7,7 +7,7 @@
 import { IErrorEvent } from '@fluidframework/core-interfaces';
 import { IEventProvider } from '@fluidframework/core-interfaces';
 import type { IFluidDataStoreFactory } from '@fluidframework/runtime-definitions/internal';
-import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
+import { IInboundSignalMessage } from '@fluidframework/runtime-definitions/internal';
 import { Jsonable } from '@fluidframework/datastore-definitions/internal';
 import type { NamedFluidDataStoreRegistryEntry } from '@fluidframework/runtime-definitions/internal';
 import type { SharedObjectKind } from '@fluidframework/shared-object-base';

--- a/experimental/framework/data-objects/src/signaler/signaler.ts
+++ b/experimental/framework/data-objects/src/signaler/signaler.ts
@@ -16,7 +16,7 @@ import type {
 	IFluidDataStoreFactory,
 	NamedFluidDataStoreRegistryEntry,
 } from "@fluidframework/runtime-definitions/internal";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 
 // TODO:

--- a/packages/runtime/container-runtime/api-report/container-runtime.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.api.md
@@ -41,7 +41,7 @@ import { IGarbageCollectionDetailsBase } from '@fluidframework/runtime-definitio
 import { IGetPendingLocalStateProps } from '@fluidframework/container-definitions/internal';
 import type { IIdCompressor } from '@fluidframework/id-compressor';
 import type { IIdCompressorCore } from '@fluidframework/id-compressor/internal';
-import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
+import { IInboundSignalMessage } from '@fluidframework/runtime-definitions/internal';
 import { IProvideFluidHandleContext } from '@fluidframework/core-interfaces/internal';
 import { IQuorumClients } from '@fluidframework/driver-definitions';
 import { IRequest } from '@fluidframework/core-interfaces';

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -22,7 +22,6 @@ import {
 import type { ISnapshot } from "@fluidframework/driver-definitions/internal";
 import { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import {
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -41,6 +40,7 @@ import {
 	InboundAttachMessage,
 	NamedFluidDataStoreRegistryEntries,
 	channelsTreeName,
+	IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	GCDataBuilder,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -70,7 +70,6 @@ import {
 	ISummaryTree,
 	SummaryType,
 } from "@fluidframework/driver-definitions";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import {
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -88,6 +87,7 @@ import {
 	SummarizeInternalFn,
 	channelsTreeName,
 	gcTreeKey,
+	IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	GCDataBuilder,

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -34,7 +34,6 @@ import {
 	IQuorumClients,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import {
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -57,6 +56,7 @@ import {
 	SummarizeInternalFn,
 	channelsTreeName,
 	gcDataBlobKey,
+	IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	addBlobToSummary,

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.api.md
@@ -17,7 +17,7 @@ import type { IFluidHandleContext } from '@fluidframework/core-interfaces/intern
 import type { IFluidLoadable } from '@fluidframework/core-interfaces';
 import type { IGarbageCollectionData } from '@fluidframework/runtime-definitions/internal';
 import type { IIdCompressor } from '@fluidframework/id-compressor';
-import type { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
+import type { IInboundSignalMessage } from '@fluidframework/runtime-definitions/internal';
 import type { IQuorumClients } from '@fluidframework/driver-definitions';
 import type { ISequencedDocumentMessage } from '@fluidframework/driver-definitions';
 import type { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/internal';

--- a/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore-definitions/src/dataStoreRuntime.ts
@@ -16,7 +16,7 @@ import type {
 import type { IFluidHandleContext } from "@fluidframework/core-interfaces/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type { IQuorumClients, ISequencedDocumentMessage } from "@fluidframework/driver-definitions";
-import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import type { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 
 import type { IChannel } from "./channel.js";
 

--- a/packages/runtime/datastore/api-report/datastore.api.md
+++ b/packages/runtime/datastore/api-report/datastore.api.md
@@ -23,7 +23,7 @@ import { IFluidHandleContext } from '@fluidframework/core-interfaces/internal';
 import type { IFluidHandleInternal } from '@fluidframework/core-interfaces/internal';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions/internal';
 import { IIdCompressor } from '@fluidframework/id-compressor';
-import { IInboundSignalMessage } from '@fluidframework/runtime-definitions';
+import { IInboundSignalMessage } from '@fluidframework/runtime-definitions/internal';
 import { IQuorumClients } from '@fluidframework/driver-definitions';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResponse } from '@fluidframework/core-interfaces';

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -33,7 +33,6 @@ import {
 	SummaryType,
 } from "@fluidframework/driver-definitions";
 import { IDocumentMessage, type ISnapshotTree } from "@fluidframework/driver-definitions/internal";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
 import {
 	ISummaryTreeWithStats,
 	ITelemetryContext,
@@ -46,6 +45,7 @@ import {
 	IFluidDataStoreContext,
 	VisibilityState,
 	gcDataBlobKey,
+	IInboundSignalMessage,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	GCDataBuilder,

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.api.md
@@ -303,10 +303,10 @@ export interface IGarbageCollectionDetailsBase {
     usedRoutes?: string[];
 }
 
-// @public
+// @alpha
 export interface IInboundSignalMessage extends ISignalMessage {
     // (undocumented)
-    type: string;
+    readonly type: string;
 }
 
 // @alpha

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -48,10 +48,10 @@ export interface ISignalEnvelope {
 
 /**
  * Represents ISignalMessage with its type.
- * @public
+ * @alpha
  */
 export interface IInboundSignalMessage extends ISignalMessage {
-	type: string;
+	readonly type: string;
 }
 
 /**

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/TestDataObject.ts
@@ -14,7 +14,7 @@ import {
 import { type IErrorEvent, IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedCounter } from "@fluidframework/counter/internal";
 import { Jsonable } from "@fluidframework/datastore-definitions/internal";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 
 class TestDataObjectClass extends DataObject {
 	public static readonly Name = "@fluid-example/test-data-object";

--- a/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/localTestSignals.spec.ts
@@ -7,7 +7,7 @@ import { strict as assert } from "assert";
 
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { ConnectionState } from "@fluidframework/container-loader";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 import {
 	DataObjectFactoryType,
 	ITestContainerConfig,

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -17,7 +17,7 @@ import { assert, delay } from "@fluidframework/core-utils/internal";
 import { IFluidDataStoreRuntime } from "@fluidframework/datastore-definitions/internal";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions/internal";
 import { getRetryDelayFromError } from "@fluidframework/driver-utils/internal";
-import { IInboundSignalMessage } from "@fluidframework/runtime-definitions";
+import { IInboundSignalMessage } from "@fluidframework/runtime-definitions/internal";
 import { GenericError, ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import commander from "commander";
 


### PR DESCRIPTION
## Description

IInboundSignalMessage  is the last public API in @fluidframework/runtime-definitions, and is only exposed via alpha APi, like the signal event on the alpha IFluidDataStoreRuntime.

## Breaking Changes

Users of `IInboundSignalMessage` will need to import it from the `/legacy` scope and should not mutate it.
Only users of existing `@alpha` APIs like `IFluidDataStoreRuntime` should be able to use this type, so it should not introduce new `/legacy` usage.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

