### PR TITLE
[GC] Remove deprecated getBaseGCDetails

### DIFF
--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -155,6 +155,10 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"Interface_IDataObjectProps": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -193,6 +193,7 @@ declare type old_as_current_for_Interface_IDataObjectProps = requireAssignableTo
  * typeValidation.broken:
  * "Interface_IDataObjectProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IDataObjectProps = requireAssignableTo<TypeOnly<current.IDataObjectProps>, TypeOnly<old.IDataObjectProps>>
 
 /*

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -232,15 +232,30 @@
 	"typeValidation": {
 		"broken": {
 			"Class_LocalFluidDataStoreContext": {
+				"backCompat": false,
 				"forwardCompat": false
 			},
 			"Class_FluidDataStoreContext": {
+				"backCompat": false,
 				"forwardCompat": false
 			},
 			"Class_LocalFluidDataStoreContextBase": {
+				"backCompat": false,
 				"forwardCompat": false
 			},
 			"Interface_IGCNodeUpdatedProps": {
+				"backCompat": false
+			},
+			"Interface_IFluidDataStoreContextInternal": {
+				"backCompat": false
+			},
+			"ClassStatics_FluidDataStoreContext": {
+				"backCompat": false
+			},
+			"ClassStatics_LocalFluidDataStoreContext": {
+				"backCompat": false
+			},
+			"ClassStatics_LocalFluidDataStoreContextBase": {
 				"backCompat": false
 			}
 		}

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -45,7 +45,6 @@ import {
 	IFluidDataStoreContextDetached,
 	IFluidDataStoreRegistry,
 	IFluidParentContext,
-	IGarbageCollectionDetailsBase,
 	IProvideFluidDataStoreFactory,
 	ISummarizeInternalResult,
 	ISummarizeResult,
@@ -930,13 +929,6 @@ export abstract class FluidDataStoreContext
 	 */
 	public setInMemoryRoot(): void {
 		this._isInMemoryRoot = true;
-	}
-
-	/**
-	 * @deprecated The functionality to get base GC details has been moved to summarizer node.
-	 */
-	public async getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase> {
-		return {};
 	}
 
 	public reSubmit(type: string, contents: any, localOpMetadata: unknown) {

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -293,6 +293,7 @@ declare type old_as_current_for_Class_FluidDataStoreContext = requireAssignableT
  * typeValidation.broken:
  * "Class_FluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_FluidDataStoreContext = requireAssignableTo<TypeOnly<current.FluidDataStoreContext>, TypeOnly<old.FluidDataStoreContext>>
 
 /*
@@ -302,6 +303,7 @@ declare type current_as_old_for_Class_FluidDataStoreContext = requireAssignableT
  * typeValidation.broken:
  * "ClassStatics_FluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_FluidDataStoreContext = requireAssignableTo<TypeOnly<typeof current.FluidDataStoreContext>, TypeOnly<typeof old.FluidDataStoreContext>>
 
 /*
@@ -842,6 +844,7 @@ declare type old_as_current_for_Interface_IFluidDataStoreContextInternal = requi
  * typeValidation.broken:
  * "Interface_IFluidDataStoreContextInternal": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IFluidDataStoreContextInternal = requireAssignableTo<TypeOnly<current.IFluidDataStoreContextInternal>, TypeOnly<old.IFluidDataStoreContextInternal>>
 
 /*
@@ -1627,6 +1630,7 @@ declare type old_as_current_for_Class_LocalFluidDataStoreContext = requireAssign
  * typeValidation.broken:
  * "Class_LocalFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_LocalFluidDataStoreContext = requireAssignableTo<TypeOnly<current.LocalFluidDataStoreContext>, TypeOnly<old.LocalFluidDataStoreContext>>
 
 /*
@@ -1636,6 +1640,7 @@ declare type current_as_old_for_Class_LocalFluidDataStoreContext = requireAssign
  * typeValidation.broken:
  * "ClassStatics_LocalFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_LocalFluidDataStoreContext = requireAssignableTo<TypeOnly<typeof current.LocalFluidDataStoreContext>, TypeOnly<typeof old.LocalFluidDataStoreContext>>
 
 /*
@@ -1655,6 +1660,7 @@ declare type old_as_current_for_Class_LocalFluidDataStoreContextBase = requireAs
  * typeValidation.broken:
  * "Class_LocalFluidDataStoreContextBase": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_LocalFluidDataStoreContextBase = requireAssignableTo<TypeOnly<current.LocalFluidDataStoreContextBase>, TypeOnly<old.LocalFluidDataStoreContextBase>>
 
 /*
@@ -1664,6 +1670,7 @@ declare type current_as_old_for_Class_LocalFluidDataStoreContextBase = requireAs
  * typeValidation.broken:
  * "ClassStatics_LocalFluidDataStoreContextBase": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_LocalFluidDataStoreContextBase = requireAssignableTo<TypeOnly<typeof current.LocalFluidDataStoreContextBase>, TypeOnly<typeof old.LocalFluidDataStoreContextBase>>
 
 /*

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -17,8 +17,7 @@ export interface AttributionInfo {
 export type AttributionKey = OpAttributionKey | DetachedAttributionKey | LocalAttributionKey;
 
 // @alpha (undocumented)
-export type CreateChildSummarizerNodeFn = (summarizeInternal: SummarizeInternalFn, getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>) => ISummarizerNodeWithGC;
+export type CreateChildSummarizerNodeFn = (summarizeInternal: SummarizeInternalFn, getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>) => ISummarizerNodeWithGC;
 
 // @alpha (undocumented)
 export type CreateChildSummarizerNodeParam = {
@@ -152,8 +151,6 @@ export interface IFluidDataStoreContext extends IFluidParentContext {
     readonly baseSnapshot: ISnapshotTree | undefined;
     // @deprecated (undocumented)
     readonly createProps?: any;
-    // @deprecated (undocumented)
-    getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
     // (undocumented)
     readonly id: string;
     readonly isLocalDataStore: boolean;
@@ -316,8 +313,7 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
     summarizeInternalFn: SummarizeInternalFn,
     id: string,
     createParam: CreateChildSummarizerNodeParam,
-    config?: ISummarizerNodeConfigWithGC, getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-    getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>): ISummarizerNodeWithGC;
+    config?: ISummarizerNodeConfigWithGC, getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>): ISummarizerNodeWithGC;
     deleteChild(id: string): void;
     // (undocumented)
     getChild(id: string): ISummarizerNodeWithGC | undefined;

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -111,6 +111,13 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"Interface_IFluidDataStoreContext": {
+				"backCompat": false
+			},
+			"Interface_IFluidDataStoreContextDetached": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -30,10 +30,7 @@ import type { IIdCompressor } from "@fluidframework/id-compressor";
 
 import type { IProvideFluidDataStoreFactory } from "./dataStoreFactory.js";
 import type { IProvideFluidDataStoreRegistry } from "./dataStoreRegistry.js";
-import type {
-	IGarbageCollectionData,
-	IGarbageCollectionDetailsBase,
-} from "./garbageCollectionDefinitions.js";
+import type { IGarbageCollectionData } from "./garbageCollectionDefinitions.js";
 import type { IInboundSignalMessage } from "./protocol.js";
 import type {
 	CreateChildSummarizerNodeParam,
@@ -388,10 +385,6 @@ export interface IFluidDataStoreChannel extends IDisposable {
 export type CreateChildSummarizerNodeFn = (
 	summarizeInternal: SummarizeInternalFn,
 	getGCDataFn: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-	/**
-	 * @deprecated The functionality to get base GC details has been moved to summarizer node.
-	 */
-	getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
 ) => ISummarizerNodeWithGC;
 
 /**
@@ -553,14 +546,6 @@ export interface IFluidDataStoreContext extends IFluidParentContext {
 	 * @deprecated 0.16 Issue #1635, #3631
 	 */
 	readonly createProps?: any;
