### PR TITLE
OdspClient: Support more extensive app scenarios (Designer app)

### DIFF
--- a/examples/service-clients/odsp-client/shared-tree-demo/package.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/package.json
@@ -35,6 +35,7 @@
 	},
 	"dependencies": {
 		"@azure/msal-browser": "^2.34.0",
+		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/odsp-client": "workspace:~",
 		"@fluidframework/odsp-doclib-utils": "workspace:~",
 		"css-loader": "^6.11.0",

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/clientProps.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { OdspClientProps, OdspConnectionConfig } from "@fluidframework/odsp-client/beta";
+// eslint-disable-next-line import/no-internal-modules
+import { OdspClientProps, OdspConnectionConfig } from "@fluidframework/odsp-client/internal";
 
 import { OdspTestTokenProvider } from "./tokenProvider.js";
 
@@ -23,7 +24,6 @@ const connectionConfig: OdspConnectionConfig = {
 	tokenProvider: new OdspTestTokenProvider(props.clientId),
 	siteUrl: props.siteUrl,
 	driveId: props.driveId,
-	filePath: "",
 };
 
 export const clientProps: OdspClientProps = {

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/fluid.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/fluid.ts
@@ -32,7 +32,7 @@ export const loadFluidData = async (
 		container,
 		services,
 	}: { container: IOdspFluidContainer; services: OdspContainerServices } =
-		await client.getContainer({ itemId }, schema);
+		await client.getContainer(itemId, schema);
 
 	return { services, container };
 };

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/fluid.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/fluid.ts
@@ -3,12 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { OdspClient, OdspContainerServices } from "@fluidframework/odsp-client/beta";
-import { ContainerSchema, IFluidContainer, SharedTree } from "fluid-framework";
+import {
+	createOdspClient,
+	OdspContainerServices,
+	IOdspFluidContainer,
+	// eslint-disable-next-line import/no-internal-modules
+} from "@fluidframework/odsp-client/internal";
+import { ContainerSchema, SharedTree } from "fluid-framework";
 
 import { clientProps } from "./clientProps.js";
 
-const client = new OdspClient(clientProps);
+const client = createOdspClient(clientProps);
 
 /**
  * This function will create a container if no item Id is passed on the hash portion of the URL.
@@ -21,13 +26,13 @@ export const loadFluidData = async (
 	schema: ContainerSchema,
 ): Promise<{
 	services: OdspContainerServices;
-	container: IFluidContainer;
+	container: IOdspFluidContainer;
 }> => {
 	const {
 		container,
 		services,
-	}: { container: IFluidContainer; services: OdspContainerServices } =
-		await client.getContainer(itemId, schema);
+	}: { container: IOdspFluidContainer; services: OdspContainerServices } =
+		await client.getContainer({ itemId }, schema);
 
 	return { services, container };
 };
@@ -36,14 +41,14 @@ export const createFluidData = async (
 	schema: ContainerSchema,
 ): Promise<{
 	services: OdspContainerServices;
-	container: IFluidContainer;
+	container: IOdspFluidContainer;
 }> => {
 	// The client will create a new detached container using the schema
 	// A detached container will enable the app to modify the container before attaching it to the client
 	const {
 		container,
 		services,
-	}: { container: IFluidContainer; services: OdspContainerServices } =
+	}: { container: IOdspFluidContainer; services: OdspContainerServices } =
 		await client.createContainer(schema);
 
 	return { services, container };

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/fluid.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/fluid.ts
@@ -6,10 +6,10 @@
 import {
 	createOdspClient,
 	OdspContainerServices,
-	IOdspFluidContainer,
+	OdspContainerAttachFunctor,
 	// eslint-disable-next-line import/no-internal-modules
 } from "@fluidframework/odsp-client/internal";
-import { ContainerSchema, SharedTree } from "fluid-framework";
+import { ContainerSchema, SharedTree, IFluidContainer } from "fluid-framework";
 
 import { clientProps } from "./clientProps.js";
 
@@ -26,12 +26,12 @@ export const loadFluidData = async (
 	schema: ContainerSchema,
 ): Promise<{
 	services: OdspContainerServices;
-	container: IOdspFluidContainer;
+	container: IFluidContainer;
 }> => {
 	const {
 		container,
 		services,
-	}: { container: IOdspFluidContainer; services: OdspContainerServices } =
+	}: { container: IFluidContainer; services: OdspContainerServices } =
 		await client.getContainer(itemId, schema);
 
 	return { services, container };
@@ -41,17 +41,14 @@ export const createFluidData = async (
 	schema: ContainerSchema,
 ): Promise<{
 	services: OdspContainerServices;
-	container: IOdspFluidContainer;
+	container: IFluidContainer;
+	createFn: OdspContainerAttachFunctor;
 }> => {
 	// The client will create a new detached container using the schema
 	// A detached container will enable the app to modify the container before attaching it to the client
-	const {
-		container,
-		services,
-	}: { container: IOdspFluidContainer; services: OdspContainerServices } =
-		await client.createContainer(schema);
+	const { container, services, createFn } = await client.createContainer(schema);
 
-	return { services, container };
+	return { services, container, createFn };
 };
 
 export const containerSchema: ContainerSchema = {

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
@@ -4,8 +4,10 @@
  */
 
 // eslint-disable-next-line import/no-internal-modules
-import { IOdspFluidContainer } from "@fluidframework/odsp-client/internal";
-import { ITree } from "fluid-framework";
+import { assert } from "@fluidframework/core-utils/internal";
+// eslint-disable-next-line import/no-internal-modules
+import { OdspContainerAttachFunctor } from "@fluidframework/odsp-client/internal";
+import { ITree, IFluidContainer } from "fluid-framework";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -25,10 +27,11 @@ async function start(): Promise<void> {
 	// a new container.
 	let itemId: string = location.hash.slice(1);
 	const createNew = itemId.length === 0;
-	let container: IOdspFluidContainer;
+	let container: IFluidContainer;
+	let createFn: OdspContainerAttachFunctor | undefined;
 
 	if (createNew) {
-		({ container } = await createFluidData(containerSchema));
+		({ container, createFn } = await createFluidData(containerSchema));
 	} else {
 		({ container } = await loadFluidData(itemId, containerSchema));
 	}
@@ -97,7 +100,8 @@ async function start(): Promise<void> {
 
 		// If the app is in a `createNew` state - no itemId, and the container is detached, we attach the container.
 		// This uploads the container to the service and connects to the collaboration session.
-		const res = await container.attach({ filePath: "foo/bar", fileName: "shared-tree-demo" });
+		assert(createFn !== undefined, "createFn is undefined");
+		const res = await createFn({ filePath: "foo/bar", fileName: "shared-tree-demo" });
 		itemId = res.itemId;
 
 		// The newly attached container is given a unique ID that can be used to access the container in another session

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
@@ -3,7 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { IFluidContainer, ITree } from "fluid-framework";
+// eslint-disable-next-line import/no-internal-modules
+import { IOdspFluidContainer } from "@fluidframework/odsp-client/internal";
+import { ITree } from "fluid-framework";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -23,7 +25,7 @@ async function start(): Promise<void> {
 	// a new container.
 	let itemId: string = location.hash.slice(1);
 	const createNew = itemId.length === 0;
-	let container: IFluidContainer;
+	let container: IOdspFluidContainer;
 
 	if (createNew) {
 		({ container } = await createFluidData(containerSchema));
@@ -95,7 +97,8 @@ async function start(): Promise<void> {
 
 		// If the app is in a `createNew` state - no itemId, and the container is detached, we attach the container.
 		// This uploads the container to the service and connects to the collaboration session.
-		itemId = await container.attach({ filePath: "foo/bar", fileName: "shared-tree-demo" });
+		const res = await container.attach({ filePath: "foo/bar", fileName: "shared-tree-demo" });
+		itemId = res.itemId;
 
 		// The newly attached container is given a unique ID that can be used to access the container in another session
 		// eslint-disable-next-line require-atomic-updates

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
@@ -5,7 +5,7 @@
 
 /* eslint-disable prefer-template */
 
-import { Tree, TreeView, IFluidContainer } from "fluid-framework";
+import { IFluidContainer, Tree, TreeView } from "fluid-framework";
 import React, { ReactNode, useEffect, useState } from "react";
 
 import { App, Letter } from "./schema.js";

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
@@ -5,7 +5,9 @@
 
 /* eslint-disable prefer-template */
 
-import { IFluidContainer, Tree, TreeView } from "fluid-framework";
+// eslint-disable-next-line import/no-internal-modules
+import { IOdspFluidContainer } from "@fluidframework/odsp-client/internal";
+import { Tree, TreeView } from "fluid-framework";
 import React, { ReactNode, useEffect, useState } from "react";
 
 import { App, Letter } from "./schema.js";
@@ -128,7 +130,7 @@ function TopRow(props: { app: App }): JSX.Element {
 
 export function ReactApp(props: {
 	data: TreeView<typeof App>;
-	container: IFluidContainer;
+	container: IOdspFluidContainer;
 	cellSize: { x: number; y: number };
 	canvasSize: { x: number; y: number };
 }): JSX.Element {

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/reactApp.tsx
@@ -5,9 +5,7 @@
 
 /* eslint-disable prefer-template */
 
-// eslint-disable-next-line import/no-internal-modules
-import { IOdspFluidContainer } from "@fluidframework/odsp-client/internal";
-import { Tree, TreeView } from "fluid-framework";
+import { Tree, TreeView, IFluidContainer } from "fluid-framework";
 import React, { ReactNode, useEffect, useState } from "react";
 
 import { App, Letter } from "./schema.js";
@@ -130,7 +128,7 @@ function TopRow(props: { app: App }): JSX.Element {
 
 export function ReactApp(props: {
 	data: TreeView<typeof App>;
-	container: IOdspFluidContainer;
+	container: IFluidContainer;
 	cellSize: { x: number; y: number };
 	canvasSize: { x: number; y: number };
 }): JSX.Element {

--- a/examples/utils/bundle-size-tests/src/odspClient.ts
+++ b/examples/utils/bundle-size-tests/src/odspClient.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { OdspClient } from "@fluidframework/odsp-client/internal";
+import { createOdspClient } from "@fluidframework/odsp-client/internal";
 
 export function apisToBundle() {
-	new OdspClient({} as any);
+	createOdspClient({} as any);
 }

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.alpha.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.alpha.api.md
@@ -59,6 +59,23 @@ export interface IFileEntry {
 }
 
 // @alpha
+export type IOdspCreateRequest = {
+    siteUrl: string;
+    driveId: string;
+    dataStorePath?: string;
+    codeHint?: {
+        containerPackageName?: string;
+    };
+    isClpCompliantApp?: boolean;
+} & ({
+    itemId: string;
+} | {
+    filePath?: string;
+    fileName: string;
+    createShareLinkType?: ISharingLinkKind;
+});
+
+// @alpha
 export interface IOdspError extends Omit<IDriverErrorBase, "errorType">, IOdspErrorAugmentations {
     // (undocumented)
     readonly errorType: OdspErrorTypes;
@@ -71,15 +88,29 @@ export interface IOdspErrorAugmentations {
     serverEpoch?: string;
 }
 
+// @alpha
+export interface IOdspOpenRequest {
+    // (undocumented)
+    codeHint?: {
+        containerPackageName?: string;
+    };
+    dataStorePath?: string;
+    driveId: string;
+    fileVersion: string | undefined;
+    isClpCompliantApp?: boolean;
+    itemId: string;
+    sharingLinkToRedeem?: string;
+    siteUrl: string;
+    summarizer: boolean;
+}
+
 // @alpha (undocumented)
 export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
     // (undocumented)
     codeHint?: {
         containerPackageName?: string;
     };
-    // (undocumented)
     dataStorePath?: string;
-    // (undocumented)
     endpoints: {
         snapshotStorageUrl: string;
         attachmentPOSTStorageUrl: string;
@@ -88,18 +119,14 @@ export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
     };
     // (undocumented)
     fileName: string;
-    // (undocumented)
+    filePath?: string;
     fileVersion: string | undefined;
-    // (undocumented)
     hashedDocumentId: string;
-    // (undocumented)
     isClpCompliantApp?: boolean;
     // (undocumented)
     odspResolvedUrl: true;
     shareLinkInfo?: ShareLinkInfoType;
-    // (undocumented)
     summarizer: boolean;
-    // (undocumented)
     tokens: {};
     // (undocumented)
     type: "fluid";
@@ -107,13 +134,10 @@ export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
     url: string;
 }
 
-// @alpha (undocumented)
+// @alpha
 export interface IOdspUrlParts {
-    // (undocumented)
     driveId: string;
-    // (undocumented)
     itemId: string;
-    // (undocumented)
     siteUrl: string;
 }
 
@@ -233,6 +257,7 @@ export interface OdspResourceTokenFetchOptions extends TokenFetchOptions {
 // @alpha
 export interface ShareLinkInfoType {
     createLink?: {
+        createKind: ISharingLinkKind;
         link?: ISharingLink;
         error?: any;
         shareId?: string;

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.alpha.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.alpha.api.md
@@ -59,13 +59,9 @@ export interface IFileEntry {
 }
 
 // @alpha
-export type IOdspCreateRequest = {
+export type IOdspCreateArgs = {
     siteUrl: string;
     driveId: string;
-    dataStorePath?: string;
-    codeHint?: {
-        containerPackageName?: string;
-    };
     isClpCompliantApp?: boolean;
 } & ({
     itemId: string;
@@ -89,12 +85,7 @@ export interface IOdspErrorAugmentations {
 }
 
 // @alpha
-export interface IOdspOpenRequest {
-    // (undocumented)
-    codeHint?: {
-        containerPackageName?: string;
-    };
-    dataStorePath?: string;
+export interface IOdspOpenArgs {
     driveId: string;
     fileVersion: string | undefined;
     isClpCompliantApp?: boolean;

--- a/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.alpha.api.md
+++ b/packages/drivers/odsp-driver-definitions/api-report/odsp-driver-definitions.legacy.alpha.api.md
@@ -7,7 +7,7 @@
 // @alpha (undocumented)
 export type CacheContentType = "snapshot" | "ops" | "snapshotWithLoadingGroupId";
 
-// @alpha (undocumented)
+// @alpha
 export interface HostStoragePolicy {
     avoidPrefetchSnapshotCache?: boolean;
     cacheCreateNewSummary?: boolean;

--- a/packages/drivers/odsp-driver-definitions/package.json
+++ b/packages/drivers/odsp-driver-definitions/package.json
@@ -108,6 +108,13 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"Interface_ShareLinkInfoType": {
+				"forwardCompat": false
+			},
+			"Interface_IOdspResolvedUrl": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/drivers/odsp-driver-definitions/src/factory.ts
+++ b/packages/drivers/odsp-driver-definitions/src/factory.ts
@@ -86,6 +86,7 @@ export interface ICollabSessionOptions {
 }
 
 /**
+ * Various policies controlling behavior of ODSP driver
  * @legacy
  * @alpha
  */

--- a/packages/drivers/odsp-driver-definitions/src/index.ts
+++ b/packages/drivers/odsp-driver-definitions/src/index.ts
@@ -23,8 +23,8 @@ export {
 } from "./odspCache.js";
 export {
 	IOdspResolvedUrl,
-	IOdspOpenRequest,
-	IOdspCreateRequest,
+	IOdspOpenArgs,
+	IOdspCreateArgs,
 	IOdspUrlParts,
 	ISharingLink,
 	ISharingLinkKind,

--- a/packages/drivers/odsp-driver-definitions/src/index.ts
+++ b/packages/drivers/odsp-driver-definitions/src/index.ts
@@ -23,6 +23,8 @@ export {
 } from "./odspCache.js";
 export {
 	IOdspResolvedUrl,
+	IOdspOpenRequest,
+	IOdspCreateRequest,
 	IOdspUrlParts,
 	ISharingLink,
 	ISharingLinkKind,

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -161,7 +161,8 @@ export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
 	summarizer: boolean;
 
 	/*
-	 * containerPackageName is used for adding the package name to the request headers.
+	 * Contains hints to the application on what code version to load to interact with data model.
+	 * containerPackageName property is used for adding the package name to the request headers.
 	 * This may be used for preloading the container package when loading Fluid content.
 	 */
 	codeHint?: {
@@ -169,7 +170,7 @@ export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
 	};
 
 	/**
-	 * If privided, tells version of a file to open
+	 * If provided, tells version of a file to open
 	 */
 	fileVersion: string | undefined;
 
@@ -193,7 +194,7 @@ export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
 }
 
 /**
- * Input arguments required to create IOdspResolvedUrl that OdspDriver can work with.
+ * A set of inputs to the driver for file open scenarios.
  * @legacy
  * @alpha
  */
@@ -247,7 +248,7 @@ export interface IOdspOpenRequest {
 }
 
 /**
- * Input arguments required to create IOdspResolvedUrl that OdspDriver can work with.
+ * A set of inputs for the driver to create a new file or a FF partition on existing file.
  * @legacy
  * @alpha
  */
@@ -281,7 +282,9 @@ export type IOdspCreateRequest = {
 } & (
 	| {
 			/**
-			 * {@inheritDoc (IOdspUrlParts:interface).itemId}
+			 * Microsoft internal only. Creates alternate partition with FF content.
+			 * Can be only used for a files that provisioned to support FF protocol on alternative paritions.
+			 * {@link (IOdspUrlParts:interface).itemId}
 			 */
 			itemId: string;
 	  }

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -6,12 +6,25 @@
 import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
 
 /**
+ * Identifies a file in SharePoint.
+ * This is required information to do any Graph / Vroom REST API calls.
  * @legacy
  * @alpha
  */
 export interface IOdspUrlParts {
+	/**
+	 * Site URL where file is located
+	 */
 	siteUrl: string;
+
+	/**
+	 * driveId where file is located.
+	 */
 	driveId: string;
+
+	/**
+	 * itemId within a drive that identifies a file.
+	 */
 	itemId: string;
 }
 
@@ -78,6 +91,12 @@ export interface ShareLinkInfoType {
 	 */
 	createLink?: {
 		/**
+		 * Kind of the link requested at creation time.
+		 * Should be equal to the value in {@link ShareLinkInfoType.createLink.link} property, but may differ if ODSP created different type of link
+		 */
+		createKind: ISharingLinkKind;
+
+		/**
 		 * Share link created when the file is created for the first time with /snapshot api call.
 		 */
 		link?: ISharingLink;
@@ -96,6 +115,7 @@ export interface ShareLinkInfoType {
 	 */
 	sharingLinkToRedeem?: string;
 }
+
 /**
  * @legacy
  * @alpha
@@ -107,9 +127,14 @@ export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
 	// URL to send to fluid, contains the documentId and the path
 	url: string;
 
-	// A hashed identifier that is unique to this document
+	/**
+	 * A hashed identifier that is unique to this document
+	 */
 	hashedDocumentId: string;
 
+	/**
+	 * Endpoints for various REST calls
+	 */
 	endpoints: {
 		snapshotStorageUrl: string;
 		attachmentPOSTStorageUrl: string;
@@ -117,22 +142,40 @@ export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
 		deltaStorageUrl: string;
 	};
 
-	// Tokens are not obtained by the ODSP driver using the resolve flow, the app must provide them.
+	/**
+	 * Tokens are not obtained by the ODSP driver using the resolve flow, the app must provide them.
+	 */
 	// eslint-disable-next-line @typescript-eslint/ban-types
 	tokens: {};
 
 	fileName: string;
 
+	/**
+	 * Path to a file. Required on file creation path. Not used on file open path.
+	 */
+	filePath?: string;
+
+	/**
+	 * Tells driver if a given container instance is a summarizer instance.
+	 */
 	summarizer: boolean;
 
+	/*
+	 * containerPackageName is used for adding the package name to the request headers.
+	 * This may be used for preloading the container package when loading Fluid content.
+	 */
 	codeHint?: {
-		// containerPackageName is used for adding the package name to the request headers.
-		// This may be used for preloading the container package when loading Fluid content.
 		containerPackageName?: string;
 	};
 
+	/**
+	 * If privided, tells version of a file to open
+	 */
 	fileVersion: string | undefined;
 
+	/**
+	 * This field can be used by the application code to create deep links into document
+	 */
 	dataStorePath?: string;
 
 	/**
@@ -142,5 +185,119 @@ export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
 	 */
 	shareLinkInfo?: ShareLinkInfoType;
 
+	/**
+	 * Should be set to true only by application that is CLP compliant, for CLP compliant workflow.
+	 * This argument has no impact if application is not properly registered with Sharepoint.
+	 */
 	isClpCompliantApp?: boolean;
 }
+
+/**
+ * Input arguments required to create IOdspResolvedUrl that OdspDriver can work with.
+ * @legacy
+ * @alpha
+ */
+export interface IOdspOpenRequest {
+	/**
+	 * {@inheritDoc (IOdspUrlParts:interface).siteUrl}
+	 */
+	siteUrl: string;
+
+	/**
+	 * {@inheritDoc (IOdspUrlParts:interface).driveId}
+	 */
+	driveId: string;
+
+	/**
+	 * {@inheritDoc (IOdspUrlParts:interface).itemId}
+	 */
+	itemId: string;
+
+	/**
+	 * {@inheritDoc (IOdspResolvedUrl:interface).summarizer}
+	 */
+	summarizer: boolean;
+
+	/**
+	 * {@inheritDoc (IOdspResolvedUrl:interface).fileVersion}
+	 */
+	fileVersion: string | undefined;
+
+	/**
+	 * {@inheritDoc (IOdspResolvedUrl:interface).isClpCompliantApp}
+	 */
+	isClpCompliantApp?: boolean;
+
+	/**
+	 * {@inheritDoc (ShareLinkInfoType:interface).sharingLinkToRedeem}
+	 */
+	sharingLinkToRedeem?: string;
+
+	/**
+	 * {@inheritDoc (IOdspResolvedUrl:interface).dataStorePath}
+	 */
+	dataStorePath?: string;
+
+	/**
+	 * {@inheritDoc (IOdspResolvedUrl:interface).codeHint}
+	 */
+	codeHint?: {
+		containerPackageName?: string;
+	};
+}
+
+/**
+ * Input arguments required to create IOdspResolvedUrl that OdspDriver can work with.
+ * @legacy
+ * @alpha
+ */
+export type IOdspCreateRequest = {
+	/**
+	 * {@inheritDoc (IOdspUrlParts:interface).siteUrl}
+	 */
+	siteUrl: string;
+
+	/**
+	 * {@inheritDoc (IOdspUrlParts:interface).driveId}
+	 */
+	driveId: string;
+
+	/**
+	 * {@inheritDoc (IOdspResolvedUrl:interface).dataStorePath}
+	 */
+	dataStorePath?: string;
+
+	/**
+	 * {@inheritDoc (IOdspResolvedUrl:interface).codeHint}
+	 */
+	codeHint?: {
+		containerPackageName?: string;
+	};
+
+	/**
+	 * {@inheritDoc (IOdspResolvedUrl:interface).isClpCompliantApp}
+	 */
+	isClpCompliantApp?: boolean;
+} & (
+	| {
+			/**
+			 * {@inheritDoc (IOdspUrlParts:interface).itemId}
+			 */
+			itemId: string;
+	  }
+	| {
+			/**
+			 * Path to a file within site. If not provided, files will be created in the root of the collection.
+			 */
+			filePath?: string;
+
+			/**
+			 * {@inheritDoc (IOdspResolvedUrl:interface).fileName}
+			 */
+			fileName: string;
+			/**
+			 * Instructs ODSP to create a sharing link as part of file creation.
+			 */
+			createShareLinkType?: ISharingLinkKind;
+	  }
+);

--- a/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
+++ b/packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts
@@ -198,7 +198,7 @@ export interface IOdspResolvedUrl extends IResolvedUrl, IOdspUrlParts {
  * @legacy
  * @alpha
  */
-export interface IOdspOpenRequest {
+export interface IOdspOpenArgs {
 	/**
 	 * {@inheritDoc (IOdspUrlParts:interface).siteUrl}
 	 */
@@ -233,18 +233,6 @@ export interface IOdspOpenRequest {
 	 * {@inheritDoc (ShareLinkInfoType:interface).sharingLinkToRedeem}
 	 */
 	sharingLinkToRedeem?: string;
-
-	/**
-	 * {@inheritDoc (IOdspResolvedUrl:interface).dataStorePath}
-	 */
-	dataStorePath?: string;
-
-	/**
-	 * {@inheritDoc (IOdspResolvedUrl:interface).codeHint}
-	 */
-	codeHint?: {
-		containerPackageName?: string;
-	};
 }
 
 /**
@@ -252,7 +240,7 @@ export interface IOdspOpenRequest {
  * @legacy
  * @alpha
  */
-export type IOdspCreateRequest = {
+export type IOdspCreateArgs = {
 	/**
 	 * {@inheritDoc (IOdspUrlParts:interface).siteUrl}
 	 */
@@ -262,18 +250,6 @@ export type IOdspCreateRequest = {
 	 * {@inheritDoc (IOdspUrlParts:interface).driveId}
 	 */
 	driveId: string;
-
-	/**
-	 * {@inheritDoc (IOdspResolvedUrl:interface).dataStorePath}
-	 */
-	dataStorePath?: string;
-
-	/**
-	 * {@inheritDoc (IOdspResolvedUrl:interface).codeHint}
-	 */
-	codeHint?: {
-		containerPackageName?: string;
-	};
 
 	/**
 	 * {@inheritDoc (IOdspResolvedUrl:interface).isClpCompliantApp}

--- a/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
+++ b/packages/drivers/odsp-driver-definitions/src/test/types/validateOdspDriverDefinitionsPrevious.generated.ts
@@ -166,6 +166,7 @@ declare type current_as_old_for_Interface_IOdspErrorAugmentations = requireAssig
  * typeValidation.broken:
  * "Interface_IOdspResolvedUrl": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IOdspResolvedUrl = requireAssignableTo<TypeOnly<old.IOdspResolvedUrl>, TypeOnly<current.IOdspResolvedUrl>>
 
 /*
@@ -463,6 +464,7 @@ declare type current_as_old_for_Interface_OdspResourceTokenFetchOptions = requir
  * typeValidation.broken:
  * "Interface_ShareLinkInfoType": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ShareLinkInfoType = requireAssignableTo<TypeOnly<old.ShareLinkInfoType>, TypeOnly<current.ShareLinkInfoType>>
 
 /*

--- a/packages/drivers/odsp-driver/src/createOdspUrl.ts
+++ b/packages/drivers/odsp-driver/src/createOdspUrl.ts
@@ -10,7 +10,7 @@ import { OdspFluidDataStoreLocator } from "./contractsPublic.js";
  */
 
 /**
- * Encodes ODC/SPO information into a URL format that can be handled by the Loader
+ * Encodes ODC/SPO information into a URL format that can be parsed later by decodeOdspUrl().
  * @param l -The property bag of necessary properties to locate a Fluid data store and craft a url for it
  * @legacy
  * @alpha

--- a/packages/drivers/odsp-driver/src/index.ts
+++ b/packages/drivers/odsp-driver/src/index.ts
@@ -35,7 +35,11 @@ export { OdspDocumentServiceFactoryWithCodeSplit } from "./odspDocumentServiceFa
 export { createOdspCreateContainerRequest } from "./createOdspCreateContainerRequest.js";
 
 // URI Resolver functionality, URI management
-export { OdspDriverUrlResolver } from "./odspDriverUrlResolver.js";
+export {
+	OdspDriverUrlResolver,
+	createOpenOdspResolvedUrl,
+	createCreateOdspResolvedUrl,
+} from "./odspDriverUrlResolver.js";
 export {
 	OdspDriverUrlResolverForShareLink,
 	ShareLinkFetcherProps,

--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -21,11 +21,11 @@ import {
 	IOdspUrlParts,
 	IPersistedCache,
 	IRelaySessionAwareDriverFactory,
+	ISharingLinkKind,
 	ISocketStorageDiscovery,
 	OdspResourceTokenFetchOptions,
 	TokenFetchOptions,
 	TokenFetcher,
-	ISharingLinkKind,
 } from "@fluidframework/odsp-driver-definitions/internal";
 import { PerformanceEvent, createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import { v4 as uuid } from "uuid";

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolver.ts
@@ -217,7 +217,6 @@ export function createCreateOdspResolvedUrl(input: IOdspCreateArgs): IOdspResolv
 		filePath,
 		fileName,
 
-		// Is url even used?
 		url: `https://${siteUrl}?&version=null`,
 
 		endpoints: {

--- a/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
+++ b/packages/drivers/odsp-driver/src/odspDriverUrlResolverForShareLink.ts
@@ -21,12 +21,8 @@ import { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/internal";
 import { OdspFluidDataStoreLocator, SharingLinkHeader } from "./contractsPublic.js";
 import { createOdspUrl } from "./createOdspUrl.js";
 import { getFileLink } from "./getFileLink.js";
-import { OdspDriverUrlResolver } from "./odspDriverUrlResolver.js";
-import {
-	getLocatorFromOdspUrl,
-	locatorQueryParamName,
-	storeLocatorInOdspUrl,
-} from "./odspFluidFileLink.js";
+import { OdspDriverUrlResolver, removeNavParam } from "./odspDriverUrlResolver.js";
+import { getLocatorFromOdspUrl, storeLocatorInOdspUrl } from "./odspFluidFileLink.js";
 import { createOdspLogger, getOdspResolvedUrl } from "./odspUtils.js";
 
 /**
@@ -152,7 +148,7 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
 			// when redeeming the share link during the redeem fallback for trees latest call becomes greater than
 			// the eligible length.
 			odspResolvedUrl.shareLinkInfo = Object.assign(odspResolvedUrl.shareLinkInfo ?? {}, {
-				sharingLinkToRedeem: this.removeNavParam(request.url),
+				sharingLinkToRedeem: removeNavParam(request.url),
 			});
 		}
 		if (odspResolvedUrl.itemId) {
@@ -161,14 +157,6 @@ export class OdspDriverUrlResolverForShareLink implements IUrlResolver {
 			this.getShareLinkPromise(odspResolvedUrl).catch(() => {});
 		}
 		return odspResolvedUrl;
-	}
-
-	private removeNavParam(link: string): string {
-		const url = new URL(link);
-		const params = new URLSearchParams(url.search);
-		params.delete(locatorQueryParamName);
-		url.search = params.toString();
-		return url.href;
 	}
 
 	private async getShareLinkPromise(resolvedUrl: IOdspResolvedUrl): Promise<string> {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -54,9 +54,6 @@ export namespace ConnectionStateType {
 export type ConnectionStateType = ConnectionStateType.Disconnected | ConnectionStateType.EstablishingConnection | ConnectionStateType.CatchingUp | ConnectionStateType.Connected;
 
 // @public
-export type ContainerAttachProps<T = unknown> = T;
-
-// @public
 export interface ContainerSchema {
     readonly dynamicObjectTypes?: readonly SharedObjectKind[];
     readonly initialObjects: Record<string, SharedObjectKind>;
@@ -332,8 +329,8 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 } ? TransformedEvent<TThis, E0, A0> : TransformedEvent<TThis, string, any[]>;
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(props?: ContainerAttachProps): Promise<string>;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
+    attach: TAttachType;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -329,8 +329,8 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 } ? TransformedEvent<TThis, E0, A0> : TransformedEvent<TThis, string, any[]>;
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
-    attach: TAttachType;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
+    attach(param?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -330,7 +330,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 
 // @public @sealed
 export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(param?: unknown): Promise<string>;
+    attach(props?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -368,7 +368,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 
 // @public @sealed
 export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(param?: unknown): Promise<string>;
+    attach(props?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -54,9 +54,6 @@ export namespace ConnectionStateType {
 export type ConnectionStateType = ConnectionStateType.Disconnected | ConnectionStateType.EstablishingConnection | ConnectionStateType.CatchingUp | ConnectionStateType.Connected;
 
 // @public
-export type ContainerAttachProps<T = unknown> = T;
-
-// @public
 export interface ContainerSchema {
     readonly dynamicObjectTypes?: readonly SharedObjectKind[];
     readonly initialObjects: Record<string, SharedObjectKind>;
@@ -370,8 +367,8 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 } ? TransformedEvent<TThis, E0, A0> : TransformedEvent<TThis, string, any[]>;
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(props?: ContainerAttachProps): Promise<string>;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
+    attach: TAttachType;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -367,8 +367,8 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 } ? TransformedEvent<TThis, E0, A0> : TransformedEvent<TThis, string, any[]>;
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
-    attach: TAttachType;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
+    attach(param?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -358,7 +358,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 
 // @public @sealed
 export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(param?: unknown): Promise<string>;
+    attach(props?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -357,8 +357,8 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 } ? TransformedEvent<TThis, E0, A0> : TransformedEvent<TThis, string, any[]>;
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
-    attach: TAttachType;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
+    attach(param?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -54,9 +54,6 @@ export namespace ConnectionStateType {
 export type ConnectionStateType = ConnectionStateType.Disconnected | ConnectionStateType.EstablishingConnection | ConnectionStateType.CatchingUp | ConnectionStateType.Connected;
 
 // @public
-export type ContainerAttachProps<T = unknown> = T;
-
-// @public
 export interface ContainerSchema {
     readonly dynamicObjectTypes?: readonly SharedObjectKind[];
     readonly initialObjects: Record<string, SharedObjectKind>;
@@ -360,8 +357,8 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 } ? TransformedEvent<TThis, E0, A0> : TransformedEvent<TThis, string, any[]>;
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(props?: ContainerAttachProps): Promise<string>;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
+    attach: TAttachType;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -54,9 +54,6 @@ export namespace ConnectionStateType {
 export type ConnectionStateType = ConnectionStateType.Disconnected | ConnectionStateType.EstablishingConnection | ConnectionStateType.CatchingUp | ConnectionStateType.Connected;
 
 // @public
-export type ContainerAttachProps<T = unknown> = T;
-
-// @public
 export interface ContainerSchema {
     readonly dynamicObjectTypes?: readonly SharedObjectKind[];
     readonly initialObjects: Record<string, SharedObjectKind>;
@@ -332,8 +329,8 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 } ? TransformedEvent<TThis, E0, A0> : TransformedEvent<TThis, string, any[]>;
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(props?: ContainerAttachProps): Promise<string>;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
+    attach: TAttachType;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -329,8 +329,8 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 } ? TransformedEvent<TThis, E0, A0> : TransformedEvent<TThis, string, any[]>;
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
-    attach: TAttachType;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
+    attach(param?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -330,7 +330,7 @@ export type IEventTransformer<TThis, TEvent extends IEvent> = TEvent extends {
 
 // @public @sealed
 export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(param?: unknown): Promise<string>;
+    attach(props?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionStateType;

--- a/packages/framework/fluid-framework/src/index.ts
+++ b/packages/framework/fluid-framework/src/index.ts
@@ -21,7 +21,6 @@ export type {
 export { AttachState } from "@fluidframework/container-definitions";
 export { ConnectionState } from "@fluidframework/container-loader";
 export type {
-	ContainerAttachProps,
 	ContainerSchema,
 	IConnection,
 	IFluidContainer,

--- a/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
@@ -20,8 +20,8 @@ export interface IConnection {
 }
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
-    attach: TAttachType;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
+    attach(param?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionState;

--- a/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
@@ -21,7 +21,7 @@ export interface IConnection {
 
 // @public @sealed
 export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(param?: unknown): Promise<string>;
+    attach(props?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionState;

--- a/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
@@ -8,9 +8,6 @@
 export type CompatibilityMode = "1" | "2";
 
 // @public
-export type ContainerAttachProps<T = unknown> = T;
-
-// @public
 export interface ContainerSchema {
     readonly dynamicObjectTypes?: readonly SharedObjectKind[];
     readonly initialObjects: Record<string, SharedObjectKind>;
@@ -23,8 +20,8 @@ export interface IConnection {
 }
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(props?: ContainerAttachProps): Promise<string>;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
+    attach: TAttachType;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionState;

--- a/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
@@ -20,8 +20,8 @@ export interface IConnection {
 }
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
-    attach: TAttachType;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
+    attach(param?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionState;

--- a/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
@@ -21,7 +21,7 @@ export interface IConnection {
 
 // @public @sealed
 export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(param?: unknown): Promise<string>;
+    attach(props?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionState;

--- a/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
@@ -8,9 +8,6 @@
 export type CompatibilityMode = "1" | "2";
 
 // @public
-export type ContainerAttachProps<T = unknown> = T;
-
-// @public
 export interface ContainerSchema {
     readonly dynamicObjectTypes?: readonly SharedObjectKind[];
     readonly initialObjects: Record<string, SharedObjectKind>;
@@ -23,8 +20,8 @@ export interface IConnection {
 }
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(props?: ContainerAttachProps): Promise<string>;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
+    attach: TAttachType;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionState;

--- a/packages/framework/fluid-static/api-report/fluid-static.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.public.api.md
@@ -20,8 +20,8 @@ export interface IConnection {
 }
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
-    attach: TAttachType;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
+    attach(param?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionState;

--- a/packages/framework/fluid-static/api-report/fluid-static.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.public.api.md
@@ -21,7 +21,7 @@ export interface IConnection {
 
 // @public @sealed
 export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(param?: unknown): Promise<string>;
+    attach(props?: unknown): Promise<string>;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionState;

--- a/packages/framework/fluid-static/api-report/fluid-static.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.public.api.md
@@ -8,9 +8,6 @@
 export type CompatibilityMode = "1" | "2";
 
 // @public
-export type ContainerAttachProps<T = unknown> = T;
-
-// @public
 export interface ContainerSchema {
     readonly dynamicObjectTypes?: readonly SharedObjectKind[];
     readonly initialObjects: Record<string, SharedObjectKind>;
@@ -23,8 +20,8 @@ export interface IConnection {
 }
 
 // @public @sealed
-export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> extends IEventProvider<IFluidContainerEvents> {
-    attach(props?: ContainerAttachProps): Promise<string>;
+export interface IFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema, TAttachType = () => Promise<string>> extends IEventProvider<IFluidContainerEvents> {
+    attach: TAttachType;
     readonly attachState: AttachState;
     connect(): void;
     readonly connectionState: ConnectionState;

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -139,6 +139,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedTypeAlias_ContainerAttachProps": {
+				"forwardCompat": false,
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/framework/fluid-static/src/fluidContainer.ts
+++ b/packages/framework/fluid-static/src/fluidContainer.ts
@@ -170,7 +170,7 @@ export interface IFluidContainer<TContainerSchema extends ContainerSchema = Cont
 	 *
 	 * @returns A promise which resolves when the attach is complete, with the string identifier of the container.
 	 */
-	attach(param?: unknown): Promise<string>;
+	attach(props?: unknown): Promise<string>;
 
 	/**
 	 * Attempts to connect the container to the delta stream and process operations.
@@ -236,8 +236,7 @@ export interface IFluidContainer<TContainerSchema extends ContainerSchema = Cont
  * @internal
  */
 export function createFluidContainer<
-	TContainerSchema extends ContainerSchema,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	TContainerSchema extends ContainerSchema = ContainerSchema,
 >(props: {
 	container: IContainer;
 	rootDataObject: IRootDataObject;
@@ -254,7 +253,7 @@ export function createFluidContainer<
  * Note: this implementation is not complete. Consumers who rely on {@link IFluidContainer.attach}
  * will need to utilize or provide a service-specific implementation of this type that implements that method.
  */
-class FluidContainer<TContainerSchema extends ContainerSchema>
+class FluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema>
 	extends TypedEventEmitter<IFluidContainerEvents>
 	implements IFluidContainer<TContainerSchema>
 {

--- a/packages/framework/fluid-static/src/index.ts
+++ b/packages/framework/fluid-static/src/index.ts
@@ -20,7 +20,6 @@ export { createServiceAudience } from "./serviceAudience.js";
 export type {
 	CompatibilityMode,
 	ContainerSchema,
-	ContainerAttachProps,
 	IConnection,
 	IMember,
 	IProvideRootDataObject,

--- a/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
+++ b/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
@@ -38,18 +38,16 @@ declare type current_as_old_for_TypeAlias_CompatibilityMode = requireAssignableT
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAlias_ContainerAttachProps": {"forwardCompat": false}
+ * "RemovedTypeAlias_ContainerAttachProps": {"forwardCompat": false}
  */
-declare type old_as_current_for_TypeAlias_ContainerAttachProps = requireAssignableTo<TypeOnly<old.ContainerAttachProps>, TypeOnly<current.ContainerAttachProps>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "TypeAlias_ContainerAttachProps": {"backCompat": false}
+ * "RemovedTypeAlias_ContainerAttachProps": {"backCompat": false}
  */
-declare type current_as_old_for_TypeAlias_ContainerAttachProps = requireAssignableTo<TypeOnly<current.ContainerAttachProps>, TypeOnly<old.ContainerAttachProps>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -58,12 +58,6 @@ export interface DataObjectClass<T extends IFluidLoadable> {
 }
 
 /**
- * Represents properties that can be attached to a container.
- * @public
- */
-export type ContainerAttachProps<T = unknown> = T;
-
-/**
  * Declares the Fluid objects that will be available in the {@link IFluidContainer | Container}.
  *
  * @remarks

--- a/packages/service-clients/azure-client/src/AzureClient.ts
+++ b/packages/service-clients/azure-client/src/AzureClient.ts
@@ -174,7 +174,7 @@ export class AzureClient {
 		url.searchParams.append("containerId", encodeURIComponent(id));
 		const container = await loader.resolve({ url: url.href });
 		const rootDataObject = await this.getContainerEntryPoint(container);
-		const fluidContainer = createFluidContainer<TContainerSchema>({
+		const fluidContainer = createFluidContainer<TContainerSchema, () => Promise<string>>({
 			container,
 			rootDataObject,
 		});
@@ -213,7 +213,7 @@ export class AzureClient {
 			headers: { [LoaderHeader.version]: version.id },
 		});
 		const rootDataObject = await this.getContainerEntryPoint(container);
-		const fluidContainer = createFluidContainer<TContainerSchema>({
+		const fluidContainer = createFluidContainer<TContainerSchema, () => Promise<string>>({
 			container,
 			rootDataObject,
 		});
@@ -322,7 +322,7 @@ export class AzureClient {
 			}
 			return container.resolvedUrl.id;
 		};
-		const fluidContainer = createFluidContainer<TContainerSchema>({
+		const fluidContainer = createFluidContainer<TContainerSchema, () => Promise<string>>({
 			container,
 			rootDataObject,
 		});

--- a/packages/service-clients/azure-client/src/AzureClient.ts
+++ b/packages/service-clients/azure-client/src/AzureClient.ts
@@ -174,7 +174,7 @@ export class AzureClient {
 		url.searchParams.append("containerId", encodeURIComponent(id));
 		const container = await loader.resolve({ url: url.href });
 		const rootDataObject = await this.getContainerEntryPoint(container);
-		const fluidContainer = createFluidContainer<TContainerSchema, () => Promise<string>>({
+		const fluidContainer = createFluidContainer<TContainerSchema>({
 			container,
 			rootDataObject,
 		});
@@ -213,7 +213,7 @@ export class AzureClient {
 			headers: { [LoaderHeader.version]: version.id },
 		});
 		const rootDataObject = await this.getContainerEntryPoint(container);
-		const fluidContainer = createFluidContainer<TContainerSchema, () => Promise<string>>({
+		const fluidContainer = createFluidContainer<TContainerSchema>({
 			container,
 			rootDataObject,
 		});
@@ -322,7 +322,7 @@ export class AzureClient {
 			}
 			return container.resolvedUrl.id;
 		};
-		const fluidContainer = createFluidContainer<TContainerSchema, () => Promise<string>>({
+		const fluidContainer = createFluidContainer<TContainerSchema>({
 			container,
 			rootDataObject,
 		});

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/OdspClientFactory.ts
@@ -7,7 +7,11 @@ import {
 	IConfigProviderBase,
 	type ITelemetryBaseLogger,
 } from "@fluidframework/core-interfaces";
-import { OdspClient, OdspConnectionConfig } from "@fluidframework/odsp-client/internal";
+import {
+	type IOdspClient,
+	createOdspClient as createOdspClientCore,
+	OdspConnectionConfig,
+} from "@fluidframework/odsp-client/internal";
 import { MockLogger, createMultiSinkLogger } from "@fluidframework/telemetry-utils/internal";
 
 import { OdspTestTokenProvider } from "./OdspTokenFactory.js";
@@ -107,13 +111,13 @@ export function getCredentials(): IOdspLoginCredentials[] {
 
 /**
  * This function will determine if local or remote mode is required (based on FLUID_CLIENT), and return a new
- * {@link OdspClient} instance based on the mode by setting the Connection config accordingly.
+ * {@link IOdspClient} instance based on the mode by setting the Connection config accordingly.
  */
 export function createOdspClient(
 	creds: IOdspLoginCredentials,
 	logger?: MockLogger,
 	configProvider?: IConfigProviderBase,
-): OdspClient {
+): IOdspClient {
 	const siteUrl = process.env.odsp__client__siteUrl as string;
 	const driveId = process.env.odsp__client__driveId as string;
 	const clientId = process.env.odsp__client__clientId as string;
@@ -137,7 +141,6 @@ export function createOdspClient(
 		siteUrl,
 		tokenProvider: new OdspTestTokenProvider(credentials),
 		driveId,
-		filePath: "",
 	};
 	const getLogger = (): ITelemetryBaseLogger | undefined => {
 		const testLogger = getTestLogger?.();
@@ -149,7 +152,7 @@ export function createOdspClient(
 		}
 		return logger ?? testLogger;
 	};
-	return new OdspClient({
+	return createOdspClientCore({
 		connection: connectionProps,
 		logger: getLogger(),
 		configProvider,

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
@@ -110,7 +110,7 @@ describe("Fluid audience", () => {
 				"Fluid.Container.ForceWriteConnection": true,
 			}),
 		);
-		const { services: servicesGet } = await client2.getContainer({ itemId }, schema);
+		const { services: servicesGet } = await client2.getContainer(itemId, schema);
 
 		/* This is a workaround for a known bug, we should have one member (self) upon container connection */
 		const partner = await waitForMember(servicesGet.audience, client2Creds.email);
@@ -154,7 +154,7 @@ describe("Fluid audience", () => {
 				"Fluid.Container.ForceWriteConnection": true,
 			}),
 		);
-		const { services: servicesGet } = await client2.getContainer({ itemId }, schema);
+		const { services: servicesGet } = await client2.getContainer(itemId, schema);
 
 		/* This is a workaround for a known bug, we should have one member (self) upon container connection */
 		const partner = await waitForMember(servicesGet.audience, client2Creds.email);

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
@@ -46,8 +46,7 @@ describe("Fluid audience", () => {
 	 */
 	it("can find original member", async () => {
 		const { container, services } = await client.createContainer(schema);
-		const res = await container.attach();
-		const itemId = res.itemId;
+		const itemId = await container.attach();
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
@@ -81,8 +80,7 @@ describe("Fluid audience", () => {
 	 */
 	it.skip("can find partner member", async () => {
 		const { container, services } = await client.createContainer(schema);
-		const res = await container.attach();
-		const itemId = res.itemId;
+		const itemId = await container.attach();
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
@@ -136,8 +134,7 @@ describe("Fluid audience", () => {
 	 */
 	it.skip("can observe member leaving", async () => {
 		const { container } = await client.createContainer(schema);
-		const res = await container.attach();
-		const itemId = res.itemId;
+		const itemId = await container.attach();
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/audience.spec.ts
@@ -10,7 +10,7 @@ import { ConnectionState } from "@fluidframework/container-loader";
 import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
-import { OdspClient } from "@fluidframework/odsp-client/internal";
+import { type IOdspClient } from "@fluidframework/odsp-client/internal";
 import { timeoutPromise } from "@fluidframework/test-utils/internal";
 
 import { createOdspClient, getCredentials } from "./OdspClientFactory.js";
@@ -22,7 +22,7 @@ const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderB
 
 describe("Fluid audience", () => {
 	const connectTimeoutMs = 10_000;
-	let client: OdspClient;
+	let client: IOdspClient;
 	let schema: ContainerSchema;
 	const [client1Creds, client2Creds] = getCredentials();
 
@@ -46,7 +46,8 @@ describe("Fluid audience", () => {
 	 */
 	it("can find original member", async () => {
 		const { container, services } = await client.createContainer(schema);
-		const itemId = await container.attach();
+		const res = await container.attach();
+		const itemId = res.itemId;
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
@@ -80,7 +81,8 @@ describe("Fluid audience", () => {
 	 */
 	it.skip("can find partner member", async () => {
 		const { container, services } = await client.createContainer(schema);
-		const itemId = await container.attach();
+		const res = await container.attach();
+		const itemId = res.itemId;
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
@@ -108,7 +110,7 @@ describe("Fluid audience", () => {
 				"Fluid.Container.ForceWriteConnection": true,
 			}),
 		);
-		const { services: servicesGet } = await client2.getContainer(itemId, schema);
+		const { services: servicesGet } = await client2.getContainer({ itemId }, schema);
 
 		/* This is a workaround for a known bug, we should have one member (self) upon container connection */
 		const partner = await waitForMember(servicesGet.audience, client2Creds.email);
@@ -134,7 +136,8 @@ describe("Fluid audience", () => {
 	 */
 	it.skip("can observe member leaving", async () => {
 		const { container } = await client.createContainer(schema);
-		const itemId = await container.attach();
+		const res = await container.attach();
+		const itemId = res.itemId;
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
@@ -151,7 +154,7 @@ describe("Fluid audience", () => {
 				"Fluid.Container.ForceWriteConnection": true,
 			}),
 		);
-		const { services: servicesGet } = await client2.getContainer(itemId, schema);
+		const { services: servicesGet } = await client2.getContainer({ itemId }, schema);
 
 		/* This is a workaround for a known bug, we should have one member (self) upon container connection */
 		const partner = await waitForMember(servicesGet.audience, client2Creds.email);

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
@@ -126,7 +126,7 @@ describe("Container create scenarios", () => {
 			});
 		}
 
-		const resources = client.getContainer({ itemId }, schema);
+		const resources = client.getContainer(itemId, schema);
 		await assert.doesNotReject(
 			resources,
 			() => true,
@@ -140,7 +140,7 @@ describe("Container create scenarios", () => {
 	 * Expected behavior: an error should be thrown when trying to get a non-existent container.
 	 */
 	it("cannot load improperly created container (cannot load a non-existent container)", async () => {
-		const containerAndServicesP = client.getContainer({ itemId: "containerConfig" }, schema);
+		const containerAndServicesP = client.getContainer("containerConfig" /* itemId */, schema);
 
 		const errorFn = (error: Error): boolean => {
 			assert.notStrictEqual(error.message, undefined, "Odsp Client error is undefined");

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/containerCreate.spec.ts
@@ -50,8 +50,7 @@ describe("Container create scenarios", () => {
 		);
 
 		// Make sure we can attach.
-		const res = await container.attach();
-		const itemId = res.itemId;
+		const itemId = await container.attach();
 		assert.strictEqual(typeof itemId, "string", "Attach did not return a string ID");
 	});
 
@@ -63,8 +62,7 @@ describe("Container create scenarios", () => {
 	 */
 	it("can attach a container", async () => {
 		const { container } = await client.createContainer(schema);
-		const res = await container.attach();
-		const itemId = res.itemId;
+		const itemId = await container.attach();
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
@@ -89,8 +87,7 @@ describe("Container create scenarios", () => {
 	 */
 	it("cannot attach a container twice", async () => {
 		const { container } = await client.createContainer(schema);
-		const res = await container.attach();
-		const itemId = res.itemId;
+		const itemId = await container.attach();
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
@@ -116,8 +113,7 @@ describe("Container create scenarios", () => {
 	 */
 	it("can retrieve existing ODSP container successfully", async () => {
 		const { container: newContainer } = await client.createContainer(schema);
-		const res = await newContainer.attach();
-		const itemId = res.itemId;
+		const itemId = await newContainer.attach();
 
 		if (newContainer.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => newContainer.once("connected", () => resolve()), {

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
@@ -44,8 +44,7 @@ describe("Fluid data updates", () => {
 	 */
 	it("can set DDSes as initial objects for a container", async () => {
 		const { container: newContainer } = await client.createContainer(schema);
-		const res = await newContainer.attach();
-		const itemId = res.itemId;
+		const itemId = await newContainer.attach();
 
 		if (newContainer.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => newContainer.once("connected", () => resolve()), {
@@ -76,8 +75,7 @@ describe("Fluid data updates", () => {
 	 */
 	it("can change DDSes within initialObjects value", async () => {
 		const { container } = await client.createContainer(schema);
-		const res = await container.attach();
-		const itemId = res.itemId;
+		const itemId = await container.attach();
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
@@ -110,8 +108,7 @@ describe("Fluid data updates", () => {
 			},
 		};
 		const { container } = await client.createContainer(doSchema);
-		const res = await container.attach();
-		const itemId = res.itemId;
+		const itemId = await container.attach();
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
@@ -158,8 +155,7 @@ describe("Fluid data updates", () => {
 			},
 		};
 		const { container } = await client.createContainer(doSchema);
-		const res = await container.attach();
-		const itemId = res.itemId;
+		const itemId = await container.attach();
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {
@@ -219,8 +215,7 @@ describe("Fluid data updates", () => {
 
 		assert.strictEqual(mdo2.value, 3);
 
-		const res = await container.attach();
-		const itemId = res.itemId;
+		const itemId = await container.attach();
 
 		if (container.connectionState !== ConnectionState.Connected) {
 			await timeoutPromise((resolve) => container.once("connected", () => resolve()), {

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/ddsTests.spec.ts
@@ -54,7 +54,7 @@ describe("Fluid data updates", () => {
 			});
 		}
 
-		const resources = client.getContainer({ itemId }, schema);
+		const resources = client.getContainer(itemId, schema);
 		await assert.doesNotReject(
 			resources,
 			() => true,
@@ -91,7 +91,7 @@ describe("Fluid data updates", () => {
 		map1Create.set("new-key", "new-value");
 		const valueCreate: string | undefined = map1Create.get("new-key");
 
-		const { container: containerGet } = await client.getContainer({ itemId }, schema);
+		const { container: containerGet } = await client.getContainer(itemId, schema);
 		const map1Get = containerGet.initialObjects.map1;
 		const valueGet: string | undefined = await mapWait(map1Get, "new-key");
 		assert.strictEqual(valueGet, valueCreate, "container can't change initial objects");
@@ -130,7 +130,7 @@ describe("Fluid data updates", () => {
 			"container returns the wrong type for mdo2",
 		);
 
-		const { container: containerGet } = await client.getContainer({ itemId }, doSchema);
+		const { container: containerGet } = await client.getContainer(itemId, doSchema);
 		const initialObjectsGet = containerGet.initialObjects;
 		assert(
 			initialObjectsGet.mdo1 instanceof TestDataObject,
@@ -182,7 +182,7 @@ describe("Fluid data updates", () => {
 			"container returns the wrong type for mdo3",
 		);
 
-		const { container: containerGet } = await client.getContainer({ itemId }, doSchema);
+		const { container: containerGet } = await client.getContainer(itemId, doSchema);
 		const initialObjectsGet = containerGet.initialObjects;
 		assert(
 			initialObjectsGet.mdo1 instanceof TestDataObject,
@@ -229,7 +229,7 @@ describe("Fluid data updates", () => {
 			});
 		}
 
-		const { container: containerGet } = await client.getContainer({ itemId }, doSchema);
+		const { container: containerGet } = await client.getContainer(itemId, doSchema);
 		const initialObjectsGet = containerGet.initialObjects;
 		const mdo2get: CounterTestDataObject = initialObjectsGet.mdo2;
 

--- a/packages/service-clients/odsp-client/README.md
+++ b/packages/service-clients/odsp-client/README.md
@@ -104,9 +104,9 @@ const containerSchema = {
 	],
 };
 const odspClient = new OdspClient(clientProps);
-const { container, services } = await odspClient.createContainer(containerSchema);
+const { container, services, createFn } = await odspClient.createContainer(containerSchema);
 
-const response = await container.attach();
+const response = await createFn();
 const itemId = response.itemId;
 
 ```

--- a/packages/service-clients/odsp-client/README.md
+++ b/packages/service-clients/odsp-client/README.md
@@ -106,7 +106,9 @@ const containerSchema = {
 const odspClient = new OdspClient(clientProps);
 const { container, services } = await odspClient.createContainer(containerSchema);
 
-const itemId = await container.attach();
+const response = await container.attach();
+const itemId = response.itemId;
+
 ```
 
 ## Using Fluid Containers

--- a/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
@@ -16,7 +16,7 @@ export interface IOdspClient {
         container: IOdspFluidContainer<T>;
         services: OdspContainerServices;
     }>;
-    getContainer<T extends ContainerSchema>(request: OdspContainerIdentifier, containerSchema: T, options?: OdspContainerOpenOptions): Promise<{
+    getContainer<T extends ContainerSchema>(itemId: string, containerSchema: T, options?: OdspContainerOpenOptions): Promise<{
         container: IOdspFluidContainer<T>;
         services: OdspContainerServices;
     }>;
@@ -41,12 +41,15 @@ export interface OdspClientProps {
 }
 
 // @beta
-export interface OdspConnectionConfig extends OdspSiteLocation {
+export interface OdspConnectionConfig {
+    driveId: string;
+    isClpCompliant?: boolean;
+    siteUrl: string;
     tokenProvider: IOdspTokenProvider;
 }
 
 // @alpha
-export type OdspContainerAttachInfo = {
+export type OdspContainerAttachRequest = {
     filePath?: string;
     fileName?: string;
     createShareLinkType?: ISharingLinkKind;
@@ -58,26 +61,14 @@ export type OdspContainerAttachInfo = {
 export interface OdspContainerAttachResult {
     itemId: string;
     shareLinkInfo?: ShareLinkInfoType;
-    sharingLink?: string;
 }
 
 // @alpha
-export type OdspContainerAttachType = (param?: OdspContainerAttachInfo, options?: OdspContainerCreateOptions) => Promise<OdspContainerAttachResult>;
-
-// @alpha
-export interface OdspContainerCreateOptions {
-    isClpCompliant?: boolean;
-}
-
-// @alpha
-export interface OdspContainerIdentifier {
-    itemId: string;
-}
+export type OdspContainerAttachType = (param?: OdspContainerAttachRequest) => Promise<OdspContainerAttachResult>;
 
 // @alpha
 export interface OdspContainerOpenOptions {
     fileVersion?: string;
-    isClpCompliant?: boolean;
     sharingLinkToRedeem?: string;
 }
 
@@ -91,12 +82,6 @@ export interface OdspMember extends IMember {
     email: string;
     id: string;
     name: string;
-}
-
-// @beta
-export interface OdspSiteLocation {
-    driveId: string;
-    siteUrl: string;
 }
 
 // @beta

--- a/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
@@ -4,8 +4,26 @@
 
 ```ts
 
-// @beta
+// @alpha
+export function createOdspClient(properties: OdspClientProps): IOdspClient;
+
+// @alpha
 export type IOdspAudience = IServiceAudience<OdspMember>;
+
+// @alpha
+export interface IOdspClient {
+    createContainer<T extends ContainerSchema>(containerSchema: T): Promise<{
+        container: IOdspFluidContainer<T>;
+        services: OdspContainerServices;
+    }>;
+    getContainer<T extends ContainerSchema>(request: OdspGetContainerArgType, containerSchema: T): Promise<{
+        container: IOdspFluidContainer<T>;
+        services: OdspContainerServices;
+    }>;
+}
+
+// @alpha
+export type IOdspFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> = IFluidContainer<TContainerSchema, OdspContainerAttachType>;
 
 // @beta
 export interface IOdspTokenProvider {
@@ -13,46 +31,59 @@ export interface IOdspTokenProvider {
     fetchWebsocketToken(siteUrl: string, refresh: boolean): Promise<TokenResponse>;
 }
 
-// @beta @sealed
-export class OdspClient {
-    constructor(properties: OdspClientProps);
-    // (undocumented)
-    createContainer<T extends ContainerSchema>(containerSchema: T): Promise<{
-        container: IFluidContainer<T>;
-        services: OdspContainerServices;
-    }>;
-    // (undocumented)
-    getContainer<T extends ContainerSchema>(id: string, containerSchema: T): Promise<{
-        container: IFluidContainer<T>;
-        services: OdspContainerServices;
-    }>;
-}
-
-// @beta (undocumented)
+// @alpha (undocumented)
 export interface OdspClientProps {
     readonly configProvider?: IConfigProviderBase;
     readonly connection: OdspConnectionConfig;
+    readonly hostPolicy?: HostStoragePolicy;
     readonly logger?: ITelemetryBaseLogger;
+    readonly persistedCache?: IPersistedCache;
 }
 
 // @beta
-export interface OdspConnectionConfig {
-    driveId: string;
-    filePath: string;
-    siteUrl: string;
+export interface OdspConnectionConfig extends OdspSiteIdentification {
     tokenProvider: IOdspTokenProvider;
 }
 
-// @beta
+// @alpha
+export type OdspContainerAttachArgType = {
+    filePath?: string | undefined;
+    fileName?: string | undefined;
+    createShareLinkType?: ISharingLinkKind;
+} | {
+    itemId: string;
+};
+
+// @alpha
+export interface OdspContainerAttachReturnType {
+    itemId: string;
+    shareLinkInfo?: ShareLinkInfoType;
+}
+
+// @alpha
+export type OdspContainerAttachType = (param?: OdspContainerAttachArgType) => Promise<OdspContainerAttachReturnType>;
+
+// @alpha
 export interface OdspContainerServices {
     audience: IOdspAudience;
 }
 
-// @beta
+// @alpha
+export type OdspGetContainerArgType = {
+    itemId: string;
+} | IRequest;
+
+// @alpha
 export interface OdspMember extends IMember {
     email: string;
     id: string;
     name: string;
+}
+
+// @beta
+export interface OdspSiteIdentification {
+    driveId: string;
+    siteUrl: string;
 }
 
 // @beta

--- a/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
@@ -7,7 +7,7 @@
 // @alpha
 export function createOdspClient(properties: OdspClientProps): IOdspClient;
 
-// @alpha
+// @beta
 export type IOdspAudience = IServiceAudience<OdspMember>;
 
 // @alpha
@@ -70,12 +70,12 @@ export interface OdspContainerOpenOptions {
     sharingLinkToRedeem?: string;
 }
 
-// @alpha
+// @beta
 export interface OdspContainerServices {
     audience: IOdspAudience;
 }
 
-// @alpha
+// @beta
 export interface OdspMember extends IMember {
     email: string;
     id: string;

--- a/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
@@ -16,7 +16,7 @@ export interface IOdspClient {
         container: IOdspFluidContainer<T>;
         services: OdspContainerServices;
     }>;
-    getContainer<T extends ContainerSchema>(request: OdspGetContainerArgType, containerSchema: T): Promise<{
+    getContainer<T extends ContainerSchema>(request: OdspContainerIdentifier, containerSchema: T, isClpCompliant?: boolean): Promise<{
         container: IOdspFluidContainer<T>;
         services: OdspContainerServices;
     }>;
@@ -41,12 +41,12 @@ export interface OdspClientProps {
 }
 
 // @beta
-export interface OdspConnectionConfig extends OdspSiteIdentification {
+export interface OdspConnectionConfig extends OdspSiteLocation {
     tokenProvider: IOdspTokenProvider;
 }
 
 // @alpha
-export type OdspContainerAttachArgType = {
+export type OdspContainerAttachInfo = {
     filePath?: string | undefined;
     fileName?: string | undefined;
     createShareLinkType?: ISharingLinkKind;
@@ -55,26 +55,26 @@ export type OdspContainerAttachArgType = {
 };
 
 // @alpha
-export interface OdspContainerAttachReturnType {
+export interface OdspContainerAttachResult {
     itemId: string;
     shareLinkInfo?: ShareLinkInfoType;
     sharingLink?: string;
 }
 
 // @alpha
-export type OdspContainerAttachType = (param?: OdspContainerAttachArgType) => Promise<OdspContainerAttachReturnType>;
+export type OdspContainerAttachType = (param?: OdspContainerAttachInfo, isClpCompliant?: boolean) => Promise<OdspContainerAttachResult>;
+
+// @alpha
+export type OdspContainerIdentifier = {
+    itemId: string;
+} | {
+    sharingLinkToRedeem: string;
+};
 
 // @alpha
 export interface OdspContainerServices {
     audience: IOdspAudience;
 }
-
-// @alpha
-export type OdspGetContainerArgType = {
-    itemId: string;
-} | {
-    sharingLinkToRedeem: string;
-};
 
 // @alpha
 export interface OdspMember extends IMember {
@@ -84,7 +84,7 @@ export interface OdspMember extends IMember {
 }
 
 // @beta
-export interface OdspSiteIdentification {
+export interface OdspSiteLocation {
     driveId: string;
     siteUrl: string;
 }

--- a/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
@@ -13,17 +13,15 @@ export type IOdspAudience = IServiceAudience<OdspMember>;
 // @alpha
 export interface IOdspClient {
     createContainer<T extends ContainerSchema>(containerSchema: T): Promise<{
-        container: IOdspFluidContainer<T>;
+        container: IFluidContainer<T>;
         services: OdspContainerServices;
+        createFn: OdspContainerAttachFunctor;
     }>;
     getContainer<T extends ContainerSchema>(itemId: string, containerSchema: T, options?: OdspContainerOpenOptions): Promise<{
-        container: IOdspFluidContainer<T>;
+        container: IFluidContainer<T>;
         services: OdspContainerServices;
     }>;
 }
-
-// @alpha
-export type IOdspFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> = IFluidContainer<TContainerSchema, OdspContainerAttachType>;
 
 // @beta
 export interface IOdspTokenProvider {
@@ -49,7 +47,7 @@ export interface OdspConnectionConfig {
 }
 
 // @alpha
-export type OdspContainerAttachRequest = {
+export type OdspContainerAttachArgs = {
     filePath?: string;
     fileName?: string;
     createShareLinkType?: ISharingLinkKind;
@@ -58,13 +56,13 @@ export type OdspContainerAttachRequest = {
 };
 
 // @alpha
+export type OdspContainerAttachFunctor = (param?: OdspContainerAttachArgs) => Promise<OdspContainerAttachResult>;
+
+// @alpha
 export interface OdspContainerAttachResult {
     itemId: string;
     shareLinkInfo?: ShareLinkInfoType;
 }
-
-// @alpha
-export type OdspContainerAttachType = (param?: OdspContainerAttachRequest) => Promise<OdspContainerAttachResult>;
 
 // @alpha
 export interface OdspContainerOpenOptions {

--- a/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
@@ -16,7 +16,7 @@ export interface IOdspClient {
         container: IOdspFluidContainer<T>;
         services: OdspContainerServices;
     }>;
-    getContainer<T extends ContainerSchema>(request: OdspContainerIdentifier, containerSchema: T, isClpCompliant?: boolean): Promise<{
+    getContainer<T extends ContainerSchema>(request: OdspContainerIdentifier, containerSchema: T, options?: OdspContainerOpenOptions): Promise<{
         container: IOdspFluidContainer<T>;
         services: OdspContainerServices;
     }>;
@@ -47,8 +47,8 @@ export interface OdspConnectionConfig extends OdspSiteLocation {
 
 // @alpha
 export type OdspContainerAttachInfo = {
-    filePath?: string | undefined;
-    fileName?: string | undefined;
+    filePath?: string;
+    fileName?: string;
     createShareLinkType?: ISharingLinkKind;
 } | {
     itemId: string;
@@ -62,14 +62,24 @@ export interface OdspContainerAttachResult {
 }
 
 // @alpha
-export type OdspContainerAttachType = (param?: OdspContainerAttachInfo, isClpCompliant?: boolean) => Promise<OdspContainerAttachResult>;
+export type OdspContainerAttachType = (param?: OdspContainerAttachInfo, options?: OdspContainerCreateOptions) => Promise<OdspContainerAttachResult>;
 
 // @alpha
-export type OdspContainerIdentifier = {
+export interface OdspContainerCreateOptions {
+    isClpCompliant?: boolean;
+}
+
+// @alpha
+export interface OdspContainerIdentifier {
     itemId: string;
-} | {
-    sharingLinkToRedeem: string;
-};
+}
+
+// @alpha
+export interface OdspContainerOpenOptions {
+    fileVersion?: string;
+    isClpCompliant?: boolean;
+    sharingLinkToRedeem?: string;
+}
 
 // @alpha
 export interface OdspContainerServices {

--- a/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.alpha.api.md
@@ -58,6 +58,7 @@ export type OdspContainerAttachArgType = {
 export interface OdspContainerAttachReturnType {
     itemId: string;
     shareLinkInfo?: ShareLinkInfoType;
+    sharingLink?: string;
 }
 
 // @alpha
@@ -71,7 +72,9 @@ export interface OdspContainerServices {
 // @alpha
 export type OdspGetContainerArgType = {
     itemId: string;
-} | IRequest;
+} | {
+    sharingLinkToRedeem: string;
+};
 
 // @alpha
 export interface OdspMember extends IMember {

--- a/packages/service-clients/odsp-client/api-report/odsp-client.beta.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.beta.api.md
@@ -5,6 +5,9 @@
 ```ts
 
 // @beta
+export type IOdspAudience = IServiceAudience<OdspMember>;
+
+// @beta
 export interface IOdspTokenProvider {
     fetchStorageToken(siteUrl: string, refresh: boolean): Promise<TokenResponse>;
     fetchWebsocketToken(siteUrl: string, refresh: boolean): Promise<TokenResponse>;
@@ -16,6 +19,18 @@ export interface OdspConnectionConfig {
     isClpCompliant?: boolean;
     siteUrl: string;
     tokenProvider: IOdspTokenProvider;
+}
+
+// @beta
+export interface OdspContainerServices {
+    audience: IOdspAudience;
+}
+
+// @beta
+export interface OdspMember extends IMember {
+    email: string;
+    id: string;
+    name: string;
 }
 
 // @beta

--- a/packages/service-clients/odsp-client/api-report/odsp-client.beta.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.beta.api.md
@@ -5,54 +5,20 @@
 ```ts
 
 // @beta
-export type IOdspAudience = IServiceAudience<OdspMember>;
-
-// @beta
 export interface IOdspTokenProvider {
     fetchStorageToken(siteUrl: string, refresh: boolean): Promise<TokenResponse>;
     fetchWebsocketToken(siteUrl: string, refresh: boolean): Promise<TokenResponse>;
 }
 
-// @beta @sealed
-export class OdspClient {
-    constructor(properties: OdspClientProps);
-    // (undocumented)
-    createContainer<T extends ContainerSchema>(containerSchema: T): Promise<{
-        container: IFluidContainer<T>;
-        services: OdspContainerServices;
-    }>;
-    // (undocumented)
-    getContainer<T extends ContainerSchema>(id: string, containerSchema: T): Promise<{
-        container: IFluidContainer<T>;
-        services: OdspContainerServices;
-    }>;
-}
-
-// @beta (undocumented)
-export interface OdspClientProps {
-    readonly configProvider?: IConfigProviderBase;
-    readonly connection: OdspConnectionConfig;
-    readonly logger?: ITelemetryBaseLogger;
-}
-
 // @beta
-export interface OdspConnectionConfig {
-    driveId: string;
-    filePath: string;
-    siteUrl: string;
+export interface OdspConnectionConfig extends OdspSiteIdentification {
     tokenProvider: IOdspTokenProvider;
 }
 
 // @beta
-export interface OdspContainerServices {
-    audience: IOdspAudience;
-}
-
-// @beta
-export interface OdspMember extends IMember {
-    email: string;
-    id: string;
-    name: string;
+export interface OdspSiteIdentification {
+    driveId: string;
+    siteUrl: string;
 }
 
 // @beta

--- a/packages/service-clients/odsp-client/api-report/odsp-client.beta.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.beta.api.md
@@ -11,14 +11,11 @@ export interface IOdspTokenProvider {
 }
 
 // @beta
-export interface OdspConnectionConfig extends OdspSiteLocation {
-    tokenProvider: IOdspTokenProvider;
-}
-
-// @beta
-export interface OdspSiteLocation {
+export interface OdspConnectionConfig {
     driveId: string;
+    isClpCompliant?: boolean;
     siteUrl: string;
+    tokenProvider: IOdspTokenProvider;
 }
 
 // @beta

--- a/packages/service-clients/odsp-client/api-report/odsp-client.beta.api.md
+++ b/packages/service-clients/odsp-client/api-report/odsp-client.beta.api.md
@@ -11,12 +11,12 @@ export interface IOdspTokenProvider {
 }
 
 // @beta
-export interface OdspConnectionConfig extends OdspSiteIdentification {
+export interface OdspConnectionConfig extends OdspSiteLocation {
     tokenProvider: IOdspTokenProvider;
 }
 
 // @beta
-export interface OdspSiteIdentification {
+export interface OdspSiteLocation {
     driveId: string;
     siteUrl: string;
 }

--- a/packages/service-clients/odsp-client/src/index.ts
+++ b/packages/service-clients/odsp-client/src/index.ts
@@ -20,12 +20,11 @@ export type {
 	IOdspAudience,
 	OdspMember,
 	TokenResponse,
-	OdspContainerAttachRequest,
-	OdspContainerAttachType,
+	OdspContainerAttachArgs,
+	OdspContainerAttachFunctor,
 	OdspContainerAttachResult,
 	OdspContainerOpenOptions,
 	IOdspClient,
-	IOdspFluidContainer,
 } from "./interfaces.js";
 export { createOdspClient } from "./odspClient.js";
 export { type IOdspTokenProvider } from "./token.js";

--- a/packages/service-clients/odsp-client/src/index.ts
+++ b/packages/service-clients/odsp-client/src/index.ts
@@ -14,23 +14,18 @@
  */
 
 export type {
-	OdspSiteLocation,
 	OdspConnectionConfig,
 	OdspClientProps,
 	OdspContainerServices,
 	IOdspAudience,
 	OdspMember,
 	TokenResponse,
-	OdspContainerAttachInfo,
+	OdspContainerAttachRequest,
 	OdspContainerAttachType,
 	OdspContainerAttachResult,
-	OdspContainerIdentifier,
 	OdspContainerOpenOptions,
-	OdspContainerCreateOptions,
+	IOdspClient,
+	IOdspFluidContainer,
 } from "./interfaces.js";
-export {
-	type IOdspClient,
-	type IOdspFluidContainer,
-	createOdspClient,
-} from "./odspClient.js";
+export { createOdspClient } from "./odspClient.js";
 export { type IOdspTokenProvider } from "./token.js";

--- a/packages/service-clients/odsp-client/src/index.ts
+++ b/packages/service-clients/odsp-client/src/index.ts
@@ -14,12 +14,21 @@
  */
 
 export type {
+	OdspSiteIdentification,
 	OdspConnectionConfig,
 	OdspClientProps,
 	OdspContainerServices,
 	IOdspAudience,
 	OdspMember,
 	TokenResponse,
+	OdspContainerAttachArgType,
+	OdspContainerAttachType,
+	OdspContainerAttachReturnType,
+	OdspGetContainerArgType,
 } from "./interfaces.js";
-export { OdspClient } from "./odspClient.js";
+export {
+	type IOdspClient,
+	type IOdspFluidContainer,
+	createOdspClient,
+} from "./odspClient.js";
 export { type IOdspTokenProvider } from "./token.js";

--- a/packages/service-clients/odsp-client/src/index.ts
+++ b/packages/service-clients/odsp-client/src/index.ts
@@ -25,6 +25,8 @@ export type {
 	OdspContainerAttachType,
 	OdspContainerAttachResult,
 	OdspContainerIdentifier,
+	OdspContainerOpenOptions,
+	OdspContainerCreateOptions,
 } from "./interfaces.js";
 export {
 	type IOdspClient,

--- a/packages/service-clients/odsp-client/src/index.ts
+++ b/packages/service-clients/odsp-client/src/index.ts
@@ -14,17 +14,17 @@
  */
 
 export type {
-	OdspSiteIdentification,
+	OdspSiteLocation,
 	OdspConnectionConfig,
 	OdspClientProps,
 	OdspContainerServices,
 	IOdspAudience,
 	OdspMember,
 	TokenResponse,
-	OdspContainerAttachArgType,
+	OdspContainerAttachInfo,
 	OdspContainerAttachType,
-	OdspContainerAttachReturnType,
-	OdspGetContainerArgType,
+	OdspContainerAttachResult,
+	OdspContainerIdentifier,
 } from "./interfaces.js";
 export {
 	type IOdspClient,

--- a/packages/service-clients/odsp-client/src/interfaces.ts
+++ b/packages/service-clients/odsp-client/src/interfaces.ts
@@ -172,7 +172,7 @@ export interface OdspContainerOpenOptions {
  * FluidContainer is persisted in the backend and consumed by users. Any functionality regarding
  * how the data is handled within the FluidContainer itself, i.e. which data objects or DDSes to
  * use, will not be included here but rather on the FluidContainer class itself.
- * @alpha
+ * @beta
  */
 export interface OdspContainerServices {
 	/**
@@ -185,7 +185,7 @@ export interface OdspContainerServices {
  * Since ODSP provides user names and email for all of its members, we extend the
  * {@link @fluidframework/fluid-static#IMember} interface to include this service-specific value.
  * It will be returned for all audience members connected.
- * @alpha
+ * @beta
  */
 export interface OdspMember extends IMember {
 	/**
@@ -204,7 +204,7 @@ export interface OdspMember extends IMember {
 
 /**
  * Audience object for ODSP containers
- * @alpha
+ * @beta
  */
 export type IOdspAudience = IServiceAudience<OdspMember>;
 

--- a/packages/service-clients/odsp-client/src/interfaces.ts
+++ b/packages/service-clients/odsp-client/src/interfaces.ts
@@ -32,11 +32,6 @@ export interface OdspConnectionConfig {
 	 * SharePoint Embedded Container Id of the tenant where Fluid containers are created
 	 */
 	driveId: string;
-
-	/**
-	 * Specifies the file path where Fluid files are created. If passed an empty string, the Fluid files will be created at the root level.
-	 */
-	filePath: string;
 }
 /**
  * @beta

--- a/packages/service-clients/odsp-client/src/interfaces.ts
+++ b/packages/service-clients/odsp-client/src/interfaces.ts
@@ -89,14 +89,14 @@ export type OdspContainerAttachInfo =
 			/**
 			 * The file path where Fluid containers are created. If undefined, the file is created at the root.
 			 */
-			filePath?: string | undefined;
+			filePath?: string;
 
 			/**
 			 * The file name of the Fluid file. If undefined, the file is named with a GUID.
 			 * If a file with such name exists, file with different name is created - Sharepoint will
 			 * add (2), (3), ... to file name to make it unique and avoid conflict on creation.
 			 */
-			fileName?: string | undefined;
+			fileName?: string;
 
 			/**
 			 * If provided, will instrcuct Sharepoint to create a sharing link as part of file creation flow.
@@ -139,13 +139,12 @@ export interface OdspContainerAttachResult {
  * IFluidContainer.attach() function signature for IOdspClient
  * @param param - Specifies where file should be created and how it should be named. If not provided,
  * file with random name (uuid) will be created in the root of the drive.
- * @param isClpCompliant - Should be set to true only by application that is CLP compliant, for CLP compliant workflow.
- * This argument has no impact if application is not properly registered with Sharepoint.
+ * @param options - options controlling creation.
  * @alpha
  */
 export type OdspContainerAttachType = (
 	param?: OdspContainerAttachInfo,
-	isClpCompliant?: boolean,
+	options?: OdspContainerCreateOptions,
 ) => Promise<OdspContainerAttachResult>;
 
 /**
@@ -153,26 +152,54 @@ export type OdspContainerAttachType = (
  * Identifies a container instance in storage.
  * @alpha
  */
-export type OdspContainerIdentifier =
-	| {
-			/**
-			 * If itemId is provided, then OdspSiteLocation information (see OdspClientProps.connection) passed to createOdspClient()
-			 * is used together with itemId to identify a file in Sharepoint.
-			 */
-			itemId: string;
-	  }
-	| {
-			/**
-			 * A sharing link could be provided to identify a file. This link has to be in very specific format - see
-			 * OdspContainerAttachResult.sharingLink, result of calling IOdspFluidContainer.
-			 * When sharing link is provided, it uniquely identifies a file in Sharepoint - OdspSiteLocation information
-			 * (part of OdspClientProps.connection provided to createOdspClient()) is ignored in such case.
-			 *
-			 * This is used to save the network calls while doing trees/latest call as if the client does not have
-			 * permission then this link can be redeemed for the permissions in the same network call.
-			 */
-			sharingLinkToRedeem: string;
-	  };
+export interface OdspContainerIdentifier {
+	/**
+	 * If itemId is provided, then OdspSiteLocation information (see OdspClientProps.connection) passed to createOdspClient()
+	 * is used together with itemId to identify a file in Sharepoint.
+	 */
+	itemId: string;
+}
+
+/**
+ * Interface describing various options controling container open
+ * @alpha
+ */
+export interface OdspContainerOpenOptions {
+	/**
+	 * A sharing link could be provided to identify a file. This link has to be in very specific format - see
+	 * OdspContainerAttachResult.sharingLink, result of calling IOdspFluidContainer.
+	 * When sharing link is provided, it uniquely identifies a file in Sharepoint - OdspSiteLocation information
+	 * (part of OdspClientProps.connection provided to createOdspClient()) is ignored in such case.
+	 *
+	 * This is used to save the network calls while doing trees/latest call as if the client does not have
+	 * permission then this link can be redeemed for the permissions in the same network call.
+	 */
+	sharingLinkToRedeem?: string;
+
+	/**
+	 * Should be set to true only by application that is CLP compliant, for CLP compliant workflow.
+	 * This argument has no impact if application is not properly registered with Sharepoint.
+	 */
+	isClpCompliant?: boolean;
+
+	/**
+	 * Can specify specific file version to open. If specified, opened container will be read-only.
+	 * If not specified, current (latest, read-write) version of the file is opened.
+	 */
+	fileVersion?: string;
+}
+
+/**
+ * Interface describing various options controling container open
+ * @alpha
+ */
+export interface OdspContainerCreateOptions {
+	/**
+	 * Should be set to true only by application that is CLP compliant, for CLP compliant workflow.
+	 * This argument has no impact if application is not properly registered with Sharepoint.
+	 */
+	isClpCompliant?: boolean;
+}
 
 /**
  * OdspContainerServices is returned by the OdspClient alongside a FluidContainer. It holds the

--- a/packages/service-clients/odsp-client/src/interfaces.ts
+++ b/packages/service-clients/odsp-client/src/interfaces.ts
@@ -23,7 +23,7 @@ import type { IOdspTokenProvider } from "./token.js";
  * required for ODSP.
  * @beta
  */
-export interface OdspSiteIdentification {
+export interface OdspSiteLocation {
 	/**
 	 * Site url representing ODSP resource location. It points to the specific SharePoint site where you can store and access the containers you create.
 	 */
@@ -41,7 +41,7 @@ export interface OdspSiteIdentification {
  * required for ODSP.
  * @beta
  */
-export interface OdspConnectionConfig extends OdspSiteIdentification {
+export interface OdspConnectionConfig extends OdspSiteLocation {
 	/**
 	 * Instance that provides AAD endpoint tokens for Push and SharePoint
 	 */
@@ -84,7 +84,7 @@ export interface OdspClientProps {
  * If no argument is provided, file with random name (uuid) will be created.
  * @alpha
  */
-export type OdspContainerAttachArgType =
+export type OdspContainerAttachInfo =
 	| {
 			/**
 			 * The file path where Fluid containers are created. If undefined, the file is created at the root.
@@ -114,14 +114,14 @@ export type OdspContainerAttachArgType =
  * An object type returned by IOdspFluidContainer.attach() call. *
  * @alpha
  */
-export interface OdspContainerAttachReturnType {
+export interface OdspContainerAttachResult {
 	/**
 	 * An ID of the document created. This ID could be passed to future IOdspClient.getContainer() call
 	 */
 	itemId: string;
 
 	/**
-	 * If OdspContainerAttachArgType.createShareLinkType was provided at the time of IOdspFluidContainer.attach() call,
+	 * If OdspContainerAttachInfo.createShareLinkType was provided at the time of IOdspFluidContainer.attach() call,
 	 * this value will contain sharing link information for created file.
 	 */
 	shareLinkInfo?: ShareLinkInfoType;
@@ -139,20 +139,24 @@ export interface OdspContainerAttachReturnType {
  * IFluidContainer.attach() function signature for IOdspClient
  * @param param - Specifies where file should be created and how it should be named. If not provided,
  * file with random name (uuid) will be created in the root of the drive.
+ * @param isClpCompliant - Should be set to true only by application that is CLP compliant, for CLP compliant workflow.
+ * This argument has no impact if application is not properly registered with Sharepoint.
  * @alpha
  */
 export type OdspContainerAttachType = (
-	param?: OdspContainerAttachArgType,
-) => Promise<OdspContainerAttachReturnType>;
+	param?: OdspContainerAttachInfo,
+	isClpCompliant?: boolean,
+) => Promise<OdspContainerAttachResult>;
 
 /**
  * Type of argument to IOdspClient.getContainer()
+ * Identifies a container instance in storage.
  * @alpha
  */
-export type OdspGetContainerArgType =
+export type OdspContainerIdentifier =
 	| {
 			/**
-			 * If itemId is provided, then OdspSiteIdentification information (see OdspClientProps.connection) passed to createOdspClient()
+			 * If itemId is provided, then OdspSiteLocation information (see OdspClientProps.connection) passed to createOdspClient()
 			 * is used together with itemId to identify a file in Sharepoint.
 			 */
 			itemId: string;
@@ -160,8 +164,8 @@ export type OdspGetContainerArgType =
 	| {
 			/**
 			 * A sharing link could be provided to identify a file. This link has to be in very specific format - see
-			 * OdspContainerAttachReturnType.sharingLink, result of calling IOdspFluidContainer.
-			 * When sharing link is provided, it uniquely identifies a file in Sharepoint - OdspSiteIdentification information
+			 * OdspContainerAttachResult.sharingLink, result of calling IOdspFluidContainer.
+			 * When sharing link is provided, it uniquely identifies a file in Sharepoint - OdspSiteLocation information
 			 * (part of OdspClientProps.connection provided to createOdspClient()) is ignored in such case.
 			 *
 			 * This is used to save the network calls while doing trees/latest call as if the client does not have

--- a/packages/service-clients/odsp-client/src/interfaces.ts
+++ b/packages/service-clients/odsp-client/src/interfaces.ts
@@ -82,12 +82,12 @@ export interface OdspClientProps {
 }
 
 /**
- * Argument type of IFluidContainer.attach() for containers created by IOdspClient
  * Specifies location / name of the file.
  * If no argument is provided, file with random name (uuid) will be created.
+ * Please see {@link OdspContainerAttachFunctor} for more details
  * @alpha
  */
-export type OdspContainerAttachRequest =
+export type OdspContainerAttachArgs =
 	| {
 			/**
 			 * The file path where Fluid containers are created. If undefined, the file is created at the root.
@@ -114,7 +114,8 @@ export type OdspContainerAttachRequest =
 	  };
 
 /**
- * An object type returned by IOdspFluidContainer.attach() call. *
+ * An object type returned by attach call.
+ * Please see {@link OdspContainerAttachFunctor} for more details
  * @alpha
  */
 export interface OdspContainerAttachResult {
@@ -124,21 +125,22 @@ export interface OdspContainerAttachResult {
 	itemId: string;
 
 	/**
-	 * If OdspContainerAttachRequest.createShareLinkType was provided at the time of IOdspFluidContainer.attach() call,
-	 * this value will contain sharing link information for created file.
+	 * If OdspContainerAttachArgs.createShareLinkType was provided as part of OdspContainerAttachArgs payload,
+	 * `shareLinkInfo` will contain sharing link information for created file.
 	 */
 	shareLinkInfo?: ShareLinkInfoType;
 }
 
 /**
- * IFluidContainer.attach() function signature for IOdspClient
+ * Signature of the createFn callback returned by IOdspClient.createContainer().
+ * Used to attach container to stroage (create container in storage).
  * @param param - Specifies where file should be created and how it should be named. If not provided,
  * file with random name (uuid) will be created in the root of the drive.
  * @param options - options controlling creation.
  * @alpha
  */
-export type OdspContainerAttachType = (
-	param?: OdspContainerAttachRequest,
+export type OdspContainerAttachFunctor = (
+	param?: OdspContainerAttachArgs,
 ) => Promise<OdspContainerAttachResult>;
 
 /**
@@ -148,7 +150,7 @@ export type OdspContainerAttachType = (
 export interface OdspContainerOpenOptions {
 	/**
 	 * A sharing link could be provided to identify a file. This link has to be in very specific format - see
-	 * OdspContainerAttachResult.sharingLink, result of calling IOdspFluidContainer.
+	 * OdspContainerAttachResult.sharingLink.
 	 * When sharing link is provided, it uniquely identifies a file in Sharepoint - OdspConnectionConfig information
 	 * (part of OdspClientProps.connection provided to createOdspClient()) is ignored in such case.
 	 *
@@ -224,13 +226,6 @@ export interface TokenResponse {
 }
 
 /**
- * Fluid Container type
- * @alpha
- */
-export type IOdspFluidContainer<TContainerSchema extends ContainerSchema = ContainerSchema> =
-	IFluidContainer<TContainerSchema, OdspContainerAttachType>;
-
-/**
  * IOdspClient provides the ability to manipulate Fluid containers backed by the ODSP service within the context of Microsoft 365 (M365) tenants.
  * @alpha
  */
@@ -242,8 +237,9 @@ export interface IOdspClient {
 	createContainer<T extends ContainerSchema>(
 		containerSchema: T,
 	): Promise<{
-		container: IOdspFluidContainer<T>;
+		container: IFluidContainer<T>;
 		services: OdspContainerServices;
+		createFn: OdspContainerAttachFunctor;
 	}>;
 
 	/**
@@ -258,7 +254,7 @@ export interface IOdspClient {
 		containerSchema: T,
 		options?: OdspContainerOpenOptions,
 	): Promise<{
-		container: IOdspFluidContainer<T>;
+		container: IFluidContainer<T>;
 		services: OdspContainerServices;
 	}>;
 }

--- a/packages/service-clients/odsp-client/src/odspClient.ts
+++ b/packages/service-clients/odsp-client/src/odspClient.ts
@@ -32,6 +32,8 @@ import {
 	createOdspUrl,
 	isOdspResolvedUrl,
 	SharingLinkHeader,
+	type OdspFluidDataStoreLocator,
+	storeLocatorInOdspUrl,
 } from "@fluidframework/odsp-driver/internal";
 import type { OdspResourceTokenFetchOptions } from "@fluidframework/odsp-driver-definitions/internal";
 import { wrapConfigProviderWithDefaults } from "@fluidframework/telemetry-utils/internal";
@@ -204,13 +206,19 @@ class OdspClient implements IOdspClient {
 		services: OdspContainerServices;
 	}> {
 		const loader = this.createLoader(containerSchema);
+
+		const locator: OdspFluidDataStoreLocator = {
+			siteUrl: this.connectionConfig.siteUrl,
+			driveId: this.connectionConfig.driveId,
+			itemId: request.itemId,
+			dataStorePath: "",
+		}
+		const url = new URL(baseUrl);
+		storeLocatorInOdspUrl(url, locator);
+		// return url.href;
+
 		const container = await loader.resolve({
-			url: createOdspUrl({
-				siteUrl: this.connectionConfig.siteUrl,
-				driveId: this.connectionConfig.driveId,
-				itemId: request.itemId,
-				dataStorePath: "",
-			}),
+			url: createOdspUrl(locator),
 			headers: {
 				[SharingLinkHeader.isSharingLinkToRedeem]: request.sharingLinkToRedeem !== undefined,
 			},

--- a/packages/service-clients/odsp-client/src/test/odspClient.spec.ts
+++ b/packages/service-clients/odsp-client/src/test/odspClient.spec.ts
@@ -11,7 +11,7 @@ import { type ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
 
 import type { OdspConnectionConfig } from "../interfaces.js";
-import { OdspClient } from "../odspClient.js";
+import { type IOdspClient, createOdspClient as createOdspClientCore } from "../odspClient.js";
 
 import { OdspTestTokenProvider } from "./odspTestTokenProvider.js";
 
@@ -36,18 +36,17 @@ const clientCreds: OdspTestCredentials = {
 /**
  * Creates an instance of the odsp-client with the specified test credentials.
  *
- * @returns OdspClient - An instance of the odsp-client.
+ * @returns IOdspClient - An instance of the odsp-client.
  */
-function createOdspClient(props: { configProvider?: IConfigProviderBase } = {}): OdspClient {
+function createOdspClient(props: { configProvider?: IConfigProviderBase } = {}): IOdspClient {
 	// Configuration for connecting to the ODSP service.
 	const connectionProperties: OdspConnectionConfig = {
 		tokenProvider: new OdspTestTokenProvider(clientCreds), // Token provider using the provided test credentials.
 		siteUrl: "<site_url>",
 		driveId: "<sharepoint_embedded_container_id>",
-		filePath: "<file_path>",
 	};
 
-	return new OdspClient({
+	return createOdspClientCore({
 		connection: connectionProperties,
 		configProvider: props.configProvider,
 	});
@@ -55,7 +54,7 @@ function createOdspClient(props: { configProvider?: IConfigProviderBase } = {}):
 
 describe("OdspClient", () => {
 	// const connectTimeoutMs = 5000;
-	let client: OdspClient;
+	let client: IOdspClient;
 	let schema: ContainerSchema;
 
 	beforeEach(() => {

--- a/packages/service-clients/odsp-client/src/test/odspClient.spec.ts
+++ b/packages/service-clients/odsp-client/src/test/odspClient.spec.ts
@@ -10,8 +10,8 @@ import type { IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { type ContainerSchema } from "@fluidframework/fluid-static";
 import { SharedMap } from "@fluidframework/map/internal";
 
-import type { OdspConnectionConfig } from "../interfaces.js";
-import { type IOdspClient, createOdspClient as createOdspClientCore } from "../odspClient.js";
+import type { OdspConnectionConfig, IOdspClient } from "../interfaces.js";
+import { createOdspClient as createOdspClientCore } from "../odspClient.js";
 
 import { OdspTestTokenProvider } from "./odspTestTokenProvider.js";
 

--- a/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
@@ -112,7 +112,7 @@ export class TinyliciousClient {
 			return container.resolvedUrl.id;
 		};
 
-		const fluidContainer = createFluidContainer<TContainerSchema>({
+		const fluidContainer = createFluidContainer<TContainerSchema, () => Promise<string>>({
 			container,
 			rootDataObject,
 		});
@@ -140,7 +140,7 @@ export class TinyliciousClient {
 		const loader = this.createLoader(containerSchema, compatibilityMode);
 		const container = await loader.resolve({ url: id });
 		const rootDataObject = await this.getContainerEntryPoint(container);
-		const fluidContainer = createFluidContainer<TContainerSchema>({
+		const fluidContainer = createFluidContainer<TContainerSchema, () => Promise<string>>({
 			container,
 			rootDataObject,
 		});

--- a/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
+++ b/packages/service-clients/tinylicious-client/src/TinyliciousClient.ts
@@ -112,7 +112,7 @@ export class TinyliciousClient {
 			return container.resolvedUrl.id;
 		};
 
-		const fluidContainer = createFluidContainer<TContainerSchema, () => Promise<string>>({
+		const fluidContainer = createFluidContainer<TContainerSchema>({
 			container,
 			rootDataObject,
 		});
@@ -140,7 +140,7 @@ export class TinyliciousClient {
 		const loader = this.createLoader(containerSchema, compatibilityMode);
 		const container = await loader.resolve({ url: id });
 		const rootDataObject = await this.getContainerEntryPoint(container);
-		const fluidContainer = createFluidContainer<TContainerSchema, () => Promise<string>>({
+		const fluidContainer = createFluidContainer<TContainerSchema>({
 			container,
 			rootDataObject,
 		});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4268,6 +4268,9 @@ importers:
       '@azure/msal-browser':
         specifier: ^2.34.0
         version: 2.38.3
+      '@fluidframework/core-utils':
+        specifier: workspace:~
+        version: link:../../../../packages/common/core-utils
       '@fluidframework/odsp-client':
         specifier: workspace:~
         version: link:../../../../packages/service-clients/odsp-client


### PR DESCRIPTION
## Scenario/ success criteria
The goal of it is to enable more scenarios for OdspClient, in particular - enable scenarios that Designer app needs, and scenarios that they will likely need in nearest future (based on our experience with another Odsp app - Loop).

1. Leverage our declarative model (mostly this is about SharedTree).
2. Successfully implement the following scenarios (in priority order):
   1. Store FF content in alternate partitions. Designer will follow SPO Pages design and store FF data not in main partition of a file, but in alternate partition of SharePoint file. This difference is mostly transparent for FF layers (as SharePoint redirects all calls to such partition, based on file extension), but creation flow differs - instead of file name, we need to pass itemId of existing file.
   2. Support CLP (i.e. clp-compliant apps need to pass extra header).
   3. Expose ODSP driver policies and capabilities, including provide ability for the app to use caching layer.
   4. Enable sharing flow and working with sharing links, including single roundtrip scenarios
   5. Properly expose types & signatures of the APIs: IFluidContainer.attach() should have proper type and reflect the input parameter type (broken today).

## Reframing in Fluid language
The problem is - how do we expose rich set of scenarios that ODSP driver supports, in a way that is
1. Easily discoverable
2. Self documenting
3. And ideally - can be leveraged using our declarative API model (i.e. using OdspClient), with an eye toward learning and taking this knowledge / direction to encapsulated model as well.

## Sharing workflow & Design choices
We provide a set of URI resolvers that make it easier for the application to work with SharePoint canonical and sharing links. Canonical links are not controlled by the application, and thus there some value in providing common tools to deal with that. Sharing links are a bit more nuanced, as applications could (depending on scenarios) add their own payloads (`nav` parameter) and construction of such payload could be app specific. It's not possible to work efficiently with sharing links without having file identity information that is usually encoded in such nav parameter.

On top of that dealing with URIs and URI resolves is extremely hard - the protocol / types are not in clear sight, it's extremely hard to learn what functionality exists or functionality app has to use.

As such, I chose to build and expose `IOdspCreateRequest` & `IOdspOpenRequest` (see [here](https://github.com/microsoft/FluidFramework/pull/22129/files#diff-335b8a48455a3b93918d28d170bfd8f8ec80deeb5160b935774e28dd4c701416R255)) interfaces that describe all the functionality that ODSP driver exposes and provide adapters to convert them to existing flows (based on IOdspResolvedUrl used across the driver). This way clients could
- encode & decode URIs on their own, fully controlling their format
- have type-safe interaction with FF
- know all the functionality available or required from the app.

This does not eliminate us providing stock implementations for various common flows, like parsing or generating canonical links.

## Compatibility considerations
This prototype explores what it takes to make existing OdspClient flows to support scenarios outlined above.
It goes without saying that it will be **breaking change** if we go that route (and we will need to introduce these breaks ASAP), and the only issue is - how breaking.

That said, we could also abandon OdspClient as is and create OdspClient2.
Or push Designer (and any new app that is in similar need) toward using loader + odsp driver.
That said, even if we go loader + odsp driver, it's not wasted effort, as it's really hard to figure out contracts in the system hiding behind IRequest opaque interface. Part of this work is discovery and figuring out what typical app needs, and thus having right inputs into decision tree.

The other aspect to consider - these changes impact AzureClient. There are options here, but if we absolutely do not want to change any type touching AzureClient, we likely need a bigger fork (I've tried to preserve as much of shared types here as possible between AFR and ODSP flows).

## Where to start with review
1. [packages/drivers/odsp-driver-definitions/src/resolvedUrl.ts](https://github.com/microsoft/FluidFramework/pull/22129/files#diff-335b8a48455a3b93918d28d170bfd8f8ec80deeb5160b935774e28dd4c701416) - newly created ODSP interfaces
4. [packages/framework/fluid-static/src/fluidContainer.ts](https://github.com/microsoft/FluidFramework/compare/main...vladsud:FluidFramework:OdspClient?expand=1#diff-42368aa6fb581b7ad472b6df67c4371c644d5443b363cd3bd5702566d6672aff) - common code between various clients, parametrization of various interfaces to properly support customized flows.
5. [packages/service-clients/odsp-client/src/interfaces.ts](https://github.com/microsoft/FluidFramework/compare/main...vladsud:FluidFramework:OdspClient?expand=1#diff-efb67b5596d362b36a48b472aae5c2dba86cd73571d9e50dbbe2c590188db8b6) has most of the changes (types) for OdspClient flow.
6. [packages/service-clients/odsp-client/src/odspClient.ts](https://github.com/microsoft/FluidFramework/compare/main...vladsud:FluidFramework:OdspClient?expand=1#diff-ef83214596a96fcf9fbb88c39c5fc2cf8c28f5c0d5564bfb9df596f704570042) demonstrates actual flows (encoding / decoding sharing links, etc.) 

## Open questions / Questionable flows
1. It's a bit weird to provide driveId & siteURI when container open flow is based on sharing link and thus does not use this info - it gets identity of the file from sharing link. Maybe we move it out into stand-alone API (to create container from sharing link)?
3. I downgraded some OdspClient types from @ beta to @ alpha, as I have to take dependency on a bunch of @ alpha types. We can upgrade them all to beta

## What is not done
1. Test everything
   - sharing flow
   - alt partition flow
2. There are a number of _eslint-disable-next-line import/no-internal-modules_ rules to import from @fluidframework/odsp-client/internal - need to add proper projects into exception list.
