### PR TITLE
tree: Reuse flex tree fields in most cases

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -64,7 +64,11 @@ import {
 } from "./lazyEntity.js";
 import { type LazyTreeNode, makeTree } from "./lazyNode.js";
 import { unboxedUnion } from "./unboxed.js";
-import { indexForAt, treeStatusFromAnchorCache, treeStatusFromDetachedField } from "./utilities.js";
+import {
+	indexForAt,
+	treeStatusFromAnchorCache,
+	treeStatusFromDetachedField,
+} from "./utilities.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 /**
@@ -118,7 +122,11 @@ export function makeField(
 		return makeFlexTreeField();
 	}
 
-	const innerCache = getOrCreate(fieldCache, cacheKey, () => new Map<FieldKey, FlexTreeField>());
+	const innerCache = getOrCreate(
+		fieldCache,
+		cacheKey,
+		() => new Map<FieldKey, FlexTreeField>(),
+	);
 	const result = getOrCreate(innerCache, fieldAnchor.fieldKey, makeFlexTreeField);
 	if (!usedAnchor) {
 		// The anchor must be disposed to avoid leaking. In the case of a cache hit,
@@ -283,9 +291,7 @@ export abstract class LazyField<TKind extends FlexFieldKind, TTypes extends Flex
 	 */
 	public getFieldPathForEditing(): FieldUpPath {
 		if (this.treeStatus() !== TreeStatus.InDocument) {
-			throw new UsageError(
-				"Editing only allowed on fields with TreeStatus.InDocument status",
-			);
+			throw new UsageError("Editing only allowed on fields with TreeStatus.InDocument status");
 		}
 		return this.getFieldPath();
 	}
@@ -333,7 +339,7 @@ export class LazySequence<TTypes extends FlexAllowedTypes>
 					Array.from(value, (item) =>
 						applyTypesFromContext(this.context, this.schema.allowedTypeSet, item),
 					),
-			  );
+				);
 
 		const fieldEditor = this.sequenceEditor();
 		fieldEditor.insert(index, content);
@@ -353,7 +359,10 @@ export class LazySequence<TTypes extends FlexAllowedTypes>
 	}
 
 	public moveToStart(sourceIndex: number): void;
-	public moveToStart(sourceIndex: number, source: FlexTreeSequenceField<FlexAllowedTypes>): void;
+	public moveToStart(
+		sourceIndex: number,
+		source: FlexTreeSequenceField<FlexAllowedTypes>,
+	): void;
 	public moveToStart(
 		sourceIndex: number,
 		source?: FlexTreeSequenceField<FlexAllowedTypes>,
@@ -362,7 +371,10 @@ export class LazySequence<TTypes extends FlexAllowedTypes>
 	}
 	public moveToEnd(sourceIndex: number): void;
 	public moveToEnd(sourceIndex: number, source: FlexTreeSequenceField<FlexAllowedTypes>): void;
-	public moveToEnd(sourceIndex: number, source?: FlexTreeSequenceField<FlexAllowedTypes>): void {
+	public moveToEnd(
+		sourceIndex: number,
+		source?: FlexTreeSequenceField<FlexAllowedTypes>,
+	): void {
 		this._moveRangeToIndex(this.length, sourceIndex, sourceIndex + 1, source);
 	}
 	public moveToIndex(index: number, sourceIndex: number): void;
@@ -565,8 +577,8 @@ export class LazyOptionalField<TTypes extends FlexAllowedTypes>
 			newContent === undefined
 				? []
 				: isCursor(newContent)
-				? prepareNodeCursorForInsert(newContent)
-				: [cursorFromContextualData(this.context, this.schema.allowedTypeSet, newContent)];
+					? prepareNodeCursorForInsert(newContent)
+					: [cursorFromContextualData(this.context, this.schema.allowedTypeSet, newContent)];
 		const fieldEditor = this.optionalEditor();
 		assert(
 			content.length <= 1,

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -129,6 +129,8 @@ export function makeField(
 	);
 	const result = getOrCreate(innerCache, fieldAnchor.fieldKey, makeThing);
 	if (!usedAnchor) {
+		// The anchor must be disposed to avoid leaking. In the case of a cache hit,
+		// we are not transferring ownership to a new FlexTreeField, so it must be disposed of here to avoid the leak.
 		context.checkout.forest.anchors.forget(fieldAnchor.parent);
 	}
 	return result;


### PR DESCRIPTION
## Description

Currently flex-tree fields tend to be leaked until the nodes they are part of are disposed (if ever) or the context is disposed.

Due to this, allocating tons of separate objects for the same field is really bad. This change reuses flex tree fields in most cases, mitigating this issue.

This was observed to make bubble bench >10x faster, however most of that win was due to avoiding the O(number of leaked copies of the field) creation cost in the event subscription logic which is being removed independently.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
