### PR TITLE
docs(tree): fix single json cursor comment

### DIFF
--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -94,6 +94,7 @@ const adapter: CursorAdapter<JsonCompatible> = {
 
 /**
  * Used to read generic json compatible data as a tree in the JSON domain.
+ * The returned tree will have a schema in the json domain as defined by {@link jsonRoot}.
  *
  * @returns an {@link ITreeCursorSynchronous} for a single {@link JsonCompatible}.
  */

--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -93,7 +93,7 @@ const adapter: CursorAdapter<JsonCompatible> = {
 };
 
 /**
- * Used to read a Jsonable tree for testing and benchmarking.
+ * Used to read generic json compatible data for testing and benchmarking.
  *
  * @returns an {@link ITreeCursorSynchronous} for a single {@link JsonCompatible}.
  */

--- a/packages/dds/tree/src/domains/json/jsonCursor.ts
+++ b/packages/dds/tree/src/domains/json/jsonCursor.ts
@@ -93,7 +93,7 @@ const adapter: CursorAdapter<JsonCompatible> = {
 };
 
 /**
- * Used to read generic json compatible data for testing and benchmarking.
+ * Used to read generic json compatible data as a tree in the JSON domain.
  *
  * @returns an {@link ITreeCursorSynchronous} for a single {@link JsonCompatible}.
  */


### PR DESCRIPTION
comment previously was misleading towards a different concept