### PR TITLE
feat(check:policy): Policy handler to prevent tab indentation in yml files

### DIFF
--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/index.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/index.ts
@@ -13,6 +13,7 @@ import { handlers as lockfileHandlers } from "./lockfiles.js";
 import { handler as noJsFileHandler } from "./noJsFiles.js";
 import { handlers as npmPackageContentsHandlers } from "./npmPackages.js";
 import { handlers as pnpmHandlers } from "./pnpm.js";
+import { handler as yamlTabsHandler } from "./spacesOverTabsInYaml.js";
 
 /**
  * declared file handlers
@@ -27,6 +28,7 @@ export const policyHandlers: Handler[] = [
 	...pnpmHandlers,
 	...fluidBuildTasks,
 	noJsFileHandler,
+	yamlTabsHandler,
 ];
 
 export { type Handler } from "./common.js";

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/spacesOverTabsInYaml.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/spacesOverTabsInYaml.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Handler, readFile } from "./common.js";
+
+/**
+ * Checks that *.yml/*.yaml files do not use tabs for indentation.
+ * Deliberately does not provide a resolver because automatic changes to yaml files, in particular those related to
+ * indentation, can be risky.
+ */
+export const handler: Handler = {
+	name: "indent-with-spaces-in-yaml",
+	match: /(^|\/)[^/]+\.ya?ml$/i,
+	handler: async (file: string): Promise<string | undefined> => {
+		const content = readFile(file);
+
+		// /m is multiline mode, so ^ matches the start of any line, not just the start of the full string
+		if (content.search(/^\t/m) !== -1) {
+			return `Tab indentation detected in YAML file. Please use spaces for indentation.`;
+		}
+	},
+};

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/spacesOverTabsInYaml.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/spacesOverTabsInYaml.ts
@@ -15,10 +15,25 @@ export const handler: Handler = {
 	match: /(^|\/)[^/]+\.ya?ml$/i,
 	handler: async (file: string): Promise<string | undefined> => {
 		const content = readFile(file);
-
-		// /m is multiline mode, so ^ matches the start of any line, not just the start of the full string
-		if (content.search(/^\t/m) !== -1) {
-			return `Tab indentation detected in YAML file. Please use spaces for indentation.`;
-		}
+		return lookForTabs(content);
 	},
 };
+
+/**
+ * Checks for tabs in the indentation of the specified file contents.
+ * @remarks Exported only for testing purposes
+ * @param fileContents - the file contents to check.
+ * @returns an error message if tabs are found; otherwise undefined.
+ */
+export function lookForTabs(fileContents: string): string | undefined {
+	// /m is multiline mode, so ^ matches the start of any line, not just the start of the full string
+	// Fail on tabs right at the start of the line, or after whitespace but before any non-whitespace character.
+	if (fileContents.search(/^\s*\t/m) !== -1) {
+		return errorMessage;
+	}
+}
+
+/**
+ * Exported only for testing purposes.
+ */
+export const errorMessage = `Tab indentation detected in YAML file. Please use spaces for indentation.`;

--- a/build-tools/packages/build-cli/test/library/repoPolicyCheck/spacesOverTabsInYaml.test.ts
+++ b/build-tools/packages/build-cli/test/library/repoPolicyCheck/spacesOverTabsInYaml.test.ts
@@ -1,0 +1,37 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { expect } from "chai";
+import { lookForTabs, errorMessage } from "../../../src/library/repoPolicyCheck/spacesOverTabsInYaml.js";
+
+describe("indent-with-spaces-in-yaml", () => {
+	it("does not fail when no tabs are present", () => {
+		const error = lookForTabs(`
+no indentation
+  indented with spaces`)
+		expect(error).to.equal(undefined);
+	});
+
+	it("fails when tabs are present at the start of a line", () => {
+		const error = lookForTabs(`
+no indentation
+	indented with tabs`);
+		expect(error).to.equal(errorMessage);
+	});
+
+	it("fails when tabs are present after spaces but before text", () => {
+		const error = lookForTabs(`
+no indentation
+  	indented with spaces followed by tabs`);
+		expect(error).to.equal(errorMessage);
+	});
+
+	it("ignores tabs after first character in line", () => {
+		const error = lookForTabs(`
+no indentation
+  indented with spaces but there's a tab	in the middle of line`);
+		expect(error).to.equal(undefined);
+	});
+});

--- a/build-tools/packages/build-cli/test/library/repoPolicyCheck/spacesOverTabsInYaml.test.ts
+++ b/build-tools/packages/build-cli/test/library/repoPolicyCheck/spacesOverTabsInYaml.test.ts
@@ -5,8 +5,8 @@
 
 import { expect } from "chai";
 import {
-	lookForTabs,
 	errorMessage,
+	lookForTabs,
 } from "../../../src/library/repoPolicyCheck/spacesOverTabsInYaml.js";
 
 describe("indent-with-spaces-in-yaml", () => {

--- a/build-tools/packages/build-cli/test/library/repoPolicyCheck/spacesOverTabsInYaml.test.ts
+++ b/build-tools/packages/build-cli/test/library/repoPolicyCheck/spacesOverTabsInYaml.test.ts
@@ -4,13 +4,16 @@
  */
 
 import { expect } from "chai";
-import { lookForTabs, errorMessage } from "../../../src/library/repoPolicyCheck/spacesOverTabsInYaml.js";
+import {
+	lookForTabs,
+	errorMessage,
+} from "../../../src/library/repoPolicyCheck/spacesOverTabsInYaml.js";
 
 describe("indent-with-spaces-in-yaml", () => {
 	it("does not fail when no tabs are present", () => {
 		const error = lookForTabs(`
 no indentation
-  indented with spaces`)
+  indented with spaces`);
 		expect(error).to.equal(undefined);
 	});
 


### PR DESCRIPTION
## Description

Adds a new policy check handler that errors out if it detects yaml files where tabs are used for indentation. Since we don't have a formatter for yaml files, this should help enforce that we at least stick to spaces all the time. It's also motivated by the fact that one of our internal pipelines recently started complaining when it encountered a yaml file that was using a mix of tabs and spaces (fixed by https://github.com/microsoft/FluidFramework/pull/21627).

As indicated by a comment, no resolver is provided since we don't want to auto-format YAML files because messing up indentation can break them inadvertently.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I validated the handler locally.