### PR TITLE
server: Clean up kafka producer error listener memory leak

### DIFF
--- a/server/routerlicious/.changeset/gold-dingos-warn.md
+++ b/server/routerlicious/.changeset/gold-dingos-warn.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/server-lambdas": major
+---
+
+Orderer Connection "error" listener disposed on disconnect
+
+The Nexus lambda's per-socket-orderer-connection error listener is now removed when the socket connection ends.

--- a/server/routerlicious/.changeset/gold-dingos-warn.md
+++ b/server/routerlicious/.changeset/gold-dingos-warn.md
@@ -1,5 +1,5 @@
 ---
-"@fluidframework/server-lambdas": major
+"@fluidframework/server-lambdas": minor
 ---
 
 Orderer Connection "error" listener disposed on disconnect

--- a/server/routerlicious/.changeset/six-goats-refuse.md
+++ b/server/routerlicious/.changeset/six-goats-refuse.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/server-services-core": major
+---
+
+`.off()` instance method added to IProducer and IOrdererConnection types
+
+In order to allow consumers of IProducer and IOrdererConnection implementations to cleanup event listeners added using the already-exposed `.once()` and `.on()` methods, a `.off()` method was added as a required property to both interfaces.

--- a/server/routerlicious/.changeset/witty-years-exist.md
+++ b/server/routerlicious/.changeset/witty-years-exist.md
@@ -2,11 +2,10 @@
 "@fluidframework/server-kafka-orderer": major
 "@fluidframework/server-memory-orderer": major
 "@fluidframework/server-routerlicious-base": major
-"@fluidframework/server-services-core": major
 "@fluidframework/server-services-ordering-kafkanode": major
 "@fluidframework/server-test-utils": major
 ---
 
-`.off()` instance method added to IProducer and IOrdererConnection types and implementations
+`.off()` instance method added to IProducer and IOrdererConnection implementations
 
-In order to allow consumers of IProducer and IOrdererConnection implementations to cleanup event listeners added using the already-exposed `.once()` and `.on()` methods, a `.off()` method was added as a required property to both interfaces. All exported implementations of IProducer and IOrdererConnection have had a `.off()` method added
+In order to allow consumers of IProducer and IOrdererConnection implementations to cleanup event listeners added using the already-exposed `.once()` and `.on()` methods, a `.off()` method was added as a required property to both interfaces. All exported implementations of IProducer and IOrdererConnection have had a `.off()` method added, and all functions that take IProducer or IOrdererConnection params have had their types updated as well.

--- a/server/routerlicious/.changeset/witty-years-exist.md
+++ b/server/routerlicious/.changeset/witty-years-exist.md
@@ -1,0 +1,13 @@
+---
+"@fluidframework/server-kafka-orderer": major
+"@fluidframework/server-lambdas": major
+"@fluidframework/server-memory-orderer": major
+"@fluidframework/server-routerlicious-base": major
+"@fluidframework/server-services-core": major
+"@fluidframework/server-services-ordering-kafkanode": major
+"@fluidframework/server-test-utils": major
+---
+
+`.off()` instance method added to IProducer and IOrdererConnection types and implementations
+
+In order to allow consumers of IProducer and IOrdererConnection implementations to cleanup event listeners added using the already-exposed `.once()` and `.on()` methods, a `.off()` method was added as a required property to both interfaces. All exported implementations of IProducer and IOrdererConnection have had a `.off()` method added

--- a/server/routerlicious/.changeset/witty-years-exist.md
+++ b/server/routerlicious/.changeset/witty-years-exist.md
@@ -1,6 +1,5 @@
 ---
 "@fluidframework/server-kafka-orderer": major
-"@fluidframework/server-lambdas": major
 "@fluidframework/server-memory-orderer": major
 "@fluidframework/server-routerlicious-base": major
 "@fluidframework/server-services-core": major

--- a/server/routerlicious/packages/kafka-orderer/package.json
+++ b/server/routerlicious/packages/kafka-orderer/package.json
@@ -53,6 +53,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_KafkaOrdererConnection": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/kafkaOrderer.ts
@@ -144,6 +144,10 @@ export class KafkaOrdererConnection implements core.IOrdererConnection {
 		this.producer.once(event, listener);
 	}
 
