### PR TITLE
fix(tree): handle idOverride in replaceRevision for sequence changeset

### DIFF
--- a/packages/dds/tree/src/feature-libraries/sequence-field/replaceRevisions.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/replaceRevisions.ts
@@ -54,7 +54,9 @@ function updateEffect<TMark extends MarkEffect>(
 	revisionsToReplace: Set<RevisionTag | undefined>,
 	newRevision: RevisionTag | undefined,
 ): TMark {
-	const mark = isDetach(input) ? updateIdOverride(input, revisionsToReplace, newRevision) : input;
+	const mark = isDetach(input)
+		? updateIdOverride(input, revisionsToReplace, newRevision)
+		: input;
 	const type = mark.type;
 	switch (type) {
 		case NoopMarkType:
@@ -92,12 +94,11 @@ function updateIdOverride<TEffect extends Detach>(
 			revisionsToReplace,
 			newRevision,
 		);
-		return { ...effect, idOverride }
+		return { ...effect, idOverride };
 	} else {
 		return effect;
 	}
 }
-
 
 function updateMoveEffect<TEffect extends HasMoveFields>(
 	effect: TEffect,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/replaceRevisions.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/replaceRevisions.ts
@@ -15,6 +15,7 @@ import {
 	NoopMarkType,
 } from "./types.js";
 import type { MoveMarkEffect } from "./helperTypes.js";
+import { isDetach } from "./utils.js";
 
 export function replaceRevisions(
 	changeset: Changeset,
@@ -44,6 +45,13 @@ function updateMark(
 		updatedMark.changes = replaceAtomRevisions(mark.changes, revisionsToReplace, newRevision);
 	}
 
+	if (isDetach(updatedMark) && updatedMark.idOverride !== undefined) {
+		updatedMark.idOverride = replaceAtomRevisions(
+			updatedMark.idOverride,
+			revisionsToReplace,
+			newRevision,
+		);
+	}
 	return updatedMark;
 }
 

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/replaceRevisions.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/replaceRevisions.test.ts
@@ -133,16 +133,16 @@ function runCases(outputRev: RevisionTag | undefined) {
 
 	it("attach an detach marks", () => {
 		const input: SF.Changeset = [
-			Mark.attachAndDetach(Mark.moveIn(1, atom0), Mark.moveOut(1, atom0)),
-			Mark.attachAndDetach(Mark.moveIn(1, atom1), Mark.moveOut(1, atom2)),
-			Mark.attachAndDetach(Mark.moveIn(1, atom2), Mark.moveOut(1, atom3)),
-			Mark.attachAndDetach(Mark.moveIn(1, atom3), Mark.moveOut(1, atom1)),
+			Mark.attachAndDetach(Mark.moveIn(1, atom0), Mark.moveOut(1, atom0, { finalEndpoint: atom0, idOverride: atom1 })),
+			Mark.attachAndDetach(Mark.moveIn(1, atom1), Mark.moveOut(1, atom2, { finalEndpoint: atom1, idOverride: atom2 })),
+			Mark.attachAndDetach(Mark.moveIn(1, atom2), Mark.moveOut(1, atom3, { finalEndpoint: atom2, idOverride: atom3 })),
+			Mark.attachAndDetach(Mark.moveIn(1, atom3), Mark.moveOut(1, atom1, { finalEndpoint: atom3, idOverride: atom0 })),
 		];
 		const expected: SF.Changeset = [
-			Mark.attachAndDetach(Mark.moveIn(1, atom0), Mark.moveOut(1, atom0)),
-			Mark.attachAndDetach(Mark.moveIn(1, atomOut1), Mark.moveOut(1, atomOut2)),
-			Mark.attachAndDetach(Mark.moveIn(1, atomOut2), Mark.moveOut(1, atomOut3)),
-			Mark.attachAndDetach(Mark.moveIn(1, atomOut3), Mark.moveOut(1, atomOut1)),
+			Mark.attachAndDetach(Mark.moveIn(1, atom0), Mark.moveOut(1, atom0, { finalEndpoint: atom0, idOverride: atomOut1 })),
+			Mark.attachAndDetach(Mark.moveIn(1, atomOut1), Mark.moveOut(1, atomOut2, { finalEndpoint: atomOut1, idOverride: atomOut2 })),
+			Mark.attachAndDetach(Mark.moveIn(1, atomOut2), Mark.moveOut(1, atomOut3, { finalEndpoint: atomOut2, idOverride: atomOut3 })),
+			Mark.attachAndDetach(Mark.moveIn(1, atomOut3), Mark.moveOut(1, atomOut1, { finalEndpoint: atomOut3, idOverride: atom0 })),
 		];
 		const actual = process(input);
 		assertChangesetsEqual(actual, expected);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/replaceRevisions.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/replaceRevisions.test.ts
@@ -87,20 +87,20 @@ function runCases(outputRev: RevisionTag | undefined) {
 			Mark.insert(1, atom1),
 			Mark.insert(1, atom2),
 			Mark.insert(1, atom3),
-			Mark.remove(1, atom0),
-			Mark.remove(1, atom1),
-			Mark.remove(1, atom2),
-			Mark.remove(1, atom3),
+			Mark.remove(1, atom0, { idOverride: atom1 }),
+			Mark.remove(1, atom1, { idOverride: atom2 }),
+			Mark.remove(1, atom2, { idOverride: atom3 }),
+			Mark.remove(1, atom3, { idOverride: atom0 }),
 		];
 		const expected: SF.Changeset = [
 			Mark.insert(1, atom0),
 			Mark.insert(1, atomOut1),
 			Mark.insert(1, atomOut2),
 			Mark.insert(1, atomOut3),
-			Mark.remove(1, atom0),
-			Mark.remove(1, atomOut1),
-			Mark.remove(1, atomOut2),
-			Mark.remove(1, atomOut3),
+			Mark.remove(1, atom0, { idOverride: atomOut1 }),
+			Mark.remove(1, atomOut1, { idOverride: atomOut2 }),
+			Mark.remove(1, atomOut2, { idOverride: atomOut3 }),
+			Mark.remove(1, atomOut3, { idOverride: atom0 }),
 		];
 		const actual = process(input);
 		assertChangesetsEqual(actual, expected);
@@ -108,20 +108,20 @@ function runCases(outputRev: RevisionTag | undefined) {
 
 	it("move marks", () => {
 		const input: SF.Changeset = [
-			Mark.moveOut(1, atom0, { finalEndpoint: atom0 }),
-			Mark.moveOut(1, atom1, { finalEndpoint: atom1 }),
-			Mark.moveOut(1, atom2, { finalEndpoint: atom2 }),
-			Mark.moveOut(1, atom3, { finalEndpoint: atom3 }),
+			Mark.moveOut(1, atom0, { finalEndpoint: atom0, idOverride: atom1 }),
+			Mark.moveOut(1, atom1, { finalEndpoint: atom1, idOverride: atom2 }),
+			Mark.moveOut(1, atom2, { finalEndpoint: atom2, idOverride: atom3 }),
+			Mark.moveOut(1, atom3, { finalEndpoint: atom3, idOverride: atom0 }),
 			Mark.moveIn(1, atom0, { finalEndpoint: atom0 }),
 			Mark.moveIn(1, atom1, { finalEndpoint: atom1 }),
 			Mark.moveIn(1, atom2, { finalEndpoint: atom2 }),
 			Mark.moveIn(1, atom3, { finalEndpoint: atom3 }),
 		];
 		const expected: SF.Changeset = [
-			Mark.moveOut(1, atom0, { finalEndpoint: atom0 }),
-			Mark.moveOut(1, atomOut1, { finalEndpoint: atomOut1 }),
-			Mark.moveOut(1, atomOut2, { finalEndpoint: atomOut2 }),
-			Mark.moveOut(1, atomOut3, { finalEndpoint: atomOut3 }),
+			Mark.moveOut(1, atom0, { finalEndpoint: atom0, idOverride: atomOut1 }),
+			Mark.moveOut(1, atomOut1, { finalEndpoint: atomOut1, idOverride: atomOut2 }),
+			Mark.moveOut(1, atomOut2, { finalEndpoint: atomOut2, idOverride: atomOut3 }),
+			Mark.moveOut(1, atomOut3, { finalEndpoint: atomOut3, idOverride: atom0 }),
 			Mark.moveIn(1, atom0, { finalEndpoint: atom0 }),
 			Mark.moveIn(1, atomOut1, { finalEndpoint: atomOut1 }),
 			Mark.moveIn(1, atomOut2, { finalEndpoint: atomOut2 }),

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/replaceRevisions.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/replaceRevisions.test.ts
@@ -133,16 +133,40 @@ function runCases(outputRev: RevisionTag | undefined) {
 
 	it("attach an detach marks", () => {
 		const input: SF.Changeset = [
-			Mark.attachAndDetach(Mark.moveIn(1, atom0), Mark.moveOut(1, atom0, { finalEndpoint: atom0, idOverride: atom1 })),
-			Mark.attachAndDetach(Mark.moveIn(1, atom1), Mark.moveOut(1, atom2, { finalEndpoint: atom1, idOverride: atom2 })),
-			Mark.attachAndDetach(Mark.moveIn(1, atom2), Mark.moveOut(1, atom3, { finalEndpoint: atom2, idOverride: atom3 })),
-			Mark.attachAndDetach(Mark.moveIn(1, atom3), Mark.moveOut(1, atom1, { finalEndpoint: atom3, idOverride: atom0 })),
+			Mark.attachAndDetach(
+				Mark.moveIn(1, atom0),
+				Mark.moveOut(1, atom0, { finalEndpoint: atom0, idOverride: atom1 }),
+			),
+			Mark.attachAndDetach(
+				Mark.moveIn(1, atom1),
+				Mark.moveOut(1, atom2, { finalEndpoint: atom1, idOverride: atom2 }),
+			),
+			Mark.attachAndDetach(
+				Mark.moveIn(1, atom2),
+				Mark.moveOut(1, atom3, { finalEndpoint: atom2, idOverride: atom3 }),
+			),
+			Mark.attachAndDetach(
+				Mark.moveIn(1, atom3),
+				Mark.moveOut(1, atom1, { finalEndpoint: atom3, idOverride: atom0 }),
+			),
 		];
 		const expected: SF.Changeset = [
-			Mark.attachAndDetach(Mark.moveIn(1, atom0), Mark.moveOut(1, atom0, { finalEndpoint: atom0, idOverride: atomOut1 })),
-			Mark.attachAndDetach(Mark.moveIn(1, atomOut1), Mark.moveOut(1, atomOut2, { finalEndpoint: atomOut1, idOverride: atomOut2 })),
-			Mark.attachAndDetach(Mark.moveIn(1, atomOut2), Mark.moveOut(1, atomOut3, { finalEndpoint: atomOut2, idOverride: atomOut3 })),
-			Mark.attachAndDetach(Mark.moveIn(1, atomOut3), Mark.moveOut(1, atomOut1, { finalEndpoint: atomOut3, idOverride: atom0 })),
+			Mark.attachAndDetach(
+				Mark.moveIn(1, atom0),
+				Mark.moveOut(1, atom0, { finalEndpoint: atom0, idOverride: atomOut1 }),
+			),
+			Mark.attachAndDetach(
+				Mark.moveIn(1, atomOut1),
+				Mark.moveOut(1, atomOut2, { finalEndpoint: atomOut1, idOverride: atomOut2 }),
+			),
+			Mark.attachAndDetach(
+				Mark.moveIn(1, atomOut2),
+				Mark.moveOut(1, atomOut3, { finalEndpoint: atomOut2, idOverride: atomOut3 }),
+			),
+			Mark.attachAndDetach(
+				Mark.moveIn(1, atomOut3),
+				Mark.moveOut(1, atomOut1, { finalEndpoint: atomOut3, idOverride: atom0 }),
+			),
 		];
 		const actual = process(input);
 		assertChangesetsEqual(actual, expected);


### PR DESCRIPTION
## Description

Fixes a bug where the revisions in the `idOverride` field of detach marks were not being updated

## Breaking Changes

None
