### PR TITLE
[Prototype] NoOp container message type 

### DIFF
--- a/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
+++ b/packages/common/container-definitions/api-report/container-definitions.legacy.alpha.api.md
@@ -143,6 +143,8 @@ export interface IContainerContext {
     readonly id: string;
     // (undocumented)
     readonly loader: ILoader;
+    // (undocumented)
+    readonly offlineLoadEnabled?: boolean;
     readonly options: Record<string | number, any>;
     // (undocumented)
     pendingLocalState?: unknown;

--- a/packages/common/container-definitions/src/runtime.ts
+++ b/packages/common/container-definitions/src/runtime.ts
@@ -148,6 +148,7 @@ export interface IContainerContext {
 	readonly storage: IDocumentStorageService;
 	readonly connected: boolean;
 	readonly baseSnapshot: ISnapshotTree | undefined;
+	readonly offlineLoadEnabled?: boolean;
 	/**
 	 * @deprecated Please use submitBatchFn & submitSummaryFn
 	 */

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -489,6 +489,7 @@ export class Container
 	private readonly detachedBlobStorage: IDetachedBlobStorage | undefined;
 	private readonly protocolHandlerBuilder: ProtocolHandlerBuilder;
 	private readonly client: IClient;
+	private readonly offlineLoadEnabled: boolean;
 
 	private readonly mc: MonitoringContext;
 
@@ -999,7 +1000,7 @@ export class Container
 			enableSummarizeProtocolTree,
 		);
 
-		const offlineLoadEnabled =
+		this.offlineLoadEnabled =
 			(this.isInteractiveClient &&
 				this.mc.config.getBoolean("Fluid.Container.enableOfflineLoad")) ??
 			options.enableOfflineLoad === true;
@@ -1007,7 +1008,7 @@ export class Container
 			pendingLocalState,
 			this.subLogger,
 			this.storageAdapter,
-			offlineLoadEnabled,
+			this.offlineLoadEnabled,
 			this,
 			() => this._deltaManager.connectionManager.shouldJoinWrite(),
 			() => this.supportGetSnapshotApi(),
@@ -2438,6 +2439,7 @@ export class Container
 			this.subLogger,
 			pendingLocalState,
 			snapshot,
+			this.offlineLoadEnabled,
 		);
 
 		this._runtime = await PerformanceEvent.timedExecAsync(

--- a/packages/loader/container-loader/src/containerContext.ts
+++ b/packages/loader/container-loader/src/containerContext.ts
@@ -112,6 +112,7 @@ export class ContainerContext implements IContainerContext {
 		public readonly taggedLogger: ITelemetryLoggerExt,
 		public readonly pendingLocalState?: unknown,
 		public readonly snapshotWithContents?: ISnapshot,
+		public readonly offlineLoadEnabled?: boolean,
 	) {}
 
 	public getLoadedFromVersion(): IVersion | undefined {

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -29,6 +29,8 @@ export enum ContainerMessageType {
     GC = "GC",
     IdAllocation = "idAllocation",
     // (undocumented)
+    NoOp = "noop",
+    // (undocumented)
     Rejoin = "rejoin"
 }
 
@@ -129,6 +131,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     makeLocallyVisible(): void;
     // (undocumented)
     notifyOpReplay(message: ISequencedDocumentMessage): Promise<void>;
+    // (undocumented)
+    offlineLoadEnabled: any;
     // (undocumented)
     onSchemaChange(schema: IDocumentSchemaCurrent): void;
     // (undocumented)

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -228,6 +228,13 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"EnumDeclaration_ContainerMessageType": {
+				"backCompat": false
+			},
+			"ClassDeclaration_ContainerRuntime": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/container-runtime/src/messageTypes.ts
+++ b/packages/runtime/container-runtime/src/messageTypes.ts
@@ -56,6 +56,8 @@ export enum ContainerMessageType {
 	 * state across all clients.
 	 */
 	GC = "GC",
+
+	NoOp = "noop",
 }
 
 /**
@@ -129,6 +131,10 @@ export type ContainerRuntimeRejoinMessage = TypedContainerRuntimeMessage<
 	ContainerMessageType.Rejoin,
 	undefined
 >;
+export type ContainerRuntimeNoOpMessage = TypedContainerRuntimeMessage<
+	ContainerMessageType.NoOp,
+	undefined
+>;
 export type ContainerRuntimeAliasMessage = TypedContainerRuntimeMessage<
 	ContainerMessageType.Alias,
 	IDataStoreAliasMessage
@@ -173,6 +179,7 @@ export type InboundContainerRuntimeMessage =
 	| ContainerRuntimeChunkedOpMessage
 	| ContainerRuntimeBlobAttachMessage
 	| ContainerRuntimeRejoinMessage
+	| ContainerRuntimeNoOpMessage
 	| ContainerRuntimeAliasMessage
 	| ContainerRuntimeIdAllocationMessage
 	| ContainerRuntimeGCMessage
@@ -189,6 +196,7 @@ export type LocalContainerRuntimeMessage =
 	| OutboundContainerRuntimeAttachMessage
 	| ContainerRuntimeBlobAttachMessage
 	| ContainerRuntimeRejoinMessage
+	| ContainerRuntimeNoOpMessage
 	| ContainerRuntimeAliasMessage
 	| ContainerRuntimeIdAllocationMessage
 	| ContainerRuntimeGCMessage
@@ -203,6 +211,7 @@ export type OutboundContainerRuntimeMessage =
 	| ContainerRuntimeChunkedOpMessage
 	| ContainerRuntimeBlobAttachMessage
 	| ContainerRuntimeRejoinMessage
+	| ContainerRuntimeNoOpMessage
 	| ContainerRuntimeAliasMessage
 	| ContainerRuntimeIdAllocationMessage
 	| ContainerRuntimeGCMessage

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -209,6 +209,7 @@ declare function get_current_EnumDeclaration_ContainerMessageType():
 declare function use_old_EnumDeclaration_ContainerMessageType(
     use: TypeOnly<old.ContainerMessageType>): void;
 use_old_EnumDeclaration_ContainerMessageType(
+    // @ts-expect-error compatibility expected to be broken
     get_current_EnumDeclaration_ContainerMessageType());
 
 /*
@@ -223,6 +224,7 @@ declare function get_old_ClassDeclaration_ContainerRuntime():
 declare function use_current_ClassDeclaration_ContainerRuntime(
     use: TypeOnly<current.ContainerRuntime>): void;
 use_current_ClassDeclaration_ContainerRuntime(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_ContainerRuntime());
 
 /*

--- a/packages/tools/fetch-tool/src/fluidAnalyzeMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidAnalyzeMessages.ts
@@ -596,6 +596,7 @@ function processOp(
 			case ContainerMessageType.IdAllocation:
 			case ContainerMessageType.FluidDataStoreOp:
 			case ContainerMessageType.Alias:
+			case ContainerMessageType.NoOp:
 			case ContainerMessageType.Rejoin: {
 				let envelope = runtimeMessage.contents as IEnvelope;
 				// TODO: Legacy?


### PR DESCRIPTION
Solves [AB#8283](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8283)
We need a way to catch whenever a batch becomes empty on resubmission. The "NoOp" message type is intended to accomplish that by being sent in case we have offline load enabled and we try tu resubmit an empty batch. 
There's still an optimization to be made about just catching the case where the batch "becomes" empty on resubmt instead just "being" empty in the first place. 
