### PR TITLE
[GC] Added message timestamps when calling GarbageCollector::addedOutboundReference

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.alpha.api.md
@@ -101,7 +101,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     protected constructor(context: IContainerContext, registry: IFluidDataStoreRegistry, metadata: IContainerRuntimeMetadata | undefined, electedSummarizerData: ISerializedElection | undefined, chunks: [string, string[]][], dataStoreAliasMap: [string, string][], runtimeOptions: Readonly<Required<IContainerRuntimeOptions>>, containerScope: FluidObject, baseLogger: ITelemetryBaseLogger, existing: boolean, blobManagerSnapshot: IBlobManagerLoadInfo, _storage: IDocumentStorageService, createIdCompressor: () => Promise<IIdCompressor & IIdCompressorCore>, documentsSchemaController: DocumentsSchemaController, featureGatesForTelemetry: Record<string, boolean | number | undefined>, provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>, requestHandler?: ((request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>) | undefined, summaryConfiguration?: ISummaryConfiguration);
     // (undocumented)
     protected addContainerStateToSummary(summaryTree: ISummaryTreeWithStats, fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext): void;
-    addedGCOutboundRoute(fromPath: string, toPath: string): void;
+    addedGCOutboundRoute(fromPath: string, toPath: string, timestampMs?: number): void;
     // (undocumented)
     get attachState(): AttachState;
     // (undocumented)

--- a/packages/runtime/container-runtime/api-report/container-runtime.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.alpha.api.md
@@ -101,7 +101,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     protected constructor(context: IContainerContext, registry: IFluidDataStoreRegistry, metadata: IContainerRuntimeMetadata | undefined, electedSummarizerData: ISerializedElection | undefined, chunks: [string, string[]][], dataStoreAliasMap: [string, string][], runtimeOptions: Readonly<Required<IContainerRuntimeOptions>>, containerScope: FluidObject, baseLogger: ITelemetryBaseLogger, existing: boolean, blobManagerSnapshot: IBlobManagerLoadInfo, _storage: IDocumentStorageService, createIdCompressor: () => Promise<IIdCompressor & IIdCompressorCore>, documentsSchemaController: DocumentsSchemaController, featureGatesForTelemetry: Record<string, boolean | number | undefined>, provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>, requestHandler?: ((request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>) | undefined, summaryConfiguration?: ISummaryConfiguration);
     // (undocumented)
     protected addContainerStateToSummary(summaryTree: ISummaryTreeWithStats, fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext): void;
-    addedGCOutboundRoute(fromPath: string, toPath: string, timestampMs?: number): void;
+    addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number): void;
     // (undocumented)
     get attachState(): AttachState;
     // (undocumented)

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -275,6 +275,9 @@
 			},
 			"TypeAliasDeclaration_SubmitSummaryResult": {
 				"backCompat": false
+			},
+			"InterfaceDeclaration_IGCNodeUpdatedProps": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -517,7 +517,11 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			return false;
 		}
 
-		this.parentContext.addedGCOutboundRoute("/", `/${internalId}`, messageTimestampMs);
+		// If message timestamp doesn't exist, this is called in a detached container. Don't notify GC in that case
+		// because it doesn't run in detached container and doesn't need to know about this route.
+		if (messageTimestampMs) {
+			this.parentContext.addedGCOutboundRoute("/", `/${internalId}`, messageTimestampMs);
+		}
 
 		this.aliasMap.set(alias, context.id);
 		this.aliasedDataStores.add(context.id);

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -391,7 +391,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 		const foundGCData = processAttachMessageGCData(attachMessage.snapshot, (nodeId, toPath) => {
 			// nodeId is the relative path under the node being attached. Always starts with "/", but no trailing "/" after an id
 			const fromPath = `/${attachMessage.id}${nodeId === "/" ? "" : nodeId}`;
-			this.parentContext.addedGCOutboundRoute(fromPath, toPath);
+			this.parentContext.addedGCOutboundRoute(fromPath, toPath, message.timestamp);
 		});
 
 		// Only log once per container to avoid noise/cost.
