### PR TITLE
refactor(tree): simplify getInputCellId

### DIFF
--- a/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/utils.ts
@@ -119,26 +119,7 @@ export function areEqualCellIds(a: CellId | undefined, b: CellId | undefined): b
 }
 
 export function getInputCellId(mark: Mark): CellId | undefined {
-	const cellId = mark.cellId;
-	if (cellId === undefined) {
-		return undefined;
-	}
-
-	if (cellId.revision !== undefined) {
-		return cellId;
-	}
-
-	let markRevision: RevisionTag | undefined;
-	if (isAttachAndDetachEffect(mark)) {
-		markRevision = mark.attach.revision;
-	} else if (!isNoopMark(mark)) {
-		markRevision = mark.revision;
-	}
-
-	return {
-		...cellId,
-		revision: markRevision,
-	};
+	return mark.cellId;
 }
 
 export function getOutputCellId(mark: Mark): CellId | undefined {


### PR DESCRIPTION
## Description

This change leverages the fact that revisions are no longer implicit to simplify the logic of the getInputCellId helper function.

## Breaking Changes

None