### PR TITLE
Remove TreeConfiguration and simplify schematizingTreeView

### DIFF
--- a/docs/content/docs/start/tutorial.md
+++ b/docs/content/docs/start/tutorial.md
@@ -36,7 +36,7 @@ The app creates Fluid containers using a schema that defines a set of *initial o
 Lastly, `root` defines the HTML element that the Dice will render on.
 
 ```js
-import { SharedTree, TreeConfiguration, SchemaFactory, Tree } from "fluid-framework";
+import { SharedTree, TreeViewConfiguration, SchemaFactory, Tree } from "fluid-framework";
 import { TinyliciousClient } from "@fluidframework/tinylicious-client";
 
 const client = new TinyliciousClient();

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -53,8 +53,6 @@ import {
 import type {
 	ITree,
 	ImplicitFieldSchema,
-	// eslint-disable-next-line import/no-deprecated
-	TreeConfiguration,
 	TreeView,
 	TreeViewConfiguration,
 } from "../simple-tree/index.js";
@@ -320,22 +318,6 @@ export class SharedTree
 			onDispose,
 			createNodeKeyManager(this.runtime.idCompressor),
 		);
-	}
-
-	public schematize<TRoot extends ImplicitFieldSchema>(
-		// eslint-disable-next-line import/no-deprecated
-		config: TreeConfiguration<TRoot>,
-	): TreeView<TRoot> {
-		const view = new SchematizingSimpleTreeView(
-			this.checkout,
-			config,
-			createNodeKeyManager(this.runtime.idCompressor),
-		);
-		// As a subjective API design choice, we initialize the tree here if it is not already initialized.
-		if (view.compatibility.canInitialize === true) {
-			view.initialize(config.initialTree());
-		}
-		return view;
 	}
 
 	public viewWith<TRoot extends ImplicitFieldSchema>(

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -7,7 +7,6 @@ export {
 	type ITree,
 	type TreeView,
 	type TreeViewEvents,
-	TreeConfiguration,
 	TreeViewConfiguration,
 	type ITreeViewConfiguration,
 	type SchemaCompatibilityStatus,
@@ -42,7 +41,7 @@ export {
 export { SchemaFactory, type ScopedSchemaName } from "./schemaFactory.js";
 export { getFlexNode } from "./proxyBinding.js";
 export { treeNodeApi, type TreeNodeApi, type TreeChangeEvents } from "./treeNodeApi.js";
-export { toFlexConfig, cursorFromUnhydratedRoot } from "./toFlexSchema.js";
+export { toFlexSchema, cursorFromUnhydratedRoot } from "./toFlexSchema.js";
 export type {
 	FieldHasDefaultUnsafe,
 	ObjectFromSchemaRecordUnsafe,

--- a/packages/dds/tree/src/simple-tree/toFlexSchema.ts
+++ b/packages/dds/tree/src/simple-tree/toFlexSchema.ts
@@ -27,7 +27,6 @@ import {
 	schemaIsLeaf,
 } from "../feature-libraries/index.js";
 import { normalizeFlexListEager } from "../feature-libraries/typed-schema/flexList.js";
-import type { TreeContent } from "../shared-tree/index.js";
 import { brand, fail, isReadonlyArray, mapIterable } from "../util/index.js";
 
 import type { InsertableContent } from "./proxies.js";
@@ -48,8 +47,6 @@ import {
 	getStoredKey,
 } from "./schemaTypes.js";
 import { cursorFromNodeData } from "./toMapTree.js";
-// eslint-disable-next-line import/no-deprecated
-import { TreeConfiguration, type TreeViewConfiguration } from "./tree.js";
 
 /**
  * Returns a cursor (in nodes mode) for the root node.
@@ -75,50 +72,6 @@ export function cursorFromUnhydratedRoot(
 			schemaValidationPolicy,
 		) ?? fail("failed to decode tree")
 	);
-}
-
-/* eslint-disable import/no-deprecated */
-function isTreeConfiguration(
-	config: TreeViewConfiguration | TreeConfiguration,
-): config is TreeConfiguration {
-	return config instanceof TreeConfiguration;
-}
-/* eslint-enable import/no-deprecated */
-
-/**
- * Generates a configuration object (schema + initial tree) for a FlexTree.
- * @param config - Configuration for how to {@link ITree.schematize|schematize} a tree.
- * @param nodeKeyManager - See {@link NodeKeyManager}.
- * @param schemaValidationPolicy - Stored schema and policy for the tree. If the policy specifies
- * `{@link SchemaPolicy.validateSchema} === true`, new content inserted into the tree will be validated using this
- * object.
- * @returns A configuration object for a FlexTree.
- *
- * @privateremarks
- * I wrote these docs without a ton of context, they can probably be improved.
- */
-export function toFlexConfig(
-	// eslint-disable-next-line import/no-deprecated
-	config: TreeViewConfiguration | TreeConfiguration,
-	nodeKeyManager: NodeKeyManager,
-	schemaValidationPolicy: SchemaAndPolicy | undefined = undefined,
-): TreeContent {
-	const unhydrated = isTreeConfiguration(config) ? config.initialTree() : undefined;
-	const initialTree =
-		unhydrated === undefined
-			? undefined
-			: [
-					cursorFromUnhydratedRoot(
-						config.schema,
-						unhydrated,
-						nodeKeyManager,
-						schemaValidationPolicy,
-					),
-				];
-	return {
-		schema: toFlexSchema(config.schema),
-		initialTree,
-	};
 }
 
 interface SchemaInfo {

--- a/packages/dds/tree/src/simple-tree/tree.ts
+++ b/packages/dds/tree/src/simple-tree/tree.ts
@@ -134,43 +134,6 @@ export class TreeViewConfiguration<TSchema extends ImplicitFieldSchema = Implici
 }
 
 /**
- * Configuration for how to {@link ITree.schematize | schematize} a tree.
- * @sealed @public
- * @deprecated Please migrate to use {@link TreeViewConfiguration} with {@link ITree.viewWith} instead.
- */
-export class TreeConfiguration<TSchema extends ImplicitFieldSchema = ImplicitFieldSchema> {
-	/**
-	 * If `true`, the tree will validate new content against its stored schema at insertion time
-	 * and throw an error if the new content doesn't match the expected schema.
-	 *
-	 * @defaultValue `false`.
-	 *
-	 * @remarks Enabling schema validation has a performance penalty when inserting new content into the tree because
-	 * additional checks are done. Enable this option only in scenarios where you are ok with that operation being a
-	 * bit slower.
-	 */
-	public readonly enableSchemaValidation: boolean;
-
-	/**
-	 * @param schema - The schema which the application wants to view the tree with.
-	 * @param initialTree - A function that returns the default tree content to initialize the tree with iff the tree is uninitialized
-	 * (meaning it does not even have any schema set at all).
-	 * If `initialTree` returns any actual node instances, they should be recreated each time `initialTree` runs.
-	 * This is because if the config is used a second time any nodes that were not recreated could error since nodes cannot be inserted into the tree multiple times.
-	 * @param options - Additional options that can be specified when {@link ITree.schematize | schematizing } a tree.
-	 */
-	public constructor(
-		public readonly schema: TSchema,
-		public readonly initialTree: () => InsertableTreeFieldFromImplicitField<TSchema>,
-		options?: ITreeConfigurationOptions,
-	) {
-		this.enableSchemaValidation =
-			options?.enableSchemaValidation ??
-			defaultTreeConfigurationOptions.enableSchemaValidation;
-	}
-}
-
-/**
  * An editable view of a (version control style) branch of a shared tree based on some schema.
  *
  * This schema--known as the view schema--may or may not align the stored schema of the document.


### PR DESCRIPTION
## Description

Removes the implementation of several APIs that were removed from the public API in #21430. This allows some simplification in other bits of code (e.g. removal of `toFlexConfig`).
