### PR TITLE
tree: Prepare to move TreeNode

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -440,7 +440,7 @@ export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
     abstract get [typeNameSymbol](): string;
-    protected constructor();
+    protected constructor(token: unknown);
 }
 
 // @public @sealed

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -437,7 +437,7 @@ export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
     abstract get [typeNameSymbol](): string;
-    protected constructor();
+    protected constructor(token: unknown);
 }
 
 // @public @sealed

--- a/packages/dds/tree/api-report/tree.public.api.md
+++ b/packages/dds/tree/api-report/tree.public.api.md
@@ -437,7 +437,7 @@ export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
     abstract get [typeNameSymbol](): string;
-    protected constructor();
+    protected constructor(token: unknown);
 }
 
 // @public @sealed

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -40,12 +40,12 @@ import {
 	type NodeKind,
 	type TreeNodeSchema,
 	type TreeNodeSchemaClass,
-	type WithType,
 	type FieldProps,
 	createFieldSchema,
 	type DefaultProvider,
 	getDefaultProvider,
 } from "../schemaTypes.js";
+import type { WithType } from "../core/index.js";
 import { type TreeArrayNode, arraySchema } from "../arrayNode.js";
 import {
 	type InsertableObjectFromSchemaRecord,

--- a/packages/dds/tree/src/simple-tree/api/schemaFactoryRecursive.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactoryRecursive.ts
@@ -16,9 +16,9 @@ import {
 	type InsertableTreeNodeFromImplicitAllowedTypes,
 	type NodeKind,
 	type TreeNodeSchemaClass,
-	type WithType,
 	type TreeNodeSchema,
 } from "../schemaTypes.js";
+import type { WithType } from "../core/index.js";
 import type { TreeNode } from "../types.js";
 import type { FieldSchemaUnsafe } from "../typesUnsafe.js";
 

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -28,11 +28,10 @@ import {
 	type InsertableTreeNodeFromImplicitAllowedTypes,
 	type TreeNodeFromImplicitAllowedTypes,
 	type TreeNodeSchemaClass,
-	type WithType,
 	type TreeNodeSchema,
-	typeNameSymbol,
 	normalizeFieldSchema,
 } from "./schemaTypes.js";
+import { type WithType, typeNameSymbol } from "./core/index.js";
 import { mapTreeFromNodeData } from "./toMapTree.js";
 import {
 	type TreeNode,

--- a/packages/dds/tree/src/simple-tree/core/index.ts
+++ b/packages/dds/tree/src/simple-tree/core/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { isTreeNode, TreeNodeKernel, getKernel } from "./treeNodeKernel.js";
+export { type WithType, typeNameSymbol } from "./withType.js";

--- a/packages/dds/tree/src/simple-tree/core/withType.ts
+++ b/packages/dds/tree/src/simple-tree/core/withType.ts
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * The type of a {@link TreeNode}.
+ * For more information about the type, use `Tree.schema(theNode)` instead.
+ * @remarks
+ * This symbol mainly exists on nodes to allow TypeScript to provide more accurate type checking.
+ * `Tree.is` and `Tree.schema` provide a superset of this information in more friendly ways.
+ *
+ * This symbol should not manually be added to objects as doing so allows the object to be invalidly used where nodes are expected.
+ * Instead construct a real node of the desired type using its constructor.
+ * @privateRemarks
+ * This prevents non-nodes from being accidentally used as nodes, as well as allows the type checker to distinguish different node types.
+ * @public
+ */
+export const typeNameSymbol: unique symbol = Symbol("TreeNode Type");
+
+/**
+ * Adds a type symbol to a type for stronger typing.
+ * @remarks
+ * An implementation detail of {@link TreeNode}'s strong typing setup: not intended for direct use outside of this package.
+ * @sealed @public
+ */
+export interface WithType<TName extends string = string> {
+	/**
+	 * Type symbol, marking a type in a way to increase type safety via strong type checking.
+	 */
+	get [typeNameSymbol](): TName;
+}

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+export { typeNameSymbol, type WithType } from "./core/index.js";
 export {
 	type ITree,
 	type TreeView,
@@ -39,8 +40,6 @@ export {
 	type TreeNodeFromImplicitAllowedTypes,
 	type InsertableTreeNodeFromImplicitAllowedTypes,
 	type TreeLeafValue,
-	typeNameSymbol,
-	type WithType,
 	type AllowedTypes,
 	FieldKind,
 	FieldSchema,

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -25,11 +25,10 @@ import {
 	type ImplicitAllowedTypes,
 	type InsertableTreeNodeFromImplicitAllowedTypes,
 	type TreeNodeSchemaClass,
-	type WithType,
 	type TreeNodeSchema,
 	type TreeNodeFromImplicitAllowedTypes,
-	typeNameSymbol,
 } from "./schemaTypes.js";
+import { type WithType, typeNameSymbol } from "./core/index.js";
 import { mapTreeFromNodeData } from "./toMapTree.js";
 import { type MostDerivedData, type TreeNode, TreeNodeValid } from "./types.js";
 import { getFlexSchema } from "./toFlexSchema.js";

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -29,7 +29,6 @@ import { getOrCreateInnerNode } from "./proxyBinding.js";
 import {
 	NodeKind,
 	type ImplicitFieldSchema,
-	type WithType,
 	type TreeNodeSchema,
 	getStoredKey,
 	getExplicitStoredKey,
@@ -37,10 +36,10 @@ import {
 	type InsertableTreeFieldFromImplicitField,
 	type FieldSchema,
 	normalizeFieldSchema,
-	typeNameSymbol,
 	type ImplicitAllowedTypes,
 	FieldKind,
 } from "./schemaTypes.js";
+import { type WithType, typeNameSymbol } from "./core/index.js";
 import { mapTreeFromNodeData } from "./toMapTree.js";
 import {
 	type InternalTreeNode,

--- a/packages/dds/tree/src/simple-tree/proxyBinding.ts
+++ b/packages/dds/tree/src/simple-tree/proxyBinding.ts
@@ -22,7 +22,7 @@ import {
 	isMapTreeNode,
 } from "../feature-libraries/index.js";
 import { fail } from "../util/index.js";
-import type { WithType } from "./schemaTypes.js";
+import type { WithType } from "./core/index.js";
 import type { TreeArrayNode } from "./arrayNode.js";
 import type { TreeNode } from "./types.js";
 // TODO: decide how to deal with dependencies on flex-tree implementation.

--- a/packages/dds/tree/src/simple-tree/schemaTypes.ts
+++ b/packages/dds/tree/src/simple-tree/schemaTypes.ts
@@ -584,31 +584,3 @@ export type NodeBuilderData<T extends TreeNodeSchema> = T extends TreeNodeSchema
  */
 // eslint-disable-next-line @rushstack/no-new-null
 export type TreeLeafValue = number | string | boolean | IFluidHandle | null;
-
-/**
- * The type of a {@link TreeNode}.
- * For more information about the type, use `Tree.schema(theNode)` instead.
- * @remarks
- * This symbol mainly exists on nodes to allow TypeScript to provide more accurate type checking.
- * `Tree.is` and `Tree.schema` provide a superset of this information in more friendly ways.
- *
- * This symbol should not manually be added to objects as doing so allows the object to be invalidly used where nodes are expected.
- * Instead construct a real node of the desired type using its constructor.
- * @privateRemarks
- * This prevents non-nodes from being accidentally used as nodes, as well as allows the type checker to distinguish different node types.
- * @public
- */
-export const typeNameSymbol: unique symbol = Symbol("TreeNode Type");
-
-/**
- * Adds a type symbol to a type for stronger typing.
- * @remarks
- * An implementation detail of {@link TreeNode}'s strong typing setup: not intended for direct use outside of this package.
- * @sealed @public
- */
-export interface WithType<TName extends string = string> {
-	/**
-	 * Type symbol, marking a type in a way to increase type safety via strong type checking.
-	 */
-	get [typeNameSymbol](): TName;
-}

--- a/packages/dds/tree/src/simple-tree/types.ts
+++ b/packages/dds/tree/src/simple-tree/types.ts
@@ -200,7 +200,7 @@ export abstract class TreeNode implements WithType {
 	}
 
 	/**
-	 * TreeNodes must extend schema classes created by SchemaFactory, and therefor this constructor should not be invoked directly by code outside this package.
+	 * TreeNodes must extend schema classes created by SchemaFactory, and therefore this constructor should not be invoked directly by code outside this package.
 	 * @privateRemarks
 	 * `token` must be the {@link privateToken} value, which is not package exported.
 	 * This is used to detect invalid subclasses.

--- a/packages/dds/tree/src/simple-tree/types.ts
+++ b/packages/dds/tree/src/simple-tree/types.ts
@@ -6,13 +6,8 @@
 import type { ErasedType } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 
-import {
-	NodeKind,
-	type TreeNodeSchema,
-	type TreeNodeSchemaClass,
-	type WithType,
-	typeNameSymbol,
-} from "./schemaTypes.js";
+import { NodeKind, type TreeNodeSchema, type TreeNodeSchemaClass } from "./schemaTypes.js";
+import { type WithType, typeNameSymbol } from "./core/index.js";
 import {
 	type FlexTreeNode,
 	type MapTreeNode,
@@ -204,12 +199,25 @@ export abstract class TreeNode implements WithType {
 		return inPrototypeChain(schema.prototype, this.prototype);
 	}
 
-	protected constructor() {
-		if (!inPrototypeChain(Reflect.getPrototypeOf(this), TreeNodeValid.prototype)) {
+	/**
+	 * TreeNodes must extend schema classes created by SchemaFactory, and therefor this constructor should not be invoked directly by code outside this package.
+	 * @privateRemarks
+	 * `token` must be the {@link privateToken} value, which is not package exported.
+	 * This is used to detect invalid subclasses.
+	 *
+	 * All valid subclass should use {@link TreeNodeValid}, but this code doesn't directly reference it to avoid cyclic dependencies.
+	 */
+	protected constructor(token: unknown) {
+		if (token !== privateToken) {
 			throw new UsageError("TreeNodes must extend schema classes created by SchemaFactory");
 		}
 	}
 }
+
+/**
+ * `token` to pass to {@link TreeNode}'s constructor used to detect invalid subclasses.
+ */
+const privateToken = {};
 
 /**
  * Returns a schema for a value if the value is a {@link TreeNode}.
@@ -349,7 +357,7 @@ export abstract class TreeNodeValid<TInput> extends TreeNode {
 	}
 
 	public constructor(input: TInput | InternalTreeNode) {
-		super();
+		super(privateToken);
 		const schema = this.constructor as typeof TreeNodeValid & TreeNodeSchema;
 		const cache = schema.markMostDerived();
 		if (!cache.oneTimeInitialized) {

--- a/packages/dds/tree/src/simple-tree/typesUnsafe.ts
+++ b/packages/dds/tree/src/simple-tree/typesUnsafe.ts
@@ -17,8 +17,8 @@ import type {
 	NodeKind,
 	TreeNodeFromImplicitAllowedTypes,
 	TreeNodeSchema,
-	WithType,
 } from "./schemaTypes.js";
+import type { WithType } from "./core/index.js";
 import type { TreeArrayNodeBase, TreeArrayNode } from "./arrayNode.js";
 import type { TreeNode, Unhydrated } from "./types.js";
 

--- a/packages/dds/tree/src/test/simple-tree/types.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/types.spec.ts
@@ -61,7 +61,7 @@ describe("simple-tree types", () => {
 					throw new Error("Method not implemented.");
 				}
 				public constructor() {
-					super();
+					super({});
 				}
 			}
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -809,7 +809,7 @@ export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
     abstract get [typeNameSymbol](): string;
-    protected constructor();
+    protected constructor(token: unknown);
 }
 
 // @public @sealed

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -1206,7 +1206,7 @@ export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
     abstract get [typeNameSymbol](): string;
-    protected constructor();
+    protected constructor(token: unknown);
 }
 
 // @public @sealed

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -849,7 +849,7 @@ export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
     abstract get [typeNameSymbol](): string;
-    protected constructor();
+    protected constructor(token: unknown);
 }
 
 // @public @sealed

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -809,7 +809,7 @@ export abstract class TreeNode implements WithType {
     static [Symbol.hasInstance](value: unknown): value is TreeNode;
     static [Symbol.hasInstance]<TSchema extends abstract new (...args: any[]) => TreeNode>(this: TSchema, value: unknown): value is InstanceType<TSchema>;
     abstract get [typeNameSymbol](): string;
-    protected constructor();
+    protected constructor(token: unknown);
 }
 
 // @public @sealed


### PR DESCRIPTION
## Description

Refactors needed to prepare for moving TreeNode to simple-tree/core

Removes TreeNode's reference to TreeNodeValid to remove a cycle and instead use a non-exported token value to do the validation.

Moves WithType.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
