### PR TITLE
fix(tree): only restore sequence cell IDs on rollbacks

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -607,10 +607,7 @@ describe("ModularChangeFamily integration", () => {
 			};
 
 			const fieldBExpected = [
-				MarkMaker.moveOut(1, brand(2), {
-					changes: nodeId2,
-					idOverride: { revision: tag1, localId: brand(3) },
-				}),
+				MarkMaker.moveOut(1, brand(2), { changes: nodeId2 }),
 				{ count: 1 },
 				MarkMaker.returnTo(1, brand(2), { revision: tag1, localId: brand(2) }),
 			];
@@ -623,10 +620,7 @@ describe("ModularChangeFamily integration", () => {
 			};
 
 			const fieldAExpected = [
-				MarkMaker.moveOut(1, brand(0), {
-					changes: nodeId1,
-					idOverride: { revision: tag1, localId: brand(1) },
-				}),
+				MarkMaker.moveOut(1, brand(0), { changes: nodeId1 }),
 				{ count: 1 },
 				MarkMaker.returnTo(1, brand(0), { revision: tag1, localId: brand(0) }),
 			];

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
@@ -285,6 +285,16 @@ export function testRebaserAxioms() {
 			}
 		});
 
+		// Hand-crafted version of the above tests to add coverage for returns
+		it("Return ↷ [Return, Return⁻¹] === Return", () => {
+			const move: SF.Changeset = Mark.move(1, { revision: tag0, localId: brand(0) });
+			const r: SF.Changeset = invert(tagChange(move, tag0), false);
+			const base1 = tagChange(r, tag1);
+			const base2 = tagChange(invert(base1, true), tag2);
+			const actual = rebaseOverChanges(tagChange(r, tag3), [base1, base2]);
+			assertChangesetsEqual(withoutTombstones(actual.change), r);
+		});
+
 		/**
 		 * This test simulates rebasing over an do-undo pair.
 		 * It is different from the above in two ways:

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -295,13 +295,13 @@ export function invertDeep(change: TaggedChange<WrappedChange>): WrappedChange {
 	return ChangesetWrapper.invert(change, (c) => invert(c));
 }
 
-export function invert(change: TaggedChange<SF.Changeset>): SF.Changeset {
+export function invert(change: TaggedChange<SF.Changeset>, isRollback = true): SF.Changeset {
 	deepFreeze(change.change);
 	const table = SF.newCrossFieldTable();
 	const revisionMetadata = defaultRevisionMetadataFromChanges([change]);
 	let inverted = SF.invert(
 		change.change,
-		true,
+		isRollback,
 		// Sequence fields should not generate IDs during invert
 		fakeIdAllocator,
 		table,
@@ -314,7 +314,7 @@ export function invert(change: TaggedChange<SF.Changeset>): SF.Changeset {
 		table.dstQueries.clear();
 		inverted = SF.invert(
 			change.change,
-			true,
+			isRollback,
 			// Sequence fields should not generate IDs during invert
 			fakeIdAllocator,
 			table,


### PR DESCRIPTION
## Description

Changes the implementation of `invert` for sequence field such that detaches only restore the original cell ID with a detach ID override (from before the attach) when performing rollbacks.

Doing so for non-rollback inverses can lead to bugs:
- A detach with a detach ID override may be rebased over a move on the detached content, which would then assign the cell ID to the wrong cell (i.e., the destination cell).
- A detach with a detach ID override may lose the override if it gets rebased over a move of the detached content that effectively converts the detach into a pin. If that pin is then further rebased over a move of the pinned content, the pin will transform into a detach once the again but without the detach ID override. This is problematic because it makes rebasing the original detach over the two operations produce a different result than rebasing over the composition of these two operations (which would not lose the detach ID override). This can lead peers to diverge in their interpretation of what the cell ID really is, which can then lead to bugs/crashes.

## Breaking Changes

None