### PR TITLE
docs(cell): Update README with common template contents and to indicate its status as an example

### DIFF
--- a/packages/dds/cell/README.md
+++ b/packages/dds/cell/README.md
@@ -3,7 +3,7 @@
 The `SharedCell` Distributed Data Structure (DDS) stores a single, shared value that can be edited or deleted.
 
 This package is primarily intended as a minimal example of how distributed data structures work.
-For real-world scenarios, we recommend DDSs like [SharedTree]() or [SharedMap]().
+For real-world scenarios, we recommend DDSs like [SharedTree](https://fluidframework.com./docs/data-structures/tree/) or [SharedMap](https://fluidframework.com./docs/data-structures/map/).
 
 <!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README:scripts=FALSE) -->
 

--- a/packages/dds/cell/README.md
+++ b/packages/dds/cell/README.md
@@ -3,7 +3,7 @@
 The `SharedCell` Distributed Data Structure (DDS) stores a single, shared value that can be edited or deleted.
 
 This package is primarily intended as a minimal example of how distributed data structures work.
-For real-world scenarios, we recommend using one of our other DDSs like [SharedTree](https://fluidframework.com./docs/data-structures/tree/).
+For real-world scenarios, we recommend using one of our other DDSs, like [SharedTree](https://fluidframework.com./docs/data-structures/tree/).
 
 <!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README:scripts=FALSE) -->
 

--- a/packages/dds/cell/README.md
+++ b/packages/dds/cell/README.md
@@ -3,7 +3,7 @@
 The `SharedCell` Distributed Data Structure (DDS) stores a single, shared value that can be edited or deleted.
 
 This package is primarily intended as a minimal example of how distributed data structures work.
-For real-world scenarios, we recommend DDSs like [SharedTree](https://fluidframework.com./docs/data-structures/tree/) or [SharedMap](https://fluidframework.com./docs/data-structures/map/).
+For real-world scenarios, we recommend using one of our other DDSs like [SharedTree](https://fluidframework.com./docs/data-structures/tree/).
 
 <!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README:scripts=FALSE) -->
 

--- a/packages/dds/cell/README.md
+++ b/packages/dds/cell/README.md
@@ -2,24 +2,10 @@
 
 The `SharedCell` Distributed Data Structure (DDS) stores a single, shared value that can be edited or deleted.
 
-<!-- AUTO-GENERATED-CONTENT:START (README_INSTALLATION_SECTION:includeHeading=TRUE) -->
+This package is primarily intended as a minimal example of how distributed data structures work.
+For real-world scenarios, we recommend DDSs like [SharedTree]() or [SharedMap]().
 
-<!-- prettier-ignore-start -->
-<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
-
-## Installation
-
-To get started, install the package by running the following command:
-
-```bash
-npm i @fluidframework/cell
-```
-
-<!-- prettier-ignore-end -->
-
-<!-- AUTO-GENERATED-CONTENT:END -->
-
-<!-- AUTO-GENERATED-CONTENT:START (README_DEPENDENCY_GUIDELINES_SECTION:includeHeading=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README:scripts=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
@@ -30,28 +16,17 @@ When taking a dependency on a Fluid Framework library, we recommend using a `^` 
 While Fluid Framework libraries may use different ranges with interdependencies between other Fluid Framework libraries,
 library consumers should always prefer `^`.
 
-<!-- prettier-ignore-end -->
+## Installation
 
-<!-- AUTO-GENERATED-CONTENT:END -->
+To get started, install the package by running the following command:
 
-<!-- AUTO-GENERATED-CONTENT:START (README_API_DOCS_SECTION:includeHeading=TRUE) -->
-
-<!-- prettier-ignore-start -->
-
-<!-- This section is automatically generated. To update it, make the appropriate changes to docs/md-magic.config.js or the embedded content, then run 'npm run build:md-magic' in the docs folder. -->
+```bash
+npm i @fluidframework/cell
+```
 
 ## API Documentation
 
 API documentation for **@fluidframework/cell** is available at <https://fluidframework.com/docs/apis/cell>.
-
-<!-- prettier-ignore-end -->
-
-<!-- AUTO-GENERATED-CONTENT:END -->
-
-<!-- AUTO-GENERATED-CONTENT:START (README_CONTRIBUTION_GUIDELINES_SECTION:includeHeading=TRUE) -->
-
-<!-- prettier-ignore-start -->
-<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
 
 ## Contribution Guidelines
 
@@ -71,15 +46,6 @@ This project may contain Microsoft trademarks or logos for Microsoft projects, p
 Use of these trademarks or logos must follow Microsoft’s [Trademark & Brand Guidelines](https://www.microsoft.com/trademarks).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 
-<!-- prettier-ignore-end -->
-
-<!-- AUTO-GENERATED-CONTENT:END -->
-
-<!-- AUTO-GENERATED-CONTENT:START (README_HELP_SECTION:includeHeading=TRUE) -->
-
-<!-- prettier-ignore-start -->
-<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
-
 ## Help
 
 Not finding what you're looking for in this README? Check out [fluidframework.com](https://fluidframework.com/docs/).
@@ -87,15 +53,6 @@ Not finding what you're looking for in this README? Check out [fluidframework.co
 Still not finding what you're looking for? Please [file an issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
 
 Thank you!
-
-<!-- prettier-ignore-end -->
-
-<!-- AUTO-GENERATED-CONTENT:END -->
-
-<!-- AUTO-GENERATED-CONTENT:START (README_TRADEMARK_SECTION:includeHeading=TRUE) -->
-
-<!-- prettier-ignore-start -->
-<!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
 
 ## Trademark
 


### PR DESCRIPTION
Cell isn't a DDS we actually expect customers to use, but there is nothing in its documentation to indicate such. This PR adds notes to this effect, and also updates the package README to use our complete README template.