### PR TITLE
Fix nexus uncaught exception during graceful shutdown

### DIFF
--- a/server/routerlicious/packages/services-shared/src/socketIoServer.ts
+++ b/server/routerlicious/packages/services-shared/src/socketIoServer.ts
@@ -190,7 +190,8 @@ class SocketIoServer implements core.IWebSocketServer {
 			if (drainTime > 0 && drainInterval > 0) {
 				// Stop receiving new connections
 				this.io.engine.use((_, res, __) => {
-					res.status(503).send("Graceful Shutdown");
+					res.writeHead(503);
+					res.end("Graceful Shutdown");
 				});
 
 				const connections = await this.io.local.fetchSockets();


### PR DESCRIPTION
## Description

During nexus graceful shutdown, we need to stop receiving new connections. However, the code was throwing uncaught exception as "res.status is not a function". So, fixing that by using res.writeHead instead.

Tested it with fluid-chat and verified that the new connections were receiving 503 during graceful shutdown as expected.
