### PR TITLE
test(tree): Add FieldChangeHandler method to get nested changes from a field change

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultFieldKinds.ts
@@ -46,6 +46,7 @@ export const noChangeHandler: FieldChangeHandler<0> = {
 	intoDelta: (change, deltaFromChild: ToDelta): DeltaFieldChanges => ({}),
 	relevantRemovedRoots: (change): Iterable<DeltaDetachedNodeId> => [],
 	isEmpty: (change: 0) => true,
+	getNestedChanges: (change: 0) => [],
 	createEmpty: () => 0,
 };
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -75,9 +75,13 @@ export interface FieldChangeHandler<
 	 * @param change - The field change to get the child changes from.
 	 *
 	 * @returns The set of `NodeId`s that correspond to nested changes in the given `change`.
+	 * Each `NodeId` is associated with the index of the node in the field in the input context of the changeset
+	 * (or `undefined` if the node is not attached in the input context).
+	 * For all returned entries where the index is defined,
+	 * the indices are are ordered from smallest to largest (with no duplicates).
 	 * The returned array is owned by the caller.
 	 */
-	getNestedChanges(change: TChangeset): NodeId[];
+	getNestedChanges(change: TChangeset): [NodeId, number | undefined][];
 
 	createEmpty(): TChangeset;
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -71,6 +71,14 @@ export interface FieldChangeHandler<
 	 */
 	isEmpty(change: TChangeset): boolean;
 
+	/**
+	 * @param change - The field change to get the child changes from.
+	 *
+	 * @returns The set of children nodes for which the given `change` has nested changes.
+	 * The returned array is owned by the caller.
+	 */
+	getNestedChanges(change: TChangeset): NodeId[];
+
 	createEmpty(): TChangeset;
 }
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -74,7 +74,7 @@ export interface FieldChangeHandler<
 	/**
 	 * @param change - The field change to get the child changes from.
 	 *
-	 * @returns The set of children nodes for which the given `change` has nested changes.
+	 * @returns The set of `NodeId`s that correspond to nested changes in the given `change`.
 	 * The returned array is owned by the caller.
 	 */
 	getNestedChanges(change: TChangeset): NodeId[];

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -101,8 +101,13 @@ export const genericChangeHandler: FieldChangeHandler<GenericChangeset> = {
 	},
 	relevantRemovedRoots,
 	isEmpty: (change: GenericChangeset): boolean => change.length === 0,
+	getNestedChanges,
 	createEmpty: (): GenericChangeset => [],
 };
