### PR TITLE
[GC] Added telemetry when an unreferenced data store is realized during summarization

### DIFF
--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -239,6 +239,9 @@
 			},
 			"ClassDeclaration_LocalFluidDataStoreContextBase": {
 				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IGCNodeUpdatedProps": {
+				"backCompat": false
 			}
 		}
 	}

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -230,6 +230,16 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_LocalFluidDataStoreContext": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_FluidDataStoreContext": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_LocalFluidDataStoreContextBase": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -1300,7 +1300,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			this.mc.logger.sendTelemetryEvent({
 				eventName: "GC_DeletingLoadedDataStore",
 				...tagCodeArtifacts({
-					id: `/${dataStoreId}`,
+					id: `/${dataStoreId}`, // Make the id consistent with GC node path format by prefixing a slash.
 					pkg: dataStoreContext.packagePath.join("/"),
 				}),
 				details: {

--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -69,6 +69,7 @@ import {
 	createChildMonitoringContext,
 	extractSafePropertiesFromMessage,
 	tagCodeArtifacts,
+	type ITelemetryPropertiesExt,
 } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
 
@@ -1186,6 +1187,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 	 */
 	private async visitContextsDuringSummary(
 		visitor: (contextId: string, context: FluidDataStoreContext) => Promise<void>,
+		telemetryProps: ITelemetryPropertiesExt,
 	): Promise<void> {
 		for (const [contextId, context] of this.contexts) {
 			// Summarizer client and hence GC works only with clients with no local changes. A data store in
@@ -1201,7 +1203,23 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			}
 
 			if (context.attachState === AttachState.Attached) {
+				// If summary / getGCData results in this data store's realization, let GC know so that it can log in
+				// case the data store is not referenced. This will help identifying scenarios that we see today where
+				// unreferenced data stores are being loaded.
+				const contextLoadedBefore = context.isLoaded;
+				const trailingOpCount = context.pendingCount;
+
 				await visitor(contextId, context);
+
+				if (!contextLoadedBefore && context.isLoaded) {
+					this.gcNodeUpdated({
+						node: { type: "DataStore", path: `/${context.id}` },
+						reason: "Realized",
+						packagePath: context.packagePath,
+						timestampMs: undefined, // This will be added by the parent context if needed.
+						additionalProps: { trailingOpCount, ...telemetryProps },
+					});
+				}
 			}
 		}
 	}
@@ -1214,25 +1232,10 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 		const summaryBuilder = new SummaryTreeBuilder();
 		await this.visitContextsDuringSummary(
 			async (contextId: string, context: FluidDataStoreContext) => {
-				// If summarize results in this data store's realization, let GC know so that it can log in case
-				// the data store is not referenced. This will help identifying scenarios that we see today where
-				// unreferenced data stores are being loaded.
-				const contextLoadedBefore = context.isLoaded;
-				const pendingCount = context.pendingCount;
-
 				const contextSummary = await context.summarize(fullTree, trackState, telemetryContext);
-
-				if (!contextLoadedBefore && context.isLoaded) {
-					this.gcNodeUpdated({
-						node: { type: "DataStore", path: `/${context.id}` },
-						reason: "Loaded",
-						packagePath: context.packagePath,
-						timestampMs: undefined, // This will be added by the parent context if needed.
-						additionalProps: { opCount: pendingCount, fullTree, duringSummarize: true },
-					});
-				}
 				summaryBuilder.addWithStats(contextId, contextSummary);
 			},
+			{ fullTree, realizedDuring: "summarize" },
 		);
 		return summaryBuilder.getSummaryTree();
 	}
@@ -1259,6 +1262,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 				// This also gradually builds the id of each node to be a path from the root.
 				builder.prefixAndAddNodes(contextId, contextGCData.gcNodes);
 			},
+			{ fullGC, realizedDuring: "getGCData" },
 		);
 
 		// Get the outbound routes and add a GC node for this channel.

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -59,7 +59,6 @@ import {
 	isSnapshotFetchRequiredForLoadingGroupId,
 } from "@fluidframework/runtime-utils/internal";
 import {
-	DataCorruptionError,
 	DataProcessingError,
 	LoggingError,
 	MonitoringContext,
@@ -305,6 +304,9 @@ export abstract class FluidDataStoreContext
 		return this._isInMemoryRoot;
 	}
 
+	/**
+	 * Returns the count of pending messages that are stored until the data store is realized.
+	 */
 	public get pendingCount(): number {
 		return this.pending?.length ?? 0;
 	}
