### PR TITLE
[Port rc-3.0] odsp e2e tests

### DIFF
--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
@@ -10,10 +10,33 @@ import { MockLogger, createMultiSinkLogger } from "@fluidframework/telemetry-uti
 import { OdspTestTokenProvider } from "./OdspTokenFactory.js";
 
 /**
+ * Interface representing the range of login credentials for a tenant.
+ */
+interface LoginTenantRange {
+	prefix: string;
+	start: number;
+	count: number;
+	password: string;
+}
+
+/**
+ * Interface representing a collection of tenants with their respective login ranges.
+ * @example
+ * ```string
+ * {"tenantName":{"range":{"prefix":"prefixName","password":"XYZ","start":0,"count":2}}}
+ * ```
+ */
+export interface LoginTenants {
+	[tenant: string]: {
+		range: LoginTenantRange;
+	};
+}
+
+/**
  * Interface representing the odsp-client login account credentials.
  */
 export interface IOdspLoginCredentials {
-	username: string;
+	email: string;
 	password: string;
 }
 
@@ -23,6 +46,60 @@ export interface IOdspLoginCredentials {
  */
 export interface IOdspCredentials extends IOdspLoginCredentials {
 	clientId: string;
+}
+
+/**
+ * Get set of credential to use from env variable.
+ */
+export function getCredentials(): IOdspLoginCredentials[] {
+	const creds: IOdspLoginCredentials[] = [];
+	const loginTenants = process.env.login__odspclient__spe__test__tenants as string;
+
+	if (loginTenants === "" || loginTenants === undefined) {
+		throw new Error("Login tenant is missing");
+	}
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	const tenants: LoginTenants = JSON.parse(loginTenants);
+	const tenantKey = Object.keys(tenants);
+	const tenantName = tenantKey[0];
+	if (tenantName === undefined) {
+		throw new Error("Tenant is undefined");
+	}
+	const tenantInfo = tenants[tenantName];
+
+	if (tenantInfo === undefined) {
+		throw new Error("Tenant info is undefined");
+	}
+
+	const range = tenantInfo.range;
+
+	if (range === undefined) {
+		throw new Error("range is undefined");
+	}
+
+	for (let i = 0; i < range.count; i++) {
+		creds.push({
+			email: `${range.prefix}${range.start + i}@${tenantName}`,
+			password: range.password,
+		});
+	}
+
+	const [client1Creds, client2Creds] = creds;
+
+	if (client1Creds === undefined || client2Creds === undefined || creds.length < 2) {
+		throw new Error("Insufficient number of login credentials");
+	}
+
+	if (
+		client1Creds.email === undefined ||
+		client1Creds.password === undefined ||
+		client2Creds.email === undefined ||
+		client2Creds.password === undefined
+	) {
+		throw new Error("Email or password is missing for login account");
+	}
+
+	return creds;
 }
 
 /**
@@ -46,10 +123,6 @@ export function createOdspClient(
 
 	if (clientId === "" || clientId === undefined) {
 		throw new Error("client id is missing");
-	}
-
-	if (creds.username === undefined || creds.password === undefined) {
-		throw new Error("username or password is missing for login account");
 	}
 
 	const credentials: IOdspCredentials = {

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspTokenFactory.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspTokenFactory.ts
@@ -58,7 +58,7 @@ export class OdspTestTokenProvider implements IOdspTokenProvider {
 		};
 		const credentials: TokenRequestCredentials = {
 			grant_type: "password",
-			username: this.creds.username,
+			username: this.creds.email,
 			password: this.creds.password,
 		};
 		const body = {

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
@@ -13,7 +13,7 @@ import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
-import { IOdspLoginCredentials, createOdspClient } from "./OdspClientFactory.js";
+import { createOdspClient, getCredentials } from "./OdspClientFactory.js";
 import { waitForMember } from "./utils.js";
 
 const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({
@@ -24,15 +24,11 @@ describe("Fluid audience", () => {
 	const connectTimeoutMs = 10_000;
 	let client: OdspClient;
 	let schema: ContainerSchema;
-	const client1Creds: IOdspLoginCredentials = {
-		username: process.env.odsp__client__login__username as string,
-		password: process.env.odsp__client__login__password as string,
-	};
+	const [client1Creds, client2Creds] = getCredentials();
 
-	const client2Creds: IOdspLoginCredentials = {
-		username: process.env.odsp__client2__login__username as string,
-		password: process.env.odsp__client2__login__password as string,
-	};
+	if (client1Creds === undefined || client2Creds === undefined) {
+		throw new Error("Couldn't get login credentials");
+	}
 
 	beforeEach(() => {
 		client = createOdspClient(client1Creds);
@@ -67,7 +63,7 @@ describe("Fluid audience", () => {
 		);
 
 		/* This is a workaround for a known bug, we should have one member (self) upon container connection */
-		const myself = await waitForMember(services.audience, client1Creds.username);
+		const myself = await waitForMember(services.audience, client1Creds.email);
 		assert.notStrictEqual(myself, undefined, "We should have myself at this point.");
 
 		const members = services.audience.getMembers();
@@ -101,7 +97,7 @@ describe("Fluid audience", () => {
 		);
 
 		/* This is a workaround for a known bug, we should have one member (self) upon container connection */
-		const originalSelf = await waitForMember(services.audience, client1Creds.username);
+		const originalSelf = await waitForMember(services.audience, client1Creds.email);
 		assert.notStrictEqual(originalSelf, undefined, "We should have myself at this point.");
 
 		// pass client2 credentials
@@ -115,7 +111,7 @@ describe("Fluid audience", () => {
 		const { services: servicesGet } = await client2.getContainer(itemId, schema);
 
 		/* This is a workaround for a known bug, we should have one member (self) upon container connection */
-		const partner = await waitForMember(servicesGet.audience, client2Creds.username);
+		const partner = await waitForMember(servicesGet.audience, client2Creds.email);
 		assert.notStrictEqual(partner, undefined, "We should have partner at this point.");
 
 		const members = servicesGet.audience.getMembers();
@@ -158,7 +154,7 @@ describe("Fluid audience", () => {
 		const { services: servicesGet } = await client2.getContainer(itemId, schema);
 
 		/* This is a workaround for a known bug, we should have one member (self) upon container connection */
-		const partner = await waitForMember(servicesGet.audience, client2Creds.username);
+		const partner = await waitForMember(servicesGet.audience, client2Creds.email);
 		assert.notStrictEqual(partner, undefined, "We should have partner at this point.");
 
 		let members = servicesGet.audience.getMembers();

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
@@ -12,17 +12,18 @@ import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
-import { IOdspLoginCredentials, createOdspClient } from "./OdspClientFactory.js";
-
-const clientCreds: IOdspLoginCredentials = {
-	username: process.env.odsp__client__login__username as string,
-	password: process.env.odsp__client__login__password as string,
-};
+import { createOdspClient, getCredentials } from "./OdspClientFactory.js";
 
 describe("Container create scenarios", () => {
 	const connectTimeoutMs = 10_000;
 	let client: OdspClient;
 	let schema: ContainerSchema;
+
+	const [clientCreds] = getCredentials();
+
+	if (clientCreds === undefined) {
+		throw new Error("Couldn't get login credentials");
+	}
 
 	beforeEach(() => {
 		client = createOdspClient(clientCreds);

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
@@ -12,14 +12,9 @@ import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
-import { IOdspLoginCredentials, createOdspClient } from "./OdspClientFactory.js";
+import { createOdspClient, getCredentials } from "./OdspClientFactory.js";
 import { CounterTestDataObject, TestDataObject } from "./TestDataObject.js";
 import { mapWait } from "./utils.js";
-
-const clientCreds: IOdspLoginCredentials = {
-	username: process.env.odsp__client__login__username as string,
-	password: process.env.odsp__client__login__password as string,
-};
 
 describe("Fluid data updates", () => {
 	const connectTimeoutMs = 10_000;
@@ -29,6 +24,12 @@ describe("Fluid data updates", () => {
 			map1: SharedMap,
 		},
 	} satisfies ContainerSchema;
+
+	const [clientCreds] = getCredentials();
+
+	if (clientCreds === undefined) {
+		throw new Error("Couldn't get login credentials");
+	}
 
 	beforeEach(() => {
 		client = createOdspClient(clientCreds);

--- a/tools/pipelines/test-service-clients.yml
+++ b/tools/pipelines/test-service-clients.yml
@@ -83,10 +83,7 @@ stages:
           odsp__client__clientId: $(odsp-client-clientId)
           odsp__client__siteUrl: $(odsp-client-siteUrl)
           odsp__client__driveId: $(odsp-client-driveId)
-          odsp__client__login__username: $(odsp-client-login-username)
-          odsp__client__login__password: $(odsp-client-login-password)
-          odsp__client2__login__username: $(odsp-client2-login-username)
-          odsp__client2__login__password: $(odsp-client2-login-password)
+          login__odspclient__spe__test__tenants: $(login-odspclient-spe-test-tenants)
 
   # Capture pipeline stage results
   - stage: upload_run_telemetry


### PR DESCRIPTION
This PR pulls the new secret with the key name
`login__odspclient__spe__test__tenants` and removes all the unused secrets. It also renames userName to email.

[AB#8191](https://dev.azure.com/fluidframework/internal/_workitems/edit/8191)

Pipeline run:
https://dev.azure.com/fluidframework/internal/_build/results?buildId=272012&view=logs&s=5faae3bc-ab4b-555e-2b19-bb89f1c940e5 and
https://dev.azure.com/fluidframework/internal/_build/results?buildId=272809&view=logs&s=5faae3bc-ab4b-555e-2b19-bb89f1c940e5

(cherry picked from commit a917ad6666c7508d03d83fb6ab67af874733c2a5)
