### PR TITLE
[Summarization] Don't close on receiving summary ack for which there is no snapshot in storage

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -3741,18 +3741,11 @@ export class ContainerRuntime
 				};
 			}
 
-			const summaryContext =
-				this.lastAckedSummaryContext === undefined
-					? {
-							proposalHandle: undefined,
-							ackHandle: this.loadedFromVersionId,
-							referenceSequenceNumber: summaryRefSeqNum,
-						}
-					: {
-							proposalHandle: this.lastAckedSummaryContext.proposalHandle,
-							ackHandle: this.lastAckedSummaryContext.ackHandle,
-							referenceSequenceNumber: summaryRefSeqNum,
-						};
+			const summaryContext: ISummaryContext = {
+				proposalHandle: this.lastAckedSummaryContext?.proposalHandle ?? undefined,
+				ackHandle: this.lastAckedSummaryContext?.ackHandle ?? this.loadedFromVersionId,
+				referenceSequenceNumber: summaryRefSeqNum,
+			};
 
 			let handle: string;
 			try {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -4242,22 +4242,25 @@ export class ContainerRuntime
 			summaryRefSeq,
 		);
 
+		/* eslint-disable jsdoc/check-indentation */
 		/**
 		 * If the snapshot corresponding to the ack is not tracked by this client, it was submitted by another client.
 		 * Take action as per the following scenarios:
-		 * - If that snapshot is older than the one tracked by this client, ignore the ack because only the latest
-		 * snapshot is tracked.
-		 * - If that snapshot is newer, attempt to fetch the latest snapshot and do one of the following:
-		 * - If the fetched snapshot is same or newer than the one for which ack was received, close this client. The
-		 * next summarizer client will likely start from this snapshot and get out of this state. Fetching the snapshot
-		 * updates the cache for this client so if it's re-elected as summarizer, this will prevent any thrashing.
-		 * - If the fetched snapshot is older than the one for which ack was received, ignore the ack. This can happen
-		 * in scenarios where the snapshot for the ack was lost in storage (in scenarios like DB rollback, etc.) but the
-		 * summary ack is still there because it's tracked a different service. In such cases, ignoring the ack is the
-		 * correct thing to do because the latest snapshot in storage is not the one for the ack but is still the one
-		 * tracked by this client. If we were to close the summarizer like in the previous scenario, it will result in
-		 * this document stuck in this state in a loop.
+		 * 1. If that snapshot is older than the one tracked by this client, ignore the ack because only the latest
+		 *    snapshot is tracked.
+		 * 2. If that snapshot is newer, attempt to fetch the latest snapshot and do one of the following:
+		 *    2.1. If the fetched snapshot is same or newer than the one for which ack was received, close this client.
+		 *         The next summarizer client will likely start from this snapshot and get out of this state. Fetching
+		 *         the snapshot updates the cache for this client so if it's re-elected as summarizer, this will prevent
+		 *         any thrashing.
+		 *    2.2. If the fetched snapshot is older than the one for which ack was received, ignore the ack. This can
+		 *         happen in scenarios where the snapshot for the ack was lost in storage (in scenarios like DB rollback,
+		 *         etc.) but the summary ack is still there because it's tracked a different service. In such cases,
+		 *         ignoring the ack is the correct thing to do because the latest snapshot in storage is not the one for
+		 *         the ack but is still the one tracked by this client. If we were to close the summarizer like in the
+		 *         previous scenario, it will result in this document stuck in this state in a loop.
 		 */
