### PR TITLE
Remove outdated node hydration regression test

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -260,26 +260,4 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(undoStack.length, 0);
 		assert.equal(redoStack.length, 1);
 	});
-
-	// AB#8200: This test may not be necessary with the schematize API removed.
-	it("handles proxies in the initial tree", () => {
-		// This is a regression test for a bug in which the initial tree contained a proxy and subsequent reads of the tree would mix up the proxy associations.
-		const sf = new SchemaFactory(undefined);
-		class TestObject extends sf.object("TestObject", { value: sf.number }) {}
-		const viewConfig = new TreeViewConfiguration({ schema: TestObject });
-		const nodeKeyManager = new MockNodeKeyManager();
-		const view = new SchematizingSimpleTreeView(
-			checkoutWithInitialTree(viewConfig, new TestObject({ value: 3 }), nodeKeyManager),
-			viewConfig,
-			nodeKeyManager,
-		);
-
-		// We do not call `upgradeSchema()` and thus the initial tree remains unused.
-		// Therefore, the proxy for `new TestObject(...)` should not be bound.
-		assert.equal(view.root.value, 3);
-		// In the buggy case, the proxy for `new TestObject(...)` would get bound during this set, which is wrong...
-		view.root.value = 4;
-		// ...and would cause this read to return a proxy to the TestObject rather than the primitive value.
-		assert.equal(view.root.value, 4);
-	});
 });


### PR DESCRIPTION
## Description

This test was protecting against a scenario that could arise only in previous versions of the code. Originally, proxies created in the initial tree were not hydrated, and there was at one point a bug where SharedTree was attempting to hydrate them, but was doing so incorrectly. The bug was fixed and this test regression test was added. However, proxy hydration has since been improved so that the proxies in the initial tree _are_ hydrated. Therefore, this class of bug no longer exists, and this test is unnecessary.

