### PR TITLE
refactor(tinylicious-client): Clean up package exports

### DIFF
--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -9,13 +9,8 @@ import { ContainerSchema } from '@fluidframework/fluid-static';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';
-import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUser } from '@fluidframework/driver-definitions';
-
-export { ITelemetryBaseEvent }
-
-export { ITelemetryBaseLogger }
 
 ```

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -18,7 +18,4 @@ export { ITelemetryBaseEvent }
 
 export { ITelemetryBaseLogger }
 
-export { TinyliciousClient }
-export default TinyliciousClient;
-
 ```

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -9,13 +9,8 @@ import { ContainerSchema } from '@fluidframework/fluid-static';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';
-import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUser } from '@fluidframework/driver-definitions';
-
-export { ITelemetryBaseEvent }
-
-export { ITelemetryBaseLogger }
 
 ```

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -18,7 +18,4 @@ export { ITelemetryBaseEvent }
 
 export { ITelemetryBaseLogger }
 
-export { TinyliciousClient }
-export default TinyliciousClient;
-
 ```

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -9,13 +9,8 @@ import { ContainerSchema } from '@fluidframework/fluid-static';
 import { IFluidContainer } from '@fluidframework/fluid-static';
 import { IMember } from '@fluidframework/fluid-static';
 import { IServiceAudience } from '@fluidframework/fluid-static';
-import { ITelemetryBaseEvent } from '@fluidframework/core-interfaces';
 import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUser } from '@fluidframework/driver-definitions';
-
-export { ITelemetryBaseEvent }
-
-export { ITelemetryBaseLogger }
 
 ```

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -18,7 +18,4 @@ export { ITelemetryBaseEvent }
 
 export { ITelemetryBaseLogger }
 
-export { TinyliciousClient }
-export default TinyliciousClient;
-
 ```

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -107,6 +107,15 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedInterfaceDeclaration_ITelemetryBaseEvent": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"RemovedInterfaceDeclaration_ITelemetryBaseLogger": {
+				"backCompat": false,
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/service-clients/tinylicious-client/src/index.ts
+++ b/packages/service-clients/tinylicious-client/src/index.ts
@@ -15,8 +15,6 @@
  */
 
 export {
-	type ITelemetryBaseEvent,
-	type ITelemetryBaseLogger,
 	type ITinyliciousAudience,
 	type TinyliciousClientProps,
 	type TinyliciousConnectionConfig,

--- a/packages/service-clients/tinylicious-client/src/index.ts
+++ b/packages/service-clients/tinylicious-client/src/index.ts
@@ -14,8 +14,6 @@
  * @packageDocumentation
  */
 
-import { TinyliciousClient } from "./TinyliciousClient.js";
-
 export {
 	type ITelemetryBaseEvent,
 	type ITelemetryBaseLogger,
@@ -27,6 +25,3 @@ export {
 	type TinyliciousUser,
 } from "./interfaces.js";
 export { TinyliciousClient } from "./TinyliciousClient.js";
-
-// eslint-disable-next-line import/no-default-export, unicorn/prefer-export-from
-export default TinyliciousClient;

--- a/packages/service-clients/tinylicious-client/src/interfaces.ts
+++ b/packages/service-clients/tinylicious-client/src/interfaces.ts
@@ -7,11 +7,6 @@ import { type ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { type IUser } from "@fluidframework/driver-definitions";
 import { type IMember, type IServiceAudience } from "@fluidframework/fluid-static";
 import { type ITokenProvider } from "@fluidframework/routerlicious-driver";
-// Re-export so developers can build loggers without pulling in core-interfaces
-export {
-	type ITelemetryBaseEvent,
-	type ITelemetryBaseLogger,
-} from "@fluidframework/core-interfaces";
 
 /**
  * Props for initializing a {@link TinyliciousClient}

--- a/packages/service-clients/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.generated.ts
+++ b/packages/service-clients/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.generated.ts
@@ -46,56 +46,32 @@ type TypeOnly<T> = T extends number
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_ITelemetryBaseEvent": {"forwardCompat": false}
+ * "RemovedInterfaceDeclaration_ITelemetryBaseEvent": {"forwardCompat": false}
  */
-declare function get_old_InterfaceDeclaration_ITelemetryBaseEvent():
-    TypeOnly<old.ITelemetryBaseEvent>;
-declare function use_current_InterfaceDeclaration_ITelemetryBaseEvent(
-    use: TypeOnly<current.ITelemetryBaseEvent>): void;
-use_current_InterfaceDeclaration_ITelemetryBaseEvent(
-    get_old_InterfaceDeclaration_ITelemetryBaseEvent());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_ITelemetryBaseEvent": {"backCompat": false}
+ * "RemovedInterfaceDeclaration_ITelemetryBaseEvent": {"backCompat": false}
  */
-declare function get_current_InterfaceDeclaration_ITelemetryBaseEvent():
-    TypeOnly<current.ITelemetryBaseEvent>;
-declare function use_old_InterfaceDeclaration_ITelemetryBaseEvent(
-    use: TypeOnly<old.ITelemetryBaseEvent>): void;
-use_old_InterfaceDeclaration_ITelemetryBaseEvent(
-    get_current_InterfaceDeclaration_ITelemetryBaseEvent());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_ITelemetryBaseLogger": {"forwardCompat": false}
+ * "RemovedInterfaceDeclaration_ITelemetryBaseLogger": {"forwardCompat": false}
  */
-declare function get_old_InterfaceDeclaration_ITelemetryBaseLogger():
-    TypeOnly<old.ITelemetryBaseLogger>;
-declare function use_current_InterfaceDeclaration_ITelemetryBaseLogger(
-    use: TypeOnly<current.ITelemetryBaseLogger>): void;
-use_current_InterfaceDeclaration_ITelemetryBaseLogger(
-    get_old_InterfaceDeclaration_ITelemetryBaseLogger());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_ITelemetryBaseLogger": {"backCompat": false}
+ * "RemovedInterfaceDeclaration_ITelemetryBaseLogger": {"backCompat": false}
  */
-declare function get_current_InterfaceDeclaration_ITelemetryBaseLogger():
-    TypeOnly<current.ITelemetryBaseLogger>;
-declare function use_old_InterfaceDeclaration_ITelemetryBaseLogger(
-    use: TypeOnly<old.ITelemetryBaseLogger>): void;
-use_old_InterfaceDeclaration_ITelemetryBaseLogger(
-    get_current_InterfaceDeclaration_ITelemetryBaseLogger());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.


### PR DESCRIPTION
This package's primary export `TinyliciousClient` (as well as its related types) have all been made internal. Unfortunately, a bug in API-Extractor related to how it resolves `export default` statements was causing the `TinyliciousClient` type to appear in API reports when it shouldn't have.

Additionally, this package was re-exporting a couple of telemetry types to make use by external users more convenient (so they wouldn't have to import the `core-interfaces` package). But since this entire package is effectively internal-only now, these don't serve much purpose. I have removed them.