### PR TITLE
refactor(tree): make sequence codec logic more reusable

### DIFF
--- a/packages/dds/tree/src/codec/discriminatedUnions.ts
+++ b/packages/dds/tree/src/codec/discriminatedUnions.ts
@@ -26,6 +26,25 @@ export const unionOptions: ObjectOptions = {
 };
 
 /**
+ * An object containing functions for each member of the union.
+ *
+ * See {@link DiscriminatedUnionDispatcher}.
+ */
+export type DiscriminatedUnionLibrary<
+	TUnion extends object,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TArgs extends any[],
+	TResult,
+> = [
+	{
+		readonly [Property in keyof TUnion]-?: (
+			value: Required<TUnion>[Property],
+			...args: TArgs
+		) => TResult;
+	},
+][_InlineTrick];
+
+/**
  * Applies a function to the content of a [discriminated union](https://en.wikipedia.org/wiki/Tagged_union)
  * where the function to apply depends on which value from the union it holds.
  *
@@ -91,16 +110,7 @@ export class DiscriminatedUnionDispatcher<
 		(value: unknown, ...args: TArgs) => TResult
 	>;
 
-	public constructor(
-		library: [
-			{
-				readonly [Property in keyof TUnion]-?: (
-					value: Required<TUnion>[Property],
-					...args: TArgs
-				) => TResult;
-			},
-		][_InlineTrick],
-	) {
+	public constructor(library: DiscriminatedUnionLibrary<TUnion, TArgs, TResult>) {
 		this.library = objectToMap(
 			library as Record<keyof TUnion, (value: unknown, ...args: TArgs) => TResult>,
 		);

--- a/packages/dds/tree/src/codec/index.ts
+++ b/packages/dds/tree/src/codec/index.ts
@@ -19,7 +19,11 @@ export {
 	withDefaultBinaryEncoding,
 	withSchemaValidation,
 } from "./codec.js";
-export { DiscriminatedUnionDispatcher, unionOptions } from "./discriminatedUnions.js";
+export {
+	DiscriminatedUnionDispatcher,
+	type DiscriminatedUnionLibrary,
+	unionOptions,
+} from "./discriminatedUnions.js";
 export { noopValidator } from "./noopValidator.js";
 export {
 	Versioned,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/helperTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/helperTypes.ts
@@ -3,6 +3,15 @@
  * Licensed under the MIT License.
  */
 
+import type { DiscriminatedUnionLibrary, IJsonCodec } from "../../codec/index.js";
+import type {
+	ChangeAtomId,
+	ChangeEncodingContext,
+	EncodedRevisionTag,
+	RevisionTag,
+} from "../../core/index.js";
+import type { EncodedChangeAtomId } from "../modular-schema/index.js";
+
 import type {
 	AttachAndDetach,
 	CellId,
@@ -25,3 +34,27 @@ export type EmptyOutputCellMark = CellMark<Detach | AttachAndDetach>;
 export type MoveMarkEffect = MoveOut | MoveIn;
 export type DetachOfRemovedNodes = Detach & { cellId: CellId };
 export type CellRename = AttachAndDetach | DetachOfRemovedNodes;
+
+export interface SequenceCodecHelpers<TDecodedMarkEffect, TEncodedMarkEffect extends object> {
+	readonly changeAtomIdCodec: IJsonCodec<
+		ChangeAtomId,
+		EncodedChangeAtomId,
+		EncodedChangeAtomId,
+		ChangeEncodingContext
+	>;
+	readonly markEffectCodec: IJsonCodec<
+		TDecodedMarkEffect,
+		TEncodedMarkEffect,
+		TEncodedMarkEffect,
+		ChangeEncodingContext
+	>;
+	readonly decoderLibrary: DiscriminatedUnionLibrary<
+		TEncodedMarkEffect,
+		/* args */ [context: ChangeEncodingContext],
+		TDecodedMarkEffect
+	>;
+	readonly decodeRevision: (
+		encodedRevision: EncodedRevisionTag | undefined,
+		context: ChangeEncodingContext,
+	) => RevisionTag;
+}


### PR DESCRIPTION
## Description

Refactors the logic for the sequence field changeset codec so that later versions can replicate that logic without duplication.

## Breaking Changes

None