### PR TITLE
test(tree): Tests to validate no flex nodes are allocated on leaf access

### DIFF
--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -53,7 +53,6 @@ import {
 import type {
 	ITree,
 	ImplicitFieldSchema,
-	TreeView,
 	TreeViewConfiguration,
 } from "../simple-tree/index.js";
 
@@ -322,7 +321,7 @@ export class SharedTree
 
 	public viewWith<TRoot extends ImplicitFieldSchema>(
 		config: TreeViewConfiguration<TRoot>,
-	): TreeView<TRoot> {
+	): SchematizingSimpleTreeView<TRoot> {
 		return new SchematizingSimpleTreeView(
 			this.checkout,
 			config,

--- a/packages/dds/tree/src/test/simple-tree/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/tree.spec.ts
@@ -155,3 +155,81 @@ describe("class-tree tree", () => {
 		});
 	});
 });
+
+describe("object allocation tests", () => {
+	it("accessing leaf on object node does not allocate flex nodes", () => {
+		class TreeWithLeaves extends schema.object("TreeWithLeaves", { leaf: schema.number }) {}
+		const config = new TreeViewConfiguration({ schema: TreeWithLeaves });
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+		const view = tree.viewWith(config);
+		view.initialize({ leaf: 1 });
+		const context = view.getView().context;
+		// Note: access the root before trying to access just the leaf, to not count any object allocations that result from
+		// accessing the root as part of the allocations from the leaf access. Also, store it to avoid additional computation
+		// from any intermediate getters when accessing the leaf.
+		const root = view.root;
+		const countBefore = context.withAnchors.size;
+		const _accessLeaf = root.leaf;
+		const countAfter = context.withAnchors.size;
+
+		// As of 2024-07-01 we still allocate flex fields when accessing leaves, so the after-count is expected to be one higher
+		// than the before count.
+		// TODO: if/when we stop allocating flex fields when accessing leaves, this test will fail and should be updated so
+		// the two counts match, plus its title updated accordingly.
+		assert.equal(countAfter, countBefore + 1);
+	});
+
+	it("accessing leaf on map node does not allocate flex nodes", () => {
+		class TreeWithLeaves extends schema.map("MapOfLeaves", schema.number) {}
+		const config = new TreeViewConfiguration({ schema: TreeWithLeaves });
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+		const view = tree.viewWith(config);
+		view.initialize(new Map([["1", 1]]));
+		const context = view.getView().context;
+		// Note: access the map that contains leaves before trying to access just the leaf at one of the keys, to not
+		// count any object allocations that result from accessing the root/map as part of the allocations from the leaf
+		// access. Also, store it to avoid additional computation from any intermediate getters when accessing the leaf.
+		const root = view.root;
+		const countBefore = context.withAnchors.size;
+		const _accessLeaf = root.get("1");
+		const countAfter = context.withAnchors.size;
+
+		// As of 2024-07-01 we still allocate flex fields when accessing leaves, so the after-count is expected to be one higher
+		// than the before count.
+		// TODO: if/when we stop allocating flex fields when accessing leaves, this test will fail and should be updated so
+		// the two counts match, plus its title updated accordingly.
+		assert.equal(countAfter, countBefore + 1);
+	});
+
+	// TODO: AB#8575 re-enable this test once leaf access on arrays does not allocate flex nodes
+	it.skip("accessing leaf on array node does not allocate flex nodes", () => {
+		class TreeWithLeaves extends schema.array("ArrayOfLeaves", schema.number) {}
+		const config = new TreeViewConfiguration({ schema: TreeWithLeaves });
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+		const view = tree.viewWith(config);
+		view.initialize([1]);
+		const context = view.getView().context;
+		// Note: access the array that contains leaves before trying to access just the leaf at one of its indices, to not
+		// count any object allocations that result from accessing the root/array as part of the allocations from the leaf
+		// access. Also, store it to avoid additional computation from any intermediat getters when accessing the leaf.
+		const root = view.root;
+		const countBefore = context.withAnchors.size;
+		const _accessLeaf = root[0];
+		const countAfter = context.withAnchors.size;
+
+		// As of 2024-07-01 we still allocate flex fields when accessing leaves, so the after-count is expected to be one higher
+		// than the before count.
+		// TODO: if/when we stop allocating flex fields when accessing leaves, this test will fail and should be updated so
+		// the two counts match, plus its title updated accordingly.
+		assert.equal(countAfter, countBefore + 1);
+	});
+});


### PR DESCRIPTION
## Description

Add tests to validate that no flex nodes are allocated when accessing leaves through simple-tree.

Note: accessing leaves in an array still allocates flex nodes for them, so that test is skipped in this PR, with a TODO pointing to the corresponding ADO item.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).