### PR TITLE
refactor(tinylicious-client): Promote `TinyliciousClient` APIs to beta

### DIFF
--- a/.changeset/late-gourds-shower.md
+++ b/.changeset/late-gourds-shower.md
@@ -1,0 +1,5 @@
+---
+"@fluidframework/tinylicious-client": minor
+---
+
+Promotes `TinyliciousClient` and related types to `@beta`.

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -31,30 +31,30 @@ export class TinyliciousClient {
 
 // @beta
 export interface TinyliciousClientProps {
-    connection?: TinyliciousConnectionConfig;
-    logger?: ITelemetryBaseLogger;
+    readonly connection?: TinyliciousConnectionConfig;
+    readonly logger?: ITelemetryBaseLogger;
 }
 
 // @beta
 export interface TinyliciousConnectionConfig {
-    domain?: string;
-    port?: number;
-    tokenProvider?: ITokenProvider;
+    readonly domain?: string;
+    readonly port?: number;
+    readonly tokenProvider?: ITokenProvider;
 }
 
 // @beta
 export interface TinyliciousContainerServices {
-    audience: ITinyliciousAudience;
+    readonly audience: ITinyliciousAudience;
 }
 
 // @beta
 export interface TinyliciousMember extends IMember {
-    name: string;
+    readonly name: string;
 }
 
 // @beta
 export interface TinyliciousUser extends IUser {
-    name: string;
+    readonly name: string;
 }
 
 ```

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -13,4 +13,48 @@ import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUser } from '@fluidframework/driver-definitions';
 
+// @beta
+export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
+
+// @beta @sealed
+export class TinyliciousClient {
+    constructor(props?: TinyliciousClientProps | undefined);
+    createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TinyliciousContainerServices;
+    }>;
+    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TinyliciousContainerServices;
+    }>;
+}
+
+// @beta
+export interface TinyliciousClientProps {
+    connection?: TinyliciousConnectionConfig;
+    logger?: ITelemetryBaseLogger;
+}
+
+// @beta
+export interface TinyliciousConnectionConfig {
+    domain?: string;
+    port?: number;
+    tokenProvider?: ITokenProvider;
+}
+
+// @beta
+export interface TinyliciousContainerServices {
+    audience: ITinyliciousAudience;
+}
+
+// @beta
+export interface TinyliciousMember extends IMember {
+    name: string;
+}
+
+// @beta
+export interface TinyliciousUser extends IUser {
+    name: string;
+}
+
 ```

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -31,30 +31,30 @@ export class TinyliciousClient {
 
 // @beta
 export interface TinyliciousClientProps {
-    connection?: TinyliciousConnectionConfig;
-    logger?: ITelemetryBaseLogger;
+    readonly connection?: TinyliciousConnectionConfig;
+    readonly logger?: ITelemetryBaseLogger;
 }
 
 // @beta
 export interface TinyliciousConnectionConfig {
-    domain?: string;
-    port?: number;
-    tokenProvider?: ITokenProvider;
+    readonly domain?: string;
+    readonly port?: number;
+    readonly tokenProvider?: ITokenProvider;
 }
 
 // @beta
 export interface TinyliciousContainerServices {
-    audience: ITinyliciousAudience;
+    readonly audience: ITinyliciousAudience;
 }
 
 // @beta
 export interface TinyliciousMember extends IMember {
-    name: string;
+    readonly name: string;
 }
 
 // @beta
 export interface TinyliciousUser extends IUser {
-    name: string;
+    readonly name: string;
 }
 
 ```

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -13,4 +13,48 @@ import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUser } from '@fluidframework/driver-definitions';
 
+// @beta
+export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
+
+// @beta @sealed
+export class TinyliciousClient {
+    constructor(props?: TinyliciousClientProps | undefined);
+    createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TinyliciousContainerServices;
+    }>;
+    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TinyliciousContainerServices;
+    }>;
+}
+
+// @beta
+export interface TinyliciousClientProps {
+    connection?: TinyliciousConnectionConfig;
+    logger?: ITelemetryBaseLogger;
+}
+
+// @beta
+export interface TinyliciousConnectionConfig {
+    domain?: string;
+    port?: number;
+    tokenProvider?: ITokenProvider;
+}
+
+// @beta
+export interface TinyliciousContainerServices {
+    audience: ITinyliciousAudience;
+}
+
+// @beta
+export interface TinyliciousMember extends IMember {
+    name: string;
+}
+
+// @beta
+export interface TinyliciousUser extends IUser {
+    name: string;
+}
+
 ```

--- a/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
@@ -43,7 +43,9 @@ import { type TinyliciousClientProps, type TinyliciousContainerServices } from "
  * Provides the ability to have a Fluid object backed by a Tinylicious service.
  *
  * @see {@link https://fluidframework.com/docs/testing/tinylicious/}
- * @internal
+ *
+ * @sealed
+ * @beta
  */
 export class TinyliciousClient {
 	private readonly documentServiceFactory: IDocumentServiceFactory;

--- a/packages/service-clients/tinylicious-client/src/interfaces.ts
+++ b/packages/service-clients/tinylicious-client/src/interfaces.ts
@@ -9,8 +9,8 @@ import { type IMember, type IServiceAudience } from "@fluidframework/fluid-stati
 import { type ITokenProvider } from "@fluidframework/routerlicious-driver";
 
 /**
- * Props for initializing a {@link TinyliciousClient}
- * @internal
+ * Properties for initializing a {@link TinyliciousClient}
+ * @beta
  */
 export interface TinyliciousClientProps {
 	/**
@@ -18,6 +18,7 @@ export interface TinyliciousClientProps {
 	 * If not specified, will use {@link TinyliciousConnectionConfig}'s default values.
 	 */
 	connection?: TinyliciousConnectionConfig;
+
 	/**
 	 * Optional. A logger instance to receive diagnostic messages.
 	 */
@@ -26,7 +27,7 @@ export interface TinyliciousClientProps {
 
 /**
  * Parameters for establishing a connection with the a Tinylicious service.
- * @internal
+ * @beta
  */
 export interface TinyliciousConnectionConfig {
 	/**
@@ -54,25 +55,28 @@ export interface TinyliciousConnectionConfig {
 }
 
 /**
- * TinyliciousContainerServices is returned by the TinyliciousClient alongside a FluidContainer.
- * It holds the functionality specifically tied to the Tinylicious service, and how the data stored in
- * the FluidContainer is persisted in the backend and consumed by users. Any functionality regarding
- * how the data is handled within the FluidContainer itself, i.e. which data objects or DDSes to use,
- * will not be included here but rather on the FluidContainer class itself.
- * @internal
+ * Holds the functionality specifically tied to the Tinylicious service, and how the data stored in
+ * the {@link @fluidframework/fluid-static#IFluidContainer} is persisted in the backend and consumed by users.
+ *
+ * @remarks
+ * Any functionality regarding how the data is handled within the FluidContainer itself (e.g., which data objects or
+ * DDSes to use) will not be included here but rather on the FluidContainer class itself.
+ *
+ * Returned by {@link TinyliciousClient.createContainer} alongside the FluidContainer.
+ *
+ * @beta
  */
 export interface TinyliciousContainerServices {
 	/**
 	 * Provides an object that can be used to get the users that are present in this Fluid session and
-	 * listeners for when the roster has any changes from users joining/leaving the session
+	 * listeners for when the roster has any changes from users joining/leaving the session.
 	 */
 	audience: ITinyliciousAudience;
 }
 
 /**
- * Since Tinylicious provides user names for all of its members, we extend the `IUser` interface to include
- * this service-specific value.
- * @internal
+ * Tinylicious {@link @fluidframework/fluid-static#IUser}.
+ * @beta
  */
 export interface TinyliciousUser extends IUser {
 	/**
@@ -82,9 +86,8 @@ export interface TinyliciousUser extends IUser {
 }
 
 /**
- * Since Tinylicious provides user names for all of its members, we extend the `IMember` interface to include
- * this service-specific value. It will be returned for all audience members connected to Tinylicious.
- * @internal
+ * Tinylicious {@link @fluidframework/fluid-static#IMember}.
+ * @beta
  */
 export interface TinyliciousMember extends IMember {
 	/**
@@ -94,7 +97,7 @@ export interface TinyliciousMember extends IMember {
 }
 
 /**
- * Tinylicious-specific {@link @fluidframework/fluid-static#IServiceAudience} implementation.
- * @internal
+ * Tinylicious {@link @fluidframework/fluid-static#IServiceAudience}.
+ * @beta
  */
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;

--- a/packages/service-clients/tinylicious-client/src/interfaces.ts
+++ b/packages/service-clients/tinylicious-client/src/interfaces.ts
@@ -17,12 +17,12 @@ export interface TinyliciousClientProps {
 	 * Optional. Configuration for establishing a connection with the Tinylicious.
 	 * If not specified, will use {@link TinyliciousConnectionConfig}'s default values.
 	 */
-	connection?: TinyliciousConnectionConfig;
+	readonly connection?: TinyliciousConnectionConfig;
 
 	/**
 	 * Optional. A logger instance to receive diagnostic messages.
 	 */
-	logger?: ITelemetryBaseLogger;
+	readonly logger?: ITelemetryBaseLogger;
 }
 
 /**
@@ -35,14 +35,14 @@ export interface TinyliciousConnectionConfig {
 	 *
 	 * @defaultValue {@link @fluidframework/tinylicious-driver#defaultTinyliciousPort}
 	 */
-	port?: number;
+	readonly port?: number;
 
 	/**
 	 * Optional. Override of the domain.
 	 *
 	 * @defaultValue {@link @fluidframework/tinylicious-driver#defaultTinyliciousEndpoint}
 	 */
-	domain?: string;
+	readonly domain?: string;
 
 	/**
 	 * Optional. Override of tokenProvider. If a param is not provided, TinyliciousConnectionConfig
@@ -51,7 +51,7 @@ export interface TinyliciousConnectionConfig {
 	 *
 	 * @defaultValue {@link @fluidframework/tinylicious-driver#InsecureTinyliciousTokenProvider}
 	 */
-	tokenProvider?: ITokenProvider;
+	readonly tokenProvider?: ITokenProvider;
 }
 
 /**
@@ -71,7 +71,7 @@ export interface TinyliciousContainerServices {
 	 * Provides an object that can be used to get the users that are present in this Fluid session and
 	 * listeners for when the roster has any changes from users joining/leaving the session.
 	 */
-	audience: ITinyliciousAudience;
+	readonly audience: ITinyliciousAudience;
 }
 
 /**
@@ -82,7 +82,7 @@ export interface TinyliciousUser extends IUser {
 	/**
 	 * The user's name
 	 */
-	name: string;
+	readonly name: string;
 }
 
 /**
@@ -93,7 +93,7 @@ export interface TinyliciousMember extends IMember {
 	/**
 	 * {@inheritDoc TinyliciousUser.name}
 	 */
-	name: string;
+	readonly name: string;
 }
 
 /**

--- a/packages/service-clients/tinylicious-client/src/interfaces.ts
+++ b/packages/service-clients/tinylicious-client/src/interfaces.ts
@@ -62,7 +62,7 @@ export interface TinyliciousConnectionConfig {
  * Any functionality regarding how the data is handled within the FluidContainer itself (e.g., which data objects or
  * DDSes to use) will not be included here but rather on the FluidContainer class itself.
  *
- * Returned by {@link TinyliciousClient.createContainer} alongside the FluidContainer.
+ * Returned by {@link TinyliciousClient.createContainer} and {@link TinyliciousClient.getContainer} alongside the FluidContainer.
  *
  * @beta
  */


### PR DESCRIPTION
These APIs are used in external-facing examples and documentation (e.g., [FluidHelloWorld]()), so they can't be internal. We don't wish to support these for production scenarios, but we do wish for them to be externally visible. For now, we are promoting them to `@beta` to signal that external users may use them, but not depend on their stability.

Also...
* marks the `TinyliciousClient` class as `@sealed`.
* updates interface properties to be `readonly`
* cleans up some source code docs

[AB#8229](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8229)