### PR TITLE
build(client): remove unused @internal re-exports

### DIFF
--- a/packages/common/container-definitions/api-report/container-definitions.beta.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.beta.api.md
@@ -40,8 +40,6 @@ export type ICriticalContainerError = IErrorBase_2;
 
 export { IErrorBase }
 
-export { IGenericError }
-
 // @public
 export interface ISelf {
     readonly client?: IClient;
@@ -49,7 +47,5 @@ export interface ISelf {
 }
 
 export { IThrottlingWarning }
-
-export { IUsageError }
 
 ```

--- a/packages/common/container-definitions/api-report/container-definitions.public.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.public.api.md
@@ -40,8 +40,6 @@ export type ICriticalContainerError = IErrorBase_2;
 
 export { IErrorBase }
 
-export { IGenericError }
-
 // @public
 export interface ISelf {
     readonly client?: IClient;
@@ -49,7 +47,5 @@ export interface ISelf {
 }
 
 export { IThrottlingWarning }
-
-export { IUsageError }
 
 ```

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -112,6 +112,15 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedInterfaceDeclaration_IGenericError": {
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"RemovedInterfaceDeclaration_IUsageError": {
+				"backCompat": false,
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/common/container-definitions/src/index.ts
+++ b/packages/common/container-definitions/src/index.ts
@@ -71,15 +71,7 @@ export type {
 	 */
 	IErrorBase,
 	/**
-	 * @deprecated IGenericError is being deprecated as a public export is moving to "core-interfaces".
-	 */
-	IGenericError,
-	/**
 	 * @deprecated IThrottlingWarning is being deprecated as a public export is moving to "core-interfaces".
 	 */
 	IThrottlingWarning,
-	/**
-	 * @deprecated IUsageError is being deprecated as a public export is moving to "core-interfaces".
-	 */
-	IUsageError,
 } from "@fluidframework/core-interfaces/internal";

--- a/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
+++ b/packages/common/container-definitions/src/test/types/validateContainerDefinitionsPrevious.generated.ts
@@ -874,28 +874,16 @@ use_old_InterfaceDeclaration_IFluidPackageEnvironment(
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_IGenericError": {"forwardCompat": false}
+ * "RemovedInterfaceDeclaration_IGenericError": {"forwardCompat": false}
  */
-declare function get_old_InterfaceDeclaration_IGenericError():
-    TypeOnly<old.IGenericError>;
-declare function use_current_InterfaceDeclaration_IGenericError(
-    use: TypeOnly<current.IGenericError>): void;
-use_current_InterfaceDeclaration_IGenericError(
-    get_old_InterfaceDeclaration_IGenericError());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_IGenericError": {"backCompat": false}
+ * "RemovedInterfaceDeclaration_IGenericError": {"backCompat": false}
  */
-declare function get_current_InterfaceDeclaration_IGenericError():
-    TypeOnly<current.IGenericError>;
-declare function use_old_InterfaceDeclaration_IGenericError(
-    use: TypeOnly<old.IGenericError>): void;
-use_old_InterfaceDeclaration_IGenericError(
-    get_current_InterfaceDeclaration_IGenericError());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.
@@ -1322,28 +1310,16 @@ use_old_InterfaceDeclaration_IThrottlingWarning(
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_IUsageError": {"forwardCompat": false}
+ * "RemovedInterfaceDeclaration_IUsageError": {"forwardCompat": false}
  */
-declare function get_old_InterfaceDeclaration_IUsageError():
-    TypeOnly<old.IUsageError>;
-declare function use_current_InterfaceDeclaration_IUsageError(
-    use: TypeOnly<current.IUsageError>): void;
-use_current_InterfaceDeclaration_IUsageError(
-    get_old_InterfaceDeclaration_IUsageError());
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "InterfaceDeclaration_IUsageError": {"backCompat": false}
+ * "RemovedInterfaceDeclaration_IUsageError": {"backCompat": false}
  */
-declare function get_current_InterfaceDeclaration_IUsageError():
-    TypeOnly<current.IUsageError>;
-declare function use_old_InterfaceDeclaration_IUsageError(
-    use: TypeOnly<old.IUsageError>): void;
-use_old_InterfaceDeclaration_IUsageError(
-    get_current_InterfaceDeclaration_IUsageError());
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.


### PR DESCRIPTION
Note: api reports suggest there is an export change, but there is no public or beta export change. The report was incorrect.