### PR TITLE
Prototype for binary signal support

### DIFF
--- a/packages/common/driver-definitions/api-report/driver-definitions.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.api.md
@@ -127,6 +127,7 @@ export interface IDocumentDeltaConnection extends IDisposable, IEventProvider<ID
     serviceConfiguration: IClientConfiguration;
     submit(messages: IDocumentMessage[]): void;
     submitSignal: (content: string, targetClientId?: string) => void;
+    submitSignal2?: (content: unknown, targetClientId?: string) => void;
     version: string;
 }
 

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -314,11 +314,15 @@ export interface IDocumentDeltaConnection
 
 	/**
 	 * Submits a new signal to the server
-	 *
-	 * @privateRemarks
-	 * UnknownShouldBe<string> can be string if {@link IDocumentServiceFactory} becomes internal.
 	 */
 	submitSignal: (content: string, targetClientId?: string) => void;
+
+	/**
+	 * Submits a new signal to the server
+	 * Content is a JS object. It may container properties of type ArrayBuffer.
+	 * Other than such properties, the content should be serializable using JSON.serialize().
+	 */
+	submitSignal2?: (content: unknown, targetClientId?: string) => void;
 }
 
 /**

--- a/packages/drivers/local-driver/api-report/local-driver.api.md
+++ b/packages/drivers/local-driver/api-report/local-driver.api.md
@@ -60,7 +60,9 @@ export class LocalDocumentDeltaConnection extends DocumentDeltaConnection {
     disconnectClient(disconnectReason: string): void;
     nackClient(code: number | undefined, type: NackErrorType | undefined, message: any): void;
     submit(messages: IDocumentMessage[]): void;
-    submitSignal(message: string): void;
+    submitSignal(content: string): void;
+    // (undocumented)
+    submitSignal2(content: unknown): void;
 }
 
 // @internal

--- a/packages/drivers/local-driver/package.json
+++ b/packages/drivers/local-driver/package.json
@@ -147,6 +147,10 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_LocalDocumentDeltaConnection": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/drivers/local-driver/src/test/types/validateLocalDriverPrevious.generated.ts
+++ b/packages/drivers/local-driver/src/test/types/validateLocalDriverPrevious.generated.ts
@@ -63,6 +63,7 @@ declare function get_old_ClassDeclaration_LocalDocumentDeltaConnection():
 declare function use_current_ClassDeclaration_LocalDocumentDeltaConnection(
     use: TypeOnly<current.LocalDocumentDeltaConnection>): void;
 use_current_ClassDeclaration_LocalDocumentDeltaConnection(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_LocalDocumentDeltaConnection());
 
 /*

--- a/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
+++ b/packages/drivers/routerlicious-driver/src/documentDeltaConnection.ts
@@ -9,6 +9,7 @@ import {
 	IAnyDriverError,
 } from "@fluidframework/driver-definitions/internal";
 import { IClient, IConnect } from "@fluidframework/protocol-definitions";
+import { encodeJsonableOrBinary } from "@fluidframework/driver-utils/internal";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import type { io as SocketIOClientStatic } from "socket.io-client";
 
@@ -64,6 +65,27 @@ export class R11sDocumentDeltaConnection extends DocumentDeltaConnection {
 
 		await deltaConnection.initialize(connectMessage, timeoutMs);
 		return deltaConnection;
+	}
+
+	public submitSignal2(content: unknown): void {
+		// WARNING:
+		// This code here is only for demonstration purposes. While driver can do encoding here,
+		// it would need to do symmetrical decoding for "signal" event payloads, as well as this.initialSignals
+		// From efficiency POV, it does not make sense to implement this method if protocol does not support property
+		// binary payloads.
+		// There are two ways to accomplish it:
+		// 1. Leave it as is at socket.io level - it can transfer mixes (JS + binary) messages just fine. On service side,
+		//    likely would need to serialize it into binary blob and pass around binary. Maybe doing encodeJsonableOrBinary
+		//    on service side is fine (saves bandwidth as we do not waste +33% overhead of base64 encoding), but this makes
+		//    service side less efficient (compared if service does some more efficient binary serialization)
+		// 2. Serialize into binary here (in driver), and deserialize back on receiving signals, but service and socket.io
+		//    works only with binary payloads. Likely most efficient, as avoids extra serialization - deserialization at
+		//    socket.io level.
+		// The only reason it works as is - ConnectionManager will do decodeJsonableOrBinary() if it gets a string payload.
+		// But this is wrong, as we should not have any assumptions going across layers on what kind of serialization format
+		// is used - both serialization / deserialization should happen on one layer! (it's Ok to temporarily break this rule
+		//  for staging purpose only)
+		super.submitSignal(encodeJsonableOrBinary(content));
 	}
 
 	/**

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -2329,9 +2329,8 @@ export class Container
 		this.emit("op", message);
 	}
 
-	// unknown should be removed once `@alpha` tag is removed from IContainerContext
-	private submitSignal(content: unknown | ISignalEnvelope, targetClientId?: string) {
-		this._deltaManager.submitSignal(JSON.stringify(content), targetClientId);
+	private submitSignal(content: unknown, targetClientId?: string) {
+		this._deltaManager.submitSignal(content, targetClientId);
 	}
 
 	private processSignal(message: ISignalMessage) {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -35,7 +35,6 @@ import {
 	ITelemetryBaseProperties,
 	LogLevel,
 } from "@fluidframework/core-interfaces";
-import { type ISignalEnvelope } from "@fluidframework/core-interfaces/internal";
 import { assert, isPromiseLike, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
 	IDocumentService,

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -100,7 +100,7 @@ export interface IConnectionManager {
 	 * Submits signal to relay service.
 	 * Called only when active connection is present.
 	 */
