### PR TITLE
Use unofficial 1ES pipeline template for public builds

### DIFF
--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -41,11 +41,8 @@ extends:
     sdl:
       arrow:
         # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
-        # Currently we want to use different names for internal and public builds for Arrow Service Connection
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           serviceConnection: ff-internal-arrow-sc
-        ${{ else }}:
-          serviceConnection: ff-public-arrow-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -30,7 +30,10 @@ resources:
     ref: refs/tags/release
 extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
-  template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  ${{ else }}:
+    template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
       name: Small-1ES # This is one of the Fluid Orgs new 1ES hosted pools.

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -29,10 +29,13 @@ resources:
     name: 1ESPipelineTemplates/M365GPT
     ref: refs/tags/release
 extends:
-  # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
+  # The pipeline extends the 1ES pipeline template which will inject different SDL and compliance tasks.
+  # Read more: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview
   ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
   ${{ else }}:
+    # For non-production pipelines, we use "Unofficial" 1ES pipeline template
+    # The unofficial template skips some of the jobs that are irrelevant for the pipelines that do not have the potential to produce a production release candidate.(For example ARROW).
     template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:

--- a/tools/pipelines/repo-policy-check.yml
+++ b/tools/pipelines/repo-policy-check.yml
@@ -39,9 +39,9 @@ extends:
       name: Small-1ES # This is one of the Fluid Orgs new 1ES hosted pools.
       os: linux
     sdl:
-      arrow:
-        # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        arrow:
+          # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
           serviceConnection: ff-internal-arrow-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -129,11 +129,8 @@ extends:
     sdl:
       arrow:
         # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
-        # Currently we want to use different names for internal and public builds for Arrow Service Connection
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           serviceConnection: ff-internal-arrow-sc
-        ${{ else }}:
-          serviceConnection: ff-public-arrow-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -127,9 +127,9 @@ extends:
       name: ${{ parameters.pool }}
       os: linux
     sdl:
-      arrow:
-        # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        arrow:
+          # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
           serviceConnection: ff-internal-arrow-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -117,7 +117,11 @@ resources:
     name: 1ESPipelineTemplates/M365GPT
     ref: refs/tags/release
 extends:
-  template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  ${{ else }}:
+    template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
       name: ${{ parameters.pool }}

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -117,10 +117,13 @@ resources:
     name: 1ESPipelineTemplates/M365GPT
     ref: refs/tags/release
 extends:
-  # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
+  # The pipeline extends the 1ES pipeline template which will inject different SDL and compliance tasks.
+  # Read more: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview
   ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
   ${{ else }}:
+    # For non-production pipelines, we use "Unofficial" 1ES pipeline template
+    # The unofficial template skips some of the jobs that are irrelevant for the pipelines that do not have the potential to produce a production release candidate.(For example ARROW).
     template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -155,9 +155,9 @@ extends:
       name: ${{ parameters.poolBuild }}
       os: linux
     sdl:
-      arrow:
-        # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        arrow:
+          # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
           serviceConnection: ff-internal-arrow-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -145,7 +145,11 @@ resources:
 extends:
   # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
   # Read more: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview
-  template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  ${{ else }}:
+    template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
       name: ${{ parameters.poolBuild }}

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -143,12 +143,13 @@ resources:
       ref: refs/tags/release
 
 extends:
-  # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
+  # The pipeline extends the 1ES pipeline template which will inject different SDL and compliance tasks.
   # Read more: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview
-  # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
   ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
   ${{ else }}:
+    # For non-production pipelines, we use "Unofficial" 1ES pipeline template
+    # The unofficial template skips some of the jobs that are irrelevant for the pipelines that do not have the potential to produce a production release candidate.(For example ARROW).
     template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -157,11 +157,8 @@ extends:
     sdl:
       arrow:
         # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
-        # Currently we want to use different names for internal and public builds for Arrow Service Connection
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           serviceConnection: ff-internal-arrow-sc
-        ${{ else }}:
-          serviceConnection: ff-public-arrow-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022


### PR DESCRIPTION
- Added conditional use of Officeial/Unofficial 1ES pipeline template based on whether it is running for internal build or PR build.
- Removed the `sdl.arrow.serviceConnection` param which was optional 1es template for public builds ([link](https://o365exchange.visualstudio.com/1ESPipelineTemplates/_git/M365GPT?path=/v1/M365.Unofficial.PipelineTemplate.yml&version=GBmaster&line=91&lineEnd=92&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents)) . This should disable the arrow tasks from running thus shortening the build times for PRs.

[AB#7419](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7419)
[AB#7032](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7032)