### PR TITLE
build: Fix build break due to mismatched dependency versions

### DIFF
--- a/packages/common/core-utils/package.json
+++ b/packages/common/core-utils/package.json
@@ -120,7 +120,7 @@
 		"@arethetypeswrong/cli": "^0.15.2",
 		"@biomejs/biome": "~1.8.3",
 		"@fluid-internal/mocha-test-setup": "workspace:~",
-		"@fluid-tools/benchmark": "^0.47.0",
+		"@fluid-tools/benchmark": "^0.48.0",
 		"@fluid-tools/build-cli": "^0.42.0",
 		"@fluidframework/build-common": "^2.0.3",
 		"@fluidframework/build-tools": "^0.42.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8034,8 +8034,8 @@ importers:
         specifier: workspace:~
         version: link:../../test/mocha-test-setup
       '@fluid-tools/benchmark':
-        specifier: ^0.47.0
-        version: 0.47.0
+        specifier: ^0.48.0
+        version: 0.48.0
       '@fluid-tools/build-cli':
         specifier: ^0.42.0
         version: 0.42.0(@types/node@18.19.1)(webpack-cli@4.10.0)
@@ -21034,20 +21034,6 @@ packages:
     dependencies:
       '@fluidframework/core-interfaces': 2.1.0
       '@fluidframework/driver-definitions': 2.1.0
-    dev: true
-
-  /@fluid-tools/benchmark@0.47.0:
-    resolution: {integrity: sha512-lQ2ijhUJ68aOHqH1UxOBmAsSWfx2dIuI4vAlQ4e/ueh0a8KUZ8D8AUpJPu1k1pwuTlOuvb629BY9Q4HC6H/KBQ==}
-    dependencies:
-      chai: 4.3.10
-      chalk: 4.1.2
-      easy-table: 1.2.0
-      mocha: 10.2.0
-      mocha-json-output-reporter: 2.1.0(mocha@10.2.0)(moment@2.29.4)
-      mocha-multi-reporters: 1.5.1(mocha@10.2.0)
-      moment: 2.29.4
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@fluid-tools/benchmark@0.48.0:


### PR DESCRIPTION
Build was broken due to #22128. This fixes the mismatched dependency versions.