### PR TITLE
tree: Add tracking of cursor sources to ObjectForest

### DIFF
--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -955,7 +955,7 @@ export interface IEmitter<TListeners extends Listeners<TListeners>> {
 
 // @internal
 export interface IForestSubscription extends Listenable<ForestEvents> {
-    allocateCursor(): ITreeSubscriptionCursor;
+    allocateCursor(source?: string): ITreeSubscriptionCursor;
     readonly anchors: AnchorSet;
     clone(schema: TreeStoredSchemaSubscription, anchors: AnchorSet): IEditableForest;
     forgetAnchor(anchor: Anchor): void;
@@ -1144,7 +1144,7 @@ export interface ITreeSubscriptionCursor extends ITreeCursor {
     buildFieldAnchor(): FieldAnchor;
     clear(): void;
     // (undocumented)
-    fork(): ITreeSubscriptionCursor;
+    fork(source?: string): ITreeSubscriptionCursor;
     free(): void;
     readonly state: ITreeSubscriptionCursorState;
 }

--- a/packages/dds/tree/src/core/forest/forest.ts
+++ b/packages/dds/tree/src/core/forest/forest.ts
@@ -80,8 +80,9 @@ export interface IForestSubscription extends Listenable<ForestEvents> {
 
 	/**
 	 * Allocates a cursor in the "cleared" state.
+	 * @param source - optional string identifying the source of the cursor for debugging purposes when cursors are not properly cleaned up.
 	 */
-	allocateCursor(): ITreeSubscriptionCursor;
+	allocateCursor(source?: string): ITreeSubscriptionCursor;
 
 	/**
 	 * Frees an Anchor, stopping tracking its position across edits.
@@ -178,9 +179,10 @@ export interface FieldAnchor {
  */
 export interface ITreeSubscriptionCursor extends ITreeCursor {
 	/**
+	 * @param source - optional string identifying the source of the cursor for debugging purposes when cursors are not properly cleaned up.
 	 * @returns an independent copy of this cursor at the same location in the tree.
 	 */
-	fork(): ITreeSubscriptionCursor;
+	fork(source?: string): ITreeSubscriptionCursor;
 
 	/**
 	 * Release any resources this cursor is holding onto.

--- a/packages/dds/tree/src/feature-libraries/flex-tree/context.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/context.ts
@@ -137,7 +137,7 @@ export class Context implements FlexTreeContext, IDisposable {
 
 	public get root(): FlexTreeField {
 		assert(this.disposed === false, 0x804 /* use after dispose */);
-		const cursor = this.checkout.forest.allocateCursor();
+		const cursor = this.checkout.forest.allocateCursor("root");
 		moveToDetachedField(this.checkout.forest, cursor);
 		const field = makeField(this, this.schema.rootFieldSchema, cursor);
 		cursor.free();

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
@@ -52,7 +52,7 @@ export abstract class LazyEntity<TSchema = unknown, TAnchor = unknown>
 		anchor: TAnchor,
 	) {
 		this[anchorSymbol] = anchor;
-		this.#lazyCursor = cursor.fork();
+		this.#lazyCursor = cursor.fork("LazyEntity Fork");
 		context.withCursors.add(this);
 		this.context.withAnchors.add(this);
 	}

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -79,7 +79,7 @@ export class ForestSummarizer implements Summarizable {
 		// TODO: Encode all detached fields in one operation for better performance and compression
 		forEachField(rootCursor, (cursor) => {
 			const key = cursor.getFieldKey();
-			const innerCursor = this.forest.allocateCursor();
+			const innerCursor = this.forest.allocateCursor("getTreeString");
 			assert(
 				this.forest.tryMoveCursorToField(
 					{ fieldKey: key, parent: undefined },

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -261,7 +261,7 @@ export class SharedTree
 	}
 
 	public contentSnapshot(): SharedTreeContentSnapshot {
-		const cursor = this.checkout.forest.allocateCursor();
+		const cursor = this.checkout.forest.allocateCursor("contentSnapshot");
 		try {
 			moveToDetachedField(this.checkout.forest, cursor);
 			return {

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -571,7 +571,7 @@ export class TreeCheckout implements ITreeCheckoutFork {
 
 	public getRemovedRoots(): [string | number | undefined, number, JsonableTree][] {
 		const trees: [string | number | undefined, number, JsonableTree][] = [];
-		const cursor = this.forest.allocateCursor();
+		const cursor = this.forest.allocateCursor("getRemovedRoots");
 		for (const { id, root } of this.removedRoots.entries()) {
 			const parentField = this.removedRoots.toFieldKey(root);
 			this.forest.moveCursorToPath(

--- a/packages/dds/tree/src/simple-tree/proxyBinding.ts
+++ b/packages/dds/tree/src/simple-tree/proxyBinding.ts
@@ -97,7 +97,7 @@ export function getFlexNode(proxy: TreeNode, allowFreed = false): FlexTreeNode {
 			return flexNode; // If it does have a flex node, return it...
 		} // ...otherwise, the flex node must be created
 		const context = anchorNode.anchorSet.slots.get(ContextSlot) ?? fail("missing context");
-		const cursor = context.checkout.forest.allocateCursor();
+		const cursor = context.checkout.forest.allocateCursor("getFlexNode");
 		context.checkout.forest.moveCursorToPath(anchorNode, cursor);
 		const newFlexNode = makeTree(context, cursor);
 		cursor.free();


### PR DESCRIPTION
## Description

Add optional "source" to forest cursor creation. In ObjectForest, use it to produce more descriptive errors about unexpected cursors.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
