### PR TITLE
Retry count with rest API calls

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -143,7 +143,7 @@ export class DocumentService
 						this.logger,
 						rateLimiter,
 						this.driverPolicies.enableRestLess,
-						this.storageUrl,
+						this.storageUrl /* baseUrl */,
 					);
 				}
 				const historian = new Historian(true, false, this.storageRestWrapper);

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -137,7 +137,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			logger2,
 			rateLimiter,
 			this.driverPolicies.enableRestLess,
-			resolvedUrl.endpoints.ordererUrl,
+			resolvedUrl.endpoints.ordererUrl /* baseUrl */,
 		);
 
 		const createAsEphemeral = isRouterliciousResolvedUrl(resolvedUrl)
@@ -339,7 +339,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			logger2,
 			new RateLimiter(this.driverPolicies.maxConcurrentStorageRequests),
 			this.driverPolicies.enableRestLess,
-			storageUrl,
+			storageUrl /* baseUrl */,
 			storageTokenP,
 		);
 

--- a/packages/drivers/routerlicious-driver/src/historian.ts
+++ b/packages/drivers/routerlicious-driver/src/historian.ts
@@ -18,8 +18,9 @@ import {
 } from "@fluidframework/server-services-client";
 
 import { IWholeFlatSnapshot } from "./contracts.js";
+import { type QueryStringType } from "./queryStringUtils.js";
 import { IR11sResponse } from "./restWrapper.js";
