### PR TITLE
gitssh: Add base image sha to Dockerfile

### DIFF
--- a/server/gitssh/Dockerfile
+++ b/server/gitssh/Dockerfile
@@ -3,7 +3,7 @@
 
 # DisableDockerDetector "No feasible secure solution for OSS repos yet"
 
-FROM alpine:3.12
+FROM alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69
 
 # Install Git and OpenSSH so we can run a git server
 RUN apk add --no-cache git

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -90,4 +90,5 @@ extends:
     buildDirectory: server/gitssh
     containerName: fluidframework/routerlicious/gitssh
     setVersion: false
+    enableDockerImagePull: false
     tagName: gitssh


### PR DESCRIPTION
## Description

Similar to what we did with the routerlicious, historian, and gitrest Dockerfiles in https://github.com/microsoft/FluidFramework/pull/21758, this adds the sha256 digest for the base image we use for gitssh and disables pulling updated images during build, while we implement a long-term solution to the throttling issues we've been seeing when pulling from docker hub.

This should unblock PRs that are hitting [build issues for gitssh](https://dev.azure.com/fluidframework/public/_build/results?buildId=277955&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=f90788c4-9567-5b73-8a0d-1736388b7d37).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
