### PR TITLE
Hydrate nodes in the initial tree passed to SharedTree's view initialization

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizeTree.ts
+++ b/packages/dds/tree/src/shared-tree/schematizeTree.ts
@@ -12,6 +12,7 @@ import {
 	type TreeStoredSchema,
 	rootFieldKey,
 	schemaDataIsEmpty,
+	isCursor,
 } from "../core/index.js";
 import {
 	FieldKinds,
@@ -168,11 +169,14 @@ export function initialize(checkout: ITreeCheckout, treeContent: TreeContent): v
 	try {
 		initializeContent(checkout, treeContent.schema, () => {
 			const field = { field: rootFieldKey, parent: undefined };
-			const content = normalizeNewFieldContent(
-				{ schema: treeContent.schema },
-				treeContent.schema.rootFieldSchema,
-				treeContent.initialTree,
-			);
+
+			const content = isCursor(treeContent)
+				? (treeContent as ITreeCursorSynchronous)
+				: normalizeNewFieldContent(
+						{ schema: treeContent.schema },
+						treeContent.schema.rootFieldSchema,
+						treeContent.initialTree,
+					);
 			switch (checkout.storedSchema.rootFieldSchema.kind) {
 				case FieldKinds.optional.identifier: {
 					const fieldEditor = checkout.editor.optionalField(field);

--- a/packages/dds/tree/src/shared-tree/schematizeTree.ts
+++ b/packages/dds/tree/src/shared-tree/schematizeTree.ts
@@ -12,7 +12,6 @@ import {
 	type TreeStoredSchema,
 	rootFieldKey,
 	schemaDataIsEmpty,
-	isCursor,
 } from "../core/index.js";
 import {
 	FieldKinds,
@@ -169,14 +168,11 @@ export function initialize(checkout: ITreeCheckout, treeContent: TreeContent): v
 	try {
 		initializeContent(checkout, treeContent.schema, () => {
 			const field = { field: rootFieldKey, parent: undefined };
-
-			const content = isCursor(treeContent)
-				? (treeContent as ITreeCursorSynchronous)
-				: normalizeNewFieldContent(
-						{ schema: treeContent.schema },
-						treeContent.schema.rootFieldSchema,
-						treeContent.initialTree,
-					);
+			const content = normalizeNewFieldContent(
+				{ schema: treeContent.schema },
+				treeContent.schema.rootFieldSchema,
+				treeContent.initialTree,
+			);
 			switch (checkout.storedSchema.rootFieldSchema.kind) {
 				case FieldKinds.optional.identifier: {
 					const fieldEditor = checkout.editor.optionalField(field);

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -60,7 +60,11 @@ export type {
 	NodeFromSchemaUnsafe,
 } from "./typesUnsafe.js";
 export type { ValidateRecursiveSchema } from "./schemaFactoryRecursive.js";
-export { getProxyForField, type InsertableContent } from "./proxies.js";
+export {
+	getProxyForField,
+	type InsertableContent,
+	prepareContentForHydration,
+} from "./proxies.js";
 
 export {
 	adaptEnum,
@@ -93,3 +97,4 @@ export {
 	setField,
 } from "./objectNode.js";
 export type { TreeMapNode } from "./mapNode.js";
+export { mapTreeFromNodeData } from "./toMapTree.js";

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -194,8 +194,7 @@ describe("SharedTree", () => {
 			assert.equal(schematized.flexTree.content, undefined);
 		});
 
-		// TODO: ensure unhydrated initialTree input is correctly hydrated.
-		it.skip("unhydrated tree input", () => {
+		it("unhydrated tree input", () => {
 			const tree = DebugSharedTree.create(new MockSharedTreeRuntime());
 			const sb = new SchemaFactory("test-factory");
 			class Foo extends sb.object("Foo", {}) {}

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/tree.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/tree.spec.ts
@@ -300,12 +300,13 @@ for (const testOpts of testMatrix) {
 					new TreeViewConfiguration({ schema: Doll, enableSchemaValidation: true }),
 				);
 
-				view.initialize(new Doll({ nested: new Doll({ nested: new Doll({}) }) }));
-				const depth0 = view.root;
-				const depth1 = depth0.nested;
-				assert(depth1 !== undefined);
-				const depth2 = depth1.nested;
-				assert(depth2 !== undefined);
+				// These nodes in the initial tree are unhydrated...
+				const depth1 = new Doll({ nested: new Doll({}) });
+				const depth0 = new Doll({ nested: depth1 });
+				view.initialize(depth0);
+				// ...and confirmed to be the same nodes we get when we read the tree after initialization
+				assert.equal(view.root, depth0);
+				assert.equal(view.root.nested, depth1);
 				// Record a list of the node events fired
 				const eventLog: string[] = [];
 				Tree.on(depth0, "nodeChanged", () => {


### PR DESCRIPTION
## Description

Previously, nodes in the initial tree were not hydrated (as they are when inserting content in general). This meant that users holding on to references to the nodes passed to initialization would not find them to be the same as the nodes that are read out of the tree after initialization. This PR updates the behavior to be the same as when inserting nodes - the inserted nodes can be used after the insertion.