### PR TITLE
fix(version-tools): Fix comparison of 2.0 releases to RC builds

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import * as childProcess from "node:child_process";
 import * as fs from "node:fs";
 import { Flags } from "@oclif/core";
 
@@ -101,10 +100,12 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
 			this.error("Test build shouldn't be released");
 		}
 
+		const context = await this.getContext();
+		const tags = flags.tags ?? (await context.gitRepo.getAllTags());
+
 		if (!useSimplePatchVersion && flags.tag !== undefined) {
 			const tagName = `${flags.tag}_v${fileVersion}`;
-			const out = childProcess.execSync(`git tag -l ${tagName}`, { encoding: "utf8" });
-			if (out.trim() === tagName) {
+			if (tags.includes(tagName)) {
 				if (isRelease) {
 					this.error(`Tag ${tagName} already exists.`);
 				}
@@ -154,8 +155,6 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
 		this.log(`version=${version}`);
 		this.log(`##vso[task.setvariable variable=version;isOutput=true]${version}`);
 
-		const context = await this.getContext();
-		const tags = flags.tags ?? (await context.gitRepo.getAllTags());
 		if (flags.tag !== undefined) {
 			const isLatest = getIsLatest(
 				flags.tag,

--- a/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
+++ b/build-tools/packages/build-cli/test/commands/generate/buildVersion.test.ts
@@ -26,7 +26,7 @@ const test_tags = [
 	"client_v2.0.0-rc.3.0.0",
 	"client_v2.0.0-rc.4.0.0",
 	"client_v2.1.0",
-	"build-tools_v0.5.2002",
+	"build-tools_v0.5.2001",
 	"build-tools_v0.4.2001",
 	"client_v2.0.0-rc.6.0.0",
 	"build-tools_v0.4.1000",
@@ -390,8 +390,8 @@ describe("generate:buildVersion", () => {
 			"client_v2.0.0-internal.1.4.2",
 		])
 		.it("lts test case from 2022-10-13", (ctx) => {
-			stdoutLineEquals(ctx.stdout, 1, "version=1.3.0-100339");
-			stdoutLineEquals(ctx.stdout, 4, "isLatest=false");
+			stdoutLineEquals(ctx.stdout, 0, "version=1.3.0-100339");
+			stdoutLineEquals(ctx.stdout, 3, "isLatest=false");
 		});
 
 	test
@@ -470,10 +470,10 @@ describe("generate:buildVersion", () => {
 			VERSION_INCLUDE_INTERNAL_VERSIONS: "False",
 		})
 		.stdout()
-		.command(["generate:buildVersion", "--fileVersion", "2.0.0", "--tags", ...test_tags])
-		.it("2.0 version, release", (ctx) => {
-			stdoutLineEquals(ctx.stdout, 0, "version=2.0.0");
-			stdoutLineEquals(ctx.stdout, 3, "isLatest=false");
+		.command(["generate:buildVersion", "--fileVersion", "3.0.0", "--tags", ...test_tags])
+		.it("major version, release", (ctx) => {
+			stdoutLineEquals(ctx.stdout, 0, "version=3.0.0");
+			stdoutLineEquals(ctx.stdout, 3, "isLatest=true");
 		});
 
 	test
@@ -485,9 +485,9 @@ describe("generate:buildVersion", () => {
 			VERSION_INCLUDE_INTERNAL_VERSIONS: "False",
 		})
 		.stdout()
-		.command(["generate:buildVersion", "--fileVersion", "2.0.0", "--tags", ...test_tags])
-		.it("2.0 version, prerelease", (ctx) => {
-			stdoutLineEquals(ctx.stdout, 0, "version=2.0.0-212045");
+		.command(["generate:buildVersion", "--fileVersion", "3.0.0", "--tags", ...test_tags])
+		.it("major version, prerelease", (ctx) => {
+			stdoutLineEquals(ctx.stdout, 0, "version=3.0.0-212045");
 			stdoutLineEquals(ctx.stdout, 3, "isLatest=false");
 		});
 
@@ -500,8 +500,8 @@ describe("generate:buildVersion", () => {
 			VERSION_INCLUDE_INTERNAL_VERSIONS: "False",
 		})
 		.stdout()
-		.command(["generate:buildVersion", "--fileVersion", "2.0.0", "--tags", ...test_tags])
-		.it("2.0 version, test", (ctx) => {
+		.command(["generate:buildVersion", "--fileVersion", "3.0.0", "--tags", ...test_tags])
+		.it("major version, test", (ctx) => {
 			stdoutLineEquals(ctx.stdout, 2, "version=0.0.0-212045-test");
 			stdoutLineEquals(ctx.stdout, 5, "isLatest=false");
 		});

--- a/build-tools/packages/version-tools/src/semver.ts
+++ b/build-tools/packages/version-tools/src/semver.ts
@@ -121,18 +121,24 @@ export function detectBumpType(
 		v2PrereleaseId = prereleaseId;
 	}
 
+	const v2Scheme = detectVersionScheme(v2Parsed);
 	if (
-		v1PrereleaseId === DEFAULT_PRERELEASE_IDENTIFIER &&
-		v2PrereleaseId === RC_PRERELEASE_IDENTIFER
-	) {
 		// This is a special case for RC and internal builds. RC builds are always a
 		// major bump compared to an internal build.
+		(v1PrereleaseId === DEFAULT_PRERELEASE_IDENTIFIER &&
+			v2PrereleaseId === RC_PRERELEASE_IDENTIFER) ||
+		// This is a special case for RC and public semver builds. Semver releases with major >= 2
+		// are always major releases compared to RC builds.
+		(v1PrereleaseId === RC_PRERELEASE_IDENTIFER &&
+			v2Scheme === "semver" &&
+			v2Parsed.major >= 2)
+	) {
 		return "major";
 	}
 
 	if (v1PrereleaseId !== v2PrereleaseId) {
 		throw new Error(
-			`v1 prerelease ID: ${v1PrereleaseId} cannot be compared to v2 prerelease ID: ${v2PrereleaseId}`,
+			`v1 prerelease ID: '${v1PrereleaseId}' cannot be compared to v2 prerelease ID: '${v2PrereleaseId}'`,
 		);
 	}
 

--- a/build-tools/packages/version-tools/src/test/semver.test.ts
+++ b/build-tools/packages/version-tools/src/test/semver.test.ts
@@ -129,6 +129,18 @@ describe("semver", () => {
 		it("v1 is rc, v2 is rc", () => {
 			assert.equal(detectBumpType("2.0.0-rc.1.0.0", "2.0.0-rc.1.0.1"), "patch");
 		});
+
+		it("v1 is rc, v2 is semver with major < 1", () => {
+			assert.throws(() => detectBumpType("2.0.0-rc.5.0.0", "1.6.0"));
+		});
+
+		it("v1 is rc, v2 is semver with major === 2", () => {
+			assert.equal(detectBumpType("1.0.0-rc.5.0.0", "2.0.0"), "major");
+		});
+
+		it("v1 is rc, v2 is semver with major > 2", () => {
+			assert.equal(detectBumpType("1.0.0-rc.5.0.0", "3.0.0"), "major");
+		});
 	});
 
 	describe("internal version scheme ranges", () => {


### PR DESCRIPTION
With the 2.0.0 release, we now have semver releases that are compared with RC and internal build numbers. I have fixed the logic in version-tools to correctly treat RC -> 2.0 as a major bump.

I also updated the generate:buildVersion command to use the list of tags passed in for all logic. There was some code that checked for existing tags and it always used the in-repo tag list. Now, if a list of tags is passed in, it is used for all logic. The repo tags are only consulted when none are passed in.