### PR TITLE
Remove deprecation from SharedDirectory (#21423)

### DIFF
--- a/packages/dds/map/api-report/map.api.md
+++ b/packages/dds/map/api-report/map.api.md
@@ -126,7 +126,7 @@ export class MapFactory implements IChannelFactory<ISharedMap> {
 // @alpha
 export const SharedDirectory: ISharedObjectKind<ISharedDirectory>;
 
-// @alpha @deprecated
+// @alpha
 export type SharedDirectory = ISharedDirectory;
 
 // @alpha

--- a/packages/dds/map/src/directoryFactory.ts
+++ b/packages/dds/map/src/directoryFactory.ts
@@ -87,7 +87,6 @@ export const SharedDirectory: ISharedObjectKind<ISharedDirectory> =
 /**
  * Entrypoint for {@link ISharedDirectory} creation.
  * @alpha
- * @deprecated Use ISharedDirectory instead.
  * @privateRemarks
  * This alias is for legacy compat from when the SharedDirectory class was exported as public.
  */

--- a/packages/framework/fluid-framework/api-report/fluid-framework.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.api.md
@@ -763,7 +763,7 @@ export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
 // @alpha
 export const SharedDirectory: ISharedObjectKind<ISharedDirectory>;
 
-// @alpha @deprecated
+// @alpha
 export type SharedDirectory = ISharedDirectory;
 
 // @alpha


### PR DESCRIPTION
Remove the deprecation tag from SharedDirectory, to make it consistent with other SharedObjects

Cherry pick of https://github.com/microsoft/FluidFramework/commit/d9ad80d0c3271ccad424efaba22f39eb4eb40a58