### PR TITLE
launch.json: Debug current tests suggestions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -347,9 +347,10 @@
 			"request": "launch",
 			"name": "Debug Current Mocha Test (auto build)",
 			"env": {
-				// "fluid__test__driver": "odsp", //values: local, tinylicious, routerlicious, odsp,
-				// "fluid__test__backCompat": "FULL", //values: FULL This tests loader-driver compatibility for describeCompat tests
+				// "fluid__test__driver": "odsp", //values: local, t9s, r11s, odsp,
 				// "fluid__test__odspEndpointName": "odsp-df", //values: odsp, odsp-df
+				// "fluid__test__r11sEndpointName": "docker", //values: frs, docker
+				// "fluid__test__backCompat": "FULL", //values: FULL This tests loader-driver compatibility for describeCompat tests
 				// "FLUID_TEST_VERBOSE": "1",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
@@ -396,9 +397,10 @@
 			"request": "launch",
 			"name": "Debug Current Mocha Test (ESM-lib;no build)",
 			"env": {
-				// "fluid__test__driver": "odsp", //values: local, tinylicious, routerlicious, odsp,
+				// "fluid__test__driver": "odsp", //values: local, t9s, r11s, odsp,
+				// "fluid__test__odspEndpointName": "odsp-df", //values: odsp, odsp-df
+				// "fluid__test__r11sEndpointName": "docker", //values: frs, docker
 				// "fluid__test__backCompat": "FULL", //values: FULL This tests loader-driver compatibility for describeCompat tests
-				// "fluid__test__odspEndpointName": "odsp", //values: odsp, odsp-df
 				// "FLUID_TEST_VERBOSE": "1",
 			},
 			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
@@ -437,9 +439,10 @@
 			"request": "launch",
 			"name": "Debug Current Mocha Test (CommonJS-dist;no build)",
 			"env": {
-				// "fluid__test__driver": "odsp", //values: local, tinylicious, routerlicious, odsp,
+				// "fluid__test__driver": "odsp", //values: local, t9s, r11s, odsp,
+				// "fluid__test__odspEndpointName": "odsp-df", //values: odsp, odsp-df
+				// "fluid__test__r11sEndpointName": "docker", //values: frs, docker
 				// "fluid__test__backCompat": "FULL", //values: FULL This tests loader-driver compatibility for describeCompat tests
-				// "fluid__test__odspEndpointName": "odsp", //values: odsp, odsp-df
 				// "FLUID_TEST_VERBOSE": "1",
 			},
 			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",


### PR DESCRIPTION
Updated launch.json file to include r11s, t9s etc. endpoint details as comment suggestions - to enable devs to be able to quickly run tests against the desired service, without having to remember or look up these configs. 