### PR TITLE
ci: Add warning to release branch PRs

### DIFF
--- a/.github/workflows/data/release-branch-warning.md
+++ b/.github/workflows/data/release-branch-warning.md
@@ -1,0 +1,16 @@
+> [!WARNING]
+> WARNING: This PR is targeting a release branch!
+
+All changes must first be merged into `main` and then backported to the target release branch.
+Please include a link to the `main` PR in the description of this PR.
+
+Changes to release branches require approval from (TODO: whatever review group) before merging.
+You should have already discussed this change with them so they know to expect it.
+
+For more details on process and policy see internal documentation for [patch releases][patch] and
+[minor releases][minor].
+
+[patch]:
+    https://eng.ms/docs/experiences-devices/opg/office-shared/fluid-framework/fluid-framework-internal/fluid-framework/docs/on-call/release/release-patch
+[minor]:
+    https://eng.ms/docs/experiences-devices/opg/office-shared/fluid-framework/fluid-framework-internal/fluid-framework/docs/on-call/release/release-minor

--- a/.github/workflows/data/release-branch-warning.md
+++ b/.github/workflows/data/release-branch-warning.md
@@ -4,13 +4,13 @@
 All changes must first be merged into `main` and then backported to the target release branch.
 Please include a link to the `main` PR in the description of this PR.
 
-Changes to release branches require approval from (TODO: whatever review group) before merging.
+Changes to release branches require approval from the Patch Triage group before merging.
 You should have already discussed this change with them so they know to expect it.
 
-For more details on process and policy see internal documentation for [patch releases][patch] and
-[minor releases][minor].
+For more details, see our internal documentation for the [patch policy][policy] and processes for
+[patch releases][patch].
 
 [patch]:
     https://eng.ms/docs/experiences-devices/opg/office-shared/fluid-framework/fluid-framework-internal/fluid-framework/docs/on-call/release/release-patch
-[minor]:
-    https://eng.ms/docs/experiences-devices/opg/office-shared/fluid-framework/fluid-framework-internal/fluid-framework/docs/on-call/release/release-minor
+[policy]:
+    https://eng.ms/docs/experiences-devices/opg/office-shared/fluid-framework/fluid-framework-internal/fluid-framework/docs/dev/resources/patch-policy

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -1,0 +1,25 @@
+name: Release branch warning
+on:
+  pull_request:
+    types:
+      - opened
+
+      # this is triggered when the  base branch changes; this ensures you can't open a PR against main then change the
+      # base branch to a release branch.
+      - edited
+    branches:
+      - release/client/**
+      - release/server/**
+
+permissions:
+  pull-requests: write
+
+jobs:
+  warning:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post warning in comment
+        uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
+        with:
+          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
+          only_create: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -4,7 +4,7 @@ on:
     types:
       - opened
 
-      # this is triggered when the  base branch changes; this ensures you can't open a PR against main then change the
+      # This is triggered when the base branch changes; handles the case where you open a PR against main then change the
       # base branch to a release branch.
       - edited
     branches:


### PR DESCRIPTION
Adds a GitHub actions workflow to post a comment to any PR targeting client/server release branches.

[AB#8813](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8813)