### PR TITLE
refactor(test-utils): Clean up tests for timeoutPromise and improve docs

### DIFF
--- a/packages/test/test-utils/src/test/timeoutUtils.spec.ts
+++ b/packages/test/test-utils/src/test/timeoutUtils.spec.ts
@@ -114,11 +114,23 @@ describe("TimeoutPromise", () => {
 			}
 		}).timeout(25);
 
+		it("Times out as expected if called multiple times inside a test with no specific durations", async () => {
+			try {
+				// First call will resolve before test timeout.
+				await timeoutPromise((resolve) => { setTimeout(resolve, 75); }, { errorMsg: "First call" });
+				// Second call on its own would resolve before test timeout, but the first call already "consumed"
+				// 75ms of the 100ms (total test timeout) so this one should get timed out by timeoutPromise.
+				await timeoutPromise((resolve) => { setTimeout(resolve, 75); }, { errorMsg: "Second call" });
+				assert(false, "should have timed out");
+			} catch (e: any) {
+				assert.equal(e.message, "Second call (85ms)");
+			}
+		}).timeout(100);
+
 		let retryCount = -1;
 		it("timeoutPromise state is reset correctly if a mocha test times out", async () => {
 			// Cause a timeout the first time but pass on retry, to ensure that if a test is timed out by mocha
 			// we reset the state used by timeoutPromise.
-
 			retryCount++;
 			if (retryCount === 0) {
 				await new Promise(() => {});

--- a/packages/test/test-utils/src/test/timeoutUtils.spec.ts
+++ b/packages/test/test-utils/src/test/timeoutUtils.spec.ts
@@ -136,7 +136,7 @@ describe("TimeoutPromise", () => {
 					{ errorMsg: "First call" },
 				);
 				// Second call on its own would resolve before test timeout, but the first call already "consumed"
-				// 75ms of the 100ms (total test timeout) so this one should get timed out by timeoutPromise.
+				// 30ms of the 50ms (total test timeout) so this one should get timed out by timeoutPromise.
 				await timeoutPromise(
 					(resolve) => {
 						setTimeout(resolve, 30);

--- a/packages/test/test-utils/src/test/timeoutUtils.spec.ts
+++ b/packages/test/test-utils/src/test/timeoutUtils.spec.ts
@@ -7,192 +7,179 @@ import { strict as assert } from "assert";
 
 import { timeoutPromise } from "../timeoutUtils.js";
 
+/**
+ * NOTE: it's a bit tricky to test this utility using mocha tests, because by design it has special behavior if it
+ * is running in a mocha test that is about to time out.
+ * Keep that in mind as you read/update the tests below.
+ */
 describe("TimeoutPromise", () => {
-	beforeEach(async () => {
-		// Make sure there are no timeout set left behind, wait larger then the test timeout
-		await timeoutPromise((resolve) => setTimeout(resolve, 50));
-	});
-
-	afterEach(async () => {
-		// Make sure there are no timeout set left behind, wait larger then the test timeout
-		await timeoutPromise((resolve) => setTimeout(resolve, 50));
-	});
-
-	let runCount = 0;
-
-	it("No timeout", async () => {
-		if (runCount++ !== 1) {
-			// only timeout the first time to test, but pass the second one,
-			// to test the behavior of test timed out by mocha
-			// to ensure that we reset the timeoutPromise state.
+	describe("Tests unrelated to mocha timeouts", () => {
+		it("Doesn't time out and provides return value", async () => {
 			const value = await timeoutPromise<number>((resolve) => {
 				resolve(3);
 			});
-			assert(value === 3, "Value not returned");
-		}
-	})
-		.timeout(25)
-		.retries(1);
+			assert.equal(value, 3, "Value not returned");
+		});
 
-	it("Timeout", async () => {
-		if (runCount++ !== 1) {
-			// only timeout the first time to test, but pass the second one,
-			// to test the behavior of test timed out by mocha
-			// to ensure that we reset the timeoutPromise state.
-			return new Promise(() => {});
-		}
-	})
-		.timeout(25)
-		.retries(1);
+		it("Times out if it goes past a specified valid duration", async () => {
+			try {
+				await timeoutPromise(() => {}, { durationMs: 1 });
+				assert(false, "should have timed out");
+			} catch (e: any) {
+				assert.equal(e.message, "Timed out (1ms)");
+			}
+		});
 
-	it("Timeout with no options", async () => {
-		try {
-			await timeoutPromise(() => {});
-			assert(false, "should have timed out");
-		} catch (e: any) {
-			assert(
-				e.message.startsWith("Test timed out ("),
-				`expected timeout error message: got ${e.message}`,
-			);
-		}
-	}).timeout(25);
+		it("Doesn't time out with duration of 0", async () => {
+			try {
+				await timeoutPromise(
+					(resolve) => {
+						// Need to subtract enough time to account for the buffer that the TestTimeout class uses, so the utility
+						// function's behavior when it runs inside a mocha test that is about to time out doesn't trigger.
+						setTimeout(resolve, 25 - 15);
+					},
+					{ durationMs: 0 },
+				);
+			} catch (e: any) {
+				assert(false, `should not have timed out: ${e.message}`);
+			}
+		}).timeout(25);
 
-	it("Timeout with no duration", async () => {
-		try {
-			await timeoutPromise(() => {}, {});
-			assert(false, "should have timed out");
-		} catch (e: any) {
-			assert(
-				e.message.startsWith("Test timed out ("),
-				`expected timeout error message: got ${e.message}`,
-			);
-		}
-	}).timeout(25);
+		it("Doesn't time out if promise is rejected", async () => {
+			try {
+				await timeoutPromise((resolve, reject) => {
+					reject(new Error("blah"));
+				});
+				assert(false, "should have thrown");
+			} catch (e: any) {
+				assert.equal(e.message, "blah");
+			}
+		});
 
-	it("Timeout with duration", async () => {
-		try {
-			await timeoutPromise(() => {}, { durationMs: 1 });
-			assert(false, "should have timed out");
-		} catch (e: any) {
-			assert(
-				e.message.startsWith("Timed out ("),
-				`expected timeout error message: got ${e.message}`,
-			);
-		}
-	}).timeout(25);
+		it("Provides the specified value if 'reject: false' is specified, instead of timing out", async () => {
+			try {
+				const value = await timeoutPromise(() => {}, {
+					durationMs: 1,
+					reject: false,
+					value: 1,
+				});
+				assert.equal(value, 1, "Timeout should have returned the value given in options");
+			} catch (e: any) {
+				assert(false, `should not have timed out: ${e.message}`);
+			}
+		});
 
-	it("No timeout with zero duration", async () => {
-		try {
-			await timeoutPromise(
-				(resolve) => {
-					setTimeout(resolve, 10);
-				},
-				{ durationMs: 0 },
-			);
-		} catch (e: any) {
-			assert(false, `should not have timed out: ${e.message}`);
-		}
-	}).timeout(25);
+		it("Custom error message is included in timeout", async () => {
+			try {
+				await timeoutPromise(() => {}, {
+					durationMs: 1,
+					errorMsg: "hello",
+				});
+				assert(false, "should have timed out");
+			} catch (e: any) {
+				assert.equal(
+					e.message,
+					"hello (1ms)",
+					"Error message should have been the one given in options",
+				);
+			}
+		});
+	});
 
-	it("No timeout with negative duration", async function () {
-		// Make sure resetTimeout in the test works
-		this.timeout(100);
-		try {
-			await timeoutPromise(
-				(resolve) => {
-					setTimeout(resolve, 50);
-				},
-				{ durationMs: -1 },
-			);
-		} catch (e: any) {
-			assert(false, `should not have timed out: ${e.message}`);
-		}
-	}).timeout(25);
+	describe("Tests for behavior related to mocha timeouts", () => {
+		it("Times out if no options are specified", async () => {
+			try {
+				await timeoutPromise(() => {});
+				assert(false, "should have timed out");
+			} catch (e: any) {
+				assert.equal(e.message, "Forcing timeout before test does (10ms)");
+			}
+		}).timeout(25);
 
-	it("No timeout with Infinity duration", async function () {
-		// Make sure resetTimeout in the test works
-		this.timeout(100);
-		try {
-			await timeoutPromise(
-				(resolve) => {
-					setTimeout(resolve, 50);
-				},
-				{ durationMs: Infinity },
-			);
-		} catch (e: any) {
-			assert(false, `should not have timed out: ${e.message}`);
-		}
-	}).timeout(25);
+		it("Times out if empty options are specified", async () => {
+			try {
+				await timeoutPromise(() => {}, {});
+				assert(false, "should have timed out");
+			} catch (e: any) {
+				assert.equal(e.message, "Forcing timeout before test does (10ms)");
+			}
+		}).timeout(25);
 
-	it("No timeout with valid duration", async function () {
-		// Make sure resetTimeout in the test works
-		this.timeout(100);
-		try {
-			await timeoutPromise(
-				(resolve) => {
-					setTimeout(resolve, 50);
-				},
-				{ durationMs: 75 },
-			);
-		} catch (e: any) {
-			assert(false, `should not have timed out: ${e.message}`);
-		}
-	}).timeout(25);
+		it("Times out if duration (longer than mocha test timeout) is specified", async () => {
+			try {
+				await timeoutPromise(() => {}, { durationMs: 100 });
+				assert(false, "should have timed out");
+			} catch (e: any) {
+				assert.equal(e.message, "Forcing timeout before test does (10ms)");
+			}
+		}).timeout(25);
 
-	it("No timeout with throw", async function () {
-		// Make sure resetTimeout in the test works
-		this.timeout(100);
-		try {
-			await timeoutPromise((resolve, reject) => {
-				reject(new Error("blah"));
-			});
-			assert(false, "should have thrown");
-		} catch (e: any) {
-			assert(e.message === "blah", `should not have timed out: ${e.message}`);
-		}
-	}).timeout(25);
+		let retryCount = -1;
+		it("timeoutPromise state is reset correctly if a mocha test times out", async () => {
+			// Cause a timeout the first time but pass on retry, to ensure that if a test is timed out by mocha
+			// we reset the state used by timeoutPromise.
 
-	it("Timeout with valid duration", async function () {
-		// Make sure resetTimeout in the test works
-		this.timeout(100);
-		try {
-			await timeoutPromise(
-				(resolve) => {
-					setTimeout(resolve, 75);
-				},
-				{ durationMs: 50 },
-			);
-			assert(false, "should have timed out");
-		} catch (e: any) {
-			assert(e.message.startsWith("Timed out ("), "expected timeout error message");
-		}
-	}).timeout(25);
+			retryCount++;
+			if (retryCount === 0) {
+				await new Promise(() => {});
+				assert(false, "should have timed out the first time");
+			}
+			// Should not time out when retried
+			assert.equal(retryCount, 1);
+		})
+			.timeout(25)
+			.retries(1);
 
-	it("Timeout with no reject option", async () => {
-		try {
-			const value = await timeoutPromise(() => {}, {
-				durationMs: 1,
-				reject: false,
-				value: 1,
-			});
-			assert(value === 1, "expect timeout to return value given in option");
-		} catch (e: any) {
-			assert(false, `should not have timed out: ${e.message}`);
-		}
-	}).timeout(25);
+		describe("Updating timeout from inside test", () => {
+			// These tests make sure that if Mocha's methods to update a test timeout (e.g. calling this.timeout() inside the
+			// test) are used, our timeout utils react appropriately.
+			// The general idea is that we create the tests with some base timeout, inside the test we increase it, and we
+			// use our utility function on a promise that resolves after a time longer than the original test timeout but less
+			// than the updated one.
 
-	it("Timeout rejection with error option", async () => {
-		try {
-			await timeoutPromise(() => {}, {
-				durationMs: 1,
-				errorMsg: "hello",
-			});
-			assert(false, "should have timed out");
-		} catch (e: any) {
-			assert(
-				e.message.startsWith("hello"),
-				"expected timeout reject error message given in option",
-			);
-		}
-	}).timeout(25);
+			it("Doesn't time out if promise resolves before new mocha test timeout", async function () {
+				this.timeout(100);
+				try {
+					await timeoutPromise((resolve) => {
+						// The timeout here should be higher than the original test timeout, but lower than the updated one (minus
+						// the buffer used in TestTimeout), so we're actually testing that the utility function doesn't trigger
+						// based on the original test timeout.
+						setTimeout(resolve, 50);
+					});
+				} catch (e: any) {
+					assert(false, `should not have timed out: ${e.message}`);
+				}
+			}).timeout(25);
+
+			it("Times out if promise would take longer than new mocha test timeout", async function () {
+				const updatedTimeout = 100;
+				this.timeout(updatedTimeout);
+				try {
+					await timeoutPromise((resolve) => {
+						// The timeout here should be higher than the original test timeout, and also higher than the updated one
+						// minus the buffer used in TestTimeout, so the utility function triggers.
+						setTimeout(resolve, updatedTimeout - 10);
+					});
+					assert(false, "should have timed out");
+				} catch (e: any) {
+					assert.equal(e.message, "Forcing timeout before test does (85ms)");
+				}
+			}).timeout(25);
+
+			it("Times out with specific duration provided", async function () {
+				this.timeout(100);
+				try {
+					await timeoutPromise(
+						(resolve) => {
+							setTimeout(resolve, 100);
+						},
+						{ durationMs: 1 },
+					);
+					assert(false, "should have timed out");
+				} catch (e: any) {
+					assert.equal(e.message, "Timed out (1ms)");
+				}
+			}).timeout(25);
+		});
+	});
 });

--- a/packages/test/test-utils/src/test/timeoutUtils.spec.ts
+++ b/packages/test/test-utils/src/test/timeoutUtils.spec.ts
@@ -13,6 +13,18 @@ import { timeoutPromise } from "../timeoutUtils.js";
  * Keep that in mind as you read/update the tests below.
  */
 describe("TimeoutPromise", () => {
+	beforeEach(async () => {
+		// Make sure there are no setTimeouts left behind from previous tests,
+		// by waiting longer than the timeout we use for tests.
+		await timeoutPromise((resolve) => setTimeout(resolve, 50));
+	});
+
+	afterEach(async () => {
+		// Make sure there are no setTimeouts left behind from the test that just ran,
+		// by waiting longer than the timeout we use for tests.
+		await timeoutPromise((resolve) => setTimeout(resolve, 50));
+	});
+
 	describe("Tests unrelated to mocha timeouts", () => {
 		it("Doesn't time out and provides return value", async () => {
 			const value = await timeoutPromise<number>((resolve) => {

--- a/packages/test/test-utils/src/test/timeoutUtils.spec.ts
+++ b/packages/test/test-utils/src/test/timeoutUtils.spec.ts
@@ -119,7 +119,7 @@ describe("TimeoutPromise", () => {
 				// First call will resolve before test timeout.
 				await timeoutPromise(
 					(resolve) => {
-						setTimeout(resolve, 75);
+						setTimeout(resolve, 30);
 					},
 					{ errorMsg: "First call" },
 				);
@@ -127,15 +127,15 @@ describe("TimeoutPromise", () => {
 				// 75ms of the 100ms (total test timeout) so this one should get timed out by timeoutPromise.
 				await timeoutPromise(
 					(resolve) => {
-						setTimeout(resolve, 75);
+						setTimeout(resolve, 30);
 					},
 					{ errorMsg: "Second call" },
 				);
 				assert(false, "should have timed out");
 			} catch (e: any) {
-				assert.equal(e.message, "Second call (85ms)");
+				assert.equal(e.message, "Second call (35ms)");
 			}
-		}).timeout(100);
+		}).timeout(50);
 
 		let retryCount = -1;
 		it("timeoutPromise state is reset correctly if a mocha test times out", async () => {
@@ -166,15 +166,15 @@ describe("TimeoutPromise", () => {
 						// The timeout here should be higher than the original test timeout, but lower than the updated one (minus
 						// the buffer used in TestTimeout), so we're actually testing that the utility function doesn't trigger
 						// based on the original test timeout.
-						setTimeout(resolve, 50);
+						setTimeout(resolve, 30);
 					});
 				} catch (e: any) {
 					assert(false, `should not have timed out: ${e.message}`);
 				}
-			}).timeout(25);
+			}).timeout(15);
 
 			it("Times out if promise would take longer than new mocha test timeout", async function () {
-				const updatedTimeout = 100;
+				const updatedTimeout = 50;
 				this.timeout(updatedTimeout);
 				try {
 					await timeoutPromise((resolve) => {
@@ -184,9 +184,9 @@ describe("TimeoutPromise", () => {
 					});
 					assert(false, "should have timed out");
 				} catch (e: any) {
-					assert.equal(e.message, "Forcing timeout before test does (85ms)");
+					assert.equal(e.message, "Forcing timeout before test does (35ms)");
 				}
-			}).timeout(25);
+			}).timeout(15);
 
 			it("Times out with specific duration provided", async function () {
 				this.timeout(100);

--- a/packages/test/test-utils/src/timeoutUtils.ts
+++ b/packages/test/test-utils/src/timeoutUtils.ts
@@ -62,13 +62,13 @@ class TestTimeout {
 		assert(!this.deferred.isCompleted, "can't reset a completed TestTimeout");
 
 		// Check the test timeout setting
-		const timeout = runnable.timeout();
-		if (!(Number.isFinite(timeout) && timeout > 0)) {
+		const timeoutFromMochaTest = runnable.timeout();
+		if (!(Number.isFinite(timeoutFromMochaTest) && timeoutFromMochaTest > 0)) {
 			return;
 		}
 
 		// subtract a buffer
-		this.timeout = Math.max(timeout - timeBuffer, 1);
+		this.timeout = Math.max(timeoutFromMochaTest - timeBuffer, 1);
 
 		// Set up timer to reject near the test timeout.
 		this.timer = setTimeout(() => {
@@ -84,10 +84,12 @@ class TestTimeout {
 	}
 }
 
-// only register if we are running with mocha-test-setup loaded
+// Only register if we are running with mocha-test-setup loaded (that package is what sets globalThis.getMochaModule).
 if (globalThis.getMochaModule !== undefined) {
-	// patching resetTimeout and clearTimeout on the runnable object
-	// so we can track when test timeout are enforced
+	// Patch the private methods resetTimeout and clearTimeout on Mocha's runnable objects so we can do the appropriate
+	// calls in TestTimeout above when the Mocha methods are called.
+	// These are not part of the public API so if Mocha changes how it works, this could break.
+	// See https://github.com/mochajs/mocha/blob/8d0ca3ed77ba8a704b2aa8b58267a084a475a51b/lib/runnable.js#L234.
 	const mochaModule = globalThis.getMochaModule() as typeof Mocha;
 	const runnablePrototype = mochaModule.Runnable.prototype;
 	// eslint-disable-next-line @typescript-eslint/unbound-method
@@ -141,14 +143,17 @@ export type PromiseExecutor<T = void> = (
 ) => void;
 
 /**
- * Wraps the given promise around with promise that will complete after a specific timeout if the original promise does
- * not resolve by then. By default, it uses the mocha test timeout and complete the promise just before that so that
- * tests don't time out because of unpredictable awaits.
- * The timeout can be overridden via timeoutOptions but it's recommended to use the default value.
- * @param promise - The promise to be awaited.
- * @param timeoutOptions - Options that can be used to override the timeout and / or define the behavior
- * when the promise is not fulfilled. For example, instead of rejecting the promise, resolve with a
- * specific value.
+ * Wraps the given promise with another one that will complete after a specific timeout if the original promise does
+ * not resolve by then.
+ *
+ * @remarks
+ * If used inside a mocha test, it uses the test timeout by default and completes the returned promise just before
+ * the test timeout hits, so that tests don't time out because of unpredictable awaits.
+ * In that scenario the timeout can still be overridden via `timeoutOptions` but it's recommended to use the default value.
+ *
+ * @param promise - The promise to be wrapped.
+ * @param timeoutOptions - Options that can be used to override the timeout and / or define the behavior when
+ * the promise is not fulfilled. For example, instead of rejecting the promise, resolve with a specific value.
  * @returns A new promise that will complete when the given promise resolves or the timeout expires.
  * @internal
  */
@@ -160,9 +165,13 @@ export async function timeoutAwait<T = void>(
 }
 
 /**
- * Creates a promise from the given executor that will complete after a specific timeout. By default, it uses the mocha
- * test timeout and complete the promise just before that so that tests don't time out because of unpredictable awaits.
- * The timeout can be overridden via timeoutOptions but it's recommended to use the default value.
+ * Creates a promise from the given executor that will complete after a specific timeout.
+ *
+ * @remarks
+ * If used inside a mocha test, it uses the test timeout by default and completes the returned promise just before
+ * the test timeout hits, so that tests don't time out because of unpredictable awaits.
+ * In that scenario the timeout can still be overridden via `timeoutOptions` but it's recommended to use the default value.
+ *
  * @param executor - The executor for the promise.
  * @param timeoutOptions - Options that can be used to override the timeout and / or define the behavior when
  * the promise is not fulfilled. For example, instead of rejecting the promise, resolve with a specific value.
@@ -196,7 +205,7 @@ export async function timeoutPromise<T = void>(
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				const errorObject = err!;
 				errorObject.message = `${
-					timeoutOptions.errorMsg ?? "Test timed out"
+					timeoutOptions.errorMsg ?? "Forcing timeout before test does"
 				} (${currentTestTimeout.getTimeout()}ms)`;
 				throw errorObject;
 			}


### PR DESCRIPTION
## Description

I was looking at this code while troubleshooting why e2e tests agains local server sometimes time out in pipeline runs and did a bit of docs improvement and test cleanup.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Note: most of the tests still exist, just have better names or moved around in the file. Unfortunately the diff doesn't make it easy to tell.
