### PR TITLE
e2e tests: Refactor handleValidation.spec.ts for clarity

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
@@ -75,19 +75,48 @@ function treeSetup(dds: ITree) {
 	return view;
 }
 
-interface aDDSType {
+/**
+ * Abstraction over some DDS which allows storing and retrieving a handle in that DDS.
+ *
+ * The attach flow for new DDS/data stores relies on walking the graph of referenced content.
+ * That graph is constructed at the time the referencer produces an op or attach summary.
+ *
+ * This file ensures that all DDS types we support work correctly when they act as the referencer
+ * for various different types of attach scenarios.
+ * This abstraction allows us to write a single test for a particular handle reference graph and exercise it
+ * using various different DDS types.
+ */
+interface HandleStorage {
+	/**
+	 * {@link IChannel.id} of the corresponding DDS.
+	 */
 	id: string;
 	storeHandle(handle: IFluidHandle): Promise<void>;
 	readHandle(): Promise<unknown>;
+	/**
+	 * {@link IChannel.handle} of the corresponding DDS.
+	 */
 	handle: IFluidHandle;
 }
 
-interface aDDSFactory {
+interface HandleStorageFactory {
+	/**
+	 * Registry ID for this type of DDS within TestFluidObject.
+	 */
 	id: string;
+	/**
+	 * {@link IChannelAttributes.type} of the DDS that this factory creates.
+	 */
 	type: string;
-	createDDS(runtime: IFluidDataStoreRuntime): aDDSType;
-	downCast(channel: IChannel): aDDSType;
-	getDDS(dataStore: ITestFluidObject): Promise<aDDSType>;
+	/**
+	 * Like {@link IChannelFactory.create}, but wraps the returned channel to make it a {@link HandleStorage}.
+	 */
+	createDDS(runtime: IFluidDataStoreRuntime): HandleStorage;
+	/**
+	 * Turns a channel into a {@link HandleStorage}.
+	 * Fails if the channel is not of the expected type (i.e. `IChannel.attributes.type !== this.type`).
+	 */
+	downCast(channel: IChannel): HandleStorage;
 }
 
 /**
@@ -127,6 +156,18 @@ async function dereferenceToSharedObject<TSharedObject>(
 	return sharedObject;
 }
 
+/**
+ * Retrieves an (already attached) handle storage from the given test fluid object based on the pre-initialized
+ * DDS of the given factory's type.
+ */
+async function getExistingHandleStorage(
+	testFluidObject: ITestFluidObject,
+	factory: HandleStorageFactory,
+): Promise<HandleStorage> {
+	const channel = await testFluidObject.getSharedObject(factory.id);
+	return factory.downCast(channel);
+}
+
 describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) => {
 	const {
 		SharedMap,
@@ -164,7 +205,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 		// ],
 	];
 
-	const handleStorageFactories: aDDSFactory[] = [
+	const handleStorageFactories: HandleStorageFactory[] = [
 		{
 			id: mapId,
 			type: "https://graph.microsoft.com/types/map",
@@ -172,7 +213,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 				const map = runtime.createChannel(undefined, SharedMap.getFactory().type);
 				return this.downCast(map);
 			},
-			downCast(channel): aDDSType {
+			downCast(channel): HandleStorage {
 				const map = channel as ISharedMap;
 				return {
 					id: map.id,
@@ -185,10 +226,6 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 					handle: map.handle,
 				};
 			},
-			async getDDS(dataStore) {
-				const map = await dataStore.getSharedObject<ISharedMap>(mapId);
-				return this.downCast(map);
-			},
 		},
 		{
 			id: cellId,
@@ -197,7 +234,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 				const cell = runtime.createChannel(undefined, SharedCell.getFactory().type);
 				return this.downCast(cell);
 			},
-			downCast(channel): aDDSType {
+			downCast(channel): HandleStorage {
 				const cell = channel as ISharedCell;
 				return {
 					id: cell.id,
@@ -210,10 +247,6 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 					handle: cell.handle,
 				};
 			},
-			async getDDS(dataStore) {
-				const cell = await dataStore.getSharedObject<ISharedCell>(cellId);
-				return this.downCast(cell);
-			},
 		},
 		{
 			id: directoryId,
@@ -222,7 +255,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 				const directory = runtime.createChannel(undefined, SharedDirectory.getFactory().type);
 				return this.downCast(directory);
 			},
-			downCast(channel): aDDSType {
+			downCast(channel): HandleStorage {
 				const directory = channel as ISharedDirectory;
 				return {
 					id: directory.id,
@@ -235,10 +268,6 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 					handle: directory.handle,
 				};
 			},
-			async getDDS(dataStore) {
-				const directory = await dataStore.getSharedObject<ISharedDirectory>(directoryId);
-				return this.downCast(directory);
-			},
 		},
 		{
 			id: stringId,
@@ -247,7 +276,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 				const string = runtime.createChannel(undefined, SharedString.getFactory().type);
 				return this.downCast(string);
 			},
-			downCast(channel): aDDSType {
+			downCast(channel): HandleStorage {
 				const string = channel as SharedString;
 				return {
 					id: string.id,
@@ -262,10 +291,6 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 					handle: string.handle,
 				};
 			},
-			async getDDS(dataStore) {
-				const string = await dataStore.getSharedObject<SharedString>(stringId);
-				return this.downCast(string);
-			},
 		},
 		{
 			id: matrixId,
@@ -274,7 +299,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 				const matrix = runtime.createChannel(undefined, SharedMatrix.getFactory().type);
 				return this.downCast(matrix);
 			},
-			downCast(channel): aDDSType {
+			downCast(channel): HandleStorage {
 				const matrix = channel as ISharedMatrix;
 				return {
 					id: matrix.id,
@@ -289,10 +314,6 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 					handle: matrix.handle,
 				};
 			},
-			async getDDS(dataStore) {
-				const matrix = await dataStore.getSharedObject<ISharedMatrix>(matrixId);
-				return this.downCast(matrix);
-			},
 		},
 		{
 			id: treeId,
@@ -301,7 +322,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 				const tree = runtime.createChannel(undefined, SharedTree.getFactory().type);
 				return this.downCast(tree);
 			},
-			downCast(channel): aDDSType {
+			downCast(channel): HandleStorage {
 				const view: TreeView<typeof Bar> = treeSetup(channel as ISharedTree);
 
 				return {
@@ -315,10 +336,6 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 					handle: channel.handle,
 				};
 			},
-			async getDDS(dataStore) {
-				const tree = await dataStore.getSharedObject<ISharedTree>(treeId);
-				return this.downCast(tree);
-			},
 		},
 		{
 			id: registerId,
@@ -330,7 +347,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 				);
 				return this.downCast(register);
 			},
-			downCast(channel): aDDSType {
+			downCast(channel): HandleStorage {
 				const register = channel as IConsensusRegisterCollection<FluidObject>;
 				return {
 					id: register.id,
@@ -343,13 +360,6 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 					handle: register.handle,
 				};
 			},
-			async getDDS(dataStore) {
-				const register =
-					await dataStore.getSharedObject<IConsensusRegisterCollection<FluidObject>>(
-						registerId,
-					);
-				return this.downCast(register);
-			},
 		},
 		{
 			id: queueId,
@@ -358,7 +368,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 				const register = runtime.createChannel(undefined, ConsensusQueue.getFactory().type);
 				return this.downCast(register);
 			},
-			downCast(channel): aDDSType {
+			downCast(channel): HandleStorage {
 				const queue = channel as ConsensusQueue<FluidObject>;
 				return {
 					id: queue.id,
@@ -379,18 +389,14 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 					handle: queue.handle,
 				};
 			},
-			async getDDS(dataStore) {
-				const queue = await dataStore.getSharedObject<ConsensusQueue<FluidObject>>(queueId);
-				return this.downCast(queue);
-			},
 		},
 	];
 
-	const ddsFactoriesByType = new Map<string, aDDSFactory>(
+	const ddsFactoriesByType = new Map<string, HandleStorageFactory>(
 		handleStorageFactories.map((factory) => [factory.type, factory]),
 	);
 
-	async function getReferencedDDS(handle: IFluidHandle): Promise<aDDSType> {
+	async function getReferencedDDS(handle: IFluidHandle): Promise<HandleStorage> {
 		const channel = (await handle.get()) as IChannel;
 		const factory = ddsFactoriesByType.get(channel.attributes.type);
 		assert(factory !== undefined);
@@ -543,15 +549,15 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 	}
 
 	for (const {
-		detachedDds1Utils,
-		attachedDdsUtils,
-		detachedDds2Utils,
+		detachedFactory1,
+		detachedFactory2,
+		attachedFactory,
 	} of generatePairwiseOptions({
-		detachedDds1Utils: handleStorageFactories,
-		detachedDds2Utils: handleStorageFactories,
-		attachedDdsUtils: handleStorageFactories,
+		detachedFactory1: handleStorageFactories,
+		detachedFactory2: handleStorageFactories,
+		attachedFactory: handleStorageFactories,
 	})) {
-		it(`stores ${detachedDds1Utils.id} handle in ${detachedDds2Utils.id} and attaches by storing in ${attachedDdsUtils.id}`, async () => {
+		it(`stores ${detachedFactory1.id} handle in ${detachedFactory2.id} and attaches by storing in ${attachedFactory.id}`, async () => {
 			/**
 			 * setup required for all portions of the test
 			 */
@@ -563,18 +569,18 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 			/**
 			 * create the first detached dds
 			 */
-			const createdDds1 = detachedDds1Utils.createDDS(attachedDataStore.runtime);
+			const createdDds1 = detachedFactory1.createDDS(attachedDataStore.runtime);
 
 			/**
 			 * create the second detached dds and store a handle to the first dds in it
 			 */
-			const createdDds2 = detachedDds2Utils.createDDS(attachedDataStore.runtime);
+			const createdDds2 = detachedFactory2.createDDS(attachedDataStore.runtime);
 			await createdDds2.storeHandle(createdDds1.handle);
 
 			/**
 			 * get the attached dds
 			 */
-			const attachedDds = await attachedDdsUtils.getDDS(attachedDataStore);
+			const attachedDds = await getExistingHandleStorage(attachedDataStore, attachedFactory);
 
 			/**
 			 * store handle to dds2 in attached dds (which will attach dds 1 and 2)
@@ -587,7 +593,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 			container1.dispose();
 
 			const default2 = (await container2.getEntryPoint()) as ITestFluidObject;
-			const attached2 = await attachedDdsUtils.getDDS(default2);
+			const attached2 = await getExistingHandleStorage(default2, attachedFactory);
 			/**
 			 * validation
 			 */
@@ -611,15 +617,15 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 	}
 
 	for (const {
-		detachedDds1Utils,
-		attachedDdsUtils,
-		detachedDds2Utils,
+		detachedFactory1,
+		detachedFactory2,
+		attachedFactory,
 	} of generatePairwiseOptions({
-		detachedDds1Utils: handleStorageFactories,
-		detachedDds2Utils: handleStorageFactories,
-		attachedDdsUtils: handleStorageFactories,
+		detachedFactory1: handleStorageFactories,
+		detachedFactory2: handleStorageFactories,
+		attachedFactory: handleStorageFactories,
 	})) {
-		it(`stores ${detachedDds1Utils.id} handle in ${detachedDds2Utils.id} and attaches by storing in ${attachedDdsUtils.id} with new data store`, async () => {
+		it(`stores ${detachedFactory1.id} handle in ${detachedFactory2.id} and attaches by storing in ${attachedFactory.id} with new data store`, async () => {
 			/**
 			 * setup required for all portions of the test
 			 */
@@ -636,18 +642,18 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 			/**
 			 * create the first detached dds
 			 */
-			const createdDds1 = detachedDds1Utils.createDDS(dataObjectB.runtime);
+			const createdDds1 = detachedFactory1.createDDS(dataObjectB.runtime);
 
 			/**
 			 * create the second detached dds and store a handle to the first dds in it
 			 */
-			const createdDds2 = detachedDds2Utils.createDDS(dataObjectB.runtime);
+			const createdDds2 = detachedFactory2.createDDS(dataObjectB.runtime);
 			await createdDds2.storeHandle(createdDds1.handle);
 
 			/**
 			 * get the attached dds
 			 */
-			const attachedDds = await attachedDdsUtils.getDDS(attachedDataStore);
+			const attachedDds = await getExistingHandleStorage(attachedDataStore, attachedFactory);
 
 			/**
 			 * store handle to dds2 in attached dds (which will attach ddss 1 and 2)
@@ -660,7 +666,7 @@ describeCompat("handle validation", "NoCompat", (getTestObjectProvider, apis) =>
 			container1.dispose();
 
 			const default2 = (await container2.getEntryPoint()) as ITestFluidObject;
-			const attached2 = await attachedDdsUtils.getDDS(default2);
+			const attached2 = await getExistingHandleStorage(default2, attachedFactory);
 			/**
 			 * validation
 			 */

--- a/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
@@ -105,7 +105,7 @@ interface HandleStorageFactory {
 	 */
 	id: string;
 	/**
-	 * {@link IChannelAttributes.type} of the DDS that this factory creates.
+	 * `IChannel.attributes.type` of the DDS that this factory creates.
 	 */
 	type: string;
 	/**

--- a/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
@@ -157,7 +157,7 @@ async function dereferenceToSharedObject<TSharedObject>(
 }
 
 /**
- * Retrieves an (already attached) handle storage from the given test fluid object based on the pre-initialized
+ * Retrieves an (already attached) handle storage from the given TestFluidObject based on the pre-initialized
  * DDS of the given factory's type.
  */
 async function getExistingHandleStorage(


### PR DESCRIPTION
## Description

Follow-up to #22014. Refactors the handle validation tests for better clarity:

- Several renames to make variable naming more consistent
- Add doc comments to main abstractions (which allow parameterizing the test workload over different DDS types)
- Move `HandleStorageFactory.getDDS` to a free function and document its behavior, as we want its implementation to be the same (and it was) across implementations of `HandleStorageFactory`.

## Reviewer Guidance

This PR should not have any semantic changes to the tests.