### PR TITLE
fix(historian): Replace tabs with spaces in gitrest configmap

### DIFF
--- a/server/charts/historian/templates/gitrest-configmap.yaml
+++ b/server/charts/historian/templates/gitrest-configmap.yaml
@@ -70,7 +70,7 @@ data:
             "enableRedisFsMetrics": {{ .Values.gitrest.git.enableRedisFsMetrics }},
             "enableHashmapRedisFs": {{ .Values.gitrest.git.enableHashmapRedisFs }},
             "redisApiMetricsSamplingPeriod": {{ .Values.gitrest.git.redisApiMetricsSamplingPeriod }},
-		    "enforceStrictPersistedFullSummaryReads": {{ .Values.gitrest.git.enforceStrictPersistedFullSummaryReads }},
+            "enforceStrictPersistedFullSummaryReads": {{ .Values.gitrest.git.enforceStrictPersistedFullSummaryReads }},
             "enableRedisFsOptimizedStat": {{ .Values.gitrest.git.enableRedisFsOptimizedStat }},
             "redisApiMetricsSamplingPeriod": {{ .Values.gitrest.git.redisApiMetricsSamplingPeriod }}
         },


### PR DESCRIPTION
## Description

One of the lines added to the configmap in https://github.com/microsoft/FluidFramework/pull/19285/files ended up indented with tabs, and our internal deployment pipelines are complaining that they expect a space there. This PR replaces the tabs with spaces.

https://github.com/microsoft/FluidFramework/pull/21626 adds a policy handler to detect tab-indentation in yaml files and error out.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
