### PR TITLE
Enable noUncheckedIndexedAccess for Driver Base

### DIFF
--- a/packages/drivers/driver-base/src/driverUtils.ts
+++ b/packages/drivers/driver-base/src/driverUtils.ts
@@ -133,10 +133,10 @@ export function validateMessages(
 				let validOpsCount = 1;
 				while (
 					validOpsCount < messages.length &&
-					// Why are we non null asserting here
+					// TODO Why are we non null asserting here
 					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 					messages[validOpsCount]!.sequenceNumber ===
-						// Why are we non null asserting here
+						// TODO Why are we non null asserting here
 						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 						messages[validOpsCount - 1]!.sequenceNumber + 1
 				) {

--- a/packages/drivers/driver-base/src/driverUtils.ts
+++ b/packages/drivers/driver-base/src/driverUtils.ts
@@ -117,9 +117,13 @@ export function validateMessages(
 	strict: boolean = true,
 ) {
 	if (messages.length !== 0) {
-		const start = messages[0].sequenceNumber;
+		// Non null asserting here because of the length check above
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const start = messages[0]!.sequenceNumber;
 		const length = messages.length;
-		const last = messages[length - 1].sequenceNumber;
+		// Non null asserting here because of the length check above
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const last = messages[length - 1]!.sequenceNumber;
 		if (last + 1 !== from + length) {
 			// If not strict, then return the first consecutive sub-block. If strict or start
 			// seq number is not what we expected, then return no ops.
@@ -129,8 +133,12 @@ export function validateMessages(
 				let validOpsCount = 1;
 				while (
 					validOpsCount < messages.length &&
-					messages[validOpsCount].sequenceNumber ===
-						messages[validOpsCount - 1].sequenceNumber + 1
+					// Why are we non null asserting here
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					messages[validOpsCount]!.sequenceNumber ===
+						// Why are we non null asserting here
+						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+						messages[validOpsCount - 1]!.sequenceNumber + 1
 				) {
 					validOpsCount++;
 				}
@@ -146,7 +154,11 @@ export function validateMessages(
 				details: JSON.stringify({
 					validLength: messages.length,
 					lastValidOpSeqNumber:
-						messages.length > 0 ? messages[messages.length - 1].sequenceNumber : undefined,
+						messages.length > 0
+							? // Non null asserting here because of the length check
+								// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+								messages[messages.length - 1]!.sequenceNumber
+							: undefined,
 					strict,
 				}),
 			});

--- a/packages/drivers/driver-base/tsconfig.json
+++ b/packages/drivers/driver-base/tsconfig.json
@@ -6,6 +6,5 @@
 		"rootDir": "./src",
 		"outDir": "./lib",
 		"exactOptionalPropertyTypes": false,
-		"noUncheckedIndexedAccess": false,
 	},
 }


### PR DESCRIPTION
Enable noUncheckedIndexedAccess for Driver Base
We are enabling `noUncheckedIndexedAccess` to protect us from changing a type of a record where there was a named property and reduce the risk of runtime errors by ensuring that indexed access on objects are properly checked for undefined values.

Arrays are impacted by this and must be annotated even though it is not the reason for using the setting

[AB#8216](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8216)