### PR TITLE
build(client-tree): generate legacy API report

### DIFF
--- a/packages/dds/tree/.gitignore
+++ b/packages/dds/tree/.gitignore
@@ -54,3 +54,6 @@ temp_modules/
 # Fuzz test operation files
 **/fuzz/failures/**
 **/fuzz/successes/**
+
+# API report + node10 compat collateral
+internal-api-report.d.ts

--- a/packages/dds/tree/.npmignore
+++ b/packages/dds/tree/.npmignore
@@ -4,6 +4,9 @@ nyc
 src/test
 dist/test
 lib/test
+dist/tree.api-report.legacy.d.ts
+lib/tree.api-report.legacy.d.ts
+internal-api-report.d.ts
 **/_api-extractor-temp/**
 
 # These are large test files that we don't need to distribute.

--- a/packages/dds/tree/api-extractor.json
+++ b/packages/dds/tree/api-extractor.json
@@ -1,14 +1,4 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "../../../common/build/build-common/api-extractor-base.esm.no-legacy.json",
-	"compiler": {
-		// api-extractor has trouble with Node16 moduleResolution, but Bundler looks okay.
-		"overrideTsconfig": {
-			"$schema": "http://json.schemastore.org/tsconfig",
-			"extends": "./tsconfig.json",
-			"compilerOptions": {
-				"moduleResolution": "Bundler"
-			}
-		}
-	}
+	"extends": "../../../common/build/build-common/api-extractor-base.esm.current.json"
 }

--- a/packages/dds/tree/api-extractor/api-extractor-lint-legacy.cjs.json
+++ b/packages/dds/tree/api-extractor/api-extractor-lint-legacy.cjs.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
+	"mainEntryPointFilePath": "<projectFolder>/dist/tree.api-report.legacy.d.ts"
+}

--- a/packages/dds/tree/api-extractor/api-extractor-lint-legacy.esm.json
+++ b/packages/dds/tree/api-extractor/api-extractor-lint-legacy.esm.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/tree.api-report.legacy.d.ts"
+}

--- a/packages/dds/tree/api-extractor/api-extractor.legacy.json
+++ b/packages/dds/tree/api-extractor/api-extractor.legacy.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-base.esm.legacy.json",
+	"mainEntryPointFilePath": "<projectFolder>/lib/tree.api-report.legacy.d.ts"
+}

--- a/packages/dds/tree/api-report/tree.legacy.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.alpha.api.md
@@ -142,7 +142,7 @@ declare namespace InternalTypes {
         TreeArrayNodeBase,
         ScopedSchemaName,
         DefaultProvider,
-        typeNameSymbol_2 as typeNameSymbol,
+        typeNameSymbol,
         InsertableObjectFromSchemaRecord,
         ObjectFromSchemaRecord,
         FieldHasDefaultUnsafe,
@@ -247,10 +247,6 @@ type ObjectFromSchemaRecordUnsafe<T extends Unenforced<RestrictiveReadonlyRecord
 
 // @public
 export type Off = () => void;
-
-export { Range_2 as Range }
-
-export { Required_2 as Required }
 
 // @public
 export type RestrictiveReadonlyRecord<K extends symbol | string, T> = {
@@ -421,7 +417,7 @@ export interface TreeMapNodeUnsafe<T extends Unenforced<ImplicitAllowedTypes>> e
 export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
-    abstract get [typeNameSymbol_2](): string;
+    abstract get [typeNameSymbol](): string;
     protected constructor();
 }
 
@@ -482,7 +478,7 @@ export enum TreeStatus {
 }
 
 // @public @sealed
-export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable_2 {
+export interface TreeView<TSchema extends ImplicitFieldSchema> extends IDisposable {
     readonly compatibility: SchemaCompatibilityStatus;
     readonly events: Listenable<TreeViewEvents>;
     initialize(content: InsertableTreeFieldFromImplicitField<TSchema>): void;
@@ -506,7 +502,7 @@ export interface TreeViewEvents {
 }
 
 // @public
-const typeNameSymbol_2: unique symbol;
+const typeNameSymbol: unique symbol;
 
 // @public
 export type Unenforced<_DesiredExtendsConstraint> = unknown;
@@ -527,7 +523,7 @@ export type ValidateRecursiveSchema<T extends TreeNodeSchemaClass<string, NodeKi
 
 // @public @sealed
 export interface WithType<TName extends string = string> {
-    get [typeNameSymbol_2](): TName;
+    get [typeNameSymbol](): TName;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -42,36 +42,50 @@
 				"types": "./dist/index.d.ts",
 				"default": "./dist/index.js"
 			}
+		},
+		"./internal-api-report": {
+			"types": {
+				"legacy report": {
+					"import": "./lib/tree.api-report.legacy.d.ts",
+					"require": "./dist/tree.api-report.legacy.d.ts"
+				}
+			}
 		}
 	},
 	"main": "lib/index.js",
 	"types": "lib/public.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
-		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha legacy --outDir ./dist",
-		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha legacy --outDir ./lib --node10TypeCompat",
+		"api-extractor:commonjs": "flub generate entrypoints --outFileAlpha tree.api-report.legacy --outDir ./dist",
+		"api-extractor:esnext": "flub generate entrypoints --outFileAlpha tree.api-report.legacy --outDir ./lib --node10TypeCompat",
 		"bench": "mocha --timeout 999999 --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js",
 		"bench:profile": "mocha --v8-prof --v8-logfile=profile.log --v8-no-logfile-per-isolate --timeout 999999 --perfMode --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js && node --prof-process profile.log > profile.txt && rimraf profile.log && echo See results in profile.txt",
 		"build": "fluid-build . --task build",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
-		"build:docs": "api-extractor run --local",
+		"build:docs": "concurrently \"npm:build:docs:*\"",
+		"build:docs:current": "api-extractor run --local",
+		"build:docs:legacy": "api-extractor run --local --config api-extractor/api-extractor.legacy.json",
 		"build:esnext": "tsc --project ./tsconfig.json && copyfiles -f ../../../common/build/build-common/src/esm/package.json ./lib",
 		"build:genver": "gen-version",
 		"build:test": "npm run build:test:esm && npm run build:test:cjs",
 		"build:test:cjs": "fluid-tsc commonjs --project ./src/test/tsconfig.cjs.json",
 		"build:test:esm": "tsc --project ./src/test/tsconfig.json",
-		"check:are-the-types-wrong": "attw --pack .",
+		"check:are-the-types-wrong": "attw --pack . --exclude-entrypoints internal-api-report",
 		"check:biome": "biome check . --formatter-enabled=true",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
 		"check:exports:bundle-release-tags": "api-extractor run --config api-extractor/api-extractor-lint-bundle.json",
 		"check:exports:cjs:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.cjs.json",
+		"check:exports:cjs:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.cjs.json",
 		"check:exports:cjs:public": "api-extractor run --config api-extractor/api-extractor-lint-public.cjs.json",
 		"check:exports:esm:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.esm.json",
+		"check:exports:esm:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.esm.json",
 		"check:exports:esm:public": "api-extractor run --config api-extractor/api-extractor-lint-public.esm.json",
 		"check:format": "npm run check:biome",
 		"check:prettier": "prettier --check . --cache --ignore-path ../../../.prettierignore",
-		"ci:build:docs": "api-extractor run",
+		"ci:build:docs": "concurrently \"npm:ci:build:docs:*\"",
+		"ci:build:docs:current": "api-extractor run",
+		"ci:build:docs:legacy": "api-extractor run --config api-extractor/api-extractor.legacy.json",
 		"clean": "rimraf --glob dist lib \"*.d.ts\" \"**/*.tsbuildinfo\" \"**/*.build.log\" _api-extractor-temp nyc",
 		"depcruise": "depcruise src/ --ignore-known",
 		"depcruise:regen-known-issues": "depcruise-baseline src",


### PR DESCRIPTION
`tree` has no direct `/legacy` exports but does provide `SharedTree` to `fluid-framework`.

Setup a non-production legacy "roll up" file. Generate legacy API report and perform linting like packages with `/legacy` but using the faux "roll ups".

Additionally remove api-extractor tsconfig override that no longer appears to be required.