### PR TITLE
[rc4] Re-expose full API in default export

### DIFF
--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -45,7 +45,7 @@
 		}
 	},
 	"main": "lib/index.js",
-	"types": "lib/public.d.ts",
+	"types": "lib/index.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
 		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -15,11 +15,11 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./lib/public.d.ts",
+				"types": "./lib/index.d.ts",
 				"default": "./lib/index.js"
 			},
 			"require": {
-				"types": "./dist/public.d.ts",
+				"types": "./dist/index.d.ts",
 				"default": "./dist/index.js"
 			}
 		},

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -45,7 +45,7 @@
 		}
 	},
 	"main": "lib/index.js",
-	"types": "lib/public.d.ts",
+	"types": "lib/index.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
 		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -15,11 +15,11 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./lib/public.d.ts",
+				"types": "./lib/index.d.ts",
 				"default": "./lib/index.js"
 			},
 			"require": {
-				"types": "./dist/public.d.ts",
+				"types": "./dist/index.d.ts",
 				"default": "./dist/index.js"
 			}
 		},

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -45,7 +45,7 @@
 		}
 	},
 	"main": "lib/index.js",
-	"types": "lib/public.d.ts",
+	"types": "lib/index.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
 		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -15,11 +15,11 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./lib/public.d.ts",
+				"types": "./lib/index.d.ts",
 				"default": "./lib/index.js"
 			},
 			"require": {
-				"types": "./dist/public.d.ts",
+				"types": "./dist/index.d.ts",
 				"default": "./dist/index.js"
 			}
 		},


### PR DESCRIPTION
DRAFT - more info coming soon.

Re-exposes the full API in the default export for the following packages:

- container-definitions
- core-interfaces
- driver-definitions
