### PR TITLE
improvement(markdown-magic): Only generate API docs sections for "public" packages

### DIFF
--- a/packages/loader/test-loader-utils/README.md
+++ b/packages/loader/test-loader-utils/README.md
@@ -30,7 +30,7 @@ npm i @fluid-private/test-loader-utils
 
 <!-- AUTO-GENERATED-CONTENT:END -->
 
-<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README_FOOTER&apiDocs=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README_FOOTER) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/packages/test/test-pairwise-generator/README.md
+++ b/packages/test/test-pairwise-generator/README.md
@@ -14,7 +14,7 @@ See [examples.spec.ts](./src/test/examples.spec.ts) for usage examples.
 
 <!-- AUTO-GENERATED-CONTENT:END -->
 
-<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README_FOOTER:apiDocs=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README_FOOTER) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/tools/api-markdown-documenter/README.md
+++ b/tools/api-markdown-documenter/README.md
@@ -239,7 +239,7 @@ Use at your own risk.
 -   Handle multiple package entry-points
 -   Add separate HTML transformation path, for consumers that want to go straight to HTML
 
-<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README_FOOTER:apiDocs=FALSE&clientRequirements=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README_FOOTER:clientRequirements=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -175,7 +175,7 @@ Breaking Changes:
 -   `onCycle` renamed to `beforeEachBatch`.
 -   Many renames and a lot of refactoring unlikely to impact users of the mocha test APIs, but likely to break more integrated code, like custom reporters.
 
-<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README_FOOTER:apiDocs=FALSE&clientRequirements=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README_FOOTER:clientRequirements=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/tools/markdown-magic/README.md
+++ b/tools/markdown-magic/README.md
@@ -82,9 +82,9 @@ Notes:
     You will still need to fill in semantic and usage information.
 -   This is effectively just a wrapper around lower-level templates.
     If you want more fine-grained control over the content structure, we recommend using other templates.
