### PR TITLE
Remove testing of unsupported scenarios

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -93,9 +93,6 @@ stages:
             flags: --compatVersion=LTS
           - name: Cross-version
             flags: --compatVersion=CROSS_VERSION
-          # Assumes Non-compat and N-1 scenarios are covered
-          - name: N-2ToLTS+1-back-compat
-            flags: --compatVersion=FULL
         env:
           fluid__test__driver__r11s: $(automation-fluid-test-driver-r11s)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
@@ -126,9 +123,6 @@ stages:
             flags: --compatVersion=LTS
           - name: Cross-Version
             flags: --compatVersion=CROSS_VERSION
-          # Assumes Non-compat and N-1 scenarios are covered
-          - name: N-2ToLTS+1-back-compat
-            flags: --compatVersion=FULL
         env:
           fluid__test__driver__frs: $(automation-fluid-test-driver-frs)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject


### PR DESCRIPTION
[AB#8163](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8163)

Reduce e2e pipeline duration for FRS and routerlicious testing (although it may not have an impact as odsp lock tests still will take the longest).