### PR TITLE
build: Set prefer-frozen-lockfile=true in all .npmrc files

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/build-tools/.npmrc
+++ b/build-tools/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/build-tools/.npmrc
+++ b/build-tools/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/common/build/build-common/.npmrc
+++ b/common/build/build-common/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/common/build/build-common/.npmrc
+++ b/common/build/build-common/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/common/build/eslint-config-fluid/.npmrc
+++ b/common/build/eslint-config-fluid/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/common/build/eslint-config-fluid/.npmrc
+++ b/common/build/eslint-config-fluid/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/common/build/eslint-plugin-fluid/.npmrc
+++ b/common/build/eslint-plugin-fluid/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/common/build/eslint-plugin-fluid/.npmrc
+++ b/common/build/eslint-plugin-fluid/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/common/lib/common-utils/.npmrc
+++ b/common/lib/common-utils/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/common/lib/common-utils/.npmrc
+++ b/common/lib/common-utils/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/common/lib/protocol-definitions/.npmrc
+++ b/common/lib/protocol-definitions/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/common/lib/protocol-definitions/.npmrc
+++ b/common/lib/protocol-definitions/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/packages/tools/changelog-generator-wrapper/.npmrc
+++ b/packages/tools/changelog-generator-wrapper/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/packages/tools/changelog-generator-wrapper/.npmrc
+++ b/packages/tools/changelog-generator-wrapper/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/server/gitrest/.npmrc
+++ b/server/gitrest/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/server/gitrest/.npmrc
+++ b/server/gitrest/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/server/historian/.npmrc
+++ b/server/historian/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/server/historian/.npmrc
+++ b/server/historian/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/server/routerlicious/.npmrc
+++ b/server/routerlicious/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/server/routerlicious/.npmrc
+++ b/server/routerlicious/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/server/routerlicious/packages/tinylicious/.npmrc
+++ b/server/routerlicious/packages/tinylicious/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/server/routerlicious/packages/tinylicious/.npmrc
+++ b/server/routerlicious/packages/tinylicious/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/tools/api-markdown-documenter/.npmrc
+++ b/tools/api-markdown-documenter/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/tools/api-markdown-documenter/.npmrc
+++ b/tools/api-markdown-documenter/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/tools/benchmark/.npmrc
+++ b/tools/benchmark/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/tools/benchmark/.npmrc
+++ b/tools/benchmark/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/tools/test-tools/.npmrc
+++ b/tools/test-tools/.npmrc
@@ -1,5 +1,5 @@
 engine-strict=true
-prefer-frozen-lockfile=true
+frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers

--- a/tools/test-tools/.npmrc
+++ b/tools/test-tools/.npmrc
@@ -1,4 +1,5 @@
 engine-strict=true
+prefer-frozen-lockfile=true
 strict-peer-dependencies=true
 
 # Disable pnpm update notifications since we use corepack to install package managers


### PR DESCRIPTION
We always want to prefer a headless install and require explicit action update the lockfiles. pnpm supports CLI arguments set in npmrc files, so we set [frozen-lockfile](https://pnpm.io/cli/install#--frozen-lockfile) to true, which will make the default install experience error out when a lockfile update is needed. Users can pass --no-frozen-lockfile to override and update the lockfile.