### PR TITLE
Restore SharedMap usage to fluid-framework bundle size test

### DIFF
--- a/examples/utils/bundle-size-tests/src/fluidFramework.ts
+++ b/examples/utils/bundle-size-tests/src/fluidFramework.ts
@@ -4,7 +4,12 @@
  */
 
 import { SharedTree } from "fluid-framework";
+// eslint-disable-next-line import/no-internal-modules
+import { SharedMap } from "fluid-framework/legacy";
 
 export function apisToBundle() {
-	return SharedTree;
+	return {
+		SharedMap,
+		SharedTree,
+	};
 }


### PR DESCRIPTION
SharedMap was removed from the fluid-framework bundle size test [here](https://github.com/microsoft/FluidFramework/pull/20584/files#diff-c2d36eeba5c881e927b56920013695b438c3cb3e0cbbbf4b586d2e491d9a8322) corresponding with the removal of SharedMap from the fluid-framework package entirely [here](https://github.com/microsoft/FluidFramework/pull/20584/files#diff-0cf38bc54b625bd919add7591667aebf30c4e11ab43b20ceed535fe3139203e4L38).

However, that change was semi-reverted [here](https://github.com/microsoft/FluidFramework/commit/7b2eac1740e23725ff0f13f6f3b2034b21e7b1f0#diff-cb5abdd84727883b14be63e8409a45ee2ad25b8a027cc3caa7a02efb4f75ea7eR29) (adding it back, but only exported from /legacy).  But the usage of SharedMap was not restored to the bundle-size-test at that time.

Since the objective of the test remains the same as before the removal (ensuring we don't regress bundle size for the patterns our current customers use), this change restores the usage of SharedMap to the bundle-size-test.