### PR TITLE
docs: data-objects API clarity

### DIFF
--- a/docs/content/docs/concepts/signals.md
+++ b/docs/content/docs/concepts/signals.md
@@ -44,7 +44,7 @@ const containerSchema: ContainerSchema = {
 
 const { container, services } = await client.createContainer(containerSchema);
 
-const signaler = container.initialObjects.signaler;
+const signaler = container.initialObjects.signaler; // type is ISignaler
 ```
 
 `signaler` can then be directly used in your Fluid application!
@@ -53,7 +53,7 @@ For more information on using `ContainerSchema` to create objects please see [Da
 
 ### API
 
-`Signaler` provides a few simple methods to send signals and add/remove listeners to specific signals as well:
+`ISignaler` provides a few simple methods to send signals and add/remove listeners to specific signals as well:
 
 -   `submitSignal(signalName: string, payload?: Jsonable)` - Sends a signal with a payload to its connected listeners
 -   `onSignal(signalName: string, listener: SignalListener)` - Adds a listener for the specified signal. Similar behavior as EventEmitter's `on` method.

--- a/experimental/framework/data-objects/api-report/data-objects.alpha.api.md
+++ b/experimental/framework/data-objects/api-report/data-objects.alpha.api.md
@@ -4,6 +4,21 @@
 
 ```ts
 
-// (No @packageDocumentation comment for this package)
+// @alpha
+export interface ISignaler extends IEventProvider<IErrorEvent> {
+    offSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
+    onSignal<T>(signalName: string, listener: SignalListener<T>): ISignaler;
+    submitSignal<T>(signalName: string, payload?: Jsonable<T>): any;
+}
+
+// @alpha
+export const Signaler: {
+    readonly factory: IFluidDataStoreFactory & {
+        readonly registryEntry: NamedFluidDataStoreRegistryEntry;
+    };
+} & SharedObjectKind<ISignaler>;
+
+// @alpha
+export type SignalListener<T> = (clientId: string, local: boolean, payload: Jsonable<T>) => void;
 
 ```

--- a/experimental/framework/data-objects/api-report/data-objects.beta.api.md
+++ b/experimental/framework/data-objects/api-report/data-objects.beta.api.md
@@ -4,6 +4,4 @@
 
 ```ts
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/experimental/framework/data-objects/api-report/data-objects.public.api.md
+++ b/experimental/framework/data-objects/api-report/data-objects.public.api.md
@@ -4,6 +4,4 @@
 
 ```ts
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/experimental/framework/data-objects/src/index.ts
+++ b/experimental/framework/data-objects/src/index.ts
@@ -3,4 +3,14 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Experimental data object providing access to signals infrastructure.
+ *
+ * @packageDocumentation
+ *
+ * @privateRemarks
+ * This package is tagged despite being experimental to make API surface
+ * more visible. Import specs do not need qualified with `/alpha`, etc.
+ */
+
 export { IRuntimeSignaler, ISignaler, Signaler, SignalListener } from "./signaler/index.js";

--- a/experimental/framework/data-objects/src/signaler/README.md
+++ b/experimental/framework/data-objects/src/signaler/README.md
@@ -21,7 +21,7 @@ const containerSchema: ContainerSchema = {
 
 const { container, services } = await client.createContainer(containerSchema);
 
-const signaler = container.initialObjects.signaler as Signaler;
+const signaler = container.initialObjects.signaler; // type is ISignaler
 ```
 
 `signaler` can then be directly used in your Fluid application!
@@ -30,7 +30,7 @@ For more information on using `ContainerSchema` to create objects please see [Da
 
 ## API
 
-`Signaler` provides a few simple methods to send signals and add/remove listeners to specific signals as well:
+`ISignaler` provides a few simple methods to send signals and add/remove listeners to specific signals as well:
 
 -   `submitSignal(signalName: string, payload?: Jsonable)` - Sends a signal with a payload to its connected listeners
 -   `onSignal(signalName: string, listener: SignalListener)` - Adds a listener for the specified signal. Same behavior as EventEmitter's `on` method.

--- a/experimental/framework/data-objects/src/signaler/signaler.ts
+++ b/experimental/framework/data-objects/src/signaler/signaler.ts
@@ -24,7 +24,8 @@ import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 // throttling and batching
 
 /**
- * @internal
+ * Signature for listening to a signal event
+ * @alpha
  */
 export type SignalListener<T> = (
 	clientId: string,
@@ -36,7 +37,7 @@ export type SignalListener<T> = (
  * ISignaler defines an interface for working with signals that is similar to the more common
  * eventing patterns of EventEmitter.  In addition to sending and responding to signals, it
  * provides explicit methods around signal requests to other connected clients.
- * @internal
+ * @alpha
  */
 export interface ISignaler extends IEventProvider<IErrorEvent> {
 	/**
@@ -67,6 +68,8 @@ export interface ISignaler extends IEventProvider<IErrorEvent> {
  * Duck type of something that provides the expected signalling functionality:
  * A way to verify we can signal, a way to send a signal, and a way to listen for incoming signals
  * @internal
+ * @privateRemarks
+ * There is no use external to package and export can be removed once breaking changes are permitted.
  */
 export interface IRuntimeSignaler {
 	connected: boolean;
@@ -193,8 +196,8 @@ class SignalerClass
  * Implementation of ISignaler for declarative API.
  * @privateRemarks
  * `factory` part of the type is included here to satisfy the usage in `@fluid-example/presence-tracker`, which is accessing encapsulated API surfaces from this.
- * If this eventually gets promoted to `@public` and/or part of `fluid-framework`, that part of the type should be left as `@internal` or `@alpha`.
- * @internal
+ * If this eventually gets promoted to `@public` and/or part of `fluid-framework`, an alternate LegacySignaler (`@legacy`) should be created to continue exposing `factory`.
+ * @alpha
  */
 export const Signaler: {
 	readonly factory: IFluidDataStoreFactory & {


### PR DESCRIPTION
1. Acknowledge `ISignaler` distinct from `Signaler`
2. Tag experimental APIs as `@alpha` for some visibility