### PR TITLE
chore(merge-tree): Remove unused lint disable directives 

### DIFF
--- a/packages/dds/merge-tree/src/client.ts
+++ b/packages/dds/merge-tree/src/client.ts
@@ -73,7 +73,6 @@ import {
 	MergeTreeDeltaType,
 	ReferenceType,
 } from "./ops.js";
-// eslint-disable-next-line import/no-deprecated
 import { PropertySet, createMap } from "./properties.js";
 import { DetachedReferencePosition, ReferencePosition } from "./referencePositions.js";
 import { SnapshotLoader } from "./snapshotLoader.js";
@@ -831,7 +830,6 @@ export class Client extends TypedEventEmitter<IClientEvents> {
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 					if (typeof resetOp.seg === "object" && resetOp.seg.props !== undefined) {
 						segInsertOp = segment.clone();
-						// eslint-disable-next-line import/no-deprecated
 						segInsertOp.properties = createMap();
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
 						segInsertOp.addProperties(resetOp.seg.props);

--- a/packages/dds/merge-tree/src/localReference.ts
+++ b/packages/dds/merge-tree/src/localReference.ts
@@ -10,7 +10,6 @@ import { DoublyLinkedList, ListNode, walkList } from "./collections/index.js";
 import { ISegment } from "./mergeTreeNodes.js";
 import { TrackingGroup, TrackingGroupCollection } from "./mergeTreeTracking.js";
 import { ReferenceType } from "./ops.js";
-// eslint-disable-next-line import/no-deprecated
 import { PropertySet, addProperties } from "./properties.js";
 import { ReferencePosition, refTypeIncludesFlag } from "./referencePositions.js";
 
@@ -131,7 +130,6 @@ class LocalReference implements LocalReferencePosition {
 	}
 
 	public addProperties(newProps: PropertySet): void {
-		// eslint-disable-next-line import/no-deprecated
 		this.properties = addProperties(this.properties, newProps);
 	}
 

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -77,7 +77,6 @@ import {
 } from "./ops.js";
 import { PartialSequenceLengths } from "./partialLengths.js";
 import { PerspectiveImpl, isSegmentPresent } from "./perspective.js";
-// eslint-disable-next-line import/no-deprecated
 import { PropertySet, createMap, extend, extendIfUndefined } from "./properties.js";
 import {
 	DetachedReferencePosition,
@@ -2513,9 +2512,9 @@ export class MergeTree {
 	private blockUpdate(block: MergeBlock): void {
 		let len: number | undefined;
 
-		// eslint-disable-next-line import/no-deprecated
+
 		const rightmostTiles = createMap<Marker>();
-		// eslint-disable-next-line import/no-deprecated
+
 		const leftmostTiles = createMap<Marker>();
 
 		for (let i = 0; i < block.childCount; i++) {
@@ -2550,9 +2549,7 @@ export class MergeTree {
 					}
 				}
 			} else {
-				// eslint-disable-next-line import/no-deprecated
 				extend(rightmostTiles, node.rightmostTiles);
-				// eslint-disable-next-line import/no-deprecated
 				extendIfUndefined(leftmostTiles, node.leftmostTiles);
 			}
 		}

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -2512,9 +2512,7 @@ export class MergeTree {
 	private blockUpdate(block: MergeBlock): void {
 		let len: number | undefined;
 
-
 		const rightmostTiles = createMap<Marker>();
-
 		const leftmostTiles = createMap<Marker>();
 
 		for (let i = 0; i < block.childCount; i++) {

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -20,7 +20,6 @@ import { TrackingGroupCollection } from "./mergeTreeTracking.js";
 import { IJSONSegment, IMarkerDef, MergeTreeDeltaType, ReferenceType } from "./ops.js";
 import { computeHierarchicalOrdinal } from "./ordinal.js";
 import type { PartialSequenceLengths } from "./partialLengths.js";
-// eslint-disable-next-line import/no-deprecated
 import { PropertySet, clone, createMap, type MapLike } from "./properties.js";
 import {
 	ReferencePosition,
@@ -451,9 +450,7 @@ export class MergeBlock implements IMergeNodeCommon {
 		// Using Array.from leads to unused children being undefined, which are counted in childCount.
 		// eslint-disable-next-line unicorn/no-new-array
 		this.children = new Array<IMergeNode>(MaxNodesInBlock);
-		// eslint-disable-next-line import/no-deprecated
 		this.rightmostTiles = createMap<Marker>();
-		// eslint-disable-next-line import/no-deprecated
 		this.leftmostTiles = createMap<Marker>();
 	}
 
@@ -524,7 +521,7 @@ export abstract class BaseSegment implements ISegment {
 	): PropertySet {
 		this.propertyManager ??= new PropertiesManager();
 		// A property set must be able to hold properties of any type, so the any is needed.
-		// eslint-disable-next-line import/no-deprecated, @typescript-eslint/no-explicit-any
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		this.properties ??= createMap<any>();
 		return this.propertyManager.addProperties(
 			this.properties,
@@ -546,7 +543,6 @@ export abstract class BaseSegment implements ISegment {
 	protected cloneInto(b: ISegment): void {
 		b.clientId = this.clientId;
 		// TODO: deep clone properties
-		// eslint-disable-next-line import/no-deprecated
 		b.properties = clone(this.properties);
 		b.removedClientIds = this.removedClientIds?.slice();
 		// TODO: copy removed client overlap and branch removal info

--- a/packages/dds/merge-tree/src/segmentPropertiesManager.ts
+++ b/packages/dds/merge-tree/src/segmentPropertiesManager.ts
@@ -9,7 +9,6 @@ import { assert } from "@fluidframework/core-utils/internal";
 
 import { UnassignedSequenceNumber, UniversalSequenceNumber } from "./constants.js";
 import { IMergeTreeAnnotateMsg } from "./ops.js";
-// eslint-disable-next-line import/no-deprecated
 import { MapLike, PropertySet, createMap } from "./properties.js";
 
 /**
@@ -63,7 +62,6 @@ export class PropertiesManager {
 		collaborating: boolean = false,
 		rollback: PropertiesRollback = PropertiesRollback.None,
 	): PropertySet {
-		// eslint-disable-next-line import/no-deprecated
 		this.pendingKeyUpdateCount ??= createMap<number>();
 
 		// Clean up counts for rolled back edits before modifying oldProps
@@ -122,7 +120,7 @@ export class PropertiesManager {
 		newManager: PropertiesManager,
 	): PropertySet | undefined {
 		if (oldProps) {
-			// eslint-disable-next-line no-param-reassign, import/no-deprecated
+			// eslint-disable-next-line no-param-reassign
 			newProps ??= createMap<unknown>();
 			if (!newManager) {
 				throw new Error("Must provide new PropertyManager");
@@ -131,7 +129,6 @@ export class PropertiesManager {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 				newProps[key] = oldProps[key];
 			}
-			// eslint-disable-next-line import/no-deprecated
 			newManager.pendingKeyUpdateCount = createMap<number>();
 			for (const key of Object.keys(this.pendingKeyUpdateCount!)) {
 				// TODO Non null asserting, why is this not null?


### PR DESCRIPTION
Follow up to #21878, which removed `@deprecated` tags from some of the properties helpers. There were many `import/no-deprecated` directives still in the code, so I'm removing them now. 