### PR TITLE
Fix chunk sizing in messageSize tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -29,7 +29,7 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 
-describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
+describeCompat.only("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 	const { SharedMap } = apis.dds;
 	const mapId = "mapId";
 	const registry: ChannelFactoryRegistry = [[mapId, SharedMap.getFactory()]];
@@ -295,6 +295,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 			runtimeOptions: {
 				summaryOptions: { summaryConfigOverrides: { state: "disabled" } },
 				enableGroupedBatching,
+				chunkSizeInBytes: 204800, // compatUtils.ts is currently defaulting to 1000 (TODO: should remove this line and reduce sizes in these tests)
 			},
 		};
 
@@ -507,11 +508,6 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 								provider.driver.type === "local" ||
 								provider.driver.type === "tinylicious"
 							) {
-								this.skip();
-							}
-
-							// TODO: This test is consistently failing on routerlicious. See ADO:7883 and ADO:7924
-							if (provider.driver.type === "routerlicious") {
 								this.skip();
 							}
 


### PR DESCRIPTION
These tests are failing on checking the total count of messages being sent. Before, we assumed chunking wasn't happening and the message count would be 1, but there was a change to the chunk size override option in [compatUtils.ts](https://github.com/microsoft/FluidFramework/blob/main/packages/test/test-version-utils/src/compatUtils.ts#L99) that caused this number to be 1000. Thus, the tests were actually producing 6 ops and failing the check.

I'm leaving this is as a draft because I want to do the actual fix of reducing message sizes and config options across the board. This PR in its current state is to show that the fix is not needed urgently.

[AB#7883](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7883)
[AB#7924](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7924)