### PR TITLE
ci: Use correct release tag in manual runs

### DIFF
--- a/.github/workflows/push-tag-create-release.yml
+++ b/.github/workflows/push-tag-create-release.yml
@@ -60,7 +60,6 @@ jobs:
       - name: Set tag name from push
         if: github.event_name == 'push'
         run: echo "TAG_NAME=${GITHUB_REF}" >> $GITHUB_ENV
-
       - name: Set tag name from manual input
         if: github.event_name == 'workflow_dispatch'
         run: echo "TAG_NAME=refs/tags/${{ github.event.inputs.tag }}" >> $GITHUB_ENV
@@ -81,10 +80,16 @@ jobs:
         run: |
           echo "releaseType=${{ fromJson(env.RELEASE_JSON).packageOrReleaseGroup }}" >> "$GITHUB_OUTPUT"
 
-      # Generate release reports
-      - name: Check out tag
+      - name: Check out tag from push
+        if: github.event_name == 'push'
         run: |
           git checkout ${{ github.ref }}
+      - name: Check out tag from manual input
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git checkout refs/tags/${{ github.event.inputs.tag }}
+
+      # Generate release reports
       - name: Create release reports (manifests)
         run: |
           mkdir reports


### PR DESCRIPTION
The push-tag-create-release workflow was recently updated to support manual runs using the GitHub UI. However, that change did not update the step that checked out the release tag, so the release reports are generated with the wrong data.