@@ -571,8 +573,10 @@ export abstract class FluidDataStoreContext
 		// "verifyNotClosed" which logs tombstone errors. Throw error if tombstoned and throwing on load is configured.
 		this.verifyNotClosed("process", false /* checkTombstone */, safeTelemetryProps);
 		if (this.tombstoned && this.gcThrowOnTombstoneUsage) {
-			throw new DataCorruptionError(
+			throw DataProcessingError.create(
 				"Context is tombstoned! Call site [process]",
+				"process",
+				undefined /* sequencedMessage */,
 				safeTelemetryProps,
 			);
 		}

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -305,6 +305,10 @@ export abstract class FluidDataStoreContext
 		return this._isInMemoryRoot;
 	}
 
+	public get pendingCount(): number {
+		return this.pending?.length ?? 0;
+	}
+
 	protected registry: IFluidDataStoreRegistry | undefined;
 
 	protected detachedRuntimeCreation = false;
@@ -961,7 +965,12 @@ export abstract class FluidDataStoreContext
 	) {
 		if (this.deleted) {
 			const messageString = `Context is deleted! Call site [${callSite}]`;
-			const error = new DataCorruptionError(messageString, safeTelemetryProps);
+			const error = DataProcessingError.create(
+				messageString,
+				callSite,
+				undefined /* sequencedMessage */,
+				safeTelemetryProps,
+			);
 			this.mc.logger.sendErrorEvent(
 				{
 					eventName: "GC_Deleted_DataStore_Changed",
@@ -979,7 +988,12 @@ export abstract class FluidDataStoreContext
 
 		if (checkTombstone && this.tombstoned) {
 			const messageString = `Context is tombstoned! Call site [${callSite}]`;
-			const error = new DataCorruptionError(messageString, safeTelemetryProps);
+			const error = DataProcessingError.create(
+				messageString,
+				callSite,
+				undefined /* sequencedMessage */,
+				safeTelemetryProps,
+			);
 
 			sendGCUnexpectedUsageEvent(
 				this.mc,

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -404,11 +404,7 @@ export class GarbageCollector implements IGarbageCollector {
 			{
 				eventName: "InitializeOrUpdateGCState",
 			},
-			async (perfEvent: {
-				end: (arg0: {
-					details: { initialized: boolean; unrefNodeCount: number };
-				}) => void;
-			}) => {
+			async (event) => {
 				// If the GC state hasn't been initialized yet, initialize it and return.
 				if (!initialized) {
 					await this.initializeGCStateFromBaseSnapshotP;
@@ -419,7 +415,7 @@ export class GarbageCollector implements IGarbageCollector {
 						nodeStateTracker.updateTracking(currentReferenceTimestampMs);
 					}
 				}
-				perfEvent.end({
+				event.end({
 					details: { initialized, unrefNodeCount: this.unreferencedNodesState.size },
 				});
 			},

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -403,20 +403,25 @@ export class GarbageCollector implements IGarbageCollector {
 			this.mc.logger,
 			{
 				eventName: "InitializeOrUpdateGCState",
-				details: { initialized, unrefNodeCount: this.unreferencedNodesState.size },
 			},
-			async () => {
+			async (perfEvent: {
+				end: (arg0: {
+					details: { initialized: boolean; unrefNodeCount: number };
+				}) => void;
+			}) => {
 				// If the GC state hasn't been initialized yet, initialize it and return.
 				if (!initialized) {
 					await this.initializeGCStateFromBaseSnapshotP;
-					return;
+				} else {
+					// If the GC state has been initialized, update the tracking of unreferenced nodes as per the current
+					// reference timestamp.
+					for (const [, nodeStateTracker] of this.unreferencedNodesState) {
+						nodeStateTracker.updateTracking(currentReferenceTimestampMs);
+					}
 				}
-
-				// If the GC state has been initialized, update the tracking of unreferenced nodes as per the current
-				// reference timestamp.
-				for (const [, nodeStateTracker] of this.unreferencedNodesState) {
-					nodeStateTracker.updateTracking(currentReferenceTimestampMs);
-				}
+				perfEvent.end({
+					details: { initialized, unrefNodeCount: this.unreferencedNodesState.size },
+				});
 			},
 		);
 	}
@@ -1003,6 +1008,7 @@ export class GarbageCollector implements IGarbageCollector {
 		packagePath,
 		request,
 		headerData,
+		additionalProps,
 	}: IGCNodeUpdatedProps) {
 		// If there is no reference timestamp to work with, no ops have been processed after creation. If so, skip
 		// logging as nothing interesting would have happened worth logging.
@@ -1029,6 +1035,7 @@ export class GarbageCollector implements IGarbageCollector {
 			headers: headerData,
 			requestUrl: request?.url,
 			requestHeaders: JSON.stringify(request?.headers),
+			additionalProps,
 		});
 
 		// Any time we log a Tombstone Loaded error (via Telemetry Tracker),

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -13,7 +13,10 @@ import {
 	ISummarizeResult,
 } from "@fluidframework/runtime-definitions/internal";
 import { ReadAndParseBlob } from "@fluidframework/runtime-utils/internal";
-import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
+import {
+	ITelemetryLoggerExt,
+	type ITelemetryPropertiesExt,
+} from "@fluidframework/telemetry-utils/internal";
 
 import { RuntimeHeaderData } from "../containerRuntime.js";
 import { ContainerRuntimeGCMessage } from "../messageTypes.js";
@@ -409,6 +412,8 @@ export interface IGCNodeUpdatedProps {
 	request?: IRequest;
 	/** If the node was loaded via request path, the header data. May be modified from the original request */
 	headerData?: RuntimeHeaderData;
+	/** Any other properties to be logged. */
+	additionalProps?: ITelemetryPropertiesExt;
 }
 
 /** Parameters necessary for creating a GarbageCollector. */

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -400,7 +400,7 @@ export interface IGCNodeUpdatedProps {
 	/** Type and path of the updated node */
 	node: { type: (typeof GCNodeType)["DataStore" | "Blob"]; path: string };
 	/** Whether the node (or a subpath) was loaded or changed. */
-	reason: "Loaded" | "Changed";
+	reason: "Loaded" | "Changed" | "Realized";
 	/**
 	 * The op-based timestamp when the node changed. If the update is from receiving an op, this should
 	 * be the timestamp of the op. If not, this should be the timestamp of the last op processed.

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -11,6 +11,7 @@ import {
 	generateStack,
 	tagCodeArtifacts,
 	type ITelemetryGenericEventExt,
+	type ITelemetryPropertiesExt,
 } from "@fluidframework/telemetry-utils/internal";
 
 import { RuntimeHeaderData } from "../containerRuntime.js";
@@ -37,6 +38,7 @@ interface ICommonProps {
 	isTombstoned: boolean;
 	lastSummaryTime?: number;
 	headers?: RuntimeHeaderData;
+	additionalProps?: ITelemetryPropertiesExt;
 }
 
 /** The event that is logged when unreferenced node is used after a certain time. */
@@ -240,7 +242,8 @@ export class GCTelemetryTracker {
 			// Events generated:
 			// InactiveObject_Loaded, SweepReadyObject_Loaded
 			if (usageType === "Loaded") {
-				const { id, fromId, headers, gcConfigs, ...detailedProps } = unrefEventProps;
+				const { id, fromId, headers, gcConfigs, additionalProps, ...detailedProps } =
+					unrefEventProps;
 				const event = {
 					eventName: `${state}Object_${usageType}`,
 					...tagCodeArtifacts({ pkg: packagePath?.join("/") }),
@@ -248,7 +251,7 @@ export class GCTelemetryTracker {
 					id,
 					fromId,
 					headers: { ...headers },
-					details: detailedProps,
+					details: { ...detailedProps, ...additionalProps },
 					gcConfigs,
 				};
 
@@ -272,7 +275,8 @@ export class GCTelemetryTracker {
 		// GC_Tombstone_DataStore_Requested, GC_Tombstone_DataStore_Changed, GC_Tombstone_DataStore_Revived
 		// GC_Tombstone_SubDataStore_Requested, GC_Tombstone_SubDataStore_Changed, GC_Tombstone_SubDataStore_Revived
 		// GC_Tombstone_Blob_Requested, GC_Tombstone_Blob_Changed, GC_Tombstone_Blob_Revived
-		const { id, fromId, headers, gcConfigs, ...detailedProps } = unrefEventProps;
+		const { id, fromId, headers, gcConfigs, additionalProps, ...detailedProps } =
+			unrefEventProps;
 		const eventUsageName = usageType === "Loaded" ? "Requested" : usageType;
 		const event = {
 			eventName: `GC_Tombstone_${nodeType}_${eventUsageName}`,
@@ -281,7 +285,7 @@ export class GCTelemetryTracker {
 			id,
 			fromId,
 			headers: { ...headers },
-			details: detailedProps, // Also includes some properties from INodeUsageProps type
+			details: { ...detailedProps, ...additionalProps }, // Also includes some properties from INodeUsageProps type
 			gcConfigs,
 			tombstoneFlags: {
 				DisableTombstone: this.mc.config.getBoolean(disableTombstoneKey),
@@ -370,8 +374,16 @@ export class GCTelemetryTracker {
 		// InactiveObject_Loaded, InactiveObject_Changed, InactiveObject_Revived
 		// SweepReadyObject_Loaded, SweepReadyObject_Changed, SweepReadyObject_Revived
 		for (const eventProps of this.pendingEventsQueue) {
-			const { usageType, state, id, fromId, headers, gcConfigs, ...detailedProps } =
-				eventProps;
+			const {
+				usageType,
+				state,
+				id,
+				fromId,
+				headers,
+				gcConfigs,
+				additionalProps,
+				...detailedProps
+			} = eventProps;
 			/**
 			 * Revived event is logged only if the node is active. If the node is not active, the reference to it was
 			 * from another unreferenced node and this scenario is not interesting to log.
@@ -391,7 +403,7 @@ export class GCTelemetryTracker {
 					id,
 					fromId,
 					headers: { ...headers },
-					details: detailedProps,
+					details: { ...detailedProps, ...additionalProps },
 					gcConfigs,
 					...tagCodeArtifacts({
 						pkg: pkg?.join("/"),

--- a/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
+++ b/packages/runtime/container-runtime/src/gc/gcTelemetry.ts
@@ -29,7 +29,7 @@ import {
 import { getGCVersionInEffect } from "./gcHelpers.js";
 import { UnreferencedStateTracker } from "./gcUnreferencedStateTracker.js";
 
-type NodeUsageType = "Changed" | "Loaded" | "Revived";
+type NodeUsageType = "Changed" | "Loaded" | "Revived" | "Realized";
 
 /** Properties that are common to IUnreferencedEventProps and INodeUsageProps */
 interface ICommonProps {

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -274,6 +274,7 @@ declare type current_as_old_for_TypeAliasDeclaration_EnqueueSummarizeResult = re
  * typeValidation.broken:
  * "ClassDeclaration_FluidDataStoreContext": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_ClassDeclaration_FluidDataStoreContext = requireAssignableTo<TypeOnly<old.FluidDataStoreContext>, TypeOnly<current.FluidDataStoreContext>>
 
 /*
@@ -1606,6 +1607,7 @@ declare type current_as_old_for_VariableDeclaration_InactiveResponseHeaderKey = 
  * typeValidation.broken:
  * "ClassDeclaration_LocalFluidDataStoreContext": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_ClassDeclaration_LocalFluidDataStoreContext = requireAssignableTo<TypeOnly<old.LocalFluidDataStoreContext>, TypeOnly<current.LocalFluidDataStoreContext>>
 
 /*
@@ -1624,6 +1626,7 @@ declare type current_as_old_for_ClassDeclaration_LocalFluidDataStoreContext = re
  * typeValidation.broken:
  * "ClassDeclaration_LocalFluidDataStoreContextBase": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_ClassDeclaration_LocalFluidDataStoreContextBase = requireAssignableTo<TypeOnly<old.LocalFluidDataStoreContextBase>, TypeOnly<current.LocalFluidDataStoreContextBase>>
 
 /*

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -878,6 +878,7 @@ declare type old_as_current_for_InterfaceDeclaration_IGCNodeUpdatedProps = requi
  * typeValidation.broken:
  * "InterfaceDeclaration_IGCNodeUpdatedProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_InterfaceDeclaration_IGCNodeUpdatedProps = requireAssignableTo<TypeOnly<current.IGCNodeUpdatedProps>, TypeOnly<old.IGCNodeUpdatedProps>>
 
 /*

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -50,7 +50,7 @@
 		"test:realsvc:r11s:docker": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=docker --timeout=20s",
 		"test:realsvc:routerlicious": "npm run test:realsvc:r11s",
 		"test:realsvc:routerlicious:report": "npm run test:realsvc:r11s --",
-		"test:realsvc:run": "mocha lib/test --config src/test/.mocharc.cjs --exclude \"lib/test/benchmark/**/*\" --verbose",
+		"test:realsvc:run": "mocha lib/test/gc --config src/test/.mocharc.cjs --exclude \"lib/test/benchmark/**/*\" --verbose",
 		"test:realsvc:tinylicious": "start-server-and-test start:tinylicious:test 7070 test:realsvc:tinylicious:run",
 		"test:realsvc:tinylicious:report": "npm run test:realsvc:tinylicious",
 		"test:realsvc:tinylicious:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:tinylicious",


### PR DESCRIPTION
Recently, we have seen cases where GC deletes a data store which is loaded in summarizer but it's not loaded in regular clients. Ideally, this should never happen because there should be no way to load an unreferenced data store. 
However, the theory is that these data stores have trailing ops that were sent after they were unreferenced. A summarizer loads after sweep timeout and realizes the data store due to these trailing ops and then deletes it. This PR makes following changes to help identify these scenarios:
- Added telemetry when an unreferenced data store is realized during summarization. It adds properties such as number of trailing ops and if fullTree was enabled.
- Changed the `Context is deleted` errors to be data processing errors instead of data corruption errors because the document is not corrupted in these cases.
  
[AB#8802](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8802)

Here's a rough sketch Mark made of the scenario, in case it helps (added here by Mark)
![image](https://github.com/user-attachments/assets/19f4582b-6055-4dc3-b418-a1a1bd411646)
