### PR TITLE
Disabled messageSize test for t9s

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/messageSize.spec.ts
@@ -339,6 +339,10 @@ describeCompat("Message size", "NoCompat", (getTestObjectProvider, apis) => {
 								2,
 							)} KB`,
 						async function () {
+							// This test is flaky on tinylicious (1500 messages being sent sometimes slows the system down)
+							if (provider.driver.type === "tinylicious") {
+								this.skip();
+							}
 							await setupContainers({
 								...containerConfig,
 								runtimeOptions: {


### PR DESCRIPTION
Partial revert of https://github.com/microsoft/FluidFramework/pull/22010

It caused the continuous tinylicious stage failure, due to a test related to large message sizes with regular batches, causing a timeout while waiting for a container to be saved.

In favor of: https://github.com/microsoft/FluidFramework/pull/22097