### PR TITLE
build(server): Update type tests to 5.0 baseline

### DIFF
--- a/server/routerlicious/packages/gitresources/package.json
+++ b/server/routerlicious/packages/gitresources/package.json
@@ -33,7 +33,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@4.0.0",
+		"@fluidframework/gitresources-previous": "npm:@fluidframework/gitresources@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"concurrently": "^8.2.1",
 		"copyfiles": "^2.4.1",

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -36,7 +36,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@4.0.0",
+		"@fluidframework/server-kafka-orderer-previous": "npm:@fluidframework/server-kafka-orderer@5.0.0",
 		"@types/node": "^18.17.1",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",

--- a/server/routerlicious/packages/lambdas-driver/package.json
+++ b/server/routerlicious/packages/lambdas-driver/package.json
@@ -68,7 +68,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@4.0.0",
+		"@fluidframework/server-lambdas-driver-previous": "npm:@fluidframework/server-lambdas-driver@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/async": "^3.2.9",
 		"@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/lambdas/package.json
+++ b/server/routerlicious/packages/lambdas/package.json
@@ -79,7 +79,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@4.0.0",
+		"@fluidframework/server-lambdas-previous": "npm:@fluidframework/server-lambdas@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/async": "^3.2.9",
 		"@types/json-stringify-safe": "^5.0.0",
@@ -102,13 +102,6 @@
 		"webpack": "^5.82.0"
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_DeliLambda": {
-				"backCompat": false
-			},
-			"InterfaceDeclaration_ICheckpointParams": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/server/routerlicious/packages/lambdas/src/test/types/validateServerLambdasPrevious.generated.ts
+++ b/server/routerlicious/packages/lambdas/src/test/types/validateServerLambdasPrevious.generated.ts
@@ -165,7 +165,6 @@ declare function get_current_ClassDeclaration_DeliLambda():
 declare function use_old_ClassDeclaration_DeliLambda(
     use: TypeOnly<old.DeliLambda>): void;
 use_old_ClassDeclaration_DeliLambda(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_DeliLambda());
 
 /*
@@ -286,7 +285,6 @@ declare function get_current_InterfaceDeclaration_ICheckpointParams():
 declare function use_old_InterfaceDeclaration_ICheckpointParams(
     use: TypeOnly<old.ICheckpointParams>): void;
 use_old_InterfaceDeclaration_ICheckpointParams(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_ICheckpointParams());
 
 /*

--- a/server/routerlicious/packages/local-server/package.json
+++ b/server/routerlicious/packages/local-server/package.json
@@ -75,7 +75,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@4.0.0",
+		"@fluidframework/server-local-server-previous": "npm:@fluidframework/server-local-server@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/jsrsasign": "^10.5.12",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -82,7 +82,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@4.0.0",
+		"@fluidframework/server-memory-orderer-previous": "npm:@fluidframework/server-memory-orderer@5.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/uuid": "^9.0.2",
 		"c8": "^8.0.1",

--- a/server/routerlicious/packages/protocol-base/package.json
+++ b/server/routerlicious/packages/protocol-base/package.json
@@ -69,7 +69,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@4.0.0",
+		"@fluidframework/protocol-base-previous": "npm:@fluidframework/protocol-base@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/assert": "^1.5.1",
 		"@types/mocha": "^10.0.1",

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -91,7 +91,7 @@
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-local-server": "workspace:~",
-		"@fluidframework/server-routerlicious-base-previous": "npm:@fluidframework/server-routerlicious-base@4.0.0",
+		"@fluidframework/server-routerlicious-base-previous": "npm:@fluidframework/server-routerlicious-base@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/body-parser": "^1.19.2",
 		"@types/bytes": "^3.0.0",
@@ -130,13 +130,6 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"ClassDeclaration_NexusResources": {
-				"backCompat": false
-			},
-			"ClassDeclaration_RiddlerResources": {
-				"forwardCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
@@ -405,7 +405,6 @@ declare function get_current_ClassDeclaration_NexusResources():
 declare function use_old_ClassDeclaration_NexusResources(
     use: TypeOnly<old.NexusResources>): void;
 use_old_ClassDeclaration_NexusResources(
-    // @ts-expect-error compatibility expected to be broken
     get_current_ClassDeclaration_NexusResources());
 
 /*
@@ -514,7 +513,6 @@ declare function get_old_ClassDeclaration_RiddlerResources():
 declare function use_current_ClassDeclaration_RiddlerResources(
     use: TypeOnly<current.RiddlerResources>): void;
 use_current_ClassDeclaration_RiddlerResources(
-    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_RiddlerResources());
 
 /*

--- a/server/routerlicious/packages/routerlicious/package.json
+++ b/server/routerlicious/packages/routerlicious/package.json
@@ -64,7 +64,7 @@
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
 		"@fluidframework/server-local-server": "workspace:~",
-		"@fluidframework/server-routerlicious-previous": "npm:@fluidframework/server-routerlicious@4.0.0",
+		"@fluidframework/server-routerlicious-previous": "npm:@fluidframework/server-routerlicious@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/nconf": "^0.10.2",
 		"@types/node": "^18.17.1",

--- a/server/routerlicious/packages/services-client/package.json
+++ b/server/routerlicious/packages/services-client/package.json
@@ -77,7 +77,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@4.0.0",
+		"@fluidframework/server-services-client-previous": "npm:@fluidframework/server-services-client@5.0.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/debug": "^4.1.5",
 		"@types/jsrsasign": "^10.5.12",

--- a/server/routerlicious/packages/services-client/src/test/types/validateServerServicesClientPrevious.generated.ts
+++ b/server/routerlicious/packages/services-client/src/test/types/validateServerServicesClientPrevious.generated.ts
@@ -986,6 +986,30 @@ use_old_InterfaceDeclaration_IWriteSummaryResponse(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_InternalErrorCode": {"forwardCompat": false}
+*/
+declare function get_old_EnumDeclaration_InternalErrorCode():
+    TypeOnly<old.InternalErrorCode>;
+declare function use_current_EnumDeclaration_InternalErrorCode(
+    use: TypeOnly<current.InternalErrorCode>): void;
+use_current_EnumDeclaration_InternalErrorCode(
+    get_old_EnumDeclaration_InternalErrorCode());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "EnumDeclaration_InternalErrorCode": {"backCompat": false}
+*/
+declare function get_current_EnumDeclaration_InternalErrorCode():
+    TypeOnly<current.InternalErrorCode>;
+declare function use_old_EnumDeclaration_InternalErrorCode(
+    use: TypeOnly<old.InternalErrorCode>): void;
+use_old_EnumDeclaration_InternalErrorCode(
+    get_current_EnumDeclaration_InternalErrorCode());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "VariableDeclaration_LatestSummaryId": {"forwardCompat": false}
 */
 declare function get_old_VariableDeclaration_LatestSummaryId():

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -45,7 +45,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@4.0.0",
+		"@fluidframework/server-services-core-previous": "npm:@fluidframework/server-services-core@5.0.0",
 		"concurrently": "^8.2.1",
 		"eslint": "~8.55.0",
 		"prettier": "~3.0.3",
@@ -61,31 +61,6 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"VariableDeclaration_DefaultServiceConfiguration": {
-				"forwardCompat": false
-			},
-			"InterfaceDeclaration_IServerConfiguration": {
-				"forwardCompat": false
-			},
-			"InterfaceDeclaration_IServiceConfiguration": {
-				"forwardCompat": false
-			},
-			"InterfaceDeclaration_IScribeServerConfiguration": {
-				"forwardCompat": false
-			},
-			"InterfaceDeclaration_IOrdererConnection": {
-				"forwardCompat": false
-			},
-			"InterfaceDeclaration_IScribe": {
-				"forwardCompat": false
-			},
-			"InterfaceDeclaration_IDeliServerConfiguration": {
-				"forwardCompat": false
-			},
-			"InterfaceDeclaration_IDeliState": {
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -201,7 +201,6 @@ declare function get_old_VariableDeclaration_DefaultServiceConfiguration():
 declare function use_current_VariableDeclaration_DefaultServiceConfiguration(
     use: TypeOnly<typeof current.DefaultServiceConfiguration>): void;
 use_current_VariableDeclaration_DefaultServiceConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_old_VariableDeclaration_DefaultServiceConfiguration());
 
 /*
@@ -802,7 +801,6 @@ declare function get_old_InterfaceDeclaration_IDeliServerConfiguration():
 declare function use_current_InterfaceDeclaration_IDeliServerConfiguration(
     use: TypeOnly<current.IDeliServerConfiguration>): void;
 use_current_InterfaceDeclaration_IDeliServerConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IDeliServerConfiguration());
 
 /*
@@ -839,7 +837,6 @@ declare function get_current_InterfaceDeclaration_IDeliState():
 declare function use_old_InterfaceDeclaration_IDeliState(
     use: TypeOnly<old.IDeliState>): void;
 use_old_InterfaceDeclaration_IDeliState(
-    // @ts-expect-error compatibility expected to be broken
     get_current_InterfaceDeclaration_IDeliState());
 
 /*
@@ -1428,7 +1425,6 @@ declare function get_old_InterfaceDeclaration_IOrdererConnection():
 declare function use_current_InterfaceDeclaration_IOrdererConnection(
     use: TypeOnly<current.IOrdererConnection>): void;
 use_current_InterfaceDeclaration_IOrdererConnection(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IOrdererConnection());
 
 /*
@@ -1981,7 +1977,6 @@ declare function get_old_InterfaceDeclaration_IScribe():
 declare function use_current_InterfaceDeclaration_IScribe(
     use: TypeOnly<current.IScribe>): void;
 use_current_InterfaceDeclaration_IScribe(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IScribe());
 
 /*
@@ -2006,7 +2001,6 @@ declare function get_old_InterfaceDeclaration_IScribeServerConfiguration():
 declare function use_current_InterfaceDeclaration_IScribeServerConfiguration(
     use: TypeOnly<current.IScribeServerConfiguration>): void;
 use_current_InterfaceDeclaration_IScribeServerConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IScribeServerConfiguration());
 
 /*
@@ -2103,7 +2097,6 @@ declare function get_old_InterfaceDeclaration_IServerConfiguration():
 declare function use_current_InterfaceDeclaration_IServerConfiguration(
     use: TypeOnly<current.IServerConfiguration>): void;
 use_current_InterfaceDeclaration_IServerConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IServerConfiguration());
 
 /*
@@ -2128,7 +2121,6 @@ declare function get_old_InterfaceDeclaration_IServiceConfiguration():
 declare function use_current_InterfaceDeclaration_IServiceConfiguration(
     use: TypeOnly<current.IServiceConfiguration>): void;
 use_current_InterfaceDeclaration_IServiceConfiguration(
-    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IServiceConfiguration());
 
 /*
@@ -3606,6 +3598,30 @@ declare function use_old_FunctionDeclaration_extractBoxcar(
     use: TypeOnly<typeof old.extractBoxcar>): void;
 use_old_FunctionDeclaration_extractBoxcar(
     get_current_FunctionDeclaration_extractBoxcar());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_httpUsageStorageId": {"forwardCompat": false}
+*/
+declare function get_old_VariableDeclaration_httpUsageStorageId():
+    TypeOnly<typeof old.httpUsageStorageId>;
+declare function use_current_VariableDeclaration_httpUsageStorageId(
+    use: TypeOnly<typeof current.httpUsageStorageId>): void;
+use_current_VariableDeclaration_httpUsageStorageId(
+    get_old_VariableDeclaration_httpUsageStorageId());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "VariableDeclaration_httpUsageStorageId": {"backCompat": false}
+*/
+declare function get_current_VariableDeclaration_httpUsageStorageId():
+    TypeOnly<typeof current.httpUsageStorageId>;
+declare function use_old_VariableDeclaration_httpUsageStorageId(
+    use: TypeOnly<typeof old.httpUsageStorageId>): void;
+use_old_VariableDeclaration_httpUsageStorageId(
+    get_current_VariableDeclaration_httpUsageStorageId());
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -43,7 +43,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@4.0.0",
+		"@fluidframework/server-services-ordering-kafkanode-previous": "npm:@fluidframework/server-services-ordering-kafkanode@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",
 		"@types/lru-cache": "^5.1.0",

