### PR TITLE
[port 2.1] refactor(ci): Use Small pool for first stage of Test DDS Stress pipeline 

### DIFF
--- a/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
+++ b/tools/pipelines/templates/include-conditionally-run-stress-tests.yml
@@ -31,6 +31,7 @@ parameters:
 stages:
   - stage: CheckAffectedPaths
     displayName: Determine changed packages
+    pool: Small
     jobs:
     - job: Job
       displayName: Check for DDS package changes


### PR DESCRIPTION
## Description

Ports https://github.com/microsoft/FluidFramework/pull/21966 to the 2.1. release branch.

Makes it so we use our Small agent pool for the first stage of the Test DDS Stress pipeline, which has been failing after we used up all the free minutes for hosted agents.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
