### PR TITLE
[GC] Removed deprecated getBaseGCDetails and related code

### DIFF
--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -155,6 +155,10 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"InterfaceDeclaration_IDataObjectProps": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -157,6 +157,7 @@ declare type old_as_current_for_InterfaceDeclaration_IDataObjectProps = requireA
  * typeValidation.broken:
  * "InterfaceDeclaration_IDataObjectProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_InterfaceDeclaration_IDataObjectProps = requireAssignableTo<TypeOnly<current.IDataObjectProps>, TypeOnly<old.IDataObjectProps>>
 
 /*

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -232,15 +232,21 @@
 	"typeValidation": {
 		"broken": {
 			"ClassDeclaration_LocalFluidDataStoreContext": {
+				"backCompat": false,
 				"forwardCompat": false
 			},
 			"ClassDeclaration_FluidDataStoreContext": {
+				"backCompat": false,
 				"forwardCompat": false
 			},
 			"ClassDeclaration_LocalFluidDataStoreContextBase": {
+				"backCompat": false,
 				"forwardCompat": false
 			},
 			"InterfaceDeclaration_IGCNodeUpdatedProps": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_IFluidDataStoreContextInternal": {
 				"backCompat": false
 			}
 		}

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -45,7 +45,6 @@ import {
 	IFluidDataStoreContextDetached,
 	IFluidDataStoreRegistry,
 	IFluidParentContext,
-	IGarbageCollectionDetailsBase,
 	IProvideFluidDataStoreFactory,
 	ISummarizeInternalResult,
 	ISummarizeResult,
@@ -930,13 +929,6 @@ export abstract class FluidDataStoreContext
 	 */
 	public setInMemoryRoot(): void {
 		this._isInMemoryRoot = true;
-	}
-
-	/**
-	 * @deprecated The functionality to get base GC details has been moved to summarizer node.
-	 */
-	public async getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase> {
-		return {};
 	}
 
 	public reSubmit(type: string, contents: any, localOpMetadata: unknown) {

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -284,6 +284,7 @@ declare type old_as_current_for_ClassDeclaration_FluidDataStoreContext = require
  * typeValidation.broken:
  * "ClassDeclaration_FluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassDeclaration_FluidDataStoreContext = requireAssignableTo<TypeOnly<current.FluidDataStoreContext>, TypeOnly<old.FluidDataStoreContext>>
 
 /*
@@ -824,6 +825,7 @@ declare type old_as_current_for_InterfaceDeclaration_IFluidDataStoreContextInter
  * typeValidation.broken:
  * "InterfaceDeclaration_IFluidDataStoreContextInternal": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_InterfaceDeclaration_IFluidDataStoreContextInternal = requireAssignableTo<TypeOnly<current.IFluidDataStoreContextInternal>, TypeOnly<old.IFluidDataStoreContextInternal>>
 
 /*
@@ -1618,6 +1620,7 @@ declare type old_as_current_for_ClassDeclaration_LocalFluidDataStoreContext = re
  * typeValidation.broken:
  * "ClassDeclaration_LocalFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassDeclaration_LocalFluidDataStoreContext = requireAssignableTo<TypeOnly<current.LocalFluidDataStoreContext>, TypeOnly<old.LocalFluidDataStoreContext>>
 
 /*
@@ -1637,6 +1640,7 @@ declare type old_as_current_for_ClassDeclaration_LocalFluidDataStoreContextBase 
  * typeValidation.broken:
  * "ClassDeclaration_LocalFluidDataStoreContextBase": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassDeclaration_LocalFluidDataStoreContextBase = requireAssignableTo<TypeOnly<current.LocalFluidDataStoreContextBase>, TypeOnly<old.LocalFluidDataStoreContextBase>>
 
 /*

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -17,8 +17,7 @@ export interface AttributionInfo {
 export type AttributionKey = OpAttributionKey | DetachedAttributionKey | LocalAttributionKey;
 
 // @alpha (undocumented)
-export type CreateChildSummarizerNodeFn = (summarizeInternal: SummarizeInternalFn, getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>) => ISummarizerNodeWithGC;
+export type CreateChildSummarizerNodeFn = (summarizeInternal: SummarizeInternalFn, getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>) => ISummarizerNodeWithGC;
 
 // @alpha (undocumented)
 export type CreateChildSummarizerNodeParam = {
@@ -152,8 +151,6 @@ export interface IFluidDataStoreContext extends IFluidParentContext {
     readonly baseSnapshot: ISnapshotTree | undefined;
     // @deprecated (undocumented)
     readonly createProps?: any;
-    // @deprecated (undocumented)
-    getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
     // (undocumented)
     readonly id: string;
     readonly isLocalDataStore: boolean;
@@ -316,8 +313,7 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     summarizeInternalFn: SummarizeInternalFn,
     id: string,
     createParam: CreateChildSummarizerNodeParam,
-    config?: ISummarizerNodeConfigWithGC, getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-    getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>): ISummarizerNodeWithGC;
+    config?: ISummarizerNodeConfigWithGC, getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>): ISummarizerNodeWithGC;
     deleteChild(id: string): void;
     // (undocumented)
     getChild(id: string): ISummarizerNodeWithGC | undefined;

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -111,6 +111,13 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"InterfaceDeclaration_IFluidDataStoreContext": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_IFluidDataStoreContextDetached": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -30,10 +30,7 @@ import type { IIdCompressor } from "@fluidframework/id-compressor";
 
 import type { IProvideFluidDataStoreFactory } from "./dataStoreFactory.js";
 import type { IProvideFluidDataStoreRegistry } from "./dataStoreRegistry.js";
-import type {
-	IGarbageCollectionData,
-	IGarbageCollectionDetailsBase,
-} from "./garbageCollectionDefinitions.js";
+import type { IGarbageCollectionData } from "./garbageCollectionDefinitions.js";
 import type { IInboundSignalMessage } from "./protocol.js";
 import type {
 	CreateChildSummarizerNodeParam,
@@ -388,10 +385,6 @@ export interface IFluidDataStoreChannel extends IDisposable {
 export type CreateChildSummarizerNodeFn = (
 	summarizeInternal: SummarizeInternalFn,
 	getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-	/**
-	 * @deprecated The functionality to get base GC details has been moved to summarizer node.
-	 */
-	getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
 ) => ISummarizerNodeWithGC;
 
 /**
@@ -553,14 +546,6 @@ export interface IFluidDataStoreContext extends IFluidParentContext {
 	 * @deprecated 0.16 Issue #1635, #3631
 	 */
 	readonly createProps?: any;
