### PR TITLE
server: Undo enablePull and SHA256 digests changes during build

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-FROM node:18.17.1-buster-slim@sha256:cb2a746612c2564d3bd0f871174618337af9d0f4d895df6a623fd7a69ca6e5bd AS base
+FROM node:18.17.1-buster-slim AS base
 
 # Add Tini
 ENV TINI_VERSION v0.18.0

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -3,7 +3,7 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-FROM node:18.17.1-buster-slim@sha256:cb2a746612c2564d3bd0f871174618337af9d0f4d895df6a623fd7a69ca6e5bd AS base
+FROM node:18.17.1-buster-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -3,9 +3,7 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-# Use a direct sha256 hash to ensure we are always using the same version of the base image.
-# This avoids throttling issues with Docker Hub by using an image baked into the pipeline build image.
-FROM node:18.17.1-buster-slim@sha256:cb2a746612c2564d3bd0f871174618337af9d0f4d895df6a623fd7a69ca6e5bd AS base
+FROM node:18.17.1-buster-slim AS base
 
 # node-gyp dependencies
 RUN apt-get update && apt-get install -y \

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -114,6 +114,5 @@ extends:
     tagName: gitrest
     lint: true
     pack: true
-    enableDockerImagePull: false
     checks:
     - prettier

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -116,6 +116,5 @@ extends:
     tagName: historian
     lint: true
     pack: true
-    enableDockerImagePull: false
     checks:
     - prettier

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -143,4 +143,3 @@ extends:
     - check:versions
     - generate:packageList
     additionalBuildArguments: --build-context root=.
-    enableDockerImagePull: false

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -103,11 +103,6 @@ parameters:
     type: boolean
     default: false
 
-  # Whether the docker image build should try to pull from the registry
-  - name: enableDockerImagePull
-    type: boolean
-    default: true
-
 trigger: none
 
 resources:
@@ -346,7 +341,6 @@ extends:
               useBuildKit: true
               enableNetwork: true
               enableCache: true
-              enablePull: ${{ parameters.enableDockerImagePull }}
 
           # Pack
           - ${{ if eq(parameters.pack, true) }}:
@@ -473,7 +467,6 @@ extends:
           # At this point we want to publish the artifact with docs, but as part of 1ES migration that's now part of
           # templateContext.outputs below.
 
-
         # Build final image
         - task: 1ES.BuildContainerImage@1
           inputs:
@@ -484,7 +477,6 @@ extends:
             useBuildKit: true
             enableNetwork: true
             enableCache: true
-            enablePull: ${{ parameters.enableDockerImagePull }}
 
         # TODO: move the image pushes to templateContext.outputs?
         # Push


### PR DESCRIPTION
## Description

We tried testing if static public IPs in the build agent pools would resolve the throttling issue but we did not hit it again today even in the pool with no static public IPs. We suspect that's probably still a good solution, so we're undoing the changes that removed the need to pull images from docker hub, so the next time we try to do that and hit throttling we can apply the static public IPs and confirm that they actually solve the problem.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

