### PR TITLE
Factor out SharedTree field defaulting into a separate function

### DIFF
--- a/packages/dds/tree/src/simple-tree/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/schemaFactory.ts
@@ -500,8 +500,8 @@ export class SchemaFactory<
 			return undefined;
 		});
 		return createFieldSchema(FieldKind.Optional, t, {
-			...props,
 			defaultProvider: defaultOptionalProvider,
+			...props,
 		});
 	}
 

--- a/packages/dds/tree/src/simple-tree/schemaTypes.ts
+++ b/packages/dds/tree/src/simple-tree/schemaTypes.ts
@@ -258,7 +258,24 @@ export interface FieldProps {
 	readonly defaultProvider?: DefaultProvider;
 }
 
-export type FieldProvider = (context: NodeKeyManager) => InsertableContent | undefined;
+/**
+ * A {@link FieldProvider} which requires additional context in order to produce its content
+ */
+export type ContextualFieldProvider = (context: NodeKeyManager) => InsertableContent | undefined;
+/**
+ * A {@link FieldProvider} which can produce its content in a vacuum
+ */
+export type ConstantFieldProvider = () => InsertableContent | undefined;
+/**
+ * A function which produces content for a field every time that it is called
+ */
+export type FieldProvider = ContextualFieldProvider | ConstantFieldProvider;
+/**
+ * Returns true if the given {@link FieldProvider} is a {@link ConstantFieldProvider}
+ */
+export function isConstant(fieldProvider: FieldProvider): fieldProvider is ConstantFieldProvider {
+	return fieldProvider.length === 0;
+}
 
 /**
  * Provides a default value for a field.

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -23,7 +23,7 @@ import {
 	valueSchemaAllows,
 	NodeKeyManager,
 } from "../feature-libraries/index.js";
-import { brand, fail, isReadonlyArray } from "../util/index.js";
+import { brand, fail, isReadonlyArray, find } from "../util/index.js";
 
 import { nullSchema } from "./leafNodeSchema.js";
 import { InsertableContent } from "./proxies.js";
@@ -38,6 +38,8 @@ import {
 	normalizeFieldSchema,
 	getStoredKey,
 	extractFieldProvider,
+	isConstant,
+	FieldProvider,
 } from "./schemaTypes.js";
 import { SchemaValidationErrors, isNodeInSchema } from "../feature-libraries/index.js";
 
@@ -56,40 +58,39 @@ import { SchemaValidationErrors, isNodeInSchema } from "../feature-libraries/ind
  * Transforms an input {@link TypedNode} tree to a {@link MapTree}, and wraps the tree in a {@link CursorWithNode}.
  * @param data - The input tree to be converted.
  * @param allowedTypes - The set of types allowed by the parent context. Used to validate the input tree.
- * @param nodeKeyManager - See {@link NodeKeyManager}.
+ * @param context - An optional context which, if present, will allow defaults to be created by {@link ContextualFieldProvider}s.
+ * If absent, only defaults from {@link ConstantFieldProvider}s will be created.
  * @param schemaValidationPolicy - The stored schema and policy to be used for validation, if the policy says schema
  * validation should happen. If it does, the input tree will be validated against this schema + policy, and an error will
  * be thrown if the tree does not conform to the schema. If undefined, no validation against the stored schema is done.
  *
  * @returns A cursor (in nodes mode) for the mapped tree if the input data was defined. Otherwise, returns `undefined`.
+ * @remarks The resulting tree will be populated with any defaults from {@link FieldProvider}s in the schema.
  */
 export function cursorFromNodeData(
 	data: InsertableContent,
 	allowedTypes: ImplicitAllowedTypes,
-	nodeKeyManager: NodeKeyManager,
+	context?: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
 ): CursorWithNode<MapTree>;
 export function cursorFromNodeData(
 	data: InsertableContent | undefined,
 	allowedTypes: ImplicitAllowedTypes,
-	nodeKeyManager: NodeKeyManager,
+	context?: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
 ): CursorWithNode<MapTree> | undefined;
 export function cursorFromNodeData(
 	data: InsertableContent | undefined,
 	allowedTypes: ImplicitAllowedTypes,
-	nodeKeyManager: NodeKeyManager,
+	context?: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
 ): CursorWithNode<MapTree> | undefined {
 	if (data === undefined) {
 		return undefined;
 	}
-	const mappedContent = nodeDataToMapTree(
-		data,
-		normalizeAllowedTypes(allowedTypes),
-		nodeKeyManager,
-		schemaValidationPolicy,
-	);
+	const normalizedTypes = normalizeAllowedTypes(allowedTypes);
+	const mappedContent = nodeDataToMapTree(data, normalizedTypes, schemaValidationPolicy);
+	addDefaultsToMapTree(mappedContent, normalizedTypes, context);
 	return cursorForMapTreeNode(mappedContent);
 }
 
