### PR TITLE
tree: Improve and document use of "any" in BrandedMapSubset

### DIFF
--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -220,7 +220,7 @@ export interface AnchorNode extends UpPath<AnchorNode>, Listenable<AnchorEvents>
 	 * Allows access to data stored on the Anchor in "slots".
 	 * Use {@link anchorSlot} to create slots.
 	 */
-	// TODO: use something other than `any`
+	// See note on BrandedKey
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	readonly slots: BrandedMapSubset<AnchorSlot<any>>;
 
@@ -328,7 +328,7 @@ export class AnchorSet implements Listenable<AnchorSetRootEvents>, AnchorLocator
 	 * @privateRemarks
 	 * This forwards to the slots of the special above root anchor which locate can't access.
 	 */
-	// TODO: use something other than `any`
+	// See note on BrandedKey.
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	public get slots(): BrandedMapSubset<AnchorSlot<any>> {
 		return this.root.slots;
@@ -1142,7 +1142,7 @@ class PathNode extends ReferenceCountedBase implements UpPath<PathNode>, AnchorN
 	 */
 	public readonly children: Map<FieldKey, PathNode[]> = new Map();
 
-	// TODO: use something other than `any`
+	// See note on BrandedKey.
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	public readonly slots: BrandedMapSubset<AnchorSlot<any>> = new Map();
 

--- a/packages/dds/tree/src/test/util/brandedMap.spec.ts
+++ b/packages/dds/tree/src/test/util/brandedMap.spec.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	brandedSlot,
+	getOrCreateSlotContent,
+	type BrandedKey,
+	type BrandedMapSubset,
+	// Allow importing from this specific file which is being tested:
+	/* eslint-disable-next-line import/no-internal-modules */
+} from "../../util/brandedMap.js";
+import type { Brand, Opaque } from "../../util/index.js";
+
+// These tests currently just cover the type checking.
+
+describe("BrandedMap", () => {
+	it("basic use", () => {
+		//  See note on BrandedKey.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		type Key = BrandedKey<number, any>;
+		const m: BrandedMapSubset<Key> = new Map();
+		const keyA: BrandedKey<number, "A"> = brandedSlot();
+		// @ts-expect-error Wrong value type
+		m.set(keyA, "B");
+		m.set(keyA, "A");
+
+		// @ts-expect-error Wrong value type
+		const outBad = getOrCreateSlotContent(m, keyA, () => "B");
+		const out = getOrCreateSlotContent(m, keyA, () => "A");
+
+		const x: "A" | undefined = m.get(keyA);
+
+		// Generic access with `any` typed key is unsafe, but can't be prevented while being compatible with map.
+		m.set(keyA as Key, "B");
+		const x2: "B" | undefined = m.get<Key>(keyA);
+	});
+
+	// Example from BrandedMapSubset docs.
+	it("example", () => {
+		type FooSlot<TContent> = BrandedKey<Opaque<Brand<number, "FooSlot">>, TContent>;
+		const counterSlot = brandedSlot<FooSlot<number>>();
+		// See note on BrandedKey
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const slots: BrandedMapSubset<FooSlot<any>> = new Map();
+		slots.set(counterSlot, slots.get(counterSlot) ?? 0 + 1);
+	});
+});

--- a/packages/dds/tree/src/util/brandedMap.ts
+++ b/packages/dds/tree/src/util/brandedMap.ts
@@ -3,11 +3,16 @@
  * Licensed under the MIT License.
  */
 
+import type { Brand } from "./brand.js";
+import type { Opaque } from "./opaque.js";
 import type { Invariant } from "./typeCheck.js";
 import { getOrCreate } from "./utils.js";
 
 /**
  * Key in a {@link BrandedMapSubset}.
+ * @remarks
+ * Due to the `TContent` type parameter being invariant (which it has to be since keys are used to both read and write data),
+ * generic collections end up needing to constrain their key's `TContent` to `any`.
  * @internal
  */
 export type BrandedKey<TKey, TContent> = TKey & Invariant<TContent>;
@@ -49,16 +54,15 @@ export interface BrandedMapSubset<K extends BrandedKey<unknown, any>> {
 
 /**
  * Version of {@link getOrCreate} with better typing for {@link BrandedMapSubset}.
+ * @privateRemarks
+ * Only infers type from key to avoid inferring `any` from map's key.
  */
-export function getOrCreateSlotContent<
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	M extends BrandedMapSubset<BrandedKey<unknown, any>>,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	K extends BrandedKey<unknown, any>,
->(map: M, key: K, defaultValue: (key: K) => BrandedKeyContent<K>): BrandedKeyContent<K> {
-	const result: BrandedKeyContent<K> = getOrCreate(map, key, defaultValue);
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-	return result;
+export function getOrCreateSlotContent<K, V>(
+	map: NoInfer<BrandedMapSubset<BrandedKey<K, V>>>,
+	key: BrandedKey<K, V>,
+	defaultValue: NoInfer<(key: BrandedKey<K, V>) => V>,
+): V {
+	return getOrCreate<BrandedKey<K, V>, V>(map, key, defaultValue);
 }
 
 /**
@@ -72,7 +76,10 @@ let slotCounter = 0;
  * Define a strongly typed slot in which data can be stored in a {@link BrandedMapSubset}.
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function brandedSlot<TSlot extends BrandedKey<any, any>>(): TSlot {
+export function brandedSlot<
+	// See note on BrandedKey.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TSlot extends BrandedKey<number | Opaque<Brand<number, string>>, any>,
+>(): TSlot {
 	return slotCounter++ as TSlot;
 }


### PR DESCRIPTION
## Description

BrandedMapSubset is used internally inside tree, and ends up needing to use `any` do to its invariant value type.

This change adds tests, uses NoInfer to improve safety, and documents why any is used.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

