### PR TITLE
fix(docs): Add missing folder in clean script

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
 		"ci:build": "npm run build",
 		"ci:linkcheck": "start-server-and-test ci:start 1313 linkcheck:full",
 		"ci:start": "http-server ./public --port 1313 --silent",
-		"clean": "rimraf --glob public content/docs/api _api-extractor-temp",
+		"clean": "rimraf --glob public content/docs/api _api-extractor-temp _doc-models",
 		"download:api": "node ./download-apis.js",
 		"format": "npm run prettier:fix",
 		"hugo": "hugo",


### PR DESCRIPTION
## Description

The build of docs/ generates a `_doc-models` folder that we don't track in git. This updates the `clean` script for that release group to also remove that folder.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
