### PR TITLE
Enable single commit summary via supportedFeatures in routerlicious

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -8,6 +8,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import { IClient } from "@fluidframework/driver-definitions";
 import {
 	IDocumentServiceEvents,
+	IDocumentServicePolicies,
 	IDocumentDeltaConnection,
 	IDocumentDeltaStorageService,
 	IDocumentService,
@@ -70,6 +71,8 @@ export class DocumentService
 	private storageManager: GitManager | undefined;
 	private noCacheStorageManager: GitManager | undefined;
 
+	private _policies: IDocumentServicePolicies | undefined;
+
 	public get resolvedUrl() {
 		return this._resolvedUrl;
 	}
@@ -99,6 +102,10 @@ export class DocumentService
 	}
 
 	private documentStorageService: DocumentStorageService | undefined;
+
+	public get policies(): IDocumentServicePolicies | undefined {
+		return this._policies;
+	}
 
 	public dispose() {}
 
@@ -281,6 +288,17 @@ export class DocumentService
 		// Retry with new token on authorization error; otherwise, allow container layer to handle.
 		try {
 			const connection = await connect();
+			// Enable single-commit summaries via driver policy based on the enable_single_commit_summary flag provided by the service during connection
+			// summarizeProtocolTree flag is used by the loader layer to attach protocol tree along with the summary required in the single-commit summaries.
+			const shouldSummarizeProtocolTree = (connection as R11sDocumentDeltaConnection).details
+				?.supportedFeatures?.enable_single_commit_summary
+				? true
+				: false;
+			this._policies = {
+				...this._policies,
+				summarizeProtocolTree: shouldSummarizeProtocolTree,
+			};
+
 			return connection;
 		} catch (error: any) {
 			if (error?.statusCode === 401) {

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -288,7 +288,7 @@ export class DocumentService
 		// Retry with new token on authorization error; otherwise, allow container layer to handle.
 		try {
 			const connection = await connect();
-			// Enable single-commit summaries via driver policy based on the enable_single_commit_summary flag provided by the service during connection
+			// Enable single-commit summaries via driver policy based on the enable_single_commit_summary flag which maybe provided by the service during connection.
 			// summarizeProtocolTree flag is used by the loader layer to attach protocol tree along with the summary required in the single-commit summaries.
 			const shouldSummarizeProtocolTree = (connection as R11sDocumentDeltaConnection).details
 				?.supportedFeatures?.enable_single_commit_summary

--- a/packages/drivers/routerlicious-driver/src/test/documentService.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/documentService.spec.ts
@@ -1,0 +1,145 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { IClient } from "@fluidframework/driver-definitions";
+import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
+import { stub } from "sinon";
+
+import { DefaultTokenProvider } from "../defaultTokenProvider.js";
+import { R11sDocumentDeltaConnection } from "../documentDeltaConnection.js";
+import { DocumentService } from "../documentService.js";
+import { RouterliciousDocumentServiceFactory } from "../documentServiceFactory.js";
+
+describe("DocumentService", () => {
+	let documentService: DocumentService;
+	let routerliciousDocumentServiceFactory: RouterliciousDocumentServiceFactory;
+	let deltaConnection;
+	let resolvedUrl;
+
+	beforeEach(async () => {
+		routerliciousDocumentServiceFactory = new RouterliciousDocumentServiceFactory(
+			new DefaultTokenProvider("jwt"),
+		);
+		resolvedUrl = {
+			type: "fluid",
+			id: "id",
+			url: "https://mock.url/tenantId/documentId",
+			endpoints: {
+				ordererUrl: "ordererUrl",
+				storageUrl: "storageUrl",
+				deltaStorageUrl: "deltaStorageUrl",
+				deltaStreamUrl: "deltaStreamUrl",
+			},
+			tokens: {},
+		};
+		documentService = (await routerliciousDocumentServiceFactory.createDocumentService(
+			resolvedUrl as IResolvedUrl,
+		)) as DocumentService;
+
+		deltaConnection = {
+			clientId: "clientId",
+			existing: true,
+			initialClients: [],
+			initialMessages: [],
+			initialSignals: [],
+			version: "1.0",
+			mode: "write",
+			claims: {
+				documentId: "docId",
+				exp: 0,
+				iat: 0,
+				scopes: [],
+				tenantId: "ten",
+				ver: "ver",
+				user: {
+					id: "id",
+				},
+			},
+			serviceConfiguration: {
+				blockSize: 100,
+				maxMessageSize: 16000,
+				summary: {
+					minIdleTime: 0,
+					maxIdleTime: 0,
+					maxAckWaitTime: 0,
+					maxOps: 100,
+					maxTime: 10,
+				},
+			},
+			dispose: (): void => {},
+			disposed: false,
+			submit: (): void => {},
+			submitSignal: (): void => {},
+			on: (): void => {},
+			once: (): void => {},
+		};
+	});
+
+	it("connectToDeltaStream() enables summarizeProtocolTree policy when enable_single_commit_summary is true", async () => {
+		const client: IClient = {
+			mode: "read",
+			details: { capabilities: { interactive: true } },
+			permission: [],
+			user: { id: "id" },
+			scopes: [],
+		};
+
+		deltaConnection = {
+			...deltaConnection,
+			// getter for conneciton details emulating enable_single_commit_summary feature flag as true
+			get details() {
+				return { supportedFeatures: { enable_single_commit_summary: true } };
+			},
+		};
+
+		const stubbedDeltaConnectionCreate = stub(R11sDocumentDeltaConnection, "create").callsFake(
+			async () => deltaConnection as R11sDocumentDeltaConnection,
+		);
+		await documentService.connectToDeltaStream(client);
+		assert.equal(documentService.policies?.summarizeProtocolTree, true);
+		stubbedDeltaConnectionCreate.restore();
+	});
+
+	it("connectToDeltaStream() does not set summarizeProtocolTree policy when enable_single_commit_summary is false", async () => {
+		const client: IClient = {
+			mode: "read",
+			details: { capabilities: { interactive: true } },
+			permission: [],
+			user: { id: "id" },
+			scopes: [],
+		};
+
+		deltaConnection = {
+			...deltaConnection,
+			// getter for conneciton details emulating enable_single_commit_summary feature flag as false
+			get details() {
+				return { supportedFeatures: { enable_single_commit_summary: false } };
+			},
+		};
+
+		const stubbedDeltaConnectionCreate = stub(R11sDocumentDeltaConnection, "create").callsFake(
+			async () => deltaConnection as R11sDocumentDeltaConnection,
+		);
+
+		await documentService.connectToDeltaStream(client);
+		assert.equal(documentService.policies?.summarizeProtocolTree, false);
+
+		// Update the delta connection to emulate service enabling of enable_single_commit_summary flag on reconnection
+		deltaConnection = {
+			...deltaConnection,
+			// getter for conneciton details emulating enable_single_commit_summary feature flag as false
+			get details() {
+				return { supportedFeatures: { enable_single_commit_summary: true } };
+			},
+		};
+
+		// emulate reconneciton to see if the new updated value of enable_single_commit_summary is picked up.
+		await documentService.connectToDeltaStream(client);
+		assert.equal(documentService.policies?.summarizeProtocolTree, true);
+		stubbedDeltaConnectionCreate.restore();
+	});
+});

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -965,9 +965,9 @@ export class Container
 				? summaryTree
 				: combineAppAndProtocolSummary(summaryTree, this.captureProtocolSummary());
 
-		// Whether the combined summary tree has been forced on by either the loader option or the monitoring context.
+		// Whether the combined summary tree has been forced on by either the loader option or the monitoring context or supportedFeatures flag by the service.
 		// Even if not forced on via this flag, combined summaries may still be enabled by service policy.
-		const forceEnableSummarizeProtocolTree =
+		const shouldSummarizeProtocolTree =
 			this.mc.config.getBoolean("Fluid.Container.summarizeProtocolTree2") ??
 			options.summarizeProtocolTree;
 
@@ -977,7 +977,7 @@ export class Container
 			pendingLocalState?.snapshotBlobs,
 			pendingLocalState?.loadedGroupIdSnapshots,
 			addProtocolSummaryIfMissing,
-			forceEnableSummarizeProtocolTree,
+			shouldSummarizeProtocolTree,
 		);
 
 		const offlineLoadEnabled =

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -74,7 +74,7 @@ export class ContainerStorageAdapter
 	 * @param loadingGroupIdSnapshotsFromPendingState - in offline mode, any loading group snapshots we've downloaded from the service that were stored in the pending state
 	 * @param addProtocolSummaryIfMissing - a callback to permit the container to inspect the summary we're about to
 	 * upload, and fix it up with a protocol tree if needed
-	 * @param forceEnableSummarizeProtocolTree - Enforce uploading a protocol summary regardless of the service's policy
+	 * @param shouldSummarizeProtocolTree  - Enforce uploading a protocol summary regardless of the service's policy.
 	 */
 	public constructor(
 		// eslint-disable-next-line import/no-deprecated
@@ -86,10 +86,10 @@ export class ContainerStorageAdapter
 		private readonly blobContents: { [id: string]: ArrayBufferLike | string } = {},
 		private loadingGroupIdSnapshotsFromPendingState: Record<string, ISnapshotInfo> | undefined,
 		private readonly addProtocolSummaryIfMissing: (summaryTree: ISummaryTree) => ISummaryTree,
-		forceEnableSummarizeProtocolTree: boolean | undefined,
+		shouldSummarizeProtocolTree: boolean | undefined,
 	) {
 		this._storageService = new BlobOnlyStorage(detachedBlobStorage, logger);
-		this._summarizeProtocolTree = forceEnableSummarizeProtocolTree;
+		this._summarizeProtocolTree = shouldSummarizeProtocolTree;
 	}
 
 	disposed: boolean = false;
@@ -109,15 +109,22 @@ export class ContainerStorageAdapter
 			this.logger,
 		));
 
