### PR TITLE
[Prototype] Offline: Try having PendingStateManager deal in Grouped Batches, not individual messages, to detect forked containers

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2580,6 +2580,13 @@ export class ContainerRuntime
 		// We do not need to make a deep copy. Each layer will just replace message.contents itself,
 		// but will not modify the contents object (likely it will replace it on the message).
 		const messageCopy = { ...messageArg };
+
+		//* Shoot....... losing easy access to localOpMetadata... :(
+		let localOpMetadata: unknown;
+		if (local && modernRuntimeMessage) {
+			localOpMetadata = this.pendingStateManager.processPendingLocalMessage(messageCopy);
+		}
+
 		const savedOp = (messageCopy.metadata as ISavedOpMetadata)?.savedOp;
 		for (const message of this.remoteMessageProcessor.process(messageCopy)) {
 			const msg: MessageWithContext = modernRuntimeMessage
@@ -2641,11 +2648,13 @@ export class ContainerRuntime
 			);
 
 			let localOpMetadata: unknown;
-			if (local && messageWithContext.modernRuntimeMessage) {
-				localOpMetadata = this.pendingStateManager.processPendingLocalMessage(
-					messageWithContext.message,
-				);
-			}
+			//* Shoot....... losing easy access to localOpMetadata... :(
+			// if (local && messageWithContext.modernRuntimeMessage) {
+			// 	localOpMetadata = this.pendingStateManager.processPendingLocalMessage(
+			// 		messageWithContext.message,
+			// 	);
+			// }
+			//*
 
 			// If there are no more pending messages after processing a local message,
 			// the document is no longer dirty.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2853,13 +2853,13 @@ export class ContainerRuntime
 	 * Flush the pending ops manually.
 	 * This method is expected to be called at the end of a batch.
 	 */
-	private flush(): void {
+	private flush(batchId?: string): void {
 		assert(
 			this._orderSequentiallyCalls === 0,
 			0x24c /* "Cannot call `flush()` from `orderSequentially`'s callback" */,
 		);
 
-		this.outbox.flush();
+		this.outbox.flush(batchId);
 		assert(this.outbox.isEmpty, 0x3cf /* reentrancy */);
 	}
 
@@ -4092,13 +4092,13 @@ export class ContainerRuntime
 		}
 	}
 
