### PR TITLE
Cleanup flex layer `treeStatus`

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -431,7 +431,7 @@ export interface TreeNodeApi {
     parent(node: TreeNode): TreeNode | undefined;
     schema<T extends TreeNode | TreeLeafValue>(node: T): TreeNodeSchema<string, NodeKind, unknown, T>;
     shortId(node: TreeNode): number | string | undefined;
-    readonly status: (node: TreeNode) => TreeStatus;
+    status(node: TreeNode): TreeStatus;
 }
 
 // @public

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -431,7 +431,7 @@ export interface TreeNodeApi {
     parent(node: TreeNode): TreeNode | undefined;
     schema<T extends TreeNode | TreeLeafValue>(node: T): TreeNodeSchema<string, NodeKind, unknown, T>;
     shortId(node: TreeNode): number | string | undefined;
-    readonly status: (node: TreeNode) => TreeStatus;
+    status(node: TreeNode): TreeStatus;
 }
 
 // @public

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -431,7 +431,7 @@ export interface TreeNodeApi {
     parent(node: TreeNode): TreeNode | undefined;
     schema<T extends TreeNode | TreeLeafValue>(node: T): TreeNodeSchema<string, NodeKind, unknown, T>;
     shortId(node: TreeNode): number | string | undefined;
-    readonly status: (node: TreeNode) => TreeStatus;
+    status(node: TreeNode): TreeStatus;
 }
 
 // @public

--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -34,7 +34,6 @@ import {
 	type FlexTreeUnboxNodeUnion,
 	type FlexibleFieldContent,
 	type FlexibleNodeSubSequence,
-	TreeStatus,
 	flexTreeMarker,
 	indexForAt,
 } from "../flex-tree/index.js";
@@ -210,10 +209,6 @@ export class EagerMapTreeNode<TSchema extends FlexTreeNodeSchema> implements Map
 		return mapIterable(this.mapTree.fields.entries(), ([key, field]) =>
 			getOrCreateField(this, key, field, this.schema.getFieldSchema(key)),
 		);