-	submitSignal: (content: string, targetClientId?: string) => void;
+	submitSignal: (content: unknown, targetClientId?: string) => void;
 
 	/**
 	 * Submits messages to relay service.

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -136,7 +136,7 @@ export interface IConnectionManagerFactoryArgs {
 	 * Called by connection manager for each incoming signal.
 	 * May be called before connectHandler is called (due to initial signals on socket connection)
 	 */
-	readonly signalHandler: (signals: ISignalMessage[]) => void;
+	readonly signalHandler: (signal: ISignalMessage) => void;
 
 	/**
 	 * Called when connection manager experiences delay in connecting to relay service.

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -428,11 +428,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 					this.close(normalizeError(error));
 				}
 			},
-			signalHandler: (signals: ISignalMessage[]) => {
-				for (const signal of signals) {
-					this._inboundSignal.push(signal);
-				}
-			},
+			signalHandler: (signal: ISignalMessage) => this._inboundSignal.push(signal),
 			reconnectionDelayHandler: (delayMs: number, error: unknown) =>
 				this.emitDelayInfo(this.deltaStreamDelayId, delayMs, error),
 			closeHandler: (error: any) => this.close(error),
@@ -477,7 +473,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			}
 			this.handler.processSignal({
 				clientId: message.clientId,
-				content: JSON.parse(message.content as string),
+				content: message.content,
 			});
 		});
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -329,7 +329,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		return message.clientSequenceNumber;
 	}
 
-	public submitSignal(content: string, targetClientId?: string) {
+	public submitSignal(content: unknown, targetClientId?: string) {
 		return this.connectionManager.submitSignal(content, targetClientId);
 	}
 

--- a/packages/loader/driver-utils/api-report/driver-utils.api.md
+++ b/packages/loader/driver-utils/api-report/driver-utils.api.md
@@ -121,6 +121,9 @@ export function createGenericNetworkError(message: string, retryInfo: {
 // @internal (undocumented)
 export const createWriteError: (message: string, props: DriverErrorTelemetryProps) => NonRetryableError<"writeError">;
 
+// @internal
+export function decodeJsonableOrBinary(content: string): unknown;
+
 // @internal (undocumented)
 export class DeltaStreamConnectionForbiddenError extends LoggingError implements IDriverErrorBase, IFluidErrorBase {
     constructor(message: string, props: DriverErrorTelemetryProps, storageOnlyReason?: string);
@@ -165,6 +168,9 @@ export type DriverErrorTelemetryProps = ITelemetryBaseProperties & {
 
 // @internal (undocumented)
 export const emptyMessageStream: IStream<ISequencedDocumentMessage[]>;
+
+// @internal
+export function encodeJsonableOrBinary<T>(content: unknown): string;
 
 // @internal
 export class FluidInvalidSchemaError extends LoggingError implements IDriverErrorBase, IFluidErrorBase {

--- a/packages/loader/driver-utils/src/binaryEncoding.ts
+++ b/packages/loader/driver-utils/src/binaryEncoding.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { JsonableOrBinary, Jsonable } from "@fluidframework/core-interfaces/internal";
 import { Uint8ArrayToString, stringToBuffer } from "@fluid-internal/client-utils";
 
 const binaryType = "__fluid_binary__";
@@ -14,8 +13,8 @@ const binaryType = "__fluid_binary__";
  * @returns string
  * @internal
  */
