### PR TITLE
client/server decoupling: avoid exposing IDocumentSequenceMessage via f-f/legacy

### DIFF
--- a/packages/dds/sequence/api-report/sequence.alpha.api.md
+++ b/packages/dds/sequence/api-report/sequence.alpha.api.md
@@ -23,6 +23,7 @@ import { IRelativePosition } from '@fluidframework/merge-tree/internal';
 import { ISegment } from '@fluidframework/merge-tree/internal';
 import { ISegmentAction } from '@fluidframework/merge-tree/internal';
 import { ISequencedDocumentMessage } from '@fluidframework/driver-definitions/internal';
+import { ISequencedOpMessage } from '@fluidframework/runtime-definitions/internal';
 import { ISharedObject } from '@fluidframework/shared-object-base/internal';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base/internal';
 import { ISharedObjectKind } from '@fluidframework/shared-object-base/internal';
@@ -85,7 +86,7 @@ export interface IInterval {
     compare(b: IInterval): number;
     compareEnd(b: IInterval): number;
     compareStart(b: IInterval): number;
-    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, useNewSlidingBehavior?: boolean): IInterval | undefined;
+    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedOpMessage, localSeq?: number, useNewSlidingBehavior?: boolean): IInterval | undefined;
     // (undocumented)
     overlaps(b: IInterval): boolean;
     union(b: IInterval): IInterval;