-	}
-
-	public treeStatus(): TreeStatus {
-		return TreeStatus.New;
 	}
 
 	public get value(): Value {
@@ -418,9 +413,6 @@ export const rootMapTreeField: MapTreeField<FlexAllowedTypes> = {
 	get context(): FlexTreeContext {
 		return fail("MapTreeField does not implement context");
 	},
-	treeStatus(): TreeStatus {
-		return TreeStatus.New;
-	},
 	mapTrees: [],
 };
 
@@ -491,10 +483,6 @@ class MapTreeField<T extends FlexAllowedTypes> implements FlexTreeField {
 
 	public get context(): FlexTreeContext {
 		return fail("MapTreeField does not implement context");
-	}
-
-	public treeStatus(): TreeStatus {
-		return TreeStatus.New;
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -99,14 +99,6 @@ export interface FlexTreeEntity<out TSchema = unknown> {
 	readonly context: FlexTreeContext;
 
 	/**
-	 * Gets the {@link TreeStatus} of this tree.
-	 *
-	 * @remarks
-	 * For non-root fields, this is the status of the parent node, since fields do not have a separate lifetime.
-	 */
-	treeStatus(): TreeStatus;
-
-	/**
 	 * Iterate through all nodes/fields in this field/node.
 	 *
 	 * @remarks
@@ -588,7 +580,6 @@ export const reservedObjectNodeFieldPropertyNames = [
 	"on",
 	"parentField",
 	"schema",
-	"treeStatus",
 	"tryGetField",
 	"type",
 	"value",

--- a/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
@@ -60,6 +60,12 @@ export type {
 	FlexibleNodeSubSequence,
 } from "./flexTreeTypes.js";
 
-export { assertFlexTreeEntityNotFreed } from "./lazyEntity.js";
+export {
+	assertFlexTreeEntityNotFreed,
+	isFreedSymbol,
+	LazyEntity,
+} from "./lazyEntity.js";
 
 export { getSchemaAndPolicy, indexForAt } from "./utilities.js";
+
+export { treeStatusFromAnchorCache } from "./utilities.js";

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
@@ -16,7 +16,6 @@ import type { Context } from "./context.js";
 import {
 	type FlexTreeEntity,
 	type FlexTreeEntityKind,
-	type TreeStatus,
 	flexTreeMarker,
 } from "./flexTreeTypes.js";
 
@@ -64,8 +63,6 @@ export abstract class LazyEntity<TSchema = unknown, TAnchor = unknown>
 
 	public abstract boxedIterator(): IterableIterator<FlexTreeEntity>;
 	public abstract get [flexTreeMarker](): FlexTreeEntityKind;
-
-	public abstract treeStatus(): TreeStatus;
 
 	public [disposeSymbol](): void {
 		this.#lazyCursor.free();

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -12,11 +12,12 @@ import {
 	type FieldUpPath,
 	type ITreeCursorSynchronous,
 	type ITreeSubscriptionCursor,
+	ITreeSubscriptionCursorState,
 	type TreeNavigationResult,
 	inCursorNode,
 	isCursor,
 	iterateCursorField,
-	keyAsDetachedField,
+	rootFieldKey,
 } from "../../core/index.js";
 import {
 	assertValidIndex,
@@ -64,11 +65,7 @@ import {
 } from "./lazyEntity.js";
 import { type LazyTreeNode, makeTree } from "./lazyNode.js";
 import { unboxedUnion } from "./unboxed.js";
-import {
-	indexForAt,
-	treeStatusFromAnchorCache,
-	treeStatusFromDetachedField,
-} from "./utilities.js";
+import { indexForAt, treeStatusFromAnchorCache } from "./utilities.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 /**
@@ -259,23 +256,6 @@ export abstract class LazyField<
 		);
 	}
 
-	public treeStatus(): TreeStatus {
-		if (this[isFreedSymbol]()) {
-			return TreeStatus.Deleted;
-		}
-		const fieldAnchor = this[anchorSymbol];
-		const parentAnchor = fieldAnchor.parent;
-		// If the parentAnchor is undefined it is a detached field.
-		if (parentAnchor === undefined) {
-			return treeStatusFromDetachedField(keyAsDetachedField(fieldAnchor.fieldKey));
-		}
-		const parentAnchorNode = this.context.checkout.forest.anchors.locate(parentAnchor);
-
-		// As the "parentAnchor === undefined" case is handled above, parentAnchorNode should exist.
-		assert(parentAnchorNode !== undefined, 0x77e /* parentAnchorNode must exist. */);
-		return treeStatusFromAnchorCache(parentAnchorNode);
-	}
-
 	public getFieldPath(): FieldUpPath {
 		return this[cursorSymbol].getFieldPath();
 	}
@@ -285,10 +265,19 @@ export abstract class LazyField<
 	 * This path is not valid to hold onto across edits: this must be recalled for each edit.
 	 */
 	public getFieldPathForEditing(): FieldUpPath {
-		if (this.treeStatus() !== TreeStatus.InDocument) {
-			throw new UsageError("Editing only allowed on fields with TreeStatus.InDocument status");
+		if (!this[isFreedSymbol]()) {
+			if (
+				// Only allow editing if we are the root document field...
+				(this.parent === undefined && this[anchorSymbol].fieldKey === rootFieldKey) ||
+				// ...or are under a node in the document
+				(this.parent !== undefined &&
+					treeStatusFromAnchorCache(this.parent.anchorNode) === TreeStatus.InDocument)
+			) {
+				return this.getFieldPath();
+			}
 		}
-		return this.getFieldPath();
+
+		throw new UsageError("Editing only allowed on fields with TreeStatus.InDocument status");
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -12,7 +12,6 @@ import {
 	type FieldUpPath,
 	type ITreeCursorSynchronous,
 	type ITreeSubscriptionCursor,
-	ITreeSubscriptionCursorState,
 	type TreeNavigationResult,
 	inCursorNode,
 	isCursor,

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -55,7 +55,6 @@ import {
 	type FlexibleFieldContent,
 	type FlexibleNodeContent,
 	type PropertyNameFromFieldKey,
-	TreeStatus,
 	flexTreeMarker,
 	flexTreeSlot,
 	reservedObjectNodeFieldPropertyNamePrefixes,
@@ -66,13 +65,11 @@ import {
 	anchorSymbol,
 	cursorSymbol,
 	forgetAnchorSymbol,
-	isFreedSymbol,
 	tryMoveCursorToAnchorSymbol,
 } from "./lazyEntity.js";
 import { makeField } from "./lazyField.js";
 import type { FlexTreeNodeEvents } from "./treeEvents.js";
 import { unboxedField } from "./unboxed.js";
-import { treeStatusFromAnchorCache } from "./utilities.js";
 
 /**
  * @param cursor - This does not take ownership of this cursor: Node will fork it as needed.
@@ -255,13 +252,6 @@ export abstract class LazyTreeNode<TSchema extends FlexTreeNodeSchema = FlexTree
 		cursor.enterNode(index);
 
 		return { parent: proxifiedField, index };
-	}
-
-	public override treeStatus(): TreeStatus {
-		if (this[isFreedSymbol]()) {
-			return TreeStatus.Deleted;
-		}
-		return treeStatusFromAnchorCache(this.anchorNode);
 	}
 
 	public on<K extends keyof FlexTreeNodeEvents>(

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -280,6 +280,9 @@ export {
 	assertFlexTreeEntityNotFreed,
 	flexTreeSlot,
 	getSchemaAndPolicy,
+	isFreedSymbol,
+	LazyEntity,
+	treeStatusFromAnchorCache,
 } from "./flex-tree/index.js";
 
 export { treeSchemaFromStoredSchema } from "./storedToViewSchema.js";

--- a/packages/dds/tree/src/shared-tree/treeApi.ts
+++ b/packages/dds/tree/src/shared-tree/treeApi.ts
@@ -455,7 +455,7 @@ function runTransactionInCheckout<TResult>(
 			case "nodeInDocument": {
 				const node = getFlexNode(constraint.node);
 				assert(
-					node.treeStatus() === TreeStatus.InDocument,
+					treeApi.status(constraint.node) === TreeStatus.InDocument,
 					0x90f /* Attempted to apply "nodeExists" constraint when building a transaction, but the node is not in the document. */,
 				);
 				checkout.editor.addNodeExistsConstraint(node.anchorNode);

--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -9,7 +9,6 @@ import {
 	FieldKinds,
 	FlexFieldSchema,
 	SchemaBuilderBase,
-	TreeStatus,
 } from "../../../feature-libraries/index.js";
 import { EmptyKey, type FieldKey, type MapTree } from "../../../core/index.js";
 import { leaf as leafDomain } from "../../../domains/index.js";
@@ -207,12 +206,6 @@ describe("MapTreeNodes", () => {
 		assert.equal(map.is(fieldNodeSchema), false);
 		assert.equal(fieldNode.is(objectSchema), false);
 		assert.equal(object.is(mapSchema), false);
-	});
-
-	it("can get their tree status", () => {
-		assert.equal(map.treeStatus(), TreeStatus.New);
-		assert.equal(fieldNode.treeStatus(), TreeStatus.New);
-		assert.equal(object.treeStatus(), TreeStatus.New);
 	});
 
 	describe("cannot", () => {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -796,7 +796,7 @@ export interface TreeNodeApi {
     parent(node: TreeNode): TreeNode | undefined;
     schema<T extends TreeNode | TreeLeafValue>(node: T): TreeNodeSchema<string, NodeKind, unknown, T>;
     shortId(node: TreeNode): number | string | undefined;
-    readonly status: (node: TreeNode) => TreeStatus;
+    status(node: TreeNode): TreeStatus;
 }
 
 // @public

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -1206,7 +1206,7 @@ export interface TreeNodeApi {
     parent(node: TreeNode): TreeNode | undefined;
     schema<T extends TreeNode | TreeLeafValue>(node: T): TreeNodeSchema<string, NodeKind, unknown, T>;
     shortId(node: TreeNode): number | string | undefined;
-    readonly status: (node: TreeNode) => TreeStatus;
+    status(node: TreeNode): TreeStatus;
 }
 
 // @public

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -830,7 +830,7 @@ export interface TreeNodeApi {
     parent(node: TreeNode): TreeNode | undefined;
     schema<T extends TreeNode | TreeLeafValue>(node: T): TreeNodeSchema<string, NodeKind, unknown, T>;
     shortId(node: TreeNode): number | string | undefined;
-    readonly status: (node: TreeNode) => TreeStatus;
+    status(node: TreeNode): TreeStatus;
 }
 
 // @public

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -796,7 +796,7 @@ export interface TreeNodeApi {
     parent(node: TreeNode): TreeNode | undefined;
     schema<T extends TreeNode | TreeLeafValue>(node: T): TreeNodeSchema<string, NodeKind, unknown, T>;
     shortId(node: TreeNode): number | string | undefined;
-    readonly status: (node: TreeNode) => TreeStatus;
+    status(node: TreeNode): TreeStatus;
 }
 
 // @public


### PR DESCRIPTION
## Description

This removes `treeStatus()` from the flex API and does various related cleanup. This is part of an ongoing effort to reduce the code in SharedTree's middle API layer.
