### PR TITLE
fix(tree): prevent merges and rebases while a transaction is in progress

### DIFF
--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -572,6 +572,10 @@ export class TreeCheckout implements ITreeCheckoutFork {
 
 	public rebase(view: TreeCheckout): void {
 		this.checkNotDisposed();
+		assert(
+			!view.transaction.inProgress(),
+			"A view cannot be rebased while it has a pending transaction",
+		);
 		view.branch.rebaseOnto(this.branch);
 	}
 
@@ -585,8 +589,8 @@ export class TreeCheckout implements ITreeCheckoutFork {
 	public merge(view: TreeCheckout, disposeView = true): void {
 		this.checkNotDisposed();
 		assert(
-			!this.transaction.inProgress() || disposeView,
-			0x710 /* A view that is merged into an in-progress transaction must be disposed */,
+			!this.transaction.inProgress(),
+			"Views cannot be merged into a view while it has a pending transaction",
 		);
 		while (view.transaction.inProgress()) {
 			view.transaction.commit();


### PR DESCRIPTION
## Description

The ability to merge changes into a branch (or rebase a branch) while that branch has an open transaction has never been supported. This PR updates the `TreeCheckout` logic to forbid such operations.

## Breaking Changes

None. (SharedTree users have not yet been given the means of performing such operations.)