### PR TITLE
Fix azure-client ephemeral container tests

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/tree.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/tree.spec.ts
@@ -96,7 +96,6 @@ for (const testOpts of testMatrix) {
 				treeData = (container1.initialObjects.tree1 as ITree).viewWith(
 					treeConfiguration, // This is defined in schema.ts
 				);
-				treeData.initialize(new StringArray([]));
 			} else {
 				({ container: container1 } = await client.createContainer(schema, "2"));
 
@@ -151,7 +150,6 @@ for (const testOpts of testMatrix) {
 				({ container: container1 } = await client.getContainer(containerId, schema, "2"));
 
 				treeData1 = (container1.initialObjects.tree1 as ITree).viewWith(treeConfiguration);
-				treeData1.initialize(new StringArray([]));
 			} else {
 				({ container: container1 } = await client.createContainer(schema, "2"));
 


### PR DESCRIPTION
## Description

The ephemeral scenarios for these tests do not actually create new containers, they exercise load scenarios. As such, the trees should not be initialized in those codepaths.