### PR TITLE
fix(markdown-magic): Bugs introduced through overlapping changes

### DIFF
--- a/tools/markdown-magic/src/md-magic.config.cjs
+++ b/tools/markdown-magic/src/md-magic.config.cjs
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 
-const { PackageName } = require("@rushstack/node-core-library");
 const scripts = require("markdown-magic-package-scripts");
 
 const {
 	createSectionFromTemplate,
 	formattedGeneratedContentBody,
 	getPackageMetadata,
+	getScopeKindFromPackage,
 	resolveRelativePackageJsonPath,
 } = require("./utilities.cjs");
 const {
@@ -66,25 +66,6 @@ const generateHelpSection = (includeHeading) =>
  */
 const generateTrademarkSection = (includeHeading) =>
 	createSectionFromTemplate("Trademark-Template.md", includeHeading ? "Trademark" : undefined);
-
-/**
- * Gets the appropriate scope kind for the provided package name.
- *
- * @param {string} packageName
- * @returns {"EXPERIMENTAL" | "INTERNAL" | "PRIVATE" | undefined} A scope kind based on the package's scope (namespace).
- */
-const getScopeKindFromPackage = (packageName) => {
-	const packageScope = PackageName.getScope(packageName);
-	if (packageScope === `@fluid-experimental`) {
-		return "EXPERIMENTAL";
-	} else if (packageScope === `@fluid-internal`) {
-		return "INTERNAL";
-	} else if (packageScope === `@fluid-private`) {
-		return "PRIVATE";
-	} else {
-		return undefined;
-	}
-};
 
 /**
  * Generates simple README contents for a library package.
@@ -432,7 +413,7 @@ module.exports = {
 		README_DEPENDENCY_GUIDELINES_SECTION: (content, options, config) =>
 			templateTransform(
 				"Dependency-Guidelines-Template.md",
-				options.includeHeading !== "FALSE" ? "Dependency Guidelines" : undefined,
+				options.includeHeading !== "FALSE" ? "Using Fluid Framework libraries" : undefined,
 			),
 
 		/**

--- a/tools/markdown-magic/src/transforms/packageScopeNoticeTransform.cjs
+++ b/tools/markdown-magic/src/transforms/packageScopeNoticeTransform.cjs
@@ -6,6 +6,7 @@
 const {
 	formattedSectionText,
 	getPackageMetadata,
+	getScopeKindFromPackage,
 	readTemplate,
 	resolveRelativePackageJsonPath,
 } = require("../utilities.cjs");

--- a/tools/markdown-magic/src/utilities.cjs
+++ b/tools/markdown-magic/src/utilities.cjs
@@ -5,6 +5,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const { PackageName } = require("@rushstack/node-core-library");
 
 const {
 	embeddedContentNotice,
@@ -85,6 +86,25 @@ function getPackageMetadata(packageJsonFilePath) {
 }
 
 /**
+ * Gets the appropriate scope kind for the provided package name.
+ *
+ * @param {string} packageName
+ * @returns {"EXPERIMENTAL" | "INTERNAL" | "PRIVATE" | undefined} A scope kind based on the package's scope (namespace).
+ */
+const getScopeKindFromPackage = (packageName) => {
+	const packageScope = PackageName.getScope(packageName);
+	if (packageScope === `@fluid-experimental`) {
+		return "EXPERIMENTAL";
+	} else if (packageScope === `@fluid-internal`) {
+		return "INTERNAL";
+	} else if (packageScope === `@fluid-private`) {
+		return "PRIVATE";
+	} else {
+		return undefined;
+	}
+};
+
+/**
  * Generates the appropriately formatted Markdown section contents for the provided section body.
  * If header text is provided, a level 2 heading (i.e. `##`) will be included with the provided text.
  * The section will be wrapped in leading and trailing newlines to ensure adequate spacing between generated contents.
@@ -135,6 +155,7 @@ module.exports = {
 	formattedGeneratedContentBody,
 	formattedEmbeddedContentBody,
 	getPackageMetadata,
+	getScopeKindFromPackage,
 	readTemplate,
 	resolveRelativePackageJsonPath,
 	resolveRelativePath,


### PR DESCRIPTION
Some previous PRs implicitly overlapped in breaking ways. This fixes the markdown-magic package to preserve correct existing behaviors.