### PR TITLE
fix(docs): Remove broken link from nav

### DIFF
--- a/docs/data/packages.json
+++ b/docs/data/packages.json
@@ -30,7 +30,6 @@
 			"DDSes": {
 				"Map": {
 					"Interfaces": ["ISharedMap", "ISharedMapEvents", "IValueChanged"],
-					"Classes": ["SharedMap"]
 				},
 				"Tree": { "Interfaces": ["ITree"] }
 			}

--- a/docs/data/packages.json
+++ b/docs/data/packages.json
@@ -29,7 +29,7 @@
 			},
 			"DDSes": {
 				"Map": {
-					"Interfaces": ["ISharedMap", "ISharedMapEvents", "IValueChanged"],
+					"Interfaces": ["ISharedMap", "ISharedMapEvents", "IValueChanged"]
 				},
 				"Tree": { "Interfaces": ["ITree"] }
 			}


### PR DESCRIPTION
The `SharedMap` class was removed from package exports a while back, but our custom nav was explicitly pointing to it, so we have a broken link. This removes the reference to the removed class.