@@ -134,9 +135,9 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval> ex
 
 // @alpha
 export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval> extends IEvent {
-    (event: "changeInterval", listener: (interval: TInterval, previousInterval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): void;
-    (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
-    (event: "propertyChanged", listener: (interval: TInterval, propertyDeltas: PropertySet, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
+    (event: "changeInterval", listener: (interval: TInterval, previousInterval: TInterval, local: boolean, op: ISequencedOpMessage | undefined, slide: boolean) => void): void;
+    (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedOpMessage | undefined) => void): void;
+    (event: "propertyChanged", listener: (interval: TInterval, propertyDeltas: PropertySet, local: boolean, op: ISequencedOpMessage | undefined) => void): void;
     (event: "changed", listener: (interval: TInterval, propertyDeltas: PropertySet, previousInterval: TInterval | undefined, local: boolean, slide: boolean) => void): void;
 }
 
@@ -394,7 +395,7 @@ export class SequenceInterval implements ISerializableInterval {
     getIntervalId(): string;
     // (undocumented)
     intervalType: IntervalType;
-    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, useNewSlidingBehavior?: boolean): SequenceInterval;
+    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedOpMessage, localSeq?: number, useNewSlidingBehavior?: boolean): SequenceInterval;
     // (undocumented)
     overlaps(b: SequenceInterval): boolean;
     // (undocumented)

--- a/packages/dds/sequence/api-report/sequence.beta.api.md
+++ b/packages/dds/sequence/api-report/sequence.beta.api.md
@@ -23,6 +23,7 @@ import { IRelativePosition } from '@fluidframework/merge-tree/internal';
 import { ISegment } from '@fluidframework/merge-tree/internal';
 import { ISegmentAction } from '@fluidframework/merge-tree/internal';
 import { ISequencedDocumentMessage } from '@fluidframework/driver-definitions/internal';
+import { ISequencedOpMessage } from '@fluidframework/runtime-definitions/internal';
 import { ISharedObject } from '@fluidframework/shared-object-base/internal';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base/internal';
 import { ISharedObjectKind } from '@fluidframework/shared-object-base/internal';

--- a/packages/dds/sequence/api-report/sequence.public.api.md
+++ b/packages/dds/sequence/api-report/sequence.public.api.md
@@ -23,6 +23,7 @@ import { IRelativePosition } from '@fluidframework/merge-tree/internal';
 import { ISegment } from '@fluidframework/merge-tree/internal';
 import { ISegmentAction } from '@fluidframework/merge-tree/internal';
 import { ISequencedDocumentMessage } from '@fluidframework/driver-definitions/internal';
+import { ISequencedOpMessage } from '@fluidframework/runtime-definitions/internal';
 import { ISharedObject } from '@fluidframework/shared-object-base/internal';
 import { ISharedObjectEvents } from '@fluidframework/shared-object-base/internal';
 import { ISharedObjectKind } from '@fluidframework/shared-object-base/internal';

--- a/packages/dds/sequence/src/intervalCollectionMap.ts
+++ b/packages/dds/sequence/src/intervalCollectionMap.ts
@@ -6,7 +6,7 @@
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import { ISequencedOpMessage } from "@fluidframework/runtime-definitions/internal";
 import { ValueType, IFluidSerializer } from "@fluidframework/shared-object-base/internal";
 
 import { IntervalCollectionTypeLocalValue, makeSerializable } from "./IntervalCollectionValues.js";
@@ -86,7 +86,7 @@ export class IntervalCollectionMap<T extends ISerializableInterval> {
 		process: (
 			op: IMapOperation,
 			local: boolean,
-			message: ISequencedDocumentMessage,
+			message: ISequencedOpMessage,
 			localOpMetadata: IMapMessageLocalMetadata,
 		) => {
 			const localValue = this.data.get(op.key) ?? this.createCore(op.key, local);
@@ -285,7 +285,7 @@ export class IntervalCollectionMap<T extends ISerializableInterval> {
 	public tryProcessMessage(
 		op: unknown,
 		local: boolean,
-		message: ISequencedDocumentMessage,
+		message: ISequencedOpMessage,
 		localOpMetadata: unknown,
 	): boolean {
 		if (isMapOperation(op)) {

--- a/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
+++ b/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
@@ -4,7 +4,7 @@
  */
 
 import { IEventThisPlaceHolder } from "@fluidframework/core-interfaces";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
+import { ISequencedOpMessage } from "@fluidframework/runtime-definitions/internal";
 import { ISharedObjectEvents } from "@fluidframework/shared-object-base/internal";
 
 import type { IntervalCollection } from "./intervalCollection.js";
@@ -135,7 +135,7 @@ export interface IIntervalCollectionOperation<T extends ISerializableInterval> {
 		value: IntervalCollection<T>,
 		params: ISerializedInterval,
 		local: boolean,
-		message: ISequencedDocumentMessage | undefined,
+		message: ISequencedOpMessage | undefined,
 		localOpMetadata: IMapMessageLocalMetadata | undefined,
 	): void;
 

--- a/packages/dds/sequence/src/intervals/interval.ts
+++ b/packages/dds/sequence/src/intervals/interval.ts
@@ -6,13 +6,13 @@
 /* eslint-disable import/no-deprecated */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	PropertiesManager,
 	PropertySet,
 	createMap,
 	reservedRangeLabelsKey,
 } from "@fluidframework/merge-tree/internal";
+import { ISequencedOpMessage } from "@fluidframework/runtime-definitions/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { SequencePlace, reservedIntervalIdKey } from "../intervalCollection.js";
@@ -188,7 +188,7 @@ export class Interval implements ISerializableInterval {
 		label: string,
 		start?: SequencePlace,
 		end?: SequencePlace,
-		op?: ISequencedDocumentMessage,
+		op?: ISequencedOpMessage,
 	) {
 		if (typeof start === "string" || typeof end === "string") {
 			throw new UsageError(

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -5,7 +5,6 @@
 
 /* eslint-disable no-bitwise */
 
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	// eslint-disable-next-line import/no-deprecated
 	Client,
@@ -13,6 +12,7 @@ import {
 	PropertySet,
 	SlidingPreference,
 } from "@fluidframework/merge-tree/internal";
+import { ISequencedOpMessage } from "@fluidframework/runtime-definitions/internal";
 
 import { SequencePlace, Side } from "../intervalCollection.js";
 
@@ -52,7 +52,7 @@ export interface IInterval {
 		label: string,
 		start: SequencePlace | undefined,
 		end: SequencePlace | undefined,
-		op?: ISequencedDocumentMessage,
+		op?: ISequencedOpMessage,
 		localSeq?: number,
 		useNewSlidingBehavior?: boolean,
 	): IInterval | undefined;
@@ -236,7 +236,7 @@ export interface IIntervalHelpers<TInterval extends ISerializableInterval> {
 		// eslint-disable-next-line import/no-deprecated
 		client: Client | undefined,
 		intervalType: IntervalType,
-		op?: ISequencedDocumentMessage,
+		op?: ISequencedOpMessage,
 		fromSnapshot?: boolean,
 		useNewSlidingBehavior?: boolean,
 	): TInterval;

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -7,7 +7,6 @@
 /* eslint-disable import/no-deprecated */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	Client,
 	ISegment,
@@ -25,6 +24,7 @@ import {
 	refTypeIncludesFlag,
 	reservedRangeLabelsKey,
 } from "@fluidframework/merge-tree/internal";
+import { ISequencedOpMessage } from "@fluidframework/runtime-definitions/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
@@ -350,7 +350,7 @@ export class SequenceInterval implements ISerializableInterval {
 		label: string,
 		start: SequencePlace | undefined,
 		end: SequencePlace | undefined,
-		op?: ISequencedDocumentMessage,
+		op?: ISequencedOpMessage,
 		localSeq?: number,
 		useNewSlidingBehavior: boolean = false,
 	) {
@@ -430,7 +430,7 @@ export function createPositionReferenceFromSegoff(
 	client: Client,
 	segoff: { segment: ISegment | undefined; offset: number | undefined } | "start" | "end",
 	refType: ReferenceType,
-	op?: ISequencedDocumentMessage,
+	op?: ISequencedOpMessage,
 	localSeq?: number,
 	fromSnapshot?: boolean,
 	slidingPreference?: SlidingPreference,
@@ -480,7 +480,7 @@ function createPositionReference(
 	client: Client,
 	pos: number | "start" | "end",
 	refType: ReferenceType,
-	op?: ISequencedDocumentMessage,
+	op?: ISequencedOpMessage,
 	fromSnapshot?: boolean,
 	localSeq?: number,
 	slidingPreference?: SlidingPreference,
@@ -532,7 +532,7 @@ export function createSequenceInterval(
 	end: SequencePlace | undefined,
 	client: Client,
 	intervalType: IntervalType,
-	op?: ISequencedDocumentMessage,
+	op?: ISequencedOpMessage,
 	fromSnapshot?: boolean,
 	useNewSlidingBehavior: boolean = false,
 ): SequenceInterval {

--- a/packages/dds/sequence/src/test/intervalCollection.events.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.events.spec.ts
@@ -6,8 +6,8 @@
 import { strict as assert, fail } from "assert";
 
 import { AttachState } from "@fluidframework/container-definitions";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { PropertySet, toRemovalInfo } from "@fluidframework/merge-tree/internal";
+import { ISequencedOpMessage } from "@fluidframework/runtime-definitions/internal";
 import {
 	MockContainerRuntimeFactory,
 	MockFluidDataStoreRuntime,
@@ -22,7 +22,7 @@ import { SharedStringClass, ISharedString } from "../sharedString.js";
 interface IntervalEventInfo {
 	interval: { start: number; end: number };
 	local: boolean;
-	op: ISequencedDocumentMessage | undefined;
+	op: ISequencedOpMessage | undefined;
 }
 
 describe("SharedString interval collection event spec", () => {

--- a/packages/dds/shared-object-base/api-report/shared-object-base.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.alpha.api.md
@@ -24,6 +24,7 @@ import { IFluidHandleContext } from '@fluidframework/core-interfaces/internal';
 import { IFluidHandleInternal } from '@fluidframework/core-interfaces/internal';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions/internal';
 import { ISequencedDocumentMessage } from '@fluidframework/driver-definitions/internal';
+import { ISequencedOpMessage } from '@fluidframework/runtime-definitions/internal';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
@@ -45,9 +46,9 @@ export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjec
 // @alpha
 export interface ISharedObjectEvents extends IErrorEvent {
     // @eventProperty
-    (event: "pre-op", listener: (op: ISequencedDocumentMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "pre-op", listener: (op: ISequencedOpMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
     // @eventProperty
-    (event: "op", listener: (op: ISequencedDocumentMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "op", listener: (op: ISequencedOpMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
 // @alpha

--- a/packages/dds/shared-object-base/api-report/shared-object-base.beta.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.beta.api.md
@@ -24,6 +24,7 @@ import { IFluidHandleContext } from '@fluidframework/core-interfaces/internal';
 import { IFluidHandleInternal } from '@fluidframework/core-interfaces/internal';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions/internal';
 import { ISequencedDocumentMessage } from '@fluidframework/driver-definitions/internal';
+import { ISequencedOpMessage } from '@fluidframework/runtime-definitions/internal';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';

--- a/packages/dds/shared-object-base/api-report/shared-object-base.public.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.public.api.md
@@ -24,6 +24,7 @@ import { IFluidHandleContext } from '@fluidframework/core-interfaces/internal';
 import { IFluidHandleInternal } from '@fluidframework/core-interfaces/internal';
 import { IGarbageCollectionData } from '@fluidframework/runtime-definitions/internal';
 import { ISequencedDocumentMessage } from '@fluidframework/driver-definitions/internal';
+import { ISequencedOpMessage } from '@fluidframework/runtime-definitions/internal';
 import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryContext } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';

--- a/packages/dds/shared-object-base/src/types.ts
+++ b/packages/dds/shared-object-base/src/types.ts
@@ -9,8 +9,10 @@ import {
 	IEventThisPlaceHolder,
 } from "@fluidframework/core-interfaces";
 import { IChannel } from "@fluidframework/datastore-definitions/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
-import { IGarbageCollectionData } from "@fluidframework/runtime-definitions/internal";
+import {
+	IGarbageCollectionData,
+	ISequencedOpMessage,
+} from "@fluidframework/runtime-definitions/internal";
 
 /**
  * Events emitted by {@link ISharedObject}.
@@ -27,11 +29,7 @@ export interface ISharedObjectEvents extends IErrorEvent {
 	 */
 	(
 		event: "pre-op",
-		listener: (
-			op: ISequencedDocumentMessage,
-			local: boolean,
-			target: IEventThisPlaceHolder,
-		) => void,
+		listener: (op: ISequencedOpMessage, local: boolean, target: IEventThisPlaceHolder) => void,
 	);
 
 	/**
@@ -44,11 +42,7 @@ export interface ISharedObjectEvents extends IErrorEvent {
 	 */
 	(
 		event: "op",
-		listener: (
-			op: ISequencedDocumentMessage,
-			local: boolean,
-			target: IEventThisPlaceHolder,
-		) => void,
+		listener: (op: ISequencedOpMessage, local: boolean, target: IEventThisPlaceHolder) => void,
 	);
 }
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -15,6 +15,7 @@ import { IMergeTreeMaintenanceCallbackArgs } from '@fluidframework/merge-tree/in
 import { IRelativePosition } from '@fluidframework/merge-tree/internal';
 import { ISegment } from '@fluidframework/merge-tree/internal';
 import { ISegmentAction } from '@fluidframework/merge-tree/internal';
+import { ISequencedOpMessage } from '@fluidframework/runtime-definitions/internal';
 import { ISharedObjectKind } from '@fluidframework/shared-object-base/internal';
 import { LocalReferencePosition } from '@fluidframework/merge-tree/internal';
 import { Marker } from '@fluidframework/merge-tree/internal';
@@ -147,13 +148,6 @@ export type FluidObject<T = unknown> = {
 
 // @public
 export type FluidObjectProviderKeys<T, TProp extends keyof T = keyof T> = string extends TProp ? never : number extends TProp ? never : TProp extends keyof Required<T>[TProp] ? Required<T>[TProp] extends Required<Required<T>[TProp]>[TProp] ? TProp : never : never;
-
-// @alpha
-export interface IBranchOrigin {
-    id: string;
-    minimumSequenceNumber: number;
-    sequenceNumber: number;
-}
 
 // @public
 export interface IConnection {
@@ -437,7 +431,7 @@ export interface IInterval {
     compare(b: IInterval): number;
     compareEnd(b: IInterval): number;
     compareStart(b: IInterval): number;
-    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, useNewSlidingBehavior?: boolean): IInterval | undefined;
+    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedOpMessage, localSeq?: number, useNewSlidingBehavior?: boolean): IInterval | undefined;
     // (undocumented)
     overlaps(b: IInterval): boolean;
     union(b: IInterval): IInterval;
@@ -486,9 +480,9 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval> ex
 
 // @alpha
 export interface IIntervalCollectionEvent<TInterval extends ISerializableInterval> extends IEvent {
-    (event: "changeInterval", listener: (interval: TInterval, previousInterval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined, slide: boolean) => void): void;
-    (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
-    (event: "propertyChanged", listener: (interval: TInterval, propertyDeltas: PropertySet, local: boolean, op: ISequencedDocumentMessage | undefined) => void): void;
+    (event: "changeInterval", listener: (interval: TInterval, previousInterval: TInterval, local: boolean, op: ISequencedOpMessage | undefined, slide: boolean) => void): void;
+    (event: "addInterval" | "deleteInterval", listener: (interval: TInterval, local: boolean, op: ISequencedOpMessage | undefined) => void): void;
+    (event: "propertyChanged", listener: (interval: TInterval, propertyDeltas: PropertySet, local: boolean, op: ISequencedOpMessage | undefined) => void): void;
     (event: "changed", listener: (interval: TInterval, propertyDeltas: PropertySet, previousInterval: TInterval | undefined, local: boolean, slide: boolean) => void): void;
 }
 
@@ -584,27 +578,6 @@ export interface IProvideFluidLoadable {
 }
 
 // @alpha
-export interface ISequencedDocumentMessage {
-    clientId: string | null;
-    clientSequenceNumber: number;
-    // @deprecated
-    compression?: string;
-    contents: unknown;
-    data?: string;
-    // @deprecated
-    expHash1?: string;
-    metadata?: unknown;
-    minimumSequenceNumber: number;
-    origin?: IBranchOrigin;
-    referenceSequenceNumber: number;
-    sequenceNumber: number;
-    serverMetadata?: unknown;
-    timestamp: number;
-    traces?: ITrace[];
-    type: string;
-}
-
-// @alpha
 export interface ISequenceDeltaRange<TOperation extends MergeTreeDeltaOperationTypes = MergeTreeDeltaOperationTypes> {
     operation: TOperation;
     position: number;
@@ -697,9 +670,9 @@ export interface ISharedObject<TEvent extends ISharedObjectEvents = ISharedObjec
 // @alpha
 export interface ISharedObjectEvents extends IErrorEvent {
     // @eventProperty
-    (event: "pre-op", listener: (op: ISequencedDocumentMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "pre-op", listener: (op: ISequencedOpMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
     // @eventProperty
-    (event: "op", listener: (op: ISequencedDocumentMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
+    (event: "op", listener: (op: ISequencedOpMessage, local: boolean, target: IEventThisPlaceHolder) => void): any;
 }
 
 // @alpha (undocumented)
@@ -777,13 +750,6 @@ export interface ITelemetryBaseProperties {
 // @public
 export class IterableTreeArrayContent<T> implements Iterable<T> {
     [Symbol.iterator](): Iterator<T>;
-}
-
-// @alpha
-export interface ITrace {
-    action: string;
-    service: string;
-    timestamp: number;
 }
 
 // @public
@@ -995,7 +961,7 @@ export class SequenceInterval implements ISerializableInterval {
     getIntervalId(): string;
     // (undocumented)
     intervalType: IntervalType;
-    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedDocumentMessage, localSeq?: number, useNewSlidingBehavior?: boolean): SequenceInterval;
+    modify(label: string, start: SequencePlace | undefined, end: SequencePlace | undefined, op?: ISequencedOpMessage, localSeq?: number, useNewSlidingBehavior?: boolean): SequenceInterval;
     // (undocumented)
     overlaps(b: SequenceInterval): boolean;
     // (undocumented)

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -15,6 +15,7 @@ import { IMergeTreeMaintenanceCallbackArgs } from '@fluidframework/merge-tree/in
 import { IRelativePosition } from '@fluidframework/merge-tree/internal';
 import { ISegment } from '@fluidframework/merge-tree/internal';
 import { ISegmentAction } from '@fluidframework/merge-tree/internal';
+import { ISequencedOpMessage } from '@fluidframework/runtime-definitions/internal';
 import { ISharedObjectKind } from '@fluidframework/shared-object-base/internal';
 import { LocalReferencePosition } from '@fluidframework/merge-tree/internal';
 import { Marker } from '@fluidframework/merge-tree/internal';

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -15,6 +15,7 @@ import { IMergeTreeMaintenanceCallbackArgs } from '@fluidframework/merge-tree/in
 import { IRelativePosition } from '@fluidframework/merge-tree/internal';
 import { ISegment } from '@fluidframework/merge-tree/internal';
 import { ISegmentAction } from '@fluidframework/merge-tree/internal';
+import { ISequencedOpMessage } from '@fluidframework/runtime-definitions/internal';
 import { ISharedObjectKind } from '@fluidframework/shared-object-base/internal';
 import { LocalReferencePosition } from '@fluidframework/merge-tree/internal';
 import { Marker } from '@fluidframework/merge-tree/internal';

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -138,10 +138,4 @@ export type {
 	ISharedObjectEvents,
 } from "@fluidframework/shared-object-base/internal";
 
-export type {
-	ISequencedDocumentMessage, // Leaked via ISharedObjectEvents
-	IBranchOrigin, // Required for ISequencedDocumentMessage
-	ITrace, // Required for ISequencedDocumentMessage
-} from "@fluidframework/driver-definitions/internal";
-
 // #endregion Legacy exports

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.alpha.api.md
@@ -295,6 +295,16 @@ export interface IProvideFluidDataStoreRegistry {
 }
 
 // @alpha
+export interface ISequencedOpMessage {
+    clientId: string | null;
+    contents: unknown;
+    referenceSequenceNumber: number;
+    sequenceNumber: number;
+    timestamp: number;
+    type: string;
+}
+
+// @alpha
 export interface ISummarizeInternalResult extends ISummarizeResult {
     // (undocumented)
     id: string;

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -47,6 +47,7 @@ export type {
 	IEnvelope,
 	IInboundSignalMessage,
 	InboundAttachMessage,
+	ISequencedOpMessage,
 	ISignalEnvelope,
 } from "./protocol.js";
 export type {

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -85,3 +85,41 @@ export interface IAttachMessage {
 export type InboundAttachMessage = Omit<IAttachMessage, "snapshot"> & {
 	snapshot: IAttachMessage["snapshot"] | null;
 };
+
+/**
+ * Sequenced message for the container.
+ * @alpha
+ */
+export interface ISequencedOpMessage {
+	/**
+	 * The client ID that submitted the message.
+	 * For server generated messages the clientId will be null;
+	 */
+	// eslint-disable-next-line @rushstack/no-new-null
+	clientId: string | null;
+
+	/**
+	 * The sequenced identifier.
+	 */
+	sequenceNumber: number;
+
+	/**
+	 * The reference sequence number the message was sent relative to.
+	 */
+	referenceSequenceNumber: number;
+
+	/**
+	 * The type of operation.
+	 */
+	type: string;
+
+	/**
+	 * The contents of the message.
+	 */
+	contents: unknown;
+
+	/**
+	 * Timestamp when the server ticketed the message.
+	 */
+	timestamp: number;
+}


### PR DESCRIPTION
Prior to this PR, the following work has already happened:
1.  ISequencedDocumentMessage has been forked into driver-definitions.
2. ISequencedDocumentMessage has been downgraded from public to alpha.

The goal of this change is to further reduce the exposure of ISequencedDocumentMessage.  This is done by changing APIs that leak ISequencedDocumentMessage via 'f-f/legacy' to use a new interface (ISequencedOpMessage) that only exposes the fields currently consumed by users of these APIs.

These are the currently consumed fields:

```ts
// @alpha
export interface ISequencedOpMessage {
    clientId: string | null;
    contents: unknown;
    referenceSequenceNumber: number;
    sequenceNumber: number;
    timestamp: number;
    type: string;
}
```