### PR TITLE
Tune test-service-load config

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -710,7 +710,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 						config.logger.sendTelemetryEvent({
 							eventName: "VirtualDataStoreCreation",
 							runId: config.runId,
-							opsSent: opsSentCurrent,
+							localOpCount: opsSentCurrent,
 							virtualCreateJitter,
 							virtualCreateRate,
 						});
@@ -720,7 +720,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 							{
 								eventName: "VirtualDataStoreCreationFailed",
 								runId: config.runId,
-								opsSent: opsSentCurrent,
+								localOpCount: opsSentCurrent,
 								virtualCreateJitter,
 								virtualCreateRate,
 							},
@@ -750,7 +750,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 						config.logger.sendTelemetryEvent({
 							eventName: "VirtualDataStoreLoaded",
 							runId: config.runId,
-							opsSent: opsSentCurrent,
+							localOpCount: opsSentCurrent,
 							virtualCreateJitter,
 							virtualCreateRate,
 						});
@@ -760,7 +760,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 							{
 								eventName: "VirtualDataStoreLoadFailed",
 								runId: config.runId,
-								opsSent: opsSentCurrent,
+								localOpCount: opsSentCurrent,
 								virtualLoadRate,
 							},
 							error,
@@ -790,7 +790,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 						config.logger.sendTelemetryEvent({
 							eventName: "VirtualDataStoreOpSent",
 							runId: config.runId,
-							opsSent: opsSentCurrent,
+							localOpCount: opsSentCurrent,
 							virtualCreateJitter,
 							virtualCreateRate,
 						});
@@ -800,7 +800,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 							{
 								eventName: "VirtualDataStoreOpFailed",
 								runId: config.runId,
-								opsSent: opsSentCurrent,
+								localOpCount: opsSentCurrent,
 								virtualOpRate,
 							},
 							error,

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -624,6 +624,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 		// To avoid growing the file size unnecessarily, not all clients should be sending large ops
 		const maxClientsSendingLargeOps = config.testConfig.content?.numClients ?? 1;
 
+		const maxClientsForVirtualDatastores = config.testConfig.virtualization?.numClients ?? 1;
 		const virtualCreateRate = config.testConfig.virtualization?.createRate;
 		const virtualCreateJitter = Math.min(config.runId, virtualCreateRate ?? 0);
 		const virtualLoadRate = config.testConfig.virtualization?.loadRate;
@@ -682,7 +683,15 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 			}
 
 			// This creates a virtual data store