+		/* eslint-enable jsdoc/check-indentation */
 		if (!result.isSummaryTracked) {
 			if (result.isSummaryNewer) {
 				await this.fetchLatestSnapshotAndMaybeClose(summaryRefSeq, ackHandle, summaryLogger);

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -313,7 +313,7 @@ describe("Outbox", () => {
 	});
 
 	it("Batch ID added when applicable", () => {
-		const outbox = getOutbox({ context: getMockContext() as IContainerContext });
+		const outbox = getOutbox({ context: getMockContext() });
 
 		// Flush 1 - resubmit multi-message batch including ID Allocation
 		outbox.submitIdAllocation(createMessage(ContainerMessageType.IdAllocation, "0")); // Separate batch, batch ID not used

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -313,7 +313,7 @@ describe("Outbox", () => {
 	});
 
 	it("Batch ID added when applicable", () => {
-		const outbox = getOutbox({ context: getMockContext() });
+		const outbox = getOutbox({ context: getMockContext() as IContainerContext });
 
 		// Flush 1 - resubmit multi-message batch including ID Allocation
 		outbox.submitIdAllocation(createMessage(ContainerMessageType.IdAllocation, "0")); // Separate batch, batch ID not used

--- a/packages/test/test-end-to-end-tests/src/test/summarization/newerSummaryAcks.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/newerSummaryAcks.spec.ts
@@ -222,6 +222,33 @@ describeCompat(
 				summaryAckHandle,
 				"Should not use summary ack handle",
 			);
+
+			const fetchEventDetailsString = mockLogger.events.find((event) =>
+				event.eventName.includes("RefreshLatestSummaryAckFetch_end"),
+			)?.details;
+			assert(
+				fetchEventDetailsString !== undefined,
+				"Did not find RefreshLatestSummaryAckFetch_end event",
+			);
+			const fetchEventDetails = JSON.parse(fetchEventDetailsString as string);
+			assert(
+				fetchEventDetails !== undefined,
+				"RefreshLatestSummaryAckFetch_end doesn't have details",
+			);
+			assert(
+				fetchEventDetails.newerSnapshotPresent === false,
+				"It should not fetch newer snapshot",
+			);
+			assert.strictEqual(
+				fetchEventDetails.targetAckHandle,
+				summaryAckHandle,
+				"The target handle should be the fake summary ack handle",
+			);
+			assert.notStrictEqual(
+				fetchEventDetails.snapshotVersion,
+				summaryAckHandle,
+				"The fetched snapshot handle should not be the fake summary ack handle",
+			);
 		});
 	},
 );

--- a/packages/test/test-end-to-end-tests/src/test/summarization/newerSummaryAcks.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/summarization/newerSummaryAcks.spec.ts
@@ -6,14 +6,20 @@
 import { strict as assert } from "assert";
 
 import { ITestDataObject, describeCompat, itExpects } from "@fluid-private/test-version-utils";
+import type {
+	ContainerRuntime,
+	ISummaryAckMessage,
+	ISummaryOpMessage,
+	Summarizer,
+	SummaryCollection,
+} from "@fluidframework/container-runtime/internal";
 import {
-	IDocumentService,
-	IDocumentServiceFactory,
-	type IDocumentStorageService,
-	type ISnapshotTree,
+	MessageType,
+	type ISequencedDocumentMessage,
+	type ISummaryAck,
+	type ISummaryContent,
 } from "@fluidframework/driver-definitions/internal";
-import { readAndParse } from "@fluidframework/driver-utils/internal";
-import { seqFromTree } from "@fluidframework/runtime-utils/internal";
+import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 import {
 	ITestContainerConfig,
 	ITestObjectProvider,
@@ -21,9 +27,24 @@ import {
 	createTestConfigProvider,
 	summarizeNow,
 } from "@fluidframework/test-utils/internal";
+import { createSandbox, SinonSandbox } from "sinon";
 
-import { wrapObjectAndOverride } from "../../mocking.js";
 import { reconnectSummarizerToBeElected } from "../gc/index.js";
+
+type WithPrivates<T, TPrivates> = Omit<T, keyof TPrivates> & TPrivates;
+type SummaryCollectionWithPrivates = WithPrivates<
+	SummaryCollection,
+	{
+		handleOp(opArg: ISequencedDocumentMessage): void;
+	}
+>;
+type SummarizerWithPrivates = WithPrivates<
+	Summarizer,
+	{
+		summaryCollection: SummaryCollectionWithPrivates;
+		runtime: ContainerRuntime;
+	}
+>;
 
 /**
  * These tests validate the behavior of the summarizer when it gets summary acks that are newer than the summary
@@ -44,12 +65,18 @@ describeCompat(
 
 		let provider: ITestObjectProvider;
 
+		let sandbox: SinonSandbox;
+		before(() => {
+			sandbox = createSandbox();
+		});
+
 		beforeEach("getTestObjectProvider", async () => {
 			provider = getTestObjectProvider({ syncSummarizer: true });
 			configProvider.set("Fluid.ContainerRuntime.Test.CloseSummarizerDelayOverrideMs", 0);
 		});
 
 		afterEach(() => {
+			sandbox.restore();
 			configProvider.clear();
 		});
 
@@ -86,7 +113,7 @@ describeCompat(
 				// will be processed as well since it's sequenced before this op.
 				defaultDataStore1._root.set("2", "3");
 				await provider.ensureSynchronized();
-				await assert.rejects(async () => summarizeNow(summarizer2));
+				await assert.rejects(async () => summarizeNow(summarizer2), "Summarize should fail");
 				assert.strictEqual(
 					summarizer2Container.disposed,
 					true,
@@ -97,96 +124,104 @@ describeCompat(
 
 		/**
 		 * This test tests a scenario where a summarizer gets a newer summary ack, but on fetching the latest snapshot,
-		 * it gets a snapshot which is older than the one corresponding to the ack. The summarizer then closes.
+		 * it gets a snapshot which is older than the one corresponding to the ack.
 		 * This can happen in cases such as database rollbacks in server which results in losing recent snapshots but
 		 * not the corresponding acks.
-		 * Currently, documents in this state are corrupted because they will keep doing this in a loop.
+		 * Summarizers should not close in this scenario. They should continue generating summaries.
 		 */
-		itExpects(
-			"closes the container on getting a newer summary ack and fetching a snapshot older than the ack's snapshot",
-			[{ eventName: "fluid:telemetry:Summarizer:Running:SummarizeFailed" }],
-			async () => {
-				const container1 = await provider.makeTestContainer(testContainerConfig);
-				const defaultDataStore1 = (await container1.getEntryPoint()) as ITestDataObject;
-				defaultDataStore1._root.set("1", "2");
+		it("doesn't fail on getting a newer summary ack and fetching a snapshot older than the ack's snapshot", async () => {
+			const container1 = await provider.makeTestContainer(testContainerConfig);
+			const defaultDataStore1 = (await container1.getEntryPoint()) as ITestDataObject;
 
-				const { summarizer: summarizer1 } = await createSummarizer(provider, container1, {
+			const mockLogger = new MockLogger();
+			const createResult = await createSummarizer(
+				provider,
+				container1,
+				{
 					loaderProps: { configProvider },
-				});
+				},
+				undefined /* summaryVersion */,
+				mockLogger,
+			);
 
-				// Intercept the document storage service's getSnapshotTree function and configure it to send an older
-				// snapshot if it has seen one before. This will re-create a scenario where the storage sends an older
-				// snapshot because the latest one is lost.
-				// Note that this is done after creating the first summarizer so it shouldn't be affected.
-				let previousSnapshotTree: ISnapshotTree | null = null;
-				const snapshotHandler = async (
-					storage: IDocumentStorageService,
-					snapshotTree: ISnapshotTree | null,
-				): Promise<ISnapshotTree | null> => {
-					assert(snapshotTree !== null, "The server did not return a snapshot");
-					const readAndParseBlob = async <T>(id: string) => readAndParse<T>(storage, id);
-					// When the second summarizer loads, previousSnapshotTree will be null. So, the snapshot tree from
-					// the server is returned.
-					// The next time this is called on getting the summary ack, return the previousSnapshotTree after
-					// validating that it is in fact older that the one received from the server. The validation is not
-					// necessary but it will ensure that the test is non-flaky.
-					if (previousSnapshotTree !== null) {
-						const latestRefSeqNumber = await seqFromTree(snapshotTree, readAndParseBlob);
-						const previousRefSeqNumber = await seqFromTree(
-							previousSnapshotTree,
-							readAndParseBlob,
-						);
-						if (latestRefSeqNumber > previousRefSeqNumber) {
-							return previousSnapshotTree;
-						}
-					}
-					previousSnapshotTree = snapshotTree;
-					return snapshotTree;
-				};
-				(provider as any)._documentServiceFactory =
-					wrapObjectAndOverride<IDocumentServiceFactory>(provider.documentServiceFactory, {
-						createDocumentService:
-							(factory) =>
-							async (...args) => {
-								const service = await factory.createDocumentService(...args);
-								return wrapObjectAndOverride<IDocumentService>(service, {
-									connectToStorage: {
-										getSnapshotTree: (storage) => async (version, scenarioName) => {
-											const res = await storage.getSnapshotTree(version, scenarioName);
-											return snapshotHandler(storage, res);
-										},
-									},
-								});
-							},
-					});
+			const summarizerContainer = createResult.container;
+			const summarizer = createResult.summarizer as SummarizerWithPrivates;
+			const summaryCollection = summarizer.summaryCollection;
 
-				const { summarizer: summarizer2, container: summarizer2Container } =
-					await createSummarizer(provider, container1, {
-						loaderProps: { configProvider },
-					});
+			defaultDataStore1._root.set("1", "2");
+			await provider.ensureSynchronized();
+			const lastOp = summarizer.runtime.deltaManager.lastMessage;
+			assert(lastOp !== undefined, "No ops in delta manager");
 
-				// Summarize via the first summarizer.
-				await provider.ensureSynchronized();
-				await summarizeNow(summarizer1);
+			/**
+			 * The only snapshot for this container is the create snapshot at reference seq# 0.
+			 * Manufacture a summary op and a summary ack with reference seq# of the last processed op. This simulates
+			 * an op / ack pair for a snapshot that doesn't exist in storage.
+			 */
+			const summaryOpHandle = "deletedSummaryHandle1";
+			const summaryAckHandle = "deletedSummaryHandle2";
+			const summaryOpContent: ISummaryContent = {
+				handle: summaryOpHandle,
+				message: "summary@100:50",
+				parents: [],
+				head: "deletedSummaryHead",
+			};
+			const fakeSummaryOp: ISummaryOpMessage = {
+				...lastOp,
+				type: MessageType.Summarize,
+				contents: summaryOpContent,
+				referenceSequenceNumber: lastOp.sequenceNumber, // This is greater than 0 representing a newer summary.
+				sequenceNumber: lastOp.sequenceNumber + 1,
+			};
 
-				// Close the first summarizer and elect the second summarizer to be able to summarize. This step is
-				// needed to run the second summarizer so that it starts listening for summary acks and processes them.
-				summarizer1.close();
-				await reconnectSummarizerToBeElected(summarizer2Container);
+			const summaryAck: ISummaryAck = {
+				handle: summaryAckHandle,
+				summaryProposal: { summarySequenceNumber: fakeSummaryOp.sequenceNumber },
+			};
+			const fakeSummaryAck: ISummaryAckMessage = {
+				...fakeSummaryOp,
+				type: MessageType.SummaryAck,
+				contents: summaryAck,
+				sequenceNumber: fakeSummaryOp.sequenceNumber + 1,
+			};
 
-				// The second summarizer will fail to summarize because it will get a newer ack, fetch the latest
-				// snapshot and then close.
-				// Send an op and wait for it to be processed by the summarizer. This will ensure that the summary ack
-				// will be processed as well since it's sequenced before this op.
-				defaultDataStore1._root.set("2", "3");
-				await provider.ensureSynchronized();
-				await assert.rejects(async () => summarizeNow(summarizer2));
-				assert.strictEqual(
-					summarizer2Container.disposed,
-					true,
-					"Summarizer container should have disposed",
-				);
-			},
-		);
+			// Simulate calling summary collection with the above summary op / ack pair. This will end up calling
+			// container runtime which will attempt to fetch the latest snapshot but will not find a newer snapshot.
+			// So, it should ignore this ack.
+			summaryCollection.handleOp(fakeSummaryOp);
+			summaryCollection.handleOp(fakeSummaryAck);
+
+			const getSnapshotTreeSpy = sandbox.spy(summarizer.runtime.storage, "getSnapshotTree");
+			const uploadSummarySpy = sandbox.spy(
+				summarizer.runtime.storage,
+				"uploadSummaryWithContext",
+			);
+
+			await assert.doesNotReject(summarizeNow(summarizer), "Summarize should not fail");
+			assert.notStrictEqual(
+				summarizerContainer.disposed,
+				true,
+				"Summarizer should not close on receiving ack with no corresponding snapshot",
+			);
+			assert(
+				getSnapshotTreeSpy.calledOnce,
+				"Summarizer should call getSnapshotTree in response to the ack",
+			);
+			assert(uploadSummarySpy.calledOnce, "A summary should be uploaded");
+
+			// Validate that when uploading the summary, container runtime does not use the handles of the fake
+			// summary op / ack as the parent ack handle.
+			const uploadedSummaryContext = uploadSummarySpy.args[0][1];
+			assert.notStrictEqual(
+				uploadedSummaryContext.ackHandle,
+				summaryOpHandle,
+				"Should not use summary op handle",
+			);
+			assert.notStrictEqual(
+				uploadedSummaryContext.ackHandle,
+				summaryAckHandle,
+				"Should not use summary ack handle",
+			);
+		});
 	},
 );


### PR DESCRIPTION
## Bug / root cause
There can be scenarios such as DB rollback in storage, where the latest snapshot is lost but the corresponding summary ack is still present because ops are maintained by another service. Currentlty, if a summarizer receives an ack that is newer that the summary it's tracking, it will fetch latest snapshot and close. So, in the above scenario, the summarizer would get the ack, attempt to fetch the snapshot and close. When a new summarizer loads, it will do the same thing because the ack corresponding to the snapshot doesn't exist. The document will be stuck in this loop and reach 10k+ unsummarizer ops after which it won't be able to make any changes.

## Fix
When the client gets a newer ack, it fetches the snapshot and if the fetched snapshot is older than the one for the ack, it will ignore this ack and not close. The idea being that the server will send a summary ack only after it has a snapshot present for it, so a snapshot should exist. The only reason it wouldn't exist is that it was deleted **_later_**. So, the client assumes this is the case and moves on.

Let's say this is not the case and the snapshot was not deleted but the server did not return it during snapshot fetch for some reason. The next summary upload by this client will fail because the "parent handle" (the last summary id) will be incorrect. The summarizer will close and the next summarizer will most likely not run into this issue because this is a very rare scenario.

The PR has the following changes:
- Container runtime now tracks the details of the last summary ack it has processed. It uses the information from this as the "parent" summary's handle when uploading a summary. Currently, it gets this information from the "SummaryCollection" but in the scenario described above, "SummaryCollection" has already updated the last ack to the one for which there is no snapshot. So, using that will fail the next summary upload.
- If the fetched snapshot's reference seq# is lower than the reference seq# in the ack, simply return.
- Added a property `newerSnapshotPresent` to the `RefreshLatestSummaryAckFetch` telemetry which will tell us if there was a newer snapshot present or not. I could add another telemetry when this case is hit, but I think this should be enough.

## Testing
- Added a container runtime unit test that mocks the storage layer. It only has one snapshot and it always returns that. The test calls `ContainerRuntime::refreshLatestSummaryAck` with a newer ref seq# and then calls `ContainerRuntime::submitSummary`. It validates that both succeed and call storage with right properties.
- Added an end-to-end test. In the test, there is only one snapshot (initial one from detached container). The test then creates a summarizer and calls its `SummaryCollection` (that handles summary op / ack) with a fake summary op and summary ack whose ref seq# is greater than the initial snapshot. This simulates the scenario because from the client perspective, it got a summary ack for a snapshot that doesn't exist.


[AB#8334](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8334)