### PR TITLE
refactor(markdown-magic): Rename example app header template

### DIFF
--- a/examples/apps/attributable-map/README.md
+++ b/examples/apps/attributable-map/README.md
@@ -14,7 +14,7 @@ When the app loads it will update the URL. Copy that new URL into a second brows
 
 ![timestamp-watcher](./images/hitcounter.gif)
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/apps/collaborative-textarea/README.md
+++ b/examples/apps/collaborative-textarea/README.md
@@ -3,7 +3,7 @@
 **Collaborative TextArea** is a basic example that creates a SharedString and uses the react CollaborativeTextArea
 component to launch a basic collaborative HTML `<textarea>`
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/apps/contact-collection/README.md
+++ b/examples/apps/contact-collection/README.md
@@ -15,7 +15,7 @@ The specific access mechanisms can vary -- in this example, `ContactCollection` 
 
 For another example of this pattern, consider the `SharedDirectory` DDS. The `getWorkingDirectory()` method allows granular access to an `IDirectory` that can be used separately from the remainder of the `SharedDirectory`, despite the data being stored in the same data store. Although the details differ since it is a DDS rather than a data object, the principle is the same.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/apps/data-object-grid/README.md
+++ b/examples/apps/data-object-grid/README.md
@@ -2,7 +2,7 @@
 
 **Data object grid** is a Fluid component that provides a grid layout for users to compose their own experiences by adding and re-arranging data objects. This example explores how modular document types could work in Fluid.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/apps/presence-tracker/README.md
+++ b/examples/apps/presence-tracker/README.md
@@ -6,7 +6,7 @@
 
 This implementation visualizes the Container in a standalone application, rather than using the webpack-fluid-loader environment that most of our examples use. This implementation relies on [Tinylicious](/server/routerlicious/packages/tinylicious), so there are a few extra steps to get started. We bring our own view that we will bind to the data in the container.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/apps/task-selection/README.md
+++ b/examples/apps/task-selection/README.md
@@ -2,7 +2,7 @@
 
 The task selection example demonstrates a couple different ways to pick a single client amongst the connected clients to perform a task (in this case, rolling a dice once per second). This builds upon the external-views sample as a base.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/apps/tree-comparison/README.md
+++ b/examples/apps/tree-comparison/README.md
@@ -2,7 +2,7 @@
 
 This example compares usage of the legacy SharedTree with the new SharedTree to build the same inventory list application.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/benchmarks/bubblebench/baseline/README.md
+++ b/examples/benchmarks/bubblebench/baseline/README.md
@@ -1,6 +1,6 @@
 # @fluid-example/bubblebench-baseline
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/benchmarks/bubblebench/experimental-tree/README.md
+++ b/examples/benchmarks/bubblebench/experimental-tree/README.md
@@ -3,7 +3,7 @@
 Implementation of bubble bench using the legacy/experimental tree (which predated `@fluidframework/tree`).
 This exists to allow for performance comparison between the legacy shared tree and the new one.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/benchmarks/bubblebench/ot/README.md
+++ b/examples/benchmarks/bubblebench/ot/README.md
@@ -1,6 +1,6 @@
 # @fluid-example/bubblebench-ot
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/benchmarks/odspsnapshotfetch-perftestapp/README.md
+++ b/examples/benchmarks/odspsnapshotfetch-perftestapp/README.md
@@ -2,7 +2,7 @@
 
 A simple app to fetch and compare same file in json and binary format.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/benchmarks/tablebench/README.md
