### PR TITLE
Fix fuzz compose vs individual bug

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -105,7 +105,7 @@ export function applySynchronizationOp(state: DDSFuzzTestState<SharedTreeFactory
 }
 
 // TODO: Update this function to be done in a more ergonomic way using libraries
-function generateLeafNodeSchemas(nodeTypes: string[]) {
+export function generateLeafNodeSchemas(nodeTypes: string[]) {
 	const builder = new SchemaBuilderInternal({ scope: "com.fluidframework.leaf" });
 	const leafNodeSchemas = [];
 	for (const nodeType of nodeTypes) {


### PR DESCRIPTION
## Description

This PR fixes tests in `composeVsIndividual.fuzz.spec.ts`, where the schema ops were being processed on the main tree rather than its fork.