### PR TITLE
upgrade Arrow app to v5

### DIFF
--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -234,7 +234,7 @@ stages:
           displayName: Guardian Asset Retention
           condition: and(succeeded(), eq(variables.shouldRetainGuardianAssets, true))
           inputs:
-            ArrowServiceConnection: 'ff-internal-arrow-arm-sc'
+            ArrowServiceConnection: 'ff-internal-arrow-sc'
             AssetGroupName: 'fluidframework_$(System.TeamProject)_$(Build.DefinitionName)'
             AssetNumber: '$(Build.BuildId)'
             IsShipped: false # based on value of arrow.releasedtoproduction variable

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -230,7 +230,7 @@ stages:
           inputs:
             ArtifactType: M365
 
-        - task: AssetRetention@4
+        - task: AssetRetention@5
           displayName: Guardian Asset Retention
           condition: and(succeeded(), eq(variables.shouldRetainGuardianAssets, true))
           inputs:

--- a/tools/pipelines/build-docs.yml
+++ b/tools/pipelines/build-docs.yml
@@ -234,7 +234,7 @@ stages:
           displayName: Guardian Asset Retention
           condition: and(succeeded(), eq(variables.shouldRetainGuardianAssets, true))
           inputs:
-            ArrowARMServiceConnection: 'ff-internal-arrow-arm-sc'
+            ArrowServiceConnection: 'ff-internal-arrow-arm-sc'
             AssetGroupName: 'fluidframework_$(System.TeamProject)_$(Build.DefinitionName)'
             AssetNumber: '$(Build.BuildId)'
             IsShipped: false # based on value of arrow.releasedtoproduction variable

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -40,9 +40,9 @@ extends:
         # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
         # Currently we want to use different names for internal and public builds for Arrow Service Connection
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          armServiceConnection: ff-internal-arrow-arm-sc
+          serviceConnection: ff-internal-arrow-arm-sc
         ${{ else }}:
-          armServiceConnection: ff-public-arrow-arm-sc
+          serviceConnection: ff-public-arrow-arm-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -40,9 +40,9 @@ extends:
         # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
         # Currently we want to use different names for internal and public builds for Arrow Service Connection
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          serviceConnection: ff-internal-arrow-arm-sc
+          serviceConnection: ff-internal-arrow-sc
         ${{ else }}:
-          serviceConnection: ff-public-arrow-arm-sc
+          serviceConnection: ff-public-arrow-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -122,9 +122,9 @@ extends:
         # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
         # Currently we want to use different names for internal and public builds for Arrow Service Connection
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          serviceConnection: ff-internal-arrow-arm-sc
+          serviceConnection: ff-internal-arrow-sc
         ${{ else }}:
-          serviceConnection: ff-public-arrow-arm-sc
+          serviceConnection: ff-public-arrow-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -122,9 +122,9 @@ extends:
         # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
         # Currently we want to use different names for internal and public builds for Arrow Service Connection
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          armServiceConnection: ff-internal-arrow-arm-sc
+          serviceConnection: ff-internal-arrow-arm-sc
         ${{ else }}:
-          armServiceConnection: ff-public-arrow-arm-sc
+          serviceConnection: ff-public-arrow-arm-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -159,9 +159,9 @@ extends:
         # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
         # Currently we want to use different names for internal and public builds for Arrow Service Connection
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          serviceConnection: ff-internal-arrow-arm-sc
+          serviceConnection: ff-internal-arrow-sc
         ${{ else }}:
-          serviceConnection: ff-public-arrow-arm-sc
+          serviceConnection: ff-public-arrow-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -159,9 +159,9 @@ extends:
         # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
         # Currently we want to use different names for internal and public builds for Arrow Service Connection
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          armServiceConnection: ff-internal-arrow-arm-sc
+          serviceConnection: ff-internal-arrow-arm-sc
         ${{ else }}:
-          armServiceConnection: ff-public-arrow-arm-sc
+          serviceConnection: ff-public-arrow-arm-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022


### PR DESCRIPTION
upgrading Arrow app to v5 since v4 was a temporary fix to move users away from secretless authentication for Arrow app. V4 has been deprecated in favor for V5, which adds support for secretless auth using an Arrow service connection (rather than an Azure Resource Manager service connection).
[AB#8345](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8345)