### PR TITLE
fix(docs): Don't hide `@alpha` APIs from website docs

### DIFF
--- a/docs/api-markdown-documenter/alert-node.js
+++ b/docs/api-markdown-documenter/alert-node.js
@@ -19,7 +19,7 @@ export const alertNodeType = "Alert";
  * @example Example rendering output (in Hugo Markdown)
  *
  * ```md
- * {{% callout TIP Unit tests are super useful! %}}
+ * {{% callout tip "Unit tests are super useful!" %}}
  *
  * More details about unit testing...
  * {{% /callout %}}

--- a/docs/api-markdown-documenter/alert-node.js
+++ b/docs/api-markdown-documenter/alert-node.js
@@ -19,7 +19,7 @@ export const alertNodeType = "Alert";
  * @example Example rendering output (in Hugo Markdown)
  *
  * ```md
- * {{% callout tip "Unit tests are super useful!" %}}
+ * {{% callout note "Unit tests are super useful!" %}}
  *
  * More details about unit testing...
  * {{% /callout %}}

--- a/docs/api-markdown-documenter/alert-node.js
+++ b/docs/api-markdown-documenter/alert-node.js
@@ -30,7 +30,7 @@ export const alertNodeType = "Alert";
 export class AlertNode extends DocumentationParentNodeBase {
 	/**
 	 * @param {@fluid-tools/api-markdown-documenter#DocumentationNode[]} children - Child node content.
-	 * @param {string} alertKind - The kind of alert.
+	 * @param {string} alertKind - The kind of alert. See {@link https://hugo-docs-theme.netlify.app/docs/guide/shortcodes/callout/}.
 	 * @param {string | undefined} title - (Optional) Title text for the alert.
 	 */
 	constructor(children, alertKind, title) {

--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -18,8 +18,11 @@ import { AlertNode } from "./alert-node.js";
 const customExamplesSectionTitle = "Usage";
 const customThrowsSectionTitle = "Error Handling";
 
+// Temporary workaround for items tagged as `@alpha` (to mean "legacy").
+// This messaging should be changed back to standard "alpha" terminology once we have
+// cleaned up our tag meanings.
 const alphaWarning = SpanNode.createFromPlainText(
-	"WARNING: This API is provided as an alpha preview and may change without notice. Use at your own risk.",
+	"LEGACY: This API is provided as is for existing users, but is not recommended for new users.",
 );
 const betaWarning = SpanNode.createFromPlainText(
 	"WARNING: This API is provided as a beta preview and may change without notice. Use at your own risk.",

--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -60,11 +60,11 @@ function createBetaWarning(apiItem) {
  *
  * 1. Heading (if not the document-root item, in which case headings are handled specially by document-level rendering)
  *
- * 1. Beta warning (if item annotated with `@beta`)
+ * 1. Summary (if any)
  *
  * 1. Deprecation notice (if any)
  *
- * 1. Summary (if any)
+ * 1. Alpha/Beta warning (if item annotated with `@alpha` or `@beta`)
  *
  * 1. Item Signature
  *

--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -5,8 +5,10 @@
 
 import {
 	ApiItemUtilities,
+	CodeSpanNode,
 	HeadingNode,
 	LayoutUtilities,
+	PlainTextNode,
 	ReleaseTag,
 	SectionNode,
 	SpanNode,
@@ -21,12 +23,35 @@ const customThrowsSectionTitle = "Error Handling";
 // Temporary workaround for items tagged as `@alpha` (to mean "legacy").
 // This messaging should be changed back to standard "alpha" terminology once we have
 // cleaned up our tag meanings.
-const alphaWarning = SpanNode.createFromPlainText(
-	"LEGACY: This API is provided as is for existing users, but is not recommended for new users.",
-);
-const betaWarning = SpanNode.createFromPlainText(
-	"WARNING: This API is provided as a beta preview and may change without notice. Use at your own risk.",
-);
+function createAlphaWarning(apiItem) {
+	const packageName = apiItem.getAssociatedPackage().displayName;
+	return new AlertNode(
+		[
+			new SpanNode([
+				new PlainTextNode("To use, import via "),
+				CodeSpanNode.createFromPlainText(`${packageName}/legacy`),
+				new PlainTextNode("."),
+			]),
+		],
+		/* alertKind: */ "note",
+		/* title: */ "This API is provided as-is for existing users, but is not recommended for new users.",
+	);
+}
+
+function createBetaWarning(apiItem) {
+	const packageName = apiItem.getAssociatedPackage().displayName;
+	return new AlertNode(
+		[
+			new SpanNode([
+				new PlainTextNode("To use, import via "),
+				CodeSpanNode.createFromPlainText(`${packageName}/beta`),
+				new PlainTextNode("."),
+			]),
+		],
+		/* alertKind: */ "warning",
+		/* title: */ "This API is provided as a beta preview and may change without notice. Use at your own risk.",
+	);
+}
 
 /**
  * Default content layout for all API items.
@@ -77,9 +102,9 @@ export function layoutContent(apiItem, itemSpecificContent, config) {
 	// Render alpha/beta notice if applicable
 	const releaseTag = ApiItemUtilities.getReleaseTag(apiItem);
 	if (releaseTag === ReleaseTag.Alpha) {
-		sections.push(new SectionNode([alphaWarning]));
+		sections.push(new SectionNode([createAlphaWarning(apiItem)]));
 	} else if (releaseTag === ReleaseTag.Beta) {
-		sections.push(new SectionNode([betaWarning]));
+		sections.push(new SectionNode([createBetaWarning(apiItem)]));
 	}
 
 	// Render signature (if any)

--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -8,6 +8,8 @@ import {
 	CodeSpanNode,
 	HeadingNode,
 	LayoutUtilities,
+	LineBreakNode,
+	LinkNode,
 	PlainTextNode,
 	ReleaseTag,
 	SectionNode,
@@ -19,6 +21,12 @@ import { AlertNode } from "./alert-node.js";
 
 const customExamplesSectionTitle = "Usage";
 const customThrowsSectionTitle = "Error Handling";
+
+const supportDocsLinkSpan = new SpanNode([
+	new PlainTextNode("For more information about our API support guarantees, see "),
+	LinkNode.createFromPlainText("here", "https://fluidframework.com/docs/build/releases-and-apitags/#api-support-levels"),
+	new PlainTextNode("."),
+]);
 
 // Temporary workaround for items tagged as `@alpha` (to mean "legacy").
 // This messaging should be changed back to standard "alpha" terminology once we have
@@ -32,9 +40,11 @@ function createAlphaWarning(apiItem) {
 				CodeSpanNode.createFromPlainText(`${packageName}/legacy`),
 				new PlainTextNode("."),
 			]),
+			LineBreakNode.Singleton,
+			supportDocsLinkSpan,
 		],
 		/* alertKind: */ "note",
-		/* title: */ "This API is provided as-is for existing users, but is not recommended for new users.",
+		/* title: */ "This API is provided for existing users, but is not recommended for new users.",
 	);
 }
 
@@ -47,9 +57,11 @@ function createBetaWarning(apiItem) {
 				CodeSpanNode.createFromPlainText(`${packageName}/beta`),
 				new PlainTextNode("."),
 			]),
+			LineBreakNode.Singleton,
+			supportDocsLinkSpan,
 		],
 		/* alertKind: */ "warning",
-		/* title: */ "This API is provided as a beta preview and may change without notice. Use at your own risk.",
+		/* title: */ "This API is provided as a beta preview and may change without notice.",
 	);
 }
 

