### PR TITLE
Add e2e test vscode workspace with more flexible launch targets

### DIFF
--- a/packages/test/test-end-to-end-tests/.vscode/e2e-tests.code-workspace
+++ b/packages/test/test-end-to-end-tests/.vscode/e2e-tests.code-workspace
@@ -1,0 +1,17 @@
+{
+	"folders": [
+		{
+			"name": "FluidFramework",
+			"path": "../../../.."
+		},
+		{
+			"name": "@fluid-private/test-end-to-end-tests",
+			"path": ".."
+		},
+		// This is a reasonably convenient entrypoint for the set of installed packages for compat tests.
+		{
+			"name": "Legacy FluidFramework versions",
+			"path": "../../test-version-utils/node_modules/.legacy"
+		}
+	]
+}

--- a/packages/test/test-end-to-end-tests/.vscode/launch.json
+++ b/packages/test/test-end-to-end-tests/.vscode/launch.json
@@ -28,7 +28,7 @@
 			"cwd": "${fileDirname}",
 			"skipFiles": [
 				"<node_internals>/**",
-				// Allow debugging into legacy fluid packages (and breakpoints to be set in them)
+				// Allow debugging into legacy Fluid packages (and breakpoints to be set in them)
 				"**/node_modules/!(.legacy)/**",
 			],
 			"outFiles": [

--- a/packages/test/test-end-to-end-tests/.vscode/launch.json
+++ b/packages/test/test-end-to-end-tests/.vscode/launch.json
@@ -237,10 +237,13 @@
 			"description": "Which r11s endpoint should be used?",
 			"type": "pickString",
 			"default": "frs",
-			"options": ["frs", {
-				"label": "docker (local service must be started separately prior to debugging)",
-				"value": "docker",
-			}],
-		}
+			"options": [
+				"frs",
+				{
+					"label": "docker (local service must be started separately prior to debugging)",
+					"value": "docker",
+				},
+			],
+		},
 	],
 }

--- a/packages/test/test-end-to-end-tests/.vscode/launch.json
+++ b/packages/test/test-end-to-end-tests/.vscode/launch.json
@@ -36,10 +36,10 @@
 				// This reduces the number of source files VSCode needs to load to debug the e2e tests
 				// considerably, which decreases the time it takes to start debugging.
 				// Note: these globs include files under node_modules, which is explicitly desirable when trying to set breakpoints
-				// in legacy FF packages. When the user doesn't select that option, debugLegacyModules will handle excluding node_modules.
+				// in legacy FF packages. When the user doesn't select that option, debugOldFluidModules will handle excluding node_modules.
 				"${workspaceFolder}/lib/**/*.js",
 				"${workspaceFolder:FluidFramework}/**/{dist,lib}/**/!(*.spec,*.test,*.tests).[mc]?js",
