### PR TITLE
Telemetry to observe single-commit-summ

### DIFF
--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -970,8 +970,7 @@ export class Container
 				? summaryTree
 				: combineAppAndProtocolSummary(summaryTree, this.captureProtocolSummary());
 
-		// Whether the combined summary tree has been forced on by either the loader option or the monitoring context or supportedFeatures flag by the service.
-		// Note Even if not forced on via this flag, combined summaries may still be enabled by service policy.
+		// Whether the combined summary tree has been forced on by either the supportedFeatures flag by the service or the the loader option or the monitoring context
 		const enableSummarizeProtocolTree =
 			this.mc.config.getBoolean("Fluid.Container.summarizeProtocolTree2") ??
 			options.summarizeProtocolTree;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -971,8 +971,8 @@ export class Container
 				: combineAppAndProtocolSummary(summaryTree, this.captureProtocolSummary());
 
 		// Whether the combined summary tree has been forced on by either the loader option or the monitoring context or supportedFeatures flag by the service.
-		// Even if not forced on via this flag, combined summaries may still be enabled by service policy.
-		const shouldSummarizeProtocolTree =
+		// Note Even if not forced on via this flag, combined summaries may still be enabled by service policy.
+		const enableSummarizeProtocolTree =
 			this.mc.config.getBoolean("Fluid.Container.summarizeProtocolTree2") ??
 			options.summarizeProtocolTree;
 
@@ -982,7 +982,7 @@ export class Container
 			pendingLocalState?.snapshotBlobs,
 			pendingLocalState?.loadedGroupIdSnapshots,
 			addProtocolSummaryIfMissing,
-			shouldSummarizeProtocolTree,
+			enableSummarizeProtocolTree,
 		);
 
 		const offlineLoadEnabled =

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -77,8 +77,7 @@ export class ContainerStorageAdapter
 	 * @param loadingGroupIdSnapshotsFromPendingState - in offline mode, any loading group snapshots we've downloaded from the service that were stored in the pending state
 	 * @param addProtocolSummaryIfMissing - a callback to permit the container to inspect the summary we're about to
 	 * upload, and fix it up with a protocol tree if needed
-	 * @param enableSummarizeProtocolTree  - Enable uploading a protocol summary. If false, protocol tree is never included in summaries. If true or undefined,
-	 * service's policy "summarizeProtocolTree" is also taken into account.
+	 * @param enableSummarizeProtocolTree  - Enable uploading a protocol summary. Note: preference is given to service policy's "summarizeProtocolTree" before this value.
 	 */
 	public constructor(
 		// eslint-disable-next-line import/no-deprecated
@@ -90,17 +89,9 @@ export class ContainerStorageAdapter
 		private readonly blobContents: { [id: string]: ArrayBufferLike | string } = {},
 		private loadingGroupIdSnapshotsFromPendingState: Record<string, ISnapshotInfo> | undefined,
 		private readonly addProtocolSummaryIfMissing: (summaryTree: ISummaryTree) => ISummaryTree,
-		enableSummarizeProtocolTree: boolean | undefined,
+		private readonly enableSummarizeProtocolTree: boolean | undefined,
 	) {
 		this._storageService = new BlobOnlyStorage(detachedBlobStorage, logger);
-		this._summarizeProtocolTree = enableSummarizeProtocolTree;
-		if (enableSummarizeProtocolTree === false) {
-			// summarizeProtocolTree was disabled
-			this.logger.sendTelemetryEvent({
-				eventName: "isSummarizeProtocolTreeEnabled",
-				details: { value: false },
-			});
-		}
 	}
 
 	disposed: boolean = false;
