### PR TITLE
Expose `editor` for flex fields

### DIFF
--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -121,7 +121,7 @@ export interface IDefaultEditBuilder {
 	 * The returned object can be used (i.e., have its methods called) multiple times but its lifetime
 	 * is bounded by the lifetime of this edit builder.
 	 */
-	valueField(field: FieldUpPath): ValueFieldEditBuilder;
+	valueField(field: FieldUpPath): ValueFieldEditBuilder<ITreeCursorSynchronous>;
 
 	/**
 	 * @param field - the optional field which is being edited under the parent node
@@ -129,7 +129,7 @@ export interface IDefaultEditBuilder {
 	 * The returned object can be used (i.e., have its methods called) multiple times but its lifetime
 	 * is bounded by the lifetime of this edit builder.
 	 */
-	optionalField(field: FieldUpPath): OptionalFieldEditBuilder;
+	optionalField(field: FieldUpPath): OptionalFieldEditBuilder<ITreeCursorSynchronous>;
 
 	/**
 	 * @param field - the sequence field which is being edited under the parent node
@@ -138,7 +138,7 @@ export interface IDefaultEditBuilder {
 	 * The returned object can be used (i.e., have its methods called) multiple times but its lifetime
 	 * is bounded by the lifetime of this edit builder.
 	 */
-	sequenceField(field: FieldUpPath): SequenceFieldEditBuilder;
+	sequenceField(field: FieldUpPath): SequenceFieldEditBuilder<ITreeCursorSynchronous>;
 
 	/**
 	 * Moves a subsequence from one sequence field to another sequence field.
@@ -183,7 +183,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 		this.modularBuilder.addNodeExistsConstraint(path);
 	}
 
-	public valueField(field: FieldUpPath): ValueFieldEditBuilder {
+	public valueField(field: FieldUpPath): ValueFieldEditBuilder<ITreeCursorSynchronous> {
 		return {
 			set: (newContent: ITreeCursorSynchronous): void => {
 				const fillId = this.modularBuilder.generateId();
@@ -207,7 +207,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 		};
 	}
 
-	public optionalField(field: FieldUpPath): OptionalFieldEditBuilder {
+	public optionalField(field: FieldUpPath): OptionalFieldEditBuilder<ITreeCursorSynchronous> {
 		return {
 			set: (newContent: ITreeCursorSynchronous | undefined, wasEmpty: boolean): void => {
 				const detachId = this.modularBuilder.generateId();
@@ -329,7 +329,7 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 		}
 	}
 
-	public sequenceField(field: FieldUpPath): SequenceFieldEditBuilder {
+	public sequenceField(field: FieldUpPath): SequenceFieldEditBuilder<ITreeCursorSynchronous> {
 		return {
 			insert: (index: number, content: ITreeCursorSynchronous): void => {
 				const length =
@@ -386,36 +386,36 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 
 /**
  */
-export interface ValueFieldEditBuilder {
+export interface ValueFieldEditBuilder<TContent> {
 	/**
 	 * Issues a change which replaces the current newContent of the field with `newContent`.
 	 * @param newContent - the new content for the field.
 	 * The cursor can be in either Field or Node mode and must represent exactly one node.
 	 */
-	set(newContent: ITreeCursorSynchronous): void;
+	set(newContent: TContent): void;
 }
 
 /**
  */
-export interface OptionalFieldEditBuilder {
+export interface OptionalFieldEditBuilder<TContent> {
 	/**
 	 * Issues a change which replaces the current newContent of the field with `newContent`
 	 * @param newContent - the new content for the field.
 	 * If provided, the cursor can be in either Field or Node mode and must represent exactly one node.
 	 * @param wasEmpty - whether the field is empty when creating this change
 	 */
-	set(newContent: ITreeCursorSynchronous | undefined, wasEmpty: boolean): void;
+	set(newContent: TContent | undefined, wasEmpty: boolean): void;
 }
 
 /**
  */
-export interface SequenceFieldEditBuilder {
+export interface SequenceFieldEditBuilder<TContent> {
 	/**
 	 * Issues a change which inserts the `newContent` at the given `index`.
 	 * @param index - the index at which to insert the `newContent`.
 	 * @param newContent - the new content to be inserted in the field. Cursor can be in either Field or Node mode.
 	 */
-	insert(index: number, newContent: ITreeCursorSynchronous): void;
+	insert(index: number, newContent: TContent): void;
 
 	/**
 	 * Issues a change which removes `count` elements starting at the given `index`.

--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -50,7 +50,12 @@ import {
 } from "../typed-schema/index.js";
 import { type FlexImplicitAllowedTypes, normalizeAllowedTypes } from "../schemaBuilderBase.js";
 import type { FlexFieldKind } from "../modular-schema/index.js";
-import { FieldKinds, type SequenceFieldEditBuilder } from "../default-schema/index.js";
+import {
+	FieldKinds,
+	type OptionalFieldEditBuilder,
+	type SequenceFieldEditBuilder,
+	type ValueFieldEditBuilder,
+} from "../default-schema/index.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 // #region Nodes
@@ -431,11 +436,12 @@ class EagerMapTreeRequiredField<T extends FlexAllowedTypes>
 	extends EagerMapTreeField<T>
 	implements FlexTreeRequiredField<T>
 {
+	public get editor(): ValueFieldEditBuilder<ExclusiveMapTree> {
+		throw unsupportedUsageError("Setting a required field");
+	}
+
 	public get content(): FlexTreeUnboxNodeUnion<T> {
 		return unboxedUnion(this.schema, this.mapTrees[0] ?? oob(), { parent: this, index: 0 });
-	}
-	public set content(_: FlexTreeUnboxNodeUnion<T>) {
-		throw unsupportedUsageError("Setting an optional field");
 	}
 }
 
@@ -443,6 +449,10 @@ class EagerMapTreeOptionalField<T extends FlexAllowedTypes>
 	extends EagerMapTreeField<T>
 	implements FlexTreeOptionalField<T>
 {
+	public get editor(): OptionalFieldEditBuilder<ExclusiveMapTree> {
+		throw unsupportedUsageError("Setting an optional field");
+	}
+
 	public get content(): FlexTreeUnboxNodeUnion<T> | undefined {
 		return this.mapTrees.length > 0
 			? unboxedUnion(this.schema, this.mapTrees[0] ?? oob(), {
@@ -451,15 +461,16 @@ class EagerMapTreeOptionalField<T extends FlexAllowedTypes>
 				})
 			: undefined;
 	}
-	public set content(_: FlexTreeUnboxNodeUnion<T> | undefined) {
-		throw unsupportedUsageError("Setting an optional field");
-	}
 }
 
 class EagerMapTreeSequenceField<T extends FlexAllowedTypes>
 	extends EagerMapTreeField<T>
 	implements FlexTreeSequenceField<T>
 {
+	public get editor(): SequenceFieldEditBuilder<ExclusiveMapTree[]> {
+		throw unsupportedUsageError("Editing an array");
+	}
+
 	public at(index: number): FlexTreeUnboxNodeUnion<T> | undefined {
 		const i = indexForAt(index, this.length);
 		if (i === undefined) {
@@ -480,12 +491,8 @@ class EagerMapTreeSequenceField<T extends FlexAllowedTypes>
 		}
 	}
 
-	public sequenceEditor(): SequenceFieldEditBuilder {
-		throw unsupportedUsageError("Editing a sequence");
-	}
-
 	public getFieldPath(): FieldUpPath {
-		throw unsupportedUsageError("Editing a sequence");
+		throw unsupportedUsageError("Editing an array");
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -12,7 +12,12 @@ import {
 	anchorSlot,
 } from "../../core/index.js";
 import type { Assume, FlattenKeys } from "../../util/index.js";
-import type { FieldKinds, SequenceFieldEditBuilder } from "../default-schema/index.js";
+import type {
+	FieldKinds,
+	SequenceFieldEditBuilder,
+	ValueFieldEditBuilder,
+	OptionalFieldEditBuilder,
+} from "../default-schema/index.js";
 import type { FlexFieldKind } from "../modular-schema/index.js";
 import type {
 	Any,
@@ -686,7 +691,7 @@ export interface FlexTreeSequenceField<in out TTypes extends FlexAllowedTypes>
 	/**
 	 * Get an editor for this sequence.
 	 */
-	sequenceEditor(): SequenceFieldEditBuilder;
+	editor: SequenceFieldEditBuilder<FlexibleFieldContent>;
 
 	boxedIterator(): IterableIterator<FlexTreeTypedNodeUnion<TTypes>>;
 
@@ -707,7 +712,8 @@ export interface FlexTreeSequenceField<in out TTypes extends FlexAllowedTypes>
 export interface FlexTreeRequiredField<in out TTypes extends FlexAllowedTypes>
 	extends FlexTreeField {
 	get content(): FlexTreeUnboxNodeUnion<TTypes>;
-	set content(content: FlexibleNodeContent);
+
+	editor: ValueFieldEditBuilder<FlexibleNodeContent>;
 }
 
 /**
@@ -726,7 +732,8 @@ export interface FlexTreeRequiredField<in out TTypes extends FlexAllowedTypes>
 export interface FlexTreeOptionalField<in out TTypes extends FlexAllowedTypes>
 	extends FlexTreeField {
 	get content(): FlexTreeUnboxNodeUnion<TTypes> | undefined;
-	set content(newContent: FlexibleNodeContent | undefined);
+
+	editor: OptionalFieldEditBuilder<FlexibleNodeContent>;
 }
 
 // #endregion

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -7,9 +7,11 @@ import { assert } from "@fluidframework/core-utils/internal";
 
 import {
 	CursorLocationType,
+	type ExclusiveMapTree,
 	type FieldAnchor,
 	type FieldKey,
 	type FieldUpPath,
+	type ITreeCursorSynchronous,
 	type ITreeSubscriptionCursor,
 	type TreeNavigationResult,
 	inCursorNode,
@@ -37,7 +39,6 @@ import {
 	type FlexTreeTypedField,
 	type FlexTreeTypedNodeUnion,
 	type FlexTreeUnboxNodeUnion,
-	type FlexibleNodeContent,
 	TreeStatus,
 	flexTreeMarker,
 	flexTreeSlot,
@@ -54,7 +55,7 @@ import { type LazyTreeNode, makeTree } from "./lazyNode.js";
 import { unboxedUnion } from "./unboxed.js";
 import { indexForAt, treeStatusFromAnchorCache } from "./utilities.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-import { cursorForMapTreeNode } from "../mapTreeCursor.js";
+import { cursorForMapTreeField, cursorForMapTreeNode } from "../mapTreeCursor.js";
 
 /**
  * Reuse fields.
@@ -297,10 +298,21 @@ export class LazySequence<TTypes extends FlexAllowedTypes>
 		return this.map((x) => x);
 	}
 
-	public sequenceEditor(): SequenceFieldEditBuilder {
+	public editor: SequenceFieldEditBuilder<ExclusiveMapTree[]> = {
+		insert: (index, newContent) => {
+			this.sequenceEditor().insert(index, cursorForMapTreeField(newContent));
+		},
+		remove: (index, count) => {
+			this.sequenceEditor().remove(index, count);
+		},
+		move: (sourceIndex, count, destIndex) => {
+			this.sequenceEditor().move(sourceIndex, count, destIndex);
+		},
+	};
+
+	private sequenceEditor(): SequenceFieldEditBuilder<ITreeCursorSynchronous> {
 		const fieldPath = this.getFieldPathForEditing();
-		const fieldEditor = this.context.checkout.editor.sequenceField(fieldPath);
-		return fieldEditor;
+		return this.context.checkout.editor.sequenceField(fieldPath);
 	}
 }
 
@@ -317,12 +329,14 @@ export class ReadonlyLazyValueField<TTypes extends FlexAllowedTypes>
 		super(context, schema, cursor, fieldAnchor);
 	}
 
+	public editor: ValueFieldEditBuilder<ExclusiveMapTree> = {
+		set: (newContent) => {
+			assert(false, "Unexpected set of readonly field");
+		},
+	};
+
 	public get content(): FlexTreeUnboxNodeUnion<TTypes> {
 		return this.atIndex(0);
-	}
-
-	public set content(newContent: FlexibleNodeContent) {
-		fail("cannot set content in readonly field");
 	}
 }
 
@@ -339,7 +353,13 @@ export class LazyValueField<TTypes extends FlexAllowedTypes>
 		super(context, schema, cursor, fieldAnchor);
 	}
 
-	private valueFieldEditor(): ValueFieldEditBuilder {
+	public override editor: ValueFieldEditBuilder<ExclusiveMapTree> = {
+		set: (newContent) => {
+			this.valueFieldEditor().set(cursorForMapTreeNode(newContent));
+		},
+	};
+
+	private valueFieldEditor(): ValueFieldEditBuilder<ITreeCursorSynchronous> {
 		const fieldPath = this.getFieldPathForEditing();
 		const fieldEditor = this.context.checkout.editor.valueField(fieldPath);
 		return fieldEditor;
@@ -347,11 +367,6 @@ export class LazyValueField<TTypes extends FlexAllowedTypes>
 
 	public override get content(): FlexTreeUnboxNodeUnion<TTypes> {
 		return this.atIndex(0);
-	}
-
-	public override set content(newContent: FlexibleNodeContent) {
-		assert(newContent !== undefined, "Cannot set a required field to undefined");
-		this.valueFieldEditor().set(cursorForMapTreeNode(newContent));
 	}
 }
 
@@ -382,7 +397,16 @@ export class LazyOptionalField<TTypes extends FlexAllowedTypes>
 		super(context, schema, cursor, fieldAnchor);
 	}
 
-	private optionalEditor(): OptionalFieldEditBuilder {
+	public editor: OptionalFieldEditBuilder<ExclusiveMapTree> = {
+		set: (newContent, wasEmpty) => {
+			this.optionalEditor().set(
+				newContent !== undefined ? cursorForMapTreeNode(newContent) : newContent,
+				wasEmpty,
+			);
+		},
+	};
+
+	private optionalEditor(): OptionalFieldEditBuilder<ITreeCursorSynchronous> {
 		const fieldPath = this.getFieldPathForEditing();
 		const fieldEditor = this.context.checkout.editor.optionalField(fieldPath);
 		return fieldEditor;
@@ -390,13 +414,6 @@ export class LazyOptionalField<TTypes extends FlexAllowedTypes>
 
 	public get content(): FlexTreeUnboxNodeUnion<TTypes> | undefined {
 		return this.length === 0 ? undefined : this.atIndex(0);
-	}
-
-	public set content(newContent: FlexibleNodeContent | undefined) {
-		this.optionalEditor().set(
-			newContent !== undefined ? cursorForMapTreeNode(newContent) : undefined,
-			this.length === 0,
-		);
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -338,7 +338,7 @@ export class LazyMap<TSchema extends FlexMapNodeSchema>
 
 		if (fieldSchema.kind === FieldKinds.optional) {
 			const optionalField = field as FlexTreeOptionalField<FlexAllowedTypes>;
-			optionalField.content = content?.[0];
+			optionalField.editor.set(content?.[0], optionalField.length === 0);
 		} else {
 			assert(fieldSchema.kind === FieldKinds.sequence, 0x807 /* Unexpected map field kind */);
 
@@ -477,7 +477,7 @@ function buildStructClass<TSchema extends FlexObjectNodeSchema>(
 						key,
 						fieldSchema,
 					) as FlexTreeOptionalField<FlexAllowedTypes>;
-					field.content = newContent;
+					field.editor.set(newContent, field.length === 0);
 				};
 				break;
 			}
@@ -488,7 +488,7 @@ function buildStructClass<TSchema extends FlexObjectNodeSchema>(
 						key,
 						fieldSchema,
 					) as FlexTreeRequiredField<FlexAllowedTypes>;
-					field.content = newContent;
+					field.editor.set(newContent);
 				};
 				break;
 			}

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -51,6 +51,7 @@ export {
 	cursorForMapTreeField,
 	cursorForMapTreeNode,
 	mapTreeFromCursor,
+	mapTreeFieldFromCursor,
 } from "./mapTreeCursor.js";
 export { MemoizedIdRangeAllocator, type IdRange } from "./memoizedIdRangeAllocator.js";
 export { buildForest } from "./object-forest/index.js";

