### PR TITLE
Move OOB function to core-utils

### DIFF
--- a/packages/common/core-utils/src/index.ts
+++ b/packages/common/core-utils/src/index.ts
@@ -16,3 +16,4 @@ export type { IPromiseTimer, IPromiseTimerResult, ITimer } from "./timer.js";
 export { PromiseTimer, setLongTimeout, Timer } from "./timer.js";
 export { unreachableCase } from "./unreachable.js";
 export { isObject, isPromiseLike } from "./typesGuards.js";
+export { oob } from "./oob.js";

--- a/packages/common/core-utils/src/oob.ts
+++ b/packages/common/core-utils/src/oob.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Use this function to assert that an array index is not out-of-bounds.
+ * @example
+ * ```ts
+ * // We know that `numberArray` has four elements in it, so this is safe.
+ * const n: number = numberArray[3] ?? oob();
+ * ```
+ * @internal
+ */
+export function oob(): never {
+	throw new Error("Array index is out of bounds");
+}

--- a/packages/dds/tree/src/core/rebase/utils.ts
+++ b/packages/dds/tree/src/core/rebase/utils.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
-import { oob, type Mutable } from "../../util/index.js";
+import type { Mutable } from "../../util/index.js";
 
 import {
 	type ChangeRebaser,

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodec.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
 import {
 	type ICodecOptions,
@@ -24,7 +24,6 @@ import type {
 	Major,
 } from "./detachedFieldIndexTypes.js";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
-import { oob } from "../../util/index.js";
 
 class MajorCodec implements IJsonCodec<Major> {
 	public constructor(

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/basicChunk.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
@@ -16,7 +16,7 @@ import {
 	type UpPath,
 	type Value,
 } from "../../core/index.js";
-import { ReferenceCountedBase, fail, oob } from "../../util/index.js";
+import { ReferenceCountedBase, fail } from "../../util/index.js";
 import { SynchronousCursor, prefixPath } from "../treeCursorUtils.js";
 
 import { type ChunkedCursor, type TreeChunk, cursorChunk, dummyRoot } from "./chunk.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
@@ -21,7 +21,7 @@ import {
 	mapCursorFields,
 	Multiplicity,
 } from "../../core/index.js";
-import { fail, getOrCreate, oob } from "../../util/index.js";
+import { fail, getOrCreate } from "../../util/index.js";
 import type { FullSchemaPolicy } from "../modular-schema/index.js";
 
 import { BasicChunk } from "./basicChunk.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunkedForest.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
 import {
 	type Anchor,
@@ -29,7 +29,7 @@ import {
 	rootFieldKey,
 } from "../../core/index.js";
 import { createEmitter } from "../../events/index.js";
-import { assertValidRange, brand, fail, getOrAddEmptyToMap, oob } from "../../util/index.js";
+import { assertValidRange, brand, fail, getOrAddEmptyToMap } from "../../util/index.js";
 
 import { BasicChunk, BasicChunkCursor, type SiblingsOrKey } from "./basicChunk.js";
 import type { ChunkedCursor, TreeChunk } from "./chunk.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkCodecUtilities.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkCodecUtilities.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
 import type { TreeValue } from "../../../core/index.js";
-import { assertValidIndex, oob } from "../../../util/index.js";
+import { assertValidIndex } from "../../../util/index.js";
 import { type FluidSerializableReadOnly, assertAllowedValue } from "../../valueUtilities.js";
 import type { TreeChunk } from "../chunk.js";
 

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/chunkDecoding.ts
@@ -3,11 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, oob } from "@fluidframework/core-utils/internal";
 
 import { DiscriminatedUnionDispatcher } from "../../../codec/index.js";
 import type { FieldKey, TreeNodeSchemaIdentifier, Value } from "../../../core/index.js";
-import { assertValidIndex, oob } from "../../../util/index.js";
+import { assertValidIndex } from "../../../util/index.js";
 import { BasicChunk } from "../basicChunk.js";
 import type { TreeChunk } from "../chunk.js";
 import { emptyChunk } from "../emptyChunk.js";

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, compareArrays } from "@fluidframework/core-utils/internal";
+import { assert, compareArrays, oob } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
@@ -15,7 +15,7 @@ import {
 	type UpPath,
 	type Value,
 } from "../../core/index.js";
-import { ReferenceCountedBase, fail, oob } from "../../util/index.js";
+import { ReferenceCountedBase, fail } from "../../util/index.js";
 import { SynchronousCursor, prefixFieldPath, prefixPath } from "../treeCursorUtils.js";
 
 import { type ChunkedCursor, type TreeChunk, cursorChunk, dummyRoot } from "./chunk.js";

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { oob } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import type { ICodecFamily } from "../../codec/index.js";
@@ -22,7 +23,7 @@ import {
 	compareFieldUpPaths,
 	topDownPath,
 } from "../../core/index.js";
-import { brand, oob } from "../../util/index.js";
+import { brand } from "../../util/index.js";
 import {
 	type EditDescription,
 	type FieldChangeset,

--- a/packages/dds/tree/src/feature-libraries/editableTreeBinder.ts
+++ b/packages/dds/tree/src/feature-libraries/editableTreeBinder.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
 import {
 	type DetachedPlaceUpPath,
@@ -17,7 +17,7 @@ import {
 	topDownPath,
 } from "../core/index.js";
 import type { Listeners, Listenable } from "../events/index.js";
-import { brand, getOrCreate, oob } from "../util/index.js";
+import { brand, getOrCreate } from "../util/index.js";
 
 import type { FlexTreeNode } from "./flex-tree/index.js";
 

--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import {
 	type AnchorNode,
 	EmptyKey,
@@ -14,7 +14,7 @@ import {
 	type TreeValue,
 	type Value,
 } from "../../core/index.js";
-import { brand, fail, mapIterable, oob } from "../../util/index.js";
+import { brand, fail, mapIterable } from "../../util/index.js";
 import {
 	type FlexTreeContext,
 	FlexTreeEntityKind,

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
@@ -24,7 +24,6 @@ import {
 	disposeSymbol,
 	fail,
 	getOrCreate,
-	oob,
 } from "../../util/index.js";
 // TODO: stop depending on contextuallyTyped
 import { applyTypesFromContext, cursorFromContextualData } from "../contextuallyTyped.js";

--- a/packages/dds/tree/src/feature-libraries/forest-summary/codec.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/codec.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
 import {
 	type ICodecOptions,
@@ -14,7 +14,6 @@ import type { FieldKey, ITreeCursorSynchronous } from "../../core/index.js";
 import type { FieldBatchCodec, FieldBatchEncodingContext } from "../chunked-forest/index.js";
 
 import { Format } from "./format.js";
-import { oob } from "../../util/index.js";
 
 /**
  * Uses field cursors

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import type { TAnySchema } from "@sinclair/typebox";
 
 import {
@@ -33,7 +33,6 @@ import {
 	brand,
 	fail,
 	idAllocatorFromMaxId,
-	oob,
 	setInNestedMap,
 	tryGetFromNestedMap,
 } from "../../util/index.js";

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import { BTree } from "@tylerbu/sorted-btree-es6";
 
 import type { ICodecFamily } from "../../codec/index.js";
@@ -60,7 +60,6 @@ import {
 	tryGetFromNestedMap,
 	type NestedMap,
 	type RangeQueryResult,
-	oob,
 } from "../../util/index.js";
 import {
 	type TreeChunk,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -3,10 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, oob } from "@fluidframework/core-utils/internal";
 
 import type { RevisionTag } from "../../core/index.js";
-import { type IdAllocator, type Mutable, fail, oob } from "../../util/index.js";
+import { type IdAllocator, type Mutable, fail } from "../../util/index.js";
 import {
 	type CrossFieldManager,
 	CrossFieldTarget,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/markQueue.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/markQueue.ts
@@ -3,11 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import { type MoveEffectTable, splitMarkForMoveEffects } from "./moveEffectTable.js";
 import type { Mark } from "./types.js";
 import { splitMark } from "./utils.js";
-import { oob } from "../../util/index.js";
 
 export class MarkQueue {
 	private readonly stack: Mark[] = [];

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldToDelta.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert, unreachableCase } from "@fluidframework/core-utils/internal";
+import { assert, unreachableCase, oob } from "@fluidframework/core-utils/internal";
 
 import {
 	type DeltaDetachedNodeChanges,
@@ -12,7 +12,7 @@ import {
 	type DeltaMark,
 	areEqualChangeAtomIds,
 } from "../../core/index.js";
-import { oob, type Mutable } from "../../util/index.js";
+import type { Mutable } from "../../util/index.js";
 import { nodeIdFromChangeAtom } from "../deltaUtils.js";
 
 import { isMoveIn, isMoveOut } from "./moveEffectTable.js";

--- a/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/treeCursorUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
@@ -19,7 +19,7 @@ import {
 	detachedFieldAsKey,
 	rootField,
 } from "../core/index.js";
-import { fail, oob } from "../util/index.js";
+import { fail } from "../util/index.js";
 
 /**
  * {@link ITreeCursorSynchronous} that can return the underlying node objects.

--- a/packages/dds/tree/src/shared-tree-core/branch.ts
+++ b/packages/dds/tree/src/shared-tree-core/branch.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import { type TelemetryEventBatcher, measure } from "@fluidframework/telemetry-utils/internal";
 
 import {
@@ -26,7 +26,7 @@ import {
 import { EventEmitter, type Listenable } from "../events/index.js";
 
 import { TransactionStack } from "./transactionStack.js";
-import { fail, oob } from "../util/index.js";
+import { fail } from "../util/index.js";
 
 /**
  * Describes a change to a `SharedTreeBranch`. Various operations can mutate the head of the branch;

--- a/packages/dds/tree/src/shared-tree-core/defaultResubmitMachine.ts
+++ b/packages/dds/tree/src/shared-tree-core/defaultResubmitMachine.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import type { ChangeRebaser, GraphCommit } from "../core/index.js";
-import { disposeSymbol, oob } from "../util/index.js";
+import { disposeSymbol } from "../util/index.js";
 import type { ChangeEnricherReadonlyCheckout, ResubmitMachine } from "./index.js";
 
 /**

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import type {
 	IChannelAttributes,
 	IFluidDataStoreRuntime,
@@ -41,7 +41,6 @@ import {
 	type WithBreakable,
 	throwIfBroken,
 	breakingClass,
-	oob,
 } from "../util/index.js";
 
 import { type SharedTreeBranch, getChangeReplaceType } from "./branch.js";

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
 import type { ICodecFamily, ICodecOptions } from "../codec/index.js";
 import {
@@ -33,7 +33,6 @@ import {
 	addToNestedSet,
 	fail,
 	nestedSetContains,
-	oob,
 } from "../util/index.js";
 
 import { makeSharedTreeChangeCodecFamily } from "./sharedTreeChangeCodecs.js";

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
 import {
 	UsageError,
@@ -53,13 +53,7 @@ import {
 	makeFieldBatchCodec,
 } from "../feature-libraries/index.js";
 import { SharedTreeBranch, getChangeReplaceType } from "../shared-tree-core/index.js";
-import {
-	type IDisposable,
-	TransactionResult,
-	disposeSymbol,
-	fail,
-	oob,
-} from "../util/index.js";
+import { type IDisposable, TransactionResult, disposeSymbol, fail } from "../util/index.js";
 
 import { SharedTreeChangeFamily, hasSchemaChange } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
@@ -24,7 +24,7 @@ import {
 	type NodeKeyManager,
 	isMapTreeNode,
 } from "../feature-libraries/index.js";
-import { brand, fail, isReadonlyArray, find, oob } from "../util/index.js";
+import { brand, fail, isReadonlyArray, find } from "../util/index.js";
 
 import { nullSchema } from "./leafNodeSchema.js";
 import type { InsertableContent } from "./proxies.js";

--- a/packages/dds/tree/src/simple-tree/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/treeNodeApi.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { assert } from "@fluidframework/core-utils/internal";
+import { assert, oob } from "@fluidframework/core-utils/internal";
 
 import { Multiplicity, rootFieldKey } from "../core/index.js";
 import {
@@ -13,7 +13,7 @@ import {
 	isTreeValue,
 	FlexObjectNodeSchema,
 } from "../feature-libraries/index.js";
-import { fail, extractFromOpaque, isReadonlyArray, oob } from "../util/index.js";
+import { fail, extractFromOpaque, isReadonlyArray } from "../util/index.js";
 
 import { getOrCreateNodeProxy, isTreeNode } from "./proxies.js";
 import { getFlexNode, getKernel } from "./proxyBinding.js";

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -58,7 +58,6 @@ export {
 	clone,
 	compareSets,
 	fail,
-	oob,
 	getOrAddEmptyToMap,
 	getOrCreate,
 	isJsonObject,

--- a/packages/dds/tree/src/util/nestedMap.ts
+++ b/packages/dds/tree/src/util/nestedMap.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { oob, type MapGetSet } from "./utils.js";
+import { oob } from "@fluidframework/core-utils/internal";
+import type { MapGetSet } from "./utils.js";
 
 /**
  * A dictionary whose values are keyed off of two objects (key1, key2).

--- a/packages/dds/tree/src/util/rangeMap.ts
+++ b/packages/dds/tree/src/util/rangeMap.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { oob } from "./utils.js";
+import { oob } from "@fluidframework/core-utils/internal";
 
 /**
  * A map keyed on integers allowing reading and writing contiguous ranges of integer keys.

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -55,18 +55,6 @@ export function fail(message: string): never {
 }
 
 /**
- * Use this function to assert that an array index is not out-of-bounds.
- * @example
- * ```ts
- * // We know that `numberArray` has four elements in it, so this is safe.
- * const n: number = numberArray[3] ?? oob();
- * ```
- */
-export function oob(): never {
-	return fail("Array index is out of bounds");
-}
-
-/**
  * Checks whether or not the given object is a `readonly` array.
  *
  * Note that this does NOT indicate if a given array should be treated as readonly.


### PR DESCRIPTION
oob was migrated from the tree packge. this function will be useful for the remaining FF packages, moving the function from tree to core-utils. tree was using oob, changed all imports of oob to core-utils