### PR TITLE
test(client): add @legacy and @system custom tag support

### DIFF
--- a/azure/packages/azure-service-utils/tsdoc.json
+++ b/azure/packages/azure-service-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/common/build/build-common/tsdoc-base.json
+++ b/common/build/build-common/tsdoc-base.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+
+	// Include the definitions that are required for API Extractor
+	"extends": ["@microsoft/api-extractor/extends/tsdoc-base.json"],
+
+	"tagDefinitions": [
+		{
+			// This tag indicates API is part of a legacy API set.
+			"tagName": "@legacy",
+			"syntaxKind": "modifier",
+			"allowMultiple": true
+		},
+		{
+			// This tag indicates API is part of reserved system types
+			// and should not be inspected by external parties. It may
+			// change version to version.
+			"tagName": "@system",
+			"syntaxKind": "modifier",
+			"allowMultiple": true
+		}
+	],
+
+	"supportForTags": {
+		"@legacy": true,
+		"@system": true
+	}
+}

--- a/common/build/build-common/tsdoc-base.json
+++ b/common/build/build-common/tsdoc-base.json
@@ -8,16 +8,14 @@
 		{
 			// This tag indicates API is part of a legacy API set.
 			"tagName": "@legacy",
-			"syntaxKind": "modifier",
-			"allowMultiple": true
+			"syntaxKind": "modifier"
 		},
 		{
 			// This tag indicates API is part of reserved system types
 			// and should not be inspected by external parties. It may
 			// change version to version.
 			"tagName": "@system",
-			"syntaxKind": "modifier",
-			"allowMultiple": true
+			"syntaxKind": "modifier"
 		}
 	],
 

