### PR TITLE
Remove boxedContent from flex API

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -282,16 +282,6 @@ export class EagerMapTreeFieldNode<TSchema extends FlexFieldNodeSchema>
 		return unboxedField(field, EmptyKey, this.mapTree, this);
 	}
 
-	public get boxedContent(): FlexTreeTypedField<TSchema["info"]> {
-		const field = this.mapTree.fields.get(EmptyKey) ?? [];
-		return getOrCreateField(
-			this,
-			EmptyKey,
-			field,
-			this.schema.info,
-		) as unknown as FlexTreeTypedField<TSchema["info"]>;
-	}
-
 	public override getBoxed(key: string): FlexTreeTypedField<TSchema["info"]> {
 		return super.getBoxed(key) as FlexTreeTypedField<TSchema["info"]>;
 	}
@@ -518,10 +508,6 @@ class MapTreeRequiredField<T extends FlexAllowedTypes>
 	public set content(_: FlexTreeUnboxNodeUnion<T>) {
 		throw unsupportedUsageError("Setting an optional field");
 	}
-
-	public get boxedContent(): FlexTreeTypedNodeUnion<T> {
-		return this.boxedAt(0) ?? fail("Required field must have exactly one node");
-	}
 }
 
 class MapTreeOptionalField<T extends FlexAllowedTypes>
@@ -535,10 +521,6 @@ class MapTreeOptionalField<T extends FlexAllowedTypes>
 	}
 	public set content(_: FlexTreeUnboxNodeUnion<T> | undefined) {
 		throw unsupportedUsageError("Setting an optional field");
-	}
-
-	public get boxedContent(): FlexTreeTypedNodeUnion<T> | undefined {
-		return this.boxedAt(0);
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -456,20 +456,8 @@ export interface FlexTreeFieldNode<in out TSchema extends FlexFieldNodeSchema>
 
 	/**
 	 * The content this field node wraps.
-	 * @remarks
-	 * This is a version of {@link FlexTreeFieldNode.boxedContent} but does unboxing.
-	 * Since field node are usually used to wrap fields which don't do unboxing (like {@link FlexTreeSequenceField})
 	 */
 	readonly content: FlexTreeUnboxField<TSchema["info"]>;
-	/**
-	 * The field this field node wraps.
-	 *
-	 * @remarks
-	 * Since field nodes are usually used to wrap fields which don't do unboxing (like {@link FlexTreeSequenceField}),
-	 * this is usually the same as {@link FlexTreeFieldNode.content}.
-	 * This is also the same as `[...this][0]`.
-	 */
-	readonly boxedContent: FlexTreeTypedField<TSchema["info"]>;
 }
 
 /**
@@ -975,8 +963,6 @@ export interface FlexTreeRequiredField<in out TTypes extends FlexAllowedTypes>
 	extends FlexTreeField {
 	get content(): FlexTreeUnboxNodeUnion<TTypes>;
 	set content(content: FlexibleNodeContent<TTypes>);
-
-	readonly boxedContent: FlexTreeTypedNodeUnion<TTypes>;
 }
 
 /**
@@ -997,8 +983,6 @@ export interface FlexTreeOptionalField<in out TTypes extends FlexAllowedTypes>
 	extends FlexTreeField {
 	get content(): FlexTreeUnboxNodeUnion<TTypes> | undefined;
 	set content(newContent: FlexibleNodeContent<TTypes> | undefined);
-
-	readonly boxedContent?: FlexTreeTypedNodeUnion<TTypes>;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -487,10 +487,6 @@ export class ReadonlyLazyValueField<TTypes extends FlexAllowedTypes>
 	public set content(newContent: FlexibleNodeContent<TTypes>) {
 		fail("cannot set content in readonly field");
 	}
-
-	public get boxedContent(): FlexTreeTypedNodeUnion<TTypes> {
-		return this.boxedAt(0) ?? fail("value node must have 1 item");
-	}
 }
 
 export class LazyValueField<TTypes extends FlexAllowedTypes>
@@ -523,10 +519,6 @@ export class LazyValueField<TTypes extends FlexAllowedTypes>
 		const fieldEditor = this.valueFieldEditor();
 		assert(content.length === 1, 0x780 /* value field content should normalize to one item */);
 		fieldEditor.set(content[0]);
-	}
-
-	public override get boxedContent(): FlexTreeTypedNodeUnion<TTypes> {
-		return this.boxedAt(0) ?? fail("value node must have 1 item");
 	}
 }
 
@@ -580,10 +572,6 @@ export class LazyOptionalField<TTypes extends FlexAllowedTypes>
 			0x781 /* optional field content should normalize at most one item */,
 		);
 		fieldEditor.set(content.length === 0 ? undefined : content[0], this.length === 0);
