### PR TITLE
Use the correct settings for compression combinations test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/compression.spec.ts
@@ -135,13 +135,15 @@ const compressionSuite = (getProvider) => {
 					this.skip();
 				}
 				await setupContainers({
-					compressionOptions: option.compressionAndChunking.compression
-						? {
-								minimumBatchSizeInBytes: 10,
-								compressionAlgorithm: CompressionAlgorithms.lz4,
-							}
-						: undefined,
-					chunkSizeInBytes: option.compressionAndChunking.chunking ? 100 : undefined,
+					compressionOptions: {
+						minimumBatchSizeInBytes: option.compressionAndChunking.compression
+							? 10
+							: Number.POSITIVE_INFINITY,
+						compressionAlgorithm: CompressionAlgorithms.lz4,
+					},
+					chunkSizeInBytes: option.compressionAndChunking.chunking
+						? 100
+						: Number.POSITIVE_INFINITY,
 					enableGroupedBatching: option.grouping,
 				});
 				const values = [


### PR DESCRIPTION
A change in `compatUtils.ts` means that we aren't using the defaults from the ContainerRuntime. Thus, this test isn't actually testing what we want.

This wasn't causing any failures or flaky behavior, but it needed to be corrected.