### PR TITLE
Fix sharedString legacy snapshot where there is 0 segements with attribution yet 

### DIFF
--- a/packages/dds/merge-tree/src/attributionCollection.ts
+++ b/packages/dds/merge-tree/src/attributionCollection.ts
@@ -425,6 +425,10 @@ export class AttributionCollection implements IAttributionCollection<Attribution
 			{ seqs, posBreakpoints }: SequenceOffsets,
 			assignToSegment: (collection: AttributionCollection, segment: ISegment) => void,
 		): void => {
+			if (seqs.length === 0) {
+				assert(posBreakpoints.length === 0, "seqs and posBreakpoints length should match");
+				return;
+			}
 			let curIndex = 0;
 			let cumulativeSegPos = 0;
 
@@ -474,8 +478,11 @@ export class AttributionCollection implements IAttributionCollection<Attribution
 		if (channels) {
 			for (const [name, collectionSpec] of Object.entries(channels)) {
 				extractOntoSegments(collectionSpec, (collection, segment) => {
-					// Cast is valid as we just assigned this field above
-					((segment.attribution as AttributionCollection).channels ??= {})[name] = collection;
+					if (segment.attribution !== undefined) {
+						// Cast is valid as we just assigned this field above
+						((segment.attribution as AttributionCollection).channels ??= {})[name] =
+							collection;
+					}
 				});
 			}
 		}

--- a/packages/dds/merge-tree/src/snapshotlegacy.ts
+++ b/packages/dds/merge-tree/src/snapshotlegacy.ts
@@ -113,7 +113,7 @@ export class SnapshotLegacy {
 			chunkSequenceNumber: this.header!.seq,
 			segmentTexts: segs.map((seg) => seg.toJSONObject() as JsonSegmentSpecs),
 			attribution:
-				segsWithAttribution > 0
+				segsWithAttribution > 0 || this.mergeTree.attributionPolicy?.isAttached
 					? attributionSerializer?.serializeAttributionCollections(segs)
 					: undefined,
 		};

--- a/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/attributionEndToEnd.spec.ts
@@ -141,7 +141,8 @@ describeCompat("Attributor", "NoCompat", (getTestObjectProvider, apis) => {
 			const attributor = createRuntimeAttributor();
 			const container1 = await provider.makeTestContainer(getTestConfig(attributor));
 			const sharedString1 = await sharedStringFromContainer(container1);
-			const container2 = await provider.loadTestContainer(testContainerConfig);
+			const attributor2 = createRuntimeAttributor();
+			const container2 = await provider.loadTestContainer(getTestConfig(attributor2));
 			const sharedString2 = await sharedStringFromContainer(container2);
 
 			const text = "client 1";
@@ -160,6 +161,12 @@ describeCompat("Attributor", "NoCompat", (getTestObjectProvider, apis) => {
 				user: container1.audience.getMember(container2.clientId)?.user,
 			});
 			assertAttributionMatches(sharedString1, 13, attributor, {
+				user: container1.audience.getMember(container1.clientId)?.user,
+			});
+			assertAttributionMatches(sharedString2, 3, attributor2, {
+				user: container1.audience.getMember(container2.clientId)?.user,
+			});
+			assertAttributionMatches(sharedString2, 13, attributor2, {
 				user: container1.audience.getMember(container1.clientId)?.user,
 			});
 		},

--- a/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
@@ -127,7 +127,8 @@ describeCompat("Attributor for SharedCell", "NoCompat", (getTestObjectProvider, 
 			const attributor = createRuntimeAttributor();
 			const container1 = await provider.makeTestContainer(getTestConfig(attributor));
 			const sharedCell1 = await sharedCellFromContainer(container1);
-			const container2 = await provider.loadTestContainer(testContainerConfig);
+			const attributor2 = createRuntimeAttributor();
+			const container2 = await provider.loadTestContainer(getTestConfig(attributor2));
 			const sharedCell2 = await sharedCellFromContainer(container2);
 
 			assert(
@@ -146,10 +147,16 @@ describeCompat("Attributor for SharedCell", "NoCompat", (getTestObjectProvider, 
 				user: container1.audience.getMember(container2.clientId)?.user,
 			});
 
+			assertAttributionMatches(sharedCell2, attributor2, {
+				user: container1.audience.getMember(container2.clientId)?.user,
+			});
 			sharedCell1.set(3);
 			await provider.ensureSynchronized();
 
 			assertAttributionMatches(sharedCell1, attributor, {
+				user: container2.audience.getMember(container1.clientId)?.user,
+			});
+			assertAttributionMatches(sharedCell2, attributor2, {
 				user: container2.audience.getMember(container1.clientId)?.user,
 			});
 		},


### PR DESCRIPTION
## Description

Attribution is not initialized on segments yet as min seq number could still be 0. So, while snapshotting we don't set the attribution prop on segment. So, when we reload the segment, then in extractAttribution() in snapshpotLoader.ts file, we detach from the attribution policy since if the summarized segments do not have attribution, then loaded file should not have attribution too as they are enabled on new file and then all future loads should have attribution.