-	}
-
-	public get boxedContent(): FlexTreeTypedNodeUnion<TTypes> | undefined {
-		return this.length === 0 ? undefined : this.boxedAt(0);
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -434,12 +434,6 @@ export class LazyFieldNode<TSchema extends FlexFieldNodeSchema>
 			unboxedField(this.context, this.schema.info, cursor),
 		) as FlexTreeUnboxField<TSchema["info"]>;
 	}
-
-	public get boxedContent(): FlexTreeTypedField<TSchema["info"]> {
-		return inCursorField(this[cursorSymbol], EmptyKey, (cursor) =>
-			makeField(this.context, this.schema.info, cursor),
-		) as FlexTreeTypedField<TSchema["info"]>;
-	}
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -558,10 +558,8 @@ function createArrayNodeProxy(
 				return Reflect.get(dispatchTarget, key, receiver) as unknown;
 			}
 
-			const maybeUnboxedContent = field.at(maybeIndex);
-			return isFlexTreeNode(maybeUnboxedContent)
-				? getOrCreateNodeProxy(maybeUnboxedContent)
-				: maybeUnboxedContent;
+			const maybeContent = field.at(maybeIndex);
+			return isFlexTreeNode(maybeContent) ? getOrCreateNodeProxy(maybeContent) : maybeContent;
 		},
 		set: (target, key, newValue, receiver) => {
 			if (key === "length") {

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -61,10 +61,8 @@ export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | u
 			FlexFieldSchema<typeof FieldKinds.required | typeof FieldKinds.optional>
 		>,
 	): TreeNode | TreeValue | undefined {
-		const maybeUnboxedContent = flexField.content;
-		return isFlexTreeNode(maybeUnboxedContent)
-			? getOrCreateNodeProxy(maybeUnboxedContent)
-			: maybeUnboxedContent;
+		const maybeContent = flexField.content;
+		return isFlexTreeNode(maybeContent) ? getOrCreateNodeProxy(maybeContent) : maybeContent;
 	}
 	switch (field.schema.kind) {
 		case FieldKinds.required: {

--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -152,7 +152,6 @@ describe("MapTreeNodes", () => {
 		assert.equal(fieldNode.getBoxed(EmptyKey).at(1), undefined);
 		assert.equal([...fieldNode.boxedIterator()].length, 1);
 		assert.equal([...fieldNode.boxedIterator()][0].boxedAt(0)?.value, childValue);
-		assert.deepEqual(fieldNode.boxedContent.length, 1);
 		assert.deepEqual([...fieldNode.content], [childValue]);
 	});
 

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/editableTreeTypes.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/editableTreeTypes.spec.ts
@@ -54,23 +54,6 @@ import type {
 
 describe("flexTreeTypes", () => {
 	/**
-	 * Example showing narrowing and exhaustive matches.
-	 */
-	function exhaustiveMatchSimple(root: FlexTreeField): void {
-		const schema = SchemaBuilder.required([() => leaf.number, leaf.string]);
-		assert(root.is(schema));
-		const tree = root.boxedContent;
-		if (tree.is(leaf.number)) {
-			const n: number = tree.value;
-		} else if (tree.is(leaf.string)) {
-			const s: string = tree.value;
-		} else {
-			// Proves at compile time exhaustive match checking works, and tree is typed `never`.
-			unreachableCase(tree);
-		}
-	}
-
-	/**
 	 * Example showing the node kinds used in the json domain (everything except structs),
 	 * including narrowing and exhaustive matches.
 	 */
@@ -140,7 +123,6 @@ describe("flexTreeTypes", () => {
 	 */
 	function boxingExample(mixed: Mixed): void {
 		const leafNode: number = mixed.leaf;
-		const leafBoxed: FlexTreeTypedNode<typeof leaf.number> = mixed.boxedLeaf.boxedContent;
 
 		// Current policy is to box polymorphic values so they can be checked for type with `is`.
 		// Note that this still unboxes the value field.
@@ -154,8 +136,6 @@ describe("flexTreeTypes", () => {
 		> = mixed.boxedPolymorphic;
 
 		const optionalLeaf: number | undefined = mixed.optionalLeaf;
-		const boxedOptionalLeaf: FlexTreeTypedNode<typeof leaf.number> | undefined =
-			mixed.boxedOptionalLeaf.boxedContent;
 		const sequence: FlexTreeSequenceField<readonly [typeof leaf.number]> = mixed.sequence;
 
 		const child: number | undefined = sequence.at(0);

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -305,8 +305,8 @@ describe("SharedTree", () => {
 			schema,
 		});
 		const root = view.flexTree;
-		const leafNode = root.boxedContent;
-		assert.equal(leafNode.value, 1);
+		const leafNode = root.boxedAt(0);
+		assert.equal(leafNode?.value, 1);
 		root.content = 2;
 		assert(leafNode.treeStatus() !== TreeStatus.InDocument);
 		assert.equal(root.content, 2);


### PR DESCRIPTION
## Description

This API is no longer used by simple-tree and can therefore be removed.
