### PR TITLE
Remove ITree.schematize and TreeConfiguration from the public API

### DIFF
--- a/.changeset/silly-clocks-tan.md
+++ b/.changeset/silly-clocks-tan.md
@@ -15,9 +15,9 @@ To make the details of schema compatibilities that SharedTree supports more clea
 `TreeView.error` has been functionally replaced with the `compatibility` property.
 Users desiring the previous strict behavior should use `view.compatibility.isEquivalent` at appropriate places in application logic.
 
-# `ITree.schematize` deprecation
+# `ITree.schematize` removal
 
-`ITree.schematize` has been deprecated in favor of `ITree.viewWith`.
+`ITree.schematize` (and its argument `TreeConfiguration`) has been removed. Instead, call `ITree.viewWith` and provide it a `TreeViewConfiguration`.
 Unlike `schematize`, `viewWith` does not implicitly initialize the document.
 As such, it doesn't take an `initialTree` property.
 Instead, applications should initialize their trees in document creation codepaths using the added `TreeView.initialize` API.
@@ -68,6 +68,15 @@ const view = tree.viewWith(treeConfig);
 
 Besides only making the initial tree required to specify in places that actually perform document initialization, this is beneficial for mutation semantics: `tree.viewWith` never modifies the state of the underlying tree.
 This means applications are free to attempt to view a document using multiple schemas (e.g. legacy versions of their document format) without worrying about altering the document state.
