### PR TITLE
fix(ci) Restore previous iteration counts to prevent Perf Benchmarks timeouts

### DIFF
--- a/packages/dds/matrix/src/test/memory/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/matrix.spec.ts
@@ -52,7 +52,7 @@ describe("Matrix memory usage", () => {
 		);
 
 		const numbersOfEntriesForTests = isInPerformanceTestingMode
-			? [1000, 10_000, 100_000]
+			? [100, 1000, 10_000]
 			: // When not measuring perf, use a single smaller data size so the tests run faster.
 				[10];
 

--- a/packages/dds/sequence/src/test/memory/sharedSequence.spec.ts
+++ b/packages/dds/sequence/src/test/memory/sharedSequence.spec.ts
@@ -44,7 +44,7 @@ describe("SharedSequence memory usage", () => {
 	);
 
 	const numbersOfEntriesForTests = isInPerformanceTestingMode
-		? [1000, 10_000, 100_000]
+		? [100, 1000, 10_000]
 		: // When not measuring perf, use a single smaller data size so the tests run faster.
 			[10];
 

--- a/packages/dds/sequence/src/test/memory/sharedString.spec.ts
+++ b/packages/dds/sequence/src/test/memory/sharedString.spec.ts
@@ -59,7 +59,7 @@ describe("SharedString memory usage", () => {
 	);
 
 	const numbersOfEntriesForTests = isInPerformanceTestingMode
-		? [1000, 10_000, 100_000]
+		? [100, 1000, 10_000]
 		: // When not measuring perf, use a single smaller data size so the tests run faster.
 			[10];
 


### PR DESCRIPTION
## Description

In https://github.com/microsoft/FluidFramework/pull/22000 I applied a pattern to reduce the number of iterations we do of some tests when not running in performance benchmarking mode. However, I mistakenly copy pasted the same code across several files, and significantly increased the number of iterations done in perf mode for some tests, which started causing timeous in the performance benchmarks pipeline. This restores the previous number of iterations.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