@@ -486,13 +486,18 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 		const aliasResult = this.processAliasMessageCore(
 			aliasMessage.internalId,
 			aliasMessage.alias,
+			message.timestamp,
 		);
 		if (local) {
 			resolve(aliasResult);
 		}
 	}
 
-	public processAliasMessageCore(internalId: string, alias: string): boolean {
+	public processAliasMessageCore(
+		internalId: string,
+		alias: string,
+		messageTimestampMs?: number,
+	): boolean {
 		if (this.alreadyProcessed(alias)) {
 			return false;
 		}
@@ -512,7 +517,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			return false;
 		}
 
-		this.parentContext.addedGCOutboundRoute("/", `/${internalId}`);
+		this.parentContext.addedGCOutboundRoute("/", `/${internalId}`, messageTimestampMs);
 
 		this.aliasMap.set(alias, context.id);
 		this.aliasedDataStores.add(context.id);
@@ -816,7 +821,11 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 					envelope.address,
 					transformed.contents,
 					(fromPath: string, toPath: string) =>
-						this.parentContext.addedGCOutboundRoute(fromPath, toPath),
+						this.parentContext.addedGCOutboundRoute(
+							fromPath,
+							toPath,
+							message.timestamp,
+						),
 				);
 				break;
 			}
@@ -1392,6 +1401,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			packagePath: details.pkg,
 			request,
 			headerData,
