### PR TITLE
Breaking change: Remove `"afterBatch"` event from `TreeView`

### DIFF
--- a/.changeset/salty-donkeys-rescue.md
+++ b/.changeset/salty-donkeys-rescue.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/tree": minor
+---
+
+Breaking change: Removed the `"afterBatch"` event from `Treeview`.
+
+This event is no longer necessary.
+In the past, it provided a means for waiting for a batch of changes to finish applying to the tree before taking some action.
+However, the tree change events exposed via `Tree.on` wait for a batch to complete before firing, so the `"afterBatch"` event provides no additional guarantees.
+Listeners of this event who wish to respond to changes to the tree view can use `"rootChanged"` instead.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -508,7 +508,6 @@ export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = Implici
 
 // @public
 export interface TreeViewEvents {
-    afterBatch(): void;
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
     schemaChanged(): void;

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -505,7 +505,6 @@ export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = Implici
 
 // @public
 export interface TreeViewEvents {
-    afterBatch(): void;
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
     schemaChanged(): void;

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -505,7 +505,6 @@ export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = Implici
 
 // @public
 export interface TreeViewEvents {
-    afterBatch(): void;
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
     schemaChanged(): void;

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -233,8 +233,6 @@ export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitField
 					lastRoot = this.root;
 					this.events.emit("rootChanged");
 				}
-
-				this.events.emit("afterBatch");
 			});
 
 			const onViewDispose = (): void => {

--- a/packages/dds/tree/src/simple-tree/tree.ts
+++ b/packages/dds/tree/src/simple-tree/tree.ts
@@ -343,11 +343,6 @@ export interface SchemaCompatibilityStatus {
  */
 export interface TreeViewEvents {
 	/**
-	 * A batch of changes has finished processing and the view has been updated.
-	 */
-	afterBatch(): void;
-
-	/**
 	 * Raised whenever {@link TreeView.root} is invalidated.
 	 *
 	 * This includes changes to the document schema.

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -85,8 +85,8 @@ describe("SchematizingSimpleTreeView", () => {
 		const unsubscribe = view.events.on("schemaChanged", () =>
 			log.push(["schemaChanged", getChangeData(view)]),
 		);
-		const unsubscribe2 = view.events.on("afterBatch", () =>
-			log.push(["afterBatch", view.root]),
+		const unsubscribe2 = view.events.on("rootChanged", () =>
+			log.push(["rootChanged", view.root]),
 		);
 
 		// Should be a no op since not in an error state;
@@ -109,16 +109,12 @@ describe("SchematizingSimpleTreeView", () => {
 		const view = new SchematizingSimpleTreeView(checkout, config, new MockNodeKeyManager());
 		view.events.on("schemaChanged", () => log.push(["schemaChanged", getChangeData(view)]));
 		view.events.on("rootChanged", () => log.push(["rootChanged", getChangeData(view)]));
-		view.events.on("afterBatch", () => log.push(["afterBatch", view.root]));
 		assert.equal(view.root, 5);
 		const log: [string, unknown][] = [];
 
 		view.root = 6;
 
-		assert.deepEqual(log, [
-			["rootChanged", 6],
-			["afterBatch", 6],
-		]);
+		assert.deepEqual(log, [["rootChanged", 6]]);
 	});
 
 	// TODO: AB#8121: When adding support for additional optional fields, we may want a variant of this test which does the analogous flow using

--- a/packages/dds/tree/src/test/shared-tree/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeNodeApi.spec.ts
@@ -224,7 +224,7 @@ describe("treeApi", () => {
 			it.skip("emits change events", () => {
 				const view = getTestObjectView();
 				let event = false;
-				view.events.on("afterBatch", () => (event = true));
+				view.events.on("rootChanged", () => (event = true));
 				view.root.content = 44;
 				Tree.runTransaction(view, (root) => {
 					root.content = 43;
@@ -235,7 +235,7 @@ describe("treeApi", () => {
 			it.skip("emits change events on rollback", () => {
 				const view = getTestObjectView();
 				let eventCount = 0;
-				view.events.on("afterBatch", () => (eventCount += 1));
+				view.events.on("rootChanged", () => (eventCount += 1));
 				Tree.runTransaction(view, (r) => {
 					r.content = 43;
 					return Tree.runTransaction.rollback;

--- a/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
@@ -716,7 +716,7 @@ describe("schemaFactory", () => {
 			// to the tree are not visible in the listener. 'nodeChanged' only fires once we confirmed that a
 			// relevant change was actually applied to the tree so the side effects this test validates already happened.
 			Tree.on(view.root, "nodeChanged", () => validate(view, nodes));
-			view.events.on("afterBatch", () => validate(view, nodes));
+			view.events.on("rootChanged", () => validate(view, nodes));
 			view.root.root = parent;
 			validate(view, nodes);
 		}

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1294,7 +1294,6 @@ export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = Implici
 
 // @public
 export interface TreeViewEvents {
-    afterBatch(): void;
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
     schemaChanged(): void;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -884,7 +884,6 @@ export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = Implici
 
 // @public
 export interface TreeViewEvents {
-    afterBatch(): void;
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
     schemaChanged(): void;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -884,7 +884,6 @@ export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = Implici
 
 // @public
 export interface TreeViewEvents {
-    afterBatch(): void;
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
     schemaChanged(): void;


### PR DESCRIPTION
## Description

This event is no longer necessary.
In the past, it provided a means for waiting for a batch of changes to finish applying to the tree before taking some action.
However, the tree change events exposed via `Tree.on` wait for a batch to complete before firing, so the `"afterBatch"` event provides no additional guarantees.
Listeners of this event who wish to respond to changes to the tree view can use `"rootChanged"` instead.