### PR TITLE
fix(tree): codec handling of constraint violation count

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -429,6 +429,7 @@ function makeModularChangeCodec(
 				changes: encodeFieldChangesForJson(change.fieldChanges, context, change.nodeChanges),
 				builds: encodeDetachedNodes(change.builds, context),
 				refreshers: encodeDetachedNodes(change.refreshers, context),
+				violations: change.constraintViolationCount,
 			};
 		},
 
@@ -448,6 +449,10 @@ function makeModularChangeCodec(
 			}
 			if (encodedChange.refreshers !== undefined) {
 				decoded.refreshers = decodeDetachedNodes(encodedChange.builds, context);
+			}
+
+			if (encodedChange.violations !== undefined) {
+				decoded.constraintViolationCount = encodedChange.violations;
 			}
 
 			const decodedRevInfos = decodeRevisionInfos(encodedChange.revisions, context);

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFormat.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFormat.ts
@@ -132,6 +132,10 @@ export const EncodedModularChangeset = Type.Object(
 		revisions: Type.ReadonlyOptional(Type.Array(EncodedRevisionInfo)),
 		builds: Type.Optional(EncodedBuilds),
 		refreshers: Type.Optional(EncodedBuilds),
+		/**
+		 * The number of constraints within this changeset that are violated.
+		 */
+		violations: Type.Optional(Type.Number({ minimum: 0, multipleOf: 1 })),
 	},
 	noAdditionalProps,
 );

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -1418,6 +1418,11 @@ describe("ModularChangeFamily", () => {
 			successes: [
 				["without constraint", inlineRevision(rootChange1a, tag1), context],
 				["with constraint", inlineRevision(rootChange3, tag1), context],
+				[
+					"with violated constraint",
+					inlineRevision({ ...buildChangeset([]), constraintViolationCount: 42 }, tag1),
+					context,
+				],
 				["with node existence constraint", inlineRevision(rootChange4, tag1), context],
 				[
 					"without node field changes",


### PR DESCRIPTION
Cherry-pick of https://github.com/microsoft/FluidFramework/pull/21719
This fix was tested and validated by SharePoint Pages (the customer that needs it).

## Description

The codec for `ModularChangeFamily` did not include constraint violation count information during encoding (and did not try to read it during decoding).

This led to document corruption and state divergence bugs because receiving peers would apply the changesets instead of considering them violated, while the sender did not apply it.

## Breaking Changes

While this fixes the issue, this fix will cause clients running older code (i.e., before this change) to crash when receiving a changeset  with constraint violations. This is arguably better than corrupting the document, but since not all such scenarios would have led to corruption, it's possible that this fix will make some scenarios worse. The remedy is to update the clients to this newer code.