### PR TITLE
fix(client-odsp-client): apply API trimming

### DIFF
--- a/examples/service-clients/odsp-client/shared-tree-demo/.eslintrc.cjs
+++ b/examples/service-clients/odsp-client/shared-tree-demo/.eslintrc.cjs
@@ -5,5 +5,27 @@
 
 module.exports = {
 	extends: [require.resolve("@fluidframework/eslint-config-fluid/recommended"), "prettier"],
-	rules: {},
+	rules: {
+		/**
+		 * Allow Fluid Framework examples to import from unstable APIs.
+		 * https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-internal-modules.md
+		 */
+		"import/no-internal-modules": [
+			"error",
+			{
+				allow: [
+					// Within Fluid Framework allow import of '/beta' from other FF packages.
+					"@fluidframework/*/beta",
+
+					// Experimental package APIs and exports are unknown, so allow any imports from them.
+					"@fluid-experimental/**",
+
+					// Allow imports from sibling and ancestral sibling directories,
+					// but not from cousin directories. Parent is allowed but only
+					// because there isn't a known way to deny it.
+					"*/index.js",
+				],
+			},
+		],
+	},
 };

--- a/examples/service-clients/odsp-client/shared-tree-demo/package.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/package.json
@@ -37,7 +37,6 @@
 		"@azure/msal-browser": "^2.34.0",
 		"@fluidframework/odsp-client": "workspace:~",
 		"@fluidframework/odsp-doclib-utils": "workspace:~",
-		"@fluidframework/odsp-driver-definitions": "workspace:~",
 		"css-loader": "^6.11.0",
 		"fluid-framework": "workspace:~",
 		"react": "^17.0.1",

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { OdspClientProps, OdspConnectionConfig } from "@fluidframework/odsp-client";
+import { OdspClientProps, OdspConnectionConfig } from "@fluidframework/odsp-client/beta";
 
 import { OdspTestTokenProvider } from "./tokenProvider.js";
 

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/fluid.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/fluid.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { OdspClient, OdspContainerServices } from "@fluidframework/odsp-client";
+import { OdspClient, OdspContainerServices } from "@fluidframework/odsp-client/beta";
 import { ContainerSchema, IFluidContainer, SharedTree } from "fluid-framework";
 
 import { clientProps } from "./clientProps.js";

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/tokenProvider.ts
@@ -4,8 +4,7 @@
  */
 
 import { PublicClientApplication } from "@azure/msal-browser";
