### PR TITLE
[bump] build-tools: 0.41.0 => 0.42.0 (minor)

### DIFF
--- a/build-tools/lerna.json
+++ b/build-tools/lerna.json
@@ -1,1 +1,1 @@
-{ "version": "0.41.0", "npmClient": "pnpm", "useWorkspaces": true }
+{ "version": "0.42.0", "npmClient": "pnpm", "useWorkspaces": true }

--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "root",
-	"version": "0.41.0",
+	"version": "0.42.0",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/build-cli",
-	"version": "0.41.0",
+	"version": "0.42.0",
 	"description": "Build tools for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-tools",
-	"version": "0.41.0",
+	"version": "0.42.0",
 	"description": "Fluid Build tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/bundle-size-tools/package.json
+++ b/build-tools/packages/bundle-size-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/bundle-size-tools",
-	"version": "0.41.0",
+	"version": "0.42.0",
 	"description": "Utility for analyzing bundle size regressions",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/readme-command/package.json
+++ b/build-tools/packages/readme-command/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-private/readme-command",
-	"version": "0.41.0",
+	"version": "0.42.0",
 	"private": true,
 	"description": "CLI to generate readmes for Fluid build-tools",
 	"homepage": "https://fluidframework.com",

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/version-tools",
-	"version": "0.41.0",
+	"version": "0.42.0",
 	"description": "Versioning tools for Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
Bumped build-tools from 0.41.0 to 0.42.0. Command used:

```shell
flub release -g build-tools
```