### PR TITLE
[GC] Removed unreferenced event Q for summarizer and log unreferenced events only if node was not revived first

### DIFF
--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -37,7 +37,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     protected constructor(context: IContainerContext, registry: IFluidDataStoreRegistry, metadata: IContainerRuntimeMetadata | undefined, electedSummarizerData: ISerializedElection | undefined, chunks: [string, string[]][], dataStoreAliasMap: [string, string][], runtimeOptions: Readonly<Required<IContainerRuntimeOptions>>, containerScope: FluidObject, baseLogger: ITelemetryBaseLogger, existing: boolean, blobManagerSnapshot: IBlobManagerLoadInfo, _storage: IDocumentStorageService, createIdCompressor: () => Promise<IIdCompressor & IIdCompressorCore>, documentsSchemaController: DocumentsSchemaController, featureGatesForTelemetry: Record<string, boolean | number | undefined>, provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>, requestHandler?: ((request: IRequest, runtime: IContainerRuntime) => Promise<IResponse>) | undefined, summaryConfiguration?: ISummaryConfiguration);
     // (undocumented)
     protected addContainerStateToSummary(summaryTree: ISummaryTreeWithStats, fullTree: boolean, trackState: boolean, telemetryContext?: ITelemetryContext): void;
-    addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number): void;
+    addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number, fromPkg?: readonly string[], toPkg?: readonly string[]): void;
     // (undocumented)
     get attachState(): AttachState;
     // (undocumented)
@@ -96,7 +96,7 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     getCurrentReferenceTimestampMs(): number | undefined;
     getEntryPoint(): Promise<FluidObject>;
     getGCData(fullGC?: boolean): Promise<IGarbageCollectionData>;
-    getGCNodePackagePath(nodePath: string): Promise<readonly string[] | undefined>;
+    getGCNodePackagePath(nodePath: string): readonly string[] | undefined;
     getNodeType(nodePath: string): GCNodeType;
     // (undocumented)
     getPendingLocalState(props?: IGetPendingLocalStateProps): unknown;

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -737,9 +737,23 @@ export abstract class FluidDataStoreContext
 	 * @param fromPath - The absolute path of the node that added the reference.
 	 * @param toPath - The absolute path of the outbound node that is referenced.
 	 * @param messageTimestampMs - The timestamp of the message that added the reference.
+	 * @param fromPkg - The package path of the node that adds the reference.
+	 * @param toPkg - The package path of the node to which reference is added.
 	 */
