### PR TITLE
chore(merge-tree): Cleanup related to lint fixes 

### DIFF
--- a/packages/dds/merge-tree/src/attributionCollection.ts
+++ b/packages/dds/merge-tree/src/attributionCollection.ts
@@ -325,7 +325,7 @@ export class AttributionCollection implements IAttributionCollection<Attribution
 			if (i !== 0 || !areEqualAttributionKeys(lastEntry, other.keys[i])) {
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				this.offsets.push(other.offsets[i]! + this.length);
-				// TODO: see line 305
+				// Looping through the keys, so we can be sure that the key is not undefined.
 				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 				this.keys.push(other.keys[i]!);
 			}

--- a/packages/dds/merge-tree/src/endOfTreeSegment.ts
+++ b/packages/dds/merge-tree/src/endOfTreeSegment.ts
@@ -139,8 +139,8 @@ export class StartOfTreeSegment extends BaseEndpointSegment implements ISegment,
 	}
 
 	get ordinal(): string {
-		// Since ordinals don't deal with user input and would require minor behavior changes,
-		// disable the rule to use code points when dealing with ordinals.
+		// Ordinals exist purely for lexicographical sort order and use a small set of valid bytes for each string character.
+		// The extra handling fromCodePoint has for things like surrogate pairs is therefore unnecessary.
 		// eslint-disable-next-line unicorn/prefer-code-point
 		return String.fromCharCode(0x00);
 	}

