### PR TITLE
fix(telemetry-utils): Update `MockLogger` to correctly respect `minLogLevel`

### DIFF
--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.alpha.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.alpha.api.md
@@ -87,7 +87,7 @@ export interface ITelemetryPropertiesExt {
 
 // @alpha
 export class MockLogger implements ITelemetryBaseLogger {
-    constructor(minLogLevel?: LogLevel | undefined);
+    constructor(minLogLevel?: LogLevel);
     assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean): void;
     assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean): void;
     assertMatchNone(disallowedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean): void;
@@ -99,10 +99,8 @@ export class MockLogger implements ITelemetryBaseLogger {
     matchAnyEvent(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean): boolean;
     matchEvents(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean): boolean;
     matchEventStrict(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean): boolean;
-    // (undocumented)
-    readonly minLogLevel?: LogLevel | undefined;
-    // (undocumented)
-    send(event: ITelemetryBaseEvent): void;
+    readonly minLogLevel: LogLevel;
+    send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
     // (undocumented)
     toTelemetryLogger(): ITelemetryLoggerExt;
 }

--- a/packages/utils/telemetry-utils/package.json
+++ b/packages/utils/telemetry-utils/package.json
@@ -141,6 +141,9 @@
 	},
 	"typeValidation": {
 		"broken": {
+			"ClassDeclaration_MockLogger": {
+				"forwardCompat": false
+			},
 			"RemovedFunctionDeclaration_isValidLegacyError": {
 				"forwardCompat": false,
 				"backCompat": false

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -26,19 +26,19 @@ export class MockLogger implements ITelemetryBaseLogger {
 
 	public readonly minLogLevel: LogLevel;
 
-	constructor(minLogLevel?: LogLevel) {
+	public constructor(minLogLevel?: LogLevel) {
 		this.minLogLevel = minLogLevel ?? LogLevel.default;
 	}
 
-	clear(): void {
+	public clear(): void {
 		this.events = [];
 	}
 
-	toTelemetryLogger(): ITelemetryLoggerExt {
+	public toTelemetryLogger(): ITelemetryLoggerExt {
 		return createChildLogger({ logger: this });
 	}
 
-	send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void {
+	public send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void {
 		if (logLevel ?? LogLevel.default >= this.minLogLevel) {
 			this.events.push(event);
 		}

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -24,6 +24,9 @@ import { ITelemetryLoggerExt, ITelemetryPropertiesExt } from "./telemetryTypes.j
 export class MockLogger implements ITelemetryBaseLogger {
 	events: ITelemetryBaseEvent[] = [];
 
+	/**
+	 * {@inheritDoc @fluidframework/core-interfaces#ITelemetryBaseLogger.minLogLevel}
+	 */
 	public readonly minLogLevel: LogLevel;
 
 	public constructor(minLogLevel?: LogLevel) {
@@ -38,6 +41,9 @@ export class MockLogger implements ITelemetryBaseLogger {
 		return createChildLogger({ logger: this });
 	}
 
+	/**
+	 * {@inheritDoc @fluidframework/core-interfaces#ITelemetryBaseLogger.send}
+	 */
 	public send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void {
 		if (logLevel ?? LogLevel.default >= this.minLogLevel) {
 			this.events.push(event);

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -24,7 +24,11 @@ import { ITelemetryLoggerExt, ITelemetryPropertiesExt } from "./telemetryTypes.j
 export class MockLogger implements ITelemetryBaseLogger {
 	events: ITelemetryBaseEvent[] = [];
 
-	constructor(public readonly minLogLevel?: LogLevel) {}
+	public readonly minLogLevel: LogLevel;
+
+	constructor(minLogLevel?: LogLevel) {
+		this.minLogLevel = minLogLevel ?? LogLevel.default;
+	}
 
 	clear(): void {
 		this.events = [];
@@ -34,8 +38,10 @@ export class MockLogger implements ITelemetryBaseLogger {
 		return createChildLogger({ logger: this });
 	}
 
-	send(event: ITelemetryBaseEvent): void {
-		this.events.push(event);
+	send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void {
+		if (logLevel ?? LogLevel.default >= this.minLogLevel) {
+			this.events.push(event);
+		}
 	}
 
 	/**

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -14,8 +14,10 @@ import { createChildLogger } from "./logger.js";
 import { ITelemetryLoggerExt, ITelemetryPropertiesExt } from "./telemetryTypes.js";
 
 /**
- * The MockLogger records events sent to it, and then can walk back over those events
- * searching for a set of expected events to match against the logged events.
+ * Mock {@link @fluidframework/core-interfaces#ITelemetryBaseLogger} implementation.
+ *
+ * Records events sent to it, and then can walk back over those events, searching for a set of expected events to
+ * match against the logged events.
  *
  * @alpha
  */

--- a/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
+++ b/packages/utils/telemetry-utils/src/test/types/validateTelemetryUtilsPrevious.generated.ts
@@ -587,6 +587,7 @@ declare function get_old_ClassDeclaration_MockLogger():
 declare function use_current_ClassDeclaration_MockLogger(
     use: TypeOnly<current.MockLogger>): void;
 use_current_ClassDeclaration_MockLogger(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_MockLogger());
 
 /*


### PR DESCRIPTION
The class was taking in `minLogLevel` at construction, but was not applying it to calls to `send`. This PR updates the implementation to respect the `minLogLevel` property, and simplifies some of the logic around it.