### PR TITLE
service-clients cleanup

### DIFF
--- a/packages/service-clients/azure-client/src/AzureClient.ts
+++ b/packages/service-clients/azure-client/src/AzureClient.ts
@@ -96,10 +96,11 @@ export class AzureClient {
 	 * @param properties - Properties for initializing a new AzureClient instance
 	 */
 	public constructor(properties: AzureClientProps) {
-		// remove trailing slash from URL if any
-		properties.connection.endpoint = properties.connection.endpoint.replace(/\/$/, "");
-		this.urlResolver = new AzureUrlResolver();
 		this.connectionConfig = properties.connection;
+		this.logger = properties.logger;
+		// remove trailing slash from URL if any
+		this.connectionConfig.endpoint = this.connectionConfig.endpoint.replace(/\/$/, "");
+		this.urlResolver = new AzureUrlResolver();
 		// The local service implementation differs from the Azure Fluid Relay in blob
 		// storage format. Azure Fluid Relay supports whole summary upload. Local currently does not.
 		const isRemoteConnection = isAzureRemoteConnectionConfig(this.connectionConfig);

--- a/packages/service-clients/azure-client/src/AzureClient.ts
+++ b/packages/service-clients/azure-client/src/AzureClient.ts
@@ -10,7 +10,7 @@ import {
 	LoaderHeader,
 } from "@fluidframework/container-definitions/internal";
 import { Loader, loadContainerPaused } from "@fluidframework/container-loader/internal";
-import type { FluidObject, IConfigProviderBase } from "@fluidframework/core-interfaces";
+import type { FluidObject, IConfigProviderBase, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import type { IClient } from "@fluidframework/driver-definitions";
 import type {
@@ -40,6 +40,8 @@ import type {
 	AzureContainerServices,
 	AzureContainerVersion,
 	AzureGetVersionsOptions,
+	AzureLocalConnectionConfig,
+	AzureRemoteConnectionConfig,
 } from "./interfaces.js";
 import { isAzureRemoteConnectionConfig } from "./utils.js";
 
@@ -82,20 +84,23 @@ export class AzureClient {
 	private readonly documentServiceFactory: IDocumentServiceFactory;
 	private readonly urlResolver: IUrlResolver;
 	private readonly configProvider: IConfigProviderBase | undefined;
+	private readonly connectionConfig: AzureRemoteConnectionConfig | AzureLocalConnectionConfig;
+	private readonly logger: ITelemetryBaseLogger | undefined;
 
 	/**
 	 * Creates a new client instance using configuration parameters.
 	 * @param properties - Properties for initializing a new AzureClient instance
 	 */
-	public constructor(private readonly properties: AzureClientProps) {
+	public constructor(properties: AzureClientProps) {
 		// remove trailing slash from URL if any
 		properties.connection.endpoint = properties.connection.endpoint.replace(/\/$/, "");
 		this.urlResolver = new AzureUrlResolver();
+		this.connectionConfig = properties.connection;
 		// The local service implementation differs from the Azure Fluid Relay in blob
 		// storage format. Azure Fluid Relay supports whole summary upload. Local currently does not.
-		const isRemoteConnection = isAzureRemoteConnectionConfig(this.properties.connection);
+		const isRemoteConnection = isAzureRemoteConnectionConfig(this.connectionConfig);
 		const origDocumentServiceFactory: IDocumentServiceFactory =
-			new RouterliciousDocumentServiceFactory(this.properties.connection.tokenProvider, {
+			new RouterliciousDocumentServiceFactory(this.connectionConfig.tokenProvider, {
 				enableWholeSummaryUpload: isRemoteConnection,
 				enableDiscovery: isRemoteConnection,
 			});
@@ -131,7 +136,7 @@ export class AzureClient {
 
 		const fluidContainer = await this.createFluidContainer<TContainerSchema>(
 			container,
-			this.properties.connection,
+			this.connectionConfig,
 		);
 		const services = this.getContainerServices(container);
 		return { container: fluidContainer, services };
@@ -155,14 +160,14 @@ export class AzureClient {
 		services: AzureContainerServices;
 	}> {
 		const loader = this.createLoader(containerSchema, compatibilityMode);
-		const url = new URL(this.properties.connection.endpoint);
+		const url = new URL(this.connectionConfig.endpoint);
 		url.searchParams.append(
 			"storage",
-			encodeURIComponent(this.properties.connection.endpoint),
+			encodeURIComponent(this.connectionConfig.endpoint),
 		);
 		url.searchParams.append(
 			"tenantId",
-			encodeURIComponent(getTenantId(this.properties.connection)),
+			encodeURIComponent(getTenantId(this.connectionConfig)),
 		);
 		url.searchParams.append("containerId", encodeURIComponent(id));
 		const container = await loader.resolve({ url: url.href });
@@ -194,14 +199,14 @@ export class AzureClient {
 		container: IFluidContainer<TContainerSchema>;
 	}> {
 		const loader = this.createLoader(containerSchema, compatibilityMode);
-		const url = new URL(this.properties.connection.endpoint);
+		const url = new URL(this.connectionConfig.endpoint);
 		url.searchParams.append(
 			"storage",
-			encodeURIComponent(this.properties.connection.endpoint),
+			encodeURIComponent(this.connectionConfig.endpoint),
 		);
 		url.searchParams.append(
 			"tenantId",
-			encodeURIComponent(getTenantId(this.properties.connection)),
+			encodeURIComponent(getTenantId(this.connectionConfig)),
 		);
 		url.searchParams.append("containerId", encodeURIComponent(id));
 		const container = await loadContainerPaused(loader, {
@@ -227,14 +232,14 @@ export class AzureClient {
 		id: string,
 		options?: AzureGetVersionsOptions,
 	): Promise<AzureContainerVersion[]> {
-		const url = new URL(this.properties.connection.endpoint);
+		const url = new URL(this.connectionConfig.endpoint);
 		url.searchParams.append(
 			"storage",
-			encodeURIComponent(this.properties.connection.endpoint),
+			encodeURIComponent(this.connectionConfig.endpoint),
 		);
 		url.searchParams.append(
 			"tenantId",
-			encodeURIComponent(getTenantId(this.properties.connection)),
+			encodeURIComponent(getTenantId(this.connectionConfig)),
 		);
 		url.searchParams.append("containerId", encodeURIComponent(id));
 
@@ -291,7 +296,7 @@ export class AzureClient {
 			urlResolver: this.urlResolver,
 			documentServiceFactory: this.documentServiceFactory,
 			codeLoader,
-			logger: this.properties.logger,
+			logger: this.logger,
 			options: { client },
 			configProvider: this.configProvider,
 		});

--- a/packages/service-clients/azure-client/src/AzureClient.ts
+++ b/packages/service-clients/azure-client/src/AzureClient.ts
@@ -10,7 +10,11 @@ import {
 	LoaderHeader,
 } from "@fluidframework/container-definitions/internal";
 import { Loader, loadContainerPaused } from "@fluidframework/container-loader/internal";
-import type { FluidObject, IConfigProviderBase, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import type {
+	FluidObject,
+	IConfigProviderBase,
+	ITelemetryBaseLogger,
+} from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import type { IClient } from "@fluidframework/driver-definitions";
 import type {
@@ -161,10 +165,7 @@ export class AzureClient {
 	}> {
 		const loader = this.createLoader(containerSchema, compatibilityMode);
 		const url = new URL(this.connectionConfig.endpoint);
-		url.searchParams.append(
-			"storage",
-			encodeURIComponent(this.connectionConfig.endpoint),
-		);
+		url.searchParams.append("storage", encodeURIComponent(this.connectionConfig.endpoint));
 		url.searchParams.append(
 			"tenantId",
 			encodeURIComponent(getTenantId(this.connectionConfig)),
@@ -200,10 +201,7 @@ export class AzureClient {
 	}> {
 		const loader = this.createLoader(containerSchema, compatibilityMode);
 		const url = new URL(this.connectionConfig.endpoint);
-		url.searchParams.append(
-			"storage",
-			encodeURIComponent(this.connectionConfig.endpoint),
-		);
+		url.searchParams.append("storage", encodeURIComponent(this.connectionConfig.endpoint));
 		url.searchParams.append(
 			"tenantId",
 			encodeURIComponent(getTenantId(this.connectionConfig)),
@@ -233,10 +231,7 @@ export class AzureClient {
 		options?: AzureGetVersionsOptions,
 	): Promise<AzureContainerVersion[]> {
 		const url = new URL(this.connectionConfig.endpoint);
-		url.searchParams.append(
-			"storage",
-			encodeURIComponent(this.connectionConfig.endpoint),
-		);
+		url.searchParams.append("storage", encodeURIComponent(this.connectionConfig.endpoint));
 		url.searchParams.append(
 			"tenantId",
 			encodeURIComponent(getTenantId(this.connectionConfig)),

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -6,12 +6,12 @@
 
 export { CompatibilityMode }
 
-// @public
+// @public @sealed
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @sealed
 export class TinyliciousClient {
-    constructor(props?: TinyliciousClientProps | undefined);
+    constructor(properties?: TinyliciousClientProps);
     createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
@@ -22,30 +22,30 @@ export class TinyliciousClient {
     }>;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousClientProps {
     readonly connection?: TinyliciousConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousConnectionConfig {
     readonly domain?: string;
     readonly port?: number;
     readonly tokenProvider?: ITokenProvider;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousMember extends IMember {
     readonly name: string;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousUser extends IUser {
     readonly name: string;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -6,7 +6,7 @@
 
 export { CompatibilityMode }
 
-// @public @sealed
+// @public
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @sealed
@@ -22,30 +22,30 @@ export class TinyliciousClient {
     }>;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousClientProps {
     readonly connection?: TinyliciousConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousConnectionConfig {
     readonly domain?: string;
     readonly port?: number;
     readonly tokenProvider?: ITokenProvider;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousMember extends IMember {
     readonly name: string;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousUser extends IUser {
     readonly name: string;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -6,12 +6,12 @@
 
 export { CompatibilityMode }
 
-// @public
+// @public @sealed
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @sealed
 export class TinyliciousClient {
-    constructor(props?: TinyliciousClientProps | undefined);
+    constructor(properties?: TinyliciousClientProps);
     createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
@@ -22,30 +22,30 @@ export class TinyliciousClient {
     }>;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousClientProps {
     readonly connection?: TinyliciousConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousConnectionConfig {
     readonly domain?: string;
     readonly port?: number;
     readonly tokenProvider?: ITokenProvider;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousMember extends IMember {
     readonly name: string;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousUser extends IUser {
     readonly name: string;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -6,7 +6,7 @@
 
 export { CompatibilityMode }
 
-// @public @sealed
+// @public
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @sealed
@@ -22,30 +22,30 @@ export class TinyliciousClient {
     }>;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousClientProps {
     readonly connection?: TinyliciousConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousConnectionConfig {
     readonly domain?: string;
     readonly port?: number;
     readonly tokenProvider?: ITokenProvider;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousMember extends IMember {
     readonly name: string;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousUser extends IUser {
     readonly name: string;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -6,12 +6,12 @@
 
 export { CompatibilityMode }
 
-// @public
+// @public @sealed
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @sealed
 export class TinyliciousClient {
-    constructor(props?: TinyliciousClientProps | undefined);
+    constructor(properties?: TinyliciousClientProps);
     createContainer<TContainerSchema extends ContainerSchema>(containerSchema: TContainerSchema, compatibilityMode: CompatibilityMode): Promise<{
         container: IFluidContainer<TContainerSchema>;
         services: TinyliciousContainerServices;
@@ -22,30 +22,30 @@ export class TinyliciousClient {
     }>;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousClientProps {
     readonly connection?: TinyliciousConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousConnectionConfig {
     readonly domain?: string;
     readonly port?: number;
     readonly tokenProvider?: ITokenProvider;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousMember extends IMember {
     readonly name: string;
 }
 
-// @public
+// @public @sealed
 export interface TinyliciousUser extends IUser {
     readonly name: string;
 }

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -6,7 +6,7 @@
 
 export { CompatibilityMode }
 
-// @public @sealed
+// @public
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @sealed
@@ -22,30 +22,30 @@ export class TinyliciousClient {
     }>;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousClientProps {
     readonly connection?: TinyliciousConnectionConfig;
     readonly logger?: ITelemetryBaseLogger;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousConnectionConfig {
     readonly domain?: string;
     readonly port?: number;
     readonly tokenProvider?: ITokenProvider;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousContainerServices {
     readonly audience: ITinyliciousAudience;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousMember extends IMember {
     readonly name: string;
 }
 
-// @public @sealed
+// @public
 export interface TinyliciousUser extends IUser {
     readonly name: string;
 }

--- a/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
@@ -10,7 +10,11 @@ import type {
 	IHostLoader,
 } from "@fluidframework/container-definitions/internal";
 import { Loader } from "@fluidframework/container-loader/internal";
-import type { ConfigTypes, FluidObject, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
+import type {
+	ConfigTypes,
+	FluidObject,
+	ITelemetryBaseLogger,
+} from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import type { IClient } from "@fluidframework/driver-definitions";
 import type {

--- a/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
@@ -61,6 +61,7 @@ export class TinyliciousClient {
 	 * @param properties - Optional. Properties for initializing a new TinyliciousClient instance
 	 */
 	public constructor(properties?: TinyliciousClientProps) {
+		this.logger = properties?.logger;
 		const tokenProvider = new InsecureTinyliciousTokenProvider();
 		this.urlResolver = new InsecureTinyliciousUrlResolver(
 			properties?.connection?.port,
@@ -69,7 +70,6 @@ export class TinyliciousClient {
 		this.documentServiceFactory = new RouterliciousDocumentServiceFactory(
 			properties?.connection?.tokenProvider ?? tokenProvider,
 		);
-		this.logger = properties?.logger;
 	}
 
 	/**

--- a/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
@@ -10,7 +10,7 @@ import type {
 	IHostLoader,
 } from "@fluidframework/container-definitions/internal";
 import { Loader } from "@fluidframework/container-loader/internal";
-import type { ConfigTypes, FluidObject } from "@fluidframework/core-interfaces";
+import type { ConfigTypes, FluidObject, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import type { IClient } from "@fluidframework/driver-definitions";
 import type {
@@ -50,20 +50,22 @@ import type { TinyliciousClientProps, TinyliciousContainerServices } from "./int
 export class TinyliciousClient {
 	private readonly documentServiceFactory: IDocumentServiceFactory;
 	private readonly urlResolver: IUrlResolver;
+	private readonly logger: ITelemetryBaseLogger | undefined;
 
 	/**
 	 * Creates a new client instance using configuration parameters.
-	 * @param props - Optional. Properties for initializing a new TinyliciousClient instance
+	 * @param properties - Optional. Properties for initializing a new TinyliciousClient instance
 	 */
-	public constructor(private readonly props?: TinyliciousClientProps) {
+	public constructor(properties?: TinyliciousClientProps) {
 		const tokenProvider = new InsecureTinyliciousTokenProvider();
 		this.urlResolver = new InsecureTinyliciousUrlResolver(
-			this.props?.connection?.port,
-			this.props?.connection?.domain,
+			properties?.connection?.port,
+			properties?.connection?.domain,
 		);
 		this.documentServiceFactory = new RouterliciousDocumentServiceFactory(
-			this.props?.connection?.tokenProvider ?? tokenProvider,
+			properties?.connection?.tokenProvider ?? tokenProvider,
 		);
+		this.logger = properties?.logger;
 	}
 
 	/**
@@ -186,7 +188,7 @@ export class TinyliciousClient {
 			urlResolver: this.urlResolver,
 			documentServiceFactory: this.documentServiceFactory,
 			codeLoader,
-			logger: this.props?.logger,
+			logger: this.logger,
 			options: { client },
 			configProvider: wrapConfigProviderWithDefaults(/* original */ undefined, featureGates),
 		});

--- a/packages/service-clients/tinylicious-client/src/interfaces.ts
+++ b/packages/service-clients/tinylicious-client/src/interfaces.ts
@@ -10,7 +10,6 @@ import type { ITokenProvider } from "@fluidframework/routerlicious-driver";
 
 /**
  * Properties for initializing a {@link TinyliciousClient}
- * @sealed
  * @public
  */
 export interface TinyliciousClientProps {
@@ -28,7 +27,6 @@ export interface TinyliciousClientProps {
 
 /**
  * Parameters for establishing a connection with the a Tinylicious service.
- * @sealed
  * @public
  */
 export interface TinyliciousConnectionConfig {
@@ -66,7 +64,6 @@ export interface TinyliciousConnectionConfig {
  *
  * Returned by {@link TinyliciousClient.createContainer} and {@link TinyliciousClient.getContainer} alongside the FluidContainer.
  *
- * @sealed
  * @public
  */
 export interface TinyliciousContainerServices {
@@ -79,7 +76,6 @@ export interface TinyliciousContainerServices {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IUser}.
- * @sealed
  * @public
  */
 export interface TinyliciousUser extends IUser {
@@ -91,7 +87,6 @@ export interface TinyliciousUser extends IUser {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IMember}.
- * @sealed
  * @public
  */
 export interface TinyliciousMember extends IMember {
@@ -103,7 +98,6 @@ export interface TinyliciousMember extends IMember {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IServiceAudience}.
- * @sealed
  * @public
  */
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;

--- a/packages/service-clients/tinylicious-client/src/interfaces.ts
+++ b/packages/service-clients/tinylicious-client/src/interfaces.ts
@@ -10,6 +10,7 @@ import type { ITokenProvider } from "@fluidframework/routerlicious-driver";
 
 /**
  * Properties for initializing a {@link TinyliciousClient}
+ * @sealed
  * @public
  */
 export interface TinyliciousClientProps {
@@ -27,6 +28,7 @@ export interface TinyliciousClientProps {
 
 /**
  * Parameters for establishing a connection with the a Tinylicious service.
+ * @sealed
  * @public
  */
 export interface TinyliciousConnectionConfig {
@@ -64,6 +66,7 @@ export interface TinyliciousConnectionConfig {
  *
  * Returned by {@link TinyliciousClient.createContainer} and {@link TinyliciousClient.getContainer} alongside the FluidContainer.
  *
+ * @sealed
  * @public
  */
 export interface TinyliciousContainerServices {
@@ -76,6 +79,7 @@ export interface TinyliciousContainerServices {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IUser}.
+ * @sealed
  * @public
  */
 export interface TinyliciousUser extends IUser {
@@ -87,6 +91,7 @@ export interface TinyliciousUser extends IUser {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IMember}.
+ * @sealed
  * @public
  */
 export interface TinyliciousMember extends IMember {
@@ -98,6 +103,7 @@ export interface TinyliciousMember extends IMember {
 
 /**
  * Tinylicious {@link @fluidframework/fluid-static#IServiceAudience}.
+ * @sealed
  * @public
  */
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;


### PR DESCRIPTION
This change just does two things:
1. Unabbreviates "props" in TinyliciousClient to match AzureClient
2. Makes the properties object short-lived as a best practice, for all three clients.

Does not touch the sealed state of any APIs as that's being handled by #21845