### PR TITLE
Remove deprecation from SharedDirectory

### DIFF
--- a/packages/dds/map/api-report/map.alpha.api.md
+++ b/packages/dds/map/api-report/map.alpha.api.md
@@ -127,7 +127,7 @@ export class MapFactory implements IChannelFactory<ISharedMap> {
 // @alpha
 export const SharedDirectory: ISharedObjectKind<ISharedDirectory> & SharedObjectKind<ISharedDirectory>;
 
-// @alpha @deprecated
+// @alpha
 export type SharedDirectory = ISharedDirectory;
 
 // @alpha

--- a/packages/dds/map/src/directoryFactory.ts
+++ b/packages/dds/map/src/directoryFactory.ts
@@ -85,7 +85,6 @@ export const SharedDirectory = createSharedObjectKind<ISharedDirectory>(Director
 /**
  * Entrypoint for {@link ISharedDirectory} creation.
  * @alpha
- * @deprecated Use ISharedDirectory instead.
  * @privateRemarks
  * This alias is for legacy compat from when the SharedDirectory class was exported as public.
  */

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1079,7 +1079,7 @@ export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
 // @alpha
 export const SharedDirectory: ISharedObjectKind<ISharedDirectory> & SharedObjectKind_2<ISharedDirectory>;
 
-// @alpha @deprecated
+// @alpha
 export type SharedDirectory = ISharedDirectory;
 
 // @alpha


### PR DESCRIPTION
Remove the deprecation tag from SharedDirectory, to make it consistent with other SharedObjects