### PR TITLE
Disable the full-compat testing of local/t9s on main

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -44,7 +44,7 @@ stages:
         testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
-        testCommand: test:realsvc:local:report:full
+        testCommand: test:realsvc:local:report
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 
@@ -59,7 +59,7 @@ stages:
         testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
-        testCommand: test:realsvc:tinylicious:report:full
+        testCommand: test:realsvc:tinylicious:report
         # TODO: AB#8968 tracks figuring out the root cause of the extended delay, and restoring this timeout to 90m or less
         timeoutInMinutes: 120
         env:

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -44,7 +44,7 @@ stages:
         testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
-        testCommand: test:realsvc:local:report
+        testCommand: test:realsvc:local:report # TODO: AB#9085 - restore full compat matrix
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 
@@ -59,7 +59,7 @@ stages:
         testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
-        testCommand: test:realsvc:tinylicious:report
+        testCommand: test:realsvc:tinylicious:report # TODO: AB#9085 - restore full compat matrix
         # TODO: AB#8968 tracks figuring out the root cause of the extended delay, and restoring this timeout to 90m or less
         timeoutInMinutes: 120
         env:


### PR DESCRIPTION
Bump to 2.2.0 broke full-compat e2e tests (local server and t9s), disable full-compat testing on main as a mitigation. 

[AB#9085](https://dev.azure.com/fluidframework/internal/_workitems/edit/9085) is created to track the follow-up workaround. 

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

> List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
> Things you might want to include:
>
> -   Questions about how to properly make automated tests for your changes.
> -   Questions about design choices you made.
> -   Descriptions of how to manually test the changes (and how much of that you have done).
> -   etc.
>
> If you have any questions in this section, consider making the PR a draft until all questions have been resolved.
