### PR TITLE
Fix(tree): composition bugs

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -257,7 +257,7 @@ export class ModularChangeFamily
 				);
 				const { change1: fieldChange1, change2: fieldChange2, composedChange } = context;
 
-				const rebaser = getChangeHandler(this.fieldKinds, fieldChange.fieldKind).rebaser;
+				const rebaser = getChangeHandler(this.fieldKinds, composedChange.fieldKind).rebaser;
 				const composeNodes = (
 					child1: NodeId | undefined,
 					child2: NodeId | undefined,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/compose.ts
@@ -677,7 +677,7 @@ function setEndpoint(
 	count: number,
 	endpoint: ChangeAtomId,
 ): void {
-	const effect = getMoveEffect(moveEffects, target, id.revision, id.localId, count);
+	const effect = getMoveEffect(moveEffects, target, id.revision, id.localId, count, false);
 	const newEffect = effect.value !== undefined ? { ...effect.value, endpoint } : { endpoint };
 	setMoveEffect(moveEffects, target, id.revision, id.localId, effect.length, newEffect);
 


### PR DESCRIPTION
## Description

Fixes two bugs in composition logic:
* setEndpoint was calling getMoveEffect with addDependency set to true
* ModularChangeFamily was using the wrong field rebaser during some compositions