### PR TITLE
server: Add tenantId and documentId to socket connection metric

### DIFF
--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -146,13 +146,15 @@ class SocketIoServer implements core.IWebSocketServer {
 		private readonly apiCounters: IApiCounters = new InMemoryApiCounters(),
 	) {
 		this.io.on("connection", (socket: Socket) => {
+			/**
+			 * Fluid Socket.io connection URL looks like:
+			 * "<hostname>/socket.io/?documentId=[documentId]&tenantId=[tenantId]&EIO=[3/4]&transport=[websocket/polling]"
+			 * [socket.handshake.query](https://socket.io/docs/v4/server-socket-instance/#sockethandshake) contains parsed query params.
+			 * The following properties are used for **telemetry purposes only.**
+			 * These should **not** be used to identify the tenant and document associated with the socket connection
+			 * for real logic and access purposes without validating against the JWT access token.
+			 */
 			const telemetryProperties = {
-				// Fluid Socket.io connection URL looks like:
-				// <hostname>/socket.io/?documentId=<documentId>&tenantId=<tenantId>&EIO=<3/4>&transport=<websocket/polling>
-				// [socket.handshake.query](https://socket.io/docs/v4/server-socket-instance/#sockethandshake) contains parsed query params.
-				// The following properties are used for **telemetry purposes only.**
-				// These should **not** be used to identify the tenant and document associated with the socket connection
-				// for real logic and access purposes without validating against the JWT access token.
 				[BaseTelemetryProperties.tenantId]: socket.handshake.query.tenantId,
 				[BaseTelemetryProperties.documentId]: socket.handshake.query.documentId,
 			};

--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -146,9 +146,19 @@ class SocketIoServer implements core.IWebSocketServer {
 		private readonly apiCounters: IApiCounters = new InMemoryApiCounters(),
 	) {
 		this.io.on("connection", (socket: Socket) => {
+			const telemetryProperties = {
+				// Fluid Socket.io connection URL looks like:
+				// <hostname>/socket.io/?documentId=<documentId>&tenantId=<tenantId>&EIO=<3/4>&transport=<websocket/polling>
+				// [socket.handshake.query](https://socket.io/docs/v4/server-socket-instance/#sockethandshake) contains parsed query params.
+				// The following properties are used for **telemetry purposes only.**
+				// These should **not** be used to identify the tenant and document associated with the socket connection
+				// for real logic and access purposes without validating against the JWT access token.
+				[BaseTelemetryProperties.tenantId]: socket.handshake.query.tenantId,
+				[BaseTelemetryProperties.documentId]: socket.handshake.query.documentId,
+			};
 			const socketConnectionMetric = Lumberjack.newLumberMetric(
 				LumberEventName.SocketConnection,
-				{},
+				telemetryProperties,
 			);
 			const webSocket = new SocketIoSocket(socket);
 			this.events.emit("connection", webSocket);


### PR DESCRIPTION
## Description

#21211 added a new Socket connection metric, but it is lacking tenantId and documentId properties which are crucial for debugging customer issues. This PR adds those properties by parsing the Socket.io connection URL which already contains this information.