### PR TITLE
Fix op reentry flaky test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/opReentrancy.spec.ts
@@ -96,6 +96,11 @@ describeCompat(
 
 			await setupContainers(testContainerConfig);
 
+			// ! We need to force container1 to be in "write" mode to ensure its messages are sent before container2
+			// ! Saw some flakiness against r11s where container2 would sometimes reconnect faster
+			sharedMap1.set("key3", "3");
+			await provider.ensureSynchronized();
+
 			sharedMap1.on("valueChanged", (changed) => {
 				if (changed.key !== "key2") {
 					sharedMap1.set("key2", `${sharedMap1.get("key1")} updated`);
@@ -113,6 +118,7 @@ describeCompat(
 			// The other container is fine
 			assert.equal(sharedMap2.get("key1"), "1");
 			assert.equal(sharedMap2.get("key2"), "2");
+			assert.equal(sharedMap2.get("key3"), "3");
 			assert.ok(mapsAreEqual(sharedMap1, sharedMap2));
 		});
 


### PR DESCRIPTION
Saw flakiness against r11s for this container. This was caused by the containers sometimes reconnecting to "write" mode in an unintended way, thus throwing off the expected result of the key-value pairs. By forcing container1 to reconnect as "write" before testing the reentrancy, we ensure the messages are sent/processed in the intended order.

**Expected flow:**
1. container1 submit ["key2", "1 updated"] and ["key1", "1"]
2. container2 submit ["key2", "2"]
3. container1 reconnect to "write"
4. container1 submit ["key2", "1 updated"] and ["key1", "1"]
5. container2 reconnect to "write"
6. container2 submit ["key2", "2"]
**Result: ["key1", "1"] and ["key2", "2"]**

**Flow that would hit about 50%:**
1. container1 submit ["key2", "1 updated"] and ["key1", "1"]
2. container2 submit ["key2", "2"]
3. container2 reconnect to "write"
4. container2 submit ["key2", "2"]
5. container1 reconnect to "write"
6. container1 submit ["key2", "1 updated"] and ["key1", "1"]
**Result: ["key1", "1"] and ["key2", "1 updated"]**

[AB#7934](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/7934)
[AB#10966](https://dev.azure.com/fluidframework/internal/_workitems/edit/10966)
[AB#10999](https://dev.azure.com/fluidframework/internal/_workitems/edit/10999)