### PR TITLE
ci: Run `build:readme` in client build

### DIFF
--- a/tools/markdown-magic/src/templates/Help-Template.md
+++ b/tools/markdown-magic/src/templates/Help-Template.md
@@ -1,5 +1,1 @@
-Not finding what you're looking for in this README? Check out [fluidframework.com](https://fluidframework.com/docs/).
-
-Still not finding what you're looking for? Please [file an issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
-
-Thank you!
+TEST

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -171,6 +171,13 @@ extends:
     checks:
     - checks
     additionalBuildSteps:
+    # Run markdown-magic generation to ensure README contents are up-to-date
+    - task: Npm@1
+      displayName: Build README
+      inputs:
+        command: 'custom'
+        customCommand: 'ci:build:readme'
+
     - task: Bash@3
       displayName: Inject devtools telemetry logger token
       inputs:


### PR DESCRIPTION
Ensure `markdown-magic`-generated README contents are up-to-date.