### PR TITLE
build(client): remove /legacy from fluid-telemetry

### DIFF
--- a/packages/framework/client-logger/fluid-telemetry/api-extractor.json
+++ b/packages/framework/client-logger/fluid-telemetry/api-extractor.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../../common/build/build-common/api-extractor-base.esm.current.json",
+	"extends": "../../../../common/build/build-common/api-extractor-base.esm.no-legacy.json",
 	"messages": {
 		// The following overrides are workarounds for API-Extractor incorrectly running analysis on our application
 		// insights dependency.

--- a/packages/framework/client-logger/fluid-telemetry/api-extractor/api-extractor-lint-legacy.cjs.json
+++ b/packages/framework/client-logger/fluid-telemetry/api-extractor/api-extractor-lint-legacy.cjs.json
@@ -1,5 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "<projectFolder>/../../../../common/build/build-common/api-extractor-lint.entrypoint.json",
-	"mainEntryPointFilePath": "<projectFolder>/dist/legacy.d.ts"
-}

--- a/packages/framework/client-logger/fluid-telemetry/api-extractor/api-extractor-lint-legacy.esm.json
+++ b/packages/framework/client-logger/fluid-telemetry/api-extractor/api-extractor-lint-legacy.esm.json
@@ -1,5 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "<projectFolder>/../../../../common/build/build-common/api-extractor-lint.entrypoint.json",
-	"mainEntryPointFilePath": "<projectFolder>/lib/legacy.d.ts"
-}

--- a/packages/framework/client-logger/fluid-telemetry/api-extractor/api-extractor.legacy.json
+++ b/packages/framework/client-logger/fluid-telemetry/api-extractor/api-extractor.legacy.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "<projectFolder>/../../../../common/build/build-common/api-extractor-base.esm.legacy.json"
-}

--- a/packages/framework/client-logger/fluid-telemetry/package.json
+++ b/packages/framework/client-logger/fluid-telemetry/package.json
@@ -23,16 +23,6 @@
 				"default": "./dist/index.js"
 			}
 		},
-		"./legacy": {
-			"import": {
-				"types": "./lib/legacy.d.ts",
-				"default": "./lib/index.js"
-			},
-			"require": {
-				"types": "./dist/legacy.d.ts",
-				"default": "./dist/index.js"
-			}
-		},
 		"./beta": {
 			"import": {
 				"types": "./lib/beta.d.ts",
@@ -58,30 +48,24 @@
 	"types": "lib/index.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib --node10TypeCompat",
+		"api-extractor:commonjs": "flub generate entrypoints --outDir ./dist",
+		"api-extractor:esnext": "flub generate entrypoints --outDir ./lib --node10TypeCompat",
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:docs": "concurrently \"npm:build:docs:*\"",
-		"build:docs:current": "api-extractor run --local",
-		"build:docs:legacy": "api-extractor run --local --config api-extractor/api-extractor.legacy.json",
+		"build:docs": "api-extractor run --local",
 		"build:esnext": "tsc --project ./tsconfig.json",
 		"check:are-the-types-wrong": "attw --pack .",
 		"check:biome": "biome check . --formatter-enabled=true",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
 		"check:exports:bundle-release-tags": "api-extractor run --config api-extractor/api-extractor-lint-bundle.json",
 		"check:exports:cjs:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.cjs.json",
-		"check:exports:cjs:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.cjs.json",
 		"check:exports:cjs:public": "api-extractor run --config api-extractor/api-extractor-lint-public.cjs.json",
 		"check:exports:esm:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.esm.json",
-		"check:exports:esm:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.esm.json",
 		"check:exports:esm:public": "api-extractor run --config api-extractor/api-extractor-lint-public.esm.json",
 		"check:format": "npm run check:biome",
 		"check:prettier": "prettier --check . --cache --ignore-path ../../../../.prettierignore",
-		"ci:build:docs": "concurrently \"npm:ci:build:docs:*\"",
-		"ci:build:docs:current": "api-extractor run",
-		"ci:build:docs:legacy": "api-extractor run --config api-extractor/api-extractor.legacy.json",
+		"ci:build:docs": "api-extractor run",
 		"clean": "rimraf --glob _api-extractor-temp coverage dist lib \"*.d.ts\" nyc \"**/*.tsbuildinfo\" \"**/*.build.log\"",
 		"eslint": "eslint --format stylish src",
 		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",


### PR DESCRIPTION
It has no legacy support and provides nothing through /legacy path.