### PR TITLE
Mitigation: Disable long running Performance test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/benchmark/e2eDocsConfig.json
+++ b/packages/test/test-end-to-end-tests/src/test/benchmark/e2eDocsConfig.json
@@ -73,7 +73,7 @@
 				"stringSize": 100
 			},
 			"minSampleCount": 1,
-			"supportedEndpoints": ["local", "odsp"]
+			"supportedEndpoints": []
 		},
 		{
 			"testTitle": "1Mb Map",


### PR DESCRIPTION
As a quick mitigation, we have a test that is causing our whole pipeline to run into some serious locks.

This performance test has successfully caught a performance regression, we have an item investigating and fixing that [AB#8127](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8127)

I ran without this locally, and was able to get these tests to pass.