--- a/packages/dds/merge-tree/src/endOfTreeSegment.ts
+++ b/packages/dds/merge-tree/src/endOfTreeSegment.ts
@@ -139,7 +139,10 @@ export class StartOfTreeSegment extends BaseEndpointSegment implements ISegment,
 	}
 
 	get ordinal(): string {
-		return String.fromCodePoint(0x00);
+		// Since ordinals don't deal with user input and would require minor behavior changes,
+		// disable the rule to use code points when dealing with ordinals.
+		// eslint-disable-next-line unicorn/prefer-code-point
+		return String.fromCharCode(0x00);
 	}
 }
 

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -651,7 +651,10 @@ export abstract class BaseSegment implements ISegment {
 		// Give the leaf a temporary yet valid ordinal.
 		// when this segment is put in the tree, it will get its real ordinal,
 		// but this ordinal meets all the necessary invariants for now.
-		leafSegment.ordinal = this.ordinal + String.fromCodePoint(0);
+		// Since ordinals don't deal with user input and would require minor behavior changes,
+		// disable the rule to use code points when dealing with ordinals.
+		// eslint-disable-next-line unicorn/prefer-code-point
+		leafSegment.ordinal = this.ordinal + String.fromCharCode(0);
 
 		leafSegment.removedClientIds = this.removedClientIds?.slice();
 		leafSegment.removedSeq = this.removedSeq;
@@ -913,15 +916,11 @@ export class CollaborationWindow {
 
 /**
  * Compares two numbers.
- *
- * @internal
  */
 export const compareNumbers = (a: number, b: number): number => a - b;
 
 /**
  * Compares two strings.
- *
- * @internal
  */
 export const compareStrings = (a: string, b: string): number => a.localeCompare(b);
 

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -651,8 +651,8 @@ export abstract class BaseSegment implements ISegment {
 		// Give the leaf a temporary yet valid ordinal.
 		// when this segment is put in the tree, it will get its real ordinal,
 		// but this ordinal meets all the necessary invariants for now.
-		// Since ordinals don't deal with user input and would require minor behavior changes,
-		// disable the rule to use code points when dealing with ordinals.
+		// Ordinals exist purely for lexicographical sort order and use a small set of valid bytes for each string character.
+		// The extra handling fromCodePoint has for things like surrogate pairs is therefore unnecessary.
 		// eslint-disable-next-line unicorn/prefer-code-point
 		leafSegment.ordinal = this.ordinal + String.fromCharCode(0);
 

--- a/packages/dds/merge-tree/src/ordinal.ts
+++ b/packages/dds/merge-tree/src/ordinal.ts
@@ -19,13 +19,18 @@ export function computeHierarchicalOrdinal(
 
 	const ordinalWidth = 1 << (maxCount - actualCount);
 	let ordinal: string;
-	if (previousOrdinal === undefined || previousOrdinal === "") {
-		ordinal = parentOrdinal + String.fromCodePoint(ordinalWidth - 1);
+	if (previousOrdinal === undefined) {
+		// Since ordinals don't deal with user input and would require minor behavior changes,
+		// disable the rule to use code points when dealing with ordinals.
+		// eslint-disable-next-line unicorn/prefer-code-point
+		ordinal = parentOrdinal + String.fromCharCode(ordinalWidth - 1);
 	} else {
-		const prevOrdCode = previousOrdinal.codePointAt(previousOrdinal.length - 1);
+		// eslint-disable-next-line unicorn/prefer-code-point
+		const prevOrdCode = previousOrdinal.charCodeAt(previousOrdinal.length - 1);
 		assert(prevOrdCode !== undefined, "previous ordinal should not be empty");
 		const localOrdinal = prevOrdCode + ordinalWidth;
-		ordinal = parentOrdinal + String.fromCodePoint(localOrdinal);
+		// eslint-disable-next-line unicorn/prefer-code-point
+		ordinal = parentOrdinal + String.fromCharCode(localOrdinal);
 	}
 
 	return ordinal;

--- a/packages/dds/merge-tree/src/ordinal.ts
+++ b/packages/dds/merge-tree/src/ordinal.ts
@@ -20,7 +20,8 @@ export function computeHierarchicalOrdinal(
 	const ordinalWidth = 1 << (maxCount - actualCount);
 	let ordinal: string;
 	if (previousOrdinal === undefined) {
-		// Since ordinals don't deal with user input and would require minor behavior changes,
+		// Ordinals exist purely for lexicographical sort order and use a small set of valid bytes for each string character.
+		// The extra handling fromCodePoint has for things like surrogate pairs is therefore unnecessary.
 		// disable the rule to use code points when dealing with ordinals.
 		// eslint-disable-next-line unicorn/prefer-code-point
 		ordinal = parentOrdinal + String.fromCharCode(ordinalWidth - 1);

--- a/packages/dds/merge-tree/src/test/ordinal.spec.ts
+++ b/packages/dds/merge-tree/src/test/ordinal.spec.ts
@@ -11,8 +11,12 @@ import { doOverRange } from "./mergeTreeOperationRunner.js";
 
 function computeNumericOrdinal(index: number): string {
 	const prefixLen = Math.floor(index / 0xffff);
-	const prefix = String.fromCodePoint(0xffff).repeat(prefixLen);
-	return `${prefix}${String.fromCodePoint(index - prefixLen * 0xffff)}`;
+	// Since ordinals don't deal with user input and would require minor behavior changes,
+	// disable the rule to use code points when dealing with ordinals.
+	// eslint-disable-next-line unicorn/prefer-code-point
+	const prefix = String.fromCharCode(0xffff).repeat(prefixLen);
+	// eslint-disable-next-line unicorn/prefer-code-point
+	return `${prefix}${String.fromCharCode(index - prefixLen * 0xffff)}`;
 }
 
 describe("MergeTree.ordinals", () => {
@@ -20,7 +24,8 @@ describe("MergeTree.ordinals", () => {
 		{ min: 1, max: 16 },
 		(i) => i + 1,
 		(max) => {
-			let parentOrdinal = String.fromCodePoint(0);
+			// eslint-disable-next-line unicorn/prefer-code-point
+			let parentOrdinal = String.fromCharCode(0);
 			it(`Max ${max}`, () => {
 				doOverRange(
 					{ min: 1, max },
@@ -44,7 +49,8 @@ describe("MergeTree.ordinals", () => {
 	);
 
 	it("numericOrdinal", () => {
-		let previous = String.fromCodePoint(0);
+		// eslint-disable-next-line unicorn/prefer-code-point
+		let previous = String.fromCharCode(0);
 		for (let i = 2; i < Number.MAX_SAFE_INTEGER; i = Math.pow(i, 2)) {
 			const current = computeNumericOrdinal(i);
 			assert(

--- a/packages/dds/merge-tree/src/test/ordinal.spec.ts
+++ b/packages/dds/merge-tree/src/test/ordinal.spec.ts
@@ -11,8 +11,8 @@ import { doOverRange } from "./mergeTreeOperationRunner.js";
 
 function computeNumericOrdinal(index: number): string {
 	const prefixLen = Math.floor(index / 0xffff);
-	// Since ordinals don't deal with user input and would require minor behavior changes,
-	// disable the rule to use code points when dealing with ordinals.
+	// Ordinals exist purely for lexicographical sort order and use a small set of valid bytes for each string character.
+	// The extra handling fromCodePoint has for things like surrogate pairs is therefore unnecessary.
 	// eslint-disable-next-line unicorn/prefer-code-point
 	const prefix = String.fromCharCode(0xffff).repeat(prefixLen);
 	// eslint-disable-next-line unicorn/prefer-code-point


### PR DESCRIPTION
Minor improvements to #21684, including disabling [prefer-code-point](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-code-point.md) for ordinals, reverting function scope changes, and updating documentation. 