### PR TITLE
refactor: Mark `TinyliciousClient` interfaces as `@sealed`

### DIFF
--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -40,12 +40,12 @@ export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousMember extends IMember {
     readonly name: string;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousUser extends IUser {
     readonly name: string;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -6,7 +6,7 @@
 
 export { CompatibilityMode }
 
-// @public
+// @public @sealed
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @sealed
@@ -22,20 +22,20 @@ export class TinyliciousClient {
     }>;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousClientProps {
     readonly connection?: TinyliciousConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousConnectionConfig {
     readonly domain?: string;
     readonly port?: number;
     readonly tokenProvider?: ITokenProvider;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -40,12 +40,12 @@ export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousMember extends IMember {
     readonly name: string;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousUser extends IUser {
     readonly name: string;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -6,7 +6,7 @@
 
 export { CompatibilityMode }
 
-// @public
+// @public @sealed
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @sealed
@@ -22,20 +22,20 @@ export class TinyliciousClient {
     }>;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousClientProps {
     readonly connection?: TinyliciousConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousConnectionConfig {
     readonly domain?: string;
     readonly port?: number;
     readonly tokenProvider?: ITokenProvider;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -40,12 +40,12 @@ export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousMember extends IMember {
     readonly name: string;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousUser extends IUser {
     readonly name: string;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -6,7 +6,7 @@
 
 export { CompatibilityMode }
 
-// @public
+// @public @sealed
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @sealed
@@ -22,20 +22,20 @@ export class TinyliciousClient {
     }>;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousClientProps {
     readonly connection?: TinyliciousConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousConnectionConfig {
     readonly domain?: string;
     readonly port?: number;
     readonly tokenProvider?: ITokenProvider;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }

--- a/packages/service-clients/tinylicious-client/src/interfaces.ts
+++ b/packages/service-clients/tinylicious-client/src/interfaces.ts
@@ -9,7 +9,8 @@ import type { IMember, IServiceAudience } from "@fluidframework/fluid-static";
 import type { ITokenProvider } from "@fluidframework/routerlicious-driver";
 
 /**
- * Properties for initializing a {@link TinyliciousClient}
+ * Properties for initializing a {@link TinyliciousClient}.
+ * @sealed
  * @public
  */
 export interface TinyliciousClientProps {
@@ -27,6 +28,7 @@ export interface TinyliciousClientProps {
 
 /**
  * Parameters for establishing a connection with the a Tinylicious service.
+ * @sealed
  * @public
  */
 export interface TinyliciousConnectionConfig {
@@ -64,6 +66,7 @@ export interface TinyliciousConnectionConfig {
  *
  * Returned by {@link TinyliciousClient.createContainer} and {@link TinyliciousClient.getContainer} alongside the FluidContainer.
  *
+ * @sealed
  * @public
  */
 export interface TinyliciousContainerServices {
@@ -98,6 +101,7 @@ export interface TinyliciousMember extends IMember {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IServiceAudience}.
+ * @sealed
  * @public
  */
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;

--- a/packages/service-clients/tinylicious-client/src/interfaces.ts
+++ b/packages/service-clients/tinylicious-client/src/interfaces.ts
@@ -79,6 +79,7 @@ export interface TinyliciousContainerServices {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IUser}.
+ * @sealed
  * @public
  */
 export interface TinyliciousUser extends IUser {
@@ -90,6 +91,7 @@ export interface TinyliciousUser extends IUser {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IMember}.
+ * @sealed
  * @public
  */
 export interface TinyliciousMember extends IMember {


### PR DESCRIPTION
Quick follow-up to #21830