### PR TITLE
[Data Virtualization]: Repro groupId and offline causing extra network calls

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdBlobReads.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdBlobReads.spec.ts
@@ -1,0 +1,97 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	describeCompat,
+	TestDataObjectType,
+	type ITestDataObject,
+} from "@fluid-private/test-version-utils";
+import { type IContainerRuntimeOptions } from "@fluidframework/container-runtime/internal";
+import type { IContainerRuntimeBase } from "@fluidframework/runtime-definitions/internal";
+import { MockLogger } from "@fluidframework/telemetry-utils/internal";
+import {
+	type ITestObjectProvider,
+	createSummarizer,
+	createTestConfigProvider,
+	summarizeNow,
+} from "@fluidframework/test-utils/internal";
+
+import { TestSnapshotCache } from "../../testSnapshotCache.js";
+
+describeCompat("Odsp Network calls", "NoCompat", (getTestObjectProvider) => {
+	// Allow us to control summaries
+	const runtimeOptions: IContainerRuntimeOptions = {
+		summaryOptions: {
+			summaryConfigOverrides: {
+				state: "disabled",
+			},
+		},
+	};
+	const configProvider = createTestConfigProvider({
+		"Fluid.Container.UseLoadingGroupIdForSnapshotFetch2": true,
+		"Fluid.Container.enableOfflineLoad": true,
+	});
+
+	let provider: ITestObjectProvider;
+	const testSnapshotCache = new TestSnapshotCache();
+
+	beforeEach("setup", async function () {
+		provider = getTestObjectProvider({ persistedCache: testSnapshotCache });
+		if (provider.driver.type === "odsp") {
+			this.skip();
+		}
+	});
+
+	const loadingGroupId = "loadingGroupId";
+	const createDataObjectsWithGroupIds = async (
+		mainObject: ITestDataObject,
+		containerRuntime: IContainerRuntimeBase,
+	) => {
+		const dataStoreA = await containerRuntime.createDataStore(
+			TestDataObjectType,
+			loadingGroupId,
+		);
+		const dataStoreB = await containerRuntime.createDataStore(
+			TestDataObjectType,
+			loadingGroupId,
+		);
+
+		mainObject._root.set("dataObjectA", dataStoreA.entryPoint);
+		mainObject._root.set("dataObjectB", dataStoreB.entryPoint);
+	};
+
+	it("Should not make odsp network calls", async () => {
+		const container = await provider.makeTestContainer({
+			runtimeOptions,
+			loaderProps: { configProvider },
+		});
+		const mainObject = (await container.getEntryPoint()) as ITestDataObject;
+		const containerRuntime = mainObject._context.containerRuntime;
+
+		// Testing all apis for creating a data store with a loadingGroupId
+		await createDataObjectsWithGroupIds(mainObject, containerRuntime);
+		const { summarizer } = await createSummarizer(provider, container, {
+			loaderProps: { configProvider },
+		});
+		await provider.ensureSynchronized();
+		await summarizeNow(summarizer);
+
+		testSnapshotCache.clearCache();
+		const logger = new MockLogger();
+		await provider.loadTestContainer({
+			loaderProps: { configProvider, logger },
+		});
+		if (provider.driver.type === "odsp") {
+			logger.assertMatchNone(
+				[
+					{
+						eventName: "fluid:telemetry:OdspDriver:readDataBlob_end",
+					},
+				],
+				"Should not have any odps network calls",
+			);
+		}
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdBlobReads.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/data-virtualization/groupIdBlobReads.spec.ts
@@ -39,7 +39,7 @@ describeCompat("Odsp Network calls", "NoCompat", (getTestObjectProvider) => {
 
 	beforeEach("setup", async function () {
 		provider = getTestObjectProvider({ persistedCache: testSnapshotCache });
-		if (provider.driver.type === "odsp") {
+		if (provider.driver.type !== "odsp") {
 			this.skip();
 		}
 	});
@@ -62,7 +62,7 @@ describeCompat("Odsp Network calls", "NoCompat", (getTestObjectProvider) => {
 		mainObject._root.set("dataObjectB", dataStoreB.entryPoint);
 	};
 
-	it("Should not make odsp network calls", async () => {
+	it.skip("Should not make odsp network calls", async () => {
 		const container = await provider.makeTestContainer({
 			runtimeOptions,
 			loaderProps: { configProvider },


### PR DESCRIPTION
[AB#8937](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8937)

This PR is expected to fail until the fix is merged in: https://github.com/microsoft/FluidFramework/pull/21908

The repro is:
- Offline and Data virtualization are enabled
- A virtualized datastore is created
- It is summarized
- A new container loads from that summary
- In offline mode, we store the blobs on load that we have. 
- Because some of the blobs are not there, the loader makes a network call for each blob.