### PR TITLE
refactor(ci): Increase timeout of local server e2e tests from 3s to 15s

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -40,7 +40,7 @@
 		"test:realsvc": "npm run test:realsvc:local && npm run test:realsvc:tinylicious",
 		"test:realsvc:frs": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=frs --timeout=20s",
 		"test:realsvc:frs:report": "npm run test:realsvc:frs --",
-		"test:realsvc:local": "npm run test:realsvc:run -- --driver=local --timeout=15s",
+		"test:realsvc:local": "npm run test:realsvc:run -- --driver=local --timeout=15s && echo 'TEMP: Revert to 2s when AB#8942 is fixed",
 		"test:realsvc:local:report": "npm run test:realsvc:local --",
 		"test:realsvc:local:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:local --",
 		"test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -40,7 +40,7 @@
 		"test:realsvc": "npm run test:realsvc:local && npm run test:realsvc:tinylicious",
 		"test:realsvc:frs": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=frs --timeout=20s",
 		"test:realsvc:frs:report": "npm run test:realsvc:frs --",
-		"test:realsvc:local": "npm run test:realsvc:run -- --driver=local --timeout=3s",
+		"test:realsvc:local": "npm run test:realsvc:run -- --driver=local --timeout=15s",
 		"test:realsvc:local:report": "npm run test:realsvc:local --",
 		"test:realsvc:local:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:local --",
 		"test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",

--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -40,7 +40,7 @@
 		"test:realsvc": "npm run test:realsvc:local && npm run test:realsvc:tinylicious",
 		"test:realsvc:frs": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=frs --timeout=20s",
 		"test:realsvc:frs:report": "npm run test:realsvc:frs --",
-		"test:realsvc:local": "npm run test:realsvc:run -- --driver=local --timeout=15s && echo 'TEMP: Revert to 2s when AB#8942 is fixed",
+		"test:realsvc:local": "npm run test:realsvc:run -- --driver=local --timeout=15s && echo TEMP: Revert to 2s when AB#8942 is fixed",
 		"test:realsvc:local:report": "npm run test:realsvc:local --",
 		"test:realsvc:local:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:local --",
 		"test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",


### PR DESCRIPTION
Despite increasing the timeout for local server e2e tests from 2s to 3s https://github.com/microsoft/FluidFramework/pull/21928, timeout issues continue to occur. We determine to aggressively bump the timeout threshold as a mitigation. Given that each previous failure involved only one timeout, and there's a 1-hour hard cap for local server tests, this adjustment should be safe.

In addition, we need to identify and address the root cause ASAP and restore the timeout to 2s once the issue is resolved, tracked by [AB#8942](https://dev.azure.com/fluidframework/internal/_workitems/edit/8942)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).


