### PR TITLE
[bump] benchmark: 0.49.0 => 0.50.0 (minor)

### DIFF
--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/benchmark",
-	"version": "0.49.0",
+	"version": "0.50.0",
 	"description": "Benchmarking tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
## Description

Used `flub release -p "@fluid-tools/benchmark"`

Bumped benchmark from 0.49.0 to 0.50.0.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
