### PR TITLE
Fix offline attach ops with child DDSes

### DIFF
--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -1474,6 +1474,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			subRequest.url.startsWith("/"),
 			0x126 /* "Expected createSubRequest url to include a leading slash" */,
 		);
+
 		return dataStore.request(subRequest);
 	}
 }

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -930,7 +930,6 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			);
 		}
 
-		console.log("get context");
 		const context = await this.contexts.getBoundOrRemoted(id, headerData.wait);
 		if (context === undefined) {
 			// The requested data store does not exits. Throw a 404 response exception.
@@ -1450,9 +1449,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 
 		await this.waitIfPendingAlias(id);
 		const internalId = this.internalId(id);
-		console.log("get Data Store");
 		const dataStoreContext = await this.getDataStore(internalId, headerData, request);
-		console.log("got Data Store");
 
 		// Get the initial snapshot details which contain the data store package path.
 		const details = await dataStoreContext.getInitialSnapshotDetails();
@@ -1468,7 +1465,6 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			timestampMs: undefined, // This will be added by the parent context if needed.
 		});
 
-		console.log("realize Data Store");
 		const dataStore = await dataStoreContext.realize();
 
 		const subRequest = requestParser.createSubRequest(1);
@@ -1478,7 +1474,6 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			subRequest.url.startsWith("/"),
 			0x126 /* "Expected createSubRequest url to include a leading slash" */,
 		);
-		console.log("realize Data Store request");
 		return dataStore.request(subRequest);
 	}
 }

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -812,11 +812,11 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 		// loaded, as this client is playing the role of creating client,
 		// and creating clients always create realized data store contexts.
 		const channel = await dataStoreContext.realize();
-		await channel.entryPoint.get();
-
 		// add to the list of bound or remoted, as this context must be bound
 		// to had an attach message sent, and is the non-detached case is remoted.
 		this.contexts.addBoundOrRemoted(dataStoreContext);
+		await channel.entryPoint.get();
+
 		if (this.parentContext.attachState !== AttachState.Detached) {
 			// if the client is not detached put in the pending attach list
 			// so that on ack of the stashed op, the context is found.
@@ -930,6 +930,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			);
 		}
 
+		console.log("get context");
 		const context = await this.contexts.getBoundOrRemoted(id, headerData.wait);
 		if (context === undefined) {
 			// The requested data store does not exits. Throw a 404 response exception.
@@ -1449,7 +1450,9 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 
 		await this.waitIfPendingAlias(id);
 		const internalId = this.internalId(id);
+		console.log("get Data Store");
 		const dataStoreContext = await this.getDataStore(internalId, headerData, request);
+		console.log("got Data Store");
 
 		// Get the initial snapshot details which contain the data store package path.
 		const details = await dataStoreContext.getInitialSnapshotDetails();
@@ -1465,6 +1468,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			timestampMs: undefined, // This will be added by the parent context if needed.
 		});
 
+		console.log("realize Data Store");
 		const dataStore = await dataStoreContext.realize();
 
 		const subRequest = requestParser.createSubRequest(1);
@@ -1474,7 +1478,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			subRequest.url.startsWith("/"),
 			0x126 /* "Expected createSubRequest url to include a leading slash" */,
 		);
-
+		console.log("realize Data Store request");
 		return dataStore.request(subRequest);
 	}
 }

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -807,14 +807,14 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			makeLocallyVisibleFn: () => this.makeDataStoreLocallyVisible(id),
 			snapshotTree,
 		});
+		// add to the list of bound or remoted, as this context must be bound
+		// to had an attach message sent, and is the non-detached case is remoted.
+		this.contexts.addBoundOrRemoted(dataStoreContext);
 
 		// realize the local context, as local contexts shouldn't be delay
 		// loaded, as this client is playing the role of creating client,
 		// and creating clients always create realized data store contexts.
 		const channel = await dataStoreContext.realize();
