### PR TITLE
Deprecate summarizeProtocolTree in ILoaderOptions

### DIFF
--- a/.changeset/many-moments-juggle.md
+++ b/.changeset/many-moments-juggle.md
@@ -4,4 +4,4 @@
 
 Deprecated summarizeProtocolTree and it's corresponding duplicate ILoaderOptions definition from container layer.
 
-summarizeProtocolTree property in ILoaderOptions was added to test single-commit summaries during the initial implementation phase. The flag is no longer required or should be used, so marked it as deprecated. If a driver needs to enable or disable single-commit summaries, it can do so via IDocumentServicePolicies.
+summarizeProtocolTree property in ILoaderOptions was added to test single-commit summaries during the initial implementation phase. The flag is no longer required and should no longer be used, so marked it as deprecated. If a driver needs to enable or disable single-commit summaries, it can do so via IDocumentServicePolicies.

--- a/.changeset/many-moments-juggle.md
+++ b/.changeset/many-moments-juggle.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-loader": minor
+---
+
+Deprecated summarizeProtocolTree and it's corresponding duplicate ILoaderOptions definition from container layer.
+
+summarizeProtocolTree property in ILoaderOptions was added to test single-commit summaries during the initial implementation phase. The flag is no longer required or should be used, so marked it as deprecated. If a driver needs to enable or disable single-commit summaries, it can do so via IDocumentServicePolicies.

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -48,9 +48,9 @@ export interface IFluidModuleWithDetails {
     module: IFluidModule;
 }
 
-// @alpha (undocumented)
+// @alpha @deprecated (undocumented)
 export interface ILoaderOptions extends ILoaderOptions_2 {
-    // (undocumented)
+    // @deprecated (undocumented)
     summarizeProtocolTree?: boolean;
 }
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -221,6 +221,7 @@ export interface IContainerCreateProps {
 	 * A property bag of options used by various layers
 	 * to control features
 	 */
+	// eslint-disable-next-line import/no-deprecated
 	readonly options: ILoaderOptions;
 
 	/**
@@ -482,6 +483,7 @@ export class Container
 	private readonly urlResolver: IUrlResolver;
 	private readonly serviceFactory: IDocumentServiceFactory;
 	private readonly codeLoader: ICodeDetailsLoader;
+	// eslint-disable-next-line import/no-deprecated
 	private readonly options: ILoaderOptions;
 	private readonly scope: FluidObject;
 	private readonly subLogger: ITelemetryLoggerExt;

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -93,14 +93,14 @@ export class RelativeLoader implements ILoader {
 /**
  * @legacy
  * @alpha
- * @deprecated
+ * @deprecated Use ILoaderOptions from container-definitions instead
  */
 export interface ILoaderOptions extends ILoaderOptions1 {
 	/**
-	 * Used to enable including of protocol tree in the summaries.
-	 * This flag was introduced for initial testing and controlled rollout of single-commit summaries.
+	 *
+	 * @deprecated No longer needed or used (initially introduced to test single-commit summaries).
+	 * Driver layer can enable single-commit summaries via document service policies if needed.
 	 * ADO #9098: To remove declaration and usage from code.
-	 * @deprecated
 	 */
 	summarizeProtocolTree?: boolean;
 }

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -93,8 +93,15 @@ export class RelativeLoader implements ILoader {
 /**
  * @legacy
  * @alpha
+ * @deprecated
  */
 export interface ILoaderOptions extends ILoaderOptions1 {
+	/**
+	 * Used to enable including of protocol tree in the summaries.
+	 * This flag was introduced for initial testing and controlled rollout of single-commit summaries.
+	 * ADO #9098: To remove declaration and usage from code.
+	 * @deprecated
+	 */
 	summarizeProtocolTree?: boolean;
 }
 

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -93,7 +93,7 @@ export class RelativeLoader implements ILoader {
 /**
  * @legacy
  * @alpha
- * @deprecated Use ILoaderOptions from container-definitions instead
+ * @deprecated Use {@link @fluidframework/container-definitions#ILoaderOptions} instead
  */
 export interface ILoaderOptions extends ILoaderOptions1 {
 	/**

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -10,6 +10,7 @@ import {
 	generatePairwiseOptions,
 	numberCases,
 } from "@fluid-private/test-pairwise-generator";
+// eslint-disable-next-line import/no-deprecated
 import { ILoaderOptions } from "@fluidframework/container-loader/internal";
 import {
 	CompressionAlgorithms,
@@ -22,6 +23,7 @@ import { LoggingError } from "@fluidframework/telemetry-utils/internal";
 
 import { ILoadTestConfig, OptionOverride } from "./testConfigFile.js";
 
+// eslint-disable-next-line import/no-deprecated
 interface ILoaderOptionsExperimental extends ILoaderOptions {
 	enableOfflineSnapshotRefresh?: boolean;
 	snapshotRefreshTimeoutMs?: number;
@@ -32,6 +34,7 @@ const loaderOptionsMatrix: OptionsMatrix<ILoaderOptionsExperimental> = {
 	client: [undefined],
 	provideScopeLoader: booleanCases,
 	maxClientLeaveWaitTime: numberCases,
+	summarizeProtocolTree: [undefined],
 	enableOfflineLoad: booleanCases,
 	enableOfflineSnapshotRefresh: booleanCases,
 	snapshotRefreshTimeoutMs: [undefined, 60 * 5 * 1000 /* 5min */],

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -32,7 +32,6 @@ const loaderOptionsMatrix: OptionsMatrix<ILoaderOptionsExperimental> = {
 	client: [undefined],
 	provideScopeLoader: booleanCases,
 	maxClientLeaveWaitTime: numberCases,
-	summarizeProtocolTree: [undefined],
 	enableOfflineLoad: booleanCases,
 	enableOfflineSnapshotRefresh: booleanCases,
 	snapshotRefreshTimeoutMs: [undefined, 60 * 5 * 1000 /* 5min */],


### PR DESCRIPTION
Marked `summarizeProtocolTree` as deprecated in the extended `ILoaderOptions` in container layer. Also created an ADO item to remove the declaration and it's usage in the future versions when we can alter the alpha apis.

summarizeProtocolTree property in ILoaderOptions (the extended definition in container layer) was added to test single-commit summaries during the initial implementation phase. The flag is no longer required or should be used, so marked it as deprecated. If a driver needs to enable or disable single-commit summaries, it can do so via IDocumentServicePolicies.