### PR TITLE
RC.4.0 Port - Put Memory Blob Storage Under a Flag (#21612)

### DIFF
--- a/packages/loader/container-loader/src/memoryBlobStorage.ts
+++ b/packages/loader/container-loader/src/memoryBlobStorage.ts
@@ -20,7 +20,7 @@ interface MemoryDetachedBlobStorage extends IDetachedBlobStorage {
 
 function isMemoryDetachedBlobStorage(
 	// eslint-disable-next-line import/no-deprecated
-	detachedStorage: IDetachedBlobStorage,
+	detachedStorage: IDetachedBlobStorage | undefined,
 ): detachedStorage is MemoryDetachedBlobStorage {
 	return (
 		isObject(detachedStorage) &&
@@ -31,16 +31,20 @@ function isMemoryDetachedBlobStorage(
 
 export function serializeMemoryDetachedBlobStorage(
 	// eslint-disable-next-line import/no-deprecated
-	detachedStorage: IDetachedBlobStorage,
+	detachedStorage: IDetachedBlobStorage | undefined,
 ): string | undefined {
-	if (detachedStorage.size > 0 && isMemoryDetachedBlobStorage(detachedStorage)) {
+	if (
+		detachedStorage !== undefined &&
+		detachedStorage.size > 0 &&
+		isMemoryDetachedBlobStorage(detachedStorage)
+	) {
 		return detachedStorage.serialize();
 	}
 }
 
 export function tryInitializeMemoryDetachedBlobStorage(
 	// eslint-disable-next-line import/no-deprecated
-	detachedStorage: IDetachedBlobStorage,
+	detachedStorage: IDetachedBlobStorage | undefined,
 	attachmentBlobs: string,
 ) {
 	if (!isMemoryDetachedBlobStorage(detachedStorage)) {

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -18,12 +18,7 @@ import {
 	ContainerMessageType,
 	DefaultSummaryConfiguration,
 } from "@fluidframework/container-runtime/internal";
-import {
-	ConfigTypes,
-	IConfigProviderBase,
-	IErrorBase,
-	IFluidHandle,
-} from "@fluidframework/core-interfaces";
+import { IErrorBase, IFluidHandle } from "@fluidframework/core-interfaces";
 import { Deferred } from "@fluidframework/core-utils/internal";
 import { IDocumentServiceFactory } from "@fluidframework/driver-definitions/internal";
 import { ReferenceType } from "@fluidframework/merge-tree/internal";
@@ -32,6 +27,7 @@ import {
 	ChannelFactoryRegistry,
 	ITestContainerConfig,
 	ITestObjectProvider,
+	createTestConfigProvider,
 	getContainerEntryPointBackCompat,
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
@@ -45,10 +41,6 @@ import {
 	driverSupportsBlobs,
 	getUrlFromDetachedBlobStorage,
 } from "./mockDetachedBlobStorage.js";
-
-const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
-	getRawConfig: (name: string): ConfigTypes => settings[name],
-});
 
 function makeTestContainerConfig(registry: ChannelFactoryRegistry): ITestContainerConfig {
 	return {
@@ -447,6 +439,9 @@ function serializationTests({
 							loaderProps: {
 								detachedBlobStorage,
 								options: { summarizeProtocolTree },
+								configProvider: createTestConfigProvider({
+									"Fluid.Container.MemoryBlobStorageEnabled": true,
+								}),
 							},
 						});
 						const container = await loader.createDetachedContainer(
@@ -499,7 +494,12 @@ function serializationTests({
 			it("serialize/rehydrate container with blobs", async function () {
 				const loader = provider.makeTestLoader({
 					...testContainerConfig,
-					loaderProps: { detachedBlobStorage },
+					loaderProps: {
+						detachedBlobStorage,
+						configProvider: createTestConfigProvider({
+							"Fluid.Container.MemoryBlobStorageEnabled": true,
+						}),
+					},
 				});
 				const serializeContainer = await loader.createDetachedContainer(
 					provider.defaultCodeDetails,
@@ -549,10 +549,10 @@ function serializationTests({
 					loaderProps: {
 						detachedBlobStorage,
 						documentServiceFactory,
-						configProvider: {
-							getRawConfig: (name) =>
-								name === "Fluid.Container.RetryOnAttachFailure" ? true : undefined,
-						},
+						configProvider: createTestConfigProvider({
+							"Fluid.Container.MemoryBlobStorageEnabled": true,
+							"Fluid.Container.RetryOnAttachFailure": true,
+						}),
 					},
 				});
 				const serializeContainer = await loader.createDetachedContainer(
@@ -603,13 +603,19 @@ function serializationTests({
 				ContainerCloseUsageError,
 				async function () {
 					// test with and without offline load enabled
-					const offlineCfg = configProvider({
+					const offlineCfg = {
 						"Fluid.Container.enableOfflineLoad": true,
-					});
+					};
 					for (const cfg of [undefined, offlineCfg]) {
 						const loader = provider.makeTestLoader({
 							...testContainerConfig,
-							loaderProps: { detachedBlobStorage, configProvider: cfg },
+							loaderProps: {
+								detachedBlobStorage,
+								configProvider: createTestConfigProvider({
+									"Fluid.Container.MemoryBlobStorageEnabled": true,
+									...offlineCfg,
+								}),
+							},
 						});
 						const detachedContainer = await loader.createDetachedContainer(
 							provider.defaultCodeDetails,
@@ -684,7 +690,12 @@ function serializationTests({
 				async function () {
 					const loader = provider.makeTestLoader({
 						...testContainerConfig,
-						loaderProps: { detachedBlobStorage },
+						loaderProps: {
+							detachedBlobStorage,
+							configProvider: createTestConfigProvider({
+								"Fluid.Container.MemoryBlobStorageEnabled": true,
+							}),
+						},
 					});
 					const serializeContainer = await loader.createDetachedContainer(
 						provider.defaultCodeDetails,
@@ -733,7 +744,12 @@ function serializationTests({
 				async function () {
 					const loader = provider.makeTestLoader({
 						...testContainerConfig,
-						loaderProps: { detachedBlobStorage },
+						loaderProps: {
+							detachedBlobStorage,
+							configProvider: createTestConfigProvider({
+								"Fluid.Container.MemoryBlobStorageEnabled": true,
+							}),
+						},
 					});
 					let container = await loader.createDetachedContainer(
 						provider.defaultCodeDetails,

--- a/packages/test/test-utils/api-report/test-utils.api.md
+++ b/packages/test/test-utils/api-report/test-utils.api.md
@@ -97,7 +97,7 @@ export function createSummarizerFromFactory(provider: ITestObjectProvider, conta
 }>;
 
 // @internal
-export const createTestConfigProvider: () => ITestConfigProvider;
+export const createTestConfigProvider: (defaults?: Record<string, ConfigTypes>) => ITestConfigProvider;
 
 // @internal
 export const createTestContainerRuntimeFactory: (containerRuntimeCtor: typeof ContainerRuntime) => {

--- a/packages/test/test-utils/src/TestConfigs.ts
+++ b/packages/test/test-utils/src/TestConfigs.ts
@@ -22,8 +22,10 @@ export interface ITestConfigProvider extends IConfigProviderBase {
  * Creates a test config provider with the ability to set configs values and clear all config values.
  * @internal
  */
-export const createTestConfigProvider = (): ITestConfigProvider => {
-	const settings: Record<string, ConfigTypes> = {};
+export const createTestConfigProvider = (
+	defaults: Record<string, ConfigTypes> = {},
+): ITestConfigProvider => {
+	const settings: Record<string, ConfigTypes> = { ...defaults };
 	return {
 		getRawConfig: (name: string): ConfigTypes => settings[name],
 		set: (key: string, value: ConfigTypes) => {


### PR DESCRIPTION
We recently made changes to how detached blob storage works, and enabled a default in-memory blob storage such that blobs would be supported by default in detached containers.

However, when blobs are in a detached container, it changes the container attachment flow, specifically, an empty file is created, the blobs are uploaded, and then the summary is uploaded. Due to this differing flow some drivers, like odsp, create files with a `.tmp` extension appended to the file name, this is meant to signify that that file could be incomplete. For example, the summary could fail to upload after blobs have been uploaded, and this will not be a valid fluid file. it is expected that the application will rename the file after attachment completes if the `.tmp` extension is not desired. If an application does not expect the `.tmp` extension this can create issues, so for now, we will put this support under a flag, that must be explicitly enabled `"Fluid.Container.MemoryBlobStorageEnabled" = true` so that apps must opt into this behavior.

related to #21144
