### PR TITLE
Enable noUncheckedIndexedAccess for Driver Web Cache

### DIFF
--- a/packages/drivers/driver-web-cache/src/scheduleIdleTask.ts
+++ b/packages/drivers/driver-web-cache/src/scheduleIdleTask.ts
@@ -71,7 +71,8 @@ function runTasks(
 			break;
 		}
 
-		const taskQueueItem = taskQueue[index];
+		// Non null asserting here because we are iterating though taskQueue
+		const taskQueueItem = taskQueue[index]!;
 
 		if (filter && !filter(taskQueueItem)) {
 			newTaskQueue.push(taskQueueItem);

--- a/packages/drivers/driver-web-cache/tsconfig.json
+++ b/packages/drivers/driver-web-cache/tsconfig.json
@@ -7,6 +7,5 @@
 		"outDir": "./lib",
 		"skipLibCheck": true,
 		"exactOptionalPropertyTypes": false,
-		"noUncheckedIndexedAccess": false,
 	},
 }


### PR DESCRIPTION
Enable noUncheckedIndexedAccess for Driver Web Cache
We are enabling `noUncheckedIndexedAccess` to protect us from changing a type of a record where there was a named property and reduce the risk of runtime errors by ensuring that indexed access on objects are properly checked for undefined values.

Arrays are impacted by this and must be annotated even though it is not the reason for using the setting

[AB#8216](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8216)