### PR TITLE
Update @fluid-experimental/property-inspector-table peer deps

### DIFF
--- a/experimental/PropertyDDS/packages/property-inspector-table/package.json
+++ b/experimental/PropertyDDS/packages/property-inspector-table/package.json
@@ -120,11 +120,11 @@
 		"webpack-merge": "^5.8.0"
 	},
 	"peerDependencies": {
-		"@fluid-experimental/property-binder": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
-		"@fluid-experimental/property-changeset": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
-		"@fluid-experimental/property-dds": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
-		"@fluid-experimental/property-properties": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
-		"@fluid-experimental/property-proxy": ">=2.0.0-internal.3.2.0 <2.0.0-internal.4.0.0",
+		"@fluid-experimental/property-binder": "workspace:~",
+		"@fluid-experimental/property-changeset": "workspace:~",
+		"@fluid-experimental/property-dds": "workspace:~",
+		"@fluid-experimental/property-properties": "workspace:~",
+		"@fluid-experimental/property-proxy": "workspace:~",
 		"react": "^17.0.1"
 	},
 	"fluidBuild": {


### PR DESCRIPTION
## Description

@fluid-experimental/property-inspector-table had out of date peer deps. This fixes them.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