+	public off(event: "error", listener: (...args: any[]) => void) {
+		this.producer.off(event, listener);
+	}
+
 	private async submitRawOperation(messages: core.IRawOperationMessage[]): Promise<void> {
 		if (this.serviceConfiguration.enableTraces) {
 			// Add trace

--- a/server/routerlicious/packages/kafka-orderer/src/test/types/validateServerKafkaOrdererPrevious.generated.ts
+++ b/server/routerlicious/packages/kafka-orderer/src/test/types/validateServerKafkaOrdererPrevious.generated.ts
@@ -57,6 +57,7 @@ declare function get_old_ClassDeclaration_KafkaOrdererConnection():
 declare function use_current_ClassDeclaration_KafkaOrdererConnection(
     use: TypeOnly<current.KafkaOrdererConnection>): void;
 use_current_ClassDeclaration_KafkaOrdererConnection(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_KafkaOrdererConnection());
 
 /*

--- a/server/routerlicious/packages/memory-orderer/package.json
+++ b/server/routerlicious/packages/memory-orderer/package.json
@@ -95,6 +95,13 @@
 		"webpack": "^5.82.0"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_LocalKafka": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_LocalOrderer": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/server/routerlicious/packages/memory-orderer/src/localKafka.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localKafka.ts
@@ -105,4 +105,11 @@ export class LocalKafka implements IProducer {
 	): this {
 		return this;
 	}
+
+	public off(
+		event: "connected" | "produced" | "error",
+		listener: (...args: any[]) => void,
+	): this {
+		return this;
+	}
 }

--- a/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
+++ b/server/routerlicious/packages/memory-orderer/src/localOrdererConnection.ts
@@ -112,6 +112,10 @@ export class LocalOrdererConnection implements IOrdererConnection {
 		this.producer.once(event, listener);
 	}
 
+	public off(event: "error", listener: (...args: any[]) => void) {
+		this.producer.off(event, listener);
+	}
+
 	private submitRawOperation(messages: IRawOperationMessage[]) {
 		if (this.serviceConfiguration.enableTraces) {
 			// Add trace

--- a/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
+++ b/server/routerlicious/packages/memory-orderer/src/remoteNode.ts
@@ -72,6 +72,10 @@ class ProxySocketConnection implements IOrdererConnection {
 	public once(event: "error", listener: (...args: any[]) => void) {
 		return;
 	}
+
+	public off(event: "error", listener: (...args: any[]) => void) {
+		return;
+	}
 }
 
 class ProxySocketThing implements IOrdererConnectionFactory {

--- a/server/routerlicious/packages/memory-orderer/src/test/types/validateServerMemoryOrdererPrevious.generated.ts
+++ b/server/routerlicious/packages/memory-orderer/src/test/types/validateServerMemoryOrdererPrevious.generated.ts
@@ -345,6 +345,7 @@ declare function get_old_ClassDeclaration_LocalKafka():
 declare function use_current_ClassDeclaration_LocalKafka(
     use: TypeOnly<current.LocalKafka>): void;
 use_current_ClassDeclaration_LocalKafka(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_LocalKafka());
 
 /*
@@ -465,6 +466,7 @@ declare function get_old_ClassDeclaration_LocalOrderer():
 declare function use_current_ClassDeclaration_LocalOrderer(
     use: TypeOnly<current.LocalOrderer>): void;
 use_current_ClassDeclaration_LocalOrderer(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_LocalOrderer());
 
 /*

--- a/server/routerlicious/packages/routerlicious-base/package.json
+++ b/server/routerlicious/packages/routerlicious-base/package.json
@@ -136,6 +136,9 @@
 			},
 			"ClassDeclaration_OrdererManager": {
 				"forwardCompat": false
+			},
+			"ClassDeclaration_AlfredResources": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/test/types/validateServerRouterliciousBasePrevious.generated.ts
@@ -33,6 +33,7 @@ declare function get_old_ClassDeclaration_AlfredResources():
 declare function use_current_ClassDeclaration_AlfredResources(
     use: TypeOnly<current.AlfredResources>): void;
 use_current_ClassDeclaration_AlfredResources(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_AlfredResources());
 
 /*

--- a/server/routerlicious/packages/services-core/package.json
+++ b/server/routerlicious/packages/services-core/package.json
@@ -64,6 +64,15 @@
 		"broken": {
 			"InterfaceDeclaration_IOrdererManager": {
 				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IProducer": {
+				"forwardCompat": false
+			},
+			"ClassDeclaration_CombinedProducer": {
+				"forwardCompat": false
+			},
+			"InterfaceDeclaration_IOrdererConnection": {
+				"forwardCompat": false
 			}
 		}
 	}

--- a/server/routerlicious/packages/services-core/src/combinedProducer.ts
+++ b/server/routerlicious/packages/services-core/src/combinedProducer.ts
@@ -66,4 +66,11 @@ export class CombinedProducer<T = ITicketedMessage> implements IProducer<T> {
 	): this {
 		return this;
 	}
+
+	public off(
+		event: "connected" | "produced" | "error",
+		listener: (...args: any[]) => void,
+	): this {
+		return this;
+	}
 }

--- a/server/routerlicious/packages/services-core/src/orderer.ts
+++ b/server/routerlicious/packages/services-core/src/orderer.ts
@@ -58,6 +58,7 @@ export interface IOrdererConnection {
 	 * Error event Handler.
 	 */
 	once(event: "error", listener: (...args: any[]) => void): void;
+	off(event: "error", listener: (...args: any[]) => void): void;
 
 	/**
 	 * Sends the client leave op for this connection

--- a/server/routerlicious/packages/services-core/src/queue.ts
+++ b/server/routerlicious/packages/services-core/src/queue.ts
@@ -126,6 +126,10 @@ export interface IProducer<T = ITicketedMessage> {
 		event: "connected" | "disconnected" | "closed" | "produced" | "throttled" | "log" | "error",
 		listener: (...args: any[]) => void,
 	): this;
+	off(
+		event: "connected" | "disconnected" | "closed" | "produced" | "throttled" | "log" | "error",
+		listener: (...args: any[]) => void,
+	): this;
 }
 
 /**

--- a/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
+++ b/server/routerlicious/packages/services-core/src/test/types/validateServerServicesCorePrevious.generated.ts
@@ -129,6 +129,7 @@ declare function get_old_ClassDeclaration_CombinedProducer():
 declare function use_current_ClassDeclaration_CombinedProducer(
     use: TypeOnly<current.CombinedProducer>): void;
 use_current_ClassDeclaration_CombinedProducer(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_CombinedProducer());
 
 /*
@@ -1425,6 +1426,7 @@ declare function get_old_InterfaceDeclaration_IOrdererConnection():
 declare function use_current_InterfaceDeclaration_IOrdererConnection(
     use: TypeOnly<current.IOrdererConnection>): void;
 use_current_InterfaceDeclaration_IOrdererConnection(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IOrdererConnection());
 
 /*
@@ -1666,6 +1668,7 @@ declare function get_old_InterfaceDeclaration_IProducer():
 declare function use_current_InterfaceDeclaration_IProducer(
     use: TypeOnly<current.IProducer>): void;
 use_current_InterfaceDeclaration_IProducer(
+    // @ts-expect-error compatibility expected to be broken
     get_old_InterfaceDeclaration_IProducer());
 
 /*

--- a/server/routerlicious/packages/services-ordering-kafkanode/package.json
+++ b/server/routerlicious/packages/services-ordering-kafkanode/package.json
@@ -65,6 +65,10 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_KafkaNodeProducer": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/kafkaNodeProducer.ts
@@ -106,6 +106,14 @@ export class KafkaNodeProducer implements IProducer {
 		return this;
 	}
 
+	public off(
+		event: "connected" | "produced" | "error",
+		listener: (...args: any[]) => void,
+	): this {
+		this.events.off(event, listener);
+		return this;
+	}
+
 	/**
 	 * Notifies of the need to send pending messages. We defer sending messages to batch together messages
 	 * to the same partition.

--- a/server/routerlicious/packages/services-ordering-kafkanode/src/test/types/validateServerServicesOrderingKafkanodePrevious.generated.ts
+++ b/server/routerlicious/packages/services-ordering-kafkanode/src/test/types/validateServerServicesOrderingKafkanodePrevious.generated.ts
@@ -81,6 +81,7 @@ declare function get_old_ClassDeclaration_KafkaNodeProducer():
 declare function use_current_ClassDeclaration_KafkaNodeProducer(
     use: TypeOnly<current.KafkaNodeProducer>): void;
 use_current_ClassDeclaration_KafkaNodeProducer(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_KafkaNodeProducer());
 
 /*

--- a/server/routerlicious/packages/test-utils/package.json
+++ b/server/routerlicious/packages/test-utils/package.json
@@ -90,6 +90,10 @@
 		"typescript": "~5.1.6"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_TestProducer": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
+++ b/server/routerlicious/packages/test-utils/src/test/types/validateServerTestUtilsPrevious.generated.ts
@@ -489,6 +489,7 @@ declare function get_old_ClassDeclaration_TestProducer():
 declare function use_current_ClassDeclaration_TestProducer(
     use: TypeOnly<current.TestProducer>): void;
 use_current_ClassDeclaration_TestProducer(
+    // @ts-expect-error compatibility expected to be broken
     get_old_ClassDeclaration_TestProducer());
 
 /*

--- a/server/routerlicious/packages/test-utils/src/testKafka.ts
+++ b/server/routerlicious/packages/test-utils/src/testKafka.ts
@@ -144,6 +144,10 @@ export class TestProducer implements IProducer {
 	public once(event: string, listener: (...args: any[]) => void): this {
 		return this;
 	}
+
+	public off(event: string, listener: (...args: any[]) => void): this {
+		return this;
+	}
 }
 
 /**


### PR DESCRIPTION
## Description

Another entry in the Never Ending Story of cleaning up Nexus memory leaks. For some reason, this listener leak did not appear in local FRS and Routerlicious runs; however, it was easily reproduced in a deployed FRS instance.

## Breaking Changes

A few types have had `.off()` instance methods added to them to allow Nexus to properly clean up the listener that it adds.

## Reviewer Guidance

Hopefully will come back to making the "dispose" flow a bit cleaner, but this seems good enough for now