--- a/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/mapTreeCursor.ts
@@ -76,3 +76,11 @@ export function mapTreeFromCursor(cursor: ITreeCursor): ExclusiveMapTree {
 
 	return node;
 }
+
+/**
+ * Extract an array of MapTrees (a field) from the contents of the given ITreeCursor's current field.
+ */
+export function mapTreeFieldFromCursor(cursor: ITreeCursor): ExclusiveMapTree[] {
+	assert(cursor.mode === CursorLocationType.Fields, "must start at field");
+	return mapCursorField(cursor, mapTreeFromCursor);
+}

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -3,14 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { CursorLocationType, EmptyKey, type ITreeCursorSynchronous } from "../core/index.js";
+import { EmptyKey, type ExclusiveMapTree } from "../core/index.js";
 import {
 	type FlexAllowedTypes,
 	type FlexFieldNodeSchema,
 	type FlexTreeNode,
 	type FlexTreeSequenceField,
 	type MapTreeNode,
-	cursorForMapTreeField,
 	getOrCreateMapTreeNode,
 	getSchemaAndPolicy,
 	isMapTreeNode,
@@ -41,7 +40,6 @@ import { mapTreeFromNodeData } from "./toMapTree.js";
 import { fail } from "../util/index.js";
 import { getFlexSchema } from "./toFlexSchema.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-import { assert } from "@fluidframework/core-utils/internal";
 import { getKernel } from "./core/index.js";
 import { TreeNodeValid, type MostDerivedData } from "./treeNodeValid.js";
 
@@ -684,7 +682,7 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		});
 	}
 
