### PR TITLE
Update SharedTree benchmark tests to use json cursor

### DIFF
--- a/packages/dds/tree/src/domains/index.ts
+++ b/packages/dds/tree/src/domains/index.ts
@@ -12,6 +12,8 @@ export {
 	jsonSchema,
 	singleJsonCursor,
 	typedJsonCursor,
+	type TypedJsonCompatible,
+	type TypedJsonCompatibleObject,
 } from "./json/index.js";
 
 export { leaf } from "./leafDomain.js";

--- a/packages/dds/tree/src/domains/json/index.ts
+++ b/packages/dds/tree/src/domains/json/index.ts
@@ -3,5 +3,11 @@
  * Licensed under the MIT License.
  */
 
-export { singleJsonCursor, cursorToJsonObject, typedJsonCursor } from "./jsonCursor.js";
+export {
+	singleJsonCursor,
+	cursorToJsonObject,
+	typedJsonCursor,
+	type TypedJsonCompatible,
+	type TypedJsonCompatibleObject,
+} from "./jsonCursor.js";
 export { jsonSchema, jsonObject, jsonArray, jsonRoot } from "./jsonDomainSchema.js";

--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -145,12 +145,17 @@ export function cursorToJsonObject(reader: ITreeCursor): JsonCompatible {
 
 // #region TypedJsonCursor
 
-interface TypedJsonCompatibleObject {
+/** Used to construct a {@link TypedJsonCursor} */
+export interface TypedJsonCompatibleObject {
 	[key: string]: TypedJsonCompatible;
 	[typedJsonSymbol]: string | TreeNodeSchemaBase;
 }
 
-type TypedJsonCompatible = JsonCompatible | TypedJsonCompatibleObject | TypedJsonCompatible[];
+/** Used to construct a {@link TypedJsonCursor} */
+export type TypedJsonCompatible =
+	| JsonCompatible
+	| TypedJsonCompatibleObject
+	| TypedJsonCompatible[];
 
 const typedJsonSymbol = Symbol("JSON Cursor Type");
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -13,13 +13,11 @@ import {
 } from "@fluid-tools/benchmark";
 
 import { rootFieldKey } from "../../core/index.js";
-import { singleJsonCursor } from "../../domains/index.js";
+import { singleJsonCursor, typedJsonCursor } from "../../domains/index.js";
 // eslint-disable-next-line import/no-internal-modules
 import { typeboxValidator } from "../../external-utilities/typeboxValidator.js";
 import {
 	TreeCompressionStrategy,
-	cursorForTypedData,
-	cursorForTypedTreeData,
 	jsonableTreeFromCursor,
 } from "../../feature-libraries/index.js";
 import { type FlexTreeView, SharedTreeFactory } from "../../shared-tree/index.js";
@@ -27,7 +25,7 @@ import {
 	type JSDeepTree,
 	type JSWideTree,
 	deepPath,
-	deepSchema,
+	type deepSchema,
 	localFieldKey,
 	makeDeepContent,
 	makeJsDeepTree,
@@ -39,7 +37,6 @@ import {
 	readWideCursorTree,
 	readWideFlexTree,
 	readWideTreeAsJSObject,
-	wideRootSchema,
 	wideSchema,
 } from "../scalableTestTrees.js";
 import {
@@ -214,13 +211,9 @@ describe("SharedTree benchmarks", () => {
 				type: benchmarkType,
 				title: `Wide Tree with Flex Tree: reads with ${numberOfNodes} nodes`,
 				before: () => {
-					const numbers = [];
-					for (let index = 0; index < numberOfNodes; index++) {
-						numbers.push(index);
-						expected += index;
-					}
+					expected = ((numberOfNodes - 1) * numberOfNodes) / 2; // Arithmetic sum of [0, numberOfNodes)
 					tree = flexTreeViewWithContent({
-						initialTree: { foo: numbers },
+						initialTree: makeJsWideTreeWithEndValue(numberOfNodes),
 						schema: wideSchema,
 					});
 				},
@@ -261,11 +254,7 @@ describe("SharedTree benchmarks", () => {
 
 						// Cleanup + validation
 						const expected = jsonableTreeFromCursor(
-							cursorForTypedData(
-								{ schema: deepSchema },
-								deepSchema.rootFieldSchema.allowedTypes,
-								makeJsDeepTree(numberOfNodes, setCount),
-							),
+							typedJsonCursor(makeJsDeepTree(numberOfNodes, setCount)),
 						);
 						const actual = toJsonableTree(tree);
 						assert.deepEqual(actual, [expected]);
@@ -288,12 +277,8 @@ describe("SharedTree benchmarks", () => {
 						assert.equal(state.iterationsPerBatch, 1);
 
 						// Setup
-						const numbers = [];
-						for (let index = 0; index < numberOfNodes; index++) {
-							numbers.push(index);
-						}
 						const tree = checkoutWithContent({
-							initialTree: { foo: numbers },
+							initialTree: makeJsWideTreeWithEndValue(numberOfNodes),
 							schema: wideSchema,
 						});
 
@@ -319,13 +304,7 @@ describe("SharedTree benchmarks", () => {
 
 						// Cleanup + validation
 						const expected = jsonableTreeFromCursor(
-							cursorForTypedTreeData(
-								{
-									schema: wideSchema,
-								},
-								wideRootSchema,
-								makeJsWideTreeWithEndValue(numberOfNodes, setCount),
-							),
+							typedJsonCursor(makeJsWideTreeWithEndValue(numberOfNodes, setCount)),
 						);
 						const actual = toJsonableTree(tree);
 						assert.deepEqual(actual, [expected]);


### PR DESCRIPTION
## Description

This continues an effort to remove usages of contextuallyTyped and schemaAware.

This PR also exposes some of the TypedJsonCompatible types for internal use.
