### PR TITLE
Avoid explicitly targeting older than default targets

### DIFF
--- a/examples/data-objects/smde/tsconfig.json
+++ b/examples/data-objects/smde/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "../../../common/build/build-common/tsconfig.node16.json",
 	"compilerOptions": {
-		"target": "es6",
 		"outDir": "./lib",
 		"types": ["react"],
 	},

--- a/packages/tools/devtools/devtools-browser-extension/tsconfig.json
+++ b/packages/tools/devtools/devtools-browser-extension/tsconfig.json
@@ -5,7 +5,6 @@
 		"outDir": "./lib/tsc",
 		"types": ["chai", "chrome", "mocha", "node"],
 		"jsx": "react-jsx",
-		"target": "es2018",
 		"forceConsistentCasingInFileNames": true,
 		"skipLibCheck": true,
 	},

--- a/packages/tools/devtools/devtools-core/tsconfig.json
+++ b/packages/tools/devtools/devtools-core/tsconfig.json
@@ -3,7 +3,6 @@
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "./lib",
-		"target": "es6",
 		"types": ["chai", "mocha"],
 	},
 	"include": ["src/**/*"],


### PR DESCRIPTION
## Description

Our default target is es2020. There is no need to explicitly target older than that.

## Breaking Changes

Devtool and build-common may now require ES 2020, just like all other client packages.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