-    -  [README_PACKAGE_SCOPE_NOTICE](#readme_package_scope_notice)
-    -  [README_INSTALLATION_SECTION](#readme_installation_section)
-    -  [README_IMPORT_INSTRUCTIONS](#readme_import_instructions)
+    -   [README_PACKAGE_SCOPE_NOTICE](#readme_package_scope_notice)
+    -   [README_INSTALLATION_SECTION](#readme_installation_section)
+    -   [README_IMPORT_INSTRUCTIONS](#readme_import_instructions)
 
 Arguments:
 
@@ -116,6 +116,7 @@ Notes:
     -  [README_CONTRIBUTION_GUIDELINES_SECTION](#contribution-guidelines)
     -  [README_HELP_SECTION](#readme_help_section)
     -  [README_TRADEMARK_SECTION](#readme_trademark_section)
+
 Arguments:
 
 -   `packageJsonPath`: Relative file path to the library package's `package.json` file.

--- a/tools/markdown-magic/README.md
+++ b/tools/markdown-magic/README.md
@@ -110,12 +110,12 @@ Notes:
     You will still need to fill in semantic and usage information.
 -   This is effectively just a wrapper around lower-level templates.
     If you want more fine-grained control over the content structure, we recommend using other templates.
-    -  [API_DOCS_LINK_SECTION](#api_docs_link_section)
-    -  [README_PACKAGE_SCRIPTS](#readme_package_scripts)
-    -  [README_CLIENT_REQUIREMENTS_SECTION](#readme_client_requirements_section)
-    -  [README_CONTRIBUTION_GUIDELINES_SECTION](#contribution-guidelines)
-    -  [README_HELP_SECTION](#readme_help_section)
-    -  [README_TRADEMARK_SECTION](#readme_trademark_section)
+    -   [API_DOCS_LINK_SECTION](#api_docs_link_section)
+    -   [README_PACKAGE_SCRIPTS](#readme_package_scripts)
+    -   [README_CLIENT_REQUIREMENTS_SECTION](#readme_client_requirements_section)
+    -   [README_CONTRIBUTION_GUIDELINES_SECTION](#contribution-guidelines)
+    -   [README_HELP_SECTION](#readme_help_section)
+    -   [README_TRADEMARK_SECTION](#readme_trademark_section)
 
 Arguments:
 

--- a/tools/markdown-magic/README.md
+++ b/tools/markdown-magic/README.md
@@ -326,7 +326,7 @@ Arguments:
     -   Default: `./package.json`.
 -   `scopeKind`: (optional) Override the automatic scope detection behavior with an explicit scope kind: `EXPERIMENTAL`, `INTERNAL`, or `PRIVATE`.
 
-<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README_FOOTER:clientRequirements=FALSE&apiDocs=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (LIBRARY_PACKAGE_README_FOOTER:clientRequirements=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/tools/markdown-magic/src/md-magic.config.cjs
+++ b/tools/markdown-magic/src/md-magic.config.cjs
@@ -132,7 +132,7 @@ const generateTrademarkSection = (headingOptions) =>
  * Will include the section if the property is found, and one of our special paths is found (`/alpha`, `/beta`, or `/legacy`).
  * Can be explicitly disabled by specifying `FALSE`.
  * @param {"TRUE" | "FALSE" | undefined} options.apiDocs - (optional) Whether or not to include a section pointing readers to the package's generated API documentation on <fluidframework.com>.
- * Default: Will be displayed if the package is a member of the `@fluidframework` or `@fluid-experimental` namespaces, of if the package is unscoped (e.g. "fluid-framework").
+ * Default: `TRUE` if the package is a member of the `@fluidframework` or `@fluid-experimental` namespaces, of if the package is unscoped (e.g. "fluid-framework"). `FALSE` otherwise.
  * @param {"TRUE" | "FALSE" | undefined} options.scripts - (optional) Whether or not to include a section enumerating the package.json file's dev scripts.
  * Default: `FALSE`.
  * @param {"TRUE" | "FALSE" | undefined} options.clientRequirements - (optional) Whether or not to include a section listing Fluid Framework's minimum client requirements.

--- a/tools/markdown-magic/src/md-magic.config.cjs
+++ b/tools/markdown-magic/src/md-magic.config.cjs
@@ -10,8 +10,10 @@ const {
 	formattedGeneratedContentBody,
 	getPackageMetadata,
 	getScopeKindFromPackage,
+	parseBooleanOption,
 	parseHeadingOptions,
 	resolveRelativePackageJsonPath,
+	shouldLinkToApiDocs,
 } = require("./utilities.cjs");
 const {
 	apiDocsLinkSectionTransform,
@@ -130,7 +132,7 @@ const generateTrademarkSection = (headingOptions) =>
  * Will include the section if the property is found, and one of our special paths is found (`/alpha`, `/beta`, or `/legacy`).
  * Can be explicitly disabled by specifying `FALSE`.
  * @param {"TRUE" | "FALSE" | undefined} options.apiDocs - (optional) Whether or not to include a section pointing readers to the package's generated API documentation on <fluidframework.com>.
- * Default: `TRUE`.
+ * Default: Will be displayed if the package is a member of the `@fluidframework` or `@fluid-experimental` namespaces, of if the package is unscoped (e.g. "fluid-framework").
  * @param {"TRUE" | "FALSE" | undefined} options.scripts - (optional) Whether or not to include a section enumerating the package.json file's dev scripts.
  * Default: `FALSE`.
  * @param {"TRUE" | "FALSE" | undefined} options.clientRequirements - (optional) Whether or not to include a section listing Fluid Framework's minimum client requirements.
@@ -160,7 +162,10 @@ function libraryPackageReadmeFooterTransform(content, options, config) {
 
 	const sections = [];
 
-	if (options.apiDocs !== "FALSE") {
+	const includeApiDocsSection = parseBooleanOption(options.apiDocs, () =>
+		shouldLinkToApiDocs(packageName),
+	);
+	if (includeApiDocsSection) {
 		sections.push(generateApiDocsLinkSection(packageName, sectionHeadingOptions));
 	}
 
@@ -242,8 +247,9 @@ function libraryPackageReadmeHeaderTransform(content, options, config) {
 
 	// Note: if the user specified an explicit scope, that takes precedence over the package namespace.
 	const scopeKind = options.packageScopeNotice ?? getScopeKindFromPackage(packageName);
-	if (scopeKind !== undefined) {
-		sections.push(generatePackageScopeNotice(scopeKind));
+	const scopeNoticeSection = generatePackageScopeNotice(scopeKind);
+	if (scopeNoticeSection !== undefined) {
+		sections.push(scopeNoticeSection);
 	}
 
 	if (options.installation !== "FALSE") {

--- a/tools/markdown-magic/src/transforms/generateSectionFromTemplate.cjs
+++ b/tools/markdown-magic/src/transforms/generateSectionFromTemplate.cjs
@@ -17,10 +17,7 @@ const { formattedSectionText, readTemplate } = require("../utilities.cjs");
  * A heading will only be included if this is specified.
  */
 const generateSectionFromTemplate = (templateFileName, headingOptions) => {
-	const sectionBody = readTemplate(
-		templateFileName,
-		headingOptions?.headingLevel ?? 0,
-	);
+	const sectionBody = readTemplate(templateFileName, headingOptions?.headingLevel ?? 0);
 	return formattedSectionText(sectionBody, headingOptions);
 };
 

--- a/tools/markdown-magic/src/transforms/packageScopeNoticeTransform.cjs
+++ b/tools/markdown-magic/src/transforms/packageScopeNoticeTransform.cjs
@@ -40,10 +40,12 @@ const generatePrivatePackageNotice = () => {
 /**
  * Generates simple Markdown contents indicating implications of the specified kind of package scope.
  *
- * @param {"EXPERIMENTAL" | "INTERNAL" | "PRIVATE"} kind - Scope kind to switch on.
+ * @param {string} kind - Scope kind to switch on.
  * EXPERIMENTAL: See templates/Experimental-Package-Notice-Template.md.
  * INTERNAL: See templates/Internal-Package-Notice-Template.md.
  * PRIVATE: See templates/Private-Package-Notice-Template.md.
+ *
+ * @returns The appropriate notice, if applicable. Otherwise, `undefined`.
  */
 const generatePackageScopeNotice = (kind) => {
 	switch (kind) {
@@ -54,7 +56,7 @@ const generatePackageScopeNotice = (kind) => {
 		case "PRIVATE":
 			return generatePrivatePackageNotice();
 		default:
-			throw new Error(`Unrecognized package scope kind: ${kind}`);
+			return undefined;
 	}
 };
 
@@ -85,9 +87,7 @@ function packageScopeNoticeTransform(content, options, config) {
 
 	// Note: if the user specified an explicit scope, that takes precedence over the package namespace.
 	const scopeKindWithInheritance = scopeKind ?? getScopeKindFromPackage(packageName);
-	if (scopeKindWithInheritance !== undefined) {
-		return generatePackageScopeNotice(scopeKindWithInheritance);
-	}
+	return generatePackageScopeNotice(scopeKindWithInheritance);
 }
 
 module.exports = {

--- a/tools/markdown-magic/src/utilities.cjs
+++ b/tools/markdown-magic/src/utilities.cjs
@@ -92,22 +92,36 @@ function getPackageMetadata(packageJsonFilePath) {
 }
 
 /**
- * Gets the appropriate scope kind for the provided package name.
+ * Gets the appropriate special scope kind for the provided package name, if applicable.
  *
  * @param {string} packageName
- * @returns {"EXPERIMENTAL" | "INTERNAL" | "PRIVATE" | undefined} A scope kind based on the package's scope (namespace).
+ * @returns {"FRAMEWORK" | "EXPERIMENTAL" | "INTERNAL" | "PRIVATE" | "TOOLS" | undefined} A scope kind based on the package's scope (namespace).
+ * Will be `undefined` if the package has no scope, or has an unrecognized scope.
  */
 const getScopeKindFromPackage = (packageName) => {
 	const packageScope = PackageName.getScope(packageName);
-	if (packageScope === `@fluid-experimental`) {
+	if (packageScope === `@fluidframework`) {
+		return "FRAMEWORK";
+	} else if (packageScope === `@fluid-experimental`) {
 		return "EXPERIMENTAL";
 	} else if (packageScope === `@fluid-internal`) {
 		return "INTERNAL";
 	} else if (packageScope === `@fluid-private`) {
 		return "PRIVATE";
+	} else if (packageScope === "@fluid-tools") {
+		return "TOOLS";
 	} else {
 		return undefined;
 	}
+};
+
+/**
+ * Determines if the package's README should link to the Fluid Framework API documentation for that package by default.
+ * @param {string} packageName
+ */
+const shouldLinkToApiDocs = (packageName) => {
+	const scope = getScopeKindFromPackage(packageName);
+	return scope === "FRAMEWORK" || scope === "EXPERIMENTAL" || scope === undefined;
 };
 
 /**
@@ -197,14 +211,36 @@ function parseHeadingOptions(transformationOptions, headingText) {
 	};
 }
 
+/**
+ * Parses a provided "boolean" (i.e., "TRUE" | "FALSE") MarkdownMagic transform option.
+ * Returns the provided default if no option was specified.
+ * @param {"TRUE" | "FALSE" | undefined} option
+ * @param {function} defaultValue - The default value, or a callback that returns the default value to use for the option.
+ * Used if the option is not explicitly provided.
+ */
+function parseBooleanOption(option, defaultValue) {
+	if (option === "TRUE") {
+		return true;
+	}
+	if (option === "FALSE") {
+		return false;
+	}
+	if (typeof defaultValue === "function") {
+		return defaultValue();
+	}
+	return defaultValue;
+}
+
 module.exports = {
 	formattedSectionText,
 	formattedGeneratedContentBody,
 	formattedEmbeddedContentBody,
 	getPackageMetadata,
 	getScopeKindFromPackage,
+	parseBooleanOption,
 	parseHeadingOptions,
 	readTemplate,
 	resolveRelativePackageJsonPath,
 	resolveRelativePath,
+	shouldLinkToApiDocs,
 };


### PR DESCRIPTION
Ensures we don't generate API docs sections for packages that are not published / whose docs are not published.

Also removes now-unneeded param overrides in private/internal package READMEs.