### PR TITLE
fix(fluid-tsc): Make --build fluid-tsc command not fail with no output

### DIFF
--- a/build-tools/packages/build-tools/src/common/tscUtils.ts
+++ b/build-tools/packages/build-tools/src/common/tscUtils.ts
@@ -195,10 +195,25 @@ function createTscUtil(tsLib: typeof ts) {
 				console.warn("Warning: '&&' is not supported in tsc command.");
 			}
 
-			const parsedCommand = tsLib.parseCommandLine(args.slice(1));
+			let slicedArgs = args.slice(1);
+			// workaround for https://github.com/microsoft/TypeScript/issues/59095
+			// TODO: This breaks --force (by removing it). Find a way to fix --force.
+			// See code in leaf/tscTask.ts which adds --force.
+			if (slicedArgs.at(-1) === "--force") {
+				slicedArgs = slicedArgs.slice(0, slicedArgs.length - 1);
+			}
+			const parsedCommand = tsLib.parseCommandLine(slicedArgs);
+
 			if (parsedCommand.errors.length) {
+				console.error(
+					`Error parsing tsc command: ${command} (split into ${JSON.stringify(slicedArgs)}.`,
+				);
+				for (const error of parsedCommand.errors) {
+					console.error(error);
+				}
 				return undefined;
 			}
+
 			return parsedCommand;
 		},
 

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/leaf/tscTask.ts
@@ -52,6 +52,7 @@ export class TscTask extends LeafTask {
 			// `tsc -b` by design doesn't rebuild if dependent packages changed
 			// but not a referenced project. Just force it if we detected the change and
 			// invoke the build.
+			// `--force` is not fully supported, due to workaround in createTscUtil, so this may not actually work.
 			return `${this.command} --force`;
 		}
 		return this.command;


### PR DESCRIPTION
## Description

tsCompile.ts just does nothing when parseCommandLine returned undefined, and parseCommandLine returns undefined if tsLib.parseCommandLine reports errors.

When the command was 'tsc --build ./src/test/tsconfig.cjs.json --force', an error "Compiler option '--force' may only be used with '--build'." is reported (due to https://github.com/microsoft/TypeScript/issues/59095 ), which used to be dropped.

This change ensures the error is at least printed (confirmed to work with manual testing), as well as removed --force to work around this specific error.

This workaround may convert cases which silently error into having an incremental build bug in some cases. This is required to enable https://github.com/microsoft/FluidFramework/pull/21579 which will allow us to detect bad d.ts file generation by importing d.ts files from test schema in the tree tests. As we have multiple know issues with the d.ts file generation, testing it is valuable. Given we already have known incremental build issues with tests (cleanup of extra files), so we have to clean build them occasionally, this seems like a decent tradeoff.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

