### PR TITLE
remove(container-definitions): Deprecated DeltaManager events

### DIFF
--- a/.changeset/seven-sketches-toss.md
+++ b/.changeset/seven-sketches-toss.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/container-definitions": major
+---
+
+Remove `prepareSend` and `submitOp` `DeltaManager` events, which have been long deprecated.
+
+No replacement APIs recommended.
+These events were never intended for use outside of `fluid-framework`, and have been marked as deprecated for more than 18 months.

--- a/packages/common/container-definitions/api-report/container-definitions.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.alpha.api.md
@@ -252,10 +252,6 @@ export interface IDeltaManager<T, U> extends IEventProvider<IDeltaManagerEvents>
 
 // @alpha @sealed
 export interface IDeltaManagerEvents extends IEvent {
-    // @deprecated (undocumented)
-    (event: "prepareSend", listener: (messageBuffer: any[]) => void): any;
-    // @deprecated (undocumented)
-    (event: "submitOp", listener: (message: IDocumentMessage) => void): any;
     (event: "op", listener: (message: ISequencedDocumentMessage, processingTime: number) => void): any;
     (event: "pong", listener: (latency: number) => void): any;
     (event: "connect", listener: (details: IConnectionDetails, opsBehind?: number) => void): any;

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -14,7 +14,6 @@ import type { IClientDetails } from "@fluidframework/driver-definitions";
 import type {
 	IAnyDriverError,
 	IClientConfiguration,
-	IDocumentMessage,
 	ITokenClaims,
 	ISequencedDocumentMessage,
 	ISignalMessage,

--- a/packages/common/container-definitions/src/deltas.ts
+++ b/packages/common/container-definitions/src/deltas.ts
@@ -67,17 +67,6 @@ export interface IDeltaSender {
  */
 export interface IDeltaManagerEvents extends IEvent {
 	/**
-	 * @deprecated No replacement API recommended.
-	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	(event: "prepareSend", listener: (messageBuffer: any[]) => void);
-
-	/**
-	 * @deprecated No replacement API recommended.
-	 */
-	(event: "submitOp", listener: (message: IDocumentMessage) => void);
-
-	/**
 	 * Emitted immediately after processing an incoming operation (op).
 	 *
 	 * @remarks


### PR DESCRIPTION
These events have been deprecated for more than 18 months. Before we cut our release candidate branch, we should remove them.