### PR TITLE
Use MapTrees as flexible node content

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -5,9 +5,9 @@
 
 import {
 	type AnchorNode,
+	type ExclusiveMapTree,
 	type FieldKey,
 	type FieldUpPath,
-	type ITreeCursorSynchronous,
 	type TreeValue,
 	anchorSlot,
 } from "../../core/index.js";
@@ -533,7 +533,7 @@ export type FlexTreeObjectNodeFieldsInner<TFields extends FlexObjectNodeFields> 
 		// Setter method (when the field is of a kind that has a logical set operation).
 		readonly [key in keyof TFields as TFields[key]["kind"] extends AssignableFieldKinds
 			? `set${Capitalize<key & string>}`
-			: never]: (content: FlexibleFieldContent) => void;
+			: never]: (content: FlexibleNodeContent) => void;
 	}
 >;
 
@@ -610,26 +610,20 @@ export type AssignableFieldKinds = typeof FieldKinds.optional | typeof FieldKind
 
 /**
  * Strongly typed tree literals for inserting as the content of a field.
- *
- * If a cursor is provided, it must be in Fields mode.
  */
-export type FlexibleFieldContent = ITreeCursorSynchronous;
+export type FlexibleFieldContent = ExclusiveMapTree[];
 
 /**
  * Strongly typed tree literals for inserting as a node.
- *
- * If a cursor is provided, it must be in Nodes mode.
  */
-export type FlexibleNodeContent = ITreeCursorSynchronous;
+export type FlexibleNodeContent = ExclusiveMapTree;
 
 /**
  * Strongly typed tree literals for inserting a subsequence of nodes.
  *
  * Used to insert a batch of 0 or more nodes into some location in a {@link FlexTreeSequenceField}.
- *
- * If a cursor is provided, it must be in Fields mode.
  */
-export type FlexibleNodeSubSequence = ITreeCursorSynchronous;
+export type FlexibleNodeSubSequence = ExclusiveMapTree[];
 
 /**
  * Type to ensures two types overlap in at least one way.

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -54,6 +54,7 @@ import { type LazyTreeNode, makeTree } from "./lazyNode.js";
 import { unboxedUnion } from "./unboxed.js";
 import { indexForAt, treeStatusFromAnchorCache } from "./utilities.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { cursorForMapTreeNode } from "../mapTreeCursor.js";
 
 /**
  * Reuse fields.
@@ -350,8 +351,7 @@ export class LazyValueField<TTypes extends FlexAllowedTypes>
 
 	public override set content(newContent: FlexibleNodeContent) {
 		assert(newContent !== undefined, "Cannot set a required field to undefined");
-		assert(newContent.mode === CursorLocationType.Nodes, "should be in nodes mode");
-		this.valueFieldEditor().set(newContent);
+		this.valueFieldEditor().set(cursorForMapTreeNode(newContent));
 	}
 }
 
@@ -393,7 +393,10 @@ export class LazyOptionalField<TTypes extends FlexAllowedTypes>
 	}
 
 	public set content(newContent: FlexibleNodeContent | undefined) {
-		this.optionalEditor().set(newContent, this.length === 0);
+		this.optionalEditor().set(
+			newContent !== undefined ? cursorForMapTreeNode(newContent) : undefined,
+			this.length === 0,
+		);
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -338,7 +338,7 @@ export class LazyMap<TSchema extends FlexMapNodeSchema>
 
 		if (fieldSchema.kind === FieldKinds.optional) {
 			const optionalField = field as FlexTreeOptionalField<FlexAllowedTypes>;
-			optionalField.content = content;
+			optionalField.content = content?.[0];
 		} else {
 			assert(fieldSchema.kind === FieldKinds.sequence, 0x807 /* Unexpected map field kind */);
 

