### PR TITLE
build: Use flub generate assertTags for assert tagging

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"lint:fix": "fluid-build --task lint:fix",
 		"policy-check": "flub check policy",
 		"policy-check-help": "echo Detect (and error on) policy-check violations, like package.json sorting, copyright headers etc. Excludes assert-short-code. Run the check or \"pnpm flub check policy --listHandlers\" for a full list.",
-		"policy-check:asserts": "flub check policy --handler assert-short-codes --fix && pretty-quick",
+		"policy-check:asserts": "flub generate assertTags --all && pretty-quick",
 		"policy-check:fix": "flub check policy --excludeHandler assert-short-codes --fix",
 		"policy-check:fix-help": "echo Fix policy-check violations excludes assert-short-code/",
 		"prettier": "fluid-build --task prettier",


### PR DESCRIPTION
Assert tagging has historically been part of policy-check, but it does not fit there for many reasons, including that we don't need to run it as a part of every build, only as part of release prep. This change switches to `flub generate assertTags`, which will allow us to fully remove the policy-check handler logic in a future change.

I verified that this command creates the same changes as the existing command; #21457 demonstrates the results.