### PR TITLE
(dds-interceptions): Enable exactOptionalPropertyTypes  

### DIFF
--- a/packages/framework/dds-interceptions/tsconfig.json
+++ b/packages/framework/dds-interceptions/tsconfig.json
@@ -5,6 +5,5 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		"exactOptionalPropertyTypes": false,
 	},
 }


### PR DESCRIPTION
build failures seen from sequence and merge-tree