--- a/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
@@ -8,6 +8,7 @@ import { assert } from "@fluidframework/core-utils/internal";
 import {
 	CursorLocationType,
 	type DetachedField,
+	type ExclusiveMapTree,
 	type FieldKey,
 	type ITreeCursor,
 	type MapTree,
@@ -59,15 +60,15 @@ const adapter: CursorAdapter<MapTree> = {
 /**
  * Extract a MapTree from the contents of the given ITreeCursor's current node.
  */
-export function mapTreeFromCursor(cursor: ITreeCursor): MapTree {
+export function mapTreeFromCursor(cursor: ITreeCursor): ExclusiveMapTree {
 	assert(cursor.mode === CursorLocationType.Nodes, 0x3b7 /* must start at node */);
-	const fields: Map<FieldKey, MapTree[]> = new Map();
+	const fields: Map<FieldKey, ExclusiveMapTree[]> = new Map();
 	for (let inField = cursor.firstField(); inField; inField = cursor.nextField()) {
-		const field: MapTree[] = mapCursorField(cursor, mapTreeFromCursor);
+		const field: ExclusiveMapTree[] = mapCursorField(cursor, mapTreeFromCursor);
 		fields.set(cursor.getFieldKey(), field);
 	}
 
-	const node: MapTree = {
+	const node: ExclusiveMapTree = {
 		type: cursor.type,
 		value: cursor.value,
 		fields,

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -7,7 +7,6 @@ import {
 	type FlexMapNodeSchema,
 	type FlexTreeNode,
 	type MapTreeNode,
-	cursorForMapTreeNode,
 	getOrCreateMapTreeNode,
 	getSchemaAndPolicy,
 	isMapTreeNode,
@@ -190,7 +189,7 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 			prepareContentForHydration(mapTree, node.context.checkout.forest);
 		}
 
-		node.set(key, cursorForMapTreeNode(mapTree));
+		node.set(key, [mapTree]);
 		return this;
 	}
 	public get size(): number {

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -7,7 +7,6 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import type { FieldKey } from "../core/index.js";
 import {
-	cursorForMapTreeNode,
 	FieldKinds,
 	type FlexAllowedTypes,
 	type FlexObjectNodeSchema,
@@ -279,7 +278,7 @@ export function setField(
 				prepareContentForHydration(mapTree, field.context.checkout.forest);
 			}
 
-			typedField.content = mapTree !== undefined ? cursorForMapTreeNode(mapTree) : undefined;
+			typedField.content = mapTree;
 			break;
 		}
 

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -36,6 +36,7 @@ import {
 	FlexFieldSchema,
 	cursorForJsonableTreeNode,
 	SchemaBuilderBase,
+	mapTreeFromCursor,
 } from "../../../feature-libraries/index.js";
 import { brand, disposeSymbol } from "../../../util/index.js";
 import { flexTreeViewWithContent, forestWithContent } from "../../utils.js";
@@ -86,7 +87,7 @@ describe("LazyField", () => {
 				validateAssertionError(e, /only allowed on fields with TreeStatus.InDocument status/),
 		);
 		assert.throws(
-			() => (valueField.content = singleJsonCursor({})),
+			() => (valueField.content = mapTreeFromCursor(singleJsonCursor({}))),
 			(e: Error) =>
 				validateAssertionError(e, /only allowed on fields with TreeStatus.InDocument status/),
 		);
@@ -388,14 +389,16 @@ describe("LazyOptionalField", () => {
 			initialTree: singleJsonCursor(5),
 		});
 		assert.equal(view.flexTree.content, 5);
-		view.flexTree.content = singleJsonCursor(6);
+		view.flexTree.content = mapTreeFromCursor(singleJsonCursor(6));
 		assert.equal(view.flexTree.content, 6);
 		view.flexTree.content = undefined;
 		assert.equal(view.flexTree.content, undefined);
-		view.flexTree.content = cursorForJsonableTreeNode({
-			type: leaf.string.name,
-			value: 7,
-		});
+		view.flexTree.content = mapTreeFromCursor(
+			cursorForJsonableTreeNode({
+				type: leaf.string.name,
+				value: 7,
+			}),
+		);
 		assert.equal(view.flexTree.content, 7);
 	});
 });
@@ -447,10 +450,10 @@ describe("LazyValueField", () => {
 			initialTree: singleJsonCursor("X"),
 		});
 		assert.equal(view.flexTree.content, "X");
-		view.flexTree.content = singleJsonCursor("Y");
+		view.flexTree.content = mapTreeFromCursor(singleJsonCursor("Y"));
 		assert.equal(view.flexTree.content, "Y");
 		const zCursor = cursorForJsonableTreeNode({ type: leaf.string.name, value: "Z" });
-		view.flexTree.content = zCursor;
+		view.flexTree.content = mapTreeFromCursor(zCursor);
 		assert.equal(view.flexTree.content, "Z");
 	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyNode.spec.ts
@@ -48,6 +48,7 @@ import {
 	type FlexTreeField,
 	type FlexTreeNode,
 	type FlexTreeNodeSchema,
+	mapTreeFromCursor,
 } from "../../../feature-libraries/index.js";
 import type { TreeContent, ITreeCheckout } from "../../../shared-tree/index.js";
 import { brand, capitalize } from "../../../util/index.js";
@@ -374,12 +375,12 @@ describe("LazyNode", () => {
 			const mapNode = view.flexTree.content;
 			assert(mapNode.is(mapNodeSchema));
 
-			mapNode.set("baz", singleJsonCursor("First edit"));
-			mapNode.set("foo", singleJsonCursor("Second edit"));
+			mapNode.set("baz", [mapTreeFromCursor(singleJsonCursor("First edit"))]);
+			mapNode.set("foo", [mapTreeFromCursor(singleJsonCursor("Second edit"))]);
 			assert.equal(mapNode.get("baz"), "First edit");
 			assert.equal(mapNode.get("foo"), "Second edit");
 
-			mapNode.set("foo", singleJsonCursor("X"));
+			mapNode.set("foo", [mapTreeFromCursor(singleJsonCursor("X"))]);
 			assert.equal(mapNode.get("foo"), "X");
 			mapNode.set("foo", undefined);
 			assert.equal(mapNode.get("foo"), undefined);
@@ -472,10 +473,10 @@ describe("LazyNode", () => {
 		it("Value assignment generates edits", () => {
 			assert.equal(editCallCount, 0);
 
-			node.setFoo(singleJsonCursor("First edit"));
+			node.setFoo(mapTreeFromCursor(singleJsonCursor("First edit")));
 			assert.equal(editCallCount, 1);
 
-			node.setFoo(singleJsonCursor("Second edit"));
+			node.setFoo(mapTreeFromCursor(singleJsonCursor("Second edit")));
 			assert.equal(editCallCount, 2);
 		});
 	});

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -22,6 +22,7 @@ import {
 	cursorForJsonableTreeNode,
 	intoStoredSchema,
 	type Any,
+	mapTreeFromCursor,
 } from "../../../feature-libraries/index.js";
 import type { SharedTreeFactory } from "../../../shared-tree/index.js";
 import { brand, fail } from "../../../util/index.js";
@@ -200,7 +201,7 @@ function applyRequiredFieldEdit(
 ): void {
 	switch (change.type) {
 		case "set": {
-			field.content = cursorForJsonableTreeNode(change.value);
+			field.content = mapTreeFromCursor(cursorForJsonableTreeNode(change.value));
 			break;
 		}
 		default:
@@ -215,7 +216,7 @@ function applyOptionalFieldEdit(
 ): void {
 	switch (change.type) {
 		case "set": {
-			field.content = cursorForJsonableTreeNode(change.value);
+			field.content = mapTreeFromCursor(cursorForJsonableTreeNode(change.value));
 			break;
 		}
 		case "clear": {


### PR DESCRIPTION
## Description

This updates the flex tree layer to use MapTrees as input for new content, rather than cursors. 

### Why?

* Unhydrated nodes are soon going to be editable, and in order for that to work they need direct access to the MapTrees that they are handed as input. Without this change, the inserted content would need to "round trip" from a MapTree to a cursor and then back to a MapTree, which not only loses the identity of the MapTree object (important for caching of unhydrated nodes' backing state) but is also unnecessarily inefficient.
* The distinction between FlexibleNodeContent and FlexibleFieldContent is now more type safe - the former is a single object and the latter is an array, rather than each being a cursor whose mode ("node" or "field") cannot be evaluated at compile time. 

### How?

All production codepaths from simple-tree already use MapTrees for new content, so no significant changes were required to support this. A smattering of tests needed to be updated by adding a conversion wrapper for new content (though, many of those tests will be removed in the coming days anyway as the flex layer continues to be stripped down).
