### PR TITLE
Move `indexForAt` helper into utilties folder

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
@@ -63,4 +63,4 @@ export {
 
 export { assertFlexTreeEntityNotFreed } from "./lazyEntity.js";
 
-export { getSchemaAndPolicy } from "./utilities.js";
+export { getSchemaAndPolicy, indexForAt } from "./utilities.js";

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -62,31 +62,7 @@ import {
 } from "./lazyEntity.js";
 import { makeTree } from "./lazyNode.js";
 import { unboxedUnion } from "./unboxed.js";
-import { treeStatusFromAnchorCache, treeStatusFromDetachedField } from "./utilities.js";
-
-/**
- * Indexing for {@link LazyField.at} and {@link LazyField.boxedAt} supports the
- * usage of negative indices, which regular indexing using `[` and `]` does not.
- *
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at
- * for additional context on the semantics.
- *
- * @returns A positive index that can be used in regular indexing. Returns
- * undefined if that index would be out-of-bounds.
- */
-function indexForAt(index: number, length: number): number | undefined {
-	let finalIndex = Math.trunc(+index);
-	if (isNaN(finalIndex)) {
-		finalIndex = 0;
-	}
-	if (finalIndex < -length || finalIndex >= length) {
-		return undefined;
-	}
-	if (finalIndex < 0) {
-		finalIndex = finalIndex + length;
-	}
-	return finalIndex;
-}
+import { indexForAt, treeStatusFromAnchorCache, treeStatusFromDetachedField } from "./utilities.js";
 
 export function makeField(
 	context: Context,

--- a/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
@@ -85,3 +85,27 @@ export function getSchemaAndPolicy(nodeOrField: FlexTreeEntity): SchemaAndPolicy
 		policy: nodeOrField.context.schema.policy,
 	};
 }
+
+/**
+ * Indexing for {@link FlexTreeField.boxedAt} and {@link FlexTreeSequenceField.at} supports the
+ * usage of negative indices, which regular indexing using `[` and `]` does not.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at
+ * for additional context on the semantics.
+ *
+ * @returns A positive index that can be used in regular indexing. Returns
+ * undefined if that index would be out-of-bounds.
+ */
+export function indexForAt(index: number, length: number): number | undefined {
+	let finalIndex = Math.trunc(+index);
+	if (isNaN(finalIndex)) {
+		finalIndex = 0;
+	}
+	if (finalIndex < -length || finalIndex >= length) {
+		return undefined;
+	}
+	if (finalIndex < 0) {
+		finalIndex = finalIndex + length;
+	}
+	return finalIndex;
+}


### PR DESCRIPTION
This small change will make it easier for future implementations of "flex trees" to access `indexForAt`.