### PR TITLE
Signal Telemetry for Targeted Signals

### DIFF
--- a/packages/common/core-interfaces/src/messages.ts
+++ b/packages/common/core-interfaces/src/messages.ts
@@ -25,4 +25,9 @@ export interface ISignalEnvelope {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		content: any;
 	};
+
+	/**
+	 * Client ID of the singular client the signal is being (or has been) sent to.
+	 */
+	targetClientId?: string;
 }

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -448,7 +448,7 @@ export interface IPerfSignalReport {
 	 * Identifier for broadcast signals being submitted in order to
 	 * allow collection of data around the roundtrip of signal messages.
 	 */
-	broadcastSignalSequenceNumber: number;
+	broadcastSignalCount: number;
 
 	/**
 	 * Number of signals that were expected but not received.

--- a/packages/runtime/container-runtime/src/connectionTelemetry.ts
+++ b/packages/runtime/container-runtime/src/connectionTelemetry.ts
@@ -440,10 +440,16 @@ class OpPerfTelemetry {
 }
 export interface IPerfSignalReport {
 	/**
-	 * Identifier for the signal being submitted in order to
-	 * allow collection of data around the roundtrip of signal messages.
+	 * Identifier for the signal being submitted in order
 	 */
 	signalSequenceNumber: number;
+
+	/**
+	 * Identifier for broadcast signals being submitted in order to
+	 * allow collection of data around the roundtrip of signal messages.
+	 */
+	broadcastSignalSequenceNumber: number;
+
 	/**
 	 * Number of signals that were expected but not received.
 	 */
@@ -458,6 +464,11 @@ export interface IPerfSignalReport {
 	 * Expected Signal Sequence to be received.
 	 */
 	trackingSignalSequenceNumber: number | undefined;
+
+	/**
+	 * Minimum out-of-sequence signal that we expect to receive.
+	 */
+	minimumSignalSequenceNumber: number | undefined;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1272,7 +1272,7 @@ export class ContainerRuntime
 	private readonly _perfSignalData: IPerfSignalReport = {
 		signalsLost: 0,
 		signalSequenceNumber: 0,
-		broadcastSignalSequenceNumber: 0,
+		broadcastSignalCount: 0,
 		signalTimestamp: 0,
 		trackingSignalSequenceNumber: undefined,
 		minimumSignalSequenceNumber: undefined,
@@ -3170,7 +3170,7 @@ export class ContainerRuntime
 			this._perfSignalData.trackingSignalSequenceNumber = nextSignalSequenceNumber;
 			this._perfSignalData.minimumSignalSequenceNumber = nextSignalSequenceNumber;
 		} else {
-			this._perfSignalData.broadcastSignalSequenceNumber++;
+			this._perfSignalData.broadcastSignalCount++;
 		}
 
 		const newEnvelope: ISignalEnvelope = {
@@ -3181,8 +3181,7 @@ export class ContainerRuntime
 		};
 
 		if (
-			this._perfSignalData.broadcastSignalSequenceNumber %
-				this.defaultTelemetrySignalSampleCount ===
+			this._perfSignalData.broadcastSignalCount % this.defaultTelemetrySignalSampleCount ===
 				1 &&
 			!isTargetedSignal
 		) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2853,7 +2853,7 @@ export class ContainerRuntime
 
 		// Only collect signal telemetry for messages sent by the current client.
 		if (message.clientId === this.clientId && this.connected) {
-			// Initialize the perf signal data in case of reconnect.
+			// Initialize the perf signal data to track next signal if undefined.
 			if (
 				this._perfSignalData.trackingSignalSequenceNumber === undefined ||
 				this._perfSignalData.minimumSignalSequenceNumber === undefined
@@ -2909,7 +2909,7 @@ export class ContainerRuntime
 				this._perfSignalData.trackingSignalSequenceNumber++;
 			}
 
-			// only logging for the first connection and the signal latency.
+			// only log roundtrip time of signals with timestamps on first connection
 			if (this._perfSignalData.signalTimestamp !== 0 && this.consecutiveReconnects === 0) {
 				this.sendSignalTelemetryEvent(envelope.clientSignalSequenceNumber);
 			}


### PR DESCRIPTION
## Description
Targeted signals present a new challenge to tracking signal metrics since non-self-targeted signals will not come back (if the service has targeting support). This case motivates a more holistic investigation into signal monitoring and if targeted support should change the way we do things currently.

### Summary of Changes
We now look at all incoming signals to see if they are coming in sequential order. If a signal sequence number(s) is skipped, we log a 'SignalLost' event and continue to monitor for both new signals and out of sequence signals. Once we receive an out of order signal (previously logged as lost), we log a 'SignalOutOfOrder' event. 
 
The sliding 'signal tracking window' is defined by [minimumSignalSequenceNumber, trackingSignalSequenceNumber]. If a targeted signal is sent, the local signal sequence is now broken, so we will ignore all previously sent outbound signals (minimumSignalSequenceNumber = trackingSignalSequenceNumber = 'nextSignalExpected'). We do a similar 'tracking window reset' on reconnect, since we might have missed signals in flight while disconnected.
 
We still log the roundtrip time for every 100th broadcast signal (broadcastSignalSequenceNumber was added to avoid degenerate case of attempting to track any targeted signal RTT).