### PR TITLE
refactor: Reduce number of iterations for memory benchmarks when not running in perf mode

### DIFF
--- a/experimental/dds/attributable-map/src/test/memory/map.spec.ts
+++ b/experimental/dds/attributable-map/src/test/memory/map.spec.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { IMemoryTestObject, benchmarkMemory } from "@fluid-tools/benchmark";
+import {
+	type IMemoryTestObject,
+	benchmarkMemory,
+	isInPerformanceTestingMode,
+} from "@fluid-tools/benchmark";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import type { ISharedMap } from "../../interfaces.js";
@@ -50,7 +54,10 @@ describe("SharedMap memory usage", () => {
 		})(),
 	);
 
-	const numbersOfEntriesForTests = [1000, 10_000, 100_000];
+	const numbersOfEntriesForTests = isInPerformanceTestingMode
+		? [1000, 10_000, 100_000]
+		: // When not measuring perf, use a single smaller data size so the tests run faster.
+			[10];
 
 	for (const x of numbersOfEntriesForTests) {
 		benchmarkMemory(

--- a/packages/dds/map/src/test/memory/directory.spec.ts
+++ b/packages/dds/map/src/test/memory/directory.spec.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { type IMemoryTestObject, benchmarkMemory } from "@fluid-tools/benchmark";
+import {
+	type IMemoryTestObject,
+	benchmarkMemory,
+	isInPerformanceTestingMode,
+} from "@fluid-tools/benchmark";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import { type ISharedDirectory, SharedDirectory } from "../../index.js";
@@ -48,7 +52,10 @@ describe("SharedDirectory memory usage", () => {
 		})(),
 	);
 
-	const numbersOfEntriesForTests = [1000, 10_000, 100_000];
+	const numbersOfEntriesForTests = isInPerformanceTestingMode
+		? [1000, 10_000, 100_000]
+		: // When not measuring perf, use a single smaller data size so the tests run faster.
+			[10];
 
 	for (const x of numbersOfEntriesForTests) {
 		benchmarkMemory(

--- a/packages/dds/map/src/test/memory/map.spec.ts
+++ b/packages/dds/map/src/test/memory/map.spec.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { type IMemoryTestObject, benchmarkMemory } from "@fluid-tools/benchmark";
+import {
+	type IMemoryTestObject,
+	benchmarkMemory,
+	isInPerformanceTestingMode,
+} from "@fluid-tools/benchmark";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
 import { type ISharedMap, SharedMap } from "../../index.js";
@@ -48,7 +52,10 @@ describe("SharedMap memory usage", () => {
 		})(),
 	);
 
-	const numbersOfEntriesForTests = [1000, 10_000, 100_000];
+	const numbersOfEntriesForTests = isInPerformanceTestingMode
+		? [1000, 10_000, 100_000]
+		: // When not measuring perf, use a single smaller data size so the tests run faster.
+			[10];
 
 	for (const x of numbersOfEntriesForTests) {
 		benchmarkMemory(

--- a/packages/dds/matrix/src/test/memory/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/matrix.spec.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { IMemoryTestObject, benchmarkMemory } from "@fluid-tools/benchmark";
+import {
+	type IMemoryTestObject,
+	benchmarkMemory,
+	isInPerformanceTestingMode,
+} from "@fluid-tools/benchmark";
 import type { IChannel } from "@fluidframework/datastore-definitions/internal";
 import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
 
@@ -47,7 +51,10 @@ describe("Matrix memory usage", () => {
 			})(),
 		);
 
-		const numbersOfEntriesForTests = [100, 1000, 5000];
+		const numbersOfEntriesForTests = isInPerformanceTestingMode
+			? [1000, 10_000, 100_000]
+			: // When not measuring perf, use a single smaller data size so the tests run faster.
+				[10];
 
 		for (const x of numbersOfEntriesForTests) {
 			benchmarkMemory(

--- a/packages/dds/sequence/src/test/memory/sharedSequence.spec.ts
+++ b/packages/dds/sequence/src/test/memory/sharedSequence.spec.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { IMemoryTestObject, benchmarkMemory } from "@fluid-tools/benchmark";
+import {
+	type IMemoryTestObject,
+	benchmarkMemory,
+	isInPerformanceTestingMode,
+} from "@fluid-tools/benchmark";
 
 import { SubSequence } from "../../sharedSequence.js";
 
@@ -39,7 +43,10 @@ describe("SharedSequence memory usage", () => {
 		})(),
 	);
 
-	const numbersOfEntriesForTests = [100, 1000, 10_000];
+	const numbersOfEntriesForTests = isInPerformanceTestingMode
+		? [1000, 10_000, 100_000]
+		: // When not measuring perf, use a single smaller data size so the tests run faster.
+			[10];
 
 	numbersOfEntriesForTests.forEach((x) => {
 		benchmarkMemory(

--- a/packages/dds/sequence/src/test/memory/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/memory/sharedString.spec.ts
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { IMemoryTestObject, benchmarkMemory } from "@fluid-tools/benchmark";
+import {
+	type IMemoryTestObject,
+	benchmarkMemory,
+	isInPerformanceTestingMode,
+} from "@fluid-tools/benchmark";
 import {
 	Marker,
 	ReferenceType,
@@ -54,7 +58,10 @@ describe("SharedString memory usage", () => {
 		})(),
 	);
 
-	const numbersOfEntriesForTests = [100, 1000, 10_000];
+	const numbersOfEntriesForTests = isInPerformanceTestingMode
+		? [1000, 10_000, 100_000]
+		: // When not measuring perf, use a single smaller data size so the tests run faster.
+			[10];
 
 	numbersOfEntriesForTests.forEach((x) => {
 		benchmarkMemory(


### PR DESCRIPTION
## Description

Reduces the number of iterations done for memory benchmarks when they're not running in perf mode. Saves a bit of time when running unit tests normally. Same kind of change as in https://github.com/microsoft/FluidFramework/pull/21996.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

