### PR TITLE
Data virtualization: Disable virtualization in stress tests

### DIFF
--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -51,12 +51,6 @@
 				"opSizeinBytes": 214800,
 				"largeOpRate": 2000,
 				"numClients": 12
-			},
-			"virtualization": {
-				"createRate": 2000,
-				"loadRate": 2000,
-				"opRate": 2000,
-				"numClients": 2
 			}
 		},
 		"ci_frs": {


### PR DESCRIPTION
[AB#8578](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8578)

Disable Data virtualization in stress tests because it's causing a timeout that needs investigation. The feature is off for AFR and that is running as usual.