### PR TITLE
ci: Upgrade pnpm/action-setup to v4

### DIFF
--- a/.github/workflows/pr-check-changeset.yml
+++ b/.github/workflows/pr-check-changeset.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }} # Check out the head commit, not the merge commit
 
       # install and configure node, pnpm and the changeset tools
-      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # ratchet:pnpm/action-setup@v2
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # ratchet:pnpm/action-setup@v4
       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # ratchet:actions/setup-node@v3
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: "0" # all history
           persist-credentials: false
 
-      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # ratchet:pnpm/action-setup@v2
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # ratchet:pnpm/action-setup@v4
       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # ratchet:actions/setup-node@v3
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -12,6 +12,12 @@ on:
   push:
     tags:
       - "*_v*"
+  # Allow manually triggering this workflow from the web UI
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'git release tag to process'
+        required: true
 
 permissions:
   contents: write
@@ -51,9 +57,17 @@ jobs:
           flub --help
           flub commands
 
+      - name: Set tag name from push
+        if: github.event_name == 'push'
+        run: echo "TAG_NAME=${GITHUB_REF}" >> $GITHUB_ENV
+
+      - name: Set tag name from manual input
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "TAG_NAME=refs/tags/${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+
       - name: Get release metadata JSON
         run: |
-          flub release fromTag ${{ github.ref }} --json | jq -c > release-metadata.json
+          flub release fromTag $TAG_NAME --json | jq -c > release-metadata.json
       - name: Upload release metadata JSON
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # ratchet:actions/upload-artifact@v3
         with:

--- a/.github/workflows/website-validation.yml
+++ b/.github/workflows/website-validation.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # ratchet:actions/checkout@v4
         with:
           submodules: false
-      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # ratchet:pnpm/action-setup@v2
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # ratchet:pnpm/action-setup@v4
       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # ratchet:actions/setup-node@v3
         with:
           node-version: "18"
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # ratchet:actions/checkout@v4
         with:
           submodules: false
-      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # ratchet:pnpm/action-setup@v2
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # ratchet:pnpm/action-setup@v4
       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # ratchet:actions/setup-node@v3
         with:
           node-version: "18"
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: false
-      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # ratchet:pnpm/action-setup@v2
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # ratchet:pnpm/action-setup@v4
       - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # ratchet:actions/setup-node@v3
         with:
           node-version: "18"


### PR DESCRIPTION
Upgrades pnpm/action-setup to v4 to fix https://github.com/pnpm/action-setup/issues/135.

I also updated the GH release creation job to support manual runs. That will allow us to create releases semi-manually from main, so we don't have to port all the CI fixes to every release branch before we create the releases.