### PR TITLE
refactor(tree): Optimize leaf access on arrays

### DIFF
--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -556,11 +556,6 @@ function createArrayNodeProxy(
 			}
 
 			const maybeUnboxedContent = field.at(maybeIndex);
-
-			if (maybeUnboxedContent === undefined) {
-				return undefined;
-			}
-
 			return isFlexTreeNode(maybeUnboxedContent)
 				? getOrCreateNodeProxy(maybeUnboxedContent)
 				: maybeUnboxedContent;

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -19,6 +19,7 @@ import {
 	getOrCreateMapTreeNode,
 	getSchemaAndPolicy,
 	isMapTreeNode,
+	isFlexTreeNode,
 } from "../feature-libraries/index.js";
 import {
 	type InsertableContent,
@@ -554,16 +555,15 @@ function createArrayNodeProxy(
 				return Reflect.get(dispatchTarget, key, receiver) as unknown;
 			}
 
-			const value = field.boxedAt(maybeIndex);
+			const maybeUnboxedContent = field.at(maybeIndex);
 
-			if (value === undefined) {
+			if (maybeUnboxedContent === undefined) {
 				return undefined;
 			}
 
-			// TODO: Ideally, we would return leaves without first boxing them.  However, this is not
-			//       as simple as calling '.content' since this skips the node and returns the FieldNode's
-			//       inner field.
-			return getOrCreateNodeProxy(value);
+			return isFlexTreeNode(maybeUnboxedContent)
+				? getOrCreateNodeProxy(maybeUnboxedContent)
+				: maybeUnboxedContent;
 		},
 		set: (target, key, newValue, receiver) => {
 			if (key === "length") {

--- a/packages/dds/tree/src/test/simple-tree/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/tree.spec.ts
@@ -247,8 +247,7 @@ describe("object allocation tests", () => {
 		assert.equal(countAfter, countBefore + 1);
 	});
 
-	// TODO: AB#8575 re-enable this test once leaf access on arrays does not allocate flex nodes
-	it.skip("accessing leaf on array node does not allocate flex nodes", () => {
+	it("accessing leaf on array node does not allocate flex nodes", () => {
 		class TreeWithLeaves extends schema.array("ArrayOfLeaves", schema.number) {}
 		const config = new TreeViewConfiguration({ schema: TreeWithLeaves });
 		const tree = factory.create(

--- a/packages/dds/tree/src/test/simple-tree/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/tree.spec.ts
@@ -255,20 +255,21 @@ describe("object allocation tests", () => {
 			"tree",
 		);
 		const view = tree.viewWith(config);
-		view.initialize([1]);
+		view.initialize([1, 2]);
 		const context = view.getView().context;
-		// Note: access the array that contains leaves before trying to access just the leaf at one of its indices, to not
-		// count any object allocations that result from accessing the root/array as part of the allocations from the leaf
-		// access. Also, store it to avoid additional computation from any intermediat getters when accessing the leaf.
+		// Note: prior to taking the "before count", access the array that contains leaves *and the first leaf in it*,
+		// to ensure that the sequence field for the array is allocated and accounted for. We expect the sequence field
+		// to be required anyway (vs the field for a leaf property on an object node, for example, where we might be able
+		// to optimize away its allocation) so might as well count it up front. The subsequent access to the second leaf
+		// should then not allocate anything new.
+		// Also, store the array/root to avoid additional computation from any intermediate getters when accessing leaves.
 		const root = view.root;
+		const _accessLeaf0 = root[0];
 		const countBefore = context.withAnchors.size;
-		const _accessLeaf = root[0];
+		const _accessLeaf1 = root[1];
 		const countAfter = context.withAnchors.size;
 
-		// As of 2024-07-01 we still allocate flex fields when accessing leaves, so the after-count is expected to be one higher
-		// than the before count.
-		// TODO: if/when we stop allocating flex fields when accessing leaves, this test will fail and should be updated so
-		// the two counts match, plus its title updated accordingly.
-		assert.equal(countAfter, countBefore + 1);
+		// The array test is deliberately distinct from the object and map ones, see the comment above for the rationale.
+		assert.equal(countAfter, countBefore);
 	});
 });


### PR DESCRIPTION
## Description

Skips boxing when accessing leaves on arrays.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Benchmark comparison with main looks as expected:

![image](https://github.com/microsoft/FluidFramework/assets/716334/817d2d51-2bb7-4211-8ee7-9542107d3279)

[AB#8575](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8575)