### PR TITLE
ContainerRuntime: Update Op Lifecycle classes to use InboundSequencedContainerRuntimeMessage type

### DIFF
--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -112,7 +112,7 @@ export {
 	IFluidDataStoreAttributes2,
 	OmitAttributesVersions,
 } from "./summary/index.js";
-export { IChunkedOp, unpackRuntimeMessage } from "./opLifecycle/index.js";
+export { IChunkedOp } from "./opLifecycle/index.js";
 export { ChannelCollection } from "./channelCollection.js";
 export {
 	IFluidDataStoreContextInternal,
@@ -126,3 +126,17 @@ export {
 	IFluidDataStoreContextEvents,
 } from "./dataStoreContext.js";
 export { DataStoreContexts } from "./dataStoreContexts.js";
+
+//* MOVE to core-utils
+
+export type Json<T> = undefined extends T
+	? (string & { __json: T }) | undefined
+	: string & { __json: T };
+
+export function toJson<T>(value: T): Json<T> {
+	return JSON.stringify(value) as Json<T>;
+}
+
+export function fromJson<T>(value: Json<T>): T {
+	return value && (JSON.parse(value) as T);
+}

--- a/packages/runtime/container-runtime/src/messageTypes.ts
+++ b/packages/runtime/container-runtime/src/messageTypes.ts
@@ -211,12 +211,13 @@ export type OutboundContainerRuntimeMessage =
 /**
  * An unpacked ISequencedDocumentMessage with the inner TypedContainerRuntimeMessage type/contents/etc
  * promoted up to the outer object
+ * We also know clientId will not be null - this came from another client, not the server.
  */
 export type InboundSequencedContainerRuntimeMessage = Omit<
 	ISequencedDocumentMessage,
 	"type" | "contents"
 > &
-	InboundContainerRuntimeMessage;
+	InboundContainerRuntimeMessage & { clientId: string };
 
 /** Essentially ISequencedDocumentMessage except that `type` is not `string` to enable narrowing
  * as `Exclude<string, InboundContainerRuntimeMessage['type']>` is not supported.

--- a/packages/runtime/container-runtime/src/opLifecycle/index.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/index.ts
@@ -16,7 +16,11 @@ export { Outbox, getLongStack } from "./outbox.js";
 export { OpCompressor } from "./opCompressor.js";
 export { OpDecompressor } from "./opDecompressor.js";
 export { OpSplitter, splitOp, isChunkedMessage } from "./opSplitter.js";
-export { RemoteMessageProcessor, unpackRuntimeMessage } from "./remoteMessageProcessor.js";
+export {
+	isModernRuntimeMessage,
+	RemoteMessageProcessor,
+	unpackRuntimeMessage,
+} from "./remoteMessageProcessor.js";
 export {
 	OpGroupingManager,
 	OpGroupingManagerConfig,

--- a/packages/runtime/container-runtime/src/opLifecycle/index.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/index.ts
@@ -19,7 +19,6 @@ export { OpSplitter, splitOp, isChunkedMessage } from "./opSplitter.js";
 export {
 	isModernRuntimeMessage,
 	RemoteMessageProcessor,
-	unpackRuntimeMessage,
 } from "./remoteMessageProcessor.js";
 export {
 	OpGroupingManager,

--- a/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opDecompressor.ts
@@ -6,6 +6,7 @@
 import { IsoBuffer, Uint8ArrayToString } from "@fluid-internal/client-utils";
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
+import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import { decompress } from "lz4js";
 
@@ -38,7 +39,7 @@ export class OpDecompressor {
 		this.logger = createChildLogger({ logger, namespace: "OpDecompressor" });
 	}
 
-	public isCompressedMessage(message: InboundSequencedContainerRuntimeMessage): boolean {
+	public isCompressedMessage(message: ISequencedDocumentMessage): boolean {
 		if (message.compression === CompressionAlgorithms.lz4) {
 			return true;
 		}

--- a/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
@@ -6,19 +6,22 @@
 import { IBatchMessage } from "@fluidframework/container-definitions/internal";
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import {
 	DataCorruptionError,
 	createChildLogger,
 	extractSafePropertiesFromMessage,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { ContainerMessageType, ContainerRuntimeChunkedOpMessage } from "../messageTypes.js";
+import {
+	ContainerMessageType,
+	ContainerRuntimeChunkedOpMessage,
+	type InboundSequencedContainerRuntimeMessage,
+} from "../messageTypes.js";
 
 import { estimateSocketSize } from "./batchManager.js";
 import { BatchMessage, IBatch, IChunkedOp } from "./definitions.js";
 
-export function isChunkedMessage(message: ISequencedDocumentMessage): boolean {
+export function isChunkedMessage(message: InboundSequencedContainerRuntimeMessage): boolean {
 	return isChunkedContents(message.contents);
 }
 
@@ -71,7 +74,7 @@ export class OpSplitter {
 	private addChunk(
 		clientId: string,
 		chunkedContent: IChunkedOp,
-		originalMessage: ISequencedDocumentMessage,
+		originalMessage: InboundSequencedContainerRuntimeMessage,
 	) {
 		let map = this.chunkMap.get(clientId);
 		if (map === undefined) {
@@ -189,7 +192,7 @@ export class OpSplitter {
 		};
 	}
 
-	public processChunk(message: ISequencedDocumentMessage): ProcessChunkResult {
+	public processChunk(message: InboundSequencedContainerRuntimeMessage): ProcessChunkResult {
 		assert(isChunkedContents(message.contents), 0x948 /* message not of type ChunkedOp */);
 		const contents: IChunkedContents = message.contents;
 
@@ -235,7 +238,7 @@ type ProcessChunkResult =
 	  }
 	| {
 			readonly isFinalChunk: true;
-			readonly message: ISequencedDocumentMessage;
+			readonly message: InboundSequencedContainerRuntimeMessage;
 	  };
 
 const chunkToBatchMessage = (

--- a/packages/runtime/container-runtime/src/opLifecycle/remoteMessageProcessor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/remoteMessageProcessor.ts
@@ -102,7 +102,7 @@ export class RemoteMessageProcessor {
 				return;
 			}
 			// This message will always be compressed
-			message = chunkProcessingResult.message as InboundSequencedContainerRuntimeMessage; //* CAST
+			message = chunkProcessingResult.message;
 		}
 
 		if (this.opDecompressor.isCompressedMessage(message)) {
@@ -110,7 +110,7 @@ export class RemoteMessageProcessor {
 		}
 
 		if (this.opDecompressor.currentlyUnrolling) {
-			message = this.opDecompressor.unroll(message) as InboundSequencedContainerRuntimeMessage; //* CAST
+			message = this.opDecompressor.unroll(message);
 			// Need to unpack after unrolling if not a groupedBatch
 			if (!isGroupedBatch(message)) {
 				unpack(message);


### PR DESCRIPTION
## Description

I got some key parts wrong here, will update later when it's back on track.

~Currently they all use `ISequencedDocumentMessage`. But we know that only "modern" runtime messages will go through the "Op Lifecycle" system, and these are modeled by the `InboundSequencedContainerRuntimeMessage` type.~

~This also updates that type to model the fact that clientId isn't null for these.  This is helpful for an upcoming change related to Batch ID (which is computed using clientId)~

## Reviewer Guidance

This is still WIP.  `//*` comments will all be resolved/removed before marking as ready for review.