-				"${input:debugLegacyModules}",
+				"${input:debugOldFluidModules}",
 			],
 			"presentation": {
 				"group": "e2e-tests",
@@ -74,7 +74,7 @@
 			"outFiles": [
 				"${workspaceFolder}/lib/**/*.js",
 				"${workspaceFolder:FluidFramework}/**/{dist,lib}/**/!(*.spec,*.test,*.tests).[mc]?js",
-				"${input:debugLegacyModules}",
+				"${input:debugOldFluidModules}",
 			],
 			"presentation": {
 				"hidden": true,
@@ -129,7 +129,7 @@
 			"outFiles": [
 				"${workspaceFolder}/lib/**/*.js",
 				"${workspaceFolder:FluidFramework}/**/{dist,lib}/**/!(*.spec,*.test,*.tests).[mc]?js",
-				"${input:debugLegacyModules}",
+				"${input:debugOldFluidModules}",
 			],
 			"presentation": {
 				"group": "e2e-tests",
@@ -164,7 +164,7 @@
 			"outFiles": [
 				"${workspaceFolder}/lib/**/*.js",
 				"${workspaceFolder:FluidFramework}/**/{dist,lib}/**/!(*.spec,*.test,*.tests).[mc]?js",
-				"${input:debugLegacyModules}",
+				"${input:debugOldFluidModules}",
 			],
 			"presentation": {
 				"group": "e2e-tests",
@@ -214,8 +214,8 @@
 			"options": [{ "label": "No", "value": "" }, { "label": "Yes", "value": "1" }],
 		},
 		{
-			"id": "debugLegacyModules",
-			"description": "Load source maps for compat matrix? (slower, but allows breakpoints in node_modules/.legacy TS files)",
+			"id": "debugOldFluidModules",
+			"description": "Load source maps for compat matrix? (slower, but allows breakpoints in compat Fluid packages)",
 			"type": "pickString",
 			"default": "!**/node_modules/**",
 			"options": [

--- a/packages/test/test-end-to-end-tests/.vscode/launch.json
+++ b/packages/test/test-end-to-end-tests/.vscode/launch.json
@@ -1,0 +1,235 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Debug Current e2e test (local driver)",
+			"env": {
+				"fluid__test__driver": "local",
+				"fluid__test__backCompat": "${input:backCompat}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
+			},
+			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
+			"windows": {
+				"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha.cmd",
+			},
+			"sourceMaps": true,
+			"program": "${file}",
+			"args": [
+				// "--fgrep",               // Uncomment to filter by test case name
+				// "<test case name>",
+				"--no-timeouts",
+				"--exit",
+			],
+			"cwd": "${fileDirname}",
+			"skipFiles": [
+				"<node_internals>/**",
+				// Allow debugging into legacy fluid packages (and breakpoints to be set in them)
+				"**/node_modules/!(.legacy)/**",
+			],
+			"outFiles": [
+				// This config avoids loading dependent packages' test files, just those in test-end-to-end-tests.
+				// This reduces the number of source files VSCode needs to load to debug the e2e tests
+				// considerably, which decreases the time it takes to start debugging.
+				// Note: these globs include files under node_modules, which is explicitly desirable when trying to set breakpoints
+				// in legacy FF packages. When the user doesn't select that option, debugLegacyModules will handle excluding node_modules.
+				"${workspaceFolder}/lib/**/*.js",
+				"${workspaceFolder:FluidFramework}/**/{dist,lib}/**/!(*.spec,*.test,*.tests).[mc]?js",
+				"${input:debugLegacyModules}",
+			],
+			"presentation": {
+				"group": "e2e-tests",
+				"order": 1,
+			},
+			"preLaunchTask": "Build Current Tests",
+			"internalConsoleOptions": "openOnSessionStart",
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Client: Debug Current e2e test (tinylicious)",
+			"env": {
+				"fluid__test__driver": "t9s",
+				"fluid__test__backCompat": "${input:backCompat}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
+			},
+			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
+			"windows": {
+				"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha.cmd",
+			},
+			"sourceMaps": true,
+			"program": "${file}",
+			"args": [
+				// "--fgrep",               // Uncomment to filter by test case name
+				// "<test case name>",
+				"--no-timeouts",
+				"--exit",
+			],
+			"cwd": "${fileDirname}",
+			"skipFiles": ["<node_internals>/**", "**/node_modules/!(.legacy)/**"],
+			"outFiles": [
+				"${workspaceFolder}/lib/**/*.js",
+				"${workspaceFolder:FluidFramework}/**/{dist,lib}/**/!(*.spec,*.test,*.tests).[mc]?js",
+				"${input:debugLegacyModules}",
+			],
+			"presentation": {
+				"hidden": true,
+			},
+			"preLaunchTask": "Build Current Tests",
+			"internalConsoleOptions": "openOnSessionStart",
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "tinylicious",
+			"cwd": "${workspaceFolder}",
+			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tinylicious",
+			"windows": {
+				"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tinylicious.cmd",
+			},
+			"sourceMaps": true,
+			"skipFiles": ["<node_internals>/**"],
+			// Only load source maps for tinylicious and Fluid packages
+			"outFiles": [
+				"${workspaceFolder:FluidFramework}/node_modules/**/tinylicious/**/*.[mc]?js",
+				"${workspaceFolder:FluidFramework}/node_modules/**/@fluid*/**/*.[mc]?js",
+			],
+			"presentation": {
+				"hidden": true,
+			},
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Debug Current e2e test (odsp)",
+			"env": {
+				"fluid__test__driver": "odsp",
+				"fluid__test__backCompat": "${input:backCompat}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
+				"fluid__test__odspEndpointName": "${input:odspEndpoint}",
+			},
+			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
+			"windows": {
+				"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha.cmd",
+			},
+			"sourceMaps": true,
+			"program": "${file}",
+			"args": [
+				// "--fgrep",               // Uncomment to filter by test case name
+				// "<test case name>",
+				"--no-timeouts",
+				"--exit",
+			],
+			"cwd": "${fileDirname}",
+			"skipFiles": ["<node_internals>/**", "**/node_modules/!(.legacy)/**"],
+			"outFiles": [
+				"${workspaceFolder}/lib/**/*.js",
+				"${workspaceFolder:FluidFramework}/**/{dist,lib}/**/!(*.spec,*.test,*.tests).[mc]?js",
+				"${input:debugLegacyModules}",
+			],
+			"presentation": {
+				"group": "e2e-tests",
+				"order": 3,
+			},
+			"preLaunchTask": "Build Current Tests",
+			"internalConsoleOptions": "openOnSessionStart",
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Debug Current e2e test (routerlicious)",
+			"env": {
+				"fluid__test__driver": "r11s",
+				"fluid__test__backCompat": "${input:backCompat}",
+				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
+			},
+			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
+			"windows": {
+				"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha.cmd",
+			},
+			"sourceMaps": true,
+			"program": "${file}",
+			"args": [
+				// "--fgrep",               // Uncomment to filter by test case name
+				// "<test case name>",
+				"--no-timeouts",
+				"--exit",
+			],
+			"cwd": "${fileDirname}",
+			"skipFiles": ["<node_internals>/**", "**/node_modules/!(.legacy)/**"],
+			"outFiles": [
+				"${workspaceFolder}/lib/**/*.js",
+				"${workspaceFolder:FluidFramework}/**/{dist,lib}/**/!(*.spec,*.test,*.tests).[mc]?js",
+				"${input:debugLegacyModules}",
+			],
+			"presentation": {
+				"group": "e2e-tests",
+				"order": 4,
+			},
+			"preLaunchTask": "Build Current Tests",
+			"internalConsoleOptions": "openOnSessionStart",
+		},
+	],
+	"compounds": [
+		{
+			"name": "Debug Current e2e test (tinylicious)",
+			"configurations": ["tinylicious", "Client: Debug Current e2e test (tinylicious)"],
+			"presentation": {
+				"group": "e2e-tests",
+				"order": 2,
+			},
+		},
+	],
+	// Note: if launching some debug configuration with non-default values repeatedly, you can use "restart" to avoid specifying
+	// the inputs each time.
+	// We could consider using something like https://marketplace.visualstudio.com/items?itemName=spadin.memento-inputs to make
+	// this a bit more ergonomic, but that would require extension installation to make these launch targets work.
+	"inputs": [
+		{
+			"id": "argDriver",
+			"description": "e2e test driver to use",
+			"default": "local",
+			"type": "pickString",
+			"options": ["local", "tinylicious", "routerlicious", "odsp"],
+		},
+		{
+			"id": "backCompat",
+			"description": "compatibility matrix",
+			"default": "small",
+			"type": "pickString",
+			"options": [
+				{ "label": "default (PR)", "value": "" },
+				{ "label": "full (CI)", "value": "FULL" },
+			],
+		},
+		{
+			"id": "verboseConsoleOutputt",
+			"description": "Show console output?",
+			"default": "",
+			"type": "pickString",
+			"options": [{ "label": "No", "value": "" }, { "label": "Yes", "value": "1" }],
+		},
+		{
+			"id": "debugLegacyModules",
+			"description": "Load source maps for compat matrix? (slower, but allows breakpoints in node_modules/.legacy TS files)",
+			"type": "pickString",
+			"default": "!**/node_modules/**",
+			"options": [
+				{ "label": "No", "value": "!**/node_modules/**" },
+				// VSCode doesn't correctly handle an empty string in outFiles. This is an arbitrary glob that doesn't match any files.
+				{ "label": "Yes", "value": "**/dummy-folder-unused/**" },
+			],
+		},
+		{
+			"id": "odspEndpoint",
+			"description": "Which odsp endpoint should be used?",
+			"type": "pickString",
+			"default": "odsp",
+			"options": ["odsp", "odsp-df"],
+		},
+	],
+}

--- a/packages/test/test-end-to-end-tests/.vscode/launch.json
+++ b/packages/test/test-end-to-end-tests/.vscode/launch.json
@@ -145,6 +145,7 @@
 			"env": {
 				"fluid__test__driver": "r11s",
 				"fluid__test__backCompat": "${input:backCompat}",
+				"fluid__test__r11sEndpointName": "${input:r11sEndpoint}",
 				"FLUID_TEST_VERBOSE": "${input:verboseConsoleOutputt}",
 			},
 			"runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
@@ -231,5 +232,15 @@
 			"default": "odsp",
 			"options": ["odsp", "odsp-df"],
 		},
+		{
+			"id": "r11sEndpoint",
+			"description": "Which r11s endpoint should be used?",
+			"type": "pickString",
+			"default": "frs",
+			"options": ["frs", {
+				"label": "docker (local service must be started separately prior to debugging)",
+				"value": "docker",
+			}],
+		}
 	],
 }

