### PR TITLE
tree: Prefer type imports in VSCode workspace

### DIFF
--- a/packages/dds/tree/.vscode/Tree.code-workspace
+++ b/packages/dds/tree/.vscode/Tree.code-workspace
@@ -18,6 +18,7 @@
 			"**/node_modules/**/@fluid*/*-previous",
 			"**/node_modules/**/@fluid*/*-previous/*"
 		],
-		"typescript.preferences.importModuleSpecifier": "project-relative"
+		"typescript.preferences.importModuleSpecifier": "project-relative",
+		"typescript.preferences.preferTypeOnlyAutoImports": true
 	}
 }


### PR DESCRIPTION
## Description

Tree's lints are configured to prefer type imports, so make auto-importing match.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

