### PR TITLE
(odsp-client): Enable `can find original member` audience test

### DIFF
--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
@@ -48,7 +48,7 @@ describe("Fluid audience", () => {
 	 *
 	 * Expected behavior: container should have a single member upon creation.
 	 */
-	it.skip("can find original member", async () => {
+	it("can find original member", async () => {
 		const { container, services } = await client.createContainer(schema);
 		const itemId = await container.attach();
 


### PR DESCRIPTION
This PR enables the first audience e2e tests. 

[AB#8189](https://dev.azure.com/fluidframework/internal/_workitems/edit/8189)