### PR TITLE
tree: Fix bug in isTreeNode for "marinated" nodes, and tidy up proxy binding

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -30,7 +30,7 @@ import {
 	type TreeFieldFromImplicitField,
 	type TreeView,
 	type TreeViewEvents,
-	getProxyForField,
+	getTreeNodeForField,
 	toFlexSchema,
 	setField,
 	normalizeFieldSchema,
@@ -315,7 +315,7 @@ export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitField
 			);
 		}
 		const view = this.getView();
-		return getProxyForField(view.flexTree) as TreeFieldFromImplicitField<TRootSchema>;
+		return getTreeNodeForField(view.flexTree) as TreeFieldFromImplicitField<TRootSchema>;
 	}
 
 	public set root(newRoot: InsertableTreeFieldFromImplicitField<TRootSchema>) {

--- a/packages/dds/tree/src/shared-tree/treeApi.ts
+++ b/packages/dds/tree/src/shared-tree/treeApi.ts
@@ -11,7 +11,7 @@ import {
 	type TreeNode,
 	type TreeNodeApi,
 	type TreeView,
-	getFlexNode,
+	getOrCreateInnerNode,
 	treeNodeApi,
 } from "../simple-tree/index.js";
 import { fail } from "../util/index.js";
@@ -435,7 +435,7 @@ export function runTransaction<
 	} else {
 		const node = treeOrNode as TNode;
 		const t = transaction as (node: TNode) => TResult | typeof rollback;
-		const context = getFlexNode(node).context;
+		const context = getOrCreateInnerNode(node).context;
 		assert(context instanceof Context, 0x901 /* Unsupported context */);
 		const treeView =
 			contextToTreeView.get(context) ?? fail("Expected view to be registered for context");
@@ -453,7 +453,7 @@ function runTransactionInCheckout<TResult>(
 	for (const constraint of preconditions) {
 		switch (constraint.type) {
 			case "nodeInDocument": {
-				const node = getFlexNode(constraint.node);
+				const node = getOrCreateInnerNode(constraint.node);
 				assert(
 					treeApi.status(constraint.node) === TreeStatus.InDocument,
 					0x90f /* Attempted to apply "nodeExists" constraint when building a transaction, but the node is not in the document. */,

--- a/packages/dds/tree/src/simple-tree/ProxyBinding.md
+++ b/packages/dds/tree/src/simple-tree/ProxyBinding.md
@@ -24,6 +24,8 @@ This feature is supported by doing some bookkeeping to ensure that the proxy obj
 flex tree nodes and anchor nodes in the tree get associated and disassociated at the right times.
 There are three states that a node proxy can be in: "raw", "marinated" and "cooked".
 
+Note from the public API perspective, `Unhydrated` nodes are "raw", and hydrated nodes are either "marinated" or "cooked".
+
 ### Raw Proxies
 
 A newly created proxy, a.k.a. a **raw** proxy. A raw proxy is produced by invoking the schema-provided constructor for a node:

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -18,10 +18,10 @@ import {
 } from "../feature-libraries/index.js";
 import {
 	type InsertableContent,
-	getOrCreateNodeProxy,
+	getOrCreateNodeFromFlexTreeNode,
 	prepareContentForHydration,
 } from "./proxies.js";
-import { getFlexNode, getKernel } from "./proxyBinding.js";
+import { getOrCreateInnerNode } from "./proxyBinding.js";
 import {
 	NodeKind,
 	type ImplicitAllowedTypes,
@@ -44,6 +44,7 @@ import { fail } from "../util/index.js";
 import { getFlexSchema } from "./toFlexSchema.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { assert } from "@fluidframework/core-utils/internal";
+import { getKernel } from "./treeNodeKernel.js";
 
 /**
  * A generic array type, used to defined types like {@link (TreeArrayNode:interface)}.
@@ -288,7 +289,7 @@ function getSequenceField<
 	TTypes extends FlexAllowedTypes,
 	TSimpleType extends ImplicitAllowedTypes,
 >(arrayNode: TreeArrayNode<TSimpleType>): FlexTreeSequenceField<TTypes> {
-	return getFlexNode(arrayNode).getBoxed(EmptyKey) as FlexTreeSequenceField<TTypes>;
+	return getOrCreateInnerNode(arrayNode).getBoxed(EmptyKey) as FlexTreeSequenceField<TTypes>;
 }
 
 // For compatibility, we are initially implement 'readonly T[]' by applying the Array.prototype methods
@@ -558,7 +559,9 @@ function createArrayNodeProxy(
 			}
 
 			const maybeContent = field.at(maybeIndex);
-			return isFlexTreeNode(maybeContent) ? getOrCreateNodeProxy(maybeContent) : maybeContent;
+			return isFlexTreeNode(maybeContent)
+				? getOrCreateNodeFromFlexTreeNode(maybeContent)
+				: maybeContent;
 		},
 		set: (target, key, newValue, receiver) => {
 			if (key === "length") {
@@ -620,7 +623,7 @@ function createArrayNodeProxy(
 					// TODO: Ideally, we would return leaves without first boxing them.  However, this is not
 					//       as simple as calling '.at' since this skips the node and returns the FieldNode's
 					//       inner field.
-					value: val === undefined ? val : getOrCreateNodeProxy(val),
+					value: val === undefined ? val : getOrCreateNodeFromFlexTreeNode(val),
 					writable: true, // For MVP, disallow setting indexed properties.
 					enumerable: true,
 					configurable: true,
@@ -683,7 +686,7 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 	}
 
 	#cursorFromFieldData(value: Insertable<T>): ITreeCursorSynchronous {
-		if (isMapTreeNode(getFlexNode(this))) {
+		if (isMapTreeNode(getOrCreateInnerNode(this))) {
 			throw new UsageError(`An array cannot be mutated before being inserted into the tree`);
 		}
 
@@ -748,7 +751,7 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 			return val;
 		}
 
-		return getOrCreateNodeProxy(val) as TreeNodeFromImplicitAllowedTypes<T>;
+		return getOrCreateNodeFromFlexTreeNode(val) as TreeNodeFromImplicitAllowedTypes<T>;
 	}
 	public insertAt(index: number, ...value: Insertable<T>): void {
 		const field = getSequenceField(this);

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -39,7 +39,7 @@ export {
 	type ApplyKind,
 } from "./schemaTypes.js";
 export { SchemaFactory, type ScopedSchemaName } from "./schemaFactory.js";
-export { getFlexNode, tryDisposeTreeNode } from "./proxyBinding.js";
+export { getOrCreateInnerNode, tryDisposeTreeNode } from "./proxyBinding.js";
 export { treeNodeApi, type TreeNodeApi } from "./treeNodeApi.js";
 export { toFlexSchema } from "./toFlexSchema.js";
 export type {
@@ -61,7 +61,7 @@ export type {
 } from "./typesUnsafe.js";
 export type { ValidateRecursiveSchema } from "./schemaFactoryRecursive.js";
 export {
-	getProxyForField,
+	getTreeNodeForField,
 	type InsertableContent,
 	prepareContentForHydration,
 } from "./proxies.js";

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -15,10 +15,10 @@ import {
 import {
 	type FactoryContent,
 	type InsertableContent,
-	getProxyForField,
+	getTreeNodeForField,
 	prepareContentForHydration,
 } from "./proxies.js";
-import { getFlexNode } from "./proxyBinding.js";
+import { getOrCreateInnerNode } from "./proxyBinding.js";
 import { getSimpleNodeSchema } from "./schemaCaching.js";
 import {
 	NodeKind,
@@ -135,7 +135,7 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 		return this.entries();
 	}
 	public delete(key: string): void {
-		const node = getFlexNode(this);
+		const node = getOrCreateInnerNode(this);
 		if (isMapTreeNode(node)) {
 			throw new UsageError(`A map cannot be mutated before being inserted into the tree`);
 		}
@@ -143,26 +143,29 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 		node.delete(key);
 	}
 	public *entries(): IterableIterator<[string, TreeNodeFromImplicitAllowedTypes<T>]> {
-		const node = getFlexNode(this);
+		const node = getOrCreateInnerNode(this);
 		for (const key of node.keys()) {
-			yield [key, getProxyForField(node.getBoxed(key)) as TreeNodeFromImplicitAllowedTypes<T>];
+			yield [
+				key,
+				getTreeNodeForField(node.getBoxed(key)) as TreeNodeFromImplicitAllowedTypes<T>,
+			];
 		}
 	}
 	public get(key: string): TreeNodeFromImplicitAllowedTypes<T> {
-		const node = getFlexNode(this);
+		const node = getOrCreateInnerNode(this);
 		const field = node.getBoxed(key);
-		return getProxyForField(field) as TreeNodeFromImplicitAllowedTypes<T>;
+		return getTreeNodeForField(field) as TreeNodeFromImplicitAllowedTypes<T>;
 	}
 	public has(key: string): boolean {
-		const node = getFlexNode(this);
+		const node = getOrCreateInnerNode(this);
 		return node.has(key);
 	}
 	public keys(): IterableIterator<string> {
-		const node = getFlexNode(this);
+		const node = getOrCreateInnerNode(this);
 		return node.keys();
 	}
 	public set(key: string, value: InsertableTreeNodeFromImplicitAllowedTypes<T>): TreeMapNode {
-		const node = getFlexNode(this);
+		const node = getOrCreateInnerNode(this);
 		if (isMapTreeNode(node)) {
 			throw new UsageError(`A map cannot be mutated before being inserted into the tree`);
 		}
@@ -181,7 +184,7 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 		return this;
 	}
 	public get size(): number {
-		return getFlexNode(this).size;
+		return getOrCreateInnerNode(this).size;
 	}
 	public *values(): IterableIterator<TreeNodeFromImplicitAllowedTypes<T>> {
 		for (const [, value] of this.entries()) {
@@ -193,8 +196,8 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 		callbackFn: (value: TreeNodeFromImplicitAllowedTypes<T>, key: string, map: TThis) => void,
 		thisArg?: unknown,
 	): void {
-		for (const field of getFlexNode(this).boxedIterator()) {
-			const node = getProxyForField(field) as TreeNodeFromImplicitAllowedTypes<T>;
+		for (const field of getOrCreateInnerNode(this).boxedIterator()) {
+			const node = getTreeNodeForField(field) as TreeNodeFromImplicitAllowedTypes<T>;
 			callbackFn.call(thisArg, node, field.key, this);
 		}
 	}

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -22,10 +22,10 @@ import {
 } from "../feature-libraries/index.js";
 import {
 	type InsertableContent,
-	getProxyForField,
+	getTreeNodeForField,
 	prepareContentForHydration,
 } from "./proxies.js";
-import { getFlexNode } from "./proxyBinding.js";
+import { getOrCreateInnerNode } from "./proxyBinding.js";
 import {
 	NodeKind,
 	type ImplicitFieldSchema,
@@ -170,10 +170,10 @@ function createProxyHandler(
 			const fieldInfo = flexKeyMap.get(viewKey);
 
 			if (fieldInfo !== undefined) {
-				const flexNode = getFlexNode(proxy);
+				const flexNode = getOrCreateInnerNode(proxy);
 				const field = flexNode.tryGetField(fieldInfo.storedKey);
 				if (field !== undefined) {
-					return getProxyForField(field);
+					return getTreeNodeForField(field);
 				}
 
 				// Check if the user is trying to read an identifier field of an unhydrated node, but the identifier is not present.
@@ -198,7 +198,7 @@ function createProxyHandler(
 				return allowAdditionalProperties ? Reflect.set(target, viewKey, value, proxy) : false;
 			}
 
-			const flexNode = getFlexNode(proxy);
+			const flexNode = getOrCreateInnerNode(proxy);
 			if (isMapTreeNode(flexNode)) {
 				throw new UsageError(
 					`An object cannot be mutated before being inserted into the tree`,
@@ -239,10 +239,10 @@ function createProxyHandler(
 			// If a refactoring is done to associated flex tree data with the target not the proxy, this extra map could be removed,
 			// and the design would be more compatible with proxyless nodes.
 			const proxy = targetToProxy.get(target) ?? fail("missing proxy");
-			const field = getFlexNode(proxy).tryGetField(fieldInfo.storedKey);
+			const field = getOrCreateInnerNode(proxy).tryGetField(fieldInfo.storedKey);
 
 			const p: PropertyDescriptor = {
-				value: field === undefined ? undefined : getProxyForField(field),
+				value: field === undefined ? undefined : getTreeNodeForField(field),
 				writable: true,
 				// Report empty fields as own properties so they shadow inherited properties (even when empty) to match TypeScript typing.
 				// Make empty fields not enumerable so they get skipped when iterating over an object to better align with

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -25,39 +25,23 @@ import {
 } from "../feature-libraries/index.js";
 import { type Mutable, fail, isReadonlyArray } from "../util/index.js";
 
-import { anchorProxy, tryGetFlexNode, tryGetProxy } from "./proxyBinding.js";
+import { anchorProxy, tryGetCachedTreeNode } from "./proxyBinding.js";
 import { tryGetSimpleNodeSchema } from "./schemaCaching.js";
 import type { TreeNode, Unhydrated } from "./types.js";
 
 /**
- * Detects if the given 'candidate' is a TreeNode.
- *
- * @remarks
- * Supports both Hydrated and {@link Unhydrated} TreeNodes, both of which return true.
- *
- * Because the common usage is to check if a value being inserted/set is a TreeNode,
- * this function permits calling with primitives as well as objects.
- *
- * Primitives will always return false (as they are copies of data, not references to nodes).
- *
- * @param candidate - Value which may be a TreeNode
- * @returns true if the given 'candidate' is a hydrated TreeNode.
+ * Retrieve the associated {@link TreeNode} for the given field's content.
  */
-export function isTreeNode(candidate: unknown): candidate is TreeNode | Unhydrated<TreeNode> {
-	return tryGetFlexNode(candidate) !== undefined;
-}
-
-/**
- * Retrieve the associated proxy for the given field.
- */
-export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | undefined {
+export function getTreeNodeForField(field: FlexTreeField): TreeNode | TreeValue | undefined {
 	function tryToUnboxLeaves(
 		flexField: FlexTreeTypedField<
 			FlexFieldSchema<typeof FieldKinds.required | typeof FieldKinds.optional>
 		>,
 	): TreeNode | TreeValue | undefined {
 		const maybeContent = flexField.content;
-		return isFlexTreeNode(maybeContent) ? getOrCreateNodeProxy(maybeContent) : maybeContent;
+		return isFlexTreeNode(maybeContent)
+			? getOrCreateNodeFromFlexTreeNode(maybeContent)
+			: maybeContent;
 	}
 	switch (field.schema.kind) {
 		case FieldKinds.required: {
@@ -89,8 +73,8 @@ export function getProxyForField(field: FlexTreeField): TreeNode | TreeValue | u
 	}
 }
 
-export function getOrCreateNodeProxy(flexNode: FlexTreeNode): TreeNode | TreeValue {
-	const cachedProxy = tryGetProxy(flexNode);
+export function getOrCreateNodeFromFlexTreeNode(flexNode: FlexTreeNode): TreeNode | TreeValue {
+	const cachedProxy = tryGetCachedTreeNode(flexNode);
 	if (cachedProxy !== undefined) {
 		return cachedProxy;
 	}
@@ -185,7 +169,7 @@ function walkMapTree(
 ): void {
 	const mapTreeNode = tryGetMapTreeNode(mapTree);
 	if (mapTreeNode !== undefined) {
-		const treeNode = tryGetProxy(mapTreeNode);
+		const treeNode = tryGetCachedTreeNode(mapTreeNode);
 		if (treeNode !== undefined) {
 			onVisitTreeNode(path, treeNode);
 		}

--- a/packages/dds/tree/src/simple-tree/proxyBinding.ts
+++ b/packages/dds/tree/src/simple-tree/proxyBinding.ts
@@ -29,41 +29,69 @@ import type { TreeNode } from "./types.js";
 // eslint-disable-next-line import/no-internal-modules
 import { makeTree } from "../feature-libraries/flex-tree/lazyNode.js";
 import type { TreeMapNode } from "./mapNode.js";
-import { TreeNodeKernel } from "./treeNodeKernel.js";
+import { getKernel } from "./treeNodeKernel.js";
 
-// This file contains various maps and helpers for supporting proxy binding (a.k.a. proxy hydration).
+// This file contains various maps and helpers for supporting associating simple TreeNodes with their InnerNodes, and swapping those InnerNodes as part of hydration.
 // See ./ProxyBinding.md for a high-level overview of the process.
 
 /**
- * An anchor slot which associates an anchor with its corresponding node proxy, if there is one.
+ * An anchor slot which associates an anchor with its corresponding TreeNode, if there is one.
+ * @remarks
+ * For this to work, we have to require that there is at most a single view using a given AnchorSet.
+ * FlexTree already has this assumption, and we also assume there is a single simple-tree per FlexTree, so this is valid.
  */
 const proxySlot = anchorSlot<TreeNode>();
 
-// The following records are maintained as WeakMaps, rather than a private symbol (e.g. like `targetSymbol`) on the node proxy itself.
+// The following records are maintained as WeakMaps, rather than a private symbol (e.g. like `targetSymbol`) on the TreeNode.
 // The map behaves essentially the same, except that performing a lookup in the map will not perform a property read/get on the key object (as is the case with a symbol).
 // Since `SharedTreeNodes` are proxies with non-trivial `get` traps, this choice is meant to prevent the confusion of the lookup passing through multiple objects
 // via the trap, or the trap not properly handling the special symbol, etc.
 
-/** A reverse mapping of {@link proxySlot} that is updated at the same time. */
+/**
+ * A reverse mapping of {@link proxySlot} that is updated at the same time.
+ *
+ * @remarks
+ * Nodes in this map are hydrated (and thus "marinated" or "cooked").
+ * Nodes not in this map are known to be {@link Unhydrated}.
+ * Thus this map can be used to check if a node is hydrated.
+ *
+ * Any node not in this map must be in {@link proxyToMapTreeNode} since it contains all unhydrated nodes.
+ * It also contains "marinated" nodes which are in both.
+ */
 const proxyToAnchorNode = new WeakMap<TreeNode, AnchorNode>();
 
-// Map unhydrated nodes to and from their underlying flex tree implementation.
-// These maps are populated after a user calls `const proxy = new Foo({})` but before `proxy` is inserted into the tree and queried.
+/**
+ * Map {@link Unhydrated} nodes and "marinated" nodes to and from their underlying MapTreeNode.
+ * These maps are populated by the TreeNode's constructor when called by a user before the node is inserted into the tree and queried.
+ */
 const proxyToMapTreeNode = new WeakMap<TreeNode, MapTreeNode>();
+
+/**
+ * {@inheritdoc proxyToMapTreeNode}
+ */
 const mapTreeNodeToProxy = new WeakMap<MapTreeNode, TreeNode>();
-/** Used by `anchorProxy` as an optimization to ensure that only one anchor is remembered at a time for a given anchor node */
+
+/**
+ * Used by {@link anchorProxy} as an optimization to ensure that only one anchor is remembered at a time for a given anchor node
+ */
 const anchorForgetters = new WeakMap<TreeNode, () => void>();
 
 /**
  * Creates an anchor node and associates it with the given proxy.
- * @privateRemarks Use `forgetters` to cleanup the anchor allocated by this function once the anchor is no longer needed.
+ * @privateRemarks
+ * Use `forgetters` to cleanup the anchor allocated by this function once the anchor is no longer needed.
  * In practice, this happens when either the anchor node is destroyed, or another anchor to the same node is created by a new flex node.
+ *
+ * The FlexTreeNode holds a reference to the same anchor, and has a lifetime at least as long as the simple-tree,
+ * so this would be unnecessary except for the case of "marinated" nodes, which have an anchor,
+ * but might not have a FlexTreeNode.
+ * Handling this case is an optimization assuming that this extra anchor reference is cheaper than eagerly creating FlexTreeNodes.
  */
 export function anchorProxy(anchors: AnchorSet, path: UpPath, proxy: TreeNode): AnchorNode {
 	assert(!anchorForgetters.has(proxy), 0x91c /* Proxy anchor should not be set twice */);
 	const anchor = anchors.track(path);
 	const anchorNode = anchors.locate(anchor) ?? fail("Expected anchor node to be present");
-	bindProxyToAnchorNode(proxy, anchorNode);
+	bindHydratedNodeToAnchor(proxy, anchorNode);
 	const forget = (): void => {
 		if (anchors.locate(anchor)) {
 			anchors.forget(anchor);
@@ -77,21 +105,26 @@ export function anchorProxy(anchors: AnchorSet, path: UpPath, proxy: TreeNode): 
 }
 
 /**
- * Retrieves the flex node associated with the given target via {@link setFlexNode}.
- * @remarks Fails if the flex node has not been set.
+ * Retrieves the flex node associated with the given target via {@link setInnerNode}.
+ * @remarks
+ * For {@link Unhydrated} nodes, this returns the MapTreeNode.
+ *
+ * For hydrated nodes it returns a FlexTreeNode backed by the forest.
+ * Note that for "marinated" nodes, this FlexTreeNode exists and returns it: it does not return the MapTreeNode which is the current InnerNode.
  */
-export function getFlexNode(
-	proxy: TypedNode<FlexObjectNodeSchema>,
+export function getOrCreateInnerNode(
+	treeNode: TypedNode<FlexObjectNodeSchema>,
 	allowFreed?: true,
-): FlexTreeObjectNode;
-export function getFlexNode(proxy: TreeArrayNode, allowFreed?: true): FlexTreeNode;
-export function getFlexNode(
-	proxy: TreeMapNode,
+): InnerNode & FlexTreeObjectNode;
+export function getOrCreateInnerNode(treeNode: TreeArrayNode, allowFreed?: true): InnerNode;
+export function getOrCreateInnerNode(
+	treeNode: TreeMapNode,
 	allowFreed?: true,
-): FlexTreeMapNode<FlexMapNodeSchema<string, FlexFieldSchema<typeof FieldKinds.optional>>>;
-export function getFlexNode(proxy: TreeNode, allowFreed?: true): FlexTreeNode;
-export function getFlexNode(proxy: TreeNode, allowFreed = false): FlexTreeNode {
-	const anchorNode = proxyToAnchorNode.get(proxy);
+): InnerNode &
+	FlexTreeMapNode<FlexMapNodeSchema<string, FlexFieldSchema<typeof FieldKinds.optional>>>;
+export function getOrCreateInnerNode(treeNode: TreeNode, allowFreed?: true): InnerNode;
+export function getOrCreateInnerNode(treeNode: TreeNode, allowFreed = false): InnerNode {
+	const anchorNode = proxyToAnchorNode.get(treeNode);
 	if (anchorNode !== undefined) {
 		// The proxy is bound to an anchor node, but it may or may not have an actual flex node yet
 		const flexNode = anchorNode.slots.get(flexTreeSlot);
@@ -104,89 +137,125 @@ export function getFlexNode(proxy: TreeNode, allowFreed = false): FlexTreeNode {
 		const newFlexNode = makeTree(context, cursor);
 		cursor.free();
 		// Calling this is a performance improvement, however, do this only after demand to avoid momentarily having no anchors to anchorNode
-		anchorForgetters?.get(proxy)?.();
+		anchorForgetters?.get(treeNode)?.();
 		if (!allowFreed) {
 			assertFlexTreeEntityNotFreed(newFlexNode);
 		}
 		return newFlexNode;
 	}
 
-	return proxyToMapTreeNode.get(proxy) ?? fail("Expected raw tree node for proxy");
+	// Unhydrated case
+	return proxyToMapTreeNode.get(treeNode) ?? fail("Expected raw tree node for proxy");
 }
 
 /**
- * Retrieves the flex node associated with the given target via {@link setFlexNode}, if any.
+ * For "cooked" nodes this is a FlexTreeNode thats a projection of forest content.
+ * For {@link Unhydrated} nodes this is a MapTreeNode.
+ * For "marinated" nodes, some code (ex: getOrCreateInnerNode) returns the FlexTreeNode thats a projection of forest content, and some code (ex: tryGetInnerNode) returns undefined.
+ *
+ * @remarks
+ * Currently MapTreeNode extends FlexTreeNode, and most code which can work with either just uses FlexTreeNode.
+ * TODO: Code should be migrating toward using this type to distinguish to two use-cases.
+ *
+ * TODO: The inconsistent handling of "marinated" cases should be cleaned up.
+ * Maybe getOrCreateInnerNode should cook marinated nodes so they have a proper InnerNode?
  */
-export function tryGetFlexNode(target: unknown): FlexTreeNode | undefined {
+export type InnerNode = FlexTreeNode | MapTreeNode;
+
+/**
+ * Retrieves the InnerNode associated with the given target via {@link setInnerNode}, if any.
+ * @remarks
+ * If `target` is a unhydrated node, returns its MapTreeNode.
+ * If `target` is a cooked node (or marinated but a FlexTreeNode exists) returns the FlexTreeNode.
+ * If the target is not a node, or a marinated node with no FlexTreeNode for its anchor, returns undefined.
+ */
+export function tryGetInnerNode(target: unknown): InnerNode | undefined {
 	// Calling 'WeakMap.get()' with primitives (numbers, strings, etc.) will return undefined.
 	// This is in contrast to 'WeakMap.set()', which will throw a TypeError if given a non-object key.
-	return (
-		proxyToAnchorNode.get(target as TreeNode)?.slots.get(flexTreeSlot) ??
-		proxyToMapTreeNode.get(target as TreeNode)
-	);
+	const anchorNode = proxyToAnchorNode.get(target as TreeNode);
+	// Hydrated node case
+	if (anchorNode !== undefined) {
+		const flex = anchorNode.slots.get(flexTreeSlot);
+		if (flex !== undefined) {
+			// Cooked, or possible Marinated but something else cased the flex tree node to exist.
+			return flex;
+		}
+		// Marinated case
+		assert(
+			proxyToMapTreeNode.get(target as TreeNode) === undefined,
+			"marinated nodes should not have MapTreeNodes",
+		);
+		return undefined;
+	}
+	// Unhydrated node or not a node case:
+	return proxyToMapTreeNode.get(target as TreeNode);
 }
 
 /**
- * Retrieves the proxy associated with the given flex node via {@link setFlexNode}, if any.
+ * Retrieves the proxy associated with the given flex node via {@link setInnerNode}, if any.
  */
-export function tryGetProxy(flexNode: FlexTreeNode): TreeNode | undefined {
+export function tryGetCachedTreeNode(flexNode: InnerNode): TreeNode | undefined {
 	if (isMapTreeNode(flexNode)) {
+		// Unhydrated case
 		return mapTreeNodeToProxy.get(flexNode);
 	}
+	// Hydrated case
 	return flexNode.anchorNode.slots.get(proxySlot);
 }
 
 /**
- * Associate the given proxy and the given flex node.
- * @returns The proxy
+ * Associate the given TreeNode and the given flex node.
+ * @returns The node.
  * @remarks
- * This creates a 1:1 mapping between the proxy and tree node.
- * Either can be retrieved from the other via {@link getFlexNode}/{@link tryGetFlexNode} or {@link tryGetProxy}.
+ * This creates a 1:1 mapping between the tree node and InnerNode.
+ * Either can be retrieved from the other via {@link getOrCreateInnerNode}/{@link tryGetInnerNode} or {@link tryGetCachedTreeNode}.
  * If the given proxy is already mapped to an flex node, the existing mapping will be overwritten.
  * If the given flex node is already mapped to a different proxy, this function will fail.
  */
-export function setFlexNode<TProxy extends TreeNode>(
-	proxy: TProxy,
-	flexNode: FlexTreeNode,
-): TProxy {
-	const existingFlexNode = proxyToAnchorNode.get(proxy)?.slots.get(flexTreeSlot);
+export function setInnerNode<TNode extends TreeNode>(
+	node: TNode,
+	innerNode: InnerNode,
+): TNode {
+	const existingFlexNode = proxyToAnchorNode.get(node)?.slots.get(flexTreeSlot);
 	assert(
 		existingFlexNode === undefined,
 		0x91d /* Cannot associate a flex node with multiple targets */,
 	);
-	if (isMapTreeNode(flexNode)) {
-		proxyToMapTreeNode.set(proxy, flexNode);
-		mapTreeNodeToProxy.set(flexNode, proxy);
+	if (isMapTreeNode(innerNode)) {
+		// Unhydrated case
+		proxyToMapTreeNode.set(node, innerNode);
+		mapTreeNodeToProxy.set(innerNode, node);
 	} else {
+		// Hydrated case
 		assert(
-			tryGetProxy(flexNode) === undefined,
+			tryGetCachedTreeNode(innerNode) === undefined,
 			0x7f5 /* Cannot associate an flex node with multiple targets */,
 		);
-		bindProxyToAnchorNode(proxy, flexNode.anchorNode);
+		bindHydratedNodeToAnchor(node, innerNode.anchorNode);
 	}
-	return proxy;
+	return node;
 }
 
 /**
- * Bi-directionally associates the given proxy to the given anchor node.
- * @remarks Cleans up mappings to raw flex nodes - it is assumed that they are no longer needed once the proxy has an anchor node.
+ * Bi-directionally associates the given hydrated TreeNode to the given anchor node.
+ * @remarks Cleans up mappings to {@link MapTreeNode} - it is assumed that they are no longer needed once the proxy has an anchor node.
  */
-function bindProxyToAnchorNode(proxy: TreeNode, anchorNode: AnchorNode): void {
+function bindHydratedNodeToAnchor(node: TreeNode, anchorNode: AnchorNode): void {
 	// If the proxy currently has a raw node, forget it
-	const mapTreeNode = proxyToMapTreeNode.get(proxy);
+	const mapTreeNode = proxyToMapTreeNode.get(node);
 	if (mapTreeNode !== undefined) {
-		proxyToMapTreeNode.delete(proxy);
+		proxyToMapTreeNode.delete(node);
 		mapTreeNodeToProxy.delete(mapTreeNode);
 	}
 	// Once a proxy has been associated with an anchor node, it should never change to another anchor node
 	assert(
-		!proxyToAnchorNode.has(proxy),
+		!proxyToAnchorNode.has(node),
 		0x91e /* Proxy has already been bound to a different anchor node */,
 	);
-	proxyToAnchorNode.set(proxy, anchorNode);
+	proxyToAnchorNode.set(node, anchorNode);
 	// However, it's fine for an anchor node to rotate through different proxies when the content at that place in the tree is replaced.
-	anchorNode.slots.set(proxySlot, proxy);
-	getKernel(proxy).hydrate(anchorNode);
+	anchorNode.slots.set(proxySlot, node);
+	getKernel(node).hydrate(anchorNode);
 }
 
 /**
@@ -194,23 +263,10 @@ function bindProxyToAnchorNode(proxy: TreeNode, anchorNode: AnchorNode): void {
  */
 type TypedNode<TSchema extends FlexTreeNodeSchema> = TreeNode & WithType<TSchema["name"]>;
 
-export function createKernel(node: TreeNode): void {
-	treeNodeToKernel.set(node, new TreeNodeKernel(node));
-}
-
-export function getKernel(node: TreeNode): TreeNodeKernel {
-	const kernel = treeNodeToKernel.get(node);
-	assert(kernel !== undefined, 0x9b1 /* Expected tree node to have kernel */);
-	return kernel;
-}
-
 export function tryDisposeTreeNode(anchorNode: AnchorNode): void {
 	const treeNode = anchorNode.slots.get(proxySlot);
 	if (treeNode !== undefined) {
-		const kernel = treeNodeToKernel.get(treeNode);
-		assert(kernel !== undefined, 0x9b2 /* Expected tree node to have kernel */);
+		const kernel = getKernel(treeNode);
 		kernel.dispose();
 	}
 }
-
-const treeNodeToKernel = new WeakMap<TreeNode, TreeNodeKernel>();

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -38,7 +38,7 @@ import {
 	type FieldProvider,
 } from "./schemaTypes.js";
 import { SchemaValidationErrors, isNodeInSchema } from "../feature-libraries/index.js";
-import { tryGetFlexNode } from "./proxyBinding.js";
+import { tryGetInnerNode } from "./proxyBinding.js";
 import { isObjectNodeSchema } from "./objectNodeTypes.js";
 
 /**
@@ -186,7 +186,7 @@ function nodeDataToMapTree(
 
 	// A special cache path for processing unhydrated nodes.
 	// They already have the mapTree, so there is no need to recompute it.
-	const flexNode = tryGetFlexNode(data);
+	const flexNode = tryGetInnerNode(data);
 	if (flexNode !== undefined) {
 		if (isMapTreeNode(flexNode)) {
 			// TODO: mapTreeFromNodeData modifies the trees it gets to add defaults.

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -48,7 +48,7 @@ import {
 	type InsertableTreeFieldFromImplicitField,
 } from "../../index.js";
 // eslint-disable-next-line import/no-internal-modules
-import { getFlexNode } from "../../simple-tree/proxyBinding.js";
+import { getOrCreateInnerNode } from "../../simple-tree/proxyBinding.js";
 // eslint-disable-next-line import/no-internal-modules
 import type { SchematizingSimpleTreeView } from "../../shared-tree/schematizingTreeView.js";
 import { toFlexSchema } from "../../simple-tree/index.js";
@@ -71,7 +71,7 @@ describe("sharedTreeView", () => {
 			);
 			view.initialize({ x: 24 });
 			const root = view.root;
-			const anchorNode = getFlexNode(root).anchorNode;
+			const anchorNode = getOrCreateInnerNode(root).anchorNode;
 			const log: string[] = [];
 			const unsubscribe = anchorNode.on("childrenChanging", () => log.push("change"));
 			const unsubscribeSubtree = anchorNode.on("subtreeChanging", () => {
@@ -111,7 +111,7 @@ describe("sharedTreeView", () => {
 			);
 			view.initialize({ x: 24 });
 			const root = view.root;
-			const anchorNode = getFlexNode(root).anchorNode;
+			const anchorNode = getOrCreateInnerNode(root).anchorNode;
 			const log: string[] = [];
 			const unsubscribe = anchorNode.on("childrenChanging", (upPath) =>
 				log.push(`change-${String(upPath.parentField)}-${upPath.parentIndex}`),
@@ -324,7 +324,10 @@ describe("sharedTreeView", () => {
 		itView("update anchors after applying a change", (view) => {
 			view.root.insertAtStart("A");
 			let cursor = view.checkout.forest.allocateCursor();
-			view.checkout.forest.moveCursorToPath(getFlexNode(view.root).anchorNode, cursor);
+			view.checkout.forest.moveCursorToPath(
+				getOrCreateInnerNode(view.root).anchorNode,
+				cursor,
+			);
 			cursor.enterField(EmptyKey);
 			cursor.firstNode();
 			const anchor = cursor.buildAnchor();
@@ -339,7 +342,10 @@ describe("sharedTreeView", () => {
 		itView("update anchors after merging into a parent", (parent) => {
 			parent.root.insertAtStart("A");
 			let cursor = parent.checkout.forest.allocateCursor();
-			parent.checkout.forest.moveCursorToPath(getFlexNode(parent.root).anchorNode, cursor);
+			parent.checkout.forest.moveCursorToPath(
+				getOrCreateInnerNode(parent.root).anchorNode,
+				cursor,
+			);
 			cursor.enterField(EmptyKey);
 			cursor.firstNode();
 			const anchor = cursor.buildAnchor();
@@ -356,7 +362,10 @@ describe("sharedTreeView", () => {
 		itView("update anchors after merging a branch into a divergent parent", (parent) => {
 			parent.root.insertAtStart("A");
 			let cursor = parent.checkout.forest.allocateCursor();
-			parent.checkout.forest.moveCursorToPath(getFlexNode(parent.root).anchorNode, cursor);
+			parent.checkout.forest.moveCursorToPath(
+				getOrCreateInnerNode(parent.root).anchorNode,
+				cursor,
+			);
 			cursor.enterField(EmptyKey);
 			cursor.firstNode();
 			const anchor = cursor.buildAnchor();
@@ -375,7 +384,10 @@ describe("sharedTreeView", () => {
 			const { undoStack, unsubscribe } = createTestUndoRedoStacks(view.events);
 			view.root.insertAtStart("A");
 			let cursor = view.checkout.forest.allocateCursor();
-			view.checkout.forest.moveCursorToPath(getFlexNode(view.root).anchorNode, cursor);
+			view.checkout.forest.moveCursorToPath(
+				getOrCreateInnerNode(view.root).anchorNode,
+				cursor,
+			);
 			cursor.enterField(EmptyKey);
 			cursor.firstNode();
 			const anchor = cursor.buildAnchor();
@@ -620,7 +632,10 @@ describe("sharedTreeView", () => {
 		itView("update anchors correctly", (view) => {
 			view.root.insertAtStart("A");
 			let cursor = view.checkout.forest.allocateCursor();
-			view.checkout.forest.moveCursorToPath(getFlexNode(view.root).anchorNode, cursor);
+			view.checkout.forest.moveCursorToPath(
+				getOrCreateInnerNode(view.root).anchorNode,
+				cursor,
+			);
 			cursor.enterField(EmptyKey);
 			cursor.firstNode();
 			const anchor = cursor.buildAnchor();

--- a/packages/dds/tree/src/test/simple-tree/mapNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/mapNode.spec.ts
@@ -9,7 +9,7 @@ import { SchemaFactory } from "../../simple-tree/index.js";
 import { hydrate } from "./utils.js";
 import { Tree } from "../../shared-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
-import { isTreeNode } from "../../simple-tree/proxies.js";
+import { isTreeNode } from "../../simple-tree/treeNodeKernel.js";
 
 const schemaFactory = new SchemaFactory("Test");
 

--- a/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/proxies.spec.ts
@@ -13,9 +13,9 @@ import {
 	TreeArrayNode,
 	TreeViewConfiguration,
 } from "../../simple-tree/index.js";
-// TODO: test other things from "proxies" file.
-// eslint-disable-next-line import/no-internal-modules
-import { isTreeNode } from "../../simple-tree/proxies.js";
+
+// TODO: import and unit test other things from "proxies" file.
+// // eslint-disable-next-line import/no-internal-modules
 
 import { hydrate, pretty } from "./utils.js";
 import { getView } from "../utils.js";
@@ -64,17 +64,6 @@ describe("simple-tree proxies", () => {
 		const mapProxy = root.map;
 		const mapProxyAgain = root.map;
 		assert.equal(mapProxyAgain, mapProxy);
-	});
-
-	it("isTreeNode", () => {
-		// Non object
-		assert(!isTreeNode(5));
-		// Non node object
-		assert(!isTreeNode({}));
-		// Unhydrated node:
-		assert(isTreeNode(new childSchema({ content: 5 })));
-		// Hydrated node:
-		assert(isTreeNode(hydrate(schema, initialTree)));
 	});
 });
 

--- a/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/schemaFactory.spec.ts
@@ -25,7 +25,7 @@ import {
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../simple-tree/types.js";
 // eslint-disable-next-line import/no-internal-modules
-import { isTreeNode } from "../../simple-tree/proxies.js";
+import { isTreeNode } from "../../simple-tree/treeNodeKernel.js";
 import {
 	SchemaFactory,
 	schemaFromValue,

--- a/packages/dds/tree/src/test/simple-tree/treeNodeKernel.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/treeNodeKernel.spec.ts
@@ -1,0 +1,83 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { MockFluidDataStoreRuntime } from "@fluidframework/test-runtime-utils/internal";
+import { createIdCompressor } from "@fluidframework/id-compressor/internal";
+
+import { SchemaFactory, TreeViewConfiguration } from "../../simple-tree/index.js";
+// TODO: test other things from "treeNodeKernel" file.
+// eslint-disable-next-line import/no-internal-modules
+import { isTreeNode } from "../../simple-tree/treeNodeKernel.js";
+
+import { hydrate } from "./utils.js";
+import { TreeFactory } from "../../treeFactory.js";
+
+describe("simple-tree proxies", () => {
+	const sb = new SchemaFactory("test");
+
+	const childSchema = sb.object("object", {
+		content: sb.required(sb.number, { key: "storedContentKey" }),
+	});
+
+	const schema = sb.object("parent", {
+		object: childSchema,
+	});
+
+	const initialTree = {
+		object: { content: 42 },
+	};
+
+	it("isTreeNode", () => {
+		// Non object
+		assert(!isTreeNode(5));
+		// Non node object
+		assert(!isTreeNode({}));
+		// Unhydrated/Raw node:
+		assert(isTreeNode(new childSchema({ content: 5 })));
+		// Hydrated node created during hydration:
+		assert(isTreeNode(hydrate(schema, initialTree)));
+		// Hydrated existing node:
+		assert(isTreeNode(hydrate(childSchema, new childSchema({ content: 5 }))));
+	});
+
+	it("Marinated isTreeNode - initialize", () => {
+		const config = new TreeViewConfiguration({ schema: sb.optional(schema) });
+		const factory = new TreeFactory({});
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+
+		const view = tree.viewWith(config);
+
+		view.initialize(undefined);
+		const root = new schema({ object: { content: 6 } });
+		assert(isTreeNode(root));
+		view.root = root;
+		// TODO: this case doesn't seem to produce a marinated node (or it got a flex tree node from some other source).
+		assert(isTreeNode(root));
+	});
+
+	it("Marinated isTreeNode - inserted", () => {
+		const config = new TreeViewConfiguration({ schema });
+		const factory = new TreeFactory({});
+		const tree = factory.create(
+			new MockFluidDataStoreRuntime({ idCompressor: createIdCompressor() }),
+			"tree",
+		);
+
+		const view = tree.viewWith(config);
+		const inner = { content: 6 };
+		const root = new schema({ object: inner });
+		assert(isTreeNode(root));
+		assert(isTreeNode(root.object));
+		assert(!isTreeNode(inner));
+		view.initialize(root);
+		assert(isTreeNode(root));
+		assert(isTreeNode(root.object));
+	});
+});

--- a/packages/dds/tree/src/test/simple-tree/types.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/types.spec.ts
@@ -121,7 +121,7 @@ describe("simple-tree types", () => {
 		it("Valid subclass", () => {
 			const log: string[] = [];
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-			const customThis: TreeNodeValid<unknown> = {} as TreeNodeValid<unknown>;
+			let customThis: TreeNodeValid<unknown> = {} as TreeNodeValid<unknown>;
 
 			class Subclass extends TreeNodeValid<number> {
 				public static readonly kind = NodeKind.Array;
@@ -168,6 +168,12 @@ describe("simple-tree types", () => {
 			}
 
 			const node = new Subclass(1);
+			assert.equal(node, customThis);
+			// Avoid creating two nodes with same object, as that errors due to tree node kernel association.
+			// Suggested way to avoid this lint is impossible in this case, so suppress the lint.
+			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+			customThis = {} as TreeNodeValid<unknown>;
+
 			const node2 = new Subclass(2);
 			assert.deepEqual(log, [
 				"oneTimeSetup",
@@ -180,8 +186,6 @@ describe("simple-tree types", () => {
 				"prepareInstance",
 				"done",
 			]);
-
-			assert.equal(node, customThis);
 			assert.equal(node2, customThis);
 		});
 

--- a/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "assert";
 import { Tree } from "../../shared-tree/index.js";
 import { rootFieldKey } from "../../core/index.js";
 import {
-	getFlexNode,
+	getOrCreateInnerNode,
 	SchemaFactory,
 	type FieldProps,
 	type TreeNode,
@@ -40,15 +40,15 @@ describe("Unhydrated nodes", () => {
 		const map = new TestMap([]);
 		const array = new TestArray([leaf]);
 		const object = new TestObject({ map, array });
-		assert.equal(isMapTreeNode(getFlexNode(leaf)), true);
-		assert.equal(isMapTreeNode(getFlexNode(map)), true);
-		assert.equal(isMapTreeNode(getFlexNode(array)), true);
-		assert.equal(isMapTreeNode(getFlexNode(object)), true);
+		assert.equal(isMapTreeNode(getOrCreateInnerNode(leaf)), true);
+		assert.equal(isMapTreeNode(getOrCreateInnerNode(map)), true);
+		assert.equal(isMapTreeNode(getOrCreateInnerNode(array)), true);
+		assert.equal(isMapTreeNode(getOrCreateInnerNode(object)), true);
 		const hydratedObject = hydrate(TestObject, object);
-		assert.equal(isMapTreeNode(getFlexNode(leaf)), false);
-		assert.equal(isMapTreeNode(getFlexNode(map)), false);
-		assert.equal(isMapTreeNode(getFlexNode(array)), false);
-		assert.equal(isMapTreeNode(getFlexNode(object)), false);
+		assert.equal(isMapTreeNode(getOrCreateInnerNode(leaf)), false);
+		assert.equal(isMapTreeNode(getOrCreateInnerNode(map)), false);
+		assert.equal(isMapTreeNode(getOrCreateInnerNode(array)), false);
+		assert.equal(isMapTreeNode(getOrCreateInnerNode(object)), false);
 		assert.equal(hydratedObject, object);
 		assert.equal(hydratedObject.array, array);
 		assert.equal(hydratedObject.map, map);

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -18,7 +18,7 @@ import {
 	type TreeFieldFromImplicitField,
 } from "../../simple-tree/index.js";
 import {
-	getProxyForField,
+	getTreeNodeForField,
 	prepareContentForHydration,
 	type InsertableContent,
 	// eslint-disable-next-line import/no-internal-modules
@@ -31,6 +31,8 @@ import { flexTreeFromForest, testIdCompressor, testRevisionTagCodec } from "../u
  * Given the schema and initial tree data, returns a hydrated tree node.
  *
  * For minimal/concise targeted unit testing of specific simple-tree content.
+ *
+ * TODO: determine and document if this produces "cooked" or "marinated" nodes.
  */
 export function hydrate<TSchema extends ImplicitFieldSchema>(
 	schema: TSchema,
@@ -48,7 +50,7 @@ export function hydrate<TSchema extends ImplicitFieldSchema>(
 	prepareContentForHydration(mapTree, field.context.checkout.forest);
 	const cursor = cursorForMapTreeNode(mapTree);
 	initializeForest(forest, [cursor], testRevisionTagCodec, testIdCompressor, true);
-	return getProxyForField(field) as TreeFieldFromImplicitField<TSchema>;
+	return getTreeNodeForField(field) as TreeFieldFromImplicitField<TSchema>;
 }
 
 /**


### PR DESCRIPTION
## Description

During a cleanup/clarification of the proxy binding code, I found a bug in isTreeNode: the edge case of hydrated nodes which are marinated not cooked return false when there is no flex tree node.

This includes some cleanup, and a reimplementation of isTreeNode to be faster and simpler by using the tree node kernels.

This also resulted in moving its implementation (and tests).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
