### PR TITLE
Set up fetch-tool for usage of a different app registration

### DIFF
--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/src/expressApp.ts
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/src/expressApp.ts
@@ -4,11 +4,14 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import { type IOdspTokens, getServer } from "@fluidframework/odsp-doclib-utils/internal";
+import {
+	type IOdspTokens,
+	type IPublicClientConfig,
+	getServer,
+} from "@fluidframework/odsp-doclib-utils/internal";
 import {
 	OdspTokenConfig,
 	OdspTokenManager,
-	getMicrosoftConfiguration,
 	odspTokensCache,
 } from "@fluidframework/tool-utils/internal";
 import express, { type Response } from "express";
@@ -58,6 +61,18 @@ app.listen(8080, () => {
 	console.log("Node server is running..");
 });
 
+const clientConfig: IPublicClientConfig = {
+	get clientId(): string {
+		const clientId = process.env.fetch__tool__clientId;
+		if (clientId === undefined) {
+			throw new Error(
+				"Client ID environment variable not set: fetch__tool__clientId. Use the getkeys tool to populate it.",
+			);
+		}
+		return clientId;
+	},
+};
+
 async function getOdspToken(res: Response, originalUrl: string): Promise<boolean> {
 	const buildTokenConfig = (
 		response: Response,
@@ -70,7 +85,7 @@ async function getOdspToken(res: Response, originalUrl: string): Promise<boolean
 	const tokenManager = new OdspTokenManager(odspTokensCache);
 	await tokenManager.getOdspTokens(
 		getServer("spo-df"),
-		getMicrosoftConfiguration(),
+		clientConfig,
 		buildTokenConfig(res, async (tokens: IOdspTokens) => {
 			odspAccessToken = tokens.accessToken;
 			odspAuthStage += 1;

--- a/packages/tools/fetch-tool/src/fluidFetchInit.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchInit.ts
@@ -20,10 +20,9 @@ import {
 } from "@fluidframework/odsp-urlresolver/internal";
 import * as r11s from "@fluidframework/routerlicious-driver/internal";
 import { RouterliciousUrlResolver } from "@fluidframework/routerlicious-urlresolver/internal";
-import { getMicrosoftConfiguration } from "@fluidframework/tool-utils/internal";
 
 import { localDataOnly, paramJWT } from "./fluidFetchArgs.js";
-import { resolveWrapper } from "./fluidFetchSharePoint.js";
+import { resolveWrapper, fetchToolClientConfig } from "./fluidFetchSharePoint.js";
 
 export let latestVersionsId: string = "";
 export let connectionInfo: any;
@@ -173,7 +172,7 @@ export async function fluidFetchInit(urlStr: string) {
 		return initializeODSPCore(
 			odspResolvedUrl,
 			new URL(odspResolvedUrl.siteUrl).host,
-			getMicrosoftConfiguration(),
+			fetchToolClientConfig,
 		);
 	} else if (resolvedInfo.serviceType === "r11s") {
 		const url = new URL(urlStr);


### PR DESCRIPTION
## Description

Adjusts the `IPublicClientConfig` that fetch-tool uses to obtain a distinct clientId from the environment. This sets us up better for using a less-permissioned app registration (fetch-tool only doesn't need write access to graph). I haven't yet created this new app registration, so this is for now a no-op on the registration we're using.

I've also updated `odspsnapshotfetch-perftestapp` to use the same registration, as its intent closely matches fetch tool (test perf of fetching snapshot on a document the signed in user has access to).

For some more context on the direction we're moving in for managing different flows against odsp, see also #21591 or changes to internal documentation on infrastructure.