### PR TITLE
[Prototype only]: Add GC handle for incremental GC and remove tracking state in summarizer nodes

### DIFF
--- a/packages/dds/test-dds-utils/src/gcTestRunner.ts
+++ b/packages/dds/test-dds-utils/src/gcTestRunner.ts
@@ -54,6 +54,7 @@ export const runGCTests = (ctor: new () => IGCTestProvider): void => {
 
 		const [id, outboundRoutes] = gcNodes[0];
 		assert.strictEqual(id, "/", "GC node's id should be /");
+		assert(typeof outboundRoutes !== "string");
 		assert.deepStrictEqual(
 			outboundRoutes.sort(),
 			provider.expectedOutboundRoutes.sort(),

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -447,10 +447,10 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		for (const s of this.summarizables) {
 			for (const [id, routes] of Object.entries(s.getGCData(fullGC).gcNodes)) {
 				gcNodes[id] ??= [];
-				for (const route of routes) {
-					assert(typeof gcNodes[id] !== "string", "");
-					gcNodes[id].push(route);
-				}
+				const outboundRoutes = gcNodes[id] ?? [];
+				assert(typeof outboundRoutes !== "string", "");
+				assert(typeof routes !== "string", "");
+				outboundRoutes.push(...routes);
 			}
 		}
 

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -448,6 +448,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 			for (const [id, routes] of Object.entries(s.getGCData(fullGC).gcNodes)) {
 				gcNodes[id] ??= [];
 				for (const route of routes) {
+					assert(typeof gcNodes[id] !== "string", "");
 					gcNodes[id].push(route);
 				}
 			}

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1650,8 +1650,6 @@ export class ContainerRuntime
 			},
 			// Function to get GC data if needed. This will always be called by the root summarizer node to get GC data.
 			async (fullGC?: boolean) => this.getGCDataInternal(fullGC),
-			// Function to get the GC details from the base snapshot we loaded from.
-			async () => this.garbageCollector.getBaseGCDetails(),
 		);
 
 		if (baseSnapshot) {

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -9,7 +9,6 @@ import { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 import {
 	ITelemetryContext,
 	IGarbageCollectionData,
-	IGarbageCollectionDetailsBase,
 	ISummarizeResult,
 } from "@fluidframework/runtime-definitions/internal";
 import { ReadAndParseBlob } from "@fluidframework/runtime-utils/internal";
@@ -364,8 +363,6 @@ export interface IGarbageCollector {
 	): ISummarizeResult | undefined;
 	/** Returns the garbage collector specific metadata to be written into the summary. */
 	getMetadata(): IGCMetadata;
-	/** Returns the GC details generated from the base snapshot. */
-	getBaseGCDetails(): Promise<IGarbageCollectionDetailsBase>;
 	/** Called when the latest summary of the system has been refreshed. */
 	refreshLatestSummary(result: IRefreshSummaryResult): Promise<void>;
 	/**

--- a/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
+++ b/packages/runtime/container-runtime/src/gc/gcDefinitions.ts
@@ -557,3 +557,10 @@ export interface IGCResult {
 	/** The ids of nodes that are not-referenced or deleted in the referenced graph */
 	deletedNodeIds: string[];
 }
+
+export interface IGarbageCollectionDataNoHandle {
+	/**
+	 * The GC nodes of a Fluid object in the Container. Each node has an id and a set of routes to other GC nodes.
+	 */
+	gcNodes: { [id: string]: string[] };
+}

--- a/packages/runtime/container-runtime/src/gc/index.ts
+++ b/packages/runtime/container-runtime/src/gc/index.ts
@@ -39,6 +39,7 @@ export {
 	GarbageCollectionMessage,
 	GarbageCollectionMessageType,
 	ISweepMessage,
+	IGarbageCollectionDataNoHandle,
 } from "./gcDefinitions.js";
 export {
 	cloneGCData,

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeWithGc.ts
@@ -10,7 +10,6 @@ import {
 	ITelemetryContext,
 	IGarbageCollectionData,
 	CreateChildSummarizerNodeParam,
-	IGarbageCollectionDetailsBase,
 	ISummarizeInternalResult,
 	ISummarizeResult,
 	ISummarizerNodeConfigWithGC,
@@ -100,7 +99,6 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 		latestSummary?: SummaryNode,
 		wipSummaryLogger?: ITelemetryBaseLogger,
 		private readonly getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-		getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
 		/** A unique id of this node to be logged when sending telemetry. */
 		telemetryId?: string,
 	) {
@@ -348,7 +346,6 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
 			createDetails.latestSummary,
 			this.wipSummaryLogger,
 			getGCDataFn,
-			undefined,
 			createDetails.telemetryNodeId,
 		);
 
@@ -470,7 +467,6 @@ export class SummarizerNodeWithGC extends SummarizerNode implements IRootSummari
  * or undefined if not loaded from summary
  * @param config - Configure behavior of summarizer node
  * @param getGCDataFn - Function to get the GC data of this node
- * @param baseGCDetailsP - Function to get the initial GC details of this node
  */
 export const createRootSummarizerNodeWithGC = (
 	logger: ITelemetryBaseLogger,
@@ -479,7 +475,6 @@ export const createRootSummarizerNodeWithGC = (
 	referenceSequenceNumber: number | undefined,
 	config: ISummarizerNodeConfigWithGC = {},
 	getGCDataFn?: (fullGC?: boolean) => Promise<IGarbageCollectionData>,
-	getBaseGCDetailsFn?: () => Promise<IGarbageCollectionDetailsBase>,
 ): IRootSummarizerNodeWithGC =>
 	new SummarizerNodeWithGC(
 		logger,
@@ -491,6 +486,5 @@ export const createRootSummarizerNodeWithGC = (
 			: SummaryNode.createForRoot(referenceSequenceNumber),
 		undefined /* wipSummaryLogger */,
 		getGCDataFn,
-		getBaseGCDetailsFn,
 		"" /* telemetryId */,
 	);

--- a/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreContext.spec.ts
@@ -32,14 +32,10 @@ import {
 	IFluidDataStoreFactory,
 	IFluidDataStoreRegistry,
 	IFluidParentContext,
-	IGarbageCollectionDetailsBase,
 	SummarizeInternalFn,
 	channelsTreeName,
 } from "@fluidframework/runtime-definitions/internal";
-import {
-	GCDataBuilder,
-	convertSummaryTreeToITree,
-} from "@fluidframework/runtime-utils/internal";
+import { convertSummaryTreeToITree } from "@fluidframework/runtime-utils/internal";
 import {
 	MockLogger,
 	TelemetryDataTag,
@@ -710,21 +706,6 @@ describe("Data Store Context Tests", () => {
 		});
 
 		describe("Garbage Collection", () => {
-			// The base GC details of the root summarizer node. The child base GC details from this is passed on to the
-			// child summarizer node during its creation.
-			let rootBaseGCDetails: IGarbageCollectionDetailsBase;
-			const getRootBaseGCDetails = async (): Promise<IGarbageCollectionDetailsBase> =>
-				rootBaseGCDetails;
-
-			/**
-			 * Given the GC data of a data store, build the GC data of the root (parent) node.
-			 */
-			function buildRootGCData(dataStoreGCData: IGarbageCollectionData, id: string) {
-				const builder = new GCDataBuilder();
-				builder.prefixAndAddNodes(id, dataStoreGCData.gcNodes);
-				return builder.getGCData();
-			}
-
 			beforeEach(() => {
 				summarizerNode = createRootSummarizerNodeWithGC(
 					createChildLogger(),
@@ -733,7 +714,6 @@ describe("Data Store Context Tests", () => {
 					0,
 					undefined,
 					undefined,
-					getRootBaseGCDetails,
 				);
 				summarizerNode.startSummary(0, createChildLogger(), 0);
 
@@ -805,11 +785,6 @@ describe("Data Store Context Tests", () => {
 						"/dds1": ["/dds2", "/"],
 					},
 				};
-				// Set the root base GC details to include the child node's base GC data.
-				rootBaseGCDetails = {
-					usedRoutes: [],
-					gcData: buildRootGCData(dataStoreGCData, dataStoreId),
-				};
 
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({
 					id: dataStoreId,
@@ -853,11 +828,6 @@ describe("Data Store Context Tests", () => {
 					gcNodes: {
 						"/": [],
 					},
-				};
-				// Set the root base GC details to include the child node's base GC data.
-				rootBaseGCDetails = {
-					usedRoutes: [`/${dataStoreId}`],
-					gcData: buildRootGCData(dataStoreGCData, dataStoreId),
 				};
 
 				remoteDataStoreContext = new RemoteFluidDataStoreContext({

--- a/packages/runtime/container-runtime/src/test/gc/gcHelpers.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcHelpers.spec.ts
@@ -5,8 +5,11 @@
 
 import { strict as assert } from "assert";
 
+import { IGarbageCollectionData } from "@fluidframework/runtime-definitions/internal";
+
 import {
 	dataStoreNodePathOnly,
+	getChildTreeNodeIds,
 	shouldAllowGcSweep,
 	urlToGCNodePath,
 	// eslint-disable-next-line import/no-internal-modules
@@ -196,6 +199,38 @@ describe("Garbage Collection Helpers Tests", () => {
 			it(`url=${url}`, () => {
 				const result = urlToGCNodePath(url);
 				assert.equal(result, expected);
+			});
+		});
+	});
+
+	describe("getChildNodesList", () => {
+		it.only("splits correctly", () => {
+			const gcData1: IGarbageCollectionData = {
+				gcNodes: {},
+			};
+			gcData1.gcNodes["/"] = ["/1", "/2"];
+			gcData1.gcNodes["/1"] = ["/1/1", "/1/2"];
+			gcData1.gcNodes["/1/1"] = ["/1"];
+			gcData1.gcNodes["/1/2"] = ["/1", "/2"];
+			gcData1.gcNodes["/2"] = ["/2/1", "/2/2"];
+			gcData1.gcNodes["/2/1"] = ["/2"];
+			gcData1.gcNodes["/2/2"] = ["/2", "/2/2/1"];
+			gcData1.gcNodes["/2/2/1"] = ["/2/2", "/3"];
+			gcData1.gcNodes["/2/2/2"] = ["/2/2"];
+			gcData1.gcNodes["/2/2/1/1"] = ["/2/2"];
+			gcData1.gcNodes["/2/2/1/2"] = ["/2/2"];
+			gcData1.gcNodes["/3"] = ["/3/1"];
+			gcData1.gcNodes["/3/1"] = ["/3"];
+
+			// gcData1.gcNodes["/2"] = ["/2/1", "/2/2"];
+			// gcData1.gcNodes["/2/1"] = ["/2"];
+			// gcData1.gcNodes["/2/2"] = ["/2", "/2/2/1"];
+
+			const result = getChildTreeNodeIds(gcData1);
+			assert(result !== undefined);
+			// console.log(result);
+			result.forEach((value, key) => {
+				console.log(`${key} -> ${value}`);
 			});
 		});
 	});

--- a/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcStats.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 
 import { ICriticalContainerError } from "@fluidframework/container-definitions";
-import { IGarbageCollectionData } from "@fluidframework/runtime-definitions/internal";
 import {
 	MockLogger,
 	MonitoringContext,
@@ -27,6 +26,7 @@ import {
 	defaultSweepGracePeriodMs,
 	oneDayMs,
 	stableGCVersion,
+	type IGarbageCollectionDataNoHandle,
 } from "../../gc/index.js";
 import { ContainerRuntimeGCMessage } from "../../messageTypes.js";
 import { pkgVersion } from "../../packageVersion.js";
@@ -43,7 +43,7 @@ describe("Garbage Collection Stats", () => {
 	let gcMessagesCount: number = 0;
 
 	// The default GC data returned by `getGCData` on which GC is run. Update this to update the referenced graph.
-	let defaultGCData: IGarbageCollectionData = { gcNodes: {} };
+	let defaultGCData: IGarbageCollectionDataNoHandle = { gcNodes: {} };
 
 	/**
 	 * Called when sweep runs. It deleted the nodes from defaultGCData.

--- a/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
+++ b/packages/runtime/container-runtime/src/test/gc/gcTelemetry.spec.ts
@@ -6,7 +6,6 @@
 import { strict as assert } from "assert";
 
 import { ITelemetryBaseEvent } from "@fluidframework/core-interfaces";
-import { IGarbageCollectionData } from "@fluidframework/runtime-definitions/internal";
 import {
 	MockLogger,
 	MonitoringContext,
@@ -27,6 +26,7 @@ import {
 	defaultSessionExpiryDurationMs,
 	oneDayMs,
 	stableGCVersion,
+	type IGarbageCollectionDataNoHandle,
 } from "../../gc/index.js";
 import { pkgVersion } from "../../packageVersion.js";
 
@@ -619,8 +619,8 @@ describe("GC Telemetry Tracker", () => {
 
 	describe("gcUnknownOutboundReferences telemetry", () => {
 		const unknownReferenceEventName = "GarbageCollector:gcUnknownOutboundReferences";
-		const currentGCData: IGarbageCollectionData = { gcNodes: {} };
-		let previousGCData: IGarbageCollectionData;
+		const currentGCData: IGarbageCollectionDataNoHandle = { gcNodes: {} };
+		let previousGCData: IGarbageCollectionDataNoHandle;
 		let explicitReferences: Map<string, string[]>;
 
 		beforeEach(() => {

--- a/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
@@ -23,7 +23,7 @@ import {
 	createChildLogger,
 } from "@fluidframework/telemetry-utils/internal";
 
-import { cloneGCData } from "../gc/index.js";
+import { cloneGCData, IGarbageCollectionDataNoHandle } from "../gc/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { ValidateSummaryResult } from "../summary/summarizerNode/index.js";
 import {
@@ -35,7 +35,6 @@ import {
 
 type SummarizerNodeWithPrivates = ISummarizerNodeWithGC & {
 	baseGCDetailsP: Promise<IGarbageCollectionDetailsBase>;
-	loadBaseGCDetails(): Promise<void>;
 	hasUsedStateChanged(): boolean;
 };
 
@@ -192,7 +191,7 @@ describe("SummarizerNodeWithGC Tests", () => {
 			);
 
 			// Make a clone of the GC data returned above because we are about to change it.
-			const cachedGCData = cloneGCData(gcData);
+			const cachedGCData = cloneGCData(gcData as IGarbageCollectionDataNoHandle);
 
 			// Add a new node to the GC data returned by getChildInternalGCData to make it different from cachedGCData above.
 			// This will validate that the data returned by getGCData is not childInternalGCData.
@@ -265,7 +264,6 @@ describe("SummarizerNodeWithGC Tests", () => {
 				usedRoutes,
 			};
 			summarizerNode.baseGCDetailsP = Promise.resolve(baseGCDetails);
-			await summarizerNode.loadBaseGCDetails();
 			summarizerNode.updateUsedRoutes(usedRoutes);
 			assert.strictEqual(
 				summarizerNode.hasUsedStateChanged(),
@@ -283,7 +281,6 @@ describe("SummarizerNodeWithGC Tests", () => {
 				usedRoutes,
 			};
 			summarizerNode.baseGCDetailsP = Promise.resolve(baseGCDetails);
-			await summarizerNode.loadBaseGCDetails();
 			summarizerNode.updateUsedRoutes([...usedRoutes, "newRoute"]);
 			assert.strictEqual(
 				summarizerNode.hasUsedStateChanged(),
@@ -300,7 +297,6 @@ describe("SummarizerNodeWithGC Tests", () => {
 				usedRoutes: undefined,
 			};
 			summarizerNode.baseGCDetailsP = Promise.resolve(baseGCDetails);
-			await summarizerNode.loadBaseGCDetails();
 			summarizerNode.updateUsedRoutes(["newRoute"]);
 			assert.strictEqual(
 				summarizerNode.hasUsedStateChanged(),
@@ -325,7 +321,6 @@ describe("SummarizerNodeWithGC Tests", () => {
 				usedRoutes: undefined,
 			};
 			summarizerNodeGCDisabled.baseGCDetailsP = Promise.resolve(baseGCDetails);
-			await summarizerNodeGCDisabled.loadBaseGCDetails();
 			summarizerNodeGCDisabled.updateUsedRoutes(["newRoute"]);
 			assert.strictEqual(
 				summarizerNodeGCDisabled.hasUsedStateChanged(),

--- a/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summarizerNodeWithGc.spec.ts
@@ -54,8 +54,6 @@ describe("SummarizerNodeWithGC Tests", () => {
 	let childInternalGCData: IGarbageCollectionData;
 	let mockLogger: MockLogger;
 
-	const getRootBaseGCDetails = async (): Promise<IGarbageCollectionDetailsBase> =>
-		rootBaseGCDetails;
 	const getChildInternalGCData = async (): Promise<IGarbageCollectionData> =>
 		childInternalGCData;
 
@@ -68,7 +66,6 @@ describe("SummarizerNodeWithGC Tests", () => {
 			0,
 			undefined,
 			undefined,
-			getRootBaseGCDetails,
 		);
 		rootSummarizerNode.startSummary(0, createChildLogger(), 0);
 

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -58,6 +58,9 @@ export enum FlushMode {
     TurnBased = 1
 }
 
+// @alpha (undocumented)
+export const GarbageCollectionHandle = "gcHandle";
+
 // @alpha
 export interface IAttachMessage {
     id: string;
@@ -233,7 +236,7 @@ export interface IFluidParentContext extends IProvideFluidHandleContext, Partial
 // @alpha
 export interface IGarbageCollectionData {
     gcNodes: {
-        [id: string]: string[];
+        [id: string]: string[] | typeof GarbageCollectionHandle;
     };
 }
 

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -111,6 +111,13 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"InterfaceDeclaration_IGarbageCollectionData": {
+				"backCompat": false
+			},
+			"InterfaceDeclaration_IGarbageCollectionDetailsBase": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/runtime-definitions/src/garbageCollectionDefinitions.ts
+++ b/packages/runtime/runtime-definitions/src/garbageCollectionDefinitions.ts
@@ -35,6 +35,12 @@ export const gcDeletedBlobKey = "__deletedNodes";
 export const gcDataBlobKey = ".gcdata";
 
 /**
+ * @legacy
+ * @alpha
+ */
+export const GarbageCollectionHandle = "gcHandle";
+
+/**
  * Garbage collection data returned by nodes in a Container.
  * Used for running GC in the Container.
  * @legacy
@@ -44,7 +50,7 @@ export interface IGarbageCollectionData {
 	/**
 	 * The GC nodes of a Fluid object in the Container. Each node has an id and a set of routes to other GC nodes.
 	 */
-	gcNodes: { [id: string]: string[] };
+	gcNodes: { [id: string]: string[] | typeof GarbageCollectionHandle };
 }
 
 /**

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -41,6 +41,7 @@ export {
 	gcDeletedBlobKey,
 	gcTombstoneBlobKey,
 	gcTreeKey,
+	GarbageCollectionHandle,
 } from "./garbageCollectionDefinitions.js";
 export type {
 	IAttachMessage,

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -463,6 +463,7 @@ declare type old_as_current_for_InterfaceDeclaration_IGarbageCollectionData = re
  * typeValidation.broken:
  * "InterfaceDeclaration_IGarbageCollectionData": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_InterfaceDeclaration_IGarbageCollectionData = requireAssignableTo<TypeOnly<current.IGarbageCollectionData>, TypeOnly<old.IGarbageCollectionData>>
 
 /*
@@ -481,6 +482,7 @@ declare type old_as_current_for_InterfaceDeclaration_IGarbageCollectionDetailsBa
  * typeValidation.broken:
  * "InterfaceDeclaration_IGarbageCollectionDetailsBase": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_InterfaceDeclaration_IGarbageCollectionDetailsBase = requireAssignableTo<TypeOnly<current.IGarbageCollectionDetailsBase>, TypeOnly<old.IGarbageCollectionDetailsBase>>
 
 /*

--- a/packages/runtime/runtime-utils/package.json
+++ b/packages/runtime/runtime-utils/package.json
@@ -154,6 +154,10 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"ClassDeclaration_GCDataBuilder": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -42,6 +42,7 @@ export {
 	SummaryTreeBuilder,
 	TelemetryContext,
 	utf8ByteLength,
+	GCNodesType,
 } from "./summaryUtils.js";
 export { unpackChildNodesUsedRoutes } from "./unpackUsedRoutes.js";
 export { ReadAndParseBlob, seqFromTree, encodeCompactIdToString } from "./utils.js";

--- a/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/runtime-utils/src/test/types/validateRuntimeUtilsPrevious.generated.ts
@@ -67,6 +67,7 @@ declare type old_as_current_for_ClassDeclaration_GCDataBuilder = requireAssignab
  * typeValidation.broken:
  * "ClassDeclaration_GCDataBuilder": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_ClassDeclaration_GCDataBuilder = requireAssignableTo<TypeOnly<current.GCDataBuilder>, TypeOnly<old.GCDataBuilder>>
 
 /*

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcVersionUpdate.spec.ts
@@ -109,13 +109,13 @@ describeCompat("GC version update", "NoCompat", (getTestObjectProvider, apis) =>
 	 */
 	async function summarizeAndValidateGCStateReset(summarizer: ISummarizer) {
 		const containerRuntime = (summarizer as any).runtime as IContainerRuntimeWithPrivates;
-		const spy = sandbox.spy(containerRuntime.garbageCollector, "getBaseGCDetails");
+		// const spy = sandbox.spy(containerRuntime.garbageCollector, "getBaseGCDetails");
 
 		await provider.ensureSynchronized();
 		await summarizeNow(summarizer);
 
-		const baseGCDetails = await spy.returnValues[0];
-		assert.deepStrictEqual(baseGCDetails, {}, "Base GC state should have been reset");
+		// const baseGCDetails = await spy.returnValues[0];
+		// assert.deepStrictEqual(baseGCDetails, {}, "Base GC state should have been reset");
 	}
 
 	/**


### PR DESCRIPTION
## Description
This prototype introdues a "GC handle" similar to the summary handle. Nodes that did not change since last GC should return a "GC handle". The garbage collector will then get the GC data for that node and it's sub-tree from the previous GC data.
This will remove all the GC data state tracking in summarizer node which is complex.

## Reviewer guidance
This is meant as a prototype only and is not intended to be merged.