### PR TITLE
Clean-up MapTreeNode and allow FlexTreeContext to be undefined

### DIFF
--- a/packages/dds/tree/src/core/tree/mapTree.ts
+++ b/packages/dds/tree/src/core/tree/mapTree.ts
@@ -8,23 +8,24 @@ import type { FieldKey } from "../schema-stored/index.js";
 import type { NodeData } from "./types.js";
 
 /**
- * This modules provides a simple in memory tree format.
+ * This module provides a simple in-memory tree format.
  */
 
 /**
- * Simple in memory tree representation based on Maps.
- * MapTrees should not store empty fields.
+ * Simple in-memory tree representation based on Maps.
+ * @remarks MapTrees should not store empty fields.
  */
 export interface MapTree extends NodeData {
 	readonly fields: ReadonlyMap<FieldKey, readonly MapTree[]>;
 }
 
 /**
- * {@link MapTree} which is owned by a single reference, and allowed to be mutated.
+ * A {@link MapTree} which is owned by a single reference, and therefore allowed to be mutated.
  *
  * @remarks
- * To not keep multiple references to a value with this type around to avoid unexpected mutations.
- * While this type does implement MapTree, it should not be used as a MapTree while it is being mutated.
+ * To ensure unexpected mutations, this object should have a single owner/context.
+ * Though this type does implement MapTree, it should not be used as a MapTree while it can possibly be mutated.
+ * If it is shared to other contexts, it should first be upcast to a {@link MapTree} and further mutations should be avoided.
  */
 export interface ExclusiveMapTree extends NodeData, MapTree {
 	fields: Map<FieldKey, ExclusiveMapTree[]>;

--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -7,6 +7,7 @@ import { assert, oob } from "@fluidframework/core-utils/internal";
 import {
 	type AnchorNode,
 	EmptyKey,
+	type ExclusiveMapTree,
 	type FieldKey,
 	type FieldUpPath,
 	type MapTree,
@@ -14,9 +15,8 @@ import {
 	type TreeValue,
 	type Value,
 } from "../../core/index.js";
-import { brand, fail, mapIterable } from "../../util/index.js";
+import { brand, fail, getOrCreate, mapIterable } from "../../util/index.js";
 import {
-	type FlexTreeContext,
 	FlexTreeEntityKind,
 	type FlexTreeField,
 	type FlexTreeFieldNode,
@@ -73,7 +73,7 @@ export function isMapTreeNode(flexNode: FlexTreeNode): flexNode is MapTreeNode {
 
 /** A node's parent field and its index in that field */
 interface LocationInField {
-	readonly parent: MapTreeField<FlexAllowedTypes>;
+	readonly parent: MapTreeField;
 	readonly index: number;
 }
 
@@ -98,7 +98,7 @@ export class EagerMapTreeNode<TSchema extends FlexTreeNodeSchema> implements Map
 	public constructor(
 		public readonly schema: TSchema,
 		/** The underlying {@link MapTree} that this `MapTreeNode` reads its data from */
-		public readonly mapTree: MapTree,
+		public readonly mapTree: ExclusiveMapTree,
 		private location: LocationInField | undefined,
 	) {
 		assert(!nodeCache.has(mapTree), 0x98b /* A node already exists for the given MapTree */);
@@ -122,7 +122,7 @@ export class EagerMapTreeNode<TSchema extends FlexTreeNodeSchema> implements Map
 	 * Set this node's parentage (see {@link FlexTreeNode.parentField}).
 	 * @remarks A node may only be adopted to a new parent one time, and only if it was not constructed with a parent.
 	 */
-	public adopt(parent: MapTreeField<FlexAllowedTypes>, index: number): void {
+	public adopt(parent: MapTreeField, index: number): void {
 		assert(
 			this.location === undefined,
 			0x98c /* Node may not be adopted if it already has a parent */,
@@ -151,7 +151,7 @@ export class EagerMapTreeNode<TSchema extends FlexTreeNodeSchema> implements Map
 		return (schema as unknown) === this.schema;
 	}
 
-	public tryGetField(key: FieldKey): MapTreeField<FlexAllowedTypes> | undefined {
+	public tryGetField(key: FieldKey): EagerMapTreeField<FlexAllowedTypes> | undefined {
 		const field = this.mapTree.fields.get(key);
 		// Only return the field if it is not empty, in order to fulfill the contract of `tryGetField`.
 		if (field !== undefined && field.length > 0) {
@@ -175,11 +175,7 @@ export class EagerMapTreeNode<TSchema extends FlexTreeNodeSchema> implements Map
 		return this.mapTree.value;
 	}
 
-	public get context(): FlexTreeContext {
-		// This API is relevant to `LazyTreeNode`s, but not `MapTreeNode`s.
-		// TODO: Refactor the FlexTreeNode interface so that stubbing this out isn't necessary.
-		return fail("MapTreeNode does not implement context");
-	}
+	public context = undefined;
 
 	public get anchorNode(): AnchorNode {
 		// This API is relevant to `LazyTreeNode`s, but not `MapTreeNode`s.
@@ -335,6 +331,10 @@ class EagerMapTreeLeafNode<TSchema extends LeafNodeSchema>
 
 // #region Fields
 
+interface MapTreeField extends FlexTreeField {
+	readonly mapTrees: readonly ExclusiveMapTree[];
+}
+
 /**
  * A special singleton that is the implicit parent field of all un-parented {@link EagerMapTreeNode}s.
  * @remarks This exists because {@link EagerMapTreeNode.parentField} must return a field.
@@ -342,7 +342,7 @@ class EagerMapTreeLeafNode<TSchema extends LeafNodeSchema>
  * However, this field cannot be used in any practical way because it is empty, i.e. it does not actually contain the children that claim to be parented under it.
  * It has the "empty" schema and it will always contain zero children if queried.
  */
-export const rootMapTreeField: MapTreeField<FlexAllowedTypes> = {
+export const rootMapTreeField: MapTreeField = {
 	[flexTreeMarker]: FlexTreeEntityKind.Field as const,
 	length: 0,
 	key: EmptyKey,
@@ -357,26 +357,22 @@ export const rootMapTreeField: MapTreeField<FlexAllowedTypes> = {
 		return undefined;
 	},
 	schema: FlexFieldSchema.empty,
-	get context(): FlexTreeContext {
-		return fail("MapTreeField does not implement context");
-	},
+	context: undefined,
 	mapTrees: [],
 };
 
-class MapTreeField<T extends FlexAllowedTypes> implements FlexTreeField {
+class EagerMapTreeField<T extends FlexAllowedTypes> implements MapTreeField {
 	public [flexTreeMarker] = FlexTreeEntityKind.Field as const;
 
 	public constructor(
 		public readonly schema: FlexFieldSchema<FlexFieldKind, T>,
 		public readonly key: FieldKey,
-		public readonly parent: FlexTreeNode | undefined,
-		public readonly mapTrees: readonly MapTree[],
+		public readonly parent: MapTreeNode,
+		public readonly mapTrees: readonly ExclusiveMapTree[],
 	) {
-		assert(
-			!fieldCache.has(mapTrees),
-			0x990 /* A field already exists for the given MapTrees */,
-		);
-		fieldCache.set(mapTrees, this);
+		const fieldKeyCache = getFieldKeyCache(parent);
+		assert(!fieldKeyCache.has(key), 0x990 /* A field already exists for the given MapTrees */);
+		fieldKeyCache.set(key, this);
 
 		// When this field is created (which only happens one time, because it is cached), all the children become parented for the first time.
 		// "Adopt" each child by updating its parent information to point to this field.
@@ -428,13 +424,11 @@ class MapTreeField<T extends FlexAllowedTypes> implements FlexTreeField {
 		}
 	}
 
-	public get context(): FlexTreeContext {
-		return fail("MapTreeField does not implement context");
-	}
+	public context: undefined;
 }
 
-class MapTreeRequiredField<T extends FlexAllowedTypes>
-	extends MapTreeField<T>
+class EagerMapTreeRequiredField<T extends FlexAllowedTypes>
+	extends EagerMapTreeField<T>
 	implements FlexTreeRequiredField<T>
 {
 	public get content(): FlexTreeUnboxNodeUnion<T> {
@@ -445,8 +439,8 @@ class MapTreeRequiredField<T extends FlexAllowedTypes>
 	}
 }
 
-class MapTreeOptionalField<T extends FlexAllowedTypes>
-	extends MapTreeField<T>
+class EagerMapTreeOptionalField<T extends FlexAllowedTypes>
+	extends EagerMapTreeField<T>
 	implements FlexTreeOptionalField<T>
 {
 	public get content(): FlexTreeUnboxNodeUnion<T> | undefined {
@@ -462,8 +456,8 @@ class MapTreeOptionalField<T extends FlexAllowedTypes>
 	}
 }
 
-class MapTreeSequenceField<T extends FlexAllowedTypes>
-	extends MapTreeField<T>
+class EagerMapTreeSequenceField<T extends FlexAllowedTypes>
+	extends EagerMapTreeField<T>
 	implements FlexTreeSequenceField<T>
 {
 	public at(index: number): FlexTreeUnboxNodeUnion<T> | undefined {
@@ -500,7 +494,16 @@ class MapTreeSequenceField<T extends FlexAllowedTypes>
 // #region Caching and unboxing utilities
 
 const nodeCache = new WeakMap<MapTree, EagerMapTreeNode<FlexTreeNodeSchema>>();
-const fieldCache = new WeakMap<readonly MapTree[], MapTreeField<FlexAllowedTypes>>();
+/** Node Parent -\> Field Key -\> Field */
+const fieldCache = new WeakMap<
+	MapTreeNode,
+	Map<FieldKey, EagerMapTreeField<FlexAllowedTypes>>
+>();
+function getFieldKeyCache(
+	parent: MapTreeNode,
+): WeakMap<FieldKey, EagerMapTreeField<FlexAllowedTypes>> {
+	return getOrCreate(fieldCache, parent, () => new Map());
+}
 
 /**
  * If there exists a {@link EagerMapTreeNode} for the given {@link MapTree}, returns it, otherwise returns `undefined`.
@@ -518,7 +521,7 @@ export function tryGetMapTreeNode(mapTree: MapTree): MapTreeNode | undefined {
  */
 export function getOrCreateMapTreeNode(
 	nodeSchema: FlexTreeNodeSchema,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 ): MapTreeNode {
 	return getOrCreateNode(nodeSchema, mapTree);
 }
@@ -532,23 +535,23 @@ export function getOrCreateMapTreeNode(
  */
 export function getOrCreateNode<TSchema extends LeafNodeSchema>(
 	nodeSchema: TSchema,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 ): EagerMapTreeLeafNode<TSchema>;
 export function getOrCreateNode<TSchema extends FlexMapNodeSchema>(
 	nodeSchema: TSchema,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 ): EagerMapTreeMapNode<TSchema>;
 export function getOrCreateNode<TSchema extends FlexFieldNodeSchema>(
 	nodeSchema: TSchema,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 ): EagerMapTreeFieldNode<TSchema>;
 export function getOrCreateNode<TSchema extends FlexTreeNodeSchema>(
 	nodeSchema: TSchema,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 ): EagerMapTreeNode<TSchema>;
 export function getOrCreateNode<TSchema extends FlexTreeNodeSchema>(
 	nodeSchema: TSchema,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 ): EagerMapTreeNode<TSchema> {
 	const cached = tryGetMapTreeNode(mapTree);
 	if (cached !== undefined) {
@@ -559,7 +562,7 @@ export function getOrCreateNode<TSchema extends FlexTreeNodeSchema>(
 
 /** Helper for creating a `MapTreeNode` given the parent field (e.g. when "walking down") */
 function getOrCreateChild(
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 	implicitAllowedTypes: FlexImplicitAllowedTypes,
 	parent: LocationInField | undefined,
 ): EagerMapTreeNode<FlexTreeNodeSchema> {
@@ -583,27 +586,27 @@ function getOrCreateChild(
 /** Always constructs a new node, therefore may not be called twice for the same `MapTree`. */
 function createNode<TSchema extends LeafNodeSchema>(
 	nodeSchema: TSchema,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 	parentField: LocationInField | undefined,
 ): EagerMapTreeLeafNode<TSchema>;
 function createNode<TSchema extends FlexMapNodeSchema>(
 	nodeSchema: TSchema,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 	parentField: LocationInField | undefined,
 ): EagerMapTreeMapNode<TSchema>;
 function createNode<TSchema extends FlexFieldNodeSchema>(
 	nodeSchema: TSchema,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 	parentField: LocationInField | undefined,
 ): EagerMapTreeFieldNode<TSchema>;
 function createNode<TSchema extends FlexTreeNodeSchema>(
 	nodeSchema: TSchema,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 	parentField: LocationInField | undefined,
 ): EagerMapTreeNode<TSchema>;
 function createNode<TSchema extends FlexTreeNodeSchema>(
 	nodeSchema: TSchema,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 	parentField: LocationInField | undefined,
 ): EagerMapTreeNode<TSchema> {
 	if (schemaIsLeaf(nodeSchema)) {
@@ -623,12 +626,12 @@ function createNode<TSchema extends FlexTreeNodeSchema>(
 
 /** Creates a field with the given attributes, or returns a cached field if there is one */
 function getOrCreateField(
-	parent: FlexTreeNode,
+	parent: MapTreeNode,
 	key: FieldKey,
-	mapTrees: readonly MapTree[],
+	mapTrees: readonly ExclusiveMapTree[],
 	schema: FlexFieldSchema,
-): MapTreeField<FlexFieldSchema["allowedTypes"]> {
-	const cached = fieldCache.get(mapTrees);
+): EagerMapTreeField<FlexFieldSchema["allowedTypes"]> {
+	const cached = getFieldKeyCache(parent).get(key);
 	if (cached !== undefined) {
 		return cached;
 	}
@@ -637,24 +640,24 @@ function getOrCreateField(
 		schema.kind.identifier === FieldKinds.required.identifier ||
 		schema.kind.identifier === FieldKinds.identifier.identifier
 	) {
-		return new MapTreeRequiredField(schema, key, parent, mapTrees);
+		return new EagerMapTreeRequiredField(schema, key, parent, mapTrees);
 	}
 
 	if (schema.kind.identifier === FieldKinds.optional.identifier) {
-		return new MapTreeOptionalField(schema, key, parent, mapTrees);
+		return new EagerMapTreeOptionalField(schema, key, parent, mapTrees);
 	}
 
 	if (schema.kind.identifier === FieldKinds.sequence.identifier) {
-		return new MapTreeSequenceField(schema, key, parent, mapTrees);
+		return new EagerMapTreeSequenceField(schema, key, parent, mapTrees);
 	}
 
-	return new MapTreeField(schema, key, parent, mapTrees);
+	return new EagerMapTreeField(schema, key, parent, mapTrees);
 }
 
 /** Unboxes non-polymorphic leaf nodes to their values, if applicable */
 function unboxedUnion<TTypes extends FlexAllowedTypes>(
 	schema: FlexFieldSchema<FlexFieldKind, TTypes>,
-	mapTree: MapTree,
+	mapTree: ExclusiveMapTree,
 	parent: LocationInField,
 ): FlexTreeUnboxNodeUnion<TTypes> {
 	const type = schema.monomorphicChildType;
@@ -674,10 +677,10 @@ function unboxedUnion<TTypes extends FlexAllowedTypes>(
 
 /** Unboxes non-polymorphic required and optional fields holding leaf nodes to their values, if applicable */
 function unboxedField<TFieldSchema extends FlexFieldSchema>(
-	field: MapTreeField<FlexAllowedTypes>,
+	field: EagerMapTreeField<FlexAllowedTypes>,
 	key: FieldKey,
-	mapTree: MapTree,
-	parentNode: FlexTreeNode,
+	mapTree: ExclusiveMapTree,
+	parentNode: MapTreeNode,
 ): FlexTreeUnboxField<TFieldSchema> {
 	const fieldSchema = field.schema;
 	const mapTrees =

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -86,8 +86,9 @@ export interface FlexTreeEntity<out TSchema = unknown> {
 
 	/**
 	 * A common context of a "forest" of FlexTrees.
+	 * @remarks This is `undefined` for unhydrated nodes or fields that have not yet been inserted into the tree.
 	 */
-	readonly context: FlexTreeContext;
+	readonly context?: FlexTreeContext;
 
 	/**
 	 * Iterate through all nodes/fields in this field/node.

--- a/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
@@ -78,8 +78,13 @@ export interface DetachedFieldCache {
  * Utility function to get a {@link SchemaAndPolicy} object from a {@link FlexTreeNode} or {@link FlexTreeField}.
  * @param nodeOrField - {@link FlexTreeNode} or {@link FlexTreeField} to get the schema and policy from.
  * @returns A {@link SchemaAndPolicy} object with the stored schema and policy from the node or field provided.
+ * If the schema information is not available on the given node or field (e.g. because it is an unhydrated node), returns `undefined`.
  */
-export function getSchemaAndPolicy(nodeOrField: FlexTreeEntity): SchemaAndPolicy {
+export function getSchemaAndPolicy(nodeOrField: FlexTreeEntity): SchemaAndPolicy | undefined {
+	if (nodeOrField.context === undefined) {
+		return undefined;
+	}
+
 	return {
 		schema: nodeOrField.context.checkout.storedSchema,
 		policy: nodeOrField.context.schema.policy,

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -707,12 +707,15 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 				mapTreeFromNodeData(
 					c,
 					simpleFieldSchema.allowedTypes,
-					sequenceField.context.nodeKeyManager,
+					sequenceField.context?.nodeKeyManager,
 					getSchemaAndPolicy(sequenceField),
 				),
 			);
 
-		prepareContentForHydration(mapTrees, sequenceField.context.checkout.forest);
+		if (sequenceField.context !== undefined) {
+			prepareContentForHydration(mapTrees, sequenceField.context.checkout.forest);
+		}
+
 		return cursorForMapTreeField(mapTrees);
 	}
 
@@ -838,6 +841,10 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		source?: TreeArrayNode,
 	): void {
 		const destinationField = getSequenceField(this);
+		if (destinationField.context === undefined) {
+			throw new UsageError(`An array cannot be mutated before being inserted into the tree`);
+		}
+
 		validateIndex(destinationIndex, destinationField, "moveRangeToIndex", true);
 		validateIndexRange(sourceStart, sourceEnd, source ?? destinationField, "moveRangeToIndex");
 		const sourceField = source !== undefined ? getSequenceField(source) : destinationField;

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -174,7 +174,7 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 		const mapTree = mapTreeFromNodeData(
 			value as InsertableContent | undefined,
 			classSchema.info as ImplicitAllowedTypes,
-			node.context.nodeKeyManager,
+			node.context?.nodeKeyManager,
 			getSchemaAndPolicy(node),
 		);
 
@@ -183,7 +183,10 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 			return this;
 		}
 
-		prepareContentForHydration(mapTree, node.context.checkout.forest);
+		if (node.context !== undefined) {
+			prepareContentForHydration(mapTree, node.context.checkout.forest);
+		}
+
 		node.set(key, cursorForMapTreeNode(mapTree));
 		return this;
 	}

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -272,11 +272,14 @@ export function setField(
 			const mapTree = mapTreeFromNodeData(
 				value,
 				simpleFieldSchema.allowedTypes,
-				field.context.nodeKeyManager,
+				field.context?.nodeKeyManager,
 				getSchemaAndPolicy(field),
 			);
 
-			prepareContentForHydration(mapTree, field.context.checkout.forest);
+			if (field.context !== undefined) {
+				prepareContentForHydration(mapTree, field.context.checkout.forest);
+			}
+
 			typedField.content = mapTree !== undefined ? cursorForMapTreeNode(mapTree) : undefined;
 			break;
 		}

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -140,19 +140,19 @@ export function mapTreeFromNodeData(
 	allowedTypes: ImplicitAllowedTypes,
 	context?: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
-): MapTree;
+): ExclusiveMapTree;
 export function mapTreeFromNodeData(
 	data: InsertableContent | undefined,
 	allowedTypes: ImplicitAllowedTypes,
 	context?: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
-): MapTree | undefined;
+): ExclusiveMapTree | undefined;
 export function mapTreeFromNodeData(
 	data: InsertableContent | undefined,
 	allowedTypes: ImplicitAllowedTypes,
 	context?: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
-): MapTree | undefined {
+): ExclusiveMapTree | undefined {
 	if (data === undefined) {
 		return undefined;
 	}

--- a/packages/dds/tree/src/simple-tree/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/treeNodeApi.ts
@@ -214,7 +214,7 @@ export const treeNodeApi: TreeNodeApi = {
 					}
 					return identifier.value as string;
 				}
-				assert(identifier !== undefined, 0x927 /* The identifier must exist */);
+				assert(identifier?.context !== undefined, "Expected LazyIdentifierField");
 				const identifierValue = identifier.value as string;
 
 				const localNodeKey =

--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -10,7 +10,7 @@ import {
 	FlexFieldSchema,
 	SchemaBuilderBase,
 } from "../../../feature-libraries/index.js";
-import { EmptyKey, type FieldKey, type MapTree } from "../../../core/index.js";
+import { EmptyKey, type ExclusiveMapTree, type FieldKey } from "../../../core/index.js";
 import { leaf as leafDomain } from "../../../domains/index.js";
 import { brand } from "../../../util/index.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -38,28 +38,28 @@ describe("MapTreeNodes", () => {
 
 	// #region The `MapTree`s used to construct the `MapTreeNode`s
 	const childValue = "childValue";
-	const mapChildMapTree: MapTree = {
+	const mapChildMapTree: ExclusiveMapTree = {
 		type: leafDomain.string.name,
 		value: childValue,
 		fields: new Map(),
 	};
 	const mapKey = "key" as FieldKey;
-	const mapMapTree: MapTree = {
+	const mapMapTree: ExclusiveMapTree = {
 		type: brand("map"),
 		fields: new Map([[mapKey, [mapChildMapTree]]]),
 	};
-	const fieldNodeChildMapTree: MapTree = {
+	const fieldNodeChildMapTree: ExclusiveMapTree = {
 		type: leafDomain.string.name,
 		value: childValue,
 		fields: new Map(),
 	};
-	const fieldNodeMapTree: MapTree = {
+	const fieldNodeMapTree: ExclusiveMapTree = {
 		type: brand("array"),
 		fields: new Map([[EmptyKey, [fieldNodeChildMapTree]]]),
 	};
 	const objectMapKey = "map" as FieldKey;
 	const objectFieldNodeKey = "fieldNode" as FieldKey;
-	const objectMapTree: MapTree = {
+	const objectMapTree: ExclusiveMapTree = {
 		type: brand("object"),
 		fields: new Map([
 			[objectMapKey, [mapMapTree]],
@@ -156,7 +156,7 @@ describe("MapTreeNodes", () => {
 			}),
 		);
 
-		const duplicateChild: MapTree = {
+		const duplicateChild: ExclusiveMapTree = {
 			type: leafDomain.string.name,
 			value: childValue,
 			fields: new Map(),
@@ -193,9 +193,9 @@ describe("MapTreeNodes", () => {
 
 	describe("cannot", () => {
 		it("get their context", () => {
-			assert.throws(() => map.context);
-			assert.throws(() => fieldNode.context);
-			assert.throws(() => object.context);
+			assert.equal(map.context, undefined);
+			assert.equal(fieldNode.context, undefined);
+			assert.equal(object.context, undefined);
 		});
 
 		it("get their anchor node", () => {

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -178,6 +178,7 @@ function applySequenceFieldEdit(
 		case "crossFieldMove": {
 			const dstField = navigateToField(tree, change.dstField);
 			assert(dstField.is(tree.currentSchema.objectNodeFieldsObject.sequenceChildren));
+			assert(dstField.context !== undefined, "Expected LazyField");
 			dstField.context.checkout.editor.move(
 				field.getFieldPath(),
 				change.range.first,

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { assert } from "@fluidframework/core-utils/internal";
 import { initializeForest } from "../../core/index.js";
 import {
 	buildForest,
@@ -41,6 +42,7 @@ export function hydrate<TSchema extends ImplicitFieldSchema>(
 ): TreeFieldFromImplicitField<TSchema> {
 	const forest = buildForest();
 	const field = flexTreeFromForest(toFlexSchema(schema), forest, { nodeKeyManager });
+	assert(field.context !== undefined, "Expected LazyField");
 	const mapTree = mapTreeFromNodeData(
 		initialTree as InsertableContent,
 		normalizeFieldSchema(schema).allowedTypes,


### PR DESCRIPTION
## Description

This does some clean-up of MapTreeNode and related types in preparation for future work (in particular, making MapTreeNodes mutable).

* MapTreeNodes now use `ExclusiveMapTree` rather than `MapTree`
* MapTreeFields are now renamed to EagerMapTreeField, as MapTreeField is now an interface (used, notably, by the constant root field)
* MapTreeFields are now cached on the parent node rather than on the MapTree field array object.
* FlexTreeContext can now be undefined for a given flex entity
* Some internal documentation improvement