### PR TITLE
tree: Make "SharedTree memory usage" fast when not in perf mode

### DIFF
--- a/packages/dds/tree/src/test/memory/tree.spec.ts
+++ b/packages/dds/tree/src/test/memory/tree.spec.ts
@@ -4,7 +4,11 @@
  */
 
 import { strict as assert } from "assert";
-import { type IMemoryTestObject, benchmarkMemory } from "@fluid-tools/benchmark";
+import {
+	type IMemoryTestObject,
+	benchmarkMemory,
+	isInPerformanceTestingMode,
+} from "@fluid-tools/benchmark";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 import { testIdCompressor } from "../utils.js";
 
@@ -86,7 +90,10 @@ describe("SharedTree memory usage", () => {
 		})(),
 	);
 
-	const numbersOfEntriesForTests = [1000, 10_000, 100_000];
+	const numbersOfEntriesForTests = isInPerformanceTestingMode
+		? [1000, 10_000, 100_000]
+		: // When not measuring perf, use a single smaller data size so the tests run faster.
+			[10];
 
 	for (const x of numbersOfEntriesForTests) {
 		benchmarkMemory(


### PR DESCRIPTION
## Description

This makes running the "SharedTree memory usage" in correctness mode take ~25ms instead of ~23 seconds, so about 1000 times faster.

Since this test suite was taking a lot longer than our other tests, this makes running the tree test suite faster.

This should not impact when running the performance tests in performance mode to actually collect data.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
