### PR TITLE
(docs): skip github issue links from linkchecker

### DIFF
--- a/docs/skipped-urls.txt
+++ b/docs/skipped-urls.txt
@@ -9,6 +9,7 @@ https://twitter.com/intent/follow*
 https://twitter.com/intent/tweet*
 https://twitter.com/fluidframework
 https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/*
+https://github.com/microsoft/FluidFramework/issues/*
 
 # These URLs have false positives with their anchors. Linkcheck thinks the anchors are missing.
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort*

--- a/docs/skipped-urls.txt
+++ b/docs/skipped-urls.txt
@@ -9,7 +9,12 @@ https://twitter.com/intent/follow*
 https://twitter.com/intent/tweet*
 https://twitter.com/fluidframework
 https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/*
+# GitHub returns 429
 https://github.com/microsoft/FluidFramework/issues/*
+
+# denied by robots.txt
+https://aka.ms/*
+https://go.microsoft.com/fwlink/*
 
 # These URLs have false positives with their anchors. Linkcheck thinks the anchors are missing.
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort*


### PR DESCRIPTION
currently running into rate limit issues with linkchecker when trying to access github links. 

To address the issue, we will need either githb authorization for a higher rate limit or caching to not check the same link repeatedly. However, the current linkcheck package does not support either of the features.
Excluding the checks for github issue links as a temporary fix. In the meantime, I'll create a github issue for the linkcheck package to request the features mentioned as well as look into alternative link checker pacakges.