@@ -131,12 +122,13 @@ export class ContainerStorageAdapter
 			// A callback to ensure we fetch the most updated value of service.policies.summarizeProtocolTree, which could be set
 			// based on the response received from the service after connection is established.
 			() => {
-				// If the enableSummarizeProtocolTree has disabled the single-commit summaries, then it is given a higher priority than driver policy.
-				// Driver policy is accounted for only when enableSummarizeProtocolTree was undefined or true.
+				// Determine whether or not container should upload the protocol summary along with the summary.
+				// This is determined based on what value is set for serve policy's summariProtocolTree value or the enableSummarizeProtocolTree
+				// retrievd from the loader options or monitoring context config.
 				const shouldSummarize =
-					this._summarizeProtocolTree === false
-						? false
-						: service.policies?.summarizeProtocolTree ?? false;
+					service.policies?.summarizeProtocolTree ??
+					this.enableSummarizeProtocolTree ??
+					false;
 
 				if (this._summarizeProtocolTree !== shouldSummarize) {
 					this.logger.sendTelemetryEvent({

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -93,10 +93,11 @@ export class ContainerStorageAdapter
 	) {
 		this._storageService = new BlobOnlyStorage(detachedBlobStorage, logger);
 		this._summarizeProtocolTree = shouldSummarizeProtocolTree;
-		this.logger.sendTelemetryEvent({
-			eventName: "isSummarizeProtocolTreeEnabled",
-			details: { value: this._summarizeProtocolTree ?? false },
-		});
+		if (this._summarizeProtocolTree !== undefined)
+			this.logger.sendTelemetryEvent({
+				eventName: "isSummarizeProtocolTreeEnabled",
+				details: { value: this._summarizeProtocolTree ?? false },
+			});
 	}
 
 	disposed: boolean = false;

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -126,9 +126,7 @@ export class ContainerStorageAdapter
 				// This is determined based on what value is set for serve policy's summariProtocolTree value or the enableSummarizeProtocolTree
 				// retrievd from the loader options or monitoring context config.
 				const shouldSummarizeProtocolTree =
-					service.policies?.summarizeProtocolTree ??
-					this.enableSummarizeProtocolTree ??
-					false;
+					service.policies?.summarizeProtocolTree ?? this.enableSummarizeProtocolTree ?? false;
 
 				if (this._summarizeProtocolTree !== shouldSummarizeProtocolTree) {
 					this.logger.sendTelemetryEvent({

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -125,18 +125,18 @@ export class ContainerStorageAdapter
 				// Determine whether or not container should upload the protocol summary along with the summary.
 				// This is determined based on what value is set for serve policy's summariProtocolTree value or the enableSummarizeProtocolTree
 				// retrievd from the loader options or monitoring context config.
-				const shouldSummarize =
+				const shouldSummarizeProtocolTree =
 					service.policies?.summarizeProtocolTree ??
 					this.enableSummarizeProtocolTree ??
 					false;
 
-				if (this._summarizeProtocolTree !== shouldSummarize) {
+				if (this._summarizeProtocolTree !== shouldSummarizeProtocolTree) {
 					this.logger.sendTelemetryEvent({
 						eventName: "isSummarizeProtocolTreeEnabled",
-						details: { value: shouldSummarize },
+						details: { value: shouldSummarizeProtocolTree },
 					});
 				}
-				this._summarizeProtocolTree = shouldSummarize;
+				this._summarizeProtocolTree = shouldSummarizeProtocolTree;
 				return this._summarizeProtocolTree;
 			},
 		);

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -93,6 +93,9 @@ export class ContainerStorageAdapter
 	) {
 		this._storageService = new BlobOnlyStorage(detachedBlobStorage, logger);
 		this._summarizeProtocolTree = shouldSummarizeProtocolTree;
+		if (this._summarizeProtocolTree === true) {
+			this.logger.sendTelemetryEvent({ eventName: "summarizeProtocolTreeEnabled" });
+		}
 	}
 
 	disposed: boolean = false;
@@ -123,8 +126,17 @@ export class ContainerStorageAdapter
 			// A callback to ensure we fetch the most updated value of service.policies.summarizeProtocolTree, which could be set
 			// based on the response received from the service after connection is established.
 			() => {
-				this._summarizeProtocolTree =
+				const latestShouldSummarizeProtocolTree =
 					this._summarizeProtocolTree ?? service.policies?.summarizeProtocolTree ?? false;
+				if (this._summarizeProtocolTree !== latestShouldSummarizeProtocolTree) {
+					// log everytime the summarization preference changes
+					this.logger.sendTelemetryEvent({
+						eventName: "isSummarizeProtocolTreeEnabled",
+						value: latestShouldSummarizeProtocolTree,
+					});
+				}
+				this._summarizeProtocolTree = latestShouldSummarizeProtocolTree;
+
 				return this._summarizeProtocolTree;
 			},
 		);

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -93,9 +93,10 @@ export class ContainerStorageAdapter
 	) {
 		this._storageService = new BlobOnlyStorage(detachedBlobStorage, logger);
 		this._summarizeProtocolTree = shouldSummarizeProtocolTree;
-		if (this._summarizeProtocolTree === true) {
-			this.logger.sendTelemetryEvent({ eventName: "summarizeProtocolTreeEnabled" });
-		}
+		this.logger.sendTelemetryEvent({
+			eventName: "isSummarizeProtocolTreeEnabled",
+			value: this._summarizeProtocolTree,
+		});
 	}
 
 	disposed: boolean = false;

--- a/packages/loader/container-loader/src/containerStorageAdapter.ts
+++ b/packages/loader/container-loader/src/containerStorageAdapter.ts
@@ -95,7 +95,7 @@ export class ContainerStorageAdapter
 		this._summarizeProtocolTree = shouldSummarizeProtocolTree;
 		this.logger.sendTelemetryEvent({
 			eventName: "isSummarizeProtocolTreeEnabled",
-			value: this._summarizeProtocolTree,
+			details: { value: this._summarizeProtocolTree ?? false },
 		});
 	}
 
@@ -133,7 +133,7 @@ export class ContainerStorageAdapter
 					// log everytime the summarization preference changes
 					this.logger.sendTelemetryEvent({
 						eventName: "isSummarizeProtocolTreeEnabled",
-						value: latestShouldSummarizeProtocolTree,
+						details: { value: latestShouldSummarizeProtocolTree },
 					});
 				}
 				this._summarizeProtocolTree = latestShouldSummarizeProtocolTree;


### PR DESCRIPTION
Fixed telemetry to observe the latest value of whether single-commit summary is enabled or disabled. The log will be made only when there is a change in the value during re-connections if any.
Followup for https://github.com/microsoft/FluidFramework/pull/21380

[AB#8325](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8325)