-	#cursorFromFieldData(value: Insertable<T>): ITreeCursorSynchronous {
+	#mapTreesFromFieldData(value: Insertable<T>): ExclusiveMapTree[] {
 		if (isMapTreeNode(getOrCreateInnerNode(this))) {
 			throw new UsageError(`An array cannot be mutated before being inserted into the tree`);
 		}
@@ -715,7 +713,7 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 			prepareContentForHydration(mapTrees, sequenceField.context.checkout.forest);
 		}
 
-		return cursorForMapTreeField(mapTrees);
+		return mapTrees;
 	}
 
 	public toJSON(): unknown {
@@ -758,9 +756,8 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 	public insertAt(index: number, ...value: Insertable<T>): void {
 		const field = getSequenceField(this);
 		validateIndex(index, field, "insertAt", true);
-		const content = prepareFieldCursorForInsert(this.#cursorFromFieldData(value));
-		const fieldEditor = field.sequenceEditor();
-		fieldEditor.insert(index, content);
+		const content = this.#mapTreesFromFieldData(value);
+		field.editor.insert(index, content);
 	}
 	public insertAtStart(...value: Insertable<T>): void {
 		this.insertAt(0, ...value);
@@ -771,11 +768,10 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 	public removeAt(index: number): void {
 		const field = getSequenceField(this);
 		validateIndex(index, field, "removeAt");
-		field.sequenceEditor().remove(index, 1);
+		field.editor.remove(index, 1);
 	}
 	public removeRange(start?: number, end?: number): void {
 		const field = getSequenceField(this);
-		const fieldEditor = field.sequenceEditor();
 		const { length } = field;
 		const removeStart = start ?? 0;
 		const removeEnd = Math.min(length, end ?? length);
@@ -785,7 +781,7 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 			// This catches both the case where start is > array.length and when start is > end.
 			throw new UsageError('Too large of "start" value passed to TreeArrayNode.removeRange.');
 		}
-		fieldEditor.remove(removeStart, removeEnd - removeStart);
+		field.editor.remove(removeStart, removeEnd - removeStart);
 	}
 	public moveToStart(sourceIndex: number, source?: TreeArrayNode): void {
 		const sourceArray = source ?? this;
@@ -1041,14 +1037,4 @@ function validateIndexRange(
 			`Index value passed to TreeArrayNode.${methodName} is out of bounds.`,
 		);
 	}
-}
-
-/**
- * Prepare a fields cursor (holding a sequence of nodes) for inserting.
- */
-function prepareFieldCursorForInsert(cursor: ITreeCursorSynchronous): ITreeCursorSynchronous {
-	// TODO: optionally validate content against schema.
-
-	assert(cursor.mode === CursorLocationType.Fields, 0x9a8 /* should be in fields mode */);
-	return cursor;
 }

--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -206,7 +206,7 @@ describe("MapTreeNodes", () => {
 
 		it("be mutated", () => {
 			assert.throws(() => map.delete(mapKey));
-			assert.throws(() => fieldNode.content.sequenceEditor());
+			assert.throws(() => fieldNode.content.editor);
 		});
 	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -82,12 +82,12 @@ describe("LazyField", () => {
 		);
 		cursor.free();
 		assert.throws(
-			() => (optionalField.content = undefined),
+			() => optionalField.editor.set(undefined, optionalField.length === undefined),
 			(e: Error) =>
 				validateAssertionError(e, /only allowed on fields with TreeStatus.InDocument status/),
 		);
 		assert.throws(
-			() => (valueField.content = mapTreeFromCursor(singleJsonCursor({}))),
+			() => valueField.editor.set(mapTreeFromCursor(singleJsonCursor({}))),
 			(e: Error) =>
 				validateAssertionError(e, /only allowed on fields with TreeStatus.InDocument status/),
 		);
@@ -389,15 +389,21 @@ describe("LazyOptionalField", () => {
 			initialTree: singleJsonCursor(5),
 		});
 		assert.equal(view.flexTree.content, 5);
-		view.flexTree.content = mapTreeFromCursor(singleJsonCursor(6));
+		view.flexTree.editor.set(
+			mapTreeFromCursor(singleJsonCursor(6)),
+			view.flexTree.length === 0,
+		);
 		assert.equal(view.flexTree.content, 6);
-		view.flexTree.content = undefined;
+		view.flexTree.editor.set(undefined, view.flexTree.length === 0);
 		assert.equal(view.flexTree.content, undefined);
-		view.flexTree.content = mapTreeFromCursor(
-			cursorForJsonableTreeNode({
-				type: leaf.string.name,
-				value: 7,
-			}),
+		view.flexTree.editor.set(
+			mapTreeFromCursor(
+				cursorForJsonableTreeNode({
+					type: leaf.string.name,
+					value: 7,
+				}),
+			),
+			view.flexTree.length === 0,
 		);
 		assert.equal(view.flexTree.content, 7);
 	});
@@ -450,10 +456,10 @@ describe("LazyValueField", () => {
 			initialTree: singleJsonCursor("X"),
 		});
 		assert.equal(view.flexTree.content, "X");
-		view.flexTree.content = mapTreeFromCursor(singleJsonCursor("Y"));
+		view.flexTree.editor.set(mapTreeFromCursor(singleJsonCursor("Y")));
 		assert.equal(view.flexTree.content, "Y");
 		const zCursor = cursorForJsonableTreeNode({ type: leaf.string.name, value: "Z" });
-		view.flexTree.content = mapTreeFromCursor(zCursor);
+		view.flexTree.editor.set(mapTreeFromCursor(zCursor));
 		assert.equal(view.flexTree.content, "Z");
 	});
 });

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -23,6 +23,7 @@ import {
 	intoStoredSchema,
 	type Any,
 	mapTreeFromCursor,
+	mapTreeFieldFromCursor,
 } from "../../../feature-libraries/index.js";
 import type { SharedTreeFactory } from "../../../shared-tree/index.js";
 import { brand, fail } from "../../../util/index.js";