+++ b/examples/benchmarks/tablebench/README.md
@@ -1,6 +1,6 @@
 # @fluid-internal/tablebench
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/client-logger/app-insights-logger/README.md
+++ b/examples/client-logger/app-insights-logger/README.md
@@ -26,7 +26,7 @@ function initializeTinyliciousClient(): TinyliciousClient {
 }
 ```
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/data-objects/canvas/README.md
+++ b/examples/data-objects/canvas/README.md
@@ -2,7 +2,7 @@
 
 **Canvas** is a Fluid Component that displays a collaborative canvas you can draw on.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/data-objects/clicker/README.md
+++ b/examples/data-objects/clicker/README.md
@@ -8,7 +8,7 @@ classes.
 
 There is another experimental implementation of Clicker using a WiP Fluid React Component in components/experimental/clicker-react. While it uses a state update model instead of an event-listening model that some React developers may find more familiar, the code is still being developed and may contain bugs.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/data-objects/codemirror/README.md
+++ b/examples/data-objects/codemirror/README.md
@@ -3,7 +3,7 @@
 An experimental implementation of how to take the open source [CodeMirror](https://codemirror.net/) code editor
 and enable real-time coauthoring using the Fluid Framework.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/data-objects/diceroller/README.md
+++ b/examples/data-objects/diceroller/README.md
@@ -4,7 +4,7 @@
 persists the value in the root SharedDirectory. The Fluid Container is defined index.ts, the Fluid object is
 defined in main.tsx.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/data-objects/inventory-app/README.md
+++ b/examples/data-objects/inventory-app/README.md
@@ -2,7 +2,7 @@
 
 Minimal sample demonstrating use of the SharedTree API.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/data-objects/monaco/README.md
+++ b/examples/data-objects/monaco/README.md
@@ -3,7 +3,7 @@
 An experimental implementation of how to take the Microsoft's open source [Monaco](https://github.com/Microsoft/monaco-editor) code editor
 and enable real-time coauthoring using the Fluid Framework.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/data-objects/multiview/container/README.md
+++ b/examples/data-objects/multiview/container/README.md
@@ -2,7 +2,7 @@
 
 The container package is an example of how a container author might pick and choose multiple views and models and combine them in various ways.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/data-objects/prosemirror/README.md
+++ b/examples/data-objects/prosemirror/README.md
@@ -3,7 +3,7 @@
 An experimental implementation of how to take the open source [ProseMirror](https://prosemirror.net/) rich text editor and
 enable real-time coauthoring using the Fluid Framework.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/data-objects/smde/README.md
+++ b/examples/data-objects/smde/README.md
@@ -3,7 +3,7 @@
 An experimental implementation of how to take the open source [SimpleMDE](https://simplemde.com/) markdown editor and
 enable real-time coauthoring using the Fluid Framework.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/data-objects/todo/README.md
+++ b/examples/data-objects/todo/README.md
@@ -4,7 +4,7 @@
 
 ![Todo Example](./resources/todo-screen-capture.gif)
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/data-objects/webflow/README.md
+++ b/examples/data-objects/webflow/README.md
@@ -2,7 +2,7 @@
 
 WebFlow is an experimental collaborative rich text editor built on top of the Fluid SharedString distributed data structure.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/external-data/README.md
+++ b/examples/external-data/README.md
@@ -101,7 +101,7 @@ SavedData - Data that comes in fresh from the external data source is first stor
 
 DraftData - Local collaboration state between the Fluid clients is stored in a SharedMap known as "DraftData". This is known as draft data because we are treating the Fluid collaboration session as a drafting surface.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/service-clients/azure-client/external-controller/README.md
+++ b/examples/service-clients/azure-client/external-controller/README.md
@@ -10,7 +10,7 @@ This implementation demonstrates plugging that Container into a standalone appli
 [Tinylicious](/server/routerlicious/packages/tinylicious), so there are a few extra steps to get started. We bring our own view that we will
 bind to the data in the container.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/version-migration/live-schema-upgrade/README.md
+++ b/examples/version-migration/live-schema-upgrade/README.md
@@ -27,7 +27,7 @@ There are a number of ways to handle rendering the view. In this example, we inc
 -   Load the appropriate view after the model is instantiated.
 -   Only include the latest view and ensure that the model upgrades before rendering.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/version-migration/same-container/README.md
+++ b/examples/version-migration/same-container/README.md
@@ -48,7 +48,7 @@ With the exported and transformed data in hand, we can create a new container us
 
 As clients observe the migration complete, they load the new container and swap it in for the old one. This includes loading in the approporate new container code, model code, and view code if necessary. Once complete, the client can begin collaborating on the new container.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/version-migration/schema-upgrade/README.md
+++ b/examples/version-migration/schema-upgrade/README.md
@@ -64,7 +64,7 @@ As mentioned above, the `ModelLoader` is able to load directly to a container mo
 
 Similarly, the view used on a model must be compatible with that model. A view loader can inspect the model and load the appropriate view. This portion is still under development, but will likely be similar to the model loading flow.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/version-migration/tree-shim/README.md
+++ b/examples/version-migration/tree-shim/README.md
@@ -6,7 +6,7 @@ This example experiments with an approach for migrating data in an existing lega
 
 Please note that the ideas explored here are experimental and under development. Do not use them in production.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/view-integration/container-views/README.md
+++ b/examples/view-integration/container-views/README.md
@@ -4,7 +4,7 @@
 
 This implementation demonstrates plugging the container into a standalone application, rather than using the webpack-fluid-loader environment that most of our packages use. This implementation relies on [Tinylicious](/server/routerlicious/packages/tinylicious), so there are a few extra steps to get started. We expect the container to respond with a mountable view that we can use for rendering.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/view-integration/external-views/README.md
+++ b/examples/view-integration/external-views/README.md
@@ -4,7 +4,7 @@
 
 This implementation demonstrates plugging that Container into a standalone application, rather than using the webpack-fluid-loader environment that most of our packages use. This implementation relies on [Tinylicious](/server/routerlicious/packages/tinylicious), so there are a few extra steps to get started. We bring our own view that we will bind to the data in the container.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/examples/view-integration/view-framework-sampler/README.md
+++ b/examples/view-integration/view-framework-sampler/README.md
@@ -2,7 +2,7 @@
 
 **View framework sampler** demonstrates how a data object can be integrated with the view framework of your choosing.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=TRUE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=TRUE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/packages/tools/devtools/devtools-example/README.md
+++ b/packages/tools/devtools/devtools-example/README.md
@@ -4,7 +4,7 @@ This package contains a simple example application aimed at demonstrating how us
 
 Note: while this example is built using [React](), the developer tools are not specific to `React`; they should be compatible with the view framework of your choice.
 
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:usesTinylicious=FALSE) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:usesTinylicious=FALSE) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->

--- a/tools/markdown-magic/README.md
+++ b/tools/markdown-magic/README.md
@@ -115,7 +115,7 @@ Arguments:
     -   Assumes that the package is published, uses [API-Extractor][], and has its documentation published under `fluidframework.com/apis/<package-name>`.
     -   See [API_DOCS](#api_docs)
 
-#### `EXAMPLE_README_HEADER`
+#### `EXAMPLE_APP_README_HEADER`
 
 Generates a complete starter `README.md` file for an `Fluid` example app package.
 

--- a/tools/markdown-magic/README.md
+++ b/tools/markdown-magic/README.md
@@ -117,7 +117,7 @@ Arguments:
 
 #### `EXAMPLE_APP_README_HEADER`
 
-Generates a complete starter `README.md` file for an `Fluid` example app package.
+Generates a complete starter `README.md` file for a `Fluid` example app package.
 
 Notes:
 

--- a/tools/markdown-magic/src/md-magic.config.cjs
+++ b/tools/markdown-magic/src/md-magic.config.cjs
@@ -303,7 +303,7 @@ function libraryReadmeHeaderTransform(content, options, config) {
  * @param {object} config - Transform configuration.
  * @param {string} config.originalPath - Path to the document being modified.
  */
-function exampleReadmeHeaderTransform(content, options, config) {
+function exampleAppReadmeHeaderTransform(content, options, config) {
 	const { packageJsonPath: relativePackageJsonPath } = options;
 
 	const resolvedPackageJsonPath = resolveRelativePackageJsonPath(
@@ -374,16 +374,16 @@ module.exports = {
 		LIBRARY_README_HEADER: libraryReadmeHeaderTransform,
 
 		/**
-		 * See {@link exampleReadmeHeaderTransform}.
+		 * See {@link exampleAppReadmeHeaderTransform}.
 		 *
 		 * @example
 		 *
 		 * ```markdown
