### PR TITLE
fix(devtools): Fixed bug causing multiple focuses on Audience tables

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
@@ -8,7 +8,6 @@ import {
 	TableBody,
 	TableCell,
 	TableHeader,
-	TableHeaderCell,
 	TableRow,
 	makeStyles,
 	tokens,
@@ -80,7 +79,7 @@ export function AudienceHistoryTable(props: AudienceHistoryTableProps): React.Re
 			<TableHeader>
 				<TableRow>
 					{audienceHistoryColumns.map((column, columnIndex) => (
-						<TableHeaderCell key={columnIndex}>
+						<TableCell key={columnIndex}>
 							{column.columnKey === "event" && (
 								<LabelCellLayout icon={<DoorArrowLeftRegular />}>
 									{column.label}
@@ -100,7 +99,7 @@ export function AudienceHistoryTable(props: AudienceHistoryTableProps): React.Re
 									{column.label}
 								</LabelCellLayout>
 							)}
-						</TableHeaderCell>
+						</TableCell>
 					))}
 				</TableRow>
 			</TableHeader>

--- a/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
@@ -79,6 +79,7 @@ export function AudienceHistoryTable(props: AudienceHistoryTableProps): React.Re
 			<TableHeader>
 				<TableRow>
 					{audienceHistoryColumns.map((column, columnIndex) => (
+						// TODO: Replace TableCell with TableHeaderCell once https://github.com/microsoft/fluentui/issues/31588 is fixed.
 						<TableCell key={columnIndex}>
 							{column.columnKey === "event" && (
 								<LabelCellLayout icon={<DoorArrowLeftRegular />}>

--- a/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
@@ -8,7 +8,6 @@ import {
 	TableBody,
 	TableCell,
 	TableHeader,
-	TableHeaderCell,
 	TableRow,
 	makeStyles,
 	tokens,
@@ -76,7 +75,7 @@ export function AudienceStateTable(props: AudienceStateTableProps): React.ReactE
 			<TableHeader>
 				<TableRow>
 					{audienceStateColumns.map((column, columnIndex) => (
-						<TableHeaderCell key={columnIndex}>
+						<TableCell key={columnIndex}>
 							{column.columnKey === "clientId" && (
 								<LabelCellLayout
 									icon={<Person12Regular />}
@@ -109,7 +108,7 @@ export function AudienceStateTable(props: AudienceStateTableProps): React.ReactE
 									{column.label}
 								</LabelCellLayout>
 							)}
-						</TableHeaderCell>
+						</TableCell>
 					))}
 				</TableRow>
 			</TableHeader>

--- a/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
@@ -75,6 +75,7 @@ export function AudienceStateTable(props: AudienceStateTableProps): React.ReactE
 			<TableHeader>
 				<TableRow>
 					{audienceStateColumns.map((column, columnIndex) => (
+						// TODO: Replace TableCell with TableHeaderCell once https://github.com/microsoft/fluentui/issues/31588 is fixed.
 						<TableCell key={columnIndex}>
 							{column.columnKey === "clientId" && (
 								<LabelCellLayout


### PR DESCRIPTION
[AB#4839](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4839)

## Description

This PR fixes an a11y bug where tab navigating to the Audience table would show multiple focuses on the table cell and info icon, without being able to interact with it to show the tooltip text. The fix ensures only the info icon is accessible with tab/arrow navigation.

#### Notes
I tried using the built in utilities like useArrowNavigationGroup and tweaking tabIndex, but that didn't work. [reference](https://react.fluentui.dev/?path=/docs/components-table--default)
Updating from TableHeaderCell to TableCell seemed to do the trick without any major changes to the appearance.