### PR TITLE
Update more tests to use json cursor

### DIFF
--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -150,7 +150,7 @@ interface TypedJsonCompatibleObject {
 	[typedJsonSymbol]: string | TreeNodeSchemaBase;
 }
 
-type TypedJsonCompatible = JsonCompatible | TypedJsonCompatibleObject;
+type TypedJsonCompatible = JsonCompatible | TypedJsonCompatibleObject | TypedJsonCompatible[];
 
 const typedJsonSymbol = Symbol("JSON Cursor Type");
 

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -35,6 +35,7 @@ import {
 	jsonSchema,
 	leaf,
 	singleJsonCursor,
+	typedJsonCursor,
 } from "../domains/index.js";
 import { typeboxValidator } from "../external-utilities/index.js";
 import {
@@ -42,7 +43,6 @@ import {
 	FlexFieldSchema,
 	SchemaBuilderBase,
 	cursorForJsonableTreeNode,
-	cursorForTypedTreeData,
 	defaultSchemaPolicy,
 	intoStoredSchema,
 	isNeverField,
@@ -1156,7 +1156,8 @@ export function testForest(config: ForestTestConfiguration): void {
 				initializeForest(
 					forest,
 					[
-						cursorForTypedTreeData({ schema }, root, {
+						typedJsonCursor({
+							[typedJsonCursor.type]: root,
 							x: [2],
 							y: [1],
 						}),
@@ -1182,8 +1183,8 @@ export function testForest(config: ForestTestConfiguration): void {
 				};
 				const delta: DeltaFieldMap = new Map([[rootFieldKey, { local: [modify] }]]);
 				applyTestDelta(delta, forest);
-				const expectedCursor = cursorForTypedTreeData({ schema }, root, {
-					x: [],
+				const expectedCursor = typedJsonCursor({
+					[typedJsonCursor.type]: root,
 					y: [1, 2],
 				});
 				const expected: JsonableTree[] = [jsonableTreeFromCursor(expectedCursor)];

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzUtils.ts
@@ -24,7 +24,7 @@ import {
 	forEachNodeInSubtree,
 	moveToDetachedField,
 } from "../../../core/index.js";
-import { SchemaBuilder, leaf } from "../../../domains/index.js";
+import { SchemaBuilder, leaf, typedJsonCursor } from "../../../domains/index.js";
 import {
 	Any,
 	FieldKinds,
@@ -33,7 +33,6 @@ import {
 	type LeafNodeSchema,
 	type SchemaLibrary,
 	intoStoredSchema,
-	typeNameSymbol,
 } from "../../../feature-libraries/index.js";
 import type { ITreeCheckout, SharedTree, TreeContent } from "../../../shared-tree/index.js";
 import { testSrcPath } from "../../testSrcPath.cjs";
@@ -191,28 +190,24 @@ export const deterministicIdCompressorFactory: (
 
 export const populatedInitialState: TreeContent<
 	typeof fuzzSchema.rootFieldSchema
->["initialTree"] = {
-	[typeNameSymbol]: fuzzNode.name,
+>["initialTree"] = typedJsonCursor({
+	[typedJsonCursor.type]: fuzzNode,
 	sequenceChildren: [
 		{
-			[typeNameSymbol]: fuzzNode.name,
+			[typedJsonCursor.type]: fuzzNode,
 			sequenceChildren: ["AA", "AB", "AC"],
 			requiredChild: "A",
-			optionalChild: undefined,
 		},
 		{
-			[typeNameSymbol]: fuzzNode.name,
+			[typedJsonCursor.type]: fuzzNode,
 			sequenceChildren: ["BA", "BB", "BC"],
 			requiredChild: "B",
-			optionalChild: undefined,
 		},
 		{
-			[typeNameSymbol]: fuzzNode.name,
+			[typedJsonCursor.type]: fuzzNode,
 			sequenceChildren: ["CA", "CB", "CC"],
 			requiredChild: "C",
-			optionalChild: undefined,
 		},
 	],
 	requiredChild: "R",
-	optionalChild: undefined,
-};
+});

--- a/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
@@ -15,13 +15,12 @@ import {
 	TreeStoredSchemaRepository,
 	type AnchorSetRootEvents,
 } from "../../core/index.js";
-import { SchemaBuilder, leaf } from "../../domains/index.js";
+import { SchemaBuilder, leaf, singleJsonCursor } from "../../domains/index.js";
 import {
 	Any,
 	FieldKinds,
 	FlexFieldSchema,
 	type FlexTreeSchema,
-	type NewFieldContent,
 	SchemaBuilderBase,
 	ViewSchema,
 	allowsRepoSuperset,
@@ -124,7 +123,7 @@ describe("schematizeTree", () => {
 						previousSchema = new TreeStoredSchemaRepository(storedSchema);
 					});
 
-					let currentData: NewFieldContent;
+					let currentData: typeof content.initialTree;
 					initializeContent(makeSchemaRepository(storedSchema), content.schema, () => {
 						// TODO: check currentData is compatible with current schema.
 						// TODO: check data in cursors is compatible with current schema.
@@ -158,8 +157,8 @@ describe("schematizeTree", () => {
 		}
 
 		testInitialize("optional-empty", { schema, initialTree: undefined });
-		testInitialize("optional-full", { schema, initialTree: 5 });
-		testInitialize("value", { schema: schemaValueRoot, initialTree: 6 });
+		testInitialize("optional-full", { schema, initialTree: singleJsonCursor(5) });
+		testInitialize("value", { schema: schemaValueRoot, initialTree: singleJsonCursor(6) });
 
 		// TODO: Test schema validation of initial tree (once we have a utility for it)
 	});
@@ -276,7 +275,7 @@ describe("schematizeTree", () => {
 			const emptyCheckout = checkoutWithContent(emptyContent);
 			const content: TreeContent<typeof schemaGeneralized.rootFieldSchema> = {
 				schema: schemaGeneralized,
-				initialTree: 5,
+				initialTree: singleJsonCursor(5),
 			};
 			const initializedCheckout = checkoutWithContent(content);
 			// Schema upgraded, but content not initialized
@@ -358,7 +357,7 @@ describe("schematizeTree", () => {
 			const emptyCheckout = checkoutWithContent(emptyContent);
 			const content: TreeContent<typeof schemaValueRoot.rootFieldSchema> = {
 				schema: schemaValueRoot,
-				initialTree: 5,
+				initialTree: singleJsonCursor(5),
 			};
 			const initializedCheckout = checkoutWithContent(content);
 
@@ -413,12 +412,14 @@ describe("schematizeTree", () => {
 		it("update non-empty", () => {
 			const initialContent = {
 				schema,
-				initialTree: 5,
+				get initialTree() {
+					return singleJsonCursor(5);
+				},
 			};
 			const initialCheckout = checkoutWithContent(initialContent);
 			const content: TreeContent<typeof schemaGeneralized.rootFieldSchema> = {
 				schema: schemaGeneralized,
-				initialTree: "Should not be used",
+				initialTree: singleJsonCursor("Should not be used"),
 			};
 			const updatedCheckout = checkoutWithContent({
 				schema: schemaGeneralized,


### PR DESCRIPTION
## Description

This continues the effort to remove dependencies on schemaAware and contextuallyTyped. 

This also updates the `TypedJsonCompatible` once again to allow it to handle arrays recursively.