-		 * <!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:packageJsonPath=./package.json&gettingStarted=TRUE&usesTinylicious=TRUE&scripts=FALSE&contributionGuidelines=TRUE&help=TRUE&trademark=TRUE) -->
+		 * <!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:packageJsonPath=./package.json&gettingStarted=TRUE&usesTinylicious=TRUE&scripts=FALSE&contributionGuidelines=TRUE&help=TRUE&trademark=TRUE) -->
 		 * <!-- AUTO-GENERATED-CONTENT:END -->
 		 * ```
 		 */
-		EXAMPLE_README_HEADER: exampleReadmeHeaderTransform,
+		EXAMPLE_APP_README_HEADER: exampleAppReadmeHeaderTransform,
 
 		/**
 		 * See {@link readmeFooterTransform}.

--- a/tools/markdown-magic/test/example-readme-header.md
+++ b/tools/markdown-magic/test/example-readme-header.md
@@ -1,4 +1,4 @@
-<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_README_HEADER:packageJsonPath=./package.json) -->
+<!-- AUTO-GENERATED-CONTENT:START (EXAMPLE_APP_README_HEADER:packageJsonPath=./package.json) -->
 
 <!-- prettier-ignore-start -->
 <!-- NOTE: This section is automatically generated using @fluid-tools/markdown-magic. Do not update these generated contents directly. -->


### PR DESCRIPTION
The template is for use specifically in example _app_ READMEs. We also have example _library_ packages, which are better served by our library README template. This PR renames the example app template to make this distinction more clear.