### PR TITLE
tree: Stop pruning change compositions

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -236,7 +236,7 @@ export class ModularChangeFamily
 		]);
 
 		return makeModularChangeset(
-			this.pruneFieldMap(fieldChanges, nodeChanges),
+			fieldChanges,
 			nodeChanges,
 			nodeToParent,
 			nodeAliases,

--- a/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modularChangeFamilyIntegration.spec.ts
@@ -692,35 +692,6 @@ describe("ModularChangeFamily integration", () => {
 			);
 			assert.deepEqual(actualDelta, expectedDelta);
 		});
-
-		it("prunes its output", () => {
-			const a = buildChangeset([
-				{
-					type: "field",
-					field: {
-						parent: undefined,
-						field: brand("foo"),
-					},
-					fieldKind: sequence.identifier,
-					change: brand([]),
-				},
-			]);
-
-			const b = buildChangeset([
-				{
-					type: "field",
-					field: {
-						parent: undefined,
-						field: brand("bar"),
-					},
-					fieldKind: sequence.identifier,
-					change: brand([]),
-				},
-			]);
-
-			const composed = family.compose([makeAnonChange(a), makeAnonChange(b)]);
-			assert.deepEqual(composed, ModularChangeFamily.emptyChange);
-		});
 	});
 
 	describe("invert", () => {


### PR DESCRIPTION
## Description

Removed the prune pass from ModularChangeFamily's compose implementation. This is a step toward improving the asymptotic performance of compose, since pruning was doing a full walk of the changeset.