### PR TITLE
Fix TypeTest scoping and aliasing

### DIFF
--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -74,6 +74,23 @@ in some way. Other commands could adopt this, but only the `release command` use
 The `release` command also provides a `state` flag that can be used to initialize the state machine to a specific state.
 This is intended for testing.
 
+### Manual Integration Testing and Debugging
+
+There are some VS Code launch targets like `flub generate typetests` that may work in some cases.
+
+To run a locally built version of flub in contexts where the invocation of flub is done via package.json scripts, use a pnpm override.
+For client that is:
+
+```
+			"@fluid-tools/build-cli": "file:./build-tools/packages/build-cli",
+			"@fluidframework/build-tools": "file:./build-tools/packages/build-tools",
+			"@fluid-tools/version-tools": "file:./build-tools/packages/version-tools",
+			"@fluidframework/bundle-size-tools": "file:./build-tools/packages/bundle-size-tools"
+```
+
+This approach can be for `flub generate typetests` ensure that the `--level` configuration from the scripts is included, and can be done from a JavaScript Debug console to debug, though breakpoints will need to be set in the `.js` files in `node_modules` (for example in `node_modules/.pnpm/file+build-tools+packages+build-cli_@types+node@18.19.1/node_modules/@fluid-tools/build-cli/lib/commands/generate/typetests.js`).
+
+
 <!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->
 
 <!-- prettier-ignore-start -->