-export function encodeJsonableOrBinary<T>(content: JsonableOrBinary<T>): string {
-	return JSON.stringify(content, (_key: string, value: JsonableOrBinary<T>) => {
+export function encodeJsonableOrBinary<T>(content: unknown): string {
+	return JSON.stringify(content, (_key: string, value: unknown) => {
 		if (value instanceof ArrayBuffer) {
 			return {
 				type: binaryType,
@@ -33,11 +32,11 @@ export function encodeJsonableOrBinary<T>(content: JsonableOrBinary<T>): string 
  * @returns decoded JS object
  * @internal
  */
-export function decodeJsonableOrBinary(content: string): JsonableOrBinary {
-	return JSON.parse(content, (_key: string, value: Jsonable) => {
+export function decodeJsonableOrBinary(content: string): unknown {
+	return JSON.parse(content, (_key: string, value: unknown) => {
 		if (value !== null && (value as any).type === binaryType) {
 			return stringToBuffer((value as any).content, "base64");
 		}
 		return value;
-	}) as JsonableOrBinary;
+	}) as unknown;
 }

--- a/packages/loader/driver-utils/src/binaryEncoding.ts
+++ b/packages/loader/driver-utils/src/binaryEncoding.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { JsonableOrBinary, Jsonable } from "@fluidframework/core-interfaces/internal";
+import { Uint8ArrayToString, stringToBuffer } from "@fluid-internal/client-utils";
+
+const binaryType = "__fluid_binary__";
+
+/**
+ * Encodes JsonableOrBinary into a string
+ * @param content - content to stringify
+ * @returns string
+ * @internal
+ */
+export function encodeJsonableOrBinary<T>(content: JsonableOrBinary<T>): string {
+	return JSON.stringify(content, (_key: string, value: JsonableOrBinary<T>) => {
+		if (value instanceof ArrayBuffer) {
+			return {
+				type: binaryType,
+				content: Uint8ArrayToString(new Uint8Array(value), "base64"),
+			};
+		}
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return value;
+	});
+}
+
+/**
+ * Decodes string back to JsonableOrBinary
+ * @param content - an encoded string
+ * @returns decoded JS object
+ * @internal
+ */
+export function decodeJsonableOrBinary(content: string): JsonableOrBinary {
+	return JSON.parse(content, (_key: string, value: Jsonable) => {
+		if (value !== null && (value as any).type === binaryType) {
+			return stringToBuffer((value as any).content, "base64");
+		}
+		return value;
+	}) as JsonableOrBinary;
+}

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -55,3 +55,4 @@ export {
 	blobHeadersBlobName,
 } from "./adapters/index.js";
 export { getSnapshotTree, isInstanceOfISnapshot } from "./storageUtils.js";
+export { encodeJsonableOrBinary, decodeJsonableOrBinary } from "./binaryEncoding.js";

--- a/packages/loader/driver-utils/src/test/binaryEncoding.spec.ts
+++ b/packages/loader/driver-utils/src/test/binaryEncoding.spec.ts
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import type { JsonableOrBinary, Jsonable } from "@fluidframework/core-interfaces/internal";
+import { encodeJsonableOrBinary, decodeJsonableOrBinary } from "../binaryEncoding.js";
+
+describe("Binary encoding", () => {
+	function testSameAsJson(content: Jsonable) {
+		const res = JSON.stringify(content);
+		const res2 = encodeJsonableOrBinary(content);
+		assert(res === res2, "not same as JSON.stringify");
+		if (res !== undefined) {
+			assert.deepEqual(
+				JSON.parse(res),
+				decodeJsonableOrBinary(res),
+				"not same as JSON.parse",
+			);
+		}
+	}
+
+	it("test no binary", () => {
+		testSameAsJson(undefined);
+		testSameAsJson(null);
+		testSameAsJson({});
+		testSameAsJson({ a: "test", b: 5 });
+		testSameAsJson({ a: "test", b: { c: "test", d: undefined, e: [5, 6, undefined] } });
+	});
+
+	function testBinaryRoundtrip(content: JsonableOrBinary) {
+		const res = encodeJsonableOrBinary(content);
+		const content2 = decodeJsonableOrBinary(res);
+
+		// This will not compare contents of arrays, only their presence!
+		assert.deepEqual(content, content2);
+		assert(res === encodeJsonableOrBinary(content2));
+	}
+
+	it("test binary conversions", () => {
+		const arr = new Uint8Array([5, 6, 7, 100]);
+		testBinaryRoundtrip({ a: 5, arr: arr.buffer, c: { x: arr.buffer } });
+	});
+});

--- a/packages/loader/driver-utils/src/test/binaryEncoding.spec.ts
+++ b/packages/loader/driver-utils/src/test/binaryEncoding.spec.ts
@@ -4,11 +4,11 @@
  */
 
 import { strict as assert } from "assert";
-import type { JsonableOrBinary, Jsonable } from "@fluidframework/core-interfaces/internal";
+
 import { encodeJsonableOrBinary, decodeJsonableOrBinary } from "../binaryEncoding.js";
 
 describe("Binary encoding", () => {
-	function testSameAsJson(content: Jsonable) {
+	function testSameAsJson(content: unknown) {
 		const res = JSON.stringify(content);
 		const res2 = encodeJsonableOrBinary(content);
 		assert(res === res2, "not same as JSON.stringify");
@@ -29,7 +29,7 @@ describe("Binary encoding", () => {
 		testSameAsJson({ a: "test", b: { c: "test", d: undefined, e: [5, 6, undefined] } });
 	});
 
-	function testBinaryRoundtrip(content: JsonableOrBinary) {
+	function testBinaryRoundtrip(content: unknown) {
 		const res = encodeJsonableOrBinary(content);
 		const content2 = decodeJsonableOrBinary(res);
 


### PR DESCRIPTION
DO NOT MERGE

This is stand-alone PR that demonstrates ability to add binary payloads to signals.
1. A new submitSignal2 method is added that receives payload that could contain ArrayBuffer properties, but with exception of such properties, it is jsonable payload (i.e. could be serialized using JSON.stringify).
2. Driver implementing such API is responsible can either send it on the wire as is (more on socket.io support later) or encode it all as one binary or text payload.
3. Driver is supposed to decode content (on receiving) into exactly same structure. If it's a string, we assume it's either plain JSON, or content encoded with encodeJsonableOrBinary(), and thus loader will leverage decodeJsonableOrBinary() to decode it.
4. Local driver change is made to support binary payloads, and new workflow. Even though none of our E22 tests implement binary payloads, it tests new responsibility of driver to own encoding.
   - TBD: add actual E2E test with binary payloads to ensure whole pipeline works as expected.

What is required from service:
- Implement proper binary support, in a form that appropriate driver implements.
   - If sample R11S driver change is used, appropriate service needs to support mixes payloads.

For more info about binary support by socket.io, please consult the following resources:
1. https://socket.io/blog/introducing-socket-io-1-0/#binary-support talks about mixing buffers with other content in same message
2. https://socket.io/how-to/upload-a-file, https://socket.io/docs/v4/socket-io-protocol/ is interesting to consult, as it sounds like payload is split into text & binary frames, and thus there could be some penalty for mixing content.
6. It is worth reading through https://blog.cantremember.com/optimizing-socketio-performance-with-binary-mode, as it feels like they are solving similar problems that our clients are hitting.

Other related PRs
- https://github.com/microsoft/FluidFramework/pull/20954
- https://github.com/microsoft/FluidFramework/pull/20953
- https://github.com/microsoft/FluidFramework/pull/20956
