### PR TITLE
Add smoke test to stress test

### DIFF
--- a/packages/test/test-service-load/src/smokeTest.ts
+++ b/packages/test/test-service-load/src/smokeTest.ts
@@ -1,0 +1,98 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ITestDriver } from "@fluid-internal/test-driver-definitions";
+import { IContainer, IFluidCodeDetails } from "@fluidframework/container-definitions/internal";
+import { Loader } from "@fluidframework/container-loader/internal";
+import { assert } from "@fluidframework/core-utils/internal";
+
+import { FileLogger } from "./FileLogger.js";
+import { pkgName, pkgVersion } from "./packageVersion.js";
+import { createCodeLoader } from "./utils.js";
+
+const packageName = `${pkgName}@${pkgVersion}`;
+const codeDetails: IFluidCodeDetails = {
+	package: packageName,
+	config: {},
+};
+
+// The stress smoke test is run before the actual stress test.  Its job is not to actually
+// perform stress, but instead just to confirm that the basic prerequisite capabilities
+// (authentication, container creation, container loading, etc.) are functioning prior to
+// running stress.  If the smoke test isn't working, it will give us a concrete failure
+// to investigate and allow us to skip a (doomed) attempt at running the stress tests.
+
+export async function smokeTest(testDriver: ITestDriver, profileName: string) {
+	const logger = await FileLogger.createLogger({
+		driverType: testDriver.type,
+		driverEndpointName: testDriver.endpointName,
+		profile: profileName,
+		runId: undefined,
+	});
+
+	// Construct the loader
+	const loader = new Loader({
+		urlResolver: testDriver.createUrlResolver(),
+		documentServiceFactory: testDriver.createDocumentServiceFactory(),
+		codeLoader: createCodeLoader(), // For the smoke test, just run with default container runtime options
+		logger,
+	});
+
+	// Verify container creation works
+	const createContainerAndGetUrl = async () => {
+		const createdContainer: IContainer = await loader.createDetachedContainer(codeDetails);
+
+		const testId = Date.now().toString();
+		const request = testDriver.createCreateNewRequest(testId);
+
+		await createdContainer.attach(request);
+		assert(
+			createdContainer.resolvedUrl !== undefined,
+			"Container missing resolved URL after attach",
+		);
+
+		const resolvedUrl = createdContainer.resolvedUrl;
+		createdContainer.dispose();
+
+		return testDriver.createContainerUrl(testId, resolvedUrl);
+	};
+	console.log("Creating container and attaching...");
+	const url = await tryNTimes(createContainerAndGetUrl, 3, 3);
+	console.log("Container successfully created and attached!");
+
+	// Verify container loading works
+	const loadContainer = async () => {
+		const loadedContainer = await loader.resolve({ url });
+		loadedContainer.dispose();
+	};
+	console.log("Loading container...");
+	await tryNTimes(loadContainer, 3, 3);
+	console.log("Container successfully loaded!");
+
+	return url;
+}
+
+const tryNTimes = async <UnwrappedCallbackReturnType>(
+	callback: () => Promise<UnwrappedCallbackReturnType>,
+	attempts: number,
+	attemptsDelaySeconds: number,
+) => {
+	for (let i = 1; i <= attempts; i++) {
+		try {
+			return await callback();
+		} catch (error) {
+			console.error(`Attempt ${i} / ${attempts} failed:`);
+			console.error(error);
+			if (i < attempts) {
+				console.error(`Trying again in ${attemptsDelaySeconds} seconds...`);
+				await new Promise((resolve) => setTimeout(resolve, attemptsDelaySeconds * 1000));
+			} else {
+				console.error(`Giving up.`);
+				throw error;
+			}
+		}
+	}
+	throw new Error("Unreachable");
+};

--- a/packages/test/test-service-load/src/stressTest.ts
+++ b/packages/test/test-service-load/src/stressTest.ts
@@ -12,7 +12,7 @@ import ps from "ps-node";
 import { FileLogger } from "./FileLogger.js";
 import type { TestUsers } from "./getTestUsers.js";
 import type { TestConfiguration } from "./testConfigFile.js";
-import { initialize, safeExit } from "./utils.js";
+import { initialize } from "./utils.js";
 
 const createLoginEnv = (userName: string, password: string) =>
 	`{"${userName}": "${password}"}`;
@@ -143,12 +143,14 @@ export async function stressTest(
 				return new Promise((resolve) => runnerProcess.once("close", resolve));
 			}),
 		);
-	} finally {
 		const endTime = Date.now();
 		console.log(`End time: ${endTime} ms\n`);
 		console.log(`Total run time: ${(endTime - startTime) / 1000}s\n`);
-		await safeExit(0, url);
+	} catch {
+		// Swallow all errors. A previous implementation exited the process here with code 0.
 	}
+
+	return url;
 }
 
 /**


### PR DESCRIPTION
Final split of #21926, will close that one out now.  No changes as compared to that PR but we can continue the discussion here.

This change also moves process exit out to main() (rather than exiting directly from stressTest).  To minimize change to the test I swallow all errors (to approximate process exit with status 0 in the finally block), but really I think it would make more sense to allow the error to throw and exit with -1.  Happy to leave it as-is or change, or could consider a change in a followup PR.

Re: using runWithRetry or reusing the stress container instead of creating a new container with tryNTimes():

> I think runWithRetry really only works for errors of type IDriverErrorBase - I'm probably OK limiting retries to just driver (network) errors, but this would retry in fewer scenarios than as currently written.
>
>I favor not reusing the container for two main reasons:
>
>1. I like having the separation between the two - changes to either smoke or stress can be made without worrying about impacting the other
>1. The loader options for the stress test's document creation are more complex and randomly selected which could produce inconsistent results across random seeds. My goal is for smoke to be super-consistent run-to-run such that its failure is a super-strong signal that basic functionality is broken.

[AB#9092](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/9092)