### PR TITLE
IFluidContainer.attach() test

### DIFF
--- a/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/index.tsx
@@ -95,7 +95,7 @@ async function start(): Promise<void> {
 
 		// If the app is in a `createNew` state - no itemId, and the container is detached, we attach the container.
 		// This uploads the container to the service and connects to the collaboration session.
-		itemId = await container.attach({ filePath: "foo/bar", fileName: "shared-tree-demo" });
+		itemId = await container.attach({ filePathXX: "foo/bar", fileName: "shared-tree-demo" });
 
 		// The newly attached container is given a unique ID that can be used to access the container in another session
 		// eslint-disable-next-line require-atomic-updates


### PR DESCRIPTION
This PR shows issue with IFluidContainer.attach signature.
It should fail compilation, but it does not.
It demonstrates that users have no clue what is allowed / supported in this flow. There is no way to find it (other than parsing code), and no way to enforce contract.