### PR TITLE
tree: Add breakingClass decorator, allow views to break

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -39,8 +39,8 @@ import {
 	brand,
 	Breakable,
 	type WithBreakable,
-	breakingMethod,
 	throwIfBroken,
+	breakingClass,
 } from "../util/index.js";
 
 import { type SharedTreeBranch, getChangeReplaceType } from "./branch.js";
@@ -69,11 +69,9 @@ export interface ClonableSchemaAndPolicy extends SchemaAndPolicy {
 }
 
 /**
- * Generic shared tree, which needs to be configured with indexes, field kinds and a history policy to be used.
- *
- * TODO: actually implement
- * TODO: is history policy a detail of what indexes are used, or is there something else to it?
+ * Generic shared tree, which needs to be configured with indexes, field kinds and other configuration.
  */
+@breakingClass
 export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 	extends SharedObject
 	implements WithBreakable
@@ -300,7 +298,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		return builder.getSummaryTree();
 	}
 
-	@breakingMethod
 	protected async loadCore(services: IChannelStorageService): Promise<void> {
 		const loadSummaries = this.summarizables.map(async (summaryElement) =>
 			summaryElement.load(
@@ -318,7 +315,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 	 * @returns the submitted commit. This is undefined if the underlying `SharedObject` is not attached,
 	 * and may differ from `commit` due to enrichments like detached tree refreshers.
 	 */
-	@breakingMethod
+
 	private submitCommit(
 		commit: GraphCommit<TChange>,
 		schemaAndPolicy: ClonableSchemaAndPolicy,
@@ -366,7 +363,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		this.resubmitMachine.onCommitSubmitted(commit);
 	}
 
-	@breakingMethod
 	protected processCore(
 		message: ISequencedDocumentMessage,
 		local: boolean,
@@ -402,7 +398,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		}
 	}
 
-	@breakingMethod
 	protected override reSubmitCore(
 		content: JsonCompatibleReadOnly,
 		localOpMetadata: unknown,
@@ -435,7 +430,6 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		this.submitCommit(enrichedCommit, localOpMetadata, true);
 	}
 
-	@breakingMethod
 	protected applyStashedOp(content: JsonCompatibleReadOnly): void {
 		assert(
 			!this.getLocalBranch().isTransacting(),

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -39,7 +39,7 @@ import {
 	mapTreeFromNodeData,
 	prepareContentForHydration,
 } from "../simple-tree/index.js";
-import { disposeSymbol } from "../util/index.js";
+import { Breakable, breakingClass, disposeSymbol, type WithBreakable } from "../util/index.js";
 
 import { canInitialize, ensureSchema, initialize } from "./schematizeTree.js";
 import type { TreeCheckout } from "./treeCheckout.js";
@@ -48,8 +48,9 @@ import { CheckoutFlexTreeView } from "./treeView.js";
 /**
  * Implementation of TreeView wrapping a FlexTreeView.
  */
+@breakingClass
 export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitFieldSchema>
-	implements TreeView<TRootSchema>
+	implements TreeView<TRootSchema>, WithBreakable
 {
 	/**
 	 * The view is set to undefined when this object is disposed or the view schema does not support viewing the document's stored schema.
@@ -86,6 +87,7 @@ export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitField
 		public readonly checkout: TreeCheckout,
 		public readonly config: TreeViewConfiguration<TRootSchema>,
 		public readonly nodeKeyManager: NodeKeyManager,
+		public readonly breaker: Breakable = new Breakable("SchematizingSimpleTreeView"),
 	) {
 		const policy = {
 			...defaultSchemaPolicy,
@@ -306,6 +308,7 @@ export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitField
 	}
 
 	public get root(): TreeFieldFromImplicitField<TRootSchema> {
+		this.breaker.use();
 		if (!this.compatibility.canView) {
 			throw new UsageError(
 				"Document is out of schema. Check TreeView.compatibility before accessing TreeView.root.",
@@ -316,6 +319,7 @@ export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitField
 	}
 
 	public set root(newRoot: InsertableTreeFieldFromImplicitField<TRootSchema>) {
+		this.breaker.use();
 		if (!this.compatibility.canView) {
 			throw new UsageError(
 				"Document is out of schema. Check TreeView.compatibility before accessing TreeView.root.",

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -64,6 +64,7 @@ import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import type { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
 import { type CheckoutEvents, type TreeCheckout, createTreeCheckout } from "./treeCheckout.js";
 import type { CheckoutFlexTreeView, FlexTreeView } from "./treeView.js";
+import { breakingClass, throwIfBroken } from "../util/index.js";
 
 /**
  * Copy of data from an {@link ISharedTree} at some point in time.
@@ -162,6 +163,7 @@ function getCodecVersions(formatVersion: number): ExplicitCodecVersions {
  *
  * TODO: detail compatibility requirements.
  */
+@breakingClass
 export class SharedTree
 	extends SharedTreeCore<SharedTreeEditBuilder, SharedTreeChange>
 	implements ISharedTree
@@ -288,6 +290,7 @@ export class SharedTree
 		);
 	}
 
+	@throwIfBroken
 	public contentSnapshot(): SharedTreeContentSnapshot {
 		const cursor = this.checkout.forest.allocateCursor("contentSnapshot");
 		try {
@@ -326,6 +329,7 @@ export class SharedTree
 			this.checkout,
 			config,
 			createNodeKeyManager(this.runtime.idCompressor),
+			this.breaker,
 		);
 	}
 

--- a/packages/dds/tree/src/util/breakable.ts
+++ b/packages/dds/tree/src/util/breakable.ts
@@ -174,7 +174,7 @@ function isBreaker(f: Function): boolean {
 /**
  * Decorator for classes which should break when their methods throw.
  * @remarks
- * Applies {@link breakingMethod} to all methods declared directly class or its base classes.
+ * Applies {@link breakingMethod} to all methods declared directly by class or its base classes.
  * Does not include those on derived classes.
  * Does not include getters or setters, or value properties.
  * Methods already marked as {@link breakingMethod} or {@link throwIfBroken} are unaffected.
@@ -199,6 +199,7 @@ export function breakingClass<Target extends abstract new (...args: any[]) => Wi
 					// Method
 					if (typeof descriptor.value === "function") {
 						if (!isBreaker(descriptor.value)) {
+							// This does not affect the original class, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
 							descriptor.value = breakingMethod(descriptor.value);
 							Object.defineProperty(DecoratedBreakable.prototype, key, descriptor);
 						}

--- a/packages/dds/tree/src/util/breakable.ts
+++ b/packages/dds/tree/src/util/breakable.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 /**
@@ -51,7 +52,7 @@ export class Breakable {
 			this.break(brokenBy);
 		}
 		this.break(
-			new Error(`Non-error throw breaking ${this.name}. Thrown value: "${brokenBy}"`),
+			new Error(`Non-error thrown breaking ${this.name}. Thrown value: "${brokenBy}"`),
 		);
 	}
 
@@ -69,6 +70,17 @@ export class Breakable {
 		} catch (error: unknown) {
 			this.rethrowCaught(error);
 		}
+	}
+
+	/**
+	 * Clears the existing broken state.
+	 * @remarks
+	 * This is rarely safe to to: it is only ok when all objects using this breaker are known to not have been left in an invalid state.
+	 * This is pretty much only safe in tests which just were checking a specific error was thrown, and which know that error closepath is actually exception safe.
+	 */
+	public clearError(): void {
+		assert(this.brokenBy !== undefined, "No error to clear");
+		this.brokenBy = undefined;
 	}
 }
 
@@ -97,13 +109,20 @@ export function breakingMethod<
 	This extends WithBreakable,
 	Args extends never[],
 	Return,
->(target: Target, context: ClassMethodDecoratorContext<This, Target>): Target {
+>(target: Target, context?: ClassMethodDecoratorContext<This, Target>): Target {
 	function replacementMethod(this: This, ...args: Args): Return {
+		if (this.breaker === undefined) {
+			// This case is necessary for when wrapping methods which are invoked inside the constructor of the base class before `breaker` is set.
+			// Since the constructor throwing does not return an object, failing to put it into a broken state is not too bad.
+			// However when more than just the constructed object should be broken, this can result in missing a break.
+			return target.call(this, ...args);
+		}
 		return this.breaker.run(() => {
 			return target.call(this, ...args);
 		});
 	}
-
+	markBreaker(replacementMethod);
+	nameFunctionFrom(replacementMethod, target);
 	return replacementMethod as Target;
 }
 
@@ -124,6 +143,71 @@ export function throwIfBroken<
 		this.breaker.use();
 		return target.call(this, ...args);
 	}
-
+	markBreaker(replacementMethod);
+	nameFunctionFrom(replacementMethod, target);
 	return replacementMethod as Target;
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type PossiblyNamedFunction = Function & { displayName?: undefined | string };
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+function nameFunctionFrom(toName: Function, nameFrom: Function): void {
+	(toName as PossiblyNamedFunction).displayName =
+		(nameFrom as PossiblyNamedFunction).displayName ?? nameFrom.name;
+}
+
+const isBreakerSymbol: unique symbol = Symbol("isBreaker");
+
+// Accepting any function like value is desired and safe here as this does not call the provided function.
+// eslint-disable-next-line @typescript-eslint/ban-types
+function markBreaker(f: Function): void {
+	(f as unknown as Record<typeof isBreakerSymbol, true>)[isBreakerSymbol] = true;
+}
+
+// Accepting any function like value is desired and safe here as this does not call the provided function.
+// eslint-disable-next-line @typescript-eslint/ban-types
+function isBreaker(f: Function): boolean {
+	return isBreakerSymbol in (f as unknown as Record<typeof isBreakerSymbol, true>);
+}
+
+/**
+ * Decorator for classes which should break when their methods throw.
+ * @remarks
+ * Applies {@link breakingMethod} to all methods declared directly class or its base classes.
+ * Does not include those on derived classes.
+ * Does not include getters or setters, or value properties.
+ * Methods already marked as {@link breakingMethod} or {@link throwIfBroken} are unaffected.
+ */
+export function breakingClass<Target extends abstract new (...args: any[]) => WithBreakable>(
+	target: Target,
+	context: ClassDecoratorContext<Target>,
+): Target {
+	abstract class DecoratedBreakable extends target {}
+
+	// Keep track of what keys we have seen,
+	// since we visit most derived properties first and need to avoid wrapping base properties overriding more derived ones.
+	const overriddenKeys: Set<string | symbol> = new Set();
+
+	let prototype: object | null = target.prototype;
+	while (prototype !== null) {
+		for (const key of Reflect.ownKeys(prototype)) {
+			if (!overriddenKeys.has(key)) {
+				overriddenKeys.add(key);
+				const descriptor = Reflect.getOwnPropertyDescriptor(prototype, key);
+				if (descriptor !== undefined) {
+					// Method
+					if (typeof descriptor.value === "function") {
+						if (!isBreaker(descriptor.value)) {
+							descriptor.value = breakingMethod(descriptor.value);
+							Object.defineProperty(DecoratedBreakable.prototype, key, descriptor);
+						}
+					}
+				}
+			}
+		}
+		prototype = Reflect.getPrototypeOf(prototype);
+	}
+
+	return DecoratedBreakable;
 }

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -127,4 +127,10 @@ export {
 	fakeIdAllocator,
 } from "./idAllocator.js";
 
-export { Breakable, type WithBreakable, breakingMethod, throwIfBroken } from "./breakable.js";
+export {
+	Breakable,
+	type WithBreakable,
+	breakingMethod,
+	throwIfBroken,
+	breakingClass,
+} from "./breakable.js";


### PR DESCRIPTION
## Description

Add breakingClass decorator, and allow views to break (and be broken by) SharedTree.

This makes more errors fatal, preventing many operations from running and instead reporting that a previous error has occured.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
