### PR TITLE
refactor(ci): Remove redundant component detection job

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -51,10 +51,6 @@ parameters:
   type: boolean
   default: true
 
-- name: poolCG
-  type: object
-  default: Small-1ES
-
 - name: poolBuild
   type: object
   default: Small-1ES

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -592,25 +592,6 @@ extends:
                     sbomEnabled: false
                     publishLocation: pipeline
 
-          # Job - Component detection
-          - ${{ if eq(parameters.publish, true) }}:
-              - job: CG
-                displayName: Component Detection
-                pool: ${{ parameters.poolCG }}
-                steps:
-                  - checkout: self
-                    clean: true
-                    lfs: false
-                    submodules: false
-                  - ${{ parameters.preCG }}
-                  - task: ComponentGovernanceComponentDetection@0
-                    displayName: Component Detection
-                    inputs:
-                      sourceScanPath: ${{ parameters.buildDirectory }}/${{ parameters.cgSubDirectory }}
-                      verbosity: Verbose
-                      scanType: Register
-                      alertWarningLevel: High
-
       # Publish stage
       - ${{ if eq(parameters.publish, true) }}:
         - template: include-publish-npm-package.yml


### PR DESCRIPTION
## Description

Removes the explicit Component Detection job/task which is redundant now that we use 1ES pipeline templates which auto-inject component governance tasks. The `poolCG` parameter was only used for that job so it is also removed.

The one we ran explicitly tries to be smart and only scan the relevant directories for the specific thing being built, but since the auto-injected task covers the whole repo, it's redundant. Furthermore, since we run that job in small build agents, it takes longer to finish than the auto-injected task which scans the whole repo, because that one runs in the large build agents. For example, when building build-tools, [the explicit job which only scans `build-tools/` reports 18s in logs and a total task time of 23s](https://dev.azure.com/fluidframework/internal/_build/results?buildId=273670&view=logs&j=189bf95d-4688-543c-ef32-29eb64497bc0&t=6f877908-1312-595c-5922-0456f1e657b1&l=130), whereas [the auto-injected task that scans the whole repo reports 10s in logs and a total task time of 19s](https://dev.azure.com/fluidframework/internal/_build/results?buildId=273670&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=833edf1b-3669-5dbb-11e6-ee7d22230825&l=1604). 

The [detected component issues for the whole-repo-task](https://dev.azure.com/fluidframework/internal/_build/results?buildId=273670&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=833edf1b-3669-5dbb-11e6-ee7d22230825&l=41845) also are a super-set of [what the explicit job reports](https://dev.azure.com/fluidframework/internal/_build/results?buildId=273670&view=logs&j=189bf95d-4688-543c-ef32-29eb64497bc0&t=6f877908-1312-595c-5922-0456f1e657b1&l=7760).

Finally, we only run the explicit job in pipelines that are going to publish packages, which means only in the internal ADO project. That's a good attempt at reducing execution time for PR builds, but the auto-injected task already runs in both public and internal builds. So we're not losing coverage by removing the explicit job, and in fact its attempt at reducing the time for PR builds is being negated by the fact that 1ES templates auto-inject component governance tasks in those builds anyway. That's something we might want to take another look at while we attempt to reduce pipeline runtime (cc @pragya91). If we can disable those tasks in PR builds we might still be ok, since our workflows currently care about the CG alerts once things have been merged, not the 
ones that come out of PR builds.

Of note, I don't expect this to reduce the runtime of our current builds because the explicit job runs in parallel to the build job. This just saves us wasted compute time; if anything, it increases the availability of small build agents by not using one unnecessarily.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).