### PR TITLE
Add `TreeStatus.Created` and tighten transaction APIs

### DIFF
--- a/.changeset/great-candies-win.md
+++ b/.changeset/great-candies-win.md
@@ -1,0 +1,9 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+---
+
+A new tree status has been added for SharedTree nodes.
+
+`TreeStatus.Created` indicates that a SharedTree node has been constructed but not yet inserted into the tree.
+Constraints passed to the `runTransaction` API are now marked as `readonly`.

--- a/packages/dds/tree/api-report/tree.api.md
+++ b/packages/dds/tree/api-report/tree.api.md
@@ -1315,9 +1315,9 @@ export type NodeIndex = number;
 // @public
 export interface NodeInDocumentConstraint {
     // (undocumented)
-    node: TreeNode;
+    readonly node: TreeNode;
     // (undocumented)
-    type: "nodeInDocument";
+    readonly type: "nodeInDocument";
 }
 
 // @internal
@@ -1538,12 +1538,12 @@ export interface RunTransaction {
     <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult | typeof rollback): TResult | typeof rollback;
     <TNode extends TreeNode>(node: TNode, transaction: (node: TNode) => void): void;
     <TView extends TreeView<ImplicitFieldSchema>>(tree: TView, transaction: (root: TView["root"]) => void): void;
-    <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult, preconditions?: TransactionConstraint[]): TResult;
-    <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult, preconditions?: TransactionConstraint[]): TResult;
-    <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult | typeof rollback, preconditions?: TransactionConstraint[]): TResult | typeof rollback;
-    <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult | typeof rollback, preconditions?: TransactionConstraint[]): TResult | typeof rollback;
-    <TNode extends TreeNode>(node: TNode, transaction: (node: TNode) => void, preconditions?: TransactionConstraint[]): void;
-    <TView extends TreeView<ImplicitFieldSchema>>(tree: TView, transaction: (root: TView["root"]) => void, preconditions?: TransactionConstraint[]): void;
+    <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult, preconditions?: readonly TransactionConstraint[]): TResult;
+    <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult, preconditions?: readonly TransactionConstraint[]): TResult;
+    <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult | typeof rollback, preconditions?: readonly TransactionConstraint[]): TResult | typeof rollback;
+    <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult | typeof rollback, preconditions?: readonly TransactionConstraint[]): TResult | typeof rollback;
+    <TNode extends TreeNode>(node: TNode, transaction: (node: TNode) => void, preconditions?: readonly TransactionConstraint[]): void;
+    <TView extends TreeView<ImplicitFieldSchema>>(tree: TView, transaction: (root: TView["root"]) => void, preconditions?: readonly TransactionConstraint[]): void;
     readonly rollback: typeof rollback;
 }
 
