### PR TITLE
Revert @fluid-tools/benchmark version to 0.49

### DIFF
--- a/tools/benchmark/CHANGELOG.md
+++ b/tools/benchmark/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @fluid-tools/benchmark
 
-## 0.51.0
+## 0.49.0
 
 Provide @benchmarkCustom feature to log custom measurements. To profile custom usage, define tests using the `benchmarkCustom()` function. The argument `run` to the function includes a reporter with `addMeasurement()`
 to write custom data to report.
@@ -9,9 +9,5 @@ to write custom data to report.
 
 Mocha reporters have been consolidated into a single one that can handle arbitrary properties through `BenchmarkData.customData`, plus `BenchmarkData.customDataFormatters` to specify how each value should be printed to console.
 Consumers who previously used `MochaMemoryTestReporter.js` should now use `MochaReporter.js`.
-
-## 0.50.0
-
-### ⚠ BREAKING CHANGES
 
 Update `typescript` dependency from `4.x` to `5.x`.

--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/benchmark",
-	"version": "0.51.0",
+	"version": "0.49.0",
 	"description": "Benchmarking tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
#### Description
Related Work: https://dev.azure.com/fluidframework/internal/_workitems/edit/7825/
NPM Registry: https://www.npmjs.com/package/@fluid-tools/benchmark?activeTab=readme

`@fluid-tools/benchmark` in repo is at version `0.51.0` whereas that in the NPM registry is at `0.48.0`. This PR sets the version to `0.49.0` and include the separate breaking changes introduced from `0.50.0` and `0.50.1` in a single release. 