### PR TITLE
Add compatibilityMode flag to READMEs for service-clients

### DIFF
--- a/packages/service-clients/azure-client/README.md
+++ b/packages/service-clients/azure-client/README.md
@@ -106,7 +106,7 @@ const schema = {
 	],
 };
 const azureClient = new AzureClient(props);
-const { container, services } = await azureClient.createContainer(schema);
+const { container, services } = await azureClient.createContainer(schema, "2" /* compatibilityMode */);
 
 // Set any default data on the container's `initialObjects` before attaching
 // Returned ID can be used to fetch the container via `getContainer` below
@@ -121,7 +121,7 @@ Using the `AzureClient` object the developer can create and get Fluid containers
 import { AzureClient } from "@fluidframework/azure-client";
 
 const azureClient = new AzureClient(props);
-const { container, services } = await azureClient.getContainer("_unique-id_", schema);
+const { container, services } = await azureClient.getContainer("_unique-id_", schema, "2" /* compatibilityMode */);
 ```
 
 **Note:** When using the `AzureClient` with `tenantId` set to `"local"`, all containers that have been created will be deleted when the instance of the local Azure Fluid Relay service (not client) that was run from the terminal window is closed. However, any containers created when running against a remote Azure Fluid Relay service will be persisted. Container IDs **cannot** be reused between local and remote Azure Fluid Relay services to fetch back the same container.
@@ -143,7 +143,7 @@ const schema = {
 };
 
 // Fetch back the container that had been created earlier with the same ID and schema
-const { container, services } = await azureClient.getContainer("_unique-id_", schema);
+const { container, services } = await azureClient.getContainer("_unique-id_", schema, "2" /* compatibilityMode */);
 
 // Get our list of initial objects that we had defined in the schema. initialObjects here will have the same signature
 const initialObjects = container.initialObjects;
@@ -168,7 +168,7 @@ const schema = {
 	dynamicObjectTypes: [SharedString],
 };
 
-const { container, services } = await azureClient.getContainer("_unique-id_", schema);
+const { container, services } = await azureClient.getContainer("_unique-id_", schema, "2" /* compatibilityMode */);
 const map1 = container.initialObjects.map1;
 
 const text1 = await container.create(SharedString);

--- a/packages/service-clients/tinylicious-client/README.md
+++ b/packages/service-clients/tinylicious-client/README.md
@@ -60,7 +60,7 @@ const schema = {
 	],
 };
 const tinyliciousClient = new TinyliciousClient();
-const { container, services } = await tinyliciousClient.createContainer(schema);
+const { container, services } = await tinyliciousClient.createContainer(schema, "2" /* compatibilityMode */);
 
 // Set any default data on the container's `initialObjects` before attaching
 // Returned ID can be used to fetch the container via `getContainer` below
@@ -75,7 +75,7 @@ Using the default `TinyliciousClient` object the developer can create and get Fl
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
 
 const tinyliciousClient = new TinyliciousClient(props);
-const { container, services } = await tinyliciousClient.getContainer("_unique-id_", schema);
+const { container, services } = await tinyliciousClient.getContainer("_unique-id_", schema, "2" /* compatibilityMode */);
 ```
 
 ## Using initial objects
@@ -94,7 +94,7 @@ const schema = {
 	},
 };
 const tinyliciousClient = new TinyliciousClient();
-const { container, services } = await tinyliciousClient.getContainer("_unique-id_", schema);
+const { container, services } = await tinyliciousClient.getContainer("_unique-id_", schema, "2" /* compatibilityMode */);
 
 const initialObjects = container.initialObjects;
 const map1 = initialObjects.map1;
@@ -117,7 +117,7 @@ const schema = {
 	dynamicObjectTypes: [SharedString],
 };
 const tinyliciousClient = new TinyliciousClient();
-const { container, services } = await tinyliciousClient.getContainer("_unique-id_", schema);
+const { container, services } = await tinyliciousClient.getContainer("_unique-id_", schema, "2" /* compatibilityMode */);
 const map1 = container.initialObjects.map1;
 
 const newText = await container.create(SharedString);


### PR DESCRIPTION
Add compatibilityMode flag to calls to getContainer/createContainer so the examples are valid.  Main documentation for the flag and its usage in migration is under review and will be published separately.

[AB#8479](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8479)