### PR TITLE
Move connected state from IMigratableModel to MigrationTool

### DIFF
--- a/examples/utils/example-utils/src/index.ts
+++ b/examples/utils/example-utils/src/index.ts
@@ -24,7 +24,6 @@ export type {
 	IAcceptedMigrationDetails,
 	IImportExportModel,
 	IMigratableModel,
-	IMigratableModelEvents,
 	IMigrationTool,
 	IMigrationToolEvents,
 	IMigrator,

--- a/examples/utils/example-utils/src/migrationInterfaces/index.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/index.ts
@@ -6,7 +6,6 @@
 export {
 	IImportExportModel,
 	IMigratableModel,
-	IMigratableModelEvents,
 	IVersionedModel,
 } from "./migratableModel.js";
 export {

--- a/examples/utils/example-utils/src/migrationInterfaces/migratableModel.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/migratableModel.ts
@@ -52,10 +52,12 @@ export interface IMigratableModelEvents extends IEvent {
 /**
  * @internal
  */
-export interface IMigratableModel
-	extends IVersionedModel,
-		IImportExportModel<unknown, unknown>,
-		IEventProvider<IMigratableModelEvents> {
+export interface IMigratableModel extends IVersionedModel, IImportExportModel<unknown, unknown> {
+	/**
+	 * The event provider that will emit when migration status changes.
+	 */
+	readonly migrationEvents: IEventProvider<IMigratableModelEvents>;
+
 	/**
 	 * The tool that will be used to facilitate the migration.
 	 */

--- a/examples/utils/example-utils/src/migrationInterfaces/migratableModel.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/migratableModel.ts
@@ -3,8 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { IEvent, IEventProvider } from "@fluidframework/core-interfaces";
-
 import type { IMigrationTool } from "./migrationTool.js";
 
 /**
@@ -40,13 +38,6 @@ export interface IImportExportModel<ImportType, ExportType> {
 	exportData: () => Promise<ExportType>;
 }
 
-/**
- * @internal
- */
-export interface IMigratableModelEvents extends IEvent {
-	(event: "connected", listener: () => void);
-}
-
 // TODO: Is there a better way to express the unknown format here?  I think I'd prefer to put the burden of calling
 // supportsDataFormat() on the callers of importData() (and allow implementers of IMigratableModel to assume
 // importData() is called with valid data).
@@ -57,21 +48,9 @@ export interface IMigratableModel
 	extends IVersionedModel,
 		IImportExportModel<unknown, unknown> {
 	/**
-	 * The event provider that will emit when migration status changes.
-	 * TODO: Should this live on the migrationTool?
-	 */
-	readonly migrationEvents: IEventProvider<IMigratableModelEvents>;
-
-	/**
 	 * The tool that will be used to facilitate the migration.
 	 */
 	readonly migrationTool: IMigrationTool;
-
-	/**
-	 * Returns if the runtime is currently connected.
-	 * TODO: Should this live on the migrationTool?
-	 */
-	connected(): boolean;
 
 	/**
 	 * Close the model, rendering it inoperable and closing connections.

--- a/examples/utils/example-utils/src/migrationInterfaces/migratableModel.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/migratableModel.ts
@@ -13,6 +13,7 @@ import type { IMigrationTool } from "./migrationTool.js";
 export interface IVersionedModel {
 	/**
 	 * The string version of the model, matching the version of the container code it's paired with.
+	 * TODO: Should this live on the migrationTool?
 	 */
 	readonly version: string;
 }
@@ -52,9 +53,12 @@ export interface IMigratableModelEvents extends IEvent {
 /**
  * @internal
  */
-export interface IMigratableModel extends IVersionedModel, IImportExportModel<unknown, unknown> {
+export interface IMigratableModel
+	extends IVersionedModel,
+		IImportExportModel<unknown, unknown> {
 	/**
 	 * The event provider that will emit when migration status changes.
+	 * TODO: Should this live on the migrationTool?
 	 */
 	readonly migrationEvents: IEventProvider<IMigratableModelEvents>;
 
@@ -65,6 +69,7 @@ export interface IMigratableModel extends IVersionedModel, IImportExportModel<un
 
 	/**
 	 * Returns if the runtime is currently connected.
+	 * TODO: Should this live on the migrationTool?
 	 */
 	connected(): boolean;
 

--- a/examples/utils/example-utils/src/migrationInterfaces/migratableModel.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/migratableModel.ts
@@ -11,7 +11,6 @@ import type { IMigrationTool } from "./migrationTool.js";
 export interface IVersionedModel {
 	/**
 	 * The string version of the model, matching the version of the container code it's paired with.
-	 * TODO: Should this live on the migrationTool?
 	 */
 	readonly version: string;
 }

--- a/examples/utils/example-utils/src/migrationInterfaces/migrationTool.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/migrationTool.ts
@@ -36,7 +36,7 @@ export interface IAcceptedMigrationDetails {
  */
 export interface IMigrationToolEvents extends IEvent {
 	(event: "stopping" | "migrating" | "migrated", listener: () => void);
-	(event: "connected", listener: () => void);
+	(event: "connected" | "disconnected", listener: () => void);
 	(event: "disposed", listener: () => void);
 }
 

--- a/examples/utils/example-utils/src/migrationInterfaces/migrationTool.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/migrationTool.ts
@@ -36,13 +36,17 @@ export interface IAcceptedMigrationDetails {
  */
 export interface IMigrationToolEvents extends IEvent {
 	(event: "stopping" | "migrating" | "migrated", listener: () => void);
+	(event: "connected", listener: () => void);
 	(event: "disposed", listener: () => void);
 }
 
 /**
  * @internal
  */
-export interface IMigrationTool extends IEventProvider<IMigrationToolEvents> {
+export interface IMigrationTool {
+	readonly events: IEventProvider<IMigrationToolEvents>;
+
+	readonly connected: boolean;
 	/**
 	 * The current state of migration.
 	 */

--- a/examples/utils/example-utils/src/migrationTool/migrationTool.ts
+++ b/examples/utils/example-utils/src/migrationTool/migrationTool.ts
@@ -81,6 +81,9 @@ class MigrationTool extends TypedEventEmitter<IMigrationToolEvents> implements I
 			this.runtime.once("dispose", this.dispose);
 			this.pactMap.on("pending", (key: string) => {
 				if (key === newVersionKey) {
+					// TODO: Here take some action to prevent collaboration - the host might not provide a Migrator,
+					// and we need to ensure we still don't break expectations in that case.  Note that during this
+					// event firing the pactMap has not yet sent its accept op though.
 					this.emit("stopping");
 				}
 			});

--- a/examples/utils/example-utils/src/migrationTool/migrationTool.ts
+++ b/examples/utils/example-utils/src/migrationTool/migrationTool.ts
@@ -5,6 +5,7 @@
 
 import { IPactMap, PactMap } from "@fluid-experimental/pact-map";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import type { IEventProvider } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { FluidDataStoreRuntime } from "@fluidframework/datastore/internal";
 import type {
@@ -36,11 +37,20 @@ const newVersionKey = "newVersion";
 const migrateTaskName = "migrate";
 const newContainerIdKey = "newContainerId";
 
-class MigrationTool extends TypedEventEmitter<IMigrationToolEvents> implements IMigrationTool {
+class MigrationTool implements IMigrationTool {
 	private _disposed = false;
 
 	public get disposed() {
 		return this._disposed;
+	}
+
+	private readonly _events = new TypedEventEmitter<IMigrationToolEvents>();
+	public get events(): IEventProvider<IMigrationToolEvents> {
+		return this._events;
+	}
+
+	public get connected() {
+		return this.runtime.connected;
 	}
 
 	public get handle() {
@@ -73,30 +83,31 @@ class MigrationTool extends TypedEventEmitter<IMigrationToolEvents> implements I
 		private readonly pactMap: IPactMap<string>,
 		private readonly taskManager: ITaskManager,
 	) {
-		super();
-
 		if (this.runtime.disposed) {
 			this.dispose();
 		} else {
 			this.runtime.once("dispose", this.dispose);
+			this.runtime.on("connected", () => {
+				this._events.emit("connected");
+			});
 			this.pactMap.on("pending", (key: string) => {
 				if (key === newVersionKey) {
 					// TODO: Here take some action to prevent collaboration - the host might not provide a Migrator,
 					// and we need to ensure we still don't break expectations in that case.  Note that during this
 					// event firing the pactMap has not yet sent its accept op though.
-					this.emit("stopping");
+					this._events.emit("stopping");
 				}
 			});
 
 			this.pactMap.on("accepted", (key: string) => {
 				if (key === newVersionKey) {
-					this.emit("migrating");
+					this._events.emit("migrating");
 				}
 			});
 
 			this.consensusRegisterCollection.on("atomicChanged", (key: string) => {
 				if (key === newContainerIdKey) {
-					this.emit("migrated");
+					this._events.emit("migrated");
 				}
 			});
 		}
@@ -165,7 +176,7 @@ class MigrationTool extends TypedEventEmitter<IMigrationToolEvents> implements I
 	private readonly dispose = (): void => {
 		this._disposed = true;
 		// TODO: Unregister listeners
-		this.emit("disposed");
+		this._events.emit("disposed");
 	};
 }
 

--- a/examples/utils/example-utils/src/migrationTool/migrationTool.ts
+++ b/examples/utils/example-utils/src/migrationTool/migrationTool.ts
@@ -90,6 +90,9 @@ class MigrationTool implements IMigrationTool {
 			this.runtime.on("connected", () => {
 				this._events.emit("connected");
 			});
+			this.runtime.on("disconnected", () => {
+				this._events.emit("disconnected");
+			});
 			this.pactMap.on("pending", (key: string) => {
 				if (key === newVersionKey) {
 					// TODO: Here take some action to prevent collaboration - the host might not provide a Migrator,
@@ -102,6 +105,8 @@ class MigrationTool implements IMigrationTool {
 			this.pactMap.on("accepted", (key: string) => {
 				if (key === newVersionKey) {
 					this._events.emit("migrating");
+					// TODO: Here we should stop submitting new summaries since it will complicate loading from the
+					// accepted sequence number
 				}
 			});
 

--- a/examples/utils/example-utils/src/migrator/migrator.ts
+++ b/examples/utils/example-utils/src/migrator/migrator.ts
@@ -34,7 +34,7 @@ export class Migrator extends TypedEventEmitter<IMigratorEvents> implements IMig
 	}
 
 	public get connected(): boolean {
-		return this._currentModel.connected();
+		return this._currentModel.migrationTool.connected;
 	}
 
 	/**
@@ -85,7 +85,7 @@ export class Migrator extends TypedEventEmitter<IMigratorEvents> implements IMig
 		} else if (migrationState === "migrated") {
 			this.ensureLoading();
 		} else {
-			this._currentModel.migrationTool.once(
+			this._currentModel.migrationTool.events.once(
 				"migrating",
 				this.takeAppropriateActionForCurrentMigratable,
 			);
@@ -99,7 +99,7 @@ export class Migrator extends TypedEventEmitter<IMigratorEvents> implements IMig
 		if (!this.connected) {
 			// If we are not connected we should wait until we reconnect and try again. Note: we re-enter the state
 			// machine, since it's possible another client has already completed the migration by the time we reconnect.
-			this.currentModel.migrationEvents.once(
+			this.currentModel.migrationTool.events.once(
 				"connected",
 				this.takeAppropriateActionForCurrentMigratable,
 			);

--- a/examples/utils/example-utils/src/migrator/migrator.ts
+++ b/examples/utils/example-utils/src/migrator/migrator.ts
@@ -99,7 +99,10 @@ export class Migrator extends TypedEventEmitter<IMigratorEvents> implements IMig
 		if (!this.connected) {
 			// If we are not connected we should wait until we reconnect and try again. Note: we re-enter the state
 			// machine, since its possible another client has already completed the migration by the time we reconnect.
-			this.currentModel.once("connected", this.takeAppropriateActionForCurrentMigratable);
+			this.currentModel.migrationEvents.once(
+				"connected",
+				this.takeAppropriateActionForCurrentMigratable,
+			);
 			return;
 		}
 

--- a/examples/utils/example-utils/src/migrator/migrator.ts
+++ b/examples/utils/example-utils/src/migrator/migrator.ts
@@ -98,7 +98,7 @@ export class Migrator extends TypedEventEmitter<IMigratorEvents> implements IMig
 
 		if (!this.connected) {
 			// If we are not connected we should wait until we reconnect and try again. Note: we re-enter the state
-			// machine, since its possible another client has already completed the migration by the time we reconnect.
+			// machine, since it's possible another client has already completed the migration by the time we reconnect.
 			this.currentModel.migrationEvents.once(
 				"connected",
 				this.takeAppropriateActionForCurrentMigratable,

--- a/examples/utils/example-utils/src/modelLoader/modelLoader.ts
+++ b/examples/utils/example-utils/src/modelLoader/modelLoader.ts
@@ -69,6 +69,8 @@ export class ModelLoader<ModelType> implements IModelLoader<ModelType> {
 
 	// It would be preferable for attaching to look more like service.attach(model) rather than returning an attach
 	// callback here, but this callback at least allows us to keep the method off the model interface.
+	// TODO: Consider making the version param optional, and in that case having a mechanism to query the codeLoader
+	// for the latest/default version to use?
 	public async createDetached(version: string): Promise<IDetachedModel<ModelType>> {
 		const container = await this.loader.createDetachedContainer({ package: version });
 		const model = await this.getModelFromContainer(container);

--- a/examples/version-migration/schema-upgrade/src/modelInterfaces.ts
+++ b/examples/version-migration/schema-upgrade/src/modelInterfaces.ts
@@ -3,25 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import {
-	EventEmitter,
-	type IMigratableModel,
-	type IMigratableModelEvents,
-} from "@fluid-example/example-utils";
-import type { IEventProvider } from "@fluidframework/core-interfaces";
+import { EventEmitter, type IMigratableModel } from "@fluid-example/example-utils";
 import { SharedString } from "@fluidframework/sequence/internal";
-
-// TODO: Consider property-events rather than extending an emitter.
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IInventoryListAppModelEvents extends IMigratableModelEvents {}
 
 /**
  * For demo purposes this is a super-simple interface, but in a real scenario this should have all relevant surface
  * for the application to run.
  */
-export interface IInventoryListAppModel
-	extends IMigratableModel,
-		IEventProvider<IInventoryListAppModelEvents> {
+export interface IInventoryListAppModel extends IMigratableModel {
 	/**
 	 * An inventory tracker list.
 	 */

--- a/examples/version-migration/schema-upgrade/src/modelInterfaces.ts
+++ b/examples/version-migration/schema-upgrade/src/modelInterfaces.ts
@@ -3,14 +3,14 @@
  * Licensed under the MIT License.
  */
 
-import { EventEmitter, type IMigratableModel } from "@fluid-example/example-utils";
+import { EventEmitter } from "@fluid-example/example-utils";
 import { SharedString } from "@fluidframework/sequence/internal";
 
 /**
  * For demo purposes this is a super-simple interface, but in a real scenario this should have all relevant surface
  * for the application to run.
  */
-export interface IInventoryListAppModel extends IMigratableModel {
+export interface IInventoryListAppModel {
 	/**
 	 * An inventory tracker list.
 	 */

--- a/examples/version-migration/schema-upgrade/src/modelInterfaces.ts
+++ b/examples/version-migration/schema-upgrade/src/modelInterfaces.ts
@@ -11,6 +11,7 @@ import {
 import type { IEventProvider } from "@fluidframework/core-interfaces";
 import { SharedString } from "@fluidframework/sequence/internal";
 
+// TODO: Consider property-events rather than extending an emitter.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IInventoryListAppModelEvents extends IMigratableModelEvents {}
 

--- a/examples/version-migration/schema-upgrade/src/modelVersion1/appModel.ts
+++ b/examples/version-migration/schema-upgrade/src/modelVersion1/appModel.ts
@@ -3,16 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import type {
-	IMigratableModel,
-	IMigratableModelEvents,
-	IMigrationTool,
-} from "@fluid-example/example-utils";
-import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import type { IMigratableModel, IMigrationTool } from "@fluid-example/example-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { ConnectionState } from "@fluidframework/container-loader";
-import type { IEventProvider } from "@fluidframework/core-interfaces";
 
 import { parseStringDataVersionOne, readVersion } from "../dataTransform.js";
 import type { IInventoryList, IInventoryListAppModel } from "../modelInterfaces.js";
@@ -30,20 +23,11 @@ export class InventoryListAppModel implements IInventoryListAppModel, IMigratabl
 	// To be used by the consumer of the model to pair with an appropriate view.
 	public readonly version = "one";
 
-	private readonly _migrationEvents = new TypedEventEmitter<IMigratableModelEvents>();
-	public get migrationEvents(): IEventProvider<IMigratableModelEvents> {
-		return this._migrationEvents;
-	}
-
 	public constructor(
 		public readonly inventoryList: IInventoryList,
 		public readonly migrationTool: IMigrationTool,
 		private readonly container: IContainer,
-	) {
-		this.container.on("connected", () => {
-			this._migrationEvents.emit("connected");
-		});
-	}
+	) {}
 
 	public readonly supportsDataFormat = (
 		initialData: unknown,
@@ -76,10 +60,6 @@ export class InventoryListAppModel implements IInventoryListAppModel, IMigratabl
 		});
 		return `version:one\n${inventoryItemStrings.join("\n")}`;
 	};
-
-	public connected() {
-		return this.container.connectionState === ConnectionState.Connected;
-	}
 
 	public close() {
 		this.container.close();

--- a/examples/version-migration/schema-upgrade/src/modelVersion1/appModel.ts
+++ b/examples/version-migration/schema-upgrade/src/modelVersion1/appModel.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import type { IMigratableModelEvents, IMigrationTool } from "@fluid-example/example-utils";
+import type {
+	IMigratableModel,
+	IMigratableModelEvents,
+	IMigrationTool,
+} from "@fluid-example/example-utils";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { IContainer } from "@fluidframework/container-definitions/internal";
@@ -22,7 +26,7 @@ export type InventoryListAppModelExportFormat1 = string;
  * the Container (e.g. no direct access to the Loader).  It does not have a goal of being general-purpose like
  * Container does -- instead it is specially designed for the specific container code.
  */
-export class InventoryListAppModel implements IInventoryListAppModel {
+export class InventoryListAppModel implements IInventoryListAppModel, IMigratableModel {
 	// To be used by the consumer of the model to pair with an appropriate view.
 	public readonly version = "one";
 

--- a/examples/version-migration/schema-upgrade/src/modelVersion1/containerCode.ts
+++ b/examples/version-migration/schema-upgrade/src/modelVersion1/containerCode.ts
@@ -63,7 +63,6 @@ export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeF
 	 * {@inheritDoc ModelContainerRuntimeFactory.containerHasInitialized}
 	 */
 	protected async containerHasInitialized(runtime: IContainerRuntime) {
-		console.info("Using runtime factory version one");
 		// Force the MigrationTool to instantiate in all cases.  The Quorum it uses must be loaded and running in
 		// order to respond with accept ops, and without this call the MigrationTool won't be instantiated on the
 		// summarizer client.

--- a/examples/version-migration/schema-upgrade/src/modelVersion2/appModel.ts
+++ b/examples/version-migration/schema-upgrade/src/modelVersion2/appModel.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { IMigratableModelEvents, type IMigrationTool } from "@fluid-example/example-utils";
+import type {
+	IMigratableModelEvents,
+	IMigratableModel,
+	IMigrationTool,
+} from "@fluid-example/example-utils";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { IContainer } from "@fluidframework/container-definitions/internal";
@@ -22,7 +26,7 @@ export type InventoryListAppModelExportFormat2 = string;
  * the Container (e.g. no direct access to the Loader).  It does not have a goal of being general-purpose like
  * Container does -- instead it is specially designed for the specific container code.
  */
-export class InventoryListAppModel implements IInventoryListAppModel {
+export class InventoryListAppModel implements IInventoryListAppModel, IMigratableModel {
 	// To be used by the consumer of the model to pair with an appropriate view.
 	public readonly version = "two";
 

--- a/examples/version-migration/schema-upgrade/src/modelVersion2/appModel.ts
+++ b/examples/version-migration/schema-upgrade/src/modelVersion2/appModel.ts
@@ -3,18 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import type { IMigrationTool } from "@fluid-example/example-utils";
+import { IMigratableModelEvents, type IMigrationTool } from "@fluid-example/example-utils";
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { IContainer } from "@fluidframework/container-definitions/internal";
 import { ConnectionState } from "@fluidframework/container-loader";
+import type { IEventProvider } from "@fluidframework/core-interfaces";
 
 import { parseStringDataVersionTwo, readVersion } from "../dataTransform.js";
-import type {
-	IInventoryList,
-	IInventoryListAppModel,
-	IInventoryListAppModelEvents,
-} from "../modelInterfaces.js";
+import type { IInventoryList, IInventoryListAppModel } from "../modelInterfaces.js";
 
 // This type represents a stronger expectation than just any string - it needs to be in the right format.
 export type InventoryListAppModelExportFormat2 = string;
@@ -25,21 +22,22 @@ export type InventoryListAppModelExportFormat2 = string;
  * the Container (e.g. no direct access to the Loader).  It does not have a goal of being general-purpose like
  * Container does -- instead it is specially designed for the specific container code.
  */
-export class InventoryListAppModel
-	extends TypedEventEmitter<IInventoryListAppModelEvents>
-	implements IInventoryListAppModel
-{
+export class InventoryListAppModel implements IInventoryListAppModel {
 	// To be used by the consumer of the model to pair with an appropriate view.
 	public readonly version = "two";
+
+	private readonly _migrationEvents = new TypedEventEmitter<IMigratableModelEvents>();
+	public get migrationEvents(): IEventProvider<IMigratableModelEvents> {
+		return this._migrationEvents;
+	}
 
 	public constructor(
 		public readonly inventoryList: IInventoryList,
 		public readonly migrationTool: IMigrationTool,
 		private readonly container: IContainer,
 	) {
-		super();
 		this.container.on("connected", () => {
-			this.emit("connected");
+			this._migrationEvents.emit("connected");
 		});
 	}
 

--- a/examples/version-migration/schema-upgrade/src/modelVersion2/appModel.ts
+++ b/examples/version-migration/schema-upgrade/src/modelVersion2/appModel.ts
@@ -3,16 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import type {
-	IMigratableModelEvents,
-	IMigratableModel,
-	IMigrationTool,
-} from "@fluid-example/example-utils";
-import { TypedEventEmitter } from "@fluid-internal/client-utils";
+import type { IMigratableModel, IMigrationTool } from "@fluid-example/example-utils";
 import { AttachState } from "@fluidframework/container-definitions";
 import { IContainer } from "@fluidframework/container-definitions/internal";
-import { ConnectionState } from "@fluidframework/container-loader";
-import type { IEventProvider } from "@fluidframework/core-interfaces";
 
 import { parseStringDataVersionTwo, readVersion } from "../dataTransform.js";
 import type { IInventoryList, IInventoryListAppModel } from "../modelInterfaces.js";
@@ -30,20 +23,11 @@ export class InventoryListAppModel implements IInventoryListAppModel, IMigratabl
 	// To be used by the consumer of the model to pair with an appropriate view.
 	public readonly version = "two";
 
-	private readonly _migrationEvents = new TypedEventEmitter<IMigratableModelEvents>();
-	public get migrationEvents(): IEventProvider<IMigratableModelEvents> {
-		return this._migrationEvents;
-	}
-
 	public constructor(
 		public readonly inventoryList: IInventoryList,
 		public readonly migrationTool: IMigrationTool,
 		private readonly container: IContainer,
-	) {
-		this.container.on("connected", () => {
-			this._migrationEvents.emit("connected");
-		});
-	}
+	) {}
 
 	public readonly supportsDataFormat = (
 		initialData: unknown,
@@ -76,10 +60,6 @@ export class InventoryListAppModel implements IInventoryListAppModel, IMigratabl
 		});
 		return `version:two\n${inventoryItemStrings.join("\n")}`;
 	};
-
-	public connected() {
-		return this.container.connectionState === ConnectionState.Connected;
-	}
 
 	public close() {
 		this.container.close();

--- a/examples/version-migration/schema-upgrade/src/modelVersion2/containerCode.ts
+++ b/examples/version-migration/schema-upgrade/src/modelVersion2/containerCode.ts
@@ -60,7 +60,6 @@ export class InventoryListContainerRuntimeFactory extends ModelContainerRuntimeF
 	 * {@inheritDoc ModelContainerRuntimeFactory.containerHasInitialized}
 	 */
 	protected async containerHasInitialized(runtime: IContainerRuntime) {
-		console.info("Using runtime factory version two");
 		// Force the MigrationTool to instantiate in all cases.  The Quorum it uses must be loaded and running in
 		// order to respond with accept ops, and without this call the MigrationTool won't be instantiated on the
 		// summarizer client.

--- a/examples/version-migration/schema-upgrade/src/start.ts
+++ b/examples/version-migration/schema-upgrade/src/start.ts
@@ -97,9 +97,9 @@ async function start(): Promise<void> {
 	);
 	migrator.on("migrated", () => {
 		model.close();
+		model = migrator.currentModel;
 		render(migrator.currentModel);
 		updateTabForId(migrator.currentModelId);
-		model = migrator.currentModel;
 	});
 	// If the ModelLoader doesn't know how to load the model required for migration, it emits "migrationNotSupported".
 	// For example, this might be hit if another client has a newer ModelLoader and proposes a version our

--- a/examples/version-migration/schema-upgrade/src/start.ts
+++ b/examples/version-migration/schema-upgrade/src/start.ts
@@ -102,7 +102,7 @@ async function start(): Promise<void> {
 	migrator.on("migrated", () => {
 		model.close();
 		model = migrator.currentModel;
-		render(migrator.currentModel);
+		render(model);
 		updateTabForId(migrator.currentModelId);
 	});
 	// If the ModelLoader doesn't know how to load the model required for migration, it emits "migrationNotSupported".

--- a/examples/version-migration/schema-upgrade/src/start.ts
+++ b/examples/version-migration/schema-upgrade/src/start.ts
@@ -27,7 +27,9 @@ const updateTabForId = (id: string) => {
 	document.title = id;
 };
 
-const isIInventoryListAppModel = (model: IVersionedModel): model is IInventoryListAppModel => {
+const isIInventoryListAppModel = (
+	model: IVersionedModel,
+): model is IInventoryListAppModel & IMigratableModel => {
 	return model.version === "one" || model.version === "two";
 };
 
@@ -62,6 +64,8 @@ async function start(): Promise<void> {
 	// in here as well as in the Migrator -- both places just need a reliable way to get a model regardless of the
 	// (unknown) container version.  So the ModelLoader would be replaced by e.g. container.getEntryPoint() or
 	// container.getEntryPoint().model if we knew that was the model.
+	// TODO: This is really loading an IInventoryListAppModel & IMigratableModel (we know this because of what the
+	// DemoCodeLoader supports).  Should we just use that more-specific type in the typing here?
 	const modelLoader = new ModelLoader<IMigratableModel>({
 		urlResolver: new InsecureTinyliciousUrlResolver(),
 		documentServiceFactory: new RouterliciousDocumentServiceFactory(

--- a/examples/version-migration/schema-upgrade/src/view/appView.tsx
+++ b/examples/version-migration/schema-upgrade/src/view/appView.tsx
@@ -34,14 +34,14 @@ export const InventoryListAppView: React.FC<IInventoryListAppViewProps> = (
 		const migrationStateChangedHandler = () => {
 			setDisableInput(model.migrationTool.migrationState !== "collaborating");
 		};
-		model.migrationTool.on("stopping", migrationStateChangedHandler);
-		model.migrationTool.on("migrating", migrationStateChangedHandler);
-		model.migrationTool.on("migrated", migrationStateChangedHandler);
+		model.migrationTool.events.on("stopping", migrationStateChangedHandler);
+		model.migrationTool.events.on("migrating", migrationStateChangedHandler);
+		model.migrationTool.events.on("migrated", migrationStateChangedHandler);
 		migrationStateChangedHandler();
 		return () => {
-			model.migrationTool.off("stopping", migrationStateChangedHandler);
-			model.migrationTool.off("migrating", migrationStateChangedHandler);
-			model.migrationTool.off("migrated", migrationStateChangedHandler);
+			model.migrationTool.events.off("stopping", migrationStateChangedHandler);
+			model.migrationTool.events.off("migrating", migrationStateChangedHandler);
+			model.migrationTool.events.off("migrated", migrationStateChangedHandler);
 		};
 	}, [model]);
 

--- a/examples/version-migration/schema-upgrade/src/view/appView.tsx
+++ b/examples/version-migration/schema-upgrade/src/view/appView.tsx
@@ -11,6 +11,7 @@ import type { IInventoryListAppModel } from "../modelInterfaces.js";
 import { InventoryListView } from "./inventoryView.js";
 
 export interface IInventoryListAppViewProps {
+	// TODO: All we really want here is a "readonly" indicator - maybe don't need the full IMigratableModel interface.
 	model: IInventoryListAppModel & IMigratableModel;
 }
 

--- a/examples/version-migration/schema-upgrade/src/view/appView.tsx
+++ b/examples/version-migration/schema-upgrade/src/view/appView.tsx
@@ -12,6 +12,7 @@ import { InventoryListView } from "./inventoryView.js";
 
 export interface IInventoryListAppViewProps {
 	// TODO: All we really want here is a "readonly" indicator - maybe don't need the full IMigratableModel interface.
+	// Would maybe be better to grab that info from the Migrator rather than the MigrationTool anyway.
 	model: IInventoryListAppModel & IMigratableModel;
 }
 

--- a/examples/version-migration/schema-upgrade/src/view/appView.tsx
+++ b/examples/version-migration/schema-upgrade/src/view/appView.tsx
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import type { IMigratableModel } from "@fluid-example/example-utils";
 import React, { useEffect, useState } from "react";
 
 import type { IInventoryListAppModel } from "../modelInterfaces.js";
@@ -10,7 +11,7 @@ import type { IInventoryListAppModel } from "../modelInterfaces.js";
 import { InventoryListView } from "./inventoryView.js";
 
 export interface IInventoryListAppViewProps {
-	model: IInventoryListAppModel;
+	model: IInventoryListAppModel & IMigratableModel;
 }
 
 /**

--- a/examples/version-migration/schema-upgrade/src/view/debugView.tsx
+++ b/examples/version-migration/schema-upgrade/src/view/debugView.tsx
@@ -9,7 +9,7 @@ import React, { useEffect, useState } from "react";
 import type { IInventoryListAppModel } from "../modelInterfaces.js";
 
 export interface IDebugViewProps {
-	model: IInventoryListAppModel;
+	model: IInventoryListAppModel & IMigratableModel;
 	getUrlForContainerId?: (containerId: string) => string;
 }
 

--- a/examples/version-migration/schema-upgrade/src/view/debugView.tsx
+++ b/examples/version-migration/schema-upgrade/src/view/debugView.tsx
@@ -24,14 +24,14 @@ export const DebugView: React.FC<IDebugViewProps> = (props: IDebugViewProps) => 
 		const migrationStateChangedHandler = () => {
 			setDisableControls(model.migrationTool.migrationState !== "collaborating");
 		};
-		model.migrationTool.on("stopping", migrationStateChangedHandler);
-		model.migrationTool.on("migrating", migrationStateChangedHandler);
-		model.migrationTool.on("migrated", migrationStateChangedHandler);
+		model.migrationTool.events.on("stopping", migrationStateChangedHandler);
+		model.migrationTool.events.on("migrating", migrationStateChangedHandler);
+		model.migrationTool.events.on("migrated", migrationStateChangedHandler);
 		migrationStateChangedHandler();
 		return () => {
-			model.migrationTool.off("stopping", migrationStateChangedHandler);
-			model.migrationTool.off("migrating", migrationStateChangedHandler);
-			model.migrationTool.off("migrated", migrationStateChangedHandler);
+			model.migrationTool.events.off("stopping", migrationStateChangedHandler);
+			model.migrationTool.events.off("migrating", migrationStateChangedHandler);
+			model.migrationTool.events.off("migrated", migrationStateChangedHandler);
 		};
 	}, [model]);
 
@@ -66,14 +66,14 @@ const MigrationStatusView: React.FC<IMigrationStatusViewProps> = (
 		const migrationStateChangedHandler = () => {
 			setMigrationState(model.migrationTool.migrationState);
 		};
-		model.migrationTool.on("stopping", migrationStateChangedHandler);
-		model.migrationTool.on("migrating", migrationStateChangedHandler);
-		model.migrationTool.on("migrated", migrationStateChangedHandler);
+		model.migrationTool.events.on("stopping", migrationStateChangedHandler);
+		model.migrationTool.events.on("migrating", migrationStateChangedHandler);
+		model.migrationTool.events.on("migrated", migrationStateChangedHandler);
 		migrationStateChangedHandler();
 		return () => {
-			model.migrationTool.off("stopping", migrationStateChangedHandler);
-			model.migrationTool.off("migrating", migrationStateChangedHandler);
-			model.migrationTool.off("migrated", migrationStateChangedHandler);
+			model.migrationTool.events.off("stopping", migrationStateChangedHandler);
+			model.migrationTool.events.off("migrating", migrationStateChangedHandler);
+			model.migrationTool.events.off("migrated", migrationStateChangedHandler);
 		};
 	}, [model]);
 

--- a/examples/version-migration/schema-upgrade/tests/index.tsx
+++ b/examples/version-migration/schema-upgrade/tests/index.tsx
@@ -26,7 +26,9 @@ const updateTabForId = (id: string) => {
 	document.title = id;
 };
 
-const isIInventoryListAppModel = (model: IVersionedModel): model is IInventoryListAppModel => {
+const isIInventoryListAppModel = (
+	model: IVersionedModel,
+): model is IInventoryListAppModel & IMigratableModel => {
 	return model.version === "one" || model.version === "two";
 };
 
@@ -43,7 +45,7 @@ window["migrators"] = [];
 export async function createContainerAndRenderInElement(element: HTMLDivElement) {
 	const searchParams = new URLSearchParams(location.search);
 	const testMode = searchParams.get("testMode") !== null;
-	const modelLoader = new SessionStorageModelLoader<IInventoryListAppModel>(
+	const modelLoader = new SessionStorageModelLoader<IInventoryListAppModel & IMigratableModel>(
 		new DemoCodeLoader(testMode),
 	);
 	let id: string;


### PR DESCRIPTION
This PR includes several tweaks to the migration tools and example, most notably moving the responsibility of reporting the connected state to the MigrationTool rather than having the customer implement it as part of their IMigratableModel.  This should make the customer's job a little easier since they can avoid the need to implement any events if they choose.

It also switches MigrationTool to use an .events property rather than inheriting from TypedEventEmitter, as we believe this is a better and more sustainable approach.

Lastly, it adds some TODOs for planning purposes.