### PR TITLE
Don't suggest autoImport from -previous package versions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,13 @@
 
 	// We prefer to use type-only imports, so we want the autoimporter to do that by default.
 	"typescript.preferences.preferTypeOnlyAutoImports": true,
+	"typescript.preferences.autoImportFileExcludePatterns": [
+		"**/dist/**",
+		"**/lib/**",
+		// Avoid suggesting autoimports for the 'previous' version packages which are used for typetesting.
+		"**/node_modules/**/@fluid*/*-previous",
+		"**/node_modules/**/@fluid*/*-previous/*",
+	],
 
 	// Autodetecting tasks on a repo this size makes 'Tasks: Run Build Task' unusably slow.
 	// (See https://github.com/Microsoft/vscode/issues/34387)

--- a/packages/dds/tree/.vscode/Tree.code-workspace
+++ b/packages/dds/tree/.vscode/Tree.code-workspace
@@ -11,7 +11,14 @@
 	],
 	"settings": {
 		"search.followSymlinks": false,
-		"typescript.preferences.autoImportFileExcludePatterns": ["**/dist/**"],
+		"typescript.preferences.autoImportFileExcludePatterns": [
+			"**/dist/**",
+			"**/lib/**",
+			// Avoid suggesting autoimports for the 'previous' version packages which are used for typetesting.
+			"**/node_modules/**/@fluid*/*-previous",
+			"**/node_modules/**/@fluid*/*-previous/*"
+		],
+		"typescript.preferences.includePackageJsonAutoImports": "on",
 		"typescript.preferences.importModuleSpecifier": "project-relative"
 	}
 }


### PR DESCRIPTION
## Description

Tweaks vscode settings to avoid having typescript suggest auto imports from various `-previous` package versions which we use for type testing. These imports are basically always wrong, and can frequently lead to confusing errors (because the type will usually be *close* to the type you really want).

Note: auto imports are a bit finnicky, and I wasn't able to validate this works myself due to not seeing the problematic auto imports in the baseline. But I know I have seen them in the past, and Noah (who was seeing problematic imports) confirmed that this removed them.