### PR TITLE
RemoteDatastoreContext should handle snapshot with groupId with older loader

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -1058,6 +1058,7 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 	private snapshotFetchRequired: boolean | undefined;
 	private readonly runtime: IContainerRuntimeBase;
 	private readonly blobContents: Map<string, ArrayBuffer> | undefined;
+	private readonly isSnapshotInISnapshotFormat: boolean | undefined;
 
 	constructor(props: IRemoteFluidDataStoreContextProps) {
 		super(props, true /* existing */, false /* isLocalDataStore */, () => {
@@ -1068,8 +1069,10 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 		if (isInstanceOfISnapshot(props.snapshot)) {
 			this.blobContents = props.snapshot.blobContents;
 			this._baseSnapshot = props.snapshot.snapshotTree;
+			this.isSnapshotInISnapshotFormat = true;
 		} else {
 			this._baseSnapshot = props.snapshot;
+			this.isSnapshotInISnapshotFormat = false;
 		}
 		if (this._baseSnapshot !== undefined) {
 			this.summarizerNode.updateBaseSummaryState(this._baseSnapshot);
@@ -1091,10 +1094,13 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 	private readonly initialSnapshotDetailsP = new LazyPromise<ISnapshotDetails>(async () => {
 		// Sequence number of the snapshot.
 		let sequenceNumber: number | undefined;
-		// Check whether we need to fetch the snapshot first to load.
+		// Check whether we need to fetch the snapshot first to load. The snapshot should be in new format to see
+		// whether we want to evaluate to fetch snapshot or not for loadingGroupId. Otherwise, the snapshot
+		// will contain all the blobs.
 		if (
 			this.snapshotFetchRequired === undefined &&
-			this._baseSnapshot?.groupId !== undefined
+			this._baseSnapshot?.groupId !== undefined &&
+			this.isSnapshotInISnapshotFormat
 		) {
 			assert(
 				this.blobContents !== undefined,

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -20,7 +20,6 @@ import { SummaryType } from "@fluidframework/driver-definitions";
 import type { ISnapshot, ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import { getSnapshotTree } from "@fluidframework/driver-utils/internal";
 import type { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/internal";
-import type { IFluidErrorBase } from "@fluidframework/telemetry-utils/internal";
 import {
 	type ITestObjectProvider,
 	createSummarizerFromFactory,
@@ -375,21 +374,7 @@ describeCompat(
 			const handleB2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectB");
 			const handleC2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectC");
 
-			// Essentially, this should not reject
-			// When fixed, this function should be removed.
-			const assertInvertDoesNotReject = async (promise: Promise<unknown>, message: string) => {
-				await assert.rejects(
-					promise,
-					// Not sure which error interface to use here, but the key is the message
-					(thrown: IFluidErrorBase) => {
-						assert(thrown.message.includes("0x97a"), "Error message should be correct");
-						return true;
-					},
-					message,
-				);
-			};
-
-			await assertInvertDoesNotReject(
+			await assert.doesNotReject(
 				mainObject2.containerRuntime.getAliasedDataStoreEntryPoint("dataObjectD"),
 				"D should not be loaded",
 			);
@@ -398,9 +383,9 @@ describeCompat(
 			assert(handleC2 !== undefined, "handleC2 should not be undefined");
 
 			// When fixed, all these should not fail.
-			await assertInvertDoesNotReject(handleA2.get(), "should be able to retrieve A");
-			await assertInvertDoesNotReject(handleB2.get(), "should be able to retrieve B");
-			await assertInvertDoesNotReject(handleC2.get(), "should be able to retrieve C");
+			await assert.doesNotReject(handleA2.get(), "should be able to retrieve A");
+			await assert.doesNotReject(handleB2.get(), "should be able to retrieve B");
+			await assert.doesNotReject(handleC2.get(), "should be able to retrieve C");
 		});
 
 		it("Can create loadingGroupId via detached flow", async () => {


### PR DESCRIPTION
## Description

RemoteDatastoreContext should handle snapshot with groupId with older loader. So, in case where we fetch the snapshot using old loader and does not have ISnapshot which contains blobContents, then that means we must have fetched the full snapshot using older format, so there is no need to evaluate in that case whether to fetch the snapshot or not.  

Enable the test as it passes with odsp.