### PR TITLE
ci: Run PR labeler on release branches

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -2,7 +2,7 @@ name: "Pull Request Labeler"
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches: [main, next, release/*]
+    branches: [main, next, release/**/*]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
The PR labeler workflow was ignoring release branches since the glob pattern was incorrect. It's now fixed, so release branch PRs should get labeled correctly.