### PR TITLE
Remove unused fluidErrorCode from LoggingError

### DIFF
--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -401,13 +401,6 @@ export class LoggingError
 	}
 
 	/**
-	 * Backwards compatibility to appease {@link isFluidError} in old code that may handle this error.
-	 */
-	// @ts-expect-error - This field shouldn't be referenced in the current version, but needs to exist at runtime.
-	// eslint-disable-next-line @typescript-eslint/prefer-as-const
-	private readonly fluidErrorCode: "-" = "-";
-
-	/**
 	 * Create a new LoggingError
 	 * @param message - Error message to use for Error base class
 	 * @param props - telemetry props to include on the error for when it's logged

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -1167,9 +1167,5 @@ describe("Error Discovery", () => {
 			"Valid Fluid Error with errorInstanceId removed is not a Fluid Error",
 		);
 		assert(isFluidError(createTestError("hello")), "Valid Fluid Error is a Fluid Error");
-		assert(
-			isFluidError(Object.assign(createTestError("hello"), { fluidErrorCode: undefined })),
-			"isFluidError should not require fluidErrorCode",
-		);
 	});
 });


### PR DESCRIPTION
## Description

This property hasn't been used since before 1.0, yet it shows up in the logs and can be confusing.