### PR TITLE
LoadingGroupId breaks on clients without the feature enabled

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -314,7 +314,10 @@ describeCompat(
 			}
 		});
 
-		it("Can create loadingGroupId without feature", async () => {
+		it("Can create loadingGroupId without feature", async function () {
+			if (!supportsDataVirtualization(provider)) {
+				this.skip();
+			}
 			const container = await provider.createContainer(runtimeFactory);
 			const mainObject = (await container.getEntryPoint()) as TestDataObject;
 			const containerRuntime = mainObject.containerRuntime;

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -314,7 +314,7 @@ describeCompat(
 			}
 		});
 
-		it("Can create loadingGroupId without feature", async function () {
+		it("Loading Snapshot with GroupId using feature gate off should load properly", async function () {
 			if (!supportsDataVirtualization(provider)) {
 				this.skip();
 			}

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -20,6 +20,7 @@ import { SummaryType } from "@fluidframework/driver-definitions";
 import type { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import { getSnapshotTree } from "@fluidframework/driver-utils/internal";
 import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
+import type { IFluidErrorBase } from "@fluidframework/telemetry-utils/internal";
 import {
 	type ITestObjectProvider,
 	createSummarizerFromFactory,
@@ -374,7 +375,15 @@ describeCompat(
 			// Essentially, this should not reject
 			// When fixed, this function should be removed.
 			const assertInvertDoesNotReject = async (promise: Promise<unknown>, message: string) => {
-				await assert.rejects(promise, message);
+				await assert.rejects(
+					promise,
+					// Not sure which error interface to use here, but the key is the message
+					(thrown: IFluidErrorBase) => {
+						assert(thrown.message.includes("0x97a"), "Error message should be correct");
+						return true;
+					},
+					message,
+				);
 			};
 
 			await assertInvertDoesNotReject(


### PR DESCRIPTION
[AB#8547](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8547)

While working on adding data virtualization to stress tests, I found this bug.

1. With loadingroupId feature **enabled**, create a datastore with a groupId
2. summarize that datastore
3. load a new container with loading feature **disabled** from that summary
4. attempt to realize (call `handle.get()` or `runtime.getAliasedDataStoreEntryPoint`
5. Assert `0x97a is hit