### PR TITLE
Fix bug for No context for Op

### DIFF
--- a/packages/drivers/odsp-driver/src/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createNewUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { Uint8ArrayToString, stringToBuffer } from "@fluid-internal/client-utils";
-import { unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
 import {
 	ISummaryBlob,
 	ISummaryTree,
@@ -149,6 +149,7 @@ function convertSummaryToSnapshotTreeForCreateNew(summary: ISummaryTree): IOdspS
 
 	const keys = Object.keys(summary.tree);
 	for (const key of keys) {
+		assert(!key.includes("/"), "id should not include slashes");
 		const summaryObject = summary.tree[key];
 
 		let value: OdspSummaryTreeValue;
@@ -188,7 +189,7 @@ function convertSummaryToSnapshotTreeForCreateNew(summary: ISummaryTree): IOdspS
 		}
 
 		const entry: OdspSummaryTreeEntry = {
-			path: encodeURIComponent(key),
+			path: key,
 			type: getGitType(summaryObject),
 			value,
 			unreferenced,

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -231,7 +231,7 @@ export class OdspDriverUrlResolver implements IUrlResolver {
 	}
 }
 
-function decodeOdspUrl(url: string): {
+export function decodeOdspUrl(url: string): {
 	siteUrl: string;
 	driveId: string;
 	itemId: string;

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -90,7 +90,7 @@ function decodeOdspFluidDataStoreLocator(
 
 	let siteUrl: URL | undefined;
 	try {
-		siteUrl = new URL(sitePath, siteOriginUrl);
+		siteUrl = new URL(decodeURIComponent(sitePath), siteOriginUrl);
 	} catch {
 		// Ignore failure to parse url as input might be malformed
 	}
@@ -101,13 +101,15 @@ function decodeOdspFluidDataStoreLocator(
 
 	return {
 		siteUrl: siteUrl.href,
-		driveId,
-		itemId,
-		dataStorePath,
-		appName,
-		containerPackageName,
-		fileVersion,
-		context,
+		driveId: decodeURIComponent(driveId),
+		itemId: decodeURIComponent(itemId),
+		dataStorePath: decodeURIComponent(dataStorePath),
+		appName: appName ? decodeURIComponent(appName) : appName,
+		containerPackageName: containerPackageName
+			? decodeURIComponent(containerPackageName)
+			: containerPackageName,
+		fileVersion: fileVersion ? decodeURIComponent(fileVersion) : fileVersion,
+		context: context ? decodeURIComponent(context) : context,
 	};
 }
 

--- a/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
+++ b/packages/drivers/odsp-driver/src/odspFluidFileLink.ts
@@ -90,7 +90,7 @@ function decodeOdspFluidDataStoreLocator(
 
 	let siteUrl: URL | undefined;
 	try {
-		siteUrl = new URL(decodeURIComponent(sitePath), siteOriginUrl);
+		siteUrl = new URL(sitePath, siteOriginUrl);
 	} catch {
 		// Ignore failure to parse url as input might be malformed
 	}
@@ -101,15 +101,13 @@ function decodeOdspFluidDataStoreLocator(
 
 	return {
 		siteUrl: siteUrl.href,
-		driveId: decodeURIComponent(driveId),
-		itemId: decodeURIComponent(itemId),
-		dataStorePath: decodeURIComponent(dataStorePath),
-		appName: appName ? decodeURIComponent(appName) : appName,
-		containerPackageName: containerPackageName
-			? decodeURIComponent(containerPackageName)
-			: containerPackageName,
-		fileVersion: fileVersion ? decodeURIComponent(fileVersion) : fileVersion,
-		context: context ? decodeURIComponent(context) : context,
+		driveId,
+		itemId,
+		dataStorePath,
+		appName,
+		containerPackageName,
+		fileVersion,
+		context,
 	};
 }
 

--- a/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/odspSnapshotParser.ts
@@ -38,10 +38,10 @@ function buildHierarchy(flatTree: IOdspSnapshotCommit): ISnapshotTree {
 				unreferenced: entry.unreferenced,
 				groupId: entry.groupId,
 			};
-			node.trees[decodeURIComponent(entryPathBase)] = newTree;
+			node.trees[entryPathBase] = newTree;
 			lookup[entry.path] = newTree;
 		} else if (entry.type === "blob") {
-			node.blobs[decodeURIComponent(entryPathBase)] = entry.id;
+			node.blobs[entryPathBase] = entry.id;
 		}
 	}
 

--- a/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
+++ b/packages/drivers/odsp-driver/src/odspSummaryUploadManager.ts
@@ -179,6 +179,7 @@ export class OdspSummaryUploadManager {
 		let blobs = 0;
 		const keys = Object.keys(tree.tree);
 		for (const key of keys) {
+			assert(!key.includes("/"), "id should not include slashes");
 			const summaryObject = tree.tree[key];
 
 			let id: string | undefined;
@@ -243,7 +244,7 @@ export class OdspSummaryUploadManager {
 			}
 
 			const baseEntry: IOdspSummaryTreeBaseEntry = {
-				path: encodeURIComponent(key),
+				path: key,
 				type: getGitType(summaryObject),
 			};
 

--- a/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverResolverTest.spec.ts
@@ -11,7 +11,8 @@ import { IOdspResolvedUrl } from "@fluidframework/odsp-driver-definitions/intern
 
 import { createOdspCreateContainerRequest } from "../createOdspCreateContainerRequest.js";
 import { createOdspUrl } from "../createOdspUrl.js";
-import { OdspDriverUrlResolver } from "../odspDriverUrlResolver.js";
+import { OdspDriverUrlResolver, decodeOdspUrl } from "../odspDriverUrlResolver.js";
+import { getLocatorFromOdspUrl, storeLocatorInOdspUrl } from "../odspFluidFileLink.js";
 import { getHashedDocumentId } from "../odspPublicUtils.js";
 
 describe("Odsp Driver Resolver", () => {
@@ -358,7 +359,7 @@ describe("Odsp Driver Resolver", () => {
 	it("Should resolve url with special characters", async () => {
 		// Arrange
 		const testFilePath = "data1/data2/!@$";
-		const itemId = "item!@$";
+		const itemId = "item! @$";
 		const testRequest: IRequest = {
 			url: `${siteUrl}?driveId=${driveId}&path=${testFilePath}&itemId=${itemId}`,
 		};
@@ -385,6 +386,32 @@ describe("Odsp Driver Resolver", () => {
 		const expectedResolvedUrl =
 			`https://placeholder/placeholder/${resolvedUrl.hashedDocumentId}/` + `${testFilePath}`;
 		assert.strictEqual(resolvedUrl.url, expectedResolvedUrl, "resolved url is wrong");
+	});
+
+	it("Should resolve url with URI encodable characters", async () => {
+		const itemId = "item /";
+		const driveId1 = "driveId {}[] ";
+		const encodedUrl = createOdspUrl({
+			siteUrl,
+			driveId: driveId1,
+			itemId,
+			dataStorePath: "",
+		});
+		const decodedOdspUrl = decodeOdspUrl(encodedUrl);
+		assert.strictEqual(itemId, decodedOdspUrl.itemId, "itemid should match");
+		assert.strictEqual(driveId1, decodedOdspUrl.driveId, "driveId should match");
+
+		const testUrl = new URL(siteUrl);
+		storeLocatorInOdspUrl(testUrl, {
+			driveId: driveId1,
+			itemId,
+			siteUrl,
+			dataStorePath: "",
+		});
+		const decodedUrlLocator = getLocatorFromOdspUrl(testUrl);
+		assert(decodedUrlLocator !== undefined, "locator should be present");
+		assert.strictEqual(itemId, decodedUrlLocator.itemId, "itemid should match in locator");
+		assert.strictEqual(driveId1, decodedUrlLocator.driveId, "driveId should match in locator");
 	});
 
 	it("resolves urls with datastore path in url path", async () => {

--- a/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspDriverUrlResolverForShareLink.spec.ts
@@ -218,6 +218,39 @@ describe("Tests for OdspDriverUrlResolverForShareLink resolver", () => {
 		return assert.strictEqual(actualShareLink, undefined, "Sharing link should be undefined");
 	});
 
+	it("Should resolve url with special characters", async () => {
+		const testUrl = new URL("https://microsoft.sharepoint-df.com/test");
+		const dataStorePathWithSpecialChars = "data/Store Path";
+		storeLocatorInOdspUrl(testUrl, {
+			driveId,
+			itemId,
+			siteUrl,
+			dataStorePath: dataStorePathWithSpecialChars,
+		});
+		const runTest = async (resolver: OdspDriverUrlResolverForShareLink): Promise<void> => {
+			const resolvedUrl = await resolver.resolve({ url: testUrl.href });
+			assert.strictEqual(resolvedUrl.driveId, driveId, "Drive id should be equal");
+			assert.strictEqual(resolvedUrl.siteUrl, siteUrl, "SiteUrl should be equal");
+			assert.strictEqual(resolvedUrl.itemId, itemId, "Item id should be equal");
+			assert.strictEqual(
+				resolvedUrl.dataStorePath,
+				dataStorePathWithSpecialChars,
+				"dataStorePath should be equal",
+			);
+			assert.strictEqual(
+				resolvedUrl.hashedDocumentId,
+				await getHashedDocumentId(driveId, itemId),
+				"Doc id should be equal",
+			);
+			assert(
+				resolvedUrl.endpoints.snapshotStorageUrl !== undefined,
+				"Snapshot url should not be empty",
+			);
+		};
+		await runTest(urlResolverWithShareLinkFetcher);
+		await runTest(urlResolverWithoutShareLinkFetcher);
+	});
+
 	it("getAbsoluteUrl - Should generate sharelink if none was generated on resolve", async () => {
 		const absoluteUrl = await mockGetFileLink(Promise.resolve(sharelink), async () => {
 			return urlResolverWithShareLinkFetcher.getAbsoluteUrl(mockResolvedUrl, dataStorePath);

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -16,7 +16,6 @@ import type { ISharedCell } from "@fluidframework/cell/internal";
 import { AttachState } from "@fluidframework/container-definitions";
 import {
 	IContainer,
-	type ICriticalContainerError,
 	type IFluidCodeDetails,
 } from "@fluidframework/container-definitions/internal";
 import { Loader } from "@fluidframework/container-loader/internal";
@@ -26,7 +25,7 @@ import {
 	IdCompressorMode,
 } from "@fluidframework/container-runtime/internal";
 import { IFluidHandle, IRequest } from "@fluidframework/core-interfaces";
-import { Deferred, delay } from "@fluidframework/core-utils/internal";
+import { delay } from "@fluidframework/core-utils/internal";
 import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 import { ISummaryTree } from "@fluidframework/driver-definitions";
 import { type ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";

--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -11,7 +11,6 @@ import {
 	ITestDataObject,
 	TestDataObjectType,
 	describeCompat,
-	itExpects,
 } from "@fluid-private/test-version-utils";
 import type { ISharedCell } from "@fluidframework/cell/internal";
 import { AttachState } from "@fluidframework/container-definitions";
@@ -1164,13 +1163,6 @@ describeCompat(
 			(provider as any)._documentServiceFactory = undefined;
 
 			const container2 = await provider.loadContainer(runtimeFactory);
-
-			const closeErrorWait = new Deferred<void>();
-			let closeError: ICriticalContainerError | undefined;
-			container2.on("closed", (error?: ICriticalContainerError) => {
-				closeError = error;
-				closeErrorWait.resolve();
-			});
 
 			await provider.ensureSynchronized();
 


### PR DESCRIPTION
## Breaking Changes

[ADO item link](https://dev.azure.com/fluidframework/internal/_workitems/edit/7045)

The issue was that we were encoding the ids of datastores/ddses when uploading the summary while on the snapshot download path for binary snapshot we were decoding them. Previously, when we were not using short ids, the encoded ids were same as original ids as they did not contain special characters, so we never faced this issue before. With the usage of short ids, we discovered this long-hidden bug for ODSP.
Also, enabled the e2e tests which were written to reproduce the scenario.