### PR TITLE
TokenFetcher fix for getWebsocketToken

### DIFF
--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.api.md
@@ -300,7 +300,7 @@ export interface TokenFetchOptions {
     tenantId?: string;
 }
 
-// @internal @deprecated
+// @internal
 export const tokenFromResponse: (tokenResponse: string | TokenResponse | null | undefined) => string | null;
 
 // @beta

--- a/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
+++ b/packages/drivers/odsp-driver-definitions/src/tokenFetch.ts
@@ -88,7 +88,6 @@ export type TokenFetcher<T> = (options: T) => Promise<string | TokenResponse | n
  * @param tokenResponse - return value for TokenFetcher method
  * @returns Token value
  * @internal
- * @deprecated - Use authHeaderFromTokenResponse instead
  */
 export const tokenFromResponse = (
 	tokenResponse: string | TokenResponse | null | undefined,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -303,11 +303,13 @@ export class OdspDocumentServiceFactoryCore
 			this.getWebsocketToken === undefined
 				? undefined
 				: async (options: TokenFetchOptions): Promise<string | null> =>
+						// websocket expects a plain token
 						toInstrumentedOdspTokenFetcher(
 							extLogger,
 							resolvedUrlData,
 							this.getWebsocketToken!,
 							false /* throwOnNullToken */,
+							true /* returnPlainToken */,
 						)(options, "GetWebsocketToken");
 
 		return OdspDocumentService.create(

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -34,6 +34,7 @@ import {
 	TokenFetcher,
 	isTokenFromCache,
 	snapshotKey,
+	tokenFromResponse,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import {
 	type IFluidErrorBase,
@@ -372,6 +373,7 @@ export function toInstrumentedOdspTokenFetcher(
 	resolvedUrlParts: IOdspUrlParts,
 	tokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions>,
 	throwOnNullToken: boolean,
+	returnPlainToken: boolean = false,
 ): InstrumentedTokenFetcher {
 	return async (
 		options: TokenFetchOptions,
@@ -396,7 +398,9 @@ export function toInstrumentedOdspTokenFetcher(
 					...resolvedUrlParts,
 				}).then(
 					(tokenResponse) => {
-						const authHeader = authHeaderFromTokenResponse(tokenResponse);
+						const returnVal = returnPlainToken
+							? tokenFromResponse(tokenResponse)
+							: authHeaderFromTokenResponse(tokenResponse);
 						// This event alone generates so many events that is materially impacts cost of telemetry
 						// Thus do not report end event when it comes back quickly.
 						// Note that most of the hosts do not report if result is comming from cache or not,
@@ -405,10 +409,10 @@ export function toInstrumentedOdspTokenFetcher(
 						if (alwaysRecordTokenFetchTelemetry || event.duration >= 32) {
 							event.end({
 								fromCache: isTokenFromCache(tokenResponse),
-								isNull: authHeader === null,
+								isNull: returnVal === null,
 							});
 						}
-						if (authHeader === null && throwOnNullToken) {
+						if (returnVal === null && throwOnNullToken) {
 							throw new NonRetryableError(
 								// pre-0.58 error message: Token is null for ${name} call
 								`The Host-provided token fetcher returned null`,
@@ -416,7 +420,7 @@ export function toInstrumentedOdspTokenFetcher(
 								{ method: name, driverVersion },
 							);
 						}
-						return authHeader;
+						return returnVal;
 					},
 					(error) => {
 						// There is an important but unofficial contract here where token providers can set canRetry: true

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -357,7 +357,8 @@ export function toInstrumentedOdspStorageTokenFetcher(
 		logger,
 		resolvedUrlParts,
 		tokenFetcher,
-		true, // throwOnNullToken,
+		true, // throwOnNullToken
+		false, // returnPlainToken
 	);
 	// Drop undefined from signature - we can do it safely due to throwOnNullToken == true above
 	return res as InstrumentedStorageTokenFetcher;
@@ -367,13 +368,14 @@ export function toInstrumentedOdspStorageTokenFetcher(
  * Returns a function that can be used to fetch storage or websocket token.
  * There are scenarios where websocket token is not required / present (consumer stack and ordering service token),
  * thus it could return null. Use toInstrumentedOdspStorageTokenFetcher if you deal with storage token.
+ * @param returnPlainToken: When true, tokenResponse.token is returned. When false, tokenResponse.authorizationHeader is returned or an authorization header value is created based on tokenResponse.token
  */
 export function toInstrumentedOdspTokenFetcher(
 	logger: ITelemetryLoggerExt,
 	resolvedUrlParts: IOdspUrlParts,
 	tokenFetcher: TokenFetcher<OdspResourceTokenFetchOptions>,
 	throwOnNullToken: boolean,
-	returnPlainToken: boolean = false,
+	returnPlainToken: boolean,
 ): InstrumentedTokenFetcher {
 	return async (
 		options: TokenFetchOptions,

--- a/packages/drivers/odsp-driver/src/odspUtils.ts
+++ b/packages/drivers/odsp-driver/src/odspUtils.ts
@@ -368,7 +368,7 @@ export function toInstrumentedOdspStorageTokenFetcher(
  * Returns a function that can be used to fetch storage or websocket token.
  * There are scenarios where websocket token is not required / present (consumer stack and ordering service token),
  * thus it could return null. Use toInstrumentedOdspStorageTokenFetcher if you deal with storage token.
- * @param returnPlainToken: When true, tokenResponse.token is returned. When false, tokenResponse.authorizationHeader is returned or an authorization header value is created based on tokenResponse.token
+ * @param returnPlainToken - When true, tokenResponse.token is returned. When false, tokenResponse.authorizationHeader is returned or an authorization header value is created based on tokenResponse.token
  */
 export function toInstrumentedOdspTokenFetcher(
 	logger: ITelemetryLoggerExt,


### PR DESCRIPTION
## Description
#21601 introduced a bug to getWebsocketToken where the returned token was in authHeader format (e.g. `Berear <token>`) which push channel does not expect.

This PR adds an option to `toInstrumentedOdspTokenFetcher` to return the plain token instead of the full auth header.

## Breaking Changes
None

## Reviewer Guidance
None
