### PR TITLE
Use shouldJoinWrite() to establish dirty state in serializedStateManager

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -983,7 +983,7 @@ export class Container
 			this.storageAdapter,
 			offlineLoadEnabled,
 			this,
-			() => this.isDirty,
+			() => this._deltaManager.connectionManager.shouldJoinWrite(),
 		);
 
 		const isDomAvailable =

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -983,7 +983,7 @@ export class Container
 			this.storageAdapter,
 			offlineLoadEnabled,
 			this,
-			() => !this._deltaManager.connectionManager.shouldJoinWrite(),
+			() => this._deltaManager.connectionManager.shouldJoinWrite(),
 		);
 
 		const isDomAvailable =

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -983,7 +983,7 @@ export class Container
 			this.storageAdapter,
 			offlineLoadEnabled,
 			this,
-			() => this._deltaManager.connectionManager.shouldJoinWrite(),
+			() => !this._deltaManager.connectionManager.shouldJoinWrite(),
 		);
 
 		const isDomAvailable =

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -138,6 +138,9 @@ export class PendingStateManager implements IDisposable {
 			this.initialMessages.isEmpty(),
 			0x2e9 /* "Must call getLocalState() after applying initial states" */,
 		);
+		// Using snapshot sequence number to filter ops older than our latest snapshot.
+		// Such ops should not be declared in pending/stashed state. Snapshot seq num will not
+		// be available when the container is not attached. Therefore, no filtering is needed.
 		const newSavedOps = [...this.savedOps].filter((message) => {
 			assert(
 				message.sequenceNumber !== undefined,


### PR DESCRIPTION
This is a follow up of PR https://github.com/microsoft/FluidFramework/pull/20846.

- Some ops are excluded from "dirty" calculation. Broadening the definition of "safe" to be !ConnectionManager.shouldJoinWrite().
- Add clarification comment while filtering ops on pendingStateManager.getLocalState(). 