-
-	/**
-	 * @deprecated The functionality to get base GC details has been moved to summarizer node.
-	 *
-	 * Returns the GC details in the initial summary of this data store. This is used to initialize the data store
-	 * and its children with the GC details from the previous summary.
-	 */
-	getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
 }
 
 /**

--- a/packages/runtime/runtime-definitions/src/summary.ts
+++ b/packages/runtime/runtime-definitions/src/summary.ts
@@ -13,10 +13,7 @@ import type {
 } from "@fluidframework/driver-definitions/internal";
 import type { TelemetryEventPropertyTypeExt } from "@fluidframework/telemetry-utils/internal";
 
-import type {
-	IGarbageCollectionData,
-	IGarbageCollectionDetailsBase,
-} from "./garbageCollectionDefinitions.js";
+import type { IGarbageCollectionData } from "./garbageCollectionDefinitions.js";
 
 /**
  * Contains the aggregation data from a Tree/Subtree.
@@ -293,10 +290,6 @@ export interface ISummarizerNodeWithGC extends ISummarizerNode {
 		 */
 		config?: ISummarizerNodeConfigWithGC,
 		getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-		/**
-		 * @deprecated The functionality to update child's base GC details is incorporated in the summarizer node.
-		 */
-		getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
 	): ISummarizerNodeWithGC;
 
 	/**

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -337,6 +337,7 @@ declare type old_as_current_for_Interface_IFluidDataStoreContext = requireAssign
  * typeValidation.broken:
  * "Interface_IFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IFluidDataStoreContext = requireAssignableTo<TypeOnly<current.IFluidDataStoreContext>, TypeOnly<old.IFluidDataStoreContext>>
 
 /*
@@ -355,6 +356,7 @@ declare type old_as_current_for_Interface_IFluidDataStoreContextDetached = requi
  * typeValidation.broken:
  * "Interface_IFluidDataStoreContextDetached": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IFluidDataStoreContextDetached = requireAssignableTo<TypeOnly<current.IFluidDataStoreContextDetached>, TypeOnly<old.IFluidDataStoreContextDetached>>
 
 /*

--- a/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/test-runtime-utils/api-report/test-runtime-utils.legacy.alpha.api.md
@@ -313,8 +313,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
     // (undocumented)
     getAudience(): IAudience;
     // (undocumented)
-    getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
-    // (undocumented)
     getCreateChildSummarizerNodeFn(id: string, createParam: CreateChildSummarizerNodeParam): CreateChildSummarizerNodeFn;
     // (undocumented)
     getQuorum(): IQuorumClients;

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -156,6 +156,13 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"Class_MockFluidDataStoreContext": {
+				"backCompat": false
+			},
+			"ClassStatics_MockFluidDataStoreContext": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
+++ b/packages/runtime/test-runtime-utils/src/mocksDataStoreContext.ts
@@ -25,7 +25,6 @@ import {
 	IContainerRuntimeBase,
 	IFluidDataStoreContext,
 	IFluidDataStoreRegistry,
-	IGarbageCollectionDetailsBase,
 } from "@fluidframework/runtime-definitions/internal";
 import {
 	ITelemetryLoggerExt,
@@ -143,10 +142,6 @@ export class MockFluidDataStoreContext implements IFluidDataStoreContext {
 	public async uploadBlob(
 		blob: ArrayBufferLike,
 	): Promise<IFluidHandleInternal<ArrayBufferLike>> {
-		throw new Error("Method not implemented.");
-	}
-
-	public async getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase> {
 		throw new Error("Method not implemented.");
 	}
 

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -373,6 +373,7 @@ declare type old_as_current_for_Class_MockFluidDataStoreContext = requireAssigna
  * typeValidation.broken:
  * "Class_MockFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_MockFluidDataStoreContext = requireAssignableTo<TypeOnly<current.MockFluidDataStoreContext>, TypeOnly<old.MockFluidDataStoreContext>>
 
 /*
@@ -382,6 +383,7 @@ declare type current_as_old_for_Class_MockFluidDataStoreContext = requireAssigna
  * typeValidation.broken:
  * "ClassStatics_MockFluidDataStoreContext": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_MockFluidDataStoreContext = requireAssignableTo<TypeOnly<typeof current.MockFluidDataStoreContext>, TypeOnly<typeof old.MockFluidDataStoreContext>>
 
 /*

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -167,6 +167,19 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"Interface_IProvideTestFluidObject": {
+				"backCompat": false
+			},
+			"Interface_ITestFluidObject": {
+				"backCompat": false
+			},
+			"Class_TestFluidObject": {
+				"backCompat": false
+			},
+			"ClassStatics_TestFluidObject": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -148,6 +148,7 @@ declare type old_as_current_for_Interface_IProvideTestFluidObject = requireAssig
  * typeValidation.broken:
  * "Interface_IProvideTestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_IProvideTestFluidObject = requireAssignableTo<TypeOnly<current.IProvideTestFluidObject>, TypeOnly<old.IProvideTestFluidObject>>
 
 /*
@@ -202,6 +203,7 @@ declare type old_as_current_for_Interface_ITestFluidObject = requireAssignableTo
  * typeValidation.broken:
  * "Interface_ITestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ITestFluidObject = requireAssignableTo<TypeOnly<current.ITestFluidObject>, TypeOnly<old.ITestFluidObject>>
 
 /*
@@ -337,6 +339,7 @@ declare type old_as_current_for_Class_TestFluidObject = requireAssignableTo<Type
  * typeValidation.broken:
  * "Class_TestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Class_TestFluidObject = requireAssignableTo<TypeOnly<current.TestFluidObject>, TypeOnly<old.TestFluidObject>>
 
 /*
@@ -346,6 +349,7 @@ declare type current_as_old_for_Class_TestFluidObject = requireAssignableTo<Type
  * typeValidation.broken:
  * "ClassStatics_TestFluidObject": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassStatics_TestFluidObject = requireAssignableTo<TypeOnly<typeof current.TestFluidObject>, TypeOnly<typeof old.TestFluidObject>>
 
 /*


### PR DESCRIPTION
## Reviewer guidance
This is targetting a test branch (test/gc-2.3). Since this has legacy alpha API breaking changes which are not allowed to be merged until v2.3, this is a workaround to get the changes reviewed and merged in a test branch. Later when breaking changes are allowed, these will get merged to main.

## Description
getBaseGCDetails and related code were deprecatedmore than a year ago by https://github.com/microsoft/FluidFramework/pull/14196. This PR removes it.
