### PR TITLE
feat(fluid-build): Support additional executable names

### DIFF
--- a/build-tools/packages/build-cli/src/commands/list.ts
+++ b/build-tools/packages/build-cli/src/commands/list.ts
@@ -110,7 +110,7 @@ export default class ListCommand extends BaseCommand<typeof ListCommand> {
 				const config = context.rootFluidBuildConfig?.policy?.packageNames;
 				if (config === undefined) {
 					// exits the process
-					this.error(`No fluid-build package name policy config found.`);
+					this.error(`No package name policy config found.`);
 				}
 
 				if (feed === undefined) {

--- a/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
+++ b/build-tools/packages/build-cli/src/library/repoPolicyCheck/npmPackages.ts
@@ -11,6 +11,7 @@ import { createRequire } from "node:module";
 import { EOL as newline } from "node:os";
 import path from "node:path";
 import * as readline from "node:readline";
+import { isFluidBuildScript } from "@fluidframework/build-tools";
 import { writeJson } from "fs-extra/esm";
 import replace from "replace-in-file";
 import sortPackageJson from "sort-package-json";
@@ -1573,7 +1574,7 @@ export const handlers: Handler[] = [
 			// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 			if (cleanScript) {
 				// Ignore clean scripts that are root of the release group
-				if (cleanScript.startsWith("pnpm") || cleanScript.startsWith("fluid-build")) {
+				if (cleanScript.startsWith("pnpm") || isFluidBuildScript(cleanScript)) {
 					return undefined;
 				}
 
@@ -2005,8 +2006,7 @@ function missingCleanDirectories(scripts: { [key: string]: string | undefined })
 		expectedClean.push("lib");
 	}
 
-	// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-	if (scripts.build?.startsWith("fluid-build")) {
+	if (isFluidBuildScript(scripts.build)) {
 		expectedClean.push("*.tsbuildinfo", "*.build.log");
 	}
 

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -68,6 +68,7 @@
 		"@fluidframework/build-tools-bin": "npm:@fluidframework/build-tools@~0.40.0",
 		"@fluidframework/eslint-config-fluid": "^5.3.0",
 		"@types/async": "^3.2.20",
+		"@types/debug": "^4.1.12",
 		"@types/fs-extra": "^11.0.4",
 		"@types/glob": "^7.2.0",
 		"@types/lodash": "^4.14.195",

--- a/build-tools/packages/build-tools/src/common/fluidBuild.ts
+++ b/build-tools/packages/build-tools/src/common/fluidBuild.ts
@@ -1,0 +1,36 @@
+import registerDebug from "debug";
+import { loadFluidBuildConfig } from "./fluidUtils";
+import { findGitRootSync } from "./utils";
+
+/**
+ * The default name of the fluid-build executable. This is used for identifying fluid-build tasks and for trace log
+ * entries.
+ */
+export const defaultExecutableName = "fluid-build";
+const repoRoot = findGitRootSync();
+const config = loadFluidBuildConfig(repoRoot);
+
+/**
+ *
+ */
+const FLUID_BUILD_EXE = config.executableNames?.[0] ?? defaultExecutableName;
+
+const allValidFluidBuildExecutableNames =
+	config.executableNames === undefined || config.executableNames.length === 0
+		? [defaultExecutableName]
+		: [...config.executableNames, defaultExecutableName];
+
+export const isFluidBuildScript = (script: string | undefined): boolean => {
+	return script === undefined
+		? false
+		: // Returns true if the script starts with any of the valid executable names
+			allValidFluidBuildExecutableNames.some((executable) =>
+				script.startsWith(`${executable} `),
+			);
+};
+
+export const makeFluidBuildScript = (script: string): string => {
+	return `${FLUID_BUILD_EXE} ${script}`;
+};
+
+export const registerDebugTrace = (str: string) => registerDebug(`${FLUID_BUILD_EXE}:${str}`);

--- a/build-tools/packages/build-tools/src/common/fluidTaskDefinitions.ts
+++ b/build-tools/packages/build-tools/src/common/fluidTaskDefinitions.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { PackageJson } from "./npmPackage";
+import { isFluidBuildScript } from "./fluidBuild";
+import type { PackageJson } from "./npmPackage";
 
 /**
  * Task definitions (type `TaskDefinitions`) is an object describing build tasks for fluid-build.
@@ -246,8 +247,10 @@ export function getTaskDefinitions(
 				const script = json.scripts?.[name];
 				if (script === undefined) {
 					throw new Error(`Script not found for task definition '${name}'`);
-				} else if (script.startsWith("fluid-build ")) {
-					throw new Error(`Script task should not invoke 'fluid-build' in '${name}'`);
+				} else if (isFluidBuildScript(script)) {
+					throw new Error(
+						`Script task should not invoke the fluid-build executable in '${name}'`,
+					);
 				}
 			} else {
 				if (full.before.length !== 0 || full.after.length !== 0) {

--- a/build-tools/packages/build-tools/src/common/utils.ts
+++ b/build-tools/packages/build-tools/src/common/utils.ts
@@ -4,6 +4,7 @@
  */
 
 import * as child_process from "child_process";
+import { execFileSync } from "child_process";
 import * as fs from "fs";
 import { pathToFileURL } from "node:url";
 import * as path from "path";
@@ -260,4 +261,34 @@ export async function loadModule(modulePath: string, moduleType?: string) {
 		return await import(pathToFileURL(modulePath).toString());
 	}
 	return require(modulePath);
+}
+
+/**
+ * Finds the root directory of a Git repository synchronously.
+ *
+ * This function uses `git rev-parse --show-toplevel` command to find the top-level directory
+ * of the current Git repository. It executes the command synchronously using `child_process.execFileSync`.
+ * If the current directory is not part of a Git repository, it throws an error.
+ *
+ * @param cwd - The current working directory from which to start searching for a Git repository root.
+ * @returns The path to the root directory of the Git repository.
+ * @throws {Error} If the current directory is not part of a Git repository.
+ *
+ * @privateRemarks
+ *
+ * This function is not in the "gitRepo.ts" source file because that would create a circular dependency. The GitRepo
+ * class depends on
+ */
+export function findGitRootSync(cwd: string = process.cwd()): string {
+	try {
+		const rootPath = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd,
+			encoding: "utf8",
+		}).trim();
+		return rootPath;
+	} catch (error) {
+		throw new Error(
+			`Failed to find Git repository root. Make sure you are inside a Git repository. Error: ${error}`,
+		);
+	}
 }

