### PR TITLE
fix(tree): fix serialization of refreshers

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -448,7 +448,7 @@ function makeModularChangeCodec(
 				decoded.builds = decodeDetachedNodes(encodedChange.builds, context);
 			}
 			if (encodedChange.refreshers !== undefined) {
-				decoded.refreshers = decodeDetachedNodes(encodedChange.builds, context);
+				decoded.refreshers = decodeDetachedNodes(encodedChange.refreshers, context);
 			}
 
 			if (encodedChange.violations !== undefined) {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFormat.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFormat.ts
@@ -130,6 +130,8 @@ export const EncodedModularChangeset = Type.Object(
 		maxId: Type.Optional(ChangesetLocalIdSchema),
 		changes: EncodedFieldChangeMap,
 		revisions: Type.ReadonlyOptional(Type.Array(EncodedRevisionInfo)),
+		// TODO#8574: separating `builds` and `refreshers` here means that we encode their `EncodedBuilds.trees` separately.
+		// This can lead to a less efficient wire representation because of duplicated schema/shape information.
 		builds: Type.Optional(EncodedBuilds),
 		refreshers: Type.Optional(EncodedBuilds),
 		/**

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -1505,7 +1505,7 @@ function treeChunkFromCursor(cursor: ITreeCursorSynchronous): TreeChunk {
 	return chunkTree(cursor, defaultChunkPolicy);
 }
 
-function deepCloneTreeChunk(chunk: TreeChunk): TreeChunk {
+function deepCloneChunkedTree(chunk: TreeChunk): TreeChunk {
 	const jsonable = jsonableTreeFromFieldCursor(chunk.cursor());
 	const cursor = cursorForJsonableTreeField(jsonable);
 	const clone = chunkFieldSingle(cursor, defaultChunkPolicy);
@@ -1562,10 +1562,10 @@ function normalizeChangeset(change: ModularChangeset): ModularChangeset {
 
 	// The TreeChunk objects need to be deep cloned to avoid comparison issues on reference counting
 	if (change.builds !== undefined) {
-		normal.builds = mapNestedMap(change.builds, deepCloneTreeChunk);
+		normal.builds = mapNestedMap(change.builds, deepCloneChunkedTree);
 	}
 	if (change.refreshers !== undefined) {
-		normal.refreshers = mapNestedMap(change.refreshers, deepCloneTreeChunk);
+		normal.refreshers = mapNestedMap(change.refreshers, deepCloneChunkedTree);
 	}
 	return normal;
 }

--- a/packages/dds/tree/src/test/util/nestedMap.spec.ts
+++ b/packages/dds/tree/src/test/util/nestedMap.spec.ts
@@ -15,6 +15,7 @@ import {
 	setInNestedMap,
 	tryAddToNestedMap,
 	tryGetFromNestedMap,
+	mapNestedMap,
 } from "../../util/index.js";
 
 describe("NestedMap unit tests", () => {
@@ -292,6 +293,47 @@ describe("NestedMap unit tests", () => {
 					],
 				]),
 			);
+		});
+	});
+
+	describe("mapNestedMap", () => {
+		it("creates a new map with mapped values", () => {
+			const input: NestedMap<string, string, number> = new Map<string, Map<string, number>>();
+			setInNestedMap(input, "Foo", "Bar", 1);
+			setInNestedMap(input, "Foo", "Baz", 2);
+
+			const output = mapNestedMap(input, (n: number) => String(n));
+
+			assert.deepEqual(
+				output,
+				new Map([
+					[
+						"Foo",
+						new Map([
+							["Bar", "1"],
+							["Baz", "2"],
+						]),
+					],
+				]),
+			);
+		});
+
+		it("tolerates empty outer maps", () => {
+			const input: NestedMap<string, string, number> = new Map<string, Map<string, number>>();
+
+			const output = mapNestedMap(input, (n: number) => String(n));
+
+			assert.deepEqual(output, new Map([]));
+		});
+
+		it("tolerates (and preserves) empty inner maps", () => {
+			const input: NestedMap<string, string, number> = new Map<string, Map<string, number>>([
+				["Foo", new Map()],
+			]);
+
+			const output = mapNestedMap(input, (n: number) => String(n));
+
+			assert.deepEqual(output, new Map([["Foo", new Map()]]));
 		});
 	});
 });

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -29,6 +29,7 @@ export {
 	setInNestedMap,
 	tryAddToNestedMap,
 	tryGetFromNestedMap,
+	mapNestedMap,
 	nestedMapToFlatList,
 	nestedMapFromFlatList,
 } from "./nestedMap.js";

--- a/packages/dds/tree/src/util/nestedMap.ts
+++ b/packages/dds/tree/src/util/nestedMap.ts
@@ -229,6 +229,13 @@ export function forEachInNestedMap<Key1, Key2, Value>(
 	});
 }
 
+/**
+ * Maps the `input` map values using the provided `delegate`.
+ *
+ * @param input - The `NestedMap` whose contents are being mapped.
+ * @param delegate - The delegate to use for mapping values,
+ * @returns A new `NestedMap` with the same keys as `input`, but with the values produced by `delegate`.
+ */
 export function mapNestedMap<Key1, Key2, ValueIn, ValueOut = ValueIn>(
 	input: ReadonlyNestedMap<Key1, Key2, ValueIn>,
 	delegate: (value: ValueIn, key1: Key1, key2: Key2) => ValueOut,


### PR DESCRIPTION
## Description

Fixes a bug where builds where being serialized as refreshers (thus being sent twice) and refreshers were not being sent.
This bug currently had no impact because refreshers are not yet needed. (They will be after https://github.com/microsoft/FluidFramework/pull/21372)

Also adds a `mapNestedMap` utility function

## Breaking Changes

None