--- a/packages/test/test-end-to-end-tests/.vscode/settings.json
+++ b/packages/test/test-end-to-end-tests/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+	// Enable biome as default formatter, and disable rules that disagree with it
+	"editor.defaultFormatter": "biomejs.biome",
+	"editor.insertSpaces": false,
+	"[json]": {
+		"editor.defaultFormatter": "biomejs.biome",
+	},
+	"[javascript]": {
+		"editor.defaultFormatter": "biomejs.biome",
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "biomejs.biome",
+	},
+}

--- a/packages/test/test-end-to-end-tests/.vscode/tasks.json
+++ b/packages/test/test-end-to-end-tests/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Build Current Tests",
+			"type": "process",
+			"command": "node",
+			"args": [
+				"${workspaceRoot:FluidFramework}/node_modules/@fluidframework/build-tools/dist/fluidBuild/fluidBuild.js",
+				"--root",
+				"${workspaceRoot:FluidFramework}",
+				"--vscode",
+				"-t",
+				"build:test",
+				"${fileDirname}",
+			],
+			"group": "build",
+			"problemMatcher": [
+				{
+					"base": "$tsc",
+					"fileLocation": "absolute",
+				},
+				"$tslint5",
+			],
+		},
+	],
+}

--- a/packages/test/test-end-to-end-tests/README.md
+++ b/packages/test/test-end-to-end-tests/README.md
@@ -117,7 +117,11 @@ That same [directory](src/test) contains more complex examples too.
 
 ## Debugging
 
