### PR TITLE
Make several interfaces as sealed

### DIFF
--- a/packages/common/core-interfaces/api-report/core-interfaces.alpha.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.alpha.api.md
@@ -74,7 +74,7 @@ export interface IEvent {
     (event: string, listener: (...args: any[]) => void): any;
 }
 
-// @public
+// @public @sealed
 export interface IEventProvider<TEvent extends IEvent> {
     readonly off: IEventTransformer<this, TEvent>;
     readonly on: IEventTransformer<this, TEvent>;
@@ -242,7 +242,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 // @public (undocumented)
 export const IFluidHandle = "IFluidHandle";
 
-// @public
+// @public @sealed
 export interface IFluidHandle<out T = unknown> {
     readonly [fluidHandleSymbol]: IFluidHandleErased<T>;
     get(): Promise<T>;
@@ -262,7 +262,7 @@ export interface IFluidHandleContext extends IProvideFluidHandleContext {
     readonly routeContext?: IFluidHandleContext;
 }
 
-// @public
+// @public @sealed
 export interface IFluidHandleErased<T> extends ErasedType<readonly ["IFluidHandle", T]> {
 }
 
@@ -276,7 +276,7 @@ export interface IFluidHandleInternal<out T = unknown> extends IFluidHandle<T>, 
 // @public (undocumented)
 export const IFluidLoadable: keyof IProvideFluidLoadable;
 
-// @public
+// @public @sealed
 export interface IFluidLoadable extends IProvideFluidLoadable {
     // (undocumented)
     readonly handle: IFluidHandle;

--- a/packages/common/core-interfaces/api-report/core-interfaces.beta.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.beta.api.md
@@ -62,7 +62,7 @@ export interface IEvent {
     (event: string, listener: (...args: any[]) => void): any;
 }
 
-// @public
+// @public @sealed
 export interface IEventProvider<TEvent extends IEvent> {
     readonly off: IEventTransformer<this, TEvent>;
     readonly on: IEventTransformer<this, TEvent>;
@@ -230,21 +230,21 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 // @public (undocumented)
 export const IFluidHandle = "IFluidHandle";
 
-// @public
+// @public @sealed
 export interface IFluidHandle<out T = unknown> {
     readonly [fluidHandleSymbol]: IFluidHandleErased<T>;
     get(): Promise<T>;
     readonly isAttached: boolean;
 }
 
-// @public
+// @public @sealed
 export interface IFluidHandleErased<T> extends ErasedType<readonly ["IFluidHandle", T]> {
 }
 
 // @public (undocumented)
 export const IFluidLoadable: keyof IProvideFluidLoadable;
 
-// @public
+// @public @sealed
 export interface IFluidLoadable extends IProvideFluidLoadable {
     // (undocumented)
     readonly handle: IFluidHandle;

--- a/packages/common/core-interfaces/api-report/core-interfaces.public.api.md
+++ b/packages/common/core-interfaces/api-report/core-interfaces.public.api.md
@@ -62,7 +62,7 @@ export interface IEvent {
     (event: string, listener: (...args: any[]) => void): any;
 }
 
-// @public
+// @public @sealed
 export interface IEventProvider<TEvent extends IEvent> {
     readonly off: IEventTransformer<this, TEvent>;
     readonly on: IEventTransformer<this, TEvent>;
@@ -230,21 +230,21 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 // @public (undocumented)
 export const IFluidHandle = "IFluidHandle";
 
-// @public
+// @public @sealed
 export interface IFluidHandle<out T = unknown> {
     readonly [fluidHandleSymbol]: IFluidHandleErased<T>;
     get(): Promise<T>;
     readonly isAttached: boolean;
 }
 
-// @public
+// @public @sealed
 export interface IFluidHandleErased<T> extends ErasedType<readonly ["IFluidHandle", T]> {
 }
 
 // @public (undocumented)
 export const IFluidLoadable: keyof IProvideFluidLoadable;
 
-// @public
+// @public @sealed
 export interface IFluidLoadable extends IProvideFluidLoadable {
     // (undocumented)
     readonly handle: IFluidHandle;

--- a/packages/common/core-interfaces/src/events.ts
+++ b/packages/common/core-interfaces/src/events.ts
@@ -38,7 +38,7 @@ export interface IErrorEvent extends IEvent {
 
 /**
  * Base interface for event providers.
- * @public
+ * @sealed @public
  */
 export interface IEventProvider<TEvent extends IEvent> {
 	/**

--- a/packages/common/core-interfaces/src/fluidLoadable.ts
+++ b/packages/common/core-interfaces/src/fluidLoadable.ts
@@ -18,7 +18,7 @@ export interface IProvideFluidLoadable {
 }
 /**
  * A shared FluidObject has a URL from which it can be referenced
- * @public
+ * @sealed @public
  */
 export interface IFluidLoadable extends IProvideFluidLoadable {
 	// Handle to the loadable FluidObject

--- a/packages/common/core-interfaces/src/handles.ts
+++ b/packages/common/core-interfaces/src/handles.ts
@@ -116,7 +116,7 @@ export const fluidHandleSymbol: unique symbol = Symbol.for(
 
 /**
  * Handle to a shared {@link FluidObject}.
- * @public
+ * @sealed @public
  */
 export interface IFluidHandle<out T = unknown> {
 	/**
@@ -144,7 +144,7 @@ export interface IFluidHandle<out T = unknown> {
  * These can only be produced by the Fluid Framework and provide the implementation details needed to power {@link (IFluidHandle:interface)}.
  * @privateRemarks
  * Created from {@link IFluidHandleInternal} using {@link toFluidHandleErased}.
- * @public
+ * @sealed @public
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IFluidHandleErased<T> extends ErasedType<readonly ["IFluidHandle", T]> {}

--- a/packages/dds/shared-object-base/api-report/shared-object-base.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.alpha.api.md
@@ -113,7 +113,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
     abstract summarize(fullTree?: boolean, trackState?: boolean, telemetryContext?: ITelemetryContext): Promise<ISummaryTreeWithStats>;
 }
 
-// @public
+// @public @sealed
 export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
 }
 

--- a/packages/dds/shared-object-base/api-report/shared-object-base.beta.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.beta.api.md
@@ -28,7 +28,7 @@ import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/inter
 import { ITelemetryContext } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
 
-// @public
+// @public @sealed
 export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
 }
 

--- a/packages/dds/shared-object-base/api-report/shared-object-base.public.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.public.api.md
@@ -28,7 +28,7 @@ import { ISummaryTreeWithStats } from '@fluidframework/runtime-definitions/inter
 import { ITelemetryContext } from '@fluidframework/runtime-definitions/internal';
 import { ITelemetryLoggerExt } from '@fluidframework/telemetry-utils/internal';
 
-// @public
+// @public @sealed
 export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
 }
 

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -838,6 +838,7 @@ export interface ISharedObjectKind<TSharedObject> {
  * Type erased reference to an {@link ISharedObjectKind} or a DataObject class in for use in
  * `fluid-static`'s `IFluidContainer` and `ContainerSchema`.
  * Use {@link createSharedObjectKind} to creating an instance of this type.
+ * @sealed
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -33,13 +33,13 @@ export enum CommitKind {
     Undo = 1
 }
 
-// @public
+// @public @sealed
 export interface CommitMetadata {
     readonly isLocal: boolean;
     readonly kind: CommitKind;
 }
 
-// @public
+// @public @sealed
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
 }
 
@@ -49,7 +49,7 @@ type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? 
 // @public
 type FieldHasDefault<T extends ImplicitFieldSchema> = T extends FieldSchema<FieldKind.Optional | FieldKind.Identifier> ? true : false;
 
-// @public
+// @public @sealed
 type FieldHasDefaultUnsafe<T extends Unenforced<ImplicitFieldSchema>> = T extends FieldSchemaUnsafe<FieldKind.Optional | FieldKind.Identifier, Unenforced<ImplicitAllowedTypes>> ? true : false;
 
 // @public
@@ -139,7 +139,7 @@ Unhydrated<NodeFromSchemaUnsafe<T>> | (T extends {
 } ? NodeBuilderDataUnsafe<T> : never)
 ][_InlineTrick];
 
-// @public
+// @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
@@ -181,12 +181,12 @@ export { InternalTypes }
 // @public
 export type IsListener<TListener> = TListener extends (...args: any[]) => void ? true : false;
 
-// @public
+// @public @sealed
 export class IterableTreeArrayContent<T> implements Iterable<T> {
     [Symbol.iterator](): Iterator<T>;
 }
 
-// @public
+// @public @sealed
 export interface ITree extends IFluidLoadable {
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
@@ -205,7 +205,7 @@ export interface ITreeViewConfiguration<TSchema extends ImplicitFieldSchema = Im
 // @public
 export type LazyItem<Item = unknown> = Item | (() => Item);
 
-// @public
+// @public @sealed
 export interface Listenable<TListeners extends object> {
     on<K extends keyof Listeners<TListeners>>(eventName: K, listener: TListeners[K]): Off;
 }
@@ -215,7 +215,7 @@ export type Listeners<T extends object> = {
     [P in (string | symbol) & keyof T as IsListener<T[P]> extends true ? P : never]: T[P];
 };
 
-// @public
+// @public @sealed
 export interface MakeNominal {
 }
 
@@ -269,7 +269,7 @@ export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 
-// @public
+// @public @sealed
 export interface Revertible {
     dispose(): void;
     revert(): void;
@@ -277,7 +277,7 @@ export interface Revertible {
     readonly status: RevertibleStatus;
 }
 
-// @public
+// @public @sealed
 export type RevertibleFactory = (onRevertibleDisposed?: (revertible: Revertible) => void) => Revertible;
 
 // @public
@@ -289,7 +289,7 @@ export enum RevertibleStatus {
 // @public
 export const rollback: unique symbol;
 
-// @public
+// @public @sealed
 export interface RunTransaction {
     <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult): TResult;
     <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult): TResult;
@@ -306,7 +306,7 @@ export interface RunTransaction {
     readonly rollback: typeof rollback;
 }
 
-// @public
+// @public @sealed
 export interface SchemaCompatibilityStatus {
     readonly canInitialize: boolean;
     readonly canUpgrade: boolean;
@@ -358,22 +358,22 @@ export type TransactionConstraint = NodeInDocumentConstraint;
 // @public
 export const Tree: TreeApi;
 
-// @public
+// @public @sealed
 interface TreeApi extends TreeNodeApi {
     contains(node: TreeNode, other: TreeNode): boolean;
     readonly runTransaction: RunTransaction;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNode<TAllowedTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypes<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypes<TAllowedTypes>, TreeArrayNode> {
 }
 
 // @public
 export const TreeArrayNode: {
-    spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
+    readonly spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
 };
 
-// @public
+// @public @sealed
 interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T>, TreeNode {
     insertAt(index: number, ...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     insertAtEnd(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
@@ -394,11 +394,11 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     removeRange(start?: number, end?: number): void;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAllowedTypes>> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, TreeArrayNode> {
 }
 
-// @public
+// @public @sealed
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
@@ -413,7 +413,7 @@ type TreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<ImplicitFieldSc
 // @public
 export type TreeLeafValue = number | string | boolean | IFluidHandle | null;
 
-// @public
+// @public @sealed
 export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypes<T>>, TreeNode {
     delete(key: string): void;
     entries(): IterableIterator<[string, TreeNodeFromImplicitAllowedTypes<T>]>;
@@ -423,13 +423,13 @@ export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTyp
     values(): IterableIterator<TreeNodeFromImplicitAllowedTypes<T>>;
 }
 
-// @public
+// @public @sealed
 export interface TreeMapNodeUnsafe<T extends Unenforced<ImplicitAllowedTypes>> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypesUnsafe<T>>, TreeNode {
     delete(key: string): void;
     set(key: string, value: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T> | undefined): void;
 }
 
-// @public
+// @public @sealed
 export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
@@ -437,7 +437,7 @@ export abstract class TreeNode implements WithType {
     protected constructor();
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeApi {
     is<TSchema extends ImplicitAllowedTypes>(value: unknown, schema: TSchema): value is TreeNodeFromImplicitAllowedTypes<TSchema>;
     key(node: TreeNode): string | number;
@@ -454,16 +454,16 @@ export type TreeNodeFromImplicitAllowedTypes<TSchema extends ImplicitAllowedType
 // @public
 type TreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends Unenforced<ImplicitAllowedTypes>> = TSchema extends ImplicitAllowedTypes ? TreeNodeFromImplicitAllowedTypes<TSchema> : TSchema extends TreeNodeSchema ? NodeFromSchema<TSchema> : TSchema extends AllowedTypes ? NodeFromSchema<FlexListToUnion<TSchema>> : unknown;
 
-// @public
+// @public @sealed
 export type TreeNodeSchema<Name extends string = string, Kind extends NodeKind = NodeKind, TNode = unknown, TBuild = never, ImplicitlyConstructable extends boolean = boolean, Info = unknown> = TreeNodeSchemaClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info> | TreeNodeSchemaNonClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info>;
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // @sealed
     new (data: TInsertable | InternalTreeNode): Unhydrated<TNode>;
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaCore<out Name extends string, out Kind extends NodeKind, out ImplicitlyConstructable extends boolean, out Info = unknown> {
     // (undocumented)
     readonly identifier: Name;
@@ -473,7 +473,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly kind: Kind;
 }
 
-// @public
+// @public @sealed
 interface TreeNodeSchemaNonClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // (undocumented)
     create(data: TInsertable): TNode;
@@ -493,7 +493,7 @@ export enum TreeStatus {
     Removed = 1
 }
 
-// @public
+// @public @sealed
 export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable_2 {
     readonly compatibility: SchemaCompatibilityStatus;
     readonly events: Listenable<TreeViewEvents>;
@@ -503,14 +503,14 @@ export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposab
     upgradeSchema(): void;
 }
 
-// @public
+// @public @sealed
 export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> implements Required<ITreeViewConfiguration<TSchema>> {
     constructor(props: ITreeViewConfiguration<TSchema>);
     readonly enableSchemaValidation: boolean;
     readonly schema: TSchema;
 }
 
-// @public
+// @public @sealed
 export interface TreeViewEvents {
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
@@ -537,7 +537,7 @@ export type ValidateRecursiveSchema<T extends TreeNodeSchemaClass<string, NodeKi
     [NodeKind.Map]: ImplicitAllowedTypes;
 }[T["kind"]]>> = true;
 
-// @public
+// @public @sealed
 export interface WithType<TName extends string = string> {
     get [typeNameSymbol_2](): TName;
 }

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -33,13 +33,13 @@ export enum CommitKind {
     Undo = 1
 }
 
-// @public
+// @public @sealed
 export interface CommitMetadata {
     readonly isLocal: boolean;
     readonly kind: CommitKind;
 }
 
-// @public
+// @public @sealed
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
 }
 
@@ -49,7 +49,7 @@ type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? 
 // @public
 type FieldHasDefault<T extends ImplicitFieldSchema> = T extends FieldSchema<FieldKind.Optional | FieldKind.Identifier> ? true : false;
 
-// @public
+// @public @sealed
 type FieldHasDefaultUnsafe<T extends Unenforced<ImplicitFieldSchema>> = T extends FieldSchemaUnsafe<FieldKind.Optional | FieldKind.Identifier, Unenforced<ImplicitAllowedTypes>> ? true : false;
 
 // @public
@@ -139,7 +139,7 @@ Unhydrated<NodeFromSchemaUnsafe<T>> | (T extends {
 } ? NodeBuilderDataUnsafe<T> : never)
 ][_InlineTrick];
 
-// @public
+// @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
@@ -181,12 +181,12 @@ export { InternalTypes }
 // @public
 export type IsListener<TListener> = TListener extends (...args: any[]) => void ? true : false;
 
-// @public
+// @public @sealed
 export class IterableTreeArrayContent<T> implements Iterable<T> {
     [Symbol.iterator](): Iterator<T>;
 }
 
-// @public
+// @public @sealed
 export interface ITree extends IFluidLoadable {
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
@@ -205,7 +205,7 @@ export interface ITreeViewConfiguration<TSchema extends ImplicitFieldSchema = Im
 // @public
 export type LazyItem<Item = unknown> = Item | (() => Item);
 
-// @public
+// @public @sealed
 export interface Listenable<TListeners extends object> {
     on<K extends keyof Listeners<TListeners>>(eventName: K, listener: TListeners[K]): Off;
 }
@@ -215,7 +215,7 @@ export type Listeners<T extends object> = {
     [P in (string | symbol) & keyof T as IsListener<T[P]> extends true ? P : never]: T[P];
 };
 
-// @public
+// @public @sealed
 export interface MakeNominal {
 }
 
@@ -269,7 +269,7 @@ export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 
-// @public
+// @public @sealed
 export interface Revertible {
     dispose(): void;
     revert(): void;
@@ -277,7 +277,7 @@ export interface Revertible {
     readonly status: RevertibleStatus;
 }
 
-// @public
+// @public @sealed
 export type RevertibleFactory = (onRevertibleDisposed?: (revertible: Revertible) => void) => Revertible;
 
 // @public
@@ -289,7 +289,7 @@ export enum RevertibleStatus {
 // @public
 export const rollback: unique symbol;
 
-// @public
+// @public @sealed
 export interface RunTransaction {
     <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult): TResult;
     <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult): TResult;
@@ -306,7 +306,7 @@ export interface RunTransaction {
     readonly rollback: typeof rollback;
 }
 
-// @public
+// @public @sealed
 export interface SchemaCompatibilityStatus {
     readonly canInitialize: boolean;
     readonly canUpgrade: boolean;
@@ -355,22 +355,22 @@ export type TransactionConstraint = NodeInDocumentConstraint;
 // @public
 export const Tree: TreeApi;
 
-// @public
+// @public @sealed
 interface TreeApi extends TreeNodeApi {
     contains(node: TreeNode, other: TreeNode): boolean;
     readonly runTransaction: RunTransaction;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNode<TAllowedTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypes<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypes<TAllowedTypes>, TreeArrayNode> {
 }
 
 // @public
 export const TreeArrayNode: {
-    spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
+    readonly spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
 };
 
-// @public
+// @public @sealed
 interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T>, TreeNode {
     insertAt(index: number, ...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     insertAtEnd(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
@@ -391,11 +391,11 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     removeRange(start?: number, end?: number): void;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAllowedTypes>> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, TreeArrayNode> {
 }
 
-// @public
+// @public @sealed
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
@@ -410,7 +410,7 @@ type TreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<ImplicitFieldSc
 // @public
 export type TreeLeafValue = number | string | boolean | IFluidHandle | null;
 
-// @public
+// @public @sealed
 export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypes<T>>, TreeNode {
     delete(key: string): void;
     entries(): IterableIterator<[string, TreeNodeFromImplicitAllowedTypes<T>]>;
@@ -420,13 +420,13 @@ export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTyp
     values(): IterableIterator<TreeNodeFromImplicitAllowedTypes<T>>;
 }
 
-// @public
+// @public @sealed
 export interface TreeMapNodeUnsafe<T extends Unenforced<ImplicitAllowedTypes>> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypesUnsafe<T>>, TreeNode {
     delete(key: string): void;
     set(key: string, value: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T> | undefined): void;
 }
 
-// @public
+// @public @sealed
 export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
@@ -434,7 +434,7 @@ export abstract class TreeNode implements WithType {
     protected constructor();
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeApi {
     is<TSchema extends ImplicitAllowedTypes>(value: unknown, schema: TSchema): value is TreeNodeFromImplicitAllowedTypes<TSchema>;
     key(node: TreeNode): string | number;
@@ -451,16 +451,16 @@ export type TreeNodeFromImplicitAllowedTypes<TSchema extends ImplicitAllowedType
 // @public
 type TreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends Unenforced<ImplicitAllowedTypes>> = TSchema extends ImplicitAllowedTypes ? TreeNodeFromImplicitAllowedTypes<TSchema> : TSchema extends TreeNodeSchema ? NodeFromSchema<TSchema> : TSchema extends AllowedTypes ? NodeFromSchema<FlexListToUnion<TSchema>> : unknown;
 
-// @public
+// @public @sealed
 export type TreeNodeSchema<Name extends string = string, Kind extends NodeKind = NodeKind, TNode = unknown, TBuild = never, ImplicitlyConstructable extends boolean = boolean, Info = unknown> = TreeNodeSchemaClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info> | TreeNodeSchemaNonClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info>;
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // @sealed
     new (data: TInsertable | InternalTreeNode): Unhydrated<TNode>;
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaCore<out Name extends string, out Kind extends NodeKind, out ImplicitlyConstructable extends boolean, out Info = unknown> {
     // (undocumented)
     readonly identifier: Name;
@@ -470,7 +470,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly kind: Kind;
 }
 
-// @public
+// @public @sealed
 interface TreeNodeSchemaNonClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // (undocumented)
     create(data: TInsertable): TNode;
@@ -490,7 +490,7 @@ export enum TreeStatus {
     Removed = 1
 }
 
-// @public
+// @public @sealed
 export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable_2 {
     readonly compatibility: SchemaCompatibilityStatus;
     readonly events: Listenable<TreeViewEvents>;
@@ -500,14 +500,14 @@ export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposab
     upgradeSchema(): void;
 }
 
-// @public
+// @public @sealed
 export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> implements Required<ITreeViewConfiguration<TSchema>> {
     constructor(props: ITreeViewConfiguration<TSchema>);
     readonly enableSchemaValidation: boolean;
     readonly schema: TSchema;
 }
 
-// @public
+// @public @sealed
 export interface TreeViewEvents {
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
@@ -534,7 +534,7 @@ export type ValidateRecursiveSchema<T extends TreeNodeSchemaClass<string, NodeKi
     [NodeKind.Map]: ImplicitAllowedTypes;
 }[T["kind"]]>> = true;
 
-// @public
+// @public @sealed
 export interface WithType<TName extends string = string> {
     get [typeNameSymbol_2](): TName;
 }

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -33,13 +33,13 @@ export enum CommitKind {
     Undo = 1
 }
 
-// @public
+// @public @sealed
 export interface CommitMetadata {
     readonly isLocal: boolean;
     readonly kind: CommitKind;
 }
 
-// @public
+// @public @sealed
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
 }
 
@@ -49,7 +49,7 @@ type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? 
 // @public
 type FieldHasDefault<T extends ImplicitFieldSchema> = T extends FieldSchema<FieldKind.Optional | FieldKind.Identifier> ? true : false;
 
-// @public
+// @public @sealed
 type FieldHasDefaultUnsafe<T extends Unenforced<ImplicitFieldSchema>> = T extends FieldSchemaUnsafe<FieldKind.Optional | FieldKind.Identifier, Unenforced<ImplicitAllowedTypes>> ? true : false;
 
 // @public
@@ -139,7 +139,7 @@ Unhydrated<NodeFromSchemaUnsafe<T>> | (T extends {
 } ? NodeBuilderDataUnsafe<T> : never)
 ][_InlineTrick];
 
-// @public
+// @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
@@ -181,12 +181,12 @@ export { InternalTypes }
 // @public
 export type IsListener<TListener> = TListener extends (...args: any[]) => void ? true : false;
 
-// @public
+// @public @sealed
 export class IterableTreeArrayContent<T> implements Iterable<T> {
     [Symbol.iterator](): Iterator<T>;
 }
 
-// @public
+// @public @sealed
 export interface ITree extends IFluidLoadable {
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
@@ -205,7 +205,7 @@ export interface ITreeViewConfiguration<TSchema extends ImplicitFieldSchema = Im
 // @public
 export type LazyItem<Item = unknown> = Item | (() => Item);
 
-// @public
+// @public @sealed
 export interface Listenable<TListeners extends object> {
     on<K extends keyof Listeners<TListeners>>(eventName: K, listener: TListeners[K]): Off;
 }
@@ -215,7 +215,7 @@ export type Listeners<T extends object> = {
     [P in (string | symbol) & keyof T as IsListener<T[P]> extends true ? P : never]: T[P];
 };
 
-// @public
+// @public @sealed
 export interface MakeNominal {
 }
 
@@ -269,7 +269,7 @@ export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 
-// @public
+// @public @sealed
 export interface Revertible {
     dispose(): void;
     revert(): void;
@@ -277,7 +277,7 @@ export interface Revertible {
     readonly status: RevertibleStatus;
 }
 
-// @public
+// @public @sealed
 export type RevertibleFactory = (onRevertibleDisposed?: (revertible: Revertible) => void) => Revertible;
 
 // @public
@@ -289,7 +289,7 @@ export enum RevertibleStatus {
 // @public
 export const rollback: unique symbol;
 
-// @public
+// @public @sealed
 export interface RunTransaction {
     <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult): TResult;
     <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult): TResult;
@@ -306,7 +306,7 @@ export interface RunTransaction {
     readonly rollback: typeof rollback;
 }
 
-// @public
+// @public @sealed
 export interface SchemaCompatibilityStatus {
     readonly canInitialize: boolean;
     readonly canUpgrade: boolean;
@@ -355,22 +355,22 @@ export type TransactionConstraint = NodeInDocumentConstraint;
 // @public
 export const Tree: TreeApi;
 
-// @public
+// @public @sealed
 interface TreeApi extends TreeNodeApi {
     contains(node: TreeNode, other: TreeNode): boolean;
     readonly runTransaction: RunTransaction;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNode<TAllowedTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypes<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypes<TAllowedTypes>, TreeArrayNode> {
 }
 
 // @public
 export const TreeArrayNode: {
-    spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
+    readonly spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
 };
 
-// @public
+// @public @sealed
 interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T>, TreeNode {
     insertAt(index: number, ...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     insertAtEnd(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
@@ -391,11 +391,11 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     removeRange(start?: number, end?: number): void;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAllowedTypes>> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, TreeArrayNode> {
 }
 
-// @public
+// @public @sealed
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
@@ -410,7 +410,7 @@ type TreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<ImplicitFieldSc
 // @public
 export type TreeLeafValue = number | string | boolean | IFluidHandle | null;
 
-// @public
+// @public @sealed
 export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypes<T>>, TreeNode {
     delete(key: string): void;
     entries(): IterableIterator<[string, TreeNodeFromImplicitAllowedTypes<T>]>;
@@ -420,13 +420,13 @@ export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTyp
     values(): IterableIterator<TreeNodeFromImplicitAllowedTypes<T>>;
 }
 
-// @public
+// @public @sealed
 export interface TreeMapNodeUnsafe<T extends Unenforced<ImplicitAllowedTypes>> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypesUnsafe<T>>, TreeNode {
     delete(key: string): void;
     set(key: string, value: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T> | undefined): void;
 }
 
-// @public
+// @public @sealed
 export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
@@ -434,7 +434,7 @@ export abstract class TreeNode implements WithType {
     protected constructor();
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeApi {
     is<TSchema extends ImplicitAllowedTypes>(value: unknown, schema: TSchema): value is TreeNodeFromImplicitAllowedTypes<TSchema>;
     key(node: TreeNode): string | number;
@@ -451,16 +451,16 @@ export type TreeNodeFromImplicitAllowedTypes<TSchema extends ImplicitAllowedType
 // @public
 type TreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends Unenforced<ImplicitAllowedTypes>> = TSchema extends ImplicitAllowedTypes ? TreeNodeFromImplicitAllowedTypes<TSchema> : TSchema extends TreeNodeSchema ? NodeFromSchema<TSchema> : TSchema extends AllowedTypes ? NodeFromSchema<FlexListToUnion<TSchema>> : unknown;
 
-// @public
+// @public @sealed
 export type TreeNodeSchema<Name extends string = string, Kind extends NodeKind = NodeKind, TNode = unknown, TBuild = never, ImplicitlyConstructable extends boolean = boolean, Info = unknown> = TreeNodeSchemaClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info> | TreeNodeSchemaNonClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info>;
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // @sealed
     new (data: TInsertable | InternalTreeNode): Unhydrated<TNode>;
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaCore<out Name extends string, out Kind extends NodeKind, out ImplicitlyConstructable extends boolean, out Info = unknown> {
     // (undocumented)
     readonly identifier: Name;
@@ -470,7 +470,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly kind: Kind;
 }
 
-// @public
+// @public @sealed
 interface TreeNodeSchemaNonClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // (undocumented)
     create(data: TInsertable): TNode;
@@ -490,7 +490,7 @@ export enum TreeStatus {
     Removed = 1
 }
 
-// @public
+// @public @sealed
 export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable_2 {
     readonly compatibility: SchemaCompatibilityStatus;
     readonly events: Listenable<TreeViewEvents>;
@@ -500,14 +500,14 @@ export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposab
     upgradeSchema(): void;
 }
 
-// @public
+// @public @sealed
 export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> implements Required<ITreeViewConfiguration<TSchema>> {
     constructor(props: ITreeViewConfiguration<TSchema>);
     readonly enableSchemaValidation: boolean;
     readonly schema: TSchema;
 }
 
-// @public
+// @public @sealed
 export interface TreeViewEvents {
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
@@ -534,7 +534,7 @@ export type ValidateRecursiveSchema<T extends TreeNodeSchemaClass<string, NodeKi
     [NodeKind.Map]: ImplicitAllowedTypes;
 }[T["kind"]]>> = true;
 
-// @public
+// @public @sealed
 export interface WithType<TName extends string = string> {
     get [typeNameSymbol_2](): TName;
 }

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -169,7 +169,7 @@ export enum CommitKind {
 /**
  * Information about a commit that has been applied.
  *
- * @public
+ * @sealed @public
  */
 export interface CommitMetadata {
 	/**

--- a/packages/dds/tree/src/core/revertible/revertible.ts
+++ b/packages/dds/tree/src/core/revertible/revertible.ts
@@ -9,7 +9,7 @@
  * @remarks
  * Applications wanting to implement undo/redo support might typically maintain two stacks of Revertibles, with optional eviction policy to free up memory.
  *
- * @public
+ * @sealed @public
  */
 export interface Revertible {
 	/**

--- a/packages/dds/tree/src/events/events.ts
+++ b/packages/dds/tree/src/events/events.ts
@@ -85,7 +85,7 @@ export type TransformListeners<
  * ```
  * {@link createEmitter} can help implement this interface via delegation.
  *
- * @public
+ * @sealed @public
  */
 export interface Listenable<TListeners extends object> {
 	/**

--- a/packages/dds/tree/src/feature-libraries/typed-schema/flexList.ts
+++ b/packages/dds/tree/src/feature-libraries/typed-schema/flexList.ts
@@ -108,9 +108,6 @@ export type ExtractListItemType<List extends FlexList> = List extends FlexList<i
 	? Item
 	: unknown;
 
-/**
- * @public
- */
 export type NormalizeLazyItem<List extends LazyItem> = List extends () => unknown
 	? List
 	: () => List;

--- a/packages/dds/tree/src/shared-tree/treeApi.ts
+++ b/packages/dds/tree/src/shared-tree/treeApi.ts
@@ -31,7 +31,7 @@ export const rollback = Symbol("SharedTree Transaction Rollback");
  * @privateRemarks
  * This interface exists so that the (generously) overloaded `Tree.runTransaction` function can have the "rollback" property hanging off of it.
  * The rollback property being available on the function itself gives users a convenient option for rolling back a transaction without having to import another symbol.
- * @public
+ * @sealed @public
  */
 export interface RunTransaction {
 	/**
@@ -326,7 +326,7 @@ export interface RunTransaction {
  * This type should only be used via the public `Tree` export.
  * @privateRemarks
  * Due to limitations of API-Extractor link resolution, this type can't be moved into internalTypes but should be considered just an implementation detail of the `Tree` export.
- * @public
+ * @sealed @public
  */
 export interface TreeApi extends TreeNodeApi {
 	/**

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -97,7 +97,7 @@ export interface CheckoutEvents {
  * whichever happens first.
  * This is typically used to clean up any resources associated with the `Revertible` in the host application.
  *
- * @public
+ * @sealed @public
  */
 export type RevertibleFactory = (
 	onRevertibleDisposed?: (revertible: Revertible) => void,

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -51,7 +51,7 @@ import { assert } from "@fluidframework/core-utils/internal";
  * @privateRemarks
  * Inlining this into TreeArrayNode causes recursive array use to stop compiling.
  *
- * @public
+ * @sealed @public
  */
 export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
 	extends ReadonlyArray<T>,
@@ -222,7 +222,7 @@ export interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom>
  *
  * @typeParam TAllowedTypes - Schema for types which are allowed as members of this array.
  *
- * @public
+ * @sealed @public
  */
 export interface TreeArrayNode<
 	TAllowedTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes,
@@ -248,7 +248,7 @@ export const TreeArrayNode = {
 	 * ```
 	 */
 	spread: <T>(content: Iterable<T>) => create(content),
-};
+} as const;
 
 /**
  * Package internal construction API.
@@ -259,7 +259,7 @@ let create: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
 /**
  * Used to insert iterable content into a {@link (TreeArrayNode:interface)}.
  * Use {@link (TreeArrayNode:variable).spread} to create an instance of this type.
- * @public
+ * @sealed @public
  */
 export class IterableTreeArrayContent<T> implements Iterable<T> {
 	static {

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -42,7 +42,7 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
  * @privateRemarks
  * Add support for `clear` once we have established merge semantics for it.
  *
- * @public
+ * @sealed @public
  */
 export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTypes>
 	extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypes<T>>,

--- a/packages/dds/tree/src/simple-tree/schemaTypes.ts
+++ b/packages/dds/tree/src/simple-tree/schemaTypes.ts
@@ -27,7 +27,7 @@ import type { InsertableContent } from "./proxies.js";
  * @typeParam Info - Data used when defining this schema.
  * @remarks
  * Captures the schema both as runtime data and compile time type information.
- * @public
+ * @sealed @public
  */
 export type TreeNodeSchema<
 	Name extends string = string,
@@ -46,7 +46,7 @@ export type TreeNodeSchema<
  * This is used for schema which cannot have their instances constructed using constructors, like leaf schema.
  * @privateRemarks
  * Non-class based schema can have issues with recursive types due to https://github.com/microsoft/TypeScript/issues/55832.
- * @public
+ * @sealed @public
  */
 export interface TreeNodeSchemaNonClass<
 	out Name extends string = string,
@@ -67,7 +67,7 @@ export interface TreeNodeSchemaNonClass<
  *
  * Using classes in this way allows introducing a named type and a named value at the same time, helping keep the runtime and compile time information together and easy to refer to un a uniform way.
  * Additionally, this works around https://github.com/microsoft/TypeScript/issues/55832 which causes similar patterns with less explicit types to infer "any" in the d.ts file.
- * @public
+ * @sealed @public
  */
 export interface TreeNodeSchemaClass<
 	out Name extends string = string,
@@ -91,7 +91,7 @@ export interface TreeNodeSchemaClass<
  * Data common to all tree node schema.
  * @remarks
  * Implementation detail of {@link TreeNodeSchema} which should be accessed instead of referring to this type directly.
- * @public
+ * @sealed @public
  */
 export interface TreeNodeSchemaCore<
 	out Name extends string,
@@ -135,6 +135,8 @@ export type AllowedTypes = readonly LazyItem<TreeNodeSchema>[];
 
 /**
  * Kind of a field on a node.
+ * @remarks
+ * More kinds may be added over time, so do not assume this is an exhaustive set.
  * @public
  */
 export enum FieldKind {
@@ -160,6 +162,8 @@ export enum FieldKind {
 
 /**
  * Kind of tree node.
+ * @remarks
+ * More kinds may be added over time, so do not assume this is an exhaustive set.
  * @public
  */
 export enum NodeKind {
@@ -295,7 +299,7 @@ export function isConstant(
  * Provides a default value for a field.
  * @remarks
  * If present in a `FieldSchema`, when constructing new tree content that field can be omitted, and a default will be provided.
- * @public
+ * @sealed @public
  */
 export interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {}
 
@@ -557,7 +561,7 @@ export const typeNameSymbol: unique symbol = Symbol("TreeNode Type");
  * Adds a type symbol to a type for stronger typing.
  * @remarks
  * An implementation detail of {@link TreeNode}'s strong typing setup: not intended for direct use outside of this package.
- * @public
+ * @sealed @public
  */
 export interface WithType<TName extends string = string> {
 	/**

--- a/packages/dds/tree/src/simple-tree/tree.ts
+++ b/packages/dds/tree/src/simple-tree/tree.ts
@@ -19,7 +19,7 @@ import type {
  * Channel for a Fluid Tree DDS.
  * @remarks
  * Allows storing and collaboratively editing schema-aware hierarchial data.
- * @public
+ * @sealed @public
  */
 export interface ITree extends IFluidLoadable {
 	/**
@@ -108,7 +108,7 @@ export interface ITreeViewConfiguration<
 
 /**
  * Configuration for {@link ITree.viewWith}.
- * @public
+ * @sealed @public
  */
 export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema>
 	implements Required<ITreeViewConfiguration<TSchema>>
@@ -135,7 +135,7 @@ export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = Implici
 
 /**
  * Configuration for how to {@link ITree.schematize | schematize} a tree.
- * @public
+ * @sealed @public
  * @deprecated Please migrate to use {@link TreeViewConfiguration} with {@link ITree.viewWith} instead.
  */
 export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {
@@ -185,7 +185,7 @@ export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFie
  * Doing that would however complicate trivial "hello world" style example slightly, as well as be a breaking API change.
  * It also seems more complex to handle invalidation with that pattern.
  * Thus this design was chosen at the risk of apps blindly accessing `root` then breaking unexpectedly when the document is incompatible.
- * @public
+ * @sealed @public
  */
 export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable {
 	/**
@@ -247,7 +247,7 @@ export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposab
  * Information about a view schema's compatibility with the document's stored schema.
  *
  * See SharedTree's README for more information about choosing a compatibility policy.
- * @public
+ * @sealed @public
  */
 export interface SchemaCompatibilityStatus {
 	/**
@@ -321,7 +321,7 @@ export interface SchemaCompatibilityStatus {
 
 /**
  * Events for {@link TreeView}.
- * @public
+ * @sealed @public
  */
 export interface TreeViewEvents {
 	/**

--- a/packages/dds/tree/src/simple-tree/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/treeNodeApi.ts
@@ -48,7 +48,7 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
  * Inlining the typing of this interface onto the `Tree` object provides slightly different .d.ts generation,
  * which avoids typescript expanding the type of TreeNodeSchema and thus encountering
  * https://github.com/microsoft/rushstack/issues/1958.
- * @public
+ * @sealed @public
  */
 export interface TreeNodeApi {
 	/**
@@ -324,7 +324,7 @@ function getViewKeyFromStoredKey(
  * Add separate (non event related) API to efficiently scan tree for given set of types (using low level cursor and schema based filtering)
  * to allow efficiently searching for new content (and initial content) of a given type.
  *
- * @public
+ * @sealed @public
  */
 export interface TreeChangeEvents {
 	/**

--- a/packages/dds/tree/src/simple-tree/types.ts
+++ b/packages/dds/tree/src/simple-tree/types.ts
@@ -58,7 +58,7 @@ export type Unhydrated<T> = T;
  * and thus cause the default/built in `instanceof` to return false despite our type checking and all other APIs treating them as TreeNodes.
  * This class provides a custom `Symbol.hasInstance` to fix `instanceof` for this class and all classes extending it.
  * For now the type-only export prevents use of `instanceof` on this class (but allows it in subclasses like schema classes).
- * @public
+ * @sealed @public
  */
 export abstract class TreeNode implements WithType {
 	/**
@@ -284,7 +284,7 @@ markEager(TreeNodeValid);
  * This type is used in the construction of {@link TreeNode} as an implementation detail, but leaks into the public API due to how schema are implemented.
  * @privateRemarks
  * A {@link FlexTreeNode}. Includes {@link RawTreeNode}s.
- * @public
+ * @sealed @public
  */
 export interface InternalTreeNode
 	extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {}

--- a/packages/dds/tree/src/simple-tree/typesUnsafe.ts
+++ b/packages/dds/tree/src/simple-tree/typesUnsafe.ts
@@ -131,7 +131,7 @@ export type NodeBuilderDataUnsafe<T extends Unenforced<TreeNodeSchema>> =
  * {@link Unenforced} version of {@link (TreeArrayNode:interface)}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @sealed @public
  */
 export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAllowedTypes>>
 	extends TreeArrayNodeBase<
@@ -144,7 +144,7 @@ export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAl
  * {@link Unenforced} version of {@link TreeMapNode}.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @sealed @public
  */
 export interface TreeMapNodeUnsafe<T extends Unenforced<ImplicitAllowedTypes>>
 	extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypesUnsafe<T>>,
@@ -167,7 +167,7 @@ export interface TreeMapNodeUnsafe<T extends Unenforced<ImplicitAllowedTypes>>
  * {@link Unenforced} version of `FieldHasDefault`.
  * @remarks
  * Do note use this type directly: its only needed in the implementation of generic logic which define recursive schema, not when using recursive schema.
- * @public
+ * @sealed @public
  */
 export type FieldHasDefaultUnsafe<T extends Unenforced<ImplicitFieldSchema>> =
 	T extends FieldSchemaUnsafe<

--- a/packages/dds/tree/src/util/typeCheck.ts
+++ b/packages/dds/tree/src/util/typeCheck.ts
@@ -82,7 +82,7 @@ export type { EnforceTypeCheckTests } from "./typeCheckTests.js";
  * ```
  * @privateRemarks
  * See: {@link https://dev.azure.com/intentional/intent/_wiki/wikis/NP%20Platform/7146/Nominal-vs-Structural-Types}
- * @public
+ * @sealed @public
  */
 export interface MakeNominal {}
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -55,7 +55,7 @@ export enum CommitKind {
     Undo = 1
 }
 
-// @public
+// @public @sealed
 export interface CommitMetadata {
     readonly isLocal: boolean;
     readonly kind: CommitKind;
@@ -89,7 +89,7 @@ export interface ContainerSchema {
     readonly initialObjects: Record<string, SharedObjectKind>;
 }
 
-// @public
+// @public @sealed
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
 }
 
@@ -108,7 +108,7 @@ type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? 
 // @public
 type FieldHasDefault<T extends ImplicitFieldSchema> = T extends FieldSchema<FieldKind.Optional | FieldKind.Identifier> ? true : false;
 
-// @public
+// @public @sealed
 type FieldHasDefaultUnsafe<T extends Unenforced<ImplicitFieldSchema>> = T extends FieldSchemaUnsafe<FieldKind.Optional | FieldKind.Identifier, Unenforced<ImplicitAllowedTypes>> ? true : false;
 
 // @public
@@ -230,7 +230,7 @@ export interface IEvent {
     (event: string, listener: (...args: any[]) => void): any;
 }
 
-// @public
+// @public @sealed
 export interface IEventProvider<TEvent extends IEvent> {
     readonly off: IEventTransformer<this, TEvent>;
     readonly on: IEventTransformer<this, TEvent>;
@@ -421,21 +421,21 @@ export interface IFluidContainerEvents extends IEvent {
 // @public (undocumented)
 export const IFluidHandle = "IFluidHandle";
 
-// @public
+// @public @sealed
 export interface IFluidHandle<out T = unknown> {
     readonly [fluidHandleSymbol]: IFluidHandleErased<T>;
     get(): Promise<T>;
     readonly isAttached: boolean;
 }
 
-// @public
+// @public @sealed
 export interface IFluidHandleErased<T> extends ErasedType<readonly ["IFluidHandle", T]> {
 }
 
 // @public (undocumented)
 export const IFluidLoadable: keyof IProvideFluidLoadable;
 
-// @public
+// @public @sealed
 export interface IFluidLoadable extends IProvideFluidLoadable {
     // (undocumented)
     readonly handle: IFluidHandle;
@@ -569,7 +569,7 @@ export interface InteriorSequencePlace {
     side: Side;
 }
 
-// @public
+// @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
@@ -829,7 +829,7 @@ export interface ITelemetryBaseProperties {
     [index: string]: TelemetryBaseEventPropertyType | Tagged<TelemetryBaseEventPropertyType>;
 }
 
-// @public
+// @public @sealed
 export class IterableTreeArrayContent<T> implements Iterable<T> {
     [Symbol.iterator](): Iterator<T>;
 }
@@ -841,7 +841,7 @@ export interface ITrace {
     timestamp: number;
 }
 
-// @public
+// @public @sealed
 export interface ITree extends IFluidLoadable {
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
@@ -866,7 +866,7 @@ export interface IValueChanged {
 // @public
 export type LazyItem<Item = unknown> = Item | (() => Item);
 
-// @public
+// @public @sealed
 export interface Listenable<TListeners extends object> {
     on<K extends keyof Listeners<TListeners>>(eventName: K, listener: TListeners[K]): Off;
 }
@@ -876,7 +876,7 @@ export type Listeners<T extends object> = {
     [P in (string | symbol) & keyof T as IsListener<T[P]> extends true ? P : never]: T[P];
 };
 
-// @public
+// @public @sealed
 export interface MakeNominal {
 }
 
@@ -939,7 +939,7 @@ export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 
-// @public
+// @public @sealed
 export interface Revertible {
     dispose(): void;
     revert(): void;
@@ -947,7 +947,7 @@ export interface Revertible {
     readonly status: RevertibleStatus;
 }
 
-// @public
+// @public @sealed
 export type RevertibleFactory = (onRevertibleDisposed?: (revertible: Revertible) => void) => Revertible;
 
 // @public
@@ -959,7 +959,7 @@ export enum RevertibleStatus {
 // @public
 export const rollback: unique symbol;
 
-// @public
+// @public @sealed
 export interface RunTransaction {
     <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult): TResult;
     <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult): TResult;
@@ -976,7 +976,7 @@ export interface RunTransaction {
     readonly rollback: typeof rollback;
 }
 
-// @public
+// @public @sealed
 export interface SchemaCompatibilityStatus {
     readonly canInitialize: boolean;
     readonly canUpgrade: boolean;
@@ -1100,7 +1100,7 @@ export const SharedMap: ISharedObjectKind<ISharedMap> & SharedObjectKind_2<IShar
 // @alpha
 export type SharedMap = ISharedMap;
 
-// @public
+// @public @sealed
 export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
 }
 
@@ -1144,22 +1144,22 @@ export type TransformedEvent<TThis, E, A extends any[]> = (event: E, listener: (
 // @public
 export const Tree: TreeApi;
 
-// @public
+// @public @sealed
 interface TreeApi extends TreeNodeApi {
     contains(node: TreeNode, other: TreeNode): boolean;
     readonly runTransaction: RunTransaction;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNode<TAllowedTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypes<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypes<TAllowedTypes>, TreeArrayNode> {
 }
 
 // @public
 export const TreeArrayNode: {
-    spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
+    readonly spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
 };
 
-// @public
+// @public @sealed
 interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T>, TreeNode {
     insertAt(index: number, ...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     insertAtEnd(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
@@ -1180,11 +1180,11 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     removeRange(start?: number, end?: number): void;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAllowedTypes>> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, TreeArrayNode> {
 }
 
-// @public
+// @public @sealed
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
@@ -1199,7 +1199,7 @@ type TreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<ImplicitFieldSc
 // @public
 export type TreeLeafValue = number | string | boolean | IFluidHandle | null;
 
-// @public
+// @public @sealed
 export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypes<T>>, TreeNode {
     delete(key: string): void;
     entries(): IterableIterator<[string, TreeNodeFromImplicitAllowedTypes<T>]>;
@@ -1209,13 +1209,13 @@ export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTyp
     values(): IterableIterator<TreeNodeFromImplicitAllowedTypes<T>>;
 }
 
-// @public
+// @public @sealed
 export interface TreeMapNodeUnsafe<T extends Unenforced<ImplicitAllowedTypes>> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypesUnsafe<T>>, TreeNode {
     delete(key: string): void;
     set(key: string, value: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T> | undefined): void;
 }
 
-// @public
+// @public @sealed
 export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
@@ -1223,7 +1223,7 @@ export abstract class TreeNode implements WithType {
     protected constructor();
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeApi {
     is<TSchema extends ImplicitAllowedTypes>(value: unknown, schema: TSchema): value is TreeNodeFromImplicitAllowedTypes<TSchema>;
     key(node: TreeNode): string | number;
@@ -1240,16 +1240,16 @@ export type TreeNodeFromImplicitAllowedTypes<TSchema extends ImplicitAllowedType
 // @public
 type TreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends Unenforced<ImplicitAllowedTypes>> = TSchema extends ImplicitAllowedTypes ? TreeNodeFromImplicitAllowedTypes<TSchema> : TSchema extends TreeNodeSchema ? NodeFromSchema<TSchema> : TSchema extends AllowedTypes ? NodeFromSchema<FlexListToUnion<TSchema>> : unknown;
 
-// @public
+// @public @sealed
 export type TreeNodeSchema<Name extends string = string, Kind extends NodeKind = NodeKind, TNode = unknown, TBuild = never, ImplicitlyConstructable extends boolean = boolean, Info = unknown> = TreeNodeSchemaClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info> | TreeNodeSchemaNonClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info>;
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // @sealed
     new (data: TInsertable | InternalTreeNode): Unhydrated<TNode>;
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaCore<out Name extends string, out Kind extends NodeKind, out ImplicitlyConstructable extends boolean, out Info = unknown> {
     // (undocumented)
     readonly identifier: Name;
@@ -1259,7 +1259,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly kind: Kind;
 }
 
-// @public
+// @public @sealed
 interface TreeNodeSchemaNonClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // (undocumented)
     create(data: TInsertable): TNode;
@@ -1279,7 +1279,7 @@ export enum TreeStatus {
     Removed = 1
 }
 
-// @public
+// @public @sealed
 export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable {
     readonly compatibility: SchemaCompatibilityStatus;
     readonly events: Listenable<TreeViewEvents>;
@@ -1289,14 +1289,14 @@ export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposab
     upgradeSchema(): void;
 }
 
-// @public
+// @public @sealed
 export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> implements Required<ITreeViewConfiguration<TSchema>> {
     constructor(props: ITreeViewConfiguration<TSchema>);
     readonly enableSchemaValidation: boolean;
     readonly schema: TSchema;
 }
 
-// @public
+// @public @sealed
 export interface TreeViewEvents {
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
@@ -1323,7 +1323,7 @@ export type ValidateRecursiveSchema<T extends TreeNodeSchemaClass<string, NodeKi
     [NodeKind.Map]: ImplicitAllowedTypes;
 }[T["kind"]]>> = true;
 
-// @public
+// @public @sealed
 export interface WithType<TName extends string = string> {
     get [typeNameSymbol](): TName;
 }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -55,7 +55,7 @@ export enum CommitKind {
     Undo = 1
 }
 
-// @public
+// @public @sealed
 export interface CommitMetadata {
     readonly isLocal: boolean;
     readonly kind: CommitKind;
@@ -89,7 +89,7 @@ export interface ContainerSchema {
     readonly initialObjects: Record<string, SharedObjectKind>;
 }
 
-// @public
+// @public @sealed
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
 }
 
@@ -105,7 +105,7 @@ type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? 
 // @public
 type FieldHasDefault<T extends ImplicitFieldSchema> = T extends FieldSchema<FieldKind.Optional | FieldKind.Identifier> ? true : false;
 
-// @public
+// @public @sealed
 type FieldHasDefaultUnsafe<T extends Unenforced<ImplicitFieldSchema>> = T extends FieldSchemaUnsafe<FieldKind.Optional | FieldKind.Identifier, Unenforced<ImplicitAllowedTypes>> ? true : false;
 
 // @public
@@ -192,7 +192,7 @@ export interface IEvent {
     (event: string, listener: (...args: any[]) => void): any;
 }
 
-// @public
+// @public @sealed
 export interface IEventProvider<TEvent extends IEvent> {
     readonly off: IEventTransformer<this, TEvent>;
     readonly on: IEventTransformer<this, TEvent>;
@@ -383,21 +383,21 @@ export interface IFluidContainerEvents extends IEvent {
 // @public (undocumented)
 export const IFluidHandle = "IFluidHandle";
 
-// @public
+// @public @sealed
 export interface IFluidHandle<out T = unknown> {
     readonly [fluidHandleSymbol]: IFluidHandleErased<T>;
     get(): Promise<T>;
     readonly isAttached: boolean;
 }
 
-// @public
+// @public @sealed
 export interface IFluidHandleErased<T> extends ErasedType<readonly ["IFluidHandle", T]> {
 }
 
 // @public (undocumented)
 export const IFluidLoadable: keyof IProvideFluidLoadable;
 
-// @public
+// @public @sealed
 export interface IFluidLoadable extends IProvideFluidLoadable {
     // (undocumented)
     readonly handle: IFluidHandle;
@@ -461,7 +461,7 @@ Unhydrated<NodeFromSchemaUnsafe<T>> | (T extends {
 } ? NodeBuilderDataUnsafe<T> : never)
 ][_InlineTrick];
 
-// @public
+// @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
@@ -530,12 +530,12 @@ export interface ITelemetryBaseProperties {
     [index: string]: TelemetryBaseEventPropertyType | Tagged<TelemetryBaseEventPropertyType>;
 }
 
-// @public
+// @public @sealed
 export class IterableTreeArrayContent<T> implements Iterable<T> {
     [Symbol.iterator](): Iterator<T>;
 }
 
-// @public
+// @public @sealed
 export interface ITree extends IFluidLoadable {
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
@@ -554,7 +554,7 @@ export interface ITreeViewConfiguration<TSchema extends ImplicitFieldSchema = Im
 // @public
 export type LazyItem<Item = unknown> = Item | (() => Item);
 
-// @public
+// @public @sealed
 export interface Listenable<TListeners extends object> {
     on<K extends keyof Listeners<TListeners>>(eventName: K, listener: TListeners[K]): Off;
 }
@@ -564,7 +564,7 @@ export type Listeners<T extends object> = {
     [P in (string | symbol) & keyof T as IsListener<T[P]> extends true ? P : never]: T[P];
 };
 
-// @public
+// @public @sealed
 export interface MakeNominal {
 }
 
@@ -627,7 +627,7 @@ export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 
-// @public
+// @public @sealed
 export interface Revertible {
     dispose(): void;
     revert(): void;
@@ -635,7 +635,7 @@ export interface Revertible {
     readonly status: RevertibleStatus;
 }
 
-// @public
+// @public @sealed
 export type RevertibleFactory = (onRevertibleDisposed?: (revertible: Revertible) => void) => Revertible;
 
 // @public
@@ -647,7 +647,7 @@ export enum RevertibleStatus {
 // @public
 export const rollback: unique symbol;
 
-// @public
+// @public @sealed
 export interface RunTransaction {
     <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult): TResult;
     <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult): TResult;
@@ -664,7 +664,7 @@ export interface RunTransaction {
     readonly rollback: typeof rollback;
 }
 
-// @public
+// @public @sealed
 export interface SchemaCompatibilityStatus {
     readonly canInitialize: boolean;
     readonly canUpgrade: boolean;
@@ -707,7 +707,7 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
 // @public
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
-// @public
+// @public @sealed
 export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
 }
 
@@ -734,22 +734,22 @@ export type TransformedEvent<TThis, E, A extends any[]> = (event: E, listener: (
 // @public
 export const Tree: TreeApi;
 
-// @public
+// @public @sealed
 interface TreeApi extends TreeNodeApi {
     contains(node: TreeNode, other: TreeNode): boolean;
     readonly runTransaction: RunTransaction;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNode<TAllowedTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypes<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypes<TAllowedTypes>, TreeArrayNode> {
 }
 
 // @public
 export const TreeArrayNode: {
-    spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
+    readonly spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
 };
 
-// @public
+// @public @sealed
 interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T>, TreeNode {
     insertAt(index: number, ...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     insertAtEnd(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
@@ -770,11 +770,11 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     removeRange(start?: number, end?: number): void;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAllowedTypes>> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, TreeArrayNode> {
 }
 
-// @public
+// @public @sealed
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
@@ -789,7 +789,7 @@ type TreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<ImplicitFieldSc
 // @public
 export type TreeLeafValue = number | string | boolean | IFluidHandle | null;
 
-// @public
+// @public @sealed
 export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypes<T>>, TreeNode {
     delete(key: string): void;
     entries(): IterableIterator<[string, TreeNodeFromImplicitAllowedTypes<T>]>;
@@ -799,13 +799,13 @@ export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTyp
     values(): IterableIterator<TreeNodeFromImplicitAllowedTypes<T>>;
 }
 
-// @public
+// @public @sealed
 export interface TreeMapNodeUnsafe<T extends Unenforced<ImplicitAllowedTypes>> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypesUnsafe<T>>, TreeNode {
     delete(key: string): void;
     set(key: string, value: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T> | undefined): void;
 }
 
-// @public
+// @public @sealed
 export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
@@ -813,7 +813,7 @@ export abstract class TreeNode implements WithType {
     protected constructor();
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeApi {
     is<TSchema extends ImplicitAllowedTypes>(value: unknown, schema: TSchema): value is TreeNodeFromImplicitAllowedTypes<TSchema>;
     key(node: TreeNode): string | number;
@@ -830,16 +830,16 @@ export type TreeNodeFromImplicitAllowedTypes<TSchema extends ImplicitAllowedType
 // @public
 type TreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends Unenforced<ImplicitAllowedTypes>> = TSchema extends ImplicitAllowedTypes ? TreeNodeFromImplicitAllowedTypes<TSchema> : TSchema extends TreeNodeSchema ? NodeFromSchema<TSchema> : TSchema extends AllowedTypes ? NodeFromSchema<FlexListToUnion<TSchema>> : unknown;
 
-// @public
+// @public @sealed
 export type TreeNodeSchema<Name extends string = string, Kind extends NodeKind = NodeKind, TNode = unknown, TBuild = never, ImplicitlyConstructable extends boolean = boolean, Info = unknown> = TreeNodeSchemaClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info> | TreeNodeSchemaNonClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info>;
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // @sealed
     new (data: TInsertable | InternalTreeNode): Unhydrated<TNode>;
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaCore<out Name extends string, out Kind extends NodeKind, out ImplicitlyConstructable extends boolean, out Info = unknown> {
     // (undocumented)
     readonly identifier: Name;
@@ -849,7 +849,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly kind: Kind;
 }
 
-// @public
+// @public @sealed
 interface TreeNodeSchemaNonClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // (undocumented)
     create(data: TInsertable): TNode;
@@ -869,7 +869,7 @@ export enum TreeStatus {
     Removed = 1
 }
 
-// @public
+// @public @sealed
 export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable {
     readonly compatibility: SchemaCompatibilityStatus;
     readonly events: Listenable<TreeViewEvents>;
@@ -879,14 +879,14 @@ export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposab
     upgradeSchema(): void;
 }
 
-// @public
+// @public @sealed
 export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> implements Required<ITreeViewConfiguration<TSchema>> {
     constructor(props: ITreeViewConfiguration<TSchema>);
     readonly enableSchemaValidation: boolean;
     readonly schema: TSchema;
 }
 
-// @public
+// @public @sealed
 export interface TreeViewEvents {
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
@@ -913,7 +913,7 @@ export type ValidateRecursiveSchema<T extends TreeNodeSchemaClass<string, NodeKi
     [NodeKind.Map]: ImplicitAllowedTypes;
 }[T["kind"]]>> = true;
 
-// @public
+// @public @sealed
 export interface WithType<TName extends string = string> {
     get [typeNameSymbol](): TName;
 }

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -55,7 +55,7 @@ export enum CommitKind {
     Undo = 1
 }
 
-// @public
+// @public @sealed
 export interface CommitMetadata {
     readonly isLocal: boolean;
     readonly kind: CommitKind;
@@ -89,7 +89,7 @@ export interface ContainerSchema {
     readonly initialObjects: Record<string, SharedObjectKind>;
 }
 
-// @public
+// @public @sealed
 interface DefaultProvider extends ErasedType<"@fluidframework/tree.FieldProvider"> {
 }
 
@@ -105,7 +105,7 @@ type ExtractItemType<Item extends LazyItem> = Item extends () => infer Result ? 
 // @public
 type FieldHasDefault<T extends ImplicitFieldSchema> = T extends FieldSchema<FieldKind.Optional | FieldKind.Identifier> ? true : false;
 
-// @public
+// @public @sealed
 type FieldHasDefaultUnsafe<T extends Unenforced<ImplicitFieldSchema>> = T extends FieldSchemaUnsafe<FieldKind.Optional | FieldKind.Identifier, Unenforced<ImplicitAllowedTypes>> ? true : false;
 
 // @public
@@ -192,7 +192,7 @@ export interface IEvent {
     (event: string, listener: (...args: any[]) => void): any;
 }
 
-// @public
+// @public @sealed
 export interface IEventProvider<TEvent extends IEvent> {
     readonly off: IEventTransformer<this, TEvent>;
     readonly on: IEventTransformer<this, TEvent>;
@@ -383,21 +383,21 @@ export interface IFluidContainerEvents extends IEvent {
 // @public (undocumented)
 export const IFluidHandle = "IFluidHandle";
 
-// @public
+// @public @sealed
 export interface IFluidHandle<out T = unknown> {
     readonly [fluidHandleSymbol]: IFluidHandleErased<T>;
     get(): Promise<T>;
     readonly isAttached: boolean;
 }
 
-// @public
+// @public @sealed
 export interface IFluidHandleErased<T> extends ErasedType<readonly ["IFluidHandle", T]> {
 }
 
 // @public (undocumented)
 export const IFluidLoadable: keyof IProvideFluidLoadable;
 
-// @public
+// @public @sealed
 export interface IFluidLoadable extends IProvideFluidLoadable {
     // (undocumented)
     readonly handle: IFluidHandle;
@@ -461,7 +461,7 @@ Unhydrated<NodeFromSchemaUnsafe<T>> | (T extends {
 } ? NodeBuilderDataUnsafe<T> : never)
 ][_InlineTrick];
 
-// @public
+// @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
 
@@ -530,12 +530,12 @@ export interface ITelemetryBaseProperties {
     [index: string]: TelemetryBaseEventPropertyType | Tagged<TelemetryBaseEventPropertyType>;
 }
 
-// @public
+// @public @sealed
 export class IterableTreeArrayContent<T> implements Iterable<T> {
     [Symbol.iterator](): Iterator<T>;
 }
 
-// @public
+// @public @sealed
 export interface ITree extends IFluidLoadable {
     viewWith<TRoot extends ImplicitFieldSchema>(config: TreeViewConfiguration<TRoot>): TreeView<TRoot>;
 }
@@ -554,7 +554,7 @@ export interface ITreeViewConfiguration<TSchema extends ImplicitFieldSchema = Im
 // @public
 export type LazyItem<Item = unknown> = Item | (() => Item);
 
-// @public
+// @public @sealed
 export interface Listenable<TListeners extends object> {
     on<K extends keyof Listeners<TListeners>>(eventName: K, listener: TListeners[K]): Off;
 }
@@ -564,7 +564,7 @@ export type Listeners<T extends object> = {
     [P in (string | symbol) & keyof T as IsListener<T[P]> extends true ? P : never]: T[P];
 };
 
-// @public
+// @public @sealed
 export interface MakeNominal {
 }
 
@@ -627,7 +627,7 @@ export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
     readonly [P in symbol | string]: P extends K ? T : never;
 };
 
-// @public
+// @public @sealed
 export interface Revertible {
     dispose(): void;
     revert(): void;
@@ -635,7 +635,7 @@ export interface Revertible {
     readonly status: RevertibleStatus;
 }
 
-// @public
+// @public @sealed
 export type RevertibleFactory = (onRevertibleDisposed?: (revertible: Revertible) => void) => Revertible;
 
 // @public
@@ -647,7 +647,7 @@ export enum RevertibleStatus {
 // @public
 export const rollback: unique symbol;
 
-// @public
+// @public @sealed
 export interface RunTransaction {
     <TNode extends TreeNode, TResult>(node: TNode, transaction: (node: TNode) => TResult): TResult;
     <TView extends TreeView<ImplicitFieldSchema>, TResult>(tree: TView, transaction: (root: TView["root"]) => TResult): TResult;
@@ -664,7 +664,7 @@ export interface RunTransaction {
     readonly rollback: typeof rollback;
 }
 
-// @public
+// @public @sealed
 export interface SchemaCompatibilityStatus {
     readonly canInitialize: boolean;
     readonly canUpgrade: boolean;
@@ -707,7 +707,7 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
 // @public
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
-// @public
+// @public @sealed
 export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
 }
 
@@ -734,22 +734,22 @@ export type TransformedEvent<TThis, E, A extends any[]> = (event: E, listener: (
 // @public
 export const Tree: TreeApi;
 
-// @public
+// @public @sealed
 interface TreeApi extends TreeNodeApi {
     contains(node: TreeNode, other: TreeNode): boolean;
     readonly runTransaction: RunTransaction;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNode<TAllowedTypes extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypes<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypes<TAllowedTypes>, TreeArrayNode> {
 }
 
 // @public
 export const TreeArrayNode: {
-    spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
+    readonly spread: <T>(content: Iterable<T>) => IterableTreeArrayContent<T>;
 };
 
-// @public
+// @public @sealed
 interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<T>, TreeNode {
     insertAt(index: number, ...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
     insertAtEnd(...value: readonly (TNew | IterableTreeArrayContent<TNew>)[]): void;
@@ -770,11 +770,11 @@ interface TreeArrayNodeBase<out T, in TNew, in TMoveFrom> extends ReadonlyArray<
     removeRange(start?: number, end?: number): void;
 }
 
-// @public
+// @public @sealed
 export interface TreeArrayNodeUnsafe<TAllowedTypes extends Unenforced<ImplicitAllowedTypes>> extends TreeArrayNodeBase<TreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, InsertableTreeNodeFromImplicitAllowedTypesUnsafe<TAllowedTypes>, TreeArrayNode> {
 }
 
-// @public
+// @public @sealed
 export interface TreeChangeEvents {
     nodeChanged(): void;
     treeChanged(): void;
@@ -789,7 +789,7 @@ type TreeFieldFromImplicitFieldUnsafe<TSchema extends Unenforced<ImplicitFieldSc
 // @public
 export type TreeLeafValue = number | string | boolean | IFluidHandle | null;
 
-// @public
+// @public @sealed
 export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTypes> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypes<T>>, TreeNode {
     delete(key: string): void;
     entries(): IterableIterator<[string, TreeNodeFromImplicitAllowedTypes<T>]>;
@@ -799,13 +799,13 @@ export interface TreeMapNode<T extends ImplicitAllowedTypes = ImplicitAllowedTyp
     values(): IterableIterator<TreeNodeFromImplicitAllowedTypes<T>>;
 }
 
-// @public
+// @public @sealed
 export interface TreeMapNodeUnsafe<T extends Unenforced<ImplicitAllowedTypes>> extends ReadonlyMap<string, TreeNodeFromImplicitAllowedTypesUnsafe<T>>, TreeNode {
     delete(key: string): void;
     set(key: string, value: InsertableTreeNodeFromImplicitAllowedTypesUnsafe<T> | undefined): void;
 }
 
-// @public
+// @public @sealed
 export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
@@ -813,7 +813,7 @@ export abstract class TreeNode implements WithType {
     protected constructor();
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeApi {
     is<TSchema extends ImplicitAllowedTypes>(value: unknown, schema: TSchema): value is TreeNodeFromImplicitAllowedTypes<TSchema>;
     key(node: TreeNode): string | number;
@@ -830,16 +830,16 @@ export type TreeNodeFromImplicitAllowedTypes<TSchema extends ImplicitAllowedType
 // @public
 type TreeNodeFromImplicitAllowedTypesUnsafe<TSchema extends Unenforced<ImplicitAllowedTypes>> = TSchema extends ImplicitAllowedTypes ? TreeNodeFromImplicitAllowedTypes<TSchema> : TSchema extends TreeNodeSchema ? NodeFromSchema<TSchema> : TSchema extends AllowedTypes ? NodeFromSchema<FlexListToUnion<TSchema>> : unknown;
 
-// @public
+// @public @sealed
 export type TreeNodeSchema<Name extends string = string, Kind extends NodeKind = NodeKind, TNode = unknown, TBuild = never, ImplicitlyConstructable extends boolean = boolean, Info = unknown> = TreeNodeSchemaClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info> | TreeNodeSchemaNonClass<Name, Kind, TNode, TBuild, ImplicitlyConstructable, Info>;
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // @sealed
     new (data: TInsertable | InternalTreeNode): Unhydrated<TNode>;
 }
 
-// @public
+// @public @sealed
 export interface TreeNodeSchemaCore<out Name extends string, out Kind extends NodeKind, out ImplicitlyConstructable extends boolean, out Info = unknown> {
     // (undocumented)
     readonly identifier: Name;
@@ -849,7 +849,7 @@ export interface TreeNodeSchemaCore<out Name extends string, out Kind extends No
     readonly kind: Kind;
 }
 
-// @public
+// @public @sealed
 interface TreeNodeSchemaNonClass<out Name extends string = string, out Kind extends NodeKind = NodeKind, out TNode = unknown, in TInsertable = never, out ImplicitlyConstructable extends boolean = boolean, out Info = unknown> extends TreeNodeSchemaCore<Name, Kind, ImplicitlyConstructable, Info> {
     // (undocumented)
     create(data: TInsertable): TNode;
@@ -869,7 +869,7 @@ export enum TreeStatus {
     Removed = 1
 }
 
-// @public
+// @public @sealed
 export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable {
     readonly compatibility: SchemaCompatibilityStatus;
     readonly events: Listenable<TreeViewEvents>;
@@ -879,14 +879,14 @@ export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposab
     upgradeSchema(): void;
 }
 
-// @public
+// @public @sealed
 export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> implements Required<ITreeViewConfiguration<TSchema>> {
     constructor(props: ITreeViewConfiguration<TSchema>);
     readonly enableSchemaValidation: boolean;
     readonly schema: TSchema;
 }
 
-// @public
+// @public @sealed
 export interface TreeViewEvents {
     commitApplied(data: CommitMetadata, getRevertible?: RevertibleFactory): void;
     rootChanged(): void;
@@ -913,7 +913,7 @@ export type ValidateRecursiveSchema<T extends TreeNodeSchemaClass<string, NodeKi
     [NodeKind.Map]: ImplicitAllowedTypes;
 }[T["kind"]]>> = true;
 
-// @public
+// @public @sealed
 export interface WithType<TName extends string = string> {
     get [typeNameSymbol](): TName;
 }


### PR DESCRIPTION
## Description

This indicates, in a way understood by our type tests, and documented in https://github.com/microsoft/FluidFramework/pull/14421 which interfaces we do not support customers creating instances of/implementing themselves. This reserves our ability to add members to these interfaces in the future, as well as make assumptions about their instances as they must come from our packages.

Removing these sealed annotations is a non breaking change, but once we are more clear about the rules around our interfaces, adding them will become breaking. Getting them in now helps avoid confusion as we continue to clarify what exact usage patterns we support.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