--- a/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/buildGraph.ts
@@ -10,6 +10,7 @@ import * as semver from "semver";
 import * as assert from "assert";
 import registerDebug from "debug";
 import { FileHashCache } from "../common/fileHashCache";
+import { isFluidBuildScript } from "../common/fluidBuild";
 import {
 	TaskDefinition,
 	TaskDefinitions,
@@ -138,9 +139,9 @@ export class BuildPackage {
 		if (
 			// Only enable release group root script if it is explicitly defined, for places that don't use it yet
 			!isReleaseGroupRootScriptEnabled ||
-			// if there is no script or the script starts with "fluid-build", then use the default
+			// if there is no script or the script is a fluid-build script, then use the default
 			script === undefined ||
-			script.startsWith("fluid-build ")
+			isFluidBuildScript(script)
 		) {
 			// default for release group root is to depend on the task of all packages in the release group
 			return {
@@ -165,7 +166,7 @@ export class BuildPackage {
 
 	private createScriptTask(taskName: string, pendingInitDep: Task[]) {
 		const command = this.pkg.getScript(taskName);
-		if (command !== undefined && !command.startsWith("fluid-build ")) {
+		if (command !== undefined && !isFluidBuildScript(command)) {
 			// Find the script task (without the lifecycle task)
 			let scriptTask = this.scriptTasks.get(taskName);
 			if (scriptTask === undefined) {

--- a/build-tools/packages/build-tools/src/fluidBuild/options.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/options.ts
@@ -16,6 +16,12 @@ import { ISymlinkOptions } from "./symlinkUtils";
 const { log, warning, errorLog } = defaultLogger;
 
 interface FastBuildOptions extends IPackageMatchedOptions, ISymlinkOptions {
+/**
+ * The name of the executable that should be parsed and interpreted as fluid-build itself. This enables alternative
+ * front-end CLIs to re-use the fluid-build core but under a different name.
+ */
+	executableName: string,
+
 	nolint: boolean;
 	lintonly: boolean;
 	showExec: boolean;
@@ -38,6 +44,7 @@ interface FastBuildOptions extends IPackageMatchedOptions, ISymlinkOptions {
 
 // defaults
 export const options: FastBuildOptions = {
+	executableName: "fluid-build",
 	nolint: false,
 	lintonly: false,
 	showExec: false,

--- a/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
+++ b/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { makeFluidBuildScript } from "../../common/fluidBuild";
 import { getExecutableFromCommand } from "../../common/utils";
 import { BuildPackage } from "../buildGraph";
 import { GroupTask } from "./groupTask";
@@ -176,7 +177,7 @@ export class TaskFactory {
 	 * @returns the target task
 	 */
 	public static CreateTargetTask(node: BuildPackage, taskName: string | undefined) {
-		return new GroupTask(node, `fluid-build -t ${taskName}`, [], taskName);
+		return new GroupTask(node, makeFluidBuildScript(`-t ${taskName}`), [], taskName);
 	}
 
 	public static CreateTaskWithLifeCycle(

--- a/build-tools/packages/build-tools/src/index.ts
+++ b/build-tools/packages/build-tools/src/index.ts
@@ -27,6 +27,8 @@ export type {
 	ScriptRequirement,
 } from "./common/fluidRepo";
 
+export { isFluidBuildScript } from "./common/fluidBuild";
+
 // For repo policy check
 export {
 	normalizeGlobalTaskDefinitions,

--- a/build-tools/pnpm-lock.yaml
+++ b/build-tools/pnpm-lock.yaml
@@ -428,6 +428,9 @@ importers:
       '@types/async':
         specifier: ^3.2.20
         version: 3.2.20
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4


### PR DESCRIPTION
work in progress

The idea is to allow fluid-build to be exposed as a different executable name, so I can create an alternative CLI entrypoint.

After working on this, I now think it might be better to add custom task support to fluid-build so I could define my own task (it could even subclass the fluid-build task). But that itself is insufficient, because the "fluid-build" string is parsed in the core build graph creation process, so it's more core than the task layer. Another clue: the "fluid-build" string is not mapped to a task: https://github.com/microsoft/FluidFramework/blob/4c0c130f1df720694a1a1cab7fd0f22f792baac1/build-tools/packages/build-tools/src/fluidBuild/tasks/taskFactory.ts#L31-L72