### PR TITLE
ci: Label PRs that add/modify changesets

### DIFF
--- a/.github/labeler-areas.yml
+++ b/.github/labeler-areas.yml
@@ -76,6 +76,10 @@
 "breaking change":
   - BREAKING.md
 
+"changeset-present":
+  - .changeset/**
+  - server/routerlicious/.changeset/**
+
 dependencies:
   - lerna-package-lock.json
   - package-lock.json


### PR DESCRIPTION
It's helpful when preparing for a release to check if any pending PRs are adding changesets. If the PRs were labeled, doing that query becomes trivial.

I updated the area labeler to add the [changeset-present](https://github.com/microsoft/FluidFramework/issues?q=sort%3Aupdated-desc+is%3Aopen+label%3Achangeset-present) to changes with edits to changesets. This does nothing besides add the label. Nothing else is automated or changed.