### PR TITLE
[bump] benchmark: 0.50.0 => 0.51.0 (minor)

### DIFF
--- a/tools/benchmark/package.json
+++ b/tools/benchmark/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/benchmark",
-	"version": "0.50.0",
+	"version": "0.51.0",
 	"description": "Benchmarking tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
#### Description

Created using `flub release -p "@fluid-tools/benchmark"` command. 