### PR TITLE
[Prototype] Have ContainerRuntime wait to process until it sees the whole batch

### DIFF
--- a/packages/runtime/container-runtime/src/messageTypes.ts
+++ b/packages/runtime/container-runtime/src/messageTypes.ts
@@ -223,7 +223,7 @@ export type InboundSequencedContainerRuntimeMessage = Omit<
  * There should never be a runtime value of "__not_a_...".
  * Currently additionally replaces `contents` type until protocol-definitions update is taken with `unknown` instead of `any`.
  */
-type InboundSequencedNonContainerRuntimeMessage = Omit<
+export type InboundSequencedNonContainerRuntimeMessage = Omit<
 	ISequencedDocumentMessage,
 	"type" | "contents"
 > & { type: "__not_a_container_runtime_message_type__"; contents: unknown };

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -252,6 +252,15 @@ export class PendingStateManager implements IDisposable {
 		}
 	}
 
+	public processPendingLocalBatch(
+		batch: InboundSequencedContainerRuntimeMessage[],
+	): { message: InboundSequencedContainerRuntimeMessage; lom: unknown }[] {
+		return batch.map((message) => ({
+			message,
+			lom: this.processPendingLocalMessage(message),
+		}));
+	}
+
 	/**
 	 * Processes a local message once its ack'd by the server. It verifies that there was no data corruption and that
 	 * the batch information was preserved for batch messages.


### PR DESCRIPTION
[do not check in]

This would allow a follow-up change to switch PSM to be totally batch-based instead of individual messages.