@@ -161,19 +162,22 @@ function applySequenceFieldEdit(
 ): void {
 	switch (change.type) {
 		case "insert": {
-			field.sequenceEditor().insert(change.index, cursorForJsonableTreeField(change.content));
+			field.editor.insert(
+				change.index,
+				mapTreeFieldFromCursor(cursorForJsonableTreeField(change.content)),
+			);
 			break;
 		}
 		case "remove": {
-			field
-				.sequenceEditor()
-				.remove(change.range.first, change.range.last + 1 - change.range.first);
+			field.editor.remove(change.range.first, change.range.last + 1 - change.range.first);
 			break;
 		}
 		case "intraFieldMove": {
-			field
-				.sequenceEditor()
-				.move(change.range.first, change.range.last + 1 - change.range.first, change.dstIndex);
+			field.editor.move(
+				change.range.first,
+				change.range.last + 1 - change.range.first,
+				change.dstIndex,
+			);
 			break;
 		}
 		case "crossFieldMove": {
@@ -201,7 +205,7 @@ function applyRequiredFieldEdit(
 ): void {
 	switch (change.type) {
 		case "set": {
-			field.content = mapTreeFromCursor(cursorForJsonableTreeNode(change.value));
+			field.editor.set(mapTreeFromCursor(cursorForJsonableTreeNode(change.value)));
 			break;
 		}
 		default:
@@ -216,11 +220,14 @@ function applyOptionalFieldEdit(
 ): void {
 	switch (change.type) {
 		case "set": {
-			field.content = mapTreeFromCursor(cursorForJsonableTreeNode(change.value));
+			field.editor.set(
+				mapTreeFromCursor(cursorForJsonableTreeNode(change.value)),
+				field.length === 0,
+			);
 			break;
 		}
 		case "clear": {
-			field.content = undefined;
+			field.editor.set(undefined, field.length === 0);
 			break;
 		}
 		default:


### PR DESCRIPTION
## Description

This unifies the editing API of the flex layer by directly exposing the field editor. Sequence fields already do this, however, they expose an editor that uses cursors for new content. This updates the editor exposed by sequence fields to accept MapTrees as new content, and introduces the same pattern for value and optional fields. The flex layer now translates from the MapTrees to cursors, rather than it being done externally. This is part of a continued effort to simplify and reduce the API surface of the flex layer.

This also removes the content setter from value/optional fields, since it is now redundant with the editor.