### PR TITLE
feat(build-tools): alternate tag export support

### DIFF
--- a/build-tools/packages/build-cli/docs/generate.md
+++ b/build-tools/packages/build-cli/docs/generate.md
@@ -223,8 +223,8 @@ Generates type declaration entrypoints for Fluid Framework API levels (/alpha, /
 ```
 USAGE
   $ flub generate entrypoints [-v | --quiet] [--mainEntrypoint <value>] [--outDir <value>] [--outFilePrefix <value>]
-    [--outFileAlpha <value>] [--outFileBeta <value>] [--outFilePublic <value>] [--outFileSuffix <value>]
-    [--node10TypeCompat]
+    [--outFileAlpha <value>] [--outFileBeta <value>] [--outFileLegacy <value>] [--outFilePublic <value>]
+    [--outFileSuffix <value>] [--node10TypeCompat]
 
 FLAGS
   --mainEntrypoint=<value>  [default: ./src/index.ts] Main entrypoint file containing all untrimmed exports.
@@ -232,6 +232,7 @@ FLAGS
   --outDir=<value>          [default: ./lib] Directory to emit entrypoint declaration files.
   --outFileAlpha=<value>    [default: alpha] Base file name for alpha entrypoint declaration files.
   --outFileBeta=<value>     [default: beta] Base file name for beta entrypoint declaration files.
+  --outFileLegacy=<value>   [default: legacy] Base file name for legacy entrypoint declaration files.
   --outFilePrefix=<value>   File name prefix for emitting entrypoint declaration files. Pattern of
                             '{@unscopedPackageName}' within value will be replaced with the unscoped name of this
                             package.

--- a/build-tools/packages/build-cli/src/commands/modify/fluid-imports.ts
+++ b/build-tools/packages/build-cli/src/commands/modify/fluid-imports.ts
@@ -628,23 +628,26 @@ class ApiLevelReader {
 		const memberData = new Map<string, ApiLevel>();
 		addUniqueNamedExportsToMap(exports.public, memberData, ApiLevel.public);
 		if (this.onlyInternal) {
+			addUniqueNamedExportsToMap(exports.legacy, memberData, ApiLevel.internal);
 			addUniqueNamedExportsToMap(exports.beta, memberData, ApiLevel.internal);
 			addUniqueNamedExportsToMap(exports.alpha, memberData, ApiLevel.internal);
 		} else {
+			addUniqueNamedExportsToMap(exports.legacy, memberData, ApiLevel.legacy);
 			addUniqueNamedExportsToMap(exports.beta, memberData, ApiLevel.beta);
 			if (exports.alpha.length > 0) {
-				// @alpha APIs have been mapped to both /alpha and /legacy
-				// paths. Check for a /legacy export to map @alpha as legacy.
-				const legacyExport =
+				// @alpha APIs have been mapped to both /alpha and /legacy paths.
+				// Later @legacy tag was added explicitly.
+				// Check for a /alpha export to map @alpha as alpha.
+				const alphaExport =
 					this.tempSource
 						.addImportDeclaration({
-							moduleSpecifier: `${packageName}/legacy`,
+							moduleSpecifier: `${packageName}/alpha`,
 						})
 						.getModuleSpecifierSourceFile() !== undefined;
 				addUniqueNamedExportsToMap(
 					exports.alpha,
 					memberData,
-					legacyExport ? ApiLevel.legacy : ApiLevel.alpha,
+					alphaExport ? ApiLevel.alpha : ApiLevel.legacy,
 				);
 			}
 		}
@@ -685,7 +688,8 @@ async function loadData(dataFile: string, onlyInternal: boolean): Promise<MapDat
 			addUniqueNamedExportsToMap(
 				[member],
 				entry,
-				onlyInternal && (level === ApiLevel.beta || level === ApiLevel.alpha)
+				onlyInternal &&
+					(level === ApiLevel.beta || level === ApiLevel.alpha || level === ApiLevel.legacy)
 					? ApiLevel.internal
 					: level,
 			);

--- a/build-tools/packages/build-cli/src/library/apiTag.ts
+++ b/build-tools/packages/build-cli/src/library/apiTag.ts
@@ -3,6 +3,11 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * TSDoc tags, `@tag`, that are used to determine high-level API properties.
+ * Other tags like `@deprecated` or `@system` may be combined with these
+ * and adjust how use and alterations of API should be managed.
+ */
 export const ApiTag = {
 	public: "public",
 	legacy: "legacy",
@@ -20,7 +25,6 @@ const knownApiTagSet: ReadonlySet<string> = new Set(Object.keys(ApiTag));
  * @param tag - potential {@link ApiTag} string
  * @returns true when level exactly matches a known {@link ApiTag}
  */
-
 export function isKnownApiTag(tag: string): tag is ApiTag {
 	return knownApiTagSet.has(tag);
 }

--- a/build-tools/packages/build-cli/src/library/apiTag.ts
+++ b/build-tools/packages/build-cli/src/library/apiTag.ts
@@ -5,6 +5,7 @@
 
 export const ApiTag = {
 	public: "public",
+	legacy: "legacy",
 	beta: "beta",
 	alpha: "alpha",
 	internal: "internal",

--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -323,6 +323,14 @@ const generatedHeader: string = `/*!
 
 `;
 
+/**
+ * Generate "rollup" entrypoints for the given main entrypoint file.
+ *
+ * @param mainEntrypoint - path to main entrypoint file
+ * @param mapApiTagLevelToOutput - level oriented ApiTag to output file mapping
+ * @param log - logger
+ * @param separateBetaFromAlpha - if true, beta APIs will not be included in alpha outputs
+ */
 async function generateEntrypoints(
 	mainEntrypoint: string,
 	mapApiTagLevelToOutput: Map<ApiTag, ExportData>,
@@ -354,7 +362,11 @@ async function generateEntrypoints(
 	const mainSourceFile = project.addSourceFileAtPath(mainEntrypoint);
 	const exports = getApiExports(mainSourceFile);
 
-	// This order is critical as public should include beta should include alpha.
+	// This order is critical as alpha should include beta should include public.
+	// Legacy is separate and should not be included in any other level. But it
+	// may include public.
+	//   (public) -> (legacy)
+	//           `-> (beta) -> (alpha)
 	const apiTagLevels: readonly Exclude<ApiTag, typeof ApiTag.internal>[] = [
 		ApiTag.public,
 		ApiTag.legacy,

--- a/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
+++ b/build-tools/packages/build-cli/src/library/commands/generateEntrypoints.ts
@@ -28,6 +28,7 @@ const optionDefaults = {
 	outFilePrefix: "",
 	outFileAlpha: ApiLevel.alpha,
 	outFileBeta: ApiLevel.beta,
+	outFileLegacy: ApiLevel.legacy,
 	outFilePublic: ApiLevel.public,
 	outFileSuffix: ".d.ts",
 } as const;
@@ -63,6 +64,10 @@ export class GenerateEntrypointsCommand extends BaseCommand<
 		outFileBeta: Flags.string({
 			description: "Base file name for beta entrypoint declaration files.",
 			default: optionDefaults.outFileBeta,
+		}),
+		outFileLegacy: Flags.string({
+			description: "Base file name for legacy entrypoint declaration files.",
+			default: optionDefaults.outFileLegacy,
 		}),
 		outFilePublic: Flags.string({
 			description: "Base file name for public entrypoint declaration files.",
@@ -118,7 +123,18 @@ export class GenerateEntrypointsCommand extends BaseCommand<
 			);
 		}
 
-		promises.push(generateEntrypoints(mainEntrypoint, mapApiTagLevelToOutput, this.logger));
+		// In the past @alpha APIs could be mapped to /legacy via --outFileAlpha.
+		// When @alpha is mapped to /legacy, @beta should not be included in
+		// @alpha aka /legacy entrypoint.
+		const separateBetaFromAlpha = this.flags.outFileAlpha !== ApiLevel.alpha;
+		promises.push(
+			generateEntrypoints(
+				mainEntrypoint,
+				mapApiTagLevelToOutput,
+				this.logger,
+				separateBetaFromAlpha,
+			),
+		);
 
 		if (node10TypeCompat) {
 			promises.push(
@@ -198,7 +214,14 @@ function getOutputConfiguration(
 	mapApiTagLevelToOutput: Map<ApiTag, ExportData>;
 	mapNode10CompatExportPathToData: Map<string, Node10CompatExportData>;
 } {
-	const { outFileSuffix, outFileAlpha, outFileBeta, outFilePublic, node10TypeCompat } = flags;
+	const {
+		outFileSuffix,
+		outFileAlpha,
+		outFileBeta,
+		outFileLegacy,
+		outFilePublic,
+		node10TypeCompat,
+	} = flags;
 
 	const pathPrefix = getOutPathPrefix(flags, packageJson).replace(/\\/g, "/");
 
@@ -207,6 +230,15 @@ function getOutputConfiguration(
 		[`${pathPrefix}${outFileBeta}${outFileSuffix}`, ApiTag.beta],
 		[`${pathPrefix}${outFilePublic}${outFileSuffix}`, ApiTag.public],
 	]);
+
+	// In the past @alpha APIs could be mapped to /legacy via --outFileAlpha.
+	// If @alpha is not mapped to same as @legacy, then @legacy can be mapped.
+	if (outFileAlpha !== outFileLegacy) {
+		mapQueryPathToApiTagLevel.set(
+			`${pathPrefix}${outFileLegacy}${outFileSuffix}`,
+			ApiTag.legacy,
+		);
+	}
 
 	if (node10TypeCompat) {
 		// /internal export may be supported without API level generation; so
@@ -295,6 +327,7 @@ async function generateEntrypoints(
 	mainEntrypoint: string,
 	mapApiTagLevelToOutput: Map<ApiTag, ExportData>,
 	log: CommandLogger,
+	separateBetaFromAlpha: boolean,
 ): Promise<void> {
 	/**
 	 * List of out file save promises. Used to collect generated file save
@@ -324,10 +357,11 @@ async function generateEntrypoints(
 	// This order is critical as public should include beta should include alpha.
 	const apiTagLevels: readonly Exclude<ApiTag, typeof ApiTag.internal>[] = [
 		ApiTag.public,
+		ApiTag.legacy,
 		ApiTag.beta,
 		ApiTag.alpha,
 	] as const;
-	const namedExports: Omit<ExportSpecifierStructure, "kind">[] = [];
+	let commonNamedExports: Omit<ExportSpecifierStructure, "kind">[] = [];
 
 	if (exports.unknown.size > 0) {
 		log.errorLog(
@@ -345,13 +379,15 @@ async function generateEntrypoints(
 
 		// Export all unrecognized APIs preserving behavior of api-extractor roll-ups.
 		for (const name of [...exports.unknown.keys()].sort()) {
-			namedExports.push({ name, leadingTrivia: "\n\t" });
+			commonNamedExports.push({ name, leadingTrivia: "\n\t" });
 		}
-		namedExports[0].leadingTrivia = `\n\t// Unrestricted APIs\n\t`;
-		namedExports[namedExports.length - 1].trailingTrivia = "\n";
+		commonNamedExports[0].leadingTrivia = `\n\t// Unrestricted APIs\n\t`;
+		commonNamedExports[commonNamedExports.length - 1].trailingTrivia = "\n";
 	}
 
 	for (const apiTagLevel of apiTagLevels) {
+		const namedExports = [...commonNamedExports];
+
 		// Append this level's additional (or only) exports sorted by ascending case-sensitive name
 		const orgLength = namedExports.length;
 		const levelExports = [...exports[apiTagLevel]].sort((a, b) => (a.name > b.name ? 1 : -1));
@@ -361,6 +397,17 @@ async function generateEntrypoints(
 		if (namedExports.length > orgLength) {
 			namedExports[orgLength].leadingTrivia = `\n\t// @${apiTagLevel} APIs\n\t`;
 			namedExports[namedExports.length - 1].trailingTrivia = "\n";
+		}
+
+		// legacy APIs do not accumulate to others
+		if (apiTagLevel !== "legacy") {
+			// Additionally, if beta should not accumulate to alpha (alpha may be
+			// treated specially such as mapped to /legacy) then skip beta too.
+			// eslint-disable-next-line unicorn/no-lonely-if
+			if (!separateBetaFromAlpha || apiTagLevel !== "beta") {
+				// update common set
+				commonNamedExports = namedExports;
+			}
 		}
 
 		const output = mapApiTagLevelToOutput.get(apiTagLevel);

--- a/build-tools/packages/build-cli/src/library/typescriptApi.ts
+++ b/build-tools/packages/build-cli/src/library/typescriptApi.ts
@@ -6,6 +6,7 @@
 import type { ExportDeclaration, ExportedDeclarations, JSDoc, SourceFile } from "ts-morph";
 import { Node, SyntaxKind } from "ts-morph";
 
+import type { ApiLevel } from "./apiLevel.js";
 import type { ApiTag } from "./apiTag.js";
 import { isKnownApiTag } from "./apiTag.js";
 
@@ -15,6 +16,7 @@ interface ExportRecord {
 }
 interface ExportRecords {
 	public: ExportRecord[];
+	legacy: ExportRecord[];
 	beta: ExportRecord[];
 	alpha: ExportRecord[];
 	internal: ExportRecord[];
@@ -42,47 +44,71 @@ function isTypeExport(_decl: ExportedDeclarations): boolean {
 }
 
 /**
- * Searches given JSDocs for known {@link ApiTag} tag.
+ * Searches given JSDocs for known {@link ApiTag} tags.
  *
- * @returns Recognized {@link ApiTag} from JSDocs or undefined.
+ * @returns Recognized {@link ApiTag}s from JSDocs or undefined.
  */
-function getApiTagFromDocs(jsdocs: JSDoc[]): ApiTag | undefined {
+function getApiTagsFromDocs(jsdocs: JSDoc[]): ApiTag[] | undefined {
+	const tags: ApiTag[] = [];
 	for (const jsdoc of jsdocs) {
 		for (const tag of jsdoc.getTags()) {
 			const tagName = tag.getTagName();
 			if (isKnownApiTag(tagName)) {
-				return tagName;
+				tags.push(tagName);
 			}
 		}
 	}
-	return undefined;
+	return tags.length > 0 ? tags : undefined;
 }
 
 /**
- * Searches given Node's JSDocs for known {@link ApiTag} tag.
+ * Searches given Node's JSDocs for known {@link ApiTag} tags.
  *
- * @returns Recognized {@link ApiTag} from JSDocs or undefined.
+ * @returns Recognized {@link ApiTag}s from JSDocs or undefined.
  */
-function getNodeApiTag(node: Node): ApiTag | undefined {
+function getNodeApiTags(node: Node): ApiTag[] | undefined {
 	if (Node.isJSDocable(node)) {
-		return getApiTagFromDocs(node.getJsDocs());
+		return getApiTagsFromDocs(node.getJsDocs());
 	}
 
 	// Some nodes like `ExportSpecifier` are not JSDocable per ts-morph, but
 	// a JSDoc is present.
 	const jsdocChildren = node.getChildrenOfKind(SyntaxKind.JSDoc);
 	if (jsdocChildren.length > 0) {
-		return getApiTagFromDocs(jsdocChildren);
+		return getApiTagsFromDocs(jsdocChildren);
 	}
 
 	// Some nodes like `VariableDeclaration`s are not JSDocable, but an ancestor
 	// like `VariableStatement` is and may contain tag.
 	const parent = node.getParent();
 	if (parent !== undefined) {
-		return getNodeApiTag(parent);
+		return getNodeApiTags(parent);
 	}
 
 	return undefined;
+}
+
+/**
+ * Searches given Node's JSDocs for known {@link ApiTag} tags and derive export level.
+ *
+ * @returns Computed {@link ApiLevel} from JSDocs or undefined.
+ */
+function getNodeApiLevel(node: Node): ApiLevel | undefined {
+	const apiTags = getNodeApiTags(node);
+	if (apiTags === undefined) {
+		return undefined;
+	}
+	if (apiTags.includes("legacy")) {
+		return "legacy";
+	}
+	if (apiTags.length === 1) {
+		return apiTags[0];
+	}
+	throw new Error(
+		`No known level map from ${node.getSymbol()} with tags [${apiTags.join(",")}] at ${node
+			.getSourceFile()
+			.getFilePath()}:${node.getStartLineNumber()}.`,
+	);
 }
 
 /**
@@ -93,6 +119,7 @@ export function getApiExports(sourceFile: SourceFile): ExportRecords {
 	const exported = sourceFile.getExportedDeclarations();
 	const records: ExportRecords = {
 		public: [],
+		legacy: [],
 		beta: [],
 		alpha: [],
 		internal: [],
@@ -101,23 +128,23 @@ export function getApiExports(sourceFile: SourceFile): ExportRecords {
 	// We can't (don't know how to) distinguish duplication in exports
 	// from a type and a value export. We expect however that those will
 	// share the same tag. Track and throw if there are different tags.
-	const foundNameTags = new Map<string, ApiTag>();
+	const foundNameLevels = new Map<string, ApiLevel>();
 	for (const [name, exportedDecls] of exported.entries()) {
 		for (const exportedDecl of exportedDecls) {
-			const tag = getNodeApiTag(exportedDecl);
-			const existingTag = foundNameTags.get(name);
-			if (tag === undefined) {
+			const level = getNodeApiLevel(exportedDecl);
+			const existingLevel = foundNameLevels.get(name);
+			if (level === undefined) {
 				// Overloads might only have JSDocs for first of set; so ignore
 				// secondary exports without recognized tag.
-				if (existingTag === undefined) {
+				if (existingLevel === undefined) {
 					records.unknown.set(name, { exportedDecl });
 				}
-			} else if (existingTag === undefined) {
-				records[tag].push({ name, isTypeOnly: isTypeExport(exportedDecl) });
-				foundNameTags.set(name, tag);
-			} else if (tag !== existingTag) {
+			} else if (existingLevel === undefined) {
+				records[level].push({ name, isTypeOnly: isTypeExport(exportedDecl) });
+				foundNameLevels.set(name, level);
+			} else if (level !== existingLevel) {
 				throw new Error(
-					`${name} has been exported twice with different api tags.\nFirst as ${existingTag} and now as ${tag} from ${exportedDecl
+					`${name} has been exported twice with different api level.\nFirst as ${existingLevel} and now as ${level} from ${exportedDecl
 						.getSourceFile()
 						.getFilePath()}:${exportedDecl.getStartLineNumber()}.`,
 				);
@@ -154,11 +181,11 @@ export function getApiExports(sourceFile: SourceFile): ExportRecords {
 				console.log(
 					`namespace exports of the form 'export * as foo' are speculatively supported. See ${sourceFile.getFilePath()}:${namespaceDecl.getStartLineNumber()}:\n${namespaceDecl.getText()}`,
 				);
-				const namespaceTag = getNodeApiTag(exportDeclaration);
-				if (namespaceTag === undefined) {
+				const namespaceLevel = getNodeApiLevel(exportDeclaration);
+				if (namespaceLevel === undefined) {
 					unknownExported.exportDecl = exportDeclaration;
 				} else {
-					records[namespaceTag].push({ name, isTypeOnly: exportDeclaration.isTypeOnly() });
+					records[namespaceLevel].push({ name, isTypeOnly: exportDeclaration.isTypeOnly() });
 					records.unknown.delete(name);
 					if (records.unknown.size === 0) {
 						return records;
@@ -182,11 +209,11 @@ export function getApiExports(sourceFile: SourceFile): ExportRecords {
 			const name = exportSpecifier.getName();
 			const unknownExported = records.unknown.get(name);
 			if (unknownExported !== undefined) {
-				const exportTag = getNodeApiTag(exportSpecifier);
-				if (exportTag === undefined) {
+				const exportLevel = getNodeApiLevel(exportSpecifier);
+				if (exportLevel === undefined) {
 					unknownExported.exportDecl = exportDeclaration;
 				} else {
-					records[exportTag].push({
+					records[exportLevel].push({
 						name,
 						isTypeOnly: exportDeclaration.isTypeOnly() || exportSpecifier.isTypeOnly(),
 					});

--- a/build-tools/packages/build-cli/src/library/typescriptApi.ts
+++ b/build-tools/packages/build-cli/src/library/typescriptApi.ts
@@ -91,6 +91,10 @@ function getNodeApiTags(node: Node): ApiTag[] | undefined {
 /**
  * Searches given Node's JSDocs for known {@link ApiTag} tags and derive export level.
  *
+ * @remarks One of api-extractor standard tags will always be present as required by
+ * api-extractor. So, "legacy" is treated as priority over other tags for determining
+ * level. Otherwise, exactly one tag is required and will be exact level.
+ *
  * @returns Computed {@link ApiLevel} from JSDocs or undefined.
  */
 function getNodeApiLevel(node: Node): ApiLevel | undefined {


### PR DESCRIPTION
Allow an explicit `@legacy` tag restoring `@alpha` to traditional meaning and use.

### `generate entrypoints`
1. An explicit `@legacy` tagges API is candidate for `/legacy` listing.
2. When `@alpha` mapped to `/legacy` via `--outFileAlpha`, `@beta` is now properly removed from the `/legacy` listing. (`/legacy` APIs may not depend on `@beta`.)

Existing support with `@alpha` mapped to `/legacy` via `--outFileAlpha` is still supported. In this situation, `@legacy` tagged APIs are NOT mapped to `/legacy`.

### `modify fluid-imports`
1. `@legacy` tagged APIs are imported from `/legacy`.
2. `@alpha` tagged APIs are imported from `/alpha` if `/alpha` is viable and otherwise from `/legacy`.