### PR TITLE
Fix message size e2e tests

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -321,7 +321,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 			},
 		).timeout(chunkingBatchesTimeoutMs);
 
-		describe(`Large payloads (exceeding the 1MB limit) - ${
+		describe(`Large payloads - ${
 			enableGroupedBatching ? "grouped" : "regular"
 		} batches`, () => {
 			describe("Chunking compressed batches", () =>

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -497,11 +497,6 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 								this.skip();
 							}
 
-							// TODO: This test is consistently failing on routerlicious. See ADO:7883 and ADO:7924
-							if (provider.driver.type === "routerlicious") {
-								this.skip();
-							}
-
 							await setup();
 
 							for (let i = 0; i < config.messagesInBatch; i++) {

--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -253,6 +253,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 		},
 	);
 
+	// See ADO:8608
 	itExpects.skip(
 		"Large ops fail when compression enabled and compressed content is over max op size",
 		[{ eventName: "fluid:telemetry:Container:ContainerClose", error: "BatchTooLarge" }],
@@ -275,7 +276,6 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 	const chunkingBatchesTimeoutMs = 200000;
 
 	[false, true].forEach((enableGroupedBatching) => {
-		const compressionSizeThreshold = 1024 * 1024;
 		const containerConfig: ITestContainerConfig = {
 			...testContainerConfig,
 			runtimeOptions: {
@@ -297,8 +297,8 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 					], // Without grouped batching, it is expected for the container to never make progress
 			async function () {
 				await setupContainers(containerConfig);
-				// This is not supported by the local server. See ADO:2690
-				// This test is flaky on tinylicious. See ADO:2964
+				// This is currently not supported by the local server. Nacks will occur because too many messages without summary (see localServerTestDriver.ts).
+				// This is not supported by tinylicious. For some reason, the socket is accepting more than 1 MB.
 				if (provider.driver.type === "local" || provider.driver.type === "tinylicious") {
 					if (!enableGroupedBatching) {
 						// Workaround for the `itExpects` construct
@@ -326,26 +326,29 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 		} batches`, () => {
 			describe("Chunking compressed batches", () =>
 				[
-					{ messagesInBatch: 1, messageSize: 2 * 1024 * 1024 }, // One large message
-					{ messagesInBatch: 3, messageSize: 2 * 1024 * 1024 }, // Three large messages
-					{ messagesInBatch: 1500, messageSize: 4 * 1024 }, // Many small messages
+					{ messagesInBatch: 1, messageSize: 51 * 1024 }, // One large message (51 KB each)
+					{ messagesInBatch: 3, messageSize: 51 * 1024 }, // Three large messages (51 KB each)
+					{ messagesInBatch: 1500, messageSize: 1024 }, // Many small messages (1 KB each)
 				].forEach((testConfig) => {
 					it(
 						"Large payloads pass when compression enabled, " +
 							"compressed content is over max op size and chunking enabled. " +
 							`${testConfig.messagesInBatch.toLocaleString()} messages of ${testConfig.messageSize.toLocaleString()} bytes == ` +
-							`${(
-								(testConfig.messagesInBatch * testConfig.messageSize) /
-								(1024 * 1024)
-							).toFixed(2)} MB`,
+							`${((testConfig.messagesInBatch * testConfig.messageSize) / 1024).toFixed(
+								2,
+							)} KB`,
 						async function () {
-							// This is not supported by the local server. See ADO:2690
-							// This test is flaky on tinylicious. See ADO:2964
-							if (provider.driver.type === "local" || provider.driver.type === "tinylicious") {
-								this.skip();
-							}
-
-							await setupContainers(containerConfig);
+							await setupContainers({
+								...containerConfig,
+								runtimeOptions: {
+									...containerConfig.runtimeOptions,
+									compressionOptions: {
+										minimumBatchSizeInBytes: 50 * 1024, // 50 KB
+										compressionAlgorithm: CompressionAlgorithms.lz4,
+									},
+									chunkSizeInBytes: 20 * 1024, // 20 KB
+								},
+							});
 
 							const generated: string[] = [];
 							for (let i = 0; i < testConfig.messagesInBatch; i++) {
@@ -371,7 +374,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 								);
 							}
 						},
-					).timeout(chunkingBatchesTimeoutMs);
+					);
 				}));
 
 			itExpects(
@@ -421,8 +424,20 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 				);
 			};
 
