### PR TITLE
build(tree): Add formatter settings to tree workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,7 +55,7 @@
 		"unsequenced",
 	],
 
-	// Enable prettier as default formatter, and disable rules that disagree with it
+	// Enable biome as default formatter, and disable rules that disagree with it
 	"editor.defaultFormatter": "biomejs.biome",
 	"editor.insertSpaces": false,
 	// Also configure the formatter on a per-language basis for some common languages/file-types, to make sure it is applied

--- a/packages/dds/tree/.vscode/settings.json
+++ b/packages/dds/tree/.vscode/settings.json
@@ -16,4 +16,20 @@
 	// mocha test config isn't sufficient; it also needs to be enabled here.
 	"mochaExplorer.nodeArgv": ["--conditions", "allow-ff-test-exports"],
 	"cSpell.words": ["deprioritized", "endregion", "insertable", "reentrantly", "unhydrated"],
+
+	// Enable prettier as default formatter, and disable rules that disagree with it
+	"editor.defaultFormatter": "biomejs.biome",
+	"editor.insertSpaces": false,
+	// Also configure the formatter on a per-language basis for some common languages/file-types, to make sure it is applied
+	// even if someone's User Settings specify a different formatter at this level (which overrides the root-level
+	// 'editor.defaultFormatter').
+	"[json]": {
+		"editor.defaultFormatter": "biomejs.biome",
+	},
+	"[javascript]": {
+		"editor.defaultFormatter": "biomejs.biome",
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "biomejs.biome",
+	},
 }

--- a/packages/dds/tree/.vscode/settings.json
+++ b/packages/dds/tree/.vscode/settings.json
@@ -17,7 +17,7 @@
 	"mochaExplorer.nodeArgv": ["--conditions", "allow-ff-test-exports"],
 	"cSpell.words": ["deprioritized", "endregion", "insertable", "reentrantly", "unhydrated"],
 
-	// Enable prettier as default formatter, and disable rules that disagree with it
+	// Enable biome as default formatter, and disable rules that disagree with it
 	"editor.defaultFormatter": "biomejs.biome",
 	"editor.insertSpaces": false,
 	// Also configure the formatter on a per-language basis for some common languages/file-types, to make sure it is applied


### PR DESCRIPTION
When using the tree workspace within the repo, formatting settings were not configured correctly. This change copies the relevant settings from the root workspace.

I also corrected a comment in the root workspace settings where it referred to prettier instead of biome.