### PR TITLE
perf: Use transactions for better latency in bubblebench/sharedtree

### DIFF
--- a/examples/benchmarks/bubblebench/baseline/src/state.ts
+++ b/examples/benchmarks/bubblebench/baseline/src/state.ts
@@ -51,4 +51,8 @@ export class AppState implements IAppState {
 			bubbles.pop();
 		}
 	}
+
+	public runTransaction(inner: () => void): void {
+		inner();
+	}
 }

--- a/examples/benchmarks/bubblebench/common/src/types.ts
+++ b/examples/benchmarks/bubblebench/common/src/types.ts
@@ -38,6 +38,7 @@ export interface IAppState {
 	increaseBubbles(): void;
 	decreaseBubbles(): void;
 	applyEdits(): void;
+	runTransaction(inner: () => void);
 }
 
 // eslint-disable-next-line jsdoc/require-description

--- a/examples/benchmarks/bubblebench/common/src/view/app.tsx
+++ b/examples/benchmarks/bubblebench/common/src/view/app.tsx
@@ -79,44 +79,46 @@ export const AppView: React.FC<IAppProps> = ({ app }: IAppProps) => {
 	const [, setFrame] = useState<number>(0);
 
 	useEffect(() => {
-		const localBubbles = app.localClient.bubbles;
+		app.runTransaction(() => {
+			const localBubbles = app.localClient.bubbles;
 
-		// Move each bubble
-		for (const bubble of localBubbles) {
-			move(bubble, app.width, app.height);
-		}
-
-		// Handle collisions between each pair of local bubbles
-		for (let i = 0; i < localBubbles.length; i++) {
-			const left = localBubbles[i];
-			for (let j = i + 1; j < localBubbles.length; j++) {
-				const right = localBubbles[j];
-				collide(left, right);
+			// Move each bubble
+			for (const bubble of localBubbles) {
+				move(bubble, app.width, app.height);
 			}
-		}
 
-		// Handle collisions between local bubbles and remote bubbles (but not between pairs
-		// of remote bubbles.)
-		for (const client of app.clients) {
-			if (client.clientId === app.localClient.clientId) {
-				continue;
-			}
-			for (const right of client.bubbles) {
-				for (const left of localBubbles) {
+			// Handle collisions between each pair of local bubbles
+			for (let i = 0; i < localBubbles.length; i++) {
+				const left = localBubbles[i];
+				for (let j = i + 1; j < localBubbles.length; j++) {
+					const right = localBubbles[j];
 					collide(left, right);
 				}
 			}
-		}
 
-		// Scale the number of local bubbles to target 22-23 fps.  We choose 22-23 fps because it
-		// is below 23.98, the lowest display refresh rate typically encountered on modern displays.
-		if (!(stats.smoothFps > 22)) {
-			app.decreaseBubbles();
-		} else if (stats.smoothFps > 23) {
-			app.increaseBubbles();
-		}
+			// Handle collisions between local bubbles and remote bubbles (but not between pairs
+			// of remote bubbles.)
+			for (const client of app.clients) {
+				if (client.clientId === app.localClient.clientId) {
+					continue;
+				}
+				for (const right of client.bubbles) {
+					for (const left of localBubbles) {
+						collide(left, right);
+					}
+				}
+			}
 
-		app.applyEdits();
+			// Scale the number of local bubbles to target 22-23 fps.  We choose 22-23 fps because it
+			// is below 23.98, the lowest display refresh rate typically encountered on modern displays.
+			if (!(stats.smoothFps > 22)) {
+				app.decreaseBubbles();
+			} else if (stats.smoothFps > 23) {
+				app.increaseBubbles();
+			}
+
+			app.applyEdits();
+		});
 	});
 
 	// Force a render each frame.

--- a/examples/benchmarks/bubblebench/experimental-tree/src/state.ts
+++ b/examples/benchmarks/bubblebench/experimental-tree/src/state.ts
@@ -85,4 +85,8 @@ export class AppState implements IAppState {
 			bubbles.pop();
 		}
 	}
+
+	public runTransaction(inner: () => void): void {
+		inner();
+	}
 }

--- a/examples/benchmarks/bubblebench/ot/src/state.ts
+++ b/examples/benchmarks/bubblebench/ot/src/state.ts
@@ -75,4 +75,8 @@ export class AppState implements IAppState {
 			bubbles.pop();
 		}
 	}
+
+	public runTransaction(inner: () => void): void {
+		inner();
+	}
 }

--- a/examples/benchmarks/bubblebench/shared-tree/src/appState.ts
+++ b/examples/benchmarks/bubblebench/shared-tree/src/appState.ts
@@ -10,7 +10,7 @@ import {
 	makeBubble,
 	randomColor,
 } from "@fluid-example/bubblebench-common";
-import type { TreeView } from "@fluidframework/tree";
+import { type TreeView, Tree } from "@fluidframework/tree";
 
 import { type App, Client } from "./schema.js";
 
@@ -68,5 +68,9 @@ export class AppState implements IAppState {
 		if (bubbles.length > 1) {
 			bubbles.removeAt(bubbles.length - 1);
 		}
+	}
+
+	public runTransaction(inner: () => void): void {
+		Tree.runTransaction(this.localClient, inner);
 	}
 }


### PR DESCRIPTION
Changes:
- Added optional support for transactions to bubblebench/common
- Changed bubblebench/sharedtree to use transactions

Switching to use the Shared Tree transactional API reduced the variance in task-level latency, significantly reduced the longest task's duration, and shrank the time attributed to processDeltas to ~19% of what it was before.