### PR TITLE
[main > client/2.0]: RemoteDatastoreContext should handle snapshot with older loader

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -1058,6 +1058,7 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 	private snapshotFetchRequired: boolean | undefined;
 	private readonly runtime: IContainerRuntimeBase;
 	private readonly blobContents: Map<string, ArrayBuffer> | undefined;
+	private readonly isSnapshotInISnapshotFormat: boolean | undefined;
 
 	constructor(props: IRemoteFluidDataStoreContextProps) {
 		super(props, true /* existing */, false /* isLocalDataStore */, () => {
@@ -1068,8 +1069,10 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 		if (isInstanceOfISnapshot(props.snapshot)) {
 			this.blobContents = props.snapshot.blobContents;
 			this._baseSnapshot = props.snapshot.snapshotTree;
+			this.isSnapshotInISnapshotFormat = true;
 		} else {
 			this._baseSnapshot = props.snapshot;
+			this.isSnapshotInISnapshotFormat = false;
 		}
 		if (this._baseSnapshot !== undefined) {
 			this.summarizerNode.updateBaseSummaryState(this._baseSnapshot);
@@ -1091,10 +1094,13 @@ export class RemoteFluidDataStoreContext extends FluidDataStoreContext {
 	private readonly initialSnapshotDetailsP = new LazyPromise<ISnapshotDetails>(async () => {
 		// Sequence number of the snapshot.
 		let sequenceNumber: number | undefined;
-		// Check whether we need to fetch the snapshot first to load.
+		// Check whether we need to fetch the snapshot first to load. The snapshot should be in new format to see
+		// whether we want to evaluate to fetch snapshot or not for loadingGroupId. Otherwise, the snapshot
+		// will contain all the blobs.
 		if (
 			this.snapshotFetchRequired === undefined &&
-			this._baseSnapshot?.groupId !== undefined
+			this._baseSnapshot?.groupId !== undefined &&
+			this.isSnapshotInISnapshotFormat
 		) {
 			assert(
 				this.blobContents !== undefined,

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdInSummary.spec.ts
@@ -313,6 +313,81 @@ describeCompat(
 			}
 		});
 
+		it("Loading Snapshot with GroupId using feature gate off should load properly", async function () {
+			if (!supportsDataVirtualization(provider)) {
+				this.skip();
+			}
+			const container = await provider.createContainer(runtimeFactory);
+			const mainObject = (await container.getEntryPoint()) as TestDataObject;
+			const containerRuntime = mainObject.containerRuntime;
+
+			// Testing all apis for creating a data store with a loadingGroupId
+			await createDataObjectsWithGroupIds(mainObject, containerRuntime);
+
+			const { summarizer } = await createSummarizerFromFactory(
+				provider,
+				container,
+				dataObjectFactory,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				configProvider({
+					"Fluid.Container.UseLoadingGroupIdForSnapshotFetch2": false,
+				}),
+			);
+			await provider.ensureSynchronized();
+			const { summaryVersion, summaryTree } = await summarizeNow(summarizer);
+			const channelsTree = summaryTree.tree[".channels"];
+			assert(channelsTree.type === SummaryType.Tree, "channels should be a tree");
+			const dataObjectTreeA = channelsTree.tree[dataObjectA.id];
+			const dataObjectTreeB = channelsTree.tree[dataObjectB.id];
+			assert(dataObjectTreeA !== undefined, "dataObjectTree should exist");
+			assert(dataObjectTreeA.type === SummaryType.Tree, "dataObjectTree should be a tree");
+			assert(
+				dataObjectTreeA.groupId === loadingGroupId,
+				"GroupId missing from A summary tree",
+			);
+			assert(dataObjectTreeB !== undefined, "dataObjectTree should exist");
+			assert(dataObjectTreeB.type === SummaryType.Tree, "dataObjectTree should be a tree");
+			assert(
+				dataObjectTreeB.groupId === loadingGroupId,
+				"GroupId missing from B summary tree",
+			);
+
+			clearCacheIfOdsp(provider, persistedCache);
+			const container2 = await provider.loadContainer(
+				runtimeFactory,
+				{
+					configProvider: configProvider({
+						"Fluid.Container.UseLoadingGroupIdForSnapshotFetch2": false,
+					}),
+				},
+				{
+					// For ODSP this technically doesn't work, but the cache is cleared so we get the "latest"
+					[LoaderHeader.version]: summaryVersion,
+				},
+			);
+
+			const mainObject2 = (await container2.getEntryPoint()) as TestDataObject;
+			const handleA2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectA");
+			const handleB2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectB");
+			const handleC2 = mainObject2._root.get<IFluidHandle<TestDataObject>>("dataObjectC");
+
+			await assert.doesNotReject(
+				mainObject2.containerRuntime.getAliasedDataStoreEntryPoint("dataObjectD"),
+				"D should not be loaded",
+			);
+			assert(handleA2 !== undefined, "handleA2 should not be undefined");
+			assert(handleB2 !== undefined, "handleB2 should not be undefined");
+			assert(handleC2 !== undefined, "handleC2 should not be undefined");
+
+			// When fixed, all these should not fail.
+			await assert.doesNotReject(handleA2.get(), "should be able to retrieve A");
+			await assert.doesNotReject(handleB2.get(), "should be able to retrieve B");
+			await assert.doesNotReject(handleC2.get(), "should be able to retrieve C");
+		});
+
 		it("Can create loadingGroupId via detached flow", async () => {
 			const container = await provider.createDetachedContainer(runtimeFactory);
 			const mainObject = (await container.getEntryPoint()) as TestDataObject;


### PR DESCRIPTION
## Description

RemoteDatastoreContext should handle snapshot with groupId with older loader. So, in case where we fetch the snapshot using old loader and does not have ISnapshot which contains blobContents, then that means we must have fetched the full snapshot using older format, so there is no need to evaluate in that case whether to fetch the snapshot or not.

Enable the test as it passes with odsp.