### PR TITLE
fix(client-test-utils): prevent malformed TimeoutWithValue use

### DIFF
--- a/packages/test/test-utils/src/index.ts
+++ b/packages/test/test-utils/src/index.ts
@@ -51,8 +51,9 @@ export {
 	defaultTimeoutDurationMs,
 	timeoutAwait,
 	timeoutPromise,
-	TimeoutWithError,
-	TimeoutWithValue,
+	type TimeoutDurationOption,
+	type TimeoutWithError,
+	type TimeoutWithValue,
 } from "./timeoutUtils.js";
 export {
 	waitForContainerConnection,

--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -107,26 +107,30 @@ if (globalThis.getMochaModule !== undefined) {
 /**
  * @internal
  */
-export interface TimeoutWithError {
+export interface TimeoutDurationOption {
 	/**
 	 * Timeout duration in milliseconds, if it is great than 0 and not Infinity
 	 * If it is undefined, then it will use test timeout if we are in side the test function
 	 * Otherwise, there is no timeout
 	 */
 	durationMs?: number;
-	reject?: true;
-	errorMsg?: string;
 }
+
 /**
  * @internal
  */
-export interface TimeoutWithValue<T = void> {
-	/**
-	 * Timeout duration in milliseconds, if it is great than 0 and not Infinity
-	 * If it is undefined, then it will use test timeout if we are in side the test function
-	 * Otherwise, there is no timeout
-	 */
-	durationMs?: number;
+export interface TimeoutWithError extends TimeoutDurationOption {
+	reject?: true;
+	errorMsg?: string;
+	// Since there are no required properties, this type explicitly
+	// rejects `value` to avoid confusion with TimeoutWithValue.
+	value?: never;
+}
+
+/**
+ * @internal
+ */
+export interface TimeoutWithValue<T = void> extends TimeoutDurationOption {
 	reject: false;
 	value: T;
 }


### PR DESCRIPTION
without `reject: false` since TimeoutWithError would allow any object