### PR TITLE
Disable pre creation of groupId datastore

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -520,14 +520,14 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 	protected async initializingFirstTime() {
 		this.root.set(taskManagerKey, TaskManager.create(this.runtime).handle);
 		// Create virtual data store
-		const virtualDataStore = await VirtualDataStoreFactory.createInstance(
-			this.context.containerRuntime,
-			undefined,
-			"0",
-		);
+		// const virtualDataStore = await VirtualDataStoreFactory.createInstance(
+		// 	this.context.containerRuntime,
+		// 	undefined,
+		// 	"0",
+		// );
 		const dataStoresMap = SharedMap.create(this.runtime);
 		this.root.set(dataStoresSharedMapKey, dataStoresMap.handle);
-		dataStoresMap.set("0", virtualDataStore.handle);
+		// dataStoresMap.set("0", virtualDataStore.handle);
 	}
 
 	public async detached(config: Omit<IRunConfig, "runId">) {


### PR DESCRIPTION
[AB#8578](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8578)

Mitigation - looks like we are creating a groupId datastore on attach, I missed turning this off in the turn off stage.