### PR TITLE
tree: Allow array from map and map from array

### DIFF
--- a/.changeset/moody-toys-dance.md
+++ b/.changeset/moody-toys-dance.md
@@ -23,6 +23,7 @@ const fromArray = new Root({ data: [["x", 5]] });
 Prior versions used to have to do:
 ```typescript
 new Root({ data: new MyMapNode([["x", 5]]) });
+```
 or:
 ```typescript
 new Root({ data: new Map([["x", 5]]) });

--- a/.changeset/moody-toys-dance.md
+++ b/.changeset/moody-toys-dance.md
@@ -11,7 +11,7 @@ To avoid this being a breaking change, a priority systems was introduced.
 ArrayNodes will only be implicitly constructable from JavaScript Map objects in contexts where no MapNodes are allowed.
 Similarly MapNodes will only be implicitly constructable from JavaScript Array objects in contexts where no ArrayNodes are allowed.
 
-In practice, the main case this is likely to matter is when implicitly constructing a map node, if you provide an array of key value pairs, this now works instead of erroring, as long as no ArrayNode is valid at that location in the tree.
+In practice, the main case in which this is likely to matter is when implicitly constructing a map node. If you provide an array of key value pairs, this now works instead of erroring, as long as no ArrayNode is valid at that location in the tree.
 
 ```typescript
 class MyMapNode extends schemaFactory.map("x", schemaFactory.number) {}

--- a/.changeset/moody-toys-dance.md
+++ b/.changeset/moody-toys-dance.md
@@ -7,7 +7,7 @@ Allow constructing ArrayNodes from Maps and MapNodes from arrays when unambiguou
 
 Since the types for ArrayNodes and MapNodes indicate they can be constructed from iterables,
 it should work, even if those iterables are themselves arrays or maps.
-To avoid this being a breaking change, a priority systems was introduced.
+To avoid this being a breaking change, a priority system was introduced.
 ArrayNodes will only be implicitly constructable from JavaScript Map objects in contexts where no MapNodes are allowed.
 Similarly MapNodes will only be implicitly constructable from JavaScript Array objects in contexts where no ArrayNodes are allowed.
 
@@ -23,7 +23,6 @@ const fromArray = new Root({ data: [["x", 5]] });
 Prior versions used to have to do:
 ```typescript
 new Root({ data: new MyMapNode([["x", 5]]) });
-````
 or:
 ```typescript
 new Root({ data: new Map([["x", 5]]) });