--- a/server/routerlicious/packages/services-ordering-rdkafka/package.json
+++ b/server/routerlicious/packages/services-ordering-rdkafka/package.json
@@ -42,7 +42,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@4.0.0",
+		"@fluidframework/server-services-ordering-rdkafka-previous": "npm:@fluidframework/server-services-ordering-rdkafka@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/amqplib": "^0.5.17",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/services-ordering-rdkafka/src/test/types/validateServerServicesOrderingRdkafkaPrevious.generated.ts
+++ b/server/routerlicious/packages/services-ordering-rdkafka/src/test/types/validateServerServicesOrderingRdkafkaPrevious.generated.ts
@@ -74,6 +74,54 @@ use_old_InterfaceDeclaration_IKafkaProducerOptions(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IOauthBearerConfig": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IOauthBearerConfig():
+    TypeOnly<old.IOauthBearerConfig>;
+declare function use_current_InterfaceDeclaration_IOauthBearerConfig(
+    use: TypeOnly<current.IOauthBearerConfig>): void;
+use_current_InterfaceDeclaration_IOauthBearerConfig(
+    get_old_InterfaceDeclaration_IOauthBearerConfig());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IOauthBearerConfig": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IOauthBearerConfig():
+    TypeOnly<current.IOauthBearerConfig>;
+declare function use_old_InterfaceDeclaration_IOauthBearerConfig(
+    use: TypeOnly<old.IOauthBearerConfig>): void;
+use_old_InterfaceDeclaration_IOauthBearerConfig(
+    get_current_InterfaceDeclaration_IOauthBearerConfig());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IOauthBearerResponse": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IOauthBearerResponse():
+    TypeOnly<old.IOauthBearerResponse>;
+declare function use_current_InterfaceDeclaration_IOauthBearerResponse(
+    use: TypeOnly<current.IOauthBearerResponse>): void;
+use_current_InterfaceDeclaration_IOauthBearerResponse(
+    get_old_InterfaceDeclaration_IOauthBearerResponse());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IOauthBearerResponse": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IOauthBearerResponse():
+    TypeOnly<current.IOauthBearerResponse>;
+declare function use_old_InterfaceDeclaration_IOauthBearerResponse(
+    use: TypeOnly<old.IOauthBearerResponse>): void;
+use_old_InterfaceDeclaration_IOauthBearerResponse(
+    get_current_InterfaceDeclaration_IOauthBearerResponse());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IRdkafkaResources": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IRdkafkaResources():

--- a/server/routerlicious/packages/services-ordering-zookeeper/package.json
+++ b/server/routerlicious/packages/services-ordering-zookeeper/package.json
@@ -36,7 +36,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@4.0.0",
+		"@fluidframework/server-services-ordering-zookeeper-previous": "npm:@fluidframework/server-services-ordering-zookeeper@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",
 		"@types/lru-cache": "^5.1.0",

--- a/server/routerlicious/packages/services-shared/package.json
+++ b/server/routerlicious/packages/services-shared/package.json
@@ -82,7 +82,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@4.0.0",
+		"@fluidframework/server-services-shared-previous": "npm:@fluidframework/server-services-shared@5.0.0",
 		"@types/body-parser": "^1.19.2",
 		"@types/debug": "^4.1.5",
 		"@types/lodash": "^4.14.118",

--- a/server/routerlicious/packages/services-shared/src/test/types/validateServerServicesSharedPrevious.generated.ts
+++ b/server/routerlicious/packages/services-shared/src/test/types/validateServerServicesSharedPrevious.generated.ts
@@ -362,6 +362,30 @@ use_old_ClassDeclaration_RestLessServer(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_SocketIoAdapterCreator": {"forwardCompat": false}
+*/
+declare function get_old_TypeAliasDeclaration_SocketIoAdapterCreator():
+    TypeOnly<old.SocketIoAdapterCreator>;
+declare function use_current_TypeAliasDeclaration_SocketIoAdapterCreator(
+    use: TypeOnly<current.SocketIoAdapterCreator>): void;
+use_current_TypeAliasDeclaration_SocketIoAdapterCreator(
+    get_old_TypeAliasDeclaration_SocketIoAdapterCreator());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "TypeAliasDeclaration_SocketIoAdapterCreator": {"backCompat": false}
+*/
+declare function get_current_TypeAliasDeclaration_SocketIoAdapterCreator():
+    TypeOnly<current.SocketIoAdapterCreator>;
+declare function use_old_TypeAliasDeclaration_SocketIoAdapterCreator(
+    use: TypeOnly<old.SocketIoAdapterCreator>): void;
+use_old_TypeAliasDeclaration_SocketIoAdapterCreator(
+    get_current_TypeAliasDeclaration_SocketIoAdapterCreator());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_SocketIoNodeClusterWebServerFactory": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_SocketIoNodeClusterWebServerFactory():

--- a/server/routerlicious/packages/services-telemetry/package.json
+++ b/server/routerlicious/packages/services-telemetry/package.json
@@ -63,7 +63,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@4.0.0",
+		"@fluidframework/server-services-telemetry-previous": "npm:@fluidframework/server-services-telemetry@5.0.0",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.17.1",
 		"@types/supertest": "^2.0.5",

--- a/server/routerlicious/packages/services-utils/package.json
+++ b/server/routerlicious/packages/services-utils/package.json
@@ -76,7 +76,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@4.0.0",
+		"@fluidframework/server-services-utils-previous": "npm:@fluidframework/server-services-utils@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/debug": "^4.1.5",
 		"@types/express": "^4.17.21",
@@ -107,11 +107,6 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {
-			"RemovedFunctionDeclaration_getRedisClient": {
-				"forwardCompat": false,
-				"backCompat": false
-			}
-		}
+		"broken": {}
 	}
 }

