### PR TITLE
Fix build number for main branch

### DIFF
--- a/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
@@ -181,11 +181,11 @@ async function updateReportVersions(
  *
  * @example
  * Returns 260312
- * extractBuildNumber("2.0.0-dev-rc.4.0.0.260312");
+ * extractBuildNumber("2.1.0-260312");
  */
 
 function extractBuildNumber(version: string): number {
-	const versionParts: string[] = version.split(".");
+	const versionParts: string[] = version.split("-");
 	// Extract the last part of the version, which is the number you're looking for
 	return Number.parseInt(versionParts[versionParts.length - 1], 10);
 }


### PR DESCRIPTION
The build number from the main branch is not being retrieved correctly, which results in the manifest files not being uploaded with the correct build number.

This is how the release reports are published currently: https://dev.azure.com/fluidframework/internal/_build/results?buildId=278737&view=artifacts&pathAsName=false&type=publishedArtifacts. The build number is retrieved as 0. 