-	private reSubmitBatch(batch: IPendingBatchMessage[]) {
+	private reSubmitBatch(batch: IPendingBatchMessage[], batchId: string) {
 		this.orderSequentially(() => {
 			for (const message of batch) {
 				this.reSubmit(message);
 			}
 		});
-		this.flush();
+		this.flush(batchId);
 	}
 
 	private reSubmit(message: IPendingBatchMessage) {

--- a/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
@@ -16,6 +16,11 @@ export type BatchMessage = IBatchMessage & {
 	compression?: CompressionAlgorithms;
 };
 
+export type GroupedBatchMessage = BatchMessage & {
+	localOpMetadata?: undefined;
+	metadata: { batchId: string };
+};
+
 /**
  * Batch interface used internally by the runtime.
  */

--- a/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/definitions.ts
@@ -12,19 +12,16 @@ import { CompressionAlgorithms } from "../containerRuntime.js";
  */
 export type BatchMessage = IBatchMessage & {
 	localOpMetadata?: unknown;
-	referenceSequenceNumber: number;
+	referenceSequenceNumber: number; //* Could move up to IBatch
 	compression?: CompressionAlgorithms;
-};
-
-export type GroupedBatchMessage = BatchMessage & {
-	localOpMetadata?: undefined;
-	metadata: { batchId: string };
 };
 
 /**
  * Batch interface used internally by the runtime.
  */
 export interface IBatch<TMessages extends BatchMessage[] = BatchMessage[]> {
+	/** Unique ID for this batch, stable across resubmit and container rehydrate */
+	readonly batchId: string;
 	/**
 	 * Sum of the in-memory content sizes of all messages in the batch.
 	 * If the batch is compressed, this number reflects the post-compression size.
@@ -33,11 +30,11 @@ export interface IBatch<TMessages extends BatchMessage[] = BatchMessage[]> {
 	/**
 	 * All the messages in the batch
 	 */
-	readonly content: TMessages;
+	readonly content: TMessages; //* Rename to messages - too many "content"s!
 	/**
 	 * The reference sequence number for the batch
 	 */
-	readonly referenceSequenceNumber: number | undefined;
+	readonly referenceSequenceNumber: number | undefined; //* When is it undefined? Empty batch
 	/**
 	 * Wether or not the batch contains at least one op which was produced as the result
 	 * of processing another op. This means that the batch must be rebased before

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -3,13 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { v4 as uuid } from "uuid";
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
-import { IBatch, type GroupedBatchMessage } from "./definitions.js";
+import { IBatch, type BatchMessage } from "./definitions.js";
 
 /**
  * Grouping makes assumptions about the shape of message contents. This interface codifies those assumptions, but does not validate them.
@@ -21,7 +20,7 @@ interface IGroupedBatchMessageContents {
 
 interface IGroupedMessage {
 	contents?: unknown;
-	metadata?: Record<string, unknown>; //* only would be batch metadata for first/last
+	metadata?: Record<string, unknown> & { batch?: boolean; batchId?: string };
 	compression?: string; //* N/A because we compress after grouping now
 }
 
@@ -29,15 +28,11 @@ function isGroupContents(opContents: any): opContents is IGroupedBatchMessageCon
 	return opContents?.type === OpGroupingManager.groupedBatchOp;
 }
 
-export function isGroupedBatch(
-	op: ISequencedDocumentMessage,
-	//* DEBUG: Probably wrong
-): op is ISequencedDocumentMessage & { metadata: { batchId: string } } {
+export function isGroupedBatch(op: ISequencedDocumentMessage): boolean {
 	return isGroupContents(op.contents);
 }
 
 export interface OpGroupingManagerConfig {
-	//* Always true for prototype. If false, disable serialization w/o closing.  (will be a pain to support both modes in PSM etc...)
 	readonly groupedBatchingEnabled: boolean;
 	readonly opCountThreshold: number;
 	readonly reentrantBatchGroupingEnabled: boolean;
@@ -61,45 +56,41 @@ export class OpGroupingManager {
 	 * @remarks - Remember that a BatchMessage has its content JSON serialized, so the incoming batch message contents
 	 * must be parsed first, and then the type and contents mentioned above are hidden in that JSON serialization.
 	 */
-	public groupBatch(batch: IBatch, batchId?: string): IBatch<[GroupedBatchMessage]> {
-		assert(this.shouldGroup(batch), 0x946 /* cannot group the provided batch */);
+	public groupBatch(rawBatch: IBatch): IBatch<[BatchMessage]> {
+		assert(this.shouldGroup(rawBatch), 0x946 /* cannot group the provided batch */);
 
-		if (batch.content.length >= 1000) {
+		if (rawBatch.content.length >= 1000) {
 			this.logger.sendTelemetryEvent({
 				eventName: "GroupLargeBatch",
-				length: batch.content.length,
+				length: rawBatch.content.length,
 				threshold: this.config.opCountThreshold,
-				reentrant: batch.hasReentrantOps,
-				referenceSequenceNumber: batch.content[0].referenceSequenceNumber,
+				reentrant: rawBatch.hasReentrantOps,
+				referenceSequenceNumber: rawBatch.content[0].referenceSequenceNumber,
 			});
 		}
 
-		for (const message of batch.content) {
+		for (const message of rawBatch.content) {
 			if (message.metadata) {
-				const keys = Object.keys(message.metadata);
-				assert(keys.length < 2, 0x5dd /* cannot group ops with metadata */);
-				assert(
-					keys.length === 0 || keys[0] === "batch",
-					0x5de /* unexpected op metadata */,
-				);
+				const { batch, batchId, ...rest } = message.metadata;
+				assert(Object.keys(rest).length === 0, 0x5dd /* cannot group ops with metadata */);
 			}
 		}
 
 		const serializedContent = JSON.stringify({
 			type: OpGroupingManager.groupedBatchOp,
-			contents: batch.content.map<IGroupedMessage>((message) => ({
+			contents: rawBatch.content.map<IGroupedMessage>((message) => ({
 				contents: message.contents === undefined ? undefined : JSON.parse(message.contents),
-				metadata: message.metadata, //* Boring - just the batch metadata at front/back
+				metadata: message.metadata, //* batch metadata including batchId (on first message only)
 				compression: message.compression, //* Won't be set because we compress after grouping now
 			})),
 		});
 
-		const groupedBatch: IBatch<[GroupedBatchMessage]> = {
-			...batch,
+		const groupedBatch: IBatch<[BatchMessage]> = {
+			...rawBatch,
 			content: [
 				{
-					metadata: { batchId: batchId ?? uuid() },
-					referenceSequenceNumber: batch.content[0].referenceSequenceNumber,
+					metadata: undefined,
+					referenceSequenceNumber: rawBatch.content[0].referenceSequenceNumber,
 					contents: serializedContent, //* it's IGroupedBatchMessageContents
 				},
 			],
@@ -110,39 +101,29 @@ export class OpGroupingManager {
 	/**
 	 * Ungroups the given op, returning an array of the sub-ops that were grouped together.
 	 * @param op - incoming op (unchunked and uncompressed) to ungroup
-	 * @param loms - If the op is local (based on loader's understanding), this should be an array of localOpMetadata, one-to-one with the batched messages
 	 */
-	public ungroupOp(op: ISequencedDocumentMessage, loms?: unknown[]): ISequencedDocumentMessage[] {
+	public ungroupOp(op: ISequencedDocumentMessage): ISequencedDocumentMessage[] {
 		assert(isGroupContents(op.contents), 0x947 /* can only ungroup a grouped batch */);
 		const contents: IGroupedBatchMessageContents = op.contents;
 
-		// This would indicate the pending batch had a different length than the incoming batch
-		// Shouldn't happen if ref seq matches
-		assert(
-			loms === undefined || //* This means not local
-				contents.contents.length === loms.length,
-			"If local, should have localOpMetadata for each batched message",
-		);
-
 		let fakeCsn = 1;
-		return contents.contents.map((subMessage, i) => ({
+		return contents.contents.map((subMessage) => ({
 			...op,
 			clientSequenceNumber: fakeCsn++,
 			contents: subMessage.contents,
 			metadata: subMessage.metadata,
 			compression: subMessage.compression,
-			localOpMetadata: loms?.[i], //* will correctly be undefined for non-local
 		}));
 	}
 
 	public shouldGroup(batch: IBatch): boolean {
 		return (
 			// Grouped batching must be enabled
-			this.config.groupedBatchingEnabled //* &&
-			//* TODO: Do we need to support this? Will be great if we can always Group, to centralize batchId logic
-			//* batch.content.length >= this.config.opCountThreshold &&
-			//* TODO: Can we remove this feature gate?
-			//* (this.config.reentrantBatchGroupingEnabled || batch.hasReentrantOps !== true)
+			this.config.groupedBatchingEnabled &&
+			// The number of ops in the batch must surpass the configured threshold
+			batch.content.length >= this.config.opCountThreshold &&
+			// Support for reentrant batches must be explicitly enabled
+			(this.config.reentrantBatchGroupingEnabled || batch.hasReentrantOps !== true)
 		);
 	}
 }

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -61,7 +61,7 @@ export class OpGroupingManager {
 	 * @remarks - Remember that a BatchMessage has its content JSON serialized, so the incoming batch message contents
 	 * must be parsed first, and then the type and contents mentioned above are hidden in that JSON serialization.
 	 */
-	public groupBatch(batch: IBatch): IBatch<[GroupedBatchMessage]> {
+	public groupBatch(batch: IBatch, batchId?: string): IBatch<[GroupedBatchMessage]> {
 		assert(this.shouldGroup(batch), 0x946 /* cannot group the provided batch */);
 
 		if (batch.content.length >= 1000) {
@@ -98,7 +98,7 @@ export class OpGroupingManager {
 			...batch,
 			content: [
 				{
-					metadata: { batchId: uuid() },
+					metadata: { batchId: batchId ?? uuid() },
 					referenceSequenceNumber: batch.content[0].referenceSequenceNumber,
 					contents: serializedContent, //* it's IGroupedBatchMessageContents
 				},

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -3,12 +3,13 @@
  * Licensed under the MIT License.
  */
 
+import { v4 as uuid } from "uuid";
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 
-import { IBatch, type BatchMessage } from "./definitions.js";
+import { IBatch, type GroupedBatchMessage } from "./definitions.js";
 
 /**
  * Grouping makes assumptions about the shape of message contents. This interface codifies those assumptions, but does not validate them.
@@ -20,19 +21,23 @@ interface IGroupedBatchMessageContents {
 
 interface IGroupedMessage {
 	contents?: unknown;
-	metadata?: Record<string, unknown>;
-	compression?: string;
+	metadata?: Record<string, unknown>; //* only would be batch metadata for first/last
+	compression?: string; //* N/A because we compress after grouping now
 }
 
 function isGroupContents(opContents: any): opContents is IGroupedBatchMessageContents {
 	return opContents?.type === OpGroupingManager.groupedBatchOp;
 }
 
-export function isGroupedBatch(op: ISequencedDocumentMessage): boolean {
+export function isGroupedBatch(
+	op: ISequencedDocumentMessage,
+	//* DEBUG: Probably wrong
+): op is ISequencedDocumentMessage & { metadata: { batchId: string } } {
 	return isGroupContents(op.contents);
 }
 
 export interface OpGroupingManagerConfig {
+	//* Always true for prototype. If false, disable serialization w/o closing.  (will be a pain to support both modes in PSM etc...)
 	readonly groupedBatchingEnabled: boolean;
 	readonly opCountThreshold: number;
 	readonly reentrantBatchGroupingEnabled: boolean;
@@ -56,7 +61,7 @@ export class OpGroupingManager {
 	 * @remarks - Remember that a BatchMessage has its content JSON serialized, so the incoming batch message contents
 	 * must be parsed first, and then the type and contents mentioned above are hidden in that JSON serialization.
 	 */
-	public groupBatch(batch: IBatch): IBatch<[BatchMessage]> {
+	public groupBatch(batch: IBatch): IBatch<[GroupedBatchMessage]> {
 		assert(this.shouldGroup(batch), 0x946 /* cannot group the provided batch */);
 
 		if (batch.content.length >= 1000) {
@@ -84,46 +89,60 @@ export class OpGroupingManager {
 			type: OpGroupingManager.groupedBatchOp,
 			contents: batch.content.map<IGroupedMessage>((message) => ({
 				contents: message.contents === undefined ? undefined : JSON.parse(message.contents),
-				metadata: message.metadata,
-				compression: message.compression,
+				metadata: message.metadata, //* Boring - just the batch metadata at front/back
+				compression: message.compression, //* Won't be set because we compress after grouping now
 			})),
 		});
 
-		const groupedBatch: IBatch<[BatchMessage]> = {
+		const groupedBatch: IBatch<[GroupedBatchMessage]> = {
 			...batch,
 			content: [
 				{
-					metadata: undefined,
+					metadata: { batchId: uuid() },
 					referenceSequenceNumber: batch.content[0].referenceSequenceNumber,
-					contents: serializedContent,
+					contents: serializedContent, //* it's IGroupedBatchMessageContents
 				},
 			],
 		};
 		return groupedBatch;
 	}
 
-	public ungroupOp(op: ISequencedDocumentMessage): ISequencedDocumentMessage[] {
+	/**
+	 * Ungroups the given op, returning an array of the sub-ops that were grouped together.
+	 * @param op - incoming op (unchunked and uncompressed) to ungroup
+	 * @param loms - If the op is local (based on loader's understanding), this should be an array of localOpMetadata, one-to-one with the batched messages
+	 */
+	public ungroupOp(op: ISequencedDocumentMessage, loms?: unknown[]): ISequencedDocumentMessage[] {
 		assert(isGroupContents(op.contents), 0x947 /* can only ungroup a grouped batch */);
 		const contents: IGroupedBatchMessageContents = op.contents;
 
+		// This would indicate the pending batch had a different length than the incoming batch
+		// Shouldn't happen if ref seq matches
+		assert(
+			loms === undefined || //* This means not local
+				contents.contents.length === loms.length,
+			"If local, should have localOpMetadata for each batched message",
+		);
+
 		let fakeCsn = 1;
-		return contents.contents.map((subMessage) => ({
+		return contents.contents.map((subMessage, i) => ({
 			...op,
 			clientSequenceNumber: fakeCsn++,
 			contents: subMessage.contents,
 			metadata: subMessage.metadata,
 			compression: subMessage.compression,
+			localOpMetadata: loms?.[i], //* will correctly be undefined for non-local
 		}));
 	}
 
 	public shouldGroup(batch: IBatch): boolean {
 		return (
 			// Grouped batching must be enabled
-			this.config.groupedBatchingEnabled &&
-			// The number of ops in the batch must surpass the configured threshold
-			batch.content.length >= this.config.opCountThreshold &&
-			// Support for reentrant batches must be explicitly enabled
-			(this.config.reentrantBatchGroupingEnabled || batch.hasReentrantOps !== true)
+			this.config.groupedBatchingEnabled //* &&
+			//* TODO: Do we need to support this? Will be great if we can always Group, to centralize batchId logic
+			//* batch.content.length >= this.config.opCountThreshold &&
+			//* TODO: Can we remove this feature gate?
+			//* (this.config.reentrantBatchGroupingEnabled || batch.hasReentrantOps !== true)
 		);
 	}
 }

--- a/packages/runtime/container-runtime/src/opLifecycle/remoteMessageProcessor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/remoteMessageProcessor.ts
@@ -102,8 +102,9 @@ export class RemoteMessageProcessor {
 				}
 				//* Btw, now we know processPendingLocalBatch will succeed / return a value
 			}
-			const loms = local ? this.psm.processPendingLocalBatch(message) : undefined;
-			return this.opGroupingManager.ungroupOp(message, loms).map(unpack);
+			//* Moving away from GroupedBatch dependency
+			//* const loms = local ? this.psm.processPendingLocalBatch(message) : undefined;
+			return this.opGroupingManager.ungroupOp(message).map(unpack);
 		}
 
 		// Do a final unpack of runtime messages in case the message was not grouped, compressed, or chunked

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -67,11 +67,7 @@ import {
 	type RecentlyAddedContainerRuntimeMessageDetails,
 	type UnknownContainerRuntimeMessage,
 } from "../messageTypes.js";
-import {
-	IPendingLocalState,
-	IPendingMessage,
-	PendingStateManager,
-} from "../pendingStateManager.js";
+import { IPendingLocalState, IPendingBatch, PendingStateManager } from "../pendingStateManager.js";
 import { ISummaryCancellationToken, neverCancelledSummaryToken } from "../summary/index.js";
 
 function submitDataStoreOp(
@@ -260,16 +256,18 @@ describe("Runtime", () => {
 
 				changeConnectionState(containerRuntime, false, mockClientId);
 
-				submitDataStoreOp(containerRuntime, "1", "test");
+				submitDataStoreOp(containerRuntime, "1", "test", "lom1");
+				submitDataStoreOp(containerRuntime, "1.5", "test", "lom1.5");
 				(containerRuntime as any).flush();
 
-				submitDataStoreOp(containerRuntime, "2", "test");
+				submitDataStoreOp(containerRuntime, "2", "test", "lom2");
 				changeConnectionState(containerRuntime, true, mockClientId);
 				(containerRuntime as any).flush();
 
 				assert.strictEqual(submittedOps.length, 2);
-				assert.strictEqual(submittedOps[0].contents.address, "1");
-				assert.strictEqual(submittedOps[1].contents.address, "2");
+				assert.strictEqual(submittedOps[0].contents[0].contents.contents.address, "1");
+				assert.strictEqual(submittedOps[0].contents[1].contents.contents.address, "1.5");
+				assert.strictEqual(submittedOps[1].contents[0].contents.contents.address, "2");
 			});
 		});
 
@@ -1795,12 +1793,14 @@ describe("Runtime", () => {
 					},
 					provideEntryPoint: mockProvideEntryPoint,
 				});
-				const pendingStates = Array.from({ length: 5 }).map<IPendingMessage>((_, i) => ({
+				const pendingStates = Array.from({ length: 5 }).map<IPendingBatch>((_, i) => ({
 					content: i.toString(),
 					type: "message",
 					referenceSequenceNumber: 0,
 					localOpMetadata: undefined,
 					opMetadata: undefined,
+					batchId: "BATCH_ID", //*
+					loms: [],
 				}));
 				const mockPendingStateManager = new Proxy<PendingStateManager>({} as any, {
 					get: (_t, p: keyof PendingStateManager, _r) => {
@@ -1837,12 +1837,14 @@ describe("Runtime", () => {
 					},
 					provideEntryPoint: mockProvideEntryPoint,
 				});
-				const pendingStates = Array.from({ length: 5 }).map<IPendingMessage>((_, i) => ({
+				const pendingStates = Array.from({ length: 5 }).map<IPendingBatch>((_, i) => ({
 					content: i.toString(),
 					type: "message",
 					referenceSequenceNumber: 0,
 					localOpMetadata: undefined,
 					opMetadata: undefined,
+					batchId: "BATCH_ID", //*
+					loms: [],
 				}));
 				const mockPendingStateManager = new Proxy<PendingStateManager>({} as any, {
 					get: (_t, p: keyof PendingStateManager, _r) => {
@@ -1905,12 +1907,14 @@ describe("Runtime", () => {
 					},
 					provideEntryPoint: mockProvideEntryPoint,
 				});
-				const pendingStates = Array.from({ length: 5 }).map<IPendingMessage>((_, i) => ({
+				const pendingStates = Array.from({ length: 5 }).map<IPendingBatch>((_, i) => ({
 					content: i.toString(),
 					type: "message",
 					referenceSequenceNumber: 0,
 					localOpMetadata: undefined,
 					opMetadata: undefined,
+					batchId: "BATCH_ID", //*
+					loms: [],
 				}));
 				const mockPendingStateManager = new Proxy<PendingStateManager>({} as any, {
 					get: (_t, p: keyof PendingStateManager, _r) => {

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -17,10 +17,10 @@ import type {
 	UnknownContainerRuntimeMessage,
 } from "../messageTypes.js";
 import { BatchManager, BatchMessage } from "../opLifecycle/index.js";
-import { IPendingMessage, PendingStateManager } from "../pendingStateManager.js";
+import { IPendingBatch, PendingStateManager } from "../pendingStateManager.js";
 
 type PendingStateManager_WithPrivates = Omit<PendingStateManager, "initialMessages"> & {
-	initialMessages: Deque<IPendingMessage>;
+	initialMessages: Deque<IPendingBatch>;
 };
 
 describe("Pending State Manager", () => {
@@ -503,13 +503,15 @@ describe("Pending State Manager", () => {
 	});
 
 	describe("Minimum sequence number", () => {
-		const messages: IPendingMessage[] = [
+		const messages: IPendingBatch[] = [
 			{
 				type: "message",
 				content: '{"type":"component"}',
 				referenceSequenceNumber: 10,
 				localOpMetadata: undefined,
 				opMetadata: undefined,
+				batchId: "BATCH_ID", //*
+				loms: [],
 			},
 			{
 				type: "message",
@@ -517,6 +519,8 @@ describe("Pending State Manager", () => {
 				referenceSequenceNumber: 11,
 				localOpMetadata: undefined,
 				opMetadata: undefined,
+				batchId: "BATCH_ID", //*
+				loms: [],
 			},
 			{
 				type: "message",
@@ -524,6 +528,8 @@ describe("Pending State Manager", () => {
 				referenceSequenceNumber: 12,
 				localOpMetadata: undefined,
 				opMetadata: undefined,
+				batchId: "BATCH_ID", //*
+				loms: [],
 			},
 			{
 				type: "message",
@@ -531,10 +537,12 @@ describe("Pending State Manager", () => {
 				referenceSequenceNumber: 12,
 				localOpMetadata: undefined,
 				opMetadata: undefined,
+				batchId: "BATCH_ID", //*
+				loms: [],
 			},
 		];
 
-		function createPendingStateManager(pendingStates?: IPendingMessage[]): PendingStateManager {
+		function createPendingStateManager(pendingStates?: IPendingBatch[]): PendingStateManager {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 			return new PendingStateManager(
 				{

--- a/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/stashedOps.spec.ts
@@ -2006,7 +2006,11 @@ describeCompat("stashed ops", "NoCompat", (getTestObjectProvider, apis) => {
 	});
 
 	describe("Negative tests for Offline Phase 3 - serializing without closing", () => {
-		it(`WRONGLY duplicates ops when submitted with different clientId from pendingLocalState (via Counter DDS)`, async function () {
+		//* ONLY
+		//* ONLY
+		//* ONLY
+		//* ONLY
+		it.only(`WRONGLY duplicates ops when submitted with different clientId from pendingLocalState (via Counter DDS)`, async function () {
 			const incrementValue = 3;
 			const pendingLocalState = await getPendingOps(
 				testContainerConfig,


### PR DESCRIPTION
## Description

This is a quick and dirty prototype looking at how PendingStateManager would work if it tracked Grouped Batches, not individual messages.

We also add `batchId` which can be used to detect forked containers, in the case where a user allows two forks (from the serialization point) to both connect after that point.  In these cases, the container closes.

This does _not_ cover the race condition where two forks connect and submit corresponding batches in parallel

## Reviewer Guidance

I haven't yet tried running the code. I'm sure there are bugs/gaps.

Goal is to update the negative tests in stashedOps.spec.ts to prove this will work.

Hardest part of making this real will be supporting both message-based Pending State (if Grouped Batching is disabled) and Grouped Batch based Pending State.