### PR TITLE
build(client): generate legacy API report

### DIFF
--- a/packages/common/client-utils/.npmignore
+++ b/packages/common/client-utils/.npmignore
@@ -4,4 +4,6 @@ nyc
 src/test
 dist/test
 lib/test
+lib/client-utils.browser.*.d.ts
+lib/client-utils.node.*.d.ts
 **/_api-extractor-temp/**

--- a/packages/common/client-utils/README.md
+++ b/packages/common/client-utils/README.md
@@ -60,6 +60,18 @@ file to dist/package.json to set the module type to commonjs. When resolving int
 packages, module resolution will walk up from the \*.js file and discover this stub package.json. Because
 the stub package.json lacks an export map, internal imports will not be remapped.
 
+## Export Reports and Linting
+
+With the current case of legacy APIs that are present here and the isometric browser and Node.js support,
+generation and checking of APIs is unique within client group. `lib/client-utils.(browser|node).*.d.ts` files
+are generated but not used in production (excluded from npm package).
+
+For local (development) builds browser reports are generated first and Node.js reports are then verified to
+be the same as browser. (Both report sets use the same target files.)
+
+Package scripts `check:exports:esm:indexBrowser:legacy` and `check:exports:esm:indexNode:legacy` are not
+verifying actual exports, but the consistency of tags within the legacy API set.
+
 <!-- AUTO-GENERATED-CONTENT:START (README_DEPENDENCY_GUIDELINES_SECTION:includeHeading=TRUE) -->
 
 <!-- prettier-ignore-start -->

--- a/packages/common/client-utils/api-extractor-lint.json
+++ b/packages/common/client-utils/api-extractor-lint.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-lint.esm.primary.json"
-}

--- a/packages/common/client-utils/api-extractor.json
+++ b/packages/common/client-utils/api-extractor.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-base.esm.no-legacy.json"
-}

--- a/packages/common/client-utils/api-extractor/api-extractor-browser.json
+++ b/packages/common/client-utils/api-extractor/api-extractor-browser.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "../../../../common/build/build-common/api-extractor-base.esm.current.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/indexBrowser.d.ts"
+}

--- a/packages/common/client-utils/api-extractor/api-extractor-browser.legacy.json
+++ b/packages/common/client-utils/api-extractor/api-extractor-browser.legacy.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-base.esm.legacy.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/<unscopedPackageName>.browser.legacy.d.ts"
+}

--- a/packages/common/client-utils/api-extractor/api-extractor-lint-indexBrowser.legacy.esm.json
+++ b/packages/common/client-utils/api-extractor/api-extractor-lint-indexBrowser.legacy.esm.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/<unscopedPackageName>.browser.legacy.d.ts"
+}

--- a/packages/common/client-utils/api-extractor/api-extractor-lint-indexNode.legacy.esm.json
+++ b/packages/common/client-utils/api-extractor/api-extractor-lint-indexNode.legacy.esm.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/<unscopedPackageName>.node.legacy.d.ts"
+}

--- a/packages/common/client-utils/api-extractor/api-extractor-node.json
+++ b/packages/common/client-utils/api-extractor/api-extractor-node.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "../../../../common/build/build-common/api-extractor-base.esm.current.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/indexNode.d.ts"
+}

--- a/packages/common/client-utils/api-extractor/api-extractor-node.legacy.json
+++ b/packages/common/client-utils/api-extractor/api-extractor-node.legacy.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-base.esm.legacy.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/<unscopedPackageName>.node.legacy.d.ts"
+}

--- a/packages/common/client-utils/api-report/client-utils.legacy.alpha.api.md
+++ b/packages/common/client-utils/api-report/client-utils.legacy.alpha.api.md
@@ -9,8 +9,6 @@ export { EventEmitter }
 // @alpha
 export type EventEmitterEventType = string;
 
-export { performance_2 as performance }
-
 // @alpha
 export class TypedEventEmitter<TEvent> extends EventEmitter implements IEventProvider<TEvent & IEvent> {
     constructor();

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -35,7 +35,7 @@
 				}
 			}
 		},
-		"./internal/api-report": {
+		"./internal-api-report": {
 			"import": {
 				"types": {
 					"browser legacy": "./lib/client-utils.browser.legacy.d.ts",
@@ -66,7 +66,7 @@
 		"build:test:mocha:cjs": "fluid-tsc commonjs --project ./src/test/mocha/tsconfig.cjs.json",
 		"build:test:mocha:esm": "tsc --project ./src/test/mocha/tsconfig.json",
 		"build:test:types": "tsc --project ./src/test/types/tsconfig.json",
-		"check:are-the-types-wrong": "attw --pack .",
+		"check:are-the-types-wrong": "attw --pack . --exclude-entrypoints internal-api-report",
 		"check:biome": "biome check . --formatter-enabled=true",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
 		"check:exports:bundle-release-tags": "api-extractor run --config api-extractor/api-extractor-lint-bundle.json",

--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -34,6 +34,14 @@
 					"default": "./dist/indexBrowser.js"
 				}
 			}
+		},
+		"./internal/api-report": {
+			"import": {
+				"types": {
+					"browser legacy": "./lib/client-utils.browser.legacy.d.ts",
+					"node legacy": "./lib/client-utils.node.legacy.d.ts"
+				}
+			}
 		}
 	},
 	"main": "lib/indexBrowser.js",
@@ -42,8 +50,16 @@
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:docs": "api-extractor run --local",
+		"build:docs": "npm run build:docs:browser && npm run build:docs:node",
+		"build:docs:browser": "npm run build:exports:browser && concurrently \"npm:build:docs:browser:*\"",
+		"build:docs:browser:current": "api-extractor run --local --config api-extractor/api-extractor-browser.json",
+		"build:docs:browser:legacy": "api-extractor run --local --config api-extractor/api-extractor-browser.legacy.json",
+		"build:docs:node": "npm run build:exports:node && concurrently \"npm:build:docs:node:*\"",
+		"build:docs:node:current": "npm run ci:build:docs:node:current",
+		"build:docs:node:legacy": "npm run ci:build:docs:node:legacy",
 		"build:esnext": "tsc --project ./tsconfig.json",
+		"build:exports:browser": "flub generate entrypoints --outFilePrefix {@unscopedPackageName}.browser. --mainEntrypoint ./src/indexBrowser.ts --outFileAlpha legacy --outDir ./lib",
+		"build:exports:node": "flub generate entrypoints --outFilePrefix {@unscopedPackageName}.node. --mainEntrypoint ./src/indexNode.ts --outFileAlpha legacy --outDir ./lib",
 		"build:test": "concurrently npm:build:test:mocha npm:build:test:jest npm:build:test:types",
 		"build:test:jest": "fluid-tsc commonjs --project ./src/test/jest/tsconfig.cjs.json",
 		"build:test:mocha": "concurrently npm:build:test:mocha:esm npm:build:test:mocha:cjs",
@@ -57,10 +73,16 @@
 		"check:exports:cjs:indexBrowser": "api-extractor run --config api-extractor/api-extractor-lint-indexBrowser.cjs.json",
 		"check:exports:cjs:indexNode": "api-extractor run --config api-extractor/api-extractor-lint-indexNode.cjs.json",
 		"check:exports:esm:indexBrowser": "api-extractor run --config api-extractor/api-extractor-lint-indexBrowser.esm.json",
+		"check:exports:esm:indexBrowser:legacy": "api-extractor run --config api-extractor/api-extractor-lint-indexBrowser.legacy.esm.json",
 		"check:exports:esm:indexNode": "api-extractor run --config api-extractor/api-extractor-lint-indexNode.esm.json",
+		"check:exports:esm:indexNode:legacy": "api-extractor run --config api-extractor/api-extractor-lint-indexNode.legacy.esm.json",
 		"check:format": "npm run check:biome",
 		"check:prettier": "prettier --check . --cache --ignore-path ../../../.prettierignore",
-		"ci:build:docs": "api-extractor run",
+		"ci:build:docs": "concurrently \"npm:ci:build:docs:*\"",
+		"ci:build:docs:browser:current": "api-extractor run --config api-extractor/api-extractor-browser.json",
+		"ci:build:docs:browser:legacy": "api-extractor run --config api-extractor/api-extractor-browser.legacy.json",
+		"ci:build:docs:node:current": "api-extractor run --config api-extractor/api-extractor-node.json",
+		"ci:build:docs:node:legacy": "api-extractor run --config api-extractor/api-extractor-node.legacy.json",
 		"clean": "rimraf --glob _api-extractor-temp dist lib \"**/*.tsbuildinfo\" \"**/*.build.log\" nyc",
 		"eslint": "eslint --format stylish src",
 		"eslint:fix": "eslint --format stylish src --fix --fix-type problem,suggestion,layout",
