### PR TITLE
tree: Add Recursive ArrayNode export workaround

### DIFF
--- a/.changeset/sweet-things-wash.md
+++ b/.changeset/sweet-things-wash.md
@@ -1,0 +1,27 @@
+---
+"@fluidframework/tree": minor
+---
+
+Add `@alpha` API `FixRecursiveArraySchema` as a workaround around an issue with recursive ArrayNode schema.
+
+Importing a recursive ArrayNode schema via a d.ts file can produce an error like
+`error TS2310: Type 'RecursiveArray' recursively references itself as a base type.`
+if using a tsconfig with `"skipLibCheck": false`.
+
+This error occurs due to the TypeScript compiler splitting the class definition into two separate declarations in the d.ts file (one for the base, and one for the actual class).
+For unknown reasons, splitting the class declaration in this way breaks the recursive type handling, leading to the mentioned error.
+
+Since recursive type handling in TypeScript is order dependent, putting just the right kind of usages of the type before the declarations can cause it to not hit this error.
+For the case of ArrayNodes, this can be done via usage that looks like this:
+
+```typescript
+/**
+ * Workaround to avoid
+ * `error TS2310: Type 'RecursiveArray' recursively references itself as a base type.` in the d.ts file.
+ */
+export declare const _RecursiveArrayWorkaround: FixRecursiveArraySchema<typeof RecursiveArray>;
+export class RecursiveArray extends schema.arrayRecursive("RA", [() => RecursiveArray]) {}
+{
+	type _check = ValidateRecursiveSchema<typeof RecursiveArray>;
+}
+```

--- a/experimental/framework/tree-react-api/src/testExports.ts
+++ b/experimental/framework/tree-react-api/src/testExports.ts
@@ -44,11 +44,12 @@ import {
 	TreeViewConfiguration,
 	type NodeFromSchema,
 	type ValidateRecursiveSchema,
+	type FixRecursiveArraySchema,
 	// To diagnose `error TS2742: The inferred type of ...` errors,
 	// enable this import then look for use of it in the generated d.ts file fo find what needs to be moved out of InternalTypes
 	// // eslint-disable-next-line unused-imports/no-unused-imports
 	// InternalTypes,
-} from "@fluidframework/tree";
+} from "@fluidframework/tree/internal";
 
 // Due to limitation of the TypeScript compiler, errors like the following can be produced when exporting types from another package:
 // error TS2742: The inferred type of 'Inventory' cannot be named without a reference to '../node_modules/@fluidframework/tree/lib/internalTypes.js'. This is likely not portable. A type annotation is necessary.
@@ -95,8 +96,12 @@ export class RecursiveMap extends schema.mapRecursive("RM", [() => RecursiveMap]
 	type _check = ValidateRecursiveSchema<typeof RecursiveMap>;
 }
 
-// TODO: export once ` error TS2310: Type 'RecursiveArray' recursively references itself as a base type.` in the d.ts file is fixed.
-class RecursiveArray extends schema.arrayRecursive("RA", [() => RecursiveArray]) {}
+/**
+ * Workaround to avoid
+ * `error TS2310: Type 'RecursiveArray' recursively references itself as a base type.` in the d.ts file.
+ */
+export declare const _RecursiveArrayWorkaround: FixRecursiveArraySchema<typeof RecursiveArray>;
+export class RecursiveArray extends schema.arrayRecursive("RA", [() => RecursiveArray]) {}
 {
 	type _check = ValidateRecursiveSchema<typeof RecursiveArray>;
 }

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -70,6 +70,9 @@ export interface FieldSchemaUnsafe<out Kind extends FieldKind, out Types extends
     readonly kind: Kind;
 }
 
