### PR TITLE
Reexport CompatibilityMode from azure-client and tinylicious-client packages

### DIFF
--- a/packages/service-clients/azure-client/api-report/azure-client.alpha.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.alpha.api.md
@@ -88,6 +88,8 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     type: "remote";
 }
 
+export { CompatibilityMode }
+
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;
 

--- a/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
@@ -88,6 +88,8 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     type: "remote";
 }
 
+export { CompatibilityMode }
+
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;
 

--- a/packages/service-clients/azure-client/api-report/azure-client.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.public.api.md
@@ -88,6 +88,8 @@ export interface AzureRemoteConnectionConfig extends AzureConnectionConfig {
     type: "remote";
 }
 
+export { CompatibilityMode }
+
 // @public
 export type IAzureAudience = IServiceAudience<AzureMember>;
 

--- a/packages/service-clients/azure-client/src/index.ts
+++ b/packages/service-clients/azure-client/src/index.ts
@@ -32,4 +32,5 @@ export { type ITokenClaims, ScopeType } from "@fluidframework/driver-definitions
 // Re-export so developers can build loggers without pulling in core-interfaces
 export type { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 
+// Re-export so developers have access to parameter types for createContainer/getContainer without pulling in fluid-static
 export type { CompatibilityMode } from "@fluidframework/fluid-static";

--- a/packages/service-clients/azure-client/src/index.ts
+++ b/packages/service-clients/azure-client/src/index.ts
@@ -31,3 +31,5 @@ export { type ITokenClaims, ScopeType } from "@fluidframework/driver-definitions
 
 // Re-export so developers can build loggers without pulling in core-interfaces
 export type { ITelemetryBaseEvent, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+
+export type { CompatibilityMode } from "@fluidframework/fluid-static";

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -13,6 +13,8 @@ import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUser } from '@fluidframework/driver-definitions';
 
+export { CompatibilityMode }
+
 // @beta
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -13,6 +13,8 @@ import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUser } from '@fluidframework/driver-definitions';
 
+export { CompatibilityMode }
+
 // @beta
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -13,4 +13,6 @@ import { ITelemetryBaseLogger } from '@fluidframework/core-interfaces';
 import { ITokenProvider } from '@fluidframework/routerlicious-driver';
 import { IUser } from '@fluidframework/driver-definitions';
 
+export { CompatibilityMode }
+
 ```

--- a/packages/service-clients/tinylicious-client/src/index.ts
+++ b/packages/service-clients/tinylicious-client/src/index.ts
@@ -24,4 +24,5 @@ export {
 } from "./interfaces.js";
 export { TinyliciousClient } from "./TinyliciousClient.js";
 
+// Re-export so developers have access to parameter types for createContainer/getContainer without pulling in fluid-static
 export type { CompatibilityMode } from "@fluidframework/fluid-static";

--- a/packages/service-clients/tinylicious-client/src/index.ts
+++ b/packages/service-clients/tinylicious-client/src/index.ts
@@ -23,3 +23,5 @@ export {
 	type TinyliciousUser,
 } from "./interfaces.js";
 export { TinyliciousClient } from "./TinyliciousClient.js";
+
+export type { CompatibilityMode } from "@fluidframework/fluid-static";


### PR DESCRIPTION
Customers of azure-client and tinylicious-client will use the CompatibilityMode type in 2.0.  If they need to import the type, we'd prefer they import from their respective client package rather than directly from fluid-static.