### PR TITLE
fix(tree): Fix call to schematize() with schema validation enabled

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
@@ -33,6 +33,11 @@ export function isNodeInSchema(
 	node: MapTree,
 	schemaAndPolicy: SchemaAndPolicy,
 ): SchemaValidationErrors {
+	// If the stored schema is completely empty it means the tree is brand new and we shouldn't validate the data.
+	if (schemaAndPolicy.schema.nodeSchema.size === 0) {
+		return SchemaValidationErrors.NoError;
+	}
+
 	// Validate the schema declared by the node exists
 	const schema = schemaAndPolicy.schema.nodeSchema.get(node.type);
 	if (schema === undefined) {

--- a/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/schemaChecker.ts
@@ -33,7 +33,10 @@ export function isNodeInSchema(
 	node: MapTree,
 	schemaAndPolicy: SchemaAndPolicy,
 ): SchemaValidationErrors {
-	// If the stored schema is completely empty it means the tree is brand new and we shouldn't validate the data.
+	// If the stored schema is completely empty it _probably_ (in almost all cases?) means the tree is brand new and we
+	// shouldn't validate the data.
+	// TODO: AB#8197
+	// See https://github.com/microsoft/FluidFramework/pull/21305#discussion_r1626595991 for further discussion.
 	if (schemaAndPolicy.schema.nodeSchema.size === 0) {
 		return SchemaValidationErrors.NoError;
 	}

--- a/packages/dds/tree/src/test/feature-libraries/default-schema/schemaChecker.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-schema/schemaChecker.spec.ts
@@ -136,7 +136,11 @@ describe("schema validation", () => {
 		});
 
 		it(`not in schema due to missing node schema entry in schemaCollection`, () => {
-			const { node: stringNode, schema: stringSchema } = createLeafNode("myStringNode", "string", ValueSchema.String);
+			const { node: stringNode, schema: stringSchema } = createLeafNode(
+				"myStringNode",
+				"string",
+				ValueSchema.String,
+			);
 			assert.equal(
 				isNodeInSchema(
 					createLeafNode("myNumberNode", 1, ValueSchema.Number).node,

--- a/packages/dds/tree/src/test/feature-libraries/default-schema/schemaChecker.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-schema/schemaChecker.spec.ts
@@ -125,11 +125,24 @@ describe("schema validation", () => {
 	});
 
 	describe("isNodeInSchema", () => {
-		it(`not in schema due to missing node schema entry in schemaCollection`, () => {
+		it(`skips validation if stored schema is completely empty`, () => {
 			assert.equal(
 				isNodeInSchema(
 					createLeafNode("myNumberNode", 1, ValueSchema.Number).node,
-					createSchemaAndPolicy(),
+					createSchemaAndPolicy(), // Note this passes an empty stored schema
+				),
+				SchemaValidationErrors.NoError,
+			);
+		});
+
+		it(`not in schema due to missing node schema entry in schemaCollection`, () => {
+			const { node: stringNode, schema: stringSchema } = createLeafNode("myStringNode", "string", ValueSchema.String);
+			assert.equal(
+				isNodeInSchema(
+					createLeafNode("myNumberNode", 1, ValueSchema.Number).node,
+					// Note, this cannot use an empty stored schema because that would skip validation,
+					// So just putting a schema for a node that is not the one we pass in for validation.
+					createSchemaAndPolicy(new Map([[stringNode.type, stringSchema]])),
 				),
 				SchemaValidationErrors.Node_MissingSchema,
 			);

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1898,6 +1898,53 @@ describe("SharedTree", () => {
 			assert.deepEqual(encodedTreeData2.data[0][1], expectedCompressedTreeData);
 		});
 	});
+
+	describe("Schema validation", () => {
+		it("can create tree with schema validation enabled", async () => {
+			const provider = new TestTreeProviderLite(1);
+			const [sharedTree] = provider.trees;
+			const sf = new SchemaFactory("test");
+			const schema = sf.string;
+			assert.doesNotThrow(() =>
+				sharedTree.schematize(
+					new TreeConfiguration(schema, () => "42", {
+						enableSchemaValidation: true,
+					}),
+				),
+			);
+		});
+
+		it("schema validation throws as expected", async () => {
+			const provider = new TestTreeProviderLite(1);
+			const [sharedTree] = provider.trees;
+			const sf = new SchemaFactory("test");
+
+			// No validation failures when initializing the tree for the first time.
+			// Stored schema is set up so 'foo' is an array of strings.
+			const schema = sf.object("myObject", { foo: sf.array("foo", sf.string) });
+			sharedTree.schematize(
+				new TreeConfiguration(schema, () => ({ foo: ["42"] }), {
+					enableSchemaValidation: true,
+				}),
+			);
+
+			// Trying to use the tree with a view schema that makes 'foo' an array of strings or numbers
+			// should not cause compile-time errors when inserting a number, but stored schema validation
+			// should kick in and throw an error.
+			const viewschema = sf.object("myObject", {
+				foo: sf.array("foo", [sf.string, sf.number]),
+			});
+			const tree = sharedTree.schematize(
+				new TreeConfiguration(viewschema, () => ({ foo: ["42"] }), {
+					enableSchemaValidation: true,
+				}),
+			);
+
+			assert.throws(() => {
+				tree.root.foo.insertAtEnd(3);
+			}, "Tree does not conform to schema.");
+		});
+	});
 });
 
 function assertSchema<TRoot extends FlexFieldSchema>(


### PR DESCRIPTION
## Description

Fixes a bug where one could not `schematize()` a brand new tree while setting the `enableSchemaValidation` option to true, because we would try to validate the initial tree against a completely empty stored schema and fail to find any schemas for the nodes.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I would like feedback on whether the new check to decide if we should validate or not (whether the list of possible node schemas in the stored schema, i.e. `schemaAndPolicy.schema.nodeSchema`, is empty) makes sense or has edge cases, like being possible after the initial schematization of a tree. I suspect we might need a better condition, or alternatively, further up in the call stack, specifically in the code path where we are initializing a brand new tree, pass in a policy that does not enforce validation only at the time of populating the tree with the initial data.

Or, should (can?) the code flow of [`schematize()`](https://github.com/microsoft/FluidFramework/blob/9b954e62d366663a57170b725214a0b129de0d95/packages/dds/tree/src/shared-tree/sharedTree.ts#L294-L307) change so `view.upgradeSchema();` is called before creating a `SchematizingSimpleTreeView`?

[AB#8128](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8128)