### PR TITLE
fix(tree): fix commit enrichment and sending for aborted commits

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/branch.ts
+++ b/packages/dds/tree/src/shared-tree-core/branch.ts
@@ -305,8 +305,8 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const [startCommit, commits] = this.popTransaction();
 		this.editor.exitTransaction();
 
+		this.emit("transactionCommitted", this.transactions.size === 0);
 		if (commits.length === 0) {
-			this.emit("transactionCommitted", this.transactions.size === 0);
 			return undefined;
 		}
 
@@ -326,7 +326,6 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			newCommits: [newHead],
 		} as const;
 
-		this.emit("transactionCommitted", this.transactions.size === 0);
 		this.emit("beforeChange", changeEvent);
 		this.head = newHead;
 
@@ -353,8 +352,8 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 		const [startCommit, commits] = this.popTransaction();
 		this.editor.exitTransaction();
 
+		this.emit("transactionAborted", this.transactions.size === 0);
 		if (commits.length === 0) {
-			this.emit("transactionAborted", this.transactions.size === 0);
 			return [undefined, []];
 		}
 
@@ -378,7 +377,6 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> exten
 			removedCommits: commits,
 		} as const;
 
-		this.emit("transactionAborted", this.transactions.size === 0);
 		this.emit("beforeChange", changeEvent);
 		this.head = startCommit;
 		this.emit("afterChange", changeEvent);

