### PR TITLE
realsvc test pipeline: Try new agent pool, hoping to avoid intermittent test timeouts

### DIFF
--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -40,7 +40,7 @@ stages:
     jobs:
     - template: templates/include-test-real-service.yml
       parameters:
-        poolBuild: Large # Need Large pool for full-compat matrix
+        poolBuild: NewLarge-linux-1ES # Need Large pool for full-compat matrix
         testPackage: ${{ variables.testPackage }}
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)


### PR DESCRIPTION
## Description

We are facing intermittent individual test timeouts when running our e2e tests against Local Server and Tinylicious... but only in the Real Service pipeline, not the Build Client pipeline.  One difference between the two is the agent pool, so trying to switch it in case it mitigates this.