### PR TITLE
Count trees with GroupId separately in telemetry in odsp driver

### DIFF
--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -222,9 +222,6 @@ function readTreeSection(node: NodeCore): {
 				const groupId = getStringInstance(records.groupId, "groupId should be a string");
 				// Non null asserting since trees[path] is already created
 				trees[path]!.groupId = groupId;
-				// If the trees has a groupId, then count that separately as we didn't put its parsing
-				// into above path deliberately to reduce number of special cases.
-				slowTreeStructureCount -= 1;
 				treeStructureCountWithGroupId += 1;
 			}
 			slowTreeStructureCount += result.slowTreeStructureCount;

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -197,7 +197,7 @@ function readTreeSection(node: NodeCore): {
 		/**
 		 * More generalized workflow
 		 */
-		slowTreeStructureCount += 1;
+		slowTreeStructureCount++;
 		const records = getNodeProps(treeNode);
 
 		if (records.unreferenced !== undefined) {
@@ -222,7 +222,7 @@ function readTreeSection(node: NodeCore): {
 				const groupId = getStringInstance(records.groupId, "groupId should be a string");
 				// Non null asserting since trees[path] is already created
 				trees[path]!.groupId = groupId;
-				treeStructureCountWithGroupId += 1;
+				treeStructureCountWithGroupId++;
 			}
 			slowTreeStructureCount += result.slowTreeStructureCount;
 			treeStructureCountWithGroupId += result.treeStructureCountWithGroupId;

--- a/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
+++ b/packages/drivers/odsp-driver/src/compactSnapshotParser.ts
@@ -114,8 +114,10 @@ function readOpsSection(node: NodeTypes): ISequencedDocumentMessage[] {
 function readTreeSection(node: NodeCore): {
 	snapshotTree: ISnapshotTree;
 	slowTreeStructureCount: number;
+	treeStructureCountWithGroupId: number;
 } {
 	let slowTreeStructureCount = 0;
+	let treeStructureCountWithGroupId = 0;
 	const trees: Record<string, ISnapshotTree> = {};
 	const snapshotTree: ISnapshotTree = {
 		blobs: {},
@@ -146,6 +148,7 @@ function readTreeSection(node: NodeCore): {
 						const result = readTreeSection(treeNode.getNode(3));
 						trees[treeNode.getString(1)] = result.snapshotTree;
 						slowTreeStructureCount += result.slowTreeStructureCount;
+						treeStructureCountWithGroupId += result.treeStructureCountWithGroupId;
 						continue;
 					}
 					// "name": <node name>
@@ -178,6 +181,7 @@ function readTreeSection(node: NodeCore): {
 						const result = readTreeSection(treeNode.getNode(5));
 						trees[treeNode.getString(1)] = result.snapshotTree;
 						slowTreeStructureCount += result.slowTreeStructureCount;
+						treeStructureCountWithGroupId += result.treeStructureCountWithGroupId;
 						assert(treeNode.getBool(3), 0x3db /* Unreferenced if present should be true */);
 						snapshotTree.unreferenced = true;
 						continue;
@@ -218,13 +222,18 @@ function readTreeSection(node: NodeCore): {
 				const groupId = getStringInstance(records.groupId, "groupId should be a string");
 				// Non null asserting since trees[path] is already created
 				trees[path]!.groupId = groupId;
+				// If the trees has a groupId, then count that separately as we didn't put its parsing
+				// into above path deliberately to reduce number of special cases.
+				slowTreeStructureCount -= 1;
+				treeStructureCountWithGroupId += 1;
 			}
 			slowTreeStructureCount += result.slowTreeStructureCount;
+			treeStructureCountWithGroupId += result.treeStructureCountWithGroupId;
 		} else {
 			trees[path] = { blobs: {}, trees: {} };
 		}
 	}
-	return { snapshotTree, slowTreeStructureCount };
+	return { snapshotTree, slowTreeStructureCount, treeStructureCountWithGroupId };
 }
 
 /**
@@ -235,6 +244,7 @@ function readSnapshotSection(node: NodeTypes): {
 	sequenceNumber: number;
 	snapshotTree: ISnapshotTree;
 	slowTreeStructureCount: number;
+	treeStructureCountWithGroupId: number;
 } {
 	assertNodeCoreInstance(node, "Snapshot should be of type NodeCore");
 	const records = getNodeProps(node);
@@ -243,7 +253,8 @@ function readSnapshotSection(node: NodeTypes): {
 	assertNodeCoreInstance(records.treeNodes!, "TreeNodes should be of type NodeCore");
 	// TODO Why are we non null asserting here?
 	assertNumberInstance(records.sequenceNumber!, "sequenceNumber should be of type number");
-	const { snapshotTree, slowTreeStructureCount } = readTreeSection(records.treeNodes);
+	const { snapshotTree, slowTreeStructureCount, treeStructureCountWithGroupId } =
+		readTreeSection(records.treeNodes);
 	// TODO Why are we non null asserting here?
 	snapshotTree.id = getStringInstance(records.id!, "snapshotId should be string");
 	const sequenceNumber = records.sequenceNumber.valueOf();
@@ -251,6 +262,7 @@ function readSnapshotSection(node: NodeTypes): {
 		sequenceNumber,
 		snapshotTree,
 		slowTreeStructureCount,
+		treeStructureCountWithGroupId,
 	};
 }
 
@@ -310,6 +322,7 @@ export function parseCompactSnapshotResponse(
 			durationBlobs,
 			slowTreeStructureCount: snapshot.slowTreeStructureCount,
 			slowBlobStructureCount: blobContents.slowBlobStructureCount,
+			treeStructureCountWithGroupId: snapshot.treeStructureCountWithGroupId,
 		},
 	};
 }

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -454,7 +454,7 @@ async function fetchLatestSnapshotCore(
 						const slowTreeParseCodePaths = props.slowTreeStructureCount ?? 0;
 						const slowBlobParseCodePaths = props.slowBlobStructureCount ?? 0;
 						const treeStructureCountWithGroupId = props.treeStructureCountWithGroupId ?? 0;
-						// As snapshot with groupId go through normal parsing, so exclude them.
+						// As trees with groupId go through normal parsing, so exclude them.
 						if (
 							slowTreeParseCodePaths - treeStructureCountWithGroupId > 10 ||
 							slowBlobParseCodePaths > 10

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -454,8 +454,11 @@ async function fetchLatestSnapshotCore(
 						const slowTreeParseCodePaths = props.slowTreeStructureCount ?? 0;
 						const slowBlobParseCodePaths = props.slowBlobStructureCount ?? 0;
 						const treeStructureCountWithGroupId = props.treeStructureCountWithGroupId ?? 0;
-						// Increasing it to 100 to be an error event, as snapshot with groupId go through normal parsing.
-						if (slowTreeParseCodePaths > 100 || slowBlobParseCodePaths > 10) {
+						// As snapshot with groupId go through normal parsing, so exclude them.
+						if (
+							slowTreeParseCodePaths - treeStructureCountWithGroupId > 10 ||
+							slowBlobParseCodePaths > 10
+						) {
 							logger.sendErrorEvent({
 								eventName: "SlowSnapshotParseCodePaths",
 								slowTreeStructureCount: slowTreeParseCodePaths,

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -453,11 +453,17 @@ async function fetchLatestSnapshotCore(
 						const props = snapshotContents.telemetryProps;
 						const slowTreeParseCodePaths = props.slowTreeStructureCount ?? 0;
 						const slowBlobParseCodePaths = props.slowBlobStructureCount ?? 0;
-						if (slowTreeParseCodePaths > 10 || slowBlobParseCodePaths > 10) {
+						const treeStructureCountWithGroupId = props.treeStructureCountWithGroupId ?? 0;
+						if (
+							slowTreeParseCodePaths > 10 ||
+							slowBlobParseCodePaths > 10 ||
+							treeStructureCountWithGroupId > 100
+						) {
 							logger.sendErrorEvent({
 								eventName: "SlowSnapshotParseCodePaths",
 								slowTreeStructureCount: slowTreeParseCodePaths,
 								slowBlobStructureCount: slowBlobParseCodePaths,
+								treeStructureCountWithGroupId,
 							});
 						}
 						parsedSnapshotContents = { ...odspResponse, content: snapshotContents };

--- a/packages/drivers/odsp-driver/src/fetchSnapshot.ts
+++ b/packages/drivers/odsp-driver/src/fetchSnapshot.ts
@@ -454,11 +454,8 @@ async function fetchLatestSnapshotCore(
 						const slowTreeParseCodePaths = props.slowTreeStructureCount ?? 0;
 						const slowBlobParseCodePaths = props.slowBlobStructureCount ?? 0;
 						const treeStructureCountWithGroupId = props.treeStructureCountWithGroupId ?? 0;
-						if (
-							slowTreeParseCodePaths > 10 ||
-							slowBlobParseCodePaths > 10 ||
-							treeStructureCountWithGroupId > 100
-						) {
+						// Increasing it to 100 to be an error event, as snapshot with groupId go through normal parsing.
+						if (slowTreeParseCodePaths > 100 || slowBlobParseCodePaths > 10) {
 							logger.sendErrorEvent({
 								eventName: "SlowSnapshotParseCodePaths",
 								slowTreeStructureCount: slowTreeParseCodePaths,

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -265,7 +265,7 @@ describe("Snapshot Format Conversion Tests", () => {
 		);
 		assert(result.telemetryProps.slowBlobStructureCount === 0);
 		// there is { name, unreferenced } structure (i.e. empty unreferenced tree) that we do not optimize
-		assert(result.telemetryProps.slowTreeStructureCount === 1);
+		assert(result.telemetryProps.slowTreeStructureCount === 4);
 		assert(result.telemetryProps.treeStructureCountWithGroupId === 3);
 
 		// Convert to compact snapshot again and then match to previous one.

--- a/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/snapshotFormatTests.spec.ts
@@ -265,7 +265,8 @@ describe("Snapshot Format Conversion Tests", () => {
 		);
 		assert(result.telemetryProps.slowBlobStructureCount === 0);
 		// there is { name, unreferenced } structure (i.e. empty unreferenced tree) that we do not optimize
-		assert(result.telemetryProps.slowTreeStructureCount === 4);
+		assert(result.telemetryProps.slowTreeStructureCount === 1);
+		assert(result.telemetryProps.treeStructureCountWithGroupId === 3);
 
 		// Convert to compact snapshot again and then match to previous one.
 		const compactSnapshot2 = convertToCompactSnapshot(result);


### PR DESCRIPTION
## Description

Count trees with GroupId separately in telemetry in ODSP driver when parsing the snapshot as we didn't put its parsing into above path deliberately to reduce number of special cases for parsing.