@@ -2002,6 +2002,7 @@ export function treeSchemaFromStoredSchema(schema: TreeStoredSchema): FlexTreeSc
 
 // @public
 export enum TreeStatus {
+    Created = 3,
     Deleted = 2,
     InDocument = 0,
     Removed = 1

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -131,6 +131,11 @@ export enum TreeStatus {
 	 * Is removed and cannot be added back to the original document tree.
 	 */
 	Deleted = 2,
+
+	/**
+	 * Is created but has not yet been inserted into the tree.
+	 */
+	Created = 3,
 }
 
 /**

--- a/packages/dds/tree/src/shared-tree/treeApi.ts
+++ b/packages/dds/tree/src/shared-tree/treeApi.ts
@@ -186,7 +186,7 @@ export interface RunTransaction {
 	<TNode extends TreeNode, TResult>(
 		node: TNode,
 		transaction: (node: TNode) => TResult,
-		preconditions?: TransactionConstraint[],
+		preconditions?: readonly TransactionConstraint[],
 	): TResult;
 	/**
 	 * Apply one or more edits to the tree as a single atomic unit.
@@ -211,7 +211,7 @@ export interface RunTransaction {
 	<TView extends TreeView<ImplicitFieldSchema>, TResult>(
 		tree: TView,
 		transaction: (root: TView["root"]) => TResult,
-		preconditions?: TransactionConstraint[],
+		preconditions?: readonly TransactionConstraint[],
 	): TResult;
 	/**
 	 * Apply one or more edits to the tree as a single atomic unit.
@@ -238,7 +238,7 @@ export interface RunTransaction {
 	<TNode extends TreeNode, TResult>(
 		node: TNode,
 		transaction: (node: TNode) => TResult | typeof rollback,
-		preconditions?: TransactionConstraint[],
+		preconditions?: readonly TransactionConstraint[],
 	): TResult | typeof rollback;
 	/**
 	 * Apply one or more edits to the tree as a single atomic unit.
@@ -264,7 +264,7 @@ export interface RunTransaction {
 	<TView extends TreeView<ImplicitFieldSchema>, TResult>(
 		tree: TView,
 		transaction: (root: TView["root"]) => TResult | typeof rollback,
-		preconditions?: TransactionConstraint[],
+		preconditions?: readonly TransactionConstraint[],
 	): TResult | typeof rollback;
 	/**
 	 * Apply one or more edits to the tree as a single atomic unit.
@@ -289,7 +289,7 @@ export interface RunTransaction {
 	<TNode extends TreeNode>(
 		node: TNode,
 		transaction: (node: TNode) => void,
-		preconditions?: TransactionConstraint[],
+		preconditions?: readonly TransactionConstraint[],
 	): void;
 	/**
 	 * Apply one or more edits to the tree as a single atomic unit.
@@ -313,7 +313,7 @@ export interface RunTransaction {
 	<TView extends TreeView<ImplicitFieldSchema>>(
 		tree: TView,
 		transaction: (root: TView["root"]) => void,
-		preconditions?: TransactionConstraint[],
+		preconditions?: readonly TransactionConstraint[],
 	): void;
 }
 
@@ -383,8 +383,8 @@ export type TransactionConstraint = NodeInDocumentConstraint; // TODO: Add more 
  * @public
  */
 export interface NodeInDocumentConstraint {
-	type: "nodeInDocument";
-	node: TreeNode;
+	readonly type: "nodeInDocument";
+	readonly node: TreeNode;
 }
 
 // TODO: Add more constraint types here
@@ -396,7 +396,7 @@ function createRunTransaction(): RunTransaction {
 		target: T,
 	): T & { rollback: typeof rollback } {
 		Reflect.defineProperty(target, "rollback", { value: rollback });
-		return target as T & { rollback: typeof rollback };
+		return target as T & { readonly rollback: typeof rollback };
 	}
 
 	return defineRollbackProperty(runTransaction.bind({}));
@@ -412,7 +412,7 @@ export function runTransaction<TNode extends TreeNode, TRoot extends ImplicitFie
 	transaction:
 		| ((node: TNode) => TResult | typeof rollback)
 		| ((root: TRoot) => TResult | typeof rollback),
-	preconditions: TransactionConstraint[] = [],
+	preconditions: readonly TransactionConstraint[] = [],
 ): TResult | typeof rollback {
 	if (treeOrNode instanceof SchematizingSimpleTreeView) {
 		const t = transaction as (root: TRoot) => TResult | typeof rollback;
@@ -436,7 +436,7 @@ export function runTransaction<TNode extends TreeNode, TRoot extends ImplicitFie
 function runTransactionInCheckout<TResult>(
 	checkout: TreeCheckout,
 	transaction: () => TResult | typeof rollback,
-	preconditions: TransactionConstraint[],
+	preconditions: readonly TransactionConstraint[],
 ): TResult | typeof rollback {
 	checkout.transaction.start();
 	for (const constraint of preconditions) {

--- a/packages/dds/tree/src/simple-tree/rawNode.ts
+++ b/packages/dds/tree/src/simple-tree/rawNode.ts
@@ -92,8 +92,7 @@ export abstract class RawTreeNode<TSchema extends FlexTreeNodeSchema, TContent>
 	}
 
 	public treeStatus(): TreeStatus {
-		// TODO: We could add a new TreeStatus for "raw" nodes.
-		throw rawError("Status querying");
+		return TreeStatus.Created;
 	}
 
 	public value: undefined;

--- a/packages/dds/tree/src/test/simple-tree/rawObjectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/rawObjectNode.spec.ts
@@ -14,6 +14,7 @@ import {
 	FlexFieldSchema,
 	FlexObjectNodeSchema,
 	SchemaBuilderBase,
+	TreeStatus,
 } from "../../feature-libraries/index.js";
 import { extractRawNodeContent } from "../../simple-tree/rawNode.js";
 import { brand } from "../../util/index.js";
@@ -58,14 +59,18 @@ describe("raw object nodes", () => {
 		assert.equal(rawObjectNode.value, undefined);
 	});
 
+	it("allow reading tree status", () => {
+		const { rawObjectNode } = getRawObjectNode();
+		assert.equal(rawObjectNode.treeStatus(), TreeStatus.Created);
+	});
+
 	it("disallow reading most node properties", () => {
-		const { rawObjectNode, objectSchema } = getRawObjectNode();
+		const { rawObjectNode } = getRawObjectNode();
 		assert.throws(() => rawObjectNode.context);
 		assert.throws(() => rawObjectNode.parentField);
 		assert.throws(() => rawObjectNode.tryGetField(brand("foo")));
 		assert.throws(() => rawObjectNode.boxedIterator());
 		assert.throws(() => rawObjectNode.on("changing", () => {}));
-		assert.throws(() => rawObjectNode.treeStatus());
 	});
 
 	it("disallow reading fields", () => {

--- a/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
@@ -639,6 +639,7 @@ describe("schemaFactory", () => {
 						unreachableCase(layout.parentType);
 				}
 				nodes.push(parent);
+				assert.equal(Tree.status(parent), TreeStatus.Created);
 				return parent;
 			}
 
@@ -658,6 +659,7 @@ describe("schemaFactory", () => {
 						unreachableCase(layout.childType);
 				}
 				nodes.push(child);
+				assert.equal(Tree.status(child), TreeStatus.Created);
 				return child;
 			}
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -621,9 +621,9 @@ export type NodeFromSchemaUnsafe<T extends Unenforced<TreeNodeSchema>> = T exten
 // @public
 export interface NodeInDocumentConstraint {
     // (undocumented)
-    node: TreeNode;
+    readonly node: TreeNode;
     // (undocumented)
-    type: "nodeInDocument";
+    readonly type: "nodeInDocument";
 }
 
 // @public
@@ -680,12 +680,12 @@ export interface RunTransaction {
     <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult | typeof rollback): TResult | typeof rollback;
     <TNode extends TreeNode>(node: TNode, transaction: (node: TNode) => void): void;
     <TView extends TreeView<ImplicitFieldSchema>>(tree: TView, transaction: (root: TView["root"]) => void): void;
-    <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult, preconditions?: TransactionConstraint[]): TResult;
-    <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult, preconditions?: TransactionConstraint[]): TResult;
-    <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult | typeof rollback, preconditions?: TransactionConstraint[]): TResult | typeof rollback;
-    <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult | typeof rollback, preconditions?: TransactionConstraint[]): TResult | typeof rollback;
-    <TNode extends TreeNode>(node: TNode, transaction: (node: TNode) => void, preconditions?: TransactionConstraint[]): void;
-    <TView extends TreeView<ImplicitFieldSchema>>(tree: TView, transaction: (root: TView["root"]) => void, preconditions?: TransactionConstraint[]): void;
+    <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult, preconditions?: readonly TransactionConstraint[]): TResult;
+    <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult, preconditions?: readonly TransactionConstraint[]): TResult;
+    <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult | typeof rollback, preconditions?: readonly TransactionConstraint[]): TResult | typeof rollback;
+    <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult | typeof rollback, preconditions?: readonly TransactionConstraint[]): TResult | typeof rollback;
+    <TNode extends TreeNode>(node: TNode, transaction: (node: TNode) => void, preconditions?: readonly TransactionConstraint[]): void;
+    <TView extends TreeView<ImplicitFieldSchema>>(tree: TView, transaction: (root: TView["root"]) => void, preconditions?: readonly TransactionConstraint[]): void;
     readonly rollback: typeof rollback;
 }
 
@@ -977,6 +977,7 @@ export type TreeObjectNodeUnsafe<T extends Unenforced<RestrictiveReadonlyRecord<
 
 // @public
 export enum TreeStatus {
+    Created = 3,
     Deleted = 2,
     InDocument = 0,
     Removed = 1


### PR DESCRIPTION
BREAKING CHANGE: A new tree status has been added for SharedTree nodes.

`TreeStatus.Created` indicates that a SharedTree node has been constructed but not yet inserted into the tree.
Constraints passed to the `runTransaction` API are now marked as `readonly`.