### PR TITLE
tree: Avoid adding an empty changeset to compositions

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -211,16 +211,12 @@ export class ModularChangeFamily
 		const { revInfos, maxId } = getRevInfoFromTaggedChanges(changes);
 		const idState: IdAllocationState = { maxId };
 
-		return changes.reduce(
-			(change1, change2) =>
-				makeAnonChange(this.composePair(change1, change2, revInfos, idState)),
-			makeAnonChange({
-				fieldChanges: new Map(),
-				nodeChanges: new Map(),
-				nodeToParent: new Map(),
-				nodeAliases: new Map(),
-				crossFieldKeys: newCrossFieldKeyTable(),
-			}),
+		if (changes.length === 0) {
+			return makeModularChangeset();
+		}
+
+		return changes.reduce((change1, change2) =>
+			makeAnonChange(this.composePair(change1, change2, revInfos, idState)),
 		).change;
 	}
 

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
@@ -222,10 +222,12 @@ function rebaseComposedWrapped(
 	change: TaggedChange<WrappedChangeset>,
 	...baseChanges: TaggedChange<WrappedChangeset>[]
 ): WrappedChangeset {
-	const composed = baseChanges.reduce(
-		(change1, change2) => makeAnonChange(composeWrapped(change1, change2)),
-		makeAnonChange(ChangesetWrapper.create(Change.empty())),
-	);
+	const composed =
+		baseChanges.length === 0
+			? makeAnonChange(ChangesetWrapper.create(Change.empty()))
+			: baseChanges.reduce((change1, change2) =>
+					makeAnonChange(composeWrapped(change1, change2)),
+				);
 
 	return rebaseWrapped(change, composed, metadata);
 }

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -92,15 +92,15 @@ export function composeDeep(
 ): WrappedChange {
 	const metadata = revisionMetadata ?? defaultRevisionMetadataFromChanges(changes);
 
-	return changes.reduce(
-		(change1, change2) =>
-			makeAnonChange(
-				ChangesetWrapper.compose(change1, change2, (c1, c2, composeChild) =>
-					composePair(c1.change, c2.change, composeChild, metadata, idAllocatorFromMaxId()),
+	return changes.length === 0
+		? ChangesetWrapper.create([])
+		: changes.reduce((change1, change2) =>
+				makeAnonChange(
+					ChangesetWrapper.compose(change1, change2, (c1, c2, composeChild) =>
+						composePair(c1.change, c2.change, composeChild, metadata, idAllocatorFromMaxId()),
+					),
 				),
-			),
-		makeAnonChange(ChangesetWrapper.create([])),
-	).change;
+			).change;
 }
 
 export function composeNoVerify(


### PR DESCRIPTION
## Description

This PR removes a behavior where ModularChangeFamily, as well as some test change handlers, would include an empty changeset into the composition whenever composing an array of changesets. This was done so that even composing a single changeset would cause a full composition pass. In the past this was necessary because the composition pass had the side effect of inlining revision tags. Now that revision tag inlining is done separately, this pass is unnecessary.