### PR TITLE
fix(build-cli): Fix broken filter test

### DIFF
--- a/build-tools/packages/build-cli/test/filter.test.ts
+++ b/build-tools/packages/build-cli/test/filter.test.ts
@@ -178,7 +178,6 @@ describe("selectAndFilterPackages", async () => {
 			"@fluidframework/protocol-definitions",
 			"@fluid-tools/api-markdown-documenter",
 			"@fluid-tools/benchmark",
-			"@fluid-private/changelog-generator-wrapper",
 			"@fluid-internal/getkeys",
 			"@fluidframework/test-tools",
 		]);


### PR DESCRIPTION
Fixes a broken filter test in build-cli. It broke because the layout of the repo changed in #21393.

These tests are known to be brittle because they are partially based on the state of the repo. Until we have a better mocking strategy, we live with these occasional breaks.