### PR TITLE
Increase describeInstallVersions timeout

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
@@ -65,12 +65,9 @@ describe("entryPoint compat", () => {
 	});
 
 	const loaderWithRequest = "2.0.0-internal.7.0.0";
-	describeInstallVersions(
-		{
-			requestAbsoluteVersions: [loaderWithRequest],
-		},
-		180000, // timeoutMs 3 minutes
-	)("loader compat", (_) => {
+	describeInstallVersions({
+		requestAbsoluteVersions: [loaderWithRequest],
+	})("loader compat", (_) => {
 		beforeEach("getVersionedTestObjectProvider", async () => {
 			provider = await getVersionedTestObjectProvider(
 				pkgVersion, // base version

--- a/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/entryPointCompat.spec.ts
@@ -65,9 +65,12 @@ describe("entryPoint compat", () => {
 	});
 
 	const loaderWithRequest = "2.0.0-internal.7.0.0";
-	describeInstallVersions({
-		requestAbsoluteVersions: [loaderWithRequest],
-	})("loader compat", (_) => {
+	describeInstallVersions(
+		{
+			requestAbsoluteVersions: [loaderWithRequest],
+		},
+		180000, // timeoutMs 3 minutes
+	)("loader compat", (_) => {
 		beforeEach("getVersionedTestObjectProvider", async () => {
 			provider = await getVersionedTestObjectProvider(
 				pkgVersion, // base version

--- a/packages/test/test-version-utils/src/describeWithVersions.ts
+++ b/packages/test/test-version-utils/src/describeWithVersions.ts
@@ -65,7 +65,7 @@ const installRequiredVersions = async (config: IRequestedFluidVersions) => {
 	}
 };
 
-const defaultTimeoutMs = 20000;
+const defaultTimeoutMs = 180000; // 3 minutes
 const defaultRequestedVersions: IRequestedFluidVersions = { requestRelativeVersions: -2 };
 
 function createTestSuiteWithInstalledVersion(


### PR DESCRIPTION
We are seeing a lot of flakiness around this test util timing out while trying to install package versions. Increasing the timeout should help alleviate those failures.

[AB#8170](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8170)