@@ -97,27 +98,29 @@ export function cursorFromNodeData(
  * Transforms an input {@link InsertableContent} tree to an array of {@link MapTree}s, and wraps the tree in a {@link CursorWithNode}.
  * @param data - The input tree to be converted.
  * @param schema - Schema of the field with which the input `data` is associated.
- * @param nodeKeyManager - See {@link NodeKeyManager}.
+ * @param context - An optional context which, if present, will allow defaults to be created by {@link ContextualFieldProvider}s.
+ * If absent, only defaults from {@link ConstantFieldProvider}s will be created.
  * @param schemaValidationPolicy - The stored schema and policy to be used for validation, if the policy says schema
  * validation should happen. If it does, the input tree will be validated against this schema + policy, and an error will
  * be thrown if the tree does not conform to the schema. If undefined, no validation against the stored schema is done.
+ * @remarks The resulting tree will be populated with any defaults from {@link FieldProvider}s in the schema.
  */
 export function cursorFromFieldData(
 	data: InsertableContent,
 	schema: FieldSchema,
-	nodeKeyManager: NodeKeyManager,
+	context?: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
 ): CursorWithNode<MapTree>;
 export function cursorFromFieldData(
 	data: InsertableContent | undefined,
 	schema: FieldSchema,
-	nodeKeyManager: NodeKeyManager,
+	context?: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
 ): CursorWithNode<MapTree> | undefined;
 export function cursorFromFieldData(
 	data: InsertableContent | undefined,
 	schema: FieldSchema,
-	nodeKeyManager: NodeKeyManager,
+	context?: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
 ): CursorWithNode<MapTree> | undefined {
 	if (data === undefined) {
@@ -126,8 +129,12 @@ export function cursorFromFieldData(
 
 	// TODO: array node content should not go through here since sequence fields don't exist at this abstraction layer.
 	const mappedContent = Array.isArray(data)
-		? arrayToMapTreeFields(data, schema.allowedTypeSet, nodeKeyManager, schemaValidationPolicy)
-		: [nodeDataToMapTree(data, schema.allowedTypeSet, nodeKeyManager, schemaValidationPolicy)];
+		? arrayToMapTreeFields(data, schema.allowedTypeSet, schemaValidationPolicy)
+		: [nodeDataToMapTree(data, schema.allowedTypeSet, schemaValidationPolicy)];
+
+	for (const content of mappedContent) {
+		addDefaultsToMapTree(content, schema.allowedTypeSet, context);
+	}
 	return cursorForMapTreeField(mappedContent);
 }
 
@@ -146,7 +153,6 @@ export function cursorFromFieldData(
  * * `-0` =\> `+0`
  *
  * @param allowedTypes - The set of types allowed by the parent context. Used to validate the input tree.
- * @param nodeKeyManager - See {@link NodeKeyManager}.
  * @param schemaValidationPolicy - The stored schema and policy to be used for validation, if the policy says schema
  * validation should happen. If it does, the input tree will be validated against this schema + policy, and an error will
  * be thrown if the tree does not conform to the schema. If undefined, no validation against the stored schema is done.
@@ -154,19 +160,16 @@ export function cursorFromFieldData(
 export function nodeDataToMapTree(
 	data: InsertableContent,
 	allowedTypes: ReadonlySet<TreeNodeSchema>,
-	nodeKeyManager: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
 ): MapTree;
 export function nodeDataToMapTree(
 	data: InsertableContent | undefined,
 	allowedTypes: ReadonlySet<TreeNodeSchema>,
-	nodeKeyManager: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
 ): MapTree | undefined;
 export function nodeDataToMapTree(
 	data: InsertableContent | undefined,
 	allowedTypes: ReadonlySet<TreeNodeSchema>,
-	nodeKeyManager: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
 ): MapTree | undefined {
 	if (data === undefined) {
@@ -181,13 +184,13 @@ export function nodeDataToMapTree(
 			result = leafToMapTree(data, schema, allowedTypes);
 			break;
 		case NodeKind.Array:
-			result = arrayToMapTree(data, schema, nodeKeyManager);
+			result = arrayToMapTree(data, schema);
 			break;
 		case NodeKind.Map:
-			result = mapToMapTree(data, schema, nodeKeyManager);
+			result = mapToMapTree(data, schema);
 			break;
 		case NodeKind.Object:
-			result = objectToMapTree(data, schema, nodeKeyManager);
+			result = objectToMapTree(data, schema);
 			break;
 		default:
 			fail(`Unrecognized schema kind: ${schema.kind}.`);
@@ -276,7 +279,6 @@ function mapValueWithFallbacks(
  * Transforms data under an Array schema.
  * @param data - The tree data to be transformed.
  * @param allowedTypes - The set of types allowed by the parent context. Used to validate the input tree.
- * @param nodeKeyManager - See {@link NodeKeyManager}.
  * @param schemaValidationPolicy - The stored schema and policy to be used for validation, if the policy says schema
  * validation should happen. If it does, the input tree will be validated against this schema + policy, and an error will
  * be thrown if the tree does not conform to the schema. If undefined, no validation against the stored schema is done.
@@ -284,7 +286,6 @@ function mapValueWithFallbacks(
 function arrayToMapTreeFields(
 	data: readonly InsertableContent[],
 	allowedTypes: ReadonlySet<TreeNodeSchema>,
-	nodeKeyManager: NodeKeyManager,
 	schemaValidationPolicy: SchemaAndPolicy | undefined = undefined,
 ): MapTree[] {
 	const mappedData: MapTree[] = [];
@@ -302,7 +303,6 @@ function arrayToMapTreeFields(
 		const mappedChild = nodeDataToMapTree(
 			childWithFallback,
 			allowedTypes,
-			nodeKeyManager,
 			schemaValidationPolicy,
 		);
 		mappedData.push(mappedChild);
@@ -315,7 +315,6 @@ function arrayToMapTreeFields(
  * Transforms data under an Array schema.
  * @param data - The tree data to be transformed. Must be an array.
  * @param schema - The schema associated with the value.
- * @param nodeKeyManager - See {@link NodeKeyManager}.
  * @param schemaValidationPolicy - The stored schema and policy to be used for validation, if the policy says schema
  * validation should happen. If it does, the input tree will be validated against this schema + policy, and an error will
  * be thrown if the tree does not conform to the schema. If undefined, no validation against the stored schema is done.
@@ -323,7 +322,6 @@ function arrayToMapTreeFields(
 function arrayToMapTree(
 	data: InsertableContent,
 	schema: TreeNodeSchema,
-	nodeKeyManager: NodeKeyManager,
 	schemaValidationPolicy: SchemaAndPolicy | undefined = undefined,
 ): MapTree {
 	assert(schema.kind === NodeKind.Array, 0x922 /* Expected an array schema. */);
@@ -333,12 +331,7 @@ function arrayToMapTree(
 
 	const allowedChildTypes = normalizeAllowedTypes(schema.info as ImplicitAllowedTypes);
 
-	const mappedData = arrayToMapTreeFields(
-		data,
-		allowedChildTypes,
-		nodeKeyManager,
-		schemaValidationPolicy,
-	);
+	const mappedData = arrayToMapTreeFields(data, allowedChildTypes, schemaValidationPolicy);
 
 	// Array node children are represented as a single field entry denoted with `EmptyKey`
 	const fieldsEntries: [FieldKey, MapTree[]][] =
@@ -355,7 +348,6 @@ function arrayToMapTree(
  * Transforms data under a Map schema.
  * @param data - The tree data to be transformed. Must be a TypeScript Map.
  * @param schema - The schema associated with the value.
- * @param nodeKeyManager - See {@link NodeKeyManager}.
  * @param schemaValidationPolicy - The stored schema and policy to be used for validation, if the policy says schema
  * validation should happen. If it does, the input tree will be validated against this schema + policy, and an error will
  * be thrown if the tree does not conform to the schema. If undefined, no validation against the stored schema is done.
@@ -363,7 +355,6 @@ function arrayToMapTree(
 function mapToMapTree(
 	data: InsertableContent,
 	schema: TreeNodeSchema,
-	nodeKeyManager: NodeKeyManager,
 	schemaValidationPolicy: SchemaAndPolicy | undefined = undefined,
 ): MapTree {
 	assert(schema.kind === NodeKind.Map, 0x923 /* Expected a Map schema. */);
@@ -379,12 +370,7 @@ function mapToMapTree(
 
 		// Omit undefined values - an entry with an undefined value is equivalent to one that has been removed or omitted
 		if (value !== undefined) {
-			const mappedField = nodeDataToMapTree(
-				value,
-				allowedChildTypes,
-				nodeKeyManager,
-				schemaValidationPolicy,
-			);
+			const mappedField = nodeDataToMapTree(value, allowedChildTypes, schemaValidationPolicy);
 			transformedFields.set(brand(key), [mappedField]);
 		}
 	}
@@ -399,13 +385,8 @@ function mapToMapTree(
  * Transforms data under an Object schema.
  * @param data - The tree data to be transformed. Must be a Record-like object.
  * @param schema - The schema associated with the value.
- * @param nodeKeyManager - See {@link NodeKeyManager}.
  */
-function objectToMapTree(
-	data: InsertableContent,
-	schema: TreeNodeSchema,
-	nodeKeyManager: NodeKeyManager,
-): MapTree {
+function objectToMapTree(data: InsertableContent, schema: TreeNodeSchema): MapTree {
 	assert(schema.kind === NodeKind.Object, 0x924 /* Expected an Object schema. */);
 	if (typeof data !== "object" || data === null) {
 		throw new UsageError(`Input data is incompatible with Object schema: ${data}`);
@@ -414,20 +395,10 @@ function objectToMapTree(
 	const fields = new Map<FieldKey, MapTree[]>();
 
 	// Loop through field keys without data, and assign value from its default provider.
-	for (const [key, fieldSchema] of Object.entries(
-		schema.info as Record<string, ImplicitFieldSchema>,
-	)) {
+	for (const key of Object.keys(schema.info as Record<string, ImplicitFieldSchema>)) {
 		const value = (data as Record<string, InsertableContent>)[key];
 		if (value !== undefined && Object.hasOwnProperty.call(data, key)) {
-			setFieldValue(fields, value, getObjectFieldSchema(schema, key), nodeKeyManager, key);
-		} else {
-			if (fieldSchema instanceof FieldSchema) {
-				const defaultProvider = fieldSchema.props?.defaultProvider;
-				if (defaultProvider !== undefined) {
-					const fieldValue = extractFieldProvider(defaultProvider)(nodeKeyManager);
-					setFieldValue(fields, fieldValue, fieldSchema, nodeKeyManager, key);
-				}
-			}
+			setFieldValue(fields, value, getObjectFieldSchema(schema, key), key);
 		}
 	}
 
@@ -438,18 +409,13 @@ function objectToMapTree(
 }
 
 function setFieldValue(
-	fields: Map<FieldKey, MapTree[]>,
+	fields: Map<FieldKey, readonly MapTree[]>,
 	fieldValue: InsertableContent | undefined,
 	fieldSchema: FieldSchema,
-	nodeKeyManager: NodeKeyManager,
 	key: string,
 ): void {
 	if (fieldValue !== undefined) {
-		const mappedChildTree = nodeDataToMapTree(
-			fieldValue,
-			fieldSchema.allowedTypeSet,
-			nodeKeyManager,
-		);
+		const mappedChildTree = nodeDataToMapTree(fieldValue, fieldSchema.allowedTypeSet);
 		const flexKey: FieldKey = brand(getStoredKey(key, fieldSchema));
 
 		assert(!fields.has(flexKey), 0x956 /* Keys must not be duplicated */);
@@ -648,4 +614,93 @@ export interface ContextuallyTypedNodeDataObject {
 	 * Allow unbranded field keys as a convenience for literals.
 	 */
 	[key: string]: ContextuallyTypedFieldData;
+}
+
+/**
+ * Walk the given {@link MapTree} and provide any field defaults for fields that are missing in the tree but present in the schema.
+ * @param mapTree - The tree to populate with defaults
+ * @param allowedTypes - Some {@link TreeNodeSchema}, at least one of which the input tree must conform to
+ * @param context - An optional context for generating defaults.
+ * If present, all applicable defaults will be provided.
+ * If absent, only defaults produced by a {@link ConstantFieldProvider} will be provided, and defaults produced by a {@link ContextualFieldProvider} will be ignored.
+ * @remarks This function mutates the input tree by adding new fields to the field maps where applicable.
+ * @privateRemarks TODO: Create a more established type for mutable MapTrees, and use where appropriate.
+ */
+export function addDefaultsToMapTree(
+	mapTree: MapTree,
+	allowedTypes: Iterable<TreeNodeSchema>,
+	context?: NodeKeyManager,
+): void {
+	const schema =
+		find(allowedTypes, (s) => s.identifier === mapTree.type) ??
+		fail("MapTree is incompatible with schema");
+
+	switch (schema.kind) {
+		case NodeKind.Array:
+		case NodeKind.Map:
+			{
+				const allowedChildTypes = normalizeAllowedTypes(
+					schema.info as ImplicitAllowedTypes,
+				);
+				for (const field of mapTree.fields.values()) {
+					for (const child of field) {
+						addDefaultsToMapTree(child, allowedChildTypes, context);
+					}
+				}
+			}
+			break;
+		case NodeKind.Object:
+			{
+				for (const [key, fieldSchema] of Object.entries(
+					schema.info as Record<FieldKey, ImplicitFieldSchema>,
+				) as [FieldKey, ImplicitFieldSchema][]) {
+					const field = mapTree.fields.get(key);
+					if (field !== undefined) {
+						for (const child of field) {
+							addDefaultsToMapTree(
+								child,
+								getObjectFieldSchema(schema, key).allowedTypeSet,
+							);
+						}
+					} else if (fieldSchema instanceof FieldSchema) {
+						const defaultProvider = fieldSchema.props?.defaultProvider;
+						if (defaultProvider !== undefined) {
+							const fieldProvider = extractFieldProvider(defaultProvider);
+							const data = provideDefault(fieldProvider, context);
+							if (data !== undefined) {
+								const mutableMapTree = mapTree as typeof mapTree & {
+									fields: Map<FieldKey, readonly MapTree[]>;
+								};
+								setFieldValue(mutableMapTree.fields, data, fieldSchema, key);
+								for (const child of mutableMapTree.fields.get(key) ??
+									fail("Expected field to be populated")) {
+									addDefaultsToMapTree(
+										child,
+										fieldSchema.allowedTypeSet,
+										context,
+									);
+								}
+							}
+						}
+					}
+				}
+			}
+			break;
+		default:
+			assert(schema.kind === NodeKind.Leaf, "Unrecognized schema kind");
+			break;
+	}
+}
+
+function provideDefault(
+	fieldProvider: FieldProvider,
+	context: NodeKeyManager | undefined,
+): InsertableContent | undefined {
+	if (context !== undefined) {
+		return fieldProvider(context);
+	} else {
+		if (isConstant(fieldProvider)) {
+			return fieldProvider();
+		}
+	}
 }

--- a/packages/dds/tree/src/test/simple-tree/toMapTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toMapTree.spec.ts
@@ -32,13 +32,14 @@ import {
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../simple-tree/schemaTypes.js";
 import {
+	addDefaultsToMapTree,
 	cursorFromFieldData,
 	cursorFromNodeData,
 	nodeDataToMapTree as nodeDataToMapTreeBase,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../simple-tree/toMapTree.js";
 import { brand } from "../../util/index.js";
-import { createNodeKeyManager, MockNodeKeyManager } from "../../feature-libraries/index.js";
+import { MockNodeKeyManager } from "../../feature-libraries/index.js";
 
 describe("toMapTree", () => {
 	let nodeKeyManager: MockNodeKeyManager;
@@ -55,12 +56,10 @@ describe("toMapTree", () => {
 		allowedTypes: ImplicitAllowedTypes,
 		schemaValidationPolicy?: SchemaAndPolicy,
 	): MapTree {
-		return nodeDataToMapTreeBase(
-			tree,
-			normalizeAllowedTypes(allowedTypes),
-			nodeKeyManager,
-			schemaValidationPolicy,
-		);
+		const normalizedTypes = normalizeAllowedTypes(allowedTypes);
+		const mapTree = nodeDataToMapTreeBase(tree, normalizedTypes, schemaValidationPolicy);
+		addDefaultsToMapTree(mapTree, normalizedTypes);
+		return mapTree;
 	}
 
 	it("string", () => {
@@ -742,6 +741,7 @@ describe("toMapTree", () => {
 			const tree = {};
 
 			const actual = nodeDataToMapTree(tree, schema);
+			addDefaultsToMapTree(actual, [schema], nodeKeyManager);
 
 			const expected: MapTree = {
 				type: brand("test.object"),
@@ -771,6 +771,7 @@ describe("toMapTree", () => {
 			const tree = {};
 
 			const actual = nodeDataToMapTree(tree, schema);
+			addDefaultsToMapTree(actual, [schema], nodeKeyManager);
 
 			const expected: MapTree = {
 				type: brand("test.object"),
@@ -1165,7 +1166,7 @@ describe("toMapTree", () => {
 				cursorFromNodeData(
 					nodeData,
 					[schemaFactory.string],
-					createNodeKeyManager(),
+					undefined,
 					schemaValidationPolicyForSuccess,
 				);
 			});
@@ -1177,7 +1178,7 @@ describe("toMapTree", () => {
 						cursorFromNodeData(
 							content,
 							[schemaFactory.string],
-							createNodeKeyManager(),
+							undefined,
 							schemaValidationPolicyForFailure,
 						),
 					outOfSchemaExpectedError,
@@ -1192,7 +1193,7 @@ describe("toMapTree", () => {
 				cursorFromFieldData(
 					content,
 					fieldSchema,
-					createNodeKeyManager(),
+					undefined,
 					schemaValidationPolicyForSuccess,
 				);
 			});
@@ -1205,7 +1206,7 @@ describe("toMapTree", () => {
 						cursorFromFieldData(
 							content,
 							fieldSchema,
-							createNodeKeyManager(),
+							undefined,
 							schemaValidationPolicyForFailure,
 						),
 					outOfSchemaExpectedError,

--- a/packages/dds/tree/src/test/simple-tree/toMapTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toMapTree.spec.ts
@@ -32,6 +32,7 @@ import {
 	ContextualFieldProvider,
 	ConstantFieldProvider,
 	FieldProvider,
+	FieldProps,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../simple-tree/schemaTypes.js";
 import {
@@ -43,7 +44,6 @@ import {
 } from "../../simple-tree/toMapTree.js";
 import { brand } from "../../util/index.js";
 import { MockNodeKeyManager, NodeKeyManager } from "../../feature-libraries/index.js";
-import { FieldProps } from "../../../dist/index.js";
 
 describe("toMapTree", () => {
 	let nodeKeyManager: MockNodeKeyManager;

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -73,6 +73,7 @@ export {
 	assertValidRangeIndices,
 	transformObjectMap,
 	compareStrings,
+	find,
 } from "./utils.js";
 export { ReferenceCountedBase, ReferenceCounted } from "./referenceCounting.js";
 

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -168,7 +168,7 @@ export function* mapIterable<T, U>(iterable: Iterable<T>, map: (t: T) => U): Ite
 }
 
 /**
- * Finds the first element in the the given iterable that satisfies a predicate.
+ * Finds the first element in the given iterable that satisfies a predicate.
  * @param iterable - The iterable to search for an eligible element
  * @param predicate - The predicate to run against each element
  * @returns The first element in the iterable that satisfies the predicate, or undefined if the iterable contains no such element

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -168,6 +168,20 @@ export function* mapIterable<T, U>(iterable: Iterable<T>, map: (t: T) => U): Ite
 }
 
 /**
+ * Finds the first element in the the given iterable that satisfies a predicate.
+ * @param iterable - The iterable to search for an eligible element
+ * @param predicate - The predicate to run against each element
+ * @returns The first element in the iterable that satisfies the predicate, or undefined if the iterable contains no such element
+ */
+export function find<T>(iterable: Iterable<T>, predicate: (t: T) => boolean): T | undefined {
+	for (const t of iterable) {
+		if (predicate(t)) {
+			return t;
+		}
+	}
+}
+
+/**
  * Use for Json compatible data.
  *
  * Note that this does not robustly forbid non json comparable data via type checking,


### PR DESCRIPTION
## Description

Currently, when node data is converted into a MapTree, it has any missing fields populated by `FieldProvider`s at the same time. This PR splits the defaulting into a separate step. Now, node data is converted into MapTrees without populating any defaults. Then, that MapTree can be augmented by a separate function that adds the defaults to the MapTree.

Also, this PR introduces a distinction between `FieldProvider`s that need a context (e.g. to generate node identifiers) and those that do not (e.g. to default to a constant like `undefined`). The defaulting code will produce both if it is given the necessary context, but if it is not given any context then it will only generate the defaults that it can (the non-contextual, constant ones).

This also adds a more comprehensive unit test of field defaulting.

### Why?

An upcoming change will allow MapTrees to be stored in unhydrated nodes so that those unhydrated nodes can be read before being inserted into the tree. When the MapTrees are generated for the unhydrated nodes, we have enough information to populate the "constant" defaults, but we don't yet have the context for the rest of the defaults - those will have to wait until the tree is inserted, at which time the defaulting pass will be run again.