### PR TITLE
client/server decoupling: add git utility functions to driver-utils

### DIFF
--- a/packages/drivers/odsp-driver/package.json
+++ b/packages/drivers/odsp-driver/package.json
@@ -119,7 +119,6 @@
 		"@fluidframework/driver-utils": "workspace:~",
 		"@fluidframework/odsp-doclib-utils": "workspace:~",
 		"@fluidframework/odsp-driver-definitions": "workspace:~",
-		"@fluidframework/protocol-base": "^5.0.0-265463",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"node-fetch": "^2.6.9",
 		"socket.io-client": "^4.7.3",

--- a/packages/drivers/odsp-driver/src/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createNewUtils.ts
@@ -14,10 +14,10 @@ import {
 import { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import {
 	getDocAttributesFromProtocolSummary,
+	getGitType,
 	isCombinedAppAndProtocolSummary,
 } from "@fluidframework/driver-utils/internal";
 import { InstrumentedStorageTokenFetcher } from "@fluidframework/odsp-driver-definitions/internal";
-import { getGitType } from "@fluidframework/protocol-base";
 import { ITelemetryLoggerExt, PerformanceEvent } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -7,9 +7,8 @@ import { Uint8ArrayToString } from "@fluid-internal/client-utils";
 import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import { ISummaryTree, SummaryType, SummaryObject } from "@fluidframework/driver-definitions";
 import { ISummaryContext } from "@fluidframework/driver-definitions/internal";
-import { isCombinedAppAndProtocolSummary } from "@fluidframework/driver-utils/internal";
+import { getGitType, isCombinedAppAndProtocolSummary } from "@fluidframework/driver-utils/internal";
 import { InstrumentedStorageTokenFetcher } from "@fluidframework/odsp-driver-definitions/internal";
-import { getGitType } from "@fluidframework/protocol-base";
 import {
 	ITelemetryLoggerExt,
 	MonitoringContext,

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -117,7 +117,6 @@
 		"@fluidframework/driver-base": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",
 		"@fluidframework/driver-utils": "workspace:~",
-		"@fluidframework/protocol-base": "^5.0.0-265463",
 		"@fluidframework/server-services-client": "^5.0.0-265463",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"cross-fetch": "^3.1.5",

--- a/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
@@ -13,7 +13,7 @@ import {
 	ISnapshotTreeEx,
 	IVersion,
 } from "@fluidframework/driver-definitions/internal";
-import { buildGitTreeHierarchy } from "@fluidframework/protocol-base";
+import { buildGitTreeHierarchy } from "@fluidframework/driver-utils/internal";
 import {
 	ITelemetryLoggerExt,
 	MonitoringContext,

--- a/packages/drivers/routerlicious-driver/src/summaryTreeUploadManager.ts
+++ b/packages/drivers/routerlicious-driver/src/summaryTreeUploadManager.ts
@@ -8,7 +8,7 @@ import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import { ISummaryTree, SummaryObject, SummaryType } from "@fluidframework/driver-definitions";
 import type { IGitCreateTreeEntry } from "@fluidframework/driver-definitions/internal";
 import { ISnapshotTreeEx } from "@fluidframework/driver-definitions/internal";
-import { getGitMode, getGitType } from "@fluidframework/protocol-base";
+import { getGitMode, getGitType } from "@fluidframework/driver-utils/internal";
 import { IWholeSummaryPayloadType } from "@fluidframework/server-services-client";
 
 import { IGitManager, ISummaryUploadManager } from "./storageContracts.js";

--- a/packages/loader/driver-utils/api-report/driver-utils.alpha.api.md
+++ b/packages/loader/driver-utils/api-report/driver-utils.alpha.api.md
@@ -18,6 +18,7 @@ import { IDocumentStorageService } from '@fluidframework/driver-definitions/inte
 import { IDocumentStorageServicePolicies } from '@fluidframework/driver-definitions/internal';
 import { IDriverErrorBase } from '@fluidframework/driver-definitions/internal';
 import { IFluidErrorBase } from '@fluidframework/telemetry-utils/internal';
+import { IGitTree } from '@fluidframework/driver-definitions/internal';
 import { ILocationRedirectionError } from '@fluidframework/driver-definitions/internal';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResolvedUrl } from '@fluidframework/driver-definitions/internal';
@@ -25,6 +26,7 @@ import { ISequencedDocumentMessage } from '@fluidframework/driver-definitions';
 import { ISnapshot } from '@fluidframework/driver-definitions/internal';
 import { ISnapshotFetchOptions } from '@fluidframework/driver-definitions/internal';
 import { ISnapshotTree } from '@fluidframework/driver-definitions/internal';
+import { ISnapshotTreeEx } from '@fluidframework/driver-definitions/internal';
 import { IStream } from '@fluidframework/driver-definitions/internal';
 import { IStreamResult } from '@fluidframework/driver-definitions/internal';
 import { ISummaryContext } from '@fluidframework/driver-definitions/internal';
@@ -40,6 +42,7 @@ import { IUrlResolver } from '@fluidframework/driver-definitions/internal';
 import { IVersion } from '@fluidframework/driver-definitions/internal';
 import { LoaderCachingPolicy } from '@fluidframework/driver-definitions/internal';
 import { LoggingError } from '@fluidframework/telemetry-utils/internal';
+import { SummaryObject } from '@fluidframework/driver-definitions/internal';
 
 // @public (undocumented)
 export interface ICompressionStorageConfig {

--- a/packages/loader/driver-utils/api-report/driver-utils.beta.api.md
+++ b/packages/loader/driver-utils/api-report/driver-utils.beta.api.md
@@ -18,6 +18,7 @@ import { IDocumentStorageService } from '@fluidframework/driver-definitions/inte
 import { IDocumentStorageServicePolicies } from '@fluidframework/driver-definitions/internal';
 import { IDriverErrorBase } from '@fluidframework/driver-definitions/internal';
 import { IFluidErrorBase } from '@fluidframework/telemetry-utils/internal';
+import { IGitTree } from '@fluidframework/driver-definitions/internal';
 import { ILocationRedirectionError } from '@fluidframework/driver-definitions/internal';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResolvedUrl } from '@fluidframework/driver-definitions/internal';
@@ -25,6 +26,7 @@ import { ISequencedDocumentMessage } from '@fluidframework/driver-definitions';
 import { ISnapshot } from '@fluidframework/driver-definitions/internal';
 import { ISnapshotFetchOptions } from '@fluidframework/driver-definitions/internal';
 import { ISnapshotTree } from '@fluidframework/driver-definitions/internal';
+import { ISnapshotTreeEx } from '@fluidframework/driver-definitions/internal';
 import { IStream } from '@fluidframework/driver-definitions/internal';
 import { IStreamResult } from '@fluidframework/driver-definitions/internal';
 import { ISummaryContext } from '@fluidframework/driver-definitions/internal';
@@ -40,6 +42,7 @@ import { IUrlResolver } from '@fluidframework/driver-definitions/internal';
 import { IVersion } from '@fluidframework/driver-definitions/internal';
 import { LoaderCachingPolicy } from '@fluidframework/driver-definitions/internal';
 import { LoggingError } from '@fluidframework/telemetry-utils/internal';
+import { SummaryObject } from '@fluidframework/driver-definitions/internal';
 
 // @public (undocumented)
 export interface ICompressionStorageConfig {

--- a/packages/loader/driver-utils/api-report/driver-utils.public.api.md
+++ b/packages/loader/driver-utils/api-report/driver-utils.public.api.md
@@ -18,6 +18,7 @@ import { IDocumentStorageService } from '@fluidframework/driver-definitions/inte
 import { IDocumentStorageServicePolicies } from '@fluidframework/driver-definitions/internal';
 import { IDriverErrorBase } from '@fluidframework/driver-definitions/internal';
 import { IFluidErrorBase } from '@fluidframework/telemetry-utils/internal';
+import { IGitTree } from '@fluidframework/driver-definitions/internal';
 import { ILocationRedirectionError } from '@fluidframework/driver-definitions/internal';
 import { IRequest } from '@fluidframework/core-interfaces';
 import { IResolvedUrl } from '@fluidframework/driver-definitions/internal';
@@ -25,6 +26,7 @@ import { ISequencedDocumentMessage } from '@fluidframework/driver-definitions';
 import { ISnapshot } from '@fluidframework/driver-definitions/internal';
 import { ISnapshotFetchOptions } from '@fluidframework/driver-definitions/internal';
 import { ISnapshotTree } from '@fluidframework/driver-definitions/internal';
+import { ISnapshotTreeEx } from '@fluidframework/driver-definitions/internal';
 import { IStream } from '@fluidframework/driver-definitions/internal';
 import { IStreamResult } from '@fluidframework/driver-definitions/internal';
 import { ISummaryContext } from '@fluidframework/driver-definitions/internal';
@@ -40,6 +42,7 @@ import { IUrlResolver } from '@fluidframework/driver-definitions/internal';
 import { IVersion } from '@fluidframework/driver-definitions/internal';
 import { LoaderCachingPolicy } from '@fluidframework/driver-definitions/internal';
 import { LoggingError } from '@fluidframework/telemetry-utils/internal';
+import { SummaryObject } from '@fluidframework/driver-definitions/internal';
 
 // @public (undocumented)
 export interface ICompressionStorageConfig {

--- a/packages/loader/driver-utils/package.json
+++ b/packages/loader/driver-utils/package.json
@@ -105,7 +105,6 @@
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/driver-definitions": "workspace:~",
-		"@fluidframework/protocol-base": "^5.0.0-265463",
 		"@fluidframework/telemetry-utils": "workspace:~",
 		"axios": "^1.6.2",
 		"lz4js": "^0.2.0",

--- a/packages/loader/driver-utils/src/buildSnapshotTree.ts
+++ b/packages/loader/driver-utils/src/buildSnapshotTree.ts
@@ -5,15 +5,17 @@
 
 import { stringToBuffer } from "@fluid-internal/client-utils";
 import { assert } from "@fluidframework/core-utils/internal";
-import type { IGitTree, IGitTreeEntry } from "@fluidframework/driver-definitions/internal";
 import {
 	FileMode,
+	IGitTree,
+	IGitTreeEntry,
 	ISnapshotTree,
 	ITreeEntry,
 	TreeEntry,
 } from "@fluidframework/driver-definitions/internal";
-import { buildGitTreeHierarchy } from "@fluidframework/protocol-base";
 import { v4 as uuid } from "uuid";
+
+import { buildGitTreeHierarchy } from "@fluidframework/driver-utils/internal";
 
 function flattenCore(
 	path: string,

--- a/packages/loader/driver-utils/src/buildSnapshotTree.ts
+++ b/packages/loader/driver-utils/src/buildSnapshotTree.ts
@@ -15,7 +15,7 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 import { v4 as uuid } from "uuid";
 
-import { buildGitTreeHierarchy } from "@fluidframework/driver-utils/internal";
+import { buildGitTreeHierarchy } from "./protocol/index.js";
 
 function flattenCore(
 	path: string,

--- a/packages/loader/driver-utils/src/index.ts
+++ b/packages/loader/driver-utils/src/index.ts
@@ -55,3 +55,4 @@ export {
 	blobHeadersBlobName,
 } from "./adapters/index.js";
 export { getSnapshotTree, isInstanceOfISnapshot } from "./storageUtils.js";
+export { buildGitTreeHierarchy, getGitMode, getGitType } from "./protocol/index.js";

--- a/packages/loader/driver-utils/src/protocol/README.md
+++ b/packages/loader/driver-utils/src/protocol/README.md
@@ -1,0 +1,11 @@
+# @fluidframework/driver-utils/src/protocol
+
+These files should not be changed unless the Fluid service itself is changed, and
+should be aligned with the service side definitions contained here:
+
+server/routerlicious/packages/protocol-base
+
+## Notes
+
+The file names in this directory align with those in server/protocol-base to facilitate
+copying/synchronization in the future, if desireable.

--- a/packages/loader/driver-utils/src/protocol/gitHelper.ts
+++ b/packages/loader/driver-utils/src/protocol/gitHelper.ts
@@ -1,0 +1,98 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { unreachableCase } from "@fluidframework/core-utils/internal";
+import {
+	FileMode,
+	IGitTree,
+	ISnapshotTreeEx,
+	SummaryType,
+	SummaryObject,
+} from "@fluidframework/driver-definitions/internal";
+
+/**
+ * Take a summary object and returns its git mode.
+ *
+ * @param value - summary object
+ * @returns the git mode of summary object
+ * @internal
+ */
+export function getGitMode(value: SummaryObject): string {
+	const type = value.type === SummaryType.Handle ? value.handleType : value.type;
+	switch (type) {
+		case SummaryType.Blob:
+		case SummaryType.Attachment:
+			return FileMode.File;
+		case SummaryType.Tree:
+			return FileMode.Directory;
+		default:
+			unreachableCase(type, `Unknown type: ${type}`);
+	}
+}
+
+/**
+ * Take a summary object and returns its type.
+ *
+ * @param value - summary object
+ * @returns the type of summary object
+ * @internal
+ */
+export function getGitType(value: SummaryObject): "blob" | "tree" {
+	const type = value.type === SummaryType.Handle ? value.handleType : value.type;
+
+	switch (type) {
+		case SummaryType.Blob:
+		case SummaryType.Attachment:
+			return "blob";
+		case SummaryType.Tree:
+			return "tree";
+		default:
+			unreachableCase(type, `Unknown type: ${type}`);
+	}
+}
+
+/**
+ * NOTE: Renamed from `buildHierarchy` to `buildGitTreeHierarchy`. There is usage of this function in loader and driver layer.
+ * Build a tree hierarchy base on a flat tree
+ *
+ * @param flatTree - a flat tree
+ * @param blobsShaToPathCache - Map with blobs sha as keys and values as path of the blob.
+ * @param removeAppTreePrefix - Remove `.app/` from beginning of paths when present
+ * @returns the hierarchical tree
+ * @internal
+ */
+export function buildGitTreeHierarchy(
+	flatTree: IGitTree,
+	blobsShaToPathCache: Map<string, string> = new Map<string, string>(),
+	removeAppTreePrefix = false,
+): ISnapshotTreeEx {
+	const lookup: { [path: string]: ISnapshotTreeEx } = {};
+	const root: ISnapshotTreeEx = { id: flatTree.sha, blobs: {}, trees: {} };
+	lookup[""] = root;
+
+	for (const entry of flatTree.tree) {
+		const entryPath = removeAppTreePrefix ? entry.path.replace(/^\.app\//, "") : entry.path;
+		const lastIndex = entryPath.lastIndexOf("/");
+		const entryPathDir = entryPath.slice(0, Math.max(0, lastIndex));
+		const entryPathBase = entryPath.slice(lastIndex + 1);
+
+		// The flat output is breadth-first so we can assume we see tree nodes prior to their contents
+		const node = lookup[entryPathDir];
+
+		// Add in either the blob or tree
+		if (entry.type === "tree") {
+			const newTree = { id: entry.sha, blobs: {}, commits: {}, trees: {} };
+			node.trees[decodeURIComponent(entryPathBase)] = newTree;
+			lookup[entryPath] = newTree;
+		} else if (entry.type === "blob") {
+			node.blobs[decodeURIComponent(entryPathBase)] = entry.sha;
+			blobsShaToPathCache.set(entry.sha, `/${entryPath}`);
+		} else {
+			throw new Error("Unknown entry type!!");
+		}
+	}
+
+	return root;
+}

--- a/packages/loader/driver-utils/src/protocol/index.ts
+++ b/packages/loader/driver-utils/src/protocol/index.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { buildGitTreeHierarchy, getGitMode, getGitType } from "./gitHelper.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10466,9 +10466,6 @@ importers:
       '@fluidframework/odsp-driver-definitions':
         specifier: workspace:~
         version: link:../odsp-driver-definitions
-      '@fluidframework/protocol-base':
-        specifier: ^5.0.0-265463
-        version: 5.0.0-265463
       '@fluidframework/telemetry-utils':
         specifier: workspace:~
         version: link:../../utils/telemetry-utils
@@ -10785,9 +10782,6 @@ importers:
       '@fluidframework/driver-utils':
         specifier: workspace:~
         version: link:../../loader/driver-utils
-      '@fluidframework/protocol-base':
-        specifier: ^5.0.0-265463
-        version: 5.0.0-265463
       '@fluidframework/server-services-client':
         specifier: ^5.0.0-265463
         version: 5.0.0-265463
@@ -12359,9 +12353,6 @@ importers:
       '@fluidframework/driver-definitions':
         specifier: workspace:~
         version: link:../../common/driver-definitions
-      '@fluidframework/protocol-base':
-        specifier: ^5.0.0-265463
-        version: 5.0.0-265463
       '@fluidframework/telemetry-utils':
         specifier: workspace:~
         version: link:../../utils/telemetry-utils


### PR DESCRIPTION
Removes client dependence on 'protocol-base' for utility functions that work with Git summary trees.

No suprises / very straightforward.