### PR TITLE
PROPOSED: feat(client): path-based address routing

### DIFF
--- a/.changeset/wet-towns-ask.md
+++ b/.changeset/wet-towns-ask.md
@@ -1,0 +1,15 @@
+---
+"@fluidframework/azure-client": minor
+"@fluidframework/container-definitions": minor
+"@fluidframework/container-loader": minor
+"@fluidframework/container-runtime": minor
+"@fluidframework/core-interfaces": minor
+"@fluidframework/devtools": minor
+"@fluidframework/fluid-static": minor
+"@fluidframework/runtime-definitions": minor
+"@fluidframework/tinylicious-client": minor
+---
+
+Introduce path based message routing
+
+Add ability for runtime to address messages with a `/` separated path scheme. `/runtime/` is reserved for runtime where `undefined` was previously used and data store messages are prefixed with `/channels/`. To enable sending messages with this scheme `CompatibilityMode` "2.2" must be used.

--- a/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.alpha.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export type CompatibilityMode = "1" | "2";
+export type CompatibilityMode = "1" | "2" | "2.2";
 
 // @public
 export type ContainerAttachProps<T = unknown> = T;

--- a/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.beta.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export type CompatibilityMode = "1" | "2";
+export type CompatibilityMode = "1" | "2" | "2.2";
 
 // @public
 export type ContainerAttachProps<T = unknown> = T;

--- a/packages/framework/fluid-static/api-report/fluid-static.public.api.md
+++ b/packages/framework/fluid-static/api-report/fluid-static.public.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export type CompatibilityMode = "1" | "2";
+export type CompatibilityMode = "1" | "2" | "2.2";
 
 // @public
 export type ContainerAttachProps<T = unknown> = T;

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -139,6 +139,10 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"TypeAlias_CompatibilityMode": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/framework/fluid-static/src/compatibilityConfiguration.ts
+++ b/packages/framework/fluid-static/src/compatibilityConfiguration.ts
@@ -14,6 +14,7 @@ import type { CompatibilityMode } from "./types.js";
 /**
  * The CompatibilityMode selected determines the set of runtime options to use. In "1" mode we support
  * full interop with true 1.x clients, while in "2" mode we only support interop with 2.x clients.
+ * "2.2" requires all clients to be 2.2 or later.
  */
 export const compatibilityModeRuntimeOptions: Record<
 	CompatibilityMode,
@@ -47,5 +48,18 @@ export const compatibilityModeRuntimeOptions: Record<
 		// Explicitly disable running Sweep in compat mode "2". Although sweep is supported in 2.x, it is disabled by default.
 		// This setting explicitly disables it to be extra safe.
 		gcOptions: { enableGCSweep: undefined },
+	},
+	"2.2": {
+		// Explicit schema control explicitly makes the container incompatible with 1.x clients, to force their
+		// ejection from collaboration and prevent container corruption.  It is off by default and must be explicitly enabled.
+		explicitSchemaControl: true,
+		// The runtime ID compressor is a prerequisite to use SharedTree but is off by default and must be explicitly enabled.
+		// It introduces a new type of op which is not compatible with 1.x clients.
+		enableRuntimeIdCompressor: "on",
+		// Explicitly disable running Sweep in compat mode "2". Although sweep is supported in 2.x, it is disabled by default.
+		// This setting explicitly disables it to be extra safe.
+		gcOptions: { enableGCSweep: undefined },
+		// Path based address routing is off by default and must be explicitly enabled.
+		enablePathBasedAddressing: true,
 	},
 };

--- a/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
+++ b/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
@@ -31,6 +31,7 @@ declare type old_as_current_for_TypeAlias_CompatibilityMode = requireAssignableT
  * typeValidation.broken:
  * "TypeAlias_CompatibilityMode": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_CompatibilityMode = requireAssignableTo<TypeOnly<current.CompatibilityMode>, TypeOnly<old.CompatibilityMode>>
 
 /*

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -12,7 +12,7 @@ import type { ISharedObjectKind } from "@fluidframework/shared-object-base/inter
  * Valid compatibility modes that may be specified when creating a DOProviderContainerRuntimeFactory.
  * @public
  */