+
+If existing code used schematize in a context where it wasn't known whether the document needed to be initialized, you can leverage `TreeView.compatibility` like so:
+
+```typescript
+const view = tree.viewWith(config);
+if (view.compatibility.canInitialize) {
+	view.initialize(initialTree);
+}
+```
 
 # Separate `schemaChanged` event on `TreeView`
 

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -174,8 +174,6 @@ export class IterableTreeArrayContent<T> implements Iterable<T> {
 
 // @public
 export interface ITree extends IFluidLoadable {
-    // @deprecated
-    schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TRoot>;
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
 
@@ -390,16 +388,6 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
-}
-
-// @public @deprecated
-export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {
-    constructor(schema: TSchema, initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>, options?: ITreeConfigurationOptions);
-    readonly enableSchemaValidation: boolean;
-    // (undocumented)
-    readonly initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>;
-    // (undocumented)
-    readonly schema: TSchema;
 }
 
 // @public

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -174,8 +174,6 @@ export class IterableTreeArrayContent<T> implements Iterable<T> {
 
 // @public
 export interface ITree extends IFluidLoadable {
-    // @deprecated
-    schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TRoot>;
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
 
@@ -387,16 +385,6 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
-}
-
-// @public @deprecated
-export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {
-    constructor(schema: TSchema, initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>, options?: ITreeConfigurationOptions);
-    readonly enableSchemaValidation: boolean;
-    // (undocumented)
-    readonly initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>;
-    // (undocumented)
-    readonly schema: TSchema;
 }
 
 // @public

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -174,8 +174,6 @@ export class IterableTreeArrayContent<T> implements Iterable<T> {
 
 // @public
 export interface ITree extends IFluidLoadable {
-    // @deprecated
-    schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TRoot>;
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
 
@@ -387,16 +385,6 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
-}
-
-// @public @deprecated
-export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {
-    constructor(schema: TSchema, initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>, options?: ITreeConfigurationOptions);
-    readonly enableSchemaValidation: boolean;
-    // (undocumented)
-    readonly initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>;
-    // (undocumented)
-    readonly schema: TSchema;
 }
 
 // @public

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -272,7 +272,6 @@ export {
 	type TreeArrayNodeBase,
 	type ITree,
 	type TreeNodeSchema,
-	TreeConfiguration,
 	TreeViewConfiguration,
 	type ITreeViewConfiguration,
 	type ITreeConfigurationOptions,

--- a/packages/dds/tree/src/simple-tree/tree.ts
+++ b/packages/dds/tree/src/simple-tree/tree.ts
@@ -57,26 +57,6 @@ export interface ITree extends IFluidLoadable {
 	viewWith<TRoot extends ImplicitFieldSchema>(
 		config: TreeViewConfiguration<TRoot>,
 	): TreeView<TRoot>;
-
-	/**
-	 * Returns a {@link TreeView} using the provided schema.
-	 * If the stored schema is view-compatible with the view schema specified by `config`,
-	 * the returned {@link TreeView} will expose the root with a schema-aware API based on the provided view schema.
-	 * See {@link TreeView.compatibility} for information about the compatibility between the view and stored schemas.
-	 *
-	 * @remarks
-	 * If the tree is uninitialized, it will be implicitly initialized by this function.
-	 *
-	 * Note that other clients can modify the document at any time, causing the view to change its compatibility status: see {@link TreeView.events} for how to handle invalidation in these cases.
-	 *
-	 * Only one schematized view may exist for a given ITree at a time.
-	 * If creating a second, the first must be disposed before calling `schematize` again.
-	 * @deprecated Replaced by {@link ITree.viewWith}. Use that method instead. Note that `viewWith` does not implicitly initialize the tree:
-	 * to initialize it, call {@link TreeView.initialize} on the returned view.
-	 */
-	schematize<TRoot extends ImplicitFieldSchema>(
-		config: TreeConfiguration<TRoot>,
-	): TreeView<TRoot>;
 }
 
 /**

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1918,28 +1918,29 @@ describe("SharedTree", () => {
 				view.initialize("42");
 			});
 		});
+	});
 
-		it("throws when an invalid type is inserted at runtime", async () => {
-			const provider = new TestTreeProviderLite(1);
-			const [sharedTree] = provider.trees;
-			const sf = new SchemaFactory("test");
+	// Note: this is basically a more e2e version of some tests for `toMapTree`.
+	it("throws when an invalid type is inserted at runtime", async () => {
+		const provider = new TestTreeProviderLite(1);
+		const [sharedTree] = provider.trees;
+		const sf = new SchemaFactory("test");
 
-			// No validation failures when initializing the tree for the first time.
-			// Stored schema is set up so 'foo' is an array of strings.
-			const schema = sf.object("myObject", { foo: sf.array("foo", sf.string) });
-			const view = sharedTree.viewWith(
-				new TreeViewConfiguration({ schema, enableSchemaValidation: true }),
-			);
-			view.initialize({ foo: ["42"] });
-			assert.throws(
-				() => {
-					// The cast here is necessary as the API provided by `insertAtEnd` is typesafe with respect
-					// to the schema, so in order to insert invalid content we need to bypass the types.
-					view.root.foo.insertAtEnd(3 as unknown as string);
-				},
-				validateUsageError(/Tree does not conform to schema./),
-			);
-		});
+		const schema = sf.object("myObject", { foo: sf.array("foo", sf.string) });
+		const view = sharedTree.viewWith(
+			new TreeViewConfiguration({ schema, enableSchemaValidation: true }),
+		);
+		view.initialize({ foo: ["42"] });
+		assert.throws(
+			() => {
+				// The cast here is necessary as the API provided by `insertAtEnd` is typesafe with respect
+				// to the schema, so in order to insert invalid content we need to bypass the types.
+				view.root.foo.insertAtEnd(3 as unknown as string);
+			},
+			validateUsageError(
+				/The provided data is incompatible with all of the types allowed by the schema/,
+			),
+		);
 	});
 });
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -71,11 +71,7 @@ import {
 // eslint-disable-next-line import/no-internal-modules
 import { requireSchema } from "../../shared-tree/schematizingTreeView.js";
 import type { EditManager } from "../../shared-tree-core/index.js";
-import {
-	SchemaFactory,
-	TreeConfiguration,
-	TreeViewConfiguration,
-} from "../../simple-tree/index.js";
+import { SchemaFactory, TreeViewConfiguration } from "../../simple-tree/index.js";
 import { brand, disposeSymbol, fail } from "../../util/index.js";
 import {
 	type ConnectionSetter,
@@ -96,6 +92,7 @@ import {
 	validateTreeConsistency,
 	validateTreeContent,
 	validateViewConsistency,
+	validateUsageError,
 } from "../utils.js";
 import { configuredSharedTree } from "../../treeFactory.js";
 import type { ISharedObjectKind } from "@fluidframework/shared-object-base/internal";
@@ -1922,7 +1919,7 @@ describe("SharedTree", () => {
 			});
 		});
 
-		it("schema validation throws as expected", async () => {
+		it("throws when an invalid type is inserted at runtime", async () => {
 			const provider = new TestTreeProviderLite(1);
 			const [sharedTree] = provider.trees;
 			const sf = new SchemaFactory("test");
@@ -1934,22 +1931,14 @@ describe("SharedTree", () => {
 				new TreeViewConfiguration({ schema, enableSchemaValidation: true }),
 			);
 			view.initialize({ foo: ["42"] });
-
-			// Trying to use the tree with a view schema that makes 'foo' an array of strings or numbers
-			// should not cause compile-time errors when inserting a number, but stored schema validation
-			// should kick in and throw an error.
-			const viewschema = sf.object("myObject", {
-				foo: sf.array("foo", [sf.string, sf.number]),
-			});
-			const tree = sharedTree.schematize(
-				new TreeConfiguration(viewschema, () => ({ foo: ["42"] }), {
-					enableSchemaValidation: true,
-				}),
+			assert.throws(
+				() => {
+					// The cast here is necessary as the API provided by `insertAtEnd` is typesafe with respect
+					// to the schema, so in order to insert invalid content we need to bypass the types.
+					view.root.foo.insertAtEnd(3 as unknown as string);
+				},
+				validateUsageError(/Tree does not conform to schema./),
 			);
-
-			assert.throws(() => {
-				tree.root.foo.insertAtEnd(3);
-			}, "Tree does not conform to schema.");
 		});
 	});
 });

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -829,8 +829,6 @@ export interface ITrace {
 
 // @public
 export interface ITree extends IFluidLoadable {
-    // @deprecated
-    schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TRoot>;
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
 
@@ -1176,16 +1174,6 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
-}
-
-// @public @deprecated
-export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {
-    constructor(schema: TSchema, initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>, options?: ITreeConfigurationOptions);
-    readonly enableSchemaValidation: boolean;
-    // (undocumented)
-    readonly initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>;
-    // (undocumented)
-    readonly schema: TSchema;
 }
 
 // @public

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -523,8 +523,6 @@ export class IterableTreeArrayContent<T> implements Iterable<T> {
 
 // @public
 export interface ITree extends IFluidLoadable {
-    // @deprecated
-    schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TRoot>;
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
 
@@ -766,16 +764,6 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
-}
-
-// @public @deprecated
-export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {
-    constructor(schema: TSchema, initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>, options?: ITreeConfigurationOptions);
-    readonly enableSchemaValidation: boolean;
-    // (undocumented)
-    readonly initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>;
-    // (undocumented)
-    readonly schema: TSchema;
 }
 
 // @public

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -523,8 +523,6 @@ export class IterableTreeArrayContent<T> implements Iterable<T> {
 
 // @public
 export interface ITree extends IFluidLoadable {
-    // @deprecated
-    schematize<TRoot extends ImplicitFieldSchema>(config: TreeConfiguration<TRoot>): TreeView<TRoot>;
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
 
@@ -766,16 +764,6 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
-}
-
-// @public @deprecated
-export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {
-    constructor(schema: TSchema, initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>, options?: ITreeConfigurationOptions);
-    readonly enableSchemaValidation: boolean;
-    // (undocumented)
-    readonly initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>;
-    // (undocumented)
-    readonly schema: TSchema;
 }
 
 // @public


### PR DESCRIPTION
## Description

Removes `ITree.schematize` and `TreeConfiguration` from the public API. Users should switch to `ITree.viewWith` and `TreeViewConfiguration` in line with the guidance in #20815.

This PR makes the minimal possible change that removes these from the public API in the interest of getting it in before the 2.0 GA. I will more thoroughly remove the code, associated complications with `initialTree`, and other references in a follow-up which is tracked by [AB#8328](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8328). 
