### PR TITLE
build(api-markdown-documenter): Update build-tools dependency

### DIFF
--- a/tools/api-markdown-documenter/package.json
+++ b/tools/api-markdown-documenter/package.json
@@ -83,7 +83,7 @@
 		"@fluid-internal/mocha-test-setup": "~2.0.0-rc.3.0.3",
 		"@fluid-tools/markdown-magic": "file:../markdown-magic",
 		"@fluidframework/build-common": "^2.0.3",
-		"@fluidframework/build-tools": "^0.39.0-264124",
+		"@fluidframework/build-tools": "^0.39.0",
 		"@fluidframework/eslint-config-fluid": "^5.1.0",
 		"@microsoft/api-extractor": "^7.45.1",
 		"@types/chai": "^4.3.4",

--- a/tools/api-markdown-documenter/pnpm-lock.yaml
+++ b/tools/api-markdown-documenter/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       '@fluidframework/build-tools':
-        specifier: ^0.39.0-264124
-        version: 0.39.0-264124(@types/node@18.15.11)
+        specifier: ^0.39.0
+        version: 0.39.0(@types/node@18.15.11)
       '@fluidframework/eslint-config-fluid':
         specifier: ^5.1.0
         version: 5.2.0(eslint@8.55.0)(typescript@5.1.6)
@@ -229,9 +229,9 @@ packages:
       '@fluidframework/protocol-definitions': 3.2.0
     dev: true
 
-  /@fluid-tools/version-tools@0.39.0-264124:
-    resolution: {integrity: sha512-CVq50WXgAH4gJUu2Ghzq7x3//gWCEZc8cPC5qD6CT5eiFOg5GLEf35bKjOSMj+fqIUigtoWj1j+uIUhnddwYLQ==}
-    engines: {node: '>=14.17.0'}
+  /@fluid-tools/version-tools@0.39.0:
+    resolution: {integrity: sha512-HWZxKOnbfpdlI9hNVD72b6PZcg+DCO1bFnx30gYacTYXQZOZltD/v+pMXfgBqvkfN6z4kGQlBDjUZrkuU3FGuA==}
+    engines: {node: '>=18.17.1'}
     hasBin: true
     dependencies:
       '@oclif/core': 3.26.5
@@ -251,13 +251,13 @@ packages:
     hasBin: true
     dev: true
 
-  /@fluidframework/build-tools@0.39.0-264124(@types/node@18.15.11):
-    resolution: {integrity: sha512-b3Msu343idUVQb8PzQMdcwANT249/Rbz0CrMSOD/NhqCvZ4uXilBUJi6V0Eq1YPQiAl6VJlywpjgGNCemSg3Rw==}
-    engines: {node: '>=14.17.0'}
+  /@fluidframework/build-tools@0.39.0(@types/node@18.15.11):
+    resolution: {integrity: sha512-z6c5x7WkOQL/X01SY/lfUcRr7OohlfzAneKi2J6q/jBjWBLoyaQcnmU6CNeGC3xQh0mO480sa0Iei4irHqKkUA==}
+    engines: {node: '>=18.17.1'}
     hasBin: true
     dependencies:
-      '@fluid-tools/version-tools': 0.39.0-264124
-      '@fluidframework/bundle-size-tools': 0.39.0-264124
+      '@fluid-tools/version-tools': 0.39.0
+      '@fluidframework/bundle-size-tools': 0.39.0
       '@manypkg/get-packages': 2.2.0
       '@octokit/core': 4.2.4
       '@rushstack/node-core-library': 3.63.0(@types/node@18.15.11)
@@ -269,7 +269,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       detect-indent: 6.1.0
       find-up: 7.0.0
-      fs-extra: 9.1.0
+      fs-extra: 11.2.0
       glob: 7.2.3
       ignore: 5.2.4
       json5: 2.2.3
@@ -293,8 +293,8 @@ packages:
       - webpack-cli
     dev: true
 
-  /@fluidframework/bundle-size-tools@0.39.0-264124:
-    resolution: {integrity: sha512-nVRbK5X1SnRoZRA6jkxKYtDQ5cRZ1oH6XBJxkvwoPEUsjPNHaco+juwsMDucu0oBA/FnMhOZEz5DtiQz4sBbgQ==}
+  /@fluidframework/bundle-size-tools@0.39.0:
+    resolution: {integrity: sha512-X1eaDPuvQ3BHhB4+COK1sEauQxyRcXZ8aZdhqETASgLJqL3VqMlCEGqu3uGsENSkG55BU0zyFBTziZiW4aRIRQ==}
     dependencies:
       azure-devops-node-api: 11.2.0
       jszip: 3.10.1
@@ -932,7 +932,7 @@ packages:
   /@rushstack/node-core-library@5.3.0(@types/node@18.15.11):
     resolution: {integrity: sha512-t23gjdZV6aWkbwXSE3TkKr1UXJFbXICvAOJ0MRQEB/ZYGhfSJqqrQFaGd20I1a/nIIHJEkNO0xzycHixjcbCPw==}
     peerDependencies:
-      '@types/node': ^18.19.0
+      '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -958,7 +958,7 @@ packages:
   /@rushstack/terminal@0.12.2(@types/node@18.15.11):
     resolution: {integrity: sha512-yaHKyD/l6Zg34pC5zzc/KdiRBHy8zAH7ZbL3umpDLnvTrZ0SP8MVYZu9xA2lRsGkKfGbv/6gQhyNq4/tRzXH4A==}
     peerDependencies:
-      '@types/node': ^18.19.0
+      '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -1653,15 +1653,6 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  /ajv@8.12.0:
-    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
-    dependencies:
-      fast-deep-equal: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-      uri-js: 4.4.1
-    dev: true
-
   /ajv@8.13.0:
     resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
     dependencies:
@@ -1815,11 +1806,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
-
-  /at-least-node@1.0.0:
-    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
-    engines: {node: '>= 4.0.0'}
     dev: true
 
   /available-typed-arrays@1.0.5:
@@ -3250,6 +3236,15 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /fs-extra@11.2.0:
+    resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
   /fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -3265,16 +3260,6 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
-    dev: true
-
-  /fs-extra@9.1.0:
-    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      at-least-node: 1.0.0
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.0
     dev: true
 
   /fs.realpath@1.0.0:
@@ -5986,7 +5971,7 @@ packages:
     resolution: {integrity: sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==}
     engines: {node: '>=10.0.0'}
     dependencies:
-      ajv: 8.12.0
+      ajv: 8.13.0
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3


### PR DESCRIPTION
Required to unblock publishing a new version of the package, as our publishing pipelines forbid any prerelease dependencies.