### PR TITLE
Derive MapTreeField MapTrees from parent

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -335,6 +335,11 @@ class EagerMapTreeLeafNode<TSchema extends LeafNodeSchema>
 
 // #region Fields
 
+/**
+ * A readonly {@link FlexTreeField} which wraps an array of {@link MapTrees}.
+ * @remarks Reading data from the MapTreeField will read the corresponding data from the {@link MapTree}s.
+ * Create a `MapTreeField` by calling {@link getOrCreateField}.
+ */
 interface MapTreeField extends FlexTreeField {
 	readonly mapTrees: readonly MapTree[];
 }


### PR DESCRIPTION
## Description

This removes an unnecessary cache of the `MapTrees` backing unhydrated fields. Removing this cache simplifies the code but is also necessary for upcoming work that will allow unhydrated nodes to be mutated.

Also renames `adopt` to `adoptBy` for clarity.