### PR TITLE
build(client): generate "legacy" api report from rollup

### DIFF
--- a/azure/packages/azure-service-utils/api-report/azure-service-utils.alpha.api.md
+++ b/azure/packages/azure-service-utils/api-report/azure-service-utils.alpha.api.md
@@ -11,4 +11,6 @@ export { IUser }
 
 export { ScopeType }
 
+// (No @packageDocumentation comment for this package)
+
 ```

--- a/common/build/build-common/api-extractor-base.esm.legacy.json
+++ b/common/build/build-common/api-extractor-base.esm.legacy.json
@@ -1,11 +1,12 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "./api-extractor-base.esm.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/legacy.d.ts",
 	"apiReport": {
 		// Preferred:
 		// "reportFileName": "<unscopedPackageName>.legacy",
 		// "reportVariants": ["public", "alpha"] // "beta" is not included to reduce noise
-		// Currently generate a single <>.alpha.api.md report using main entrypoint.
+		// Currently generate a single <>.alpha.api.md report using legacy rollup.
 		"reportFileName": "<unscopedPackageName>",
 		"reportVariants": ["alpha"]
 	}

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -83,9 +83,14 @@ module.exports = {
 		},
 		// With most packages in client building ESM first, there is ideally just "build:esnext" dependency.
 		// The package's local 'api-extractor.json' may use the entrypoint from either CJS or ESM,
-		// therefore we need to require both before running api-extractor.
+		// therefore we need to require both before running api-extractor. For packages with /legacy
+		// exports, we need the export rollups too and in those cases we only use ESM.
 		"build:docs": ["tsc", "build:esnext"],
+		"build:docs:current": ["api-extractor:esnext"],
+		"build:docs:legacy": ["api-extractor:esnext"],
 		"ci:build:docs": ["tsc", "build:esnext"],
+		"ci:build:docs:current": ["api-extractor:esnext"],
+		"ci:build:docs:legacy": ["api-extractor:esnext"],
 		"build:readme": {
 			dependsOn: ["build:manifest"],
 			script: true,

--- a/packages/common/container-definitions/api-report/container-definitions.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.alpha.api.md
@@ -330,8 +330,6 @@ export interface IFluidPackageEnvironment {
     };
 }
 
-export { IGenericError }
-
 // @alpha
 export interface IGetPendingLocalStateProps {
     readonly notifyImminentClosure: boolean;
@@ -430,8 +428,6 @@ export interface ISnapshotTreeWithBlobContents extends ISnapshotTree {
 
 export { IThrottlingWarning }
 
-export { IUsageError }
-
 // @alpha
 export enum LoaderHeader {
     // @deprecated (undocumented)
@@ -455,5 +451,7 @@ export type ReadOnlyInfo = {
     readonly storageOnly: boolean;
     readonly storageOnlyReason?: string;
 };
+
+// (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/dds/counter/api-report/counter.alpha.api.md
+++ b/packages/dds/counter/api-report/counter.alpha.api.md
@@ -22,4 +22,6 @@ export const SharedCounter: ISharedObjectKind<ISharedCounter> & SharedObjectKind
 // @alpha
 export type SharedCounter = ISharedCounter;
 
+// (No @packageDocumentation comment for this package)
+
 ```

--- a/packages/dds/map/api-report/map.alpha.api.md
+++ b/packages/dds/map/api-report/map.alpha.api.md
@@ -123,4 +123,6 @@ export const SharedMap: ISharedObjectKind<ISharedMap> & SharedObjectKind<IShared
 // @alpha
 export type SharedMap = ISharedMap;
 
+// (No @packageDocumentation comment for this package)
+
 ```

--- a/packages/dds/sequence/api-report/sequence.alpha.api.md
+++ b/packages/dds/sequence/api-report/sequence.alpha.api.md
@@ -299,10 +299,6 @@ export { ReferenceType }
 
 export { reservedMarkerIdKey }
 
-export { reservedRangeLabelsKey }
-
-export { reservedTileLabelsKey }
-
 // @alpha
 export function revertSharedStringRevertibles(sharedString: ISharedString, revertibles: SharedStringRevertible[]): void;
 
@@ -492,5 +488,7 @@ export enum Side {
 export { TextSegment }
 
 export { TrackingGroup }
+
+// (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/dds/task-manager/api-report/task-manager.alpha.api.md
+++ b/packages/dds/task-manager/api-report/task-manager.alpha.api.md
@@ -35,4 +35,6 @@ export const TaskManager: ISharedObjectKind<ITaskManager> & SharedObjectKind<ITa
 // @alpha
 export type TaskManager = ITaskManager;
 
+// (No @packageDocumentation comment for this package)
+
 ```

--- a/packages/framework/aqueduct/api-report/aqueduct.alpha.api.md
+++ b/packages/framework/aqueduct/api-report/aqueduct.alpha.api.md
@@ -130,4 +130,6 @@ export class PureDataObjectFactory<TObj extends PureDataObject<I>, I extends Dat
     readonly type: string;
 }
 
+// (No @packageDocumentation comment for this package)
+
 ```

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1301,4 +1301,6 @@ export interface WithType<TName extends string = string> {
     get [typeNameSymbol](): TName;
 }
 
+// (No @packageDocumentation comment for this package)
+
 ```

--- a/packages/runtime/datastore-definitions/api-report/datastore-definitions.alpha.api.md
+++ b/packages/runtime/datastore-definitions/api-report/datastore-definitions.alpha.api.md
@@ -133,4 +133,6 @@ export type JsonableTypeWith<T> = undefined | null | boolean | number | string |
 // @alpha
 export type Serializable<T> = Jsonable<T, IFluidHandle>;
 
+// (No @packageDocumentation comment for this package)
+
 ```

--- a/packages/service-clients/azure-client/api-report/azure-client.alpha.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.alpha.api.md
@@ -92,4 +92,6 @@ export { IUser }
 
 export { ScopeType }
 
+// (No @packageDocumentation comment for this package)
+
 ```

--- a/packages/tools/fluid-runner/api-report/fluid-runner.alpha.api.md
+++ b/packages/tools/fluid-runner/api-report/fluid-runner.alpha.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="node" />
-
 // @alpha (undocumented)
 export type IExportFileResponse = IExportFileResponseSuccess | IExportFileResponseFailure;
 


### PR DESCRIPTION
legacy report is still generated to ".alpha.api.md" to track transition.
Ideally no reports would change here, but api-extractor both cleans up some cruft and adds more when using the rollup. The actual APIs listed are unchanged.