### PR TITLE
feat(build-tools): include peers in `combinedDependencies`

### DIFF
--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -654,9 +654,9 @@ export async function setVersion(
  * Extracts the dependencies record from a package.json file based on the dependency group.
  */
 function getDependenciesRecord(
-	packageJson: Package["packageJson"],
+	packageJson: PackageJson,
 	depClass: "prod" | "dev" | "peer",
-): Partial<Record<string, string>> | undefined {
+): PackageJson["dependencies" | "devDependencies" | "peerDependencies"] | undefined {
 	switch (depClass) {
 		case "dev": {
 			return packageJson.devDependencies;

--- a/build-tools/packages/build-cli/src/library/package.ts
+++ b/build-tools/packages/build-cli/src/library/package.ts
@@ -651,6 +651,26 @@ export async function setVersion(
 }
 
 /**
+ * Extracts the dependencies record from a package.json file based on the dependency group.
+ */
+function getDependenciesRecord(
+	packageJson: Package["packageJson"],
+	depClass: "prod" | "dev" | "peer",
+): Partial<Record<string, string>> | undefined {
+	switch (depClass) {
+		case "dev": {
+			return packageJson.devDependencies;
+		}
+		case "peer": {
+			return packageJson.peerDependencies;
+		}
+		default: {
+			return packageJson.dependencies;
+		}
+	}
+}
+
+/**
  * Set the version of _dependencies_ within a package according to the provided map of packages to range strings.
  *
  * @param pkg - The package whose dependencies should be updated.
@@ -675,14 +695,12 @@ async function setPackageDependencies(
 ): Promise<boolean> {
 	let changed = false;
 	let newRangeString: string;
-	for (const { name, dev } of pkg.combinedDependencies) {
+	for (const { name, depClass } of pkg.combinedDependencies) {
 		const dep = dependencyVersionMap.get(name);
 		if (dep !== undefined) {
 			const isSameReleaseGroup = MonoRepo.isSame(dep.pkg.monoRepo, pkg.monoRepo);
 			if (!isSameReleaseGroup || (updateWithinSameReleaseGroup && isSameReleaseGroup)) {
-				const dependencies = dev
-					? pkg.packageJson.devDependencies
-					: pkg.packageJson.dependencies;
+				const dependencies = getDependenciesRecord(pkg.packageJson, depClass);
 				if (dependencies === undefined) {
 					continue;
 				}

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildDatabase.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildDatabase.ts
@@ -9,7 +9,7 @@
 
 import path from "node:path";
 
-import { type Package, type PackageDependency, TscUtils } from "@fluidframework/build-tools";
+import { type Package, TscUtils } from "@fluidframework/build-tools";
 import type { TsConfigJson } from "type-fest";
 
 import { getGenerateEntrypointsOutput } from "../commands/index.js";
@@ -237,7 +237,10 @@ export class FluidBuildDatabase {
 		packageGroup: ReadonlyMap<PackageName, Package>,
 		packageName: PackageName,
 		script: Script,
-		ignorePackage?: (packageInfo: PackageDependency) => boolean,
+		ignorePackage?: (packageInfo: {
+			name: string;
+			version: string;
+		}) => boolean,
 	): BuildScript[][] {
 		const pkg = packageGroup.get(packageName);
 		if (pkg === undefined) {

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildDatabase.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildDatabase.ts
@@ -9,7 +9,7 @@
 
 import path from "node:path";
 
-import { type Package, TscUtils } from "@fluidframework/build-tools";
+import { type Package, type PackageDependency, TscUtils } from "@fluidframework/build-tools";
 import type { TsConfigJson } from "type-fest";
 
 import { getGenerateEntrypointsOutput } from "../commands/index.js";
@@ -237,7 +237,7 @@ export class FluidBuildDatabase {
 		packageGroup: ReadonlyMap<PackageName, Package>,
 		packageName: PackageName,
 		script: Script,
-		ignorePackage?: (packageInfo: { name: string; version: string; dev: boolean }) => boolean,
+		ignorePackage?: (packageInfo: PackageDependency) => boolean,
 	): BuildScript[][] {
 		const pkg = packageGroup.get(packageName);
 		if (pkg === undefined) {
@@ -253,8 +253,6 @@ export class FluidBuildDatabase {
 
 		const predecessors: BuildScript[][] = [];
 
-		// Note that combinedDependencies (as of 2024-05-13) does not consider peer
-		// dependencies that could be linked.
 		for (const dep of pkg.combinedDependencies) {
 			if (ignorePackage?.(dep) ?? false) {
 				continue;

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
@@ -345,16 +345,12 @@ function hasTaskDependency(
 	const packageSpecificSearchDeps = searchDeps.filter((d) => d.includes("#"));
 	/**
 	 * Set of package dependencies
-	 * True dependencies would include peer dependencies as well. Here we are
-	 * matching {@link Package.combinedDependencies} that is used in
-	 * {@link @fluidframework/build-tools/src/fluidBuild/buildGraph.ts#BuildGraph.initializePackages}
-	 * Being more conservative is not terrible as it would just look like a miss
-	 * from ^ specification and could be fixed with an explicit dependency.
 	 */
 	const packageDependencies = new Set([
 		...Object.keys(json.dependencies ?? {}),
 		// devDeps are not regular task deps, but might happen for internal type only packages.
 		...Object.keys(json.devDependencies ?? {}),
+		...Object.keys(json.peerDependencies ?? {}),
 	]);
 	const seenDep = new Set<string>();
 	const pending: string[] = [];

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -73,7 +73,7 @@ export type PackageJson = SetRequired<
 /**
  * Information about a package dependency.
  */
-export interface PackageDependency {
+interface PackageDependency {
 	name: string;
 	version: string;
 	depClass: "prod" | "dev" | "peer";

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -70,6 +70,15 @@ export type PackageJson = SetRequired<
 	"name" | "scripts" | "version"
 >;
 
+/**
+ * Information about a package dependency.
+ */
+export interface PackageDependency {
+	name: string;
+	version: string;
+	depClass: "prod" | "dev" | "peer";
+}
+
 export class Package {
 	private static packageCount: number = 0;
 	private static readonly chalkColor = [
@@ -190,22 +199,31 @@ export class Package {
 		return Object.keys(this.packageJson.dependencies ?? {});
 	}
 
-	public get combinedDependencies(): Generator<
-		{
-			name: string;
-			version: string;
-			dev: boolean;
-		},
-		void
-	> {
+	public get combinedDependencies(): Generator<PackageDependency, void> {
 		const it = function* (packageJson: PackageJson) {
 			for (const item in packageJson.dependencies) {
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				yield { name: item, version: packageJson.dependencies[item]!, dev: false };
+				yield {
+					name: item,
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					version: packageJson.dependencies[item]!,
+					depClass: "prod",
+				} as const;
 			}
 			for (const item in packageJson.devDependencies) {
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				yield { name: item, version: packageJson.devDependencies[item]!, dev: true };
+				yield {
+					name: item,
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					version: packageJson.devDependencies[item]!,
+					depClass: "dev",
+				} as const;
+			}
+			for (const item in packageJson.peerDependencies) {
+				yield {
+					name: item,
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					version: packageJson.peerDependencies[item]!,
+					depClass: "peer",
+				} as const;
 			}
 		};
 		return it(this.packageJson);

--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -14,6 +14,7 @@ export type { Logger } from "./common/logging";
 export { MonoRepo } from "./common/monoRepo";
 export {
 	Package,
+	type PackageDependency,
 	type PackageJson,
 	updatePackageJsonFile,
 	updatePackageJsonFileAsync,

--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -14,7 +14,6 @@ export type { Logger } from "./common/logging";
 export { MonoRepo } from "./common/monoRepo";
 export {
 	Package,
-	type PackageDependency,
 	type PackageJson,
 	updatePackageJsonFile,
 	updatePackageJsonFileAsync,


### PR DESCRIPTION
+ Make sure `peerDependencies` are enumerated and managed by `flub bump`.
+ Resolve errata for build task management as peers were not previously considered.

Manual test confirms peer deps in `@fluid-experimental/property-inspector-table` are now considered.