### PR TITLE
fix(tree): fix move validation bugs

### DIFF
--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -791,7 +791,8 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 	): void {
 		const sourceArray = source ?? this;
 		const sourceField = getSequenceField(sourceArray);
-		validateIndex(destinationIndex, this, "moveToIndex", true);
+		const destinationField = getSequenceField(this);
+		validateIndex(destinationIndex, destinationField, "moveToIndex", true);
 		validateIndex(sourceIndex, sourceField, "moveToIndex");
 		this.moveRangeToIndex(destinationIndex, sourceIndex, sourceIndex + 1, source);
 	}

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -774,22 +774,26 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 	}
 	public moveToStart(sourceIndex: number, source?: TreeArrayNode): void {
 		const sourceArray = source ?? this;
-		const field = getSequenceField(sourceArray);
-		validateIndex(sourceIndex, field, "moveToStart");
+		const sourceField = getSequenceField(sourceArray);
+		validateIndex(sourceIndex, sourceField, "moveToStart");
 		this.moveRangeToIndex(0, sourceIndex, sourceIndex + 1, source);
 	}
 	public moveToEnd(sourceIndex: number, source?: TreeArrayNode): void {
 		const sourceArray = source ?? this;
-		const field = getSequenceField(sourceArray);
-		validateIndex(sourceIndex, field, "moveToEnd");
+		const sourceField = getSequenceField(sourceArray);
+		validateIndex(sourceIndex, sourceField, "moveToEnd");
 		this.moveRangeToIndex(this.length, sourceIndex, sourceIndex + 1, source);
 	}
-	public moveToIndex(index: number, sourceIndex: number, source?: TreeArrayNode): void {
+	public moveToIndex(
+		destinationIndex: number,
+		sourceIndex: number,
+		source?: TreeArrayNode,
+	): void {
 		const sourceArray = source ?? this;
-		const field = getSequenceField(sourceArray);
-		validateIndex(index, field, "moveToIndex", true);
-		validateIndex(sourceIndex, field, "moveToIndex");
-		this.moveRangeToIndex(index, sourceIndex, sourceIndex + 1, source);
+		const sourceField = getSequenceField(sourceArray);
+		validateIndex(destinationIndex, this, "moveToIndex", true);
+		validateIndex(sourceIndex, sourceField, "moveToIndex");
+		this.moveRangeToIndex(destinationIndex, sourceIndex, sourceIndex + 1, source);
 	}
 	public moveRangeToStart(
 		sourceStart: number,
@@ -814,27 +818,27 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		this.moveRangeToIndex(this.length, sourceStart, sourceEnd, source);
 	}
 	public moveRangeToIndex(
-		index: number,
+		destinationIndex: number,
 		sourceStart: number,
 		sourceEnd: number,
 		source?: TreeArrayNode,
 	): void {
-		const field = getSequenceField(this);
-		validateIndex(index, field, "moveRangeToIndex", true);
-		validateIndexRange(sourceStart, sourceEnd, source ?? field, "moveRangeToIndex");
+		const destinationField = getSequenceField(this);
+		validateIndex(destinationIndex, destinationField, "moveRangeToIndex", true);
+		validateIndexRange(sourceStart, sourceEnd, source ?? destinationField, "moveRangeToIndex");
 		const sourceField =
 			source !== undefined
-				? field.isSameAs(getSequenceField(source))
-					? field
+				? destinationField.isSameAs(getSequenceField(source))
+					? destinationField
 					: getSequenceField(source)
-				: field;
+				: destinationField;
 
 		// TODO: determine support for move across different sequence types
-		if (field.schema.types !== undefined && sourceField !== field) {
+		if (destinationField.schema.types !== undefined && sourceField !== destinationField) {
 			for (let i = sourceStart; i < sourceEnd; i++) {
 				const sourceNode =
 					sourceField.boxedAt(sourceStart) ?? fail("impossible out of bounds index");
-				if (!field.schema.types.has(sourceNode.schema.name)) {
+				if (!destinationField.schema.types.has(sourceNode.schema.name)) {
 					throw new Error("Type in source sequence is not allowed in destination.");
 				}
 			}
@@ -842,13 +846,13 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		const movedCount = sourceEnd - sourceStart;
 		const sourceFieldPath = sourceField.getFieldPath();
 
-		const destinationFieldPath = field.getFieldPath();
-		field.context.checkout.editor.move(
+		const destinationFieldPath = destinationField.getFieldPath();
+		destinationField.context.checkout.editor.move(
 			sourceFieldPath,
 			sourceStart,
 			movedCount,
 			destinationFieldPath,
-			index,
+			destinationIndex,
 		);
 	}
 }

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -837,10 +837,9 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		// TODO: determine support for move across different sequence types
 		if (destinationField.schema.types !== undefined && sourceField !== destinationField) {
 			for (let i = sourceStart; i < sourceEnd; i++) {
-				const sourceNode =
-					sourceField.boxedAt(sourceStart) ?? fail("impossible out of bounds index");
+				const sourceNode = sourceField.boxedAt(i) ?? fail("impossible out of bounds index");
 				if (!destinationField.schema.types.has(sourceNode.schema.name)) {
-					throw new Error("Type in source sequence is not allowed in destination.");
+					throw new UsageError("Type in source sequence is not allowed in destination.");
 				}
 			}
 		}

--- a/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
@@ -485,6 +485,20 @@ describe("ArrayNode", () => {
 				assert.deepEqual([...array], []);
 			});
 
+			it("invalid content type", () => {
+				const schema = schemaFactory.object("parent", {
+					array1: schemaFactory.array([schemaFactory.number, schemaFactory.string]),
+					array2: schemaFactory.array(schemaFactory.number),
+				});
+				const { array1, array2 } = hydrate(schema, { array1: [1, "bad", 2], array2: [] });
+				const expected = validateUsageError(
+					/Type in source sequence is not allowed in destination./,
+				);
+				assert.throws(() => array2.moveRangeToIndex(0, 1, 3, array1), expected);
+				assert.throws(() => array2.moveRangeToIndex(0, 0, 2, array1), expected);
+				assert.throws(() => array2.moveRangeToIndex(0, 0, 3, array1), expected);
+			});
+
 			it("invalid index", () => {
 				const array = hydrate(schemaType, [1, 2, 3]);
 				// Destination index too large


### PR DESCRIPTION
## Description

This PR fixes a bug (introduced in [this PR](https://github.com/microsoft/FluidFramework/commit/bd66bafa0f9cc2fe79731c67ac008fb9232f9f4d)) where the validation for the destination index was being done against the source array. Also renames `index` to `destinationIndex`, and `field` to `sourceField` and `destinationField` for clarity

Also fixes the type validation for moved content.