--- a/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/services-utils/src/test/types/validateServerServicesUtilsPrevious.generated.ts
@@ -218,6 +218,30 @@ use_old_InterfaceDeclaration_IApiCounters(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IRedisClientConnectionManager": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_IRedisClientConnectionManager():
+    TypeOnly<old.IRedisClientConnectionManager>;
+declare function use_current_InterfaceDeclaration_IRedisClientConnectionManager(
+    use: TypeOnly<current.IRedisClientConnectionManager>): void;
+use_current_InterfaceDeclaration_IRedisClientConnectionManager(
+    get_old_InterfaceDeclaration_IRedisClientConnectionManager());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_IRedisClientConnectionManager": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_IRedisClientConnectionManager():
+    TypeOnly<current.IRedisClientConnectionManager>;
+declare function use_old_InterfaceDeclaration_IRedisClientConnectionManager(
+    use: TypeOnly<old.IRedisClientConnectionManager>): void;
+use_old_InterfaceDeclaration_IRedisClientConnectionManager(
+    get_current_InterfaceDeclaration_IRedisClientConnectionManager());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "InterfaceDeclaration_IRedisParameters": {"forwardCompat": false}
 */
 declare function get_old_InterfaceDeclaration_IRedisParameters():
@@ -262,6 +286,30 @@ declare function use_old_InterfaceDeclaration_ISimpleThrottleConfig(
     use: TypeOnly<old.ISimpleThrottleConfig>): void;
 use_old_InterfaceDeclaration_ISimpleThrottleConfig(
     get_current_InterfaceDeclaration_ISimpleThrottleConfig());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITenantKeyGenerator": {"forwardCompat": false}
+*/
+declare function get_old_InterfaceDeclaration_ITenantKeyGenerator():
+    TypeOnly<old.ITenantKeyGenerator>;
+declare function use_current_InterfaceDeclaration_ITenantKeyGenerator(
+    use: TypeOnly<current.ITenantKeyGenerator>): void;
+use_current_InterfaceDeclaration_ITenantKeyGenerator(
+    get_old_InterfaceDeclaration_ITenantKeyGenerator());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "InterfaceDeclaration_ITenantKeyGenerator": {"backCompat": false}
+*/
+declare function get_current_InterfaceDeclaration_ITenantKeyGenerator():
+    TypeOnly<current.ITenantKeyGenerator>;
+declare function use_old_InterfaceDeclaration_ITenantKeyGenerator(
+    use: TypeOnly<old.ITenantKeyGenerator>): void;
+use_old_InterfaceDeclaration_ITenantKeyGenerator(
+    get_current_InterfaceDeclaration_ITenantKeyGenerator());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -362,6 +410,30 @@ use_old_ClassDeclaration_InMemoryApiCounters(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_RedisClientConnectionManager": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_RedisClientConnectionManager():
+    TypeOnly<old.RedisClientConnectionManager>;
+declare function use_current_ClassDeclaration_RedisClientConnectionManager(
+    use: TypeOnly<current.RedisClientConnectionManager>): void;
+use_current_ClassDeclaration_RedisClientConnectionManager(
+    get_old_ClassDeclaration_RedisClientConnectionManager());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_RedisClientConnectionManager": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_RedisClientConnectionManager():
+    TypeOnly<current.RedisClientConnectionManager>;
+declare function use_old_ClassDeclaration_RedisClientConnectionManager(
+    use: TypeOnly<old.RedisClientConnectionManager>): void;
+use_old_ClassDeclaration_RedisClientConnectionManager(
+    get_current_ClassDeclaration_RedisClientConnectionManager());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_ScheduledJob": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_ScheduledJob():
@@ -382,6 +454,30 @@ declare function use_old_ClassDeclaration_ScheduledJob(
     use: TypeOnly<old.ScheduledJob>): void;
 use_old_ClassDeclaration_ScheduledJob(
     get_current_ClassDeclaration_ScheduledJob());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_TenantKeyGenerator": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_TenantKeyGenerator():
+    TypeOnly<old.TenantKeyGenerator>;
+declare function use_current_ClassDeclaration_TenantKeyGenerator(
+    use: TypeOnly<current.TenantKeyGenerator>): void;
+use_current_ClassDeclaration_TenantKeyGenerator(
+    get_old_ClassDeclaration_TenantKeyGenerator());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_TenantKeyGenerator": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_TenantKeyGenerator():
+    TypeOnly<current.TenantKeyGenerator>;
+declare function use_old_ClassDeclaration_TenantKeyGenerator(
+    use: TypeOnly<old.TenantKeyGenerator>): void;
+use_old_ClassDeclaration_TenantKeyGenerator(
+    get_current_ClassDeclaration_TenantKeyGenerator());
 
 /*
 * Validate forward compat by using old type in place of current type
@@ -982,18 +1078,6 @@ declare function use_old_FunctionDeclaration_getRandomName(
     use: TypeOnly<typeof old.getRandomName>): void;
 use_old_FunctionDeclaration_getRandomName(
     get_current_FunctionDeclaration_getRandomName());
-
-/*
-* Validate forward compat by using old type in place of current type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_getRedisClient": {"forwardCompat": false}
-*/
-
-/*
-* Validate back compat by using current type in place of old type
-* If breaking change required, add in package.json under typeValidation.broken:
-* "RemovedFunctionDeclaration_getRedisClient": {"backCompat": false}
-*/
 
 /*
 * Validate forward compat by using old type in place of current type

--- a/server/routerlicious/packages/services/package.json
+++ b/server/routerlicious/packages/services/package.json
@@ -81,7 +81,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@4.0.0",
+		"@fluidframework/server-services-previous": "npm:@fluidframework/server-services@5.0.0",
 		"@fluidframework/server-test-utils": "workspace:~",
 		"@types/amqplib": "^0.5.17",
 		"@types/debug": "^4.1.5",

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -73,7 +73,7 @@
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.38.0",
 		"@fluidframework/eslint-config-fluid": "^5.2.0",
-		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@4.0.0",
+		"@fluidframework/server-test-utils-previous": "npm:@fluidframework/server-test-utils@5.0.0",
 		"@types/lodash": "^4.14.118",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.17.1",

--- a/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
@@ -530,6 +530,30 @@ use_old_ClassDeclaration_TestPublisher(
 /*
 * Validate forward compat by using old type in place of current type
 * If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_TestRedisClientConnectionManager": {"forwardCompat": false}
+*/
+declare function get_old_ClassDeclaration_TestRedisClientConnectionManager():
+    TypeOnly<old.TestRedisClientConnectionManager>;
+declare function use_current_ClassDeclaration_TestRedisClientConnectionManager(
+    use: TypeOnly<current.TestRedisClientConnectionManager>): void;
+use_current_ClassDeclaration_TestRedisClientConnectionManager(
+    get_old_ClassDeclaration_TestRedisClientConnectionManager());
+
+/*
+* Validate back compat by using current type in place of old type
+* If breaking change required, add in package.json under typeValidation.broken:
+* "ClassDeclaration_TestRedisClientConnectionManager": {"backCompat": false}
+*/
+declare function get_current_ClassDeclaration_TestRedisClientConnectionManager():
+    TypeOnly<current.TestRedisClientConnectionManager>;
+declare function use_old_ClassDeclaration_TestRedisClientConnectionManager(
+    use: TypeOnly<old.TestRedisClientConnectionManager>): void;
+use_old_ClassDeclaration_TestRedisClientConnectionManager(
+    get_current_ClassDeclaration_TestRedisClientConnectionManager());
+
+/*
+* Validate forward compat by using old type in place of current type
+* If breaking change required, add in package.json under typeValidation.broken:
 * "ClassDeclaration_TestTenant": {"forwardCompat": false}
 */
 declare function get_old_ClassDeclaration_TestTenant():

--- a/server/routerlicious/pnpm-lock.yaml
+++ b/server/routerlicious/pnpm-lock.yaml
@@ -83,8 +83,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/gitresources-previous':
-        specifier: npm:@fluidframework/gitresources@4.0.0
-        version: /@fluidframework/gitresources@4.0.0
+        specifier: npm:@fluidframework/gitresources@5.0.0
+        version: /@fluidframework/gitresources@5.0.0
       '@microsoft/api-extractor':
         specifier: ^7.45.1
         version: 7.45.1(patch_hash=f66stvskxun56mencgf6l5564y)(@types/node@18.18.4)
@@ -129,8 +129,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-kafka-orderer-previous':
-        specifier: npm:@fluidframework/server-kafka-orderer@4.0.0
-        version: /@fluidframework/server-kafka-orderer@4.0.0
+        specifier: npm:@fluidframework/server-kafka-orderer@5.0.0
+        version: /@fluidframework/server-kafka-orderer@5.0.0
       '@types/node':
         specifier: ^18.17.1
         version: 18.17.6
@@ -229,8 +229,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-lambdas-previous':
-        specifier: npm:@fluidframework/server-lambdas@4.0.0
-        version: /@fluidframework/server-lambdas@4.0.0(debug@4.3.4)
+        specifier: npm:@fluidframework/server-lambdas@5.0.0
+        version: /@fluidframework/server-lambdas@5.0.0(debug@4.3.4)
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -338,8 +338,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-lambdas-driver-previous':
-        specifier: npm:@fluidframework/server-lambdas-driver@4.0.0
-        version: /@fluidframework/server-lambdas-driver@4.0.0
+        specifier: npm:@fluidframework/server-lambdas-driver@5.0.0
+        version: /@fluidframework/server-lambdas-driver@5.0.0
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -429,8 +429,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-local-server-previous':
-        specifier: npm:@fluidframework/server-local-server@4.0.0
-        version: /@fluidframework/server-local-server@4.0.0
+        specifier: npm:@fluidframework/server-local-server@5.0.0
+        version: /@fluidframework/server-local-server@5.0.0
       '@microsoft/api-extractor':
         specifier: ^7.45.1
         version: 7.45.1(patch_hash=f66stvskxun56mencgf6l5564y)(@types/node@18.17.6)
@@ -568,8 +568,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-memory-orderer-previous':
-        specifier: npm:@fluidframework/server-memory-orderer@4.0.0
-        version: /@fluidframework/server-memory-orderer@4.0.0
+        specifier: npm:@fluidframework/server-memory-orderer@5.0.0
+        version: /@fluidframework/server-memory-orderer@5.0.0
       '@types/mocha':
         specifier: ^10.0.1
         version: 10.0.1
@@ -629,8 +629,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/protocol-base-previous':
-        specifier: npm:@fluidframework/protocol-base@4.0.0
-        version: /@fluidframework/protocol-base@4.0.0
+        specifier: npm:@fluidframework/protocol-base@5.0.0
+        version: /@fluidframework/protocol-base@5.0.0
       '@microsoft/api-extractor':
         specifier: ^7.45.1
         version: 7.45.1(patch_hash=f66stvskxun56mencgf6l5564y)(@types/node@18.17.6)
@@ -744,8 +744,8 @@ importers:
         specifier: workspace:~
         version: link:../local-server
       '@fluidframework/server-routerlicious-previous':
-        specifier: npm:@fluidframework/server-routerlicious@4.0.0
-        version: /@fluidframework/server-routerlicious@4.0.0
+        specifier: npm:@fluidframework/server-routerlicious@5.0.0
+        version: /@fluidframework/server-routerlicious@5.0.0
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -889,8 +889,8 @@ importers:
         specifier: workspace:~
         version: link:../local-server
       '@fluidframework/server-routerlicious-base-previous':
-        specifier: npm:@fluidframework/server-routerlicious-base@4.0.0
-        version: /@fluidframework/server-routerlicious-base@4.0.0
+        specifier: npm:@fluidframework/server-routerlicious-base@5.0.0
+        version: /@fluidframework/server-routerlicious-base@5.0.0
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1064,8 +1064,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-previous':
-        specifier: npm:@fluidframework/server-services@4.0.0
-        version: /@fluidframework/server-services@4.0.0
+        specifier: npm:@fluidframework/server-services@5.0.0
+        version: /@fluidframework/server-services@5.0.0
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1176,8 +1176,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-client-previous':
-        specifier: npm:@fluidframework/server-services-client@4.0.0
-        version: /@fluidframework/server-services-client@4.0.0
+        specifier: npm:@fluidframework/server-services-client@5.0.0
+        version: /@fluidframework/server-services-client@5.0.0
       '@microsoft/api-extractor':
         specifier: ^7.45.1
         version: 7.45.1(patch_hash=f66stvskxun56mencgf6l5564y)(@types/node@18.17.6)
@@ -1270,8 +1270,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-core-previous':
-        specifier: npm:@fluidframework/server-services-core@4.0.0
-        version: /@fluidframework/server-services-core@4.0.0
+        specifier: npm:@fluidframework/server-services-core@5.0.0
+        version: /@fluidframework/server-services-core@5.0.0
       concurrently:
         specifier: ^8.2.1
         version: 8.2.1
@@ -1328,8 +1328,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-ordering-kafkanode-previous':
-        specifier: npm:@fluidframework/server-services-ordering-kafkanode@4.0.0
-        version: /@fluidframework/server-services-ordering-kafkanode@4.0.0
+        specifier: npm:@fluidframework/server-services-ordering-kafkanode@5.0.0
+        version: /@fluidframework/server-services-ordering-kafkanode@5.0.0
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1404,8 +1404,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-ordering-rdkafka-previous':
-        specifier: npm:@fluidframework/server-services-ordering-rdkafka@4.0.0
-        version: /@fluidframework/server-services-ordering-rdkafka@4.0.0
+        specifier: npm:@fluidframework/server-services-ordering-rdkafka@5.0.0
+        version: /@fluidframework/server-services-ordering-rdkafka@5.0.0
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1465,8 +1465,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-ordering-zookeeper-previous':
-        specifier: npm:@fluidframework/server-services-ordering-zookeeper@4.0.0
-        version: /@fluidframework/server-services-ordering-zookeeper@4.0.0
+        specifier: npm:@fluidframework/server-services-ordering-zookeeper@5.0.0
+        version: /@fluidframework/server-services-ordering-zookeeper@5.0.0
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1589,8 +1589,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-shared-previous':
-        specifier: npm:@fluidframework/server-services-shared@4.0.0
-        version: /@fluidframework/server-services-shared@4.0.0
+        specifier: npm:@fluidframework/server-services-shared@5.0.0
+        version: /@fluidframework/server-services-shared@5.0.0
       '@types/body-parser':
         specifier: ^1.19.2
         version: 1.19.2
@@ -1677,8 +1677,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-telemetry-previous':
-        specifier: npm:@fluidframework/server-services-telemetry@4.0.0
-        version: /@fluidframework/server-services-telemetry@4.0.0
+        specifier: npm:@fluidframework/server-services-telemetry@5.0.0
+        version: /@fluidframework/server-services-telemetry@5.0.0
       '@types/mocha':
         specifier: ^10.0.1
         version: 10.0.1
@@ -1783,8 +1783,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-services-utils-previous':
-        specifier: npm:@fluidframework/server-services-utils@4.0.0
-        version: /@fluidframework/server-services-utils@4.0.0
+        specifier: npm:@fluidframework/server-services-utils@5.0.0
+        version: /@fluidframework/server-services-utils@5.0.0
       '@fluidframework/server-test-utils':
         specifier: workspace:~
         version: link:../test-utils
@@ -1910,8 +1910,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
       '@fluidframework/server-test-utils-previous':
-        specifier: npm:@fluidframework/server-test-utils@4.0.0
-        version: /@fluidframework/server-test-utils@4.0.0
+        specifier: npm:@fluidframework/server-test-utils@5.0.0
+        version: /@fluidframework/server-test-utils@5.0.0
       '@types/lodash':
         specifier: ^4.14.118
         version: 4.14.195
@@ -2174,6 +2174,7 @@ packages:
       '@aws-crypto/util': 3.0.0
       '@aws-sdk/types': 3.567.0
       tslib: 1.14.1
+    dev: true
 
   /@aws-crypto/crc32c@3.0.0:
     resolution: {integrity: sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==}
@@ -2237,8 +2238,8 @@ packages:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.569.0
-      '@aws-sdk/client-sts': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)
+      '@aws-sdk/client-sso-oidc': 3.569.0(@aws-sdk/client-sts@3.569.0)
+      '@aws-sdk/client-sts': 3.569.0
       '@aws-sdk/core': 3.567.0
       '@aws-sdk/credential-provider-node': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)(@aws-sdk/client-sts@3.569.0)
       '@aws-sdk/middleware-host-header': 3.567.0
