### PR TITLE
fix(docs): The second column in the api docs table should only word break on mobile nav

### DIFF
--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -237,11 +237,14 @@ where bootstrap caption color is too light for white background */
 }
 
 /* fixing https://github.com/microsoft/FluidFramework/issues/3601
- Long words such as function names would not break in api docs causing layout overflow
+ * Long words such as function names would not break in api docs causing layout overflow.
+ * The original use-case was targeting the API member names specifically, which are generally in the
+ * first column of the API docs tables. If there are no contents for any of the items in a column,
+ * that column will be omitted, and a different column will become the second one.
 */
 
 @media only screen and (max-width: 600px) {
-	.table td:nth-child(2) {
+	.table td:nth-child(1) {
 		word-break: break-word;
 	}
 }

--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -240,6 +240,8 @@ where bootstrap caption color is too light for white background */
  Long words such as function names would not break in api docs causing layout overflow
 */
 
-.table td:nth-child(2) {
-	word-break: break-word;
+@media only screen and (max-width: 600px) {
+	.table td:nth-child(2) {
+		word-break: break-word;
+	}
 }

--- a/docs/assets/css/fluid.css
+++ b/docs/assets/css/fluid.css
@@ -239,8 +239,7 @@ where bootstrap caption color is too light for white background */
 /* fixing https://github.com/microsoft/FluidFramework/issues/3601
  * Long words such as function names would not break in api docs causing layout overflow.
  * The original use-case was targeting the API member names specifically, which are generally in the
- * first column of the API docs tables. If there are no contents for any of the items in a column,
- * that column will be omitted, and a different column will become the second one.
+ * first column of the API docs tables.
 */
 
 @media only screen and (max-width: 600px) {


### PR DESCRIPTION
The second column in the api docs table unnessesarily word broke. enabling this only for mobile devices