-		this._summarizeProtocolTree =
-			this._summarizeProtocolTree ?? service.policies?.summarizeProtocolTree;
-		if (this.summarizeProtocolTree) {
-			this.logger.sendTelemetryEvent({ eventName: "summarizeProtocolTreeEnabled" });
-			this._storageService = new ProtocolTreeStorageService(
-				retriableStorage,
-				this.addProtocolSummaryIfMissing,
-			);
-		}
+		// A storage service wrapper which intercept calls to uploadSummaryWithContext and ensure they include
+		// the protocol summary, provided single-commit summary is enabled.
+		this._storageService = new ProtocolTreeStorageService(
+			retriableStorage,
+			(...props) => {
+				this.logger.sendTelemetryEvent({ eventName: "summarizeProtocolTreeEnabled" });
+				return this.addProtocolSummaryIfMissing(...props);
+			},
+			// A callback to ensure we fetch the most updated value of service.policies.summarizeProtocolTree, which could be set
+			// based on the response received from the service after connection is established.
+			() => {
+				this._summarizeProtocolTree =
+					this._summarizeProtocolTree ?? service.policies?.summarizeProtocolTree ?? false;
+				return this._summarizeProtocolTree;
+			},
+		);
 	}
 
 	public loadSnapshotFromSnapshotBlobs(snapshotBlobs: ISerializableBlobContents) {

--- a/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
+++ b/packages/loader/container-loader/src/protocolTreeDocumentStorageService.ts
@@ -15,9 +15,16 @@ import {
  * the protocol summary, using the provided callback to add it if necessary.
  */
 export class ProtocolTreeStorageService implements IDocumentStorageService, IDisposable {
+	/**
+	 *
+	 * @param internalStorageService - Document storage service responsible to make api calls to the storage.
+	 * @param addProtocolSummaryIfMissing - Function to add protocol summary tree to the summary. Used in scenarios where single-commit summaries are used.
+	 * @param shouldSummarizeProtocolTree - Callback function to learn about the service preference on whether single-commit summaries are enabled.
+	 */
 	constructor(
 		private readonly internalStorageService: IDocumentStorageService & IDisposable,
 		private readonly addProtocolSummaryIfMissing: (summaryTree: ISummaryTree) => ISummaryTree,
+		private readonly shouldSummarizeProtocolTree: () => boolean,
 	) {
 		this.getSnapshotTree = internalStorageService.getSnapshotTree.bind(internalStorageService);
 		this.getSnapshot = internalStorageService.getSnapshot?.bind(internalStorageService);
@@ -46,9 +53,11 @@ export class ProtocolTreeStorageService implements IDocumentStorageService, IDis
 		summary: ISummaryTree,
 		context: ISummaryContext,
 	): Promise<string> {
-		return this.internalStorageService.uploadSummaryWithContext(
-			this.addProtocolSummaryIfMissing(summary),
-			context,
-		);
+		return this.shouldSummarizeProtocolTree()
+			? this.internalStorageService.uploadSummaryWithContext(
+					this.addProtocolSummaryIfMissing(summary),
+					context,
+			  )
+			: this.internalStorageService.uploadSummaryWithContext(summary, context);
 	}
 }


### PR DESCRIPTION
Enable single-commit summaries via `summarizeProtocolTree` policy flag in `IDocumentServicePolicies` - which for routerlicious will be set when `enable_single_commit_summary` flag is provided in the `supportedFeatures` property bag in IConnected. This change is particularly aimed at enabling slow rollouts of FRS clients on the single-commit summary flow. 

1. updated routerlicious-driver's documentService to check the supported features and set the `summarizeProtocolTree` driver policy. Container uses this flag to check whether or not the protocol tree should be added to the summary before sending the summary.
2. Updated `containerStorageAdapter` to always initialize `ProtocolTreeStorageService`.
3. `ProtocolTreeStorageService`  uses a callback to check whether it should upload protocoltree with summary or not. This is done to ensure we are using the most updated value of driver policy which will be set correctly only when the delta connection is established.
4. Renamed `forceEnableSummarizeProtocolTree` to `shouldSummarizeProtocolTree`.

[AB#7864](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7864)

(Also this PR is a recommit of the original commit here(https://github.com/microsoft/FluidFramework/pull/21060) which had to be backed out because the tests were failing for odsp. I have made a fix for that change by ensuring _summarizeProtocolTree property of containerStorageAdapter is updated to the correct value always. )