### PR TITLE
refactor(ci): Retry package install in perf benchmarks pipeline

### DIFF
--- a/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
@@ -66,6 +66,7 @@ steps:
 # Install package that has performance tests
 - task: Bash@3
   displayName: Install package with perf tests - ${{ parameters.testPackageName }}
+  retryCountOnTaskFailure: 1
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.installPath }}


### PR DESCRIPTION
## Description

Installing npm packages in pipelines sometimes runs into transient errors out of our control. As long as the tasks that install packages are focused enough and are not doing much else, it's safe to retry them at least once in case of error, to reduce overall pipeline flakiness due to ECONNRESET or similar errors. This PR adds one such retry to package installation during the execution of the performance benchmarks pipeline.

This task in particular is slightly less focused than ideal, but the error case (not finding the test package, or finding more than 1 match) has never happened as far as I know. If it were to happen, it would be a pretty quick failure and having one retry doesn't seem like it'd result in any terrible consequences (same goes if the `ls` command failed for some weird reason), whereas an actual install does benefit from the retry. So I think this change is still net good.

We already use this pattern in other pipelines like [here](https://github.com/microsoft/FluidFramework/blob/8c1f17fd54c8265cd1b303537cc1373bd61809b4/tools/pipelines/templates/include-telemetry-setup.yml#L85) and [here](https://github.com/microsoft/FluidFramework/blob/8c1f17fd54c8265cd1b303537cc1373bd61809b4/tools/pipelines/templates/include-test-real-service.yml#L254).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).