### PR TITLE
feat(markdown-magic): Add scope notice template for `@fluid-tools` packages

### DIFF
--- a/packages/tools/fetch-tool/README.md
+++ b/packages/tools/fetch-tool/README.md
@@ -9,8 +9,9 @@ Beware that to use fetch-tool on documents in the Microsoft tenant, you will nee
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
 
-**NOTE: This package is a tools library intended for use within the `@microsoft/fluid-framework` repository and is not intended for public consumption.**
-**We make no stability guarantees regarding its APIs.**
+**NOTE: This package is a library intended for use within the [microsoft/FluidFramework](https://github.com/microsoft/FluidFramework) repository.**
+**It is not intended for public use.**
+**We make no stability guarantees regarding this library and its APIs.**
 
 ## Using Fluid Framework libraries
 

--- a/packages/tools/fetch-tool/README.md
+++ b/packages/tools/fetch-tool/README.md
@@ -9,6 +9,9 @@ Beware that to use fetch-tool on documents in the Microsoft tenant, you will nee
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
 
+**NOTE: This package is a tools library intended for use within the `@microsoft/fluid-framework` repository and is not intended for public consumption.**
+**We make no stability guarantees regarding its APIs.**
+
 ## Using Fluid Framework libraries
 
 When taking a dependency on a Fluid Framework library's public APIs, we recommend using a `^` (caret) version range, such as `^1.3.4`.

--- a/tools/api-markdown-documenter/README.md
+++ b/tools/api-markdown-documenter/README.md
@@ -16,6 +16,9 @@ One may be added in the future, but for now this library is intended to be consu
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
 
+**NOTE: This package is a tools library intended for use within the `@microsoft/fluid-framework` repository and is not intended for public consumption.**
+**We make no stability guarantees regarding its APIs.**
+
 ## Using Fluid Framework libraries
 
 When taking a dependency on a Fluid Framework library's public APIs, we recommend using a `^` (caret) version range, such as `^1.3.4`.

--- a/tools/api-markdown-documenter/README.md
+++ b/tools/api-markdown-documenter/README.md
@@ -16,8 +16,9 @@ One may be added in the future, but for now this library is intended to be consu
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->
 
-**NOTE: This package is a tools library intended for use within the `@microsoft/fluid-framework` repository and is not intended for public consumption.**
-**We make no stability guarantees regarding its APIs.**
+**NOTE: This package is a library intended for use within the [microsoft/FluidFramework](https://github.com/microsoft/FluidFramework) repository.**
+**It is not intended for public use.**
+**We make no stability guarantees regarding this library and its APIs.**
 
 ## Using Fluid Framework libraries
 

--- a/tools/markdown-magic/src/md-magic.config.cjs
+++ b/tools/markdown-magic/src/md-magic.config.cjs
@@ -206,11 +206,12 @@ function readmeFooterTransform(content, options, config) {
  * @param {object} options - Transform options.
  * @param {string | undefined} options.packageJsonPath - (optional) Relative path from the document to the package's package.json file.
  * Default: "./package.json".
- * @param {"EXPERIMENTAL" | "INTERNAL" | "PRIVATE" | undefined} options.packageScopeNotice - (optional) Kind of package scope (namespace) notice to add.
+ * @param {"EXPERIMENTAL" | "INTERNAL" | "PRIVATE" | "TOOLS" | undefined} options.packageScopeNotice - (optional) Kind of package scope (namespace) notice to add.
  * EXPERIMENTAL: See templates/Experimental-Package-Notice-Template.md.
  * INTERNAL: See templates/Internal-Package-Notice-Template.md.
  * PRIVATE: See templates/Private-Package-Notice-Template.md.
- * `undefined`: Inherit from package namespace (fluid-experimental, fluid-internal, fluid-private).
+ * TOOLS: See templates/Tools-Package-Notice-Template.md.
+ * `undefined`: Inherit from package namespace (`fluid-experimental`, `fluid-internal`, `fluid-private`, `fluid-tools`, etc.).
  * @param {"TRUE" | "FALSE" | undefined} options.installation - (optional) Whether or not to include the package installation instructions section.
  * Default: `TRUE`.
  * @param {"TRUE" | "FALSE" | undefined} options.devDependency - (optional) Whether or not the package is intended to be installed as a devDependency.

--- a/tools/markdown-magic/src/templates/Tools-Package-Notice-Template.md
+++ b/tools/markdown-magic/src/templates/Tools-Package-Notice-Template.md
@@ -1,0 +1,2 @@
+**NOTE: This package is a tools library intended for use within the `@microsoft/fluid-framework` repository and is not intended for public consumption.**
+**We make no stability guarantees regarding its APIs.**

--- a/tools/markdown-magic/src/templates/Tools-Package-Notice-Template.md
+++ b/tools/markdown-magic/src/templates/Tools-Package-Notice-Template.md
@@ -1,2 +1,2 @@
-**NOTE: This package is a tools library intended for use within the `@microsoft/fluid-framework` repository and is not intended for public consumption.**
-**We make no stability guarantees regarding its APIs.**
+**NOTE: This package is a library intended for use within the [microsoft/FluidFramework](https://github.com/microsoft/FluidFramework) repository. It is not intended for public use.**
+**We make no stability guarantees regarding this library and its APIs.**

--- a/tools/markdown-magic/src/templates/Tools-Package-Notice-Template.md
+++ b/tools/markdown-magic/src/templates/Tools-Package-Notice-Template.md
@@ -1,2 +1,3 @@
-**NOTE: This package is a library intended for use within the [microsoft/FluidFramework](https://github.com/microsoft/FluidFramework) repository. It is not intended for public use.**
+**NOTE: This package is a library intended for use within the [microsoft/FluidFramework](https://github.com/microsoft/FluidFramework) repository.**
+**It is not intended for public use.**
 **We make no stability guarantees regarding this library and its APIs.**

--- a/tools/markdown-magic/src/transforms/packageScopeNoticeTransform.cjs
+++ b/tools/markdown-magic/src/transforms/packageScopeNoticeTransform.cjs
@@ -18,6 +18,7 @@ const {
  * EXPERIMENTAL: See templates/Experimental-Package-Notice-Template.md.
  * INTERNAL: See templates/Internal-Package-Notice-Template.md.
  * PRIVATE: See templates/Private-Package-Notice-Template.md.
+ * TOOLS: See templates/Tools-Package-Notice-Template.md.
  *
  * @returns The appropriate notice, if applicable. Otherwise, `undefined`.
  */
@@ -54,7 +55,8 @@ const generatePackageScopeNotice = (kind) => {
  * EXPERIMENTAL: See templates/Experimental-Package-Notice-Template.md.
  * INTERNAL: See templates/Internal-Package-Notice-Template.md.
  * PRIVATE: See templates/Private-Package-Notice-Template.md.
- * `undefined`: Inherit from package namespace (fluid-experimental, fluid-internal, fluid-private).
+ * TOOLS: See templates/Tools-Package-Notice-Template.md.
+ * `undefined`: Inherit from package namespace (`fluid-experimental`, `fluid-internal`, `fluid-private`, `fluid-tools`, etc.).
  * @param {object} config - Transform configuration.
  * @param {string} config.originalPath - Path to the document being modified.
  */

--- a/tools/markdown-magic/src/transforms/packageScopeNoticeTransform.cjs
+++ b/tools/markdown-magic/src/transforms/packageScopeNoticeTransform.cjs
@@ -51,7 +51,7 @@ const generatePackageScopeNotice = (kind) => {
  * @param {object} options - Transform options.
  * @param {string} options.packageJsonPath - (optional) Relative file path to the package.json file for the package.
  * Default: "./package.json".
- * @param {"EXPERIMENTAL" | "INTERNAL" | "PRIVATE" | undefined} scopeKind - Scope kind to switch on.
+ * @param {string | undefined} scopeKind - Scope kind to switch on.
  * EXPERIMENTAL: See templates/Experimental-Package-Notice-Template.md.
  * INTERNAL: See templates/Internal-Package-Notice-Template.md.
  * PRIVATE: See templates/Private-Package-Notice-Template.md.

--- a/tools/markdown-magic/src/transforms/packageScopeNoticeTransform.cjs
+++ b/tools/markdown-magic/src/transforms/packageScopeNoticeTransform.cjs
@@ -12,32 +12,6 @@ const {
 } = require("../utilities.cjs");
 
 /**
- * Generates simple Markdown contents indicating that the associated package is experimental.
- */
-const generateExperimentalPackageNotice = () => {
-	const rawContents = readTemplate("Experimental-Package-Notice-Template.md");
-	return formattedSectionText(rawContents, /* headingOptions: */ undefined);
-};
-
-/**
- * Generates simple Markdown contents indicating that the associated package is internal to the fluid-framework
- * (published, but not intended for external consumption).
- */
-const generateInternalPackageNotice = () => {
-	const rawContents = readTemplate("Internal-Package-Notice-Template.md");
-	return formattedSectionText(rawContents, /* headingOptions: */ undefined);
-};
-
-/**
- * Generates simple Markdown contents indicating that the associated package is private to the fluid-framework
- * (unpublished - used only within the repo).
- */
-const generatePrivatePackageNotice = () => {
-	const rawContents = readTemplate("Private-Package-Notice-Template.md");
-	return formattedSectionText(rawContents, /* headingOptions: */ undefined);
-};
-
-/**
  * Generates simple Markdown contents indicating implications of the specified kind of package scope.
  *
  * @param {string} kind - Scope kind to switch on.
@@ -48,16 +22,25 @@ const generatePrivatePackageNotice = () => {
  * @returns The appropriate notice, if applicable. Otherwise, `undefined`.
  */
 const generatePackageScopeNotice = (kind) => {
+	let rawContents;
 	switch (kind) {
 		case "EXPERIMENTAL":
-			return generateExperimentalPackageNotice();
+			rawContents = readTemplate("Experimental-Package-Notice-Template.md");
+			break;
 		case "INTERNAL":
-			return generateInternalPackageNotice();
+			rawContents = readTemplate("Internal-Package-Notice-Template.md");
+			break;
 		case "PRIVATE":
-			return generatePrivatePackageNotice();
+			rawContents = readTemplate("Private-Package-Notice-Template.md");
+			break;
+		case "TOOLS":
+			rawContents = readTemplate("Tools-Package-Notice-Template.md");
+			break;
 		default:
 			return undefined;
 	}
+
+	return formattedSectionText(rawContents, /* headingOptions: */ undefined);
 };
 
 /**


### PR DESCRIPTION
Adds auto-generated usage notice for `@fluid-tools` packages.

> **NOTE: This package is a library intended for use within the [microsoft/FluidFramework](https://github.com/microsoft/FluidFramework) repository.**
> **It is not intended for public use.**
> **We make no stability guarantees regarding this library and its APIs.**