### PR TITLE
fix(build-tools): run policy handlers before resolvers

### DIFF
--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/common.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/common.ts
@@ -14,7 +14,12 @@ export interface Handler {
 	name: string;
 	match: RegExp;
 	handler: (file: string, root: string) => Promise<string | undefined>;
-	resolver?: (file: string, root: string) => { resolved: boolean; message?: string };
+	resolver?: (
+		file: string,
+		root: string,
+	) =>
+		| Promise<{ resolved: boolean; message?: string }>
+		| { resolved: boolean; message?: string };
 	final?: (root: string, resolve: boolean) => { error?: string } | undefined;
 }
 

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
@@ -227,9 +227,6 @@ async function eslintGetScriptDependencies(
 			const configFile = fs.readFileSync(eslintConfig, "utf8");
 			config = JSON5.parse(configFile);
 		} else {
-			// TODO: Ideally loading the eslint config should use import() instead of require() but right now policy resolvers
-			// are synchronous. If they are made async in the future, then this code should be updated to use dynamic import.
-
 			config = import(`file://${path.resolve(eslintConfig)}`) as EslintConfig;
 			if (config === undefined) {
 				throw new Error(`Exports not found in ${eslintConfig}`);

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { PackageName } from "@rushstack/node-core-library";
 import { queue } from "async";
 import * as chalk from "chalk";
 import detectIndent from "detect-indent";
-import { readFileSync, readJsonSync, writeJsonSync } from "fs-extra";
+import { readFileSync, readJsonSync, writeJson, writeJsonSync } from "fs-extra";
 import sortPackageJson from "sort-package-json";
 
 import type { SetRequired, PackageJson as StandardPackageJson } from "type-fest";
@@ -544,4 +544,47 @@ export function readPackageJsonAndIndent(
  */
 function writePackageJson(packagePath: string, pkgJson: PackageJson, indent: string) {
 	return writeJsonSync(packagePath, sortPackageJson(pkgJson), { spaces: indent });
+}
+
+/**
+ * Reads the contents of package.json, applies a transform function to it, then writes
+ * the results back to the source file.
+ *
+ * @param packagePath - A path to a package.json file or a folder containing one. If the
+ * path is a directory, the package.json from that directory will be used.
+ * @param packageTransformer - A function that will be executed on the package.json
+ * contents before writing it back to the file.
+ *
+ * @remarks
+ * The package.json is always sorted using sort-package-json.
+ *
+ * @internal
+ */
+export async function updatePackageJsonFileAsync(
+	packagePath: string,
+	packageTransformer: (json: PackageJson) => Promise<void>,
+): Promise<void> {
+	packagePath = packagePath.endsWith("package.json")
+		? packagePath
+		: path.join(packagePath, "package.json");
+	const [pkgJson, indent] = await readPackageJsonAndIndentAsync(packagePath);
+
+	// Transform the package.json
+	await packageTransformer(pkgJson);
+
+	await writeJson(packagePath, sortPackageJson(pkgJson), { spaces: indent });
+}
+
+/**
+ * Reads a package.json file from a path, detects its indentation, and returns both the JSON as an object and
+ * indentation.
+ */
+async function readPackageJsonAndIndentAsync(
+	pathToJson: string,
+): Promise<[json: PackageJson, indent: string]> {
+	return fs.promises.readFile(pathToJson, { encoding: "utf8" }).then((contents) => {
+		const indentation = detectIndent(contents).indent || "\t";
+		const pkgJson: PackageJson = JSON.parse(contents);
+		return [pkgJson, indentation];
+	});
 }

--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -12,7 +12,12 @@ export {
 export { getResolvedFluidRoot, loadFluidBuildConfig } from "./common/fluidUtils";
 export type { Logger } from "./common/logging";
 export { MonoRepo } from "./common/monoRepo";
-export { Package, type PackageJson, updatePackageJsonFile } from "./common/npmPackage";
+export {
+	Package,
+	type PackageJson,
+	updatePackageJsonFile,
+	updatePackageJsonFileAsync,
+} from "./common/npmPackage";
 export { Timer } from "./common/timer";
 export type {
 	IFluidBuildConfig,


### PR DESCRIPTION
+ add support for async resolvers (which are run serially)
+ allow .mjs eslint configs
+ run fluid-build-tasks-eslint resolver async to allow dynamic import of eslint config
+ fix JSON5 import