### PR TITLE
Fix routerlicious timeouts in compression related tests 

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -17,7 +17,6 @@ import { ConfigTypes, IConfigProviderBase, IErrorBase } from "@fluidframework/co
 import { FluidErrorTypes } from "@fluidframework/core-interfaces/internal";
 import {
 	IDocumentMessage,
-	MessageType,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
 import type { ISharedMap } from "@fluidframework/map/internal";
@@ -542,12 +541,17 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 	});
 
 	describe("Resiliency", () => {
-		const messageSize = 5 * 1024 * 1024;
+		const messageSize = 50 * 1024; // 50 KB
 		const messagesInBatch = 3;
 		const config: ITestContainerConfig = {
 			...testContainerConfig,
 			runtimeOptions: {
 				summaryOptions: { summaryConfigOverrides: { state: "disabled" } },
+				compressionOptions: {
+					minimumBatchSizeInBytes: 51 * 1024, // 51 KB
+					compressionAlgorithm: CompressionAlgorithms.lz4,
+				},
+				chunkSizeInBytes: 20 * 1024, // 20 KB
 			},
 		};
 
@@ -593,14 +597,6 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 					this.skip();
 				}
 
-				// TODO: This test is consistently failing when ran against FRS. See ADO:7944
-				if (
-					provider.driver.type === "routerlicious" &&
-					provider.driver.endpointName === "frs"
-				) {
-					this.skip();
-				}
-
 				await setupContainers(config);
 				// Force the container to reconnect after processing 2 chunked ops
 				const secondConnection = reconnectAfterOpProcessing(
@@ -612,7 +608,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 				);
 
 				await sendAndAssertSynchronization(secondConnection);
-			}).timeout(chunkingBatchesTimeoutMs);
+			});
 
 			it("Reconnects while processing compressed batch", async function () {
 				// This is not supported by the local server. See ADO:2690
@@ -621,25 +617,22 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 					this.skip();
 				}
 
-				// TODO: This test is consistently failing when ran against FRS. See ADO:7944
-				if (
-					provider.driver.type === "routerlicious" &&
-					provider.driver.endpointName === "frs"
-				) {
-					this.skip();
-				}
-
 				await setupContainers(config);
-				// Force the container to reconnect after processing 2 empty ops
-				// which would unroll the original ops from compression
+				// Force the container to reconnect after processing all the chunks
 				const secondConnection = reconnectAfterOpProcessing(
 					remoteContainer,
-					(op) => op.type === MessageType.Operation && op.contents === undefined,
-					2,
+					(op) => {
+						const contents = op.contents as any | undefined;
+						return (
+							contents?.type === ContainerMessageType.ChunkedOp &&
+							contents?.contents?.chunkId === contents?.contents?.totalChunks
+						);
+					},
+					1,
 				);
 
 				await sendAndAssertSynchronization(secondConnection);
-			}).timeout(chunkingBatchesTimeoutMs);
+			});
 		});
 
 		describe("Local container", () => {
@@ -685,7 +678,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 				);
 
 				await sendAndAssertSynchronization(secondConnection);
-			}).timeout(chunkingBatchesTimeoutMs);
+			});
 
 			it("Reconnects while sending compressed batch", async function () {
 				// This is not supported by the local server. See ADO:2690
@@ -694,25 +687,22 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 					this.skip();
 				}
 
-				// TODO: This test is consistently failing when ran against FRS. See ADO:7969
-				if (
-					provider.driver.type === "routerlicious" &&
-					provider.driver.endpointName === "frs"
-				) {
-					this.skip();
-				}
-
 				await setupContainers(config);
-				// Force the container to reconnect after sending the compressed batch
+				// Force the container to reconnect after sending the compressed batch (i.e. send all chunks)
 				const secondConnection = reconnectAfterBatchSending(
 					localContainer,
-					(batch) =>
-						batch.length > 1 && batch.slice(1).every((x) => x.contents === undefined),
+					(batch) => {
+						const parsedContent = JSON.parse(batch[0].contents as string);
+						return (
+							parsedContent?.type === ContainerMessageType.ChunkedOp &&
+							parsedContent.contents.chunkId === parsedContent.contents.totalChunks
+						);
+					},
 					1,
 				);
 
 				await sendAndAssertSynchronization(secondConnection);
-			}).timeout(chunkingBatchesTimeoutMs);
+			});
 		});
 	});
 });


### PR DESCRIPTION
The timeouts for these tests were being caused by 2 things:
- Large messages being sent
- grouped batching being enable by default, thus breaking the logic in the tests that looks for empty messages

I reduced the size of messages being sent and their respective configs, as well as fixing the logic that tries to force a reconnect based on messages sent/received.

[AB#7969](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7969)
[AB#7944](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7944)