### PR TITLE
docs(core-interfaces): Document members of `ITelemetryBaseLogger`

### DIFF
--- a/packages/common/core-interfaces/api-report/core-interfaces.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.alpha.api.md
@@ -345,9 +345,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    // (undocumented)
     minLogLevel?: LogLevel;
-    // (undocumented)
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/api-report/core-interfaces.beta.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.beta.api.md
@@ -296,9 +296,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    // (undocumented)
     minLogLevel?: LogLevel;
-    // (undocumented)
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/api-report/core-interfaces.public.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.public.api.md
@@ -296,9 +296,7 @@ export interface ITelemetryBaseEvent extends ITelemetryBaseProperties {
 
 // @public
 export interface ITelemetryBaseLogger {
-    // (undocumented)
     minLogLevel?: LogLevel;
-    // (undocumented)
     send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 }
 

--- a/packages/common/core-interfaces/src/logger.ts
+++ b/packages/common/core-interfaces/src/logger.ts
@@ -75,13 +75,13 @@ export interface ITelemetryBaseLogger {
 	/**
 	 * Log a telemetry event.
 	 * @param event - The event to log.
-	 * @param logLevel - The log level of the event. Default: {@link LogLevel.default}.
+	 * @param logLevel - The log level of the event. Default: {@link (LogLevel:variable).default}.
 	 */
 	send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 
 	/**
 	 * Minimum log level to be logged.
-	 * @defaultValue {@link LogLevel.default}
+	 * @defaultValue {@link (LogLevel:variable).default}
 	 */
 	minLogLevel?: LogLevel;
 }

--- a/packages/common/core-interfaces/src/logger.ts
+++ b/packages/common/core-interfaces/src/logger.ts
@@ -73,7 +73,7 @@ export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
  */
 export interface ITelemetryBaseLogger {
 	/**
-	 * Log a telemetry event.
+	 * Log a telemetry event, if it meets the appropriate log-level threshold (see {@link ITelemetryBaseLogger.minLogLevel}).
 	 * @param event - The event to log.
 	 * @param logLevel - The log level of the event. Default: {@link (LogLevel:variable).default}.
 	 */

--- a/packages/common/core-interfaces/src/logger.ts
+++ b/packages/common/core-interfaces/src/logger.ts
@@ -72,8 +72,17 @@ export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
  * @public
  */
 export interface ITelemetryBaseLogger {
+	/**
+	 * Log a telemetry event.
+	 * @param event - The event to log.
+	 * @param logLevel - The log level of the event. Default: {@link LogLevel.default}.
+	 */
 	send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
 
+	/**
+	 * Minimum log level to be logged.
+	 * @defaultValue {@link LogLevel.default}
+	 */
 	minLogLevel?: LogLevel;
 }
 


### PR DESCRIPTION
The members were not previously documented. Critically, this meant that the contract regarding `minLogLevel` was undocumented. This PR adds the necessary documentation to ensure users can implement the interface correctly.