### PR TITLE
Remove defunct isValidLegacyError helper

### DIFF
--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -137,6 +137,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedFunctionDeclaration_isValidLegacyError": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -7,12 +7,7 @@ import type { ITelemetryBaseProperties, Tagged } from "@fluidframework/core-inte
 import type { ILoggingError } from "@fluidframework/core-interfaces/internal";
 import { v4 as uuid } from "uuid";
 
-import {
-	IFluidErrorBase,
-	hasErrorInstanceId,
-	isFluidError,
-	isValidLegacyError,
-} from "./fluidErrorBase.js";
+import { IFluidErrorBase, hasErrorInstanceId, isFluidError } from "./fluidErrorBase.js";
 import { convertToBasePropertyType } from "./logger.js";
 import type {
 	ITelemetryLoggerExt,
@@ -112,19 +107,6 @@ export interface IFluidErrorAnnotations {
 }
 
 /**
- * For backwards compatibility with pre-errorInstanceId valid errors
- */
-function patchLegacyError(
-	legacyError: Omit<IFluidErrorBase, "errorInstanceId">,
-): asserts legacyError is IFluidErrorBase {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
-	const patchMe: { -readonly [P in "errorInstanceId"]?: IFluidErrorBase[P] } = legacyError as any;
-	if (patchMe.errorInstanceId === undefined) {
-		patchMe.errorInstanceId = uuid();
-	}
-}
-
-/**
  * Normalize the given error yielding a valid Fluid Error
  * @returns A valid Fluid Error with any provided annotations applied
  * @param error - The error to normalize
@@ -136,11 +118,6 @@ export function normalizeError(
 	error: unknown,
 	annotations: IFluidErrorAnnotations = {},
 ): IFluidErrorBase {
-	// Back-compat, while IFluidErrorBase is rolled out
-	if (isValidLegacyError(error)) {
-		patchLegacyError(error);
-	}
-
 	if (isFluidError(error)) {
 		// We can simply add the telemetry props to the error and return it
 		error.addTelemetryProperties(annotations.props ?? {});
@@ -339,7 +316,7 @@ export function isExternalError(error: unknown): boolean {
 		}
 		return false;
 	}
-	return !isValidLegacyError(error);
+	return true;
 }
 
 /**

--- a/packages/utils/telemetry-utils/src/fluidErrorBase.ts
+++ b/packages/utils/telemetry-utils/src/fluidErrorBase.ts
@@ -96,18 +96,3 @@ export function isFluidError(error: unknown): error is IFluidErrorBase {
 		hasTelemetryPropFunctions(error)
 	);
 }
-
-/**
- * Type guard for old standard of valid/known errors.
- *
- * @internal
- */
-export function isValidLegacyError(
-	error: unknown,
-): error is Omit<IFluidErrorBase, "errorInstanceId"> {
-	return (
-		typeof (error as Partial<IFluidErrorBase>)?.errorType === "string" &&
-		typeof (error as Partial<IFluidErrorBase>)?.message === "string" &&
-		hasTelemetryPropFunctions(error)
-	);
-}

--- a/packages/utils/telemetry-utils/src/index.ts
+++ b/packages/utils/telemetry-utils/src/index.ts
@@ -43,12 +43,7 @@ export {
 	raiseConnectedEvent,
 	safeRaiseEvent,
 } from "./events.js";
-export {
-	hasErrorInstanceId,
-	IFluidErrorBase,
-	isFluidError,
-	isValidLegacyError,
-} from "./fluidErrorBase.js";
+export { hasErrorInstanceId, IFluidErrorBase, isFluidError } from "./fluidErrorBase.js";
 export {
 	eventNamespaceSeparator,
 	createChildLogger,

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -695,32 +695,6 @@ describe("normalizeError", () => {
 	describe("Valid Errors (Legacy and Current)", () => {
 		for (const annotationCase of Object.keys(annotationCases)) {
 			const annotations = annotationCases[annotationCase];
-			it(`Valid legacy error - Patch and return (annotations: ${annotationCase})`, () => {
-				// Arrange
-				const errorProps = { errorType: "et1", message: "m1" };
-				const legacyError = new TestFluidError(errorProps).withoutProperty(
-					"errorInstanceId",
-				);
-
-				// Act
-				const normalizedError = normalizeError(legacyError, annotations);
-
-				// Assert
-				assert.equal(
-					normalizedError,
-					legacyError,
-					"normalize should yield the same error as passed in",
-				);
-				assert.equal(normalizedError.errorType, "et1", "errorType should be unchanged");
-				assert.equal(normalizedError.message, "m1", "message should be unchanged");
-				assert.equal(normalizedError.errorInstanceId.length, 36, "should be guid-length");
-				if (annotations.props !== undefined) {
-					assert(
-						legacyError.atpStub.calledWith(annotations.props),
-						"addTelemetryProperties should have been called",
-					);
-				}
-			});
 			it(`Valid Fluid Error - untouched (annotations: ${annotationCase})`, () => {
 				// Arrange
 				const fluidError = new TestFluidError({ errorType: "et1", message: "m1" });
@@ -746,7 +720,7 @@ describe("normalizeError", () => {
 				errorType: "et1",
 				message: "m1",
 			}).withoutProperty("stack");
-			// We don't expect legacyError to be modified itself at all
+			// We don't expect fluidError to be modified itself at all
 			Object.freeze(fluidError);
 
 			// Act
@@ -755,18 +729,6 @@ describe("normalizeError", () => {
 			// Assert
 			assert(normalizedError === fluidError);
 			assert(normalizedError.stack === undefined);
-		});
-		it("Frozen legacy error - Throws", () => {
-			// Arrange
-			const errorProps = { errorType: "et1", message: "m1" };
-			const legacyError = new TestFluidError(errorProps).withoutProperty("errorInstanceId");
-			Object.freeze(legacyError);
-
-			// Act/Assert
-			assert.throws(
-				() => normalizeError(legacyError, {}),
-				/Cannot assign to read only property/,
-			);
 		});
 	});
 	describe("Errors Needing Normalization", () => {

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -30,12 +30,7 @@ import {
 	wrapError,
 	wrapErrorAndLog,
 } from "../errorLogging.js";
-import {
-	IFluidErrorBase,
-	hasErrorInstanceId,
-	isFluidError,
-	isValidLegacyError,
-} from "../fluidErrorBase.js";
+import { IFluidErrorBase, hasErrorInstanceId, isFluidError } from "../fluidErrorBase.js";
 import { TaggedLoggerAdapter, TelemetryDataTag, TelemetryLogger } from "../logger.js";
 import { MockLogger } from "../mockLogger.js";
 import type { ITelemetryPropertiesExt } from "../telemetryTypes.js";
@@ -1127,28 +1122,6 @@ describe("Error Discovery", () => {
 		assert(!isExternalError(wrappedError));
 		assert(wrappedError.getTelemetryProperties().untrustedOrigin === 1); // But it should still say untrustedOrigin
 		assert(!isExternalError(new LoggingError("testLoggingError")));
-	});
-	it("isValidLegacyError", () => {
-		const validLegacyError = {
-			message: "testMessage",
-			errorType: "someErrorType",
-			getTelemetryProperties: (): void => {},
-			addTelemetryProperties: (): void => {},
-		};
-		assert.strictEqual(isValidLegacyError(validLegacyError), true);
-		assert.strictEqual(isValidLegacyError({ ...validLegacyError, message: undefined }), false);
-		assert.strictEqual(
-			isValidLegacyError({ ...validLegacyError, errorType: undefined }),
-			false,
-		);
-		assert.strictEqual(
-			isValidLegacyError({ ...validLegacyError, getTelemetryProperties: undefined }),
-			false,
-		);
-		assert.strictEqual(
-			isValidLegacyError({ ...validLegacyError, addTelemetryProperties: undefined }),
-			false,
-		);
 	});
 
 	// I copied the old version of isFluidError here, it depends on fluidErrorCode.

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
@@ -1474,28 +1474,16 @@ use_old_FunctionDeclaration_isTaggedTelemetryPropertyValue(
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "FunctionDeclaration_isValidLegacyError": {"forwardCompat": false}
+ * "RemovedFunctionDeclaration_isValidLegacyError": {"forwardCompat": false}
  */
-declare function get_old_FunctionDeclaration_isValidLegacyError():
-    TypeOnly<typeof old.isValidLegacyError>;
-declare function use_current_FunctionDeclaration_isValidLegacyError(
-    use: TypeOnly<typeof current.isValidLegacyError>): void;
-use_current_FunctionDeclaration_isValidLegacyError(
-    get_old_FunctionDeclaration_isValidLegacyError());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "FunctionDeclaration_isValidLegacyError": {"backCompat": false}
+ * "RemovedFunctionDeclaration_isValidLegacyError": {"backCompat": false}
  */
-declare function get_current_FunctionDeclaration_isValidLegacyError():
-    TypeOnly<typeof current.isValidLegacyError>;
-declare function use_old_FunctionDeclaration_isValidLegacyError(
-    use: TypeOnly<typeof old.isValidLegacyError>): void;
-use_old_FunctionDeclaration_isValidLegacyError(
-    get_current_FunctionDeclaration_isValidLegacyError());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.


### PR DESCRIPTION
## Description

This was added 3 years ago to cover a change in error format across loader/runtime compat layers.  Errors even in 1.0 are more recent than this and don't need this helper, so we can certainly remove it.