### PR TITLE
feat(tree): Add isRepoSuperset to validate the incompatibilities between …

### DIFF
--- a/.changeset/strong-mice-talk.md
+++ b/.changeset/strong-mice-talk.md
@@ -1,0 +1,8 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+---
+
+Add a function `isRepoSuperset` to determines whether the `view` schema allows a superset of the documents that the `stored` schema allows.
+Specifically, it utilizes the incompatibilities returned from `getAllowedContentIncompatibilities` to validate if changes to a document schema
+are backward-compatible.

--- a/.changeset/strong-mice-talk.md
+++ b/.changeset/strong-mice-talk.md
@@ -3,6 +3,6 @@
 "@fluidframework/tree": minor
 ---
 
-Add a function `isRepoSuperset` to determines whether the `view` schema allows a superset of the documents that the `stored` schema allows.
-Specifically, it utilizes the incompatibilities returned from `getAllowedContentIncompatibilities` to validate if changes to a document schema
-are backward-compatible.
+Add a function `isRepoSuperset` to determine if changes to a document schema are backward-compatible.
+
+Note: These changes are not customer-facing and make progress toward future plans in Tree's schema evolution space.

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -131,6 +131,7 @@ export {
 	type FieldKindConfiguration,
 	type FieldKindConfigurationEntry,
 	getAllowedContentIncompatibilities,
+	isRepoSuperset,
 } from "./modular-schema/index.js";
 
 export {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
@@ -390,6 +390,25 @@ function trackObjectNodeDiscrepancies(
 	return differences;
 }
 
+/**
+ * This function uses incompatibilities to determine if changes to a document schema are backward-compatible.
+ * According to the policy of schema evolution, `isRepoSuperset` supports three types of changes:
+ * 1. Adding an optional field to an object node.
+ * 2. Expanding the set of allowed types for a field.
+ * 3. Relaxing a field kind to a more general field kind.
+ *
+ * Notes: We expect isRepoSuperset to return consistent results with allowsRepoSuperset. However, currently there are some inconsistencies:
+ *
+ * - Different Node Kinds: If a and b have different node kinds (e.g., a is an objectNodeSchema and b is a mapNodeSchema),
+ * `isRepoSuperset` will determine that a can never be the superset of b. In contrast, `allowsRepoSuperset` will continue
+ * validating internal fields.
+ *
+ * - Sequence Field Kind: `isRepoSuperset` does not support comparing fields with the sequence field kind.
+ *
+ * - Empty Fields: If a has an empty field and b has a field with the same identifier but includes a non-optional field
+ * with values, `allowsRepoSuperset` will consider a as a superset of b due to its more flexible field. However,
+ * `isRepoSuperset` will produce different results, as the incompatibilities indicate that b has more content than a.
+ */
 export function isRepoSuperset(view: TreeStoredSchema, stored: TreeStoredSchema): boolean {
 	const incompatibilities = getAllowedContentIncompatibilities(view, stored);
 

--- a/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
@@ -446,7 +446,12 @@ function compareFieldKind(
 		"Forbidden": 1,
 		"Value": 2,
 		"Optional": 3,
+		// "Sequence": 4,  // the sequence fieldKind is not supported yet
 	};
+
+	if (!(aKind in order) || !(bKind in order)) {
+		return false;
+	}
 
 	// Compare the order values
 	return order[aKind] <= order[bKind];

--- a/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
@@ -293,7 +293,7 @@ function trackFieldDiscrepancies(
 ): FieldIncompatibility[] {
 	const differences: FieldIncompatibility[] = [];
 
-	// Only track the intersection of the two sets.
+	// Only track the symmetric differences of two sets.
 	const findSetDiscrepancies = (
 		a: TreeTypeSet,
 		b: TreeTypeSet,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
@@ -454,7 +454,8 @@ function compareFieldKind(
 	}
 
 	// Compare the order values
-	return order[aKind] <= order[bKind];
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+	return order[aKind]! <= order[bKind]!;
 }
 
 function throwUnsupportedNodeType(type: string): never {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
@@ -465,7 +465,7 @@ function compareFieldKind(
 		"Forbidden": 1,
 		"Value": 2,
 		"Optional": 3,
-		// "Sequence": 4,  // the sequence fieldKind is not supported yet
+		// "Sequence": 4,  // Relaxing non-sequence fields to sequences is not currently supported, though we could consider doing so in the future.
 	};
 
 	if (!(aKind in order) || !(bKind in order)) {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
@@ -442,7 +442,10 @@ export function isRepoSuperset(view: TreeStoredSchema, stored: TreeStoredSchema)
 function validateFieldIncompatibility(incompatibility: FieldIncompatibility): boolean {
 	switch (incompatibility.mismatch) {
 		case "allowedTypes": {
-			return incompatibility.stored.every((item) => incompatibility.view.includes(item));
+			// Since we only track the symmetric difference between the allowed types in the view and
+			// stored schemas, it's sufficient to check if any extra allowed types still exist in the
+			// stored schema.
+			return incompatibility.stored.length === 0;
 		}
 		case "fieldKind": {
 			if (incompatibility.stored === undefined) {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/discrepancies.ts
@@ -393,23 +393,19 @@ function trackObjectNodeDiscrepancies(
 /**
  * @remarks
  *
- * This function uses incompatibilities to determine if changes to a document schema are backward-compatible.
+ * This function uses incompatibilities to determine if changes to a document schema are backward-compatible, i.e., it determines
+ * whether the `view` schema allows a superset of the documents that the `stored` schema allows.
  * According to the policy of schema evolution, `isRepoSuperset` supports three types of changes:
  * 1. Adding an optional field to an object node.
  * 2. Expanding the set of allowed types for a field.
  * 3. Relaxing a field kind to a more general field kind.
  *
- * Notes: We expect isRepoSuperset to return consistent results with allowsRepoSuperset. However, currently there are some inconsistencies:
+ * Notes: We expect isRepoSuperset to return consistent results with allowsRepoSuperset. However, currently there are some scenarios
+ * where the inconsistency will occur:
  *
  * - Different Node Kinds: If a and b have different node kinds (e.g., a is an objectNodeSchema and b is a mapNodeSchema),
  * `isRepoSuperset` will determine that a can never be the superset of b. In contrast, `allowsRepoSuperset` will continue
  * validating internal fields.
- *
- * - Sequence Field Kind: `isRepoSuperset` does not support comparing fields with the sequence field kind.
- *
- * - Empty Fields: If a has an empty field and b has a field with the same identifier but includes a non-optional field
- * with values, `allowsRepoSuperset` will consider a as a superset of b due to its more flexible field. However,
- * `isRepoSuperset` will produce different results, as the incompatibilities indicate that b has more content than a.
  */
 export function isRepoSuperset(view: TreeStoredSchema, stored: TreeStoredSchema): boolean {
 	const incompatibilities = getAllowedContentIncompatibilities(view, stored);
@@ -481,6 +477,8 @@ function validateFieldIncompatibility(incompatibility: FieldIncompatibility): bo
  * Note:
  * - "Sequence": (Currently commented out) was intended to represent a sequence field kind with a value of 4.
  * Relaxing non-sequence fields to sequences is not currently supported but may be considered in the future.
+ *
+ * TODO: We may need more coverage in realm to prove the correctness of the Forbidden -\> Value transaction
  */
 const fieldKindOrder: { [key: string]: number } = {
 	"Forbidden": 1,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
@@ -74,4 +74,4 @@ export type {
 	FieldKindConfiguration,
 	FieldKindConfigurationEntry,
 } from "./fieldKindConfiguration.js";
-export { getAllowedContentIncompatibilities } from "./discrepancies.js";
+export { getAllowedContentIncompatibilities, isRepoSuperset } from "./discrepancies.js";

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -332,6 +332,14 @@ describe("Schema Comparison", () => {
 				optionalTreeRepoWithoutValue,
 				true,
 			);
+
+			validateMethodsConsistent(anyLocalFieldTreeRepo, optionalLocalFieldTreeRepo, false);
+			validateMethodsConsistent(anyLocalFieldTreeRepo, valueLocalFieldTreeRepo, false);
+			validateMethodsConsistent(
+				anyLocalFieldTreeRepo,
+				optionalTreeRepoWithMultipleValues,
+				false,
+			);
 		});
 
 		it("Fix the TreeNodeStoredSchema and validate repo superset with different rootFieldSchemas", () => {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/comparison.spec.ts
@@ -223,10 +223,14 @@ describe("Schema Comparison", () => {
 			return allowsRepoSuperset(defaultSchemaPolicy, a, b);
 		};
 
-		const validateMethodsConsistent = (view: TreeStoredSchema, stored: TreeStoredSchema, isSuperset: boolean): void => {
+		const validateMethodsConsistent = (
+			view: TreeStoredSchema,
+			stored: TreeStoredSchema,
+			isSuperset: boolean,
+		): void => {
 			assert.equal(allowsRepoSuperset(defaultSchemaPolicy, stored, view), isSuperset);
 			assert.equal(isRepoSuperset(view, stored), isSuperset);
-		}
+		};
 
 		it("Fix the rootFieldSchema and validate repo superset with different TreeNodeStoredSchemas", () => {
 			const rootFieldSchema = fieldSchema(FieldKinds.optional);
@@ -315,11 +319,19 @@ describe("Schema Comparison", () => {
 			// Validate the consistent results of 'allowsRepoSuperset' and 'isRepoSuperset'
 			validateMethodsConsistent(emptyTreeRepo, valueLocalFieldTreeRepo, false);
 			validateMethodsConsistent(optionalTreeRepoWithoutValue, valueLocalFieldTreeRepo, false);
-			validateMethodsConsistent(optionalTreeRepoWithMultipleValues, optionalLocalFieldTreeRepo, false);
+			validateMethodsConsistent(
+				optionalTreeRepoWithMultipleValues,
+				optionalLocalFieldTreeRepo,
+				false,
+			);
 
 			validateMethodsConsistent(optionalLocalFieldTreeRepo, valueLocalFieldTreeRepo, true);
 			validateMethodsConsistent(optionalTreeRepoWithMultipleValues, emptyTreeRepo, true);
-			validateMethodsConsistent(optionalTreeRepoWithMultipleValues, optionalTreeRepoWithoutValue, true);
+			validateMethodsConsistent(
+				optionalTreeRepoWithMultipleValues,
+				optionalTreeRepoWithoutValue,
+				true,
+			);
 		});
 
 		it("Fix the TreeNodeStoredSchema and validate repo superset with different rootFieldSchemas", () => {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/discrepancies.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/discrepancies.spec.ts
@@ -125,8 +125,17 @@ describe("Schema Discrepancies", () => {
 
 		assert.deepEqual(getAllowedContentIncompatibilities(mapNodeSchema, mapNodeSchema), []);
 
+		/**
+		 * Below is an inconsistency between 'isRepoSuperset' and 'allowsRepoSuperset'. The 'isRepoSuperset' will
+		 * halt further validation if an inconsistency in `nodeKind` is found. However, the current logic of
+		 * 'allowsRepoSuperset' permits relaxing an object node to a map node, which allows for a union of all types
+		 * permitted on the object node's fields. It is unclear if this behavior is desired, as
+		 * 'getAllowedContentIncompatibilities' currently does not support it.
+		 *
+		 * TODO: If we decide to support this behavior, we will need better e2e tests for this scenario. Additionally,
+		 * we may need to adjust the encoding of map nodes and object nodes to ensure consistent encoding.
+		 */
 		assert.equal(isRepoSuperset(objectNodeSchema, mapNodeSchema), false);
-		// there is inconsistency
 		assert.equal(
 			allowsRepoSuperset(defaultSchemaPolicy, objectNodeSchema, mapNodeSchema),
 			true,

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/discrepancies.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/discrepancies.spec.ts
@@ -26,23 +26,20 @@ import { fieldSchema } from "./comparison.spec.js";
 
 /**
  * Validates the consistency between `isRepoSuperset` and `allowsRepoSuperset` functions.
- * Also ensures that the reversed relationship is false if `antisymmetric` is true.
  *
  * @param view - The view schema to compare.
  * @param stored - The stored schema to compare.
- * @param antisymmetric - If true (default), checks that the reverse relationship is false.
  */
-function validateSuperset(
-	view: TreeStoredSchema,
-	stored: TreeStoredSchema,
-	antisymmetric?: boolean,
-) {
-	assert(isRepoSuperset(view, stored) === true);
-	assert(allowsRepoSuperset(defaultSchemaPolicy, stored, view) === true);
-	if (antisymmetric ?? true) {
-		assert(isRepoSuperset(stored, view) === false);
-		assert(allowsRepoSuperset(defaultSchemaPolicy, view, stored) === false);
-	}
+function validateSuperset(view: TreeStoredSchema, stored: TreeStoredSchema) {
+	assert.equal(isRepoSuperset(view, stored), true);
+	assert.equal(allowsRepoSuperset(defaultSchemaPolicy, stored, view), true);
+}
+
+function validateStrictSuperset(view: TreeStoredSchema, stored: TreeStoredSchema) {
+	validateSuperset(view, stored);
+	// assert the superset relationship does not keep in reversed direction
+	assert.equal(isRepoSuperset(stored, view), false);
+	assert.equal(allowsRepoSuperset(defaultSchemaPolicy, view, stored), false);
 }
 
 describe("Schema Discrepancies", () => {
@@ -203,11 +200,7 @@ describe("Schema Discrepancies", () => {
 			},
 		]);
 
-		assert.equal(isRepoSuperset(mapNodeSchema4, mapNodeSchema1), true);
-		assert.equal(
-			allowsRepoSuperset(defaultSchemaPolicy, mapNodeSchema1, mapNodeSchema4),
-			true,
-		);
+		validateStrictSuperset(mapNodeSchema4, mapNodeSchema1);
 	});
 
 	it("Differing schema identifiers", () => {
@@ -479,8 +472,8 @@ describe("Schema Discrepancies", () => {
 				root2,
 			);
 
-			validateSuperset(mapNodeSchema2, mapNodeSchema1);
-			validateSuperset(mapNodeSchema3, mapNodeSchema2);
+			validateStrictSuperset(mapNodeSchema2, mapNodeSchema1);
+			validateStrictSuperset(mapNodeSchema3, mapNodeSchema2);
 		});
 
 		it("Adding to the set of allowed types for a field", () => {
@@ -505,8 +498,8 @@ describe("Schema Discrepancies", () => {
 				root1,
 			);
 
-			validateSuperset(mapNodeSchema4, mapNodeSchema2);
-			validateSuperset(mapNodeSchema3, mapNodeSchema4);
+			validateStrictSuperset(mapNodeSchema4, mapNodeSchema2);
+			validateStrictSuperset(mapNodeSchema3, mapNodeSchema4);
 		});
 
 		it("Adding an optional field to an object node", () => {
@@ -525,7 +518,7 @@ describe("Schema Discrepancies", () => {
 				root1,
 			);
 
-			validateSuperset(objectNodeSchema2, objectNodeSchema1);
+			validateStrictSuperset(objectNodeSchema2, objectNodeSchema1);
 		});
 
 		it("No superset for node kind incompatibility", () => {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/discrepancies.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/discrepancies.spec.ts
@@ -456,7 +456,7 @@ describe("Schema Discrepancies", () => {
 		});
 	});
 
-	describe("validate the current schema compatibility policy", () => {
+	describe("isRepoSuperset", () => {
 		const root1 = fieldSchema(FieldKinds.required);
 		const root2 = fieldSchema(FieldKinds.optional);
 


### PR DESCRIPTION
…two repos

[AB#8717](https://dev.azure.com/fluidframework/internal/_workitems/edit/8717)

The PR consists of two parts:

1. Fixing previous unit tests for `allowsRepoSuperset`

The previous tests contained schemas that were incorrectly treated as `neverTree`, it may not change the test result but influence the the analysis process of `allowsRepoSuperset`. This fix ensures accurate schema creation and validation.

2. Introducing `isRepoSuperset`:

This function uses incompatibilities to determine if changes to a document schema are backward-compatible. According to the [doc of schema evolution](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/docs/user-facing/schema-evolution.md), `isRepoSuperset` supports three types of changes:

- Adding an optional field to an object node.

- Expanding the set of allowed types for a field.

- Relaxing a field kind to a more general field kind.

Notes: We expect `isRepoSuperset` to return consistent results with `allowsRepoSuperset`. However, there are some inconsistencies:

- **Different Node Kinds**: If a and b have different node kinds (e.g., a is an `objectNodeSchema` and b is a `mapNodeSchema`), `isRepoSuperse` will determine that a can never be the superset of b. In contrast, `allowsRepoSuperset` will continue validating internal fields.


## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

