### PR TITLE
fix(ci): Fix hanging perf benchmarks for container-runtime

### DIFF
--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -147,7 +147,7 @@
 		"postpack": "tar -cf ./container-runtime.test-files.tar ./src/test ./dist/test ./lib/test",
 		"place:cjs:package-stub": "copyfiles -f ../../../common/build/build-common/src/cjs/package.json ./dist",
 		"test": "npm run test:mocha",
-		"test:benchmark:report": "mocha --timeout 999999 --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js \"./dist/**/*.perf.spec.*js\"",
+		"test:benchmark:report": "mocha --timeout 10s --perfMode --parentProcess --fgrep @Benchmark --reporter @fluid-tools/benchmark/dist/MochaReporter.js \"./dist/**/*.perf.spec.*js\" --exit",
 		"test:coverage": "c8 npm test",
 		"test:mocha": "npm run test:mocha:esm && echo skipping cjs to avoid overhead - npm run test:mocha:cjs",
 		"test:mocha:cjs": "mocha --recursive \"dist/test/**/*.spec.*js\" --exit",

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -37,8 +37,7 @@ parameters:
     - "@fluidframework/tree"
     - "@fluid-experimental/tree"
     - "@fluidframework/merge-tree"
-    # TODO: AB#9074. These perf benchmarks are hanging. Once we figure out why and fix it, uncomment them.
-    # - "@fluidframework/container-runtime"
+    - "@fluidframework/container-runtime"
 
 # Performance e2e tests
 - name: endpoints

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -37,7 +37,8 @@ parameters:
     - "@fluidframework/tree"
     - "@fluid-experimental/tree"
     - "@fluidframework/merge-tree"
-    - "@fluidframework/container-runtime"
+    # TODO: AB#9074. These perf benchmarks are hanging. Once we figure out why and fix it, uncomment them.
+    # - "@fluidframework/container-runtime"
 
 # Performance e2e tests
 - name: endpoints


### PR DESCRIPTION
## Description

The perf tests for the container-runtime package are hanging (not done after 4h44m in [the most recent run](https://dev.azure.com/fluidframework/internal/_build/results?buildId=281248&view=logs&j=96c48626-beae-58bd-70f1-ce94e154dbad&t=7c878d5b-0f52-57cc-3a3e-a5a81af8b7bd)) and causing the perf benchmarks pipeline runs to get cancelled by ADO. This PR fixes them by adding a missing `--exit` flag.

Note: ideally the flag should not be necessary but we don't know why these (and a few other packages in the repo) need it when running tests to not hang. The normal `mocha` test scripts in this package already had it.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

[AB#9074](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/9074)
