### PR TITLE
[Data Virtualization]: Reapply: Re-enable data virtualization in stress tests (#21864)

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -34,6 +34,8 @@ import { ITaskManager, TaskManager } from "@fluidframework/task-manager/internal
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
 import { ILoadTestConfig } from "./testConfigFile.js";
+import { printStatus } from "./utils.js";
+import { VirtualDataStoreFactory, type VirtualDataStore } from "./virtualDataStore.js";
 
 export interface IRunConfig {
 	runId: number;
@@ -56,6 +58,7 @@ export interface ILoadTest {
 const taskManagerKey = "taskManager";
 const counterKey = "counter";
 const sharedMapKey = "sharedMap";
+const dataStoresSharedMapKey = "dataStoresSharedMap";
 const startTimeKey = "startTime";
 const taskTimeKey = "taskTime";
 const gcDataStoreKey = "dataStore";
@@ -174,6 +177,9 @@ export class LoadTestDataStoreModel {
 		const counter = await runDir.get<IFluidHandle<ISharedCounter>>(counterKey)?.get();
 		const taskmanager = await root.get<IFluidHandle<ITaskManager>>(taskManagerKey)?.get();
 		const sharedmap = await runDir.get<IFluidHandle<ISharedMap>>(sharedMapKey)?.get();
+		const dataStoresSharedMap = await root
+			.get<IFluidHandle<ISharedMap>>(dataStoresSharedMapKey)
+			?.get();
 
 		if (counter === undefined) {
 			throw new Error("counter not available");
@@ -183,6 +189,9 @@ export class LoadTestDataStoreModel {
 		}
 		if (sharedmap === undefined) {
 			throw new Error("sharedmap not available");
+		}
+		if (dataStoresSharedMap === undefined) {
+			throw new Error("dataStoresSharedMap not available");
 		}
 
 		const gcDataStore = await this.getGCDataStore(config, root, containerRuntime);
@@ -197,6 +206,8 @@ export class LoadTestDataStoreModel {
 			sharedmap,
 			runDir,
 			gcDataStore.handle,
+			containerRuntime,
+			dataStoresSharedMap,
 		);
 
 		if (reset) {
@@ -233,6 +244,8 @@ export class LoadTestDataStoreModel {
 		public readonly sharedmap: ISharedMap,
 		private readonly runDir: IDirectory,
 		private readonly gcDataStoreHandle: IFluidHandle,
+		public readonly containerRuntime: IContainerRuntimeBase,
+		public readonly dataStoresSharedMap: ISharedMap,
 	) {
 		const halfClients = Math.floor(this.config.testConfig.numClients / 2);
 		// The runners are paired up and each pair shares a single taskId
@@ -507,6 +520,15 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 
 	protected async initializingFirstTime() {
 		this.root.set(taskManagerKey, TaskManager.create(this.runtime).handle);
+		const virtualDataStore = await VirtualDataStoreFactory.createInstance(
+			this.context.containerRuntime,
+			undefined,
+			"0",
+		);
+		this.root.set("0", virtualDataStore.handle);
+		const dataStoresMap = SharedMap.create(this.runtime);
+		this.root.set(dataStoresSharedMapKey, dataStoresMap.handle);
+		dataStoresMap.set("0", virtualDataStore.handle);
 	}
 
 	public async detached(config: Omit<IRunConfig, "runId">) {
@@ -602,9 +624,23 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 		const largeOpJitter = Math.min(config.runId, largeOpRate);
 		// To avoid growing the file size unnecessarily, not all clients should be sending large ops
 		const maxClientsSendingLargeOps = config.testConfig.content?.numClients ?? 1;
+
+		// Data Virtualization rates
+		const maxClientsForVirtualDatastores = config.testConfig.virtualization?.numClients ?? 1;
+		const virtualCreateRate =
+			config.testConfig.virtualization?.createRate !== undefined
+				? config.testConfig.virtualization.createRate / config.testConfig.numClients
+				: undefined;
+		const virtualLoadRate =
+			config.testConfig.virtualization?.loadRate !== undefined
+				? config.testConfig.virtualization.loadRate / config.testConfig.numClients
+				: undefined;
+
 		let opsSent = 0;
 		let largeOpsSent = 0;
 		let futureOpsSent = 0;
+		let virtualDataStoresCreated = 0;
+		let virtualDataStoresLoaded = 0;
 
 		const reportOpCount = (reason: string, error?: Error) => {
 			config.logger.sendTelemetryEvent(
@@ -616,6 +652,8 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 					localOpCount: opsSent,
 					localLargeOpCount: largeOpsSent,
 					localFutureOpCount: futureOpsSent,
+					localVirtualDataStoresCreated: virtualDataStoresCreated,
+					virtualDataStoresLoaded,
 				},
 				error,
 			);
@@ -650,6 +688,97 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 				});
 
 				largeOpsSent++;
+			}
+
+			// This creates a virtual data store
+			if (
+				this.shouldCreateVirtualDataStore(
+					virtualCreateRate,
+					opsSent,
+					maxClientsForVirtualDatastores,
+					config.runId,
+				)
+			) {
+				// create virtual data store
+				const validGroupIds = dataModel.dataStoresSharedMap.size - 1;
+				const groupId = config.random.integer(0, validGroupIds);
+				const virtualDataStoreCreation = VirtualDataStoreFactory.createInstance(
+					dataModel.containerRuntime,
+					undefined,
+					groupId.toString(),
+				);
+				const opsSentCurrent = opsSent;
+				virtualDataStoreCreation
+					.then((virtualDataStore) => {
+						dataModel.dataStoresSharedMap.set(
+							`${config.runId}${opsSentCurrent}`,
+							virtualDataStore.handle,
+						);
+						config.logger.sendTelemetryEvent({
+							eventName: "VirtualDataStoreCreation",
+							runId: config.runId,
+							localOpCount: opsSentCurrent,
+							virtualCreateRate,
+							groupId: virtualDataStore.loadingGroupId,
+						});
+						virtualDataStoresCreated++;
+						printStatus(config, `Virtual data store created`);
+					})
+					.catch((error) => {
+						config.logger.sendErrorEvent(
+							{
+								eventName: "VirtualDataStoreCreationFailed",
+								runId: config.runId,
+								localOpCount: opsSentCurrent,
+								virtualCreateRate,
+							},
+							error,
+						);
+					});
+			}
+
+			// This starts loading a virtual data store
+			if (
+				this.shouldLoadVirtualDataStore(
+					virtualLoadRate,
+					opsSent,
+					maxClientsForVirtualDatastores,
+					config.runId,
+				)
+			) {
+				// load random virtual data store
+				const dataStoreHandles = Array.from(
+					dataModel.dataStoresSharedMap.values(),
+				) as IFluidHandle<VirtualDataStore>[];
+				const handle = config.random.pick(dataStoreHandles);
+				const opsSentCurrent = opsSent;
+				const loadStartMs = Date.now();
+				handle
+					.get()
+					.then((virtualDataStore) => {
+						const loadEndMs = Date.now();
+						config.logger.sendTelemetryEvent({
+							eventName: "VirtualDataStoreLoaded",
+							runId: config.runId,
+							localOpCount: opsSentCurrent,
+							virtualLoadRate,
+							groupId: virtualDataStore.loadingGroupId,
+							loadTimeMs: loadEndMs - loadStartMs,
+						});
+						printStatus(config, `Virtual data store loaded`);
+						virtualDataStoresLoaded++;
+					})
+					.catch((error) => {
+						config.logger.sendErrorEvent(
+							{
+								eventName: "VirtualDataStoreLoadFailed",
+								runId: config.runId,
+								localOpCount: opsSentCurrent,
+								virtualLoadRate,
+							},
+							error,
+						);
+					});
 			}
 
 			// [DEPRECATED] This flow is deprecated and is expected to be removed from FF soon.
@@ -710,8 +839,9 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 				await sendSingleOpAndThenWait();
 			}
 
-			reportOpCount("Completed");
-			return !this.runtime.disposed;
+			const doneSendingOps = !this.runtime.disposed;
+			reportOpCount(doneSendingOps ? "Completed" : "Not Completed");
+			return doneSendingOps;
 		} catch (error: any) {
 			reportOpCount("Exception", error);
 			throw error;
@@ -745,6 +875,40 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 			largeOpRate > 0 &&
 			opsSent % largeOpRate === largeOpJitter
 		);
+	}
+
+	/**
+	 * @param createRate - how often should a virtual data store be created, every so op count
+	 * @param jitter - how much jitter to add to the create rate. Jitter was added so creates didn't happen at the same time
+	 * @param opsSent - how many ops have been sent by the client
+	 * @param maxClients - how many clients should be creating virtual data stores
+	 * @param runId - run id of the current test
+	 * @returns true if a virtual data store should be created, false otherwise
+	 */
+	private shouldCreateVirtualDataStore(
+		createRate: number | undefined,
+		opsSent: number,
+		maxClients: number,
+		runId: number,
+	) {
+		return runId < maxClients && createRate !== undefined && opsSent % createRate === 0;
+	}
+
+	/**
+	 *
+	 * @param loadRate - how often should a virtual data store be loaded, every so op count
+	 * @param opsSent - how many ops have been sent by the client
+	 * @param maxClients - how many clients should be creating virtual data stores
+	 * @param runId - run id of the current test
+	 * @returns true if a virtual data store should be loaded, false otherwise
+	 */
+	private shouldLoadVirtualDataStore(
+		loadRate: number | undefined,
+		opsSent: number,
+		maxClients: number,
+		runId: number,
+	) {
+		return runId < maxClients && loadRate !== undefined && opsSent % loadRate === 0;
 	}
 
 	async sendSignals(config: IRunConfig) {
@@ -786,11 +950,9 @@ const LoadTestDataStoreInstantiationFactory = new DataObjectFactory(
 export const createFluidExport = (runtimeOptions: IContainerRuntimeOptions) =>
 	new ContainerRuntimeFactoryWithDefaultDataStore({
 		defaultFactory: LoadTestDataStoreInstantiationFactory,
-		registryEntries: new Map([
-			[
-				LoadTestDataStore.DataStoreName,
-				Promise.resolve(LoadTestDataStoreInstantiationFactory),
-			],
-		]),
+		registryEntries: [
+			LoadTestDataStoreInstantiationFactory.registryEntry,
+			VirtualDataStoreFactory.registryEntry,
+		],
 		runtimeOptions,
 	});

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -107,6 +107,21 @@ export interface ILoadTestConfig {
 		 */
 		numClients?: number;
 	};
+	virtualization?: {
+		/**
+		 * Once every `createRate` ops, a virtualized dataStore will be created
+		 */
+		createRate?: number;
+		/**
+		 * Once every `loadRate` ops, a virtualized dataStore will be loaded
+		 */
+		loadRate?: number;
+		/**
+		 * How many clients should create/load virtual data stores if `createRate` is specified.
+		 * By default, only one client will send create/load virtual data stores.
+		 */
+		numClients?: number;
+	};
 }
 
 export interface OptionOverride {

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -33,7 +33,7 @@ import { ICreateBlobResponse } from "@fluidframework/driver-definitions/internal
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import { LocalCodeLoader } from "@fluidframework/test-utils/internal";
 
-import { ILoadTest, createFluidExport } from "./loadTestDataStore.js";
+import { ILoadTest, createFluidExport, type IRunConfig } from "./loadTestDataStore.js";
 import {
 	generateConfigurations,
 	generateLoaderOptions,
@@ -319,3 +319,9 @@ export const configProvider = (configs: Record<string, ConfigTypes>): IConfigPro
 		getRawConfig: (name: string): ConfigTypes => globalConfigurations[name] ?? configs[name],
 	};
 };
+
+export function printStatus(runConfig: IRunConfig, message: string) {
+	if (runConfig.verbose) {
+		console.log(`${runConfig.runId.toString().padStart(3)}> ${message}`);
+	}
+}

--- a/packages/test/test-service-load/src/virtualDataStore.ts
+++ b/packages/test/test-service-load/src/virtualDataStore.ts
@@ -1,0 +1,68 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/internal";
+import { assert } from "@fluidframework/core-utils/internal";
+import { SharedCounter } from "@fluidframework/counter/internal";
+import type {
+	IContainerRuntimeBase,
+	IFluidDataStoreContext,
+} from "@fluidframework/runtime-definitions/internal";
+
+export class VirtualDataStore extends DataObject {
+	public get loadingGroupId(): string | undefined {
+		return this.context.loadingGroupId;
+	}
+}
+
+/**
+ * A DataObjectFactory for creating virtualized data objects
+ */
+export class VirtualDataObjectFactory extends DataObjectFactory<VirtualDataStore> {
+	constructor() {
+		super("virtual-service-load", VirtualDataStore, [SharedCounter.getFactory()], {});
+	}
+
+	/**
+	 *
+	 * @param runtime - the container runtime
+	 * @param _initialState - any state
+	 * @param loadingGroupId - the loading group id used to create a basic data object
+	 * @returns a new instance of the data object
+	 */
+	public async createInstance(
+		runtime: IContainerRuntimeBase,
+		initialState: any,
+		loadingGroupId: string,
+	): Promise<VirtualDataStore> {
+		return super.createInstance(runtime, initialState, loadingGroupId);
+	}
+
+	public async createChildInstance(
+		_parentContext: IFluidDataStoreContext,
+		_initialState?: any,
+		_loadingGroupId?: string | undefined,
+	): Promise<VirtualDataStore> {
+		assert(false, "Not implemented");
+	}
+
+	public async createPeerInstance(
+		_peerContext: IFluidDataStoreContext,
+		_initialState?: any,
+		_loadingGroupId?: string | undefined,
+	): Promise<VirtualDataStore> {
+		assert(false, "Not implemented");
+	}
+
+	public async createRootInstance(
+		_rootDataStoreId: string,
+		_runtime,
+		_initialState?: any,
+	): Promise<VirtualDataStore> {
+		assert(false, "Not implemented");
+	}
+}
+
+export const VirtualDataStoreFactory = new VirtualDataObjectFactory();

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -28,13 +28,15 @@
 			"optionOverrides": {
 				"odsp": {
 					"configurations": {
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false],
+						"Fluid.Container.UseLoadingGroupIdForSnapshotFetch2": [true, false]
 					}
 				},
 				"odsp-odsp-df": {
 					"configurations": {
 						"Fluid.Driver.Odsp.snapshotFormatFetchType": [2],
-						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false]
+						"Fluid.Summarizer.PendingOpsRetryDelayMs": [true, false],
+						"Fluid.Container.UseLoadingGroupIdForSnapshotFetch2": [true, false]
 					}
 				},
 				"tinylicious": {
@@ -49,6 +51,11 @@
 				"opSizeinBytes": 214800,
 				"largeOpRate": 2000,
 				"numClients": 12
+			},
+			"virtualization": {
+				"createRate": 2000,
+				"loadRate": 2000,
+				"numClients": 2
 			}
 		},
 		"ci_frs": {


### PR DESCRIPTION
[AB#8898](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8686)

Re-enable data virtualization in stress tests. This time the bug that was found was that when offline was turned on, when we loaded our snapshot, offline would download all the virtualized blobs.