### PR TITLE
Match `skipFiles` in Debug Current Mocha Test configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -415,6 +415,7 @@
 				"../../../../lib/test/**/${fileBasenameNoExtension}.js",
 			],
 			"cwd": "${fileDirname}",
+			"skipFiles": ["<node_internals>/**", "**/node_modules/**"],
 			"outFiles": [
 				"${fileDirname}/../../lib/**/*.js",
 				"${fileDirname}/../../../lib/**/*.js",
@@ -441,6 +442,7 @@
 				"../../../../dist/test/**/${fileBasenameNoExtension}.js",
 			],
 			"cwd": "${fileDirname}",
+			"skipFiles": ["<node_internals>/**", "**/node_modules/**"],
 			"outFiles": [
 				"${fileDirname}/../../dist/**/*.js",
 				"${fileDirname}/../../../dist/**/*.js",


### PR DESCRIPTION
We use `skipFiles` in auto build launch config which helps ignoring uninteresting/test setup code when debugging mocha tests.

This should be the same in the no-build launch configurations as well so we don't break on exceptions during test setup. 

ADO Item: https://dev.azure.com/fluidframework/internal/_workitems/edit/4731 