### PR TITLE
fix(ci): Increase timeout for build job in server pipelines

### DIFF
--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -185,6 +185,10 @@ extends:
       jobs:
       - job: build
         displayName: Build Container - ${{ parameters.containerName }}
+        # Bumping timeout from default 60 minutes while we figure out why some auto-injected always time out (previously
+        # after 10 minutes, more recently after 15), and cause the job to go past 60 minutes and fail.
+        # AB#8172
+        timeoutInMinutes: 90
         variables:
           releaseBuildVar: $[variables.releaseBuild]
           hostPathToPackArtifact: $(Build.ArtifactStagingDirectory)/pack


### PR DESCRIPTION
## Description

A change in some of the auto-injected tasks (timing out after 15 min instead of 10) is causing this job to go past the 60 min default timeout in ADO and get cancelled, failing the pipeline. This PR increases the timeout for the job while we figure out what's the issue with the auto-injected task and why it can never complete for our containers.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
