### PR TITLE
feat(tinylicious-client): Promote APIs from `@beta` to `@public`

### DIFF
--- a/.changeset/fresh-corridors-curtsy.md
+++ b/.changeset/fresh-corridors-curtsy.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/tinylicious-client": minor
+---
+
+Promote Tinylicious Client APIs from `@beta` to `@public`
+
+The Tinylicious Client is used in public examples and documentation, and therefore requires public level support.

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -6,10 +6,10 @@
 
 export { CompatibilityMode }
 
-// @beta
+// @public
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
-// @beta @sealed
+// @public @sealed
 export class TinyliciousClient {
     constructor(props?: TinyliciousClientProps | undefined);
     createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
@@ -22,30 +22,30 @@ export class TinyliciousClient {
     }>;
 }
 
-// @beta
+// @public
 export interface TinyliciousClientProps {
     readonly connection?: TinyliciousConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @beta
+// @public
 export interface TinyliciousConnectionConfig {
     readonly domain?: string;
     readonly port?: number;
     readonly tokenProvider?: ITokenProvider;
 }
 
-// @beta
+// @public
 export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }
 
-// @beta
+// @public
 export interface TinyliciousMember extends IMember {
     readonly name: string;
 }
 
-// @beta
+// @public
 export interface TinyliciousUser extends IUser {
     readonly name: string;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -6,10 +6,10 @@
 
 export { CompatibilityMode }
 
-// @beta
+// @public
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
-// @beta @sealed
+// @public @sealed
 export class TinyliciousClient {
     constructor(props?: TinyliciousClientProps | undefined);
     createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
@@ -22,30 +22,30 @@ export class TinyliciousClient {
     }>;
 }
 
-// @beta
+// @public
 export interface TinyliciousClientProps {
     readonly connection?: TinyliciousConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @beta
+// @public
 export interface TinyliciousConnectionConfig {
     readonly domain?: string;
     readonly port?: number;
     readonly tokenProvider?: ITokenProvider;
 }
 
-// @beta
+// @public
 export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }
 
-// @beta
+// @public
 export interface TinyliciousMember extends IMember {
     readonly name: string;
 }
 
-// @beta
+// @public
 export interface TinyliciousUser extends IUser {
     readonly name: string;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -6,4 +6,48 @@
 
 export { CompatibilityMode }
 
+// @public
+export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
+
+// @public @sealed
+export class TinyliciousClient {
+    constructor(props?: TinyliciousClientProps | undefined);
+    createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TinyliciousContainerServices;
+    }>;
+    getContainer<TContainerSchema extends ContainerSchema>(id: string, containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
+        container: IFluidContainer<TContainerSchema>;
+        services: TinyliciousContainerServices;
+    }>;
+}
+
+// @public
+export interface TinyliciousClientProps {
+    readonly connection?: TinyliciousConnectionConfig;
+    readonly logger?: ITelemetryBaseLogger;
+}
+
+// @public
+export interface TinyliciousConnectionConfig {
+    readonly domain?: string;
+    readonly port?: number;
+    readonly tokenProvider?: ITokenProvider;
+}
+
+// @public
+export interface TinyliciousContainerServices {
+    readonly audience: ITinyliciousAudience;
+}
+
+// @public
+export interface TinyliciousMember extends IMember {
+    readonly name: string;
+}
+
+// @public
+export interface TinyliciousUser extends IUser {
+    readonly name: string;
+}
+
 ```

--- a/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
@@ -45,7 +45,7 @@ import type { TinyliciousClientProps, TinyliciousContainerServices } from "./int
  * @see {@link https://fluidframework.com/docs/testing/tinylicious/}
  *
  * @sealed
- * @beta
+ * @public
  */
 export class TinyliciousClient {
 	private readonly documentServiceFactory: IDocumentServiceFactory;

--- a/packages/service-clients/tinylicious-client/src/interfaces.ts
+++ b/packages/service-clients/tinylicious-client/src/interfaces.ts
@@ -10,7 +10,7 @@ import type { ITokenProvider } from "@fluidframework/routerlicious-driver";
 
 /**
  * Properties for initializing a {@link TinyliciousClient}
- * @beta
+ * @public
  */
 export interface TinyliciousClientProps {
 	/**
@@ -27,7 +27,7 @@ export interface TinyliciousClientProps {
 
 /**
  * Parameters for establishing a connection with the a Tinylicious service.
- * @beta
+ * @public
  */
 export interface TinyliciousConnectionConfig {
 	/**
@@ -64,7 +64,7 @@ export interface TinyliciousConnectionConfig {
  *
  * Returned by {@link TinyliciousClient.createContainer} and {@link TinyliciousClient.getContainer} alongside the FluidContainer.
  *
- * @beta
+ * @public
  */
 export interface TinyliciousContainerServices {
 	/**
@@ -76,7 +76,7 @@ export interface TinyliciousContainerServices {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IUser}.
- * @beta
+ * @public
  */
 export interface TinyliciousUser extends IUser {
 	/**
@@ -87,7 +87,7 @@ export interface TinyliciousUser extends IUser {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IMember}.
- * @beta
+ * @public
  */
 export interface TinyliciousMember extends IMember {
 	/**
@@ -98,6 +98,6 @@ export interface TinyliciousMember extends IMember {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IServiceAudience}.
- * @beta
+ * @public
  */
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;


### PR DESCRIPTION
The Tinylicious Client is used in public examples and documentation, and therefore requires public level support.