### PR TITLE
tree: Remove or document some usages of any in tests

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -957,7 +957,11 @@ export interface FlexTreeSequenceField<in out TTypes extends FlexAllowedTypes>
 		index: number,
 		sourceStart: number,
 		sourceEnd: number,
-		source: FlexTreeSequenceField<FlexAllowedTypes>,
+		// FlexTreeSequenceField is invariant over its schema so any is required here.
+		// This use of any can ve removed by migrating off this deprecated API and deleting it.
+		// If kept, this function should be fixed by making it generic and constraining it to fields which are safe to move content from.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		source: FlexTreeSequenceField<any>,
 	): void;
 
 	// #endregion

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -958,7 +958,7 @@ export interface FlexTreeSequenceField<in out TTypes extends FlexAllowedTypes>
 		sourceStart: number,
 		sourceEnd: number,
 		// FlexTreeSequenceField is invariant over its schema so any is required here.
-		// This use of any can ve removed by migrating off this deprecated API and deleting it.
+		// This use of any can be removed by migrating off this deprecated API and deleting it.
 		// If kept, this function should be fixed by making it generic and constraining it to fields which are safe to move content from.
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		source: FlexTreeSequenceField<any>,

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -57,6 +57,10 @@ import { SchemaFactory, TreeConfiguration, toFlexConfig } from "../../../simple-
 // eslint-disable-next-line import/no-internal-modules
 import { toFlexSchema } from "../../../simple-tree/toFlexSchema.js";
 import { SummaryType } from "@fluidframework/driver-definitions";
+// eslint-disable-next-line import/no-internal-modules
+import type { Format } from "../../../feature-libraries/forest-summary/format.js";
+// eslint-disable-next-line import/no-internal-modules
+import type { EncodedFieldBatch } from "../../../feature-libraries/chunked-forest/index.js";
 
 const options = {
 	jsonValidator: typeboxValidator,
@@ -157,6 +161,8 @@ describe("End to end chunked encoding", () => {
 		assert(chunk.isShared());
 	});
 
+	// This test (and the one below) ate testing for an optimization in the decoding logic to save a copy of the data array.
+	// This optimization is not implemented, so these tests fail, and are skipped.
 	it.skip(`summary values are correct, and shares reference with the original chunk when inserting content.`, () => {
 		const numberShape = new TreeShape(leaf.number.name, true, []);
 		const chunk = new UniformChunk(numberShape.withTopLevelLength(4), [1, 2, 3, 4]);
@@ -179,9 +185,7 @@ describe("End to end chunked encoding", () => {
 
 		// This function is declared in the test to have access to the original uniform chunk for comparison.
 		function stringifier(content: unknown) {
-			// TODO: use something other than `any`
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const insertedChunk = decode((content as any).fields, {
+			const insertedChunk = decode((content as Format).fields as EncodedFieldBatch, {
 				idCompressor,
 				originatorId: idCompressor.localSessionId,
 			});
@@ -192,6 +196,7 @@ describe("End to end chunked encoding", () => {
 		forestSummarizer.getAttachSummary(stringifier);
 	});
 
+	// See note on above test.
 	it.skip(`summary values are correct, and shares reference with the original chunk when initializing with content.`, () => {
 		const numberShape = new TreeShape(leaf.number.name, true, []);
 		const chunk = new UniformChunk(numberShape.withTopLevelLength(4), [1, 2, 3, 4]);
@@ -213,9 +218,7 @@ describe("End to end chunked encoding", () => {
 
 		// This function is declared in the test to have access to the original uniform chunk for comparison.
 		function stringifier(content: unknown) {
-			// TODO: use something other than `any`
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const insertedChunk = decode((content as any).fields, {
+			const insertedChunk = decode((content as Format).fields as EncodedFieldBatch, {
 				idCompressor,
 				originatorId: idCompressor.localSessionId,
 			});

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -161,7 +161,7 @@ describe("End to end chunked encoding", () => {
 		assert(chunk.isShared());
 	});
 
-	// This test (and the one below) ate testing for an optimization in the decoding logic to save a copy of the data array.
+	// This test (and the one below) are testing for an optimization in the decoding logic to save a copy of the data array.
 	// This optimization is not implemented, so these tests fail, and are skipped.
 	it.skip(`summary values are correct, and shares reference with the original chunk when inserting content.`, () => {
 		const numberShape = new TreeShape(leaf.number.name, true, []);

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
@@ -61,9 +61,10 @@ describe("EditManager - Bench", () => {
 			.insert(0, singleJsonCursor(1));
 	};
 
-	// TODO: use something other than `any`
+	// Family is invariant over the change type, so using any is required to write generic Family processing code.
+	// Refactors to make this more type safe are possible for some usages (ex: extracting a non generic base interface), but are not practical for the tests here.
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const families: Family<any>[] = [
+	const families: readonly Family<any>[] = [
 		{
 			name: "TestChange",
 			changeFamily: testChangeFamilyFactory(new NoOpChangeRebaser()),

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -23,6 +23,7 @@ import {
 	intoStoredSchema,
 	type FlexAllowedTypes,
 	type FlexibleNodeContent,
+	type Any,
 } from "../../../feature-libraries/index.js";
 import type { SharedTreeFactory } from "../../../shared-tree/index.js";
 import { brand, fail } from "../../../util/index.js";
@@ -156,9 +157,7 @@ export function applyFieldEdit(tree: FuzzView, fieldEdit: FieldEdit): void {
 
 function applySequenceFieldEdit(
 	tree: FuzzView,
-	// TODO: use something other than `any`
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	field: FlexTreeSequenceField<any>,
+	field: FlexTreeSequenceField<readonly [Any]>,
 	change: Insert | Remove | IntraFieldMove | CrossFieldMove,
 ): void {
 	switch (change.type) {
@@ -194,9 +193,7 @@ function applySequenceFieldEdit(
 
 function applyRequiredFieldEdit(
 	tree: FuzzView,
-	// TODO: use something other than `any`
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	field: FlexTreeRequiredField<any>,
+	field: FlexTreeRequiredField<readonly [Any]>,
 	change: SetField,
 ): void {
 	switch (change.type) {
@@ -213,9 +210,7 @@ function applyRequiredFieldEdit(
 
 function applyOptionalFieldEdit(
 	tree: FuzzView,
-	// TODO: use something other than `any`
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	field: FlexTreeOptionalField<any>,
+	field: FlexTreeOptionalField<readonly [Any]>,
 	change: SetField | ClearField,
 ): void {
 	switch (change.type) {


### PR DESCRIPTION
## Description

Cleanup `any` related TODO's in tests.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

