### PR TITLE
Change data properties in `@fluid-tools/benchmark`

### DIFF
--- a/tools/benchmark/CHANGELOG.md
+++ b/tools/benchmark/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fluid-tools/benchmark
 
+## 0.50.0
+
+- Fixes the time execution test to have correct key-value pairs to avoid logging `undefined`.
+- Removes `customDataFormatters` in the log output files.
+- Unifies the logging format for time execution and memory tests.
+
 ## 0.49.0
 
 Provide @benchmarkCustom feature to log custom measurements. To profile custom usage, define tests using the `benchmarkCustom()` function. The argument `run` to the function includes a reporter with `addMeasurement()`

--- a/tools/benchmark/CHANGELOG.md
+++ b/tools/benchmark/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 0.50.0
 
-- Fixes the time execution test to have correct key-value pairs to avoid logging `undefined`.
-- Removes `customDataFormatters` in the log output files.
-- Unifies the logging format for time execution and memory tests.
+-   Fixes the time execution test to have correct key-value pairs to avoid logging `undefined`.
+-   Removes `customDataFormatters` in the log output files.
+-   Unifies the logging format for time execution and memory tests.
 
 ## 0.49.0
 

--- a/tools/benchmark/api-report/benchmark.alpha.api.md
+++ b/tools/benchmark/api-report/benchmark.alpha.api.md
@@ -29,7 +29,7 @@ export function benchmarkCustom(options: CustomBenchmarkOptions): Test;
 // @public
 export interface BenchmarkData {
     customData: Record<string, unknown>;
-    customDataFormatters: Record<string, (value: unknown) => string>;
+    customDataFormatters: Record<string, string>;
     elapsedSeconds: number;
 }
 

--- a/tools/benchmark/api-report/benchmark.alpha.api.md
+++ b/tools/benchmark/api-report/benchmark.alpha.api.md
@@ -28,8 +28,7 @@ export function benchmarkCustom(options: CustomBenchmarkOptions): Test;
 
 // @public
 export interface BenchmarkData {
-    customData: Record<string, unknown>;
-    customDataFormatters: Record<string, string>;
+    customData: CustomData;
     elapsedSeconds: number;
 }
 
@@ -114,6 +113,12 @@ export type CustomBenchmarkArguments = MochaExclusiveOptions & CustomBenchmark &
 export interface CustomBenchmarkOptions extends Titled, BenchmarkDescription, MochaExclusiveOptions {
     run: (reporter: IMeasurementReporter) => void | Promise<unknown>;
 }
+
+// @public
+export type CustomData = Record<string, {
+    rawValue: unknown;
+    formattedValue: string;
+}>;
 
 // @public
 export function geometricMean(values: number[]): number;

--- a/tools/benchmark/api-report/benchmark.beta.api.md
+++ b/tools/benchmark/api-report/benchmark.beta.api.md
@@ -29,7 +29,7 @@ export function benchmarkCustom(options: CustomBenchmarkOptions): Test;
 // @public
 export interface BenchmarkData {
     customData: Record<string, unknown>;
-    customDataFormatters: Record<string, (value: unknown) => string>;
+    customDataFormatters: Record<string, string>;
     elapsedSeconds: number;
 }
 

--- a/tools/benchmark/api-report/benchmark.beta.api.md
+++ b/tools/benchmark/api-report/benchmark.beta.api.md
@@ -28,8 +28,7 @@ export function benchmarkCustom(options: CustomBenchmarkOptions): Test;
 
 // @public
 export interface BenchmarkData {
-    customData: Record<string, unknown>;
-    customDataFormatters: Record<string, string>;
+    customData: CustomData;
     elapsedSeconds: number;
 }
 
@@ -114,6 +113,12 @@ export type CustomBenchmarkArguments = MochaExclusiveOptions & CustomBenchmark &
 export interface CustomBenchmarkOptions extends Titled, BenchmarkDescription, MochaExclusiveOptions {
     run: (reporter: IMeasurementReporter) => void | Promise<unknown>;
 }
+
+// @public
+export type CustomData = Record<string, {
+    rawValue: unknown;
+    formattedValue: string;
+}>;
 
 // @public
 export function geometricMean(values: number[]): number;

