### PR TITLE
Stop using short data store IDs in detached container

### DIFF
--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -54,7 +54,6 @@ import {
 	convertSummaryTreeToITree,
 	create404Response,
 	createResponseError,
-	encodeCompactIdToString,
 	isSerializedHandle,
 	processAttachMessageGCData,
 	responseToException,
@@ -70,6 +69,7 @@ import {
 	extractSafePropertiesFromMessage,
 	tagCodeArtifacts,
 } from "@fluidframework/telemetry-utils/internal";
+import { v4 as uuid } from "uuid";
 
 import {
 	DeletedResponseHeaderKey,
@@ -610,20 +610,26 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 	 * Please note that above mentioned functions have the implementation they have (allowing #2) due to #1.
 	 */
 	protected createDataStoreId(): string {
+		/**
+		 * There is currently a bug where certain data store ids such as "[" are getting converted to ASCII characters
+		 * in the snapshot. So, return uuid() here for now while we identify and fix the issue.
+		 */
+		return uuid();
+
 		// We use three non-overlapping namespaces:
 		// - detached state: even numbers
 		// - attached state: odd numbers
 		// - uuids
 		// In first two cases we will encode result as strings in more compact form.
-		if (this.parentContext.attachState === AttachState.Detached) {
-			// container is detached, only one client observes content,  no way to hit collisions with other clients.
-			return encodeCompactIdToString(2 * this.contexts.size);
-		}
-		const id = this.parentContext.containerRuntime.generateDocumentUniqueId();
-		if (typeof id === "number") {
-			return encodeCompactIdToString(2 * id + 1);
-		}
-		return id;
+		// if (this.parentContext.attachState === AttachState.Detached) {
+		// 	// container is detached, only one client observes content,  no way to hit collisions with other clients.
+		// 	return encodeCompactIdToString(2 * this.contexts.size);
+		// }
+		// const id = this.parentContext.containerRuntime.generateDocumentUniqueId();
+		// if (typeof id === "number") {
+		// 	return encodeCompactIdToString(2 * id + 1);
+		// }
+		// return id;
 	}
 
 	public createDetachedDataStore(

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -54,6 +54,7 @@ import {
 	convertSummaryTreeToITree,
 	create404Response,
 	createResponseError,
+	encodeCompactIdToString,
 	isSerializedHandle,
 	processAttachMessageGCData,
 	responseToException,
@@ -612,24 +613,26 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 	protected createDataStoreId(): string {
 		/**
 		 * There is currently a bug where certain data store ids such as "[" are getting converted to ASCII characters
-		 * in the snapshot. So, return uuid() here for now while we identify and fix the issue.
+		 * in the snapshot.
+		 * So, return short ids only if explicitly enabled via feature flags. Else, return uuid();
 		 */
+		if (this.mc.config.getBoolean("Fluid.Runtime.UseShortIds") === true) {
+			// We use three non-overlapping namespaces:
+			// - detached state: even numbers
+			// - attached state: odd numbers
+			// - uuids
+			// In first two cases we will encode result as strings in more compact form.
+			if (this.parentContext.attachState === AttachState.Detached) {
+				// container is detached, only one client observes content,  no way to hit collisions with other clients.
+				return encodeCompactIdToString(2 * this.contexts.size);
+			}
+			const id = this.parentContext.containerRuntime.generateDocumentUniqueId();
+			if (typeof id === "number") {
+				return encodeCompactIdToString(2 * id + 1);
+			}
+			return id;
+		}
 		return uuid();
-
-		// We use three non-overlapping namespaces:
-		// - detached state: even numbers
-		// - attached state: odd numbers
-		// - uuids
-		// In first two cases we will encode result as strings in more compact form.
-		// if (this.parentContext.attachState === AttachState.Detached) {
-		// 	// container is detached, only one client observes content,  no way to hit collisions with other clients.
-		// 	return encodeCompactIdToString(2 * this.contexts.size);
-		// }
-		// const id = this.parentContext.containerRuntime.generateDocumentUniqueId();
-		// if (typeof id === "number") {
-		// 	return encodeCompactIdToString(2 * id + 1);
-		// }
-		// return id;
 	}
 
 	public createDetachedDataStore(

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -946,7 +946,7 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 	 *
 	 * While we figure out the fix, we are disabling the ability to create short IDs and this assert validates it.
 	 */
-	function assertInvert(value: unknown, message: string) {
+	function assertInvert(value: boolean, message: string) {
 		assert(!value, message);
 	}
 
@@ -995,8 +995,7 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 		// Check directly that ID compressor is issuing short IDs!
 		// If it does not, the rest of the tests would fail - this helps isolate where the bug is.
 		const idTest = defaultDataStore._context.containerRuntime.generateDocumentUniqueId();
-		assertInvert(typeof idTest === "number", "short IDs should be issued");
-		// assert(idTest >= 0, "finalId");
+		assertInvert(typeof idTest === "number" && idTest >= 0, "short IDs should be issued");
 
 		// create another datastore
 		const ds2 = await defaultDataStore._context.containerRuntime.createDataStore(pkg);

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -793,7 +793,7 @@ describeCompat(
 	},
 );
 
-describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider) => {
+describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, compatAPIs) => {
 	let provider: ITestObjectProvider;
 	const disableConfig: ITestContainerConfig = {
 		runtimeOptions: { enableRuntimeIdCompressor: undefined },
@@ -938,13 +938,25 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider) => 
 		);
 	});
 
+	/**
+	 * Function that asserts that the value is not as expected. e have a bug in one of our customer's app where a short
+	 * data store ID created is `[` but in a downloaded snapshot, it is converted to its ASCII equivalent `%5B` in
+	 * certain conditions. So, when an op comes for this data store with id `[`, containers loaded with this snapshot
+	 * cannot find the data store.
+	 *
+	 * While we figure out the fix, we are disabling the ability to create short IDs and this assert validates it.
+	 */
+	function assertInvert(value: unknown, message: string) {
+		assert(!value, message);
+	}
+
 	async function TestCompactIds(enableRuntimeIdCompressor: IdCompressorMode) {
 		const container = await createContainer({
 			runtimeOptions: { enableRuntimeIdCompressor },
 		});
 		const defaultDataStore = (await container.getEntryPoint()) as ITestDataObject;
 		// This data store was created in detached container, so it has to be short!
-		assert(
+		assertInvert(
 			defaultDataStore._runtime.id.length <= 2,
 			"short data store ID created in detached container",
 		);
@@ -983,15 +995,15 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider) => 
 		// Check directly that ID compressor is issuing short IDs!
 		// If it does not, the rest of the tests would fail - this helps isolate where the bug is.
 		const idTest = defaultDataStore._context.containerRuntime.generateDocumentUniqueId();
-		assert(typeof idTest === "number", "short IDs should be issued");
-		assert(idTest >= 0, "finalId");
+		assertInvert(typeof idTest === "number", "short IDs should be issued");
+		// assert(idTest >= 0, "finalId");
 
 		// create another datastore
 		const ds2 = await defaultDataStore._context.containerRuntime.createDataStore(pkg);
 		const entryPoint2 = (await ds2.entryPoint.get()) as ITestDataObject;
 
 		// This data store was created in attached  container, and should have used ID compressor to assign ID!
-		assert(
+		assertInvert(
 			entryPoint2._runtime.id.length <= 2,
 			"short data store ID created in attached container",
 		);
@@ -1009,7 +1021,7 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider) => 
 			undefined,
 			SharedDirectory.getFactory().type,
 		);
-		assert(channel.id.length <= 2, "DDS ID created in detached data store");
+		assertInvert(channel.id.length <= 2, "DDS ID created in detached data store");
 
 		// attached data store.
 		await ds2.trySetAlias("foo");
@@ -1027,7 +1039,7 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider) => 
 			undefined,
 			SharedDirectory.getFactory().type,
 		);
-		assert(channel2.id.length <= 2, "DDS ID created in attached data store");
+		assertInvert(channel2.id.length <= 2, "DDS ID created in attached data store");
 	}
 
 	it("Container uses short DataStore & DDS IDs in delayed mode", async () => {
@@ -1046,14 +1058,19 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider) => 
 		};
 		const container = await loader.createDetachedContainer(defaultCodeDetails);
 		const defaultDataStore = (await container.getEntryPoint()) as ITestFluidObject;
