### PR TITLE
move edits in `DefaultEditBuilder` with count of 0 does not assert

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -242,6 +242,11 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 		destinationField: FieldUpPath,
 		destIndex: number,
 	): void {
+		if (count === 0) {
+			return;
+		} else if (count < 0 || !Number.isSafeInteger(count)) {
+			throw new UsageError(`Expected non-negative count, got ${count}.`);
+		}
 		const detachId = this.modularBuilder.generateId(count);
 		const attachId = this.modularBuilder.generateId(count);
 		if (compareFieldUpPaths(sourceField, destinationField)) {
@@ -352,6 +357,11 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 				this.modularBuilder.submitChange(field, sequence.identifier, change);
 			},
 			move: (sourceIndex: number, count: number, destIndex: number): void => {
+				if (count === 0) {
+					return;
+				} else if (count < 0 || !Number.isSafeInteger(count)) {
+					throw new UsageError(`Expected non-negative count, got ${count}.`);
+				}
 				const detachId = this.modularBuilder.generateId(count);
 				const attachId = this.modularBuilder.generateId(count);
 				const change = sequence.changeHandler.editor.move(

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -245,7 +245,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 		if (count === 0) {
 			return;
 		} else if (count < 0 || !Number.isSafeInteger(count)) {
-			throw new UsageError(`Expected non-negative count, got ${count}.`);
+			throw new UsageError(`Expected non-negative integer count, got ${count}.`);
 		}
 		const detachId = this.modularBuilder.generateId(count);
 		const attachId = this.modularBuilder.generateId(count);
@@ -360,7 +360,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 				if (count === 0) {
 					return;
 				} else if (count < 0 || !Number.isSafeInteger(count)) {
-					throw new UsageError(`Expected non-negative count, got ${count}.`);
+					throw new UsageError(`Expected non-negative integer count, got ${count}.`);
 				}
 				const detachId = this.modularBuilder.generateId(count);
 				const attachId = this.modularBuilder.generateId(count);

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -962,6 +962,24 @@ describe("DefaultEditBuilder", () => {
 			};
 			assert.deepEqual(treeView, [expected]);
 		});
+
+		it("Moving 0 items does nothing.", () => {
+			const { builder, forest } = initializeEditableForest({
+				type: jsonObject.name,
+				fields: {
+					foo: [],
+				},
+			});
+			builder.move({ parent: root, field: fooKey }, 0, 0, { parent: root, field: fooKey }, 0);
+			const treeView = toJsonableTreeFromForest(forest);
+			const expected = {
+				type: jsonObject.name,
+				fields: {
+					foo: [],
+				},
+			};
+			assert.deepEqual(treeView, [expected]);
+		});
 	});
 });
 


### PR DESCRIPTION
## Description

This PR addresses an edge case where moving 0 items in the `DefaultEditBuilder` does not assert. 