### PR TITLE
Enable noUncheckedIndexedAccess for framework packages

### DIFF
--- a/packages/framework/attributor/src/encoders.ts
+++ b/packages/framework/attributor/src/encoders.ts
@@ -23,10 +23,11 @@ export const deltaEncoder: TimestampEncoder = {
 	encode: (timestamps: number[]) => {
 		const deltaTimestamps: number[] = Array.from({ length: timestamps.length });
 		let prev = 0;
-		for (let i = 0; i < timestamps.length; i++) {
-			deltaTimestamps[i] = timestamps[i] - prev;
-			prev = timestamps[i];
+		for (const [i, timestamp] of timestamps.entries()) {
+			deltaTimestamps[i] = timestamp - prev;
+			prev = timestamp;
 		}
+
 		return deltaTimestamps;
 	},
 	decode: (encoded: unknown) => {
@@ -98,10 +99,12 @@ export class AttributorSerializer implements IAttributorSerializer {
 			0x4b1 /* serialized attribution columns should have the same length */,
 		);
 		const entries: [number, AttributionInfo][] = Array.from({ length: seqs.length });
-		for (let i = 0; i < seqs.length; i++) {
-			const key = seqs[i];
-			const timestamp = timestamps[i];
-			const ref = attributionRefs[i];
+		for (const [i, key] of seqs.entries()) {
+			// Non null asserting, we asserted seqs, timestamps and attributionRefs have the same length above
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			const timestamp = timestamps[i]!;
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			const ref = attributionRefs[i]!;
 			const user = JSON.parse(interner.getString(ref)) as IUser;
 			entries[i] = [key, { user, timestamp }];
 		}

--- a/packages/framework/attributor/src/stringInterner.ts
+++ b/packages/framework/attributor/src/stringInterner.ts
@@ -61,7 +61,7 @@ export class MutableStringInterner implements StringInterner {
 	 */
 	public getString(internId: number): string {
 		const result = this.internedStrings[internId];
-		if (!result) {
+		if (result === undefined) {
 			throw new UsageError(`No string associated with ${internId}.`);
 		}
 		return result;

--- a/packages/framework/attributor/tsconfig.json
+++ b/packages/framework/attributor/tsconfig.json
@@ -5,7 +5,6 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
 	},
 }


### PR DESCRIPTION
Enable noUncheckedIndexedAccess for framework packages
We are enabling `noUncheckedIndexedAccess` to protect us from changing a type of a record where there was a named property and reduce the risk of runtime errors by ensuring that indexed access on objects are properly checked for undefined values.

Arrays are impacted by this and must be annotated even though it is not the reason for using the setting

[AB#8216](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8216)