--- a/packages/dds/tree/src/shared-tree-core/branchCommitEnricher.ts
+++ b/packages/dds/tree/src/shared-tree-core/branchCommitEnricher.ts
@@ -12,8 +12,7 @@ import { TransactionEnricher } from "./transactionEnricher.js";
  * Utility for enriching commits from a {@link Branch} before these commits are applied and submitted.
  */
 export class BranchCommitEnricher<TChange> {
-	private transactionEnricher?: TransactionEnricher<TChange>;
-	private readonly rebaser: ChangeRebaser<TChange>;
+	private readonly transactionEnricher: TransactionEnricher<TChange>;
 	private readonly enricher: ChangeEnricherReadonlyCheckout<TChange>;
 	/**
 	 * Maps each local commit to the corresponding enriched commit.
@@ -28,8 +27,8 @@ export class BranchCommitEnricher<TChange> {
 		rebaser: ChangeRebaser<TChange>,
 		enricher: ChangeEnricherReadonlyCheckout<TChange>,
 	) {
-		this.rebaser = rebaser;
 		this.enricher = enricher;
+		this.transactionEnricher = new TransactionEnricher(rebaser, this.enricher);
 	}
 
 	/**
@@ -39,6 +38,18 @@ export class BranchCommitEnricher<TChange> {
 		return this.preparedCommits.size;
 	}
 
+	public startNewTransaction(): void {
+		this.transactionEnricher.startNewTransaction();
+	}
+
+	public commitCurrentTransaction(): void {
+		this.transactionEnricher.commitCurrentTransaction();
+	}
+
+	public abortCurrentTransaction(): void {
+		this.transactionEnricher.abortCurrentTransaction();
+	}
+
 	/**
 	 * Adds a commit to the enricher.
 	 * @param commit - A commit that is part of a transaction.
@@ -46,8 +57,7 @@ export class BranchCommitEnricher<TChange> {
 	public ingestTransactionCommit(commit: GraphCommit<TChange>): void {
 		// We do not submit ops for changes that are part of a transaction.
 		// But we need to enrich the commits that will be sent if the transaction is committed.
-		this.transactionEnricher ??= new TransactionEnricher(this.rebaser, this.enricher);
-		this.transactionEnricher.addTransactionSteps(commit);
+		this.transactionEnricher.addTransactionStep(commit);
 	}
 
 	/**
@@ -66,7 +76,6 @@ export class BranchCommitEnricher<TChange> {
 				"Unexpected transaction commit without transaction steps",
 			);
 			enrichedChange = this.transactionEnricher.getComposedChange(commit.revision);
-			delete this.transactionEnricher;
 		} else {
 			enrichedChange = this.enricher.updateChangeEnrichments(commit.change, commit.revision);
 		}

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -151,6 +151,15 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange> extends
 		 */
 		const localSessionId = runtime.idCompressor.localSessionId;
 		this.editManager = new EditManager(changeFamily, localSessionId, this.mintRevisionTag);
+		this.editManager.localBranch.on("transactionStarted", () => {
+			this.commitEnricher.startNewTransaction();
+		});
+		this.editManager.localBranch.on("transactionAborted", () => {
+			this.commitEnricher.abortCurrentTransaction();
+		});
+		this.editManager.localBranch.on("transactionCommitted", () => {
+			this.commitEnricher.commitCurrentTransaction();
+		});
 		this.editManager.localBranch.on("beforeChange", (change) => {
 			// Ensure that any previously prepared commits that have not been sent are purged.
 			this.commitEnricher.purgePreparedCommits();

--- a/packages/dds/tree/src/shared-tree-core/transactionEnricher.ts
+++ b/packages/dds/tree/src/shared-tree-core/transactionEnricher.ts
@@ -16,7 +16,9 @@ export class TransactionEnricher<TChange> {
 	private readonly transactionCommits: GraphCommit<TChange>[] = [];
 	/**
 	 * The number of commits before the start of each active transaction scope.
-	 * Index 0 is used for the outermost transaction scope, the number of commits before it will always be 0.
+	 * For a stack of `n` transaction scopes, the array will contain `n` integers,
+	 * where the integer at index `i` is the number of commits made before the start of the `i`th transaction scope
+	 * (therefore, the first element in the array, if present, is always 0)
 	 */
 	private readonly transactionScopesStart: number[] = [];
 

--- a/packages/dds/tree/src/shared-tree-core/transactionEnricher.ts
+++ b/packages/dds/tree/src/shared-tree-core/transactionEnricher.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/core-utils/internal";
 import type { ChangeRebaser, GraphCommit, RevisionTag } from "../core/index.js";
 import type { ChangeEnricherReadonlyCheckout } from "./changeEnricher.js";
 
@@ -13,6 +14,11 @@ export class TransactionEnricher<TChange> {
 	private readonly rebaser: ChangeRebaser<TChange>;
 	private readonly enricher: ChangeEnricherReadonlyCheckout<TChange>;
 	private readonly transactionCommits: GraphCommit<TChange>[] = [];
+	/**
+	 * The number of commits before the start of each active transaction scope.
+	 * Index 0 is used for the outermost transaction scope, the number of commits before it will always be 0.
+	 */
+	private readonly transactionScopesStart: number[] = [];
 
 	public constructor(
 		rebaser: ChangeRebaser<TChange>,
@@ -22,14 +28,32 @@ export class TransactionEnricher<TChange> {
 		this.enricher = enricher;
 	}
 
-	public addTransactionSteps(commit: GraphCommit<TChange>): void {
+	public startNewTransaction(): void {
+		this.transactionScopesStart.push(this.transactionCommits.length);
+	}
+
+	public commitCurrentTransaction(): void {
+		const commitsCommitted = this.transactionScopesStart.pop();
+		assert(commitsCommitted !== undefined, "No transaction to commit");
+	}
+
+	public abortCurrentTransaction(): void {
+		const scopeStart = this.transactionScopesStart.pop();
+		assert(scopeStart !== undefined, "No transaction to abort");
+		this.transactionCommits.length = scopeStart;
+	}
+
+	public addTransactionStep(commit: GraphCommit<TChange>): void {
+		assert(this.transactionScopesStart.length !== 0, "No transaction to add a step to");
 		const change = this.enricher.updateChangeEnrichments(commit.change, commit.revision);
 		this.transactionCommits.push({ ...commit, change });
 	}
 
 	public getComposedChange(revision: RevisionTag): TChange {
+		assert(this.transactionScopesStart.length === 0, "Transaction not committed");
 		const squashed = this.rebaser.compose(this.transactionCommits);
 		const tagged = this.rebaser.changeRevision(squashed, revision);
+		this.transactionCommits.length = 0;
 		return tagged;
 	}
 }

--- a/packages/dds/tree/src/test/shared-tree-core/branch.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/branch.spec.ts
@@ -378,6 +378,96 @@ describe("Branches", () => {
 		assert.equal(disposed, true);
 	});
 
+	for (const withCommits of [true, false]) {
+		const [withCommitsTitle, potentiallyAddCommit] = withCommits
+			? ["(with commits)", change]
+			: ["(without commits)", () => {}];
+		it(`emit a transactionStarted event after a new transaction scope is opened ${withCommitsTitle}`, () => {
+			const branch = create();
+			const log: boolean[] = [];
+			branch.on("transactionStarted", (isOuterTransaction) => {
+				log.push(isOuterTransaction);
+			});
+			branch.startTransaction();
+			{
+				assert.deepEqual(log, [true]);
+				potentiallyAddCommit(branch);
+				branch.startTransaction();
+				{
+					assert.deepEqual(log, [true, false]);
+					potentiallyAddCommit(branch);
+				}
+				branch.abortTransaction();
+				potentiallyAddCommit(branch);
+				branch.startTransaction();
+				{
+					assert.deepEqual(log, [true, false, false]);
+					potentiallyAddCommit(branch);
+				}
+				branch.abortTransaction();
+			}
+			branch.abortTransaction();
+		});
+
+		it(`emit a transactionAborted event after a transaction scope is aborted ${withCommitsTitle}`, () => {
+			const branch = create();
+			const log: boolean[] = [];
+			branch.on("transactionAborted", (isOuterTransaction) => {
+				log.push(isOuterTransaction);
+			});
+			branch.startTransaction();
+			{
+				potentiallyAddCommit(branch);
+				branch.startTransaction();
+				{
+					potentiallyAddCommit(branch);
+					assert.deepEqual(log, []);
+				}
+				branch.abortTransaction();
+				assert.deepEqual(log, [false]);
+				potentiallyAddCommit(branch);
+				branch.startTransaction();
+				{
+					potentiallyAddCommit(branch);
+				}
+				branch.abortTransaction();
+				assert.deepEqual(log, [false, false]);
+				potentiallyAddCommit(branch);
+			}
+			branch.abortTransaction();
+			assert.deepEqual(log, [false, false, true]);
+		});
+
+		it(`emit a transactionCommitted event after a new transaction scope is committed ${withCommitsTitle}`, () => {
+			const branch = create();
+			const log: boolean[] = [];
+			branch.on("transactionCommitted", (isOuterTransaction) => {
+				log.push(isOuterTransaction);
+			});
+			branch.startTransaction();
+			{
+				potentiallyAddCommit(branch);
+				branch.startTransaction();
+				{
+					potentiallyAddCommit(branch);
+					assert.deepEqual(log, []);
+				}
+				branch.commitTransaction();
+				assert.deepEqual(log, [false]);
+				potentiallyAddCommit(branch);
+				branch.startTransaction();
+				{
+					potentiallyAddCommit(branch);
+				}
+				branch.commitTransaction();
+				assert.deepEqual(log, [false, false]);
+				potentiallyAddCommit(branch);
+			}
+			branch.commitTransaction();
+			assert.deepEqual(log, [false, false, true]);
+		});
+	}
+
 	it("can be read after disposal", () => {
 		const branch = create();
 		branch.dispose();

--- a/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -57,7 +57,12 @@ import type {
 	SummaryElementStringifier,
 } from "../../shared-tree-core/index.js";
 import { brand, disposeSymbol } from "../../util/index.js";
-import { SharedTreeTestFactory, schematizeFlexTree } from "../utils.js";
+import {
+	SharedTreeTestFactory,
+	TestTreeProviderLite,
+	schematizeFlexTree,
+	stringSequenceRootSchema,
+} from "../utils.js";
 
 import { TestSharedTreeCore } from "./utils.js";
 
@@ -347,6 +352,95 @@ describe("SharedTreeCore", () => {
 		]);
 	});
 
+	it("Does not submit changes that were aborted in an outer transaction", async () => {
+		const provider = new TestTreeProviderLite(2);
+		const content = {
+			schema: stringSequenceRootSchema,
+			allowedSchemaModifications: AllowedUpdateType.Initialize,
+			initialTree: ["A", "B"],
+		} satisfies InitializeAndSchematizeConfiguration;
+		const tree1 = schematizeFlexTree(provider.trees[0], content);
+		provider.processMessages();
+		const tree2 = schematizeFlexTree(provider.trees[1], content);
+
+		const root1 = tree1.flexTree;
+		const root2 = tree2.flexTree;
+
+		tree1.checkout.transaction.start();
+		{
+			// Remove A as part of the aborted transaction
+			root1.removeAt(0);
+			tree1.checkout.transaction.start();
+			{
+				// Remove B as part of the committed inner transaction
+				root1.removeAt(0);
+			}
+			tree1.checkout.transaction.commit();
+		}
+		tree1.checkout.transaction.abort();
+
+		provider.processMessages();
+		assert.deepEqual([...root2], ["A", "B"]);
+		assert.deepEqual([...root2], ["A", "B"]);
+
+		// Make an additional change to ensure that all changes from the previous transactions were flushed
+		tree1.checkout.transaction.start();
+		{
+			root1.insertAtEnd("C");
+		}
+		tree1.checkout.transaction.commit();
+		provider.processMessages();
+		assert.deepEqual([...root2], ["A", "B", "C"]);
+		assert.deepEqual([...root2], ["A", "B", "C"]);
+	});
+
+	it("Does not submit changes that were aborted in an inner transaction", async () => {
+		const provider = new TestTreeProviderLite(2);
+		const content = {
+			schema: stringSequenceRootSchema,
+			allowedSchemaModifications: AllowedUpdateType.Initialize,
+			initialTree: ["A", "B"],
+		} satisfies InitializeAndSchematizeConfiguration;
+		const tree1 = schematizeFlexTree(provider.trees[0], content);
+
+		provider.processMessages();
+		const tree2 = schematizeFlexTree(provider.trees[1], content);
+
+		const root1 = tree1.flexTree;
+		const root2 = tree2.flexTree;
+
+		tree1.checkout.transaction.start();
+		{
+			// Remove A as part of the committed transaction
+			root1.removeAt(0);
+			tree1.checkout.transaction.start();
+			{
+				// Remove B as part of the aborted transaction
+				root1.removeAt(0);
+			}
+			tree1.checkout.transaction.abort();
+		}
+		tree1.checkout.transaction.commit();
+
+		assert.deepEqual([...root1], ["B"]);
+		assert.deepEqual([...root2], ["A", "B"]);
+
+		provider.processMessages();
+
+		assert.deepEqual([...root1], ["B"]);
+		assert.deepEqual([...root2], ["B"]);
+
+		// Make an additional change to ensure that all changes from the previous transactions were flushed
+		tree1.checkout.transaction.start();
+		{
+			root1.insertAtEnd("C");
+		}
+		tree1.checkout.transaction.commit();
+		provider.processMessages();
+		assert.deepEqual([...root2], ["B", "C"]);
+		assert.deepEqual([...root2], ["B", "C"]);
+	});
+
 	describe("commit enrichment", () => {
 		interface EnrichedCommit extends GraphCommit<ModularChangeset> {
 			readonly original?: GraphCommit<ModularChangeset>;
@@ -478,6 +572,29 @@ describe("SharedTreeCore", () => {
 			assert.equal(enricher.enrichmentLog.length, 2);
 			assert.equal(machine.submissionLog.length, 1);
 			assert.notEqual(machine.submissionLog[0], tree.getLocalBranch().getHead().change);
+		});
+
+		it("handles aborted outer transaction", () => {
+			const enricher = new MockChangeEnricher<ModularChangeset>();
+			const machine = new MockResubmitMachine();
+			const tree = createTree([], machine, enricher);
+			const containerRuntimeFactory = new MockContainerRuntimeFactory();
+			const dataStoreRuntime1 = new MockFluidDataStoreRuntime({
+				idCompressor: createIdCompressor(),
+			});
+			containerRuntimeFactory.createContainerRuntime(dataStoreRuntime1);
+			tree.connect({
+				deltaConnection: dataStoreRuntime1.createDeltaConnection(),
+				objectStorage: new MockStorage(),
+			});
+			tree.getLocalBranch().startTransaction();
+			assert.equal(enricher.enrichmentLog.length, 0);
+			changeTree(tree);
+			assert.equal(enricher.enrichmentLog.length, 1);
+			assert.equal(enricher.enrichmentLog[0].input, tree.getLocalBranch().getHead().change);
+			tree.getLocalBranch().abortTransaction();
+			assert.equal(enricher.enrichmentLog.length, 1);
+			assert.equal(machine.submissionLog.length, 0);
 		});
 
 		it("update commit enrichments on re-submit", () => {

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1948,6 +1948,54 @@ describe("SharedTree", () => {
 			}, "Tree does not conform to schema.");
 		});
 	});
+
+	// // This test suite is only meant to contain tests that
+	// describe("Commit submission", () => {
+	// 	it("can create tree with schema validation enabled", async () => {
+	// 		const provider = new TestTreeProviderLite(1);
+	// 		const [sharedTree] = provider.trees;
+	// 		const sf = new SchemaFactory("test");
+	// 		const schema = sf.string;
+	// 		assert.doesNotThrow(() =>
+	// 			sharedTree.schematize(
+	// 				new TreeConfiguration(schema, () => "42", {
+	// 					enableSchemaValidation: true,
+	// 				}),
+	// 			),
+	// 		);
+	// 	});
+
+	// 	it("schema validation throws as expected", async () => {
+	// 		const provider = new TestTreeProviderLite(1);
+	// 		const [sharedTree] = provider.trees;
+	// 		const sf = new SchemaFactory("test");
+
+	// 		// No validation failures when initializing the tree for the first time.
+	// 		// Stored schema is set up so 'foo' is an array of strings.
+	// 		const schema = sf.object("myObject", { foo: sf.array("foo", sf.string) });
+	// 		sharedTree.schematize(
+	// 			new TreeConfiguration(schema, () => ({ foo: ["42"] }), {
+	// 				enableSchemaValidation: true,
+	// 			}),
+	// 		);
+
+	// 		// Trying to use the tree with a view schema that makes 'foo' an array of strings or numbers
+	// 		// should not cause compile-time errors when inserting a number, but stored schema validation
+	// 		// should kick in and throw an error.
+	// 		const viewschema = sf.object("myObject", {
+	// 			foo: sf.array("foo", [sf.string, sf.number]),
+	// 		});
+	// 		const tree = sharedTree.schematize(
+	// 			new TreeConfiguration(viewschema, () => ({ foo: ["42"] }), {
+	// 				enableSchemaValidation: true,
+	// 			}),
+	// 		);
+
+	// 		assert.throws(() => {
+	// 			tree.root.foo.insertAtEnd(3);
+	// 		}, "Tree does not conform to schema.");
+	// 	});
+	// });
 });
 
 function assertSchema<TRoot extends FlexFieldSchema>(

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -1948,54 +1948,6 @@ describe("SharedTree", () => {
 			}, "Tree does not conform to schema.");
 		});
 	});
-
-	// // This test suite is only meant to contain tests that
-	// describe("Commit submission", () => {
-	// 	it("can create tree with schema validation enabled", async () => {
-	// 		const provider = new TestTreeProviderLite(1);
-	// 		const [sharedTree] = provider.trees;
-	// 		const sf = new SchemaFactory("test");
-	// 		const schema = sf.string;
-	// 		assert.doesNotThrow(() =>
-	// 			sharedTree.schematize(
-	// 				new TreeConfiguration(schema, () => "42", {
-	// 					enableSchemaValidation: true,
-	// 				}),
-	// 			),
-	// 		);
-	// 	});
-
-	// 	it("schema validation throws as expected", async () => {
-	// 		const provider = new TestTreeProviderLite(1);
-	// 		const [sharedTree] = provider.trees;
-	// 		const sf = new SchemaFactory("test");
-
-	// 		// No validation failures when initializing the tree for the first time.
-	// 		// Stored schema is set up so 'foo' is an array of strings.
-	// 		const schema = sf.object("myObject", { foo: sf.array("foo", sf.string) });
-	// 		sharedTree.schematize(
-	// 			new TreeConfiguration(schema, () => ({ foo: ["42"] }), {
-	// 				enableSchemaValidation: true,
-	// 			}),
-	// 		);
-
-	// 		// Trying to use the tree with a view schema that makes 'foo' an array of strings or numbers
-	// 		// should not cause compile-time errors when inserting a number, but stored schema validation
-	// 		// should kick in and throw an error.
-	// 		const viewschema = sf.object("myObject", {
-	// 			foo: sf.array("foo", [sf.string, sf.number]),
-	// 		});
-	// 		const tree = sharedTree.schematize(
-	// 			new TreeConfiguration(viewschema, () => ({ foo: ["42"] }), {
-	// 				enableSchemaValidation: true,
-	// 			}),
-	// 		);
-
-	// 		assert.throws(() => {
-	// 			tree.root.foo.insertAtEnd(3);
-	// 		}, "Tree does not conform to schema.");
-	// 	});
-	// });
 });
 
 function assertSchema<TRoot extends FlexFieldSchema>(


### PR DESCRIPTION
## Description

Fixes bugs in the handling of enriched commits when transactions are aborted (see added tests for details)

## Breaking Changes

None