### PR TITLE
Update MapTree's deep copying function to use a stack

### DIFF
--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -97,6 +97,7 @@ export {
 	type DeltaDetachedNodeRename,
 	type DeltaFieldChanges,
 	type ExclusiveMapTree,
+	deepCopyMapTree,
 } from "./tree/index.js";
 
 export {

--- a/packages/dds/tree/src/core/tree/index.ts
+++ b/packages/dds/tree/src/core/tree/index.ts
@@ -43,7 +43,7 @@ export type {
 	DetachedNodeRename as DeltaDetachedNodeRename,
 	FieldChanges as DeltaFieldChanges,
 } from "./delta.js";
-export type { MapTree, ExclusiveMapTree } from "./mapTree.js";
+export { type MapTree, type ExclusiveMapTree, deepCopyMapTree } from "./mapTree.js";
 export {
 	clonePath,
 	topDownPath,

--- a/packages/dds/tree/src/core/tree/mapTree.ts
+++ b/packages/dds/tree/src/core/tree/mapTree.ts
@@ -30,3 +30,31 @@ export interface MapTree extends NodeData {
 export interface ExclusiveMapTree extends NodeData, MapTree {
 	fields: Map<FieldKey, ExclusiveMapTree[]>;
 }
+
+/**
+ * Returns a deep copy of the given {@link MapTree}.
+ */
+export function deepCopyMapTree(mapTree: MapTree): ExclusiveMapTree {
+	type Next = [fields: ExclusiveMapTree["fields"], sourceFields: MapTree["fields"]];
+	const rootFields = new Map();
+	const nexts: Next[] = [[rootFields, mapTree.fields]];
+	for (let next = nexts.pop(); next !== undefined; next = nexts.pop()) {
+		const [fields, sourceFields] = next;
+		for (const [key, field] of sourceFields) {
+			if (field.length > 0) {
+				const newField: ExclusiveMapTree[] = [];
+				for (const child of field) {
+					const childClone = { ...child, fields: new Map() };
+					newField.push(childClone);
+					nexts.push([childClone.fields, child.fields]);
+				}
+				fields.set(key, newField);
+			}
+		}
+	}
+
+	return {
+		...mapTree,
+		fields: rootFields,
+	};
+}

--- a/packages/dds/tree/src/core/tree/mapTree.ts
+++ b/packages/dds/tree/src/core/tree/mapTree.ts
@@ -33,10 +33,12 @@ export interface ExclusiveMapTree extends NodeData, MapTree {
 
 /**
  * Returns a deep copy of the given {@link MapTree}.
+ * @privateRemarks This is implemented iteratively (rather than recursively, which is much simpler)
+ * to avoid the possibility of a stack overflow for very deep trees.
  */
 export function deepCopyMapTree(mapTree: MapTree): ExclusiveMapTree {
 	type Next = [fields: ExclusiveMapTree["fields"], sourceFields: MapTree["fields"]];
-	const rootFields = new Map();
+	const rootFields: ExclusiveMapTree["fields"] = new Map();
 	const nexts: Next[] = [[rootFields, mapTree.fields]];
 	for (let next = nexts.pop(); next !== undefined; next = nexts.pop()) {
 		const [fields, sourceFields] = next;
@@ -44,7 +46,7 @@ export function deepCopyMapTree(mapTree: MapTree): ExclusiveMapTree {
 			if (field.length > 0) {
 				const newField: ExclusiveMapTree[] = [];
 				for (const child of field) {
-					const childClone = { ...child, fields: new Map() };
+					const childClone: ExclusiveMapTree = { ...child, fields: new Map() };
 					newField.push(childClone);
 					nexts.push([childClone.fields, child.fields]);
 				}

--- a/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
+++ b/packages/dds/tree/src/feature-libraries/object-forest/objectForest.ts
@@ -31,6 +31,7 @@ import {
 	type UpPath,
 	type Value,
 	aboveRootPlaceholder,
+	deepCopyMapTree,
 } from "../../core/index.js";
 import { createEmitter } from "../../events/index.js";
 import {
@@ -39,7 +40,6 @@ import {
 	assertValidRange,
 	brand,
 	fail,
-	mapIterable,
 } from "../../util/index.js";
 import { cursorForMapTreeNode, mapTreeFromCursor } from "../mapTreeCursor.js";
 import { type CursorWithNode, SynchronousCursor } from "../treeCursorUtils.js";
@@ -59,18 +59,6 @@ function getOrCreateField(mapTree: MutableMapTree, key: FieldKey): MutableMapTre
 	const newField: MutableMapTree[] = [];
 	mapTree.fields.set(key, newField);
 	return newField;
-}
-
-function deepCopyMapTree(mapTree: MapTree): MutableMapTree {
-	return {
-		...mapTree,
-		fields: new Map(
-			mapIterable(mapTree.fields.entries(), ([key, field]) => [
-				key,
-				field.map(deepCopyMapTree),
-			]),
-		),
-	};
 }
 
 /**

--- a/packages/dds/tree/src/test/simple-tree/mapTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/mapTree.spec.ts
@@ -1500,30 +1500,37 @@ describe("toMapTree", () => {
 	});
 });
 
-describe("mapTrees", () => {
-	it("can be deep copied", () => {
-		function generateMapTree(depth: number, i = 0): ExclusiveMapTree {
-			return {
-				type: brand(String(depth + i)),
-				value: depth + i,
-				fields: new Map(
-					depth === 0
-						? []
-						: [
-								[
-									brand("a"),
-									[generateMapTree(depth - 1, i + 1), generateMapTree(depth - 1, i + 2)],
-								],
-								[
-									brand("b"),
-									[generateMapTree(depth - 1, i + 3), generateMapTree(depth - 1, i + 4)],
-								],
-							],
-				),
-			};
-		}
+describe("deepCopyMapTree", () => {
+	/** Used by `generateMapTree` to give unique types and values to each MapTree */
+	let mapTreeGeneration = 0;
+	function generateMapTree(depth: number): ExclusiveMapTree {
+		const generation = mapTreeGeneration++;
+		return {
+			type: brand(String(generation)),
+			value: generation,
+			fields: new Map(
+				depth === 0
+					? []
+					: [
+							[brand("a"), [generateMapTree(depth - 1), generateMapTree(depth - 1)]],
+							[brand("b"), [generateMapTree(depth - 1), generateMapTree(depth - 1)]],
+						],
+			),
+		};
+	}
 
-		const mapTree = generateMapTree(3);
+	it("empty tree", () => {
+		const mapTree = generateMapTree(0);
+		assert.deepEqual(deepCopyMapTree(mapTree), mapTree);
+	});
+
+	it("shallow tree", () => {
+		const mapTree = generateMapTree(1);
+		assert.deepEqual(deepCopyMapTree(mapTree), mapTree);
+	});
+
+	it("deep tree", () => {
+		const mapTree = generateMapTree(2);
 		assert.deepEqual(deepCopyMapTree(mapTree), mapTree);
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/mapTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/mapTree.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 
 import {
+	deepCopyMapTree,
 	EmptyKey,
 	LeafNodeStoredSchema,
 	MapNodeStoredSchema,
@@ -1496,5 +1497,33 @@ describe("toMapTree", () => {
 				);
 			});
 		});
+	});
+});
+
+describe("mapTrees", () => {
+	it("can be deep copied", () => {
+		function generateMapTree(depth: number, i = 0): ExclusiveMapTree {
+			return {
+				type: brand(String(depth + i)),
+				value: depth + i,
+				fields: new Map(
+					depth === 0
+						? []
+						: [
+								[
+									brand("a"),
+									[generateMapTree(depth - 1, i + 1), generateMapTree(depth - 1, i + 2)],
+								],
+								[
+									brand("b"),
+									[generateMapTree(depth - 1, i + 3), generateMapTree(depth - 1, i + 4)],
+								],
+							],
+				),
+			};
+		}
+
+		const mapTree = generateMapTree(3);
+		assert.deepEqual(deepCopyMapTree(mapTree), mapTree);
 	});
 });


### PR DESCRIPTION
## Description

This ensures that very deep map trees will not stack overflow. This also moves the utility to a more central location and adds a unit test.
