### PR TITLE
[Port rc.2.0] fix(id-compressor): Prevent resubmission of ID allocation ops

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2170,6 +2170,7 @@ export class ContainerRuntime
 		let newState: boolean;
 
 		try {
+			this.submitIdAllocationOpIfNeeded(true);
 			// replay the ops
 			this.pendingStateManager.replayPendingStates();
 		} finally {
@@ -3663,9 +3664,11 @@ export class ContainerRuntime
 		return this.blobManager.createBlob(blob, signal);
 	}
 
-	private submitIdAllocationOpIfNeeded(): void {
+	private submitIdAllocationOpIfNeeded(resubmitOutstandingRanges = false): void {
 		if (this._idCompressor) {
-			const idRange = this._idCompressor.takeNextCreationRange();
+			const idRange = resubmitOutstandingRanges
+				? this.idCompressor?.takeUnfinalizedCreationRange()
+				: this._idCompressor.takeNextCreationRange();
 			// Don't include the idRange if there weren't any Ids allocated
 			if (idRange?.ids !== undefined) {
 				const idAllocationMessage: ContainerRuntimeIdAllocationMessage = {
@@ -3914,7 +3917,13 @@ export class ContainerRuntime
 				this.channelCollection.reSubmit(message.type, message.contents, localOpMetadata);
 				break;
 			case ContainerMessageType.IdAllocation: {
-				this.submit(message, localOpMetadata);
+				// Allocation ops are never resubmitted/rebased. This is because they require special handling to
+				// avoid being submitted out of order. For example, if the pending state manager contained
+				// [idOp1, dataOp1, idOp2, dataOp2] and the resubmission of dataOp1 generated idOp3, that would be
+				// placed into the outbox in the same batch as idOp1, but before idOp2 is resubmitted.
+				// To avoid this, allocation ops are simply never resubmitted. Prior to invoking the pending state
+				// manager to replay pending ops, the runtime will always submit a new allocation range that includes
+				// all pending IDs. The resubmitted allocation ops are then ignored here.
 				break;
 			}
 			case ContainerMessageType.ChunkedOp:

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -10,6 +10,11 @@ export interface IBatchManagerOptions {
 	readonly hardLimit: number;
 	readonly softLimit?: number;
 	readonly compressionOptions?: ICompressionRuntimeOptions;
+
+	/**
+	 * If true, the outbox is allowed to rebase the batch during flushing.
+	 */
+	readonly canRebase: boolean;
 }
 
 export interface BatchSequenceNumbers {

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -116,7 +116,7 @@ export class Outbox {
 		this.attachFlowBatch = new BatchManager({ hardLimit, softLimit, canRebase: true });
 		this.mainBatch = new BatchManager({ hardLimit, canRebase: true });
 		this.blobAttachBatch = new BatchManager({ hardLimit, canRebase: true });
-		this.idAllocationBatch = new BatchManager({ hardLimit, canRebase: true });
+		this.idAllocationBatch = new BatchManager({ hardLimit, canRebase: false });
 	}
 
 	public get messageCount(): number {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -23,7 +23,7 @@ describe("BatchManager", () => {
 
 	it("BatchManager's soft limit: a bunch of small messages", () => {
 		const message = { contents: generateStringOfSize(softLimit / 2) } as any as BatchMessage;
-		const batchManager = new BatchManager({ hardLimit, softLimit });
+		const batchManager = new BatchManager({ hardLimit, softLimit, canRebase: true });
 
 		// Can push one large message
 		assert.equal(batchManager.push(message, /* reentrant */ false), true);
@@ -52,7 +52,7 @@ describe("BatchManager", () => {
 
 	it("BatchManager's soft limit: single large message", () => {
 		const message = { contents: generateStringOfSize(softLimit * 2) } as any as BatchMessage;
-		const batchManager = new BatchManager({ hardLimit, softLimit });
+		const batchManager = new BatchManager({ hardLimit, softLimit, canRebase: true });
 
 		// Can push one large message, even above soft limit
 		assert.equal(batchManager.push(message, /* reentrant */ false), true);
@@ -76,7 +76,7 @@ describe("BatchManager", () => {
 	});
 
 	it("BatchManager: no soft limit", () => {
-		const batchManager = new BatchManager({ hardLimit });
+		const batchManager = new BatchManager({ hardLimit, canRebase: true });
 		const third = Math.floor(hardLimit / 3) + 1;
 		const message = { contents: generateStringOfSize(third) } as any as BatchMessage;
 
@@ -108,7 +108,11 @@ describe("BatchManager", () => {
 	});
 
 	it("BatchManager: soft limit is higher than hard limit", () => {
-		const batchManager = new BatchManager({ hardLimit, softLimit: hardLimit * 2 });
+		const batchManager = new BatchManager({
+			hardLimit,
+			softLimit: hardLimit * 2,
+			canRebase: true,
+		});
 		const twoThird = Math.floor((hardLimit * 2) / 3);
 		const message = { contents: generateStringOfSize(twoThird) } as any as BatchMessage;
 		const largeMessage = {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/batchManager.spec.ts
@@ -134,7 +134,7 @@ describe("BatchManager", () => {
 
 	it("BatchManager: 'infinity' hard limit allows everything", () => {
 		const message = { contents: generateStringOfSize(softLimit) } as any as BatchMessage;
-		const batchManager = new BatchManager({ hardLimit: Infinity });
+		const batchManager = new BatchManager({ hardLimit: Infinity, canRebase: true });
 
 		for (let i = 1; i <= 10; i++) {
 			assert.equal(batchManager.push(message, /* reentrant */ false), true);
@@ -143,7 +143,7 @@ describe("BatchManager", () => {
 	});
 
 	it("Batch metadata is set correctly", () => {
-		const batchManager = new BatchManager({ hardLimit });
+		const batchManager = new BatchManager({ hardLimit, canRebase: true });
 		assert.equal(
 			batchManager.push(
 				{ ...smallMessage(), referenceSequenceNumber: 0 },
@@ -183,7 +183,7 @@ describe("BatchManager", () => {
 	});
 
 	it("Batch content size is tracked correctly", () => {
-		const batchManager = new BatchManager({ hardLimit });
+		const batchManager = new BatchManager({ hardLimit, canRebase: true });
 		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), true);
 		assert.equal(batchManager.contentSizeInBytes, smallMessageSize * batchManager.length);
 		assert.equal(batchManager.push(smallMessage(), /* reentrant */ false), true);
@@ -193,7 +193,7 @@ describe("BatchManager", () => {
 	});
 
 	it("Batch reference sequence number maps to the last message", () => {
-		const batchManager = new BatchManager({ hardLimit });
+		const batchManager = new BatchManager({ hardLimit, canRebase: true });
 		assert.equal(
 			batchManager.push(
 				{ ...smallMessage(), referenceSequenceNumber: 0 },
@@ -220,7 +220,7 @@ describe("BatchManager", () => {
 	});
 
 	it("Batch size estimates", () => {
-		const batchManager = new BatchManager({ hardLimit });
+		const batchManager = new BatchManager({ hardLimit, canRebase: true });
 		batchManager.push(smallMessage(), /* reentrant */ false);
 		// 10 bytes of content + 200 bytes overhead
 		assert.equal(estimateSocketSize(batchManager.popBatch()), 210);
@@ -248,7 +248,7 @@ describe("BatchManager", () => {
 	});
 
 	it("Batch op reentry state preserved during its lifetime", () => {
-		const batchManager = new BatchManager({ hardLimit });
+		const batchManager = new BatchManager({ hardLimit, canRebase: true });
 		assert.equal(
 			batchManager.push(
 				{ ...smallMessage(), referenceSequenceNumber: 0 },

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -48,7 +48,7 @@ describe("Pending State Manager", () => {
 			rollbackContent = [];
 			rollbackShouldThrow = false;
 
-			batchManager = new BatchManager({ hardLimit: 950 * 1024 });
+			batchManager = new BatchManager({ hardLimit: 950 * 1024, canRebase: true });
 		});
 
 		it("should do nothing when rolling back empty pending stack", () => {

--- a/packages/runtime/id-compressor/api-report/id-compressor.api.md
+++ b/packages/runtime/id-compressor/api-report/id-compressor.api.md
@@ -60,6 +60,7 @@ export interface IIdCompressorCore {
     serialize(withSession: true): SerializedIdCompressorWithOngoingSession;
     serialize(withSession: false): SerializedIdCompressorWithNoSession;
     takeNextCreationRange(): IdCreationRange;
+    takeUnfinalizedCreationRange(): IdCreationRange;
 }
 
 // @internal

--- a/packages/runtime/id-compressor/api-report/id-compressor.api.md
+++ b/packages/runtime/id-compressor/api-report/id-compressor.api.md
@@ -35,6 +35,7 @@ export interface IdCreationRange {
         readonly firstGenCount: number;
         readonly count: number;
         readonly requestedClusterSize: number;
+        readonly localIdRanges: [genCount: number, count: number][];
     };
     // (undocumented)
     readonly sessionId: SessionId;

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -215,6 +215,10 @@ export class IdCompressor implements IIdCompressor, IIdCompressorCore {
 				firstGenCount: this.nextRangeBaseGenCount,
 				count,
 				requestedClusterSize: this.nextRequestedClusterSize,
+				localIdRanges: this.normalizer.getRangesBetween(
+					this.nextRangeBaseGenCount,
+					this.localGenCount,
+				),
 			},
 		};
 		this.nextRangeBaseGenCount = this.localGenCount + 1;

--- a/packages/runtime/id-compressor/src/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/idCompressor.ts
@@ -6,7 +6,11 @@
 import { assert } from "@fluidframework/core-utils";
 import { bufferToString, stringToBuffer } from "@fluid-internal/client-utils";
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
-import { ITelemetryLoggerExt, createChildLogger, LoggingError } from "@fluidframework/telemetry-utils";
+import {
+	ITelemetryLoggerExt,
+	createChildLogger,
+	LoggingError,
+} from "@fluidframework/telemetry-utils";
 import {
 	IdCreationRange,
 	IIdCompressor,

--- a/packages/runtime/id-compressor/src/sessionSpaceNormalizer.ts
+++ b/packages/runtime/id-compressor/src/sessionSpaceNormalizer.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/core-utils/internal";
 import { AppendOnlySortedMap } from "./appendOnlySortedMap.js";
 import { LocalCompressedId } from "./identifiers.js";
 import { compareFiniteNumbers, genCountFromLocalId } from "./utilities.js";
@@ -46,6 +47,68 @@ export class SessionSpaceNormalizer {
 
 	public get idRanges(): Pick<AppendOnlySortedMap<number, number>, "size" | "entries"> {
 		return this.localIdRanges;
+	}
+
+	public getRangesBetween(
+		firstGenCount: number,
+		lastGenCount: number,
+	): [genCount: number, count: number][] {
+		const ranges: [genCount: number, count: number][] = [];
+		// we need to find the first range that either contains firstGenCount or is after it,
+		// since this method must find ranges between firstGenCount and lastGenCount
+		let firstRange = this.localIdRanges.getPairOrNextLower(firstGenCount);
+		// if the first range does not contain the first ID, next higher range is between but non-containing
+		if (firstRange === undefined || !this.rangeContains(firstRange, firstGenCount)) {
+			firstRange = this.localIdRanges.getPairOrNextHigher(firstGenCount);
+			if (firstRange === undefined) {
+				return ranges;
+			}
+		}
+
+		for (const [genCount, count] of this.localIdRanges.getRange(firstRange[0], lastGenCount)) {
+			ranges.push([genCount, count]);
+		}
+
+		if (ranges.length === 0) {
+			return ranges;
+		}
+
+		// now we touch up the first and last ranges to ensure that if they contain the
+		// queried IDs they are trimmed to start/end with the queried IDs
+		const [baseGenCount, baseCount] = ranges[0];
+		if (this.rangeContains(ranges[0], firstGenCount)) {
+			ranges[0] = [firstGenCount, baseCount - (firstGenCount - baseGenCount)];
+			assert(
+				this.rangeContains(ranges[0], firstGenCount),
+				"Expected the touched up range to contain the queried ID",
+			);
+		} else {
+			assert(
+				baseGenCount > firstGenCount,
+				"Expected the first range to start after the queried ID",
+			);
+		}
+
+		const lastRangeIndex = ranges.length - 1;
+		const [limitGenCount, limitCount] = ranges[lastRangeIndex];
+		if (this.rangeContains(ranges[lastRangeIndex], lastGenCount)) {
+			ranges[lastRangeIndex] = [limitGenCount, lastGenCount - limitGenCount + 1];
+			assert(
+				this.rangeContains(ranges[lastRangeIndex], lastGenCount),
+				"Expected the touched up range to contain the queried ID",
+			);
+		} else {
+			assert(
+				limitGenCount + limitCount - 1 < lastGenCount,
+				"Expected the last range to end before the queried ID",
+			);
+		}
+		return ranges;
+	}
+
+	private rangeContains(range: readonly [number, number], genCount: number): boolean {
+		const [baseGenCount, count] = range;
+		return genCount >= baseGenCount && genCount < baseGenCount + count;
 	}
 
 	public addLocalRange(baseGenCount: number, count: number): void {

--- a/packages/runtime/id-compressor/src/test/idCompressor.perf.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.perf.spec.ts
@@ -151,6 +151,7 @@ describe("IdCompressor Perf", () => {
 						firstGenCount,
 						count: numIds,
 						requestedClusterSize: initialClusterCapacity,
+						localIdRanges: [], // no need to populate, as session is remote and compressor would ignore in production
 					},
 				};
 

--- a/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressor.spec.ts
@@ -366,6 +366,96 @@ describe("IdCompressor", () => {
 				[10, 3],
 			]);
 		});
+
+		describe("by retaking all outstanding ranges", () => {
+			it("when there are no outstanding ranges", () => {
+				const compressor = CompressorFactory.createCompressor(Client.Client1, 2);
+				let retakenRangeEmpty = compressor.takeUnfinalizedCreationRange();
+				assert.equal(retakenRangeEmpty.ids, undefined);
+				compressor.finalizeCreationRange(retakenRangeEmpty);
+				generateCompressedIds(compressor, 1);
+				compressor.finalizeCreationRange(compressor.takeNextCreationRange());
+				retakenRangeEmpty = compressor.takeUnfinalizedCreationRange();
+				assert.equal(retakenRangeEmpty.ids, undefined);
+			});
+
+			it("when there is one outstanding ranges with local IDs only", () => {
+				const compressor = CompressorFactory.createCompressor(Client.Client1, 2);
+
+				generateCompressedIds(compressor, 1);
+				compressor.takeNextCreationRange();
+
+				let retakenRangeLocalOnly = compressor.takeUnfinalizedCreationRange();
+				assert.deepEqual(retakenRangeLocalOnly.ids, {
+					firstGenCount: 1,
+					count: 1,
+					localIdRanges: [[1, 1]],
+					requestedClusterSize: 2,
+				});
+
+				generateCompressedIds(compressor, 1);
+				retakenRangeLocalOnly = compressor.takeUnfinalizedCreationRange();
+				assert.deepEqual(retakenRangeLocalOnly.ids, {
+					firstGenCount: 1,
+					count: 2,
+					localIdRanges: [[1, 2]],
+					requestedClusterSize: 2,
+				});
+
+				let postRetakeRange = compressor.takeNextCreationRange();
+				// IDs should be undefined because retaking should still advance the taken ID counter
+				// if it doesn't, ranges will be resubmitted causing out of order errors
+				assert.equal(postRetakeRange.ids, undefined);
+				generateCompressedIds(compressor, 1);
+				postRetakeRange = compressor.takeNextCreationRange();
+				assert.deepEqual(postRetakeRange.ids, {
+					firstGenCount: 3,
+					count: 1,
+					localIdRanges: [[3, 1]],
+					requestedClusterSize: 2,
+				});
+
+				compressor.finalizeCreationRange(retakenRangeLocalOnly);
+			});
+
+			it("when there are multiple outstanding ranges", () => {
+				const compressor = CompressorFactory.createCompressor(Client.Client1, 2);
+				generateCompressedIds(compressor, 1);
+				const range1 = compressor.takeNextCreationRange();
+				generateCompressedIds(compressor, 1); // one local
+				compressor.finalizeCreationRange(range1);
+				const range2 = compressor.takeNextCreationRange();
+				assert.deepEqual(range2.ids?.localIdRanges, [[2, 1]]);
+				generateCompressedIds(compressor, 1); // one eager final
+				const range3 = compressor.takeNextCreationRange();
+				assert.deepEqual(range3.ids?.localIdRanges, []);
+				generateCompressedIds(compressor, 1); // one local
+				const range4 = compressor.takeNextCreationRange();
+				assert.deepEqual(range4.ids?.localIdRanges, [[4, 1]]);
+
+				const retakenRange = compressor.takeUnfinalizedCreationRange();
+				assert.deepEqual(retakenRange.ids?.firstGenCount, 2);
+				assert.deepEqual(retakenRange.ids?.count, 3);
+				assert.deepEqual(retakenRange.ids?.localIdRanges, [
+					[2, 1],
+					[4, 1],
+				]);
+
+				compressor.finalizeCreationRange(retakenRange);
+				assert.throws(
+					() => compressor.finalizeCreationRange(range2),
+					(e: Error) => e.message === "Ranges finalized out of order",
+				);
+				assert.throws(
+					() => compressor.finalizeCreationRange(range3),
+					(e: Error) => e.message === "Ranges finalized out of order",
+				);
+				assert.throws(
+					() => compressor.finalizeCreationRange(range4),
+					(e: Error) => e.message === "Ranges finalized out of order",
+				);
+			});
+		});
 	});
 
 	describe("Finalizing", () => {
@@ -376,7 +466,10 @@ describe("IdCompressor", () => {
 			compressor.finalizeCreationRange(batchRange);
 			assert.throws(
 				() => compressor.finalizeCreationRange(batchRange),
-				(e: Error) => e.message === "Ranges finalized out of order.",
+				(e: Error) =>
+					e.message === "Ranges finalized out of order" &&
+					(e as any).expectedStart === -4 &&
+					(e as any).actualStart === -1,
 			);
 		});
 
@@ -388,7 +481,10 @@ describe("IdCompressor", () => {
 			const secondRange = compressor.takeNextCreationRange();
 			assert.throws(
 				() => compressor.finalizeCreationRange(secondRange),
-				(e: Error) => e.message === "Ranges finalized out of order.",
+				(e: Error) =>
+					e.message === "Ranges finalized out of order" &&
+					(e as any).expectedStart === -1 &&
+					(e as any).actualStart === -2,
 			);
 		});
 

--- a/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
+++ b/packages/runtime/id-compressor/src/test/idCompressorTestUtilities.ts
@@ -31,6 +31,7 @@ import {
 import { IdCompressor } from "../idCompressor.js";
 import { assertIsSessionId, createSessionId, localIdFromGenCount } from "../utilities.js";
 
+import { SessionSpaceNormalizer } from "../sessionSpaceNormalizer.js";
 import {
 	FinalCompressedId,
 	getOrCreate,
@@ -284,8 +285,7 @@ export class IdCompressorTestNetwork {
 	 * Changes the capacity request amount for a client. It will take effect immediately.
 	 */
 	public changeCapacity(client: Client, newClusterCapacity: number): void {
-		// eslint-disable-next-line @typescript-eslint/dot-notation
-		this.compressors.get(client)["nextRequestedClusterSize"] = newClusterCapacity;
+		changeCapacity(this.compressors.get(client), newClusterCapacity);
 	}
 
 	private addNewId(
@@ -425,26 +425,89 @@ export class IdCompressorTestNetwork {
 			(client) => [this.compressors.get(client), this.getSequencedIdLog(client)] as const,
 		);
 
-		// Ensure creation ranges for clients we track contain the correct local ID ranges
-		this.serverOperations.forEach(([range, opSpaceIds, clientFrom]) => {
+		const getLocalIdsInRange = (
+			range: IdCreationRange,
+			opSpaceIds?: OpSpaceCompressedId[],
+		): Set<SessionSpaceCompressedId> => {
 			const localIdsInCreationRange = new Set<SessionSpaceCompressedId>();
-			if (clientFrom !== OriginatingClient.Remote) {
-				const ids = range.ids;
-				if (ids !== undefined) {
-					const { firstGenCount, localIdRanges } = ids;
-					for (const [genCount, count] of localIdRanges) {
-						for (let g = genCount; g < genCount + count; g++) {
-							const local = localIdFromGenCount(g);
+			const ids = range.ids;
+			if (ids !== undefined) {
+				const { firstGenCount, localIdRanges } = ids;
+				for (const [genCount, count] of localIdRanges) {
+					for (let g = genCount; g < genCount + count; g++) {
+						const local = localIdFromGenCount(g);
+						if (opSpaceIds) {
 							assert.strictEqual(opSpaceIds[g - firstGenCount], local);
-							localIdsInCreationRange.add(local);
 						}
+						localIdsInCreationRange.add(local);
 					}
 				}
+			}
+			return localIdsInCreationRange;
+		};
+
+		// Ensure creation ranges for clients we track contain the correct local ID ranges
+		this.serverOperations.forEach(([range, opSpaceIds, clientFrom]) => {
+			if (clientFrom !== OriginatingClient.Remote) {
+				const localIdsInCreationRange = getLocalIdsInRange(range, opSpaceIds);
+				let localCount = 0;
 				opSpaceIds.forEach((id) => {
 					if (isLocalId(id)) {
+						localCount++;
 						assert(localIdsInCreationRange.has(id), "Local ID not in creation range");
 					}
 				});
+				assert.strictEqual(
+					localCount,
+					localIdsInCreationRange.size,
+					"Local ID count mismatch",
+				);
+			}
+		});
+
+		const undeliveredRanges = new Map<Client, IdCreationRange[]>();
+		this.clientProgress.forEach((progress, client) => {
+			const ranges = this.serverOperations
+				.slice(progress)
+				.filter((op) => op[2] === client)
+				.map(([range]) => range);
+			undeliveredRanges.set(client, ranges);
+		});
+		undeliveredRanges.forEach((ranges, client) => {
+			const compressor = this.compressors.get(client);
+			let firstGenCount: number | undefined;
+			let totalCount = 0;
+			const unionedLocalRanges = new SessionSpaceNormalizer();
+			ranges.forEach((range) => {
+				assert(range.sessionId === compressor.localSessionId);
+				if (range.ids !== undefined) {
+					// initialize firstGenCount if not set
+					if (firstGenCount === undefined) {
+						firstGenCount = range.ids.firstGenCount;
+					}
+					totalCount += range.ids.count;
+					range.ids.localIdRanges.forEach(([genCount, count]) => {
+						unionedLocalRanges.addLocalRange(genCount, count);
+					});
+				}
+			});
+
+			const retakenRange = compressor.takeUnfinalizedCreationRange();
+			if (retakenRange.ids !== undefined) {
+				const retakenLocalIds = new SessionSpaceNormalizer();
+				retakenRange.ids.localIdRanges.forEach(([genCount, count]) => {
+					retakenLocalIds.addLocalRange(genCount, count);
+				});
+				assert.strictEqual(
+					retakenLocalIds.equals(unionedLocalRanges),
+					true,
+					"Local ID ranges mismatch",
+				);
+				assert.strictEqual(retakenRange.ids.count, totalCount, "Count mismatch");
+				assert.strictEqual(retakenRange.ids.firstGenCount, firstGenCount, "Count mismatch");
+			} else {
+				assert.strictEqual(totalCount, 0);
+				assert.strictEqual(unionedLocalRanges.idRanges.size, 0);
 			}
 		});
 
@@ -586,6 +649,11 @@ export class IdCompressorTestNetwork {
 	}
 }
 
+function changeCapacity(compressor: IdCompressor, newClusterCapacity: number): void {
+	// eslint-disable-next-line @typescript-eslint/dot-notation
+	compressor["nextRequestedClusterSize"] = newClusterCapacity;
+}
+
 /**
  * Roundtrips the supplied compressor through serialization and deserialization.
  */
@@ -606,13 +674,21 @@ export function roundtrip(
 	compressor: ReadonlyIdCompressor,
 	withSession: boolean,
 ): [SerializedIdCompressorWithOngoingSession | SerializedIdCompressorWithNoSession, IdCompressor] {
+	// preserve the capacity request as this property is normally private and resets
+	// to a default on construction (deserialization)
+	// eslint-disable-next-line @typescript-eslint/dot-notation
+	const capacity = compressor["nextRequestedClusterSize"];
 	if (withSession) {
 		const serialized = compressor.serialize(withSession);
-		return [serialized, IdCompressor.deserialize(serialized)];
+		const roundtripped = IdCompressor.deserialize(serialized);
+		changeCapacity(roundtripped, capacity);
+		return [serialized, roundtripped];
+	} else {
+		const nonLocalSerialized = compressor.serialize(withSession);
+		const roundtripped = IdCompressor.deserialize(nonLocalSerialized, createSessionId());
+		changeCapacity(roundtripped, capacity);
+		return [nonLocalSerialized, roundtripped];
 	}
-
-	const nonLocalSerialized = compressor.serialize(withSession);
-	return [nonLocalSerialized, IdCompressor.deserialize(nonLocalSerialized, createSessionId())];
 }
 
 /**
@@ -809,13 +885,13 @@ export function makeOpGenerator(
 		return { type: "reconnect", client: random.pick(activeClients) };
 	}
 
-	const allocationWeight = 16;
+	const allocationWeight = 20;
 	return interleave(
 		createWeightedGenerator<Operation, FuzzTestState>([
 			[changeCapacityGenerator, 1],
 			[allocateIdsGenerator, Math.round(allocationWeight * (1 - outsideAllocationFraction))],
 			[allocateOutsideIdsGenerator, Math.round(allocationWeight * outsideAllocationFraction)],
-			[deliverAllOperationsGenerator, 2],
+			[deliverAllOperationsGenerator, 1],
 			[deliverSomeOperationsGenerator, 6],
 			[reconnectGenerator, 1],
 		]),
@@ -887,7 +963,6 @@ export function performFuzzActions(
 				return state;
 			},
 			validate: (state) => {
-				network.deliverOperations(DestinationClient.All);
 				validator?.(network);
 				return state;
 			},

--- a/packages/runtime/id-compressor/src/test/sessionSpaceNormalizer.spec.ts
+++ b/packages/runtime/id-compressor/src/test/sessionSpaceNormalizer.spec.ts
@@ -44,4 +44,49 @@ describe("SessionSpaceNormalizer", () => {
 		assert.equal(normalizer.contains(makeLocalId(-15)), true);
 		assert.equal(normalizer.contains(makeLocalId(-17)), true);
 	});
+
+	it("can compute the ranges between a query", () => {
+		const normalizer = new SessionSpaceNormalizer();
+
+		assert.deepEqual(normalizer.getRangesBetween(1, 10), []);
+
+		normalizer.addLocalRange(2, 1);
+		normalizer.addLocalRange(4, 3);
+		normalizer.addLocalRange(9, 1);
+
+		assert.deepEqual(normalizer.getRangesBetween(1, 10), [
+			[2, 1],
+			[4, 3],
+			[9, 1],
+		]);
+
+		assert.deepEqual(normalizer.getRangesBetween(2, 9), [
+			[2, 1],
+			[4, 3],
+			[9, 1],
+		]);
+
+		assert.deepEqual(normalizer.getRangesBetween(3, 9), [
+			[4, 3],
+			[9, 1],
+		]);
+
+		assert.deepEqual(normalizer.getRangesBetween(3, 8), [[4, 3]]);
+
+		assert.deepEqual(normalizer.getRangesBetween(5, 9), [
+			[5, 2],
+			[9, 1],
+		]);
+
+		assert.deepEqual(normalizer.getRangesBetween(1, 5), [
+			[2, 1],
+			[4, 2],
+		]);
+
+		assert.deepEqual(normalizer.getRangesBetween(4, 4), [[4, 1]]);
+		assert.deepEqual(normalizer.getRangesBetween(5, 5), [[5, 1]]);
+		assert.deepEqual(normalizer.getRangesBetween(6, 6), [[6, 1]]);
+
+		assert.deepEqual(normalizer.getRangesBetween(3, 3), []);
+	});
 });

--- a/packages/runtime/id-compressor/src/types/idCompressor.ts
+++ b/packages/runtime/id-compressor/src/types/idCompressor.ts
@@ -80,11 +80,22 @@ import {
 export interface IIdCompressorCore {
 	/**
 	 * Returns a range of IDs created by this session in a format for sending to the server for finalizing.
-	 * The range will include all IDs generated via calls to `generateCompressedId` since the last time this method was called.
+	 * The range will include all IDs generated via calls to `generateCompressedId` since the last time a
+	 * range was taken (via this method or `takeUnfinalizedCreationRange`).
 	 * @returns the range of IDs, which may be empty. This range must be sent to the server for ordering before
 	 * it is finalized. Ranges must be sent to the server in the order that they are taken via calls to this method.
 	 */
 	takeNextCreationRange(): IdCreationRange;
+
+	/**
+	 * Returns a range of IDs created by this session in a format for sending to the server for finalizing.
+	 * The range will include all unfinalized IDs generated via calls to `generateCompressedId`.
+	 * @returns the range of IDs, which may be empty. This range must be sent to the server for ordering before
+	 * it is finalized. Ranges must be sent to the server in the order that they are taken via calls to this method.
+	 * Note: after finalizing the range returned by this method, finalizing any ranges that had been previously taken
+	 * will result in an error.
+	 */
+	takeUnfinalizedCreationRange(): IdCreationRange;
 
 	/**
 	 * Finalizes the supplied range of IDs (which may be from either a remote or local session).

--- a/packages/runtime/id-compressor/src/types/persisted-types/0.0.1.ts
+++ b/packages/runtime/id-compressor/src/types/persisted-types/0.0.1.ts
@@ -54,5 +54,10 @@ export interface IdCreationRange {
 		 * will be equal to overflow + `requestedClusterSize`.
 		 */
 		readonly requestedClusterSize: number;
+
+		/**
+		 * The ranges of IDs that were allocated as local IDs in the range created by `sessionId.`
+		 */
+		readonly localIdRanges: [genCount: number, count: number][];
 	};
 }

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -165,6 +165,9 @@
 			},
 			"ClassDeclaration_MockDeltaManager": {
 				"forwardCompat": false
+			},
+			"ClassDeclaration_MockFluidDataStoreContext": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -165,9 +165,6 @@
 			},
 			"ClassDeclaration_MockDeltaManager": {
 				"forwardCompat": false
-			},
-			"ClassDeclaration_MockFluidDataStoreContext": {
-				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -30,11 +30,13 @@ import {
 	AttachState,
 } from "@fluidframework/container-definitions";
 import { Loader } from "@fluidframework/container-loader";
-import { ISummaryTree } from "@fluidframework/protocol-definitions";
+import { ISummaryTree, type ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { stringToBuffer } from "@fluid-internal/client-utils";
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { SharedDirectory } from "@fluidframework/map";
 import type { IChannel } from "@fluidframework/datastore-definitions";
+import { delay } from "@fluidframework/core-utils";
+import { generatePairwiseOptions } from "@fluid-private/test-pairwise-generator";
 
 function getIdCompressor(dds: IChannel): IIdCompressor {
 	return (dds as any).runtime.idCompressor as IIdCompressor;
@@ -546,32 +548,101 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		assert.strictEqual(sharedMapContainer1.get(sharedMapDecompressedId), "value");
 	});
 
-	it.skip("Ids generated when disconnected are correctly resubmitted", async () => {
-		// Disconnect the first container
-		container1.disconnect();
+	const sharedPoints = [0, 1, 2];
+	const testConfigs = generatePairwiseOptions({
+		preOfflineChanges: sharedPoints,
+		postOfflineChanges: sharedPoints,
+		allocateDuringResubmitStride: [1, 2, 3],
+		delayBetweenOfflineChanges: [true, false],
+	});
 
-		// Generate a new Id in the disconnected container
-		const id1 = getIdCompressor(sharedMapContainer1).generateCompressedId();
-		// Trigger Id submission
-		sharedMapContainer1.set("key", "value");
+	for (const testConfig of testConfigs) {
+		it(`Ids generated across batches are correctly resubmitted: ${JSON.stringify(
+			testConfig,
+		)}`, async () => {
+			const idPairs: [SessionSpaceCompressedId, IIdCompressor][] = [];
 
-		const superResubmit = (sharedMapContainer1 as any).reSubmitCore.bind(sharedMapContainer1);
-		(sharedMapContainer1 as any).reSubmitCore = (
-			content: unknown,
-			localOpMetadata: unknown,
-		) => {
-			// Simulate a DDS that generates IDs as part of the resubmit path (e.g. SharedTree)
-			// This will test that ID allocation ops are correctly sorted into a separate batch in the outbox
-			getIdCompressor(sharedMapContainer1).generateCompressedId();
-			superResubmit(content, localOpMetadata);
+			const simulateAllocation = (map: ISharedMap) => {
+				const idCompressor = getIdCompressor(map);
+				const id = idCompressor.generateCompressedId();
+				idPairs.push([id, idCompressor]);
+			};
+
+			for (let i = 0; i < testConfig.preOfflineChanges; i++) {
+				simulateAllocation(sharedMapContainer1);
+				sharedMapContainer1.set("key", i); // Trigger Id submission
+			}
+
+			container1.disconnect();
+
+			for (let i = 0; i < testConfig.postOfflineChanges; i++) {
+				simulateAllocation(sharedMapContainer1);
+				sharedMapContainer1.set("key", i); // Trigger Id submission
+
+				if (testConfig.delayBetweenOfflineChanges) {
+					await delay(100); // Trigger Id submission
+				}
+			}
+
+			let invokedCount = 0;
+			const superResubmit = (sharedMapContainer1 as any).reSubmitCore.bind(
+				sharedMapContainer1,
+			);
+			(sharedMapContainer1 as any).reSubmitCore = (
+				content: unknown,
+				localOpMetadata: unknown,
+			) => {
+				invokedCount++;
+				if (invokedCount % testConfig.allocateDuringResubmitStride === 0) {
+					// Simulate a DDS that generates IDs as part of the resubmit path (e.g. SharedTree)
+					// This will test that ID allocation ops are correctly sorted into a separate batch in the outbox
+					simulateAllocation(sharedMapContainer1);
+				}
+				superResubmit(content, localOpMetadata);
+			};
+
+			// important allocation to test the ordering of generate, takeNext, generate, retakeOutstanding, takeNext.
+			// correctness here relies on mutation in retaking if we want the last takeNext to return an empty range
+			// which it must be if we want to avoid overlapping range bugs
+			simulateAllocation(sharedMapContainer1);
+
+			container1.connect();
+			await waitForContainerConnection(container1);
+			await assureAlignment([sharedMapContainer1, sharedMapContainer2], idPairs);
+		});
+	}
+
+	it("Reentrant ops do not cause resubmission of ID allocation ops", async () => {
+		const idPairs: [SessionSpaceCompressedId, IIdCompressor][] = [];
+
+		const simulateAllocation = (map: ISharedMap) => {
+			const idCompressor = getIdCompressor(map);
+			const id = idCompressor.generateCompressedId();
+			idPairs.push([id, idCompressor]);
 		};
 
-		// Generate ids in a connected container but don't send them yet
-		const id2 = getIdCompressor(sharedMapContainer2).generateCompressedId();
-		const id3 = getIdCompressor(sharedMapContainer2).generateCompressedId();
+		container1.disconnect();
 
-		// Reconnect the first container
-		// IdRange should be resubmitted and reflected in all compressors
+		sharedMapContainer2.set("key", "first");
+
+		let invokedCount = 0;
+		const superProcessCore = (sharedMapContainer1 as any).processCore.bind(sharedMapContainer1);
+		(sharedMapContainer1 as any).processCore = (
+			message: ISequencedDocumentMessage,
+			local: boolean,
+			localOpMetadata: unknown,
+		) => {
+			if (invokedCount === 0) {
+				// Force reentrancy during first op processing to cause batch manager rebase (which should skip rebasing allocation ops)
+				simulateAllocation(sharedMapContainer1);
+				sharedMapContainer1.set("key", "reentrant1");
+				simulateAllocation(sharedMapContainer1);
+				sharedMapContainer1.set("key", "reentrant2");
+			}
+			superProcessCore(message, local, localOpMetadata);
+			invokedCount++;
+		};
+
 		container1.connect();
 		await waitForContainerConnection(container1);
 		await provider.ensureSynchronized();

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -199,7 +199,7 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		);
 	});
 
-	it.skip("can normalize session space IDs to op space", async () => {
+	it("can normalize session space IDs to op space", async () => {
 		// None of these clusters will be ack'd yet and as such they will all
 		// generate local Ids. State of compressors afterwards should be:
 		// SharedMap1 Compressor: Local IdRange { first: -1, last: -512 }
@@ -214,26 +214,12 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		// Validate the state described above: all compressors should normalize to
 		// local, negative ids as they haven't been ack'd and can't eagerly allocate
 		for (let i = 0; i < 512; i++) {
-			assert.strictEqual(
-				getIdCompressor(sharedMapContainer1).normalizeToOpSpace(
-					-(i + 1) as SessionSpaceCompressedId,
-				),
-				-(i + 1),
-			);
-
-			assert.strictEqual(
-				getIdCompressor(sharedMapContainer2).normalizeToOpSpace(
-					-(i + 1) as SessionSpaceCompressedId,
-				),
-				-(i + 1),
-			);
-
-			assert.strictEqual(
-				getIdCompressor(sharedMapContainer3).normalizeToOpSpace(
-					-(i + 1) as SessionSpaceCompressedId,
-				),
-				-(i + 1),
-			);
+			[sharedMapContainer1, sharedMapContainer2, sharedMapContainer3].forEach((map) => {
+				assert.strictEqual(
+					getIdCompressor(map).normalizeToOpSpace(-(i + 1) as SessionSpaceCompressedId),
+					-(i + 1),
+				);
+			});
 		}
 
 		// Generate DDS ops so that the compressors synchronize
@@ -252,27 +238,21 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		// SharedMap1 Compressor: { first: 0, last: 1023 }
 		// SharedMap2 Compressor: { first: 1024, last: 2047 }
 		// SharedMap3 Compressor: { first: 2048, last: 2559 }
+		const compressors = [sharedMapContainer1, sharedMapContainer2, sharedMapContainer3].map(
+			(map) => {
+				return getIdCompressor(map);
+			},
+		);
+		const firstIds = compressors.map((compressor) =>
+			compressor.normalizeToOpSpace(-1 as SessionSpaceCompressedId),
+		);
 		for (let i = 0; i < 512; i++) {
-			assert.strictEqual(
-				getIdCompressor(sharedMapContainer1).normalizeToOpSpace(
-					-(i + 1) as SessionSpaceCompressedId,
-				),
-				i,
-			);
-
-			assert.strictEqual(
-				getIdCompressor(sharedMapContainer2).normalizeToOpSpace(
-					-(i + 1) as SessionSpaceCompressedId,
-				),
-				i + 1024,
-			);
-
-			assert.strictEqual(
-				getIdCompressor(sharedMapContainer3).normalizeToOpSpace(
-					-(i + 1) as SessionSpaceCompressedId,
-				),
-				i + 2048,
-			);
+			for (let j = 0; j < compressors.length; j++) {
+				assert.strictEqual(
+					compressors[j].normalizeToOpSpace(-(i + 1) as SessionSpaceCompressedId),
+					i + firstIds[j],
+				);
+			}
 		}
 
 		assert.strictEqual(sharedMapContainer1.get("key"), "value");
@@ -280,7 +260,7 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		assert.strictEqual(sharedMapContainer3.get("key3"), "value3");
 	});
 
-	it.skip("can normalize local op space IDs from a local session to session space", async () => {
+	it("can normalize local op space IDs from a local session to session space", async () => {
 		const sessionSpaceId = getIdCompressor(sharedMapContainer1).generateCompressedId();
 		sharedMapContainer1.set("key", "value");
 
@@ -290,7 +270,7 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 			sharedMapContainer1,
 		).normalizeToSessionSpace(opSpaceId, getIdCompressor(sharedMapContainer1).localSessionId);
 
-		assert.strictEqual(opSpaceId, 0);
+		assert(opSpaceId >= 0);
 		assert.strictEqual(normalizedSessionSpaceId, -1);
 	});
 
@@ -327,7 +307,7 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		assert.equal(opSpaceId, sessionSpaceId2);
 	});
 
-	it.skip("eagerly allocates final IDs after cluster is finalized", async () => {
+	it("eagerly allocates final IDs after cluster is finalized", async () => {
 		assert(getIdCompressor(sharedMapContainer1) !== undefined, "IdCompressor is undefined");
 		const localId1 = getIdCompressor(sharedMapContainer1).generateCompressedId();
 		assert.strictEqual(localId1, -1);
@@ -338,7 +318,7 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		await provider.ensureSynchronized();
 
 		const finalId3 = getIdCompressor(sharedMapContainer1).generateCompressedId();
-		assert.strictEqual(finalId3, 2);
+		assert(finalId3 > 0);
 
 		sharedMapContainer1.set("key2", "value2");
 		await provider.ensureSynchronized();
@@ -347,9 +327,9 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		const opSpaceId2 = getIdCompressor(sharedMapContainer1).normalizeToOpSpace(localId2);
 		const opSpaceId3 = getIdCompressor(sharedMapContainer1).normalizeToOpSpace(finalId3);
 
-		assert.strictEqual(opSpaceId1, 0);
-		assert.strictEqual(opSpaceId2, 1);
-		assert.strictEqual(opSpaceId3, 2);
+		assert(opSpaceId1 >= 0);
+		assert(opSpaceId2 >= 0);
+		assert(opSpaceId3 >= 0);
 		assert.strictEqual(finalId3, opSpaceId3);
 
 		assert.strictEqual(
@@ -375,7 +355,7 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		);
 	});
 
-	it.skip("eagerly allocates IDs across DDSs using the same compressor", async () => {
+	it("eagerly allocates IDs across DDSs using the same compressor", async () => {
 		assert(getIdCompressor(sharedMapContainer1) !== undefined, "IdCompressor is undefined");
 		assert(getIdCompressor(sharedCellContainer1) !== undefined, "IdCompressor is undefined");
 
@@ -389,9 +369,9 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		await provider.ensureSynchronized();
 
 		const finalId3 = getIdCompressor(sharedMapContainer1).generateCompressedId();
-		assert.strictEqual(finalId3, 2);
+		assert(finalId3 > 0);
 		const finalId4 = getIdCompressor(sharedCellContainer1).generateCompressedId();
-		assert.strictEqual(finalId4, 3);
+		assert(finalId4 > 0);
 
 		sharedMapContainer1.set("key2", "value2");
 		sharedCellContainer1.set("value2");
@@ -402,11 +382,9 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		const opSpaceId3 = getIdCompressor(sharedMapContainer1).normalizeToOpSpace(finalId3);
 		const opSpaceId4 = getIdCompressor(sharedCellContainer1).normalizeToOpSpace(finalId4);
 
-		assert.strictEqual(opSpaceId1, 0);
-		assert.strictEqual(opSpaceId2, 1);
-		assert.strictEqual(opSpaceId3, 2);
+		assert(opSpaceId1 >= 0);
+		assert(opSpaceId2 >= 0);
 		assert.strictEqual(opSpaceId3, finalId3);
-		assert.strictEqual(opSpaceId4, 3);
 		assert.strictEqual(opSpaceId4, finalId4);
 
 		assert.equal(
@@ -439,67 +417,58 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 		);
 	});
 
-	it.skip("produces Id spaces correctly", async () => {
-		assert(getIdCompressor(sharedMapContainer1) !== undefined, "IdCompressor is undefined");
-		assert(getIdCompressor(sharedMapContainer2) !== undefined, "IdCompressor is undefined");
-		assert(getIdCompressor(sharedMapContainer3) !== undefined, "IdCompressor is undefined");
-
-		const firstIdContainer1 = getIdCompressor(sharedMapContainer1).generateCompressedId();
-		const secondIdContainer2 = getIdCompressor(sharedMapContainer2).generateCompressedId();
-		const thirdIdContainer2 = getIdCompressor(sharedMapContainer2).generateCompressedId();
-		const decompressedIds: string[] = [];
-
-		const firstDecompressedIdContainer1 =
-			getIdCompressor(sharedMapContainer1).decompress(firstIdContainer1);
-		decompressedIds.push(firstDecompressedIdContainer1);
-
-		[secondIdContainer2, thirdIdContainer2].forEach((id) => {
-			assert(getIdCompressor(sharedMapContainer2) !== undefined, "IdCompressor is undefined");
-			const decompressedId = getIdCompressor(sharedMapContainer2).decompress(id);
-			decompressedIds.push(decompressedId);
-		});
-
-		// should be negative
-		assert(
-			getIdCompressor(sharedMapContainer1).normalizeToOpSpace(firstIdContainer1) < 0,
-			"Expected op space id to be < 0",
-		);
-		assert(
-			getIdCompressor(sharedMapContainer2).normalizeToOpSpace(secondIdContainer2) < 0,
-			"Expected op space id to be < 0",
-		);
-		assert(
-			getIdCompressor(sharedMapContainer2).normalizeToOpSpace(thirdIdContainer2) < 0,
-			"Expected op space id to be < 0",
-		);
-
-		sharedMapContainer1.set(firstDecompressedIdContainer1, "value1");
-		await provider.ensureSynchronized();
-		[secondIdContainer2, thirdIdContainer2].forEach((id, index) => {
-			assert(getIdCompressor(sharedMapContainer2) !== undefined, "IdCompressor is undefined");
-			const decompressedId = getIdCompressor(sharedMapContainer2).decompress(id);
-			sharedMapContainer2.set(decompressedId, `value${index + 2}`);
-		});
-		await provider.ensureSynchronized();
-
-		assert.strictEqual(
-			getIdCompressor(sharedMapContainer1).normalizeToOpSpace(firstIdContainer1),
-			0,
-		);
-		assert.strictEqual(
-			getIdCompressor(sharedMapContainer2).normalizeToOpSpace(secondIdContainer2),
-			513,
-		);
-		assert.strictEqual(
-			getIdCompressor(sharedMapContainer2).normalizeToOpSpace(thirdIdContainer2),
-			514,
-		);
-
-		decompressedIds.forEach((id, index) => {
-			assert.equal(sharedMapContainer1.get(id), `value${index + 1}`);
-			assert.equal(sharedMapContainer2.get(id), `value${index + 1}`);
-		});
+	it("produces Id spaces correctly", async () => {
+		const maps = [sharedMapContainer1, sharedMapContainer2, sharedMapContainer3];
+		const compressors = maps.map((map) => getIdCompressor(map));
+		const idPairs: [SessionSpaceCompressedId, IIdCompressor][] = [];
+		const gens = 1000;
+		for (let i = 0; i < gens; i++) {
+			const compressor = compressors[i % compressors.length];
+			const id = compressor.generateCompressedId();
+			idPairs.push([id, compressor]);
+			if (i === gens / 2) {
+				maps.forEach((map) => {
+					map.set("key", "value");
+				});
+				await provider.ensureSynchronized();
+			}
+		}
+		await assureAlignment(maps, idPairs);
 	});
+
+	async function assureAlignment(
+		maps: ISharedMap[],
+		idPairs: [SessionSpaceCompressedId, IIdCompressor][],
+	) {
+		maps.forEach((map) => {
+			map.set("key", "value");
+		});
+		await provider.ensureSynchronized();
+		const compressors = maps.map((map) => getIdCompressor(map));
+		idPairs.forEach(([id, compressorOrigin]) => {
+			const opSpaceId = compressorOrigin.normalizeToOpSpace(id);
+			assert(opSpaceId >= 0);
+			const sessionSpaceIdOrigin = compressorOrigin.normalizeToSessionSpace(
+				opSpaceId,
+				compressorOrigin.localSessionId,
+			);
+			const decompressedOrigin = compressorOrigin.decompress(id);
+			compressors.forEach((compressor) => {
+				const sessionSpaceId = compressor.normalizeToSessionSpace(
+					opSpaceId,
+					compressorOrigin.localSessionId,
+				);
+				assert(
+					sessionSpaceId >= 0 ||
+						(compressor === compressorOrigin &&
+							sessionSpaceId === sessionSpaceIdOrigin),
+				);
+				assert(compressor.normalizeToOpSpace(sessionSpaceId) === opSpaceId);
+				const decompressed = compressor.decompress(sessionSpaceId);
+				assert(decompressed === decompressedOrigin);
+			});
+		});
+	}
 
 	// IdCompressor is at container runtime level, which means that individual DDSs
 	// in the same container should have the same underlying compressor state
@@ -645,29 +614,7 @@ describeCompat("Runtime IdCompressor", "NoCompat", (getTestObjectProvider, apis)
 
 		container1.connect();
 		await waitForContainerConnection(container1);
-		await provider.ensureSynchronized();
-
-		assert.strictEqual(
-			getIdCompressor(sharedMapContainer1).normalizeToOpSpace(id1),
-			0,
-			"First container should get first cluster and allocate Id 0",
-		);
-
-		// Send the id generated in the second, connected container
-		sharedMapContainer2.set("key2", "value2");
-		await provider.ensureSynchronized();
-
-		assert.strictEqual(
-			getIdCompressor(sharedMapContainer2).normalizeToOpSpace(id2),
-			513,
-			"Second container should get second cluster and allocate Id 512",
-		);
-
-		assert.strictEqual(
-			getIdCompressor(sharedMapContainer2).normalizeToOpSpace(id3),
-			514,
-			"Second Id from second container should get second cluster and allocate Id 513",
-		);
+		await assureAlignment([sharedMapContainer1, sharedMapContainer2], idPairs);
 	});
 
 	// IdCompressor is at container runtime level, which means that individual DDSs


### PR DESCRIPTION
### DO NOT MERGE UNTIL CONFIRMED

https://github.com/microsoft/FluidFramework/pull/21043

### Reviewer Guidance

There were a ton of commits since the commit we're interested in. I tried to take the minimum subset of changes and hot fix certain merge conflicts around `Outbox` and `BatchManager`