### PR TITLE
Fix Fuzz Test Replay and Minimization with stashing

### DIFF
--- a/packages/dds/sequence/src/test/fuzz/sharedString.fuzz.spec.ts
+++ b/packages/dds/sequence/src/test/fuzz/sharedString.fuzz.spec.ts
@@ -61,7 +61,7 @@ const baseSharedStringModel = {
 
 describe("SharedString fuzz testing", () => {
 	createDDSFuzzSuite(
-		{ ...baseSharedStringModel, workloadName: "default" },
+		{ ...baseSharedStringModel, workloadName: "SharedString default" },
 		{
 			...defaultFuzzOptions,
 			// Uncomment this line to replay a specific seed from its failure file:
@@ -72,7 +72,7 @@ describe("SharedString fuzz testing", () => {
 
 describe("SharedString fuzz with stashing", () => {
 	createDDSFuzzSuite(
-		{ ...baseSharedStringModel, workloadName: "default" },
+		{ ...baseSharedStringModel, workloadName: "SharedString with stashing" },
 		{
 			...defaultFuzzOptions,
 			clientJoinOptions: {

--- a/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
+++ b/packages/dds/test-dds-utils/src/test/ddsFuzzHarness.spec.ts
@@ -604,8 +604,12 @@ describe("DDS Fuzz Harness", () => {
 			assert.strictEqual(clientCreates[1].channel.processCoreCalls, 3);
 
 			// client loaded from stash
-			assert.strictEqual(clientCreates[2].channel.applyStashedOpCalls, 5);
-			assert.strictEqual(clientCreates[2].channel.noopCalls, 10);
+			assert.strictEqual(
+				clientCreates[2].channel.applyStashedOpCalls,
+				2,
+				"3 should be saved, and 2 should be stashed",
+			);
+			assert.strictEqual(clientCreates[2].channel.noopCalls, 7);
 			assert.strictEqual(clientCreates[2].channel.processCoreCalls, 9);
 		});
 	});


### PR DESCRIPTION
There was a problem with the operation format of stashing that made replay and minimization not work. Specifically, the stashClient operation had the container runtime id, which was a random uuid, so on replay the client id could not be found, i've changed this to the fuzz test client id, so it remains consistent. There was a related problem with the new clients id, so i've changed that to append an instance number to the original client's id, such that it can be differentiated from the original client, but still associated with it.