-
-	/**
-	 * @deprecated The functionality to get base GC details has been moved to summarizer node.
-	 *
-	 * Returns the GC details in the initial summary of this data store. This is used to initialize the data store
-	 * and its children with the GC details from the previous summary.
-	 */
-	getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
 }
 
 /**

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -13,10 +13,7 @@ import type {
 } from "@fluidframework/driver-definitions/internal";
 import type { TelemetryEventPropertyTypeExt } from "@fluidframework/telemetry-utils/internal";
 
-import type {
-	IGarbageCollectionData,
-	IGarbageCollectionDetailsBase,
-} from "./garbageCollectionDefinitions.js";
+import type { IGarbageCollectionData } from "./garbageCollectionDefinitions.js";
 
 /**
  * Contains the aggregation data from a Tree/Subtree.
@@ -293,10 +290,6 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
 		 */
 		config?: ISummarizerNodeConfigWithGC,
 		getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-		/**
-		 * @deprecated The functionality to update child's base GC details is incorporated in the summarizer node.
-		 */
-		getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
 	): ISummarizerNodeWithGC;
 
 	/**

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -337,6 +337,7 @@ declare type old_as_current_for_InterfaceDeclaration_IFluidDataStoreContext = re
  * typeValidation.broken:
  * "InterfaceDeclaration_IFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_InterfaceDeclaration_IFluidDataStoreContext = requireAssignableTo<TypeOnly<current.IFluidDataStoreContext>, TypeOnly<old.IFluidDataStoreContext>>
 
 /*
@@ -355,6 +356,7 @@ declare type old_as_current_for_InterfaceDeclaration_IFluidDataStoreContextDetac
  * typeValidation.broken:
  * "InterfaceDeclaration_IFluidDataStoreContextDetached": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_InterfaceDeclaration_IFluidDataStoreContextDetached = requireAssignableTo<TypeOnly<current.IFluidDataStoreContextDetached>, TypeOnly<old.IFluidDataStoreContextDetached>>
 
 /*

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -313,8 +313,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // (undocumented)
     getAudience(): IAudience;
     // (undocumented)
-    getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
-    // (undocumented)
     getCreateChildSummarizerNodeFn(id: string, createParam: CreateChildSummarizerNodeParam): CreateChildSummarizerNodeFn;
     // (undocumented)
     getQuorum(): IQuorumClients;

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -156,6 +156,10 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_MockFluidDataStoreContext": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -25,7 +25,6 @@ import {
 	IContainerRuntimeBase,
 	IFluidDataStoreContext,
 	IFluidDataStoreRegistry,
-	IGarbageCollectionDetailsBase,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	ITelemetryLoggerExt,
@@ -143,10 +142,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 	public async uploadBlob(
 		blob: ArrayBufferLike,
 	): Promise<IFluidHandleInternal<ArrayBufferLike>> {
-		throw new Error("Method not implemented.");
-	}
-
-	public async getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase> {
 		throw new Error("Method not implemented.");
 	}
 

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -283,6 +283,7 @@ declare type old_as_current_for_ClassDeclaration_MockFluidDataStoreContext = req
  * typeValidation.broken:
  * "ClassDeclaration_MockFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassDeclaration_MockFluidDataStoreContext = requireAssignableTo<TypeOnly<current.MockFluidDataStoreContext>, TypeOnly<old.MockFluidDataStoreContext>>
 
 /*

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -167,6 +167,16 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"InterfaceDeclaration_IProvideTestFluidObject": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_ITestFluidObject": {
+				"backCompat": false
+			},
+			"ClassDeclaration_TestFluidObject": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -139,6 +139,7 @@ declare type old_as_current_for_InterfaceDeclaration_IProvideTestFluidObject = r
  * typeValidation.broken:
  * "InterfaceDeclaration_IProvideTestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_InterfaceDeclaration_IProvideTestFluidObject = requireAssignableTo<TypeOnly<current.IProvideTestFluidObject>, TypeOnly<old.IProvideTestFluidObject>>
 
 /*
@@ -193,6 +194,7 @@ declare type old_as_current_for_InterfaceDeclaration_ITestFluidObject = requireA
  * typeValidation.broken:
  * "InterfaceDeclaration_ITestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_InterfaceDeclaration_ITestFluidObject = requireAssignableTo<TypeOnly<current.ITestFluidObject>, TypeOnly<old.ITestFluidObject>>
 
 /*
@@ -319,6 +321,7 @@ declare type old_as_current_for_ClassDeclaration_TestFluidObject = requireAssign
  * typeValidation.broken:
  * "ClassDeclaration_TestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassDeclaration_TestFluidObject = requireAssignableTo<TypeOnly<current.TestFluidObject>, TypeOnly<old.TestFluidObject>>
 
 /*


### PR DESCRIPTION
getBaseGCDetails and related code were deprecatedmore than a year ago by https://github.com/microsoft/FluidFramework/pull/14196. This PR removes it.