### PR TITLE
fix(property-properties): Ensure ESM dependencies are built

### DIFF
--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -23,8 +23,8 @@
 			}
 		}
 	},
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
+	"main": "lib/index.js",
+	"types": "lib/index.d.ts",
 	"files": [
 		"dist/**/*",
 		"lib/**/*",

--- a/experimental/PropertyDDS/packages/property-changeset/package.json
+++ b/experimental/PropertyDDS/packages/property-changeset/package.json
@@ -23,8 +23,8 @@
 			}
 		}
 	},
-	"main": "lib/index.js",
-	"types": "lib/index.d.ts",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
 	"files": [
 		"dist/**/*",
 		"lib/**/*",

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -98,6 +98,7 @@
 		"tasks": {
 			"tsc": [
 				"...",
+				"@fluid-experimental/property-common#build:esnext",
 				"@fluid-experimental/property-changeset#build:esnext"
 			]
 		}

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -94,16 +94,16 @@
 		"sinon": "^17.0.1",
 		"typescript": "~5.4.5"
 	},
-	"typeValidation": {
-		"disabled": true,
-		"broken": {}
-	},
 	"fluidBuild": {
 		"tasks": {
 			"tsc": [
 				"...",
-				"^build:esnext"
+				"@fluid-experimental/property-changeset#build:esnext"
 			]
 		}
+	},
+	"typeValidation": {
+		"disabled": true,
+		"broken": {}
 	}
 }

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -97,5 +97,13 @@
 	"typeValidation": {
 		"disabled": true,
 		"broken": {}
+	},
+	"fluidBuild": {
+		"tasks": {
+			"tsc": [
+				"...",
+				"^build:esnext"
+			]
+		}
 	}
 }

--- a/experimental/PropertyDDS/packages/property-properties/package.json
+++ b/experimental/PropertyDDS/packages/property-properties/package.json
@@ -98,7 +98,6 @@
 		"tasks": {
 			"tsc": [
 				"...",
-				"@fluid-experimental/property-common#build:esnext",
 				"@fluid-experimental/property-changeset#build:esnext"
 			]
 		}


### PR DESCRIPTION
The property-changeset package was changed to dual emit CJS and ESM, and the `main`/`types` field was changed to point to ESM. Unfortunately, the property-properties package has a dependency on this package and it is CJS-only and still using Node10 module resolution.

To address this incompatibility, I have updated the build tasks for property-properties to require the ESM builds of its dependencies.

This is an alternative change to #21744.