### PR TITLE
refactor(tree): Optimize certain leaf access cases

### DIFF
--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -72,9 +72,6 @@ export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | u
 			const asValue = field as FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.optional>>;
 
 			const maybeUnboxedContent = asValue.content;
-			if (maybeUnboxedContent === undefined) {
-				return undefined;
-			}
 			if (!isFlexTreeNode(maybeUnboxedContent)) {
 				return maybeUnboxedContent;
 			}

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -96,9 +96,8 @@ export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | u
 			fail("'sequence' field is unexpected.");
 		}
 		case FieldKinds.identifier: {
-			const identifier = field.boxedAt(0);
-			assert(identifier !== undefined, 0x91a /* identifier must exist */);
-			return getOrCreateNodeProxy(identifier);
+			// Identifier fields are just value fields that hold strings
+			return (field as FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.required>>).content as string;
 		}
 
 		default:

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -82,12 +82,6 @@ export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | u
 			}
 
 			return getOrCreateNodeProxy(maybeUnboxedContent);
-
-			// const maybeContent = asValue.boxedContent;
-
-			// // Normally, empty fields are unreachable due to the behavior of 'tryGetField'.  However, the
-			// // root field is a special case where the field is always present (even if empty).
-			// return maybeContent === undefined ? undefined : getOrCreateNodeProxy(maybeContent);
 		}
 		// TODO: Remove if/when 'FieldNode' is removed.
 		case FieldKinds.sequence: {

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -91,7 +91,8 @@ export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | u
 		}
 		case FieldKinds.identifier: {
 			// Identifier fields are just value fields that hold strings
-			return (field as FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.required>>).content as string;
+			return (field as FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.required>>)
+				.content as string;
 		}
 
 		default:

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -56,27 +56,28 @@ export function isTreeNode(candidate: unknown): candidate is TreeNode | Unhydrat
  * Retrieve the associated proxy for the given field.
  * */
 export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | undefined {
+	function tryToUnboxLeaves(
+		flexField:
+			| FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.required>>
+			| FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.optional>>,
+	): TreeNode | TreeValue | undefined {
+		const maybeUnboxedContent = flexField.content;
+		return isFlexTreeNode(maybeUnboxedContent)
+			? getOrCreateNodeProxy(maybeUnboxedContent)
+			: maybeUnboxedContent;
+	}
 	switch (field.schema.kind) {
 		case FieldKinds.required: {
-			const asValue = field as FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.required>>;
-
-			const maybeUnboxedContent = asValue.content;
-
-			if (!isFlexTreeNode(maybeUnboxedContent)) {
-				return maybeUnboxedContent;
-			}
-
-			return getOrCreateNodeProxy(maybeUnboxedContent);
+			const typedField = field as FlexTreeTypedField<
+				FlexFieldSchema<typeof FieldKinds.required>
+			>;
+			return tryToUnboxLeaves(typedField);
 		}
 		case FieldKinds.optional: {
-			const asValue = field as FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.optional>>;
-
-			const maybeUnboxedContent = asValue.content;
-			if (!isFlexTreeNode(maybeUnboxedContent)) {
-				return maybeUnboxedContent;
-			}
-
-			return getOrCreateNodeProxy(maybeUnboxedContent);
+			const typedField = field as FlexTreeTypedField<
+				FlexFieldSchema<typeof FieldKinds.optional>
+			>;
+			return tryToUnboxLeaves(typedField);
 		}
 		// TODO: Remove if/when 'FieldNode' is removed.
 		case FieldKinds.sequence: {

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -57,9 +57,9 @@ export function isTreeNode(candidate: unknown): candidate is TreeNode | Unhydrat
  * */
 export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | undefined {
 	function tryToUnboxLeaves(
-		flexField:
-			| FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.required>>
-			| FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.optional>>,
+		flexField: FlexTreeTypedField<
+			FlexFieldSchema<typeof FieldKinds.required | typeof FieldKinds.optional>
+		>,
 	): TreeNode | TreeValue | undefined {
 		const maybeUnboxedContent = flexField.content;
 		return isFlexTreeNode(maybeUnboxedContent)

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -61,9 +61,7 @@ export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | u
 			const asValue = field as FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.required>>;
 
 			const maybeUnboxedContent = asValue.content;
-			if (maybeUnboxedContent === undefined) {
-				return undefined;
-			}
+
 			if (!isFlexTreeNode(maybeUnboxedContent)) {
 				return maybeUnboxedContent;
 			}

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -25,7 +25,7 @@ import {
 	type MapTreeNode,
 	tryGetMapTreeNode,
 	typeNameSymbol,
-	isTreeValue,
+	isFlexTreeNode,
 } from "../feature-libraries/index.js";
 import { type Mutable, fail, isReadonlyArray } from "../util/index.js";
 
@@ -64,7 +64,7 @@ export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | u
 			if (maybeUnboxedContent === undefined) {
 				return undefined;
 			}
-			if (isTreeValue(maybeUnboxedContent)) {
+			if (!isFlexTreeNode(maybeUnboxedContent)) {
 				return maybeUnboxedContent;
 			}
 
@@ -77,7 +77,7 @@ export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | u
 			if (maybeUnboxedContent === undefined) {
 				return undefined;
 			}
-			if (isTreeValue(maybeUnboxedContent)) {
+			if (!isFlexTreeNode(maybeUnboxedContent)) {
 				return maybeUnboxedContent;
 			}
 

--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -82,7 +82,7 @@ describe("SimpleTree benchmarks", () => {
 			});
 		}
 
-		describe.only("Access to leaves", () => {
+		describe("Access to leaves", () => {
 			describe("Optional object property", () => {
 				const factory = new SchemaFactory("test");
 				class MyInnerSchema extends factory.object("inner", {

--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -106,7 +106,7 @@ describe("SimpleTree benchmarks", () => {
 			});
 		}
 
-		describe.only("Access to leaves", () => {
+		describe("Access to leaves", () => {
 			describe("Optional object property", () => {
 				const factory = new SchemaFactory("test");
 				class MySchema extends factory.object("root", {

--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -83,13 +83,13 @@ describe("SimpleTree benchmarks", () => {
 			});
 		}
 
-		function testAccessToLeaf<RootSchema>(
+		function testAccessToLeaf<RootNode>(
 			title: string,
-			treeInitFunction: () => RootSchema,
-			treeReadingFunction: (tree: RootSchema) => number | undefined,
+			treeInitFunction: () => RootNode,
+			treeReadingFunction: (tree: RootNode) => number | undefined,
 			expectedValue: number | undefined,
 		) {
-			let tree: RootSchema;
+			let tree: RootNode;
 			let readNumber: number | undefined;
 			benchmark({
 				type: BenchmarkType.Measurement,

--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -124,50 +124,45 @@ describe("SimpleTree benchmarks", () => {
 					{
 						title: `Read value from leaf`,
 						initUnhydrated: () => new MySchema({ value: 1 }),
-						initFlex: () => hydrate(MySchema, { value: 1 }),
 						read: (tree: MySchema) => tree.value,
 						expected: 1,
 					},
 					{
 						title: `Read value from union of two leaves`,
 						initUnhydrated: () => new MySchema({ leafUnion: 1 }),
-						initFlex: () => hydrate(MySchema, { leafUnion: 1 }),
 						read: (tree: MySchema) => tree.leafUnion as number,
 						expected: 1,
 					},
 					{
 						title: `Read value from union of leaf and non-leaf`,
 						initUnhydrated: () => new MySchema({ complexUnion: 1 }),
-						initFlex: () => hydrate(MySchema, { complexUnion: 1 }),
 						read: (tree: MySchema) => tree.complexUnion as number,
 						expected: 1,
 					},
 					{
 						title: `Read undefined from leaf`,
 						initUnhydrated: () => new MySchema({}),
-						initFlex: () => hydrate(MySchema, {}),
 						read: (tree: MySchema) => tree.value,
 						expected: undefined,
 					},
 					{
 						title: `Read undefined from union of two leaves`,
 						initUnhydrated: () => new MySchema({}),
-						initFlex: () => hydrate(MySchema, {}),
 						read: (tree: MySchema) => tree.leafUnion as number,
 						expected: undefined,
 					},
 					{
 						title: `Read undefined from union of leaf and non-leaf`,
 						initUnhydrated: () => new MySchema({}),
-						initFlex: () => hydrate(MySchema, {}),
 						read: (tree: MySchema) => tree.complexUnion as number,
 						expected: undefined,
 					},
 				];
 
-				for (const { title, initUnhydrated, initFlex, read, expected } of testCases) {
+				for (const { title, initUnhydrated, read, expected } of testCases) {
+					const initFlexNode = () => hydrate(MySchema, initUnhydrated());
 					testAccessToLeaf(`${title} (unhydrated node)`, initUnhydrated, read, expected);
-					testAccessToLeaf(`${title} (flex node)`, initFlex, read, expected);
+					testAccessToLeaf(`${title} (flex node)`, initFlexNode, read, expected);
 				}
 			});
 
@@ -187,28 +182,23 @@ describe("SimpleTree benchmarks", () => {
 				const testCases = [
 					{
 						title: `Read value from leaf`,
-						initUnhydrated: () => new MySchema({ value: 1, leafUnion: 1, complexUnion: 1 }),
-						initFlex: () => hydrate(MySchema, { value: 1, leafUnion: 1, complexUnion: 1 }),
 						read: (tree: MySchema) => tree.value,
-						expected: 1,
 					},
 					{
 						title: `Read value from union of two leaves`,
-						initUnhydrated: () => new MySchema({ value: 1, leafUnion: 1, complexUnion: 1 }),
-						initFlex: () => hydrate(MySchema, { value: 1, leafUnion: 1, complexUnion: 1 }),
 						read: (tree: MySchema) => tree.leafUnion as number,
-						expected: 1,
 					},
 					{
 						title: `Read value from union of leaf and non-leaf`,
-						initUnhydrated: () => new MySchema({ value: 1, leafUnion: 1, complexUnion: 1 }),
-						initFlex: () => hydrate(MySchema, { value: 1, leafUnion: 1, complexUnion: 1 }),
 						read: (tree: MySchema) => tree.complexUnion as number,
-						expected: 1,
 					},
 				];
 
-				for (const { title, initUnhydrated, initFlex, read, expected } of testCases) {
+				const expected = 1;
+				const initUnhydrated = () => new MySchema({ value: 1, leafUnion: 1, complexUnion: 1 });
+				const initFlex = () =>
+					hydrate(MySchema, new MySchema({ value: 1, leafUnion: 1, complexUnion: 1 }));
+				for (const { title, read } of testCases) {
 					testAccessToLeaf(`${title} (unhydrated node)`, initUnhydrated, read, expected);
 					testAccessToLeaf(`${title} (flex node)`, initFlex, read, expected);
 				}
@@ -228,61 +218,47 @@ describe("SimpleTree benchmarks", () => {
 				const testCases = [
 					{
 						title: `Read value from leaf`,
-						initUnhydrated: () => new NumberMap([["a", 1]]),
-						initFlex: () => hydrate(NumberMap, new NumberMap([["a", 1]])),
+						mapType: NumberMap,
 						read: (tree: CombinedTypes) => tree.get("a") as number,
 						expected: 1,
 					},
 					{
 						title: `Read value from union of two leaves`,
-						initUnhydrated: () => new NumberStringMap([["a", 1]]),
-						initFlex: () => hydrate(NumberStringMap, new NumberStringMap([["a", 1]])),
+						mapType: NumberStringMap,
 						read: (tree: CombinedTypes) => tree.get("a") as number,
 						expected: 1,
 					},
 					{
 						title: `Read value from union of leaf and non-leaf`,
-						initUnhydrated: () => new NumberObjectMap([["a", 1]]),
-						initFlex: () => hydrate(NumberObjectMap, new NumberObjectMap([["a", 1]])),
+						mapType: NumberObjectMap,
 						read: (tree: CombinedTypes) => tree.get("a") as number,
 						expected: 1,
 					},
 					{
 						title: `Read undefined from leaf`,
-						initUnhydrated: () => new NumberMap([["a", 1]]),
-						initFlex: () => hydrate(NumberMap, new NumberMap([["a", 1]])),
+						mapType: NumberMap,
 						read: (tree: CombinedTypes) => tree.get("b") as number,
 						expected: undefined,
 					},
 					{
 						title: `Read undefined from union of two leaves`,
-						initUnhydrated: () => new NumberStringMap([["a", 1]]),
-						initFlex: () => hydrate(NumberStringMap, new NumberStringMap([["a", 1]])),
+						mapType: NumberStringMap,
 						read: (tree: CombinedTypes) => tree.get("b") as number,
 						expected: undefined,
 					},
 					{
 						title: `Read undefined from union of leaf and non-leaf`,
-						initUnhydrated: () => new NumberObjectMap([["a", 1]]),
-						initFlex: () => hydrate(NumberObjectMap, new NumberObjectMap([["a", 1]])),
+						mapType: NumberObjectMap,
 						read: (tree: CombinedTypes) => tree.get("b") as number,
 						expected: undefined,
 					},
 				];
 
-				for (const { title, initUnhydrated, initFlex, read, expected } of testCases) {
-					testAccessToLeaf<NumberMap | NumberStringMap | NumberObjectMap>(
-						`${title} (unhydrated node)`,
-						initUnhydrated,
-						read,
-						expected,
-					);
-					testAccessToLeaf<NumberMap | NumberStringMap | NumberObjectMap>(
-						`${title} (flex node)`,
-						initFlex,
-						read,
-						expected,
-					);
+				for (const { title, mapType, read, expected } of testCases) {
+					const initUnhydrated = () => new mapType([["a", 1]]);
+					const initFlex = () => hydrate(mapType, initUnhydrated());
+					testAccessToLeaf(`${title} (unhydrated node)`, initUnhydrated, read, expected);
+					testAccessToLeaf(`${title} (flex node)`, initFlex, read, expected);
 				}
 			});
 
@@ -297,48 +273,30 @@ describe("SimpleTree benchmarks", () => {
 					factory.number,
 					factory.object("inner", { value: factory.number }),
 				]) {}
-				// Just to simplify typing a bit below in a way that keeps TypeScript happy
-				type CombinedTypes = NumberArray | NumberStringArray | NumberObjectArray;
 
 				const testCases = [
 					{
 						title: `Read value from leaf`,
-						initUnhydrated: () => new NumberArray([1]),
-						initFlex: () => hydrate(NumberArray, [1]),
-						read: (tree: CombinedTypes) => tree[0] as number,
-						expected: 1,
+						arrayType: NumberArray,
 					},
 					{
 						title: `Read value from union of two leaves`,
-						initUnhydrated: () => new NumberStringArray([1]),
-						initFlex: () => hydrate(NumberStringArray, [1]),
-						read: (tree: CombinedTypes) => tree[0] as number,
-						expected: 1,
+						arrayType: NumberStringArray,
 					},
 					{
 						title: `Read value from union of leaf and non-leaf`,
-						initUnhydrated: () => new NumberObjectArray([1]),
-						initFlex: () => hydrate(NumberObjectArray, [1]),
-						read: (tree: CombinedTypes) => tree[0] as number,
-						expected: 1,
+						arrayType: NumberObjectArray,
 					},
 				];
 
-				for (const { title, initUnhydrated, initFlex, read, expected } of testCases) {
-					// Cast to any because we know that all different schemas represent an array and thus have the same interface,
-					// so the same read function would work on any of them.
-					testAccessToLeaf<NumberArray | NumberStringArray | NumberObjectArray>(
-						`${title} (unhydrated node)`,
-						initUnhydrated,
-						read,
-						expected,
-					);
-					testAccessToLeaf<NumberArray | NumberStringArray | NumberObjectArray>(
-						`${title} (flex node)`,
-						initFlex,
-						read,
-						expected,
-					);
+				for (const { title, arrayType } of testCases) {
+					const initUnhydrated = () => new arrayType([1]);
+					const initFlex = () => hydrate(arrayType, initUnhydrated());
+					const read = (tree: NumberArray | NumberStringArray | NumberObjectArray) =>
+						tree[0] as number;
+					const expected = 1;
+					testAccessToLeaf(`${title} (unhydrated node)`, initUnhydrated, read, expected);
+					testAccessToLeaf(`${title} (flex node)`, initFlex, read, expected);
 				}
 			});
 		});


### PR DESCRIPTION
## Description

Refined PR based on the discussion in https://github.com/microsoft/FluidFramework/pull/21523 and offline chats, that works towards optimizing access to leaf values in SharedTree.

A couple of comments suggesting that the unboxing behavior of FieldNodes were causing confusion and making this seem more complicated than it ended up being, but it turns out that @CraigMacomber had already removed unboxing from FieldNodes in https://github.com/microsoft/FluidFramework/pull/18260, so this PR removes those comments and moves ahead with an initial optimization (for some cases) when accessing leaf values.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The following div shows benchmark results from main and from this PR. Some unhydrated node cases seem to have a bit of a regression, but overall the changes seem good, particularly accessing values that are "simple leaves" (not unions) both in the unhydrated node and flex node cases. For access to leaves (simple and in unions) on object properties, all cases improved.

![image](https://github.com/microsoft/FluidFramework/assets/716334/939a759e-8f62-4199-bc2a-a85398613b7e)

[AB#6908](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6908)