### PR TITLE
Port ConnectionStateHandler fixes

### DIFF
--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -473,18 +473,6 @@ class ConnectionStateHandler implements IConnectionStateHandler {
 				});
 			}
 			this.applyForConnectedState("addMemberEvent");
-		} else if (clientId === this.clientId) {
-			// If we see our clientId and it's not also our pending ID, it's our own join op
-			// being replayed, so start the timer in case our previous client is still in quorum
-			assert(
-				!this.waitingForLeaveOp,
-				0x5d2 /* Unexpected join op with current clientId while waiting */,
-			);
-			assert(
-				this.connectionState !== ConnectionState.Connected,
-				0x5d3 /* Unexpected join op with current clientId while connected */,
-			);
-			this.prevClientLeftTimer.restart();
 		}
 	}
 
@@ -532,7 +520,7 @@ class ConnectionStateHandler implements IConnectionStateHandler {
 
 	private receivedRemoveMemberEvent(clientId: string) {
 		// If the client which has left was us, then finish the timer.
-		if (this.clientId === clientId) {
+		if (this.clientId === clientId && this.waitingForLeaveOp) {
 			this.prevClientLeftTimer.clear();
 			this.applyForConnectedState("removeMemberEvent");
 		}
@@ -741,8 +729,24 @@ class ConnectionStateHandler implements IConnectionStateHandler {
 			this.receivedAddMemberEvent(this.pendingClientId!);
 		}
 
+		assert(
+			!this.waitingForLeaveOp,
+			"leave timer can't be set as we have not had access to quorum",
+		);
+
+		// This check is required for scenario of loading container from pending state, and ensuring there is no way
+		// old clientId is still in the quorum (very unlikely, but you never know)
 		// if we have a clientId from a previous container we need to wait for its leave message
-		if (this.clientId !== undefined && this.hasMember(this.clientId)) {
+		// This mimicks check in setConnectionState()
+		// Note that we are not consulting this.handler.shouldClientJoinWrite() here
+		// It could produce wrong results for stashed ops were never sent to Loader yet, and if this check
+		// makes determination only on that (and not uses "dirty" events), then it can produce wrong result.
+		// In most cases it does not matter, as this client already left quorum. But in really unfortunate case,
+		// we might wait even if we could avoid such wait.
+		if (
+			this._clientId !== undefined &&
+			protocol.quorum?.getMember(this._clientId) !== undefined
+		) {
 			this.prevClientLeftTimer.restart();
 		}
 	}

--- a/packages/loader/container-loader/src/connectionStateHandler.ts
+++ b/packages/loader/container-loader/src/connectionStateHandler.ts
@@ -11,8 +11,8 @@ import { IClient, ISequencedClient } from "@fluidframework/protocol-definitions"
 import {
 	type TelemetryEventCategory,
 	ITelemetryLoggerExt,
+	MonitoringContext,
 	PerformanceEvent,
-	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 
 import { CatchUpMonitor, ICatchUpMonitor } from "./catchUpMonitor.js";
@@ -31,6 +31,7 @@ const JoinSignalTimeoutMs = 10000;
 /** Constructor parameter type for passing in dependencies needed by the ConnectionStateHandler */
 export interface IConnectionStateHandlerInputs {
 	logger: ITelemetryLoggerExt;
+	mc: MonitoringContext;
 	/** Log to telemetry any change in state, included to Connecting */
 	connectionStateChanged: (
 		value: ConnectionState,
@@ -92,10 +93,10 @@ export function createConnectionStateHandler(
 	deltaManager: IDeltaManager<any, any>,
 	clientId?: string,
 ) {
-	const mc = loggerToMonitoringContext(inputs.logger);
+	const config = inputs.mc.config;
 	return createConnectionStateHandlerCore(
-		mc.config.getBoolean("Fluid.Container.DisableCatchUpBeforeDeclaringConnected") !== true, // connectedRaisedWhenCaughtUp
-		mc.config.getBoolean("Fluid.Container.DisableJoinSignalWait") !== true, // readClientsWaitForJoinSignal
+		config.getBoolean("Fluid.Container.DisableCatchUpBeforeDeclaringConnected") !== true, // connectedRaisedWhenCaughtUp
+		config.getBoolean("Fluid.Container.DisableJoinSignalWait") !== true, // readClientsWaitForJoinSignal
 		inputs,
 		deltaManager,
 		clientId,
@@ -188,6 +189,9 @@ class ConnectionStateHandlerPassThrough
 
 	public get logger() {
 		return this.inputs.logger;
+	}
+	public get mc() {
+		return this.inputs.mc;
 	}
 	public connectionStateChanged(
 		value: ConnectionState,

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -92,6 +92,7 @@ import {
 	normalizeError,
 	raiseConnectedEvent,
 	wrapError,
+	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 import structuredClone from "@ungap/structured-clone";
 import { v4 as uuid } from "uuid";
@@ -864,6 +865,9 @@ export class Container
 		this.connectionStateHandler = createConnectionStateHandler(
 			{
 				logger: this.mc.logger,
+				// WARNING: logger on this context should not including getters like containerConnectionState above (on this.subLogger),
+				// as that will result in attempt to dereference this.connectionStateHandler from this call while it's still undefined.
+				mc: loggerToMonitoringContext(subLogger),
 				connectionStateChanged: (value, oldState, reason) => {
 					this.logConnectionStateChangeTelemetry(value, oldState, reason);
 					if (this.loaded) {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -526,6 +526,15 @@ export class Container
 				0x969 /* not connected yet */,
 			);
 
+			// Track membership changes and update connection state accordingly
+			// We do this call here, instead of doing it in initializeProtocolState() due to pendingLocalState.
+			// When we load from stashed state, we let connectionStateHandler know about clientId from previous container instance.
+			// But we will play trailing ops from snapshot, including potentially playing join & leave ops for that same clientId!
+			// In other words, if connectionStateHandler has access to Quorum early in load sequence, it will see events (in stashed ops mode)
+			// in the order that is not possible in real life, that it may not expect.
+			// Ideally, we should supply pendingLocalState?.clientId here as well, not in constructor, but it does not matter (at least today)
+			this.connectionStateHandler.initProtocol(this.protocolHandler);
+
 			// Propagate current connection state through the system.
 			const readonly = this.readOnlyInfo.readonly ?? false;
 			// This call does not look like needed any more, with delaying all connection-related events past loaded phase.
@@ -1870,9 +1879,6 @@ export class Container
 		protocol.quorum.on("error", (error) => {
 			protocolLogger.sendErrorEvent(error);
 		});
-
-		// Track membership changes and update connection state accordingly
-		this.connectionStateHandler.initProtocol(protocol);
 
 		protocol.quorum.on("addProposal", (proposal: ISequencedProposal) => {
 			if (proposal.key === "code" || proposal.key === "code2") {

--- a/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
+++ b/packages/loader/container-loader/src/test/connectionStateHandler.spec.ts
@@ -18,6 +18,7 @@ import {
 import {
 	TelemetryEventCategory,
 	createChildLogger,
+	loggerToMonitoringContext,
 } from "@fluidframework/telemetry-utils/internal";
 import { SinonFakeTimers, useFakeTimers } from "sinon";
 
@@ -146,6 +147,7 @@ describe("ConnectionStateHandler Tests", () => {
 			(clientId: string) => false, // shouldClientHaveLeft
 		);
 		shouldClientJoinWrite = false;
+		const logger = createChildLogger();
 		handlerInputs = {
 			maxClientLeaveWaitTime: expectedTimeout,
 			shouldClientJoinWrite: () => shouldClientJoinWrite,
@@ -157,7 +159,8 @@ describe("ConnectionStateHandler Tests", () => {
 				throw new Error(`logConnectionIssue: ${eventName} ${JSON.stringify(details)}`);
 			},
 			connectionStateChanged: () => {},
-			logger: createChildLogger(),
+			logger,
+			mc: loggerToMonitoringContext(logger),
 			clientShouldHaveLeft: (clientId: string) => {},
 			onCriticalError: (error) => {
 				// eslint-disable-next-line @typescript-eslint/no-throw-literal

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -18,10 +18,18 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 import { ICreateBlobResponse, SummaryType } from "@fluidframework/protocol-definitions";
 import { isFluidError } from "@fluidframework/telemetry-utils/internal";
+import {
+	MockLogger,
+	wrapConfigProviderWithDefaults,
+	mixinMonitoringContext,
+	createChildLogger,
+} from "@fluidframework/telemetry-utils/internal";
+
 import { v4 as uuid } from "uuid";
 
 import { IDetachedBlobStorage, Loader } from "../loader.js";
 import type { IPendingDetachedContainerState } from "../serializedStateManager.js";
+import { Container } from "../container.js";
 
 import { failProxy, failSometimeProxy } from "./failProxy.js";
 
@@ -216,5 +224,38 @@ describe("loader unit test", () => {
 		assert.strictEqual(Object.keys(parsedState.snapshotBlobs).length, 4);
 		assert.ok(parsedState.baseSnapshot);
 		await loader.rehydrateDetachedContainerFromSnapshot(detachedContainerState);
+	});
+
+	it("ConnectionStateHandler feature gate overrides", () => {
+		const configProvider = wrapConfigProviderWithDefaults(
+			undefined, // original provider
+			{
+				"Fluid.Container.DisableCatchUpBeforeDeclaringConnected": true,
+				"Fluid.Container.DisableJoinSignalWait": true,
+			},
+		);
+
+		const logger = mixinMonitoringContext(
+			createChildLogger({ logger: new MockLogger() }),
+			configProvider,
+		);
+
+		// Ensure that this call does not crash due to potential reentrnacy:
+		// - Container.constructor
+		// - ConnectionStateHandler.constructor
+		// - fetching overwrites from config
+		// - logs event about fetching config
+		// - calls property getters on logger setup by Container.constructor
+		// - containerConnectionState getter
+		// - Container.connectionState getter
+		// - Container.connectionStateHandler.connectionState - crash, as Container.connectionStateHandler is undefined (not setup yet).
+		new Container({
+			urlResolver: failProxy(),
+			documentServiceFactory: failProxy(),
+			codeLoader,
+			options: {},
+			scope: {},
+			subLogger: logger.logger,
+		});
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -1125,10 +1125,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 
 	itExpects(
 		"waits for previous container's leave message",
-		[
-			{ eventName: "fluid:telemetry:Container:connectedStateRejected" },
-			{ eventName: "fluid:telemetry:Container:WaitBeforeClientLeave_end" },
-		],
+		[{ eventName: "fluid:telemetry:Container:connectedStateRejected" }],
 		async () => {
 			const container: IContainerExperimental =
 				await provider.loadTestContainer(testContainerConfig);
@@ -1284,10 +1281,7 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 
 	itExpects(
 		"waits for previous container's leave message after rehydration",
-		[
-			{ eventName: "fluid:telemetry:Container:connectedStateRejected" },
-			{ eventName: "fluid:telemetry:Container:WaitBeforeClientLeave_end" },
-		],
+		[{ eventName: "fluid:telemetry:Container:connectedStateRejected" }],
 		async () => {
 			const pendingOps = await getPendingOps(provider, false, async (c, d) => {
 				const map = await d.getSharedObject<ISharedMap>(mapId);


### PR DESCRIPTION
Port two PRs to RC4:

https://github.com/microsoft/FluidFramework/pull/21223
https://github.com/microsoft/FluidFramework/pull/21110

Please see [internal chat](https://teams.microsoft.com/l/message/19:10ccb94cae324ec2aabcd6b6322b1a25@thread.skype/1715387179369?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=9ce27575-2f82-4689-abdb-bcff07e8063b&parentMessageId=1715387179369&teamName=Fluid%20Framework&channelName=General&createdTime=1715387179369) for more details.

FYI - checked service tests on main (with these fixes) - 3 jobs run, everything looks good so far.