-		assert(defaultDataStore.context.id.length < 8, "Default data store's ID should be short");
+		assertInvert(
+			defaultDataStore.context.id.length <= 2,
+			"Default data store's ID should be short",
+		);
 		const dataStore1 =
 			await defaultDataStore.context.containerRuntime.createDataStore(TestDataObjectType);
 		const ds1 = (await dataStore1.entryPoint.get()) as ITestFluidObject;
-		assert(
-			ds1.context.id.length < 8,
-			"New data store's ID in detached container should be short",
+		assertInvert(
+			ds1.context.id.length <= 2,
+			"Data store's ID in detached container should not be short",
 		);
+		const dds1 = compatAPIs.dds.SharedDirectory.create(ds1.runtime);
+		assertInvert(dds1.id.length <= 2, "DDS's ID in detached container should not be short");
 
 		await container.attach(provider.driver.createCreateNewRequest());
 
@@ -1062,7 +1079,9 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider) => 
 		const ds2 = (await dataStore2.entryPoint.get()) as ITestFluidObject;
 		assert(
 			ds2.context.id.length > 8,
-			"New data store's ID in attached container should not be short",
+			"Data store's ID in attached container should not be short",
 		);
+		const dds2 = compatAPIs.dds.SharedDirectory.create(ds2.runtime);
+		assert(dds2.id.length > 8, "DDS's ID in attached container should not be short");
 	});
 });


### PR DESCRIPTION
## Bug
Currently, data stores created in detached container always get a short ID via id compressor. We have a bug in one of our customer's app where a short data store ID created is `[` but in a downloaded snapshot, it is converted to its ASCII equivalent `%5B` in certain conditions. So, when an op comes for this data store with id `[`, containers loaded with this snapshot cannot find the data store.

## Root-cause
We haven't yet identified what causes the id to change from `[` -> `%5B`. However, we know that it is caused by short IDs generated in detached container.

## Fix
To mitigate the issue for customers, this PR disables the generation of short IDs for data stores and DDSes. Added tests that validate that we don't generate short IDs for data stores and DDSes in detached or attached state.