-			if (this.shouldCreateVirtualDataStore(virtualCreateRate, virtualCreateJitter, opsSent)) {
+			if (
+				this.shouldCreateVirtualDataStore(
+					virtualCreateRate,
+					virtualCreateJitter,
+					opsSent,
+					maxClientsForVirtualDatastores,
+					config.runId,
+				)
+			) {
 				// create virtual data store
 				const validGroupIds = dataModel.dataStoresSharedMap.size - 1;
 				const groupId = config.random.integer(0, validGroupIds);
@@ -692,19 +701,25 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 					groupId.toString(),
 				);
 				const opsSentCurrent = opsSent;
-				const runId = config.runId;
 				virtualDataStoreCreation
 					.then((virtualDataStore) => {
 						dataModel.dataStoresSharedMap.set(
-							`${runId}${opsSentCurrent}`,
+							`${config.runId}${opsSentCurrent}`,
 							virtualDataStore.handle,
 						);
+						config.logger.sendTelemetryEvent({
+							eventName: "VirtualDataStoreCreation",
+							runId: config.runId,
+							opsSent: opsSentCurrent,
+							virtualCreateJitter,
+							virtualCreateRate,
+						});
 					})
 					.catch((error) => {
 						config.logger.sendErrorEvent(
 							{
 								eventName: "VirtualDataStoreCreationFailed",
-								runId,
+								runId: config.runId,
 								opsSent: opsSentCurrent,
 								virtualCreateJitter,
 								virtualCreateRate,
@@ -715,28 +730,53 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 			}
 
 			// This starts loading a virtual data store
-			if (this.shouldLoadVirtualDataStore(virtualLoadRate, opsSent)) {
+			if (
+				this.shouldLoadVirtualDataStore(
+					virtualLoadRate,
+					opsSent,
+					maxClientsForVirtualDatastores,
+					config.runId,
+				)
+			) {
 				// load random virtual data store
 				const dataStoreHandles = Array.from(
 					dataModel.dataStoresSharedMap.values(),
 				) as IFluidHandle<VirtualDataStore>[];
 				const handle = config.random.pick(dataStoreHandles);
 				const opsSentCurrent = opsSent;
-				handle.get().catch((error) => {
-					config.logger.sendErrorEvent(
-						{
-							eventName: "VirtualDataStoreLoadFailed",
+				handle
+					.get()
+					.then(() => {
+						config.logger.sendTelemetryEvent({
+							eventName: "VirtualDataStoreLoaded",
 							runId: config.runId,
 							opsSent: opsSentCurrent,
-							virtualLoadRate,
-						},
-						error,
-					);
-				});
+							virtualCreateJitter,
+							virtualCreateRate,
+						});
+					})
+					.catch((error) => {
+						config.logger.sendErrorEvent(
+							{
+								eventName: "VirtualDataStoreLoadFailed",
+								runId: config.runId,
+								opsSent: opsSentCurrent,
+								virtualLoadRate,
+							},
+							error,
+						);
+					});
 			}
 
 			// This sends an op to the virtual data store if it is loaded
-			if (this.shouldSendVirtualDataStoreOp(virtualOpRate, opsSent)) {
+			if (
+				this.shouldSendVirtualDataStoreOp(
+					virtualOpRate,
+					opsSent,
+					maxClientsForVirtualDatastores,
+					config.runId,
+				)
+			) {
 				// load random virtual data store
 				const dataStoreHandles = Array.from(
 					dataModel.dataStoresSharedMap.values(),
@@ -747,6 +787,13 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 					.get()
 					.then((dataStore) => {
 						dataStore.counter.increment(1);
+						config.logger.sendTelemetryEvent({
+							eventName: "VirtualDataStoreOpSent",
+							runId: config.runId,
+							opsSent: opsSentCurrent,
+							virtualCreateJitter,
+							virtualCreateRate,
+						});
 					})
 					.catch((error) => {
 						config.logger.sendErrorEvent(
@@ -860,33 +907,51 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 	 * @param createRate - how often should a virtual data store be created, every so op count
 	 * @param jitter - how much jitter to add to the create rate. Jitter was added so creates didn't happen at the same time
 	 * @param opsSent - how many ops have been sent by the client
+	 * @param maxClients - how many clients should be creating virtual data stores
+	 * @param runId - run id of the current test
 	 * @returns true if a virtual data store should be created, false otherwise
 	 */
 	private shouldCreateVirtualDataStore(
 		createRate: number | undefined,
 		jitter: number,
 		opsSent: number,
+		maxClients: number,
+		runId: number,
 	) {
-		return createRate !== undefined && opsSent % createRate === 0;
+		return runId < maxClients && createRate !== undefined && opsSent % createRate === jitter;
 	}
 
 	/**
 	 *
 	 * @param loadRate - how often should a virtual data store be loaded, every so op count
 	 * @param opsSent - how many ops have been sent by the client
+	 * @param maxClients - how many clients should be creating virtual data stores
+	 * @param runId - run id of the current test
 	 * @returns true if a virtual data store should be loaded, false otherwise
 	 */
-	private shouldLoadVirtualDataStore(loadRate: number | undefined, opsSent: number) {
-		return loadRate !== undefined && opsSent % loadRate === 0;
+	private shouldLoadVirtualDataStore(
+		loadRate: number | undefined,
+		opsSent: number,
+		maxClients: number,
+		runId: number,
+	) {
+		return runId < maxClients && loadRate !== undefined && opsSent % loadRate === 0;
 	}
 
 	/**
 	 * @param opRate - how often should a virtual data store op be sent, every so op count
 	 * @param opsSent - how many ops have been sent by the client
+	 * @param maxClients - how many clients should be creating virtual data stores
+	 * @param runId - run id of the current test
 	 * @returns true if a virtual data store op should be sent, false otherwise
 	 */
-	private shouldSendVirtualDataStoreOp(opRate: number | undefined, opsSent: number) {
-		return opRate !== undefined && opRate > 0 && opsSent % opRate === 0;
+	private shouldSendVirtualDataStoreOp(
+		opRate: number | undefined,
+		opsSent: number,
+		maxClients: number,
+		runId: number,
+	) {
+		return runId < maxClients && opRate !== undefined && opRate > 0 && opsSent % opRate === 0;
 	}
 
 	async sendSignals(config: IRunConfig) {

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -120,6 +120,11 @@ export interface ILoadTestConfig {
 		 * Once every `virtualOpRate` ops, send an op from a virtualized data store
 		 */
 		opRate?: number;
+		/**
+		 * How many clients should create/load/modify virtual data stores if `createRate` is specified.
+		 * By default, only one client will send create/load/modify virtual data stores.
+		 */
+		numClients?: number;
 	};
 }
 

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -53,9 +53,9 @@
 				"numClients": 12
 			},
 			"virtualization": {
-				"createRate": 1000,
-				"loadRate": 1000,
-				"opRate": 1000
+				"createRate": 10000,
+				"loadRate": 10000,
+				"opRate": 10000
 			}
 		},
 		"ci_frs": {

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -53,9 +53,10 @@
 				"numClients": 12
 			},
 			"virtualization": {
-				"createRate": 10000,
-				"loadRate": 10000,
-				"opRate": 10000
+				"createRate": 2000,
+				"loadRate": 2000,
+				"opRate": 2000,
+				"numClients": 2
 			}
 		},
 		"ci_frs": {
@@ -117,7 +118,8 @@
 			"virtualization": {
 				"createRate": 60,
 				"loadRate": 60,
-				"opRate": 60
+				"opRate": 60,
+				"numClients": 2
 			}
 		},
 		"debug": {


### PR DESCRIPTION
[AB#8578](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8578)

The Stress tests have been timing out.

Likely due to creating too many and loading too many datastores. This tunes the creation back significantly.