### PR TITLE
(aqueduct): Enable exactOptionalPropertyTypes 

### DIFF
--- a/packages/framework/aqueduct/tsconfig.json
+++ b/packages/framework/aqueduct/tsconfig.json
@@ -5,6 +5,5 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 	},
 }


### PR DESCRIPTION
blocked on runtime-utils, datastore, container-runtime, merge-tree

## Context:
Removing `exactOptionalPropertyTypes` implies that we do not need to explicitly set properties to undefined.

## Current Approach:
To address this, I have implemented a solution where:
- undefined is added to the API surface as compensation.

## Question for Reviewers:
- Can we consider removing undefined? Are there any other alternatives we should explore?
- Is it necessary to explicitly set properties to undefined? If so, please share the reasoning behind this.

[AB#8215](https://dev.azure.com/fluidframework/internal/_workitems/edit/8215) 