### PR TITLE
Adjust Listenable multi-event subscription policy

### DIFF
--- a/.changeset/large-weeks-sort.md
+++ b/.changeset/large-weeks-sort.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/tree": minor
+---
+
+Adjusted Listenable multi-event subscription policy.
+
+`Listenable.on()` no longer supports the same listener function object being registered twice for the same event.
+The deregister function returned by `Listenable.on()` may now be called multiple times with no effect.

--- a/packages/dds/tree/src/events/events.ts
+++ b/packages/dds/tree/src/events/events.ts
@@ -94,7 +94,7 @@ export interface Listenable<TListeners extends object> {
 	 * @param listener - the handler to run when the event is fired by the emitter
 	 * @returns a {@link Off | function} which will deregister the listener when called.
 	 * This deregistration function is idempotent and therefore may be safely called more than once with no effect.
-	 * @remarks Avoid registering the exact same `listener` object for the same event more than once.
+	 * @remarks Do not register the exact same `listener` object for the same event more than once.
 	 * Doing so will result in undefined behavior.
 	 */
 	on<K extends keyof Listeners<TListeners>>(eventName: K, listener: TListeners[K]): Off;

--- a/packages/dds/tree/src/events/events.ts
+++ b/packages/dds/tree/src/events/events.ts
@@ -95,7 +95,7 @@ export interface Listenable<TListeners extends object> {
 	 * @returns a {@link Off | function} which will deregister the listener when called.
 	 * This deregistration function is idempotent and therefore may be safely called more than once with no effect.
 	 * @remarks Do not register the exact same `listener` object for the same event more than once.
-	 * Doing so will result in undefined behavior.
+	 * Doing so will result in an error.
 	 */
 	on<K extends keyof Listeners<TListeners>>(eventName: K, listener: TListeners[K]): Off;
 }

--- a/packages/dds/tree/src/test/events/eventEmitter.spec.ts
+++ b/packages/dds/tree/src/test/events/eventEmitter.spec.ts
@@ -4,9 +4,6 @@
  */
 
 import { strict as assert } from "assert";
-
-import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
-
 import { EventEmitter, Listenable, createEmitter } from "../../events/index.js";
 
 interface TestEvents {
@@ -99,12 +96,13 @@ describe("EventEmitter", () => {
 		assert(!closed);
 	});
 
-	it("allows duplicate event listeners", () => {
+	it("correctly handles multiple event listeners", () => {
 		const emitter = createEmitter<TestEvents>();
 		let count: number;
 		const listener = () => (count += 1);
 		const off1 = emitter.on("open", listener);
-		const off2 = emitter.on("open", listener);
+		assert.throws(() => emitter.on("open", listener)); // Registering the exact same function is currently forbidden.
+		const off2 = emitter.on("open", () => listener());
 
 		count = 0;
 		emitter.emit("open");
@@ -121,28 +119,14 @@ describe("EventEmitter", () => {
 		assert.strictEqual(count, 0);
 	});
 
-	it("fails on duplicate deregistrations", () => {
+	it("allows repeat deregistrations", () => {
 		const emitter = createEmitter<TestEvents>();
 		const deregister = emitter.on("open", () => {});
 		const deregisterB = emitter.on("open", () => {});
 		deregister();
-		assert.throws(
-			() => deregister(),
-			(e: Error) =>
-				validateAssertionError(
-					e,
-					"Listener does not exist. Event deregistration functions may only be invoked once.",
-				),
-		);
+		deregister();
 		deregisterB();
-		assert.throws(
-			() => deregister(),
-			(e: Error) =>
-				validateAssertionError(
-					e,
-					"Event has no listeners. Event deregistration functions may only be invoked once.",
-				),
-		);
+		deregisterB();
 	});
 
 	it("skips events adding during event", () => {


### PR DESCRIPTION
## Description


* `Listenable.on()` no longer supports the same listener function object being registered twice for the same event.
* The deregister function returned by `Listenable.on()` may now be called multiple times with no effect.