### PR TITLE
docs(client): remove unused FluidContainer tags

### DIFF
--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -252,8 +252,6 @@ export function createFluidContainer<
  *
  * Note: this implementation is not complete. Consumers who rely on {@link IFluidContainer.attach}
  * will need to utilize or provide a service-specific implementation of this type that implements that method.
- * @deprecated use {@link createFluidContainer} and {@link IFluidContainer} instead
- * @internal
  */
 class FluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema>
 	extends TypedEventEmitter<IFluidContainerEvents>


### PR DESCRIPTION
`@deprecation` and `@internal` tags are not needed for file internal (not exported) class