### PR TITLE
Revert typescript.preferences.includePackageJsonAutoImports to 'auto'

### DIFF
--- a/packages/dds/tree/.vscode/Tree.code-workspace
+++ b/packages/dds/tree/.vscode/Tree.code-workspace
@@ -18,7 +18,6 @@
 			"**/node_modules/**/@fluid*/*-previous",
 			"**/node_modules/**/@fluid*/*-previous/*"
 		],
-		"typescript.preferences.includePackageJsonAutoImports": "on",
 		"typescript.preferences.importModuleSpecifier": "project-relative"
 	}
 }


### PR DESCRIPTION
## Description

Removes a stray change in #21890 that I was using for validation of auto imports. There's no compelling reason to force auto import of dependencies in the tree workspace; the default behavior (do so when it doesn't have a huge performance impact) is adequate.

![image](https://github.com/user-attachments/assets/7c4b36c4-10a3-4259-83e7-1d70e1d9c4d0)

