### PR TITLE
tree: Usage Error on delete field

### DIFF
--- a/.changeset/stale-rooms-bow.md
+++ b/.changeset/stale-rooms-bow.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/tree": minor
+---
+
+Using "delete" on tree fields now errors instead of not working correctly.
+
+TypeScript allows "delete" on object node optional fields if "exactOptionalPropertyTypes" is not enabled. This does not work correctly at runtime and now produces an informative error.

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -200,6 +200,12 @@ function createProxyHandler(
 			setField(flexNode.getBoxed(fieldInfo.storedKey), fieldInfo.schema, value);
 			return true;
 		},
+		deleteProperty(target, viewKey): boolean {
+			// TODO: supporting delete when it makes sense (custom local fields, and optional field) could be added as a feature in the future.
+			throw new UsageError(
+				`Object nodes do not support the delete operator. Optional fields can be assigned to undefined instead.`,
+			);
+		},
 		has: (target, viewKey) => {
 			return (
 				flexKeyMap.has(viewKey) ||

--- a/packages/dds/tree/src/test/simple-tree/objectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/objectNode.spec.ts
@@ -123,7 +123,7 @@ describe("ObjectNode", () => {
 		assert.deepEqual(keys, ["foo"]);
 	});
 
-	it("test array", () => {
+	it("delete operator", () => {
 		class Schema extends schemaFactory.object("x", {
 			foo: schemaFactory.optional(schemaFactory.number),
 		}) {}

--- a/packages/dds/tree/src/test/simple-tree/objectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/objectNode.spec.ts
@@ -11,6 +11,7 @@ import { SchemaFactory } from "../../simple-tree/index.js";
 
 import { hydrate } from "./utils.js";
 import type { requireAssignableTo } from "../../util/index.js";
+import { validateUsageError } from "../utils.js";
 
 const schemaFactory = new SchemaFactory("Test");
 
@@ -120,5 +121,19 @@ describe("ObjectNode", () => {
 		assert.equal(descriptor.value, 0);
 		const keys = Object.keys(n);
 		assert.deepEqual(keys, ["foo"]);
+	});
+
+	it("test array", () => {
+		class Schema extends schemaFactory.object("x", {
+			foo: schemaFactory.optional(schemaFactory.number),
+		}) {}
+		const n = hydrate(Schema, { foo: 0 });
+		assert.throws(
+			() => {
+				// Since we do not have exactOptionalPropertyTypes enabled, this compiles, but should error at runtime:
+				delete n.foo;
+			},
+			validateUsageError(/delete operator/),
+		);
 	});
 });


### PR DESCRIPTION
## Description

Using "delete" on tree fields now errors instead of not working correctly.

TypeScript allows "delete" on object node optional fields if "exactOptionalPropertyTypes" is not enabled. This does not work correctly at runtime and now produces an informative error.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