--- a/tools/benchmark/api-report/benchmark.public.api.md
+++ b/tools/benchmark/api-report/benchmark.public.api.md
@@ -29,7 +29,7 @@ export function benchmarkCustom(options: CustomBenchmarkOptions): Test;
 // @public
 export interface BenchmarkData {
     customData: Record<string, unknown>;
-    customDataFormatters: Record<string, (value: unknown) => string>;
+    customDataFormatters: Record<string, string>;
     elapsedSeconds: number;
 }
 

--- a/tools/benchmark/api-report/benchmark.public.api.md
+++ b/tools/benchmark/api-report/benchmark.public.api.md
@@ -28,8 +28,7 @@ export function benchmarkCustom(options: CustomBenchmarkOptions): Test;
 
 // @public
 export interface BenchmarkData {
-    customData: Record<string, unknown>;
-    customDataFormatters: Record<string, string>;
+    customData: CustomData;
     elapsedSeconds: number;
 }
 
@@ -114,6 +113,12 @@ export type CustomBenchmarkArguments = MochaExclusiveOptions & CustomBenchmark &
 export interface CustomBenchmarkOptions extends Titled, BenchmarkDescription, MochaExclusiveOptions {
     run: (reporter: IMeasurementReporter) => void | Promise<unknown>;
 }
+
+// @public
+export type CustomData = Record<string, {
+    rawValue: unknown;
+    formattedValue: string;
+}>;
 
 // @public
 export function geometricMean(values: number[]): number;

--- a/tools/benchmark/src/Reporter.ts
+++ b/tools/benchmark/src/Reporter.ts
@@ -130,12 +130,7 @@ export class BenchmarkReporter {
 		// Using this utility to print the data means missing fields don't crash and extra fields are reported.
 		// This is useful if this reporter is given unexpected data (such as from a memory test).
 		// It can also be used as a way to add extensible data formatting in the future.
-		addCells(
-			table,
-			(result as BenchmarkData).customData,
-			(result as BenchmarkData).customDataFormatters,
-			expectedKeys,
-		);
+		addCells(table, (result as BenchmarkData).customData, expectedKeys);
 
 		table.newRow();
 	}

--- a/tools/benchmark/src/Reporter.ts
+++ b/tools/benchmark/src/Reporter.ts
@@ -39,7 +39,12 @@ import * as path from "node:path";
 import chalk from "chalk";
 import Table from "easy-table";
 
-import { isResultError, type BenchmarkData, type BenchmarkResult } from "./ResultTypes";
+import {
+	isResultError,
+	type BenchmarkData,
+	type BenchmarkResult,
+	type CustomData,
+} from "./ResultTypes";
 import { pad, prettyNumber } from "./RunnerUtilities";
 import { ExpectedCell, addCells, numberCell, stringCell } from "./resultFormatting";
 
