### PR TITLE
ci: Require approval from fluid-cr-api for code ownership changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,8 @@
 #
 # ------------------------------------------------------------------------
 
+/.github/CODEOWNERS                            @microsoft/fluid-cr-api
+
 # ID compressor source
 /packages/runtime/id-compressor/src            @microsoft/fluid-cr-id-compressor
 


### PR DESCRIPTION
I noticed that changes to the codeowners file itself could be made without approval, since the file itself was not "owned". I made @microsoft/fluid-cr-api the owner, but perhaps it should be @microsoft/fluidframework-admin?