--- a/build-tools/packages/build-cli/README.md
+++ b/build-tools/packages/build-cli/README.md
@@ -88,7 +88,7 @@ For client that is:
 			"@fluidframework/bundle-size-tools": "file:./build-tools/packages/bundle-size-tools"
 ```
 
-This approach can be for `flub generate typetests` ensure that the `--level` configuration from the scripts is included, and can be done from a JavaScript Debug console to debug, though breakpoints will need to be set in the `.js` files in `node_modules` (for example in `node_modules/.pnpm/file+build-tools+packages+build-cli_@types+node@18.19.1/node_modules/@fluid-tools/build-cli/lib/commands/generate/typetests.js`).
+This approach can be used with `flub generate typetests` to ensure that the `--level` configuration from the scripts is included, and can be done from a JavaScript Debug console to debug, though breakpoints will need to be set in the `.js` files in `node_modules` (for example in `node_modules/.pnpm/file+build-tools+packages+build-cli_@types+node@18.19.1/node_modules/@fluid-tools/build-cli/lib/commands/generate/typetests.js`).
 
 
 <!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->

--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -371,6 +371,9 @@ export function typeDataFromFile(
 	return typeData;
 }
 
+/**
+ * Prefix `node`'s name with `namespacePrefix` to produce a qualified name.
+ */
 function addScope(
 	namespacePrefix: string | undefined,
 	node: NameableNodeSpecific | NamedNodeSpecificBase<Node>,
@@ -380,8 +383,11 @@ function addScope(
 	return addStringScope(namespacePrefix, scope);
 }
 
-function addStringScope(namespacePrefix: string | undefined, scope: string): string {
-	const name = namespacePrefix === undefined ? scope : `${namespacePrefix}.${scope}`;
+/**
+ * Prefix `innerName` name with `namespacePrefix` to produce a qualified name.
+ */
+function addStringScope(namespacePrefix: string | undefined, innerName: string): string {
+	const name = namespacePrefix === undefined ? innerName : `${namespacePrefix}.${innerName}`;
 	return name;
 }
 

--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -21,7 +21,16 @@ import { PackageName } from "@rushstack/node-core-library";
 import * as changeCase from "change-case";
 import { readJson } from "fs-extra/esm";
 import * as resolve from "resolve.exports";
-import { JSDoc, ModuleKind, Node, Project, type SourceFile, SyntaxKind } from "ts-morph";
+import {
+	JSDoc,
+	ModuleKind,
+	type NameableNodeSpecific,
+	type NamedNodeSpecificBase,
+	Node,
+	Project,
+	type SourceFile,
+	SyntaxKind,
+} from "ts-morph";
 import { PackageCommand } from "../../BasePackageCommand.js";
 import type { PackageSelectionDefault } from "../../flags.js";
 import {
@@ -331,7 +340,7 @@ function getTypeTestFilePath(pkg: Package, outDir: string, outFile: string): str
  * @param log - A logger to use.
  * @returns The mapping between type name and its type data.
  */
-function typeDataFromFile(
+export function typeDataFromFile(
 	file: SourceFile,
 	log: Logger,
 	namespacePrefix?: string,
@@ -339,9 +348,15 @@ function typeDataFromFile(
 	const typeData = new Map<string, TypeData>();
 	const exportedDeclarations = file.getExportedDeclarations();
 
-	for (const declarations of exportedDeclarations.values()) {
+	// Here we capture the exported name, rather than the name of the node.
+	// This ensures exports which alias names (ex: export {foo as bad} ...) report the external facing name not the internal one.
+	for (const [exportedName, declarations] of exportedDeclarations) {
 		for (const declaration of declarations) {
-			for (const typeDefinition of getNodeTypeData(declaration, log, namespacePrefix)) {
+			for (const typeDefinition of getNodeTypeData(
+				declaration,
+				log,
+				addStringScope(namespacePrefix, exportedName),
+			)) {
 				const fullName = getFullTypeName(typeDefinition);
 				if (typeData.has(fullName)) {
 					// This system does not properly handle overloads: instead it only keeps the last signature.
@@ -356,7 +371,21 @@ function typeDataFromFile(
 	return typeData;
 }
 
-function getNodeTypeData(node: Node, log: Logger, namespacePrefix?: string): TypeData[] {
+function addScope(
+	namespacePrefix: string | undefined,
+	node: NameableNodeSpecific | NamedNodeSpecificBase<Node>,
+): string {
+	const scope = node.getName();
+	if (scope === undefined) throw new Error("Missing scope where one was expected");
+	return addStringScope(namespacePrefix, scope);
+}
+
+function addStringScope(namespacePrefix: string | undefined, scope: string): string {
+	const name = namespacePrefix === undefined ? scope : `${namespacePrefix}.${scope}`;
+	return name;
+}
+
+function getNodeTypeData(node: Node, log: Logger, exportedName: string): TypeData[] {
 	/*
         handles namespaces e.g.
         export namespace foo{
@@ -371,7 +400,7 @@ function getNodeTypeData(node: Node, log: Logger, namespacePrefix?: string): Typ
 		for (const s of node.getStatements()) {
 			// only get type data for nodes that are exported from the namespace
 			if (Node.isExportable(s) && s.isExported()) {
-				typeData.push(...getNodeTypeData(s, log, node.getName()));
+				typeData.push(...getNodeTypeData(s, log, addScope(exportedName, node)));
 			}
 		}
 		return typeData;
@@ -385,7 +414,7 @@ function getNodeTypeData(node: Node, log: Logger, namespacePrefix?: string): Typ
 	if (Node.isVariableStatement(node)) {
 		const typeData: TypeData[] = [];
 		for (const dec of node.getDeclarations()) {
-			typeData.push(...getNodeTypeData(dec, log, namespacePrefix));
+			typeData.push(...getNodeTypeData(dec, log, addScope(exportedName, dec)));
 		}
 		return typeData;
 	}
@@ -393,7 +422,7 @@ function getNodeTypeData(node: Node, log: Logger, namespacePrefix?: string): Typ
 	if (Node.isIdentifier(node)) {
 		const typeData: TypeData[] = [];
 		for (const definition of node.getDefinitionNodes()) {
-			typeData.push(...getNodeTypeData(definition, log, namespacePrefix));
+			typeData.push(...getNodeTypeData(definition, log, exportedName));
 		}
 		return typeData;
 	}
@@ -406,19 +435,13 @@ function getNodeTypeData(node: Node, log: Logger, namespacePrefix?: string): Typ
 		Node.isVariableDeclaration(node) ||
 		Node.isFunctionDeclaration(node)
 	) {
-		const name =
-			namespacePrefix === undefined
-				? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					node.getName()!
-				: `${namespacePrefix}.${node.getName()}`;
-
 		const docs = Node.isVariableDeclaration(node)
 			? node.getFirstAncestorByKindOrThrow(SyntaxKind.VariableStatement).getJsDocs()
 			: node.getJsDocs();
 
 		const typeData: TypeData[] = [
 			{
-				name,
+				name: exportedName,
 				kind: node.getKindName(),
 				node,
 				tags: getTags(docs),
@@ -428,7 +451,7 @@ function getNodeTypeData(node: Node, log: Logger, namespacePrefix?: string): Typ
 	}
 
 	if (Node.isSourceFile(node)) {
-		return [...typeDataFromFile(node, log, namespacePrefix).values()];
+		return [...typeDataFromFile(node, log, exportedName).values()];
 	}
 
 	throw new Error(`Unknown Export Kind: ${node.getKindName()}`);

--- a/build-tools/packages/build-cli/test/commands/generate/typetests.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/typetests.test.ts
@@ -29,6 +29,7 @@ describe("generate:typetests", () => {
 		}));
 	}
 
+	// Test a file which looks like a rollup: a file that reexports content from other files.
 	it("rollup", () => {
 		const currentFile = loadTypesSourceFile("./test/data/exports/exports-rollup.d.ts");
 
@@ -52,6 +53,7 @@ describe("generate:typetests", () => {
 		]);
 	});
 
+	// Test a file which directly includes several kinds of exports to ensure that various export types work correctly.
 	it("direct", () => {
 		const currentFile = loadTypesSourceFile("./test/data/exports/exports.d.ts");
 

--- a/build-tools/packages/build-cli/test/commands/generate/typetests.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/typetests.test.ts
@@ -38,12 +38,12 @@ describe("generate:typetests", () => {
 			{ name: "VariableDeclaration_b", import: "b", tags: ["public"] },
 			{ name: "VariableDeclaration_c", import: "c", tags: ["internal"] },
 			{
-				name: "TypeAliasDeclaration_InternalTypes.Inner",
+				name: "TypeAliasDeclaration_InternalTypes_Inner",
 				import: "InternalTypes.Inner",
 				tags: ["public"],
 			},
 			{
-				name: "TypeAliasDeclaration_InternalTypes.InnerInternal",
+				name: "TypeAliasDeclaration_InternalTypes_InnerInternal",
 				import: "InternalTypes.InnerInternal",
 				tags: ["internal"],
 			},
@@ -62,12 +62,12 @@ describe("generate:typetests", () => {
 			{ name: "VariableDeclaration_b", import: "b", tags: ["public"] },
 			{ name: "VariableDeclaration_c", import: "c", tags: ["internal"] },
 			{
-				name: "TypeAliasDeclaration_InternalTypes.Inner",
+				name: "TypeAliasDeclaration_InternalTypes_Inner",
 				import: "InternalTypes.Inner",
 				tags: ["public"],
 			},
 			{
-				name: "TypeAliasDeclaration_InternalTypes.InnerInternal",
+				name: "TypeAliasDeclaration_InternalTypes_InnerInternal",
 				import: "InternalTypes.InnerInternal",
 				tags: ["internal"],
 			},

--- a/build-tools/packages/build-cli/test/commands/generate/typetests.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/typetests.test.ts
@@ -1,0 +1,76 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+import type { TypeData } from "@fluidframework/build-tools";
+import {
+	loadTypesSourceFile,
+	typeDataFromFile,
+} from "../../../src/commands/generate/typetests.js";
+
+describe("generate:typetests", () => {
+	const logger = {
+		log: () => assert.fail(),
+		info: () => assert.fail(),
+		warning: () => assert.fail(),
+		errorLog: () => assert.fail(),
+		verbose: () => assert.fail(),
+		logHr: () => assert.fail(),
+		logIndent: () => assert.fail(),
+	};
+
+	function forCompare(data: Map<string, TypeData>): unknown[] {
+		return [...data.entries()].map(([k, v]) => ({
+			name: k,
+			import: v.name,
+			tags: [...v.tags],
+		}));
+	}
+
+	it("rollup", () => {
+		const currentFile = loadTypesSourceFile("./test/data/exports/exports-rollup.d.ts");
+
+		const types = forCompare(typeDataFromFile(currentFile, logger));
+		assert.deepEqual(types, [
+			{ name: "TypeAliasDeclaration_A", import: "A", tags: ["public"] },
+			{ name: "VariableDeclaration_b", import: "b", tags: ["public"] },
+			{ name: "VariableDeclaration_c", import: "c", tags: ["internal"] },
+			{
+				name: "TypeAliasDeclaration_InternalTypes.Inner",
+				import: "InternalTypes.Inner",
+				tags: ["public"],
+			},
+			{
+				name: "TypeAliasDeclaration_InternalTypes.InnerInternal",
+				import: "InternalTypes.InnerInternal",
+				tags: ["internal"],
+			},
+			{ name: "TypeAliasDeclaration_OtherA", import: "OtherA", tags: ["public"] },
+			{ name: "TypeAliasDeclaration_OtherA2", import: "OtherA2", tags: ["public"] },
+		]);
+	});
+
+	it("direct", () => {
+		const currentFile = loadTypesSourceFile("./test/data/exports/exports.d.ts");
+
+		const types = forCompare(typeDataFromFile(currentFile, logger));
+		assert.deepEqual(types, [
+			{ name: "TypeAliasDeclaration_A", import: "A", tags: ["public"] },
+			{ name: "VariableDeclaration_a", import: "a", tags: ["public"] },
+			{ name: "VariableDeclaration_b", import: "b", tags: ["public"] },
+			{ name: "VariableDeclaration_c", import: "c", tags: ["internal"] },
+			{
+				name: "TypeAliasDeclaration_InternalTypes.Inner",
+				import: "InternalTypes.Inner",
+				tags: ["public"],
+			},
+			{
+				name: "TypeAliasDeclaration_InternalTypes.InnerInternal",
+				import: "InternalTypes.InnerInternal",
+				tags: ["internal"],
+			},
+		]);
+	});
+});

--- a/build-tools/packages/build-cli/test/data/exports/exports-rollup.d.ts
+++ b/build-tools/packages/build-cli/test/data/exports/exports-rollup.d.ts
@@ -2,5 +2,6 @@
  * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
  * Licensed under the MIT License.
  */
+
 export { A, b, c, InternalTypes, A as OtherA } from "./exports.js";
 export { A as OtherA2 } from "./exports.js";

--- a/build-tools/packages/build-cli/test/data/exports/exports-rollup.d.ts
+++ b/build-tools/packages/build-cli/test/data/exports/exports-rollup.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+export { A, b, c, InternalTypes, A as OtherA } from "./exports.js";
+export { A as OtherA2 } from "./exports.js";

--- a/build-tools/packages/build-cli/test/data/exports/exports.d.ts
+++ b/build-tools/packages/build-cli/test/data/exports/exports.d.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * @public
+ */
+export declare type A = number;
+/**
+ * @public
+ */
+export declare const a: number, b: string;
+/**
+ * @internal
+ */
+export declare const c: number;
+
+import * as InternalTypes from "./innerFile.js";
+export { InternalTypes };

--- a/build-tools/packages/build-cli/test/data/exports/innerFile.d.ts
+++ b/build-tools/packages/build-cli/test/data/exports/innerFile.d.ts
@@ -1,0 +1,14 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * @public
+ */
+export declare type Inner = number;
+
+/**
+ * @internal
+ */
+export declare type InnerInternal = number;

--- a/build-tools/packages/build-tools/src/typeValidator/typeData.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/typeData.ts
@@ -6,16 +6,25 @@
 import { Node, ts } from "ts-morph";
 
 export interface TypeData {
+	/**
+	 * Includes namespace prefix if needed.
+	 */
 	readonly name: string;
 	readonly kind: string;
 	readonly node: Node;
 	readonly tags: ReadonlySet<string>;
 }
 
+/**
+ * Creates a non-colliding "mangled" identifier for the type.
+ */
 export function getFullTypeName(typeData: TypeData) {
-	return `${typeData.kind}_${typeData.name}`;
+	return `${typeData.kind}_${typeData.name.replace(/\./g, "_")}`;
 }
 
+/**
+ * Generate an expression to include into the generated type tests which evaluates to the type to compare.
+ */
 export function toTypeString(prefix: string, typeData: TypeData, typePreprocessor: string) {
 	const node = typeData.node;
 	let typeParams: string | undefined;


### PR DESCRIPTION
## Description

Fix some type test issues:

1. Aliased exports, such as IBaseProtocolHandler (which was incorrectly skipped) and ConsensusRegisterCollectionClass (which was incorrectly handles as a duplicate test for ConsensusRegisterCollection) did not work properly.
2. Modules, such as tree's InternalTypes did not get their contents scoped correctly.
3. Qualified types (such as those from nested modules) did not have the periods in their names escaped correctly, so it caused the documentation to not match the declarations.

Additionally, some comments and tests are added.

These changes are necessary to support type tests for the tree package. Attempting to enable the tests for tree is what found these issues.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