@@ -2338,8 +2339,8 @@ packages:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.569.0
-      '@aws-sdk/client-sts': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)
+      '@aws-sdk/client-sso-oidc': 3.569.0(@aws-sdk/client-sts@3.569.0)
+      '@aws-sdk/client-sts': 3.569.0
       '@aws-sdk/core': 3.567.0
       '@aws-sdk/credential-provider-node': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)(@aws-sdk/client-sts@3.569.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.568.0
@@ -2397,13 +2398,13 @@ packages:
       - aws-crt
     dev: true
 
-  /@aws-sdk/client-sso-oidc@3.569.0:
+  /@aws-sdk/client-sso-oidc@3.569.0(@aws-sdk/client-sts@3.569.0):
     resolution: {integrity: sha512-u5DEjNEvRvlKKh1QLCDuQ8GIrx+OFvJFLfhorsp4oCxDylvORs+KfyKKnJAw4wYEEHyxyz9GzHD7p6a8+HLVHw==}
     engines: {node: '>=16.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)
+      '@aws-sdk/client-sts': 3.569.0
       '@aws-sdk/core': 3.567.0
       '@aws-sdk/credential-provider-node': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)(@aws-sdk/client-sts@3.569.0)
       '@aws-sdk/middleware-host-header': 3.567.0
@@ -2442,6 +2443,7 @@ packages:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
     dev: true
 
@@ -2556,42 +2558,42 @@ packages:
       '@aws-sdk/util-endpoints': 3.470.0
       '@aws-sdk/util-user-agent-browser': 3.468.0
       '@aws-sdk/util-user-agent-node': 3.470.0
-      '@smithy/config-resolver': 2.0.21
-      '@smithy/fetch-http-handler': 2.3.1
-      '@smithy/hash-node': 2.0.17
-      '@smithy/invalid-dependency': 2.0.15
-      '@smithy/middleware-content-length': 2.0.17
-      '@smithy/middleware-endpoint': 2.2.3
-      '@smithy/middleware-retry': 2.0.24
-      '@smithy/middleware-serde': 2.0.15
-      '@smithy/middleware-stack': 2.0.9
-      '@smithy/node-config-provider': 2.1.8
-      '@smithy/node-http-handler': 2.2.1
-      '@smithy/protocol-http': 3.0.11
-      '@smithy/smithy-client': 2.1.18
-      '@smithy/types': 2.7.0
-      '@smithy/url-parser': 2.0.15
-      '@smithy/util-base64': 2.0.1
-      '@smithy/util-body-length-browser': 2.0.1
-      '@smithy/util-body-length-node': 2.1.0
-      '@smithy/util-defaults-mode-browser': 2.0.22
-      '@smithy/util-defaults-mode-node': 2.0.29
-      '@smithy/util-endpoints': 1.0.7
-      '@smithy/util-retry': 2.0.8
-      '@smithy/util-utf8': 2.0.2
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       fast-xml-parser: 4.2.5
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     optional: true
 
-  /@aws-sdk/client-sts@3.569.0(@aws-sdk/client-sso-oidc@3.569.0):
+  /@aws-sdk/client-sts@3.569.0:
     resolution: {integrity: sha512-3AyipQ2zHszkcTr8n1Sp7CiMUi28aMf1vOhEo0KKi0DWGo1Z1qJEpWeRP363KG0n9/8U3p1IkXGz5FRbpXZxIw==}
     engines: {node: '>=16.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.569.0
+      '@aws-sdk/client-sso-oidc': 3.569.0(@aws-sdk/client-sts@3.569.0)
       '@aws-sdk/core': 3.567.0
       '@aws-sdk/credential-provider-node': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)(@aws-sdk/client-sts@3.569.0)
       '@aws-sdk/middleware-host-header': 3.567.0
@@ -2630,7 +2632,6 @@ packages:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
     dev: true
 
@@ -2697,13 +2698,13 @@ packages:
     requiresBuild: true
     dependencies:
       '@aws-sdk/types': 3.468.0
-      '@smithy/fetch-http-handler': 2.3.1
-      '@smithy/node-http-handler': 2.2.1
-      '@smithy/property-provider': 2.0.12
-      '@smithy/protocol-http': 3.0.11
-      '@smithy/smithy-client': 2.1.18
-      '@smithy/types': 2.7.0
-      '@smithy/util-stream': 2.0.23
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/util-stream': 2.2.0
       tslib: 2.6.2
     optional: true
 
@@ -2732,10 +2733,10 @@ packages:
       '@aws-sdk/credential-provider-sso': 3.470.0
       '@aws-sdk/credential-provider-web-identity': 3.468.0
       '@aws-sdk/types': 3.468.0
-      '@smithy/credential-provider-imds': 2.0.16
-      '@smithy/property-provider': 2.0.12
-      '@smithy/shared-ini-file-loader': 2.2.7
-      '@smithy/types': 2.7.0
+      '@smithy/credential-provider-imds': 2.3.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -2747,7 +2748,7 @@ packages:
     peerDependencies:
       '@aws-sdk/client-sts': ^3.568.0
     dependencies:
-      '@aws-sdk/client-sts': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)
+      '@aws-sdk/client-sts': 3.569.0
       '@aws-sdk/credential-provider-env': 3.568.0
       '@aws-sdk/credential-provider-process': 3.568.0
       '@aws-sdk/credential-provider-sso': 3.568.0(@aws-sdk/client-sso-oidc@3.569.0)
@@ -2774,10 +2775,10 @@ packages:
       '@aws-sdk/credential-provider-sso': 3.470.0
       '@aws-sdk/credential-provider-web-identity': 3.468.0
       '@aws-sdk/types': 3.468.0
-      '@smithy/credential-provider-imds': 2.0.16
-      '@smithy/property-provider': 2.0.12
-      '@smithy/shared-ini-file-loader': 2.2.7
-      '@smithy/types': 2.7.0
+      '@smithy/credential-provider-imds': 2.3.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -2811,9 +2812,9 @@ packages:
     requiresBuild: true
     dependencies:
       '@aws-sdk/types': 3.468.0
-      '@smithy/property-provider': 2.0.12
-      '@smithy/shared-ini-file-loader': 2.2.7
-      '@smithy/types': 2.7.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     optional: true
 
@@ -2836,9 +2837,9 @@ packages:
       '@aws-sdk/client-sso': 3.470.0
       '@aws-sdk/token-providers': 3.470.0
       '@aws-sdk/types': 3.468.0
-      '@smithy/property-provider': 2.0.12
-      '@smithy/shared-ini-file-loader': 2.2.7
-      '@smithy/types': 2.7.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -2877,7 +2878,7 @@ packages:
     peerDependencies:
       '@aws-sdk/client-sts': ^3.568.0
     dependencies:
