### PR TITLE
Remove version-tool dependency from build-tools

### DIFF
--- a/build-tools/packages/build-cli/src/commands/bump.ts
+++ b/build-tools/packages/build-cli/src/commands/bump.ts
@@ -23,7 +23,11 @@ import {
 	isInterdependencyRange,
 } from "@fluid-tools/version-tools";
 
-import { findPackageOrReleaseGroup, packageOrReleaseGroupArg } from "../args.js";
+import {
+	findPackageOrReleaseGroup,
+	getDefaultInterdependencyRange,
+	packageOrReleaseGroupArg,
+} from "../args.js";
 import { bumpTypeFlag, checkFlags, skipCheckFlag, versionSchemeFlag } from "../flags.js";
 import {
 	BaseCommand,
@@ -171,7 +175,8 @@ export default class BumpCommand extends BaseCommand<typeof BumpCommand> {
 			repoVersion = releaseRepo.version;
 			scheme = flags.scheme ?? detectVersionScheme(repoVersion);
 			// Update the interdependency range to the configured default if the one provided isn't valid
-			interdependencyRange = interdependencyRange ?? releaseRepo.interdependencyRange;
+			interdependencyRange =
+				interdependencyRange ?? getDefaultInterdependencyRange(releaseRepo, context);
 			updatedPackages.push(...releaseRepo.packages);
 			packageOrReleaseGroup = releaseRepo;
 		} else {

--- a/build-tools/packages/build-cli/src/commands/check/policy.ts
+++ b/build-tools/packages/build-cli/src/commands/check/policy.ts
@@ -9,7 +9,7 @@ import * as path from "node:path";
 import { Flags } from "@oclif/core";
 import { readJson } from "fs-extra/esm";
 
-import { loadFluidBuildConfig } from "@fluidframework/build-tools";
+import { loadFluidBuildConfig } from "../../config.js";
 
 import {
 	BaseCommand,

--- a/build-tools/packages/build-cli/src/commands/generate/assertTags.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/assertTags.ts
@@ -6,8 +6,9 @@
 import { strict as assert } from "node:assert";
 import fs from "node:fs";
 import path from "node:path";
-import { Package, loadFluidBuildConfig } from "@fluidframework/build-tools";
+import { Package } from "@fluidframework/build-tools";
 import { PackageCommand } from "../../BasePackageCommand.js";
+import { loadFluidBuildConfig } from "../../config.js";
 import { PackageKind } from "../../filter.js";
 
 import { Flags } from "@oclif/core";

--- a/build-tools/packages/build-cli/src/config.ts
+++ b/build-tools/packages/build-cli/src/config.ts
@@ -1,0 +1,252 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { VersionBumpType } from "@fluid-tools/version-tools";
+import { IRepoBuildConfig, getRepoBuildConfig } from "@fluidframework/build-tools";
+/**
+ * Fluid build configuration that is expected in the repo-root package.json.
+ */
+export interface IFluidBuildConfig extends IRepoBuildConfig {
+	/**
+	 * Policy configuration for the `check:policy` command. This can only be configured in the repo-wide Fluid build
+	 * config (the repo-root package.json).
+	 */
+	policy?: PolicyConfig;
+
+	/**
+	 * Configuration for assert tagging.
+	 */
+	assertTagging?: AssertTaggingConfig;
+
+	/**
+	 * A mapping of branch names to previous version baseline styles. The type test generator takes this information
+	 * into account when calculating the baseline version to use when it's run on a particular branch. If this is not
+	 * defined for a branch or package, then that package will be skipped during type test generation.
+	 */
+	branchReleaseTypes?: {
+		[name: string]: VersionBumpType | PreviousVersionStyle;
+	};
+}
+
+/* eslint-disable tsdoc/syntax */
+/**
+ * A type representing the different version constraint styles we use when determining the previous version for type
+ * test generation.
+ *
+ * The "base" versions are calculated by zeroing out all version segments lower than the base. That is, for a version v,
+ * the baseMajor version is `${v.major}.0.0` and the baseMinor version is `${v.major}.${v.minor}.0`.
+ *
+ * The "previous" versions work similarly, but the major/minor/patch segment is reduced by 1. That is, for a version v,
+ * the previousMajor version is `${min(v.major - 1, 1)}.0.0`, the previousMinor version is
+ * `${v.major}.${min(v.minor - 1, 0)}.0`, and the previousPatch is `${v.major}.${v.minor}.${min(v.patch - 1, 0)}.0`.
+ *
+ * The "previous" versions never roll back below 1 for the major version and 0 for minor and patch. That is, the
+ * previousMajor, previousMinor, and previousPatch versions for `1.0.0` are all `1.0.0`.
+ *
+ * @example
+ *
+ * Given the version 2.3.5:
+ *
+ * baseMajor: 2.0.0
+ * baseMinor: 2.3.0
+ * ~baseMinor: ~2.3.0
+ * previousPatch: 2.3.4
+ * previousMinor: 2.2.0
+ * previousMajor: 1.0.0
+ * ^previousMajor: ^1.0.0
+ * ^previousMinor: ^2.2.0
+ * ~previousMajor: ~1.0.0
+ * ~previousMinor: ~2.2.0
+ *
+ * @example
+ *
+ * Given the version 2.0.0-internal.2.3.5:
+ *
+ * baseMajor: 2.0.0-internal.2.0.0
+ * baseMinor: 2.0.0-internal.2.3.0
+ * ~baseMinor: >=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0
+ * previousPatch: 2.0.0-internal.2.3.4
+ * previousMinor: 2.0.0-internal.2.2.0
+ * previousMajor: 2.0.0-internal.1.0.0
+ * ^previousMajor: >=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0
+ * ^previousMinor: >=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0
+ * ~previousMajor: >=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0
+ * ~previousMinor: >=2.0.0-internal.2.2.0 <2.0.0-internal.2.2.0
+ *
+ * @example
+ *
+ * Given the version 2.0.0-internal.2.0.0:
+ *
+ * baseMajor: 2.0.0-internal.2.0.0
+ * baseMinor: 2.0.0-internal.2.0.0
+ * ~baseMinor: >=2.0.0-internal.2.0.0 <2.0.0-internal.2.1.0
+ * previousPatch: 2.0.0-internal.2.0.0
+ * previousMinor: 2.0.0-internal.2.0.0
+ * previousMajor: 2.0.0-internal.1.0.0
+ * ^previousMajor: >=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0
+ * ^previousMinor: >=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0
+ * ~previousMajor: >=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0
+ * ~previousMinor: >=2.0.0-internal.2.0.0 <2.0.0-internal.2.1.0
+ *
+ * @internal
+ */
+/* eslint-enable tsdoc/syntax */
+export type PreviousVersionStyle =
+	| "baseMajor"
+	| "baseMinor"
+	| "previousPatch"
+	| "previousMinor"
+	| "previousMajor"
+	| "~baseMinor"
+	| "^previousMajor"
+	| "^previousMinor"
+	| "~previousMajor"
+	| "~previousMinor";
+
+/**
+ * Policy configuration for the `check:policy` command.
+ */
+export interface PolicyConfig {
+	additionalLockfilePaths?: string[];
+	pnpmSinglePackageWorkspace?: string[];
+	fluidBuildTasks: {
+		tsc: {
+			ignoreTasks: string[];
+			ignoreDependencies: string[];
+			ignoreDevDependencies: string[];
+		};
+	};
+	dependencies?: {
+		commandPackages: [string, string][];
+	};
+	/**
+	 * An array of strings/regular expressions. Paths that match any of these expressions will be completely excluded from
+	 * policy-check.
+	 */
+	exclusions?: string[];
+
+	/**
+	 * An object with handler name as keys that maps to an array of strings/regular expressions to
+	 * exclude that rule from being checked.
+	 */
+	handlerExclusions?: { [rule: string]: string[] };
+
+	packageNames?: PackageNamePolicyConfig;
+
+	/**
+	 * (optional) requirements to enforce against each public package.
+	 */
+	publicPackageRequirements?: PackageRequirements;
+}
+
+export interface AssertTaggingConfig {
+	assertionFunctions: { [functionName: string]: number };
+
+	/**
+	 * An array of paths under which assert tagging applies to. If this setting is provided, only packages whose paths
+	 * match the regular expressions in this setting will be assert-tagged.
+	 */
+	enabledPaths?: RegExp[];
+}
+
+/**
+ * Configuration for package naming and publication policies.
+ */
+export interface PackageNamePolicyConfig {
+	/**
+	 * A list of package scopes that are permitted in the repo.
+	 */
+	allowedScopes?: string[];
+	/**
+	 * A list of packages that have no scope.
+	 */
+	unscopedPackages?: string[];
+	/**
+	 * Packages that must be published.
+	 */
+	mustPublish: {
+		/**
+		 * A list of package names or scopes that must publish to npm, and thus should never be marked private.
+		 */
+		npm?: string[];
+
+		/**
+		 * A list of package names or scopes that must publish to an internal feed, and thus should always be marked
+		 * private.
+		 */
+		internalFeed?: string[];
+	};
+
+	/**
+	 * Packages that may or may not be published.
+	 */
+	mayPublish: {
+		/**
+		 * A list of package names or scopes that may publish to npm, and thus might or might not be marked private.
+		 */
+		npm?: string[];
+
+		/**
+		 * A list of package names or scopes that must publish to an internal feed, and thus might or might not be marked
+		 * private.
+		 */
+		internalFeed?: string[];
+	};
+}
+
+/**
+ * Expresses requirements for a given package, applied to its package.json.
+ */
+export interface PackageRequirements {
+	/**
+	 * (optional) list of script requirements for the package.
+	 */
+	requiredScripts?: ScriptRequirement[];
+
+	/**
+	 * (optional) list of required dev dependencies for the package.
+	 * @remarks Note: there is no enforcement of version requirements, only that a dependency on the specified name must exist.
+	 */
+	requiredDevDependencies?: string[];
+}
+
+/**
+ * Requirements for a given script.
+ */
+export interface ScriptRequirement {
+	/**
+	 * Name of the script to check.
+	 */
+	name: string;
+
+	/**
+	 * Body of the script being checked.
+	 * A contents match will be enforced iff {@link ScriptRequirement.bodyMustMatch}.
+	 * This value will be used as the default contents inserted by the policy resolver (regardless of {@link ScriptRequirement.bodyMustMatch}).
+	 */
+	body: string;
+
+	/**
+	 * Whether or not the script body is required to match {@link ScriptRequirement.body} when running the policy checker.
+	 * @defaultValue `false`
+	 */
+	bodyMustMatch?: boolean;
+}
+
+/**
+ * Loads an IFluidBuildConfig from the fluidBuild property in a package.json file, or from fluidBuild.config.[c]js.
+ * Throw if not found.
+ *
+ * @param rootDir - The path to the root package.json to load.
+ * @param noCache - If true, the config cache will be cleared and the config will be reloaded.
+ * @returns The fluidBuild section of the package.json.
+ */
+export function loadFluidBuildConfig(rootDir: string, noCache = false): IFluidBuildConfig {
+	const config = getRepoBuildConfig(rootDir, noCache);
+	if (config === undefined) {
+		throw new Error(`Error loading config.`);
+	}
+	return config;
+}

--- a/build-tools/packages/build-cli/src/handlers/doFunctions.ts
+++ b/build-tools/packages/build-cli/src/handlers/doFunctions.ts
@@ -11,6 +11,7 @@ import { FluidRepo, MonoRepo } from "@fluidframework/build-tools";
 
 import { bumpVersionScheme, detectVersionScheme } from "@fluid-tools/version-tools";
 
+import { getDefaultInterdependencyRange } from "../args.js";
 import {
 	difference,
 	getPreReleaseDependencies,
@@ -177,7 +178,7 @@ export const doReleaseGroupBump: StateHandlerFunction = async (
 		context,
 		rgRepo,
 		newVersion,
-		rgRepo instanceof MonoRepo ? rgRepo.interdependencyRange : undefined,
+		rgRepo instanceof MonoRepo ? getDefaultInterdependencyRange(rgRepo, context) : undefined,
 		log,
 	);
 

--- a/build-tools/packages/build-cli/src/handlers/stateHandlers.ts
+++ b/build-tools/packages/build-cli/src/handlers/stateHandlers.ts
@@ -42,7 +42,6 @@ export abstract class BaseStateHandler implements StateHandler {
 		data: unknown,
 	): Promise<boolean>;
 
-	// eslint-disable-next-line no-useless-constructor
 	public constructor(
 		protected readonly machine: Machine<unknown>,
 		protected readonly log: CommandLogger,

--- a/build-tools/packages/build-cli/src/library/context.ts
+++ b/build-tools/packages/build-cli/src/library/context.ts
@@ -5,16 +5,10 @@
 
 import { PackageName } from "@rushstack/node-core-library";
 
-import {
-	FluidRepo,
-	GitRepo,
-	IFluidBuildConfig,
-	Package,
-	loadFluidBuildConfig,
-} from "@fluidframework/build-tools";
-
 import { ReleaseVersion } from "@fluid-tools/version-tools";
+import { FluidRepo, GitRepo, Package } from "@fluidframework/build-tools";
 import * as semver from "semver";
+import { IFluidBuildConfig, loadFluidBuildConfig } from "../config.js";
 
 /**
  * Represents a release version and its release date, if applicable.
@@ -100,9 +94,12 @@ export class Context {
 		public readonly originalBranchName: string,
 	) {
 		// Load the package
-		this.repo = FluidRepo.create(this.gitRepo.resolvedRoot);
+		this.rootFluidBuildConfig = loadFluidBuildConfig(this.gitRepo.resolvedRoot);
+		this.repo = new FluidRepo(
+			this.gitRepo.resolvedRoot,
+			this.rootFluidBuildConfig.repoPackages,
+		);
 		this.fullPackageMap = this.repo.createPackageMap();
-		this.rootFluidBuildConfig = loadFluidBuildConfig(this.repo.resolvedRoot);
 	}
 
 	/**

--- a/build-tools/packages/build-cli/src/library/layerGraph.ts
+++ b/build-tools/packages/build-cli/src/library/layerGraph.ts
@@ -36,7 +36,6 @@ interface ILayerInfoFile {
 }
 
 class BaseNode {
-	// eslint-disable-next-line no-useless-constructor
 	constructor(public readonly name: string) {}
 
 	public get dotName(): string {

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/fluidBuildTasks.ts
@@ -13,7 +13,6 @@ import {
 	TscUtils,
 	getEsLintConfigFilePath,
 	getTaskDefinitions,
-	loadFluidBuildConfig,
 	normalizeGlobalTaskDefinitions,
 	updatePackageJsonFile,
 	updatePackageJsonFileAsync,
@@ -21,6 +20,7 @@ import {
 import JSON5 from "json5";
 import * as semver from "semver";
 import { TsConfigJson } from "type-fest";
+import { loadFluidBuildConfig } from "../../config.js";
 import { Handler, readFile } from "./common.js";
 import { FluidBuildDatabase } from "./fluidBuildDatabase.js";
 
@@ -51,7 +51,8 @@ function getFluidPackageMap(root: string): Map<string, Package> {
 	const rootDir = path.resolve(root);
 	let record = repoCache.get(rootDir);
 	if (record === undefined) {
-		const repo = FluidRepo.create(rootDir);
+		const packageManifest = loadFluidBuildConfig(rootDir);
+		const repo = new FluidRepo(rootDir, packageManifest.repoPackages);
 		const packageMap = repo.createPackageMap();
 		record = { repo, packageMap };
 		repoCache.set(rootDir, record);

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/lockfiles.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/lockfiles.ts
@@ -5,7 +5,7 @@
 
 import { unlinkSync } from "node:fs";
 import path from "node:path";
-import { IFluidBuildConfig, loadFluidBuildConfig } from "@fluidframework/build-tools";
+import { IFluidBuildConfig, loadFluidBuildConfig } from "../../config.js";
 import { Handler } from "./common.js";
 
 const lockFilePattern = /.*?package-lock\.json$/i;

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
@@ -17,15 +17,18 @@ import sortPackageJson from "sort-package-json";
 
 import {
 	PackageJson,
-	PackageNamePolicyConfig,
-	ScriptRequirement,
 	getApiExtractorConfigFilePath,
-	loadFluidBuildConfig,
 	updatePackageJsonFile,
 	updatePackageJsonFileAsync,
 } from "@fluidframework/build-tools";
 import { queryTypesResolutionPathsFromPackageExports } from "../packageExports.js";
 import { Handler, readFile, writeFile } from "./common.js";
+
+import {
+	PackageNamePolicyConfig,
+	ScriptRequirement,
+	loadFluidBuildConfig,
+} from "../../config.js";
 
 const require = createRequire(import.meta.url);
 

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/pnpm.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/pnpm.ts
@@ -5,7 +5,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { PackageJson, loadFluidBuildConfig } from "@fluidframework/build-tools";
+import { PackageJson } from "@fluidframework/build-tools";
+import { loadFluidBuildConfig } from "../../config.js";
 import { Handler, readFile } from "./common.js";
 
 const match = /(?:^|\/)pnpm-lock\.yaml$/i;

--- a/build-tools/packages/build-cli/test/commands/list.test.ts
+++ b/build-tools/packages/build-cli/test/commands/list.test.ts
@@ -3,14 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import {
-	GitRepo,
-	type Package,
-	type PackageNamePolicyConfig,
-	getResolvedFluidRoot,
-} from "@fluidframework/build-tools";
+import { GitRepo, type Package, getResolvedFluidRoot } from "@fluidframework/build-tools";
 import { expect } from "chai";
 
+import { type PackageNamePolicyConfig } from "../../src/config.js";
 import { Context } from "../../src/library/index.js";
 import {
 	type Feed,

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -38,7 +38,6 @@
 		"tsc": "tsc"
 	},
 	"dependencies": {
-		"@fluid-tools/version-tools": "workspace:~",
 		"@fluidframework/bundle-size-tools": "workspace:~",
 		"@manypkg/get-packages": "^2.2.0",
 		"@octokit/core": "^4.2.4",

--- a/build-tools/packages/build-tools/src/common/fluidRepo.ts
+++ b/build-tools/packages/build-tools/src/common/fluidRepo.ts
@@ -5,24 +5,12 @@
 
 import * as path from "path";
 
-import {
-	DEFAULT_INTERDEPENDENCY_RANGE,
-	InterdependencyRange,
-	VersionBumpType,
-} from "@fluid-tools/version-tools";
-
-import registerDebug from "debug";
 import { TaskDefinitionsOnDisk } from "./fluidTaskDefinitions";
-import { loadFluidBuildConfig } from "./fluidUtils";
 import { MonoRepo } from "./monoRepo";
 import { Package, Packages } from "./npmPackage";
 import { ExecAsyncResult } from "./utils";
-const traceInit = registerDebug("fluid-build:init");
 
-/**
- * Fluid build configuration that is expected in the repo-root package.json.
- */
-export interface IFluidBuildConfig {
+export interface IRepoBuildConfig {
 	/**
 	 * Build tasks and dependencies definitions
 	 */
@@ -32,263 +20,13 @@ export interface IFluidBuildConfig {
 	 * A mapping of package or release group names to metadata about the package or release group. This can only be
 	 * configured in the repo-wide Fluid build config (the repo-root package.json).
 	 */
-	repoPackages?: {
-		[name: string]: IFluidRepoPackageEntry;
-	};
-
-	/**
-	 * Policy configuration for the `check:policy` command. This can only be configured in the repo-wide Fluid build
-	 * config (the repo-root package.json).
-	 */
-	policy?: PolicyConfig;
-
-	/**
-	 * Configuration for assert tagging.
-	 */
-	assertTagging?: AssertTaggingConfig;
-
-	/**
-	 * A mapping of branch names to previous version baseline styles. The type test generator takes this information
-	 * into account when calculating the baseline version to use when it's run on a particular branch. If this is not
-	 * defined for a branch or package, then that package will be skipped during type test generation.
-	 */
-	branchReleaseTypes?: {
-		[name: string]: VersionBumpType | PreviousVersionStyle;
-	};
-}
-
-/**
- * A type representing the different version constraint styles we use when determining the previous version for type
- * test generation.
- *
- * The "base" versions are calculated by zeroing out all version segments lower than the base. That is, for a version v,
- * the baseMajor version is `${v.major}.0.0` and the baseMinor version is `${v.major}.${v.minor}.0`.
- *
- * The "previous" versions work similarly, but the major/minor/patch segment is reduced by 1. That is, for a version v,
- * the previousMajor version is `${min(v.major - 1, 1)}.0.0`, the previousMinor version is
- * `${v.major}.${min(v.minor - 1, 0)}.0`, and the previousPatch is `${v.major}.${v.minor}.${min(v.patch - 1, 0)}.0`.
- *
- * The "previous" versions never roll back below 1 for the major version and 0 for minor and patch. That is, the
- * previousMajor, previousMinor, and previousPatch versions for `1.0.0` are all `1.0.0`.
- *
- * @example
- *
- * Given the version 2.3.5:
- *
- * baseMajor: 2.0.0
- * baseMinor: 2.3.0
- * ~baseMinor: ~2.3.0
- * previousPatch: 2.3.4
- * previousMinor: 2.2.0
- * previousMajor: 1.0.0
- * ^previousMajor: ^1.0.0
- * ^previousMinor: ^2.2.0
- * ~previousMajor: ~1.0.0
- * ~previousMinor: ~2.2.0
- *
- * @example
- *
- * Given the version 2.0.0-internal.2.3.5:
- *
- * baseMajor: 2.0.0-internal.2.0.0
- * baseMinor: 2.0.0-internal.2.3.0
- * ~baseMinor: >=2.0.0-internal.2.3.0 <2.0.0-internal.3.0.0
- * previousPatch: 2.0.0-internal.2.3.4
- * previousMinor: 2.0.0-internal.2.2.0
- * previousMajor: 2.0.0-internal.1.0.0
- * ^previousMajor: >=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0
- * ^previousMinor: >=2.0.0-internal.2.2.0 <2.0.0-internal.3.0.0
- * ~previousMajor: >=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0
- * ~previousMinor: >=2.0.0-internal.2.2.0 <2.0.0-internal.2.2.0
- *
- * @example
- *
- * Given the version 2.0.0-internal.2.0.0:
- *
- * baseMajor: 2.0.0-internal.2.0.0
- * baseMinor: 2.0.0-internal.2.0.0
- * ~baseMinor: >=2.0.0-internal.2.0.0 <2.0.0-internal.2.1.0
- * previousPatch: 2.0.0-internal.2.0.0
- * previousMinor: 2.0.0-internal.2.0.0
- * previousMajor: 2.0.0-internal.1.0.0
- * ^previousMajor: >=2.0.0-internal.1.0.0 <2.0.0-internal.2.0.0
- * ^previousMinor: >=2.0.0-internal.2.0.0 <2.0.0-internal.3.0.0
- * ~previousMajor: >=2.0.0-internal.1.0.0 <2.0.0-internal.1.1.0
- * ~previousMinor: >=2.0.0-internal.2.0.0 <2.0.0-internal.2.1.0
- *
- * @internal
- */
-export type PreviousVersionStyle =
-	| "baseMajor"
-	| "baseMinor"
-	| "previousPatch"
-	| "previousMinor"
-	| "previousMajor"
-	| "~baseMinor"
-	| "^previousMajor"
-	| "^previousMinor"
-	| "~previousMajor"
-	| "~previousMinor";
-
-/**
- * Policy configuration for the `check:policy` command.
- */
-export interface PolicyConfig {
-	additionalLockfilePaths?: string[];
-	pnpmSinglePackageWorkspace?: string[];
-	fluidBuildTasks: {
-		tsc: {
-			ignoreTasks: string[];
-			ignoreDependencies: string[];
-			ignoreDevDependencies: string[];
-		};
-	};
-	dependencies?: {
-		commandPackages: [string, string][];
-	};
-	/**
-	 * An array of strings/regular expressions. Paths that match any of these expressions will be completely excluded from
-	 * policy-check.
-	 */
-	exclusions?: string[];
-
-	/**
-	 * An object with handler name as keys that maps to an array of strings/regular expressions to
-	 * exclude that rule from being checked.
-	 */
-	handlerExclusions?: { [rule: string]: string[] };
-
-	packageNames?: PackageNamePolicyConfig;
-
-	/**
-	 * (optional) requirements to enforce against each public package.
-	 */
-	publicPackageRequirements?: PackageRequirements;
-}
-
-export interface AssertTaggingConfig {
-	assertionFunctions: { [functionName: string]: number };
-
-	/**
-	 * An array of paths under which assert tagging applies to. If this setting is provided, only packages whose paths
-	 * match the regular expressions in this setting will be assert-tagged.
-	 */
-	enabledPaths?: RegExp[];
-}
-
-/**
- * Configuration for package naming and publication policies.
- */
-export interface PackageNamePolicyConfig {
-	/**
-	 * A list of package scopes that are permitted in the repo.
-	 */
-	allowedScopes?: string[];
-	/**
-	 * A list of packages that have no scope.
-	 */
-	unscopedPackages?: string[];
-	/**
-	 * Packages that must be published.
-	 */
-	mustPublish: {
-		/**
-		 * A list of package names or scopes that must publish to npm, and thus should never be marked private.
-		 */
-		npm?: string[];
-
-		/**
-		 * A list of package names or scopes that must publish to an internal feed, and thus should always be marked
-		 * private.
-		 */
-		internalFeed?: string[];
-	};
-
-	/**
-	 * Packages that may or may not be published.
-	 */
-	mayPublish: {
-		/**
-		 * A list of package names or scopes that may publish to npm, and thus might or might not be marked private.
-		 */
-		npm?: string[];
-
-		/**
-		 * A list of package names or scopes that must publish to an internal feed, and thus might or might not be marked
-		 * private.
-		 */
-		internalFeed?: string[];
-	};
-}
-
-/**
- * Expresses requirements for a given package, applied to its package.json.
- */
-export interface PackageRequirements {
-	/**
-	 * (optional) list of script requirements for the package.
-	 */
-	requiredScripts?: ScriptRequirement[];
-
-	/**
-	 * (optional) list of required dev dependencies for the package.
-	 * @remarks Note: there is no enforcement of version requirements, only that a dependency on the specified name must exist.
-	 */
-	requiredDevDependencies?: string[];
-}
-
-/**
- * Requirements for a given script.
- */
-export interface ScriptRequirement {
-	/**
-	 * Name of the script to check.
-	 */
-	name: string;
-
-	/**
-	 * Body of the script being checked.
-	 * A contents match will be enforced iff {@link ScriptRequirement.bodyMustMatch}.
-	 * This value will be used as the default contents inserted by the policy resolver (regardless of {@link ScriptRequirement.bodyMustMatch}).
-	 */
-	body: string;
-
-	/**
-	 * Whether or not the script body is required to match {@link ScriptRequirement.body} when running the policy checker.
-	 * @defaultValue `false`
-	 */
-	bodyMustMatch?: boolean;
-}
-
-/**
- * Metadata about known-broken types.
- */
-export interface BrokenCompatSettings {
-	backCompat?: false;
-	forwardCompat?: false;
-}
-
-/**
- * A mapping of a type name to its {@link BrokenCompatSettings}.
- */
-export type BrokenCompatTypes = Partial<Record<string, BrokenCompatSettings>>;
-
-export interface ITypeValidationConfig {
-	/**
-	 * An object containing types that are known to be broken.
-	 */
-	broken: BrokenCompatTypes;
-
-	/**
-	 * If true, disables type test preparation and generation for the package.
-	 */
-	disabled?: boolean;
+	repoPackages?: IRepoBuildDirs;
 }
 
 /**
  * Configures a package or release group
  */
-export interface IFluidRepoPackage {
+export interface IRepoBuildDir {
 	/**
 	 * The path to the package. For release groups this should be the path to the root of the release group.
 	 */
@@ -298,19 +36,13 @@ export interface IFluidRepoPackage {
 	 * An array of paths under `directory` that should be ignored.
 	 */
 	ignoredDirs?: string[];
-
-	/**
-	 * The interdependencyRange controls the type of semver range to use between packages in the same release group. This
-	 * setting controls the default range that will be used when updating the version of a release group. The default can
-	 * be overridden using the `--interdependencyRange` flag in the `flub bump` command.
-	 */
-	defaultInterdependencyRange: InterdependencyRange;
 }
 
-export type IFluidRepoPackageEntry =
-	| string
-	| IFluidRepoPackage
-	| (string | IFluidRepoPackage)[];
+export type IRepoBuildDirEntry = string | IRepoBuildDir | (string | IRepoBuildDir)[];
+
+export interface IRepoBuildDirs {
+	[name: string]: IRepoBuildDirEntry;
+}
 
 export class FluidRepo {
 	private readonly _releaseGroups = new Map<string, MonoRepo>();
@@ -321,46 +53,34 @@ export class FluidRepo {
 
 	public readonly packages: Packages;
 
-	public static create(resolvedRoot: string) {
-		const packageManifest = loadFluidBuildConfig(resolvedRoot);
-		return new FluidRepo(resolvedRoot, packageManifest);
-	}
-
-	protected constructor(
+	public constructor(
 		public readonly resolvedRoot: string,
-		packageManifest: IFluidBuildConfig,
+		repoBuildDirs?: IRepoBuildDirs,
 	) {
 		// Expand to full IFluidRepoPackage and full path
-		const normalizeEntry = (
-			item: IFluidRepoPackageEntry,
-		): IFluidRepoPackage | IFluidRepoPackage[] => {
+		const normalizeEntry = (item: IRepoBuildDirEntry): IRepoBuildDir | IRepoBuildDir[] => {
 			if (Array.isArray(item)) {
-				return item.map((entry) => normalizeEntry(entry) as IFluidRepoPackage);
+				return item.map((entry) => normalizeEntry(entry) as IRepoBuildDir);
 			}
 			if (typeof item === "string") {
-				traceInit(
-					`No defaultInterdependencyRange setting found for '${item}'. Defaulting to "${DEFAULT_INTERDEPENDENCY_RANGE}".`,
-				);
 				return {
 					directory: path.join(resolvedRoot, item),
 					ignoredDirs: undefined,
-					defaultInterdependencyRange: DEFAULT_INTERDEPENDENCY_RANGE,
 				};
 			}
 			const directory = path.join(resolvedRoot, item.directory);
 			return {
 				directory,
 				ignoredDirs: item.ignoredDirs?.map((dir) => path.join(directory, dir)),
-				defaultInterdependencyRange: item.defaultInterdependencyRange,
 			};
 		};
-		const loadOneEntry = (item: IFluidRepoPackage, group: string) => {
+		const loadOneEntry = (item: IRepoBuildDir, group: string) => {
 			return Packages.loadDir(item.directory, group, item.ignoredDirs);
 		};
 
 		const loadedPackages: Package[] = [];
-		for (const group in packageManifest.repoPackages) {
-			const item = normalizeEntry(packageManifest.repoPackages[group]);
+		for (const group in repoBuildDirs) {
+			const item = normalizeEntry(repoBuildDirs[group]);
 			if (Array.isArray(item)) {
 				for (const i of item) {
 					loadedPackages.push(...loadOneEntry(i, group));

--- a/build-tools/packages/build-tools/src/common/fluidUtils.ts
+++ b/build-tools/packages/build-tools/src/common/fluidUtils.ts
@@ -11,13 +11,13 @@ import { cosmiconfigSync } from "cosmiconfig";
 import { getPackages } from "@manypkg/get-packages";
 import { readJson } from "fs-extra";
 import { commonOptions } from "./commonOptions";
-import { IFluidBuildConfig } from "./fluidRepo";
 import { realpathAsync } from "./utils";
 
 // switch to regular import once building ESM
 const findUp = import("find-up");
 
 import registerDebug from "debug";
+import { IRepoBuildConfig } from "./fluidRepo";
 const traceInit = registerDebug("fluid-build:init");
 
 async function isFluidRootPackage(dir: string) {
@@ -138,29 +138,13 @@ const configExplorer = cosmiconfigSync("fluidBuild", {
 });
 
 /**
- * Loads an IFluidBuildConfig from the fluidBuild property in a package.json file, or from fluidBuild.config.[c]js.
- * Throw if not found.
- *
- * @param rootDir - The path to the root package.json to load.
- * @param noCache - If true, the config cache will be cleared and the config will be reloaded.
- * @returns The fluidBuild section of the package.json.
- */
-export function loadFluidBuildConfig(rootDir: string, noCache = false): IFluidBuildConfig {
-	const config = getFluidBuildConfig(rootDir, noCache);
-	if (config === undefined) {
-		throw new Error(`Error loading config.`);
-	}
-	return config;
-}
-
-/**
  * Get an IFluidBuildConfig from the fluidBuild property in a package.json file, or from fluidBuild.config.[c]js.
  *
  * @param rootDir - The path to the root package.json to load.
  * @param noCache - If true, the config cache will be cleared and the config will be reloaded.
  * @returns The fluidBuild section of the package.json, or undefined if not found
  */
-export function getFluidBuildConfig(rootDir: string, noCache = false): IFluidBuildConfig {
+export function getRepoBuildConfig(rootDir: string, noCache = false): IRepoBuildConfig {
 	if (noCache === true) {
 		configExplorer.clearCaches();
 	}

--- a/build-tools/packages/build-tools/src/common/monoRepo.ts
+++ b/build-tools/packages/build-tools/src/common/monoRepo.ts
@@ -4,15 +4,11 @@
  */
 
 import * as path from "path";
-import {
-	DEFAULT_INTERDEPENDENCY_RANGE,
-	InterdependencyRange,
-} from "@fluid-tools/version-tools";
 import { getPackagesSync } from "@manypkg/get-packages";
 import { readFileSync, readJsonSync } from "fs-extra";
 import YAML from "yaml";
 
-import { IFluidBuildConfig, IFluidRepoPackage } from "./fluidRepo";
+import { IRepoBuildDir } from "./fluidRepo";
 import { Logger, defaultLogger } from "./logging";
 import { Package } from "./npmPackage";
 import { execWithErrorAsync, existsSync, rimrafWithErrorAsync } from "./utils";
@@ -63,8 +59,8 @@ export class MonoRepo {
 		return this.kind as "build-tools" | "client" | "server" | "gitrest" | "historian";
 	}
 
-	static load(group: string, repoPackage: IFluidRepoPackage) {
-		const { directory, ignoredDirs, defaultInterdependencyRange } = repoPackage;
+	static load(group: string, repoPackage: IRepoBuildDir) {
+		const { directory, ignoredDirs } = repoPackage;
 		let packageManager: PackageManager;
 		let packageDirs: string[];
 
@@ -93,24 +89,11 @@ export class MonoRepo {
 				return undefined;
 			}
 			packageDirs = packages.filter((pkg) => pkg.relativeDir !== ".").map((pkg) => pkg.dir);
-
-			if (defaultInterdependencyRange === undefined) {
-				traceInit(
-					`No defaultinterdependencyRange specified for ${group} release group. Defaulting to "${DEFAULT_INTERDEPENDENCY_RANGE}".`,
-				);
-			}
 		} catch {
 			return undefined;
 		}
 
-		return new MonoRepo(
-			group,
-			directory,
-			defaultInterdependencyRange ?? DEFAULT_INTERDEPENDENCY_RANGE,
-			packageManager,
-			packageDirs,
-			ignoredDirs,
-		);
+		return new MonoRepo(group, directory, packageManager, packageDirs, ignoredDirs);
 	}
 
 	/**
@@ -124,7 +107,6 @@ export class MonoRepo {
 	constructor(
 		public readonly kind: string,
 		public readonly repoPath: string,
-		public readonly interdependencyRange: InterdependencyRange,
 		private readonly packageManager: PackageManager,
 		packageDirs: string[],
 		ignoredDirs?: string[],
@@ -199,10 +181,6 @@ export class MonoRepo {
 			: this.packageManager === "yarn"
 				? "npm run install-strict"
 				: "npm i --no-package-lock --no-shrinkwrap";
-	}
-
-	public get fluidBuildConfig(): IFluidBuildConfig | undefined {
-		return this.pkg.packageJson.fluidBuild;
 	}
 
 	public getNodeModulePath() {

--- a/build-tools/packages/build-tools/src/common/npmPackage.ts
+++ b/build-tools/packages/build-tools/src/common/npmPackage.ts
@@ -15,9 +15,10 @@ import sortPackageJson from "sort-package-json";
 import type { SetRequired, PackageJson as StandardPackageJson } from "type-fest";
 
 import { options } from "../fluidBuild/options";
-import { type IFluidBuildConfig, type ITypeValidationConfig } from "./fluidRepo";
+import { type IRepoBuildConfig } from "./fluidRepo";
 import { defaultLogger } from "./logging";
 import { MonoRepo, PackageManager } from "./monoRepo";
+import { type ITypeValidationConfig } from "./typeValidatorConfig";
 import {
 	ExecAsyncResult,
 	execWithErrorAsync,
@@ -50,7 +51,7 @@ export type FluidPackageJson = {
 	/**
 	 * fluid-build config. Some properties only apply when set in the root or release group root package.json.
 	 */
-	fluidBuild?: IFluidBuildConfig;
+	fluidBuild?: IRepoBuildConfig;
 
 	/**
 	 * pnpm config

--- a/build-tools/packages/build-tools/src/common/typeValidatorConfig.ts
+++ b/build-tools/packages/build-tools/src/common/typeValidatorConfig.ts
@@ -1,0 +1,29 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Metadata about known-broken types.
+ */
+export interface BrokenCompatSettings {
+	backCompat?: false;
+	forwardCompat?: false;
+}
+
+/**
+ * A mapping of a type name to its {@link BrokenCompatSettings}.
+ */
+export type BrokenCompatTypes = Partial<Record<string, BrokenCompatSettings>>;
+
+export interface ITypeValidationConfig {
+	/**
+	 * An object containing types that are known to be broken.
+	 */
+	broken: BrokenCompatTypes;
+
+	/**
+	 * If true, disables type test preparation and generation for the package.
+	 */
+	disabled?: boolean;
+}

--- a/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/fluidRepoBuild.ts
@@ -6,8 +6,8 @@
 import * as path from "path";
 import chalk from "chalk";
 import registerDebug from "debug";
-import { FluidRepo, IFluidBuildConfig } from "../common/fluidRepo";
-import { getFluidBuildConfig } from "../common/fluidUtils";
+import { FluidRepo, IRepoBuildDirs } from "../common/fluidRepo";
+import { getRepoBuildConfig } from "../common/fluidUtils";
 import { defaultLogger } from "../common/logging";
 import { MonoRepo } from "../common/monoRepo";
 import { Package, Packages } from "../common/npmPackage";
@@ -35,15 +35,15 @@ export interface IPackageMatchedOptions {
 export class FluidRepoBuild extends FluidRepo {
 	public static create(resolvedRoot: string) {
 		// Default to just resolveRoot if no config is found
-		const packageManifest = getFluidBuildConfig(resolvedRoot) ?? {
+		const packageManifest = getRepoBuildConfig(resolvedRoot) ?? {
 			repoPackages: {
 				root: "",
 			},
 		};
-		return new FluidRepoBuild(resolvedRoot, packageManifest);
+		return new FluidRepoBuild(resolvedRoot, packageManifest.repoPackages);
 	}
-	private constructor(resolvedRoot: string, packageManifest: IFluidBuildConfig) {
-		super(resolvedRoot, packageManifest);
+	private constructor(resolvedRoot: string, repoPackages?: IRepoBuildDirs) {
+		super(resolvedRoot, repoPackages);
 	}
 
 	public async clean() {
@@ -141,7 +141,7 @@ export class FluidRepoBuild extends FluidRepo {
 			this.createPackageMap(),
 			this.getReleaseGroupPackages(),
 			buildTargetNames,
-			getFluidBuildConfig(this.resolvedRoot)?.tasks,
+			getRepoBuildConfig(this.resolvedRoot)?.tasks,
 			(pkg: Package) => {
 				return (dep: Package) => {
 					return options.fullSymlink || MonoRepo.isSame(pkg.monoRepo, dep.monoRepo);

--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -4,12 +4,8 @@
  */
 
 export { GitRepo } from "./common/gitRepo";
-export {
-	type ITypeValidationConfig,
-	FluidRepo,
-	type BrokenCompatTypes,
-} from "./common/fluidRepo";
-export { getResolvedFluidRoot, loadFluidBuildConfig } from "./common/fluidUtils";
+export { FluidRepo } from "./common/fluidRepo";
+export { getResolvedFluidRoot, getRepoBuildConfig } from "./common/fluidUtils";
 export type { Logger } from "./common/logging";
 export { MonoRepo } from "./common/monoRepo";
 export {
@@ -20,11 +16,8 @@ export {
 } from "./common/npmPackage";
 export { Timer } from "./common/timer";
 export type {
-	IFluidBuildConfig,
-	PackageNamePolicyConfig,
-	PolicyConfig,
-	PreviousVersionStyle,
-	ScriptRequirement,
+	IRepoBuildDir,
+	IRepoBuildConfig,
 } from "./common/fluidRepo";
 
 // For repo policy check
@@ -35,6 +28,10 @@ export {
 export { getApiExtractorConfigFilePath, getEsLintConfigFilePath } from "./common/taskUtils";
 export * as TscUtils from "./common/tscUtils";
 
+export {
+	type BrokenCompatTypes,
+	type ITypeValidationConfig,
+} from "./common/typeValidatorConfig";
 export {
 	TypeOnly,
 	MinimalType,

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -341,9 +341,6 @@ importers:
 
   packages/build-tools:
     dependencies:
-      '@fluid-tools/version-tools':
-        specifier: workspace:~
-        version: link:../version-tools
       '@fluidframework/bundle-size-tools':
         specifier: workspace:~
         version: link:../bundle-size-tools


### PR DESCRIPTION
Stop keeping track of the `defaultInterdependencyRange` with `MonoRepo` object.  Instead do a look up when it is needed.
This allows the types that is not related to building moved out of `build-tools` and stop having it depending on `version -tools`
