### PR TITLE
Make type tests not error at runtime

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/typetests.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/typetests.ts
@@ -153,7 +153,7 @@ export default class GenerateTypetestsCommand extends PackageCommand<
 
 		// Sort import statements to respect linting rules.
 		const buildToolsPackageName = "@fluidframework/build-tools";
-		const buildToolsImport = `import type { TypeOnly, MinimalType, FullType } from "${buildToolsPackageName}";`;
+		const buildToolsImport = `import type { TypeOnly, MinimalType, FullType, requireAssignableTo } from "${buildToolsPackageName}";`;
 		const previousImport = `import type * as old from "${previousPackageName}${
 			previousPackageLevel === ApiLevel.public ? "" : `/${previousPackageLevel}`
 		}";`;
@@ -177,7 +177,7 @@ ${imports.join("\n")}
 
 import type * as current from "../../index.js";
 
-declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | FullType<T> | typeof old | typeof current;
+declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | FullType<T> | typeof old | typeof current | requireAssignableTo<true, true>;
 `,
 		];
 
@@ -240,7 +240,7 @@ function getTypesPathWithFallback(
  * This implementation loosely follows TypeScript's process for finding types as described at
  * {@link https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-main-and-types}. If an export
  * map is found, the `types` and `typings` field are ignored. If an export map is not found, then the `types`/`typings`
- * fields will be used as a fallback _only_ for the public API level (which coresponds to the default export).
+ * fields will be used as a fallback _only_ for the public API level (which corresponds to the default export).
  *
  * Importantly, this code _does not_ implement falling back to the `main` field when `types` and `typings` are missing,
  * nor does it look up types from DefinitelyTyped (i.e. \@types/* packages). This fallback logic is not needed for our

--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -35,7 +35,12 @@ export {
 export { getApiExtractorConfigFilePath, getEsLintConfigFilePath } from "./common/taskUtils";
 export * as TscUtils from "./common/tscUtils";
 
-export { TypeOnly, MinimalType, FullType } from "./typeValidator/compatibility";
+export {
+	TypeOnly,
+	MinimalType,
+	FullType,
+	requireAssignableTo,
+} from "./typeValidator/compatibility";
 export { type TestCaseTypeData, buildTestCase } from "./typeValidator/testGeneration";
 export { type TypeData, getFullTypeName } from "./typeValidator/typeData";
 export { getTypeTestPreviousPackageDetails } from "./typeValidator/validatorUtils";

--- a/build-tools/packages/build-tools/src/typeValidator/compatibility.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/compatibility.ts
@@ -11,7 +11,7 @@
  * To use, simply define a type:
  * `type _check = requireAssignableTo<T, Expected>;`
  */
-type requireAssignableTo<_A extends B, B> = true;
+export type requireAssignableTo<_A extends B, B> = true;
 
 /*
  * Type meta-functions which take in a type and remove some of its type information to get structural typing.

--- a/build-tools/packages/build-tools/src/typeValidator/testGeneration.ts
+++ b/build-tools/packages/build-tools/src/typeValidator/testGeneration.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { TypeData, toTypeString } from "./typeData";
+import { TypeData, getFullTypeName, toTypeString } from "./typeData";
 
 export interface TestCaseTypeData extends TypeData {
 	prefix: "old" | "current";
@@ -15,30 +15,25 @@ export function buildTestCase(
 	useType: TestCaseTypeData,
 	isCompatible: boolean,
 	typePreprocessor: string,
-) {
+): string[] {
 	if (!isCompatible && (getAsType.removed || useType.removed)) {
-		return "";
+		return [];
 	}
 
-	const getSig = `get_${getAsType.prefix}_${getFullTypeName(getAsType).replace(".", "_")}`;
-	const useSig = `use_${useType.prefix}_${getFullTypeName(useType).replace(".", "_")}`;
-	const expectErrorString = "    // @ts-expect-error compatibility expected to be broken";
+	const expectErrorString = "// @ts-expect-error compatibility expected to be broken";
 	const testString: string[] = [];
 
-	testString.push(`declare function ${getSig}():`);
-	testString.push(`    ${toTypeString(getAsType.prefix, getAsType, typePreprocessor)};`);
-	testString.push(`declare function ${useSig}(`);
-	testString.push(
-		`    use: ${toTypeString(useType.prefix, useType, typePreprocessor)}): void;`,
-	);
-	testString.push(`${useSig}(`);
 	if (!isCompatible) {
 		testString.push(expectErrorString);
 	}
-	testString.push(`    ${getSig}());`);
+	testString.push(
+		`declare type ${getAsType.prefix}_as_${useType.prefix}_for_${getFullTypeName(
+			getAsType,
+		)} = requireAssignableTo<${toTypeString(
+			getAsType.prefix,
+			getAsType,
+			typePreprocessor,
+		)}, ${toTypeString(useType.prefix, useType, typePreprocessor)}>`,
+	);
 	return testString;
-}
-
-function getFullTypeName(typeData: TypeData) {
-	return `${typeData.kind}_${typeData.name}`;
 }


### PR DESCRIPTION
## Description

Our current type tests look like:

```typescript
declare function get_old_ClassDeclaration_Buffer():
    TypeOnly<old.Buffer>;
declare function use_current_ClassDeclaration_Buffer(
    use: TypeOnly<current.Buffer>): void;
use_current_ClassDeclaration_Buffer(
    get_old_ClassDeclaration_Buffer());
```

With this change they look like:

```typescript
declare type old_as_current_for_ClassDeclaration_Buffer = requireAssignableTo<TypeOnly<old.Buffer>, TypeOnly<current.Buffer>>
```

This removes the call to the declared but not defined function.
This means that if the tests load the type tests (ex: from mocha loading all the test files), it no longer produces a runtime error.
The new type tests only produce type code, no actual runtime effects.

This has been tested to fix the tree package's type tests if enabled.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