+// @alpha
+export type FixRecursiveArraySchema<T> = T extends TreeNodeSchema ? undefined : undefined;
+
 // @public
 type FlattenKeys<T> = [{
     [Property in keyof T]: T[Property];

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/chunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/chunk.ts
@@ -75,7 +75,7 @@ interface WithChunk {
 	 *
 	 * As more optimizations get implemented, this API may need to change to better address these issues.
 	 */
-	readonly [cursorChunk]?: TreeChunk;
+	readonly [cursorChunk]?: TreeChunk | undefined;
 }
 
 /**

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -111,6 +111,7 @@ export {
 	type FieldSchemaUnsafe,
 	// Recursive Schema APIs
 	type ValidateRecursiveSchema,
+	type FixRecursiveArraySchema,
 	// experimental @internal APIs:
 	adaptEnum,
 	enumFromStrings,

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -59,7 +59,10 @@ export type {
 	NodeFromSchemaUnsafe,
 	ReadonlyMapInlined,
 } from "./typesUnsafe.js";
-export type { ValidateRecursiveSchema } from "./schemaFactoryRecursive.js";
+export type {
+	ValidateRecursiveSchema,
+	FixRecursiveArraySchema,
+} from "./schemaFactoryRecursive.js";
 export {
 	getProxyForField,
 	type InsertableContent,

--- a/packages/dds/tree/src/simple-tree/schemaFactoryRecursive.ts
+++ b/packages/dds/tree/src/simple-tree/schemaFactoryRecursive.ts
@@ -17,6 +17,7 @@ import {
 	type NodeKind,
 	type TreeNodeSchemaClass,
 	type WithType,
+	type TreeNodeSchema,
 } from "./schemaTypes.js";
 import type { TreeNode } from "./types.js";
 import type { FieldSchemaUnsafe } from "./typesUnsafe.js";
@@ -151,3 +152,34 @@ export type ValidateRecursiveSchema<
 		}[T["kind"]]
 	>,
 > = true;
+
+/**
+ * Workaround for fixing errors an issue with recursive ArrayNode schema exports.
+ * @remarks
+ * Importing a recursive ArrayNode schema via a d.ts file can produce an error like
+ * `error TS2310: Type 'RecursiveArray' recursively references itself as a base type.`
+ * if using a tsconfig with `"skipLibCheck": false`.
+ *
+ * This error occurs due to the TypeScript compiler splitting the class definition into two separate declarations in the d.ts file (one for the base, and one for the actual class).
+ * For unknown reasons, splitting the class declaration in this way breaks the recursive type handling, leading to the mentioned error.
+ *
+ * Since recursive type handling in TypeScript is order dependent, putting just the right kind of usages of the type before the declarations can cause it to not hit this error.
+ * For the case of ArrayNodes, this can be done via usage that looks like this:
+ *
+ * @example
+ * This example should use a doc comment to ensure the workaround comment shows up in the intellisense for the dummy export,
+ * however doing so is impossible due to how this example is included in a doc comment.
+ * ```typescript
+ *  // Workaround to avoid
+ *  // `error TS2310: Type 'RecursiveArray' recursively references itself as a base type.` in the d.ts file.
+ * export declare const _RecursiveArrayWorkaround: FixRecursiveArraySchema<typeof RecursiveArray>;
+ * export class RecursiveArray extends schema.arrayRecursive("RA", [() => RecursiveArray]) {}
+ * {
+ * 	type _check = ValidateRecursiveSchema<typeof RecursiveArray>;
+ * }
+ * ```
+ *
+ * This type always evaluates to undefined to ensure the dummy export (which doesn't exist at runtime) is typed correctly.
+ * @alpha
+ */
+export type FixRecursiveArraySchema<T> = T extends TreeNodeSchema ? undefined : undefined;

--- a/packages/dds/tree/src/simple-tree/schemaFactoryRecursive.ts
+++ b/packages/dds/tree/src/simple-tree/schemaFactoryRecursive.ts
@@ -154,7 +154,7 @@ export type ValidateRecursiveSchema<
 > = true;
 
 /**
- * Workaround for fixing errors an issue with recursive ArrayNode schema exports.
+ * Workaround for fixing errors resulting from an issue with recursive ArrayNode schema exports.
  * @remarks
  * Importing a recursive ArrayNode schema via a d.ts file can produce an error like
  * `error TS2310: Type 'RecursiveArray' recursively references itself as a base type.`
@@ -179,7 +179,7 @@ export type ValidateRecursiveSchema<
  * }
  * ```
  *
- * This type always evaluates to undefined to ensure the dummy export (which doesn't exist at runtime) is typed correctly.
+ * This type always evaluates to `undefined` to ensure the dummy export (which doesn't exist at runtime) is typed correctly.
  * @alpha
  */
 export type FixRecursiveArraySchema<T> = T extends TreeNodeSchema ? undefined : undefined;

--- a/packages/dds/tree/src/simple-tree/schemaFactoryRecursive.ts
+++ b/packages/dds/tree/src/simple-tree/schemaFactoryRecursive.ts
@@ -163,10 +163,12 @@ export type ValidateRecursiveSchema<
  * This error occurs due to the TypeScript compiler splitting the class definition into two separate declarations in the d.ts file (one for the base, and one for the actual class).
  * For unknown reasons, splitting the class declaration in this way breaks the recursive type handling, leading to the mentioned error.
  *
+ * This type always evaluates to `undefined` to ensure the dummy export (which doesn't exist at runtime) is typed correctly.
+ *
+ * @example Usage
  * Since recursive type handling in TypeScript is order dependent, putting just the right kind of usages of the type before the declarations can cause it to not hit this error.
  * For the case of ArrayNodes, this can be done via usage that looks like this:
  *
- * @example
  * This example should use a doc comment to ensure the workaround comment shows up in the intellisense for the dummy export,
  * however doing so is impossible due to how this example is included in a doc comment.
  * ```typescript
@@ -179,7 +181,6 @@ export type ValidateRecursiveSchema<
  * }
  * ```
  *
- * This type always evaluates to `undefined` to ensure the dummy export (which doesn't exist at runtime) is typed correctly.
  * @alpha
  */
 export type FixRecursiveArraySchema<T> = T extends TreeNodeSchema ? undefined : undefined;

--- a/packages/dds/tree/src/simple-tree/schemaFactoryRecursive.ts
+++ b/packages/dds/tree/src/simple-tree/schemaFactoryRecursive.ts
@@ -165,6 +165,8 @@ export type ValidateRecursiveSchema<
  *
  * This type always evaluates to `undefined` to ensure the dummy export (which doesn't exist at runtime) is typed correctly.
  *
+ * [TypeScript Issue 59550](https://github.com/microsoft/TypeScript/issues/59550) tracks a suggestion which would make this workaround unnecessary.
+ *
  * @example Usage
  * Since recursive type handling in TypeScript is order dependent, putting just the right kind of usages of the type before the declarations can cause it to not hit this error.
  * For the case of ArrayNodes, this can be done via usage that looks like this:


### PR DESCRIPTION
## Description

Adds an `@alpha` API to workaround an issue with recursive ArrayNode schema.

This is alpha because this workaround is pretty nasty, likely fragile and uncommon for people to require.
Hopefully a better workaround can be found before there is real customer need for this.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).