-	public addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number) {
-		this.parentContext.addedGCOutboundRoute(fromPath, toPath, messageTimestampMs);
+	public addedGCOutboundRoute(
+		fromPath: string,
+		toPath: string,
+		messageTimestampMs?: number,
+		fromPkg?: readonly string[],
+		toPkg?: readonly string[],
+	) {
+		this.parentContext.addedGCOutboundRoute(
+			fromPath,
+			toPath,
+			messageTimestampMs,
+			fromPkg ?? this.pkg,
+			toPkg,
+		);
 	}
 
 	/**

--- a/packages/runtime/container-runtime/src/gc/gcConfigs.ts
+++ b/packages/runtime/container-runtime/src/gc/gcConfigs.ts
@@ -131,7 +131,7 @@ export function generateGCConfigs(
 		: "NO";
 
 	// If we aren't running sweep, also disable AutoRecovery which also emits the GC op.
-	// This gives a simple control surface for compability concerns around introducing the new op.
+	// This gives a simple control surface for compatibility concerns around introducing the new op.
 	const tombstoneAutorecoveryEnabled = shouldRunSweep !== "NO";
 
 	// Override inactive timeout if test config or gc options to override it is set.

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -374,12 +374,7 @@ export interface IGarbageCollector {
 	 */
 	nodeUpdated(props: IGCNodeUpdatedProps): void;
 	/** Called when a reference is added to a node. Used to identify nodes that were referenced between summaries. */
-	addedOutboundReference(
-		fromNodePath: string,
-		toNodePath: string,
-		timestampMs: number,
-		autorecovery?: true,
-	): void;
+	addedOutboundReference(props: IGCReferenceAddedProps): void;
 	/** Called to process a garbage collection message. */
 	processMessage(
 		message: ContainerRuntimeGCMessage,
@@ -406,7 +401,7 @@ export interface IGCNodeUpdatedProps {
 	 * be the timestamp of the op. If not, this should be the timestamp of the last op processed.
 	 */
 	timestampMs: number | undefined;
-	/** The package path of the node. This may not be available if the node hasn't been loaded yet */
+	/** The package path of the node. Not available if the node hasn't been loaded yet */
 	packagePath?: readonly string[];
 	/** The original request for loads to preserve it in telemetry */
 	request?: IRequest;
@@ -414,6 +409,25 @@ export interface IGCNodeUpdatedProps {
 	headerData?: RuntimeHeaderData;
 	/** Any other properties to be logged. */
 	additionalProps?: ITelemetryPropertiesExt;
+}
+
+/**
+ * Info needed by GC when notified that a reference is added
+ * @internal
+ */
+export interface IGCReferenceAddedProps {
+	/** The node from which the reference is added */
+	fromNodePath: string;
+	/** The node to which the reference is added */
+	toNodePath: string;
+	/** The timestamp of the message that added the reference */
+	timestampMs: number;
+	/** This reference is added artificially, for autorecovery. Used for logging */
+	autorecovery?: true;
+	/** The package path of the node that adds the reference. Not available if the node hasn't been loaded yet */
+	packagePath?: readonly string[];
+	/** The package path of the node to which reference is added. Not available if the node hasn't been loaded yet */
+	fromPackagePath?: readonly string[];
 }
 
 /** Parameters necessary for creating a GarbageCollector. */
@@ -426,7 +440,6 @@ export interface IGarbageCollectorCreateParams {
 	readonly createContainerMetadata: ICreateContainerMetadata;
 	readonly baseSnapshot: ISnapshotTree | undefined;
 	readonly isSummarizerClient: boolean;
-	readonly getNodePackagePath: (nodePath: string) => Promise<readonly string[] | undefined>;
 	readonly getLastSummaryTimestampMs: () => number | undefined;
 	readonly readAndParseBlob: ReadAndParseBlob;
 	readonly submitMessage: (message: ContainerRuntimeGCMessage) => void;

--- a/packages/runtime/container-runtime/src/test/gc/gc.perf.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gc.perf.spec.ts
@@ -63,7 +63,6 @@ function createGarbageCollector(gcOptions: IGCRuntimeOptions): GcWithPrivates {
 		},
 		isSummarizerClient: true,
 		readAndParseBlob: parseNothing,
-		getNodePackagePath: async (nodeId: string) => ["gcBenchmarkTestPkg"],
 		getLastSummaryTimestampMs: () => Date.now(),
 		submitMessage: (message: ContainerRuntimeGCMessage) => {},
 	}) as GcWithPrivates;

--- a/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcConfigs.spec.ts
@@ -58,7 +58,6 @@ type GcWithPrivates = IGarbageCollector & {
 };
 
 describe("Garbage Collection configurations", () => {
-	const testPkgPath = ["testPkg"];
 	const configProvider = createTestConfigProvider();
 
 	let mockLogger: MockLogger;
@@ -140,7 +139,6 @@ describe("Garbage Collection configurations", () => {
 			},
 			isSummarizerClient,
 			readAndParseBlob: async <T>(id: string) => gcBlobsMap.get(id) as T,
-			getNodePackagePath: async (nodeId: string) => testPkgPath,
 			getLastSummaryTimestampMs: () => Date.now(),
 			submitMessage: (message: ContainerRuntimeGCMessage) => {},
 		});

--- a/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
@@ -34,7 +34,6 @@ import { pkgVersion } from "../../packageVersion.js";
 describe("Garbage Collection Stats", () => {
 	// Nodes in the reference graph.
 	const nodes: string[] = ["/node1", "/node2", "/node3", "/node4", "/node5", "/node6"];
-	const testPkgPath = ["testPkg"];
 
 	let mockLogger: MockLogger;
 	let mc: MonitoringContext<MockLogger>;
@@ -114,7 +113,6 @@ describe("Garbage Collection Stats", () => {
 			},
 			isSummarizerClient,
 			readAndParseBlob: async <T>(id: string) => gcBlobsMap.get(id) as T,
-			getNodePackagePath: async (nodeId: string) => testPkgPath,
 			getLastSummaryTimestampMs: () => Date.now(),
 			submitMessage: (message: ContainerRuntimeGCMessage) => {
 				gcMessagesCount++;

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -185,7 +185,7 @@ export interface IFluidDataStoreRegistry extends IProvideFluidDataStoreRegistry 
 
 // @alpha
 export interface IFluidParentContext extends IProvideFluidHandleContext, Partial<IProvideFluidDataStoreRegistry> {
-    addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number): void;
+    addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number, fromPkg?: readonly string[], toPkg?: readonly string[]): void;
     readonly attachState: AttachState;
     // (undocumented)
     readonly baseLogger: ITelemetryBaseLogger;

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -522,8 +522,16 @@ export interface IFluidParentContext
 	 * @param fromPath - The absolute path of the node that added the reference.
 	 * @param toPath - The absolute path of the outbound node that is referenced.
 	 * @param messageTimestampMs - The timestamp of the message that added the reference.
+	 * @param fromPkg - The package path of the node that adds the reference.
+	 * @param toPkg - The package path of the node to which reference is added.
 	 */
-	addedGCOutboundRoute(fromPath: string, toPath: string, messageTimestampMs?: number): void;
+	addedGCOutboundRoute(
+		fromPath: string,
+		toPath: string,
+		messageTimestampMs?: number,
+		fromPkg?: readonly string[],
+		toPkg?: readonly string[],
+	): void;
 }
 
 /**

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepDataStores.spec.ts
@@ -672,12 +672,18 @@ describeCompat("GC data store sweep tests", "NoCompat", (getTestObjectProvider) 
 				ensureSynchronizedAndSummarize(summarizer2),
 				"summarize failed",
 			);
-			logger.assertMatch([
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:SweepReadyObject_Realized",
-					id: { value: `/${unreferencedId}`, tag: TelemetryDataTag.CodeArtifact },
-				},
-			]);
+			logger.assertMatch(
+				[
+					{
+						eventName:
+							"fluid:telemetry:ContainerRuntime:GarbageCollector:SweepReadyObject_Realized",
+						id: { value: `/${unreferencedId}`, tag: TelemetryDataTag.CodeArtifact },
+						trailingOpCount: 1,
+					},
+				],
+				"realized event not logged as expected",
+				true,
+			);
 		});
 	});
 

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneDataStores.spec.ts
@@ -453,14 +453,13 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 
 	describe("Loading tombstoned data stores", () => {
 		const expectedHeadersLogged = {
-			request: "{}",
-			handleGet: JSON.stringify({ viaHandle: true }),
-			request_allowTombstone: JSON.stringify({ allowTombstone: true }),
-			request_subDataStoreHandle: JSON.stringify({
+			handleGet: { viaHandle: true },
+			request_allowTombstone: { allowTombstone: true },
+			request_subDataStoreHandle: {
 				viaHandle: true,
 				allowTombstone: true,
 				allowInactive: true,
-			}),
+			},
 		};
 
 		beforeEach("extraSettings", () => {
@@ -476,21 +475,18 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 				{
 					eventName:
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
-					headers: expectedHeadersLogged.request,
 					clientType: "interactive",
 				},
 				// Interactive client's request w/ allowTombstone
 				{
 					eventName:
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
-					headers: expectedHeadersLogged.request_allowTombstone,
 					clientType: "interactive",
 				},
 				// Summarizer client's request
 				{
 					eventName:
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
-					headers: expectedHeadersLogged.request,
 					clientType: "noninteractive/summarizer",
 				},
 			],
@@ -558,7 +554,6 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 							eventName:
 								"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
 							clientType: "interactive",
-							headers: expectedHeadersLogged.request,
 							id: { value: `/${unreferencedId}`, tag: TelemetryDataTag.CodeArtifact },
 							trackedId: `/${unreferencedId}`,
 						},
@@ -567,7 +562,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 							category: "generic",
 							eventName:
 								"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
-							headers: expectedHeadersLogged.request_allowTombstone,
+							...expectedHeadersLogged.request_allowTombstone,
 							clientType: "interactive",
 							id: { value: `/${unreferencedId}`, tag: TelemetryDataTag.CodeArtifact },
 							trackedId: `/${unreferencedId}`,
@@ -603,7 +598,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 							eventName:
 								"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_SubDataStore_Requested",
 							clientType: "interactive",
-							headers: expectedHeadersLogged.request_subDataStoreHandle,
+							...expectedHeadersLogged.request_subDataStoreHandle,
 							id: {
 								value: ddsHandle.absolutePath,
 								tag: TelemetryDataTag.CodeArtifact,
@@ -616,7 +611,7 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 							eventName:
 								"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_SubDataStore_Requested",
 							clientType: "interactive",
-							headers: expectedHeadersLogged.request_subDataStoreHandle,
+							...expectedHeadersLogged.request_subDataStoreHandle,
 							id: {
 								value: untrackedHandle.absolutePath,
 								tag: TelemetryDataTag.CodeArtifact,
@@ -747,14 +742,12 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 				{
 					eventName:
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
-					headers: expectedHeadersLogged.handleGet,
 					clientType: "interactive",
 				},
 				// Interactive client's request w/ allowTombstone
 				{
 					eventName:
 						"fluid:telemetry:ContainerRuntime:GarbageCollector:GC_Tombstone_DataStore_Requested",
-					headers: expectedHeadersLogged.request_allowTombstone,
 					clientType: "interactive",
 				},
 			],
@@ -1358,12 +1351,18 @@ describeCompat("GC data store tombstone tests", "NoCompat", (getTestObjectProvid
 				mockLogger,
 			);
 			await assert.doesNotReject(summarize(summarizer2), "summarize failed");
-			mockLogger.assertMatch([
-				{
-					eventName: "fluid:telemetry:Summarizer:Running:TombstoneReadyObject_Realized",
-					id: { value: `/${unreferencedId}`, tag: TelemetryDataTag.CodeArtifact },
-				},
-			]);
+			mockLogger.assertMatch(
+				[
+					{
+						eventName:
+							"fluid:telemetry:ContainerRuntime:GarbageCollector:TombstoneReadyObject_Realized",
+						id: { value: `/${unreferencedId}`, tag: TelemetryDataTag.CodeArtifact },
+						trailingOpCount: 1,
+					},
+				],
+				"realized event not logged as expected",
+				true,
+			);
 		});
 	});
 


### PR DESCRIPTION
## Reviewer guidance

This is targetting a test branch (test/gc-2.3). Since this has legacy alpha API breaking changes which are not allowed to be merged until v2.3, this is a workaround to get the changes reviewed and merged in a test branch. Later when breaking changes are allowed, these will get merged to main.

## Description
In summarizer clients, unreferenced events (inactive, tombstone ready and sweep ready) are added to a queue and are logged after the next GC completes. This was done to reduce false positives in 2 scenarios:
- A node is used after it is revived. Since the revive notifcation to GC was delayed until the object reviving was loaded, GC could not build correct timeline.
- GC may get multiple reference notifications on object loads. GC was notified of references whenever an object with handles was loaded.

With the reference op work, both of these problems don't exist. So, we can remove the unreferenced event queue for summarizer clients. Also, we can check that an object is not revived before we log an event for it which will reduce false positives for non-summarizer clients too.

This PR makes 3 main changes:
1. It removes the unreferenced event queue for summarizers and logs unreferenced events right away.
2. It checks that GC did not see a reference for an unreferenced object before it was used. If it did, it does not log because the usage isn't unexpected.
3. Added packagePath and fromPackagePath properties to addedGCOutboundRoute. Since this information is already present with the runtime when it calls GC, it doesn't need to ask for it.

[AB#8938](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8938)