### PR TITLE
fix(property-changeset): Use CommonJS entrypoints for main/types fields

### DIFF
--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -23,8 +23,8 @@
 			}
 		}
 	},
-	"main": "lib/index.js",
-	"types": "lib/index.d.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"files": [
 		"dist/**/*",
 		"lib/**/*",


### PR DESCRIPTION
The property-changeset package was changed to dual emit CJS and ESM, and the `main`/`types` field was changed to point to ESM. Unfortunately, the property-properties package has a dependency on this package and it is CJS-only and still using Node10 module resolution.

To address this incompatibility, I have reverted the changes to the main and types fields - they now point to the CommonJS entrypoint.