### PR TITLE
improvement(client): remove deprecated internal `ISignalEnvelope`

### DIFF
--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -111,6 +111,11 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"RemovedInterface_ISignalEnvelope": {
+				"backCompat": false,
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/runtime/runtime-definitions/src/index.ts
+++ b/packages/runtime/runtime-definitions/src/index.ts
@@ -47,7 +47,6 @@ export type {
 	IEnvelope,
 	IInboundSignalMessage,
 	InboundAttachMessage,
-	ISignalEnvelope,
 } from "./protocol.js";
 export type {
 	CreateChildSummarizerNodeParam,

--- a/packages/runtime/runtime-definitions/src/protocol.ts
+++ b/packages/runtime/runtime-definitions/src/protocol.ts
@@ -23,30 +23,6 @@ export interface IEnvelope {
 }
 
 /**
- * @internal
- * @deprecated - This interface is now moved to `@fluidframework/container-definitions` package. Please import from that package.
- */
-export interface ISignalEnvelope {
-	/**
-	 * The target for the envelope, undefined for the container
-	 */
-	address?: string;
-
-	/**
-	 * Identifier for the signal being submitted.
-	 */
-	clientSignalSequenceNumber: number;
-
-	/**
-	 * The contents of the envelope
-	 */
-	contents: {
-		type: string;
-		content: any;
-	};
-}
-
-/**
  * Represents ISignalMessage with its type.
  * @legacy
  * @alpha

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -524,18 +524,16 @@ declare type current_as_old_for_Interface_IProvideFluidDataStoreRegistry = requi
  * If this test starts failing, it indicates a change that is not forward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "Interface_ISignalEnvelope": {"forwardCompat": false}
+ * "RemovedInterface_ISignalEnvelope": {"forwardCompat": false}
  */
-declare type old_as_current_for_Interface_ISignalEnvelope = requireAssignableTo<TypeOnly<old.ISignalEnvelope>, TypeOnly<current.ISignalEnvelope>>
 
 /*
  * Validate backward compatibility by using the current type in place of the old type.
  * If this test starts failing, it indicates a change that is not backward compatible.
  * To acknowledge the breaking change, add the following to package.json under
  * typeValidation.broken:
- * "Interface_ISignalEnvelope": {"backCompat": false}
+ * "RemovedInterface_ISignalEnvelope": {"backCompat": false}
  */
-declare type current_as_old_for_Interface_ISignalEnvelope = requireAssignableTo<TypeOnly<current.ISignalEnvelope>, TypeOnly<old.ISignalEnvelope>>
 
 /*
  * Validate forward compatibility by using the old type in place of the current type.


### PR DESCRIPTION
`ISignalEnvelope` lives in core-interfaces