@@ -266,8 +271,9 @@ export class BenchmarkReporter {
 		const benchmarkArray: unknown[] = [];
 		for (const [key, bench] of benchmarks.entries()) {
 			if (!isResultError(bench)) {
+				const benchData = bench as BenchmarkData; // the if statement above guarantees the `bench` to be of type `BenchmarkData`.
 				benchmarkArray.push(
-					this.outputFriendlyObjectFromBenchmark(key, bench as Record<string, unknown>),
+					this.outputFriendlyObjectFromBenchmark(key, benchData.customData),
 				);
 			}
 		}
@@ -291,14 +297,14 @@ export class BenchmarkReporter {
 	 */
 	private outputFriendlyObjectFromBenchmark(
 		benchmarkName: string,
-		benchmark: Record<string, unknown>,
+		benchmark: CustomData,
 	): Record<string, unknown> {
 		const keys = new Set(Object.getOwnPropertyNames(benchmark));
 		const obj = {
 			benchmarkName,
 		};
 		for (const key of keys) {
-			obj[key] = benchmark[key];
+			obj[key] = benchmark[key].rawValue;
 		}
 		return obj;
 	}

--- a/tools/benchmark/src/ResultTypes.ts
+++ b/tools/benchmark/src/ResultTypes.ts
@@ -47,6 +47,12 @@ export interface Stats {
 }
 
 /**
+ * Custom data type for a benchmark.
+ * @public
+ */
+export type CustomData = Record<string, { rawValue: unknown; formattedValue: string }>;
+
+/**
  * Result of successfully running a benchmark.
  * @public
  */
@@ -59,12 +65,7 @@ export interface BenchmarkData {
 	/**
 	 * Custom data.
 	 */
-	customData: Record<string, unknown>;
-
-	/**
-	 * Custom data formatters.
-	 */
-	customDataFormatters: Record<string, string>;
+	customData: CustomData;
 }
 
 /**

--- a/tools/benchmark/src/ResultTypes.ts
+++ b/tools/benchmark/src/ResultTypes.ts
@@ -64,7 +64,7 @@ export interface BenchmarkData {
 	/**
 	 * Custom data formatters.
 	 */
-	customDataFormatters: Record<string, (value: unknown) => string>;
+	customDataFormatters: Record<string, string>;
 }
 
 /**

--- a/tools/benchmark/src/index.ts
+++ b/tools/benchmark/src/index.ts
@@ -55,6 +55,7 @@ export {
 	BenchmarkError,
 	BenchmarkResult,
 	Stats,
+	CustomData,
 	isResultError,
 } from "./ResultTypes";
 export { Timer } from "./timer";

--- a/tools/benchmark/src/mocha/customOutputRunner.ts
+++ b/tools/benchmark/src/mocha/customOutputRunner.ts
@@ -6,7 +6,8 @@
 import { Test } from "mocha";
 
 import type { BenchmarkDescription, MochaExclusiveOptions, Titled } from "../Configuration";
-import type { BenchmarkData } from "../ResultTypes";
+import type { BenchmarkData, CustomData } from "../ResultTypes";
+import { prettyNumber } from "../RunnerUtilities";
 import { timer } from "../timer";
 
 /**
@@ -37,14 +38,13 @@ export interface CustomBenchmarkOptions
 export function benchmarkCustom(options: CustomBenchmarkOptions): Test {
 	const itFunction = options.only === true ? it.only : it;
 	const test = itFunction(`${options.title} @CustomBenchmark`, async () => {
-		const customData: Record<string, number> = {};
-		const customDataFormatters: Record<string, string> = {};
+		const customData: CustomData = {};
 		const reporter: IMeasurementReporter = {
 			addMeasurement: (key: string, value: number) => {
 				if (key in customData) {
 					throw new Error(`Measurement key '${key}' was already used.`);
 				}
-				customData[key] = value;
+				customData[key] = { rawValue: value, formattedValue: prettyNumber(value) };
 			},
 		};
 
@@ -55,7 +55,6 @@ export function benchmarkCustom(options: CustomBenchmarkOptions): Test {
 		const results: BenchmarkData = {
 			elapsedSeconds,
 			customData,
-			customDataFormatters,
 		};
 
 		test.emit("benchmark end", results);

--- a/tools/benchmark/src/mocha/customOutputRunner.ts
+++ b/tools/benchmark/src/mocha/customOutputRunner.ts
@@ -38,7 +38,7 @@ export function benchmarkCustom(options: CustomBenchmarkOptions): Test {
 	const itFunction = options.only === true ? it.only : it;
 	const test = itFunction(`${options.title} @CustomBenchmark`, async () => {
 		const customData: Record<string, number> = {};
-		const customDataFormatters: Record<string, (value: unknown) => string> = {};
+		const customDataFormatters: Record<string, string> = {};
 		const reporter: IMeasurementReporter = {
 			addMeasurement: (key: string, value: number) => {
 				if (key in customData) {

--- a/tools/benchmark/src/mocha/memoryTestRunner.ts
+++ b/tools/benchmark/src/mocha/memoryTestRunner.ts
@@ -387,25 +387,32 @@ export function benchmarkMemory(testObject: IMemoryTestObject): Test {
 			);
 
 			benchmarkStats.customData["Heap Used Avg"] = heapUsedStats.arithmeticMean;
-			benchmarkStats.customDataFormatters["Heap Used Avg"] = (value): string =>
-				prettyNumber(value as number, 2);
+			benchmarkStats.customDataFormatters["Heap Used Avg"] = prettyNumber(
+				heapUsedStats.arithmeticMean,
+				2,
+			);
+
+			benchmarkStats.customData["Heap Used StdDev"] = heapUsedStats.standardDeviation;
+			benchmarkStats.customDataFormatters["Heap Used StdDev"] = prettyNumber(
+				heapUsedStats.standardDeviation,
+				2,
+			);
 
 			benchmarkStats.customData["Margin of Error"] = heapUsedStats.marginOfError;
-			benchmarkStats.customDataFormatters["Margin of Error"] = (value): string =>
-				`±${prettyNumber(value as number, 2)}`;
+			benchmarkStats.customDataFormatters["Margin of Error"] = `±${prettyNumber(
+				heapUsedStats.marginOfError,
+				2,
+			)}`;
 
 			benchmarkStats.customData["Relative Margin of Error"] =
 				heapUsedStats.marginOfErrorPercent;
-			benchmarkStats.customDataFormatters["Relative Margin of Error"] = (value): string =>
-				`±${prettyNumber(value as number, 2)}`;
-
-			benchmarkStats.customData["Heap Used StdDev"] = heapUsedStats.standardDeviation;
-			benchmarkStats.customDataFormatters["Heap Used StdDev"] = (value): string =>
-				prettyNumber(value as number, 2);
+			benchmarkStats.customDataFormatters["Relative Margin of Error"] = `±${prettyNumber(
+				heapUsedStats.marginOfErrorPercent,
+				2,
+			)}`;
 
 			benchmarkStats.customData.Iterations = runs;
-			benchmarkStats.customDataFormatters.Iterations = (value): string =>
-				(value as number).toString();
+			benchmarkStats.customDataFormatters.Iterations = prettyNumber(runs, 0);
 		} catch (error) {
 			// TODO: This results in the mocha test passing when it should fail. Fix this.
 			benchmarkStats = {

--- a/tools/benchmark/src/mocha/memoryTestRunner.ts
+++ b/tools/benchmark/src/mocha/memoryTestRunner.ts
@@ -315,7 +315,6 @@ export function benchmarkMemory(testObject: IMemoryTestObject): Test {
 		let benchmarkStats: BenchmarkResult = {
 			elapsedSeconds: 0,
 			customData: {},
-			customDataFormatters: {},
 		};
 		const sample: MemorySampleData = {
 			before: {
@@ -386,33 +385,30 @@ export function benchmarkMemory(testObject: IMemoryTestObject): Test {
 				heapUsedStats.marginOfErrorPercent > options.maxRelativeMarginOfError
 			);
 
-			benchmarkStats.customData["Heap Used Avg"] = heapUsedStats.arithmeticMean;
-			benchmarkStats.customDataFormatters["Heap Used Avg"] = prettyNumber(
-				heapUsedStats.arithmeticMean,
-				2,
-			);
+			benchmarkStats.customData["Heap Used Avg"] = {
+				rawValue: heapUsedStats.arithmeticMean,
+				formattedValue: prettyNumber(heapUsedStats.arithmeticMean, 2),
+			};
 
-			benchmarkStats.customData["Heap Used StdDev"] = heapUsedStats.standardDeviation;
-			benchmarkStats.customDataFormatters["Heap Used StdDev"] = prettyNumber(
-				heapUsedStats.standardDeviation,
-				2,
-			);
+			benchmarkStats.customData["Heap Used StdDev"] = {
+				rawValue: heapUsedStats.standardDeviation,
+				formattedValue: prettyNumber(heapUsedStats.standardDeviation, 2),
+			};
 
-			benchmarkStats.customData["Margin of Error"] = heapUsedStats.marginOfError;
-			benchmarkStats.customDataFormatters["Margin of Error"] = `±${prettyNumber(
-				heapUsedStats.marginOfError,
-				2,
-			)}`;
+			benchmarkStats.customData["Margin of Error"] = {
+				rawValue: heapUsedStats.marginOfError,
+				formattedValue: `±${prettyNumber(heapUsedStats.marginOfError, 2)}`,
+			};
 
-			benchmarkStats.customData["Relative Margin of Error"] =
-				heapUsedStats.marginOfErrorPercent;
-			benchmarkStats.customDataFormatters["Relative Margin of Error"] = `±${prettyNumber(
-				heapUsedStats.marginOfErrorPercent,
-				2,
-			)}`;
+			benchmarkStats.customData["Relative Margin of Error"] = {
+				rawValue: heapUsedStats,
+				formattedValue: `±${prettyNumber(heapUsedStats.marginOfErrorPercent, 2)}`,
+			};
 
-			benchmarkStats.customData.Iterations = runs;
-			benchmarkStats.customDataFormatters.Iterations = prettyNumber(runs, 0);
+			benchmarkStats.customData.Iterations = {
+				rawValue: runs,
+				formattedValue: prettyNumber(runs, 0),
+			};
 		} catch (error) {
 			// TODO: This results in the mocha test passing when it should fail. Fix this.
 			benchmarkStats = {

--- a/tools/benchmark/src/resultFormatting.ts
+++ b/tools/benchmark/src/resultFormatting.ts
@@ -6,6 +6,8 @@
 import chalk from "chalk";
 import Table from "easy-table";
 
+import type { CustomData } from "./ResultTypes";
+
 /**
  * Library for converting a `Record<string, unknown>` into formatted table cells.
  * In the future this library can be used to provide extensible formatting for customized benchmarks which report different fields.
@@ -74,12 +76,7 @@ export function skipCell(key: string): ExpectedCell {
 	return { key, cell: (): void => {} };
 }
 
-export function addCells(
-	table: Table,
-	data: Record<string, unknown>,
-	dataFormatter: Record<string, string>,
-	expected: readonly ExpectedCell[],
-): void {
+export function addCells(table: Table, data: CustomData, expected: readonly ExpectedCell[]): void {
 	const keys = new Set(Object.getOwnPropertyNames(data));
 	// Add expected cells, with their custom formatting and canonical order
 	for (const cell of expected) {
@@ -89,7 +86,7 @@ export function addCells(
 	}
 	// Add custom data cells
 	for (const [key, val] of Object.entries(data)) {
-		const displayValue = key in dataFormatter ? dataFormatter[key] : (val as string);
+		const displayValue = val.formattedValue;
 		table.cell(key, displayValue, Table.padLeft);
 	}
 }

--- a/tools/benchmark/src/resultFormatting.ts
+++ b/tools/benchmark/src/resultFormatting.ts
@@ -77,7 +77,7 @@ export function skipCell(key: string): ExpectedCell {
 export function addCells(
 	table: Table,
 	data: Record<string, unknown>,
-	dataFormatter: Record<string, (value: unknown) => string>,
+	dataFormatter: Record<string, string>,
 	expected: readonly ExpectedCell[],
 ): void {
 	const keys = new Set(Object.getOwnPropertyNames(data));
@@ -89,7 +89,7 @@ export function addCells(
 	}
 	// Add custom data cells
 	for (const [key, val] of Object.entries(data)) {
-		const displayValue = key in dataFormatter ? dataFormatter[key](val) : (val as string);
+		const displayValue = key in dataFormatter ? dataFormatter[key] : (val as string);
 		table.cell(key, displayValue, Table.padLeft);
 	}
 }

--- a/tools/benchmark/src/runBenchmark.ts
+++ b/tools/benchmark/src/runBenchmark.ts
@@ -191,16 +191,18 @@ class BenchmarkState<T> implements BenchmarkTimer<T> {
 		const data: BenchmarkData = {
 			elapsedSeconds: this.timer.toSeconds(this.startTime, now),
 			customData: {
-				"batch count": this.samples.length,
-				"period (ns/op)": stats.arithmeticMean,
-				"relative margin of error": stats.marginOfErrorPercent,
-				"iterations per batch": this.iterationsPerBatch,
+				"Batch Count": this.samples.length,
+				"Period (ns/op)": stats.arithmeticMean,
+				"Margin of Error": stats.marginOfError,
+				"Relative Margin of Error": stats.marginOfErrorPercent,
+				"Iterations per Batch": this.iterationsPerBatch,
 			},
 			customDataFormatters: {
-				"batch count": (v: unknown): string => prettyNumber(v as number, 0),
-				"period (ns/op)": (v: unknown) => prettyNumber(1e9 * (v as number), 2),
-				"relative margin of error": (v: unknown) => `±${(v as number).toFixed(2)}%`,
-				"iterations per batch": (v: unknown) => `${prettyNumber(v as number, 0)}`,
+				"Batch Count": (v: unknown): string => prettyNumber(v as number, 0),
+				"Period (ns/op)": (v: unknown) => prettyNumber(1e9 * (v as number), 2),
+				"Margin of Error": (v: unknown): string => prettyNumber(v as number, 0),
+				"Relative Margin of Error": (v: unknown) => `±${(v as number).toFixed(2)}%`,
+				"Iterations per Batch": (v: unknown) => `${prettyNumber(v as number, 0)}`,
 			},
 		};
 		return data;

--- a/tools/benchmark/src/runBenchmark.ts
+++ b/tools/benchmark/src/runBenchmark.ts
@@ -192,17 +192,17 @@ class BenchmarkState<T> implements BenchmarkTimer<T> {
 			elapsedSeconds: this.timer.toSeconds(this.startTime, now),
 			customData: {
 				"Batch Count": this.samples.length,
+				"Iterations per Batch": this.iterationsPerBatch,
 				"Period (ns/op)": stats.arithmeticMean,
 				"Margin of Error": stats.marginOfError,
 				"Relative Margin of Error": stats.marginOfErrorPercent,
-				"Iterations per Batch": this.iterationsPerBatch,
 			},
 			customDataFormatters: {
-				"Batch Count": (v: unknown): string => prettyNumber(v as number, 0),
-				"Period (ns/op)": (v: unknown) => prettyNumber(1e9 * (v as number), 2),
-				"Margin of Error": (v: unknown): string => prettyNumber(v as number, 2),
-				"Relative Margin of Error": (v: unknown) => `±${(v as number).toFixed(2)}%`,
-				"Iterations per Batch": (v: unknown) => `${prettyNumber(v as number, 0)}`,
+				"Batch Count": prettyNumber(this.samples.length, 0),
+				"Iterations per Batch": prettyNumber(this.iterationsPerBatch, 0),
+				"Period (ns/op)": prettyNumber(1e9 * stats.arithmeticMean, 2),
+				"Margin of Error": `±${prettyNumber(stats.marginOfError, 2)}%`,
+				"Relative Margin of Error": `±${prettyNumber(stats.marginOfErrorPercent, 2)}%`,
 			},
 		};
 		return data;

--- a/tools/benchmark/src/runBenchmark.ts
+++ b/tools/benchmark/src/runBenchmark.ts
@@ -191,18 +191,26 @@ class BenchmarkState<T> implements BenchmarkTimer<T> {
 		const data: BenchmarkData = {
 			elapsedSeconds: this.timer.toSeconds(this.startTime, now),
 			customData: {
-				"Batch Count": this.samples.length,
-				"Iterations per Batch": this.iterationsPerBatch,
-				"Period (ns/op)": stats.arithmeticMean,
-				"Margin of Error": stats.marginOfError,
-				"Relative Margin of Error": stats.marginOfErrorPercent,
-			},
-			customDataFormatters: {
-				"Batch Count": prettyNumber(this.samples.length, 0),
-				"Iterations per Batch": prettyNumber(this.iterationsPerBatch, 0),
-				"Period (ns/op)": prettyNumber(1e9 * stats.arithmeticMean, 2),
-				"Margin of Error": `±${prettyNumber(stats.marginOfError, 2)}%`,
-				"Relative Margin of Error": `±${prettyNumber(stats.marginOfErrorPercent, 2)}%`,
+				"Batch Count": {
+					rawValue: this.samples.length,
+					formattedValue: prettyNumber(this.samples.length, 0),
+				},
+				"Iterations per Batch": {
+					rawValue: this.iterationsPerBatch,
+					formattedValue: prettyNumber(this.iterationsPerBatch, 0),
+				},
+				"Period (ns/op)": {
+					rawValue: 1e9 * stats.arithmeticMean,
+					formattedValue: prettyNumber(1e9 * stats.arithmeticMean, 2),
+				},
+				"Margin of Error": {
+					rawValue: stats.marginOfError,
+					formattedValue: `±${prettyNumber(stats.marginOfError, 2)}%`,
+				},
+				"Relative Margin of Error": {
+					rawValue: stats.marginOfErrorPercent,
+					formattedValue: `±${prettyNumber(stats.marginOfErrorPercent, 2)}%`,
+				},
 			},
 		};
 		return data;

--- a/tools/benchmark/src/runBenchmark.ts
+++ b/tools/benchmark/src/runBenchmark.ts
@@ -200,7 +200,7 @@ class BenchmarkState<T> implements BenchmarkTimer<T> {
 			customDataFormatters: {
 				"Batch Count": (v: unknown): string => prettyNumber(v as number, 0),
 				"Period (ns/op)": (v: unknown) => prettyNumber(1e9 * (v as number), 2),
-				"Margin of Error": (v: unknown): string => prettyNumber(v as number, 0),
+				"Margin of Error": (v: unknown): string => prettyNumber(v as number, 2),
 				"Relative Margin of Error": (v: unknown) => `±${(v as number).toFixed(2)}%`,
 				"Iterations per Batch": (v: unknown) => `${prettyNumber(v as number, 0)}`,
 			},


### PR DESCRIPTION
#### Description

[7825](https://dev.azure.com/fluidframework/internal/_queries/edit/7825/?triage=true)

While working on 7825, found that the `@fluid-tools/benchmark` custom data object is missing a property which will ultimately log `undefined` in Kusto. 

Also capitalized the property name to conform to the memory benchmark test. 