--- a/.changeset/moody-toys-dance.md
+++ b/.changeset/moody-toys-dance.md
@@ -1,0 +1,31 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+---
+
+Allow constructing ArrayNodes from Maps and MapNodes from arrays when unambiguous.
+
+Since the types for ArrayNodes and MapNodes indicate they can be constructed from iterables,
+it should work, even if those iterables are themselves arrays or maps.
+To avoid this being a breaking change, a priority systems was introduced.
+ArrayNodes will only be implicitly constructable from JavaScript Map objects in contexts where no MapNodes are allowed.
+Similarly MapNodes will only be implicitly constructable from JavaScript Array objects in contexts where no ArrayNodes are allowed.
+
+In practice, the main case this is likely to matter is when implicitly constructing a map node, if you provide an array of key value pairs, this now works instead of erroring, as long as no ArrayNode is valid at that location in the tree.
+
+```typescript
+class MyMapNode extends schemaFactory.map("x", schemaFactory.number) {}
+class Root extends schemaFactory.object("root", { data: MyMapNode }) {}
+// This now works (before it compiled, but error at runtime):
+const fromArray = new Root({ data: [["x", 5]] });
+```
+
+Prior versions used to have to do:
+```typescript
+new Root({ data: new MyMapNode([["x", 5]]) });
+````
+or:
+```typescript
+new Root({ data: new Map([["x", 5]]) });
+```
+Both of these options still work: strictly more cases are allowed with this change.

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -932,13 +932,7 @@ export function arraySchema<
 		): MapTreeNode {
 			return getOrCreateMapTreeNode(
 				flexSchema,
-				mapTreeFromNodeData(
-					// Ensure input iterable is not an map. See TODO in shallowCompatibilityTest.
-					Array.from(
-						input as Iterable<InsertableTreeNodeFromImplicitAllowedTypes<T>>,
-					) as object,
-					this as unknown as ImplicitAllowedTypes,
-				),
+				mapTreeFromNodeData(input as object, this as unknown as ImplicitAllowedTypes),
 			);
 		}
 

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -238,8 +238,7 @@ export function mapSchema<
 			return getOrCreateMapTreeNode(
 				flexSchema,
 				mapTreeFromNodeData(
-					// Ensure input iterable is not an array. See TODO in shallowCompatibilityTest.
-					new Map(input as Iterable<readonly [string, InsertableContent]>),
+					input as Iterable<readonly [string, InsertableContent]>,
 					this as unknown as ImplicitAllowedTypes,
 				),
 			);

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -528,11 +528,11 @@ enum CompatibilityLevel {
 	 */
 	None = 0,
 	/**
-	 * Additional iterator compatibility cases added in Fluid Framework 2.2.
+	 * Additional compatibility cases added in Fluid Framework 2.2.
 	 */
 	Low = 1,
 	/**
-	 * Compatible in Fluid Framework 2.1.
+	 * Compatible in Fluid Framework 2.0.
 	 */
 	Normal = 2,
 }
@@ -560,16 +560,13 @@ function shallowCompatibilityTest(
 		return CompatibilityLevel.None;
 	}
 
-	// TODO:
-	// current typing (of schema based constructors and thus implicit node construction)
+	// Typing (of schema based constructors and thus implicit node construction)
 	// allows iterables for constructing maps and arrays.
-	// Some current users of this API may have unions of maps and arrays,
+	// Some users of this API may have unions of maps and arrays,
 	// and rely on Arrays ending up as array nodes and maps as Map nodes,
 	// despite both being iterable and thus compatible with both.
-	// In the future, a better solution could be a priority based system where an array would be parsed as an array when unioned with a map,
+	// This uses a priority based system where an array would be parsed as an array when unioned with a map,
 	// but if in a map only context, could still be used as a map.
-	// Then this method would return a quality of fit, not just a boolean.
-	// For now, special case map and array before checking iterable to avoid regressing the union of map and array case.
 
 	if (data instanceof Map) {
 		switch (schema.kind) {

--- a/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
@@ -835,4 +835,48 @@ describe("ArrayNode", () => {
 			assert.deepEqual(result2, [1, 2, 3]);
 		});
 	});
+
+	it("explicit construction", () => {
+		class Schema extends schemaFactory.array(
+			"x",
+			schemaFactory.array([schemaFactory.number, schemaFactory.string]),
+		) {}
+		const data = [["x", 5]] as const;
+		const json = JSON.stringify(data);
+		const fromArray = new Schema(data);
+		assert.equal(JSON.stringify(fromArray), json);
+		const fromMap = new Schema(new Map(data));
+		assert.equal(JSON.stringify(fromMap), json);
+		const fromIterable = new Schema(new Map(data).entries());
+		assert.equal(JSON.stringify(fromIterable), json);
+	});
+
+	describe("implicit construction", () => {
+		it("fromArray", () => {
+			class Schema extends schemaFactory.array("x", schemaFactory.number) {}
+			class Root extends schemaFactory.object("root", { data: Schema }) {}
+			const fromArray = new Root({ data: [5] });
+			assert.deepEqual([...fromArray.data], [5]);
+		});
+		it("fromMap", () => {
+			class Schema extends schemaFactory.array(
+				"x",
+				schemaFactory.array([schemaFactory.number, schemaFactory.string]),
+			) {}
+			class Root extends schemaFactory.object("root", { data: Schema }) {}
+
+			const data = [["x", 5]] as const;
+			const json = JSON.stringify(data);
+
+			const fromMap = new Root({ data: new Map(data) });
+			assert.equal(JSON.stringify(fromMap.data), json);
+		});
+		it("fromIterable", () => {
+			class Schema extends schemaFactory.array("x", schemaFactory.number) {}
+			class Root extends schemaFactory.object("root", { data: Schema }) {}
+			const fromArray = new Root({ data: [5] });
+			const fromIterable = new Root({ data: new Set([5]) });
+			assert.deepEqual([...fromIterable.data], [5]);
+		});
+	});
 });

--- a/packages/dds/tree/src/test/simple-tree/mapNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/mapNode.spec.ts
@@ -79,8 +79,7 @@ describe("MapNode", () => {
 		class Schema extends schemaFactory.map("x", schemaFactory.number) {}
 		class Root extends schemaFactory.object("root", { data: Schema }) {}
 		const data = [["x", 5]] as const;
-		// See TODO in shallowCompatibilityTest for how to enable this case.
-		it.skip("fromArray", () => {
+		it("fromArray", () => {
 			const fromArray = new Root({ data });
 			assert.deepEqual([...fromArray.data], data);
 		});

--- a/packages/dds/tree/src/test/simple-tree/toMapTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toMapTree.spec.ts
@@ -1453,9 +1453,9 @@ describe("toMapTree", () => {
 				const arraySchema = f.array([f.null]);
 				const mapSchema = f.map([f.null]);
 				// Array makes map
-				assert.deepEqual(getPossibleTypes(new Set([mapSchema]), []), [arraySchema]);
+				assert.deepEqual(getPossibleTypes(new Set([mapSchema]), []), [mapSchema]);
 				// Map makes array
-				assert.deepEqual(getPossibleTypes(new Set([arraySchema]), new Map()), [mapSchema]);
+				assert.deepEqual(getPossibleTypes(new Set([arraySchema]), new Map()), [arraySchema]);
 			});
 		});
 

--- a/packages/dds/tree/src/test/simple-tree/toMapTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toMapTree.spec.ts
@@ -1447,6 +1447,16 @@ describe("toMapTree", () => {
 					[mapSchema, arraySchema],
 				);
 			});
+
+			it("array vs map low priority matching", () => {
+				const f = new SchemaFactory("test");
+				const arraySchema = f.array([f.null]);
+				const mapSchema = f.map([f.null]);
+				// Array makes map
+				assert.deepEqual(getPossibleTypes(new Set([mapSchema]), []), [arraySchema]);
+				// Map makes array
+				assert.deepEqual(getPossibleTypes(new Set([arraySchema]), new Map()), [mapSchema]);
+			});
 		});
 
 		describe("addDefaultsToMapTree", () => {


### PR DESCRIPTION
## Description

Allow constructing ArrayNodes from Maps and MapNodes from arrays when unambiguous.

Also removes some no longer needed shallow copies in the map and array constructors .

See changeset for details.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

