### PR TITLE
Switch Migrator to events object

### DIFF
--- a/examples/utils/example-utils/src/migrationInterfaces/migrator.ts
+++ b/examples/utils/example-utils/src/migrationInterfaces/migrator.ts
@@ -29,7 +29,9 @@ export interface IMigratorEvents extends IEvent {
 /**
  * @internal
  */
-export interface IMigrator extends IEventProvider<IMigratorEvents> {
+export interface IMigrator {
+	readonly events: IEventProvider<IMigratorEvents>;
+
 	/**
 	 * The currently monitored migratable model.  As the Migrator completes a migration, it will swap in the new
 	 * migrated model and emit a "migrated" event.

--- a/examples/version-migration/same-container/tests/sameContainer.test.ts
+++ b/examples/version-migration/same-container/tests/sameContainer.test.ts
@@ -3,9 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { IMigrator } from "@fluid-example/example-utils";
+import type { ISameContainerMigrator } from "@fluid-example/example-utils";
+import type { IContainer } from "@fluidframework/container-definitions/internal";
 import { globals } from "../jest.config.cjs";
-import { IContainer } from "@fluidframework/container-definitions/internal";
 
 describe("same-container migration", () => {
 	beforeAll(async () => {
@@ -66,11 +66,13 @@ describe("same-container migration", () => {
 
 			// Get a promise that will resolve when both sides have finished migration
 			const migrationP = page.evaluate(() => {
-				const migrationPs = (window["migrators"] as IMigrator[]).map((migrator) => {
-					return new Promise<void>((resolve) => {
-						migrator.once("migrated", resolve);
-					});
-				});
+				const migrationPs = (window["migrators"] as ISameContainerMigrator[]).map(
+					(migrator) => {
+						return new Promise<void>((resolve) => {
+							migrator.once("migrated", resolve);
+						});
+					},
+				);
 				return Promise.all(migrationPs);
 			});
 
@@ -149,11 +151,13 @@ describe("same-container migration", () => {
 
 			// Get a promise that will resolve when both sides have finished migration
 			const migrationP = page.evaluate(() => {
-				const migrationPs = (window["migrators"] as IMigrator[]).map((migrator) => {
-					return new Promise<void>((resolve) => {
-						migrator.once("migrated", resolve);
-					});
-				});
+				const migrationPs = (window["migrators"] as ISameContainerMigrator[]).map(
+					(migrator) => {
+						return new Promise<void>((resolve) => {
+							migrator.once("migrated", resolve);
+						});
+					},
+				);
 				return Promise.all(migrationPs);
 			});
 

--- a/examples/version-migration/schema-upgrade/src/start.ts
+++ b/examples/version-migration/schema-upgrade/src/start.ts
@@ -99,7 +99,7 @@ async function start(): Promise<void> {
 		id,
 		inventoryListDataTransformationCallback,
 	);
-	migrator.on("migrated", () => {
+	migrator.events.on("migrated", () => {
 		model.close();
 		model = migrator.currentModel;
 		render(model);
@@ -111,7 +111,7 @@ async function start(): Promise<void> {
 	// However, this will never be hit in this demo since we have a finite set of models to support.  If the model
 	// code loader pulls in the appropriate model dynamically, this might also never be hit since all clients
 	// are theoretically referencing the same model library.
-	migrator.on("migrationNotSupported", (version: string) => {
+	migrator.events.on("migrationNotSupported", (version: string) => {
 		// To move forward, we would need to acquire a model loader capable of loading the given model, retry the
 		// load, and set up a new Migrator with the new model loader.
 		console.error(

--- a/examples/version-migration/schema-upgrade/tests/index.tsx
+++ b/examples/version-migration/schema-upgrade/tests/index.tsx
@@ -96,7 +96,7 @@ export async function createContainerAndRenderInElement(element: HTMLDivElement)
 		id,
 		inventoryListDataTransformationCallback,
 	);
-	migrator.on("migrated", () => {
+	migrator.events.on("migrated", () => {
 		model.close();
 		render(migrator.currentModel);
 		updateTabForId(migrator.currentModelId);

--- a/examples/version-migration/schema-upgrade/tests/separateContainer.test.ts
+++ b/examples/version-migration/schema-upgrade/tests/separateContainer.test.ts
@@ -67,7 +67,7 @@ describe("separate-container migration", () => {
 			const migrationP = page.evaluate(() => {
 				const migrationPs = (window["migrators"] as IMigrator[]).map((migrator) => {
 					return new Promise<void>((resolve) => {
-						migrator.once("migrated", resolve);
+						migrator.events.once("migrated", resolve);
 					});
 				});
 				return Promise.all(migrationPs);
@@ -158,7 +158,7 @@ describe("separate-container migration", () => {
 			const migrationP = page.evaluate(() => {
 				const migrationPs = (window["migrators"] as IMigrator[]).map((migrator) => {
 					return new Promise<void>((resolve) => {
-						migrator.once("migrated", resolve);
+						migrator.events.once("migrated", resolve);
 					});
 				});
 				return Promise.all(migrationPs);


### PR DESCRIPTION
This is just a fairly mechanical change to switch Migrator to using an events object rather than class inheritance to emit events.  This is generally best practice, and I already did this for MigrationTool in #21681 .

Had this sitting around in a prototyping branch along with some more exploratory work but decided it probably makes sense to go ahead and get this bit in.

[AB#12070](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/12070)