### PR TITLE
Fix considering versions > 2.0.0 as semver

### DIFF
--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -229,6 +229,12 @@ export function validateVersionScheme(
 		);
 	}
 
+	if (parsedVersion.compare(MINIMUM_PUBLIC_VERSION) >= 0) {
+		throw new Error(
+			`The public version must be < ${MINIMUM_PUBLIC_VERSION}; found ${parsedVersion.format()}`,
+		);
+	}
+
 	if (parsedVersion.prerelease.length > MINIMUM_SEMVER_PRERELEASE_SECTIONS) {
 		if (allowPrereleases) {
 			return true;

--- a/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
+++ b/build-tools/packages/version-tools/src/test/internalVersionScheme.test.ts
@@ -167,15 +167,6 @@ describe("internalScheme", () => {
 			assert.strictEqual(calculated.version, expected);
 		});
 
-		it("parses 3.0.0-internal.1.0.0", () => {
-			const input = `3.0.0-internal.1.0.0`;
-			const expectedInt = `1.0.0`;
-			const expectedPub = `3.0.0`;
-			const [pubVer, intVer] = fromInternalScheme(input);
-			assert.strictEqual(intVer.version, expectedInt);
-			assert.strictEqual(pubVer.version, expectedPub);
-		});
-
 		it("throws on 2.0.0-internal.1.1.0.12345", () => {
 			const input = `2.0.0-internal.1.1.0.12345`;
 			const expected = `1.1.0-12345`;
@@ -210,13 +201,6 @@ describe("internalScheme", () => {
 	});
 
 	describe("converting TO internal scheme", () => {
-		it("converts 1.0.0 to internal version with public version 2.2.2", () => {
-			const input = `1.0.0`;
-			const expected = `2.2.2-internal.1.0.0`;
-			const calculated = toInternalScheme("2.2.2", input);
-			assert.strictEqual(calculated.version, expected);
-		});
-
 		it("converts 1.2.3 to internal version with public version 2.0.0, dev prerelease identifier", () => {
 			const input = `1.2.3`;
 			const expected = `2.0.0-dev.1.2.3`;

--- a/build-tools/packages/version-tools/src/test/schemes.test.ts
+++ b/build-tools/packages/version-tools/src/test/schemes.test.ts
@@ -103,6 +103,12 @@ describe("detectVersionScheme", () => {
 		assert.strictEqual(detectVersionScheme(input), expected);
 	});
 
+	it("detects 2.4.3-280913-test is semver", () => {
+		const input = `2.4.3-280913-test`;
+		const expected = "semver";
+		assert.strictEqual(detectVersionScheme(input), expected);
+	});
+
 	it("detects 2.4.3 is semver", () => {
 		const input = `2.4.3`;
 		const expected = "semver";

--- a/build-tools/packages/version-tools/src/test/semver.test.ts
+++ b/build-tools/packages/version-tools/src/test/semver.test.ts
@@ -796,13 +796,5 @@ describe("semver", () => {
 			assert.equal(result1, expected1, "previous major version mismatch");
 			assert.equal(result2, expected2, "previous minor version mismatch");
 		});
-
-		it("3.0.0-internal.3.2.2", () => {
-			const input = `3.0.0-internal.3.2.2`;
-			const [expected1, expected2] = [`3.0.0-internal.2.0.0`, `3.0.0-internal.3.1.0`];
-			const [result1, result2] = getPreviousVersions(input);
-			assert.equal(result1, expected1, "previous major version mismatch");
-			assert.equal(result2, expected2, "previous minor version mismatch");
-		});
 	});
 });


### PR DESCRIPTION
[AB#8967](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8967)

This should fix test branches and allow them to build again.