### PR TITLE
Update the SharedTree fuzz tests to use `describeFuzz`

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/fuzz/anchorStability.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/anchorStability.fuzz.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { takeAsync } from "@fluid-private/stochastic-test-utils";
+import { describeFuzz, takeAsync } from "@fluid-private/stochastic-test-utils";
 import {
 	type DDSFuzzHarnessEvents,
 	type DDSFuzzModel,
@@ -74,9 +74,8 @@ const initialTreeJson = jsonableTreeFromFieldCursor(
  *
  * See the "Fuzz - Top-Level" test suite for tests are more general in scope.
  */
-describe("Fuzz - anchor stability", () => {
+describeFuzz("Fuzz - anchor stability", ({ testCount }) => {
 	const opsPerRun = 20;
-	const runsPerBatch = 50;
 	describe("Anchors are unaffected by aborted transaction", () => {
 		const editGeneratorOpWeights: Partial<EditGeneratorOpWeights> = {
 			set: 2,
@@ -131,7 +130,7 @@ describe("Fuzz - anchor stability", () => {
 		});
 
 		createDDSFuzzSuite(model, {
-			defaultTestCount: runsPerBatch,
+			defaultTestCount: testCount,
 			numberOfClients: 1,
 			emitter,
 			saveFailures: {
@@ -213,7 +212,7 @@ describe("Fuzz - anchor stability", () => {
 		});
 
 		createDDSFuzzSuite(model, {
-			defaultTestCount: runsPerBatch,
+			defaultTestCount: testCount,
 			detachedStartOptions: { numOpsBeforeAttach: 0 },
 			numberOfClients: 2,
 			emitter,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
@@ -10,6 +10,7 @@ import {
 	type AsyncGenerator,
 	combineReducersAsync,
 	takeAsync,
+	describeFuzz,
 } from "@fluid-private/stochastic-test-utils";
 import {
 	type DDSFuzzHarnessEvents,
@@ -89,9 +90,8 @@ const fuzzComposedVsIndividualReducer = combineReducersAsync<
  *
  * See the "Fuzz - Top-Level" test suite for tests are more general in scope.
  */
-describe("Fuzz - composed vs individual changes", () => {
+describeFuzz("Fuzz - composed vs individual changes", ({ testCount }) => {
 	const opsPerRun = 20;
-	const runsPerBatch = 50;
 
 	// "start" and "commit" opWeights set to 0 in case there are changes to the default weights.
 	// AB#7593: schema weight is currently set to 0, as most tests are failing with various branch related asserts,
@@ -145,7 +145,7 @@ describe("Fuzz - composed vs individual changes", () => {
 			validateTree(tree.checkout, childTreeView);
 		});
 		createDDSFuzzSuite(model, {
-			defaultTestCount: runsPerBatch,
+			defaultTestCount: testCount,
 			numberOfClients: 1,
 			emitter,
 			idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),

--- a/packages/dds/tree/src/test/shared-tree/fuzz/move.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/move.fuzz.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { takeAsync } from "@fluid-private/stochastic-test-utils";
+import { describeFuzz, takeAsync } from "@fluid-private/stochastic-test-utils";
 import {
 	type DDSFuzzHarnessEvents,
 	type DDSFuzzModel,
@@ -29,8 +29,7 @@ import {
 import type { Operation } from "./operationTypes.js";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 
-describe("Fuzz - move", () => {
-	const runsPerBatch = 50;
+describeFuzz("Fuzz - move", ({ testCount }) => {
 	const opsPerRun = 30;
 	const editGeneratorOpWeights: Partial<EditGeneratorOpWeights> = {
 		intraFieldMove: 1,
@@ -71,7 +70,7 @@ describe("Fuzz - move", () => {
 			maxNumberOfClients: 4,
 			clientAddProbability: 1,
 		},
-		defaultTestCount: runsPerBatch,
+		defaultTestCount: testCount,
 		saveFailures: {
 			directory: failureDirectory,
 		},

--- a/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/topLevel.fuzz.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { takeAsync } from "@fluid-private/stochastic-test-utils";
+import { describeFuzz, takeAsync } from "@fluid-private/stochastic-test-utils";
 import {
 	type DDSFuzzModel,
 	type DDSFuzzSuiteOptions,
@@ -38,8 +38,7 @@ const baseOptions: Partial<DDSFuzzSuiteOptions> = {
  * The fuzz tests should validate that the clients do not crash and that their document states do not diverge.
  * See the "Fuzz - Targeted" test suite for tests that validate more specific code paths or invariants.
  */
-describe("Fuzz - Top-Level", () => {
-	const runsPerBatch = 50;
+describeFuzz("Fuzz - Top-Level", ({ testCount }) => {
 	const opsPerRun = 20;
 	// TODO: Enable other types of ops.
 	const editGeneratorOpWeights: Partial<EditGeneratorOpWeights> = {
@@ -75,7 +74,7 @@ describe("Fuzz - Top-Level", () => {
 
 		const options: Partial<DDSFuzzSuiteOptions> = {
 			...baseOptions,
-			defaultTestCount: runsPerBatch,
+			defaultTestCount: testCount,
 			saveFailures: {
 				directory: failureDirectory,
 			},
@@ -110,7 +109,7 @@ describe("Fuzz - Top-Level", () => {
 		const options: Partial<DDSFuzzSuiteOptions> = {
 			...baseOptions,
 			reconnectProbability: 0.0,
-			defaultTestCount: runsPerBatch,
+			defaultTestCount: testCount,
 			rebaseProbability: 0.2,
 			containerRuntimeOptions: {
 				flushMode: FlushMode.TurnBased,

--- a/packages/dds/tree/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/undoRedo.fuzz.spec.ts
@@ -6,7 +6,11 @@
 import { strict as assert } from "assert";
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import { type AsyncGenerator, takeAsync } from "@fluid-private/stochastic-test-utils";
+import {
+	type AsyncGenerator,
+	takeAsync,
+	describeFuzz,
+} from "@fluid-private/stochastic-test-utils";
 import {
 	type DDSFuzzHarnessEvents,
 	type DDSFuzzModel,
@@ -53,8 +57,7 @@ interface UndoRedoFuzzTestState extends FuzzTestState {
 	unsubscribe?: (() => void)[];
 }
 
-describe("Fuzz - revert", () => {
-	const runsPerBatch = 20;
+describeFuzz("Fuzz - revert", ({ testCount }) => {
 	const opsPerRun = 20;
 
 	const undoRedoWeights: Partial<EditGeneratorOpWeights> = {
@@ -142,7 +145,7 @@ describe("Fuzz - revert", () => {
 			tearDown(state);
 		});
 		createDDSFuzzSuite(model, {
-			defaultTestCount: runsPerBatch,
+			defaultTestCount: testCount,
 			numberOfClients: 3,
 			detachedStartOptions: {
 				numOpsBeforeAttach: 0,
@@ -197,7 +200,7 @@ describe("Fuzz - revert", () => {
 			tearDown(state);
 		});
 		createDDSFuzzSuite(model, {
-			defaultTestCount: runsPerBatch,
+			defaultTestCount: testCount,
 			numberOfClients: 3,
 			detachedStartOptions: {
 				numOpsBeforeAttach: 0,


### PR DESCRIPTION
## Description

This will allow the SharedTree fuzz tests to be run by the DDS stress test pipeline.