### PR TITLE
fix(ci): Correct number of iterations for matrix perf tests so tests don't time out

### DIFF
--- a/packages/dds/matrix/src/test/memory/matrix.spec.ts
+++ b/packages/dds/matrix/src/test/memory/matrix.spec.ts
@@ -52,7 +52,7 @@ describe("Matrix memory usage", () => {
 		);
 
 		const numbersOfEntriesForTests = isInPerformanceTestingMode
-			? [100, 1000, 10_000]
+			? [100, 1000, 5000]
 			: // When not measuring perf, use a single smaller data size so the tests run faster.
 				[10];
 


### PR DESCRIPTION
## Description

Follow up to https://github.com/microsoft/FluidFramework/pull/22056 (and https://github.com/microsoft/FluidFramework/pull/22000), now using the correct number of iterations that matrix memory tests used to have (5,000, not 10,000), to really fix the current timeouts in the Performance Benchmarks pipeline.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
