### PR TITLE
refactor(tree): remove unnecessary usages of rollbackOf from sequence field

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -225,13 +225,3 @@ export interface FieldChangeEncodingContext {
 	encodeNode(nodeId: NodeId): EncodedNodeChangeset;
 	decodeNode(encodedNode: EncodedNodeChangeset): NodeId;
 }
-
-/**
- * @internal
- */
-export function getIntention(
-	rev: RevisionTag | undefined,
-	revisionMetadata: RevisionMetadataSource,
-): RevisionTag | undefined {
-	return revisionMetadata.tryGetInfo(rev)?.rollbackOf ?? rev;
-}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
@@ -31,7 +31,6 @@ export {
 	FieldChangeHandler,
 	FieldChangeRebaser,
 	FieldEditor,
-	getIntention,
 	NodeChangeComposer,
 	NodeChangeInverter,
 	NodeChangeRebaser,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -5,7 +5,7 @@
 
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 
-import { RevisionMetadataSource, RevisionTag } from "../../core/index.js";
+import { RevisionTag } from "../../core/index.js";
 import { IdAllocator, Mutable, fail } from "../../util/index.js";
 import { CrossFieldManager, CrossFieldTarget, NodeId } from "../modular-schema/index.js";
 
@@ -51,26 +51,19 @@ export function invert(
 	isRollback: boolean,
 	genId: IdAllocator,
 	crossFieldManager: CrossFieldManager,
-	revisionMetadata: RevisionMetadataSource,
 ): Changeset {
-	return invertMarkList(
-		change,
-		isRollback,
-		crossFieldManager as CrossFieldManager<NodeId>,
-		revisionMetadata,
-	);
+	return invertMarkList(change, isRollback, crossFieldManager as CrossFieldManager<NodeId>);
 }
 
 function invertMarkList(
 	markList: MarkList,
 	isRollback: boolean,
 	crossFieldManager: CrossFieldManager<NodeId>,
-	revisionMetadata: RevisionMetadataSource,
 ): MarkList {
 	const inverseMarkList = new MarkListFactory();
 
 	for (const mark of markList) {
-		const inverseMarks = invertMark(mark, isRollback, crossFieldManager, revisionMetadata);
+		const inverseMarks = invertMark(mark, isRollback, crossFieldManager);
 		inverseMarkList.push(...inverseMarks);
 	}
 
@@ -81,10 +74,9 @@ function invertMark(
 	mark: Mark,
 	isRollback: boolean,
 	crossFieldManager: CrossFieldManager<NodeId>,
-	revisionMetadata: RevisionMetadataSource,
 ): Mark[] {
-	if (!isImpactful(mark, revisionMetadata)) {
-		const inputId = getInputCellId(mark, revisionMetadata);
+	if (!isImpactful(mark)) {
+		const inputId = getInputCellId(mark);
 		return [invertNodeChangeOrSkip(mark.count, mark.changes, inputId)];
 	}
 	const type = mark.type;
@@ -94,8 +86,8 @@ function invertMark(
 		}
 		case "Remove": {
 			assert(mark.revision !== undefined, 0x5a1 /* Unable to revert to undefined revision */);
-			const outputId = getOutputCellId(mark, revisionMetadata);
-			const inputId = getInputCellId(mark, revisionMetadata);
+			const outputId = getOutputCellId(mark);
+			const inputId = getInputCellId(mark);
 			let inverse: Mutable<Mark>;
 			if (inputId === undefined) {
 				inverse = {
@@ -118,7 +110,7 @@ function invertMark(
 			return [withNodeChange(inverse, mark.changes)];
 		}
 		case "Insert": {
-			const inputId = getInputCellId(mark, revisionMetadata);
+			const inputId = getInputCellId(mark);
 			assert(inputId !== undefined, 0x80c /* Active inserts should target empty cells */);
 			const removeMark: Mutable<CellMark<Remove>> = {
 				type: "Remove",
@@ -151,7 +143,7 @@ function invertMark(
 				);
 			}
 
-			const cellId = getDetachOutputCellId(mark, revisionMetadata) ?? {
+			const cellId = getDetachOutputCellId(mark) ?? {
 				revision: mark.revision ?? fail("Revision must be defined"),
 				localId: mark.id,
 			};
@@ -165,7 +157,7 @@ function invertMark(
 				moveIn.finalEndpoint = { localId: mark.finalEndpoint.localId };
 			}
 			let effect: MarkEffect = moveIn;
-			const inputId = getInputCellId(mark, revisionMetadata);
+			const inputId = getInputCellId(mark);
 			if (inputId !== undefined) {
 				const detach: Mutable<Detach> = {
 					type: "Remove",
@@ -183,7 +175,7 @@ function invertMark(
 			return [{ ...effect, count: mark.count, cellId }];
 		}
 		case "MoveIn": {
-			const inputId = getInputCellId(mark, revisionMetadata);
+			const inputId = getInputCellId(mark);
 			assert(inputId !== undefined, 0x89e /* Active move-ins should target empty cells */);
 			const invertedMark: Mutable<CellMark<MoveOut>> = {
 				type: "MoveOut",
@@ -207,7 +199,7 @@ function invertMark(
 				cellId: mark.cellId,
 				...mark.attach,
 			};
-			const idAfterAttach = getOutputCellId(attach, undefined);
+			const idAfterAttach = getOutputCellId(attach);
 
 			// We put `mark.changes` on the detach so that if it is a move source
 			// the changes can be sent to the endpoint.
@@ -217,18 +209,8 @@ function invertMark(
 				changes: mark.changes,
 				...mark.detach,
 			};
-			const attachInverses = invertMark(
-				attach,
-				isRollback,
-				crossFieldManager,
-				revisionMetadata,
-			);
-			const detachInverses = invertMark(
-				detach,
-				isRollback,
-				crossFieldManager,
-				revisionMetadata,
-			);
+			const attachInverses = invertMark(attach, isRollback, crossFieldManager);
+			const detachInverses = invertMark(detach, isRollback, crossFieldManager);
 
 			if (detachInverses.length === 0) {
 				return attachInverses;

--- a/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/rebase.ts
@@ -104,7 +104,6 @@ function rebaseMarkList(
 		const rebasedMark = rebaseMark(
 			currMark,
 			baseMark,
-			metadata,
 			rebaseChild,
 			moveEffects,
 			nodeExistenceState,
@@ -121,9 +120,9 @@ function rebaseMarkList(
  * @param revision - The revision, if available.
  * @returns A NoOp mark that targets the same cells as the input mark.
  */
-function generateNoOpWithCellId(mark: Mark, metadata: RevisionMetadataSource): CellMark<NoopMark> {
+function generateNoOpWithCellId(mark: Mark): CellMark<NoopMark> {
 	const length = mark.count;
-	const cellId = getInputCellId(mark, metadata);
+	const cellId = getInputCellId(mark);
 	return cellId === undefined ? { count: length } : { count: length, cellId };
 }
 
@@ -141,8 +140,8 @@ class RebaseQueue {
 	) {
 		this.baseMarks = new MarkQueue(baseMarks, moveEffects);
 		this.newMarks = new MarkQueue(newMarks, moveEffects);
-		this.baseMarksCellSources = cellSourcesFromMarks(baseMarks, metadata, getInputCellId);
-		this.newMarksCellSources = cellSourcesFromMarks(newMarks, metadata, getInputCellId);
+		this.baseMarksCellSources = cellSourcesFromMarks(baseMarks, getInputCellId);
+		this.newMarksCellSources = cellSourcesFromMarks(newMarks, getInputCellId);
 	}
 
 	public isEmpty(): boolean {
@@ -160,14 +159,14 @@ class RebaseQueue {
 		if (baseMark === undefined) {
 			const dequeuedNewMark = this.newMarks.dequeue();
 			return {
-				baseMark: generateNoOpWithCellId(dequeuedNewMark, this.metadata),
+				baseMark: generateNoOpWithCellId(dequeuedNewMark),
 				newMark: dequeuedNewMark,
 			};
 		} else if (newMark === undefined) {
 			return this.dequeueBase();
 		} else if (areInputCellsEmpty(baseMark) && areInputCellsEmpty(newMark)) {
-			const baseId = getInputCellId(baseMark, this.metadata);
-			const newId = getInputCellId(newMark, this.metadata);
+			const baseId = getInputCellId(baseMark);
+			const newId = getInputCellId(newMark);
 			assert(
 				baseId !== undefined && newId !== undefined,
 				0x89f /* Both marks should have cell IDs */,
@@ -202,7 +201,7 @@ class RebaseQueue {
 		const baseMark =
 			length !== undefined ? this.baseMarks.dequeueUpTo(length) : this.baseMarks.dequeue();
 
-		let newMark: Mark = generateNoOpWithCellId(baseMark, this.metadata);
+		let newMark: Mark = generateNoOpWithCellId(baseMark);
 
 		const movedEffect = getMovedEffectFromBaseMark(this.moveEffects, baseMark);
 
@@ -218,7 +217,7 @@ class RebaseQueue {
 
 	private dequeueNew(): RebaseMarks {
 		const newMark = this.newMarks.dequeue();
-		return { newMark, baseMark: generateNoOpWithCellId(newMark, this.metadata) };
+		return { newMark, baseMark: generateNoOpWithCellId(newMark) };
 	}
 
 	private dequeueBoth(): RebaseMarks {
@@ -271,7 +270,6 @@ interface RebaseMarks {
 function rebaseMark(
 	currMark: Mark,
 	baseMark: Mark,
-	metadata: RevisionMetadataSource,
 	rebaseChild: NodeChangeRebaser,
 	moveEffects: MoveEffectTable,
 	nodeExistenceState: NodeExistenceState,
@@ -286,13 +284,12 @@ function rebaseMark(
 		rebasedMark.changes = movedNodeChanges;
 	}
 
-	return rebaseMarkIgnoreChild(rebasedMark, baseMark, metadata, moveEffects, nodeExistenceState);
+	return rebaseMarkIgnoreChild(rebasedMark, baseMark, moveEffects, nodeExistenceState);
 }
 
 function rebaseMarkIgnoreChild(
 	currMark: Mark,
 	baseMark: Mark,
-	metadata: RevisionMetadataSource,
 	moveEffects: MoveEffectTable,
 	nodeExistenceState: NodeExistenceState,
 ): Mark {
@@ -306,7 +303,7 @@ function rebaseMarkIgnoreChild(
 			!isNewAttach(currMark),
 			0x69d /* A new attach should not be rebased over its cell being emptied */,
 		);
-		const baseCellId = getDetachOutputCellId(baseMark, metadata);
+		const baseCellId = getDetachOutputCellId(baseMark);
 
 		if (isMoveOut(baseMark)) {
 			assert(isMoveMark(baseMark), 0x6f0 /* Only move marks have move IDs */);
@@ -339,14 +336,12 @@ function rebaseMarkIgnoreChild(
 		const halfRebasedMark = rebaseMarkIgnoreChild(
 			currMark,
 			{ ...baseMark.attach, cellId: cloneCellId(baseMark.cellId), count: baseMark.count },
-			metadata,
 			moveEffects,
 			nodeExistenceState,
 		);
 		rebasedMark = rebaseMarkIgnoreChild(
 			halfRebasedMark,
 			{ ...baseMark.detach, count: baseMark.count },
-			metadata,
 			moveEffects,
 			nodeExistenceState,
 		);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -34,7 +34,7 @@ export function sequenceFieldToDelta(change: MarkList, deltaFromChild: ToDelta):
 
 	for (const mark of change) {
 		const deltaMark: Mutable<DeltaMark> = { count: mark.count };
-		const inputCellId = getInputCellId(mark, undefined);
+		const inputCellId = getInputCellId(mark);
 		const changes = mark.changes;
 		if (changes !== undefined) {
 			const nestedDelta = deltaFromChild(changes);
@@ -68,7 +68,7 @@ export function sequenceFieldToDelta(change: MarkList, deltaFromChild: ToDelta):
 				continue;
 			}
 
-			const outputId = getDetachedNodeId(mark.detach, undefined);
+			const outputId = getDetachedNodeId(mark.detach);
 			assert(
 				outputId !== undefined,
 				0x820 /* AttachAndDetach mark should have defined output cell ID */,
@@ -101,7 +101,7 @@ export function sequenceFieldToDelta(change: MarkList, deltaFromChild: ToDelta):
 					break;
 				}
 				case "Remove": {
-					const newDetachId = getDetachedNodeId(mark, undefined);
+					const newDetachId = getDetachedNodeId(mark);
 					if (inputCellId === undefined) {
 						deltaMark.detach = nodeIdFromChangeAtom(newDetachId);
 						local.push(deltaMark);
@@ -127,7 +127,7 @@ export function sequenceFieldToDelta(change: MarkList, deltaFromChild: ToDelta):
 				}
 				case "MoveOut": {
 					// The move destination will look for the detach ID of the source, so we can ignore `finalEndpoint`.
-					const detachId = nodeIdFromChangeAtom(getDetachedNodeId(mark, undefined));
+					const detachId = nodeIdFromChangeAtom(getDetachedNodeId(mark));
 					if (inputCellId === undefined) {
 						deltaMark.detach = detachId;
 						local.push(deltaMark);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -20,7 +20,6 @@ import {
 	CrossFieldTarget,
 	NodeId,
 	addCrossFieldQuery,
-	getIntention,
 	setInCrossFieldMap,
 } from "../modular-schema/index.js";
 
@@ -104,10 +103,7 @@ export function areEqualCellIds(a: CellId | undefined, b: CellId | undefined): b
 	return areEqualChangeAtomIds(a, b);
 }
 
-export function getInputCellId(
-	mark: Mark,
-	metadata: RevisionMetadataSource | undefined,
-): CellId | undefined {
+export function getInputCellId(mark: Mark): CellId | undefined {
 	const cellId = mark.cellId;
 	if (cellId === undefined) {
 		return undefined;
@@ -126,33 +122,29 @@ export function getInputCellId(
 
 	return {
 		...cellId,
-		revision: getIntentionIfMetadataProvided(markRevision, metadata),
+		revision: markRevision,
 	};
 }
 
-export function getOutputCellId(
-	mark: Mark,
-	metadata: RevisionMetadataSource | undefined,
-): CellId | undefined {
+export function getOutputCellId(mark: Mark): CellId | undefined {
 	if (isDetach(mark)) {
-		return getDetachOutputCellId(mark, metadata);
+		return getDetachOutputCellId(mark);
 	} else if (markFillsCells(mark)) {
 		return undefined;
 	} else if (isAttachAndDetachEffect(mark)) {
-		return getDetachOutputCellId(mark.detach, metadata);
+		return getDetachOutputCellId(mark.detach);
 	}
 
-	return getInputCellId(mark, metadata);
+	return getInputCellId(mark);
 }
 
 export function cellSourcesFromMarks(
 	marks: readonly Mark[],
-	metadata: RevisionMetadataSource | undefined,
 	contextGetter: typeof getInputCellId | typeof getOutputCellId,
 ): Set<RevisionTag | undefined> {
 	const set = new Set<RevisionTag | undefined>();
 	for (const mark of marks) {
-		const cell = contextGetter(mark, metadata);
+		const cell = contextGetter(mark);
 		if (cell !== undefined) {
 			set.add(cell.revision);
 		}
@@ -288,28 +280,17 @@ export function compareCellPositionsUsingTombstones(
 /**
  * @returns the ID of the cell in the output context of the given detach `mark`.
  */
-export function getDetachOutputCellId(
-	mark: Detach,
-	metadata: RevisionMetadataSource | undefined,
-): ChangeAtomId {
-	return (
-		mark.idOverride ?? {
-			revision: getIntentionIfMetadataProvided(mark.revision, metadata),
-			localId: mark.id,
-		}
-	);
+export function getDetachOutputCellId(mark: Detach): ChangeAtomId {
+	return mark.idOverride ?? { revision: mark.revision, localId: mark.id };
 }
 
 /**
  * @returns the ID of the detached node in the output context of the given detach `mark`.
  */
-export function getDetachedNodeId(
-	mark: Detach,
-	metadata: RevisionMetadataSource | undefined,
-): ChangeAtomId {
+export function getDetachedNodeId(mark: Detach): ChangeAtomId {
 	switch (mark.type) {
 		case "Remove": {
-			return getDetachOutputCellId(mark, metadata);
+			return getDetachOutputCellId(mark);
 		}
 		case "MoveOut": {
 			return makeChangeAtomId(mark.id, mark.revision);
@@ -317,13 +298,6 @@ export function getDetachedNodeId(
 		default:
 			unreachableCase(mark);
 	}
-}
-
-function getIntentionIfMetadataProvided(
-	revision: RevisionTag | undefined,
-	metadata: RevisionMetadataSource | undefined,
-): RevisionTag | undefined {
-	return metadata === undefined ? revision : getIntention(revision, metadata);
 }
 
 /**
@@ -440,14 +414,8 @@ export function isDetachOfRemovedNodes(mark: Mark): mark is CellMark<DetachOfRem
 	return isDetach(mark) && mark.cellId !== undefined;
 }
 
-export function isImpactfulCellRename(
-	mark: Mark,
-	revisionMetadata: RevisionMetadataSource,
-): mark is CellMark<CellRename> {
-	return (
-		(isAttachAndDetachEffect(mark) || isDetachOfRemovedNodes(mark)) &&
-		isImpactful(mark, revisionMetadata)
-	);
+export function isImpactfulCellRename(mark: Mark): mark is CellMark<CellRename> {
+	return (isAttachAndDetachEffect(mark) || isDetachOfRemovedNodes(mark)) && isImpactful(mark);
 }
 
 export function areInputCellsEmpty(mark: Mark): mark is EmptyInputCellMark {
@@ -476,12 +444,10 @@ export function areOutputCellsEmpty(mark: Mark): boolean {
  * context of that mark.
  *
  * @param mark - The mark to settle. Never mutated.
- * @param revision - The revision associated with the mark.
- * @param revisionMetadata - Metadata source for the revision associated with the mark.
  * @returns either the original mark or a shallow clone of it with effects stripped out.
  */
-export function settleMark(mark: Mark, revisionMetadata: RevisionMetadataSource): Mark {
-	if (isImpactful(mark, revisionMetadata)) {
+export function settleMark(mark: Mark): Mark {
+	if (isImpactful(mark)) {
 		return mark;
 	}
 	return omitMarkEffect(mark);
@@ -492,17 +458,17 @@ export function settleMark(mark: Mark, revisionMetadata: RevisionMetadataSource)
  * Ignores the impact of nested changes.
  * CellRename effects are considered impactful if they actually change the ID of the cells.
  */
-export function isImpactful(mark: Mark, revisionMetadata: RevisionMetadataSource): boolean {
+export function isImpactful(mark: Mark): boolean {
 	const type = mark.type;
 	switch (type) {
 		case NoopMarkType:
 			return false;
 		case "Remove": {
-			const inputId = getInputCellId(mark, revisionMetadata);
+			const inputId = getInputCellId(mark);
 			if (inputId === undefined) {
 				return true;
 			}
-			const outputId = getOutputCellId(mark, revisionMetadata);
+			const outputId = getOutputCellId(mark);
 			assert(outputId !== undefined, 0x824 /* Remove marks must have an output cell ID */);
 			return !areEqualChangeAtomIds(inputId, outputId);
 		}

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/compose.test.ts
@@ -1378,15 +1378,24 @@ export function testCompose() {
 
 		it("remove (rollback) ○ insert", () => {
 			const insertA = tagChangeInline([Mark.insert(1, brand(0))], tag1);
-			const removeB = tagChangeInline([Mark.remove(1, brand(0))], tag3, tag2);
+			const removeB = tagChangeInline(
+				[Mark.remove(1, brand(0), { idOverride: { revision: tag2, localId: brand(0) } })],
+				tag3,
+				tag2,
+			);
 			const composed = shallowCompose([removeB, insertA]);
 
-			// B is the inverse of a new attach. Since that new attach comes after A (temporally),
+			// B is the inverse of a new attach that is sequenced after insertA.
+			// Since that new attach comes after A (temporally),
 			// its tiebreak policy causes the cell to come before A's insert (spatially).
 			// When composing the rollback with A's insert, the remove should come before the insert,
 			// even though A's insert has a tiebreak policy which puts it before other new cells.
 			const expected = [
-				Mark.remove(1, { revision: tag3, localId: brand(0) }),
+				Mark.remove(
+					1,
+					{ revision: tag3, localId: brand(0) },
+					{ idOverride: { revision: tag2, localId: brand(0) } },
+				),
 				Mark.insert(1, { revision: tag1, localId: brand(0) }),
 			];
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
@@ -25,6 +25,7 @@ function invert(change: SF.Changeset, tag: RevisionTag = tag1): SF.Changeset {
 
 const tag1: RevisionTag = mintRevisionTag();
 const tag2: RevisionTag = mintRevisionTag();
+const tag3: RevisionTag = mintRevisionTag();
 
 const nodeId1: NodeId = { localId: brand(1) };
 const nodeId2: NodeId = { localId: brand(2) };
@@ -107,7 +108,11 @@ export function testInvert() {
 
 		it("remove => revive (with rollback ID)", () => {
 			const detachId: ChangeAtomId = { revision: tag2, localId: brand(0) };
-			const input = tagChangeInline([Mark.remove(2, brand(0))], tag1, tag2);
+			const input = tagChangeInline(
+				[Mark.remove(2, brand(0), { idOverride: detachId })],
+				tag1,
+				tag3, // This ID should be ignored
+			);
 			const expected = [Mark.revive(2, detachId)];
 			const actual = invertChange(input);
 			assertChangesetsEqual(actual, expected);
@@ -389,10 +394,13 @@ export function testInvert() {
 			it("remove (same detach ID through metadata)", () => {
 				const cellId: ChangeAtomId = { revision: tag1, localId: brand(0) };
 				const input = [
-					Mark.onEmptyCell(cellId, Mark.remove(1, brand(0), { changes: childChange1 })),
+					Mark.onEmptyCell(
+						cellId,
+						Mark.remove(1, brand(0), { changes: childChange1, idOverride: cellId }),
+					),
 				];
 
-				const actual = invertChange(tagChangeInline(input, tag2, tag1));
+				const actual = invertChange(tagChangeInline(input, tag2, tag3 /* <= ignored */));
 				const expected = Change.modifyDetached(
 					0,
 					{ ...childChange1, revision: tag2 },

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -298,14 +298,12 @@ export function invertDeep(change: TaggedChange<WrappedChange>): WrappedChange {
 export function invert(change: TaggedChange<SF.Changeset>, isRollback = true): SF.Changeset {
 	deepFreeze(change.change);
 	const table = SF.newCrossFieldTable();
-	const revisionMetadata = defaultRevisionMetadataFromChanges([change]);
 	let inverted = SF.invert(
 		change.change,
 		isRollback,
 		// Sequence fields should not generate IDs during invert
 		fakeIdAllocator,
 		table,
-		revisionMetadata,
 	);
 
 	if (table.isInvalidated) {
@@ -318,7 +316,6 @@ export function invert(change: TaggedChange<SF.Changeset>, isRollback = true): S
 			// Sequence fields should not generate IDs during invert
 			fakeIdAllocator,
 			table,
-			revisionMetadata,
 		);
 	}
 


### PR DESCRIPTION
## Description

In the current sequence field logic, the `rollbackOf` metadata is not necessary because detach ID overrides are used instead.

## Breaking Changes

None