### PR TITLE
Stop spammy log line

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/remoteMessageProcessor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/remoteMessageProcessor.ts
@@ -228,11 +228,11 @@ export function ensureContentsDeserialized(
 		didParseJsonContents = false;
 	}
 
-	// We expect Modern Runtime Messages to have JSON serialized contents,
-	// and all other messages not to (system messages and legacy runtime messages without outer "op" type envelope)
+	// The DeltaManager parses the contents of the message as JSON if it is a string,
+	// so we should never end up parsing it here.
 	// Let's observe if we are wrong about this to learn about these cases.
-	if (hasModernRuntimeMessageEnvelope !== didParseJsonContents) {
-		logLegacyCase("ensureContentsDeserialized_unexpectedContentsType");
+	if (didParseJsonContents) {
+		logLegacyCase("ensureContentsDeserialized_foundJsonContents");
 	}
 }
 


### PR DESCRIPTION
## Description

I added a log for a thought-unreached codepath, which in fact is hit on every single runtime op, due to some old back-compat behavior in the DeltaManager.  Flip the logic gating this log.