-In order to debug legacy code running as part of an end-to-end test, you'll need to modify the debug launch configuration to include `node_modules` in its set of loaded files.
+This package contains a VSCode workspace with launch targets for debugging e2e tests with common configurations.
+The launch targets in this configuration allow selecting different drivers, compat modes, and setting breakpoints in dependent packages installed for compat testing.
+See `.vscode/e2e-tests.code-workspace` for details.
+
+If not using this workspace, in order to debug legacy code running as part of an end-to-end test, you'll need to modify the debug launch configuration to include `node_modules` in its set of loaded files.
 
 For example, if using "Debug Current Mocha Test" or one of its variants, remove the `node_modules` entry under `"skipFiles"`.
 


### PR DESCRIPTION
## Description

Adds a VSCode workspace set up for e2e test debugging. It has the following advantages over the primary (root) workspace:

- Access to legacy module installation from the file explorer
- Dedicated launch configurations for each driver we test against
- Inputs selected at launch time for:
    - driver-specific config (e.g. odsp endpoint)
    - console output
    - whether break points can be set in legacy modules (this is a fairly large performance hit, so default is 'no')
- Tinylicious launch target is a compound target which allows simultaneous server + client debugging
- FF code under `.legacy` (i.e. the modules installed for compat testing) isn't under skipFiles by default, so break points in this code works (either in the js if source map loading is turned off, or in the ts if it is turned on, which is configurable at launch time)

The r11s tests are difficult to run on Windows, so I didn't test that launch target. Other targets all work well as far as I can tell (which includes setting breakpoints in various places in dependent packages)

Sample view of launch window when using this workspace:

![image](https://github.com/user-attachments/assets/e00569b6-9be0-4177-92f5-8e16d5587c87)

