### PR TITLE
Fixes odsp single commit summaries test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -27,6 +27,7 @@ import {
 } from "@fluidframework/test-utils/internal";
 
 import { TestSnapshotCache } from "../../testSnapshotCache.js";
+
 import { supportsDataVirtualization } from "./utils.js";
 
 const interceptResult = <T>(

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -26,7 +26,7 @@ import {
 	summarizeNow,
 } from "@fluidframework/test-utils/internal";
 
-import { TestSnapshotCache } from "./testSnapshotCache.js";
+import { TestSnapshotCache } from "../../testSnapshotCache.js";
 import { supportsDataVirtualization } from "./utils.js";
 
 const interceptResult = <T>(

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
@@ -21,7 +21,7 @@ import {
 	summarizeNow,
 } from "@fluidframework/test-utils/internal";
 
-import { TestSnapshotCache } from "./testSnapshotCache.js";
+import { TestSnapshotCache } from "../../testSnapshotCache.js";
 import { clearCacheIfOdsp, supportsDataVirtualization } from "./utils.js";
 
 const interceptResult = <T>(

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
@@ -22,6 +22,7 @@ import {
 } from "@fluidframework/test-utils/internal";
 
 import { TestSnapshotCache } from "../../testSnapshotCache.js";
+
 import { clearCacheIfOdsp, supportsDataVirtualization } from "./utils.js";
 
 const interceptResult = <T>(

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
@@ -27,6 +27,7 @@ import {
 } from "@fluidframework/test-utils/internal";
 
 import { TestSnapshotCache } from "../../testSnapshotCache.js";
+
 import { clearCacheIfOdsp, supportsDataVirtualization } from "./utils.js";
 
 const interceptResult = <T>(

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/loadNewerGroupIdSnapshot.spec.ts
@@ -26,7 +26,7 @@ import {
 	summarizeNow,
 } from "@fluidframework/test-utils/internal";
 
-import { TestSnapshotCache } from "./testSnapshotCache.js";
+import { TestSnapshotCache } from "../../testSnapshotCache.js";
 import { clearCacheIfOdsp, supportsDataVirtualization } from "./utils.js";
 
 const interceptResult = <T>(

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/utils.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/utils.ts
@@ -5,7 +5,7 @@
 
 import type { ITestObjectProvider } from "@fluidframework/test-utils/internal";
 
-import type { TestSnapshotCache } from "./testSnapshotCache.js";
+import type { TestSnapshotCache } from "../../testSnapshotCache.js";
 
 export function supportsDataVirtualization(provider: ITestObjectProvider) {
 	return provider.driver.type === "local" || provider.driver.endpointName === "odsp-df";

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -622,7 +622,7 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider) => {
 	it("TelemetryContext is populated with data even if summarize fails", getTestFn(true));
 });
 
-describeCompat.only("SingleCommit Summaries Tests", "NoCompat", (getTestObjectProvider) => {
+describeCompat("SingleCommit Summaries Tests", "NoCompat", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let configForSingleCommitSummary: ITestContainerConfig;
 	const testCache = new TestSnapshotCache();

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -45,6 +45,7 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 import { SinonSandbox, createSandbox } from "sinon";
+
 import { TestSnapshotCache } from "../testSnapshotCache.js";
 
 const flushPromises = async () => new Promise((resolve) => process.nextTick(resolve));

--- a/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summaries.spec.ts
@@ -45,6 +45,7 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 import { SinonSandbox, createSandbox } from "sinon";
+import { TestSnapshotCache } from "../testSnapshotCache.js";
 
 const flushPromises = async () => new Promise((resolve) => process.nextTick(resolve));
 const testContainerConfig: ITestContainerConfig = {
@@ -621,11 +622,12 @@ describeCompat("Summaries", "NoCompat", (getTestObjectProvider) => {
 	it("TelemetryContext is populated with data even if summarize fails", getTestFn(true));
 });
 
-describeCompat("SingleCommit Summaries Tests", "NoCompat", (getTestObjectProvider) => {
+describeCompat.only("SingleCommit Summaries Tests", "NoCompat", (getTestObjectProvider) => {
 	let provider: ITestObjectProvider;
 	let configForSingleCommitSummary: ITestContainerConfig;
+	const testCache = new TestSnapshotCache();
 	beforeEach("setup", () => {
-		provider = getTestObjectProvider();
+		provider = getTestObjectProvider({ persistedCache: testCache });
 		configForSingleCommitSummary = {
 			...testContainerConfig,
 			loaderProps: {
@@ -633,6 +635,10 @@ describeCompat("SingleCommit Summaries Tests", "NoCompat", (getTestObjectProvide
 				options: { summarizeProtocolTree: true },
 			},
 		};
+	});
+
+	afterEach("cleanup", async () => {
+		testCache.reset();
 	});
 
 	it("Non single commit summary/Match last summary ackHandle with current summary parent", async function () {
@@ -783,11 +789,14 @@ describeCompat("SingleCommit Summaries Tests", "NoCompat", (getTestObjectProvide
 		);
 		summarizer.close();
 
+		testCache.clearCache();
 		const { summarizer: summarizer2 } = await createSummarizer(
 			provider,
 			mainContainer,
 			configForSingleCommitSummary,
 		);
+
+		await provider.ensureSynchronized();
 		// Second Summary
 		const result2: ISummarizeResults = summarizer2.summarizeOnDemand({ reason: "test2" });
 		const submitResult2 = await result2.summarySubmitted;
@@ -806,77 +815,93 @@ describeCompat("SingleCommit Summaries Tests", "NoCompat", (getTestObjectProvide
 		);
 	});
 
-	it("Single commit summary/Last summary should not be discarded due to missing SummaryOp", async function () {
-		if (provider.driver.type !== "odsp") {
-			this.skip();
-		}
-		const { mainContainer, summarizer } = await createMainContainerAndSummarizer(
-			provider,
-			configForSingleCommitSummary,
-		);
+	itExpects(
+		"Single commit summary/Last summary should not be discarded due to missing SummaryOp",
+		[
+			{
+				eventName: "fluid:telemetry:Summarizer:Running:SummarizeFailed",
+				error: "disconnected",
+			},
+		],
+		async function () {
+			if (provider.driver.type !== "odsp") {
+				this.skip();
+			}
+			const { mainContainer, summarizer } = await createMainContainerAndSummarizer(
+				provider,
+				configForSingleCommitSummary,
+			);
 
-		// Summarize
-		const result: ISummarizeResults = summarizer.summarizeOnDemand({ reason: "test" });
-		const submitResult = await result.summarySubmitted;
-		assert(submitResult.success, "on-demand summary should submit");
-		const broadcastResult = await result.summaryOpBroadcasted;
-		assert(broadcastResult.success, "summary op should be broadcast");
+			// Summarize
+			const result: ISummarizeResults = summarizer.summarizeOnDemand({ reason: "test" });
+			const submitResult = await result.summarySubmitted;
+			assert(submitResult.success, "on-demand summary should submit");
+			const broadcastResult = await result.summaryOpBroadcasted;
+			assert(broadcastResult.success, "summary op should be broadcast");
 
-		const ackNackResult = await result.receivedSummaryAckOrNack;
-		assert(ackNackResult.success, "summary op should be acked");
-		summarizer.close();
+			const ackNackResult = await result.receivedSummaryAckOrNack;
+			assert(ackNackResult.success, "summary op should be acked");
+			summarizer.close();
 
-		await flushPromises();
+			await flushPromises();
 
-		// Create new summarizer
-		const { summarizer: summarizer2 } = await createSummarizer(
-			provider,
-			mainContainer,
-			configForSingleCommitSummary,
-		);
+			testCache.clearCache();
+			// Create new summarizer
+			const { summarizer: summarizer2 } = await createSummarizer(
+				provider,
+				mainContainer,
+				configForSingleCommitSummary,
+			);
 
-		let summary2Handle: string | undefined;
-		// Second summary should be discarded
-		const containerRuntime = (summarizer2 as any).runtime as ContainerRuntime;
-		let uploadSummaryUploaderFunc = containerRuntime.storage.uploadSummaryWithContext;
-		const func = async (summary: ISummaryTree, context: ISummaryContext) => {
-			uploadSummaryUploaderFunc = uploadSummaryUploaderFunc.bind(containerRuntime.storage);
-			const response = await uploadSummaryUploaderFunc(summary, context);
-			summary2Handle = response;
-			// Close summarizer so that it does not submit SummaryOp
-			summarizer2.close();
-			return response;
-		};
-		containerRuntime.storage.uploadSummaryWithContext = func;
+			let summary2Handle: string | undefined;
+			// Second summary should be discarded
+			const containerRuntime = (summarizer2 as any).runtime as ContainerRuntime;
+			let uploadSummaryUploaderFunc = containerRuntime.storage.uploadSummaryWithContext;
+			const func = async (summary: ISummaryTree, context: ISummaryContext) => {
+				uploadSummaryUploaderFunc = uploadSummaryUploaderFunc.bind(
+					containerRuntime.storage,
+				);
+				const response = await uploadSummaryUploaderFunc(summary, context);
+				summary2Handle = response;
+				// Close summarizer so that it does not submit SummaryOp
+				summarizer2.close();
+				return response;
+			};
+			containerRuntime.storage.uploadSummaryWithContext = func;
 
-		const result2: ISummarizeResults = summarizer2.summarizeOnDemand({ reason: "test2" });
-		assert((await result2.summarySubmitted).success === false, "Summary should fail");
-		await flushPromises();
+			await provider.ensureSynchronized();
 
-		// Create new summarizer
-		const { summarizer: summarizer3 } = await createSummarizer(
-			provider,
-			mainContainer,
-			configForSingleCommitSummary,
-		);
+			const result2: ISummarizeResults = summarizer2.summarizeOnDemand({ reason: "test2" });
+			assert((await result2.summarySubmitted).success === false, "Summary should fail");
+			await flushPromises();
 
-		// Summarize third time
-		const result3: ISummarizeResults = summarizer3.summarizeOnDemand({
-			reason: "test3",
-		});
-		const submitResult3 = await result3.summarySubmitted;
-		assert(submitResult3.success, "on-demand summary3 should submit");
-		assert(
-			submitResult3.data.stage === "submit",
-			"on-demand summary3 submitted data stage should be submit",
-		);
+			testCache.clearCache();
+			// Create new summarizer
+			const { summarizer: summarizer3 } = await createSummarizer(
+				provider,
+				mainContainer,
+				configForSingleCommitSummary,
+			);
 
-		const broadcastResult3 = await result3.summaryOpBroadcasted;
-		assert(broadcastResult3.success, "summary op3 should be broadcast");
-		const summary3ParentHandle = broadcastResult3.data.summarizeOp.contents.head;
-		assert(
-			summary3ParentHandle === summary2Handle,
-			"Summary Parent should match handle of summary2",
-		);
-	});
+			await provider.ensureSynchronized();
+			// Summarize third time
+			const result3: ISummarizeResults = summarizer3.summarizeOnDemand({
+				reason: "test3",
+			});
+			const submitResult3 = await result3.summarySubmitted;
+			assert(submitResult3.success, "on-demand summary3 should submit");
+			assert(
+				submitResult3.data.stage === "submit",
+				"on-demand summary3 submitted data stage should be submit",
+			);
+
+			const broadcastResult3 = await result3.summaryOpBroadcasted;
+			assert(broadcastResult3.success, "summary op3 should be broadcast");
+			const summary3ParentHandle = broadcastResult3.data.summarizeOp.contents.head;
+			assert(
+				summary3ParentHandle === summary2Handle,
+				"Summary Parent should match handle of summary2",
+			);
+		},
+	);
 });

--- a/packages/test/test-end-to-end-tests/src/testSnapshotCache.ts
+++ b/packages/test/test-end-to-end-tests/src/testSnapshotCache.ts
@@ -52,6 +52,9 @@ export class TestSnapshotCache implements IPersistedCache {
 			}
 		}
 	}
+	/**
+	 * Clears the document cache, but locally still keeps the version cache to allow controlling of which cached versions to load from
+	 */
 	public clearCache(): void {
 		this.cache.clear();
 	}


### PR DESCRIPTION
Part of [AB#7929](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7929)

What is happening in these odsp tests are that summarizers are loading from older summaries in ODSP due to caching. Because of this, these summarizers will attempt to summarize and fail and update their cache. This fixes two of those tests. LatestSummaryRefSeqNum mismatch is occurring because the summarizer will receive the newer ack and thus update the running summarizer, but its state is the old state and thus we have a real mismatch.

This begs a new question, because we will catch this error earlier in the call stack, we will emit this error when it was originally a generic event.

There will be follow-up for the next tests
- "Summarizer fetches expected number of times Non-Compat Loading Summary from older version should fetch"
- "Summarizer fetches expected number of times Non-Compat Second summarizer from latest should not fetch"