### PR TITLE
build(client): Add missing independent packages to syncpack config

### DIFF
--- a/syncpack.config.cjs
+++ b/syncpack.config.cjs
@@ -173,11 +173,15 @@ module.exports = {
 		{
 			label: "Versions of common Fluid packages should all match",
 			dependencies: [
+				"@fluid-internal/eslint-plugin-fluid",
+				"@fluid-tools/benchmark",
+				"@fluid-tools/build-cli",
 				"@fluidframework/build-common",
+				"@fluidframework/build-tools",
 				"@fluidframework/common-utils",
 				"@fluidframework/eslint-config-fluid",
-				"@fluidframework/build-tools",
-				"@fluid-tools/build-cli",
+				"@fluidframework/protocol-definitions",
+				"@fluidframework/test-tools",
 			],
 			packages: ["**"],
 		},


### PR DESCRIPTION
The syncpack config was missing several independent packages, so it wasn't catching potential inconsistencies with some packages.