-      '@aws-sdk/client-sts': 3.569.0(@aws-sdk/client-sso-oidc@3.569.0)
+      '@aws-sdk/client-sts': 3.569.0
       '@aws-sdk/types': 3.567.0
       '@smithy/property-provider': 2.2.0
       '@smithy/types': 2.12.0
@@ -2901,9 +2902,9 @@ packages:
       '@aws-sdk/credential-provider-sso': 3.470.0
       '@aws-sdk/credential-provider-web-identity': 3.468.0
       '@aws-sdk/types': 3.468.0
-      '@smithy/credential-provider-imds': 2.0.16
-      '@smithy/property-provider': 2.0.12
-      '@smithy/types': 2.7.0
+      '@smithy/credential-provider-imds': 2.3.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
@@ -3048,11 +3049,11 @@ packages:
     requiresBuild: true
     dependencies:
       '@aws-sdk/types': 3.468.0
-      '@smithy/property-provider': 2.0.12
-      '@smithy/protocol-http': 3.0.11
-      '@smithy/signature-v4': 2.0.18
-      '@smithy/types': 2.7.0
-      '@smithy/util-middleware': 2.0.8
+      '@smithy/property-provider': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-middleware': 2.2.0
       tslib: 2.6.2
     optional: true
 
@@ -3189,7 +3190,7 @@ packages:
     peerDependencies:
       '@aws-sdk/client-sso-oidc': ^3.568.0
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.569.0
+      '@aws-sdk/client-sso-oidc': 3.569.0(@aws-sdk/client-sts@3.569.0)
       '@aws-sdk/types': 3.567.0
       '@smithy/property-provider': 2.2.0
       '@smithy/shared-ini-file-loader': 2.4.0
@@ -3211,6 +3212,7 @@ packages:
     dependencies:
       '@smithy/types': 2.12.0
       tslib: 2.6.2
+    dev: true
 
   /@aws-sdk/util-arn-parser@3.568.0:
     resolution: {integrity: sha512-XUKJWWo+KOB7fbnPP0+g/o5Ulku/X53t7i/h+sPHr5xxYTJJ9CYnbToo95mzxe7xWvkLrsNtJ8L+MnNn9INs2w==}
@@ -3971,8 +3973,8 @@ packages:
       - typescript
     dev: true
 
-  /@fluidframework/gitresources@4.0.0:
-    resolution: {integrity: sha512-3E4bjOp0/el0EFIzut8fb5XDM5xF/zWKyKn8n1RLEsstMM9nktjFOhCHoP57tRsfc16p3g9GoXhtpWCwe0vqnQ==}
+  /@fluidframework/gitresources@5.0.0:
+    resolution: {integrity: sha512-nfam1KT+EUqFCENHcxrU9VwUfbhUC83UcLuOsdLpn9I7VuClL+w8KMWosoYauZraO9gDhTo2kCErjgQji5GzGA==}
     dev: true
 
   /@fluidframework/mocha-test-setup@2.0.0-internal.7.0.0:
@@ -3984,34 +3986,34 @@ packages:
       source-map-support: 0.5.21
     dev: true
 
