### PR TITLE
Fixed API extractor errors in azure client and tinylicious clients

### DIFF
--- a/packages/service-clients/azure-client/api-report/azure-client.alpha.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { CompatibilityMode } from '@fluidframework/fluid-static';
+import { CompatibilityMode } from '@fluidframework/fluid-static';
 import type { ContainerSchema } from '@fluidframework/fluid-static';
 import type { ICompressionStorageConfig } from '@fluidframework/driver-utils';
 import type { IConfigProviderBase } from '@fluidframework/core-interfaces';

--- a/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { CompatibilityMode } from '@fluidframework/fluid-static';
+import { CompatibilityMode } from '@fluidframework/fluid-static';
 import type { ContainerSchema } from '@fluidframework/fluid-static';
 import type { ICompressionStorageConfig } from '@fluidframework/driver-utils';
 import type { IConfigProviderBase } from '@fluidframework/core-interfaces';

--- a/packages/service-clients/azure-client/api-report/azure-client.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.public.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { CompatibilityMode } from '@fluidframework/fluid-static';
+import { CompatibilityMode } from '@fluidframework/fluid-static';
 import type { ContainerSchema } from '@fluidframework/fluid-static';
 import type { ICompressionStorageConfig } from '@fluidframework/driver-utils';
 import type { IConfigProviderBase } from '@fluidframework/core-interfaces';

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { CompatibilityMode } from '@fluidframework/fluid-static';
+import { CompatibilityMode } from '@fluidframework/fluid-static';
 import type { ContainerSchema } from '@fluidframework/fluid-static';
 import type { IFluidContainer } from '@fluidframework/fluid-static';
 import type { IMember } from '@fluidframework/fluid-static';

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { CompatibilityMode } from '@fluidframework/fluid-static';
+import { CompatibilityMode } from '@fluidframework/fluid-static';
 import type { ContainerSchema } from '@fluidframework/fluid-static';
 import type { IFluidContainer } from '@fluidframework/fluid-static';
 import type { IMember } from '@fluidframework/fluid-static';

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import type { CompatibilityMode } from '@fluidframework/fluid-static';
+import { CompatibilityMode } from '@fluidframework/fluid-static';
 import type { ContainerSchema } from '@fluidframework/fluid-static';
 import type { IFluidContainer } from '@fluidframework/fluid-static';
 import type { IMember } from '@fluidframework/fluid-static';


### PR DESCRIPTION
The following 2 changes went in simultaneously that modified azure client and tinylicious client has broken the build:
https://github.com/microsoft/FluidFramework/pull/21416
https://github.com/microsoft/FluidFramework/pull/21402

Fixed the build by updating the missing api md files.