-		// add to the list of bound or remoted, as this context must be bound
-		// to had an attach message sent, and is the non-detached case is remoted.
-		this.contexts.addBoundOrRemoted(dataStoreContext);
 		await channel.entryPoint.get();
 
 		if (this.parentContext.attachState !== AttachState.Detached) {

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
@@ -1,0 +1,107 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { describeCompat } from "@fluid-private/test-version-utils";
+import type { IContainerExperimental } from "@fluidframework/container-loader/internal";
+import {
+	type ContainerRuntime,
+	type IContainerRuntimeOptions,
+} from "@fluidframework/container-runtime/internal";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import { SharedCounter } from "@fluidframework/counter/internal";
+import {
+	type ITestObjectProvider,
+	createTestConfigProvider,
+} from "@fluidframework/test-utils/internal";
+
+describeCompat("Offline Attach Ops", "NoCompat", (getTestObjectProvider, apis) => {
+	const { DataObjectFactory, DataObject } = apis.dataRuntime;
+	const { ContainerRuntimeFactoryWithDefaultDataStore } = apis.containerRuntime;
+
+	// A Test Data Object that exposes some basic functionality.
+	class TestDataObject extends DataObject {
+		private readonly _childObject?: TestDataObject;
+		public get _root() {
+			return this.root;
+		}
+
+		public get containerRuntime() {
+			return this.context.containerRuntime as ContainerRuntime;
+		}
+
+		public get childObject() {
+			return this._childObject;
+		}
+
+		protected async initializingFirstTime(props?: boolean): Promise<void> {
+			const sharedCounter = SharedCounter.create(this.runtime);
+			this.root.set("counter", sharedCounter.handle);
+		}
+
+		protected async hasInitialized(): Promise<void> {
+			const counterHandle = this.root.get<IFluidHandle<SharedCounter>>("counter");
+			assert(counterHandle !== undefined, "counter handle must be defined");
+			// This is what was hanging, as this is a remote fluid object handle when applyStashedOp is called
+			await counterHandle.get();
+		}
+	}
+
+	// Allow us to control summaries
+	const runtimeOptions: IContainerRuntimeOptions = {
+		summaryOptions: {
+			summaryConfigOverrides: {
+				state: "disabled",
+			},
+		},
+	};
+
+	const testDataObjectType = "TestDataObject";
+	const dataObjectFactory = new DataObjectFactory(
+		testDataObjectType,
+		TestDataObject,
+		[SharedCounter.getFactory()],
+		{},
+	);
+
+	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
+		defaultFactory: dataObjectFactory,
+		registryEntries: [dataObjectFactory.registryEntry],
+		runtimeOptions,
+	});
+
+	let provider: ITestObjectProvider;
+	const configProvider = createTestConfigProvider({
+		"Fluid.Container.enableOfflineLoad": true,
+	});
+	beforeEach("setup", async function () {
+		provider = getTestObjectProvider();
+	});
+
+	it("Can create loadingGroupId", async () => {
+		const container = (await provider.createContainer(runtimeFactory, {
+			configProvider,
+		})) as IContainerExperimental;
+		const mainObject = (await container.getEntryPoint()) as TestDataObject;
+
+		// Disconnect and create child object attached stashed ops
+		container.disconnect();
+
+		const childObject = await dataObjectFactory.createInstance(mainObject.containerRuntime);
+		mainObject._root.set("testObject2", childObject.handle);
+
+		const serializedState = await container.closeAndGetPendingLocalState?.();
+		assert(serializedState !== undefined, "serializedState should not be undefined");
+
+		// This should not hang
+		await provider.loadContainer(
+			runtimeFactory,
+			{ configProvider },
+			undefined,
+			serializedState,
+		);
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
@@ -45,7 +45,7 @@ describeCompat("Offline Attach Ops", "NoCompat", (getTestObjectProvider, apis) =
 		protected async hasInitialized(): Promise<void> {
 			const counterHandle = this.root.get<IFluidHandle<SharedCounter>>("counter");
 			assert(counterHandle !== undefined, "counter handle must be defined");
-			// This is what was hanging, as this is a remote fluid object handle when applyStashedOp is called
+			// This is what was hanging, as this is a RemoteFluidObjectHandle when applyStashedOp is called
 			await counterHandle.get();
 		}
 	}

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
@@ -77,9 +77,9 @@ describeCompat("Offline Attach Ops", "NoCompat", (getTestObjectProvider, apis) =
 	});
 
 	it("Can create loadingGroupId", async () => {
-		const container = (await provider.createContainer(runtimeFactory, {
+		const container: IContainerExperimental = await provider.createContainer(runtimeFactory, {
 			configProvider,
-		})) as IContainerExperimental;
+		});
 		const mainObject = (await container.getEntryPoint()) as TestDataObject;
 
 		// Disconnect and create child object attached stashed ops

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/noGroupIdOfflineFlow.spec.ts
@@ -24,7 +24,6 @@ describeCompat("Offline Attach Ops", "NoCompat", (getTestObjectProvider, apis) =
 
 	// A Test Data Object that exposes some basic functionality.
 	class TestDataObject extends DataObject {
-		private readonly _childObject?: TestDataObject;
 		public get _root() {
 			return this.root;
 		}
@@ -33,11 +32,7 @@ describeCompat("Offline Attach Ops", "NoCompat", (getTestObjectProvider, apis) =
 			return this.context.containerRuntime as ContainerRuntime;
 		}
 
-		public get childObject() {
-			return this._childObject;
-		}
-
-		protected async initializingFirstTime(props?: boolean): Promise<void> {
+		protected async initializingFirstTime(): Promise<void> {
 			const sharedCounter = SharedCounter.create(this.runtime);
 			this.root.set("counter", sharedCounter.handle);
 		}


### PR DESCRIPTION
[AB#8854](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8854)

There was a particularly hard bug that was causing this specific test to hang. I looked into why we didn't originally catch this bug in the onset, and it seems that only when we call handle.get during another handle.get during attach flow do we have this issue.

The repro steps are the following
- Have a container go offline
- Create a `DataObject` with a child dds
- In the `hasInitialized` function of that DDS, load the child dds
- Serialize the container
- load a new container from the serialized state
- The new load hangs.

What happens is that while we are applying the stashed attach op, the hasInitialized function is running as we are trying to get the entry point. The entrypoint is a local handle, but the child handle is a `RemoteFluidObjectHandle`. Thus it calls back into the runtime to get the child DDS. The problem here is that we hadn't yet put the `LocalFluidDataStoreContext` we created for applying the stashed op for our `DataObject` in the list of bound contexts. Thus, we need to do so.

There may be more work to be done here, but this is the fix that gets around the issue for now.