### PR TITLE
[main>rc5] ci: fix build-tools installation in GH actions workflow

### DIFF
--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -39,10 +39,10 @@ jobs:
           cd build-tools
           pnpm install --frozen-lockfile
           pnpm run build:compile
-
-          # add the bin dir of build-cli to the path
-          cd packages/build-cli/bin
-          echo "$(pwd)" >> $GITHUB_PATH
+          # We want flub available to call, so we run npm link in the build-cli package, which creates shims that are avilable on the PATH
+          # Use npm link instead of pnpm link because it handles bins better
+          cd packages/build-cli
+          npm link
 
       - name: Check build-tools installation
         run: |


### PR DESCRIPTION
Ports #21556 from main to RC5.

This workflow was not updated after build-tools was updated to ESM instead of CJS. The fix is to use `npm link` to make `flub` available since the old shim was removed when we switched to ESM.

Tested with [act](https://github.com/nektos/act):

```
act push -W .github/workflows/push-tag-create-release.yml -v
```