@@ -158,6 +180,24 @@
 				"build:test:jest",
 				"build:test:types"
 			],
+			"build:docs:browser:current": [
+				"build:exports:browser"
+			],
+			"build:docs:browser:legacy": [
+				"build:exports:browser"
+			],
+			"build:docs:node:current": [
+				"build:docs:browser:current"
+			],
+			"build:docs:node:legacy": [
+				"build:docs:browser:legacy"
+			],
+			"check:exports:esm:indexBrowser:legacy": [
+				"build:exports:browser"
+			],
+			"check:exports:esm:indexNode:legacy": [
+				"build:exports:node"
+			],
 			"build:test:jest": [
 				"tsc"
 			],
@@ -169,6 +209,18 @@
 			],
 			"build:test:types": [
 				"build:esnext"
+			],
+			"ci:build:docs:browser:current": [
+				"build:exports:browser"
+			],
+			"ci:build:docs:browser:legacy": [
+				"build:exports:browser"
+			],
+			"ci:build:docs:node:current": [
+				"build:exports:node"
+			],
+			"ci:build:docs:node:legacy": [
+				"build:exports:node"
 			]
 		}
 	},


### PR DESCRIPTION
client-utils is in the `@fluid-internal` scope and thus does not have trimmed exports. But it currently support legacy APIs for typed event emitter.

Setup a non-production legacy "roll up" file for both the browser and Node.js entrypoints. Generate API reports and perform linting like `@fluidframework` scoped packages with /legacy, but using the faux "roll ups".

Additionally now verify API reports for browser and Node.js entrypoints are identical.

Note: `api` task and `api-extractor` named scripts are not used as in `@fluidframework` scoped packages as these scripts are not part of production API. They are only used for docs and linting which have task dependencies defined.
