### PR TITLE
refactor(telemetry-utils): Deprecate `MockLogger` for external use

### DIFF
--- a/.changeset/small-days-randomize.md
+++ b/.changeset/small-days-randomize.md
@@ -1,8 +1,8 @@
 ---
-"@fluidframework/telemetry-utils": major
+"@fluidframework/telemetry-utils": minor
 ---
 
-Remove `MockLogger` from package exports.
+Deprecate `MockLogger` for external use.
 
 No replacement API is given. This type was never intended for use outside of the `fluid-framework` repository.
 If you were depending on this class for testing purposes, we recommend creating your own mock logger implementation,

--- a/.changeset/small-days-randomize.md
+++ b/.changeset/small-days-randomize.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/telemetry-utils": major
+---
+
+Remove `MockLogger` from package exports.
+
+No replacement API is given. This type was never intended for use outside of the `fluid-framework` repository.
+If you were depending on this class for testing purposes, we recommend creating your own mock logger implementation,
+or copy and adapt the code from `fluid-framework` as needed.

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/src/fetchApp.ts
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/src/fetchApp.ts
@@ -6,6 +6,7 @@
 import { assert } from "@fluidframework/core-utils/internal";
 import { prefetchLatestSnapshot } from "@fluidframework/odsp-driver/internal";
 import { FluidAppOdspUrlResolver } from "@fluidframework/odsp-urlresolver/internal";
+// eslint-disable-next-line import/no-deprecated
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { OdspSampleCache } from "./odspPersistantCache.js";
@@ -54,6 +55,7 @@ export function start(div: HTMLDivElement, odspAccessToken: string) {
 	fetchButton1.onclick = async () => {
 		const resolvedUrl = await urlResolver.resolve({ url: text1.value });
 		assert(resolvedUrl !== undefined, "resolvedUrl should be defined");
+		// eslint-disable-next-line import/no-deprecated
 		const mockLogger = new MockLogger();
 		for (let i = 0; i < 5; ++i) {
 			await prefetchLatestSnapshot(
@@ -71,6 +73,7 @@ export function start(div: HTMLDivElement, odspAccessToken: string) {
 	fetchButton2.onclick = async () => {
 		const resolvedUrl = await urlResolver.resolve({ url: text2.value });
 		assert(resolvedUrl !== undefined, 0x31a /* resolvedUrl is undefined */);
+		// eslint-disable-next-line import/no-deprecated
 		const mockLogger = new MockLogger();
 		for (let i = 0; i < 5; ++i) {
 			await prefetchLatestSnapshot(
@@ -86,6 +89,7 @@ export function start(div: HTMLDivElement, odspAccessToken: string) {
 	};
 }
 
+// eslint-disable-next-line import/no-deprecated
 function fetchButtonClick(mockLogger: MockLogger, div: HTMLDivElement) {
 	const fields = new Set([
 		"eventName",

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.alpha.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.alpha.api.md
@@ -75,6 +75,24 @@ export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt
 // @alpha
 export type ITelemetryPropertiesExt = Record<string, TelemetryEventPropertyTypeExt | Tagged<TelemetryEventPropertyTypeExt>>;
 
+// @alpha @deprecated
+export class MockLogger implements ITelemetryBaseLogger {
+    constructor(minLogLevel?: LogLevel);
+    assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
+    assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
+    assertMatchNone(disallowedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
+    assertMatchStrict(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
+    clear(): void;
+    get events(): readonly ITelemetryBaseEvent[];
+    matchAnyEvent(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): boolean;
+    matchEvents(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): boolean;
+    matchEventStrict(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): boolean;
+    readonly minLogLevel: LogLevel;
+    send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
+    // (undocumented)
+    toTelemetryLogger(): ITelemetryLoggerExt;
+}
+
 // @alpha
 export type TelemetryEventCategory = "generic" | "error" | "performance";
 

--- a/packages/utils/telemetry-utils/api-report/telemetry-utils.alpha.api.md
+++ b/packages/utils/telemetry-utils/api-report/telemetry-utils.alpha.api.md
@@ -76,24 +76,6 @@ export interface ITelemetryPerformanceEventExt extends ITelemetryGenericEventExt
 export type ITelemetryPropertiesExt = Record<string, TelemetryEventPropertyTypeExt | Tagged<TelemetryEventPropertyTypeExt>>;
 
 // @alpha
-export class MockLogger implements ITelemetryBaseLogger {
-    constructor(minLogLevel?: LogLevel);
-    assertMatch(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
-    assertMatchAny(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
-    assertMatchNone(disallowedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
-    assertMatchStrict(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], message?: string, inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): void;
-    clear(): void;
-    get events(): readonly ITelemetryBaseEvent[];
-    matchAnyEvent(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): boolean;
-    matchEvents(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): boolean;
-    matchEventStrict(expectedEvents: Omit<ITelemetryBaseEvent, "category">[], inlineDetailsProp?: boolean, clearEventsAfterCheck?: boolean): boolean;
-    readonly minLogLevel: LogLevel;
-    send(event: ITelemetryBaseEvent, logLevel?: LogLevel): void;
-    // (undocumented)
-    toTelemetryLogger(): ITelemetryLoggerExt;
-}
-
-// @alpha
 export type TelemetryEventCategory = "generic" | "error" | "performance";
 
 // @alpha

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -31,6 +31,8 @@ import type {
  * Please migrate usages by either creating your own mock {@link @fluidframework/core-interfaces#ITelemetryBaseLogger}
  * implementation, or by copying this code as-is into your own repo.
  *
+ * @privateRemarks TODO: When we are ready, this type should be made `internal`, and the deprecation notice should be removed.
+ *
  * @alpha
  */
 export class MockLogger implements ITelemetryBaseLogger {

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -23,7 +23,7 @@ import type {
  * Records events sent to it, and then can walk back over those events, searching for a set of expected events to
  * match against the logged events.
  *
- * @alpha
+ * @internal
  */
 export class MockLogger implements ITelemetryBaseLogger {
 	/**

--- a/packages/utils/telemetry-utils/src/mockLogger.ts
+++ b/packages/utils/telemetry-utils/src/mockLogger.ts
@@ -23,7 +23,15 @@ import type {
  * Records events sent to it, and then can walk back over those events, searching for a set of expected events to
  * match against the logged events.
  *
- * @internal
+ * @deprecated
+ *
+ * This class is not intended for use outside of the `fluid-framework` repo, and will be removed from
+ * package exports in the near future.
+ *
+ * Please migrate usages by either creating your own mock {@link @fluidframework/core-interfaces#ITelemetryBaseLogger}
+ * implementation, or by copying this code as-is into your own repo.
+ *
+ * @alpha
  */
 export class MockLogger implements ITelemetryBaseLogger {
 	/**


### PR DESCRIPTION
This class was never intended for external use. 

No replacement API is given. Existing users should either create their own mock logger implementation, or copy and adapt `MockLogger` from `fluid-framework`.