--- a/examples/utils/example-utils/tsdoc.json
+++ b/examples/utils/example-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/experimental/PropertyDDS/packages/property-dds/tsdoc.json
+++ b/experimental/PropertyDDS/packages/property-dds/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/experimental/dds/attributable-map/tsdoc.json
+++ b/experimental/dds/attributable-map/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/experimental/dds/ot/ot/tsdoc.json
+++ b/experimental/dds/ot/ot/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/experimental/dds/ot/sharejs/json1/tsdoc.json
+++ b/experimental/dds/ot/sharejs/json1/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/experimental/dds/sequence-deprecated/tsdoc.json
+++ b/experimental/dds/sequence-deprecated/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/experimental/dds/tree/tsdoc.json
+++ b/experimental/dds/tree/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/experimental/framework/data-objects/tsdoc.json
+++ b/experimental/framework/data-objects/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/experimental/framework/last-edited/tsdoc.json
+++ b/experimental/framework/last-edited/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/experimental/framework/tree-react-api/tsdoc.json
+++ b/experimental/framework/tree-react-api/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/common/client-utils/tsdoc.json
+++ b/packages/common/client-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/common/container-definitions/tsdoc.json
+++ b/packages/common/container-definitions/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/common/core-interfaces/tsdoc.json
+++ b/packages/common/core-interfaces/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/common/core-utils/tsdoc.json
+++ b/packages/common/core-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/common/driver-definitions/tsdoc.json
+++ b/packages/common/driver-definitions/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/cell/tsdoc.json
+++ b/packages/dds/cell/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/counter/tsdoc.json
+++ b/packages/dds/counter/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/ink/tsdoc.json
+++ b/packages/dds/ink/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/map/tsdoc.json
+++ b/packages/dds/map/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/matrix/tsdoc.json
+++ b/packages/dds/matrix/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/merge-tree/tsdoc.json
+++ b/packages/dds/merge-tree/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/ordered-collection/tsdoc.json
+++ b/packages/dds/ordered-collection/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/pact-map/tsdoc.json
+++ b/packages/dds/pact-map/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/register-collection/tsdoc.json
+++ b/packages/dds/register-collection/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/sequence/tsdoc.json
+++ b/packages/dds/sequence/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/shared-object-base/tsdoc.json
+++ b/packages/dds/shared-object-base/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/shared-summary-block/tsdoc.json
+++ b/packages/dds/shared-summary-block/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/task-manager/tsdoc.json
+++ b/packages/dds/task-manager/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/test-dds-utils/tsdoc.json
+++ b/packages/dds/test-dds-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/dds/tree/tsdoc.json
+++ b/packages/dds/tree/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/debugger/tsdoc.json
+++ b/packages/drivers/debugger/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/driver-base/tsdoc.json
+++ b/packages/drivers/driver-base/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/driver-web-cache/tsdoc.json
+++ b/packages/drivers/driver-web-cache/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/file-driver/tsdoc.json
+++ b/packages/drivers/file-driver/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/local-driver/tsdoc.json
+++ b/packages/drivers/local-driver/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/odsp-driver-definitions/tsdoc.json
+++ b/packages/drivers/odsp-driver-definitions/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/odsp-driver/tsdoc.json
+++ b/packages/drivers/odsp-driver/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/odsp-urlResolver/tsdoc.json
+++ b/packages/drivers/odsp-urlResolver/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/replay-driver/tsdoc.json
+++ b/packages/drivers/replay-driver/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/routerlicious-driver/tsdoc.json
+++ b/packages/drivers/routerlicious-driver/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/routerlicious-urlResolver/tsdoc.json
+++ b/packages/drivers/routerlicious-urlResolver/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/drivers/tinylicious-driver/tsdoc.json
+++ b/packages/drivers/tinylicious-driver/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/agent-scheduler/tsdoc.json
+++ b/packages/framework/agent-scheduler/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/aqueduct/tsdoc.json
+++ b/packages/framework/aqueduct/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/attributor/tsdoc.json
+++ b/packages/framework/attributor/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/client-logger/app-insights-logger/tsdoc.json
+++ b/packages/framework/client-logger/app-insights-logger/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/client-logger/fluid-telemetry/tsdoc.json
+++ b/packages/framework/client-logger/fluid-telemetry/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/data-object-base/tsdoc.json
+++ b/packages/framework/data-object-base/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/dds-interceptions/tsdoc.json
+++ b/packages/framework/dds-interceptions/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/fluid-framework/tsdoc.json
+++ b/packages/framework/fluid-framework/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/fluid-static/tsdoc.json
+++ b/packages/framework/fluid-static/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/oldest-client-observer/tsdoc.json
+++ b/packages/framework/oldest-client-observer/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/request-handler/tsdoc.json
+++ b/packages/framework/request-handler/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/synthesize/tsdoc.json
+++ b/packages/framework/synthesize/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/framework/undo-redo/tsdoc.json
+++ b/packages/framework/undo-redo/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/loader/container-loader/tsdoc.json
+++ b/packages/loader/container-loader/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/loader/driver-utils/tsdoc.json
+++ b/packages/loader/driver-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/loader/test-loader-utils/tsdoc.json
+++ b/packages/loader/test-loader-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/runtime/container-runtime-definitions/tsdoc.json
+++ b/packages/runtime/container-runtime-definitions/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/runtime/container-runtime/tsdoc.json
+++ b/packages/runtime/container-runtime/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/runtime/datastore-definitions/tsdoc.json
+++ b/packages/runtime/datastore-definitions/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/runtime/datastore/tsdoc.json
+++ b/packages/runtime/datastore/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/runtime/id-compressor/tsdoc.json
+++ b/packages/runtime/id-compressor/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/runtime/runtime-definitions/tsdoc.json
+++ b/packages/runtime/runtime-definitions/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/runtime/runtime-utils/tsdoc.json
+++ b/packages/runtime/runtime-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/runtime/test-runtime-utils/tsdoc.json
+++ b/packages/runtime/test-runtime-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/service-clients/azure-client/tsdoc.json
+++ b/packages/service-clients/azure-client/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/service-clients/odsp-client/tsdoc.json
+++ b/packages/service-clients/odsp-client/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/service-clients/tinylicious-client/tsdoc.json
+++ b/packages/service-clients/tinylicious-client/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/test/mocha-test-setup/tsdoc.json
+++ b/packages/test/mocha-test-setup/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/test/stochastic-test-utils/tsdoc.json
+++ b/packages/test/stochastic-test-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/test/test-driver-definitions/tsdoc.json
+++ b/packages/test/test-driver-definitions/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/test/test-drivers/tsdoc.json
+++ b/packages/test/test-drivers/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/test/test-pairwise-generator/tsdoc.json
+++ b/packages/test/test-pairwise-generator/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/test/test-utils/tsdoc.json
+++ b/packages/test/test-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/test/test-version-utils/tsdoc.json
+++ b/packages/test/test-version-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/tools/devtools/devtools-core/tsdoc.json
+++ b/packages/tools/devtools/devtools-core/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/tools/devtools/devtools-view/tsdoc.json
+++ b/packages/tools/devtools/devtools-view/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/tools/devtools/devtools/tsdoc.json
+++ b/packages/tools/devtools/devtools/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/tools/fluid-runner/tsdoc.json
+++ b/packages/tools/fluid-runner/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/utils/odsp-doclib-utils/tsdoc.json
+++ b/packages/utils/odsp-doclib-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/utils/telemetry-utils/tsdoc.json
+++ b/packages/utils/telemetry-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}

--- a/packages/utils/tool-utils/tsdoc.json
+++ b/packages/utils/tool-utils/tsdoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["../../../common/build/build-common/tsdoc-base.json"]
+}


### PR DESCRIPTION
- Created common `tsdoc-base.json` with `@legacy` and `@system` tags.
- Used `flub exec -g client` to place a `tsdoc.json` file wherever `api-extractor.json` existed.
- Added `tsdoc.json` to `devtools-view` and `example-utils`.