### PR TITLE
refactor(ci): Increase timeout of local server e2e tests to 3s

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -40,7 +40,7 @@
 		"test:realsvc": "npm run test:realsvc:local && npm run test:realsvc:tinylicious",
 		"test:realsvc:frs": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=frs --timeout=20s",
 		"test:realsvc:frs:report": "npm run test:realsvc:frs --",
-		"test:realsvc:local": "npm run test:realsvc:run -- --driver=local",
+		"test:realsvc:local": "npm run test:realsvc:run -- --driver=local --timeout=3s",
 		"test:realsvc:local:report": "npm run test:realsvc:local --",
 		"test:realsvc:local:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:local --",
 		"test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",


### PR DESCRIPTION
## Description

Recently we're seeing more and more random tests timeout after 2s when they run against local server in the e2e tests pipeline. It's becoming a real problem causing noise for OCE. We have not been able to find a root cause, but trying to mitigate it for now by increasing the timeout a bit. If the problem is just load on the build agent, this might alleviate the issue. If the problem is real hangs, I'd expect this to not have any impact and still see tests timing out frequently, now after 3s instead of 2s.

Created [AB#8942](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8942) to follow up with addressing the problem and restoring the timeout to its current default.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