-  /@fluidframework/protocol-base@4.0.0:
-    resolution: {integrity: sha512-mpuYXOOfCXKKEdzauxQ3KTY+ZWNj+NTEQTEJW8PD/xqN95g3AYoYXiikEkuzPbKghkAWcr6gYNxmK//MLbIVFw==}
+  /@fluidframework/protocol-base@5.0.0:
+    resolution: {integrity: sha512-q5qQt269nUYQERwX5lntfEXVv7jbxFmGAZC1z1I5hZmkvSC6PJGF6GzXAtP43/eq0+hCftxmIT0jus+kLL/K4w==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 4.0.0
+      '@fluidframework/gitresources': 5.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      events: 3.3.0
+      events_pkg: /events@3.3.0
     dev: true
 
   /@fluidframework/protocol-definitions@3.2.0:
     resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
 
-  /@fluidframework/server-kafka-orderer@4.0.0:
-    resolution: {integrity: sha512-5JXFs004R3J9kfJGYQGNVJt5aHeq+BTeAuVYTtXhQ8r/NKGYyU+EinFmQDQX8rNLYcY5T8iwrFZB8HCJX81Y4g==}
+  /@fluidframework/server-kafka-orderer@5.0.0:
+    resolution: {integrity: sha512-WQaKMj6UWr4LTIf4Rib296qoTaws5e0ZWn5zxDLykDoFGTs14D4xvgBBiRMYDI66u5cy8rJq08BlPm+krntF+Q==}
     dependencies:
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-core': 5.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/server-lambdas-driver@4.0.0:
-    resolution: {integrity: sha512-3RM55xj1PrlUBYjGbtiBTMk8oFcNKUa+aofTBcoYiJsNvI7qOSifRvgl7TBLxPKLBSjZ25NjYBo0NXSG0p0l5A==}
+  /@fluidframework/server-lambdas-driver@5.0.0:
+    resolution: {integrity: sha512-tnMxsxKr2zajQ64Ew7zcTKclK2Rkp7cqK4ghiuYkzhdbt7ZxIMVmkSW3B5/DXDSxVoi4VR6q1BA6cMnGJMcwsw==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
       assert: 2.1.0
       async: 3.2.5
       events: 3.3.0
@@ -4022,18 +4024,17 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-lambdas@4.0.0(debug@4.3.4):
-    resolution: {integrity: sha512-htB+QpkRzzrJnKTl0MIxEiaD3d2l0fx7mUy3rQ6/oJzs1ZisD2KoTG4ZNaKmWBcBZpNwFYPdOfvfeKGCKovuHg==}
+  /@fluidframework/server-lambdas@5.0.0(debug@4.3.4):
+    resolution: {integrity: sha512-t0ouLtYi2y5DBYbp+WT4mIGXTSYK/1Yz+cb0prOtAUxYqsn+TAG/hr2DE8OyzHdL0RHZp/y2KX7X1jZhPxxGDg==}
     dependencies:
-      '@fluidframework/common-definitions': 1.1.0
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 4.0.0
-      '@fluidframework/protocol-base': 4.0.0
+      '@fluidframework/gitresources': 5.0.0
+      '@fluidframework/protocol-base': 5.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas-driver': 4.0.0
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
+      '@fluidframework/server-lambdas-driver': 5.0.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
       '@types/semver': 7.5.6
       assert: 2.1.0
       async: 3.2.5
@@ -4052,19 +4053,19 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-local-server@4.0.0:
-    resolution: {integrity: sha512-fHycWdu0GnP5yziN/2/l1SL3nLk82E7RwczGdhnoLEcLsZIT9paEFr0XYrNliYX9Tu82ZA1m1mHrxhAOyYHkYg==}
+  /@fluidframework/server-local-server@5.0.0:
+    resolution: {integrity: sha512-v+IBLojcZm1azQhiSEPCt3A2/xByiqDQ7/0gdkFenGrnEvnJ/9r/vv6ON0vAWFqDXov1Nu6kwEGA1bXIZTeHQw==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 4.0.0(debug@4.3.4)
-      '@fluidframework/server-memory-orderer': 4.0.0
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
-      '@fluidframework/server-test-utils': 4.0.0
+      '@fluidframework/server-lambdas': 5.0.0(debug@4.3.4)
+      '@fluidframework/server-memory-orderer': 5.0.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-test-utils': 5.0.0
       debug: 4.3.4(supports-color@8.1.1)
-      events: 3.3.0
+      events_pkg: /events@3.3.0
       jsrsasign: 11.0.0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -4073,16 +4074,16 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/server-memory-orderer@4.0.0:
-    resolution: {integrity: sha512-/Da91g+VnTUJu8Byp58csSRGsjLB9Ju+a0788Ag/IcwUBjYEDUWe8jlCLCdnNOScZnFW9W88R+F2RTC0LFlMOg==}
+  /@fluidframework/server-memory-orderer@5.0.0:
+    resolution: {integrity: sha512-S5G2TwHXlewGkZ3jAtUKr/vpku0LPvhApktOVtAidIGHlKJP0kjLiom/KZihKZT5h2KqIhFBy56JgkXPFYkNeQ==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/protocol-base': 4.0.0
+      '@fluidframework/protocol-base': 5.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 4.0.0(debug@4.3.4)
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
+      '@fluidframework/server-lambdas': 5.0.0(debug@4.3.4)
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
       '@types/debug': 4.1.12
       '@types/double-ended-queue': 2.1.7
       '@types/lodash': 4.14.202
@@ -4102,25 +4103,25 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/server-routerlicious-base@4.0.0:
-    resolution: {integrity: sha512-rQTjI3lSPrSqgVooFGzMXzPCfaynbUHCTI3U5IiQ0PDpBD9BOJQsq1nj2ZxlfRRz3/HRKFn/mWlmaIUsaoROpg==}
+  /@fluidframework/server-routerlicious-base@5.0.0:
+    resolution: {integrity: sha512-j1l8hEi8EWiC2L5AN9DgeJe1vF79yP4AU3jd+rXNPeSOfR2vYO5aQxmosgJGkHPJYG8AWQ72VEi6YPE4jFlS7w==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 4.0.0
+      '@fluidframework/gitresources': 5.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-kafka-orderer': 4.0.0
-      '@fluidframework/server-lambdas': 4.0.0(debug@4.3.4)
-      '@fluidframework/server-lambdas-driver': 4.0.0
-      '@fluidframework/server-memory-orderer': 4.0.0
-      '@fluidframework/server-services': 4.0.0
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-ordering-kafkanode': 4.0.0
-      '@fluidframework/server-services-ordering-rdkafka': 4.0.0
-      '@fluidframework/server-services-ordering-zookeeper': 4.0.0
-      '@fluidframework/server-services-shared': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
-      '@fluidframework/server-services-utils': 4.0.0
+      '@fluidframework/server-kafka-orderer': 5.0.0
+      '@fluidframework/server-lambdas': 5.0.0(debug@4.3.4)
+      '@fluidframework/server-lambdas-driver': 5.0.0
+      '@fluidframework/server-memory-orderer': 5.0.0
+      '@fluidframework/server-services': 5.0.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-ordering-kafkanode': 5.0.0
+      '@fluidframework/server-services-ordering-rdkafka': 5.0.0
+      '@fluidframework/server-services-ordering-zookeeper': 5.0.0
+      '@fluidframework/server-services-shared': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-services-utils': 5.0.0
       body-parser: 1.20.2
       bytes: 3.1.2
       compression: 1.7.4
@@ -4146,23 +4147,23 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/server-routerlicious@4.0.0:
-    resolution: {integrity: sha512-y2VREZ50RAj7/cKYSiQ4CFTcl/mdoZXBhG8tAdXfQOw7Xmsqg6O5LWTUTS+puajFO47oWofhcIQWBTtDOdKqhg==}
+  /@fluidframework/server-routerlicious@5.0.0:
+    resolution: {integrity: sha512-9zAuSxDBgl4SLYU0ZJPBDBmZLE2M+wbuIyZjBGy/JE5FlAs17DvdZLkh0bDty8Wp5AgHk9FW44KZNXwrBsUG1g==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 4.0.0
+      '@fluidframework/gitresources': 5.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-kafka-orderer': 4.0.0
-      '@fluidframework/server-lambdas': 4.0.0(debug@4.3.4)
-      '@fluidframework/server-lambdas-driver': 4.0.0
-      '@fluidframework/server-memory-orderer': 4.0.0
-      '@fluidframework/server-routerlicious-base': 4.0.0
-      '@fluidframework/server-services': 4.0.0
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-shared': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
-      '@fluidframework/server-services-utils': 4.0.0
+      '@fluidframework/server-kafka-orderer': 5.0.0
+      '@fluidframework/server-lambdas': 5.0.0(debug@4.3.4)
+      '@fluidframework/server-lambdas-driver': 5.0.0
+      '@fluidframework/server-memory-orderer': 5.0.0
+      '@fluidframework/server-routerlicious-base': 5.0.0
+      '@fluidframework/server-services': 5.0.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-shared': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-services-utils': 5.0.0
       commander: 2.20.3
       express: 4.19.2
       ioredis: 5.3.2
@@ -4176,12 +4177,12 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/server-services-client@4.0.0:
-    resolution: {integrity: sha512-ExvztSQrliaYMSeLLxlACdWkuDk6auDle4eIQ2euvkgl0RWnupatPYgUVdfnNMIE6vBIeOwDzJaWy2giFx7Z6Q==}
+  /@fluidframework/server-services-client@5.0.0:
+    resolution: {integrity: sha512-Cijcy/WUL4U20XAVmN3tDMCYmjmwAmAl6drXBYzN6QvnwMN4PsNjwgsZdEHN+2D7wEs4o/Wb+g9DNv+Lu5EmLg==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 4.0.0
-      '@fluidframework/protocol-base': 4.0.0
+      '@fluidframework/gitresources': 5.0.0
+      '@fluidframework/protocol-base': 5.0.0
       '@fluidframework/protocol-definitions': 3.2.0
       axios: 1.6.2(debug@4.3.4)
       crc-32: 1.2.0
@@ -4195,14 +4196,14 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services-core@4.0.0:
-    resolution: {integrity: sha512-gt8GLNIDf8ZALbZGsS7WDytSLXwVPYEBCmuE+J3bikd3mItGxFhxQQI/6ZynUz/lue7GvoZtSuDyeal3DarwCQ==}
+  /@fluidframework/server-services-core@5.0.0:
+    resolution: {integrity: sha512-ztrGdRStwlfBFVsm+kChu6VuI764O4TbEEE1RX4gXpLlOsUVZfgYfeUiysdk5Zh7svDKT9n5LdE6VdjLvwb7IA==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 4.0.0
+      '@fluidframework/gitresources': 5.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
       '@types/nconf': 0.10.6
       '@types/node': 18.19.3
       debug: 4.3.4(supports-color@8.1.1)
@@ -4212,14 +4213,14 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services-ordering-kafkanode@4.0.0:
-    resolution: {integrity: sha512-ThfJUiLdIl+N9v2KJU+WQF7wUwIPpkQpO+KeQAfCMZg8xLTDzrSRA45FRexztXS9UKx2jnKT/g1GzY4ySGc2oA==}
+  /@fluidframework/server-services-ordering-kafkanode@5.0.0:
+    resolution: {integrity: sha512-pbNHMD3bZ3gs8pMlQvauTMn7SiGxm46HenlnQBRlbZb+FF+PbEhf1doyJab5JllVTR0HnIso0LLxf9MHK63Mdg==}
     dependencies:
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-ordering-zookeeper': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
-      events: 3.3.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-ordering-zookeeper': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
+      events_pkg: /events@3.3.0
       kafka-node: 5.0.0
       nconf: 0.12.1
       sillyname: 0.1.0
@@ -4227,42 +4228,42 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services-ordering-rdkafka@4.0.0:
-    resolution: {integrity: sha512-o4K+RQbAhiKjn/ZOcSnpaHwdEXPZ/k+GYWUqfjC/1v6wp/8Pb7n7O6evonkvuNxsUzwx/NMeAWou39y5Hx98qA==}
+  /@fluidframework/server-services-ordering-rdkafka@5.0.0:
+    resolution: {integrity: sha512-BNq5i6Loro7OdT/Xuo1QsPDxPLySkezBXELKnyzTnJBzziNu81jmTAutJJkNDiPkv6aZNquk657q5S1mcm8FGQ==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
-      events: 3.3.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
+      events_pkg: /events@3.3.0
       nconf: 0.12.1
-      node-rdkafka: 2.18.0
+      node-rdkafka: 3.0.1
       sillyname: 0.1.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services-ordering-zookeeper@4.0.0:
-    resolution: {integrity: sha512-snj4yOeNHPLdYS6PbTsJOzV4QIYNgFbWAP2/k2fdz/xLnP3kDiGFltOa8NmxMOkkIIe8u/nKdZ5vn0jHl509yg==}
+  /@fluidframework/server-services-ordering-zookeeper@5.0.0:
+    resolution: {integrity: sha512-HZad4lMJjMduUySfTBQKN4bvgrpWrVpWRBkc3DvWOjP3NUwBf+VA6ndiN2x3fpqlyMgdyXNfgZyNrijMJpvADA==}
     dependencies:
-      '@fluidframework/server-services-core': 4.0.0
+      '@fluidframework/server-services-core': 5.0.0
       zookeeper: 5.6.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services-shared@4.0.0:
-    resolution: {integrity: sha512-R2HpaqcESJFekx5WMB9oh02j89yP+6IVye6hcp4L6potwMV/SCjuntX+tUAFaK/lUHIxTcI0wtkXJypHe+rAXw==}
+  /@fluidframework/server-services-shared@5.0.0:
+    resolution: {integrity: sha512-Qrmxq8IeUTq9n+5rpR4LY0MPZfKWXCw/MQj0Sc5xe0bx8tnPmqQ1W43uOC+or4HcWmigSYKkhPfp73BSzvNrfw==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 4.0.0
-      '@fluidframework/protocol-base': 4.0.0
+      '@fluidframework/gitresources': 5.0.0
+      '@fluidframework/protocol-base': 5.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
-      '@fluidframework/server-services-utils': 4.0.0
-      '@socket.io/redis-adapter': 7.2.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-services-utils': 5.0.0
+      '@socket.io/redis-adapter': 8.3.0(socket.io-adapter@2.5.4)
       '@socket.io/sticky': 1.0.4
       body-parser: 1.20.2
       debug: 4.3.4(supports-color@8.1.1)
@@ -4284,8 +4285,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/server-services-telemetry@4.0.0:
-    resolution: {integrity: sha512-EK3+l1a2x4rOwBr688h3DqGrDmgJnv6kYxHKaoxJ9gVPXgg866m2ajEU75IvneqOyomqUINE2oZOrRqjdvJR1Q==}
+  /@fluidframework/server-services-telemetry@5.0.0:
+    resolution: {integrity: sha512-lWymor6/GVgZpjtBOEUzCmjNJoro/oK2MKoT0MFgg70bhTgWKAOLRAkJZgq8GLGPCHW7ntZ/D+ve763kPu27CQ==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       json-stringify-safe: 5.0.1
@@ -4294,13 +4295,13 @@ packages:
       uuid: 9.0.1
     dev: true
 
-  /@fluidframework/server-services-utils@4.0.0:
-    resolution: {integrity: sha512-Lo4RTPZ0GDtz0ul69VRHhiWE/ZGfbPWPZp9Kqwh0nsv/tAzxd3lWCdxZjhPegHtCEWzAxDBzOhPP1muKhLMWDQ==}
+  /@fluidframework/server-services-utils@5.0.0:
+    resolution: {integrity: sha512-5yuVl3Wqj8GpcT1NX+GFsvIwP3nSWD/KJP0J1EQi499T5RWwdsoCcDtZhe1T968NbPQAx/gnXyMtEVy5MfTkWA==}
     dependencies:
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
       debug: 4.3.4(supports-color@8.1.1)
       express: 4.19.2
       ioredis: 5.3.2
@@ -4318,18 +4319,18 @@ packages:
       - supports-color
     dev: true
 
-  /@fluidframework/server-services@4.0.0:
-    resolution: {integrity: sha512-8ZyrPlOXdL19+O5rvPkuahnQaQDyBb/eXTLS1UyEy8EQNJaWslHnXgU6xnXOyy/JsBHnowF8wqMyXXqcEj2OwQ==}
+  /@fluidframework/server-services@5.0.0:
+    resolution: {integrity: sha512-iFh8ML/0FycJNtqNFc1uYZnA16DHXxd5kLlt6oY1lDVNeV1JgsI+6mefhp1QK++j1T3jcSe6d5MWs72nm8VUsw==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-ordering-kafkanode': 4.0.0
-      '@fluidframework/server-services-ordering-rdkafka': 4.0.0
-      '@fluidframework/server-services-shared': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
-      '@fluidframework/server-services-utils': 4.0.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-ordering-kafkanode': 5.0.0
+      '@fluidframework/server-services-ordering-rdkafka': 5.0.0
+      '@fluidframework/server-services-shared': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
+      '@fluidframework/server-services-utils': 5.0.0
       '@socket.io/redis-emitter': 4.1.1
       '@types/lodash': 4.14.202
       amqplib: 0.10.3
@@ -4352,19 +4353,22 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@fluidframework/server-test-utils@4.0.0:
-    resolution: {integrity: sha512-tygY1aWGswuY0qWJ3EOk4HlWjuCSiyPJu6OQNlSzzT50B43Ku146MQe8WdTdWmxxgQjk+/R5BPLxrCugu74LJw==}
+  /@fluidframework/server-test-utils@5.0.0:
+    resolution: {integrity: sha512-FOZ1Faw6x8VALUZh/nY6zKCfpgbPK/ylpKf/uQ2oOV9sxGNQfo5NXyHlQP1b78wfx2OYyHY5njtvYl7i9tz/zg==}
     dependencies:
       '@fluidframework/common-utils': 3.1.0
-      '@fluidframework/gitresources': 4.0.0
-      '@fluidframework/protocol-base': 4.0.0
+      '@fluidframework/gitresources': 5.0.0
+      '@fluidframework/protocol-base': 5.0.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-services-client': 4.0.0
-      '@fluidframework/server-services-core': 4.0.0
-      '@fluidframework/server-services-telemetry': 4.0.0
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/server-services-core': 5.0.0
+      '@fluidframework/server-services-telemetry': 5.0.0
+      '@types/ioredis-mock': 8.2.2
       assert: 2.1.0
       debug: 4.3.4(supports-color@8.1.1)
       events: 3.3.0
+      ioredis: 5.3.2
+      ioredis-mock: 8.7.0(@types/ioredis-mock@8.2.2)(ioredis@5.3.2)
       lodash: 4.17.21
       string-hash: 1.1.3
       uuid: 9.0.1
@@ -5447,7 +5451,6 @@ packages:
     dependencies:
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/chunked-blob-reader-native@2.2.0:
     resolution: {integrity: sha512-VNB5+1oCgX3Fzs072yuRsUoC2N4Zg/LJ11DTxX3+Qu+Paa6AmbIF0E9sc2wthz9Psrk/zcOlTCyuposlIhPjZQ==}
@@ -5483,7 +5486,6 @@ packages:
       '@smithy/util-config-provider': 2.3.0
       '@smithy/util-middleware': 2.2.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/core@1.4.2:
     resolution: {integrity: sha512-2fek3I0KZHWJlRLvRTqxTEri+qV0GRHrJIoLFuBMZB4EMg4WgeBGfF0X6abnrNYpq55KJ6R4D6x4f0vLnhzinA==}
@@ -5498,18 +5500,6 @@ packages:
       '@smithy/util-middleware': 2.2.0
       tslib: 2.6.2
     dev: true
-
-  /@smithy/credential-provider-imds@2.0.16:
-    resolution: {integrity: sha512-tKa2xF+69TvGxJT+lnJpGrKxUuAZDLYXFhqnPEgnHz+psTpkpcB4QRjHj63+uj83KaeFJdTfW201eLZeRn6FfA==}
-    engines: {node: '>=14.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/node-config-provider': 2.1.1
-      '@smithy/property-provider': 2.0.12
-      '@smithy/types': 2.7.0
-      '@smithy/url-parser': 2.0.11
-      tslib: 2.6.2
-    optional: true
 
   /@smithy/credential-provider-imds@2.1.4:
     resolution: {integrity: sha512-cwPJN1fa1YOQzhBlTXRavABEYRRchci1X79QRwzaNLySnIMJfztyv1Zkst0iZPLMnpn8+CnHu3wOHS11J5Dr3A==}
@@ -5532,17 +5522,6 @@ packages:
       '@smithy/types': 2.12.0
       '@smithy/url-parser': 2.2.0
       tslib: 2.6.2
-    dev: true
-
-  /@smithy/eventstream-codec@2.0.15:
-    resolution: {integrity: sha512-crjvz3j1gGPwA0us6cwS7+5gAn35CTmqu/oIxVbYJo2Qm/sGAye6zGJnMDk3BKhWZw5kcU1G4MxciTkuBpOZPg==}
-    requiresBuild: true
-    dependencies:
-      '@aws-crypto/crc32': 3.0.0
-      '@smithy/types': 2.7.0
-      '@smithy/util-hex-encoding': 2.0.0
-      tslib: 2.6.2
-    optional: true
 
   /@smithy/eventstream-codec@2.2.0:
     resolution: {integrity: sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==}
@@ -5607,7 +5586,6 @@ packages:
       '@smithy/types': 2.12.0
       '@smithy/util-base64': 2.3.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/hash-blob-browser@2.2.0:
     resolution: {integrity: sha512-SGPoVH8mdXBqrkVCJ1Hd1X7vh1zDXojNN1yZyZTZsCno99hVue9+IYzWDjq/EQDDXxmITB0gBmuyPh8oAZSTcg==}
@@ -5637,7 +5615,6 @@ packages:
       '@smithy/util-buffer-from': 2.2.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/hash-stream-node@2.2.0:
     resolution: {integrity: sha512-aT+HCATOSRMGpPI7bi7NSsTNVZE/La9IaxLXWoVAYMxHT5hGO3ZOGEMZQg8A6nNL+pdFGtZQtND1eoY084HgHQ==}
@@ -5661,7 +5638,6 @@ packages:
     dependencies:
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/is-array-buffer@2.0.0:
     resolution: {integrity: sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==}
@@ -5676,7 +5652,6 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
-    dev: true
 
   /@smithy/md5-js@2.2.0:
     resolution: {integrity: sha512-M26XTtt9IIusVMOWEAhIvFIr9jYj4ISPPGJROqw6vXngO3IYJCnVVSMFn4Tx1rUTG5BiKJNg9u2nxmBiZC5IlQ==}
@@ -5703,7 +5678,6 @@ packages:
       '@smithy/protocol-http': 3.3.0
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/middleware-endpoint@2.2.3:
     resolution: {integrity: sha512-nYfxuq0S/xoAjdLbyn1ixeVB6cyH9wYCMtbbOCpcCRYR5u2mMtqUtVjjPAZ/DIdlK3qe0tpB0Q76szFGNuz+kQ==}
@@ -5730,7 +5704,6 @@ packages:
       '@smithy/url-parser': 2.2.0
       '@smithy/util-middleware': 2.2.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/middleware-retry@2.0.24:
     resolution: {integrity: sha512-q2SvHTYu96N7lYrn3VSuX3vRpxXHR/Cig6MJpGWxd0BWodUQUWlKvXpWQZA+lTaFJU7tUvpKhRd4p4MU3PbeJg==}
@@ -5761,7 +5734,6 @@ packages:
       '@smithy/util-retry': 2.2.0
       tslib: 2.6.2
       uuid: 9.0.1
-    dev: true
 
   /@smithy/middleware-serde@2.0.15:
     resolution: {integrity: sha512-FOZRFk/zN4AT4wzGuBY+39XWe+ZnCFd0gZtyw3f9Okn2CJPixl9GyWe98TIaljeZdqWkgrzGyPre20AcW2UMHQ==}
@@ -5778,7 +5750,6 @@ packages:
     dependencies:
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/middleware-stack@2.0.9:
     resolution: {integrity: sha512-bCB5dUtGQ5wh7QNL2ELxmDc6g7ih7jWU3Kx6MYH1h4mZbv9xL3WyhKHojRltThCB1arLPyTUFDi+x6fB/oabtA==}
@@ -5795,18 +5766,6 @@ packages:
     dependencies:
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
-
-  /@smithy/node-config-provider@2.1.1:
-    resolution: {integrity: sha512-1lF6s1YWBi1LBu2O30tD3jyTgMtuvk/Z1twzXM4GPYe4dmZix4nNREPJIPOcfFikNU2o0eTYP80+izx5F2jIJA==}
-    engines: {node: '>=14.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/property-provider': 2.0.12
-      '@smithy/shared-ini-file-loader': 2.2.7
-      '@smithy/types': 2.7.0
-      tslib: 2.6.2
-    optional: true
 
   /@smithy/node-config-provider@2.1.8:
     resolution: {integrity: sha512-+w26OKakaBUGp+UG+dxYZtFb5fs3tgHg3/QrRrmUZj+rl3cIuw840vFUXX35cVPTUCQIiTqmz7CpVF7+hdINdQ==}
@@ -5827,7 +5786,6 @@ packages:
       '@smithy/shared-ini-file-loader': 2.4.0
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/node-http-handler@2.2.1:
     resolution: {integrity: sha512-8iAKQrC8+VFHPAT8pg4/j6hlsTQh+NKOWlctJBrYtQa4ExcxX7aSg3vdQ2XLoYwJotFUurg/NLqFCmZaPRrogw==}
@@ -5850,7 +5808,6 @@ packages:
       '@smithy/querystring-builder': 2.2.0
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/property-provider@2.0.12:
     resolution: {integrity: sha512-Un/OvvuQ1Kg8WYtoMCicfsFFuHb/TKL3pCA6ZIo/WvNTJTR94RtoRnL7mY4XkkUAoFMyf6KjcQJ76y1FX7S5rw==}
@@ -5876,7 +5833,6 @@ packages:
     dependencies:
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/protocol-http@3.0.11:
     resolution: {integrity: sha512-3ziB8fHuXIRamV/akp/sqiWmNPR6X+9SB8Xxnozzj+Nq7hSpyKdFHd1FLpBkgfGFUTzzcBJQlDZPSyxzmdcx5A==}
@@ -5893,7 +5849,6 @@ packages:
     dependencies:
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/querystring-builder@2.0.15:
     resolution: {integrity: sha512-e1q85aT6HutvouOdN+dMsN0jcdshp50PSCvxDvo6aIM57LqeXimjfONUEgfqQ4IFpYWAtVixptyIRE5frMp/2A==}
@@ -5912,7 +5867,6 @@ packages:
       '@smithy/types': 2.12.0
       '@smithy/util-uri-escape': 2.2.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/querystring-parser@2.0.15:
     resolution: {integrity: sha512-jbBvoK3cc81Cj1c1TH1qMYxNQKHrYQ2DoTntN9FBbtUWcGhc+T4FP6kCKYwRLXyU4AajwGIZstvNAmIEgUUNTQ==}
@@ -5929,7 +5883,6 @@ packages:
     dependencies:
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/service-error-classification@2.0.8:
     resolution: {integrity: sha512-jCw9+005im8tsfYvwwSc4TTvd29kXRFkH9peQBg5R/4DD03ieGm6v6Hpv9nIAh98GwgYg1KrztcINC1s4o7/hg==}
@@ -5944,7 +5897,6 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@smithy/types': 2.12.0
-    dev: true
 
   /@smithy/shared-ini-file-loader@2.2.7:
     resolution: {integrity: sha512-0Qt5CuiogIuvQIfK+be7oVHcPsayLgfLJGkPlbgdbl0lD28nUKu4p11L+UG3SAEsqc9UsazO+nErPXw7+IgDpQ==}
@@ -5961,22 +5913,6 @@ packages:
     dependencies:
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
-
-  /@smithy/signature-v4@2.0.18:
-    resolution: {integrity: sha512-SJRAj9jT/l9ocm8D0GojMbnA1sp7I4JeStOQ4lEXI8A5eHE73vbjlzlqIFB7cLvIgau0oUl4cGVpF9IGCrvjlw==}
-    engines: {node: '>=14.0.0'}
-    requiresBuild: true
-    dependencies:
-      '@smithy/eventstream-codec': 2.0.15
-      '@smithy/is-array-buffer': 2.0.0
-      '@smithy/types': 2.7.0
-      '@smithy/util-hex-encoding': 2.0.0
-      '@smithy/util-middleware': 2.0.8
-      '@smithy/util-uri-escape': 2.0.0
-      '@smithy/util-utf8': 2.0.2
-      tslib: 2.6.2
-    optional: true
 
   /@smithy/signature-v4@2.3.0:
     resolution: {integrity: sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==}
@@ -5989,7 +5925,6 @@ packages:
       '@smithy/util-uri-escape': 2.2.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/smithy-client@2.1.18:
     resolution: {integrity: sha512-7FqdbaJiVaHJDD9IfDhmzhSDbpjyx+ZsfdYuOpDJF09rl8qlIAIlZNoSaflKrQ3cEXZN2YxGPaNWGhbYimyIRQ==}
@@ -6012,7 +5947,6 @@ packages:
       '@smithy/types': 2.12.0
       '@smithy/util-stream': 2.2.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/types@2.12.0:
     resolution: {integrity: sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==}
@@ -6026,15 +5960,6 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.6.2
-
-  /@smithy/url-parser@2.0.11:
-    resolution: {integrity: sha512-h89yXMCCF+S5k9XIoKltMIWTYj+FcEkU/IIFZ6RtE222fskOTL4Iak6ZRG+ehSvZDt8yKEcxqheTDq7JvvtK3g==}
-    requiresBuild: true
-    dependencies:
-      '@smithy/querystring-parser': 2.0.15
-      '@smithy/types': 2.7.0
-      tslib: 2.6.2
-    optional: true
 
   /@smithy/url-parser@2.0.15:
     resolution: {integrity: sha512-sADUncUj9rNbOTrdDGm4EXlUs0eQ9dyEo+V74PJoULY4jSQxS+9gwEgsPYyiu8PUOv16JC/MpHonOgqP/IEDZA==}
@@ -6051,7 +5976,6 @@ packages:
       '@smithy/querystring-parser': 2.2.0
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-base64@2.0.1:
     resolution: {integrity: sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==}
@@ -6069,7 +5993,6 @@ packages:
       '@smithy/util-buffer-from': 2.2.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-body-length-browser@2.0.1:
     resolution: {integrity: sha512-NXYp3ttgUlwkaug4bjBzJ5+yIbUbUx8VsSLuHZROQpoik+gRkIBeEG9MPVYfvPNpuXb/puqodeeUXcKFe7BLOQ==}
@@ -6082,7 +6005,6 @@ packages:
     resolution: {integrity: sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==}
     dependencies:
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-body-length-node@2.1.0:
     resolution: {integrity: sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==}
@@ -6097,7 +6019,6 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-buffer-from@2.0.0:
     resolution: {integrity: sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==}
@@ -6114,7 +6035,6 @@ packages:
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-config-provider@2.0.0:
     resolution: {integrity: sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==}
@@ -6129,7 +6049,6 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-defaults-mode-browser@2.0.22:
     resolution: {integrity: sha512-qcF20IHHH96FlktvBRICDXDhLPtpVmtksHmqNGtotb9B0DYWXsC6jWXrkhrrwF7tH26nj+npVTqh9isiFV1gdA==}
@@ -6152,7 +6071,6 @@ packages:
       '@smithy/types': 2.12.0
       bowser: 2.11.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-defaults-mode-node@2.0.29:
     resolution: {integrity: sha512-+uG/15VoUh6JV2fdY9CM++vnSuMQ1VKZ6BdnkUM7R++C/vLjnlg+ToiSR1FqKZbMmKBXmsr8c/TsDWMAYvxbxQ==}
@@ -6179,7 +6097,6 @@ packages:
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-endpoints@1.0.7:
     resolution: {integrity: sha512-Q2gEind3jxoLk6hdKWyESMU7LnXz8aamVwM+VeVjOYzYT1PalGlY/ETa48hv2YpV4+YV604y93YngyzzzQ4IIA==}
@@ -6198,7 +6115,6 @@ packages:
       '@smithy/node-config-provider': 2.3.0
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-hex-encoding@2.0.0:
     resolution: {integrity: sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==}
@@ -6213,7 +6129,6 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-middleware@2.0.8:
     resolution: {integrity: sha512-qkvqQjM8fRGGA8P2ydWylMhenCDP8VlkPn8kiNuFEaFz9xnUKC2irfqsBSJrfrOB9Qt6pQsI58r3zvvumhFMkw==}
@@ -6230,7 +6145,6 @@ packages:
     dependencies:
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-retry@2.0.8:
     resolution: {integrity: sha512-cQTPnVaVFMjjS6cb44WV2yXtHVyXDC5icKyIbejMarJEApYeJWpBU3LINTxHqp/tyLI+MZOUdosr2mZ3sdziNg==}
@@ -6249,7 +6163,6 @@ packages:
       '@smithy/service-error-classification': 2.1.5
       '@smithy/types': 2.12.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-stream@2.0.23:
     resolution: {integrity: sha512-OJMWq99LAZJUzUwTk+00plyxX3ESktBaGPhqNIEVab+53gLULiWN9B/8bRABLg0K6R6Xg4t80uRdhk3B/LZqMQ==}
@@ -6278,7 +6191,6 @@ packages:
       '@smithy/util-hex-encoding': 2.2.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-uri-escape@2.0.0:
     resolution: {integrity: sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==}
@@ -6293,7 +6205,6 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-utf8@2.0.2:
     resolution: {integrity: sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==}
@@ -6310,7 +6221,6 @@ packages:
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.6.2
-    dev: true
 
   /@smithy/util-waiter@2.2.0:
     resolution: {integrity: sha512-IHk53BVw6MPMi2Gsn+hCng8rFA3ZmR3Rk7GllxDUW9qFJl/hiSvskn7XldkECapQVkIg/1dHpMAxI9xSTaLLSA==}
@@ -6324,20 +6234,6 @@ packages:
   /@socket.io/component-emitter@3.1.0:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
 
-  /@socket.io/redis-adapter@7.2.0:
-    resolution: {integrity: sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
-      notepack.io: 2.2.0
-      socket.io-adapter: 2.5.4
-      uid2: 0.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /@socket.io/redis-adapter@8.3.0(socket.io-adapter@2.5.4):
     resolution: {integrity: sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==}
     engines: {node: '>=10.0.0'}
@@ -6350,7 +6246,6 @@ packages:
       uid2: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@socket.io/redis-emitter@4.1.1:
     resolution: {integrity: sha512-N0wfcfcVJvPF1AjIlZ5efxGCz+8uY6qeCwIaRU+QUCNdqvtXQtlC/MtUJQCwVqs1MWP6Bv3TDuZGC04gIj7YuQ==}
@@ -7451,6 +7346,7 @@ packages:
 
   /are-we-there-yet@1.1.7:
     resolution: {integrity: sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==}
+    deprecated: This package is no longer supported.
     requiresBuild: true
     dependencies:
       delegates: 1.0.0
@@ -10186,6 +10082,7 @@ packages:
 
   /gauge@2.7.4:
     resolution: {integrity: sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==}
+    deprecated: This package is no longer supported.
     requiresBuild: true
     dependencies:
       aproba: 1.2.0
@@ -12645,15 +12542,6 @@ packages:
       - supports-color
     dev: true
 
-  /node-rdkafka@2.18.0:
-    resolution: {integrity: sha512-jYkmO0sPvjesmzhv1WFOO4z7IMiAFpThR6/lcnFDWgSPkYL95CtcuVNo/R5PpjujmqSgS22GMkL1qvU4DTAvEQ==}
-    engines: {node: '>=6.0.0'}
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      nan: 2.19.0
-    dev: true
-
   /node-rdkafka@3.0.1:
     resolution: {integrity: sha512-USTFu7ylRj+fEiGz0hA92GWSqmX/hu/xSTqtgmInPPmh5zKhjauTciRjDEG3yK5m6yChwyHKQTIgmr56DfhiaQ==}
     engines: {node: '>=16'}
@@ -12661,7 +12549,6 @@ packages:
     dependencies:
       bindings: 1.5.0
       nan: 2.19.0
-    dev: false
 
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
@@ -12739,16 +12626,11 @@ packages:
   /notepack.io@2.1.3:
     resolution: {integrity: sha512-AgSt+cP5XMooho1Ppn8NB3FFaVWefV+qZoZncYTUSch2GAEwlYLcIIbT5YVkMlFeNHnfwOvc4HDlbvrB5BRxXA==}
 
-  /notepack.io@2.2.0:
-    resolution: {integrity: sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==}
-    dev: true
-
   /notepack.io@2.3.0:
     resolution: {integrity: sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==}
 
   /notepack.io@3.0.1:
     resolution: {integrity: sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg==}
-    dev: false
 
   /npm-bundled@3.0.0:
     resolution: {integrity: sha512-Vq0eyEQy+elFpzsKjMss9kxqb9tG3YHg4dsyWuUENuzvSUWe1TCnW/vV9FkhvBk/brEDoDiVd+M1Btosa6ImdQ==}
@@ -15653,14 +15535,9 @@ packages:
     resolution: {integrity: sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==}
     dev: false
 
-  /uid2@0.0.3:
-    resolution: {integrity: sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==}
-    dev: true
-
   /uid2@1.0.0:
     resolution: {integrity: sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==}
     engines: {node: '>= 4.0.0'}
-    dev: false
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}


### PR DESCRIPTION
Commands used:

```shell
flub typetests -g server --reset --normalize --previous
pnpm i
pnpm build
```

[AB#8473](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8473)