### PR TITLE
Don't send ops during legacy SharedTree summarization

### DIFF
--- a/experimental/dds/tree/package.json
+++ b/experimental/dds/tree/package.json
@@ -68,7 +68,7 @@
 		"test:coverage": "c8 npm test",
 		"test:mocha": "mocha \"dist/**/*.tests.js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",
-		"test:stress": "cross-env FUZZ_TEST_COUNT=10 FUZZ_STRESS_RUN=true mocha \"dist/**/*.fuzz.tests.js\" --exit -r @fluid-internal/mocha-test-setup",
+		"test:stress": "cross-env FUZZ_TEST_COUNT=10 FUZZ_STRESS_RUN=true mocha \"dist/**/*.fuzz.tests.js\" --exit -r node_modules/@fluid-internal/mocha-test-setup",
 		"tsc": "fluid-tsc commonjs --project ./tsconfig.json && copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist"
 	},
 	"dependencies": {

--- a/experimental/dds/tree/src/SharedTree.ts
+++ b/experimental/dds/tree/src/SharedTree.ts
@@ -827,7 +827,10 @@ export class SharedTree extends SharedObject<ISharedTreeEvents> implements NodeI
 	public loadSummary(summary: SharedTreeSummaryBase): void {
 		const { version: loadedSummaryVersion } = summary;
 
-		if (isUpdateRequired(loadedSummaryVersion, this.writeFormat)) {
+		if (
+			this.deltaManager.readOnlyInfo.readonly !== true &&
+			isUpdateRequired(loadedSummaryVersion, this.writeFormat)
+		) {
 			this.submitOp({ type: SharedTreeOpType.Update, version: this.writeFormat });
 			this.logger.sendTelemetryEvent({
 				eventName: 'RequestVersionUpdate',


### PR DESCRIPTION
## Description

Previously, SharedTree would send ops from the summarizer client during certain race conditions. The op was redundant and unnecessary, but was nonetheless submitted. Recently, it has become an error to send to an op from a summarizer client, so this prevents the sending of the op. No meaningful change in the behavior of the legacy tree is expected from this change.

This also updates the legacy tree package's dds stress test command to include the `node_modules` prefix. Without it, the command will fail when running `test:stress` locally.
 