-import { IOdspTokenProvider } from "@fluidframework/odsp-client";
-import { TokenResponse } from "@fluidframework/odsp-driver-definitions/internal";
+import { IOdspTokenProvider, TokenResponse } from "@fluidframework/odsp-client/beta";
 
 export class OdspTestTokenProvider implements IOdspTokenProvider {
 	private readonly msalInstance: PublicClientApplication;

--- a/examples/utils/bundle-size-tests/src/odspClient.ts
+++ b/examples/utils/bundle-size-tests/src/odspClient.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { OdspClient } from "@fluidframework/odsp-client";
+import { OdspClient } from "@fluidframework/odsp-client/internal";
 
 export function apisToBundle() {
 	new OdspClient({} as any);

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
@@ -7,7 +7,7 @@ import {
 	IConfigProviderBase,
 	type ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import { OdspClient, OdspConnectionConfig } from "@fluidframework/odsp-client";
+import { OdspClient, OdspConnectionConfig } from "@fluidframework/odsp-client/internal";
 import { MockLogger, createMultiSinkLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { OdspTestTokenProvider } from "./OdspTokenFactory.js";

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspTokenFactory.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspTokenFactory.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import { IOdspTokenProvider } from "@fluidframework/odsp-client";
+import { IOdspTokenProvider } from "@fluidframework/odsp-client/internal";
 import {
 	IPublicClientConfig,
 	TokenRequestCredentials,

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
@@ -10,7 +10,7 @@ import { ConnectionState } from "@fluidframework/container-loader";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
-import { OdspClient } from "@fluidframework/odsp-client";
+import { OdspClient } from "@fluidframework/odsp-client/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
 import { createOdspClient, getCredentials } from "./OdspClientFactory.js";

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
@@ -9,7 +9,7 @@ import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
 import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
-import { OdspClient } from "@fluidframework/odsp-client";
+import { OdspClient } from "@fluidframework/odsp-client/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
 import { createOdspClient, getCredentials } from "./OdspClientFactory.js";

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
@@ -9,7 +9,7 @@ import { ConnectionState } from "@fluidframework/container-loader";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
-import { OdspClient } from "@fluidframework/odsp-client";
+import { OdspClient } from "@fluidframework/odsp-client/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
 import { createOdspClient, getCredentials } from "./OdspClientFactory.js";

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/utils.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { ISharedMap, IValueChanged } from "@fluidframework/map/internal";
-import { IOdspAudience, OdspMember } from "@fluidframework/odsp-client";
+import { IOdspAudience, OdspMember } from "@fluidframework/odsp-client/internal";
 
 export const waitForMember = async (
 	audience: IOdspAudience,

--- a/packages/service-clients/odsp-client/api-extractor/api-extractor-lint-public.cjs.json
+++ b/packages/service-clients/odsp-client/api-extractor/api-extractor-lint-public.cjs.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
-	"mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts"
+	"mainEntryPointFilePath": "<projectFolder>/dist/public.d.ts"
 }

--- a/packages/service-clients/odsp-client/api-extractor/api-extractor-lint-public.esm.json
+++ b/packages/service-clients/odsp-client/api-extractor/api-extractor-lint-public.esm.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
-	"mainEntryPointFilePath": "<projectFolder>/dist/index.d.ts"
+	"mainEntryPointFilePath": "<projectFolder>/lib/public.d.ts"
 }

--- a/packages/service-clients/odsp-client/package.json
+++ b/packages/service-clients/odsp-client/package.json
@@ -15,11 +15,11 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./lib/index.d.ts",
+				"types": "./lib/public.d.ts",
 				"default": "./lib/index.js"
 			},
 			"require": {
-				"types": "./dist/index.d.ts",
+				"types": "./dist/public.d.ts",
 				"default": "./dist/index.js"
 			}
 		},
@@ -45,7 +45,7 @@
 		}
 	},
 	"main": "lib/index.js",
-	"types": "lib/index.d.ts",
+	"types": "lib/public.d.ts",
 	"scripts": {
 		"api": "fluid-build . --task api",
 		"api-extractor:commonjs": "flub generate entrypoints --outDir ./dist",
@@ -63,9 +63,9 @@
 		"check:exports": "concurrently \"npm:check:exports:*\"",
 		"check:exports:bundle-release-tags": "api-extractor run --config api-extractor/api-extractor-lint-bundle.json",
 		"check:exports:cjs:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.cjs.json",
-		"check:exports:cjs:index": "api-extractor run --config api-extractor/api-extractor-lint-index.cjs.json",
+		"check:exports:cjs:public": "api-extractor run --config api-extractor/api-extractor-lint-public.cjs.json",
 		"check:exports:esm:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.esm.json",
-		"check:exports:esm:index": "api-extractor run --config api-extractor/api-extractor-lint-index.esm.json",
+		"check:exports:esm:public": "api-extractor run --config api-extractor/api-extractor-lint-public.esm.json",
 		"check:format": "npm run check:biome",
 		"check:prettier": "prettier --check . --cache --ignore-path ../../../.prettierignore",
 		"ci:build:docs": "api-extractor run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4390,9 +4390,6 @@ importers:
       '@fluidframework/odsp-doclib-utils':
         specifier: workspace:~
         version: link:../../../../packages/utils/odsp-doclib-utils
-      '@fluidframework/odsp-driver-definitions':
-        specifier: workspace:~
-        version: link:../../../../packages/drivers/odsp-driver-definitions
       css-loader:
         specifier: ^6.11.0
         version: 6.11.0(webpack@5.89.0)


### PR DESCRIPTION
typescript builds against `odsp-client` must use `/beta` import spec path to import `@beta` APIs.

Correct use within examples including mismatched `TokenResponse` import.