### PR TITLE
test(client): remove unused node type dep

### DIFF
--- a/packages/drivers/odsp-driver/src/test/tsconfig.json
+++ b/packages/drivers/odsp-driver/src/test/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",
-		"types": ["mocha", "node"],
+		"types": ["mocha"],
 		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
 	},


### PR DESCRIPTION
accidentally added in Node16 standup

[AB#7425](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7425)