### PR TITLE
docs: Fix typo in private-package notice template, and update READMEs

### DIFF
--- a/packages/dds/test-dds-utils/README.md
+++ b/packages/dds/test-dds-utils/README.md
@@ -4,7 +4,7 @@ Utilities for writing unit tests for DDS in Fluid Framework.
 
 <!-- AUTO-GENERATED-CONTENT:START (README_PACKAGE_SCOPE_NOTICE) -->
 
-**NOTE: This package is private to the `@microsot/fluid-framework` repository.**
+**NOTE: This package is private to the `@microsoft/fluid-framework` repository.**
 **It is not published, and therefore may only be used as a dev dependency.**
 
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/packages/loader/test-loader-utils/README.md
+++ b/packages/loader/test-loader-utils/README.md
@@ -7,7 +7,7 @@ Test utilities for the Fluid Framework Loader. Includes mock implementations of 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
 
-**NOTE: This package is private to the `@microsot/fluid-framework` repository.**
+**NOTE: This package is private to the `@microsoft/fluid-framework` repository.**
 **It is not published, and therefore may only be used as a dev dependency.**
 
 ## Contribution Guidelines

--- a/packages/test/stochastic-test-utils/README.md
+++ b/packages/test/stochastic-test-utils/README.md
@@ -6,7 +6,7 @@ For example, they are useful for asserting eventual convergence properties of DD
 
 <!-- AUTO-GENERATED-CONTENT:START (README_PACKAGE_SCOPE_NOTICE) -->
 
-**NOTE: This package is private to the `@microsot/fluid-framework` repository.**
+**NOTE: This package is private to the `@microsoft/fluid-framework` repository.**
 **It is not published, and therefore may only be used as a dev dependency.**
 
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/packages/test/test-pairwise-generator/README.md
+++ b/packages/test/test-pairwise-generator/README.md
@@ -7,7 +7,7 @@ See [examples.spec.ts](./src/test/examples.spec.ts) for usage examples.
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
 
-**NOTE: This package is private to the `@microsot/fluid-framework` repository.**
+**NOTE: This package is private to the `@microsoft/fluid-framework` repository.**
 **It is not published, and therefore may only be used as a dev dependency.**
 
 ## Contribution Guidelines

--- a/packages/test/test-version-utils/README.md
+++ b/packages/test/test-version-utils/README.md
@@ -9,7 +9,7 @@ exports to get the versioned Fluid APIs.
 
 <!-- AUTO-GENERATED-CONTENT:START (README_PACKAGE_SCOPE_NOTICE) -->
 
-**NOTE: This package is private to the `@microsot/fluid-framework` repository.**
+**NOTE: This package is private to the `@microsoft/fluid-framework` repository.**
 **It is not published, and therefore may only be used as a dev dependency.**
 
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/tools/markdown-magic/src/templates/Private-Package-Notice-Template.md
+++ b/tools/markdown-magic/src/templates/Private-Package-Notice-Template.md
@@ -1,2 +1,2 @@
-**NOTE: This package is private to the `@microsot/fluid-framework` repository.**
+**NOTE: This package is private to the `@microsoft/fluid-framework` repository.**
 **It is not published, and therefore may only be used as a dev dependency.**


### PR DESCRIPTION
Fixes a typo