-import { QueryStringType, RestWrapper } from "./restWrapperBase.js";
+import { RestWrapper } from "./restWrapperBase.js";
 import { IHistorian } from "./storageContracts.js";
 
 export interface ICredentials {

--- a/packages/drivers/routerlicious-driver/src/queryStringUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/queryStringUtils.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 export type QueryStringType = Record<string, string | number | boolean>;
 
 /**

--- a/packages/drivers/routerlicious-driver/src/queryStringUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/queryStringUtils.ts
@@ -1,21 +1,21 @@
 export type QueryStringType = Record<string, string | number | boolean>;
 
 /**
- * Generates query string from the given query parameters.
- * @param queryParams - Query parameters from which to create a query.
- * @param url - URL to which query params should be appended
+ * Generates URL string from the given URL and query parameters.
+ * @param url - URL to which query params should be appended. Can include base/default query params.
+ * @param queryParams - Query parameters from which to create a query. Will override any query params in url.
  */
-export function buildQueryString(queryParams: QueryStringType, url?: string): string {
-	let queryString = "";
-	for (const key of Object.keys(queryParams)) {
-		if (queryParams[key] !== undefined) {
-			const startChar = queryString === "" ? "?" : "&";
-			queryString += `${startChar}${key}=${encodeURIComponent(queryParams[key])}`;
-		}
+export function buildUrlWithQueryString(
+	url: URL | string,
+	queryParams: QueryStringType,
+): string {
+	// Initialize urlSearchParams with query params from the base URL itself
+	const outputUrl = new URL(url);
+	const updatedSearchParams = outputUrl.searchParams;
+	for (const [key, value] of Object.entries(queryParams)) {
+		// Add/override search params from query params
+		updatedSearchParams.set(key, encodeURIComponent(value));
 	}
-	if (url) {
-		// remove existing query params before appending
-		return `${url.split("?")[0]}${queryString}`;
-	}
-	return queryString;
+	outputUrl.search = updatedSearchParams.toString();
+	return outputUrl.href;
 }

--- a/packages/drivers/routerlicious-driver/src/queryStringUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/queryStringUtils.ts
@@ -1,14 +1,11 @@
 export type QueryStringType = Record<string, string | number | boolean>;
 
 /**
- * Generates URL string from the given URL and query parameters.
+ * Generates URL object from the given string request url and query parameters.
  * @param url - URL to which query params should be appended. Can include base/default query params.
- * @param queryParams - Query parameters from which to create a query. Will override any query params in url.
+ * @param queryParams - Query parameters to append. Will override any query params in url.
  */
-export function addOrUpdateQueryParams(
-	url: URL | string,
-	queryParams: QueryStringType,
-): string {
+export function addOrUpdateQueryParams(url: URL | string, queryParams: QueryStringType): URL {
 	// Initialize urlSearchParams with query params from the base URL itself
 	const outputUrl = new URL(url);
 	const updatedSearchParams = outputUrl.searchParams;
@@ -17,5 +14,5 @@ export function addOrUpdateQueryParams(
 		updatedSearchParams.set(key, encodeURIComponent(value));
 	}
 	outputUrl.search = updatedSearchParams.toString();
-	return outputUrl.href;
+	return outputUrl;
 }

--- a/packages/drivers/routerlicious-driver/src/queryStringUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/queryStringUtils.ts
@@ -1,0 +1,21 @@
+export type QueryStringType = Record<string, string | number | boolean>;
+
+/**
+ * Generates query string from the given query parameters.
+ * @param queryParams - Query parameters from which to create a query.
+ * @param url - URL to which query params should be appended
+ */
+export function buildQueryString(queryParams: QueryStringType, url?: string): string {
+	let queryString = "";
+	for (const key of Object.keys(queryParams)) {
+		if (queryParams[key] !== undefined) {
+			const startChar = queryString === "" ? "?" : "&";
+			queryString += `${startChar}${key}=${encodeURIComponent(queryParams[key])}`;
+		}
+	}
+	if (url) {
+		// remove existing query params before appending
+		return `${url.split("?")[0]}${queryString}`;
+	}
+	return queryString;
+}

--- a/packages/drivers/routerlicious-driver/src/queryStringUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/queryStringUtils.ts
@@ -5,7 +5,7 @@ export type QueryStringType = Record<string, string | number | boolean>;
  * @param url - URL to which query params should be appended. Can include base/default query params.
  * @param queryParams - Query parameters from which to create a query. Will override any query params in url.
  */
-export function buildUrlWithQueryString(
+export function addOrUpdateQueryParams(
 	url: URL | string,
 	queryParams: QueryStringType,
 ): string {

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -26,10 +26,7 @@ import fetch from "cross-fetch";
 import safeStringify from "json-stringify-safe";
 
 import type { AxiosRequestConfig, RawAxiosRequestHeaders } from "./axios.cjs";
-import {
-	RouterliciousErrorTypes,
-	throwR11sNetworkError,
-} from "./errorUtils.js";
+import { RouterliciousErrorTypes, throwR11sNetworkError } from "./errorUtils.js";
 import { pkgVersion as driverVersion } from "./packageVersion.js";
 import { QueryStringType, RestWrapper } from "./restWrapperBase.js";
 import { ITokenProvider, ITokenResponse } from "./tokens.js";
@@ -137,9 +134,7 @@ class RouterliciousRestWrapper extends RestWrapper {
 	): Promise<IR11sResponse<T>> {
 		// Check whether this request has been made before or if it is a retry.
 		const originalRequestUrl = requestConfig.url;
-		const requestKey = `${requestConfig.method ?? ""}|${
-			requestConfig.url ?? ""
-		}`;
+		const requestKey = `${requestConfig.method ?? ""}|${requestConfig.url ?? ""}`;
 		const requestRetryCount = this.retryCounter.get(requestKey);
 		if (requestRetryCount) {
 			requestConfig.url = `${requestConfig.url}&retryCount=${requestRetryCount}`;
@@ -150,19 +145,14 @@ class RouterliciousRestWrapper extends RestWrapper {
 			headers: await this.generateHeaders(requestConfig.headers),
 		};
 
-		const translatedConfig = this.useRestLess
-			? this.restLess.translate(config)
-			: config;
-		const fetchRequestConfig =
-			axiosRequestConfigToFetchRequestConfig(translatedConfig);
+		const translatedConfig = this.useRestLess ? this.restLess.translate(config) : config;
+		const fetchRequestConfig = axiosRequestConfigToFetchRequestConfig(translatedConfig);
 
 		const res = await this.rateLimiter.schedule(async () => {
 			const perfStart = performance.now();
 			const result = await fetch(...fetchRequestConfig).catch(async (error) => {
 				// Browser Fetch throws a TypeError on network error, `node-fetch` throws a FetchError
-				const isNetworkError = ["TypeError", "FetchError"].includes(
-					error?.name,
-				);
+				const isNetworkError = ["TypeError", "FetchError"].includes(error?.name);
 				const errorMessage = isNetworkError
 					? `NetworkError: ${error.message}`
 					: safeStringify(error);
@@ -171,23 +161,13 @@ class RouterliciousRestWrapper extends RestWrapper {
 				// the error message will start with NetworkError as defined in restWrapper.ts
 				// If there exists a self-signed SSL certificates error, throw a NonRetryableError
 				// TODO: instead of relying on string matching, filter error based on the error code like we do for websocket connections
-				const err = errorMessage.includes(
-					"failed, reason: self signed certificate",
-				)
-					? new NonRetryableError(
-							errorMessage,
-							RouterliciousErrorTypes.sslCertError,
-							{
-								driverVersion,
-							},
-						)
-					: new GenericNetworkError(
-							errorMessage,
-							errorMessage.startsWith("NetworkError"),
-							{
-								driverVersion,
-							},
-						);
+				const err = errorMessage.includes("failed, reason: self signed certificate")
+					? new NonRetryableError(errorMessage, RouterliciousErrorTypes.sslCertError, {
+							driverVersion,
+						})
+					: new GenericNetworkError(errorMessage, errorMessage.startsWith("NetworkError"), {
+							driverVersion,
+						});
 				throw err;
 			});
 			return {
@@ -234,10 +214,7 @@ class RouterliciousRestWrapper extends RestWrapper {
 
 		// Failure
 		// on failure, add the request entry into the retryCounter map to count the subsequent retries
-		this.retryCounter.set(
-			requestKey,
-			requestRetryCount ? requestRetryCount + 1 : 1,
-		);
+		this.retryCounter.set(requestKey, requestRetryCount ? requestRetryCount + 1 : 1);
 
 		if (response.status === 401 && canRetry) {
 			// Refresh Authorization header and retry once
@@ -416,9 +393,7 @@ export function toInstrumentedR11sOrdererTokenFetcher(
 	tokenProvider: ITokenProvider,
 	logger: ITelemetryLoggerExt,
 ): TokenFetcher {
-	const fetchOrdererToken = async (
-		refreshToken?: boolean,
-	): Promise<ITokenResponse> => {
+	const fetchOrdererToken = async (refreshToken?: boolean): Promise<ITokenResponse> => {
 		return PerformanceEvent.timedExecAsync(
 			logger,
 			{
@@ -445,9 +420,7 @@ export function toInstrumentedR11sStorageTokenFetcher(
 	tokenProvider: ITokenProvider,
 	logger: ITelemetryLoggerExt,
 ): TokenFetcher {
-	const fetchStorageToken = async (
-		refreshToken?: boolean,
-	): Promise<ITokenResponse> => {
+	const fetchStorageToken = async (refreshToken?: boolean): Promise<ITokenResponse> => {
 		return PerformanceEvent.timedExecAsync(
 			logger,
 			{

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -26,15 +26,9 @@ import fetch from "cross-fetch";
 import safeStringify from "json-stringify-safe";
 
 import type { AxiosRequestConfig, RawAxiosRequestHeaders } from "./axios.cjs";
-import {
-	RouterliciousErrorTypes,
-	throwR11sNetworkError,
-} from "./errorUtils.js";
+import { RouterliciousErrorTypes, throwR11sNetworkError } from "./errorUtils.js";
 import { pkgVersion as driverVersion } from "./packageVersion.js";
-import {
-	buildUrlWithQueryString,
-	type QueryStringType,
-} from "./queryStringUtils.js";
+import { buildUrlWithQueryString, type QueryStringType } from "./queryStringUtils.js";
 import { RestWrapper } from "./restWrapperBase.js";
 import { ITokenProvider, ITokenResponse } from "./tokens.js";
 
@@ -160,19 +154,14 @@ class RouterliciousRestWrapper extends RestWrapper {
 			headers: await this.generateHeaders(requestConfig.headers),
 		};
 
-		const translatedConfig = this.useRestLess
-			? this.restLess.translate(config)
-			: config;
-		const fetchRequestConfig =
-			axiosRequestConfigToFetchRequestConfig(translatedConfig);
+		const translatedConfig = this.useRestLess ? this.restLess.translate(config) : config;
+		const fetchRequestConfig = axiosRequestConfigToFetchRequestConfig(translatedConfig);
 
 		const res = await this.rateLimiter.schedule(async () => {
 			const perfStart = performance.now();
 			const result = await fetch(...fetchRequestConfig).catch(async (error) => {
 				// Browser Fetch throws a TypeError on network error, `node-fetch` throws a FetchError
-				const isNetworkError = ["TypeError", "FetchError"].includes(
-					error?.name,
-				);
+				const isNetworkError = ["TypeError", "FetchError"].includes(error?.name);
 				const errorMessage = isNetworkError
 					? `NetworkError: ${error.message}`
 					: safeStringify(error);
@@ -181,29 +170,16 @@ class RouterliciousRestWrapper extends RestWrapper {
 				// the error message will start with NetworkError as defined in restWrapper.ts
 				// If there exists a self-signed SSL certificates error, throw a NonRetryableError
 				// TODO: instead of relying on string matching, filter error based on the error code like we do for websocket connections
-				const err = errorMessage.includes(
-					"failed, reason: self signed certificate",
-				)
-					? new NonRetryableError(
-							errorMessage,
-							RouterliciousErrorTypes.sslCertError,
-							{
-								driverVersion,
-							},
-						)
-					: new GenericNetworkError(
-							errorMessage,
-							errorMessage.startsWith("NetworkError"),
-							{
-								driverVersion,
-							},
-						);
+				const err = errorMessage.includes("failed, reason: self signed certificate")
+					? new NonRetryableError(errorMessage, RouterliciousErrorTypes.sslCertError, {
+							driverVersion,
+						})
+					: new GenericNetworkError(errorMessage, errorMessage.startsWith("NetworkError"), {
+							driverVersion,
+						});
 
 				// on failure, add the request entry into the retryCounter map to count the subsequent retries
-				this.retryCounter.set(
-					requestKey,
-					requestRetryCount ? requestRetryCount + 1 : 1,
-				);
+				this.retryCounter.set(requestKey, requestRetryCount ? requestRetryCount + 1 : 1);
 				throw err;
 			});
 			return {
@@ -250,10 +226,7 @@ class RouterliciousRestWrapper extends RestWrapper {
 
 		// Failure
 		// on failure, add the request entry into the retryCounter map to count the subsequent retries
-		this.retryCounter.set(
-			requestKey,
-			requestRetryCount ? requestRetryCount + 1 : 1,
-		);
+		this.retryCounter.set(requestKey, requestRetryCount ? requestRetryCount + 1 : 1);
 
 		if (response.status === 401 && canRetry) {
 			// Refresh Authorization header and retry once
@@ -432,9 +405,7 @@ export function toInstrumentedR11sOrdererTokenFetcher(
 	tokenProvider: ITokenProvider,
 	logger: ITelemetryLoggerExt,
 ): TokenFetcher {
-	const fetchOrdererToken = async (
-		refreshToken?: boolean,
-	): Promise<ITokenResponse> => {
+	const fetchOrdererToken = async (refreshToken?: boolean): Promise<ITokenResponse> => {
 		return PerformanceEvent.timedExecAsync(
 			logger,
 			{
@@ -461,9 +432,7 @@ export function toInstrumentedR11sStorageTokenFetcher(
 	tokenProvider: ITokenProvider,
 	logger: ITelemetryLoggerExt,
 ): TokenFetcher {
-	const fetchStorageToken = async (
-		refreshToken?: boolean,
-	): Promise<ITokenResponse> => {
+	const fetchStorageToken = async (refreshToken?: boolean): Promise<ITokenResponse> => {
 		return PerformanceEvent.timedExecAsync(
 			logger,
 			{

--- a/packages/drivers/routerlicious-driver/src/restWrapper.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapper.ts
@@ -187,11 +187,11 @@ class RouterliciousRestWrapper extends RestWrapper {
 					const err = errorMessage.includes("failed, reason: self signed certificate")
 						? new NonRetryableError(errorMessage, RouterliciousErrorTypes.sslCertError, {
 								driverVersion,
-								retryQueryParam: requestRetryCount,
+								retryCount: requestRetryCount,
 							})
 						: new GenericNetworkError(errorMessage, errorMessage.startsWith("NetworkError"), {
 								driverVersion,
-								retryQueryParam: requestRetryCount,
+								retryCount: requestRetryCount,
 							});
 					throw err;
 				},

--- a/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
@@ -4,10 +4,7 @@
  */
 
 import type { AxiosRequestConfig, AxiosRequestHeaders } from "./axios.cjs";
-import {
-	buildUrlWithQueryString,
-	type QueryStringType,
-} from "./queryStringUtils.js";
+import { type QueryStringType } from "./queryStringUtils.js";
 import { IR11sResponse } from "./restWrapper.js";
 
 export abstract class RestWrapper {
@@ -25,12 +22,7 @@ export abstract class RestWrapper {
 		additionalOptions?: Partial<
 			Omit<
 				AxiosRequestConfig,
-				| "baseURL"
-				| "headers"
-				| "maxBodyLength"
-				| "maxContentLength"
-				| "method"
-				| "url"
+				"baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url"
 			>
 		>,
 	): Promise<IR11sResponse<T>> {
@@ -41,8 +33,8 @@ export abstract class RestWrapper {
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "GET",
-			url: this.generateQueryString(url, queryString),
-			params: queryString,
+			url,
+			params: { ...this.defaultQueryString, ...queryString },
 		};
 		return this.request<T>(options, 200);
 	}
@@ -55,12 +47,7 @@ export abstract class RestWrapper {
 		additionalOptions?: Partial<
 			Omit<
 				AxiosRequestConfig,
-				| "baseURL"
-				| "headers"
-				| "maxBodyLength"
-				| "maxContentLength"
-				| "method"
-				| "url"
+				"baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url"
 			>
 		>,
 	): Promise<IR11sResponse<T>> {
@@ -72,8 +59,8 @@ export abstract class RestWrapper {
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "POST",
-			url: this.generateQueryString(url, queryString),
-			params: queryString,
+			url,
+			params: { ...this.defaultQueryString, ...queryString },
 		};
 		return this.request<T>(options, 201);
 	}
@@ -85,12 +72,7 @@ export abstract class RestWrapper {
 		additionalOptions?: Partial<
 			Omit<
 				AxiosRequestConfig,
-				| "baseURL"
-				| "headers"
-				| "maxBodyLength"
-				| "maxContentLength"
-				| "method"
-				| "url"
+				"baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url"
 			>
 		>,
 	): Promise<IR11sResponse<T>> {
@@ -101,8 +83,8 @@ export abstract class RestWrapper {
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "DELETE",
-			url: this.generateQueryString(url, queryString),
-			params: queryString,
+			url,
+			params: { ...this.defaultQueryString, ...queryString },
 		};
 		return this.request<T>(options, 204);
 	}
@@ -115,12 +97,7 @@ export abstract class RestWrapper {
 		additionalOptions?: Partial<
 			Omit<
 				AxiosRequestConfig,
-				| "baseURL"
-				| "headers"
-				| "maxBodyLength"
-				| "maxContentLength"
-				| "method"
-				| "url"
+				"baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url"
 			>
 		>,
 	): Promise<IR11sResponse<T>> {
@@ -132,8 +109,8 @@ export abstract class RestWrapper {
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "PATCH",
-			url: this.generateQueryString(url, queryString),
-			params: queryString,
+			url,
+			params: { ...this.defaultQueryString, ...queryString },
 		};
 		return this.request<T>(options, 200);
 	}
@@ -143,22 +120,6 @@ export abstract class RestWrapper {
 		statusCode: number,
 		addNetworkCallProps?: boolean,
 	): Promise<IR11sResponse<T>>;
-
-	protected generateQueryString(
-		url: string,
-		queryStringValues?: QueryStringType,
-	) {
-		if (this.defaultQueryString || queryStringValues) {
-			const queryStringMap = {
-				...this.defaultQueryString,
-				...queryStringValues,
-			};
-
-			return buildUrlWithQueryString(url, queryStringMap);
-		}
-
-		return "";
-	}
 }
 
 /**

--- a/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
@@ -16,11 +16,10 @@ export abstract class RestWrapper {
 	) {}
 
 	/**
-	 * @param url Relative or absolute request url.(should not contain any query params)
-	 * @param queryString query params to be appended to the request url
-	 * @param headers
-	 * @param additionalOptions
-	 * @returns
+	 * @param url - Relative or absolute request url.(should not contain any query params)
+	 * @param queryString - query params to be appended to the request url
+	 * @param headers - headers
+	 * @param additionalOptions - additionalOptions
 	 */
 	public async get<T>(
 		url: string,
@@ -47,12 +46,11 @@ export abstract class RestWrapper {
 	}
 
 	/**
-	 * @param url Relative or absolute request url.(should not contain any query params)
-	 * @param requestBody
-	 * @param queryString query params to be appended to the request url
-	 * @param headers
-	 * @param additionalOptions
-	 * @returns
+	 * @param url - Relative or absolute request url.(should not contain any query params)
+	 * @param requestBody - requestBody
+	 * @param queryString - query params to be appended to the request url
+	 * @param headers - headers
+	 * @param additionalOptions - additionalOptions
 	 */
 	public async post<T>(
 		url: string,
@@ -81,11 +79,10 @@ export abstract class RestWrapper {
 	}
 
 	/**
-	 * @param url Relative or absolute request url.(should not contain any query params)
-	 * @param queryString query params to be appended to the request url
-	 * @param headers
-	 * @param additionalOptions
-	 * @returns
+	 * @param url - Relative or absolute request url.(should not contain any query params)
+	 * @param queryString - query params to be appended to the request url
+	 * @param headers - headers
+	 * @param additionalOptions - additionalOptions
 	 */
 	public async delete<T>(
 		url: string,
@@ -112,12 +109,11 @@ export abstract class RestWrapper {
 	}
 
 	/**
-	 * @param url Relative or absolute request url.(should not contain any query params)
-	 * @param requestBody
-	 * @param queryString query params to be appended to the request url
-	 * @param headers
-	 * @param additionalOptions
-	 * @returns
+	 * @param url - Relative or absolute request url.(should not contain any query params)
+	 * @param requestBody - requestBody
+	 * @param queryString - query params to be appended to the request url
+	 * @param headers - headers
+	 * @param additionalOptions - additionalOptions
 	 */
 	public async patch<T>(
 		url: string,

--- a/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
@@ -4,6 +4,7 @@
  */
 
 import type { AxiosRequestConfig, AxiosRequestHeaders } from "./axios.cjs";
+import { buildQueryString, type QueryStringType } from "./queryStringUtils.js";
 import { IR11sResponse } from "./restWrapper.js";
 
 export abstract class RestWrapper {
@@ -32,7 +33,8 @@ export abstract class RestWrapper {
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "GET",
-			url: `${url}${this.generateQueryString(queryString)}`,
+			url: this.generateQueryString(url, queryString),
+			params: queryString,
 		};
 		return this.request<T>(options, 200);
 	}
@@ -57,7 +59,8 @@ export abstract class RestWrapper {
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "POST",
-			url: `${url}${this.generateQueryString(queryString)}`,
+			url: this.generateQueryString(url, queryString),
+			params: queryString,
 		};
 		return this.request<T>(options, 201);
 	}
@@ -80,7 +83,8 @@ export abstract class RestWrapper {
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "DELETE",
-			url: `${url}${this.generateQueryString(queryString)}`,
+			url: this.generateQueryString(url, queryString),
+			params: queryString,
 		};
 		return this.request<T>(options, 204);
 	}
@@ -105,7 +109,8 @@ export abstract class RestWrapper {
 			maxBodyLength: this.maxBodyLength,
 			maxContentLength: this.maxContentLength,
 			method: "PATCH",
-			url: `${url}${this.generateQueryString(queryString)}`,
+			url: this.generateQueryString(url, queryString),
+			params: queryString,
 		};
 		return this.request<T>(options, 200);
 	}
@@ -116,11 +121,14 @@ export abstract class RestWrapper {
 		addNetworkCallProps?: boolean,
 	): Promise<IR11sResponse<T>>;
 
-	protected generateQueryString(queryStringValues?: QueryStringType) {
+	protected generateQueryString(url: string, queryStringValues?: QueryStringType) {
 		if (this.defaultQueryString || queryStringValues) {
-			const queryStringMap = { ...this.defaultQueryString, ...queryStringValues };
+			const queryStringMap = {
+				...this.defaultQueryString,
+				...queryStringValues,
+			};
 
-			return getQueryString(queryStringMap);
+			return buildQueryString(queryStringMap, url);
 		}
 
 		return "";

--- a/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
@@ -118,10 +118,7 @@ export abstract class RestWrapper {
 
 	protected generateQueryString(queryStringValues?: QueryStringType) {
 		if (this.defaultQueryString || queryStringValues) {
-			const queryStringMap = {
-				...this.defaultQueryString,
-				...queryStringValues,
-			};
+			const queryStringMap = { ...this.defaultQueryString, ...queryStringValues };
 
 			return getQueryString(queryStringMap);
 		}

--- a/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
@@ -121,22 +121,3 @@ export abstract class RestWrapper {
 		addNetworkCallProps?: boolean,
 	): Promise<IR11sResponse<T>>;
 }
-
-/**
- * Generates query string from the given query parameters.
- * @param queryParams - Query parameters from which to create a query.
- */
-export function getQueryString(queryParams: QueryStringType): string {
-	let queryString = "";
-	for (const [key, value] of Object.entries(queryParams)) {
-		if (value !== undefined) {
-			const startChar = queryString === "" ? "?" : "&";
-			queryString += `${startChar}${key}=${encodeURIComponent(value)}`;
-			queryString += `${startChar}${key}=${encodeURIComponent(queryParams[key])}`;
-		}
-	}
-
-	return queryString;
-}
-
-export type QueryStringType = Record<string, string | number | boolean>;

--- a/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
@@ -118,7 +118,10 @@ export abstract class RestWrapper {
 
 	protected generateQueryString(queryStringValues?: QueryStringType) {
 		if (this.defaultQueryString || queryStringValues) {
-			const queryStringMap = { ...this.defaultQueryString, ...queryStringValues };
+			const queryStringMap = {
+				...this.defaultQueryString,
+				...queryStringValues,
+			};
 
 			return getQueryString(queryStringMap);
 		}
@@ -137,6 +140,7 @@ export function getQueryString(queryParams: QueryStringType): string {
 		if (value !== undefined) {
 			const startChar = queryString === "" ? "?" : "&";
 			queryString += `${startChar}${key}=${encodeURIComponent(value)}`;
+			queryString += `${startChar}${key}=${encodeURIComponent(queryParams[key])}`;
 		}
 	}
 

--- a/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
@@ -15,6 +15,13 @@ export abstract class RestWrapper {
 		protected readonly maxContentLength = 1000 * 1024 * 1024,
 	) {}
 
+	/**
+	 * @param url Relative or absolute request url.(should not contain any query params)
+	 * @param queryString query params to be appended to the request url
+	 * @param headers
+	 * @param additionalOptions
+	 * @returns
+	 */
 	public async get<T>(
 		url: string,
 		queryString?: QueryStringType,
@@ -39,6 +46,14 @@ export abstract class RestWrapper {
 		return this.request<T>(options, 200);
 	}
 
+	/**
+	 * @param url Relative or absolute request url.(should not contain any query params)
+	 * @param requestBody
+	 * @param queryString query params to be appended to the request url
+	 * @param headers
+	 * @param additionalOptions
+	 * @returns
+	 */
 	public async post<T>(
 		url: string,
 		requestBody: any,
@@ -65,6 +80,13 @@ export abstract class RestWrapper {
 		return this.request<T>(options, 201);
 	}
 
+	/**
+	 * @param url Relative or absolute request url.(should not contain any query params)
+	 * @param queryString query params to be appended to the request url
+	 * @param headers
+	 * @param additionalOptions
+	 * @returns
+	 */
 	public async delete<T>(
 		url: string,
 		queryString?: QueryStringType,
@@ -89,6 +111,14 @@ export abstract class RestWrapper {
 		return this.request<T>(options, 204);
 	}
 
+	/**
+	 * @param url Relative or absolute request url.(should not contain any query params)
+	 * @param requestBody
+	 * @param queryString query params to be appended to the request url
+	 * @param headers
+	 * @param additionalOptions
+	 * @returns
+	 */
 	public async patch<T>(
 		url: string,
 		requestBody: any,

--- a/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
+++ b/packages/drivers/routerlicious-driver/src/restWrapperBase.ts
@@ -4,7 +4,10 @@
  */
 
 import type { AxiosRequestConfig, AxiosRequestHeaders } from "./axios.cjs";
-import { buildQueryString, type QueryStringType } from "./queryStringUtils.js";
+import {
+	buildUrlWithQueryString,
+	type QueryStringType,
+} from "./queryStringUtils.js";
 import { IR11sResponse } from "./restWrapper.js";
 
 export abstract class RestWrapper {
@@ -22,7 +25,12 @@ export abstract class RestWrapper {
 		additionalOptions?: Partial<
 			Omit<
 				AxiosRequestConfig,
-				"baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url"
+				| "baseURL"
+				| "headers"
+				| "maxBodyLength"
+				| "maxContentLength"
+				| "method"
+				| "url"
 			>
 		>,
 	): Promise<IR11sResponse<T>> {
@@ -47,7 +55,12 @@ export abstract class RestWrapper {
 		additionalOptions?: Partial<
 			Omit<
 				AxiosRequestConfig,
-				"baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url"
+				| "baseURL"
+				| "headers"
+				| "maxBodyLength"
+				| "maxContentLength"
+				| "method"
+				| "url"
 			>
 		>,
 	): Promise<IR11sResponse<T>> {
@@ -72,7 +85,12 @@ export abstract class RestWrapper {
 		additionalOptions?: Partial<
 			Omit<
 				AxiosRequestConfig,
-				"baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url"
+				| "baseURL"
+				| "headers"
+				| "maxBodyLength"
+				| "maxContentLength"
+				| "method"
+				| "url"
 			>
 		>,
 	): Promise<IR11sResponse<T>> {
@@ -97,7 +115,12 @@ export abstract class RestWrapper {
 		additionalOptions?: Partial<
 			Omit<
 				AxiosRequestConfig,
-				"baseURL" | "headers" | "maxBodyLength" | "maxContentLength" | "method" | "url"
+				| "baseURL"
+				| "headers"
+				| "maxBodyLength"
+				| "maxContentLength"
+				| "method"
+				| "url"
 			>
 		>,
 	): Promise<IR11sResponse<T>> {
@@ -121,14 +144,17 @@ export abstract class RestWrapper {
 		addNetworkCallProps?: boolean,
 	): Promise<IR11sResponse<T>>;
 
-	protected generateQueryString(url: string, queryStringValues?: QueryStringType) {
+	protected generateQueryString(
+		url: string,
+		queryStringValues?: QueryStringType,
+	) {
 		if (this.defaultQueryString || queryStringValues) {
 			const queryStringMap = {
 				...this.defaultQueryString,
 				...queryStringValues,
 			};
 
-			return buildQueryString(queryStringMap, url);
+			return buildUrlWithQueryString(url, queryStringMap);
 		}
 
 		return "";

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -143,7 +143,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 			});
 		});
 
-		it("retry query param is appended on subsequent api request", async () => {
+		it("retry query param is appended on subsequent api request - when retried from within request function", async () => {
 			let retryQueryParamTested = false;
 			// Fail first request with retriable error
 			nock(testHost).get(testPath).reply(401);
@@ -170,7 +170,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 			assert(retryQueryParamTested);
 		});
 
-		it("retry query param is appended on subsequent api request -- 2", async () => {
+		it("retry query param is appended on subsequent api request - when request function is invoked multiple times externally on failure", async () => {
 			let retryQueryParamTested = false;
 			// Fail first request with retriable error
 			nock(testHost).get(testPath).reply(500);

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -36,8 +36,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 		throttledAt = Date.now();
 	};
 	function replyWithThrottling() {
-		const retryAfterSeconds =
-			(throttleDurationInMs - Date.now() - throttledAt) / 1000;
+		const retryAfterSeconds = (throttleDurationInMs - Date.now() - throttledAt) / 1000;
 		const throttled = retryAfterSeconds > 0;
 		if (throttled) {
 			return [429, { retryAfter: retryAfterSeconds }];
@@ -207,9 +206,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 			nock(testHost, { reqheaders: { authorization: `Basic ${token1}` } })
 				.post(testPath)
 				.reply(200);
-			await assert.doesNotReject(
-				restWrapper.post(testUrl, { test: "payload" }),
-			);
+			await assert.doesNotReject(restWrapper.post(testUrl, { test: "payload" }));
 		});
 		it("retries a request with fresh auth headers on 401", async () => {
 			nock(testHost, { reqheaders: { authorization: `Basic ${token1}` } })
@@ -219,9 +216,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 				.post(testPath)
 				.query(true)
 				.reply(200);
-			await assert.doesNotReject(
-				restWrapper.post(testUrl, { test: "payload" }),
-			);
+			await assert.doesNotReject(restWrapper.post(testUrl, { test: "payload" }));
 		});
 		it("throws a non-retriable error on 2nd 401", async () => {
 			nock(testHost, { reqheaders: { authorization: `Basic ${token1}` } })
@@ -246,9 +241,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 		it("retries with delay on 429 with retryAfter", async () => {
 			throttle();
 			nock(testHost).post(testPath).reply(replyWithThrottling);
-			await assert.doesNotReject(
-				restWrapper.post(testUrl, { test: "payload" }),
-			);
+			await assert.doesNotReject(restWrapper.post(testUrl, { test: "payload" }));
 		});
 		it("throws a retriable error on 429 without retryAfter", async () => {
 			nock(testHost).post(testPath).reply(429, { retryAfter: undefined });
@@ -278,9 +271,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 			nock(testHost, { reqheaders: { authorization: `Basic ${token1}` } })
 				.patch(testPath)
 				.reply(200);
-			await assert.doesNotReject(
-				restWrapper.patch(testUrl, { test: "payload" }),
-			);
+			await assert.doesNotReject(restWrapper.patch(testUrl, { test: "payload" }));
 		});
 		it("retries a request with fresh auth headers on 401", async () => {
 			nock(testHost, { reqheaders: { authorization: `Basic ${token1}` } })
@@ -290,9 +281,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 				.patch(testPath)
 				.query(true)
 				.reply(200);
-			await assert.doesNotReject(
-				restWrapper.patch(testUrl, { test: "payload" }),
-			);
+			await assert.doesNotReject(restWrapper.patch(testUrl, { test: "payload" }));
 		});
 		it("throws a non-retriable error on 2nd 401", async () => {
 			nock(testHost, { reqheaders: { authorization: `Basic ${token1}` } })
@@ -317,9 +306,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 		it("retries with delay on 429 with retryAfter", async () => {
 			throttle();
 			nock(testHost).patch(testPath).reply(replyWithThrottling);
-			await assert.doesNotReject(
-				restWrapper.patch(testUrl, { test: "payload" }),
-			);
+			await assert.doesNotReject(restWrapper.patch(testUrl, { test: "payload" }));
 		});
 		it("throws a retriable error on 429 without retryAfter", async () => {
 			nock(testHost).patch(testPath).reply(429, { retryAfter: undefined });

--- a/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/restWrapper.spec.ts
@@ -170,7 +170,7 @@ describe("RouterliciousDriverRestWrapper", () => {
 			assert(retryQueryParamTested);
 		});
 
-		it.only("retry query param is appended on subsequent api request - when request function is invoked multiple times externally on failure", async () => {
+		it("retry query param is appended on subsequent api request - when request function is invoked multiple times externally on failure", async () => {
 			let isTestedSuccessfully = false;
 			// Fail first request with retriable error
 			nock(testHost).get(testPath).reply(500);

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -60,11 +60,21 @@
 	"c8": {
 		"all": true,
 		"cache-dir": "nyc/.cache",
-		"exclude": ["src/test/**/*.*ts", "lib/test/**/*.*js"],
+		"exclude": [
+			"src/test/**/*.*ts",
+			"lib/test/**/*.*js"
+		],
 		"exclude-after-remap": false,
-		"include": ["src/**/*.*ts", "lib/**/*.*js"],
+		"include": [
+			"src/**/*.*ts",
+			"lib/**/*.*js"
+		],
 		"report-dir": "nyc/report",
-		"reporter": ["cobertura", "html", "text"],
+		"reporter": [
+			"cobertura",
+			"html",
+			"text"
+		],
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"dependencies": {
@@ -142,7 +152,11 @@
 	},
 	"fluidBuild": {
 		"tasks": {
-			"build:test:esm": ["^build:esnext", "build:genver", "^tsc"]
+			"build:test:esm": [
+				"^build:esnext",
+				"build:genver",
+				"^tsc"
+			]
 		}
 	},
 	"typeValidation": {

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -60,21 +60,11 @@
 	"c8": {
 		"all": true,
 		"cache-dir": "nyc/.cache",
-		"exclude": [
-			"src/test/**/*.*ts",
-			"lib/test/**/*.*js"
-		],
+		"exclude": ["src/test/**/*.*ts", "lib/test/**/*.*js"],
 		"exclude-after-remap": false,
-		"include": [
-			"src/**/*.*ts",
-			"lib/**/*.*js"
-		],
+		"include": ["src/**/*.*ts", "lib/**/*.*js"],
 		"report-dir": "nyc/report",
-		"reporter": [
-			"cobertura",
-			"html",
-			"text"
-		],
+		"reporter": ["cobertura", "html", "text"],
 		"temp-directory": "nyc/.nyc_output"
 	},
 	"dependencies": {
@@ -152,11 +142,7 @@
 	},
 	"fluidBuild": {
 		"tasks": {
-			"build:test:esm": [
-				"^build:esnext",
-				"build:genver",
-				"^tsc"
-			]
+			"build:test:esm": ["^build:esnext", "build:genver", "^tsc"]
 		}
 	},
 	"typeValidation": {


### PR DESCRIPTION
This PR adds `retry` param to the service calls made by the driver. This would enable services (specifically FRS) to track scope of degradation of their services by using this parameter.
Changes include:
1. Updated the restWrapper to use `retryCounter` map which preserves the retry counts for apis.
2. Added a new function to append params to the request URL `addOrUpdateQueryParams`. We now use `URL` api instead of manual generation of request url which was previously done on restWrapperBase.
3. Logging `retryQueryParam` in telemetry on error.
4. Added tests.

[AB#7623](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7623)