### PR TITLE
[GC] Make getAttachGCData required on IFluidDataStoreChannel and make implementation consistent

### DIFF
--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -244,6 +244,13 @@ export function wrapContextForInnerChannel(
 }
 
 /**
+ * Returns the type of the given local data store from its package path.
+ */
+export function getLocalDataStoreType(localDataStore: LocalFluidDataStoreContext) {
+	return localDataStore.packagePath[localDataStore.packagePath.length - 1];
+}
+
+/**
  * This class encapsulates data store handling. Currently it is only used by the container runtime,
  * but eventually could be hosted on any channel once we formalize the channel api boundary.
  * @internal
@@ -527,10 +534,9 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 	}
 
 	/** Package up the context's attach summary etc into an IAttachMessage */
-	private generateAttachMessage(localContext: IFluidDataStoreContextInternal): IAttachMessage {
+	private generateAttachMessage(localContext: LocalFluidDataStoreContext): IAttachMessage {
 		// Get the attach summary.
 		const attachSummary = localContext.getAttachSummary();
-		const type = localContext.packagePath[localContext.packagePath.length - 1];
 
 		// Get the GC data and add it to the attach summary.
 		const attachGCData = localContext.getAttachGCData();
@@ -542,7 +548,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 		return {
 			id: localContext.id,
 			snapshot,
-			type,
+			type: getLocalDataStoreType(localContext),
 		} satisfies IAttachMessage;
 	}
 

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -43,11 +43,13 @@ import {
 	NamedFluidDataStoreRegistryEntries,
 	channelsTreeName,
 	IInboundSignalMessage,
+	gcDataBlobKey,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	GCDataBuilder,
 	RequestParser,
 	SummaryTreeBuilder,
+	addBlobToSummary,
 	convertSnapshotTreeToSummaryTree,
 	convertSummaryTreeToITree,
 	create404Response,
@@ -526,8 +528,13 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 
 	/** Package up the context's attach summary etc into an IAttachMessage */
 	private generateAttachMessage(localContext: IFluidDataStoreContextInternal): IAttachMessage {
-		const { attachSummary } = localContext.getAttachData(/* includeGCData: */ true);
+		// Get the attach summary.
+		const attachSummary = localContext.getAttachSummary();
 		const type = localContext.packagePath[localContext.packagePath.length - 1];
+
+		// Get the GC data and add it to the attach summary.
+		const attachGCData = localContext.getAttachGCData();
+		addBlobToSummary(attachSummary, gcDataBlobKey, JSON.stringify(attachGCData));
 
 		// Attach message needs the summary in ITree format. Convert the ISummaryTree into an ITree.
 		const snapshot = convertSummaryTreeToITree(attachSummary.summary);
@@ -1126,10 +1133,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 				.map(([key, value]) => {
 					let dataStoreSummary: ISummarizeResult;
 					if (value.isLoaded) {
-						dataStoreSummary = value.getAttachData(
-							/* includeGCCData: */ false,
-							telemetryContext,
-						).attachSummary;
+						dataStoreSummary = value.getAttachSummary(telemetryContext);
 					} else {
 						// If this data store is not yet loaded, then there should be no changes in the snapshot from
 						// which it was created as it is detached container. So just use the previous snapshot.
@@ -1146,6 +1150,36 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 		} while (notBoundContextsLength !== this.contexts.notBoundLength());
 
 		return builder.getSummaryTree();
+	}
+
+	/**
+	 * Gets the GC data. Used when attaching or serializing a detached container.
+	 */
+	public getAttachGCData(telemetryContext?: ITelemetryContext): IGarbageCollectionData {
+		const builder = new GCDataBuilder();
+		// Attaching graph of some stores can cause other stores to get bound too.
+		// So keep taking summary until no new stores get bound.
+		let notBoundContextsLength: number;
+		do {
+			notBoundContextsLength = this.contexts.notBoundLength();
+			// Iterate over each data store and ask for its GC data.
+			Array.from(this.contexts)
+				.filter(
+					([key, _]) =>
+						// Take GC data of bounded data stores only.
+						!this.contexts.isNotBound(key),
+				)
+				.map(([key, value]) => {
+					const contextGCData = value.getAttachGCData(telemetryContext);
+					// Prefix the child's id to the ids of its GC nodes so they can be identified as belonging to the child.
+					// This also gradually builds the id of each node to be a path from the root.
+					builder.prefixAndAddNodes(key, contextGCData.gcNodes);
+				});
+		} while (notBoundContextsLength !== this.contexts.notBoundLength());
+
+		// Get the outbound routes (aliased data stores) and add a GC node for this channel.
+		builder.addNode("/", Array.from(this.aliasedDataStores));
+		return builder.getGCData();
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -48,7 +48,11 @@ import {
 	validateAssertionError,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { ChannelCollection, wrapContextForInnerChannel } from "../channelCollection.js";
+import {
+	ChannelCollection,
+	getLocalDataStoreType,
+	wrapContextForInnerChannel,
+} from "../channelCollection.js";
 import { ContainerRuntime } from "../containerRuntime.js";
 import { channelToDataStore } from "../dataStore.js";
 import {
@@ -241,9 +245,11 @@ describe("Data Store Context Tests", () => {
 					dataStoreAttributes.isRootDataStore,
 					"Local DataStore root state does not match",
 				);
-				const type =
-					localDataStoreContext.packagePath[localDataStoreContext.packagePath.length - 1];
-				assert.strictEqual(type, "TestDataStore1", "Attach message type does not match.");
+				assert.strictEqual(
+					getLocalDataStoreType(localDataStoreContext),
+					"TestDataStore1",
+					"Attach message type does not match.",
+				);
 			});
 
 			it("should generate exception when incorrectly created with array of packages", async () => {
@@ -327,9 +333,11 @@ describe("Data Store Context Tests", () => {
 					dataStoreAttributes.isRootDataStore,
 					"Local DataStore root state does not match",
 				);
-				const type =
-					localDataStoreContext.packagePath[localDataStoreContext.packagePath.length - 1];
-				assert.strictEqual(type, "SubComp", "Attach message type does not match.");
+				assert.strictEqual(
+					getLocalDataStoreType(localDataStoreContext),
+					"SubComp",
+					"Attach message type does not match.",
+				);
 			});
 
 			it("can correctly initialize non-root context", async () => {

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -206,11 +206,8 @@ describe("Data Store Context Tests", () => {
 				});
 
 				await localDataStoreContext.realize();
-				const {
-					attachSummary: { summary },
-					type,
-				} = localDataStoreContext.getAttachData(/* includeGCData: */ false);
-				const snapshot = convertSummaryTreeToITree(summary);
+				const attachSummary = localDataStoreContext.getAttachSummary();
+				const snapshot = convertSummaryTreeToITree(attachSummary.summary);
 
 				const attributesEntry = snapshot.entries.find(
 					(e) => e.path === dataStoreAttributesBlobName,
@@ -244,6 +241,8 @@ describe("Data Store Context Tests", () => {
 					dataStoreAttributes.isRootDataStore,
 					"Local DataStore root state does not match",
 				);
+				const type =
+					localDataStoreContext.packagePath[localDataStoreContext.packagePath.length - 1];
 				assert.strictEqual(type, "TestDataStore1", "Attach message type does not match.");
 			});
 
@@ -295,11 +294,8 @@ describe("Data Store Context Tests", () => {
 
 				await localDataStoreContext.realize();
 
-				const {
-					attachSummary: { summary },
-					type,
-				} = localDataStoreContext.getAttachData(/* includeGCData: */ false);
-				const snapshot = convertSummaryTreeToITree(summary);
+				const attachSummary = localDataStoreContext.getAttachSummary();
+				const snapshot = convertSummaryTreeToITree(attachSummary.summary);
 				const attributesEntry = snapshot.entries.find(
 					(e) => e.path === dataStoreAttributesBlobName,
 				);
@@ -331,6 +327,8 @@ describe("Data Store Context Tests", () => {
 					dataStoreAttributes.isRootDataStore,
 					"Local DataStore root state does not match",
 				);
+				const type =
+					localDataStoreContext.packagePath[localDataStoreContext.packagePath.length - 1];
 				assert.strictEqual(type, "SubComp", "Attach message type does not match.");
 			});
 

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.alpha.api.md
@@ -157,7 +157,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
     // (undocumented)
     applyStashedOp(content: any): Promise<unknown>;
     readonly entryPoint: IFluidHandleInternal<FluidObject>;
-    getAttachGCData?(telemetryContext?: ITelemetryContext): IGarbageCollectionData;
+    getAttachGCData(telemetryContext?: ITelemetryContext): IGarbageCollectionData;
     getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
     makeVisibleAndAttachGraph(): void;

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -119,6 +119,9 @@
 			"RemovedInterfaceDeclaration_IFluidDataStoreContextEvents": {
 				"forwardCompat": false,
 				"backCompat": false
+			},
+			"InterfaceDeclaration_IFluidDataStoreChannel": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -292,7 +292,7 @@ export interface IFluidDataStoreChannel extends IDisposable {
 	/**
 	 * Synchronously retrieves GC Data (representing the outbound routes present) for the initial state of the DataStore
 	 */
-	getAttachGCData?(telemetryContext?: ITelemetryContext): IGarbageCollectionData;
+	getAttachGCData(telemetryContext?: ITelemetryContext): IGarbageCollectionData;
 
 	/**
 	 * Processes the op.

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -503,6 +503,7 @@ declare function get_old_InterfaceDeclaration_IFluidDataStoreChannel():
 declare function use_current_InterfaceDeclaration_IFluidDataStoreChannel(
     use: TypeOnly<current.IFluidDataStoreChannel>): void;
 use_current_InterfaceDeclaration_IFluidDataStoreChannel(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IFluidDataStoreChannel());
 
 /*

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -30,6 +30,7 @@ import {
 	IGarbageCollectionData,
 	ISummarizeResult,
 	ITelemetryContextExt,
+	gcDataBlobKey,
 } from "@fluidframework/runtime-definitions/internal";
 import type { TelemetryEventPropertyTypeExt } from "@fluidframework/telemetry-utils/internal";
 
@@ -386,7 +387,7 @@ export function processAttachMessageGCData(
 	snapshot: ITree | null,
 	addedGCOutboundRoute: (fromNodeId: string, toPath: string) => void,
 ): boolean {
-	const gcDataEntry = snapshot?.entries.find((e) => e.path === ".gcdata");
+	const gcDataEntry = snapshot?.entries.find((e) => e.path === gcDataBlobKey);
 
 	// Old attach messages won't have GC Data
 	// (And REALLY old DataStore Attach messages won't even have a snapshot!)

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.alpha.api.md
@@ -54,6 +54,7 @@ import { ISnapshotTree } from '@fluidframework/driver-definitions/internal';
 import { ISummaryTree } from '@fluidframework/driver-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
+import { ITelemetryContext } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { ITokenResponse } from '@fluidframework/routerlicious-driver';
@@ -469,6 +470,8 @@ export class MockFluidDataStoreRuntime extends EventEmitter implements IFluidDat
     readonly entryPoint: IFluidHandleInternal<FluidObject>;
     // (undocumented)
     readonly existing: boolean;
+    // (undocumented)
+    getAttachGCData(telemetryContext?: ITelemetryContext | undefined): IGarbageCollectionData;
     // (undocumented)
     getAttachSnapshot(): ITreeEntry[];
     // (undocumented)

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.beta.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.beta.api.md
@@ -54,6 +54,7 @@ import { ISnapshotTree } from '@fluidframework/driver-definitions/internal';
 import { ISummaryTree } from '@fluidframework/driver-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
+import { ITelemetryContext } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { ITokenResponse } from '@fluidframework/routerlicious-driver';

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.public.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.public.api.md
@@ -54,6 +54,7 @@ import { ISnapshotTree } from '@fluidframework/driver-definitions/internal';
 import { ISummaryTree } from '@fluidframework/driver-definitions';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
+import { ITelemetryContext } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { ITokenResponse } from '@fluidframework/routerlicious-driver';

--- a/packages/runtime/test-runtime-utils/src/mocks.ts
+++ b/packages/runtime/test-runtime-utils/src/mocks.ts
@@ -54,6 +54,7 @@ import {
 	FlushMode,
 	IFluidDataStoreChannel,
 	VisibilityState,
+	type ITelemetryContext,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	getNormalizedObjectStoragePathParts,
@@ -1046,6 +1047,14 @@ export class MockFluidDataStoreRuntime
 				tree: {},
 			},
 			stats,
+		};
+	}
+
+	public getAttachGCData(
+		telemetryContext?: ITelemetryContext | undefined,
+	): IGarbageCollectionData {
+		return {
+			gcNodes: {},
 		};
 	}
 


### PR DESCRIPTION
`getAttachGCData` was added to `IFluidDataStoreChannel` in 2.0.0-rc.2.0 4 months ago via #19275. This PR does the following:
- Makes `getAttachGCData` required on `IFluidDataStoreChannel`.
- Makes `getAttachGCData` logic consistent across channel collection, data store context, data store runtime and channel contexts. I found it confusing to follow the existing flow due to the implementation being different for various layers. This is how it works now:
  - `ChannelCollection` and `FluidDataStoreRuntime` both implements `getAttachGCData` which iterates through all it's children and gets their GC data by calling `getAttachGCData`.
  - `FluidDataStoreContext` and `LocalChannelContext` both implement `getAttachGCData` which returns the GC data for this node.
  - Decouples `getAttachSummary` and `getAttachGCData` in `ChannelCollection:generateAttachMessage`.

[AB#8199](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8199)
