### PR TITLE
Rename `TreeStatus.Created` to `TreeStatus.New`

### DIFF
--- a/.changeset/sharp-mangos-reply.md
+++ b/.changeset/sharp-mangos-reply.md
@@ -1,0 +1,6 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+---
+
+Breaking change: `TreeStatus.Created` has been renamed to `TreeStatus.New`

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -438,9 +438,9 @@ export type TreeObjectNodeUnsafe<T extends Unenforced<RestrictiveReadonlyRecord<
 
 // @public
 export enum TreeStatus {
-    Created = 3,
     Deleted = 2,
     InDocument = 0,
+    New = 3,
     Removed = 1
 }
 

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -435,9 +435,9 @@ export type TreeObjectNodeUnsafe<T extends Unenforced<RestrictiveReadonlyRecord<
 
 // @public
 export enum TreeStatus {
-    Created = 3,
     Deleted = 2,
     InDocument = 0,
+    New = 3,
     Removed = 1
 }
 

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -435,9 +435,9 @@ export type TreeObjectNodeUnsafe<T extends Unenforced<RestrictiveReadonlyRecord<
 
 // @public
 export enum TreeStatus {
-    Created = 3,
     Deleted = 2,
     InDocument = 0,
+    New = 3,
     Removed = 1
 }
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -135,7 +135,7 @@ export enum TreeStatus {
 	/**
 	 * Is created but has not yet been inserted into the tree.
 	 */
-	Created = 3,
+	New = 3,
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/rawNode.ts
+++ b/packages/dds/tree/src/simple-tree/rawNode.ts
@@ -92,7 +92,7 @@ export abstract class RawTreeNode<TSchema extends FlexTreeNodeSchema, TContent>
 	}
 
 	public treeStatus(): TreeStatus {
-		return TreeStatus.Created;
+		return TreeStatus.New;
 	}
 
 	public value: undefined;

--- a/packages/dds/tree/src/test/simple-tree/rawObjectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/rawObjectNode.spec.ts
@@ -61,7 +61,7 @@ describe("raw object nodes", () => {
 
 	it("allow reading tree status", () => {
 		const { rawObjectNode } = getRawObjectNode();
-		assert.equal(rawObjectNode.treeStatus(), TreeStatus.Created);
+		assert.equal(rawObjectNode.treeStatus(), TreeStatus.New);
 	});
 
 	it("disallow reading most node properties", () => {

--- a/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
@@ -639,7 +639,7 @@ describe("schemaFactory", () => {
 						unreachableCase(layout.parentType);
 				}
 				nodes.push(parent);
-				assert.equal(Tree.status(parent), TreeStatus.Created);
+				assert.equal(Tree.status(parent), TreeStatus.New);
 				return parent;
 			}
 
@@ -659,7 +659,7 @@ describe("schemaFactory", () => {
 						unreachableCase(layout.childType);
 				}
 				nodes.push(child);
-				assert.equal(Tree.status(child), TreeStatus.Created);
+				assert.equal(Tree.status(child), TreeStatus.New);
 				return child;
 			}
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -975,9 +975,9 @@ export type TreeObjectNodeUnsafe<T extends Unenforced<RestrictiveReadonlyRecord<
 
 // @public
 export enum TreeStatus {
-    Created = 3,
     Deleted = 2,
     InDocument = 0,
+    New = 3,
     Removed = 1
 }
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -600,9 +600,9 @@ export type TreeObjectNodeUnsafe<T extends Unenforced<RestrictiveReadonlyRecord<
 
 // @public
 export enum TreeStatus {
-    Created = 3,
     Deleted = 2,
     InDocument = 0,
+    New = 3,
     Removed = 1
 }
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -600,9 +600,9 @@ export type TreeObjectNodeUnsafe<T extends Unenforced<RestrictiveReadonlyRecord<
 
 // @public
 export enum TreeStatus {
-    Created = 3,
     Deleted = 2,
     InDocument = 0,
+    New = 3,
     Removed = 1
 }
 


### PR DESCRIPTION
BREAKING CHANGE:

`TreeStatus.Created` has been renamed to `TreeStatus.New`.