### PR TITLE
ci(client): Trigger client build when markdown-magic is changed

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -72,6 +72,8 @@ trigger:
     - package.json
     - pnpm-lock.yaml
     - pnpm-workspace.yaml
+    # markdown-magic is part of the client release group
+    - tools/markdown-magic/*
     - tools/pipelines/build-client.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -108,6 +108,8 @@ pr:
     - pnpm-lock.yaml
     - pnpm-workspace.yaml
     - fluidBuild.config.cjs
+    # markdown-magic is part of the client release group
+    - tools/markdown-magic/*
     - tools/pipelines/build-client.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-policy-check.yml


### PR DESCRIPTION
The markdown-magic project is now a part of the client release group, but changes to it were not triggering client CI builds. This change should address that.