### PR TITLE
docs(client): retag bufferToString as `@internal`

### DIFF
--- a/packages/common/client-utils/README.md
+++ b/packages/common/client-utils/README.md
@@ -26,6 +26,7 @@ This package has important requirements for the code within it.
 1. Code within this package should require some external dependencies. If it does not, then the **core-utils** package
    is a better location.
 1. **All exports must be designated `@internal`.** This code is intended for use within the Fluid Framework only.
+   **Excepting the small set of typed event emitter APIs** that are in use by legacy test support.
 1. This package should **only contain 'implementation' code, not type definitions.** This is the most flexible rule, and
    there are some exceptions. If the type is _only_ necessary when using this package, then it is probably OK. However,
    usually such types would be better placed in core-interfaces or in a package that corresponds to the purpose.

--- a/packages/common/client-utils/api-report/client-utils.alpha.api.md
+++ b/packages/common/client-utils/api-report/client-utils.alpha.api.md
@@ -4,9 +4,6 @@
 
 ```ts
 
-// @alpha
-export const bufferToString: (blob: ArrayBufferLike, encoding: "utf8" | "utf-8" | "base64") => string;
-
 export { EventEmitter }
 
 // @alpha

--- a/packages/common/client-utils/src/bufferBrowser.ts
+++ b/packages/common/client-utils/src/bufferBrowser.ts
@@ -55,7 +55,7 @@ export const stringToBuffer = (input: string, encoding: string): ArrayBufferLike
  * @param encoding - output string's encoding
  * @returns the blob in string format
  *
- * @alpha
+ * @internal
  */
 export const bufferToString = (
 	blob: ArrayBufferLike,

--- a/packages/common/client-utils/src/bufferNode.ts
+++ b/packages/common/client-utils/src/bufferNode.ts
@@ -80,7 +80,7 @@ export function stringToBuffer(input: string, encoding: string): ArrayBufferLike
  * @param encoding - Output string's encoding
  * @returns The blob in string format
  *
- * @alpha
+ * @internal
  */
 export const bufferToString = (
 	blob: ArrayBufferLike,


### PR DESCRIPTION
Besides client-utils being under `@fluid-internal` scope, there are no export paths; so, tagging changes make no difference other than what shows up in API report.

Update note in package requirements about some legacy APIs existing.