### PR TITLE
perf(tree): avoid unnecessary deep copy of inner maps

### DIFF
--- a/packages/dds/tree/src/util/nestedMap.ts
+++ b/packages/dds/tree/src/util/nestedMap.ts
@@ -44,7 +44,7 @@ export function tryAddToNestedMap<Key1, Key2, Value>(
  *
  * @param source - The map to copy data from. Not mutated.
  * @param destination - The map to copy data into. Both the outer and inner map may be mutated.
- * @param override - When `true` any values in `destination` will be overwritten with values from `destination` for all pairs of keys they have in common.
+ * @param override - Whether existing entries in `destination` should be replaced by corresponding entries in `source`.
  *
  * @remarks - This function performs deep copying when necessary.
  * This ensures that mutating `destination` after this call will not result in unexpected mutations to `source`.

--- a/packages/dds/tree/src/util/nestedMap.ts
+++ b/packages/dds/tree/src/util/nestedMap.ts
@@ -59,6 +59,7 @@ export function populateNestedMap<Key1, Key2, Value>(
 		let destinationInner = destination.get(key1);
 		if (destinationInner === undefined) {
 			destinationInner = new Map(sourceInner);
+			destination.set(key1, destinationInner);
 		} else {
 			for (const [key2, value] of sourceInner) {
 				if (override || !destinationInner.has(key2)) {
@@ -66,8 +67,6 @@ export function populateNestedMap<Key1, Key2, Value>(
 				}
 			}
 		}
-
-		destination.set(key1, destinationInner);
 	}
 }
 


### PR DESCRIPTION
## Description

Avoids deep-copying inner maps in `populateNestedMap` when not necessary. Documents `populateNestedMap` contract more clearly.

## Breaking Changes

None