--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -58,8 +58,6 @@ function createBetaWarning(apiItem) {
  *
  * @remarks Lays out the content in the following manner:
  *
- * 1. Heading (if not the document-root item, in which case headings are handled specially by document-level rendering)
- *
  * 1. Summary (if any)
  *
  * 1. Deprecation notice (if any)

--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -24,7 +24,10 @@ const customThrowsSectionTitle = "Error Handling";
 
 const supportDocsLinkSpan = new SpanNode([
 	new PlainTextNode("For more information about our API support guarantees, see "),
-	LinkNode.createFromPlainText("here", "https://fluidframework.com/docs/build/releases-and-apitags/#api-support-levels"),
+	LinkNode.createFromPlainText(
+		"here",
+		"https://fluidframework.com/docs/build/releases-and-apitags/#api-support-levels",
+	),
 	new PlainTextNode("."),
 ]);
 

--- a/docs/api-markdown-documenter/custom-renderers.js
+++ b/docs/api-markdown-documenter/custom-renderers.js
@@ -16,9 +16,9 @@ export function renderAlertNode(alertNode, writer, context) {
 	writer.ensureNewLine();
 
 	writer.writeLine(
-		`{{% callout ${alertNode.alertKind?.toLocaleLowerCase() ?? "note"} ${
+		`{{% callout ${alertNode.alertKind?.toLocaleLowerCase() ?? "note"} "${
 			alertNode.title ?? ""
-		} %}}`,
+		}" %}}`,
 	);
 
 	MarkdownRenderer.renderNodes(alertNode.children, writer, context);

--- a/docs/api-markdown-documenter/render-api-documentation.js
+++ b/docs/api-markdown-documenter/render-api-documentation.js
@@ -88,7 +88,9 @@ export async function renderApiDocumentation(inputDir, outputDir, uriRootDir, ap
 			// TODO: Also skip `@fluid-internal` packages once we no longer have public, user-facing APIs that reference their contents.
 			return ["@fluid-private"].includes(packageScope);
 		},
-		minimumReleaseLevel: ReleaseTag.Beta, // Don't include `@alpha` or `@internal` items in docs published to the public website.
+		// Temporary workaround to ensure APIs temporarily tagged as `@alpha` (to mean "legacy") are included in the API docs.
+		// This min level should be set back to Beta once legacy APIs have been cleaned up to not use `@alpha`.
+		minimumReleaseLevel: ReleaseTag.Alpha, // Don't include `@internal` items in docs published to the public website.
 	});
 
 	logProgress("Generating API documentation...");


### PR DESCRIPTION
Previously, when `@alpha` was strictly reserved for APIs used by internal partners, we update the website build to hide such members from public documentation. Later, the definition of `@alpha` was extended to mean "things we don't want new adoption of", and public-facing APIs like SharedMap were tagged as `@alpha`. As a result, our public API documentation has been substantially broken for some time.

This PR fixes the situation by updating the build to once again generate API docs for `@alpha` items.

It also updates the alerts we generate for `@alpha` and `@beta` to more accurately represent the usage contracts (including instructions for how to import them). E.g.
![image](https://github.com/microsoft/FluidFramework/assets/54606601/bd65b1c4-9977-43ee-9021-343adbaf31b1)
![image](https://github.com/microsoft/FluidFramework/assets/54606601/941d1570-dcbc-4062-898a-1b380ed5b4b9)

### Remaining work
There are still a number of places where `@alpha` items result in "ALPHA" disclaimer text. This behavior is not currently configurable by the documenter library. Subsequent PRs will add flexibility in the library, and leverage it in the website build.
E.g.
![image](https://github.com/microsoft/FluidFramework/assets/54606601/182b598e-fb9c-444d-9494-414b29347b02)
