### PR TITLE
TokenFetcher support to get authorizationHeader - RC.3.0

### DIFF
--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
@@ -10,7 +10,7 @@ import { IDriverErrorBase } from '@fluidframework/driver-definitions';
 import { IResolvedUrl } from '@fluidframework/driver-definitions/internal';
 
 // @internal
-export const authHeaderFromResponse: (tokenResponse: string | TokenResponse | null | undefined) => string | null;
+export const authHeaderFromTokenResponse: (tokenResponse: string | TokenResponse | null | undefined) => string | null;
 
 // @alpha (undocumented)
 export type CacheContentType = "snapshot" | "ops";

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
@@ -9,6 +9,9 @@ import { FiveDaysMs } from '@fluidframework/driver-definitions/internal';
 import { IDriverErrorBase } from '@fluidframework/driver-definitions';
 import { IResolvedUrl } from '@fluidframework/driver-definitions/internal';
 
+// @internal
+export const authHeaderFromResponse: (tokenResponse: string | TokenResponse | null | undefined) => string | null;
+
 // @alpha (undocumented)
 export type CacheContentType = "snapshot" | "ops";
 
@@ -47,6 +50,7 @@ export interface ICacheEntry extends IEntry {
 export interface ICollabSessionOptions {
     // @deprecated (undocumented)
     forceAccessTokenViaAuthorizationHeader?: boolean;
+    // @deprecated (undocumented)
     unauthenticatedUserDisplayName?: string;
 }
 
@@ -289,14 +293,19 @@ export type TokenFetcher<T> = (options: T) => Promise<string | TokenResponse | n
 export interface TokenFetchOptions {
     claims?: string;
     refresh: boolean;
+    readonly request?: {
+        url: string;
+        method: "GET" | "POST" | "PATCH" | "DELETE" | "PUT";
+    };
     tenantId?: string;
 }
 
-// @internal
+// @internal @deprecated
 export const tokenFromResponse: (tokenResponse: string | TokenResponse | null | undefined) => string | null;
 
 // @beta
 export interface TokenResponse {
+    readonly authorizationHeader?: string;
     fromCache?: boolean;
     token: string;
 }

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -64,7 +64,7 @@ export interface IOpsCachingPolicy {
  */
 export interface ICollabSessionOptions {
 	/**
-	 * @deprecated No longer needed
+	 * @deprecated starting in 2.0-RC3. No longer needed.
 	 * Value indicating the display name for session that admits unauthenticated user.
 	 * This name will be used in attribution associated with edits made by such user.
 	 */

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -64,6 +64,7 @@ export interface IOpsCachingPolicy {
  */
 export interface ICollabSessionOptions {
 	/**
+	 * @deprecated No longer needed
 	 * Value indicating the display name for session that admits unauthenticated user.
 	 * This name will be used in attribution associated with edits made by such user.
 	 */

--- a/packages/drivers/odsp-driver-definitions/src/index.ts
+++ b/packages/drivers/odsp-driver-definitions/src/index.ts
@@ -37,6 +37,7 @@ export {
 	OdspResourceTokenFetchOptions,
 	TokenFetcher,
 	TokenFetchOptions,
+	authHeaderFromResponse,
 	tokenFromResponse,
 	TokenResponse,
 } from "./tokenFetch.js";

--- a/packages/drivers/odsp-driver-definitions/src/index.ts
+++ b/packages/drivers/odsp-driver-definitions/src/index.ts
@@ -37,7 +37,7 @@ export {
 	OdspResourceTokenFetchOptions,
 	TokenFetcher,
 	TokenFetchOptions,
-	authHeaderFromResponse,
+	authHeaderFromTokenResponse,
 	tokenFromResponse,
 	TokenResponse,
 } from "./tokenFetch.js";

--- a/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
@@ -12,6 +12,13 @@ export interface TokenResponse {
 	token: string;
 
 	/**
+	 * Authorization header value will be used verbatim when making network call that requires the token.
+	 * If not returned the token value will be assumed to be a Bearer token and will be used to generate the
+	 * Authorization header value in the following format: `Bearer ${token}`.
+	 */
+	readonly authorizationHeader?: string;
+
+	/**
 	 * Whether or not the token was obtained from local cache.
 	 * @remarks `undefined` indicates that it could not be determined whether or not the token was obtained this way.
 	 */
@@ -41,6 +48,14 @@ export interface TokenFetchOptions {
 	 * to use to issue access token.
 	 */
 	tenantId?: string;
+
+	/**
+	 * Request that will be made using the fetched token.
+	 * - url: full request url, including query params
+	 * - method: method type
+	 * Request info may be encoded into the returned token that the receiver can use to validate that caller is allowed to make specific call.
+	 */
+	readonly request?: { url: string; method: "GET" | "POST" | "PATCH" | "DELETE" | "PUT" };
 }
 
 /**
@@ -73,6 +88,7 @@ export type TokenFetcher<T> = (options: T) => Promise<string | TokenResponse | n
  * @param tokenResponse - return value for TokenFetcher method
  * @returns Token value
  * @internal
+ * @deprecated - Use authHeaderFromResponse instead
  */
 export const tokenFromResponse = (
 	tokenResponse: string | TokenResponse | null | undefined,
@@ -82,6 +98,29 @@ export const tokenFromResponse = (
 		: tokenResponse === undefined
 		? null
 		: tokenResponse.token;
+
+/**
+ * Helper method which transforms return value for TokenFetcher method to Authorization header value
+ * @param tokenResponse - return value for TokenFetcher method
+ * @returns Authorization header value
+ * @internal
+ */
+export const authHeaderFromResponse = (
+	tokenResponse: string | TokenResponse | null | undefined,
+): string | null => {
+	if (
+		tokenResponse !== null &&
+		typeof tokenResponse === "object" &&
+		tokenResponse.authorizationHeader !== undefined
+	) {
+		return tokenResponse.authorizationHeader;
+	}
+	const token = tokenFromResponse(tokenResponse);
+	if (token !== null) {
+		return `Bearer ${token}`;
+	}
+	return null;
+};
 
 /**
  * Helper method which returns flag indicating whether token response comes from local cache
@@ -106,6 +145,7 @@ export const isTokenFromCache = (
 export type IdentityType = "Consumer" | "Enterprise";
 
 /**
+ * @returns Authorization header value
  * @internal
  */
 export type InstrumentedStorageTokenFetcher = (

--- a/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
@@ -108,11 +108,7 @@ export const tokenFromResponse = (
 export const authHeaderFromTokenResponse = (
 	tokenResponse: string | TokenResponse | null | undefined,
 ): string | null => {
-	if (
-		tokenResponse !== null &&
-		typeof tokenResponse === "object" &&
-		tokenResponse.authorizationHeader !== undefined
-	) {
+	if (typeof tokenResponse === "object" && tokenResponse?.authorizationHeader !== undefined) {
 		return tokenResponse.authorizationHeader;
 	}
 	const token = tokenFromResponse(tokenResponse);

--- a/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
@@ -88,7 +88,7 @@ export type TokenFetcher<T> = (options: T) => Promise<string | TokenResponse | n
  * @param tokenResponse - return value for TokenFetcher method
  * @returns Token value
  * @internal
- * @deprecated - Use authHeaderFromResponse instead
+ * @deprecated - Use authHeaderFromTokenResponse instead
  */
 export const tokenFromResponse = (
 	tokenResponse: string | TokenResponse | null | undefined,
@@ -105,7 +105,7 @@ export const tokenFromResponse = (
  * @returns Authorization header value
  * @internal
  */
-export const authHeaderFromResponse = (
+export const authHeaderFromTokenResponse = (
 	tokenResponse: string | TokenResponse | null | undefined,
 ): string | null => {
 	if (

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.api.md
@@ -267,7 +267,7 @@ export interface OdspFluidDataStoreLocator extends IOdspUrlParts {
 // @internal
 export function parseCompactSnapshotResponse(buffer: Uint8Array, logger: ITelemetryLoggerExt): ISnapshotContentsWithProps;
 
-// @alpha
+// @alpha @deprecated
 export function prefetchLatestSnapshot(resolvedUrl: IResolvedUrl, getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, persistedCache: IPersistedCache, forceAccessTokenViaAuthorizationHeader: boolean, logger: ITelemetryBaseLogger, hostSnapshotFetchOptions: ISnapshotOptions | undefined, enableRedeemFallback?: boolean, fetchBinarySnapshotFormat?: boolean, snapshotFormatFetchType?: SnapshotFormatSupportType, odspDocumentServiceFactory?: OdspDocumentServiceFactory): Promise<boolean>;
 
 // @alpha

--- a/packages/drivers/odsp-driver/src/createFile.ts
+++ b/packages/drivers/odsp-driver/src/createFile.ts
@@ -26,7 +26,7 @@ import {
 } from "./createNewUtils.js";
 import { createOdspUrl } from "./createOdspUrl.js";
 import { EpochTracker } from "./epochTracker.js";
-import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
+import { getHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
 import { OdspDriverUrlResolver } from "./odspDriverUrlResolver.js";
 import { getApiRoot } from "./odspUrlHelper.js";
 import {
@@ -48,7 +48,7 @@ const isInvalidFileName = (fileName: string): boolean => {
  * Returns resolved url
  */
 export async function createNewFluidFile(
-	getStorageToken: InstrumentedStorageTokenFetcher,
+	getAuthHeader: InstrumentedStorageTokenFetcher,
 	newFileInfo: INewFileInfo,
 	logger: ITelemetryLoggerExt,
 	createNewSummary: ISummaryTree | undefined,
@@ -73,16 +73,10 @@ export async function createNewFluidFile(
 	let summaryHandle: string = "";
 	let shareLinkInfo: ShareLinkInfoType | undefined;
 	if (createNewSummary === undefined) {
-		itemId = await createNewEmptyFluidFile(
-			getStorageToken,
-			newFileInfo,
-			logger,
-			epochTracker,
-			forceAccessTokenViaAuthorizationHeader,
-		);
+		itemId = await createNewEmptyFluidFile(getAuthHeader, newFileInfo, logger, epochTracker);
 	} else {
 		const content = await createNewFluidFileFromSummary(
-			getStorageToken,
+			getAuthHeader,
 			newFileInfo,
 			logger,
 			createNewSummary,
@@ -161,11 +155,10 @@ function extractShareLinkData(
 }
 
 export async function createNewEmptyFluidFile(
-	getStorageToken: InstrumentedStorageTokenFetcher,
+	getAuthHeader: InstrumentedStorageTokenFetcher,
 	newFileInfo: INewFileInfo,
 	logger: ITelemetryLoggerExt,
 	epochTracker: EpochTracker,
-	forceAccessTokenViaAuthorizationHeader: boolean,
 ): Promise<string> {
 	const filePath = newFileInfo.filePath ? encodeURIComponent(`/${newFileInfo.filePath}`) : "";
 	// add .tmp extension to empty file (host is expected to rename)
@@ -175,17 +168,18 @@ export async function createNewEmptyFluidFile(
 	}/items/root:/${filePath}/${encodedFilename}:/content?@name.conflictBehavior=rename&select=id,name,parentReference`;
 
 	return getWithRetryForTokenRefresh(async (options) => {
-		const storageToken = await getStorageToken(options, "CreateNewFile");
+		const url = initialUrl;
+		const method = "PUT";
+		const authHeader = await getAuthHeader(
+			{ ...options, request: { url, method } },
+			"CreateNewFile",
+		);
 
 		return PerformanceEvent.timedExecAsync(
 			logger,
 			{ eventName: "createNewEmptyFile" },
 			async (event) => {
-				const { url, headers } = getUrlAndHeadersWithAuth(
-					initialUrl,
-					storageToken,
-					forceAccessTokenViaAuthorizationHeader,
-				);
+				const headers = getHeadersWithAuth(authHeader);
 				headers["Content-Type"] = "application/json";
 
 				const fetchResponse = await runWithRetry(
@@ -195,7 +189,7 @@ export async function createNewEmptyFluidFile(
 							{
 								body: undefined,
 								headers,
-								method: "PUT",
+								method,
 							},
 							"createFile",
 						),
@@ -223,7 +217,7 @@ export async function createNewEmptyFluidFile(
 }
 
 export async function createNewFluidFileFromSummary(
-	getStorageToken: InstrumentedStorageTokenFetcher,
+	getAuthHeader: InstrumentedStorageTokenFetcher,
 	newFileInfo: INewFileInfo,
 	logger: ITelemetryLoggerExt,
 	createNewSummary: ISummaryTree,
@@ -247,7 +241,7 @@ export async function createNewFluidFileFromSummary(
 
 	return createNewFluidContainerCore<ICreateFileResponse>({
 		containerSnapshot,
-		getStorageToken,
+		getAuthHeader,
 		logger,
 		initialUrl,
 		forceAccessTokenViaAuthorizationHeader,

--- a/packages/drivers/odsp-driver/src/createNewContainerOnExistingFile.ts
+++ b/packages/drivers/odsp-driver/src/createNewContainerOnExistingFile.ts
@@ -38,7 +38,7 @@ import { IExistingFileInfo, createCacheSnapshotKey } from "./odspUtils.js";
  * "alternative file partition" where the main File stub is an ASPX page.
  */
 export async function createNewContainerOnExistingFile(
-	getStorageToken: InstrumentedStorageTokenFetcher,
+	getAuthHeader: InstrumentedStorageTokenFetcher,
 	fileInfo: IExistingFileInfo,
 	logger: ITelemetryLoggerExt,
 	createNewSummary: ISummaryTree | undefined,
@@ -62,7 +62,7 @@ export async function createNewContainerOnExistingFile(
 
 	const { id: summaryHandle } = await createNewFluidContainerCore<IWriteSummaryResponse>({
 		containerSnapshot,
-		getStorageToken,
+		getAuthHeader,
 		logger,
 		initialUrl,
 		forceAccessTokenViaAuthorizationHeader,

--- a/packages/drivers/odsp-driver/src/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createNewUtils.ts
@@ -30,7 +30,7 @@ import {
 	OdspSummaryTreeValue,
 } from "./contracts.js";
 import { EpochTracker, FetchType } from "./epochTracker.js";
-import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
+import { getHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
 import { getWithRetryForTokenRefresh, maxUmpPostBodySize } from "./odspUtils.js";
 import { runWithRetry } from "./retryUtils.js";
 
@@ -201,7 +201,7 @@ function convertSummaryToSnapshotTreeForCreateNew(summary: ISummaryTree): IOdspS
 
 export async function createNewFluidContainerCore<T>(args: {
 	containerSnapshot: IOdspSummaryPayload;
-	getStorageToken: InstrumentedStorageTokenFetcher;
+	getAuthHeader: InstrumentedStorageTokenFetcher;
 	logger: ITelemetryLoggerExt;
 	initialUrl: string;
 	forceAccessTokenViaAuthorizationHeader: boolean;
@@ -212,10 +212,9 @@ export async function createNewFluidContainerCore<T>(args: {
 }): Promise<T> {
 	const {
 		containerSnapshot,
-		getStorageToken,
+		getAuthHeader,
 		logger,
 		initialUrl,
-		forceAccessTokenViaAuthorizationHeader,
 		epochTracker,
 		telemetryName,
 		fetchType,
@@ -223,8 +222,6 @@ export async function createNewFluidContainerCore<T>(args: {
 	} = args;
 
 	return getWithRetryForTokenRefresh(async (options) => {
-		const storageToken = await getStorageToken(options, telemetryName);
-
 		return PerformanceEvent.timedExecAsync(
 			logger,
 			{ eventName: telemetryName },
@@ -234,31 +231,42 @@ export async function createNewFluidContainerCore<T>(args: {
 				let headers: { [index: string]: string };
 				let addInBody = false;
 				const formBoundary = uuid();
-				let postBody = `--${formBoundary}\r\n`;
-				postBody += `Authorization: Bearer ${storageToken}\r\n`;
-				postBody += `X-HTTP-Method-Override: POST\r\n`;
-				postBody += `Content-Type: application/json\r\n`;
-				postBody += `_post: 1\r\n`;
-				postBody += `\r\n${snapshotBody}\r\n`;
-				postBody += `\r\n--${formBoundary}--`;
+				const urlObj = new URL(initialUrl);
+				urlObj.searchParams.set("ump", "1");
+				const authInBodyUrl = urlObj.href;
+				const method = "POST";
+				const authHeader = await getAuthHeader(
+					{ ...options, request: { url: authInBodyUrl, method } },
+					telemetryName,
+				);
+				const postBodyWithAuth =
+					`--${formBoundary}\r\n` +
+					`Authorization: ${authHeader}\r\n` +
+					`X-HTTP-Method-Override: POST\r\n` +
+					`Content-Type: application/json\r\n` +
+					`_post: 1\r\n` +
+					`\r\n${snapshotBody}\r\n` +
+					`\r\n--${formBoundary}--`;
 
-				if (postBody.length <= maxUmpPostBodySize) {
-					const urlObj = new URL(initialUrl);
-					urlObj.searchParams.set("ump", "1");
-					url = urlObj.href;
+				let postBody = snapshotBody;
+				if (
+					postBodyWithAuth.length <= maxUmpPostBodySize &&
+					authHeader?.startsWith("Bearer")
+				) {
+					url = authInBodyUrl;
 					headers = {
 						"Content-Type": `multipart/form-data;boundary=${formBoundary}`,
 					};
 					addInBody = true;
+					postBody = postBodyWithAuth;
 				} else {
-					const parts = getUrlAndHeadersWithAuth(
-						initialUrl,
-						storageToken,
-						forceAccessTokenViaAuthorizationHeader,
+					url = initialUrl;
+					const authHeaderNoUmp = await getAuthHeader(
+						{ ...options, request: { url, method } },
+						telemetryName,
 					);
-					url = parts.url;
 					headers = {
-						...parts.headers,
+						...getHeadersWithAuth(authHeaderNoUmp),
 						"Content-Type": "application/json",
 					};
 					postBody = snapshotBody;
@@ -271,7 +279,7 @@ export async function createNewFluidContainerCore<T>(args: {
 							{
 								body: postBody,
 								headers,
-								method: "POST",
+								method,
 							},
 							fetchType,
 							addInBody,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -77,7 +77,7 @@ export enum SnapshotFormatSupportType {
  * @param snapshotUrl - snapshot url from where the odsp snapshot will be fetched
  * @param versionId - id of specific snapshot to be fetched
  * @param fetchFullSnapshot - whether we want to fetch full snapshot(with blobs)
- * @param forceAccessTokenViaAuthorizationHeader - DEPRECATED (true value always used instead): whether to force passing given token via authorization header
+ * @param forceAccessTokenViaAuthorizationHeader - @deprecated Not used, true value always used instead. Whether to force passing given token via authorization header
  * @param snapshotDownloader - Implementation of the get/post methods used to fetch the snapshot. snapshotDownloader is responsible for generating the appropriate headers (including Authorization header) as well as handling any token refreshes before retrying.
  * @returns A promise of the snapshot and the status code of the response
  */
@@ -235,11 +235,11 @@ async function redeemSharingLink(
 					redeemUrl = `${baseUrl}/_api/v2.0/shares/${encodedShareUrl}`;
 					const url = redeemUrl;
 					const method = "GET";
-					const storageToken = await getAuthHeader(
+					const authHeader = await getAuthHeader(
 						{ ...tokenFetchOptions, request: { url, method } },
 						"RedeemShareLink",
 					);
-					const headers = getHeadersWithAuth(storageToken);
+					const headers = getHeadersWithAuth(authHeader);
 					headers.prefer = "redeemSharingLink";
 					await fetchAndParseAsJSONHelper(url, { headers, method });
 				});

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -46,7 +46,7 @@ import {
 } from "./contracts.js";
 import { EpochTracker } from "./epochTracker.js";
 import { getQueryString } from "./getQueryString.js";
-import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
+import { getHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
 import { convertOdspSnapshotToSnapshotTreeAndBlobs } from "./odspSnapshotParser.js";
 import {
 	IOdspResponse,
@@ -58,6 +58,7 @@ import {
 	measure,
 	measureP,
 	useLegacyFlowWithoutGroupsForSnapshotFetch,
+	type TokenFetchOptionsEx,
 } from "./odspUtils.js";
 import { pkgVersion } from "./packageVersion.js";
 
@@ -74,25 +75,19 @@ export enum SnapshotFormatSupportType {
 /**
  * Fetches a snapshot from the server with a given version id.
  * @param snapshotUrl - snapshot url from where the odsp snapshot will be fetched
- * @param token - token used for authorization in the request
- * @param storageFetchWrapper - Implementation of the get/post methods used to fetch the snapshot
  * @param versionId - id of specific snapshot to be fetched
  * @param fetchFullSnapshot - whether we want to fetch full snapshot(with blobs)
- * @param forceAccessTokenViaAuthorizationHeader - whether to force passing given token via authorization header
+ * @param forceAccessTokenViaAuthorizationHeader - DEPRECATED (true value always used instead): whether to force passing given token via authorization header
+ * @param snapshotDownloader - Implementation of the get/post methods used to fetch the snapshot. snapshotDownloader is responsible for generating the appropriate headers (including Authorization header) as well as handling any token refreshes before retrying.
  * @returns A promise of the snapshot and the status code of the response
  */
 export async function fetchSnapshot(
 	snapshotUrl: string,
-	// eslint-disable-next-line @rushstack/no-new-null
-	token: string,
 	versionId: string,
 	fetchFullSnapshot: boolean,
 	forceAccessTokenViaAuthorizationHeader: boolean,
 	logger: ITelemetryLoggerExt,
-	snapshotDownloader: (
-		url: string,
-		fetchOptions: { [index: string]: RequestInit },
-	) => Promise<IOdspResponse<unknown>>,
+	snapshotDownloader: (url: string) => Promise<IOdspResponse<unknown>>,
 ): Promise<ISnapshot> {
 	const path = `/trees/${versionId}`;
 	let queryParams: ISnapshotOptions = {};
@@ -102,17 +97,13 @@ export async function fetchSnapshot(
 	}
 
 	const queryString = getQueryString(queryParams);
-	const { url, headers } = getUrlAndHeadersWithAuth(
-		`${snapshotUrl}${path}${queryString}`,
-		token,
-		forceAccessTokenViaAuthorizationHeader,
-	);
+	const url = `${snapshotUrl}${path}${queryString}`;
 	const response = (await PerformanceEvent.timedExecAsync(
 		logger,
 		{
 			eventName: "fetchSnapshot",
 		},
-		async () => snapshotDownloader(url, { headers }),
+		async () => snapshotDownloader(url),
 	)) as IOdspResponse<IOdspSnapshot>;
 	return convertOdspSnapshotToSnapshotTreeAndBlobs(response.content);
 }
@@ -125,7 +116,8 @@ export async function fetchSnapshotWithRedeem(
 	logger: ITelemetryLoggerExt,
 	snapshotDownloader: (
 		finalOdspResolvedUrl: IOdspResolvedUrl,
-		storageToken: string,
+		getAuthHeader: InstrumentedStorageTokenFetcher,
+		tokenFetchOptions: TokenFetchOptionsEx,
 		loadingGroupIds: string[] | undefined,
 		snapshotOptions: ISnapshotOptions | undefined,
 		controller?: AbortController,
@@ -218,7 +210,7 @@ export async function fetchSnapshotWithRedeem(
 
 async function redeemSharingLink(
 	odspResolvedUrl: IOdspResolvedUrl,
-	storageTokenFetcher: InstrumentedStorageTokenFetcher,
+	getAuthHeader: InstrumentedStorageTokenFetcher,
 	logger: ITelemetryLoggerExt,
 	forceAccessTokenViaAuthorizationHeader: boolean,
 ): Promise<void> {
@@ -240,18 +232,16 @@ async function redeemSharingLink(
 			let redeemUrl: string | undefined;
 			async function callSharesAPI(baseUrl: string): Promise<void> {
 				await getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
-					const storageToken = await storageTokenFetcher(
-						tokenFetchOptions,
+					redeemUrl = `${baseUrl}/_api/v2.0/shares/${encodedShareUrl}`;
+					const url = redeemUrl;
+					const method = "GET";
+					const storageToken = await getAuthHeader(
+						{ ...tokenFetchOptions, request: { url, method } },
 						"RedeemShareLink",
 					);
-					redeemUrl = `${baseUrl}/_api/v2.0/shares/${encodedShareUrl}`;
-					const { url, headers } = getUrlAndHeadersWithAuth(
-						redeemUrl,
-						storageToken,
-						forceAccessTokenViaAuthorizationHeader,
-					);
+					const headers = getHeadersWithAuth(storageToken);
 					headers.prefer = "redeemSharingLink";
-					await fetchAndParseAsJSONHelper(url, { headers });
+					await fetchAndParseAsJSONHelper(url, { headers, method });
 				});
 			}
 
@@ -277,7 +267,7 @@ async function redeemSharingLink(
 								queryParamsLength: new URL(
 									odspResolvedUrl.shareLinkInfo?.sharingLinkToRedeem,
 								).search.length,
-								useHeaders: forceAccessTokenViaAuthorizationHeader,
+								useHeaders: true,
 							}),
 						},
 						error,
@@ -291,12 +281,13 @@ async function redeemSharingLink(
 
 async function fetchLatestSnapshotCore(
 	odspResolvedUrl: IOdspResolvedUrl,
-	storageTokenFetcher: InstrumentedStorageTokenFetcher,
+	getAuthHeader: InstrumentedStorageTokenFetcher,
 	snapshotOptions: ISnapshotOptions | undefined,
 	logger: ITelemetryLoggerExt,
 	snapshotDownloader: (
 		finalOdspResolvedUrl: IOdspResolvedUrl,
-		storageToken: string,
+		getAuthHeader: InstrumentedStorageTokenFetcher,
+		tokenFetchOptions: TokenFetchOptionsEx,
 		loadingGroupIds: string[] | undefined,
 		snapshotOptions: ISnapshotOptions | undefined,
 		controller?: AbortController,
@@ -308,7 +299,6 @@ async function fetchLatestSnapshotCore(
 	return getWithRetryForTokenRefresh(async (tokenFetchOptions) => {
 		const fetchSnapshotForLoadingGroup = isSnapshotFetchForLoadingGroup(loadingGroupIds);
 		const eventName = fetchSnapshotForLoadingGroup ? "TreesLatestForGroup" : "TreesLatest";
-		const storageToken = await storageTokenFetcher(tokenFetchOptions, eventName, true);
 
 		const perfEvent = {
 			eventName,
@@ -337,7 +327,8 @@ async function fetchLatestSnapshotCore(
 			const [response, fetchTime] = await measureP(async () =>
 				snapshotDownloader(
 					odspResolvedUrl,
-					storageToken,
+					getAuthHeader,
+					tokenFetchOptions,
 					loadingGroupIds,
 					snapshotOptions,
 					controller,
@@ -575,7 +566,7 @@ export interface ISnapshotRequestAndResponseOptions {
 
 function getFormBodyAndHeaders(
 	odspResolvedUrl: IOdspResolvedUrl,
-	storageToken: string,
+	authHeader: string,
 	headers?: { [index: string]: string },
 ): {
 	body: string;
@@ -587,7 +578,7 @@ function getFormBodyAndHeaders(
 	const formParams: string[] = [];
 	formParams.push(
 		`--${formBoundary}`,
-		`Authorization: Bearer ${storageToken}`,
+		`Authorization: ${authHeader}`,
 		`X-HTTP-Method-Override: GET`,
 	);
 
@@ -671,7 +662,8 @@ function getTreeStatsCore(snapshotTree: ISnapshotTree, stats: ITreeStats): void 
  */
 export async function downloadSnapshot(
 	odspResolvedUrl: IOdspResolvedUrl,
-	storageToken: string,
+	getAuthHeader: InstrumentedStorageTokenFetcher,
+	tokenFetchOptions: TokenFetchOptionsEx,
 	loadingGroupIds: string[] | undefined,
 	snapshotOptions: ISnapshotOptions | undefined,
 	snapshotFormatFetchType?: SnapshotFormatSupportType,
@@ -705,17 +697,23 @@ export async function downloadSnapshot(
 
 	const queryString = getQueryString(queryParams);
 	const url = `${snapshotUrl}/trees/latest${queryString}`;
+	const method = "POST";
 	// The location of file can move on Spo in which case server returns 308(Permanent Redirect) error.
 	// Adding below header will make VROOM API return 404 instead of 308 and browser can intercept it.
 	// This error thrown by server will contain the new redirect location. Look at the 404 error parsing
 	// for further reference here: \packages\utils\odsp-doclib-utils\src\odspErrorUtils.ts
 	const header = { prefer: "manualredirect" };
-	const { body, headers } = getFormBodyAndHeaders(odspResolvedUrl, storageToken, header);
+	const authHeader = await getAuthHeader(
+		{ ...tokenFetchOptions, request: { url, method } },
+		"downloadSnapshot",
+	);
+	assert(authHeader !== null, 0x1e5 /* "Storage token should not be null" */);
+	const { body, headers } = getFormBodyAndHeaders(odspResolvedUrl, authHeader, header);
 	const fetchOptions = {
 		body,
 		headers,
 		signal: controller?.signal,
-		method: "POST",
+		method,
 	};
 	// Decide what snapshot format to fetch as per the feature gate.
 	switch (snapshotFormatFetchType) {

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -15,7 +15,7 @@ import {
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils";
 import { PerformanceEvent } from "@fluidframework/telemetry-utils/internal";
 
-import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
+import { getHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
 import {
 	fetchHelper,
 	getWithRetryForTokenRefresh,
@@ -112,12 +112,11 @@ async function getFileLinkCore(
 			let additionalProps;
 			const fileLink = await getWithRetryForTokenRefresh(async (options) => {
 				attempts++;
-				const storageTokenFetcher = toInstrumentedOdspStorageTokenFetcher(
+				const getAuthHeader = toInstrumentedOdspStorageTokenFetcher(
 					logger,
 					odspUrlParts,
 					getToken,
 				);
-				const storageToken = await storageTokenFetcher(options, "GetFileLinkCore");
 
 				// IMPORTANT: In past we were using GetFileByUrl() API to get to the list item that was corresponding
 				// to the file. This was intentionally replaced with GetFileById() to solve the following issue:
@@ -125,17 +124,23 @@ async function getFileLinkCore(
 				// where webDavUrl is constructed using legacy ODC format for backward compatibility reasons.
 				// GetFileByUrl() does not understand that format and thus fails. GetFileById() relies on file item
 				// unique guid (sharepointIds.listItemUniqueId) and it works uniformly across Consumer and Commercial.
-				const { url, headers } = getUrlAndHeadersWithAuth(
-					`${
-						odspUrlParts.siteUrl
-					}/_api/web/GetFileById(@a1)/ListItemAllFields/GetSharingInformation?@a1=guid${encodeURIComponent(
-						`'${fileItem.sharepointIds.listItemUniqueId}'`,
-					)}`,
-					storageToken,
-					true,
+				const url = `${
+					odspUrlParts.siteUrl
+				}/_api/web/GetFileById(@a1)/ListItemAllFields/GetSharingInformation?@a1=guid${encodeURIComponent(
+					`'${fileItem.sharepointIds.listItemUniqueId}'`,
+				)}`;
+				const method = "POST";
+				const authHeader = await getAuthHeader(
+					{ ...options, request: { url, method } },
+					"GetFileLinkCore",
 				);
+				assert(
+					authHeader !== null,
+					0x2bb /* "Instrumented token fetcher with throwOnNullToken = true should never return null" */,
+				);
+				const headers = getHeadersWithAuth(authHeader);
 				const requestInit = {
-					method: "POST",
+					method,
 					headers: {
 						"Content-Type": "application/json;odata=verbose",
 						"Accept": "application/json;odata=verbose",
@@ -208,19 +213,24 @@ async function getFileItemLite(
 			const fileItem = await getWithRetryForTokenRefresh(async (options) => {
 				attempts++;
 				const { siteUrl, driveId, itemId } = odspUrlParts;
-				const storageTokenFetcher = toInstrumentedOdspStorageTokenFetcher(
+				const getAuthHeader = toInstrumentedOdspStorageTokenFetcher(
 					logger,
 					odspUrlParts,
 					getToken,
 				);
-				const storageToken = await storageTokenFetcher(options, "GetFileItemLite");
-
-				const { url, headers } = getUrlAndHeadersWithAuth(
-					`${siteUrl}/_api/v2.0/drives/${driveId}/items/${itemId}?select=webUrl,webDavUrl,sharepointIds`,
-					storageToken,
-					forceAccessTokenViaAuthorizationHeader,
+				const url = `${siteUrl}/_api/v2.0/drives/${driveId}/items/${itemId}?select=webUrl,webDavUrl,sharepointIds`;
+				const method = "GET";
+				const authHeader = await getAuthHeader(
+					{ ...options, request: { url, method } },
+					"GetFileItemLite",
 				);
-				const requestInit = { method: "GET", headers };
+				assert(
+					authHeader !== null,
+					0x2bc /* "Instrumented token fetcher with throwOnNullToken =true should never return null" */,
+				);
+
+				const headers = getHeadersWithAuth(authHeader);
+				const requestInit = { method, headers };
 				const response = await fetchHelper(url, requestInit);
 				additionalProps = response.propsToLog;
 

--- a/packages/drivers/odsp-driver/src/getFileLink.ts
+++ b/packages/drivers/odsp-driver/src/getFileLink.ts
@@ -134,10 +134,6 @@ async function getFileLinkCore(
 					{ ...options, request: { url, method } },
 					"GetFileLinkCore",
 				);
-				assert(
-					authHeader !== null,
-					0x2bb /* "Instrumented token fetcher with throwOnNullToken = true should never return null" */,
-				);
 				const headers = getHeadersWithAuth(authHeader);
 				const requestInit = {
 					method,

--- a/packages/drivers/odsp-driver/src/getUrlAndHeadersWithAuth.ts
+++ b/packages/drivers/odsp-driver/src/getUrlAndHeadersWithAuth.ts
@@ -3,40 +3,18 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert } from "@fluidframework/core-utils";
 
-export function getUrlAndHeadersWithAuth(
-	url: string,
-	token: string,
-	forceAccessTokenViaAuthorizationHeader: boolean,
-): { url: string; headers: { [index: string]: string } } {
-	assert(token.length > 0, 0x936 /* should be token */);
-
-	if (!forceAccessTokenViaAuthorizationHeader) {
-		// Pass access token via query string: this will make request be treated as 'simple' request
-		// which does not require OPTIONS call as part of CORS check.
-		const urlWithAccessTokenInQueryString = new URL(url);
-		// IMPORTANT: Do not apply encodeURIComponent to token, param value is automatically encoded
-		// when set via URLSearchParams class
-		urlWithAccessTokenInQueryString.searchParams.set("access_token", token);
-		// ODSP APIs have a limitation that the query string cannot exceed 2048 characters.
-		// If the query string exceeds 2048, we have to fall back to sending the access token as a header, which
-		// has a negative performance implication as it adds a performance overhead.
-		// NOTE: URL.search.length value includes '?' symbol and it is unclear whether backend logic which enforces
-		// query length limit accounts for it. This logic errs on side of caution and includes that key in overall
-		// query length.
-		if (urlWithAccessTokenInQueryString.search.length <= 2048) {
-			return {
-				headers: {},
-				url: urlWithAccessTokenInQueryString.href,
-			};
-		}
+export function getHeadersWithAuth(
+	// eslint-disable-next-line @rushstack/no-new-null
+	authHeader: string | null,
+): { [index: string]: string } {
+	assert(authHeader !== null && authHeader.length > 0, 0x936 /* should be token */);
+	if (!authHeader || authHeader.length === 0) {
+		return {};
 	}
 
 	return {
-		headers: {
-			Authorization: `Bearer ${token}`,
-		},
-		url,
+		Authorization: authHeader,
 	};
 }

--- a/packages/drivers/odsp-driver/src/getUrlAndHeadersWithAuth.ts
+++ b/packages/drivers/odsp-driver/src/getUrlAndHeadersWithAuth.ts
@@ -9,10 +9,7 @@ export function getHeadersWithAuth(
 	// eslint-disable-next-line @rushstack/no-new-null
 	authHeader: string | null,
 ): { [index: string]: string } {
-	assert(authHeader !== null && authHeader.length > 0, 0x936 /* should be token */);
-	if (!authHeader || authHeader.length === 0) {
-		return {};
-	}
+	assert(!!authHeader, 0x936 /* authHeader should not be null or empty */);
 
 	return {
 		Authorization: authHeader,

--- a/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
+++ b/packages/drivers/odsp-driver/src/odspDelayLoadedDeltaStream.ts
@@ -71,7 +71,7 @@ export class OdspDelayLoadedDeltaStream {
 	/**
 	 * @param odspResolvedUrl - resolved url identifying document that will be managed by this service instance.
 	 * @param policies - Document service policies.
-	 * @param getStorageToken - function that can provide the storage token. This is is also referred to as
+	 * @param getAuthHeader - function that can provide the Authentication header value. This is is also referred to as
 	 * the "Vroom" token in SPO.
 	 * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also referred
 	 * to as the "Push" token in SPO. If undefined then websocket token is expected to be returned with joinSession
@@ -86,13 +86,13 @@ export class OdspDelayLoadedDeltaStream {
 	public constructor(
 		public readonly odspResolvedUrl: IOdspResolvedUrl,
 		public policies: IDocumentServicePolicies,
-		private readonly getStorageToken: InstrumentedStorageTokenFetcher,
+		private readonly getAuthHeader: InstrumentedStorageTokenFetcher,
 		private readonly getWebsocketToken:
 			| ((options: TokenFetchOptions) => Promise<string | null>)
 			| undefined,
 		private readonly mc: MonitoringContext,
 		private readonly cache: IOdspCache,
-		private readonly hostPolicy: HostStoragePolicy,
+		_hostPolicy: HostStoragePolicy,
 		private readonly epochTracker: EpochTracker,
 		private readonly opsReceived: (ops: ISequencedDocumentMessage[]) => void,
 		private readonly metadataUpdateHandler: (metadata: Record<string, string>) => void,
@@ -389,13 +389,12 @@ export class OdspDelayLoadedDeltaStream {
 				"opStream/joinSession",
 				"POST",
 				this.mc.logger,
-				this.getStorageToken,
+				this.getAuthHeader,
 				this.epochTracker,
 				requestSocketToken,
 				options,
 				disableJoinSessionRefresh,
 				isRefreshingJoinSession,
-				this.hostPolicy.sessionOptions?.unauthenticatedUserDisplayName,
 			);
 			// Emit event only in case it is fetched from the network.
 			if (joinSessionResponse.sensitivityLabelsInfo !== undefined) {

--- a/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
+++ b/packages/drivers/odsp-driver/src/odspDeltaStorageService.ts
@@ -29,7 +29,7 @@ import { getWithRetryForTokenRefresh } from "./odspUtils.js";
 export class OdspDeltaStorageService {
 	constructor(
 		private readonly deltaFeedUrl: string,
-		private readonly getStorageToken: InstrumentedStorageTokenFetcher,
+		private readonly getAuthHeader: InstrumentedStorageTokenFetcher,
 		private readonly epochTracker: EpochTracker,
 		private readonly logger: ITelemetryLoggerExt,
 	) {}
@@ -50,9 +50,13 @@ export class OdspDeltaStorageService {
 	): Promise<IDeltasFetchResult> {
 		return getWithRetryForTokenRefresh(async (options) => {
 			// Note - this call ends up in getSocketStorageDiscovery() and can refresh token
-			// Thus it needs to be done before we call getStorageToken() to reduce extra calls
-			const baseUrl = this.buildUrl(from, to);
-			const storageToken = await this.getStorageToken(options, "DeltaStorage");
+			// Thus it needs to be done before we call getAuthHeader() to reduce extra calls
+			const url = this.buildUrl(from, to);
+			const method = "POST";
+			const authHeader = await this.getAuthHeader(
+				{ ...options, request: { url, method } },
+				"DeltaStorage",
+			);
 
 			return PerformanceEvent.timedExecAsync(
 				this.logger,
@@ -67,7 +71,7 @@ export class OdspDeltaStorageService {
 				async (event) => {
 					const formBoundary = uuid();
 					let postBody = `--${formBoundary}\r\n`;
-					postBody += `Authorization: Bearer ${storageToken}\r\n`;
+					postBody += `Authorization: ${authHeader}\r\n`;
 					postBody += `X-HTTP-Method-Override: GET\r\n`;
 
 					postBody += `_post: 1\r\n`;
@@ -86,11 +90,11 @@ export class OdspDeltaStorageService {
 
 					const response =
 						await this.epochTracker.fetchAndParseAsJSON<IDeltaStorageGetResponse>(
-							baseUrl,
+							url,
 							{
 								headers,
 								body: postBody,
-								method: "POST",
+								method,
 								signal: abort.signal,
 							},
 							"ops",

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -60,7 +60,7 @@ export class OdspDocumentService
 	 * Creates a new OdspDocumentService instance.
 	 *
 	 * @param resolvedUrl - resolved url identifying document that will be managed by returned service instance.
-	 * @param getStorageToken - function that can provide the storage token. This is is also referred to as
+	 * @param getAuthHeader - function that can provide the Authentication header value. This is is also referred to as
 	 * the "Vroom" token in SPO.
 	 * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also referred
 	 * to as the "Push" token in SPO. If undefined then websocket token is expected to be returned with joinSession
@@ -73,7 +73,7 @@ export class OdspDocumentService
 	 */
 	public static async create(
 		resolvedUrl: IResolvedUrl,
-		getStorageToken: InstrumentedStorageTokenFetcher,
+		getAuthHeader: InstrumentedStorageTokenFetcher,
 		// eslint-disable-next-line @rushstack/no-new-null
 		getWebsocketToken: ((options: TokenFetchOptions) => Promise<string | null>) | undefined,
 		logger: ITelemetryLoggerExt,
@@ -85,7 +85,7 @@ export class OdspDocumentService
 	): Promise<IDocumentService> {
 		return new OdspDocumentService(
 			getOdspResolvedUrl(resolvedUrl),
-			getStorageToken,
+			getAuthHeader,
 			getWebsocketToken,
 			logger,
 			cache,
@@ -106,7 +106,7 @@ export class OdspDocumentService
 
 	/**
 	 * @param odspResolvedUrl - resolved url identifying document that will be managed by this service instance.
-	 * @param getStorageToken - function that can provide the storage token. This is is also referred to as
+	 * @param getAuthHeader - function that can provide the Authentication header value. This is is also referred to as
 	 * the "Vroom" token in SPO.
 	 * @param getWebsocketToken - function that can provide a token for accessing the web socket. This is also referred
 	 * to as the "Push" token in SPO. If undefined then websocket token is expected to be returned with joinSession
@@ -120,7 +120,7 @@ export class OdspDocumentService
 	 */
 	private constructor(
 		public readonly odspResolvedUrl: IOdspResolvedUrl,
-		private readonly getStorageToken: InstrumentedStorageTokenFetcher,
+		private readonly getAuthHeader: InstrumentedStorageTokenFetcher,
 		private readonly getWebsocketToken:
 			| ((options: TokenFetchOptions) => Promise<string | null>)
 			| undefined,
@@ -171,7 +171,7 @@ export class OdspDocumentService
 		if (!this.storageManager) {
 			this.storageManager = new OdspDocumentStorageService(
 				this.odspResolvedUrl,
-				this.getStorageToken,
+				this.getAuthHeader,
 				this.mc.logger,
 				true,
 				this.cache,
@@ -207,7 +207,7 @@ export class OdspDocumentService
 		const snapshotOps = this.storageManager?.ops ?? [];
 		const service = new OdspDeltaStorageService(
 			this.odspResolvedUrl.endpoints.deltaStorageUrl,
-			this.getStorageToken,
+			this.getAuthHeader,
 			this.epochTracker,
 			this.mc.logger,
 		);
@@ -284,7 +284,7 @@ export class OdspDocumentService
 		this.odspDelayLoadedDeltaStream = new module.OdspDelayLoadedDeltaStream(
 			this.odspResolvedUrl,
 			this._policies,
-			this.getStorageToken,
+			this.getAuthHeader,
 			this.getWebsocketToken,
 			this.mc,
 			this.cache,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -167,7 +167,7 @@ export class OdspDocumentServiceFactoryCore
 					this.hostPolicy.enableSingleRequestForShareLinkWithCreate,
 			},
 			async (event) => {
-				const getStorageToken = toInstrumentedOdspStorageTokenFetcher(
+				const getAuthHeader = toInstrumentedOdspStorageTokenFetcher(
 					odspLogger,
 					resolvedUrlData,
 					this.getStorageToken,
@@ -191,7 +191,7 @@ export class OdspDocumentServiceFactoryCore
 					});
 				const _odspResolvedUrl = isNewFileInfo(fileInfo)
 					? await module.createNewFluidFile(
-							getStorageToken,
+							getAuthHeader,
 							fileInfo,
 							odspLogger,
 							createNewSummary,
@@ -204,7 +204,7 @@ export class OdspDocumentServiceFactoryCore
 							this.hostPolicy.enableSingleRequestForShareLinkWithCreate,
 					  )
 					: await module.createNewContainerOnExistingFile(
-							getStorageToken,
+							getAuthHeader,
 							fileInfo,
 							odspLogger,
 							createNewSummary,

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -26,7 +26,7 @@ import {
 	OdspSummaryTreeValue,
 } from "./contracts.js";
 import { EpochTracker } from "./epochTracker.js";
-import { getUrlAndHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
+import { getHeadersWithAuth } from "./getUrlAndHeadersWithAuth.js";
 import { getWithRetryForTokenRefresh } from "./odspUtils.js";
 
 /**
@@ -40,10 +40,9 @@ export class OdspSummaryUploadManager {
 
 	constructor(
 		private readonly snapshotUrl: string,
-		private readonly getStorageToken: InstrumentedStorageTokenFetcher,
+		private readonly getAuthHeader: InstrumentedStorageTokenFetcher,
 		logger: ITelemetryLoggerExt,
 		private readonly epochTracker: EpochTracker,
-		private readonly forceAccessTokenViaAuthorizationHeader: boolean,
 		private readonly relayServiceTenantAndSessionId: () => string | undefined,
 	) {
 		this.mc = loggerToMonitoringContext(logger);
@@ -100,13 +99,14 @@ export class OdspSummaryUploadManager {
 		};
 
 		return getWithRetryForTokenRefresh(async (options) => {
-			const storageToken = await this.getStorageToken(options, "WriteSummaryTree");
-
-			const { url, headers } = getUrlAndHeadersWithAuth(
-				`${this.snapshotUrl}/snapshot`,
-				storageToken,
-				this.forceAccessTokenViaAuthorizationHeader,
+			const url = `${this.snapshotUrl}/snapshot`;
+			const method = "POST";
+			const authHeader = await this.getAuthHeader(
+				{ ...options, request: { url, method } },
+				"WriteSummaryTree",
 			);
+
+			const headers = getHeadersWithAuth(authHeader);
 			headers["Content-Type"] = "application/json";
 			const relayServiceTenantAndSessionId = this.relayServiceTenantAndSessionId();
 			// This would be undefined in case of summary is uploaded in detached container with attachment

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -28,7 +28,7 @@ import {
 	InstrumentedStorageTokenFetcher,
 	InstrumentedTokenFetcher,
 	OdspErrorTypes,
-	authHeaderFromResponse,
+	authHeaderFromTokenResponse,
 	OdspResourceTokenFetchOptions,
 	TokenFetchOptions,
 	TokenFetcher,
@@ -396,7 +396,7 @@ export function toInstrumentedOdspTokenFetcher(
 					...resolvedUrlParts,
 				}).then(
 					(tokenResponse) => {
-						const authHeader = authHeaderFromResponse(tokenResponse);
+						const authHeader = authHeaderFromTokenResponse(tokenResponse);
 						// This event alone generates so many events that is materially impacts cost of telemetry
 						// Thus do not report end event when it comes back quickly.
 						// Note that most of the hosts do not report if result is comming from cache or not,

--- a/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/prefetchLatestSnapshot.ts
@@ -47,7 +47,7 @@ import {
  * @param getStorageToken - function that can provide the storage token for a given site. This is
  * is also referred to as the "VROOM" token in SPO.
  * @param persistedCache - Cache to store the fetched snapshot.
- * @param forceAccessTokenViaAuthorizationHeader - DEPRECATED (true value always used instead): whether to force passing given token via authorization header.
+ * @param forceAccessTokenViaAuthorizationHeader - @deprecated Not used, true value always used instead. Whether to force passing given token via authorization header.
  * @param logger - Logger to have telemetry events.
  * @param hostSnapshotFetchOptions - Options to fetch the snapshot if any. Otherwise default will be used.
  * @param enableRedeemFallback - True to have the sharing link redeem fallback in case the Trees Latest/Redeem

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -143,7 +143,7 @@ describe("Tests1 for snapshot fetch", () => {
 				return await callback();
 			} finally {
 				assert(
-					getDownloadSnapshotStub.args[0][3]?.mds === undefined,
+					getDownloadSnapshotStub.args[0][4]?.mds === undefined,
 					"mds should be undefined",
 				);
 				success = true;
@@ -234,7 +234,7 @@ describe("Tests1 for snapshot fetch", () => {
 			} finally {
 				getDownloadSnapshotStub.restore();
 				assert(
-					getDownloadSnapshotStub.args[0][2]?.length === 0,
+					getDownloadSnapshotStub.args[0][3]?.length === 0,
 					"should ask for ungroupedData",
 				);
 				ungroupedData = true;

--- a/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/fetchSnapshot.spec.ts
@@ -294,7 +294,7 @@ describe("Tests1 for snapshot fetch", () => {
 			} finally {
 				getDownloadSnapshotStub.restore();
 				assert(
-					getDownloadSnapshotStub.args[0][2]?.[0] === "g1",
+					getDownloadSnapshotStub.args[0][3]?.[0] === "g1",
 					"should ask for g1 groupId",
 				);
 				success = true;

--- a/packages/drivers/odsp-driver/src/test/getUrlAndHeadersWithAuth.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/getUrlAndHeadersWithAuth.spec.ts
@@ -5,169 +5,51 @@
 
 import { strict as assert } from "node:assert";
 
-import { getUrlAndHeadersWithAuth } from "../getUrlAndHeadersWithAuth.js";
+import { getHeadersWithAuth } from "../getUrlAndHeadersWithAuth.js";
 
-describe("getUrlAndHeadersWithAuth", () => {
+describe("getHeadersWithAuth", () => {
 	const baseUrl = "https://contoso.sharepoint.com/_api/v2.1/drives/driveId/items/itemId/opstream";
-	const urlWithoutParams = new URL(baseUrl);
 	const urlWithSingleParam = new URL(`${baseUrl}?someParam=someValue`);
 	const urlWithMultipleParams = new URL(`${baseUrl}?param1=value1&param2=value2`);
 	// decrement by 1 to account for '?' character included in query string
 	const maxTokenLength = 2048 - "access_token=".length - 1;
-	const shortToken = generateToken(10);
 
 	function generateToken(length: number): string {
 		return "a".repeat(length);
 	}
 
-	const validateTokenEmbeddedIntoQueryString = (
-		originalUrl: URL,
-		token: string,
-		result: { url: string; headers: { [index: string]: string } },
-	): void => {
-		const returnedUrl = new URL(result.url);
-		assert.strictEqual(
-			returnedUrl.searchParams.get("access_token"),
-			token,
-			"Url must contain token in query string",
-		);
-		assert.deepStrictEqual(result.headers, {}, "Returned header must be empty");
-		returnedUrl.searchParams.delete("access_token");
-		assert.strictEqual(
-			returnedUrl.href,
-			originalUrl.href,
-			"Returned url must match original url",
-		);
-	};
-
 	const validateTokenEmbeddedIntoHeaders = (
-		originalUrl: URL,
 		token: string,
-		result: { url: string; headers: { [index: string]: string } },
+		result: { [index: string]: string },
 	): void => {
-		const returnedUrl = new URL(result.url);
 		assert.strictEqual(
-			returnedUrl.searchParams.get("access_token"),
-			null,
-			"Url must not contain token in query string",
-		);
-		assert.strictEqual(
-			result.headers.Authorization.endsWith(token),
+			result.Authorization.endsWith(token),
 			true,
 			"Returned header must contain token",
 		);
-		assert.strictEqual(
-			returnedUrl.href,
-			originalUrl.href,
-			"Returned url must match original url",
-		);
 	};
-
-	it("returns url with token embedded as part of query string when overall query string does not exceed 2048 characters", async () => {
-		validateTokenEmbeddedIntoQueryString(
-			urlWithoutParams,
-			shortToken,
-			getUrlAndHeadersWithAuth(urlWithoutParams.href, shortToken, false),
-		);
-
-		validateTokenEmbeddedIntoQueryString(
-			urlWithSingleParam,
-			shortToken,
-			getUrlAndHeadersWithAuth(urlWithSingleParam.href, shortToken, false),
-		);
-
-		validateTokenEmbeddedIntoQueryString(
-			urlWithMultipleParams,
-			shortToken,
-			getUrlAndHeadersWithAuth(urlWithMultipleParams.href, shortToken, false),
-		);
-
-		const longTokenForUrlWithoutParams = generateToken(maxTokenLength);
-		validateTokenEmbeddedIntoQueryString(
-			urlWithoutParams,
-			longTokenForUrlWithoutParams,
-			getUrlAndHeadersWithAuth(urlWithoutParams.href, longTokenForUrlWithoutParams, false),
-		);
-
-		const longTokenForUrlWithSingleParam = generateToken(
-			maxTokenLength - urlWithSingleParam.search.length,
-		);
-		validateTokenEmbeddedIntoQueryString(
-			urlWithSingleParam,
-			longTokenForUrlWithSingleParam,
-			getUrlAndHeadersWithAuth(
-				urlWithSingleParam.href,
-				longTokenForUrlWithSingleParam,
-				false,
-			),
-		);
-
-		const longTokenForUrlMultipleParams = generateToken(
-			maxTokenLength - urlWithMultipleParams.search.length,
-		);
-		validateTokenEmbeddedIntoQueryString(
-			urlWithMultipleParams,
-			longTokenForUrlMultipleParams,
-			getUrlAndHeadersWithAuth(
-				urlWithMultipleParams.href,
-				longTokenForUrlMultipleParams,
-				false,
-			),
-		);
-	});
 
 	it("returns headers with token embedded in Authorization header when overall query string exceeds 2048 characters", async () => {
 		const longTokenForUrlWithoutParams = generateToken(maxTokenLength + 1);
 		validateTokenEmbeddedIntoHeaders(
-			urlWithoutParams,
 			longTokenForUrlWithoutParams,
-			getUrlAndHeadersWithAuth(urlWithoutParams.href, longTokenForUrlWithoutParams, false),
+			getHeadersWithAuth(longTokenForUrlWithoutParams),
 		);
 
 		const longTokenForUrlWithSingleParam = generateToken(
 			maxTokenLength - urlWithSingleParam.search.length + 1,
 		);
 		validateTokenEmbeddedIntoHeaders(
-			urlWithSingleParam,
 			longTokenForUrlWithSingleParam,
-			getUrlAndHeadersWithAuth(
-				urlWithSingleParam.href,
-				longTokenForUrlWithSingleParam,
-				false,
-			),
+			getHeadersWithAuth(longTokenForUrlWithSingleParam),
 		);
 
 		const longTokenForUrlMultipleParams = generateToken(
 			maxTokenLength - urlWithMultipleParams.search.length + 1,
 		);
 		validateTokenEmbeddedIntoHeaders(
-			urlWithMultipleParams,
 			longTokenForUrlMultipleParams,
-			getUrlAndHeadersWithAuth(
-				urlWithMultipleParams.href,
-				longTokenForUrlMultipleParams,
-				false,
-			),
-		);
-	});
-
-	it("returns headers with token embedded in Authorization header when forced", async () => {
-		validateTokenEmbeddedIntoHeaders(
-			urlWithoutParams,
-			shortToken,
-			getUrlAndHeadersWithAuth(urlWithoutParams.href, shortToken, true),
-		);
-
-		validateTokenEmbeddedIntoHeaders(
-			urlWithSingleParam,
-			shortToken,
-			getUrlAndHeadersWithAuth(urlWithSingleParam.href, shortToken, true),
-		);
-
-		validateTokenEmbeddedIntoHeaders(
-			urlWithMultipleParams,
-			shortToken,
-			getUrlAndHeadersWithAuth(urlWithMultipleParams.href, shortToken, true),
+			getHeadersWithAuth(longTokenForUrlMultipleParams),
 		);
 	});
 });

--- a/packages/drivers/odsp-driver/src/test/tokenFetch.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/tokenFetch.spec.ts
@@ -8,7 +8,7 @@ import assert from "node:assert";
 import {
 	isTokenFromCache,
 	tokenFromResponse,
-	authHeaderFromResponse,
+	authHeaderFromTokenResponse,
 } from "@fluidframework/odsp-driver-definitions/internal";
 
 describe("tokenFromResponse", () => {
@@ -30,20 +30,20 @@ describe("tokenFromResponse", () => {
 	});
 });
 
-describe("authHeaderFromResponse", () => {
+describe("authHeaderFromTokenResponse", () => {
 	it("returns token prefixed with 'Bearer' when token value is passed as a string", async () => {
 		const token = "fake token";
-		const result = authHeaderFromResponse(token);
+		const result = authHeaderFromTokenResponse(token);
 		assert.equal(result, `Bearer ${token}`);
 	});
 	it("returns authorizationHeader value from TokenResponse when token value is passed as object", async () => {
 		const tokenResponse = { token: "fake token", authorizationHeader: "SCHEME token token" };
-		const result = authHeaderFromResponse(tokenResponse);
+		const result = authHeaderFromTokenResponse(tokenResponse);
 		assert.equal(result, tokenResponse.authorizationHeader);
 	});
 	it("returns Bearer authorization header when token is defined and authorizationHeader is not", async () => {
 		const tokenResponse = { token: "fake token" };
-		const result = authHeaderFromResponse(tokenResponse);
+		const result = authHeaderFromTokenResponse(tokenResponse);
 		assert.equal(result, "Bearer fake token");
 	});
 });

--- a/packages/drivers/odsp-driver/src/test/tokenFetch.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/tokenFetch.spec.ts
@@ -8,6 +8,7 @@ import assert from "node:assert";
 import {
 	isTokenFromCache,
 	tokenFromResponse,
+	authHeaderFromResponse,
 } from "@fluidframework/odsp-driver-definitions/internal";
 
 describe("tokenFromResponse", () => {
@@ -26,6 +27,24 @@ describe("tokenFromResponse", () => {
 	it("returns null when token value is passed as null", async () => {
 		const result = tokenFromResponse(null);
 		assert.equal(result, null);
+	});
+});
+
+describe("authHeaderFromResponse", () => {
+	it("returns token prefixed with 'Bearer' when token value is passed as a string", async () => {
+		const token = "fake token";
+		const result = authHeaderFromResponse(token);
+		assert.equal(result, `Bearer ${token}`);
+	});
+	it("returns authorizationHeader value from TokenResponse when token value is passed as object", async () => {
+		const tokenResponse = { token: "fake token", authorizationHeader: "SCHEME token token" };
+		const result = authHeaderFromResponse(tokenResponse);
+		assert.equal(result, tokenResponse.authorizationHeader);
+	});
+	it("returns Bearer authorization header when token is defined and authorizationHeader is not", async () => {
+		const tokenResponse = { token: "fake token" };
+		const result = authHeaderFromResponse(tokenResponse);
+		assert.equal(result, "Bearer fake token");
 	});
 });
 

--- a/packages/drivers/odsp-driver/src/vroom.ts
+++ b/packages/drivers/odsp-driver/src/vroom.ts
@@ -20,7 +20,7 @@ import { runWithRetry } from "./retryUtils.js";
 
 interface IJoinSessionBody {
 	requestSocketToken: boolean;
-	guestDisplayName: string;
+	guestDisplayName?: string;
 }
 
 /**
@@ -29,7 +29,7 @@ interface IJoinSessionBody {
  * @param path - The API path that is relevant to this request
  * @param method - The type of request, such as GET or POST
  * @param logger - A logger to use for this request
- * @param getStorageToken - A function that is able to provide the access token for this request
+ * @param getAuthHeader - A function that is able to provide the access token for this request
  * @param epochTracker - fetch wrapper which incorporates epoch logic around joinSession call
  * @param requestSocketToken - flag indicating whether joinSession is expected to return access token
  * which is used when establishing websocket connection with collab session backend service.
@@ -42,17 +42,18 @@ interface IJoinSessionBody {
 export async function fetchJoinSession(
 	urlParts: IOdspUrlParts,
 	path: string,
-	method: string,
+	method: "GET" | "POST",
 	logger: ITelemetryLoggerExt,
-	getStorageToken: InstrumentedStorageTokenFetcher,
+	getAuthHeader: InstrumentedStorageTokenFetcher,
 	epochTracker: EpochTracker,
 	requestSocketToken: boolean,
 	options: TokenFetchOptionsEx,
 	disableJoinSessionRefresh: boolean | undefined,
 	isRefreshingJoinSession: boolean,
-	guestDisplayName?: string,
 ): Promise<ISocketStorageDiscovery> {
-	const token = await getStorageToken(options, "JoinSession");
+	const apiRoot = getApiRoot(new URL(urlParts.siteUrl));
+	const url = `${apiRoot}/drives/${urlParts.driveId}/items/${urlParts.itemId}/${path}?ump=1`;
+	const authHeader = await getAuthHeader({ ...options, request: { url, method } }, "JoinSession");
 
 	const tokenRefreshProps = options.refresh
 		? { hasClaims: !!options.claims, hasTenantId: !!options.tenantId }
@@ -73,21 +74,18 @@ export async function fetchJoinSession(
 			...tokenRefreshProps,
 		},
 		async (event) => {
-			const apiRoot = getApiRoot(new URL(urlParts.siteUrl));
 			const formBoundary = uuid();
 			let postBody = `--${formBoundary}\r\n`;
-			postBody += `Authorization: Bearer ${token}\r\n`;
+			postBody += `Authorization: ${authHeader}\r\n`;
 			postBody += `X-HTTP-Method-Override: POST\r\n`;
 			postBody += `Content-Type: application/json\r\n`;
 			if (!disableJoinSessionRefresh) {
 				postBody += `prefer: FluidRemoveCheckAccess\r\n`;
 			}
 			postBody += `_post: 1\r\n`;
-			// Name should be there when socket token is requested and vice-versa.
-			if (requestSocketToken && guestDisplayName !== undefined) {
+			if (requestSocketToken) {
 				const body: IJoinSessionBody = {
 					requestSocketToken: true,
-					guestDisplayName,
 				};
 				postBody += `\r\n${JSON.stringify(body)}\r\n`;
 			}
@@ -99,7 +97,7 @@ export async function fetchJoinSession(
 			const response = await runWithRetry(
 				async () =>
 					epochTracker.fetchAndParseAsJSON<ISocketStorageDiscovery>(
-						`${apiRoot}/drives/${urlParts.driveId}/items/${urlParts.itemId}/${path}?ump=1`,
+						url,
 						{ method, headers, body: postBody },
 						"joinSession",
 						true,

--- a/packages/service-clients/azure-client/api-report/azure-client.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.api.md
@@ -68,7 +68,7 @@ export interface AzureContainerVersion {
 
 // @internal @deprecated
 export class AzureFunctionTokenProvider implements ITokenProvider {
-    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "userId" | "userName" | "additionalDetails"> | undefined);
+    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "additionalDetails" | "userId" | "userName"> | undefined);
     // (undocumented)
     fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)

--- a/packages/service-clients/azure-client/api-report/azure-client.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.api.md
@@ -68,7 +68,7 @@ export interface AzureContainerVersion {
 
 // @internal @deprecated
 export class AzureFunctionTokenProvider implements ITokenProvider {
-    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "additionalDetails" | "userId" | "userName"> | undefined);
+    constructor(azFunctionUrl: string, user?: Pick<AzureMember<any>, "userId" | "userName" | "additionalDetails"> | undefined);
     // (undocumented)
     fetchOrdererToken(tenantId: string, documentId?: string): Promise<ITokenResponse>;
     // (undocumented)

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="mocha" />
-
 // @internal (undocumented)
 export const mochaHooks: {
     beforeAll(): void;

--- a/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
+++ b/packages/test/mocha-test-setup/api-report/mocha-test-setup.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="mocha" />
+
 // @internal (undocumented)
 export const mochaHooks: {
     beforeAll(): void;


### PR DESCRIPTION
## Description
There is an assumption throughout the odsp-driver code that tokens are always Bearer tokens. This is not the case. AT_POP tokens could also be used. AT_POP tokens encode url path, query params and http method into the token. This means that the token itself cannot be passed via query params (otherwise that would be a circular dependency).

This PR adds authorizationHeader to TokenResponse as well as accepts request on the TokenFetcher interface.

## Breaking Changes
None, all changes to public interfaces should be backwards compatible.
Behavior changes:
- forceAccessTokenViaAuthorizationHeader is now a no-op.
- ICollabSessionOptions.unauthenticatedUserDisplayName is no longer used or passed through joinSession

## Reviewer Guidance
Nothing atm
