### PR TITLE
(ci): include .md file changes to trigger website validation

### DIFF
--- a/.github/workflows/website-validation.yml
+++ b/.github/workflows/website-validation.yml
@@ -4,6 +4,8 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "docs/**"
+      - "*.md"
+      - "**/*.md"
 
 defaults:
   run:

--- a/.github/workflows/website-validation.yml
+++ b/.github/workflows/website-validation.yml
@@ -6,9 +6,8 @@ on:
       - "docs/**"
       - "*.md"
       - "**/*.md"
-    paths-ignore:
-      - "build-tools/**"
-      - "server/**"
+      - "!build-tools/**"
+      - "!server/**"
 
 defaults:
   run:

--- a/.github/workflows/website-validation.yml
+++ b/.github/workflows/website-validation.yml
@@ -6,6 +6,9 @@ on:
       - "docs/**"
       - "*.md"
       - "**/*.md"
+    paths-ignore:
+      - "build-tools/**"
+      - "server/**"
 
 defaults:
   run:


### PR DESCRIPTION
Updating CI to run website validation for changes to any .md files instead of just changes to the "docs/" directory. 

Currently, `markdown-magic` generates some of the content in the docs using content from sources outside the docs directory including package READMEs throughout the repo. We want to validate these changes as they could implicitly break the website content.