### PR TITLE
More explicit typing for PendingStateManager.savedOps

### DIFF
--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -49,7 +49,7 @@ export interface IPendingMessage {
  * IPendingMessage but without localOpMetadata, which isn't suitable for stashing
  * (it's not serializable and will be regenerated when applying stashed ops)
  */
-interface IMessageToStash extends IPendingMessage {
+export interface IMessageToStash extends IPendingMessage {
 	localOpMetadata: undefined;
 }
 
@@ -117,7 +117,7 @@ function buildPendingMessageContent(
 	return JSON.stringify({ type, contents, compatDetails });
 }
 
-function toStash(message: IPendingMessage): IMessageToStash {
+export function toStash(message: IPendingMessage): IMessageToStash {
 	return {
 		...message,
 		localOpMetadata: undefined,

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -75,8 +75,8 @@ import {
 import type { BatchMessage } from "../opLifecycle/index.js";
 import {
 	IPendingLocalState,
-	IPendingMessage,
 	PendingStateManager,
+	type IMessageToStash,
 } from "../pendingStateManager.js";
 import {
 	ISummaryCancellationToken,
@@ -1875,7 +1875,7 @@ describe("Runtime", () => {
 					},
 					provideEntryPoint: mockProvideEntryPoint,
 				});
-				const pendingStates = Array.from({ length: 5 }).map<IPendingMessage>((_, i) => ({
+				const pendingStates = Array.from({ length: 5 }).map<IMessageToStash>((_, i) => ({
 					content: i.toString(),
 					type: "message",
 					referenceSequenceNumber: 0,
@@ -1917,7 +1917,7 @@ describe("Runtime", () => {
 					},
 					provideEntryPoint: mockProvideEntryPoint,
 				});
-				const pendingStates = Array.from({ length: 5 }).map<IPendingMessage>((_, i) => ({
+				const pendingStates = Array.from({ length: 5 }).map<IMessageToStash>((_, i) => ({
 					content: i.toString(),
 					type: "message",
 					referenceSequenceNumber: 0,
@@ -1986,7 +1986,7 @@ describe("Runtime", () => {
 					},
 					provideEntryPoint: mockProvideEntryPoint,
 				});
-				const pendingStates = Array.from({ length: 5 }).map<IPendingMessage>((_, i) => ({
+				const pendingStates = Array.from({ length: 5 }).map<IMessageToStash>((_, i) => ({
 					content: i.toString(),
 					type: "message",
 					referenceSequenceNumber: 0,

--- a/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingStateManager.spec.ts
@@ -24,7 +24,12 @@ import type {
 	UnknownContainerRuntimeMessage,
 } from "../messageTypes.js";
 import { BatchManager, BatchMessage } from "../opLifecycle/index.js";
-import { IPendingMessage, PendingStateManager } from "../pendingStateManager.js";
+import {
+	IPendingMessage,
+	PendingStateManager,
+	toStash,
+	type IMessageToStash,
+} from "../pendingStateManager.js";
 
 type PendingStateManager_WithPrivates = Omit<PendingStateManager, "initialMessages"> & {
 	initialMessages: Deque<IPendingMessage>;
@@ -573,7 +578,7 @@ describe("Pending State Manager", () => {
 		];
 
 		function createPendingStateManager(
-			pendingStates?: IPendingMessage[],
+			pendingStates?: IMessageToStash[],
 		): PendingStateManager {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 			return new PendingStateManager(
@@ -592,7 +597,7 @@ describe("Pending State Manager", () => {
 		}
 
 		it("minimum sequence number can be retrieved from initial messages", async () => {
-			const pendingStateManager = createPendingStateManager(messages);
+			const pendingStateManager = createPendingStateManager(messages.map(toStash));
 			await pendingStateManager.applyStashedOpsAt();
 
 			assert.strictEqual(


### PR DESCRIPTION
## Description

Reading through this code, I was uncertain when `IPendingMessage.sequenceNumber` should/must be present or not. I found that it's actually very unambiguous in practice - it's only used after a local message is processed and moved to the `savedOps` array.  So I updated the typing to reflect that.

Got to remove a runtime assert now that TypeScript is helping.
