### PR TITLE
docs(azure-client): Update AzureUser references

### DIFF
--- a/packages/service-clients/azure-client/src/interfaces.ts
+++ b/packages/service-clients/azure-client/src/interfaces.ts
@@ -150,12 +150,13 @@ export interface AzureContainerServices {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface AzureUser<T = any> extends IUser {
 	/**
-	 * The user's name
+	 * {@inheritDoc AzureMember.name}
+	 *
 	 */
 	name: string;
 
 	/**
-	 * Custom, app-specific user information
+	 * {@inheritDoc AzureMember.additionalDetails}
 	 */
 	additionalDetails?: T;
 }
@@ -174,12 +175,12 @@ export interface AzureUser<T = any> extends IUser {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface AzureMember<T = any> extends IMember {
 	/**
-	 * {@inheritDoc AzureUser.name}
+	 * The user's name
 	 */
 	name: string;
 
 	/**
-	 * {@inheritDoc AzureUser.additionalDetails}
+	 * Custom, app-specific user information
 	 */
 	additionalDetails?: T;
 }


### PR DESCRIPTION
Change doc references for `AzureUser` as `AzureUser` is internal which prevents `@inheritDoc AzureUser...` resolution.

[AB#8135](https://dev.azure.com/fluidframework/internal/_workitems/edit/8135)