### PR TITLE
Update tree tests to use viewWith

### DIFF
--- a/packages/dds/tree/src/simple-tree/tree.ts
+++ b/packages/dds/tree/src/simple-tree/tree.ts
@@ -80,7 +80,7 @@ export interface ITree extends IFluidLoadable {
 }
 
 /**
- * Options when schematizing a tree.
+ * Options when constructing a tree view.
  * @public
  */
 export interface ITreeConfigurationOptions {

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -20,24 +20,41 @@ import {
 } from "../../shared-tree/schematizingTreeView.js";
 import {
 	SchemaFactory,
-	TreeConfiguration,
+	TreeViewConfiguration,
 	type ImplicitFieldSchema,
+	type InsertableTreeFieldFromImplicitField,
 } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
-import { toFlexConfig, toFlexSchema } from "../../simple-tree/toFlexSchema.js";
+import { cursorFromUnhydratedRoot, toFlexSchema } from "../../simple-tree/toFlexSchema.js";
 import {
 	checkoutWithContent,
 	createTestUndoRedoStacks,
 	insert,
 	validateUsageError,
 } from "../utils.js";
+import type { TreeContent, TreeCheckout } from "../../shared-tree/index.js";
 
 const schema = new SchemaFactory("com.example");
-const config = new TreeConfiguration(schema.number, () => 5);
-const configGeneralized = new TreeConfiguration([schema.number, schema.string], () => 6);
-const configGeneralized2 = new TreeConfiguration([schema.number, schema.boolean], () => false);
-const flexConfig = toFlexConfig(config, new MockNodeKeyManager());
-const flexConfigGeneralized = toFlexConfig(configGeneralized, new MockNodeKeyManager());
+const config = new TreeViewConfiguration({ schema: schema.number });
+const configGeneralized = new TreeViewConfiguration({ schema: [schema.number, schema.string] });
+const configGeneralized2 = new TreeViewConfiguration({ schema: [schema.number, schema.boolean] });
+
+function checkoutWithInitialTree(
+	viewConfig: TreeViewConfiguration,
+	unhydratedInitialTree: InsertableTreeFieldFromImplicitField,
+	nodeKeyManager = new MockNodeKeyManager(),
+): TreeCheckout {
+	const initialTree = cursorFromUnhydratedRoot(
+		viewConfig.schema,
+		unhydratedInitialTree,
+		nodeKeyManager,
+	);
+	const treeContent: TreeContent = {
+		schema: toFlexSchema(viewConfig.schema),
+		initialTree,
+	};
+	return checkoutWithContent(treeContent);
+}
 
 // Schema for tree that must always be empty.
 const emptySchema = new SchemaBuilderBase(FieldKinds.required, {
@@ -76,7 +93,7 @@ describe("SchematizingSimpleTreeView", () => {
 	};
 
 	it("Open and close existing document", () => {
-		const checkout = checkoutWithContent(flexConfig);
+		const checkout = checkoutWithInitialTree(config, 5);
 		const view = new SchematizingSimpleTreeView(checkout, config, new MockNodeKeyManager());
 		assert.equal(view.compatibility.isEquivalent, true);
 		const root = view.root;
@@ -105,7 +122,7 @@ describe("SchematizingSimpleTreeView", () => {
 	});
 
 	it("Modify root", () => {
-		const checkout = checkoutWithContent(flexConfig);
+		const checkout = checkoutWithInitialTree(config, 5);
 		const view = new SchematizingSimpleTreeView(checkout, config, new MockNodeKeyManager());
 		view.events.on("schemaChanged", () => log.push(["schemaChanged", getChangeData(view)]));
 		view.events.on("rootChanged", () => log.push(["rootChanged", getChangeData(view)]));
@@ -124,7 +141,7 @@ describe("SchematizingSimpleTreeView", () => {
 	// TODO: AB#8121: When adding support for additional optional fields, we may want a variant of this test which does the analogous flow using
 	// an intermediate state where canView is true but canUpgrade is false.
 	it("Schema becomes un-upgradeable then exact match again", () => {
-		const checkout = checkoutWithContent(flexConfig);
+		const checkout = checkoutWithInitialTree(config, 5);
 		const view = new SchematizingSimpleTreeView(checkout, config, new MockNodeKeyManager());
 		assert.equal(view.root, 5);
 		const log: [string, unknown][] = [];
@@ -158,7 +175,7 @@ describe("SchematizingSimpleTreeView", () => {
 	});
 
 	it("Open upgradable document, then upgrade schema", () => {
-		const checkout = checkoutWithContent(flexConfig);
+		const checkout = checkoutWithInitialTree(config, 5);
 		const view = new SchematizingSimpleTreeView(
 			checkout,
 			configGeneralized,
@@ -184,7 +201,7 @@ describe("SchematizingSimpleTreeView", () => {
 	});
 
 	it("Attempt to open document using view schema that is incompatible due to being too strict compared to the stored schema", () => {
-		const checkout = checkoutWithContent(flexConfigGeneralized);
+		const checkout = checkoutWithInitialTree(configGeneralized, 6);
 		const view = new SchematizingSimpleTreeView(checkout, config, new MockNodeKeyManager());
 
 		assert.equal(view.compatibility.canView, false);
@@ -202,7 +219,7 @@ describe("SchematizingSimpleTreeView", () => {
 	});
 
 	it("Open incompatible document", () => {
-		const checkout = checkoutWithContent(flexConfigGeneralized);
+		const checkout = checkoutWithInitialTree(configGeneralized, 6);
 		const view = new SchematizingSimpleTreeView(
 			checkout,
 			configGeneralized2,
@@ -242,15 +259,16 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(redoStack.length, 1);
 	});
 
+	// AB#8200: This test may not be necessary with the schematize API removed.
 	it("handles proxies in the initial tree", () => {
 		// This is a regression test for a bug in which the initial tree contained a proxy and subsequent reads of the tree would mix up the proxy associations.
 		const sf = new SchemaFactory(undefined);
 		class TestObject extends sf.object("TestObject", { value: sf.number }) {}
-		const treeContent = new TreeConfiguration(TestObject, () => new TestObject({ value: 3 }));
+		const viewConfig = new TreeViewConfiguration({ schema: TestObject });
 		const nodeKeyManager = new MockNodeKeyManager();
 		const view = new SchematizingSimpleTreeView(
-			checkoutWithContent(toFlexConfig(treeContent, nodeKeyManager)),
-			treeContent,
+			checkoutWithInitialTree(viewConfig, new TestObject({ value: 3 }), nodeKeyManager),
+			viewConfig,
 			nodeKeyManager,
 		);
 

--- a/packages/dds/tree/src/test/shared-tree/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeNodeApi.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "../../shared-tree/index.js";
 import {
 	SchemaFactory,
-	TreeConfiguration,
+	TreeViewConfiguration,
 	type ValidateRecursiveSchema,
 	type TreeView,
 	type InsertableTypedNode,
@@ -36,12 +36,12 @@ describe("treeApi", () => {
 		}) {}
 
 		function getTestObjectView(child?: InsertableTypedNode<typeof ChildObject>) {
-			return getView(
-				new TreeConfiguration(TestObject, () => ({
-					content: 42,
-					child,
-				})),
-			);
+			const view = getView(new TreeViewConfiguration({ schema: TestObject }));
+			view.initialize({
+				content: 42,
+				child,
+			});
+			return view;
 		}
 
 		/**
@@ -140,14 +140,15 @@ describe("treeApi", () => {
 
 			it("respects a violated node existence constraint after sequencing", () => {
 				// Create two connected trees with child nodes
-				const config = new TreeConfiguration(TestObject, () => ({
-					content: 42,
-					child: {},
-				}));
+				const config = new TreeViewConfiguration({ schema: TestObject });
 				const provider = new TestTreeProviderLite(2);
 				const [treeA, treeB] = provider.trees;
-				const viewA = treeA.schematize(config);
-				const viewB = treeB.schematize(config);
+				const viewA = treeA.viewWith(config);
+				const viewB = treeB.viewWith(config);
+				viewA.initialize({
+					content: 42,
+					child: {},
+				});
 				provider.processMessages();
 
 				// Tree A removes the child node (this will be sequenced before anything else because the provider sequences ops in the order of submission).

--- a/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
@@ -11,7 +11,7 @@ import {
 	type NodeFromSchema,
 	SchemaFactory,
 	TreeArrayNode,
-	TreeConfiguration,
+	TreeViewConfiguration,
 } from "../../simple-tree/index.js";
 // TODO: test other things from "proxies" file.
 // eslint-disable-next-line import/no-internal-modules
@@ -177,11 +177,12 @@ describe("SharedTreeObject", () => {
 		});
 		const nodeKeyManager = new MockNodeKeyManager();
 		const id = nodeKeyManager.stabilizeNodeKey(nodeKeyManager.generateLocalNodeKey());
-		const config = new TreeConfiguration(schemaWithIdentifier, () => ({
-			identifier: id,
-		}));
+		const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
 
-		const root = getView(config, nodeKeyManager).root;
+		const view = getView(config, nodeKeyManager);
+		view.initialize({ identifier: id });
+		const { root } = view;
+
 		type _ = requireAssignableTo<typeof root.identifier, string>;
 		assert.equal(root.identifier, id);
 	});

--- a/packages/dds/tree/src/test/simple-tree/schemaCreationUtilities.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaCreationUtilities.spec.ts
@@ -11,7 +11,7 @@ import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/in
 import {
 	type NodeFromSchema,
 	SchemaFactory,
-	TreeConfiguration,
+	TreeViewConfiguration,
 	type TreeView,
 } from "../../simple-tree/index.js";
 import {
@@ -29,20 +29,19 @@ describe("schemaCreationUtilities", () => {
 	it("enum type switch", () => {
 		const Mode = enumFromStrings(schema, ["Fun", "Cool", "Bonus"]);
 		class Parent extends schema.object("Parent", { mode: Object.values(Mode) }) {}
-		const config = new TreeConfiguration(
-			Parent,
-			() =>
-				new Parent({
-					mode: new Mode.Bonus({}),
-				}),
-		);
+		const config = new TreeViewConfiguration({ schema: Parent });
 
 		const factory = new TreeFactory({});
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: testIdCompressor }),
 			"tree",
 		);
-		const view: TreeView<typeof Parent> = tree.schematize(config);
+		const view: TreeView<typeof Parent> = tree.viewWith(config);
+		view.initialize(
+			new Parent({
+				mode: new Mode.Bonus({}),
+			}),
+		);
 		const mode = view.root.mode;
 		switch (true) {
 			case mode instanceof Mode.Bonus: {
@@ -103,20 +102,19 @@ describe("schemaCreationUtilities", () => {
 	it("enum value switch", () => {
 		const Mode = enumFromStrings(schema, ["Fun", "Cool", "Bonus"]);
 		class Parent extends schema.object("Parent", { mode: typedObjectValues(Mode) }) {}
-		const config = new TreeConfiguration(
-			Parent,
-			() =>
-				new Parent({
-					mode: new Mode.Bonus({}),
-				}),
-		);
+		const config = new TreeViewConfiguration({ schema: Parent });
 
 		const factory = new TreeFactory({});
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: testIdCompressor }),
 			"tree",
 		);
-		const view: TreeView<typeof Parent> = tree.schematize(config);
+		const view: TreeView<typeof Parent> = tree.viewWith(config);
+		view.initialize(
+			new Parent({
+				mode: new Mode.Bonus({}),
+			}),
+		);
 		const mode = view.root.mode;
 		switch (mode.value) {
 			case "Fun": {
@@ -151,9 +149,10 @@ describe("schemaCreationUtilities", () => {
 
 		const day = Day.Today;
 
-		const view = tree.schematize(
-			new TreeConfiguration(typedObjectValues(DayNodes), () => DayNodes(day)),
+		const view = tree.viewWith(
+			new TreeViewConfiguration({ schema: typedObjectValues(DayNodes) }),
 		);
+		view.initialize(DayNodes(day));
 
 		switch (view.root.value) {
 			case Day.Today: {
@@ -188,9 +187,10 @@ describe("schemaCreationUtilities", () => {
 		// Can construct unhydrated node from enum's key:
 		const y = new DayNodes.Today({});
 
-		const view = tree.schematize(
-			new TreeConfiguration(typedObjectValues(DayNodes), () => DayNodes(Day.Today)),
+		const view = tree.viewWith(
+			new TreeViewConfiguration({ schema: typedObjectValues(DayNodes) }),
 		);
+		view.initialize(DayNodes(Day.Today));
 
 		switch (view.root.value) {
 			case Day.Today: {

--- a/packages/dds/tree/src/test/simple-tree/schemaFactory.examples.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactory.examples.spec.ts
@@ -12,7 +12,7 @@ import {
 	type ITree,
 	SchemaFactory,
 	treeNodeApi as Tree,
-	TreeConfiguration,
+	TreeViewConfiguration,
 	type TreeView,
 } from "../../simple-tree/index.js";
 import { TreeFactory } from "../../treeFactory.js";
@@ -71,31 +71,18 @@ function f(n: NodeMap): Note[] {
 
 class Canvas extends schema.object("Canvas", { stuff: [NodeMap, NodeList] }) {}
 
-const config1 = new TreeConfiguration(
-	Canvas,
-	() =>
+const config = new TreeViewConfiguration({ schema: Canvas });
+
+function setup(tree: ITree): Note[] {
+	const view: TreeView<typeof Canvas> = tree.viewWith(config);
+	view.initialize(
 		new Canvas({
 			stuff: new NodeList([
 				{ text: "a", location: undefined },
 				new Note({ text: "b", location: undefined }),
 			]),
 		}),
-);
-
-const config2 = new TreeConfiguration(
-	Canvas,
-	() =>
-		new Canvas({
-			stuff: [
-				// Trees of insertable data can mix inline insertable content and unhydrated nodes:
-				{ text: "a", location: undefined },
-				new Note({ text: "b", location: undefined }),
-			],
-		}),
-);
-
-function setup(tree: ITree): Note[] {
-	const view: TreeView<typeof Canvas> = tree.schematize(config1);
+	);
 	const stuff = view.root.stuff;
 	if (stuff instanceof NodeMap) {
 		return f(stuff);
@@ -122,13 +109,22 @@ describe("Class based end to end example", () => {
 		setup(theTree);
 	});
 
-	// Confirm that the alternative syntax for the config from the example above (config2) actually works.
-	it("config2", () => {
+	// Confirm that the alternative syntax for initialTree from the example above actually works.
+	it("using a mix of insertible content and nodes", () => {
 		const factory = new TreeFactory({});
 		const theTree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<typeof Canvas> = theTree.schematize(config2);
+		const view: TreeView<typeof Canvas> = theTree.viewWith(config);
+		view.initialize(
+			new Canvas({
+				stuff: [
+					// Trees of insertable data can mix inline insertable content and unhydrated nodes:
+					{ text: "a", location: undefined },
+					new Note({ text: "b", location: undefined }),
+				],
+			}),
+		);
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
@@ -14,7 +14,11 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 
 import { TreeStatus } from "../../feature-libraries/index.js";
-import { treeNodeApi as Tree, TreeConfiguration, type TreeView } from "../../simple-tree/index.js";
+import {
+	treeNodeApi as Tree,
+	TreeViewConfiguration,
+	type TreeView,
+} from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { isTreeNode } from "../../simple-tree/proxies.js";
 import {
@@ -94,7 +98,7 @@ describe("schemaFactory", () => {
 	it("leaf", () => {
 		const schema = new SchemaFactory("com.example");
 
-		const config = new TreeConfiguration(schema.number, () => 5);
+		const config = new TreeViewConfiguration({ schema: schema.number });
 
 		const factory = new TreeFactory({});
 		const tree = factory.create(
@@ -108,9 +112,6 @@ describe("schemaFactory", () => {
 
 	it("instanceof", () => {
 		const schema = new SchemaFactory("com.example");
-
-		const config = new TreeConfiguration(schema.number, () => 5);
-
 		const factory = new TreeFactory({});
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
@@ -188,7 +189,7 @@ describe("schemaFactory", () => {
 				y: schema.number,
 			}) {}
 
-			const config = new TreeConfiguration(Point, () => new Point({ x: 1, y: 2 }));
+			const config = new TreeViewConfiguration({ schema: Point });
 
 			const factory = new TreeFactory({});
 			const tree = factory.create(
@@ -227,14 +228,16 @@ describe("schemaFactory", () => {
 				}
 			}
 
-			const config = new TreeConfiguration(Point, () => new Point({ x: 1 }));
+			const config = new TreeViewConfiguration({ schema: Point });
 
 			const factory = new TreeFactory({});
 			const tree = factory.create(
 				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 				"tree",
 			);
-			const root = tree.schematize(config).root;
+			const view = tree.viewWith(config);
+			view.initialize(new Point({ x: 1 }));
+			const { root } = view;
 			assert.equal(root.x, 1);
 
 			const values: number[] = [];
@@ -378,20 +381,19 @@ describe("schemaFactory", () => {
 
 		class Canvas extends schema.object("Canvas", { stuff: [NodeMap, NodeList] }) {}
 
-		const config = new TreeConfiguration(
-			Canvas,
-			() =>
-				new Canvas({
-					stuff: new NodeList([new Note({ text: "hi", location: undefined })]),
-				}),
-		);
+		const config = new TreeViewConfiguration({ schema: Canvas });
 
 		const factory = new TreeFactory({});
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<typeof Canvas> = tree.schematize(config);
+		const view: TreeView<typeof Canvas> = tree.viewWith(config);
+		view.initialize(
+			new Canvas({
+				stuff: new NodeList([new Note({ text: "hi", location: undefined })]),
+			}),
+		);
 		const stuff = view.root.stuff;
 		assert(stuff instanceof NodeList);
 		const item = stuff[0];
@@ -407,20 +409,19 @@ describe("schemaFactory", () => {
 				parts: builder.array(builder.number),
 			}) {}
 
-			const treeConfiguration = new TreeConfiguration(
-				Inventory,
-				() =>
-					new Inventory({
-						parts: [1, 2],
-					}),
-			);
+			const treeConfiguration = new TreeViewConfiguration({ schema: Inventory });
 
 			const factory = new TreeFactory({});
 			const tree = factory.create(
 				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 				"tree",
 			);
-			const view = tree.schematize(treeConfiguration);
+			const view = tree.viewWith(treeConfiguration);
+			view.initialize(
+				new Inventory({
+					parts: [1, 2],
+				}),
+			);
 		});
 
 		const treeFactory = new TreeFactory({});
@@ -453,15 +454,13 @@ describe("schemaFactory", () => {
 			class Parent extends factory.object("parent", { child: NamedList }) {}
 
 			// Due to lack of support for navigating unhydrated nodes, create an actual tree so we can navigate to the list node:
-			const treeConfiguration = new TreeConfiguration(
-				Parent,
-				() => new Parent({ child: [5] }),
-			);
+			const treeConfiguration = new TreeViewConfiguration({ schema: Parent });
 			const tree = treeFactory.create(
 				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 				"tree",
 			);
-			const view = tree.schematize(treeConfiguration);
+			const view = tree.viewWith(treeConfiguration);
+			view.initialize(new Parent({ child: [5] }));
 
 			const listNode = view.root.child;
 			assert(listNode instanceof NamedList);
@@ -511,15 +510,13 @@ describe("schemaFactory", () => {
 			class Parent extends factory.object("parent", { child: NamedMap }) {}
 
 			// Due to lack of support for navigating unhydrated nodes, create an actual tree so we can navigate to the map node:
-			const treeConfiguration = new TreeConfiguration(
-				Parent,
-				() => new Parent({ child: new Map([["x", 5]]) }),
-			);
+			const treeConfiguration = new TreeViewConfiguration({ schema: Parent });
 			const tree = treeFactory.create(
 				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 				"tree",
 			);
-			const view = tree.schematize(treeConfiguration);
+			const view = tree.viewWith(treeConfiguration);
+			view.initialize(new Parent({ child: new Map([["x", 5]]) }));
 
 			const mapNode = view.root.child;
 			assert(mapNode instanceof NamedMap);
@@ -699,13 +696,14 @@ describe("schemaFactory", () => {
 			childType: (typeof objectTypes)[number],
 			validate: (view: TreeView<typeof ComboRoot>, nodes: ComboNode[]) => void,
 		) {
-			const config = new TreeConfiguration(ComboRoot, () => ({ root: undefined }));
+			const config = new TreeViewConfiguration({ schema: ComboRoot });
 			const factory = new TreeFactory({});
 			const tree = factory.create(
 				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 				"tree",
 			);
-			const view = tree.schematize(config);
+			const view = tree.viewWith(config);
+			view.initialize({ root: undefined });
 			const { parent, nodes } = createComboTree({
 				parentType,
 				childType,

--- a/packages/dds/tree/src/test/simple-tree/schemaFactoryRecursive.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactoryRecursive.spec.ts
@@ -16,7 +16,7 @@ import {
 	type InsertableTreeNodeFromImplicitAllowedTypes,
 	type InternalSimpleTreeTypes,
 	type NodeFromSchema,
-	TreeConfiguration,
+	TreeViewConfiguration,
 	type TreeNodeFromImplicitAllowedTypes,
 	type TreeView,
 	SchemaFactory,
@@ -82,17 +82,16 @@ describe("SchemaFactory Recursive methods", () => {
 				type _check = ValidateRecursiveSchema<typeof Box>;
 			}
 
-			const config = new TreeConfiguration(
-				Box,
-				() => new Box({ text: "hi", child: undefined }),
-			);
+			const config = new TreeViewConfiguration({ schema: Box });
 
 			const tree = factory.create(
 				new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 				"tree",
 			);
 
-			const view: TreeView<typeof Box> = tree.schematize(config);
+			const view: TreeView<typeof Box> = tree.viewWith(config);
+			view.initialize(new Box({ text: "hi", child: undefined }));
+
 			assert.equal(view.root?.text, "hi");
 
 			const stuff: undefined | Box = view.root.child;

--- a/packages/dds/tree/src/test/simple-tree/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/tree.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "node:assert";
 import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
-import { SchemaFactory, TreeConfiguration, type TreeView } from "../../simple-tree/index.js";
+import { SchemaFactory, TreeViewConfiguration, type TreeView } from "../../simple-tree/index.js";
 import { TreeFactory } from "../../treeFactory.js";
 import { getView } from "../utils.js";
 import { MockNodeKeyManager } from "../../feature-libraries/index.js";
@@ -23,81 +23,103 @@ const factory = new TreeFactory({});
 
 describe("class-tree tree", () => {
 	it("ListRoot", () => {
-		const config = new TreeConfiguration(NodeList, () => new NodeList(["a", "b"]));
+		const config = new TreeViewConfiguration({ schema: NodeList });
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<typeof NodeList> = tree.schematize(config);
+		const view: TreeView<typeof NodeList> = tree.viewWith(config);
+		view.initialize(new NodeList(["a", "b"]));
 		assert.deepEqual([...view.root], ["a", "b"]);
 	});
 
 	it("Implicit ListRoot", () => {
-		const config = new TreeConfiguration(NodeList, () => ["a", "b"]);
+		const config = new TreeViewConfiguration({ schema: NodeList });
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<typeof NodeList> = tree.schematize(config);
+		const view: TreeView<typeof NodeList> = tree.viewWith(config);
+		view.initialize(["a", "b"]);
 		assert.deepEqual([...view.root], ["a", "b"]);
 	});
 
 	it("ObjectRoot - Data", () => {
-		const config = new TreeConfiguration(Canvas, () => ({ stuff: ["a", "b"] }));
+		const config = new TreeViewConfiguration({ schema: Canvas });
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<typeof Canvas> = tree.schematize(config);
+		const view: TreeView<typeof Canvas> = tree.viewWith(config);
+		view.initialize({ stuff: ["a", "b"] });
 	});
 
 	it("ObjectRoot - unhydrated", () => {
-		const config = new TreeConfiguration(Canvas, () => new Canvas({ stuff: ["a", "b"] }));
+		const config = new TreeViewConfiguration({ schema: Canvas });
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view: TreeView<typeof Canvas> = tree.schematize(config);
+		const view: TreeView<typeof Canvas> = tree.viewWith(config);
+		view.initialize(new Canvas({ stuff: ["a", "b"] }));
 	});
 
 	it("Union Root", () => {
-		const config = new TreeConfiguration([schema.string, schema.number], () => "a");
+		const config = new TreeViewConfiguration({ schema: [schema.string, schema.number] });
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view = tree.schematize(config);
+		const view = tree.viewWith(config);
+		view.initialize("a");
 		assert.equal(view.root, "a");
 	});
 
-	it("optional Root - empty", () => {
-		const config = new TreeConfiguration(schema.optional(schema.string), () => undefined);
+	it("optional Root - initialized to undefined", () => {
+		const config = new TreeViewConfiguration({ schema: schema.optional(schema.string) });
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view = tree.schematize(config);
+		const view = tree.viewWith(config);
+		// Note: the tree's schema hasn't been initialized at this point, so even though the view schema
+		// allows an optional field, explicit initialization must occur.
+		assert.throws(() => view.root, /Document is out of schema./);
+		view.initialize(undefined);
+		assert.equal(view.root, undefined);
+	});
+
+	it("optional Root - initializing only schema", () => {
+		const config = new TreeViewConfiguration({ schema: schema.optional(schema.string) });
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+		const view = tree.viewWith(config);
+		view.upgradeSchema();
 		assert.equal(view.root, undefined);
 	});
 
 	it("optional Root - full", () => {
-		const config = new TreeConfiguration(schema.optional(schema.string), () => "x");
+		const config = new TreeViewConfiguration({ schema: schema.optional(schema.string) });
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view = tree.schematize(config);
+		const view = tree.viewWith(config);
+		view.initialize("x");
 		assert.equal(view.root, "x");
 	});
 
 	it("Nested list", () => {
 		const nestedList = schema.array(schema.array(schema.string));
-		const config = new TreeConfiguration(nestedList, () => [["a"]]);
+		const config = new TreeViewConfiguration({ schema: nestedList });
 		const tree = factory.create(
 			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
 			"tree",
 		);
-		const view = tree.schematize(config);
+		const view = tree.viewWith(config);
+		view.initialize([["a"]]);
 		assert.equal(view.root?.length, 1);
 		const child = view.root[0];
 		assert.equal(child.length, 1);
@@ -111,11 +133,10 @@ describe("class-tree tree", () => {
 				identifier: schema.identifier,
 			});
 			const nodeKeyManager = new MockNodeKeyManager();
-			const config = new TreeConfiguration(schemaWithIdentifier, () => ({
-				identifier: undefined,
-			}));
-			const root = getView(config, nodeKeyManager).root;
-			assert.equal(root.identifier, "a110ca7e-add1-4000-8000-000000000000");
+			const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
+			const view = getView(config, nodeKeyManager);
+			view.initialize({ identifier: undefined });
+			assert.equal(view.root.identifier, "a110ca7e-add1-4000-8000-000000000000");
 		});
 
 		it("populates field when no field defaulter is provided.", () => {
@@ -123,11 +144,10 @@ describe("class-tree tree", () => {
 				testOptionalField: schema.optional(schema.string),
 			});
 			const nodeKeyManager = new MockNodeKeyManager();
-			const config = new TreeConfiguration(schemaWithIdentifier, () => ({
-				testOptionalField: undefined,
-			}));
-			const root = getView(config, nodeKeyManager).root;
-			assert.equal(root.testOptionalField, undefined);
+			const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
+			const view = getView(config, nodeKeyManager);
+			view.initialize({ testOptionalField: undefined });
+			assert.equal(view.root.testOptionalField, undefined);
 		});
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/treeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeApi.spec.ts
@@ -17,7 +17,7 @@ import {
 	SchemaFactory,
 	treeNodeApi as Tree,
 	type TreeChangeEvents,
-	TreeConfiguration,
+	TreeViewConfiguration,
 } from "../../simple-tree/index.js";
 import { getView } from "../utils.js";
 import { hydrate } from "./utils.js";
@@ -42,8 +42,10 @@ class Point extends schema.object("Point", {}) {}
 describe("treeNodeApi", () => {
 	describe("is", () => {
 		it("is", () => {
-			const config = new TreeConfiguration([Point, schema.number], () => ({}));
-			const root = getView(config).root;
+			const config = new TreeViewConfiguration({ schema: [Point, schema.number] });
+			const view = getView(config);
+			view.initialize({});
+			const { root } = view;
 			assert(Tree.is(root, Point));
 			assert(root instanceof Point);
 			assert(!Tree.is(root, schema.number));
@@ -57,9 +59,10 @@ describe("treeNodeApi", () => {
 		});
 
 		it("`is` can narrow polymorphic leaf field content", () => {
-			const config = new TreeConfiguration([schema.number, schema.string], () => "x");
-			const root = getView(config).root;
-
+			const config = new TreeViewConfiguration({ schema: [schema.number, schema.string] });
+			const view = getView(config);
+			view.initialize("x");
+			const { root } = view;
 			if (Tree.is(root, schema.number)) {
 				const _check: number = root;
 				assert.fail();
@@ -70,9 +73,10 @@ describe("treeNodeApi", () => {
 		});
 
 		it("`is` can narrow polymorphic combinations of value and objects", () => {
-			const config = new TreeConfiguration([Point, schema.string], () => "x");
-			const root = getView(config).root;
-
+			const config = new TreeViewConfiguration({ schema: [Point, schema.string] });
+			const view = getView(config);
+			view.initialize("x");
+			const { root } = view;
 			if (Tree.is(root, Point)) {
 				const _check: Point = root;
 				assert.fail();
@@ -135,16 +139,13 @@ describe("treeNodeApi", () => {
 			y: schema.optional(Point, { key: "stable-y" }),
 		}) {}
 		const Root = schema.array(Child);
-		const config = new TreeConfiguration(Root, (): Child[] => [
-			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-			{
-				x: {},
-				y: undefined,
-			} as Child,
-			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-			{ x: {}, y: {} } as Child,
+		const config = new TreeViewConfiguration({ schema: Root });
+		const view = getView(config);
+		view.initialize([
+			{ x: {}, y: undefined },
+			{ x: {}, y: {} },
 		]);
-		const root = getView(config).root;
+		const { root } = view;
 		assert.equal(Tree.key(root), rootFieldKey);
 		assert.equal(Tree.key(root[0]), 0);
 		assert.equal(Tree.key(root[0].x), "x");
@@ -157,8 +158,10 @@ describe("treeNodeApi", () => {
 	it("parent", () => {
 		class Child extends schema.object("Child", { x: Point }) {}
 		const Root = schema.array(Child);
-		const config = new TreeConfiguration(Root, () => [{ x: {} }, { x: {} }]);
-		const root = getView(config).root;
+		const config = new TreeViewConfiguration({ schema: Root });
+		const view = getView(config);
+		view.initialize([{ x: {} }, { x: {} }]);
+		const { root } = view;
 		assert.equal(Tree.parent(root), undefined);
 		assert.equal(Tree.parent(root[0]), root);
 		assert.equal(Tree.parent(root[1]), root);
@@ -167,8 +170,10 @@ describe("treeNodeApi", () => {
 
 	it("treeStatus", () => {
 		class Root extends schema.object("Root", { x: Point }) {}
-		const config = new TreeConfiguration(Root, () => ({ x: {} }));
-		const root = getView(config).root;
+		const config = new TreeViewConfiguration({ schema: Root });
+		const view = getView(config);
+		view.initialize({ x: {} });
+		const { root } = view;
 		const child = root.x;
 		const newChild = new Point({});
 		assert.equal(Tree.status(root), TreeStatus.InDocument);
@@ -189,35 +194,31 @@ describe("treeNodeApi", () => {
 			});
 			const nodeKeyManager = new MockNodeKeyManager();
 			const id = nodeKeyManager.stabilizeNodeKey(nodeKeyManager.generateLocalNodeKey());
-			const config = new TreeConfiguration(schemaWithIdentifier, () => ({
-				identifier: id,
-			}));
+			const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
+			const view = getView(config, nodeKeyManager);
+			view.initialize({ identifier: id });
 
-			const root = getView(config, nodeKeyManager).root;
-
-			assert.equal(Tree.shortId(root), nodeKeyManager.localizeNodeKey(id));
+			assert.equal(Tree.shortId(view.root), nodeKeyManager.localizeNodeKey(id));
 		});
 		it("returns undefined when an identifier fieldkind does not exist.", () => {
 			const schemaWithIdentifier = schema.object("parent", {
 				identifier: schema.string,
 			});
-			const config = new TreeConfiguration(schemaWithIdentifier, () => ({
-				identifier: "testID",
-			}));
-			const root = getView(config).root;
-			assert.equal(Tree.shortId(root), undefined);
+			const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
+			const view = getView(config);
+			view.initialize({ identifier: "testID" });
+
+			assert.equal(Tree.shortId(view.root), undefined);
 		});
 		it("returns the uncompressed identifier value when the provided identifier is an invalid stable id.", () => {
 			const schemaWithIdentifier = schema.object("parent", {
 				identifier: schema.identifier,
 			});
-			const config = new TreeConfiguration(schemaWithIdentifier, () => ({
-				identifier: "invalidUUID",
-			}));
+			const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
+			const view = getView(config);
+			view.initialize({ identifier: "invalidUUID" });
 
-			const root = getView(config).root;
-
-			assert.equal(Tree.shortId(root), "invalidUUID");
+			assert.equal(Tree.shortId(view.root), "invalidUUID");
 		});
 		it("returns the uncompressed identifier value when the provided identifier is a valid stable id, but unknown by the idCompressor.", () => {
 			const schemaWithIdentifier = schema.object("parent", {
@@ -229,13 +230,11 @@ describe("treeNodeApi", () => {
 				nodeKeyManager.generateLocalNodeKey(),
 			);
 
-			const config = new TreeConfiguration(schemaWithIdentifier, () => ({
-				identifier: stableNodeKey,
-			}));
+			const config = new TreeViewConfiguration({ schema: schemaWithIdentifier });
+			const view = getView(config);
+			view.initialize({ identifier: stableNodeKey });
 
-			const root = getView(config).root;
-
-			assert.equal(Tree.shortId(root), stableNodeKey);
+			assert.equal(Tree.shortId(view.root), stableNodeKey);
 		});
 	});
 
@@ -656,9 +655,9 @@ describe("treeNodeApi", () => {
 				prop2: sb.number,
 			});
 
-			const { root, checkout } = getView(
-				new TreeConfiguration(treeSchema, () => ({ prop1: 1, prop2: 1 })),
-			);
+			const view = getView(new TreeViewConfiguration({ schema: treeSchema }));
+			view.initialize({ prop1: 1, prop2: 1 });
+			const { root, checkout } = view;
 
 			let shallowChanges = 0;
 			let deepChanges = 0;

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -5,14 +5,15 @@
 
 import { MockNodeKeyManager, type NodeKeyManager } from "../../feature-libraries/index.js";
 import {
+	cursorFromUnhydratedRoot,
 	type ImplicitFieldSchema,
 	type InsertableTreeFieldFromImplicitField,
-	TreeConfiguration,
 	type TreeFieldFromImplicitField,
-	toFlexConfig,
 } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { getProxyForField } from "../../simple-tree/proxies.js";
+// eslint-disable-next-line import/no-internal-modules
+import { toFlexSchema } from "../../simple-tree/toFlexSchema.js";
 import { flexTreeWithContent } from "../utils.js";
 
 /**
@@ -25,9 +26,15 @@ export function hydrate<TSchema extends ImplicitFieldSchema>(
 	initialTree: InsertableTreeFieldFromImplicitField<TSchema>,
 	nodeKeyManager?: NodeKeyManager,
 ): TreeFieldFromImplicitField<TSchema> {
-	const config = new TreeConfiguration(schema, () => initialTree);
-	const flexConfig = toFlexConfig(config, nodeKeyManager ?? new MockNodeKeyManager());
-	const tree = flexTreeWithContent(flexConfig);
+	const hydratedInitialTree = cursorFromUnhydratedRoot(
+		schema,
+		initialTree,
+		nodeKeyManager ?? new MockNodeKeyManager(),
+	);
+	const tree = flexTreeWithContent({
+		schema: toFlexSchema(schema),
+		initialTree: hydratedInitialTree,
+	});
 	return getProxyForField(tree) as TreeFieldFromImplicitField<TSchema>;
 }
 

--- a/packages/dds/tree/src/test/snapshots/gc.spec.ts
+++ b/packages/dds/tree/src/test/snapshots/gc.spec.ts
@@ -16,7 +16,7 @@ import {
 
 import { typeboxValidator } from "../../external-utilities/index.js";
 import { type ISharedTree, SharedTree, SharedTreeFactory } from "../../shared-tree/index.js";
-import { SchemaFactory, TreeConfiguration } from "../../simple-tree/index.js";
+import { SchemaFactory, TreeViewConfiguration, type TreeView } from "../../simple-tree/index.js";
 
 const builder = new SchemaFactory("test");
 class Bar extends builder.object("bar", {
@@ -27,12 +27,6 @@ class SomeType extends builder.object("foo", {
 	nested: builder.optional(Bar),
 	bump: builder.optional(builder.number),
 }) {}
-
-const config = new TreeConfiguration(SomeType, () => ({
-	handles: [],
-	nested: undefined,
-	bump: undefined,
-}));
 
 function createConnectedTree(id: string, runtimeFactory: MockContainerRuntimeFactory): ISharedTree {
 	const dataStoreRuntime = new MockFluidDataStoreRuntime({
@@ -63,15 +57,22 @@ describe("Garbage Collection", () => {
 		private _expectedRoutes: string[] = [];
 		private readonly containerRuntimeFactory: MockContainerRuntimeFactory;
 		private readonly tree1: ISharedTree;
-		private readonly tree1View;
+		private readonly view1: TreeView<typeof SomeType>;
+		private get root1(): SomeType {
+			return this.view1.root;
+		}
 		private readonly tree2: ISharedTree;
 
 		public constructor() {
 			this.containerRuntimeFactory = new MockContainerRuntimeFactory();
 			this.tree1 = createConnectedTree("tree1", this.containerRuntimeFactory);
 			this.tree2 = createConnectedTree("tree2", this.containerRuntimeFactory);
-
-			this.tree1View = this.tree1.schematize(config).root;
+			this.view1 = this.tree1.viewWith(new TreeViewConfiguration({ schema: SomeType }));
+			this.view1.initialize({
+				handles: [],
+				nested: undefined,
+				bump: undefined,
+			});
 		}
 
 		public get sharedObject(): ISharedTree {
@@ -86,7 +87,7 @@ describe("Garbage Collection", () => {
 			const subtree1 = createLocalTree(`tree-${++this.treeCount}`);
 			const subtree2 = createLocalTree(`tree-${++this.treeCount}`);
 
-			this.tree1View.handles.insertAtEnd(subtree1.handle, subtree2.handle);
+			this.root1.handles.insertAtEnd(subtree1.handle, subtree2.handle);
 
 			this._expectedRoutes.push(
 				toFluidHandleInternal(subtree1.handle).absolutePath,
@@ -96,10 +97,11 @@ describe("Garbage Collection", () => {
 		}
 
 		public async deleteOutboundRoutes(): Promise<void> {
-			assert(this.tree1View.handles.length > 0, "Route must be added before deleting");
-			const lastElementIndex = this.tree1View.handles.length - 1;
+			const root = this.root1;
+			assert(root.handles.length > 0, "Route must be added before deleting");
+			const lastElementIndex = root.handles.length - 1;
 			// Get the handles that were last added.
-			const deletedHandles = this.tree1View.handles;
+			const deletedHandles = root.handles;
 			// Get the routes of the handles.
 			const deletedHandleRoutes = Array.from(
 				deletedHandles,
@@ -107,7 +109,7 @@ describe("Garbage Collection", () => {
 			);
 
 			// Remove the last added handles.
-			this.tree1View.handles.removeRange(0, lastElementIndex + 1);
+			root.handles.removeRange(0, lastElementIndex + 1);
 
 			// Remove the deleted routes from expected routes.
 			const skip = true;
@@ -126,7 +128,7 @@ describe("Garbage Collection", () => {
 
 			// Send an op so the minimum sequence number moves past the segment which got removed.
 			// This will ensure that the segment is not part of the summary anymore.
-			this.tree1View.bump = 0;
+			root.bump = 0;
 			this.containerRuntimeFactory.processAllMessages();
 		}
 
@@ -134,7 +136,7 @@ describe("Garbage Collection", () => {
 			const subtree1 = createLocalTree(`tree-${++this.treeCount}`);
 			const subtree2 = createLocalTree(`tree-${++this.treeCount}`);
 
-			this.tree1View.nested = new Bar({
+			this.root1.nested = new Bar({
 				nestedHandles: [subtree1.handle, subtree2.handle],
 			});
 

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -135,11 +135,7 @@ import { ensureSchema } from "../shared-tree/schematizeTree.js";
 import { SchematizingSimpleTreeView, requireSchema } from "../shared-tree/schematizingTreeView.js";
 // eslint-disable-next-line import/no-internal-modules
 import type { SharedTreeOptions } from "../shared-tree/sharedTree.js";
-import {
-	type ImplicitFieldSchema,
-	type TreeConfiguration,
-	toFlexConfig,
-} from "../simple-tree/index.js";
+import type { ImplicitFieldSchema, TreeViewConfiguration } from "../simple-tree/index.js";
 import { type JsonCompatible, type Mutable, nestedMapFromFlatList } from "../util/index.js";
 import { isFluidHandle, toFluidHandleInternal } from "@fluidframework/runtime-utils/internal";
 import type { Client } from "@fluid-private/test-dds-utils";
@@ -1128,7 +1124,7 @@ export function mintRevisionTag(): RevisionTag {
 export const testRevisionTagCodec = new RevisionTagCodec(testIdCompressor);
 
 /**
- * Like {@link ITree.schematize}, but uses the flex-tree schema system and exposes the tree as a flex-tree.
+ * Like {@link ITree.viewWith}, but uses the flex-tree schema system and exposes the tree as a flex-tree.
  */
 export function schematizeFlexTree<TRoot extends FlexFieldSchema>(
 	tree: SharedTree,
@@ -1189,17 +1185,21 @@ export function treeTestFactory(
 }
 
 /**
- * Given the TreeConfiguration, returns a view.
+ * Given the TreeViewConfiguration, returns an uninitialized view.
  *
  * This works a much like the actual package public API as possible, while avoiding the actual SharedTree object.
  * This should allow realistic (app like testing) of all the simple-tree APIs.
+ *
+ * Typically, users will want to initialize the returned view with some content (thereby setting its schema) using `TreeView.initialize`.
  */
 export function getView<TSchema extends ImplicitFieldSchema>(
-	config: TreeConfiguration<TSchema>,
+	config: TreeViewConfiguration<TSchema>,
 	nodeKeyManager?: NodeKeyManager,
 ): SchematizingSimpleTreeView<TSchema> {
-	const flexConfig = toFlexConfig(config, nodeKeyManager ?? new MockNodeKeyManager());
-	const checkout = checkoutWithContent(flexConfig);
+	const checkout = createTreeCheckout(testIdCompressor, mintRevisionTag, testRevisionTagCodec, {
+		forest: buildForest(),
+		schema: new TreeStoredSchemaRepository(),
+	});
 	return new SchematizingSimpleTreeView<TSchema>(
 		checkout,
 		config,


### PR DESCRIPTION
## Description

Updates most of tree's tests to use `ITree.viewWith` rather than `ITree.schematize` (see #20815).

This change is mostly mechanical following the guidance in that changeset. There are a few places where this isn't true:

- Some tests previously raced initialization of the tree across multiple clients. I made a judgment call on some of these based on the test case name
- Tests implemented using `SchematizingTreeView` (almost always involving only one client) frequently only cared about setting up a checkout/view/etc in some initial state (with content+schema) and performing some operation. Lots of these tests used `getView`, which received a `TreeConfiguration`. However, the intention of `getView` was to match how the production APIs on `ITree` work as closely as possible. With the change to make initialization explicit in tests, this means the returned view is uninitialized. Rather than keep trying to use `getView` for tests which want to set up a view with some initial state, I've generally adjusted helpers to construct the checkout/forest/stored schema used to initialize the view directly instead. This more closely mimics a state where a client loads an already initialized document. See `checkoutWithInitialTree` in `schematizingTreeView.spec.ts`, for example.