### PR TITLE
refactor(ci): Use Small pool for first stage of Test DDS Stress pipeline

### DIFF
--- a/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
+++ b/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
@@ -31,6 +31,7 @@ parameters:
 stages:
   - stage: CheckAffectedPaths
     displayName: Determine changed packages
+    pool: Small
     jobs:
     - job: Job
       displayName: Check for DDS package changes


### PR DESCRIPTION
## Description

Use our Small pool for a stage of the Test DDS Stress pipeline that was using hosted agents, so it doesn't get affected if we run out of free minutes for the hosted agents (recent runs have failed due to that).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
