### PR TITLE
fix(ci): Try to upload tinylicious log even if pipeline run is cancelled

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -360,7 +360,7 @@ extends:
                   - ${{ if contains(convertToJson(parameters.taskTest), 'tinylicious') }}:
                     - task: Bash@3
                       displayName: Upload tinylicious log
-                      condition: succeededOrFailed()
+                      condition: always()
                       continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
                       inputs:
                         targetType: inline

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -373,7 +373,7 @@ jobs:
             targetPath: '${{ parameters.testWorkspace }}/node_modules/${{ parameters.testPackage }}/tinylicious.log'
             artifactName: 'tinyliciousLog_attempt-$(System.JobAttempt)'
             publishLocation: 'pipeline'
-          condition: succeededOrFailed()
+          condition: always()
           continueOnError: true # Keep running subsequent tasks even if this one fails (e.g. the tinylicious log wasn't there)
 
       # Log Test Failures


### PR DESCRIPTION
## Description

I was trying to determine why the tinylicious stage of e2e tests sometimes goes past its 90 minute timeout. I wanted to look at the tinylicious server logs but realized that since the pipeline run had been cancelled by ADO, the task that uploads it did not run.

This PR makes it so we attempt to upload the tinylicious log file even if the pipeline run is cancelled, for both the build pipelein and the e2e tests pipeline.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
