### PR TITLE
Document support for exactOptionalPropertyTypes

### DIFF
--- a/ClientRequirements.md
+++ b/ClientRequirements.md
@@ -19,6 +19,8 @@ When making such a request please include if the configuration already works (an
     -   All [`strict`](https://www.typescriptlang.org/tsconfig) options are supported.
     -   [`strictNullChecks`](https://www.typescriptlang.org/tsconfig) is required.
     -   [Configuration options deprecated in 5.0](https://github.com/microsoft/TypeScript/issues/51909) are not supported.
+    -   `exactOptionalPropertyTypes` is currently not fully supported.
+        If used, narrowing members of Fluid Framework types types using `in`, `Reflect.has`, `Object.hasOwn` or `Object.prototype.hasOwnProperty` should be avoided as they may incorrectly exclude `undefined` from the possible values in some cases.
 -   [webpack](https://webpack.js.org/) 5
     -   We are not intending to be prescriptive about what bundler to use.
         Other bundlers which can handle ES Modules should work, but webpack is the only one we actively test.


### PR DESCRIPTION
## Description

Clarify support for and limitations with `exactOptionalPropertyTypes`.

In the future we could remove this caveat and fully support both customers with the flag and without it if we:

- (non-breaking) if we add `| undefined` to all optional members which can be inputs into our APIs (non-breaking because of our documented (in this PR) limited support for this flag (ensuring customer code has the same set of types they can provide, regardless of it they set the flag). Alternately as a breaking change, remove the optional-ness.
- (non breaking) for outputs from our APIs, either remove the optional-ness, explicitly add `| undefined` or ensure that undefined values are never provided (ex: by setting the flag in our own codebase).

Note that for APIs which are both inputs or outputs, they would need to comply with both cases.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

