### PR TITLE
Minor improvements to stress test

### DIFF
--- a/packages/test/test-service-load/src/getProfile.ts
+++ b/packages/test/test-service-load/src/getProfile.ts
@@ -8,19 +8,14 @@ import fs from "fs";
 import type { TestConfiguration, TestConfigurationFileContents } from "./testConfigFile.js";
 
 export function getProfile(profileName: string): TestConfiguration {
-	let config: TestConfigurationFileContents;
-	try {
-		config = JSON.parse(fs.readFileSync("./testConfig.json", "utf-8"));
-	} catch (error) {
-		console.error("Failed to read testConfig.json");
-		console.error(error);
-		process.exit(-1);
-	}
+	const config: TestConfigurationFileContents = JSON.parse(
+		fs.readFileSync("./testConfig.json", "utf-8"),
+	);
+	// TODO: Consider validating the file contents.
 
 	const profile: TestConfiguration | undefined = config.profiles[profileName];
 	if (profile === undefined) {
-		console.error("Invalid --profile argument not found in testConfig.json profiles");
-		process.exit(-1);
+		throw new Error("Invalid --profile argument not found in testConfig.json profiles");
 	}
 	return profile;
 }

--- a/packages/test/test-service-load/src/getProfile.ts
+++ b/packages/test/test-service-load/src/getProfile.ts
@@ -7,7 +7,7 @@ import fs from "fs";
 
 import type { TestConfiguration, TestConfigurationFileContents } from "./testConfigFile.js";
 
