### PR TITLE
[GC] Fixed flaky GC stats end-to-end test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcStats.spec.ts
@@ -231,7 +231,77 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		await provider.ensureSynchronized();
 
 		let gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+		assert.deepStrictEqual(gcStats, expectedGCStats, "1. GC stats is not as expected");
+
+		// Remove the data store and blob handles to mark them unreferenced.
+		mainDataObject._root.delete("dataStore1");
+		mainDataObject._root.delete("dataStore2");
+		mainDataObject._root.delete("blob1");
+		mainDataObject._root.delete("blob2");
+		await provider.ensureSynchronized();
+
+		// the data stores, their DDS and the blobs should be now unreferenced. Also, their reference state updated from
+		// referenced to unreferenced.
+		expectedGCStats.unrefNodeCount += 6;
+		expectedGCStats.updatedNodeCount = 6;
+		expectedGCStats.unrefDataStoreCount += 2;
+		expectedGCStats.updatedDataStoreCount = 2;
+		expectedGCStats.unrefAttachmentBlobCount += 2;
+		expectedGCStats.updatedAttachmentBlobCount = 2;
+
+		gcStats = await summarizerRuntime.collectGarbage({});
+		assert.deepStrictEqual(gcStats, expectedGCStats, "2. GC stats is not as expected");
+
+		const summarizeResult = await summarizerRuntime.summarize({ fullTree: true });
+		const unrefDataStoreStats = getDataStoreSummaryStats(summarizeResult.summary, [
+			dataStore1._context.id,
+			dataStore2._context.id,
+		]);
+		assert.strictEqual(
+			summarizeResult.stats.unreferencedBlobSize,
+			unrefDataStoreStats.totalBlobSize,
+			"dataStore1's blobs should be in unreferenced blob size",
+		);
+	});
+
+	it("can correctly generate GC stats when nodes are sweep ready or deleted", async () => {
+		const dataStore1 = await createNewDataStore();
+		const dataStore2 = await createNewDataStore();
+		const expectedGCStats: IGCStats = {
+			nodeCount: 9,
+			unrefNodeCount: 0,
+			updatedNodeCount: 9,
+			dataStoreCount: 3,
+			unrefDataStoreCount: 0,
+			updatedDataStoreCount: 3,
+			attachmentBlobCount: 2,
+			unrefAttachmentBlobCount: 0,
+			updatedAttachmentBlobCount: 2,
+			lifetimeNodeCount: 9,
+			lifetimeDataStoreCount: 3,
+			lifetimeAttachmentBlobCount: 2,
+			deletedNodeCount: 0,
+			deletedDataStoreCount: 0,
+			deletedAttachmentBlobCount: 0,
+		};
+
+		// Add both data store handles in default data store to mark them referenced.
+		mainDataObject._root.set("dataStore1", dataStore1.handle);
+		mainDataObject._root.set("dataStore2", dataStore2.handle);
+
+		// Upload 2 attachment blobs and store their handles to mark them referenced.
+		const blob1Contents = "Blob contents 1";
+		const blob2Contents = "Blob contents 2";
+		// Blob stats will be different if we upload while not connected
+		await waitForContainerWriteModeConnectionWrite(mainContainer);
+		const blob1Handle = await mainDataObject._context.uploadBlob(
+			stringToBuffer(blob1Contents, "utf-8"),
+		);
+		const blob2Handle = await mainDataObject._context.uploadBlob(
+			stringToBuffer(blob2Contents, "utf-8"),
+		);
+		mainDataObject._root.set("blob1", blob1Handle);
+		mainDataObject._root.set("blob2", blob2Handle);
 
 		// Remove dataStore1 and blob1's handles to mark them unreferenced.
 		mainDataObject._root.delete("dataStore1");
@@ -241,85 +311,49 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		// dataStore1, its DDS and blob1 should be now unreferenced. Also, their reference state updated from referenced
 		// to unreferenced.
 		expectedGCStats.unrefNodeCount += 3;
-		expectedGCStats.updatedNodeCount = 3;
 		expectedGCStats.unrefDataStoreCount += 1;
-		expectedGCStats.updatedDataStoreCount = 1;
 		expectedGCStats.unrefAttachmentBlobCount += 1;
-		expectedGCStats.updatedAttachmentBlobCount = 1;
 
-		gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+		let gcStats = await summarizerRuntime.collectGarbage({});
+		assert.deepStrictEqual(gcStats, expectedGCStats, "1. GC stats is not as expected");
 
-		let summarizeResult = await summarizerRuntime.summarize({ fullTree: true });
-		let unrefDataStoreStats = getDataStoreSummaryStats(summarizeResult.summary, [
-			dataStore1._context.id,
-		]);
-		assert.strictEqual(
-			summarizeResult.stats.unreferencedBlobSize,
-			unrefDataStoreStats.totalBlobSize,
-			"dataStore1's blobs should be in unreferenced blob size",
-		);
-
-		// Remove dataStore2 and blob2's handles to mark them unreferenced.
-		mainDataObject._root.delete("dataStore2");
-		mainDataObject._root.delete("blob2");
-		await provider.ensureSynchronized();
-
-		// dataStore2, its DDS, and blob2 should be now unreferenced. Also, their reference state updated from referenced
-		// to unreferenced.
-		expectedGCStats.unrefNodeCount += 3;
-		expectedGCStats.updatedNodeCount = 3;
-		expectedGCStats.unrefDataStoreCount += 1;
-		expectedGCStats.updatedDataStoreCount = 1;
-		expectedGCStats.unrefAttachmentBlobCount += 1;
-		expectedGCStats.updatedAttachmentBlobCount = 1;
-
-		gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
-
-		summarizeResult = await summarizerRuntime.summarize({ fullTree: true });
-		unrefDataStoreStats = getDataStoreSummaryStats(summarizeResult.summary, [
-			dataStore1._context.id,
-			dataStore2._context.id,
-		]);
-		assert.strictEqual(
-			summarizeResult.stats.unreferencedBlobSize,
-			unrefDataStoreStats.totalBlobSize,
-			"dataStore1 and dataStore2's blobs should be in unreferenced blob size",
-		);
-
-		// Deleted stats. Wait for sweep timeout and send an op to update the current reference timestamp. Usually,
+		// Sweep ready stats. Wait for sweep timeout and send an op to update the current reference timestamp. Usually,
 		// GC wouldn't run without ops so this step is not needed for heuristics based summaries. It's needed here
 		// because we are explicitly running GC in absence of ops.
+		// All the unreferenced nodes should be sweep ready and should show up as deleted. This GC run should also
+		// generate a GC delete op.
 		await delay(tombstoneTimeoutMs + sweepGracePeriodMs);
 		mainDataObject._root.set("update", "timestamp");
 		await provider.ensureSynchronized();
+
+		// Data store 1, its DDS and blob 1 should show up as deleted.
+		expectedGCStats.deletedNodeCount += 3;
+		expectedGCStats.updatedNodeCount = 0;
+		expectedGCStats.deletedDataStoreCount += 1;
+		expectedGCStats.updatedDataStoreCount = 0;
+		expectedGCStats.deletedAttachmentBlobCount += 1;
+		expectedGCStats.updatedAttachmentBlobCount = 0;
+
+		gcStats = await summarizerRuntime.collectGarbage({});
+		assert.deepStrictEqual(gcStats, expectedGCStats, "2. GC stats is not as expected");
 
 		// Close the main container before running GC which generates a GC op. Otherwise, it will hit this error
 		// "GC_Deleted_DataStore_Unexpected_Delete". We don't expect local data stores to be deleted because
 		// their session expires before deletion. This mimics that behavior.
 		mainContainer.close();
 
-		// Run GC. This will generate a GC sweep op with the sweep ready node ids and wait for the op to be processed.
-		await summarizerRuntime.collectGarbage({});
+		// Data store 1, its DDS and blob 1 should now be deleted.
+		expectedGCStats.nodeCount -= 3;
+		expectedGCStats.unrefNodeCount -= 3;
+		expectedGCStats.dataStoreCount -= 1;
+		expectedGCStats.unrefDataStoreCount -= 1;
+		expectedGCStats.attachmentBlobCount -= 1;
+		expectedGCStats.unrefAttachmentBlobCount -= 1;
+
+		// Deleted stats. Run GC again. This time the sweep ready nodes should have been deleted.
 		await provider.ensureSynchronized();
-
-		expectedGCStats.nodeCount -= 6;
-		expectedGCStats.unrefNodeCount -= 6;
-		expectedGCStats.deletedNodeCount += 6;
-		expectedGCStats.updatedNodeCount = 0;
-		expectedGCStats.dataStoreCount -= 2;
-		expectedGCStats.unrefDataStoreCount -= 2;
-		expectedGCStats.deletedDataStoreCount += 2;
-		expectedGCStats.updatedDataStoreCount = 0;
-		expectedGCStats.attachmentBlobCount -= 2;
-		expectedGCStats.unrefAttachmentBlobCount -= 2;
-		expectedGCStats.deletedAttachmentBlobCount += 2;
-		expectedGCStats.updatedAttachmentBlobCount = 0;
-
-		// Run GC again. This will have the nodes deleted and update the delete stats.
 		gcStats = await summarizerRuntime.collectGarbage({});
-		assert.deepStrictEqual(gcStats, expectedGCStats, "GC stats is not as expected");
+		assert.deepStrictEqual(gcStats, expectedGCStats, "3. GC stats is not as expected");
 	});
 
 	it("can correctly generate GC stats when nodes are re-referenced", async () => {
@@ -360,7 +394,6 @@ describeCompat("Garbage Collection Stats", "NoCompat", (getTestObjectProvider) =
 		);
 		mainDataObject._root.set("blob1", blob1Handle);
 		mainDataObject._root.set("blob2", blob2Handle);
-		await provider.ensureSynchronized();
 
 		// Remove both data store and both blob handles to mark them unreferenced.
 		mainDataObject._root.delete("dataStore1");


### PR DESCRIPTION
## Bug and root-cause

A GC test that validates deleted stats is flaky. The test uses sweep timeout of 200 ms. It does the following in sequence:
1. Runs GC wtih every thing referenced and validates that there unreferenced stats are 0.
2. Unreferences one data store and one blob, runs GC and validates they show as unreferenced.
3. Unreferences another data store and another blob, runs GC and validates they show as unreferenced.
4. Wait for sweep timeout, runs GC so that GC delete op is sent.
5. Run GC again and validate that the unreferenced data stores and blobs show up as deleted.

If 200 ms have passed before step 3 is run, the unreferenced data store and blob will become sweep ready and will show up as deleted in GC stats. There was a change few months back that changed the logic to add sweep ready objects as deleted even when sweep is enabled (https://github.com/microsoft/FluidFramework/pull/19524) and the test probably became flaky then.

## Fix
Broke the test above into 2:
1. The first one only validates unreferenced stats (steps 1 to 3 above).
2. The second one that only validates sweep ready and deleted stats. It unreferences objects, waits for sweep timeout so that nodes are sweep ready and validates that they show as deleted. It then runs GC again so that the GC sweep op has round tripped and these nodes are deleted.
Since the test goes from unreferenced -> wait for sweep timeout -> validation, there is no intermediate GC run like bfore where it can unexpectedly become sweep ready.

[AB#8350](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8350)