### PR TITLE
Add TreeNodeKernel with `TreeStatus` and `on` events

### DIFF
--- a/packages/dds/tree/src/core/tree/anchorSet.ts
+++ b/packages/dds/tree/src/core/tree/anchorSet.ts
@@ -334,6 +334,20 @@ export class AnchorSet implements Listenable<AnchorSetRootEvents>, AnchorLocator
 		return this.root.slots;
 	}
 
+	public *[Symbol.iterator](): IterableIterator<AnchorNode> {
+		const stack: PathNode[] = [];
+		let node: PathNode | undefined = this.root;
+		while (node !== undefined) {
+			yield node;
+			for (const [_, children] of node.children) {
+				for (const child of children) {
+					stack.push(child);
+				}
+			}
+			node = stack.pop();
+		}
+	}
+
 	public on<K extends keyof AnchorSetRootEvents>(
 		eventName: K,
 		listener: AnchorSetRootEvents[K],

--- a/packages/dds/tree/src/feature-libraries/editableTreeBinder.ts
+++ b/packages/dds/tree/src/feature-libraries/editableTreeBinder.ts
@@ -741,7 +741,7 @@ class AbstractDataBinder<
 		const visitor = getOrCreate(this.visitors, anchor, () => {
 			const newVisitor = this.visitorFactory(anchor);
 			this.unregisterHandles.add(
-				anchor.on("subtreeChanging", (upPath: UpPath) => {
+				anchor.anchorNode.on("subtreeChanging", (upPath: UpPath) => {
 					assert(newVisitor !== undefined, 0x6dc /* visitor expected to be defined */);
 					if (!this.visitorLocations.has(newVisitor)) {
 						this.visitorLocations.set(newVisitor, upPath);

--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -14,7 +14,7 @@ import {
 	type TreeValue,
 	type Value,
 } from "../../core/index.js";
-import { brand, fail, getOrCreate, mapIterable } from "../../util/index.js";
+import { brand, fail, mapIterable } from "../../util/index.js";
 import {
 	type FlexTreeContext,
 	FlexTreeEntityKind,
@@ -23,7 +23,6 @@ import {
 	type FlexTreeLeafNode,
 	type FlexTreeMapNode,
 	type FlexTreeNode,
-	type FlexTreeNodeEvents,
 	type FlexTreeOptionalField,
 	type FlexTreeRequiredField,
 	type FlexTreeSequenceField,
@@ -53,7 +52,6 @@ import {
 import { type FlexImplicitAllowedTypes, normalizeAllowedTypes } from "../schemaBuilderBase.js";
 import type { FlexFieldKind } from "../modular-schema/index.js";
 import { FieldKinds, type SequenceFieldEditBuilder } from "../default-schema/index.js";
-import { ComposableEventEmitter, type Listenable, type Off } from "../../events/index.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 // #region Nodes
@@ -65,7 +63,6 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
  */
 export interface MapTreeNode extends FlexTreeNode {
 	readonly mapTree: MapTree;
-	forwardEvents(to: Listenable<FlexTreeNodeEvents>): void;
 }
 
 /**
@@ -82,38 +79,6 @@ interface LocationInField {
 }
 
 /**
- * Allows events to be forwarded to another event emitter.
- * @remarks TODO: After the eventing library is simplified, find a way to support this pattern elegantly in the library.
- */
-class ForwardingEventEmitter extends ComposableEventEmitter<FlexTreeNodeEvents> {
-	// A map from deregistration functions produced by this class to deregistration functions of Listenables that have been forwarded to
-	private readonly forwardedOffs = new Map<Off, Off[]>();
-
-	public override on<K extends keyof FlexTreeNodeEvents>(
-		eventName: K,
-		listener: FlexTreeNodeEvents[K],
-	): Off {
-		const off = super.on(eventName, listener);
-		// Return a deregister function which...
-		return (): void => {
-			off(); // ...deregisters the event in this emitter,
-			// and also deregisters the event in any Listenable that it gets forwarded to
-			(this.forwardedOffs.get(off) ?? []).forEach((f) => f());
-		};
-	}
-
-	public forwardEvents(to: Listenable<FlexTreeNodeEvents>): void {
-		for (const [eventName, listeners] of this.listeners) {
-			for (const [off, listener] of listeners) {
-				// For every one of our listeners, make the same subscription in the Listenable that we're forwarding to,
-				// and then create a mapping from our deregistration function to theirs, so we can call it later if need be.
-				getOrCreate(this.forwardedOffs, off, () => []).push(to.on(eventName, listener));
-			}
-		}
-	}
-}
-
-/**
  * A readonly implementation of {@link FlexTreeNode} which wraps a {@link MapTree}.
  * @remarks Any methods that would mutate the node will fail,
  * as will the querying of data specific to the {@link LazyTreeNode} implementation (e.g. {@link FlexTreeNode.context}).
@@ -122,10 +87,6 @@ class ForwardingEventEmitter extends ComposableEventEmitter<FlexTreeNodeEvents> 
  */
 export class EagerMapTreeNode<TSchema extends FlexTreeNodeSchema> implements MapTreeNode {
 	public readonly [flexTreeMarker] = FlexTreeEntityKind.Node as const;
-	private readonly events = new ForwardingEventEmitter();
-	public forwardEvents(to: Listenable<FlexTreeNodeEvents>): void {
-		this.events.forwardEvents(to);
-	}
 
 	/**
 	 * Create a new MapTreeNode.
@@ -213,19 +174,6 @@ export class EagerMapTreeNode<TSchema extends FlexTreeNodeSchema> implements Map
 
 	public get value(): Value {
 		return this.mapTree.value;
-	}
-
-	public on<K extends keyof FlexTreeNodeEvents>(
-		eventName: K,
-		listener: FlexTreeNodeEvents[K],
-	): () => void {
-		switch (eventName) {
-			case "nodeChanged":
-			case "treeChanged":
-				return this.events.on(eventName, listener);
-			default:
-				throw unsupportedUsageError(`Subscribing to ${eventName}`);
-		}
 	}
 
 	public get context(): FlexTreeContext {

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -34,7 +34,6 @@ import type {
 } from "../typed-schema/index.js";
 
 import type { FlexTreeContext } from "./context.js";
-import type { FlexTreeNodeEvents } from "./treeEvents.js";
 
 /**
  * An anchor slot which records the {@link FlexTreeNode} associated with that anchor, if there is one.
@@ -158,14 +157,6 @@ export interface FlexTreeNode extends FlexTreeEntity<FlexTreeNodeSchema> {
 	 * Value stored on this node.
 	 */
 	readonly value?: TreeValue;
-
-	/**
-	 * {@inheritDoc ISubscribable#on}
-	 */
-	on<K extends keyof FlexTreeNodeEvents>(
-		eventName: K,
-		listener: FlexTreeNodeEvents[K],
-	): () => void;
 
 	/**
 	 * Gets a field of this node, if it is not empty.
@@ -577,7 +568,6 @@ export const reservedObjectNodeFieldPropertyNames = [
 	"constructor",
 	"context",
 	"is",
-	"on",
 	"parentField",
 	"schema",
 	"tryGetField",

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert } from "@fluidframework/core-utils/internal";
 
 import {
 	type Anchor,
@@ -68,7 +68,6 @@ import {
 	tryMoveCursorToAnchorSymbol,
 } from "./lazyEntity.js";
 import { makeField } from "./lazyField.js";
-import type { FlexTreeNodeEvents } from "./treeEvents.js";
 import { unboxedField } from "./unboxed.js";
 
 /**
@@ -252,36 +251,6 @@ export abstract class LazyTreeNode<TSchema extends FlexTreeNodeSchema = FlexTree
 		cursor.enterNode(index);
 
 		return { parent: proxifiedField, index };
-	}
-
-	public on<K extends keyof FlexTreeNodeEvents>(
-		eventName: K,
-		listener: FlexTreeNodeEvents[K],
-	): () => void {
-		switch (eventName) {
-			case "changing": {
-				const unsubscribeFromChildrenChange = this.anchorNode.on(
-					"childrenChanging",
-					(anchorNode: AnchorNode) => listener(anchorNode),
-				);
-				return unsubscribeFromChildrenChange;
-			}
-			case "subtreeChanging": {
-				const unsubscribeFromSubtreeChange = this.anchorNode.on(
-					"subtreeChanging",
-					(anchorNode: AnchorNode) => listener(anchorNode),
-				);
-				return unsubscribeFromSubtreeChange;
-			}
-			case "nodeChanged": {
-				return this.anchorNode.on("childrenChangedAfterBatch", listener);
-			}
-			case "treeChanged": {
-				return this.anchorNode.on("subtreeChangedAfterBatch", listener);
-			}
-			default:
-				unreachableCase(eventName);
-		}
 	}
 }
 

--- a/packages/dds/tree/src/shared-tree/treeView.ts
+++ b/packages/dds/tree/src/shared-tree/treeView.ts
@@ -12,6 +12,7 @@ import {
 	type NodeKeyManager,
 	getTreeContext,
 } from "../feature-libraries/index.js";
+import { tryDisposeTreeNode } from "../simple-tree/index.js";
 import { type IDisposable, disposeSymbol } from "../util/index.js";
 
 import type { ITreeCheckout, ITreeCheckoutFork, TreeCheckout } from "./treeCheckout.js";
@@ -94,6 +95,10 @@ export class CheckoutFlexTreeView<
 	}
 
 	public [disposeSymbol](): void {
+		for (const anchorNode of this.checkout.forest.anchors) {
+			tryDisposeTreeNode(anchorNode);
+		}
+
 		this.context[disposeSymbol]();
 		this.onDispose?.();
 	}

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -27,7 +27,7 @@ import {
 	markContentType,
 	prepareContentForHydration,
 } from "./proxies.js";
-import { getFlexNode } from "./proxyBinding.js";
+import { getFlexNode, getKernel } from "./proxyBinding.js";
 import {
 	NodeKind,
 	type ImplicitAllowedTypes,
@@ -683,7 +683,7 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		input: Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>> | InternalTreeNode,
 	) {
 		super(input);
-		getFlexNode(this).on("nodeChanged", () => {
+		getKernel(this).on("nodeChanged", () => {
 			this.#generationNumber += 1;
 		});
 	}

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -39,8 +39,8 @@ export {
 	type ApplyKind,
 } from "./schemaTypes.js";
 export { SchemaFactory, type ScopedSchemaName } from "./schemaFactory.js";
-export { getFlexNode } from "./proxyBinding.js";
-export { treeNodeApi, type TreeNodeApi, type TreeChangeEvents } from "./treeNodeApi.js";
+export { getFlexNode, tryDisposeTreeNode } from "./proxyBinding.js";
+export { treeNodeApi, type TreeNodeApi } from "./treeNodeApi.js";
 export { toFlexSchema, cursorFromUnhydratedRoot } from "./toFlexSchema.js";
 export type {
 	FieldHasDefaultUnsafe,
@@ -82,7 +82,7 @@ export {
 
 // TreeNode is only type exported, which prevents use of the class object for unsupported use-cases like direct sub-classing and instancof.
 // See docs on TreeNode for more details.
-export type { TreeNode, Unhydrated, InternalTreeNode } from "./types.js";
+export type { TreeChangeEvents, TreeNode, Unhydrated, InternalTreeNode } from "./types.js";
 export {
 	TreeArrayNode,
 	IterableTreeArrayContent,

--- a/packages/dds/tree/src/simple-tree/proxyBinding.ts
+++ b/packages/dds/tree/src/simple-tree/proxyBinding.ts
@@ -29,6 +29,7 @@ import type { TreeNode } from "./types.js";
 // eslint-disable-next-line import/no-internal-modules
 import { makeTree } from "../feature-libraries/flex-tree/lazyNode.js";
 import type { TreeMapNode } from "./mapNode.js";
+import { TreeNodeKernel } from "./treeNodeKernel.js";
 
 // This file contains various maps and helpers for supporting proxy binding (a.k.a. proxy hydration).
 // See ./ProxyBinding.md for a high-level overview of the process.
@@ -185,9 +186,31 @@ function bindProxyToAnchorNode(proxy: TreeNode, anchorNode: AnchorNode): void {
 	proxyToAnchorNode.set(proxy, anchorNode);
 	// However, it's fine for an anchor node to rotate through different proxies when the content at that place in the tree is replaced.
 	anchorNode.slots.set(proxySlot, proxy);
+	getKernel(proxy).hydrate(anchorNode);
 }
 
 /**
  * Given a node's schema, return the corresponding object in the proxy-based API.
  */
 type TypedNode<TSchema extends FlexTreeNodeSchema> = TreeNode & WithType<TSchema["name"]>;
+
+export function createKernel(node: TreeNode): void {
+	treeNodeToKernel.set(node, new TreeNodeKernel(node));
+}
+
+export function getKernel(node: TreeNode): TreeNodeKernel {
+	const kernel = treeNodeToKernel.get(node);
+	assert(kernel !== undefined, "Expected tree node to have kernel");
+	return kernel;
+}
+
+export function tryDisposeTreeNode(anchorNode: AnchorNode): void {
+	const treeNode = anchorNode.slots.get(proxySlot);
+	if (treeNode !== undefined) {
+		const kernel = treeNodeToKernel.get(treeNode);
+		assert(kernel !== undefined, "Expected tree node to have kernel");
+		kernel.dispose();
+	}
+}
+
+const treeNodeToKernel = new WeakMap<TreeNode, TreeNodeKernel>();

--- a/packages/dds/tree/src/simple-tree/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/treeNodeApi.ts
@@ -3,24 +3,20 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert } from "@fluidframework/core-utils/internal";
 
 import { Multiplicity, rootFieldKey } from "../core/index.js";
 import {
 	type LazyItem,
-	TreeStatus,
+	type TreeStatus,
 	isLazy,
 	isTreeValue,
 	FlexObjectNodeSchema,
-	LazyEntity,
-	treeStatusFromAnchorCache,
-	isMapTreeNode,
-	isFreedSymbol,
 } from "../feature-libraries/index.js";
 import { fail, extractFromOpaque, isReadonlyArray } from "../util/index.js";
 
 import { getOrCreateNodeProxy, isTreeNode } from "./proxies.js";
-import { getFlexNode } from "./proxyBinding.js";
+import { getFlexNode, getKernel } from "./proxyBinding.js";
 import { tryGetSimpleNodeSchema } from "./schemaCaching.js";
 import {
 	NodeKind,
@@ -31,7 +27,7 @@ import {
 	type ImplicitAllowedTypes,
 	type TreeNodeFromImplicitAllowedTypes,
 } from "./schemaTypes.js";
-import type { TreeNode } from "./types.js";
+import type { TreeNode, TreeChangeEvents } from "./types.js";
 import {
 	booleanSchema,
 	handleSchema,
@@ -166,28 +162,10 @@ export const treeNodeApi: TreeNodeApi = {
 		eventName: K,
 		listener: TreeChangeEvents[K],
 	): Off {
-		const flex = getFlexNode(node);
-		switch (eventName) {
-			case "nodeChanged":
-				return flex.on("nodeChanged", listener);
-			case "treeChanged":
-				return flex.on("treeChanged", listener);
-			default:
-				return unreachableCase(eventName);
-		}
+		return getKernel(node).on(eventName, listener);
 	},
 	status(node: TreeNode): TreeStatus {
-		const flexNode = getFlexNode(node, true);
-		if (isMapTreeNode(flexNode)) {
-			return TreeStatus.New;
-		}
-
-		assert(flexNode instanceof LazyEntity, "Unexpected flex node implementation");
-		if (flexNode[isFreedSymbol]()) {
-			return TreeStatus.Deleted;
-		}
-
-		return treeStatusFromAnchorCache(flexNode.anchorNode);
+		return getKernel(node).getStatus();
 	},
 	is<TSchema extends ImplicitAllowedTypes>(
 		value: unknown,
@@ -318,79 +296,4 @@ function getViewKeyFromStoredKey(
 	}
 
 	return storedKey;
-}
-
-/**
- * A collection of events that can be emitted by a {@link TreeNode}.
- *
- * @privateRemarks
- * TODO: add a way to subscribe to a specific field (for nodeChanged and treeChanged).
- * Probably have object node and map node specific APIs for this.
- *
- * TODO: ensure that subscription API for fields aligns with API for subscribing to the root.
- *
- * TODO: add more wider area (avoid needing tons of nodeChanged registration) events for use-cases other than treeChanged.
- * Some ideas:
- *
- * - treeChanged, but with some subtrees/fields/paths excluded
- * - helper to batch several nodeChanged calls to a treeChanged scope
- * - parent change (ex: registration on the parent field for a specific index: maybe allow it for a range. Ex: node event takes optional field and optional index range?)
- * - new content inserted into subtree. Either provide event for this and/or enough info to treeChanged to find and search the new sub-trees.
- * Add separate (non event related) API to efficiently scan tree for given set of types (using low level cursor and schema based filtering)
- * to allow efficiently searching for new content (and initial content) of a given type.
- *
- * @sealed @public
- */
-export interface TreeChangeEvents {
-	/**
-	 * Emitted by a node after a batch of changes has been applied to the tree, if a change affected the node, where a
-	 * change is:
-	 *
-	 * - For an object node, when the value of one of its properties changes (i.e., the property's value is set
-	 * to something else, including `undefined`).
-	 *
-	 * - For an array node, when an element is added, removed, or moved.
-	 *
-	 * - For a map node, when an entry is added, updated, or removed.
-	 *
-	 * @remarks
-	 * This event is not emitted when:
-	 *
-	 * - Properties of a child node change. Notably, updates to an array node or a map node (like adding or removing
-	 * elements/entries) will emit this event on the array/map node itself, but not on the node that contains the
-	 * array/map node as one of its properties.
-	 *
-	 * - The node is moved to a different location in the tree or removed from the tree.
-	 * In this case the event is emitted on the _parent_ node, not the node itself.
-	 *
-	 * For remote edits, this event is not guaranteed to occur in the same order or quantity that it did in
-	 * the client that made the original edit.
-	 *
-	 * When it is emitted, the tree is guaranteed to be in-schema.
-	 *
-	 * @privateRemarks
-	 * This event occurs whenever the apparent contents of the node instance change, regardless of what caused the change.
-	 * For example, it will fire when the local client reassigns a child, when part of a remote edit is applied to the
-	 * node, or when the node has to be updated due to resolution of a merge conflict
-	 * (for example a previously applied local change might be undone, then reapplied differently or not at all).
-	 */
-	nodeChanged(): void;
-
-	/**
-	 * Emitted by a node after a batch of changes has been applied to the tree, when something changed anywhere in the
-	 * subtree rooted at it.
-	 *
-	 * @remarks
-	 * This event is not emitted when the node itself is moved to a different location in the tree or removed from the tree.
-	 * In that case it is emitted on the _parent_ node, not the node itself.
-	 *
-	 * The node itself is part of the subtree, so this event will be emitted even if the only changes are to the properties
-	 * of the node itself.
-	 *
-	 * For remote edits, this event is not guaranteed to occur in the same order or quantity that it did in
-	 * the client that made the original edit.
-	 *
-	 * When it is emitted, the tree is guaranteed to be in-schema.
-	 */
-	treeChanged(): void;
 }

--- a/packages/dds/tree/src/simple-tree/treeNodeKernel.ts
+++ b/packages/dds/tree/src/simple-tree/treeNodeKernel.ts
@@ -1,0 +1,91 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/core-utils/internal";
+import { createEmitter, type Listenable, type Off } from "../events/index.js";
+import type { TreeChangeEvents, TreeNode } from "./types.js";
+import type { AnchorNode } from "../core/index.js";
+import {
+	flexTreeSlot,
+	isFreedSymbol,
+	LazyEntity,
+	TreeStatus,
+	treeStatusFromAnchorCache,
+} from "../feature-libraries/index.js";
+
+/**
+ * Contains state and an internal API for managing {@link TreeNode}s.
+ * @remarks All {@link TreeNode}s have an associated kernel object.
+ * The kernel has the same lifetime as the node and spans both its unhydrated and hydrated states.
+ * When hydration occurs, the kernel is notified via the {@link TreeNodeKernel.hydrate | hydrate} method.
+ */
+export class TreeNodeKernel implements Listenable<TreeChangeEvents> {
+	#hydrated?: {
+		anchorNode: AnchorNode;
+		offAnchorNode: Off;
+	};
+	#events = createEmitter<TreeChangeEvents>();
+
+	public constructor(public readonly node: TreeNode) {}
+
+	public hydrate(anchorNode: AnchorNode): void {
+		const offChildrenChanged = anchorNode.on("childrenChangedAfterBatch", () => {
+			this.#events.emit("nodeChanged");
+		});
+
+		const offSubtreeChanged = anchorNode.on("subtreeChangedAfterBatch", () => {
+			this.#events.emit("treeChanged");
+		});
+
+		const offAfterDestroy = anchorNode.on("afterDestroy", () => this.dispose());
+
+		this.#hydrated = {
+			anchorNode,
+			offAnchorNode: () => {
+				offChildrenChanged();
+				offSubtreeChanged();
+				offAfterDestroy();
+			},
+		};
+	}
+
+	public dehydrate(): void {
+		this.#hydrated?.offAnchorNode?.();
+		this.#hydrated = undefined;
+	}
+
+	public isHydrated(): boolean {
+		return this.#hydrated !== undefined;
+	}
+
+	public getStatus(): TreeStatus {
+		if (this.#hydrated?.anchorNode === undefined) {
+			return TreeStatus.New;
+		}
+
+		// TODO: Replace this check with the proper check against the cursor state when the cursor becomes part of the kernel
+		const flex = this.#hydrated.anchorNode.slots.get(flexTreeSlot);
+		if (flex !== undefined) {
+			assert(flex instanceof LazyEntity, "Unexpected flex node implementation");
+			if (flex[isFreedSymbol]()) {
+				return TreeStatus.Deleted;
+			}
+		}
+
+		return treeStatusFromAnchorCache(this.#hydrated.anchorNode);
+	}
+
+	public on<K extends keyof TreeChangeEvents>(
+		eventName: K,
+		listener: TreeChangeEvents[K],
+	): Off {
+		return this.#events.on(eventName, listener);
+	}
+
+	public dispose(): void {
+		this.dehydrate();
+		// TODO: go to the context and remove myself from withAnchors
+	}
+}

--- a/packages/dds/tree/src/simple-tree/types.ts
+++ b/packages/dds/tree/src/simple-tree/types.ts
@@ -23,7 +23,7 @@ import { isTreeNode } from "./proxies.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { getFlexSchema } from "./toFlexSchema.js";
 import { fail } from "../util/index.js";
-import { setFlexNode } from "./proxyBinding.js";
+import { createKernel, setFlexNode } from "./proxyBinding.js";
 import { tryGetSchema } from "./treeNodeApi.js";
 
 /**
@@ -36,6 +36,81 @@ import { tryGetSchema } from "./treeNodeApi.js";
  * @public
  */
 export type Unhydrated<T> = T;
+
+/**
+ * A collection of events that can be emitted by a {@link TreeNode}.
+ *
+ * @privateRemarks
+ * TODO: add a way to subscribe to a specific field (for nodeChanged and treeChanged).
+ * Probably have object node and map node specific APIs for this.
+ *
+ * TODO: ensure that subscription API for fields aligns with API for subscribing to the root.
+ *
+ * TODO: add more wider area (avoid needing tons of nodeChanged registration) events for use-cases other than treeChanged.
+ * Some ideas:
+ *
+ * - treeChanged, but with some subtrees/fields/paths excluded
+ * - helper to batch several nodeChanged calls to a treeChanged scope
+ * - parent change (ex: registration on the parent field for a specific index: maybe allow it for a range. Ex: node event takes optional field and optional index range?)
+ * - new content inserted into subtree. Either provide event for this and/or enough info to treeChanged to find and search the new sub-trees.
+ * Add separate (non event related) API to efficiently scan tree for given set of types (using low level cursor and schema based filtering)
+ * to allow efficiently searching for new content (and initial content) of a given type.
+ *
+ * @sealed @public
+ */
+export interface TreeChangeEvents {
+	/**
+	 * Emitted by a node after a batch of changes has been applied to the tree, if a change affected the node, where a
+	 * change is:
+	 *
+	 * - For an object node, when the value of one of its properties changes (i.e., the property's value is set
+	 * to something else, including `undefined`).
+	 *
+	 * - For an array node, when an element is added, removed, or moved.
+	 *
+	 * - For a map node, when an entry is added, updated, or removed.
+	 *
+	 * @remarks
+	 * This event is not emitted when:
+	 *
+	 * - Properties of a child node change. Notably, updates to an array node or a map node (like adding or removing
+	 * elements/entries) will emit this event on the array/map node itself, but not on the node that contains the
+	 * array/map node as one of its properties.
+	 *
+	 * - The node is moved to a different location in the tree or removed from the tree.
+	 * In this case the event is emitted on the _parent_ node, not the node itself.
+	 *
+	 * For remote edits, this event is not guaranteed to occur in the same order or quantity that it did in
+	 * the client that made the original edit.
+	 *
+	 * When it is emitted, the tree is guaranteed to be in-schema.
+	 *
+	 * @privateRemarks
+	 * This event occurs whenever the apparent contents of the node instance change, regardless of what caused the change.
+	 * For example, it will fire when the local client reassigns a child, when part of a remote edit is applied to the
+	 * node, or when the node has to be updated due to resolution of a merge conflict
+	 * (for example a previously applied local change might be undone, then reapplied differently or not at all).
+	 */
+	nodeChanged(): void;
+
+	/**
+	 * Emitted by a node after a batch of changes has been applied to the tree, when something changed anywhere in the
+	 * subtree rooted at it.
+	 *
+	 * @remarks
+	 * This event is not emitted when the node itself is moved to a different location in the tree or removed from the tree.
+	 * In that case it is emitted on the _parent_ node, not the node itself.
+	 *
+	 * The node itself is part of the subtree, so this event will be emitted even if the only changes are to the properties
+	 * of the node itself.
+	 *
+	 * For remote edits, this event is not guaranteed to occur in the same order or quantity that it did in
+	 * the client that made the original edit.
+	 *
+	 * When it is emitted, the tree is guaranteed to be in-schema.
+	 */
+	treeChanged(): void;
+}
 
 /**
  * A non-{@link NodeKind.Leaf|leaf} SharedTree node. Includes objects, arrays, and maps.
@@ -285,6 +360,7 @@ export abstract class TreeNodeValid<TInput> extends TreeNode {
 		);
 
 		const result = schema.prepareInstance(this, node);
+		createKernel(result);
 		setFlexNode(result, node);
 		return result;
 	}

--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -101,23 +101,6 @@ describe("MapTreeNodes", () => {
 		assert.equal(fieldNode.tryGetField(EmptyKey)?.boxedAt(0)?.schema, leafDomain.string);
 	});
 
-	it("can register events", () => {
-		// These events don't ever fire, but they can be forwarded, so ensure that registering them does not fail
-		map.on("nodeChanged", () => {});
-		map.on("treeChanged", () => {});
-		fieldNode.on("nodeChanged", () => {});
-		fieldNode.on("treeChanged", () => {});
-		object.on("nodeChanged", () => {});
-		object.on("treeChanged", () => {});
-		// The following events are not supported for forwarding
-		assert.throws(() => map.on("changing", () => {}));
-		assert.throws(() => map.on("subtreeChanging", () => {}));
-		assert.throws(() => fieldNode.on("changing", () => {}));
-		assert.throws(() => fieldNode.on("subtreeChanging", () => {}));
-		assert.throws(() => object.on("changing", () => {}));
-		assert.throws(() => object.on("subtreeChanging", () => {}));
-	});
-
 	it("can get the children of maps", () => {
 		assert.equal(map.tryGetField(mapKey)?.key, mapKey);
 		assert.equal(map.getBoxed(mapKey).key, mapKey);

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -80,8 +80,8 @@ describe("sharedTreeView", () => {
 			});
 			const root = view.flexTree.content ?? fail("missing root");
 			const log: string[] = [];
-			const unsubscribe = root.on("changing", () => log.push("change"));
-			const unsubscribeSubtree = root.on("subtreeChanging", () => {
+			const unsubscribe = root.anchorNode.on("childrenChanging", () => log.push("change"));
+			const unsubscribeSubtree = root.anchorNode.on("subtreeChanging", () => {
 				log.push("subtree");
 			});
 			const unsubscribeAfter = view.checkout.events.on("afterBatch", () => log.push("after"));
@@ -121,10 +121,10 @@ describe("sharedTreeView", () => {
 			});
 			const root = view.flexTree.content ?? fail("missing root");
 			const log: string[] = [];
-			const unsubscribe = root.on("changing", (upPath) =>
+			const unsubscribe = root.anchorNode.on("childrenChanging", (upPath) =>
 				log.push(`change-${String(upPath.parentField)}-${upPath.parentIndex}`),
 			);
-			const unsubscribeSubtree = root.on("subtreeChanging", (upPath) => {
+			const unsubscribeSubtree = root.anchorNode.on("subtreeChanging", (upPath) => {
 				log.push(`subtree-${String(upPath.parentField)}-${upPath.parentIndex}`);
 			});
 			const unsubscribeAfter = view.checkout.events.on("afterBatch", () => log.push("after"));

--- a/packages/dds/tree/src/test/simple-tree/treeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeApi.spec.ts
@@ -181,8 +181,7 @@ describe("treeNodeApi", () => {
 		const newChild = new Point({});
 		assert.equal(Tree.status(root), TreeStatus.InDocument);
 		assert.equal(Tree.status(child), TreeStatus.InDocument);
-		// TODO: This API layer should have an Unhydrated status:
-		// assert.equal(nodeApi.status(newChild), TreeStatus.Unhydrated);
+		assert.equal(Tree.status(newChild), TreeStatus.New);
 		root.x = newChild;
 		assert.equal(Tree.status(root), TreeStatus.InDocument);
 		assert.equal(Tree.status(child), TreeStatus.Removed);


### PR DESCRIPTION
## Description

This adds an abstraction for holding internal state and APIs for TreeNodes. This will let us migrate functionality away from the flex layer and into the simple tree layer incrementally.