### PR TITLE
feat(merge-tree): add SequencePlace to the merge-tree package

### DIFF
--- a/packages/dds/merge-tree/api-report/merge-tree.legacy.alpha.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.legacy.alpha.api.md
@@ -412,6 +412,14 @@ export interface IMoveInfo {
 }
 
 // @alpha
+export interface InteriorSequencePlace {
+    // (undocumented)
+    pos: number;
+    // (undocumented)
+    side: Side;
+}
+
+// @alpha
 export interface IRelativePosition {
     before?: boolean;
     id?: string;
@@ -439,6 +447,7 @@ export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo>, Parti
     // (undocumented)
     clone(): ISegment;
     readonly endpointType?: "start" | "end";
+    endSide?: Side.Before | Side.After;
     localRefs?: LocalReferenceCollection;
     localRemovedSeq?: number;
     localSeq?: number;
@@ -449,6 +458,7 @@ export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo>, Parti
     seq?: number;
     // (undocumented)
     splitAt(pos: number): ISegment | undefined;
+    startSide?: Side.Before | Side.After;
     // (undocumented)
     toJSONObject(): any;
     // (undocumented)
@@ -714,6 +724,9 @@ export interface SequenceOffsets {
     seqs: (number | AttributionKey | null)[];
 }
 
+// @alpha
+export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
+
 // @alpha (undocumented)
 export interface SerializedAttributionCollection extends SequenceOffsets {
     // (undocumented)
@@ -722,6 +735,14 @@ export interface SerializedAttributionCollection extends SequenceOffsets {
     };
     // (undocumented)
     length: number;
+}
+
+// @alpha
+export enum Side {
+    // (undocumented)
+    After = 1,
+    // (undocumented)
+    Before = 0
 }
 
 // @alpha

--- a/packages/dds/merge-tree/api-report/merge-tree.legacy.alpha.api.md
+++ b/packages/dds/merge-tree/api-report/merge-tree.legacy.alpha.api.md
@@ -187,6 +187,14 @@ export class CollaborationWindow {
 // @alpha
 export function discardMergeTreeDeltaRevertible(revertibles: MergeTreeDeltaRevertible[]): void;
 
+// @alpha
+export function endpointPosAndSide(start: SequencePlace | undefined, end: SequencePlace | undefined): {
+    startSide: Side | undefined;
+    endSide: Side | undefined;
+    startPos: number | "start" | "end" | undefined;
+    endPos: number | "start" | "end" | undefined;
+};
+
 // @alpha (undocumented)
 export interface IAttributionCollection<T> {
     // (undocumented)

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -122,7 +122,12 @@ export {
 } from "./referencePositions.js";
 export { SegmentGroupCollection } from "./segmentGroupCollection.js";
 export { PropertiesManager, PropertiesRollback } from "./segmentPropertiesManager.js";
-export { InteriorSequencePlace, Side, SequencePlace } from "./sequencePlace.js";
+export {
+	InteriorSequencePlace,
+	Side,
+	SequencePlace,
+	endpointPosAndSide,
+} from "./sequencePlace.js";
 export { SortedSet } from "./sortedSet.js";
 export { SortedSegmentSet, SortedSegmentSetItem } from "./sortedSegmentSet.js";
 export { IJSONTextSegment, IMergeTreeTextHelper, TextSegment } from "./textSegment.js";

--- a/packages/dds/merge-tree/src/index.ts
+++ b/packages/dds/merge-tree/src/index.ts
@@ -122,6 +122,7 @@ export {
 } from "./referencePositions.js";
 export { SegmentGroupCollection } from "./segmentGroupCollection.js";
 export { PropertiesManager, PropertiesRollback } from "./segmentPropertiesManager.js";
+export { InteriorSequencePlace, Side, SequencePlace } from "./sequencePlace.js";
 export { SortedSet } from "./sortedSet.js";
 export { SortedSegmentSet, SortedSegmentSetItem } from "./sortedSegmentSet.js";
 export { IJSONTextSegment, IMergeTreeTextHelper, TextSegment } from "./textSegment.js";

--- a/packages/dds/merge-tree/src/mergeTree.ts
+++ b/packages/dds/merge-tree/src/mergeTree.ts
@@ -1637,7 +1637,11 @@ export class MergeTree {
 		return { next };
 	};
 
-	private ensureIntervalBoundary(pos: number, refSeq: number, clientId: number): void {
+	private ensureIntervalBoundary(
+		pos: number | "start" | "end",
+		refSeq: number,
+		clientId: number,
+	): void {
 		const splitNode = this.insertingWalk(
 			this.root,
 			pos,
@@ -1685,14 +1689,22 @@ export class MergeTree {
 
 	private insertingWalk(
 		block: MergeBlock,
-		pos: number,
+		pos: number | "start" | "end",
 		refSeq: number,
 		clientId: number,
 		seq: number,
 		context: InsertContext,
 		isLastChildBlock: boolean = true,
 	): MergeBlock | undefined {
-		let _pos = pos;
+		let _pos: number;
+		if (pos === "start") {
+			_pos = 0;
+		} else if (pos === "end") {
+			_pos = this.root.mergeTree?.getLength(refSeq, clientId) ?? 0;
+		} else {
+			_pos = pos;
+		}
+
 		const children = block.children;
 		let childIndex: number;
 		let child: IMergeNode;
@@ -1923,8 +1935,7 @@ export class MergeTree {
 			throw new UsageError("Attempted to send obliterate op without enabling feature flag.");
 		}
 
-		let { startPos, endPos } = endpointPosAndSide(start, end);
-		const { startSide, endSide } = endpointPosAndSide(start, end);
+		const { startPos, startSide, endPos, endSide } = endpointPosAndSide(start, end);
 
 		assert(
 			startPos !== undefined &&
@@ -1935,9 +1946,6 @@ export class MergeTree {
 				endPos !== "start",
 			"start and end cannot be undefined because they were not passed in as undefined",
 		);
-
-		startPos = startPos === "start" ? 0 : startPos;
-		endPos = endPos === "end" ? this.getLength(refSeq, clientId) : endPos;
 
 		this.ensureIntervalBoundary(startPos, refSeq, clientId);
 		this.ensureIntervalBoundary(endPos, refSeq, clientId);
@@ -1961,6 +1969,8 @@ export class MergeTree {
 			_end: number,
 		): boolean => {
 			const existingMoveInfo = toMoveInfo(segment);
+			if (startSide) segment.startSide = startSide;
+			if (endSide) segment.endSide = endSide;
 
 			if (
 				clientId !== segment.clientId &&
@@ -2037,8 +2047,8 @@ export class MergeTree {
 			markMoved,
 			undefined,
 			afterMarkMoved,
-			startPos,
-			endPos,
+			start,
+			end,
 			undefined,
 			seq === UnassignedSequenceNumber ? undefined : seq,
 		);
@@ -2679,18 +2689,28 @@ export class MergeTree {
 		leaf: ISegmentAction<TClientData>,
 		accum: TClientData,
 		post?: BlockAction<TClientData>,
-		start: number = 0,
-		end?: number,
+		start: SequencePlace = 0,
+		end?: SequencePlace,
 		localSeq?: number,
 		visibilitySeq: number = refSeq,
 	): void {
-		const endPos = end ?? this.nodeLength(this.root, refSeq, clientId, localSeq) ?? 0;
-		if (endPos === start) {
+		const maybeEndPos = end ?? this.nodeLength(this.root, refSeq, clientId, localSeq) ?? 0;
+		if (maybeEndPos === start) {
 			return;
 		}
 
 		let pos = 0;
+		let { startPos, endPos } = endpointPosAndSide(start, end);
 
+		startPos = startPos === "start" || startPos === undefined ? 0 : startPos;
+		endPos =
+			endPos === "end" || endPos === undefined
+				? this.root.mergeTree?.getLength(refSeq, clientId) ?? 0
+				: endPos;
+		assert(
+			startPos !== "end" && endPos !== "start",
+			"start cannot be 'end' and end cannot be 'start'",
+		);
 		depthFirstNodeWalk(
 			this.root,
 			this.root.children[0],
@@ -2718,13 +2738,15 @@ export class MergeTree {
 
 				const nextPos = pos + lenAtRefSeq;
 				// start is beyond the current node, so we can skip it
-				if (start >= nextPos) {
+				if (typeof startPos === "number" && startPos >= nextPos) {
 					pos = nextPos;
 					return NodeAction.Skip;
 				}
 
 				if (node.isLeaf()) {
-					if (leaf(node, pos, refSeq, clientId, start - pos, endPos - pos, accum) === false) {
+					if (
+						leaf(node, pos, refSeq, clientId, startPos - pos, endPos - pos, accum) === false
+					) {
 						return NodeAction.Exit;
 					}
 					pos = nextPos;
@@ -2734,7 +2756,7 @@ export class MergeTree {
 			post === undefined
 				? undefined
 				: (block): boolean =>
-						post(block, pos, refSeq, clientId, start - pos, endPos - pos, accum),
+						post(block, pos, refSeq, clientId, startPos - pos, endPos - pos, accum),
 		);
 	}
 }

--- a/packages/dds/merge-tree/src/mergeTreeNodes.ts
+++ b/packages/dds/merge-tree/src/mergeTreeNodes.ts
@@ -28,6 +28,7 @@ import {
 } from "./referencePositions.js";
 import { SegmentGroupCollection } from "./segmentGroupCollection.js";
 import { PropertiesManager, PropertiesRollback } from "./segmentPropertiesManager.js";
+import { Side } from "./sequencePlace.js";
 
 /**
  * Common properties for a node in a merge tree.
@@ -253,6 +254,14 @@ export interface ISegment extends IMergeNodeCommon, Partial<IRemovalInfo>, Parti
 	 * Properties that have been added to this segment via annotation.
 	 */
 	properties?: PropertySet;
+	/**
+	 * Stores side information passed to obliterate for the start of a range.
+	 */
+	startSide?: Side.Before | Side.After;
+	/**
+	 * Stores side information passed to obliterate for the end of a range.
+	 */
+	endSide?: Side.Before | Side.After;
 
 	/**
 	 * Add properties to this segment via annotation.

--- a/packages/dds/merge-tree/src/sequencePlace.ts
+++ b/packages/dds/merge-tree/src/sequencePlace.ts
@@ -49,20 +49,6 @@ export enum Side {
 	After = 1,
 }
 
-export function toSequencePlace(
-	pos: number | "start" | "end",
-	side: Side | undefined,
-): SequencePlace {
-	return typeof pos === "number" && side !== undefined ? { pos, side } : pos;
-}
-
-export function toOptionalSequencePlace(
-	pos: number | "start" | "end" | undefined,
-	side: Side | undefined,
-): SequencePlace | undefined {
-	return typeof pos === "number" && side !== undefined ? { pos, side } : pos;
-}
-
 export function endpointPosAndSide(
 	start: SequencePlace | undefined,
 	end: SequencePlace | undefined,

--- a/packages/dds/merge-tree/src/sequencePlace.ts
+++ b/packages/dds/merge-tree/src/sequencePlace.ts
@@ -26,6 +26,8 @@
  * If a SequencePlace is the endpoint of a range (e.g. start/end of an interval or search range),
  * the Side value means it is exclusive if it is nearer to the other position and inclusive if it is farther.
  * E.g. the start of a range with Side.After is exclusive of the character at the position.
+ * @legacy
+ * @alpha
  */
 export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
 
@@ -33,6 +35,8 @@ export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
  * A sequence place that does not refer to the special endpoint segments.
  *
  * See {@link SequencePlace} for additional context.
+ * @legacy
+ * @alpha
  */
 export interface InteriorSequencePlace {
 	pos: number;
@@ -43,6 +47,8 @@ export interface InteriorSequencePlace {
  * Defines a side relative to a character in a sequence.
  *
  * @remarks See {@link SequencePlace} for additional context on usage.
+ * @legacy
+ * @alpha
  */
 export enum Side {
 	Before = 0,

--- a/packages/dds/merge-tree/src/sequencePlace.ts
+++ b/packages/dds/merge-tree/src/sequencePlace.ts
@@ -1,0 +1,91 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Defines a position and side relative to a character in a sequence.
+ *
+ * For this purpose, sequences look like:
+ *
+ * `{start} - {character 0} - {character 1} - ... - {character N} - {end}`
+ *
+ * Each `{value}` in the diagram is a character within a sequence.
+ * Each `-` in the above diagram is a position where text could be inserted.
+ * Each position between a `{value}` and a `-` is a `SequencePlace`.
+ *
+ * The special endpoints `{start}` and `{end}` refer to positions outside the
+ * contents of the string.
+ *
+ * This gives us 2N + 2 possible positions to refer to within a string, where N
+ * is the number of characters.
+ *
+ * If the position is specified with a bare number, the side defaults to
+ * `Side.Before`.
+ *
+ * If a SequencePlace is the endpoint of a range (e.g. start/end of an interval or search range),
+ * the Side value means it is exclusive if it is nearer to the other position and inclusive if it is farther.
+ * E.g. the start of a range with Side.After is exclusive of the character at the position.
+ */
+export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
+
+/**
+ * A sequence place that does not refer to the special endpoint segments.
+ *
+ * See {@link SequencePlace} for additional context.
+ */
+export interface InteriorSequencePlace {
+	pos: number;
+	side: Side;
+}
+
+/**
+ * Defines a side relative to a character in a sequence.
+ *
+ * @remarks See {@link SequencePlace} for additional context on usage.
+ */
+export enum Side {
+	Before = 0,
+	After = 1,
+}
+
+export function toSequencePlace(
+	pos: number | "start" | "end",
+	side: Side | undefined,
+): SequencePlace {
+	return typeof pos === "number" && side !== undefined ? { pos, side } : pos;
+}
+
+export function toOptionalSequencePlace(
+	pos: number | "start" | "end" | undefined,
+	side: Side | undefined,
+): SequencePlace | undefined {
+	return typeof pos === "number" && side !== undefined ? { pos, side } : pos;
+}
+
+export function endpointPosAndSide(
+	start: SequencePlace | undefined,
+	end: SequencePlace | undefined,
+): {
+	startSide: Side | undefined;
+	endSide: Side | undefined;
+	startPos: number | "start" | "end" | undefined;
+	endPos: number | "start" | "end" | undefined;
+} {
+	const startIsPlainEndpoint =
+		typeof start === "number" || start === "start" || start === "end";
+	const endIsPlainEndpoint = typeof end === "number" || end === "start" || end === "end";
+
+	const startSide = startIsPlainEndpoint ? Side.Before : start?.side;
+	const endSide = endIsPlainEndpoint ? Side.Before : end?.side;
+
+	const startPos = startIsPlainEndpoint ? start : start?.pos;
+	const endPos = endIsPlainEndpoint ? end : end?.pos;
+
+	return {
+		startSide,
+		endSide,
+		startPos,
+		endPos,
+	};
+}

--- a/packages/dds/merge-tree/src/sequencePlace.ts
+++ b/packages/dds/merge-tree/src/sequencePlace.ts
@@ -55,6 +55,12 @@ export enum Side {
 	After = 1,
 }
 
+/**
+ * Returns the position and side of the start and end of a sequence.
+ *
+ * @legacy
+ * @alpha
+ */
 export function endpointPosAndSide(
 	start: SequencePlace | undefined,
 	end: SequencePlace | undefined,

--- a/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
+++ b/packages/dds/sequence/api-report/sequence.legacy.alpha.api.md
@@ -92,13 +92,7 @@ export interface IIntervalCollectionEvent<TInterval extends ISerializableInterva
     (event: "changed", listener: (interval: TInterval, propertyDeltas: PropertySet, previousInterval: TInterval | undefined, local: boolean, slide: boolean) => void): void;
 }
 
-// @alpha
-export interface InteriorSequencePlace {
-    // (undocumented)
-    pos: number;
-    // (undocumented)
-    side: Side;
-}
+export { InteriorSequencePlace }
 
 // @alpha
 export interface IntervalIndex<TInterval extends ISerializableInterval> {
@@ -368,8 +362,7 @@ export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenance
     readonly opArgs: IMergeTreeDeltaOpArgs | undefined;
 }
 
-// @alpha
-export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
+export { SequencePlace }
 
 // @alpha (undocumented)
 export abstract class SharedSegmentSequence<T extends ISegment> extends SharedObject<ISharedSegmentSequenceEvents> implements ISharedSegmentSequence<T> {
@@ -477,13 +470,7 @@ export type SharedStringRevertible = MergeTreeDeltaRevertible | IntervalRevertib
 // @alpha (undocumented)
 export type SharedStringSegment = TextSegment | Marker;
 
-// @alpha
-export enum Side {
-    // (undocumented)
-    After = 1,
-    // (undocumented)
-    Before = 0
-}
+export { Side }
 
 export { TextSegment }
 

--- a/packages/dds/sequence/api-report/sequence.legacy.public.api.md
+++ b/packages/dds/sequence/api-report/sequence.legacy.public.api.md
@@ -6,6 +6,8 @@
 
 export { BaseSegment }
 
+export { InteriorSequencePlace }
+
 export { ISegment }
 
 export { LocalReferencePosition }
@@ -23,6 +25,10 @@ export { ReferencePosition }
 export { ReferenceType }
 
 export { reservedMarkerIdKey }
+
+export { SequencePlace }
+
+export { Side }
 
 export { TextSegment }
 

--- a/packages/dds/sequence/src/index.ts
+++ b/packages/dds/sequence/src/index.ts
@@ -39,9 +39,6 @@ export {
 	IIntervalCollection,
 	IntervalLocator,
 	intervalLocatorFromEndpoint,
-	Side,
-	InteriorSequencePlace,
-	SequencePlace,
 } from "./intervalCollection.js";
 export {
 	IntervalIndex,
@@ -109,4 +106,7 @@ export {
 	reservedRangeLabelsKey,
 	TrackingGroup,
 	LocalReferencePosition,
+	Side,
+	InteriorSequencePlace,
+	SequencePlace,
 } from "@fluidframework/merge-tree/internal";

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -26,6 +26,9 @@ import {
 	getSlideToSegoff,
 	refTypeIncludesFlag,
 	reservedRangeLabelsKey,
+	Side,
+	SequencePlace,
+	endpointPosAndSide,
 } from "@fluidframework/merge-tree/internal";
 import { LoggingError, UsageError } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";
@@ -64,58 +67,6 @@ import {
 	sequenceIntervalHelpers,
 	startReferenceSlidingPreference,
 } from "./intervals/index.js";
-
-/**
- * Defines a position and side relative to a character in a sequence.
- *
- * For this purpose, sequences look like:
- *
- * `{start} - {character 0} - {character 1} - ... - {character N} - {end}`
- *
- * Each `{value}` in the diagram is a character within a sequence.
- * Each `-` in the above diagram is a position where text could be inserted.
- * Each position between a `{value}` and a `-` is a `SequencePlace`.
- *
- * The special endpoints `{start}` and `{end}` refer to positions outside the
- * contents of the string.
- *
- * This gives us 2N + 2 possible positions to refer to within a string, where N
- * is the number of characters.
- *
- * If the position is specified with a bare number, the side defaults to
- * `Side.Before`.
- *
- * If a SequencePlace is the endpoint of a range (e.g. start/end of an interval or search range),
- * the Side value means it is exclusive if it is nearer to the other position and inclusive if it is farther.
- * E.g. the start of a range with Side.After is exclusive of the character at the position.
- * @legacy
- * @alpha
- */
-export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
-
-/**
- * A sequence place that does not refer to the special endpoint segments.
- *
- * See {@link SequencePlace} for additional context.
- * @legacy
- * @alpha
- */
-export interface InteriorSequencePlace {
-	pos: number;
-	side: Side;
-}
-
-/**
- * Defines a side relative to a character in a sequence.
- *
- * @remarks See {@link SequencePlace} for additional context on usage.
- * @legacy
- * @alpha
- */
-export enum Side {
-	Before = 0,
-	After = 1,
-}
 
 export const reservedIntervalIdKey = "intervalId";
 
@@ -177,28 +128,6 @@ function compressInterval(interval: ISerializedInterval): CompressedSerializedIn
 	}
 
 	return base;
-}
-
-export function endpointPosAndSide(
-	start: SequencePlace | undefined,
-	end: SequencePlace | undefined,
-) {
-	const startIsPlainEndpoint =
-		typeof start === "number" || start === "start" || start === "end";
-	const endIsPlainEndpoint = typeof end === "number" || end === "start" || end === "end";
-
-	const startSide = startIsPlainEndpoint ? Side.Before : start?.side;
-	const endSide = endIsPlainEndpoint ? Side.Before : end?.side;
-
-	const startPos = startIsPlainEndpoint ? start : start?.pos;
-	const endPos = endIsPlainEndpoint ? end : end?.pos;
-
-	return {
-		startSide,
-		endSide,
-		startPos,
-		endPos,
-	};
 }
 
 export function toSequencePlace(
@@ -816,7 +745,7 @@ export interface IIntervalCollection<TInterval extends ISerializableInterval>
 	 * it is possible to control whether the interval expands to include content
 	 * inserted at its start or end.
 	 *
-	 *	See {@link SequencePlace} for more details on the model.
+	 *	See {@link @fluidframework/merge-tree#SequencePlace} for more details on the model.
 	 *
 	 *	@example
 	 *

--- a/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
+++ b/packages/dds/sequence/src/intervalCollectionMapInterfaces.ts
@@ -71,10 +71,10 @@ export interface SequenceOptions
 	> {
 	/**
 	 * Enable the ability to use interval APIs that rely on positions before and
-	 * after individual characters, referred to as "sides". See {@link SequencePlace}
+	 * after individual characters, referred to as "sides". See {@link @fluidframework/merge-tree#SequencePlace}
 	 * for additional context.
 	 *
-	 * This flag must be enabled to pass instances of {@link SequencePlace} to
+	 * This flag must be enabled to pass instances of {@link @fluidframework/merge-tree#SequencePlace} to
 	 * any IIntervalCollection API.
 	 *
 	 * Also see the feature flag `mergeTreeReferencesCanSlideToEndpoint` to allow

--- a/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
+++ b/packages/dds/sequence/src/intervalIndex/overlappingIntervalsIndex.ts
@@ -5,9 +5,12 @@
 
 /* eslint-disable import/no-deprecated */
 
-import { Client } from "@fluidframework/merge-tree/internal";
+import {
+	Client,
+	SequencePlace,
+	endpointPosAndSide,
+} from "@fluidframework/merge-tree/internal";
 
-import { SequencePlace, endpointPosAndSide } from "../intervalCollection.js";
 import { IntervalNode, IntervalTree } from "../intervalTree.js";
 import {
 	IIntervalHelpers,

--- a/packages/dds/sequence/src/intervals/interval.ts
+++ b/packages/dds/sequence/src/intervals/interval.ts
@@ -12,10 +12,11 @@ import {
 	PropertySet,
 	createMap,
 	reservedRangeLabelsKey,
+	SequencePlace,
 } from "@fluidframework/merge-tree/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { SequencePlace, reservedIntervalIdKey } from "../intervalCollection.js";
+import { reservedIntervalIdKey } from "../intervalCollection.js";
 
 import {
 	IIntervalHelpers,

--- a/packages/dds/sequence/src/intervals/intervalUtils.ts
+++ b/packages/dds/sequence/src/intervals/intervalUtils.ts
@@ -12,9 +12,9 @@ import {
 	PropertiesManager,
 	PropertySet,
 	SlidingPreference,
+	SequencePlace,
+	Side,
 } from "@fluidframework/merge-tree/internal";
-
-import { SequencePlace, Side } from "../intervalCollection.js";
 
 /**
  * Basic interval abstraction
@@ -235,9 +235,9 @@ export interface IIntervalHelpers<TInterval extends ISerializableInterval> {
 	 * @param op - If this create came from a remote client, op that created it. Default is undefined (i.e. local)
 	 * @param fromSnapshot - If this create came from loading a snapshot. Default is false.
 	 * @param startSide - The side on which the start position lays. See
-	 * {@link SequencePlace} for additional context
+	 * {@link @fluidframework/merge-tree#SequencePlace} for additional context
 	 * @param endSide - The side on which the end position lays. See
-	 * {@link SequencePlace} for additional context
+	 * {@link @fluidframework/merge-tree#SequencePlace} for additional context
 	 */
 	create(
 		label: string,

--- a/packages/dds/sequence/src/intervals/sequenceInterval.ts
+++ b/packages/dds/sequence/src/intervals/sequenceInterval.ts
@@ -24,14 +24,14 @@ import {
 	minReferencePosition,
 	refTypeIncludesFlag,
 	reservedRangeLabelsKey,
+	SequencePlace,
+	Side,
+	endpointPosAndSide,
 } from "@fluidframework/merge-tree/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
-	SequencePlace,
-	Side,
 	computeStickinessFromSide,
-	endpointPosAndSide,
 	reservedIntervalIdKey,
 	sidesFromStickiness,
 } from "../intervalCollection.js";

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -21,9 +21,10 @@ import {
 	isMergeTreeDeltaRevertible,
 	refTypeIncludesFlag,
 	revertMergeTreeDeltaRevertibles,
+	InteriorSequencePlace,
+	Side,
 } from "@fluidframework/merge-tree/internal";
 
-import { InteriorSequencePlace, Side } from "./intervalCollection.js";
 import { IntervalOpType, SequenceInterval } from "./intervals/index.js";
 import { ISequenceDeltaRange, SequenceDeltaEvent } from "./sequenceDeltaEvent.js";
 import { ISharedString, SharedStringSegment } from "./sharedString.js";

--- a/packages/dds/sequence/src/test/fuzz/fuzzUtils.ts
+++ b/packages/dds/sequence/src/test/fuzz/fuzzUtils.ts
@@ -24,10 +24,10 @@ import {
 	type Serializable,
 	IChannelServices,
 } from "@fluidframework/datastore-definitions/internal";
-import { PropertySet } from "@fluidframework/merge-tree/internal";
+import { PropertySet, Side } from "@fluidframework/merge-tree/internal";
 
 import type { SequenceInterval, SharedStringClass } from "../../index.js";
-import { type IIntervalCollection, Side } from "../../intervalCollection.js";
+import { type IIntervalCollection } from "../../intervalCollection.js";
 import { SharedStringRevertible, revertSharedStringRevertibles } from "../../revertibles.js";
 import { SharedStringFactory } from "../../sequenceFactory.js";
 import { ISharedString } from "../../sharedString.js";

--- a/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.snapshot.spec.ts
@@ -7,18 +7,14 @@ import { strict as assert } from "assert";
 
 import { AttachState } from "@fluidframework/container-definitions";
 import { ISummaryTree } from "@fluidframework/driver-definitions";
-import { ReferenceType, SlidingPreference } from "@fluidframework/merge-tree/internal";
+import { ReferenceType, SlidingPreference, Side } from "@fluidframework/merge-tree/internal";
 import {
 	MockContainerRuntimeFactory,
 	MockFluidDataStoreRuntime,
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import {
-	IIntervalCollection,
-	Side,
-	intervalLocatorFromEndpoint,
-} from "../intervalCollection.js";
+import { IIntervalCollection, intervalLocatorFromEndpoint } from "../intervalCollection.js";
 import { IntervalStickiness, SequenceInterval } from "../intervals/index.js";
 import { SharedStringFactory } from "../sequenceFactory.js";
 import { SharedStringClass, type ISharedString } from "../sharedString.js";

--- a/packages/dds/sequence/src/test/intervalCollection.spec.ts
+++ b/packages/dds/sequence/src/test/intervalCollection.spec.ts
@@ -11,6 +11,8 @@ import {
 	ReferenceType,
 	SlidingPreference,
 	reservedRangeLabelsKey,
+	Side,
+	type SequencePlace,
 } from "@fluidframework/merge-tree/internal";
 import { LoggingError } from "@fluidframework/telemetry-utils/internal";
 import {
@@ -22,7 +24,7 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { IIntervalCollection, Side, type SequencePlace } from "../intervalCollection.js";
+import { IIntervalCollection } from "../intervalCollection.js";
 import { IntervalIndex } from "../intervalIndex/index.js";
 import {
 	ISerializableInterval,

--- a/packages/dds/sequence/src/test/intervalIndexTestUtils.ts
+++ b/packages/dds/sequence/src/test/intervalIndexTestUtils.ts
@@ -6,10 +6,9 @@
 import { strict as assert } from "assert";
 
 import { IRandom } from "@fluid-private/stochastic-test-utils";
-import { PropertySet } from "@fluidframework/merge-tree/internal";
+import { PropertySet, type SequencePlace, Side } from "@fluidframework/merge-tree/internal";
 import { v4 as uuid } from "uuid";
 
-import { type SequencePlace, Side } from "../intervalCollection.js";
 import { Interval, IntervalStickiness, type SequenceInterval } from "../intervals/index.js";
 import type { ISharedString } from "../sharedString.js";
 

--- a/packages/dds/sequence/src/test/intervalRebasing.spec.ts
+++ b/packages/dds/sequence/src/test/intervalRebasing.spec.ts
@@ -5,10 +5,10 @@
 
 import { strict as assert } from "assert";
 
+import { Side } from "@fluidframework/merge-tree/internal";
 import { useStrictPartialLengthChecks } from "@fluidframework/merge-tree/internal/test";
 import { MockContainerRuntimeFactoryForReconnection } from "@fluidframework/test-runtime-utils/internal";
 
-import { Side } from "../intervalCollection.js";
 import { IntervalStickiness } from "../intervals/index.js";
 
 import { Client, assertConsistent, assertSequenceIntervals } from "./intervalTestUtils.js";

--- a/packages/dds/sequence/src/test/revertibles.spec.ts
+++ b/packages/dds/sequence/src/test/revertibles.spec.ts
@@ -6,13 +6,14 @@
 import { strict as assert } from "assert";
 
 import { AttachState } from "@fluidframework/container-definitions";
+import { Side } from "@fluidframework/merge-tree/internal";
 import {
 	MockContainerRuntimeFactory,
 	MockFluidDataStoreRuntime,
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { IIntervalCollection, Side } from "../intervalCollection.js";
+import { IIntervalCollection } from "../intervalCollection.js";
 import { IntervalStickiness, SequenceInterval } from "../intervals/index.js";
 import {
 	SharedStringRevertible,

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -534,13 +534,7 @@ Unhydrated<NodeFromSchemaUnsafe<T>> | (T extends {
 } ? NodeBuilderDataUnsafe<T> : never)
 ][_InlineTrick];
 
-// @alpha
-export interface InteriorSequencePlace {
-    // (undocumented)
-    pos: number;
-    // (undocumented)
-    side: Side;
-}
+export { InteriorSequencePlace }
 
 // @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
@@ -1058,8 +1052,7 @@ export class SequenceMaintenanceEvent extends SequenceEvent<MergeTreeMaintenance
     readonly opArgs: IMergeTreeDeltaOpArgs | undefined;
 }
 
-// @alpha
-export type SequencePlace = number | "start" | "end" | InteriorSequencePlace;
+export { SequencePlace }
 
 // @alpha
 export const SharedDirectory: ISharedObjectKind<ISharedDirectory> & SharedObjectKind_2<ISharedDirectory>;
@@ -1090,13 +1083,7 @@ export type SharedStringSegment = TextSegment | Marker;
 // @public
 export const SharedTree: SharedObjectKind<ITree>;
 
-// @alpha
-export enum Side {
-    // (undocumented)
-    After = 1,
-    // (undocumented)
-    Before = 0
-}
+export { Side }
 
 // @public
 export interface Tagged<V, T extends string = string> {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -462,6 +462,8 @@ Unhydrated<NodeFromSchemaUnsafe<T>> | (T extends {
 } ? NodeBuilderDataUnsafe<T> : never)
 ][_InlineTrick];
 
+export { InteriorSequencePlace }
+
 // @public @sealed
 export interface InternalTreeNode extends ErasedType<"@fluidframework/tree.InternalTreeNode"> {
 }
@@ -714,6 +716,8 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
 // @public
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
+export { SequencePlace }
+
 // @public @sealed
 export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
@@ -721,6 +725,8 @@ export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedTyp
 
 // @public
 export const SharedTree: SharedObjectKind<ITree>;
+
+export { Side }
 
 // @public
 export interface Tagged<V, T extends string = string> {


### PR DESCRIPTION
In preparation for allowing range expansion on obliterate, add the `SequencePlace` and `Side` concepts to merge tree (instead of only using them in sequence). Eventually, I'd like to have these defined in one place that can be accessed by both packages, but they are currently exposed as a part of sequence's public API, so this would be a breaking change. 

[AB#9064](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/9064)