### PR TITLE
Fix fetch-tool's handling of 410 errors from odsp

### DIFF
--- a/packages/tools/fetch-tool/src/fluidFetchMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchMessages.ts
@@ -120,7 +120,10 @@ async function* loadAllSequencedMessages(
 			lastSeq = parseInt(seq, 10);
 			firstAvailableDelta = lastSeq + 1;
 		} else {
-			throw new Error(`Unexpected structure for 410 error: ${props}`);
+			console.log(props);
+			throw new Error(
+				`Unexpected structure for 410 error: ${error.message}. Props were logged above. This indicates a problem with fetch-tool.`,
+			);
 		}
 	}
 


### PR DESCRIPTION
## Description

Fetch-tool has some logic to download 'as many ops as possible' when older ops have been deleted. This logic appears to not have been updated at some point for a new error format coming from odsp-driver, which caused fetch-tool to choke before downloading/writing messages.json with an unintuitive error. This change fixes that and makes future changes to the 410 format give a more clear error message.
