### PR TITLE
[Port rc.5.0] Fix e2e tests not running back compat due to new version bump

### DIFF
--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { fromInternalScheme } from "@fluid-tools/version-tools";
 import { assert, Lazy } from "@fluidframework/core-utils/internal";
 import * as semver from "semver";
 
@@ -205,23 +204,16 @@ const genDriverLoaderBackCompatConfig = (compatVersion: number): CompatConfig[] 
 };
 
 const getNumberOfVersionsToGoBack = (numOfVersionsAboveV2Int1: number = 0): number => {
-	const [, semverInternal, prereleaseIndentifier] = fromInternalScheme(
-		codeVersion,
-		true,
-		true,
-	);
-	assert(semverInternal !== undefined, "Unexpected pkg version");
+	const semverVersion = semver.parse(codeVersion);
+	assert(semverVersion !== null, `Unexpected pkg version '${codeVersion}'`);
 
-	// Here we check if the release is an RC release. If so, we also need to account for internal releases when
+	// Here we add the minor release to the math. If so, we also need to account for internal releases when
 	// generating back compat configs. For back compat purposes, we consider RC major release 1 to be treated as internal
 	// major release 9. This will ensure we generate back compat configs for all RC and internal major releases.
-	const greatestInternalMajor = 8;
-	const numOfVersionsToV2Int1 =
-		prereleaseIndentifier === "rc" || prereleaseIndentifier === "dev-rc"
-			? semverInternal.major + greatestInternalMajor
-			: semverInternal.major; // this happens to be the greatest major version
+	// There are 5 rc versions. 8 internal versions. 5 rc versions. 2.0 is the first minor version.
+	const greatestInternalMajor = 8 + 5 + semverVersion.minor;
 	// This allows us to increase our "LTS" support for certain versions above 2.0.0.internal.1.y.z
-	return numOfVersionsToV2Int1 - numOfVersionsAboveV2Int1;
+	return greatestInternalMajor - numOfVersionsAboveV2Int1;
 };
 
 const genFullBackCompatConfig = (driverVersionsAboveV2Int1: number = 0): CompatConfig[] => {


### PR DESCRIPTION
[AB#8480](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8480)

Ports #21571 from main to the RC5 release branch.

The e2e back compat N-2 to LTS+1 back-compat test pipeline fix due to new semver versioning