### PR TITLE
Fix missing / wrong data output stored from the benchmark tools

### DIFF
--- a/tools/benchmark/src/Reporter.ts
+++ b/tools/benchmark/src/Reporter.ts
@@ -113,6 +113,7 @@ export class BenchmarkReporter {
 
 		const { table, benchmarksMap } = results;
 
+		// Make sure to add properties that are not part of the `customData` object here.
 		benchmarksMap.set(testName, result);
 		if (isResultError(result)) {
 			table.cell("status", `${pad(4)}${chalk.red("×")}`);
@@ -299,16 +300,18 @@ export class BenchmarkReporter {
 		const keys = new Set(Object.getOwnPropertyNames(benchmark.customData));
 		const customData: Record<string, unknown> = {};
 
+		// As the name suggets, `customData` should only contain custom data that are specific to the benchmark test.
+		// If there are any other properties that are global to the benchmark test (e.g., `elapsedSeconds`), they should be added in the `benchMarkOutput` object.
 		for (const key of keys) {
 			customData[key] = benchmark.customData[key].rawValue;
 		}
 
-		const obj = {
+		const benchMarkOutput = {
 			benchmarkName,
 			elapsedSeconds: benchmark.elapsedSeconds,
 			customData,
 		};
 
-		return obj;
+		return benchMarkOutput;
 	}
 }

--- a/tools/benchmark/src/Reporter.ts
+++ b/tools/benchmark/src/Reporter.ts
@@ -122,6 +122,11 @@ export class BenchmarkReporter {
 		table.cell("name", chalk.italic(testName));
 		table.cell("total time (s)", prettyNumber((result as BenchmarkData).elapsedSeconds, 2));
 
+		// Additional if-statement to display columns in more readble order.
+		if (isResultError(result)) {
+			table.cell("error", result.error);
+		}
+
 		// Using this utility to print the data means missing fields don't crash and extra fields are reported.
 		// This is useful if this reporter is given unexpected data (such as from a memory test).
 		// It can also be used as a way to add extensible data formatting in the future.

--- a/tools/benchmark/src/mocha/memoryTestRunner.ts
+++ b/tools/benchmark/src/mocha/memoryTestRunner.ts
@@ -401,7 +401,7 @@ export function benchmarkMemory(testObject: IMemoryTestObject): Test {
 			};
 
 			benchmarkStats.customData["Relative Margin of Error"] = {
-				rawValue: heapUsedStats,
+				rawValue: heapUsedStats.marginOfErrorPercent,
 				formattedValue: `±${prettyNumber(heapUsedStats.marginOfErrorPercent, 2)}`,
 			};
 

--- a/tools/benchmark/src/resultFormatting.ts
+++ b/tools/benchmark/src/resultFormatting.ts
@@ -6,8 +6,6 @@
 import chalk from "chalk";
 import Table from "easy-table";
 
-import type { CustomData } from "./ResultTypes";
-
 /**
  * Library for converting a `Record<string, unknown>` into formatted table cells.
  * In the future this library can be used to provide extensible formatting for customized benchmarks which report different fields.
@@ -74,19 +72,4 @@ export function objectCell(key: string, title: string, f: (a: object) => string)
 
 export function skipCell(key: string): ExpectedCell {
 	return { key, cell: (): void => {} };
-}
-
-export function addCells(table: Table, data: CustomData, expected: readonly ExpectedCell[]): void {
-	const keys = new Set(Object.getOwnPropertyNames(data));
-	// Add expected cells, with their custom formatting and canonical order
-	for (const cell of expected) {
-		if (keys.delete(cell.key)) {
-			cell.cell(table, data);
-		}
-	}
-	// Add custom data cells
-	for (const [key, val] of Object.entries(data)) {
-		const displayValue = val.formattedValue;
-		table.cell(key, displayValue, Table.padLeft);
-	}
 }


### PR DESCRIPTION
#### Description

Fix problems from [22051](https://github.com/microsoft/FluidFramework/pull/22051). 

This PR achieves:
- Correctly consoles (as `total time (s)`) and stores `elapsedSeconds` from `BenchmarkData`. 
- Now stores the customData as a separate object within the output data.
- Removes the `addCells()` method.
- Fixes `relativeMarginOfError` from storing an object to a number. 

#### Output

Time Execution Test

```json
{
    "suiteName": "Direct Object",
    "benchmarks": [
        {
            "benchmarkName": "clone JS Object: 'canada'",
            "elapsedSeconds": 5.037420189,
            "customData": {
                "Batch Count": 92,
                "Iterations per Batch": 16,
                "Period (ns/op)": 3378487.7031250005,
                "Margin of Error": 0.00003538563475013932,
                "Relative Margin of Error": 1.0473808952274317
            }
        },
        {
            "benchmarkName": "sum JS Object: 'canada'",
            "elapsedSeconds": 0.37834331,
            "customData": {
                "Batch Count": 5,
                "Iterations per Batch": 8,
                "Period (ns/op)": 7759458.925,
                "Margin of Error": 0.00006417611015796642,
                "Relative Margin of Error": 0.8270693972127242
            }
        },
        {
            "benchmarkName": "averageValues JS Object: 'canada'",
            "elapsedSeconds": 0.369894621,
            "customData": {
                "Batch Count": 5,
                "Iterations per Batch": 64,
                "Period (ns/op)": 906275.3624999999,
                "Margin of Error": 0.000005163365357367206,
                "Relative Margin of Error": 0.5697347154096563
            }
        },
        {
            "benchmarkName": "clone JS Object: 'twitter'",
            "elapsedSeconds": 0.547090378,
            "customData": {
                "Batch Count": 6,
                "Iterations per Batch": 2,
                "Period (ns/op)": 39163096.16666667,
                "Margin of Error": 0.0003299327817054639,
                "Relative Margin of Error": 0.8424583702508265
            }
        },
        {
            "benchmarkName": "sum JS Object: 'twitter'",
            "elapsedSeconds": 0.450837745,
            "customData": {
                "Batch Count": 5,
                "Iterations per Batch": 32,
                "Period (ns/op)": 2337800.45625,
                "Margin of Error": 0.000015415387044734408,
                "Relative Margin of Error": 0.6593970415020707
            }
        },
        {
            "benchmarkName": "averageValues JS Object: 'twitter'",
            "elapsedSeconds": 3.90204722,
            "customData": {
                "Batch Count": 41,
                "Iterations per Batch": 16384,
                "Period (ns/op)": 5663.939121153296,
                "Margin of Error": 5.6265904442848953e-8,
                "Relative Margin of Error": 0.9934058830666251
            }
        }
    ]
}
```

<img width="1268" alt="Screenshot 2024-08-01 at 15 48 22" src="https://github.com/user-attachments/assets/a75ab86c-59ba-4ac6-8615-93516d8b2b5d">

Memory Test

```json
{
    "suiteName": "SharedDirectory memory usage",
    "benchmarks": [
        {
            "benchmarkName": "Create empty directory",
            "elapsedSeconds": 6.398396303,
            "customData": {
                "Heap Used Avg": 1691.0484210526315,
                "Heap Used StdDev": 182.91812910220978,
                "Margin of Error": 16.450004355875738,
                "Relative Margin of Error": 0.9727695641994721,
                "Iterations": 500
            }
        },
        {
            "benchmarkName": "Add 1000 integers to a local directory",
            "elapsedSeconds": 30.019151839,
            "customData": {
                "Heap Used Avg": 68668.77083333333,
                "Heap Used StdDev": 34822.68525927689,
                "Margin of Error": 1741.496961491467,
                "Relative Margin of Error": 2.5360829098255917,
                "Iterations": 1617
            }
        },
        {
            "benchmarkName": "Add 1000 integers to a local directory, clear it",
            "elapsedSeconds": 30.00917808,
            "customData": {
                "Heap Used Avg": -2032.8426209430495,
                "Heap Used StdDev": 23461.242169849073,
                "Margin of Error": 1137.925897324286,
                "Relative Margin of Error": 55.97707789087944,
                "Iterations": 1719
            }
        },
        {
            "benchmarkName": "Add 10000 integers to a local directory",
            "elapsedSeconds": 1.163637677,
            "customData": {
                "Heap Used Avg": 1019698.5531914893,
                "Heap Used StdDev": 735.5198932819601,
                "Margin of Error": 210.28174184100664,
                "Relative Margin of Error": 0.02062195157410582,
                "Iterations": 50
            }
        },
        {
            "benchmarkName": "Add 10000 integers to a local directory, clear it",
            "elapsedSeconds": 4.784802492,
            "customData": {
                "Heap Used Avg": 1931.125,
                "Heap Used StdDev": 341.06759551743096,
                "Margin of Error": 48.24428968054256,
                "Relative Margin of Error": 2.4982478959436887,
                "Iterations": 202
            }
        },
        {
            "benchmarkName": "Add 100000 integers to a local directory",
            "elapsedSeconds": 8.922699094,
            "customData": {
                "Heap Used Avg": 9270863.319148935,
                "Heap Used StdDev": 144.6442572212462,
                "Margin of Error": 41.35312536560084,
                "Relative Margin of Error": 0.000446054740988211,
                "Iterations": 50
            }
        },
        {
            "benchmarkName": "Add 100000 integers to a local directory, clear it",
            "elapsedSeconds": 27.739289924,
            "customData": {
                "Heap Used Avg": 2493.1875,
                "Heap Used StdDev": 358.0434529121128,
                "Margin of Error": 62.027863610832306,
                "Relative Margin of Error": 2.4878940557351705,
                "Iterations": 135
            }
        }
    ]
}
```

<img width="1176" alt="Screenshot 2024-08-01 at 15 46 40" src="https://github.com/user-attachments/assets/2b24ca01-def7-46c4-9622-4bd017e00d4d">

Outputs from the both of the test have:
- Separate `customData` object.
- Prettified data for console output.
- `Total Time (s)` (`elapsedSecond`) on the console which was missing from the previous package. 

#### Follow Up

Once this is merged, bump the version to `@fluid-tools/benchmark:0.51.0` and run a release on `@fluid-tools/benchmark: 0.50.0` and
