### PR TITLE
fix(docs): Differentiate `@legacy` and `@alpha` when generating API docs

### DIFF
--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -31,40 +31,53 @@ const supportDocsLinkSpan = new SpanNode([
 	new PlainTextNode("."),
 ]);
 
-// Temporary workaround for items tagged as `@alpha` (to mean "legacy").
-// This messaging should be changed back to standard "alpha" terminology once we have
-// cleaned up our tag meanings.
-function createAlphaWarning(apiItem) {
+/**
+ * Creates a special import notice for the provided API item, if one is appropriate.
+ *
+ * If the item is tagged as "@legacy", displays a legacy notice with import instructions.
+ * Otherwise, if the item is `@alpha` or `@beta`, displays the appropriate warning and import instructions.
+ *
+ * @privateRemarks
+ * If we later wish to differentiate between release tags of `@legacy` items, this function will need
+ * to be updated.
+ */
+function createImportNotice(apiItem) {
 	const packageName = apiItem.getAssociatedPackage().displayName;
-	return new AlertNode(
-		[
-			new SpanNode([
-				new PlainTextNode("To use, import via "),
-				CodeSpanNode.createFromPlainText(`${packageName}/legacy`),
-				new PlainTextNode("."),
-			]),
-			LineBreakNode.Singleton,
-			supportDocsLinkSpan,
-		],
-		/* alertKind: */ "note",
-		/* title: */ "This API is provided for existing users, but is not recommended for new users.",
-	);
-}
 
-function createBetaWarning(apiItem) {
-	const packageName = apiItem.getAssociatedPackage().displayName;
+	const isLegacy = apiItem.tsdocComment?.customBlocks?.includes("@legacy");
+	const releaseTag = ApiItemUtilities.getReleaseTag(apiItem);
+
+	let importSubpath, alertTitle, alertKind;
+	if (isLegacy) {
+		importSubpath = "legacy";
+		alertTitle =
+			"This API is provided for existing users, but is not recommended for new users.";
+		alertKind = "info";
+	} else if (releaseTag === "alpha") {
+		importSubpath = "alpha";
+		alertTitle = "This API is provided as an alpha preview and may change without notice.";
+		alertKind = "warning";
+	} else if (releaseTag === "beta") {
+		importSubpath = "beta";
+		alertTitle = "This API is provided as an beta preview and may change without notice.";
+		alertKind = "warning";
+	} else {
+		// If the API is non-legacy, and not alpha/beta, no notice is needed.
+		return undefined;
+	}
+
 	return new AlertNode(
 		[
 			new SpanNode([
 				new PlainTextNode("To use, import via "),
-				CodeSpanNode.createFromPlainText(`${packageName}/beta`),
+				CodeSpanNode.createFromPlainText(`${packageName}/${importSubpath}`),
 				new PlainTextNode("."),
 			]),
 			LineBreakNode.Singleton,
 			supportDocsLinkSpan,
 		],
-		/* alertKind: */ "warning",
-		/* title: */ "This API is provided as a beta preview and may change without notice.",
+		alertKind,
+		alertTitle,
 	);
 }
 
@@ -112,12 +125,10 @@ export function layoutContent(apiItem, itemSpecificContent, config) {
 		sections.push(new SectionNode([deprecationNotice]));
 	}
 
-	// Render alpha/beta notice if applicable
-	const releaseTag = ApiItemUtilities.getReleaseTag(apiItem);
-	if (releaseTag === ReleaseTag.Alpha) {
-		sections.push(new SectionNode([createAlphaWarning(apiItem)]));
-	} else if (releaseTag === ReleaseTag.Beta) {
-		sections.push(new SectionNode([createBetaWarning(apiItem)]));
+	// Render the appropriate API notice (with import instructions), if applicable.
+	const importNotice = createImportNotice(apiItem);
+	if (importNotice !== undefined) {
+		sections.push(new SectionNode([importNotice]));
 	}
 
 	// Render signature (if any)

--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -44,7 +44,7 @@ const supportDocsLinkSpan = new SpanNode([
 function createImportNotice(apiItem) {
 	const packageName = apiItem.getAssociatedPackage().displayName;
 
-	function createImportAlert(importSubpath, alertTitle, alertKind) {
+	function createImportAlert(importSubpath, alertTitle) {
 		return new AlertNode(
 			[
 				new SpanNode([
@@ -55,16 +55,15 @@ function createImportNotice(apiItem) {
 				LineBreakNode.Singleton,
 				supportDocsLinkSpan,
 			],
-			alertKind,
+			/* alertKind: */ "warning",
 			alertTitle,
 		);
 	}
 
-	if (apiItem.tsdocComment?.customBlocks?.includes("@legacy")) {
+	if (apiItem.tsdocComment?.modifierTagSet?.hasTagName("@legacy")) {
 		return createImportAlert(
 			"legacy",
 			"This API is provided for existing users, but is not recommended for new users.",
-			"info",
 		);
 	}
 
@@ -74,7 +73,6 @@ function createImportNotice(apiItem) {
 		return createImportAlert(
 			"alpha",
 			"This API is provided as an alpha preview and may change without notice.",
-			"warning",
 		);
 	}
 
@@ -82,7 +80,6 @@ function createImportNotice(apiItem) {
 		return createImportAlert(
 			"beta",
 			"This API is provided as a beta preview and may change without notice.",
-			"warning",
 		);
 	}
 

--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -60,6 +60,7 @@ function createImportNotice(apiItem) {
 		);
 	}
 
+	// TODO: Use `getModifierTag` helper once added to `@fluid-tools/api-markdown-documenter`
 	if (apiItem.tsdocComment?.modifierTagSet?.hasTagName("@legacy")) {
 		return createImportAlert(
 			"legacy",

--- a/docs/api-markdown-documenter/render-api-documentation.js
+++ b/docs/api-markdown-documenter/render-api-documentation.js
@@ -108,9 +108,6 @@ export async function renderApiDocumentation(inputDir, outputDir, uriRootDir, ap
 			// TODO: Also skip `@fluid-internal` packages once we no longer have public, user-facing APIs that reference their contents.
 			return ["@fluid-private"].includes(packageScope);
 		},
-		// Temporary workaround to ensure APIs temporarily tagged as `@alpha` (to mean "legacy") are included in the API docs.
-		// This min level should be set back to Beta once legacy APIs have been cleaned up to not use `@alpha`.
-		minimumReleaseLevel: ReleaseTag.Alpha, // Don't include `@internal` items in docs published to the public website.
 	});
 
 	logProgress("Generating API documentation...");

--- a/docs/api-markdown-documenter/render-api-documentation.js
+++ b/docs/api-markdown-documenter/render-api-documentation.js
@@ -87,11 +87,14 @@ export async function renderApiDocumentation(inputDir, outputDir, uriRootDir, ap
 				alerts.push("Deprecated");
 			}
 
+			// TODO: Use `getModifierTag` helper once added to `@fluid-tools/api-markdown-documenter`
+			if (apiItem.tsdocComment?.modifierTagSet?.hasTagName("@legacy")) {
+				alerts.push("Legacy");
+			}
+
 			const releaseTag = ApiItemUtilities.getReleaseTag(apiItem);
 			if (releaseTag === ReleaseTag.Alpha) {
-				// Temporary workaround for the current `@alpha` => "Legacy" state.
-				// This should be replaced with "Alpha" once that has been cleaned up.
-				alerts.push("Legacy");
+				alerts.push("Alpha");
 			} else if (releaseTag === ReleaseTag.Beta) {
 				alerts.push("Beta");
 			}


### PR DESCRIPTION
Now that we have separated `@alpha` and `@legacy`, the website build can be updated to add support for `@legacy`, and remove now-unneeded workarounds for the previous conflation of the two.
 
`@legacy` example:
![image](https://github.com/microsoft/FluidFramework/assets/54606601/d91d6dd0-d3d7-4c2e-97db-bd2b38427195)

`@beta` example:
![image](https://github.com/microsoft/FluidFramework/assets/54606601/fa47f780-504d-4bbd-8494-2e88016985f2)

`@alpha` example:
![image](https://github.com/microsoft/FluidFramework/assets/54606601/57ae5125-d789-466b-a0f6-ba1c7f236495)