### PR TITLE
[Summarization] Update the summarizer / GC APIs on channels to use visitor pattern

### DIFF
--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -744,6 +744,31 @@ export class FluidDataStoreRuntime
 	}
 
 	/**
+	 * Returns a summary at the current sequence number.
+	 * @param fullTree - true to bypass optimizations and force a full summary tree
+	 * @param trackState - This tells whether we should track state from this summary.
+	 * @param telemetryContext - summary data passed through the layers for telemetry purposes
+	 */
+	public async summarize(
+		fullTree: boolean = false,
+		trackState: boolean = true,
+		telemetryContext?: ITelemetryContext,
+	): Promise<ISummaryTreeWithStats> {
+		const summaryBuilder = new SummaryTreeBuilder();
+		await this.visitLocalBoundContextsDuringSummary(
+			async (contextId: string, context: IChannelContext) => {
+				const contextSummary = await context.summarize(
+					fullTree,
+					trackState,
+					telemetryContext,
+				);
+				summaryBuilder.addWithStats(contextId, contextSummary);
+			},
+		);
+		return summaryBuilder.getSummaryTree();
+	}
+
+	/**
 	 * Generates data used for garbage collection. This includes a list of GC nodes that represent this channel
 	 * including any of its child channel contexts. Each node has a set of outbound routes to other GC nodes in the
 	 * document. It does the following:
@@ -760,24 +785,33 @@ export class FluidDataStoreRuntime
 	 */
 	public async getGCData(fullGC: boolean = false): Promise<IGarbageCollectionData> {
 		const builder = new GCDataBuilder();
-		// Iterate over each channel context and get their GC data.
-		await Promise.all(
-			Array.from(this.contexts)
-				.filter(([contextId, _]) => {
-					// Get GC data only for attached contexts. Detached contexts are not connected in the GC reference
-					// graph so any references they might have won't be connected as well.
-					return this.isChannelAttached(contextId);
-				})
-				.map(async ([contextId, context]) => {
-					const contextGCData = await context.getGCData(fullGC);
-					// Prefix the child's id to the ids of its GC nodes so they can be identified as belonging to the child.
-					// This also gradually builds the id of each node to be a path from the root.
-					builder.prefixAndAddNodes(contextId, contextGCData.gcNodes);
-				}),
+		await this.visitLocalBoundContextsDuringSummary(
+			async (contextId: string, context: IChannelContext) => {
+				const contextGCData = await context.getGCData(fullGC);
+				// Prefix the child's id to the ids of its GC nodes so they can be identified as belonging to the child.
+				// This also gradually builds the id of each node to be a path from the root.
+				builder.prefixAndAddNodes(contextId, contextGCData.gcNodes);
+			},
 		);
-
 		this.updateGCNodes(builder);
 		return builder.getGCData();
+	}
+
+	/**
+	 * Helper method for preparing to summarize this channel.
+	 * Runs the callback for each bound context to incorporate its data however the caller specifies
+	 */
+	private async visitLocalBoundContextsDuringSummary(
+		visitor: (contextId: string, context: IChannelContext) => Promise<void>,
+	): Promise<void> {
+		for (const [contextId, context] of this.contexts) {
+			const isAttached = this.isChannelAttached(contextId);
+			// We are not expecting local dds! Summary / GC data may not capture local state.
+			assert(isAttached, 0x17f /* "Not expecting detached channels during summarize" */);
+			if (isAttached) {
+				await visitor(contextId, context);
+			}
+		}
 	}
 
 	/**
@@ -801,46 +835,6 @@ export class FluidDataStoreRuntime
 		for (const [contextId, context] of this.contexts) {
 			context.updateUsedRoutes(usedContextRoutes.get(contextId) ?? []);
 		}
-	}
-
-	/**
-	 * Returns a summary at the current sequence number.
-	 * @param fullTree - true to bypass optimizations and force a full summary tree
-	 * @param trackState - This tells whether we should track state from this summary.
-	 * @param telemetryContext - summary data passed through the layers for telemetry purposes
-	 */
-	public async summarize(
-		fullTree: boolean = false,
-		trackState: boolean = true,
-		telemetryContext?: ITelemetryContext,
-	): Promise<ISummaryTreeWithStats> {
-		const summaryBuilder = new SummaryTreeBuilder();
-
-		// Iterate over each data store and ask it to summarize
-		await Promise.all(
-			Array.from(this.contexts)
-				.filter(([contextId, _]) => {
-					const isAttached = this.isChannelAttached(contextId);
-					// We are not expecting local dds! Summary may not capture local state.
-					assert(
-						isAttached,
-						0x17f /* "Not expecting detached channels during summarize" */,
-					);
-					// If the object is registered - and we have received the sequenced op creating the object
-					// (i.e. it has a base mapping) - then we go ahead and summarize
-					return isAttached;
-				})
-				.map(async ([contextId, context]) => {
-					const contextSummary = await context.summarize(
-						fullTree,
-						trackState,
-						telemetryContext,
-					);
-					summaryBuilder.addWithStats(contextId, contextSummary);
-				}),
-		);
-
-		return summaryBuilder.getSummaryTree();
 	}
 
 	public getAttachSummary(telemetryContext?: ITelemetryContext): ISummaryTreeWithStats {


### PR DESCRIPTION
Follow up from this comment - https://github.com/microsoft/FluidFramework/pull/21347#discussion_r1633882018

During summarization or attachments, both GC and summarize runs and they iterate over data stores and channel contexts during summarization. The logic to filter and validate is duplicated for both which makes it prone to get diverged.
This PR updates the following set of function to use the [visitor](https://en.wikipedia.org/wiki/Visitor_pattern) pattern to iterate over data stores / channel contexts:
- `summarize` and `getGCData`.
- `getAttachSummary` and `getAttachGCData`. 

One logic change in this PR:
- It updates `ChannelCollection::getAttachSummary` to use a visisted set to ensure that a node is only summarized oncen similar to `FluidDataStoreRuntime::getAttachSummary`. It earlier used the summary tree to do this.

#8257