### PR TITLE
improvement(eslint-config-fluid): Disable `unicorn/no-useless-spread`

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -9,6 +9,10 @@ The following rules have been disabled in all configs because they conflict with
 -   [@typescript-eslint/brace-style](https://typescript-eslint.io/rules/brace-style)
 -   [unicorn/number-literal-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v48.0.1/docs/rules/number-literal-case.md)
 
+The following rules have been disabled due to frequency of false-positives reported:
+
+-   [unicorn/no-useless-spread](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v48.0.1/docs/rules/no-useless-spread.md)
+
 ### @typescript-eslint/explicit-function-return-type changes
 
 The [allowExpressions](https://typescript-eslint.io/rules/explicit-function-return-type/#allowexpressions) option for

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -1398,7 +1398,7 @@
             "error"
         ],
         "unicorn/no-useless-spread": [
-            "error"
+            "off"
         ],
         "unicorn/no-useless-switch-case": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -1472,7 +1472,7 @@
             "error"
         ],
         "unicorn/no-useless-spread": [
-            "error"
+            "off"
         ],
         "unicorn/no-useless-switch-case": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -1398,7 +1398,7 @@
             "error"
         ],
         "unicorn/no-useless-spread": [
-            "error"
+            "off"
         ],
         "unicorn/no-useless-switch-case": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -1444,7 +1444,7 @@
             "error"
         ],
         "unicorn/no-useless-spread": [
-            "error"
+            "off"
         ],
         "unicorn/no-useless-switch-case": [
             "error"

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -1400,7 +1400,7 @@
             "error"
         ],
         "unicorn/no-useless-spread": [
-            "error"
+            "off"
         ],
         "unicorn/no-useless-switch-case": [
             "error"

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -58,6 +58,8 @@ module.exports = {
 
 		/**
 		 * Disabled due to false positives / disruptive behavior of auto-fix.
+		 * See {@link https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2018}.
+		 * We may consider re-enabling once the above issue has been resolved.
 		 */
 		"unicorn/no-useless-spread": "off",
 

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -57,6 +57,11 @@ module.exports = {
 		"unicorn/no-nested-ternary": "off",
 
 		/**
+		 * Disabled due to false positives / disruptive behavior of auto-fix.
+		 */
+		"unicorn/no-useless-spread": "off",
+
+		/**
 		 * Disabled due to the sheer number of false positives it detects, and because it is sometimes valuable to
 		 * explicitly denote `undefined`.
 		 */


### PR DESCRIPTION
The rule reports false-positives, and its auto-fix behavior is disruptive.

Related issue: https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2018