### PR TITLE
fix(version-tools): Correctly identify test version strings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,15 @@
 			"type": "node",
 		},
 		{
+			"name": "npm test version-tools",
+			"cwd": "${workspaceFolder}/build-tools/packages/version-tools",
+			"request": "launch",
+			"runtimeArgs": ["run-script", "test"],
+			"runtimeExecutable": "npm",
+			"skipFiles": ["<node_internals>/**"],
+			"type": "node",
+		},
+		{
 			"name": "fluid-build",
 			"program": "${workspaceFolder}/build-tools/packages/build-tools/bin/fluid-build",
 			"cwd": "${workspaceFolder}/packages/common/container-definitions",

--- a/build-tools/packages/version-tools/src/internalVersionScheme.ts
+++ b/build-tools/packages/version-tools/src/internalVersionScheme.ts
@@ -22,9 +22,13 @@ export const MINIMUM_PUBLIC_VERSION = "2.0.0";
 const MINIMUM_PUBLIC_MAJOR = semver.major(MINIMUM_PUBLIC_VERSION);
 
 /**
- * The minimum number of prerelease sections a version should have to be considered a Fluid internal version.
+ * The expected number of prerelease sections a version should have to be considered a Fluid internal version. Any
+ * version string with fewer than this number of prerelease sections is not a Fluid internal version.
+ *
+ * If a version has more than this number of prerelease sections, it may be considered a prerelease Fluid internal
+ * version.
  */
-const MINIMUM_SEMVER_PRERELEASE_SECTIONS = 4;
+const EXPECTED_PRERELEASE_SECTIONS = 4;
 
 /**
  * The first part of the semver prerelease value is called the "prerelease identifier". For Fluid internal versions,
@@ -229,12 +233,15 @@ export function validateVersionScheme(
 		);
 	}
 
-	if (parsedVersion.prerelease.length > MINIMUM_SEMVER_PRERELEASE_SECTIONS) {
-		if (allowPrereleases) {
-			return true;
-		}
+	if (
+		// All versions with fewer than the min prerelease sections should not be considered internal
+		parsedVersion.prerelease.length < EXPECTED_PRERELEASE_SECTIONS ||
+		// If the version has more than the minimum prerelease sections, then it's not considered an internal version unless
+		// allowPrereleases === true
+		(parsedVersion.prerelease.length > EXPECTED_PRERELEASE_SECTIONS && !allowPrereleases)
+	) {
 		throw new Error(
-			`Prerelease value contains ${parsedVersion.prerelease.length} components; expected ${MINIMUM_SEMVER_PRERELEASE_SECTIONS}.`,
+			`Prerelease value contains ${parsedVersion.prerelease.length} components; expected ${EXPECTED_PRERELEASE_SECTIONS}.`,
 		);
 	}
 

--- a/build-tools/packages/version-tools/src/test/schemes.test.ts
+++ b/build-tools/packages/version-tools/src/test/schemes.test.ts
@@ -103,6 +103,12 @@ describe("detectVersionScheme", () => {
 		assert.strictEqual(detectVersionScheme(input), expected);
 	});
 
+	it("detects 2.1.0-281035-test is semver", () => {
+		const input = `2.1.0-281035-test`;
+		const expected = "semver";
+		assert.strictEqual(detectVersionScheme(input), expected);
+	});
+
 	it("detects 2.4.3 is semver", () => {
 		const input = `2.4.3`;
 		const expected = "semver";


### PR DESCRIPTION
For test builds, we produce versions like: 2.1.0-123456-test and 0.0.0-123456-test. version-tools identifies the former as an internal version. With this change, both are now identified as semver instead of internal versions.