-export type CompatibilityMode = "1" | "2";
+export type CompatibilityMode = "1" | "2" | "2.2";
 
 /**
  * A mapping of string identifiers to instantiated `DataObject`s or `SharedObject`s.

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -142,6 +142,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     refreshLatestSummaryAck(options: IRefreshSummaryAckOptions): Promise<void>;
     resolveHandle(request: IRequest): Promise<IResponse>;
     // (undocumented)
+    protected routeNonContainerSignal(address: NonContainerAddressInfo, signalMessage: IInboundSignalMessage, local: boolean): void;
+    // (undocumented)
     get scope(): FluidObject;
     get sessionSchema(): {
         explicitSchemaControl?: true | undefined;
@@ -161,6 +163,8 @@ export class ContainerRuntime extends TypedEventEmitter<IContainerRuntimeEvents 
     // (undocumented)
     submitMessage(type: ContainerMessageType.FluidDataStoreOp | ContainerMessageType.Alias | ContainerMessageType.Attach, contents: any, localOpMetadata?: unknown): void;
     submitSignal(type: string, content: unknown, targetClientId?: string): void;
+    // (undocumented)
+    protected submitSignalImpl(address: `/${string}/${string}` | undefined, type: string, content: unknown, targetClientId?: string): void;
     submitSummary(options: ISubmitSummaryOptions): Promise<SubmitSummaryResult>;
     summarize(options: {
         fullTree?: boolean;
@@ -339,6 +343,7 @@ export interface IContainerRuntimeOptions {
     readonly chunkSizeInBytes?: number;
     readonly compressionOptions?: ICompressionRuntimeOptions;
     readonly enableGroupedBatching?: boolean;
+    readonly enablePathBasedAddressing?: boolean;
     readonly enableRuntimeIdCompressor?: IdCompressorMode;
     readonly explicitSchemaControl?: boolean;
     readonly flushMode?: FlushMode;
@@ -711,6 +716,21 @@ export interface IUploadSummaryResult extends Omit<IGenerateSummaryTreeResult, "
     readonly uploadDuration: number;
 }
 
+// @alpha
+export interface LegacyAddressInfo {
+    // (undocumented)
+    critical: false;
+    // (undocumented)
+    fullAddress: string;
+    // (undocumented)
+    subaddress: undefined;
+    // (undocumented)
+    top: undefined;
+}
+
+// @alpha
+export type NonContainerAddressInfo = PathedAddressInfo | LegacyAddressInfo;
+
 // @alpha @deprecated (undocumented)
 export type OmitAttributesVersions<T> = Omit<T, "snapshotFormatVersion" | "summaryFormatVersion">;
 
@@ -719,6 +739,14 @@ export type OpActionEventListener = (op: ISequencedDocumentMessage) => void;
 
 // @alpha (undocumented)
 export type OpActionEventName = MessageType.Summarize | MessageType.SummaryAck | MessageType.SummaryNack | "default";
+
+// @alpha
+export interface PathedAddressInfo {
+    critical: boolean;
+    fullAddress: string;
+    subaddress: string;
+    top: string;
+}
 
 // @alpha @deprecated
 export type ReadFluidDataStoreAttributes = IFluidDataStoreAttributes0 | IFluidDataStoreAttributes1 | IFluidDataStoreAttributes2;

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -766,10 +766,7 @@ export abstract class FluidDataStoreContext
 	}
 
 	/**
-	 * Submits the signal to be sent to other clients.
-	 * @param type - Type of the signal.
-	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
-	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
+	 * {@inheritDoc @fluidframework/runtime-definitions#IFluidDataStoreContext.submitSignal}
 	 */
 	public submitSignal(type: string, content: unknown, targetClientId?: string) {
 		this.verifyNotClosed("submitSignal");

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -22,6 +22,9 @@ export {
 	CompressionAlgorithms,
 	RuntimeHeaderData,
 	disabledCompressionConfig,
+	LegacyAddressInfo,
+	NonContainerAddressInfo,
+	PathedAddressInfo,
 } from "./containerRuntime.js";
 export {
 	ContainerMessageType,

--- a/packages/runtime/runtime-definitions/src/dataStoreContext.ts
+++ b/packages/runtime/runtime-definitions/src/dataStoreContext.ts
@@ -476,7 +476,8 @@ export interface IFluidParentContext
 	/**
 	 * Submits the signal to be sent to other clients.
 	 * @param type - Type of the signal.
-	 * @param content - Content of the signal. Should be a JSON serializable object or primitive.
+	 * @param content - Content of the signal. Should be an {@link IEnvelope} with `contents` that is a JSON
+	 * serializable object or primitive.
 	 * @param targetClientId - When specified, the signal is only sent to the provided client id.
 	 */
 	submitSignal: (type: string, content: unknown, targetClientId?: string) => void;

--- a/packages/service-clients/azure-client/package.json
+++ b/packages/service-clients/azure-client/package.json
@@ -136,6 +136,10 @@
 		"uuid": "^9.0.0"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"TypeAlias_CompatibilityMode": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/service-clients/azure-client/src/test/types/validateAzureClientPrevious.generated.ts
+++ b/packages/service-clients/azure-client/src/test/types/validateAzureClientPrevious.generated.ts
@@ -238,6 +238,7 @@ declare type old_as_current_for_TypeAlias_CompatibilityMode = requireAssignableT
  * typeValidation.broken:
  * "TypeAlias_CompatibilityMode": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_CompatibilityMode = requireAssignableTo<TypeOnly<current.CompatibilityMode>, TypeOnly<old.CompatibilityMode>>
 
 /*

--- a/packages/service-clients/tinylicious-client/package.json
+++ b/packages/service-clients/tinylicious-client/package.json
@@ -126,6 +126,10 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"TypeAlias_CompatibilityMode": {
+				"backCompat": false
+			}
+		}
 	}
 }

--- a/packages/service-clients/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.generated.ts
+++ b/packages/service-clients/tinylicious-client/src/test/types/validateTinyliciousClientPrevious.generated.ts
@@ -31,6 +31,7 @@ declare type old_as_current_for_TypeAlias_CompatibilityMode = requireAssignableT
  * typeValidation.broken:
  * "TypeAlias_CompatibilityMode": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_CompatibilityMode = requireAssignableTo<TypeOnly<current.CompatibilityMode>, TypeOnly<old.CompatibilityMode>>
 
 /*

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -114,6 +114,7 @@ export function generateRuntimeOptions(
 		enableRuntimeIdCompressor: ["on", undefined, "delayed"],
 		enableGroupedBatching: [true, false],
 		explicitSchemaControl: [true, false],
+		enablePathBasedAddressing: [true, false],
 	};
 
 	return generatePairwiseOptions<IContainerRuntimeOptions>(


### PR DESCRIPTION
For Signals, use a `/` separated address in `IEnvelope`. No change to Ops.
Reading is always supported.
Writing (sending) requires "2.2" compatibility mode to be enabled.

Also cleans up imports in containerRuntime.ts