### PR TITLE
fix(tree): fix allowsRepoSuperset to check node schema identifiers

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
@@ -211,6 +211,5 @@ export function allowsRepoSuperset(
 export function normalizeField(
 	schema: TreeFieldStoredSchema | undefined,
 ): TreeFieldStoredSchema {
-	2;
 	return schema ?? storedEmptyFieldSchema;
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/comparison.ts
@@ -195,6 +195,11 @@ export function allowsRepoSuperset(
 		}
 	}
 	for (const [key, schema] of original.nodeSchema) {
+		// If a nodeStoredSchema in 'A' does not exist in the 'B', 'B' can no longer be considered a superset of
+		// 'A', and we can stop the check early.
+		if (!superset.nodeSchema.has(key)) {
+			return false;
+		}
 		// TODO: I think its ok to use the tree from superset here, but I should confirm it is, and document why.
 		if (!allowsTreeSuperset(policy, original, schema, superset.nodeSchema.get(key))) {
 			return false;
@@ -206,5 +211,6 @@ export function allowsRepoSuperset(
 export function normalizeField(
 	schema: TreeFieldStoredSchema | undefined,
 ): TreeFieldStoredSchema {
+	2;
 	return schema ?? storedEmptyFieldSchema;
 }

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -283,6 +283,11 @@ describe("Schema Comparison", () => {
 				name: brand<TreeNodeSchemaIdentifier>("testTree2"),
 				schema: new ObjectNodeStoredSchema(new Map()),
 			};
+			const node3 = {
+				name: brand<TreeNodeSchemaIdentifier>("testTree3"),
+				schema: new ObjectNodeStoredSchema(new Map()),
+			};
+
 			const repo1 = new TreeStoredSchemaRepository({
 				rootFieldSchema: root,
 				nodeSchema: new Map([[node1.name, node1.schema]]),
@@ -291,7 +296,24 @@ describe("Schema Comparison", () => {
 				rootFieldSchema: root,
 				nodeSchema: new Map([[node2.name, node2.schema]]),
 			});
-			testOrder(compareTwoRepo, [repo1, repo2]);
+			const repo3 = new TreeStoredSchemaRepository({
+				rootFieldSchema: root,
+				nodeSchema: new Map([
+					[node1.name, node1.schema],
+					[node2.name, node2.schema],
+				]),
+			});
+			const repo4 = new TreeStoredSchemaRepository({
+				rootFieldSchema: root,
+				nodeSchema: new Map([
+					[node1.name, node1.schema],
+					[node3.name, node3.schema],
+				]),
+			});
+
+			assert.equal(getOrdering(repo1, repo2, compareTwoRepo), Ordering.Incomparable);
+			assert.equal(getOrdering(repo1, repo3, compareTwoRepo), Ordering.Superset);
+			assert.equal(getOrdering(repo3, repo4, compareTwoRepo), Ordering.Incomparable);
 		});
 
 		it("The ordering should be incomparable when there is an `intersection`", () => {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -273,7 +273,6 @@ describe("Schema Comparison", () => {
 		});
 
 		it("Validate the ordering when the identifiers are different", () => {
-			// TODO: AB#8357, Improve allowsTreeSuperset to ensure it can distinguish between different identifiers.
 			const root = fieldSchema(FieldKinds.optional);
 			const node1 = {
 				name: brand<TreeNodeSchemaIdentifier>("testTree"),


### PR DESCRIPTION
[AB#8357](https://dev.azure.com/fluidframework/internal/_workitems/edit/8357)

When the allowed types at the root aren't defined, TreeTypeSet is supposed to encompass "every allowed type in the schema." Therefore, it is necessary to add a check to ensure that "every type allowed in argument 1 is a subset of those allowed in argument 2."

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

