### PR TITLE
Process ops by batches in remoteMessageProcessor and pendingStateManager

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2678,9 +2678,7 @@ export class ContainerRuntime
 
 		try {
 			// See commit that added this assert for more details.
-			// These calls should be made for all but chunked ops:
-			// 1) this.pendingStateManager.processPendingLocalMessage() below
-			// 2) this.resetReconnectCount() below
+			// These subsequent calls should be made for all but chunked ops:
 			assert(
 				message.type !== ContainerMessageType.ChunkedOp,
 				0x93b /* we should never get here with chunked ops */,

--- a/packages/runtime/container-runtime/src/opLifecycle/remoteMessageProcessor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/remoteMessageProcessor.ts
@@ -13,7 +13,6 @@ import {
 	ContainerMessageType,
 	type InboundContainerRuntimeMessage,
 	type InboundSequencedContainerRuntimeMessage,
-	type InboundSequencedContainerRuntimeMessageOrSystemMessage,
 	type InboundSequencedRecentlyAddedContainerRuntimeMessage,
 } from "../messageTypes.js";
 import { asBatchMetadata } from "../metadata.js";
@@ -36,8 +35,7 @@ export class RemoteMessageProcessor {
 	 * @remarks For chunked batches, this is the CSN of the "representative" chunk (the final chunk)
 	 */
 	private batchStartCsn: number | undefined;
-	private readonly processorBatch: InboundSequencedContainerRuntimeMessageOrSystemMessage[] =
-		[];
+	private readonly processorBatch: InboundSequencedContainerRuntimeMessage[] = [];
 
 	constructor(
 		private readonly opSplitter: OpSplitter,
@@ -75,7 +73,7 @@ export class RemoteMessageProcessor {
 	 */
 	public process(remoteMessageCopy: ISequencedDocumentMessage):
 		| {
-				messages: InboundSequencedContainerRuntimeMessageOrSystemMessage[];
+				messages: InboundSequencedContainerRuntimeMessage[];
 				batchStartCsn: number;
 		  }
 		| undefined {
@@ -122,9 +120,7 @@ export class RemoteMessageProcessor {
 
 		// Do a final unpack of runtime messages in case the message was not grouped, compressed, or chunked
 		unpackRuntimeMessage(message);
-		this.processorBatch.push(
-			message as InboundSequencedContainerRuntimeMessageOrSystemMessage,
-		);
+		this.processorBatch.push(message as InboundSequencedContainerRuntimeMessage);
 		if (this.batchStartCsn === undefined) {
 			const messages = [...this.processorBatch];
 			this.processorBatch.length = 0;

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -273,7 +273,7 @@ export class PendingStateManager implements IDisposable {
 	 * @param batchStartCsn - The clientSequenceNumber of the start of this message's batch (assigned during submit)
 	 * (not to be confused with message.clientSequenceNumber - the overwritten value in case of grouped batching)
 	 */
-	public processPendingLocalMessage(
+	private processPendingLocalMessage(
 		message: InboundSequencedContainerRuntimeMessage,
 		batchStartCsn: number,
 	): unknown {

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -15,7 +15,7 @@ import {
 } from "@fluidframework/telemetry-utils/internal";
 import Deque from "double-ended-queue";
 
-import { type InboundSequencedContainerRuntimeMessageOrSystemMessage } from "./messageTypes.js";
+import { type InboundSequencedContainerRuntimeMessage } from "./messageTypes.js";
 import { asBatchMetadata, IBatchMetadata } from "./metadata.js";
 import type { BatchMessage } from "./opLifecycle/index.js";
 import { pkgVersion } from "./packageVersion.js";
@@ -68,7 +68,7 @@ type AnyComboFromUnion<T extends object> = { [P in KeysOfUnion<T>]?: T[P] };
 function buildPendingMessageContent(
 	// AnyComboFromUnion is needed need to gain access to compatDetails that
 	// is only defined for some cases.
-	message: AnyComboFromUnion<InboundSequencedContainerRuntimeMessageOrSystemMessage>,
+	message: AnyComboFromUnion<InboundSequencedContainerRuntimeMessage>,
 ): string {
 	// IMPORTANT: Order matters here, this must match the order of the properties used
 	// when submitting the message.
@@ -254,10 +254,10 @@ export class PendingStateManager implements IDisposable {
 	}
 
 	public processPendingLocalBatch(
-		batch: InboundSequencedContainerRuntimeMessageOrSystemMessage[],
+		batch: InboundSequencedContainerRuntimeMessage[],
 		batchStartCsn: number,
 	): {
-		message: InboundSequencedContainerRuntimeMessageOrSystemMessage;
+		message: InboundSequencedContainerRuntimeMessage;
 		localOpMetadata: unknown;
 	}[] {
 		return batch.map((message) => ({
@@ -274,7 +274,7 @@ export class PendingStateManager implements IDisposable {
 	 * (not to be confused with message.clientSequenceNumber - the overwritten value in case of grouped batching)
 	 */
 	public processPendingLocalMessage(
-		message: InboundSequencedContainerRuntimeMessageOrSystemMessage,
+		message: InboundSequencedContainerRuntimeMessage,
 		batchStartCsn: number,
 	): unknown {
 		// Pre-processing part - This may be the start of a batch.

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -253,6 +253,12 @@ export class PendingStateManager implements IDisposable {
 		}
 	}
 
+	/**
+	 * Processes the incoming batch from the server. It verifies that messages are received in the right order and
+	 * that the batch information is correct.
+	 * @param batch - The batch that is being processed.
+	 * @param batchStartCsn - The clientSequenceNumber of the start of this message's batch
+	 */
 	public processPendingLocalBatch(
 		batch: InboundSequencedContainerRuntimeMessage[],
 		batchStartCsn: number,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -724,6 +724,9 @@ describe("Runtime", () => {
 					processPendingLocalMessage: (_message: ISequencedDocumentMessage) => {
 						return undefined;
 					},
+					processPendingLocalBatch: (_messages: ISequencedDocumentMessage[]) => {
+						return [];
+					},
 					get pendingMessagesCount() {
 						return pendingMessages;
 					},
@@ -881,7 +884,7 @@ describe("Runtime", () => {
 				},
 			);
 
-			it(
+			it.only(
 				`No progress for ${maxReconnects} connection state changes, with pending state, successfully ` +
 					"processing local op, should not generate telemetry event nor throw an error that closes the container",
 				async () => {
@@ -899,6 +902,7 @@ describe("Runtime", () => {
 								contents: {
 									address: "address",
 								},
+								clientSequenceNumber: 0,
 							} as any as ISequencedDocumentMessage,
 							true /* local */,
 						);

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -721,9 +721,6 @@ describe("Runtime", () => {
 					processMessage: (_message: ISequencedDocumentMessage, _local: boolean) => {
 						return { localAck: false, localOpMetadata: undefined };
 					},
-					processPendingLocalMessage: (_message: ISequencedDocumentMessage) => {
-						return undefined;
-					},
 					processPendingLocalBatch: (_messages: ISequencedDocumentMessage[]) => {
 						return _messages.map((message) => ({
 							message,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -725,7 +725,10 @@ describe("Runtime", () => {
 						return undefined;
 					},
 					processPendingLocalBatch: (_messages: ISequencedDocumentMessage[]) => {
-						return [];
+						return _messages.map((message) => ({
+							message,
+							localOpMetadata: undefined,
+						}));
 					},
 					get pendingMessagesCount() {
 						return pendingMessages;
@@ -884,7 +887,7 @@ describe("Runtime", () => {
 				},
 			);
 
-			it.only(
+			it(
 				`No progress for ${maxReconnects} connection state changes, with pending state, successfully ` +
 					"processing local op, should not generate telemetry event nor throw an error that closes the container",
 				async () => {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/remoteMessageProcessor.spec.ts
@@ -160,7 +160,6 @@ describe("RemoteMessageProcessor", () => {
 			const actual: ISequencedDocumentMessage[] = [];
 			let seqNum = 1;
 			let actualBatchStartCsn: number | undefined;
-			let emptyProcessResultCount = 0;
 			for (const message of outboundMessages) {
 				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 				const inboundMessage = {
@@ -177,7 +176,6 @@ describe("RemoteMessageProcessor", () => {
 
 				// It'll be undefined for the first n-1 chunks if chunking is enabled
 				if (processResult === undefined) {
-					++emptyProcessResultCount;
 					continue;
 				}
 
@@ -192,11 +190,6 @@ describe("RemoteMessageProcessor", () => {
 					);
 				}
 			}
-			assert.equal(
-				emptyProcessResultCount,
-				leadingChunkCount,
-				"expected empty result to be 1-1 with leading chunks",
-			);
 
 			const expected = option.grouping
 				? [

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -161,12 +161,10 @@ describe("Pending State Manager", () => {
 		};
 
 		const process = (messages: Partial<ISequencedDocumentMessage>[], batchStartCsn: number) =>
-			messages.forEach((message) => {
-				pendingStateManager.processPendingLocalMessage(
-					message as InboundSequencedContainerRuntimeMessage,
-					batchStartCsn,
-				);
-			});
+			pendingStateManager.processPendingLocalBatch(
+				messages as InboundSequencedContainerRuntimeMessage[],
+				batchStartCsn,
+			);
 
 		it("proper batch is processed correctly", () => {
 			const messages: Partial<ISequencedDocumentMessage>[] = [
@@ -422,8 +420,8 @@ describe("Pending State Manager", () => {
 					],
 					1,
 				);
-				pendingStateManager.processPendingLocalMessage(
-					futureRuntimeMessage as ISequencedDocumentMessage & UnknownContainerRuntimeMessage,
+				pendingStateManager.processPendingLocalBatch(
+					[futureRuntimeMessage as ISequencedDocumentMessage & UnknownContainerRuntimeMessage],
 					1 /* batchStartCsn */,
 				);
 			});


### PR DESCRIPTION
In order to be able to recognize a batch that becomes empty on resubmit, we need to process them by batch instead of by individual op. This will help to make subsequent changes that will allow flushing on empty batches.