### PR TITLE
fix(client): Correct repository.directory field

### DIFF
--- a/azure/packages/azure-service-utils/package.json
+++ b/azure/packages/azure-service-utils/package.json
@@ -6,7 +6,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "packages/framework/azure-service-utils"
+		"directory": "azure/packages/azure-service-utils"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/azure/packages/test/scenario-runner/package.json
+++ b/azure/packages/test/scenario-runner/package.json
@@ -6,7 +6,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "azure/packages/test/end-to-end-tests"
+		"directory": "azure/packages/test/scenario-runner"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -6,7 +6,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "build-tools/package/bundle-size-tools"
+		"directory": "build-tools/packages/bundle-size-tools"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/common/build/eslint-plugin-fluid/package.json
+++ b/common/build/eslint-plugin-fluid/package.json
@@ -6,7 +6,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "common/build/eslint-pluig-fluid/"
+		"directory": "common/build/eslint-plugin-fluid"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/examples/benchmarks/bubblebench/shared-tree-flex-tree/package.json
+++ b/examples/benchmarks/bubblebench/shared-tree-flex-tree/package.json
@@ -7,7 +7,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "examples/benchmarks/bubblebench/hared-tree-flex-tree"
+		"directory": "examples/benchmarks/bubblebench/shared-tree-flex-tree"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/examples/client-logger/app-insights-logger/package.json
+++ b/examples/client-logger/app-insights-logger/package.json
@@ -7,7 +7,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "packages/examples/client-logger/app-insights-logger"
+		"directory": "examples/client-logger/app-insights-logger"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/examples/service-clients/odsp-client/shared-tree-demo/package.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/package.json
@@ -7,7 +7,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "examples/service-clients/shared-tree-demo"
+		"directory": "examples/service-clients/odsp-client/shared-tree-demo"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/examples/version-migration/same-container/package.json
+++ b/examples/version-migration/same-container/package.json
@@ -7,7 +7,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "examples/version-migration/schema-upgrade"
+		"directory": "examples/version-migration/same-container"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/examples/version-migration/tree-shim/package.json
+++ b/examples/version-migration/tree-shim/package.json
@@ -7,7 +7,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "examples/apps/tree-shim"
+		"directory": "examples/version-migration/tree-shim"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
 	"homepage": "https://fluidframework.com",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": ""
+		"url": "https://github.com/microsoft/FluidFramework.git"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/packages/common/container-definitions/package.json
+++ b/packages/common/container-definitions/package.json
@@ -6,7 +6,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "common/lib/container-definitions"
+		"directory": "packages/common/container-definitions"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -6,7 +6,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "common/lib/core-interfaces"
+		"directory": "packages/common/core-interfaces"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/packages/common/driver-definitions/package.json
+++ b/packages/common/driver-definitions/package.json
@@ -6,7 +6,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "common/lib/driver-definitions"
+		"directory": "packages/common/driver-definitions"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/packages/framework/agent-scheduler/package.json
+++ b/packages/framework/agent-scheduler/package.json
@@ -6,7 +6,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "packages/runtime/agent-scheduler"
+		"directory": "packages/framework/agent-scheduler"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",

--- a/packages/service-clients/end-to-end-tests/azure-client/package.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/package.json
@@ -6,7 +6,7 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/microsoft/FluidFramework.git",
-		"directory": "azure/packages/test/end-to-end-tests"
+		"directory": "packages/service-clients/end-to-end-tests/azure-client"
 	},
 	"license": "MIT",
 	"author": "Microsoft and contributors",


### PR DESCRIPTION
The repository.directory field is not correct for some packages. I updated the broken ones using the policy in #21605. That policy will protect against future issues once it's merged and brought into the client release group.