### PR TITLE
Filter out ops with snapshot sequence number while getting local state

### DIFF
--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -153,7 +153,7 @@ export class PendingStateManager implements IDisposable {
 				message.sequenceNumber !== undefined,
 				0x97c /* saved op should already have a sequence number */,
 			);
-			return message.sequenceNumber >= (snapshotSequenceNumber ?? 0);
+			return message.sequenceNumber > (snapshotSequenceNumber ?? 0);
 		});
 		this.pendingMessages.toArray().forEach((message) => {
 			if (

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -302,7 +302,7 @@ describe("Pending State Manager", () => {
 					type: MessageType.Operation,
 					clientSequenceNumber: 0,
 					contents: { prop1: true },
-					sequenceNumber: i,
+					sequenceNumber: i + 1, // starting with sequence number 1 so first assert does not filter any op
 				}));
 				submitBatch(messages);
 				process(messages);

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdOffline.spec.ts
@@ -353,12 +353,6 @@ describeCompat("GroupId offline", "NoCompat", (getTestObjectProvider, apis) => {
 		dataObjectA2._root.set("A2", "A2");
 		dataObjectB2._root.set("B2", "B2");
 
-		// Hack to make sure we don't immediately fail/close the container on pending ops
-		// Another way around this is to simply have a different container send remote messages.
-		// What happens is that the last two synced ops we made are considered "saved", This may be useful for testing an offline edge case
-		// The last two saved ops (setting A and B) have reference sequence numbers that point to a sequence number
-		// before the snapshot
-		(dataObjectA2.containerRuntime as any).pendingStateManager.savedOps = [];
 		// Get Pending state and close
 		assert(container2.closeAndGetPendingLocalState !== undefined, "Missing method!");
 		const pendingState = await container2.closeAndGetPendingLocalState();


### PR DESCRIPTION
Fix condition to filter pending local ops. We should not include ops with sequence number = snapshot sequence number in the pending runtime state. After fixing this condition, hack was no longer necessary in groupIdOffline test.