+			const compressionSizeThreshold = 50 * 1024; // 50 KB;
+
 			const setup = async () => {
-				await setupContainers(containerConfig);
+				await setupContainers({
+					...containerConfig,
+					runtimeOptions: {
+						...containerConfig.runtimeOptions,
+						compressionOptions: {
+							minimumBatchSizeInBytes: compressionSizeThreshold,
+							compressionAlgorithm: CompressionAlgorithms.lz4,
+						},
+						chunkSizeInBytes: 20 * 1024, // 20 KB
+					},
+				});
 				totalPayloadSizeInBytes = 0;
 				totalOps = 0;
 				localContainer.deltaManager.outbound.on("push", (messages) => {
@@ -437,14 +452,14 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 				[
 					{
 						messagesInBatch: 1,
-						messageSize: 1024,
-						expectedSize: 1 * 1024,
+						messageSize: 10 * 1024, // 10 KB
+						expectedSize: 10 * 1024, // 10 KB
 						payloadGenerator: generateStringOfSize,
 					}, // One small uncompressed message
 					{
 						messagesInBatch: 3,
-						messageSize: 1024,
-						expectedSize: 3 * 1024,
+						messageSize: 10 * 1024, // 10 KB
+						expectedSize: 30 * 1024, // 30 KB
 						payloadGenerator: generateStringOfSize,
 					}, // Three small uncompressed messages
 					{
@@ -454,11 +469,11 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 						payloadGenerator: generateStringOfSize,
 					}, // One large message with compression
 					{
-						messagesInBatch: 20,
+						messagesInBatch: 10,
 						messageSize: compressionSizeThreshold + 1,
 						expectedSize: compressionRatio * (compressionSizeThreshold + 1),
 						payloadGenerator: generateStringOfSize,
-					}, // Twenty large messages with compression
+					}, // Ten large messages with compression
 					{
 						messagesInBatch: 10,
 						messageSize: compressionSizeThreshold + 1,
@@ -473,15 +488,12 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 						"Payload size check, " +
 							"Sending " +
 							`${config.messagesInBatch.toLocaleString()} messages of ${config.messageSize.toLocaleString()} bytes == ` +
-							`${((config.messagesInBatch * config.messageSize) / (1024 * 1024)).toFixed(
+							`${((config.messagesInBatch * config.messageSize) / 1024).toFixed(
 								4,
-							)} MB, expecting ${(config.expectedSize / (1024 * 1024)).toFixed(
-								4,
-							)} MB on the wire`,
+							)} KB, expecting ${(config.expectedSize / 1024).toFixed(4)} KB on the wire`,
 						async function () {
 							// This is not supported by the local server due to chunking. See ADO:2690
-							// This test is flaky on tinylicious. See ADO:2964
-							if (provider.driver.type === "local" || provider.driver.type === "tinylicious") {
+							if (provider.driver.type === "local") {
 								this.skip();
 							}
 
@@ -505,7 +517,7 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 									totalOps === 1,
 							);
 						},
-					).timeout(chunkingBatchesTimeoutMs);
+					);
 				}));
 		});
 	});
@@ -561,12 +573,6 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 			};
 
 			it("Reconnects while processing chunks", async function () {
-				// This is not supported by the local server. See ADO:2690
-				// This test is flaky on tinylicious. See ADO:2964
-				if (provider.driver.type === "local" || provider.driver.type === "tinylicious") {
-					this.skip();
-				}
-
 				await setupContainers(config);
 				// Force the container to reconnect after processing 2 chunked ops
 				const secondConnection = reconnectAfterOpProcessing(
@@ -581,12 +587,6 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 			});
 
 			it("Reconnects while processing compressed batch", async function () {
-				// This is not supported by the local server. See ADO:2690
-				// This test is flaky on tinylicious. See ADO:2964
-				if (provider.driver.type === "local" || provider.driver.type === "tinylicious") {
-					this.skip();
-				}
-
 				await setupContainers(config);
 				// Force the container to reconnect after processing all the chunks
 				const secondConnection = reconnectAfterOpProcessing(
@@ -650,12 +650,6 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 			});
 
 			it("Reconnects while sending compressed batch", async function () {
-				// This is not supported by the local server. See ADO:2690
-				// This test is flaky on tinylicious. See ADO:2964
-				if (provider.driver.type === "local" || provider.driver.type === "tinylicious") {
-					this.skip();
-				}
-
 				await setupContainers(config);
 				// Force the container to reconnect after sending the compressed batch (i.e. send all chunks)
 				const secondConnection = reconnectAfterBatchSending(


### PR DESCRIPTION
The flakiness of these tests was caused by the large messages being sent and processed. Service or the client wouldn't be able to keep up fast enough consistently to handle these large ops, thus causing these tests to timeout. By reducing the size of the ops being sent, and subsequently the compression/chunking limits, these tests should be much less flaky.

[AB#2964](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/2964)
[AB#8330](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8330)
[AB#7883](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7883)
[AB#7924](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7924)
[AB#10974](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/10974)
[AB#10975](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/10975)