### PR TITLE
fix(ci): Update full-compat version calculation logic

### DIFF
--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -207,13 +207,13 @@ const getNumberOfVersionsToGoBack = (numOfVersionsAboveV2Int1: number = 0): numb
 	const semverVersion = semver.parse(codeVersion);
 	assert(semverVersion !== null, `Unexpected pkg version '${codeVersion}'`);
 
-	// Here we add the minor release to the math. If so, we also need to account for internal releases when
-	// generating back compat configs. For back compat purposes, we consider RC major release 1 to be treated as internal
-	// major release 9. This will ensure we generate back compat configs for all RC and internal major releases.
-	// There are 5 rc versions. 8 internal versions. 5 rc versions. 2.0 is the first minor version.
-	const greatestInternalMajor = 8 + 5 + semverVersion.minor;
-	// This allows us to increase our "LTS" support for certain versions above 2.0.0.internal.1.y.z
-	return greatestInternalMajor - numOfVersionsAboveV2Int1;
+	// We have 8 internal and 5 RC versions.
+	// We want to generate back compat configs for all of them because they are all considered major releases.
+	// RCs can be thought of as internal 9 through 13 for this purpose, so just add them.
+	const numOfInternalMajorsBeforePublic2dot0 = 8 + 5;
+	// This allows us to increase our "LTS" support for certain versions above 2.0.0.internal.1.y.z, where
+	// we don't want to go that far.
+	return numOfInternalMajorsBeforePublic2dot0 - numOfVersionsAboveV2Int1;
 };
 
 const genFullBackCompatConfig = (driverVersionsAboveV2Int1: number = 0): CompatConfig[] => {


### PR DESCRIPTION
## Description

E2E tests with full compat are broken because they're trying to go too far back in versions. This is an attempt at fixing that.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

I'm not clear why we were considering the minor version in [this PR](https://github.com/microsoft/FluidFramework/pull/21571). Today, with 2.0 already released, it seems like the number of major versions is a fixed 13 (8 internal + 5 RCs).