### PR TITLE
improvement(eslint-config-fluid): Disable `unicorn/prefer-module` for tests

### DIFF
--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -8,8 +8,7 @@ The following rules have been disabled in all configs because they conflict with
 
 -   [@typescript-eslint/brace-style](https://typescript-eslint.io/rules/brace-style)
 -   [unicorn/number-literal-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v48.0.1/docs/rules/number-literal-case.md)
--
-The following rules have been disabled for test code:
+-   The following rules have been disabled for test code:
 
 -   [unicorn/prefer-module](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v48.0.1/docs/rules/prefer-module.md)
 

--- a/common/build/eslint-config-fluid/CHANGELOG.md
+++ b/common/build/eslint-config-fluid/CHANGELOG.md
@@ -8,6 +8,10 @@ The following rules have been disabled in all configs because they conflict with
 
 -   [@typescript-eslint/brace-style](https://typescript-eslint.io/rules/brace-style)
 -   [unicorn/number-literal-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v48.0.1/docs/rules/number-literal-case.md)
+-
+The following rules have been disabled for test code:
+
+-   [unicorn/prefer-module](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v48.0.1/docs/rules/prefer-module.md)
 
 The following rules have been disabled due to frequency of false-positives reported:
 

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -1493,7 +1493,7 @@
             "error"
         ],
         "unicorn/prefer-module": [
-            "error"
+            "off"
         ],
         "unicorn/prefer-native-coercion-functions": [
             "error"

--- a/common/build/eslint-config-fluid/recommended.js
+++ b/common/build/eslint-config-fluid/recommended.js
@@ -200,6 +200,9 @@ module.exports = {
 			rules: {
 				// Does not work well with describe/it block scoping
 				"unicorn/consistent-function-scoping": "off",
+				// We run most of our tests in a Node.js environment, so this rule is not important and makes
+				// file-system logic more cumbersome.
+				"unicorn/prefer-module": "off",
 			},
 		},
 		{


### PR DESCRIPTION
We run most of our tests in a Node.js environment, so this rule is not important and makes file-system logic more cumbersome.