+
+function getNestedChanges(change: GenericChangeset): NodeId[] {
+	return change.map(({ nodeChange }) => nodeChange);
+}
 
 function rebaseGenericChange(
 	change: GenericChangeset,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKind.ts
@@ -105,8 +105,8 @@ export const genericChangeHandler: FieldChangeHandler<GenericChangeset> = {
 	createEmpty: (): GenericChangeset => [],
 };
 
-function getNestedChanges(change: GenericChangeset): NodeId[] {
-	return change.map(({ nodeChange }) => nodeChange);
+function getNestedChanges(change: GenericChangeset): [NodeId, number | undefined][] {
+	return change.map(({ index, nodeChange }) => [nodeChange, index]);
 }
 
 function rebaseGenericChange(

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -719,8 +719,11 @@ export const optionalChangeHandler: FieldChangeHandler<OptionalChangeset, Option
 	createEmpty: () => ({ moves: [], childChanges: [] }),
 };
 
-function getNestedChanges(change: OptionalChangeset): NodeId[] {
-	return change.childChanges.map(([register, nodeId]) => nodeId);
+function getNestedChanges(change: OptionalChangeset): [NodeId, number | undefined][] {
+	return change.childChanges.map(([register, nodeId]) => [
+		nodeId,
+		register === "self" ? 0 : undefined,
+	]);
 }
 
 function* relevantRemovedRoots(

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalField.ts
@@ -714,8 +714,14 @@ export const optionalChangeHandler: FieldChangeHandler<OptionalChangeset, Option
 		change.moves.length === 0 &&
 		change.valueReplace === undefined,
 
+	getNestedChanges,
+
 	createEmpty: () => ({ moves: [], childChanges: [] }),
 };
+
+function getNestedChanges(change: OptionalChangeset): NodeId[] {
+	return change.childChanges.map(([register, nodeId]) => nodeId);
+}
 
 function* relevantRemovedRoots(
 	change: OptionalChangeset,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldChangeHandler.ts
@@ -11,7 +11,7 @@ import { sequenceFieldChangeCodecFactory } from "./sequenceFieldCodecs.js";
 import { SequenceFieldEditor, sequenceFieldEditor } from "./sequenceFieldEditor.js";
 import { sequenceFieldToDelta } from "./sequenceFieldToDelta.js";
 import { Changeset } from "./types.js";
-import { createEmpty, isEmpty } from "./utils.js";
+import { createEmpty, getNestedChanges, isEmpty } from "./utils.js";
 
 export type SequenceFieldChangeHandler = FieldChangeHandler<Changeset, SequenceFieldEditor>;
 
@@ -22,5 +22,6 @@ export const sequenceFieldChangeHandler: SequenceFieldChangeHandler = {
 	intoDelta: sequenceFieldToDelta,
 	relevantRemovedRoots,
 	isEmpty,
+	getNestedChanges,
 	createEmpty,
 };

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -62,6 +62,10 @@ export function createEmpty(): Changeset {
 	return [];
 }
 
+export function getNestedChanges(change: Changeset): NodeId[] {
+	return change.flatMap(({ changes }) => changes ?? []);
+}
+
 export function isNewAttach(mark: Mark, revision?: RevisionTag): boolean {
 	return isNewAttachEffect(mark, mark.cellId, revision);
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -62,8 +62,18 @@ export function createEmpty(): Changeset {
 	return [];
 }
 
-export function getNestedChanges(change: Changeset): NodeId[] {
-	return change.flatMap(({ changes }) => changes ?? []);
+export function getNestedChanges(change: Changeset): [NodeId, number | undefined][] {
+	const output: [NodeId, number | undefined][] = [];
+	let index = 0;
+	for (const { changes, cellId, count } of change) {
+		if (changes !== undefined) {
+			output.push([changes, cellId === undefined ? index : undefined]);
+		}
+		if (cellId === undefined) {
+			index += count;
+		}
+	}
+	return output;
 }
 
 export function isNewAttach(mark: Mark, revision?: RevisionTag): boolean {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
@@ -95,6 +95,7 @@ export const valueHandler = {
 
 	relevantRemovedRoots: (change) => [],
 	isEmpty: (change) => change === 0,
+	getNestedChanges: (change) => [],
 	createEmpty: () => 0,
 } satisfies FieldChangeHandler<ValueChangeset>;
 

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -136,7 +136,7 @@ const singleNodeHandler: FieldChangeHandler<SingleNodeChangeset> = {
 	// We create changesets by composing an empty single node field with a change to the child.
 	// We don't want the temporarily empty single node field to be pruned away leaving us with a generic field instead.
 	isEmpty: (change) => false,
-	getNestedChanges: (change) => (change === undefined ? [] : [change]),
+	getNestedChanges: (change) => (change === undefined ? [] : [[change, 0]]),
 	createEmpty: () => undefined,
 };
 

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -136,6 +136,7 @@ const singleNodeHandler: FieldChangeHandler<SingleNodeChangeset> = {
 	// We create changesets by composing an empty single node field with a change to the child.
 	// We don't want the temporarily empty single node field to be pruned away leaving us with a generic field instead.
 	isEmpty: (change) => false,
+	getNestedChanges: (change) => (change === undefined ? [] : [change]),
 	createEmpty: () => undefined,
 };
 

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -965,7 +965,7 @@ describe("optionalField", () => {
 		it("includes changes to the node in the field", () => {
 			const change: OptionalChangeset = Change.child(nodeId1);
 			const actual = optionalChangeHandler.getNestedChanges(change);
-			assert.deepEqual(actual, [nodeId1]);
+			assert.deepEqual(actual, [[nodeId1, 0]]);
 		});
 		it("includes changes to removed nodes", () => {
 			const change: OptionalChangeset = Change.atOnce(
@@ -973,7 +973,10 @@ describe("optionalField", () => {
 				Change.childAt(brand(42), nodeId2),
 			);
 			const actual = optionalChangeHandler.getNestedChanges(change);
-			assert.deepEqual(actual, [nodeId1, nodeId2]);
+			assert.deepEqual(actual, [
+				[nodeId1, undefined],
+				[nodeId2, undefined],
+			]);
 		});
 	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -955,4 +955,25 @@ describe("optionalField", () => {
 			assert.equal(actual, false);
 		});
 	});
+
+	describe("getNestedChanges", () => {
+		it("is empty for an empty change", () => {
+			const change = Change.empty();
+			const actual = optionalChangeHandler.getNestedChanges(change);
+			assert.deepEqual(actual, []);
+		});
+		it("includes changes to the node in the field", () => {
+			const change: OptionalChangeset = Change.child(nodeId1);
+			const actual = optionalChangeHandler.getNestedChanges(change);
+			assert.deepEqual(actual, [nodeId1]);
+		});
+		it("includes changes to removed nodes", () => {
+			const change: OptionalChangeset = Change.atOnce(
+				Change.childAt(brand(41), nodeId1),
+				Change.childAt(brand(42), nodeId2),
+			);
+			const actual = optionalChangeHandler.getNestedChanges(change);
+			assert.deepEqual(actual, [nodeId1, nodeId2]);
+		});
+	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceField.spec.ts
@@ -23,6 +23,7 @@ import { testEditor } from "./sequenceFieldEditor.test.js";
 import { testSnapshots } from "./sequenceFieldSnapshots.test.js";
 import { testToDelta } from "./sequenceFieldToDelta.test.js";
 import { testUtils } from "./sequenceFieldUtils.test.js";
+import { testGetNestedChanges } from "./sequenceGetNestedChanges.test.js";
 
 describe("SequenceField", () => {
 	testEditor();
@@ -43,4 +44,5 @@ describe("SequenceField", () => {
 	testCodecs();
 	testSnapshots();
 	testReplaceRevisions();
+	testGetNestedChanges();
 });

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceGetNestedChanges.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceGetNestedChanges.test.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { NodeId } from "../../../feature-libraries/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { sequenceFieldChangeHandler } from "../../../feature-libraries/sequence-field/index.js";
+import { brand } from "../../../util/index.js";
+import { MarkMaker as Mark } from "./testEdits.js";
+import { RevisionTag } from "../../../core/index.js";
+import { mintRevisionTag } from "../../utils.js";
+
+const tag1: RevisionTag = mintRevisionTag();
+const nodeId1: NodeId = { localId: brand(1) };
+const nodeId2: NodeId = { localId: brand(2) };
+
+export function testGetNestedChanges() {
+	describe("getNestedChanges", () => {
+		it("is empty for an empty change", () => {
+			const change = sequenceFieldChangeHandler.createEmpty();
+			const actual = sequenceFieldChangeHandler.getNestedChanges(change);
+			assert.deepEqual(actual, []);
+		});
+		it("includes changes to nodes in the field", () => {
+			const change = [Mark.modify(nodeId1), { count: 42 }, Mark.modify(nodeId2)];
+			const actual = sequenceFieldChangeHandler.getNestedChanges(change);
+			assert.deepEqual(actual, [nodeId1, nodeId2]);
+		});
+		it("includes changes to removed nodes", () => {
+			const change = [
+				Mark.revive(1, { revision: tag1, localId: brand(42) }, { changes: nodeId1 }),
+				Mark.modify(nodeId2, { revision: tag1, localId: brand(43) }),
+			];
+			const actual = sequenceFieldChangeHandler.getNestedChanges(change);
+			assert.deepEqual(actual, [nodeId1, nodeId2]);
+		});
+	});
+}

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceGetNestedChanges.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceGetNestedChanges.test.ts
@@ -27,7 +27,10 @@ export function testGetNestedChanges() {
 		it("includes changes to nodes in the field", () => {
 			const change = [Mark.modify(nodeId1), { count: 42 }, Mark.modify(nodeId2)];
 			const actual = sequenceFieldChangeHandler.getNestedChanges(change);
-			assert.deepEqual(actual, [nodeId1, nodeId2]);
+			assert.deepEqual(actual, [
+				[nodeId1, 0],
+				[nodeId2, 43],
+			]);
 		});
 		it("includes changes to removed nodes", () => {
 			const change = [
@@ -35,7 +38,10 @@ export function testGetNestedChanges() {
 				Mark.modify(nodeId2, { revision: tag1, localId: brand(43) }),
 			];
 			const actual = sequenceFieldChangeHandler.getNestedChanges(change);
-			assert.deepEqual(actual, [nodeId1, nodeId2]);
+			assert.deepEqual(actual, [
+				[nodeId1, undefined],
+				[nodeId2, undefined],
+			]);
 		});
 	});
 }


### PR DESCRIPTION
## Description

Adds a method to `FieldChangeHandler` so that it's possible to query the nested changes from a field change.

This is not being leveraged yet but will be leveraged in later PRs. For example, this will make it easier to check that a given field kind's rebase/compose logic recurses on nested changes when appropriate.

## Breaking Changes

None