### PR TITLE
fix(tree): deep-tag rollback changesets

### DIFF
--- a/packages/dds/tree/src/core/rebase/changeRebaser.ts
+++ b/packages/dds/tree/src/core/rebase/changeRebaser.ts
@@ -94,8 +94,8 @@ export interface ChangeRebaser<TChangeset> {
 /**
  * @internal
  */
-export interface TaggedChange<TChangeset> {
-	readonly revision: RevisionTag | undefined;
+export interface TaggedChange<TChangeset, TTag = RevisionTag | undefined> {
+	readonly revision: TTag;
 	/**
 	 * When populated, indicates that the changeset is a rollback for the purpose of a rebase sandwich.
 	 * The value corresponds to the `revision` of the original changeset being rolled back.
@@ -149,11 +149,11 @@ export function tagChange<T>(change: T, revision: RevisionTag | undefined): Tagg
 	return { revision, change };
 }
 
-export function tagRollbackInverse<T>(
-	inverseChange: T,
-	revision: RevisionTag | undefined,
+export function tagRollbackInverse<TChange, TTag>(
+	inverseChange: TChange,
+	revision: TTag,
 	rollbackOf: RevisionTag | undefined,
-): TaggedChange<T> {
+): TaggedChange<TChange, TTag> {
 	return {
 		revision,
 		change: inverseChange,

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -18,6 +18,7 @@ import {
 	brandedNumberType,
 	brandedStringType,
 } from "../../util/index.js";
+import { TaggedChange } from "./changeRebaser.js";
 
 /**
  * The identifier for a particular session/user/client that can generate `GraphCommit`s
@@ -141,8 +142,8 @@ export interface GraphCommit<TChange> {
 	readonly change: TChange;
 	/** The parent of this commit, on whose change this commit's change is based */
 	readonly parent?: GraphCommit<TChange>;
-	/** The inverse of this commit */
-	inverse?: TChange;
+	/** The rollback of this commit */
+	rollback?: TaggedChange<TChange, RevisionTag>;
 }
 
 /**
@@ -200,6 +201,6 @@ export function replaceChange<TChange>(
 	change: TChange,
 ): GraphCommit<TChange> {
 	const output = { ...commit, change };
-	delete output.inverse;
+	delete output.rollback;
 	return output;
 }

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerPerf.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerPerf.test.ts
@@ -288,8 +288,8 @@ export function testPerf() {
 							//   They therefore undergo no inverting.
 							// As part of rebasing P+, we invert...
 							//   - each of the phase-1 peer edits: P
-							// Adding both terms and simplifying:
-							inverted: P,
+							//     However, all but the last of these had their inverse already cached
+							inverted: 1,
 							// As part of rebasing the peer branch that contains the phase-1 edits,
 							//   none of the peer edits need to be rebased,
 							//   so we don't compose the changes they would need to rebase over.
@@ -375,14 +375,15 @@ export function testPerf() {
 							//   we invert...
 							//     - each of the phase-1 peer edits: P
 							//       (these are based on commit 0)
-							//   This adds up P inverts.
+							//       However, all but the last of these had their inverse already cached
+							//   This adds up 1 invert.
 							// As part of rebasing P+ to the tip of the trunk,
 							//   we invert...
 							//     - each of the phase-1 peer edits: P
 							//       (these are based on commit Tc)
 							//   This adds up P inverts.
 							// Adding both terms:
-							inverted: 2 * P,
+							inverted: P + 1,
 							// As part of rebasing the peer branch that contains the phase-1 edits, we compose...
 							//   - the trunk edits: T
 							//   then for the Ith local edit on the branch we compose...

--- a/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
@@ -8,7 +8,12 @@ import { type SessionId } from "@fluidframework/id-compressor";
 import { createSessionId } from "@fluidframework/id-compressor/internal";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
-import type { EncodedRevisionTag, GraphCommit } from "../../core/index.js";
+import type {
+	EncodedRevisionTag,
+	GraphCommit,
+	RevisionTag,
+	TaggedChange,
+} from "../../core/index.js";
 import { ChangeEncodingContext } from "../../core/index.js";
 import { typeboxValidator } from "../../external-utilities/index.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -144,7 +149,10 @@ describe("message codec", () => {
 				commit: {
 					revision,
 					change: TestChange.mint([], 1),
-					inverse: "Extra field that should be dropped" as unknown as TestChange,
+					rollback: "Extra field that should be dropped" as unknown as TaggedChange<
+						TestChange,
+						RevisionTag
+					>,
 					parent: "Extra field that should be dropped" as unknown as GraphCommit<TestChange>,
 				},
 			};


### PR DESCRIPTION
## Description

Some rollback changesets were not being deeply tagged, which can lead to bugs when several such changesets are composed. More generally, all changesets should be tagged.

This change also leads to the inverse cache getting more hits.

## Breaking Changes

None