### PR TITLE
Double the test timeout for Undo and Redo Insert & Delete

### DIFF
--- a/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
+++ b/packages/framework/undo-redo/src/test/sequenceHandler.spec.ts
@@ -121,7 +121,7 @@ describe("SharedSegmentSequenceUndoRedoHandler", () => {
 		while (undoRedoStack.redoOperation()) {}
 
 		assert.equal(sharedString.getText(), finalText, sharedString.getText());
-	});
+	}).timeout(4000); // double the default timeout. This test is a bit slow.
 
 	it("Undo and redo insert of split segment", () => {
 		const handler = new SharedSegmentSequenceUndoRedoHandler(undoRedoStack);


### PR DESCRIPTION
This test times out on CI with code coverage enabled. Double the default timeout for this test.