### PR TITLE
Update test-perf-benchmarks.yml for Azure Pipelines

### DIFF
--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -45,10 +45,10 @@ parameters:
   default:
   - endpointName: 'local'
   - endpointName: 'odsp'
-    lockVariableGroupName: 'e2e-odsp-lock'
+    lockVariableGroupName: 'stress-odsp-lock'
     timeoutInMinutes: 360
   - endpointName: 'frs'
-    lockVariableGroupName: 'e2e-frs-lock'
+    lockVariableGroupName: 'stress-frs-lock'
     timeoutInMinutes: 360
 
 variables:

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -45,10 +45,10 @@ parameters:
   default:
   - endpointName: 'local'
   - endpointName: 'odsp'
-    lockVariableGroupName: 'stress-odsp-lock'
+    lockVariableGroupName: 'perf-odsp-lock'
     timeoutInMinutes: 360
   - endpointName: 'frs'
-    lockVariableGroupName: 'stress-frs-lock'
+    lockVariableGroupName: 'perf-frs-lock'
     timeoutInMinutes: 360
 
 variables:
@@ -420,9 +420,9 @@ stages:
             FLUID_LOGGER_PROPS: '{ "hostName": "Benchmark" }'
             login__microsoft__clientId: $(login-microsoft-clientId)
             ${{ if eq( endpointObject.endpointName, 'odsp' ) }}:
-              login__odsp__test__tenants: $(automation-stress-login-odsp-test-tenants)
+              login__odsp__test__tenants: $(automation-perf-login-odsp-test-tenants)
             ${{ if eq( endpointObject.endpointName, 'frs' ) }}:
-              fluid__test__driver__frs: $(automation-fluid-test-driver-frs-stress-test)
+              fluid__test__driver__frs: $(automation-fluid-test-driver-frs-perf-test)
 
         - task: Bash@3
           displayName: Write measurements to Aria/Kusto - execution time ${{ endpointObject.endpointName }}


### PR DESCRIPTION
Update stress/perf pipeline to use its own variable group name lock instead of sharing the same one with the E2E pipeline.