### PR TITLE
azure-client: enable read-client tests for Tinylicious

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/audience.spec.ts
@@ -213,12 +213,6 @@ for (const testOpts of testMatrix) {
 		 * to resolve original member, and the original member should be able to observe the read-only member.
 		 */
 		it("can find read-only partner member", async function () {
-			// TODO: Fix tests when ran against local service - ADO:7876
-			const useAzure = process.env.FLUID_CLIENT === "azure";
-			if (!useAzure) {
-				this.skip();
-			}
-
 			let containerId: string;
 			let container: IFluidContainer;
 			let services: AzureContainerServices;
@@ -329,12 +323,6 @@ for (const testOpts of testMatrix) {
 		 * the original read-only partner should observe memberAdded event and have correct partner count.
 		 */
 		it("can observe member leaving and joining in read-only mode", async function () {
-			// TODO: Fix tests when ran against local service - ADO:7876
-			const useAzure = process.env.FLUID_CLIENT === "azure";
-			if (!useAzure) {
-				this.skip();
-			}
-
 			let containerId: string;
 			let container: IFluidContainer;
 			if (isEphemeral) {

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/signals.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/signals.spec.ts
@@ -189,12 +189,6 @@ for (const testOpts of testMatrix) {
 		 * a signal sent by any 1 client should be recieved by all 3 clients, regardless of read/write permissions.
 		 */
 		it("can send and receive read-only client signals", async function () {
-			// TODO: Fix tests when ran against local service - ADO:7876
-			const useAzure = process.env.FLUID_CLIENT === "azure";
-			if (!useAzure) {
-				this.skip();
-			}
-
 			const { signaler: writeSignaler, containerId } = await getOrCreateSignalerContainer(
 				undefined,
 				user1,


### PR DESCRIPTION
## Description

#20914 disabled a few Azure E2E tests because they were timing out in T9s due to a T9s bug that was fixed in #20312. That bug has been patched into T9s v4 and was also released in T9s v5. We can enable those tests now.

Validated locally that these pass by running `pnpm test`
