### PR TITLE
github: public and legacy API changes require council review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,8 +48,9 @@
 # Fluid Devtools source
 /packages/tools/devtools/**/src                @microsoft/fluid-cr-devtools
 
-# Public and Legacy API changes
+# Non-internal API changes
 /**/api-report/*.public.api.md                 @microsoft/fluid-cr-api
+/**/api-report/*.beta.api.md                   @microsoft/fluid-cr-api
 /**/api-report/*.alpha.api.md                  @microsoft/fluid-cr-api
 
 # Package version files are not generally interesting to review by teams signing up for source tree ownership.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,7 +46,11 @@
 /experimental/dds/tree/src                     @microsoft/fluid-cr-tree
 
 # Fluid Devtools source
-/packages/tools/devtools/**/src                   @microsoft/fluid-cr-devtools
+/packages/tools/devtools/**/src                @microsoft/fluid-cr-devtools
+
+# Public and Legacy API changes
+/**/api-report/*.public.api.md                 @microsoft/fluid-cr-api
+/**/api-report/*.alpha.api.md                  @microsoft/fluid-cr-api
 
 # Package version files are not generally interesting to review by teams signing up for source tree ownership.
 # If a release team wanted to sign up to block on changes relevant for package release,

--- a/packages/loader/driver-utils/src/adapters/compression/documentServiceCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/documentServiceCompressionAdapter.ts
@@ -18,10 +18,8 @@ export class DocumentServiceCompressionAdapter extends DocumentServiceProxy {
 		service: IDocumentService,
 		private readonly _config: ICompressionStorageConfig,
 	) {
-
 		super(service);
-
-				// Back-compat Old driver
+		// Back-compat Old driver
 		if (service.on !== undefined) {
 			service.on("metadataUpdate", (metadata: Record<string, string>) =>
 				this.emit("metadataUpdate", metadata),

--- a/packages/loader/driver-utils/src/adapters/compression/documentServiceCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/documentServiceCompressionAdapter.ts
@@ -18,8 +18,10 @@ export class DocumentServiceCompressionAdapter extends DocumentServiceProxy {
 		service: IDocumentService,
 		private readonly _config: ICompressionStorageConfig,
 	) {
+
 		super(service);
-		// Back-compat Old driver
+
+				// Back-compat Old driver
 		if (service.on !== undefined) {
 			service.on("metadataUpdate", (metadata: Record<string, string>) =>
 				this.emit("metadataUpdate", metadata),


### PR DESCRIPTION
Configure CODEOWNERS so that deltas in the generated API reports automatically add 'fluid-cr-api' as a required reviewer.