-export function getProfile(profileName: string) {
+export function getProfile(profileName: string): TestConfiguration {
 	let config: TestConfigurationFileContents;
 	try {
 		config = JSON.parse(fs.readFileSync("./testConfig.json", "utf-8"));

--- a/packages/test/test-service-load/src/getProfile.ts
+++ b/packages/test/test-service-load/src/getProfile.ts
@@ -5,19 +5,19 @@
 
 import fs from "fs";
 
-import { ILoadTestConfig, ITestConfig } from "./testConfigFile.js";
+import type { ILoadTestConfig, ITestConfig } from "./testConfigFile.js";
 
-export function getProfile(profileArg: string) {
+export function getProfile(profileName: string) {
 	let config: ITestConfig;
 	try {
 		config = JSON.parse(fs.readFileSync("./testConfig.json", "utf-8"));
-	} catch (e) {
+	} catch (error) {
 		console.error("Failed to read testConfig.json");
-		console.error(e);
+		console.error(error);
 		process.exit(-1);
 	}
 
-	const profile: ILoadTestConfig | undefined = config.profiles[profileArg];
+	const profile: ILoadTestConfig | undefined = config.profiles[profileName];
 	if (profile === undefined) {
 		console.error("Invalid --profile argument not found in testConfig.json profiles");
 		process.exit(-1);

--- a/packages/test/test-service-load/src/getProfile.ts
+++ b/packages/test/test-service-load/src/getProfile.ts
@@ -5,10 +5,10 @@
 
 import fs from "fs";
 
-import type { ILoadTestConfig, ITestConfig } from "./testConfigFile.js";
+import type { TestConfiguration, TestConfigurationFileContents } from "./testConfigFile.js";
 
 export function getProfile(profileName: string) {
-	let config: ITestConfig;
+	let config: TestConfigurationFileContents;
 	try {
 		config = JSON.parse(fs.readFileSync("./testConfig.json", "utf-8"));
 	} catch (error) {
@@ -17,7 +17,7 @@ export function getProfile(profileName: string) {
 		process.exit(-1);
 	}
 
-	const profile: ILoadTestConfig | undefined = config.profiles[profileName];
+	const profile: TestConfiguration | undefined = config.profiles[profileName];
 	if (profile === undefined) {
 		console.error("Invalid --profile argument not found in testConfig.json profiles");
 		process.exit(-1);

--- a/packages/test/test-service-load/src/getTestUsers.ts
+++ b/packages/test/test-service-load/src/getTestUsers.ts
@@ -43,21 +43,16 @@ export interface TestUser {
 export type TestUsers = TestUser[];
 
 export function getTestUsers(credFilePath: string): TestUsers {
-	try {
-		const contents = JSON.parse(fs.readFileSync(credFilePath, "utf8"));
-		if (!isTestUserFileContents(contents)) {
-			throw new Error("credFile provided, but incorrect format");
-		}
-		const testUsers = Object.entries(contents.credentials).map(([username, password]) => ({
-			username,
-			password,
-		}));
-		if (testUsers.length === 0) {
-			throw new Error("credFile contained no credentials");
-		}
-		return testUsers;
-	} catch (error) {
-		console.error(`Failed to read ${credFilePath}`);
-		throw error;
+	const contents = JSON.parse(fs.readFileSync(credFilePath, "utf8"));
+	if (!isTestUserFileContents(contents)) {
+		throw new Error("credFile provided, but incorrect format");
 	}
+	const testUsers = Object.entries(contents.credentials).map(([username, password]) => ({
+		username,
+		password,
+	}));
+	if (testUsers.length === 0) {
+		throw new Error("credFile contained no credentials");
+	}
+	return testUsers;
 }

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -33,14 +33,14 @@ import { toDeltaManagerInternal } from "@fluidframework/runtime-utils/internal";
 import { ITaskManager, TaskManager } from "@fluidframework/task-manager/internal";
 import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 
-import { ILoadTestConfig } from "./testConfigFile.js";
+import type { TestConfiguration } from "./testConfigFile.js";
 import { printStatus } from "./utils.js";
 import { VirtualDataStoreFactory, type VirtualDataStore } from "./virtualDataStore.js";
 
 export interface IRunConfig {
 	runId: number;
 	profileName: string;
-	testConfig: ILoadTestConfig;
+	testConfig: TestConfiguration;
 	verbose: boolean;
 	random: IRandom;
 	logger: ITelemetryLoggerExt;

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -70,7 +70,7 @@ const defaultBlobSize = 1024;
  * and provide common abstractions for workload scheduling
  * via task picking.
  */
-export class LoadTestDataStoreModel {
+class LoadTestDataStoreModel {
 	private static async waitForCatchupOrDispose(
 		runtime: IFluidDataStoreRuntime,
 	): Promise<void> {

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -947,7 +947,7 @@ const LoadTestDataStoreInstantiationFactory = new DataObjectFactory(
 	{},
 );
 
-export const createFluidExport = (runtimeOptions: IContainerRuntimeOptions) =>
+export const createFluidExport = (runtimeOptions?: IContainerRuntimeOptions | undefined) =>
 	new ContainerRuntimeFactoryWithDefaultDataStore({
 		defaultFactory: LoadTestDataStoreInstantiationFactory,
 		registryEntries: [

--- a/packages/test/test-service-load/src/main.ts
+++ b/packages/test/test-service-load/src/main.ts
@@ -55,11 +55,11 @@ async function main() {
 	const enableMetrics: boolean = commander.enableMetrics ?? false;
 	const createTestId: boolean = commander.createTestId ?? false;
 
-	const profile = getProfile(profileName);
-
 	if (log !== undefined) {
 		process.env.DEBUG = log;
 	}
+
+	const profile = getProfile(profileName);
 
 	const testUsers = credFilePath !== undefined ? getTestUsers(credFilePath) : undefined;
 

--- a/packages/test/test-service-load/src/main.ts
+++ b/packages/test/test-service-load/src/main.ts
@@ -11,7 +11,7 @@ import { getTestUsers } from "./getTestUsers.js";
 import { stressTest } from "./stressTest.js";
 import { createTestDriver } from "./utils.js";
 
-async function main() {
+function readRunOptions() {
 	commander
 		.version("0.0.1")
 		.requiredOption("-d, --driver <driver>", "Which test driver info to use", "odsp")
@@ -54,6 +54,38 @@ async function main() {
 	const credFilePath: string | undefined = commander.credFile;
 	const enableMetrics: boolean = commander.enableMetrics ?? false;
 	const createTestId: boolean = commander.createTestId ?? false;
+
+	return {
+		driver,
+		endpoint,
+		profileName,
+		testId,
+		debug,
+		log,
+		verbose,
+		seed,
+		supportsBrowserAuth,
+		credFilePath,
+		enableMetrics,
+		createTestId,
+	};
+}
+
+async function main() {
+	const {
+		driver,
+		endpoint,
+		profileName,
+		testId,
+		debug,
+		log,
+		verbose,
+		seed,
+		supportsBrowserAuth,
+		credFilePath,
+		enableMetrics,
+		createTestId,
+	} = readRunOptions();
 
 	if (log !== undefined) {
 		process.env.DEBUG = log;

--- a/packages/test/test-service-load/src/main.ts
+++ b/packages/test/test-service-load/src/main.ts
@@ -46,12 +46,12 @@ async function main() {
 	const endpoint: DriverEndpoint | undefined = commander.driverEndpoint;
 	const profileName: string = commander.profile;
 	const testId: string | undefined = commander.testId;
-	const debug: true | undefined = commander.debug;
+	const debug: boolean = commander.debug ?? false;
 	const log: string | undefined = commander.log;
-	const verbose: true | undefined = commander.verbose;
+	const verbose: boolean = commander.verbose ?? false;
 	const seed: number = commander.seed ?? Date.now();
-	const browserAuth: true | undefined = commander.browserAuth;
-	const credFile: string | undefined = commander.credFile;
+	const supportsBrowserAuth: boolean = commander.browserAuth ?? false;
+	const credFilePath: string | undefined = commander.credFile;
 	const enableMetrics: boolean = commander.enableMetrics ?? false;
 	const createTestId: boolean = commander.createTestId ?? false;
 
@@ -61,9 +61,15 @@ async function main() {
 		process.env.DEBUG = log;
 	}
 
-	const testUsers = await getTestUsers(credFile);
+	const testUsers = await getTestUsers(credFilePath);
 
-	const testDriver = await createTestDriver(driver, endpoint, seed, undefined, browserAuth);
+	const testDriver = await createTestDriver(
+		driver,
+		endpoint,
+		seed,
+		undefined, // runId
+		supportsBrowserAuth,
+	);
 
 	await stressTest(testDriver, profile, {
 		testId,

--- a/packages/test/test-service-load/src/main.ts
+++ b/packages/test/test-service-load/src/main.ts
@@ -11,7 +11,7 @@ import { getTestUsers } from "./getTestUsers.js";
 import { stressTest } from "./stressTest.js";
 import { createTestDriver } from "./utils.js";
 
-function readRunOptions() {
+const readRunOptions = () => {
 	commander
 		.version("0.0.1")
 		.requiredOption("-d, --driver <driver>", "Which test driver info to use", "odsp")
@@ -69,9 +69,9 @@ function readRunOptions() {
 		enableMetrics,
 		createTestId,
 	};
-}
+};
 
-async function main() {
+const main = async () => {
 	const {
 		driver,
 		endpoint,
@@ -113,7 +113,7 @@ async function main() {
 		testUsers,
 		profileName,
 	});
-}
+};
 
 main().catch((error) => {
 	console.error(error);

--- a/packages/test/test-service-load/src/main.ts
+++ b/packages/test/test-service-load/src/main.ts
@@ -61,7 +61,7 @@ async function main() {
 		process.env.DEBUG = log;
 	}
 
-	const testUsers = await getTestUsers(credFilePath);
+	const testUsers = credFilePath !== undefined ? getTestUsers(credFilePath) : undefined;
 
 	const testDriver = await createTestDriver(
 		driver,

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -20,7 +20,7 @@ import {
 import { ConfigTypes } from "@fluidframework/core-interfaces";
 import { LoggingError } from "@fluidframework/telemetry-utils/internal";
 
-import { ILoadTestConfig, OptionOverride } from "./testConfigFile.js";
+import type { OptionOverride, TestConfiguration } from "./testConfigFile.js";
 
 interface ILoaderOptionsExperimental extends ILoaderOptions {
 	enableOfflineSnapshotRefresh?: boolean;
@@ -142,7 +142,7 @@ export function generateConfigurations(
  * @returns an option override
  */
 export function getOptionOverride(
-	testConfig: ILoadTestConfig | undefined,
+	testConfig: TestConfiguration | undefined,
 	driverType: TestDriverTypes,
 	endpoint: string | undefined,
 ): OptionOverride | undefined {

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -84,11 +84,11 @@ async function main() {
 	const seed: number = commander.seed;
 	const enableOpsMetrics: boolean = commander.enableOpsMetrics ?? false;
 
-	const profile = getProfile(profileName);
-
 	if (log !== undefined) {
 		process.env.DEBUG = log;
 	}
+
+	const profile = getProfile(profileName);
 
 	if (url === undefined) {
 		console.error("Missing --url argument needed to run child process");

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -204,6 +204,7 @@ async function runnerProcess(
 		endpoint,
 		seed,
 		runConfig.runId,
+		false, // supportsBrowserAuth
 	);
 
 	// Cycle between creating new factory vs. reusing factory.

--- a/packages/test/test-service-load/src/stressTest.ts
+++ b/packages/test/test-service-load/src/stressTest.ts
@@ -10,8 +10,8 @@ import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import ps from "ps-node";
 
 import { FileLogger } from "./FileLogger.js";
-import { type ITestUserConfig } from "./getTestUsers.js";
-import { ILoadTestConfig } from "./testConfigFile.js";
+import type { ITestUserConfig } from "./getTestUsers.js";
+import type { TestConfiguration } from "./testConfigFile.js";
 import { initialize, safeExit } from "./utils.js";
 
 const createLoginEnv = (userName: string, password: string) =>
@@ -22,7 +22,7 @@ const createLoginEnv = (userName: string, password: string) =>
  */
 export async function stressTest(
 	testDriver: ITestDriver,
-	profile: ILoadTestConfig,
+	profile: TestConfiguration,
 	args: {
 		testId: string | undefined;
 		debug: boolean;

--- a/packages/test/test-service-load/src/stressTest.ts
+++ b/packages/test/test-service-load/src/stressTest.ts
@@ -158,7 +158,7 @@ function setupTelemetry(
 	process: child_process.ChildProcess,
 	logger: ITelemetryLoggerExt,
 	runId: number,
-	username?: string,
+	username: string | undefined,
 ) {
 	logger.send({
 		category: "metric",

--- a/packages/test/test-service-load/src/stressTest.ts
+++ b/packages/test/test-service-load/src/stressTest.ts
@@ -34,20 +34,13 @@ export async function stressTest(
 		profileName: string;
 	},
 ) {
-	const url = await (args.testId !== undefined && args.createTestId === false
+	const url = await (args.testId !== undefined && !args.createTestId
 		? // If testId is provided and createTestId is false, then load the file;
 			testDriver.createContainerUrl(args.testId)
-		: // If no testId is provided, (or) if testId is provided but createTestId is not false, then
+		: // If no testId is provided, (or) if testId is provided but createTestId is true, then
 			// create a file;
 			// In case testId is provided, name of the file to be created is taken as the testId provided
-			initialize(
-				testDriver,
-				args.seed,
-				profile,
-				args.verbose === true,
-				args.profileName,
-				args.testId,
-			));
+			initialize(testDriver, args.seed, profile, args.verbose, args.profileName, args.testId));
 
 	const estRunningTimeMin = Math.floor(
 		(2 * profile.totalSendCount) / (profile.opRatePerMin * profile.numClients),
@@ -80,14 +73,14 @@ export async function stressTest(
 			"--seed",
 			`0x${args.seed.toString(16)}`,
 		];
-		if (args.debug === true) {
+		if (args.debug) {
 			const debugPort = 9230 + i; // 9229 is the default and will be used for the root orchestrator process
 			childArgs.unshift(`--inspect-brk=${debugPort}`);
 		}
-		if (args.verbose === true) {
+		if (args.verbose) {
 			childArgs.push("--verbose");
 		}
-		if (args.enableMetrics === true) {
+		if (args.enableMetrics) {
 			childArgs.push("--enableOpsMetrics");
 		}
 
@@ -99,7 +92,7 @@ export async function stressTest(
 	}
 	console.log(runnerArgs.map((a) => a.join(" ")).join("\n"));
 
-	if (args.enableMetrics === true) {
+	if (args.enableMetrics) {
 		setInterval(() => {
 			ps.lookup(
 				{
@@ -143,7 +136,7 @@ export async function stressTest(
 				});
 
 				setupTelemetry(runnerProcess, logger, index, username);
-				if (args.enableMetrics === true) {
+				if (args.enableMetrics) {
 					setupDataTelemetry(runnerProcess, logger, index, username);
 				}
 

--- a/packages/test/test-service-load/src/stressTest.ts
+++ b/packages/test/test-service-load/src/stressTest.ts
@@ -10,7 +10,7 @@ import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import ps from "ps-node";
 
 import { FileLogger } from "./FileLogger.js";
-import type { ITestUserConfig } from "./getTestUsers.js";
+import type { TestUsers } from "./getTestUsers.js";
 import type { TestConfiguration } from "./testConfigFile.js";
 import { initialize, safeExit } from "./utils.js";
 
@@ -30,7 +30,7 @@ export async function stressTest(
 		seed: number;
 		enableMetrics: boolean;
 		createTestId: boolean;
-		testUsers: ITestUserConfig | undefined;
+		testUsers: TestUsers | undefined;
 		profileName: string;
 	},
 ) {
@@ -114,14 +114,14 @@ export async function stressTest(
 	}
 
 	try {
-		const usernames =
-			args.testUsers !== undefined ? Object.keys(args.testUsers.credentials) : undefined;
 		await Promise.all(
 			runnerArgs.map(async (childArgs, index) => {
-				const username =
-					usernames !== undefined ? usernames[index % usernames.length] : undefined;
-				const password =
-					username !== undefined ? args.testUsers?.credentials[username] : undefined;
+				const testUser =
+					args.testUsers !== undefined
+						? args.testUsers[index % args.testUsers.length]
+						: undefined;
+				const username = testUser !== undefined ? testUser.username : undefined;
+				const password = testUser !== undefined ? testUser.password : undefined;
 				const envVar = { ...process.env };
 				if (username !== undefined && password !== undefined) {
 					if (testDriver.endpointName === "odsp") {

--- a/packages/test/test-service-load/src/stressTest.ts
+++ b/packages/test/test-service-load/src/stressTest.ts
@@ -24,13 +24,13 @@ export async function stressTest(
 	testDriver: ITestDriver,
 	profile: ILoadTestConfig,
 	args: {
-		testId?: string;
-		debug?: true;
-		verbose?: true;
+		testId: string | undefined;
+		debug: boolean;
+		verbose: boolean;
 		seed: number;
-		enableMetrics?: boolean;
-		createTestId?: boolean;
-		testUsers?: ITestUserConfig;
+		enableMetrics: boolean;
+		createTestId: boolean;
+		testUsers: ITestUserConfig | undefined;
 		profileName: string;
 	},
 ) {

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -9,12 +9,12 @@ import { IContainerRuntimeOptions } from "@fluidframework/container-runtime/inte
 import { ConfigTypes } from "@fluidframework/core-interfaces";
 
 /** Type modeling the structure of the testConfig.json file */
-export interface ITestConfig {
-	profiles: { [name: string]: ILoadTestConfig | undefined };
+export interface TestConfigurationFileContents {
+	profiles: { [profileName: string]: TestConfiguration };
 }
 
 /** Type modeling the profile sub-structure of the testConfig.json file */
-export interface ILoadTestConfig {
+export interface TestConfiguration {
 	opRatePerMin: number;
 	progressIntervalMs: number;
 	numClients: number;

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -41,7 +41,7 @@ const codeDetails: IFluidCodeDetails = {
 	config: {},
 };
 
-export const createCodeLoader = (options: IContainerRuntimeOptions) =>
+export const createCodeLoader = (options?: IContainerRuntimeOptions | undefined) =>
 	new LocalCodeLoader([[codeDetails, createFluidExport(options)]]);
 
 // eslint-disable-next-line import/no-deprecated
@@ -75,7 +75,7 @@ export async function initialize(
 	testConfig: ILoadTestConfig,
 	verbose: boolean,
 	profileName: string,
-	testIdn?: string,
+	requestedTestId?: string,
 ) {
 	const random = makeRandom(seed);
 	const optionsOverride = getOptionOverride(
@@ -85,7 +85,7 @@ export async function initialize(
 	);
 
 	const loaderOptions = random.pick(generateLoaderOptions(seed, optionsOverride?.loader));
-	const containerOptions = random.pick(
+	const containerRuntimeOptions = random.pick(
 		generateRuntimeOptions(seed, optionsOverride?.container),
 	);
 	const configurations = random.pick(
@@ -103,7 +103,7 @@ export async function initialize(
 		eventName: "RunConfigOptions",
 		details: JSON.stringify({
 			loaderOptions,
-			containerOptions,
+			containerOptions: containerRuntimeOptions,
 			configurations: { ...globalConfigurations, ...configurations },
 		}),
 	});
@@ -112,7 +112,7 @@ export async function initialize(
 	const loader = new Loader({
 		urlResolver: testDriver.createUrlResolver(),
 		documentServiceFactory: testDriver.createDocumentServiceFactory(),
-		codeLoader: createCodeLoader(containerOptions),
+		codeLoader: createCodeLoader(containerRuntimeOptions),
 		logger,
 		options: loaderOptions,
 		detachedBlobStorage: new MockDetachedBlobStorage(),
@@ -134,7 +134,7 @@ export async function initialize(
 		}
 	}
 
-	const testId = testIdn ?? Date.now().toString();
+	const testId = requestedTestId ?? Date.now().toString();
 	assert(testId !== "", "testId specified cannot be an empty string");
 	const request = testDriver.createCreateNewRequest(testId);
 	await container.attach(request);

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -32,7 +32,7 @@ import {
 	getOptionOverride,
 } from "./optionsMatrix.js";
 import { pkgName, pkgVersion } from "./packageVersion.js";
-import { ILoadTestConfig } from "./testConfigFile.js";
+import type { TestConfiguration } from "./testConfigFile.js";
 
 const packageName = `${pkgName}@${pkgVersion}`;
 
@@ -72,7 +72,7 @@ class MockDetachedBlobStorage implements IDetachedBlobStorage {
 export async function initialize(
 	testDriver: ITestDriver,
 	seed: number,
-	testConfig: ILoadTestConfig,
+	testConfig: TestConfiguration,
 	verbose: boolean,
 	profileName: string,
 	requestedTestId?: string,

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -24,7 +24,7 @@ import { ICreateBlobResponse } from "@fluidframework/driver-definitions/internal
 import { LocalCodeLoader } from "@fluidframework/test-utils/internal";
 
 import { FileLogger } from "./FileLogger.js";
-import { ILoadTest, createFluidExport, type IRunConfig } from "./loadTestDataStore.js";
+import { createFluidExport, type ILoadTest, type IRunConfig } from "./loadTestDataStore.js";
 import {
 	generateConfigurations,
 	generateLoaderOptions,

--- a/packages/test/test-service-load/src/utils.ts
+++ b/packages/test/test-service-load/src/utils.ts
@@ -154,7 +154,7 @@ export async function createTestDriver(
 	endpointName: DriverEndpoint | undefined,
 	seed: number,
 	runId: number | undefined,
-	supportsBrowserAuth?: true,
+	supportsBrowserAuth: boolean,
 ) {
 	const options = generateOdspHostStoragePolicy(seed);
 	return createFluidTestDriver(driver, {


### PR DESCRIPTION
More staging for #21926, this PR makes a collection of minor improvements to the stress test, but does not yet add the smoke test.

Summary of the changes:
1. Have getProfile throw normally rather than directly exiting the process (which would now happen in main() instead).  Ensure env.DEBUG is set before this can happen.
2. Encapsulate the expected file format of TestUsers to getTestUsers.ts.  Callers now get an array of easy-to-use TestUser objects instead.  Also add some file format validation that's maybe a little over the top.
    * Similar to getProfile, prefer to throw and exit on read failure rather than silently proceed without the test users.
3. Convert command-line args to more convenient types earlier, e.g. `boolean` rather than `true | undefined`.
4. Container runtime options are optional, reflect that in the typing
5. Various renames for clarity
6. Generally prefer `type` imports in places where I'm making changes.