### PR TITLE
Hydrate later in simple tree benchmark tests

### DIFF
--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "node:assert";
+import { strict as assert, fail } from "node:assert";
 
 import { BenchmarkType, benchmark, isInPerformanceTestingMode } from "@fluid-tools/benchmark";
 import {
@@ -112,12 +112,15 @@ describe("SimpleTree benchmarks", () => {
 						assert.equal(readNumber, expectedValue);
 					},
 				});
-				const flexTree = flexNodeInitFunction();
+				let flexTree: RootNode | undefined;
 				benchmark({
 					type: BenchmarkType.Measurement,
 					title: `${title} (flex node)`,
+					before: () => {
+						flexTree = flexNodeInitFunction();
+					},
 					benchmarkFn: () => {
-						readNumber = treeReadingFunction(flexTree);
+						readNumber = treeReadingFunction(flexTree ?? fail("Expected flexTree to be set"));
 					},
 					after: () => {
 						assert.equal(readNumber, expectedValue);

--- a/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/simpleTree.bench.ts
@@ -100,13 +100,18 @@ describe("SimpleTree benchmarks", () => {
 				treeReadingFunction: (tree: RootNode) => number | undefined,
 				expectedValue: number | undefined,
 			) {
-				const unhydratedTree = unhydratedNodeInitFunction();
+				let unhydratedTree: RootNode | undefined;
 				let readNumber: number | undefined;
 				benchmark({
 					type: BenchmarkType.Measurement,
 					title: `${title} (unhydrated node)`,
+					before: () => {
+						unhydratedTree = unhydratedNodeInitFunction();
+					},
 					benchmarkFn: () => {
-						readNumber = treeReadingFunction(unhydratedTree);
+						readNumber = treeReadingFunction(
+							unhydratedTree ?? fail("Expected unhydratedTree to be set"),
+						);
 					},
 					after: () => {
 						assert.equal(readNumber, expectedValue);


### PR DESCRIPTION
## Description

This moves the call to hydrate to happen within each benchmark test rather than outside in the `describe()` code. Running hydrate during `describe()` means that `hydrate()` will run when _any_ test is executed by the test browser, which makes it frustrating to debug.