+			timestampMs: undefined, // This will be added by the parent context if needed.
 		});
 
 		const dataStore = await dataStoreContext.realize();

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3415,11 +3415,15 @@ export class ContainerRuntime
 	 * @param messageTimestampMs - The timestamp of the message that added the reference.
 	 */
 	public addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number) {
-		this.garbageCollector.addedOutboundReference(
-			fromPath,
-			toPath,
-			messageTimestampMs ?? this.getCurrentReferenceTimestampMs(),
+		// This is always called when processing an op so messageTimestampMs should exist. Due to back-compat
+		// across the data store runtime / container runtime boundary, this may be undefined and if so, get
+		// the timestamp from the last processed message which must exist.
+		const timestampMs = messageTimestampMs ?? this.getCurrentReferenceTimestampMs();
+		assert(
+			timestampMs !== undefined,
+			"message timestamp must exist when calling addedGCOutboundRoute",
 		);
+		this.garbageCollector.addedOutboundReference(fromPath, toPath, timestampMs);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3412,13 +3412,13 @@ export class ContainerRuntime
 	 * all references added in the system.
 	 * @param fromPath - The absolute path of the node that added the reference.
 	 * @param toPath - The absolute path of the outbound node that is referenced.
-	 * @param timestampMs - The op-based timestamp when the node changed.
+	 * @param messageTimestampMs - The timestamp of the message that added the reference.
 	 */
-	public addedGCOutboundRoute(fromPath: string, toPath: string, timestampMs?: number) {
+	public addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number) {
 		this.garbageCollector.addedOutboundReference(
 			fromPath,
 			toPath,
-			timestampMs ?? this.getCurrentReferenceTimestampMs(),
+			messageTimestampMs ?? this.getCurrentReferenceTimestampMs(),
 		);
 	}
 

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -724,10 +724,10 @@ export abstract class FluidDataStoreContext
 	 *
 	 * @param fromPath - The absolute path of the node that added the reference.
 	 * @param toPath - The absolute path of the outbound node that is referenced.
-	 * @param timestampMs - The op-based timestamp when the node changed.
+	 * @param messageTimestampMs - The timestamp of the message that added the reference.
 	 */
-	public addedGCOutboundRoute(fromPath: string, toPath: string, timestampMs?: number) {
-		this.parentContext.addedGCOutboundRoute(fromPath, toPath, timestampMs);
+	public addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number) {
+		this.parentContext.addedGCOutboundRoute(fromPath, toPath, messageTimestampMs);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -724,9 +724,10 @@ export abstract class FluidDataStoreContext
 	 *
 	 * @param fromPath - The absolute path of the node that added the reference.
 	 * @param toPath - The absolute path of the outbound node that is referenced.
+	 * @param timestampMs - The op-based timestamp when the node changed.
 	 */
-	public addedGCOutboundRoute(fromPath: string, toPath: string) {
-		this.parentContext.addedGCOutboundRoute(fromPath, toPath);
+	public addedGCOutboundRoute(fromPath: string, toPath: string, timestampMs?: number) {
+		this.parentContext.addedGCOutboundRoute(fromPath, toPath, timestampMs);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -892,11 +892,12 @@ export class GarbageCollector implements IGarbageCollector {
 	/**
 	 * Process a GC message.
 	 * @param message - The GC message from the container runtime.
+	 * @param messageTimestampMs - The timestamp of the message.
 	 * @param local - Whether it was send by this client.
 	 */
 	public processMessage(
 		message: ContainerRuntimeGCMessage,
-		messageTimestamp: number,
+		messageTimestampMs: number,
 		local: boolean,
 	) {
 		const gcMessageType = message.contents.type;
@@ -916,7 +917,7 @@ export class GarbageCollector implements IGarbageCollector {
 				this.addedOutboundReference(
 					"/",
 					tombstonedNodePath,
-					messageTimestamp,
+					messageTimestampMs,
 					true /* autorecovery */,
 				);
 
@@ -1107,7 +1108,7 @@ export class GarbageCollector implements IGarbageCollector {
 	 *
 	 * @param fromNodePath - The node from which the reference is added.
 	 * @param toNodePath - The node to which the reference is added.
-	 * @param timestampMs - The op-based timestamp when the node changed.
+	 * @param timestampMs - The timestamp of the message that added the reference.
 	 * @param autorecovery - This reference is added artificially, for autorecovery. Used for logging.
 	 */
 	public addedOutboundReference(

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -1017,8 +1017,7 @@ export class GarbageCollector implements IGarbageCollector {
 		this.telemetryTracker.nodeUsed(trackedId, {
 			id: fullPath,
 			usageType: reason,
-			currentReferenceTimestampMs:
-				timestampMs ?? this.runtime.getCurrentReferenceTimestampMs(),
+			currentReferenceTimestampMs: timestampMs,
 			packagePath,
 			completedGCRuns: this.completedRuns,
 			isTombstoned,
@@ -1114,12 +1113,10 @@ export class GarbageCollector implements IGarbageCollector {
 	public addedOutboundReference(
 		fromNodePath: string,
 		toNodePath: string,
-		timestampMs: number | undefined,
+		timestampMs: number,
 		autorecovery?: true,
 	) {
-		// If there is no reference timestamp to work with, no ops have been processed after creation. If so, skip
-		// logging as nothing interesting would have happened worth logging.
-		if (!this.shouldRunGC || timestampMs === undefined) {
+		if (!this.shouldRunGC) {
 			return;
 		}
 

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -365,9 +365,18 @@ export interface IGarbageCollector {
 	 */
 	nodeUpdated(props: IGCNodeUpdatedProps): void;
 	/** Called when a reference is added to a node. Used to identify nodes that were referenced between summaries. */
-	addedOutboundReference(fromNodePath: string, toNodePath: string, autorecovery?: true): void;
+	addedOutboundReference(
+		fromNodePath: string,
+		toNodePath: string,
+		timestampMs: number | undefined,
+		autorecovery?: true,
+	): void;
 	/** Called to process a garbage collection message. */
-	processMessage(message: ContainerRuntimeGCMessage, local: boolean): void;
+	processMessage(
+		message: ContainerRuntimeGCMessage,
+		messageTimestamp: number,
+		local: boolean,
+	): void;
 	/** Returns true if this node has been deleted by GC during sweep phase. */
 	isNodeDeleted(nodePath: string): boolean;
 	setConnectionState(connected: boolean, clientId?: string): void;
@@ -384,7 +393,7 @@ export interface IGCNodeUpdatedProps {
 	/** Whether the node (or a subpath) was loaded or changed. */
 	reason: "Loaded" | "Changed";
 	/** The op-based timestamp when the node changed, if applicable */
-	timestampMs?: number;
+	timestampMs: number | undefined;
 	/** The package path of the node. This may not be available if the node hasn't been loaded yet */
 	packagePath?: readonly string[];
 	/** The original request for loads to preserve it in telemetry */

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -374,7 +374,7 @@ export interface IGarbageCollector {
 	/** Called to process a garbage collection message. */
 	processMessage(
 		message: ContainerRuntimeGCMessage,
-		messageTimestamp: number,
+		messageTimestampMs: number,
 		local: boolean,
 	): void;
 	/** Returns true if this node has been deleted by GC during sweep phase. */
@@ -392,7 +392,10 @@ export interface IGCNodeUpdatedProps {
 	node: { type: (typeof GCNodeType)["DataStore" | "Blob"]; path: string };
 	/** Whether the node (or a subpath) was loaded or changed. */
 	reason: "Loaded" | "Changed";
-	/** The op-based timestamp when the node changed, if applicable */
+	/**
+	 * The op-based timestamp when the node changed. If the update is from receiving an op, this should
+	 * be the timestamp of the op. If not, this should be the timestamp of the last op processed.
+	 */
 	timestampMs: number | undefined;
 	/** The package path of the node. This may not be available if the node hasn't been loaded yet */
 	packagePath?: readonly string[];

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -368,7 +368,7 @@ export interface IGarbageCollector {
 	addedOutboundReference(
 		fromNodePath: string,
 		toNodePath: string,
-		timestampMs: number | undefined,
+		timestampMs: number,
 		autorecovery?: true,
 	): void;
 	/** Called to process a garbage collection message. */

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -63,7 +63,7 @@ interface INodeUsageProps extends ICommonProps {
 	/** The full path (in GC Path format) to the node in question */
 	id: string;
 	/** Latest timestamp received from the server, as a baseline for computing GC state/age */
-	currentReferenceTimestampMs: number | undefined;
+	currentReferenceTimestampMs: number;
 	/** The package path of the node. This may not be available if the node hasn't been loaded yet */
 	packagePath: readonly string[] | undefined;
 	/** In case of Revived - what node added the reference? */
@@ -165,12 +165,6 @@ export class GCTelemetryTracker {
 			...otherNodeUsageProps
 		}: INodeUsageProps,
 	) {
-		// If there is no reference timestamp to work with, no ops have been processed after creation. If so, skip
-		// logging as nothing interesting would have happened worth logging.
-		if (currentReferenceTimestampMs === undefined) {
-			return;
-		}
-
 		// Note: For SubDataStore Load usage, trackedId will be the DataStore's id, not the full path in question.
 		// This is necessary because the SubDataStore path may be unrecognized by GC (if suited for a custom request handler)
 		const nodeStateTracker = this.getNodeStateTracker(trackedId);

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -488,7 +488,7 @@ describe("Garbage Collection Tests", () => {
 			assert.deepEqual(gc.tombstones, [nodes[0]], "node 0 should be in the Tombstones list");
 
 			// Simulate usage to trigger TombstoneLoaded op.
-			nodeUpdated(gc, nodes[0], "Loaded");
+			nodeUpdated(gc, nodes[0], "Loaded", Date.now());
 			const [gcTombstoneLoadedMessage] = spies.gc.submitMessage.args[0];
 			assert.deepEqual(
 				gcTombstoneLoadedMessage,
@@ -503,12 +503,13 @@ describe("Garbage Collection Tests", () => {
 				"submitted message not as expected",
 			);
 
+			const autoRecoveryTimestampMs = Date.now();
 			// Plumb the message to processMessage fn to trigger autorecovery
 			// Autorecovery: addedOutboundReference should be called with the tombstoned node, which should transition to "Active" state
-			gc.processMessage(gcTombstoneLoadedMessage, Date.now(), true /* local */);
+			gc.processMessage(gcTombstoneLoadedMessage, autoRecoveryTimestampMs, true /* local */);
 			assert.deepEqual(
 				spies.gc.addedOutboundReference.args[0],
-				["/", nodes[0], /* autorecovery: */ true],
+				["/", nodes[0], autoRecoveryTimestampMs, /* autorecovery: */ true],
 				"addedOutboundReference should be called with node 0",
 			);
 			assert.equal(

--- a/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/garbageCollection.spec.ts
@@ -300,7 +300,7 @@ describe("Garbage Collection Tests", () => {
 			const spies = {
 				telemetryTracker: { nodeUsed: spy(garbageCollector.telemetryTracker, "nodeUsed") },
 			};
-			garbageCollector.addedOutboundReference("/from", "to/relative/url");
+			garbageCollector.addedOutboundReference("/from", "to/relative/url", Date.now());
 			mockLogger.assertMatch(
 				[{ eventName: "GarbageCollector:InvalidRelativeOutboundRoute", category: "error" }],
 				"Expected error log",
@@ -316,7 +316,7 @@ describe("Garbage Collection Tests", () => {
 			const spies = {
 				telemetryTracker: { nodeUsed: spy(garbageCollector.telemetryTracker, "nodeUsed") },
 			};
-			garbageCollector.addedOutboundReference("/from", "/to/absolute/url");
+			garbageCollector.addedOutboundReference("/from", "/to/absolute/url", Date.now());
 			mockLogger.assertMatchNone(
 				[{ eventName: "GarbageCollector:InvalidRelativeOutboundRoute" }],
 				"unexpected events logged",
@@ -505,7 +505,7 @@ describe("Garbage Collection Tests", () => {
 
 			// Plumb the message to processMessage fn to trigger autorecovery
 			// Autorecovery: addedOutboundReference should be called with the tombstoned node, which should transition to "Active" state
-			gc.processMessage(gcTombstoneLoadedMessage, true /* local */);
+			gc.processMessage(gcTombstoneLoadedMessage, Date.now(), true /* local */);
 			assert.deepEqual(
 				spies.gc.addedOutboundReference.args[0],
 				["/", nodes[0], /* autorecovery: */ true],
@@ -681,7 +681,7 @@ describe("Garbage Collection Tests", () => {
 				);
 
 				// Add reference from node 1 to node 3 and validate that we get a revived event.
-				garbageCollector.addedOutboundReference(nodes[1], nodes[3]);
+				garbageCollector.addedOutboundReference(nodes[1], nodes[3], Date.now());
 				await garbageCollector.collectGarbage({});
 				mockLogger.assertMatch(
 					[
@@ -717,7 +717,7 @@ describe("Garbage Collection Tests", () => {
 				clock.tick(1);
 				nodeUpdated(garbageCollector, nodes[2], "Changed", Date.now(), testPkgPath);
 				nodeUpdated(garbageCollector, nodes[2], "Loaded", Date.now(), testPkgPath);
-				garbageCollector.addedOutboundReference(nodes[1], nodes[2]);
+				garbageCollector.addedOutboundReference(nodes[1], nodes[2], Date.now());
 				await garbageCollector.collectGarbage({});
 
 				for (const event of mockLogger.events) {
@@ -850,7 +850,7 @@ describe("Garbage Collection Tests", () => {
 
 				// Add reference from node 2 to node 3 and validate that revived event is logged.
 				defaultGCData.gcNodes[nodes[2]] = [nodes[3]];
-				garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
+				garbageCollector.addedOutboundReference(nodes[2], nodes[3], Date.now());
 				await garbageCollector.collectGarbage({});
 				mockLogger.assertMatch(
 					[
@@ -934,7 +934,7 @@ describe("Garbage Collection Tests", () => {
 
 				// Add reference from node 2 to node 3 and validate that revived event is logged. Node 3 needs to be
 				// deleted from unreferencedNodesState otherwise revived events are not logged.
-				garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
+				garbageCollector.addedOutboundReference(nodes[2], nodes[3], Date.now());
 				garbageCollector.unreferencedNodesState.delete(nodes[3]);
 				await garbageCollector.telemetryTracker.logPendingEvents(
 					garbageCollector.mc.logger,
@@ -1013,7 +1013,7 @@ describe("Garbage Collection Tests", () => {
 				);
 
 				// No revived events should be logged as no timeouts should have occurred
-				garbageCollector.addedOutboundReference(nodes[2], nodes[3]);
+				garbageCollector.addedOutboundReference(nodes[2], nodes[3], Date.now());
 				await garbageCollector.collectGarbage({});
 				mockLogger.assertMatchNone(
 					[
@@ -1682,7 +1682,7 @@ describe("Garbage Collection Tests", () => {
 				assert(nodeBTime1 !== undefined, "B should have unreferenced timestamp");
 
 				// 2. Add reference from A to B. E = [A -\> B].
-				garbageCollector.addedOutboundReference(nodeA, nodeB);
+				garbageCollector.addedOutboundReference(nodeA, nodeB, Date.now());
 				defaultGCData.gcNodes[nodeA] = [nodeB];
 
 				// 3. Remove reference from A to B. E = [].
@@ -1726,7 +1726,7 @@ describe("Garbage Collection Tests", () => {
 				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
 
 				// 2. Add reference from A to B. E = [A -\> B, B -\> C].
-				garbageCollector.addedOutboundReference(nodeA, nodeB);
+				garbageCollector.addedOutboundReference(nodeA, nodeB, Date.now());
 				defaultGCData.gcNodes[nodeA] = [nodeB];
 
 				// 3. Remove reference from B to C. E = [A -\> B].
@@ -1779,7 +1779,7 @@ describe("Garbage Collection Tests", () => {
 				assert(nodeDTime1 !== undefined, "D should have unreferenced timestamp");
 
 				// 2. Add reference from A to B. E = [A -\> B, B -\> C, C -\> D].
-				garbageCollector.addedOutboundReference(nodeA, nodeB);
+				garbageCollector.addedOutboundReference(nodeA, nodeB, Date.now());
 				defaultGCData.gcNodes[nodeA] = [nodeB];
 
 				// 3. Remove reference from A to B. E = [B -\> C, C -\> D].
@@ -1833,11 +1833,11 @@ describe("Garbage Collection Tests", () => {
 				defaultGCData.gcNodes[nodeB] = [];
 
 				// 3. Add reference from A to B. E = [A -\> B].
-				garbageCollector.addedOutboundReference(nodeA, nodeB);
+				garbageCollector.addedOutboundReference(nodeA, nodeB, Date.now());
 				defaultGCData.gcNodes[nodeA] = [nodeB];
 
 				// 4. Add reference from B to C. E = [A -\> B, B -\> C].
-				garbageCollector.addedOutboundReference(nodeB, nodeC);
+				garbageCollector.addedOutboundReference(nodeB, nodeC, Date.now());
 				defaultGCData.gcNodes[nodeB] = [nodeC];
 
 				// 5. Remove reference from B to C. E = [A -\> B].
@@ -1882,11 +1882,11 @@ describe("Garbage Collection Tests", () => {
 				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
 
 				// 2. Add reference from A to B. E = [A -\> B].
-				garbageCollector.addedOutboundReference(nodeA, nodeB);
+				garbageCollector.addedOutboundReference(nodeA, nodeB, Date.now());
 				defaultGCData.gcNodes[nodeA] = [nodeB];
 
 				// 3. Add reference from A to C. E = [A -\> B, A -\> C].
-				garbageCollector.addedOutboundReference(nodeA, nodeC);
+				garbageCollector.addedOutboundReference(nodeA, nodeC, Date.now());
 				defaultGCData.gcNodes[nodeA] = [nodeB, nodeC];
 
 				// 4. Remove reference from A to B. E = [A -\> C].
@@ -1943,7 +1943,7 @@ describe("Garbage Collection Tests", () => {
 
 				// 4. Add reference from A to D with calling addedOutboundReference
 				defaultGCData.gcNodes[nodeA].push(nodeD);
-				garbageCollector.addedOutboundReference(nodeA, nodeD);
+				garbageCollector.addedOutboundReference(nodeA, nodeD, Date.now());
 
 				// 5. Run GC and generate summary 2. E = [A -\> B, A -\> C, A -\> E, D -\> C, E -\> A].
 				await getUnreferencedTimestamps();
@@ -1998,7 +1998,7 @@ describe("Garbage Collection Tests", () => {
 				assert(nodeCTime1 !== undefined, "C should have unreferenced timestamp");
 
 				// 2. Add reference from B to C. E = [B -\> C].
-				garbageCollector.addedOutboundReference(nodeB, nodeC);
+				garbageCollector.addedOutboundReference(nodeB, nodeC, Date.now());
 				defaultGCData.gcNodes[nodeB] = [nodeC];
 
 				// 3. Run GC and generate summary 2. E = [B -\> C].
@@ -2042,7 +2042,7 @@ describe("Garbage Collection Tests", () => {
 				assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
 
 				// 2. Add reference from B to C. E = [B -\> C, C-\> D].
-				garbageCollector.addedOutboundReference(nodeB, nodeC);
+				garbageCollector.addedOutboundReference(nodeB, nodeC, Date.now());
 				defaultGCData.gcNodes[nodeB] = [nodeC];
 
 				// 3. Run GC and generate summary 2. E = [B -\> C. C -\> D].
@@ -2093,7 +2093,7 @@ describe("Garbage Collection Tests", () => {
 				assert(nodeDTime1 !== undefined, "C should have unreferenced timestamp");
 
 				// 2. Add reference from B to C. E = [B -\> C, C-\> D].
-				garbageCollector.addedOutboundReference(nodeB, nodeC);
+				garbageCollector.addedOutboundReference(nodeB, nodeC, Date.now());
 				defaultGCData.gcNodes[nodeB] = [nodeC];
 
 				// 3. Remove reference from C to D. E = [B -\> C].
@@ -2249,7 +2249,11 @@ describe("Garbage Collection Tests", () => {
 				contents: gcMessageFromFuture as unknown as GarbageCollectionMessage,
 				compatDetails: { behavior: "Ignore" },
 			};
-			garbageCollector.processMessage(containerRuntimeGCMessage, false /* local */);
+			garbageCollector.processMessage(
+				containerRuntimeGCMessage,
+				Date.now(),
+				false /* local */,
+			);
 		});
 
 		it("process remote op with unrecognized type and 'FailToProcess' compat behavior", async () => {
@@ -2259,7 +2263,12 @@ describe("Garbage Collection Tests", () => {
 				compatDetails: { behavior: "FailToProcess" },
 			};
 			assert.throws(
-				() => garbageCollector.processMessage(containerRuntimeGCMessage, false /* local */),
+				() =>
+					garbageCollector.processMessage(
+						containerRuntimeGCMessage,
+						Date.now(),
+						false /* local */,
+					),
 				(error: IErrorBase) => error.errorType === ContainerErrorTypes.dataProcessingError,
 				"Garbage collection message of unknown type FROM_THE_FUTURE",
 			);
@@ -2271,7 +2280,12 @@ describe("Garbage Collection Tests", () => {
 				contents: gcMessageFromFuture as unknown as GarbageCollectionMessage,
 			};
 			assert.throws(
-				() => garbageCollector.processMessage(containerRuntimeGCMessage, false /* local */),
+				() =>
+					garbageCollector.processMessage(
+						containerRuntimeGCMessage,
+						Date.now(),
+						false /* local */,
+					),
 				(error: IErrorBase) => error.errorType === ContainerErrorTypes.dataProcessingError,
 				"Garbage collection message of unknown type FROM_THE_FUTURE",
 			);

--- a/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
@@ -177,7 +177,7 @@ describe("Garbage Collection Stats", () => {
 		if (lastGCMessage === undefined) {
 			return;
 		}
-		garbageCollector.processMessage(lastGCMessage, true /* local */);
+		garbageCollector.processMessage(lastGCMessage, Date.now(), true /* local */);
 	}
 
 	describe("Mark phase stats", () => {

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -1407,6 +1407,7 @@ declare function get_old_InterfaceDeclaration_IGCNodeUpdatedProps():
 declare function use_current_InterfaceDeclaration_IGCNodeUpdatedProps(
     use: TypeOnly<current.IGCNodeUpdatedProps>): void;
 use_current_InterfaceDeclaration_IGCNodeUpdatedProps(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IGCNodeUpdatedProps());
 
 /*

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -653,7 +653,11 @@ export class FluidDataStoreRuntime
 					processAttachMessageGCData(attachMessage.snapshot, (nodeId, toPath) => {
 						// Note: nodeId will be "/" unless and until we support sub-DDS GC Nodes
 						const fromPath = `/${this.id}/${id}${nodeId === "/" ? "" : nodeId}`;
-						this.dataStoreContext.addedGCOutboundRoute(fromPath, toPath);
+						this.dataStoreContext.addedGCOutboundRoute(
+							fromPath,
+							toPath,
+							message.timestamp,
+						);
 					});
 
 					// If a non-local operation then go and create the object

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.alpha.api.md
@@ -213,7 +213,7 @@ export interface IFluidDataStoreRegistry extends IProvideFluidDataStoreRegistry 
 
 // @alpha
 export interface IFluidParentContext extends IProvideFluidHandleContext, Partial<IProvideFluidDataStoreRegistry> {
-    addedGCOutboundRoute(fromPath: string, toPath: string): void;
+    addedGCOutboundRoute(fromPath: string, toPath: string, timestampMs?: number): void;
     readonly attachState: AttachState;
     // (undocumented)
     readonly baseLogger: ITelemetryBaseLogger;

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.alpha.api.md
@@ -213,7 +213,7 @@ export interface IFluidDataStoreRegistry extends IProvideFluidDataStoreRegistry 
 
 // @alpha
 export interface IFluidParentContext extends IProvideFluidHandleContext, Partial<IProvideFluidDataStoreRegistry> {
-    addedGCOutboundRoute(fromPath: string, toPath: string, timestampMs?: number): void;
+    addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number): void;
     readonly attachState: AttachState;
     // (undocumented)
     readonly baseLogger: ITelemetryBaseLogger;

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -505,9 +505,9 @@ export interface IFluidParentContext
 	 *
 	 * @param fromPath - The absolute path of the node that added the reference.
 	 * @param toPath - The absolute path of the outbound node that is referenced.
-	 * @param timestampMs - The op-based timestamp when the node changed.
+	 * @param messageTimestampMs - The timestamp of the message that added the reference.
 	 */
-	addedGCOutboundRoute(fromPath: string, toPath: string, timestampMs?: number): void;
+	addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number): void;
 }
 
 /**

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -505,8 +505,9 @@ export interface IFluidParentContext
 	 *
 	 * @param fromPath - The absolute path of the node that added the reference.
 	 * @param toPath - The absolute path of the outbound node that is referenced.
+	 * @param timestampMs - The op-based timestamp when the node changed.
 	 */
-	addedGCOutboundRoute(fromPath: string, toPath: string): void;
+	addedGCOutboundRoute(fromPath: string, toPath: string, timestampMs?: number): void;
 }
 
 /**

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.alpha.api.md
@@ -342,7 +342,7 @@ export class MockDeltaQueue<T> extends EventEmitter implements IDeltaQueue<T> {
 export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     constructor(id?: string, existing?: boolean, baseLogger?: ITelemetryLoggerExt, interactive?: boolean);
     // (undocumented)
-    addedGCOutboundRoute(fromPath: string, toPath: string): void;
+    addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number): void;
     attachState: AttachState;
     // (undocumented)
     readonly baseLogger: ITelemetryLoggerExt;

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -144,7 +144,7 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 		throw new Error("Method not implemented.");
 	}
 
-	public addedGCOutboundRoute(fromPath: string, toPath: string) {
+	public addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number) {
 		throw new Error("Method not implemented.");
 	}
 }


### PR DESCRIPTION
With the change in #18456, GC is notified of new references in response to ops. This PR adds passing the timestamp of the op when calling addedOutboundReference so that GC can use the exact timestamp of when the reference was added.
This PR also does some refactoring around types to ensure that GC always has a timestamp to work with when idenfying references or when evaluating whether an unreferenced node is used.

[AB#8201](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8201)