### PR TITLE
tree: move tree util exports to internalTypes module

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -128,8 +128,6 @@ declare namespace InternalTypes {
         Invariant,
         Contravariant,
         Covariant,
-        BrandedType,
-        ExtractFromOpaque,
         Assume,
         AllowOptional,
         RequiredFields,
@@ -139,7 +137,6 @@ declare namespace InternalTypes {
         FlattenKeys,
         AllowOptionalNotFlattened,
         isAny,
-        BrandedKeyContent,
         RestrictiveReadonlyRecord,
         MakeNominal
     }

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -123,6 +123,29 @@ export type InsertableTypedNodeUnsafe<T extends Unenforced<TreeNodeSchema>> = Un
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
+declare namespace InternalTypes {
+    export {
+        Invariant,
+        Contravariant,
+        Covariant,
+        BrandedType,
+        ExtractFromOpaque,
+        Assume,
+        AllowOptional,
+        RequiredFields,
+        OptionalFields,
+        _InlineTrick,
+        _RecursiveTrick,
+        FlattenKeys,
+        AllowOptionalNotFlattened,
+        isAny,
+        BrandedKeyContent,
+        RestrictiveReadonlyRecord,
+        MakeNominal
+    }
+}
+export { InternalTypes }
+
 // @public
 export type IsListener<TListener> = TListener extends (...args: any[]) => void ? true : false;
 
@@ -155,7 +178,7 @@ export type Listeners<T extends object> = {
 };
 
 // @public
-export interface MakeNominal {
+interface MakeNominal {
 }
 
 // @public
@@ -204,7 +227,7 @@ export { Range_2 as Range }
 export { Required_2 as Required }
 
 // @public
-export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
+type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -128,8 +128,6 @@ declare namespace InternalTypes {
         Invariant,
         Contravariant,
         Covariant,
-        BrandedType,
-        ExtractFromOpaque,
         Assume,
         AllowOptional,
         RequiredFields,
@@ -139,7 +137,6 @@ declare namespace InternalTypes {
         FlattenKeys,
         AllowOptionalNotFlattened,
         isAny,
-        BrandedKeyContent,
         RestrictiveReadonlyRecord,
         MakeNominal
     }

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -123,6 +123,29 @@ export type InsertableTypedNodeUnsafe<T extends Unenforced<TreeNodeSchema>> = Un
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
+declare namespace InternalTypes {
+    export {
+        Invariant,
+        Contravariant,
+        Covariant,
+        BrandedType,
+        ExtractFromOpaque,
+        Assume,
+        AllowOptional,
+        RequiredFields,
+        OptionalFields,
+        _InlineTrick,
+        _RecursiveTrick,
+        FlattenKeys,
+        AllowOptionalNotFlattened,
+        isAny,
+        BrandedKeyContent,
+        RestrictiveReadonlyRecord,
+        MakeNominal
+    }
+}
+export { InternalTypes }
+
 // @public
 export type IsListener<TListener> = TListener extends (...args: any[]) => void ? true : false;
 
@@ -155,7 +178,7 @@ export type Listeners<T extends object> = {
 };
 
 // @public
-export interface MakeNominal {
+interface MakeNominal {
 }
 
 // @public
@@ -204,7 +227,7 @@ export { Range_2 as Range }
 export { Required_2 as Required }
 
 // @public
-export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
+type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -128,8 +128,6 @@ declare namespace InternalTypes {
         Invariant,
         Contravariant,
         Covariant,
-        BrandedType,
-        ExtractFromOpaque,
         Assume,
         AllowOptional,
         RequiredFields,
@@ -139,7 +137,6 @@ declare namespace InternalTypes {
         FlattenKeys,
         AllowOptionalNotFlattened,
         isAny,
-        BrandedKeyContent,
         RestrictiveReadonlyRecord,
         MakeNominal
     }

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -123,6 +123,29 @@ export type InsertableTypedNodeUnsafe<T extends Unenforced<TreeNodeSchema>> = Un
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
+declare namespace InternalTypes {
+    export {
+        Invariant,
+        Contravariant,
+        Covariant,
+        BrandedType,
+        ExtractFromOpaque,
+        Assume,
+        AllowOptional,
+        RequiredFields,
+        OptionalFields,
+        _InlineTrick,
+        _RecursiveTrick,
+        FlattenKeys,
+        AllowOptionalNotFlattened,
+        isAny,
+        BrandedKeyContent,
+        RestrictiveReadonlyRecord,
+        MakeNominal
+    }
+}
+export { InternalTypes }
+
 // @public
 export type IsListener<TListener> = TListener extends (...args: any[]) => void ? true : false;
 
@@ -155,7 +178,7 @@ export type Listeners<T extends object> = {
 };
 
 // @public
-export interface MakeNominal {
+interface MakeNominal {
 }
 
 // @public
@@ -204,7 +227,7 @@ export { Range_2 as Range }
 export { Required_2 as Required }
 
 // @public
-export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
+type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -343,27 +343,6 @@ export type { ICodecOptions, JsonValidator, SchemaValidationFunction } from "./c
 export { noopValidator } from "./codec/index.js";
 export { typeboxValidator } from "./external-utilities/index.js";
 
-// TODO: When previously tagged '@internal', these types could not be included in `InternalClassTreeTypes` due to https://github.com/microsoft/rushstack/issues/3639
-export {
-	Invariant,
-	Contravariant,
-	Covariant,
-	BrandedType,
-	ExtractFromOpaque,
-	Assume,
-	AllowOptional,
-	RequiredFields,
-	OptionalFields,
-	_InlineTrick,
-	_RecursiveTrick,
-	FlattenKeys,
-	AllowOptionalNotFlattened,
-	isAny,
-	BrandedKeyContent,
-	RestrictiveReadonlyRecord,
-	MakeNominal,
-} from "./util/index.js";
-
 export {
 	NormalizeField,
 	NormalizeAllowedTypes,
@@ -394,3 +373,7 @@ export {
 	Forbidden,
 	Sequence,
 } from "./feature-libraries/index.js";
+
+// Below here are things that are used by the above, but not part of the desired API surface.
+import * as InternalTypes from "./internalTypes.js";
+export { InternalTypes };

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -343,6 +343,9 @@ export type { ICodecOptions, JsonValidator, SchemaValidationFunction } from "./c
 export { noopValidator } from "./codec/index.js";
 export { typeboxValidator } from "./external-utilities/index.js";
 
+// TODO: When previously tagged '@internal', these types could not be included in `InternalClassTreeTypes` due to https://github.com/microsoft/rushstack/issues/3639
+export { BrandedType, ExtractFromOpaque, BrandedKeyContent } from "./util/index.js";
+
 export {
 	NormalizeField,
 	NormalizeAllowedTypes,

--- a/packages/dds/tree/src/internalTypes.ts
+++ b/packages/dds/tree/src/internalTypes.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export {
+	Invariant,
+	Contravariant,
+	Covariant,
+	BrandedType,
+	ExtractFromOpaque,
+	Assume,
+	AllowOptional,
+	RequiredFields,
+	OptionalFields,
+	_InlineTrick,
+	_RecursiveTrick,
+	FlattenKeys,
+	AllowOptionalNotFlattened,
+	isAny,
+	BrandedKeyContent,
+	RestrictiveReadonlyRecord,
+	MakeNominal,
+} from "./util/index.js";

--- a/packages/dds/tree/src/internalTypes.ts
+++ b/packages/dds/tree/src/internalTypes.ts
@@ -7,8 +7,6 @@ export {
 	Invariant,
 	Contravariant,
 	Covariant,
-	BrandedType,
-	ExtractFromOpaque,
 	Assume,
 	AllowOptional,
 	RequiredFields,
@@ -18,7 +16,6 @@ export {
 	FlattenKeys,
 	AllowOptionalNotFlattened,
 	isAny,
-	BrandedKeyContent,
 	RestrictiveReadonlyRecord,
 	MakeNominal,
 } from "./util/index.js";

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -553,6 +553,29 @@ export interface InteriorSequencePlace {
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
+declare namespace InternalTypes {
+    export {
+        Invariant,
+        Contravariant,
+        Covariant,
+        BrandedType,
+        ExtractFromOpaque,
+        Assume,
+        AllowOptional,
+        RequiredFields,
+        OptionalFields,
+        _InlineTrick,
+        _RecursiveTrick,
+        FlattenKeys,
+        AllowOptionalNotFlattened,
+        isAny,
+        BrandedKeyContent,
+        RestrictiveReadonlyRecord,
+        MakeNominal
+    }
+}
+export { InternalTypes }
+
 // @alpha
 export interface IntervalIndex<TInterval extends ISerializableInterval> {
     add(interval: TInterval): void;
@@ -816,7 +839,7 @@ export type Listeners<T extends object> = {
 };
 
 // @public
-export interface MakeNominal {
+interface MakeNominal {
 }
 
 // @public
@@ -874,7 +897,7 @@ export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> = L extends any
 } : L;
 
 // @public
-export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
+type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -558,8 +558,6 @@ declare namespace InternalTypes {
         Invariant,
         Contravariant,
         Covariant,
-        BrandedType,
-        ExtractFromOpaque,
         Assume,
         AllowOptional,
         RequiredFields,
@@ -569,7 +567,6 @@ declare namespace InternalTypes {
         FlattenKeys,
         AllowOptionalNotFlattened,
         isAny,
-        BrandedKeyContent,
         RestrictiveReadonlyRecord,
         MakeNominal
     }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -450,8 +450,6 @@ declare namespace InternalTypes {
         Invariant,
         Contravariant,
         Covariant,
-        BrandedType,
-        ExtractFromOpaque,
         Assume,
         AllowOptional,
         RequiredFields,
@@ -461,7 +459,6 @@ declare namespace InternalTypes {
         FlattenKeys,
         AllowOptionalNotFlattened,
         isAny,
-        BrandedKeyContent,
         RestrictiveReadonlyRecord,
         MakeNominal
     }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -445,6 +445,29 @@ export type InsertableTypedNodeUnsafe<T extends Unenforced<TreeNodeSchema>> = Un
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
+declare namespace InternalTypes {
+    export {
+        Invariant,
+        Contravariant,
+        Covariant,
+        BrandedType,
+        ExtractFromOpaque,
+        Assume,
+        AllowOptional,
+        RequiredFields,
+        OptionalFields,
+        _InlineTrick,
+        _RecursiveTrick,
+        FlattenKeys,
+        AllowOptionalNotFlattened,
+        isAny,
+        BrandedKeyContent,
+        RestrictiveReadonlyRecord,
+        MakeNominal
+    }
+}
+export { InternalTypes }
+
 // @public (undocumented)
 export interface IProvideFluidLoadable {
     // (undocumented)
@@ -504,7 +527,7 @@ export type Listeners<T extends object> = {
 };
 
 // @public
-export interface MakeNominal {
+interface MakeNominal {
 }
 
 // @public
@@ -562,7 +585,7 @@ export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> = L extends any
 } : L;
 
 // @public
-export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
+type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -450,8 +450,6 @@ declare namespace InternalTypes {
         Invariant,
         Contravariant,
         Covariant,
-        BrandedType,
-        ExtractFromOpaque,
         Assume,
         AllowOptional,
         RequiredFields,
@@ -461,7 +459,6 @@ declare namespace InternalTypes {
         FlattenKeys,
         AllowOptionalNotFlattened,
         isAny,
-        BrandedKeyContent,
         RestrictiveReadonlyRecord,
         MakeNominal
     }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -445,6 +445,29 @@ export type InsertableTypedNodeUnsafe<T extends Unenforced<TreeNodeSchema>> = Un
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
+declare namespace InternalTypes {
+    export {
+        Invariant,
+        Contravariant,
+        Covariant,
+        BrandedType,
+        ExtractFromOpaque,
+        Assume,
+        AllowOptional,
+        RequiredFields,
+        OptionalFields,
+        _InlineTrick,
+        _RecursiveTrick,
+        FlattenKeys,
+        AllowOptionalNotFlattened,
+        isAny,
+        BrandedKeyContent,
+        RestrictiveReadonlyRecord,
+        MakeNominal
+    }
+}
+export { InternalTypes }
+
 // @public (undocumented)
 export interface IProvideFluidLoadable {
     // (undocumented)
@@ -504,7 +527,7 @@ export type Listeners<T extends object> = {
 };
 
 // @public
-export interface MakeNominal {
+interface MakeNominal {
 }
 
 // @public
@@ -562,7 +585,7 @@ export type ReplaceIEventThisPlaceHolder<L extends any[], TThis> = L extends any
 } : L;
 
 // @public
-export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
+type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 


### PR DESCRIPTION
![error when exporting internal utils from tree root](https://github.com/microsoft/FluidFramework/assets/112977307/707011be-e59d-4037-8ef9-3a02f4370da6)

moved util exports to an internalTypes module. Note API-extractor seemed to run into linking issues with some of the exports noted above, so the following types were excluded from internalTypesModule : BrandedType, ExtractFromOpaque, BrandedKeyContent