### PR TITLE
Update disconnect background colour to fix contrast ratio

### DIFF
--- a/packages/tools/devtools/devtools-view/src/components/ContainerHistoryLog.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerHistoryLog.tsx
@@ -98,7 +98,7 @@ export function ContainerHistoryLog(props: ContainerHistoryLogProps): React.Reac
 			}
 			case "disconnected": {
 				// orange
-				return tokens.colorPaletteDarkOrangeBorderActive;
+				return tokens.colorPaletteDarkOrangeBorder1;
 			}
 			case "disposed": {
 				// dark red


### PR DESCRIPTION
[AB#4854](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/4854)

## Description

This PR updates the background colour for the Devtools container history table when a container disconnects so that the colour contrast ratio is greater than 4.5:1
![Screenshot 2024-07-10 at 3 02 10 PM](https://github.com/microsoft/FluidFramework/assets/23732584/ca034c7e-6a83-4462-9b20-fd24cdb505a4)


<img width="373" alt="Screenshot 2024-07-10 at 3 02 41 PM" src="https://github.com/microsoft/FluidFramework/assets/23732584/c005ec4d-0018-4870-a767-72fdd9094ce6">
