### PR TITLE
tree: Remove cursorFromNodeData, tidy node vs field handling

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -124,7 +124,7 @@ export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitField
 		this.runSchemaEdit(() => {
 			const mapTree = mapTreeFromNodeData(
 				content as InsertableContent,
-				this.rootFieldSchema.allowedTypes,
+				this.rootFieldSchema,
 				this.nodeKeyManager,
 				{
 					schema: this.checkout.storedSchema,

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -19,10 +19,12 @@ import {
 } from "./proxies.js";
 import { getOrCreateInnerNode } from "./proxyBinding.js";
 import { getSimpleNodeSchema } from "./core/index.js";
-import type {
-	ImplicitAllowedTypes,
-	InsertableTreeNodeFromImplicitAllowedTypes,
-	TreeNodeFromImplicitAllowedTypes,
+import {
+	createFieldSchema,
+	FieldKind,
+	type ImplicitAllowedTypes,
+	type InsertableTreeNodeFromImplicitAllowedTypes,
+	type TreeNodeFromImplicitAllowedTypes,
 } from "./schemaTypes.js";
 import {
 	NodeKind,
@@ -175,7 +177,7 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 		const classSchema = getSimpleNodeSchema(node.schema);
 		const mapTree = mapTreeFromNodeData(
 			value as InsertableContent | undefined,
-			classSchema.info as ImplicitAllowedTypes,
+			createFieldSchema(FieldKind.Optional, classSchema.info as ImplicitAllowedTypes),
 			node.context?.nodeKeyManager,
 			getSchemaAndPolicy(node),
 		);

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -263,7 +263,7 @@ export function setField(
 ): void {
 	const mapTree = mapTreeFromNodeData(
 		value,
-		simpleFieldSchema.allowedTypes,
+		simpleFieldSchema,
 		field.context?.nodeKeyManager,
 		getSchemaAndPolicy(field),
 	);

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -16,8 +16,6 @@ import {
 	type ExclusiveMapTree,
 } from "../core/index.js";
 import {
-	type CursorWithNode,
-	cursorForMapTreeNode,
 	isTreeValue,
 	valueSchemaAllows,
 	type NodeKeyManager,
@@ -34,6 +32,9 @@ import {
 	extractFieldProvider,
 	isConstant,
 	type FieldProvider,
+	type ImplicitFieldSchema,
+	normalizeFieldSchema,
+	FieldKind,
 } from "./schemaTypes.js";
 import { NodeKind, tryGetSimpleNodeSchema, type TreeNodeSchema } from "./core/index.js";
 import { SchemaValidationErrors, isNodeInSchema } from "../feature-libraries/index.js";
@@ -50,49 +51,6 @@ import { isObjectNodeSchema } from "./objectNodeTypes.js";
  * array of key/value tuples to instantiate a map) we may need to rethink the structure here to be based more on the
  * schema than on the input data.
  */
-
-/**
- * Transforms an input {@link TypedNode} tree to a {@link MapTree}, and wraps the tree in a {@link CursorWithNode}.
- * @param data - The input tree to be converted.
- * @param allowedTypes - The set of types allowed by the parent context. Used to validate the input tree.
- * @param context - An optional context which, if present, will allow defaults to be created by {@link ContextualFieldProvider}s.
- * If absent, only defaults from {@link ConstantFieldProvider}s will be created.
- * @param schemaValidationPolicy - The stored schema and policy to be used for validation, if the policy says schema
- * validation should happen. If it does, the input tree will be validated against this schema + policy, and an error will
- * be thrown if the tree does not conform to the schema. If undefined, no validation against the stored schema is done.
- *
- * @returns A cursor (in nodes mode) for the mapped tree if the input data was defined. Otherwise, returns `undefined`.
- * @remarks The resulting tree will be populated with any defaults from {@link FieldProvider}s in the schema.
- */
-export function cursorFromNodeData(
-	data: InsertableContent,
-	allowedTypes: ImplicitAllowedTypes,
-	context: NodeKeyManager,
-	schemaValidationPolicy: SchemaAndPolicy,
-): CursorWithNode<MapTree>;
-export function cursorFromNodeData(
-	data: InsertableContent | undefined,
-	allowedTypes: ImplicitAllowedTypes,
-	context: NodeKeyManager,
-	schemaValidationPolicy: SchemaAndPolicy,
-): CursorWithNode<MapTree> | undefined;
-export function cursorFromNodeData(
-	data: InsertableContent | undefined,
-	allowedTypes: ImplicitAllowedTypes,
-	context: NodeKeyManager,
-	schemaValidationPolicy: SchemaAndPolicy,
-): CursorWithNode<MapTree> | undefined {
-	if (data === undefined) {
-		return undefined;
-	}
-	const mappedContent = nodeDataToMapTree(
-		data,
-		normalizeAllowedTypes(allowedTypes),
-		schemaValidationPolicy,
-	);
-	addDefaultsToMapTree(mappedContent, allowedTypes, context);
-	return cursorForMapTreeNode(mappedContent);
-}
 
 /**
  * Transforms an input {@link TypedNode} tree to a {@link MapTree}.
@@ -141,26 +99,32 @@ export function mapTreeFromNodeData(
 ): ExclusiveMapTree;
 export function mapTreeFromNodeData(
 	data: InsertableContent | undefined,
-	allowedTypes: ImplicitAllowedTypes,
+	allowedTypes: ImplicitFieldSchema,
 	context?: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
 ): ExclusiveMapTree | undefined;
 export function mapTreeFromNodeData(
 	data: InsertableContent | undefined,
-	allowedTypes: ImplicitAllowedTypes,
+	allowedTypes: ImplicitFieldSchema,
 	context?: NodeKeyManager,
 	schemaValidationPolicy?: SchemaAndPolicy,
 ): ExclusiveMapTree | undefined {
+	const normalizedFieldSchema = normalizeFieldSchema(allowedTypes);
+
 	if (data === undefined) {
+		// TODO: this code-path should support defaults
+		if (normalizedFieldSchema.kind !== FieldKind.Optional) {
+			throw new UsageError("Got undefined for non-optional field.");
+		}
 		return undefined;
 	}
 
 	const mapTree = nodeDataToMapTree(
 		data,
-		normalizeAllowedTypes(allowedTypes),
+		normalizedFieldSchema.allowedTypeSet,
 		schemaValidationPolicy,
 	);
-	addDefaultsToMapTree(mapTree, allowedTypes, context);
+	addDefaultsToMapTree(mapTree, normalizedFieldSchema.allowedTypes, context);
 	return mapTree;
 }
 
@@ -226,13 +190,26 @@ function nodeDataToMapTree(
 	}
 
 	if (schemaValidationPolicy?.policy.validateSchema === true) {
-		const maybeError = isNodeInSchema(result, schemaValidationPolicy);
-		if (maybeError !== SchemaValidationErrors.NoError) {
-			throw new UsageError("Tree does not conform to schema.");
-		}
+		inSchemaOrThrow(schemaValidationPolicy, result);
 	}
 
 	return result;
+}
+
+/**
+ * Throws a UsageError if mapTree is out of schema.
+ * @remarks
+ * This requires mapTree to have all required default values,
+ * like identifiers for identifier fields.
+ */
+export function inSchemaOrThrow(
+	schemaValidationPolicy: SchemaAndPolicy,
+	mapTree: MapTree,
+): void {
+	const maybeError = isNodeInSchema(mapTree, schemaValidationPolicy);
+	if (maybeError !== SchemaValidationErrors.NoError) {
+		throw new UsageError("Tree does not conform to schema.");
+	}
 }
 
 /**

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -51,7 +51,7 @@ import {
 import {
 	MockTreeCheckout,
 	checkoutWithContent,
-	cursorFromUnhydratedRoot,
+	cursorFromInsertableTreeField,
 	flexTreeViewWithContent,
 	numberSequenceRootSchema,
 	testIdCompressor,
@@ -89,7 +89,7 @@ class HasIdentifier extends schemaFactory.object("parent", {
 }) {}
 
 function getIdentifierEncodingContext(id: string) {
-	const initialTree = cursorFromUnhydratedRoot(
+	const initialTree = cursorFromInsertableTreeField(
 		HasIdentifier,
 		new HasIdentifier({ identifier: id }),
 		new MockNodeKeyManager(),

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -29,7 +29,7 @@ import { toFlexSchema } from "../../simple-tree/toFlexSchema.js";
 import {
 	checkoutWithContent,
 	createTestUndoRedoStacks,
-	cursorFromUnhydratedRoot,
+	cursorFromInsertableTreeField,
 	insert,
 	validateUsageError,
 } from "../utils.js";
@@ -49,7 +49,7 @@ function checkoutWithInitialTree(
 	unhydratedInitialTree: InsertableTreeFieldFromImplicitField,
 	nodeKeyManager = new MockNodeKeyManager(),
 ): TreeCheckout {
-	const initialTree = cursorFromUnhydratedRoot(
+	const initialTree = cursorFromInsertableTreeField(
 		viewConfig.schema,
 		unhydratedInitialTree,
 		nodeKeyManager,

--- a/packages/dds/tree/src/test/simple-tree/mapTree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/mapTree.spec.ts
@@ -43,7 +43,6 @@ import {
 } from "../../simple-tree/schemaTypes.js";
 import {
 	addDefaultsToMapTree,
-	cursorFromNodeData,
 	getPossibleTypes,
 	mapTreeFromNodeData,
 	// eslint-disable-next-line import/no-internal-modules
@@ -54,7 +53,7 @@ import {
 	MockNodeKeyManager,
 	type NodeKeyManager,
 } from "../../feature-libraries/index.js";
-import { validateUsageError } from "../utils.js";
+import { cursorFromInsertableTreeField, validateUsageError } from "../utils.js";
 
 /**
  * Helper for building {@link TreeFieldStoredSchema}.
@@ -1421,28 +1420,16 @@ describe("toMapTree", () => {
 			new Map(),
 		);
 
-		describe("cursorFromNodeData", () => {
+		describe("cursorFromInsertableTreeField", () => {
 			it("Success", () => {
-				const nodeData = "Hello world";
-				cursorFromNodeData(
-					nodeData,
-					[schemaFactory.string],
-					nodeKeyManager,
-					schemaValidationPolicyForSuccess,
-				);
+				cursorFromInsertableTreeField(schemaFactory.string, "Hello world", nodeKeyManager);
 			});
 
 			it("Failure", () => {
-				const content = "Hello world";
 				assert.throws(
 					() =>
-						cursorFromNodeData(
-							content,
-							[schemaFactory.string],
-							nodeKeyManager,
-							schemaValidationPolicyForFailure,
-						),
-					outOfSchemaExpectedError,
+						cursorFromInsertableTreeField(schemaFactory.number, "Hello world", nodeKeyManager),
+					validateUsageError(/incompatible/),
 				);
 			});
 		});

--- a/packages/dds/tree/src/test/simple-tree/utils.ts
+++ b/packages/dds/tree/src/test/simple-tree/utils.ts
@@ -14,7 +14,6 @@ import {
 	isTreeNode,
 	isTreeNodeSchemaClass,
 	mapTreeFromNodeData,
-	normalizeFieldSchema,
 	type ImplicitFieldSchema,
 	type InsertableTreeFieldFromImplicitField,
 	type NodeKind,
@@ -113,11 +112,12 @@ export function hydrate<TSchema extends ImplicitFieldSchema>(
 	assert(field.context !== undefined, "Expected LazyField");
 	const mapTree = mapTreeFromNodeData(
 		initialTree as InsertableContent,
-		normalizeFieldSchema(schema).allowedTypes,
+		schema,
 		field.context.nodeKeyManager,
 		getSchemaAndPolicy(field),
 	);
 	prepareContentForHydration(mapTree, field.context.checkout.forest);
+	if (mapTree === undefined) return undefined as TreeFieldFromImplicitField<TSchema>;
 	const cursor = cursorForMapTreeNode(mapTree);
 	initializeForest(forest, [cursor], testRevisionTagCodec, testIdCompressor, true);
 	return getTreeNodeForField(field) as TreeFieldFromImplicitField<TSchema>;

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -150,11 +150,11 @@ import type { SharedTreeOptions } from "../shared-tree/sharedTree.js";
 import {
 	type ImplicitFieldSchema,
 	type InsertableContent,
-	type InsertableTreeNodeFromImplicitAllowedTypes,
 	TreeViewConfiguration,
-	normalizeFieldSchema,
 	SchemaFactory,
 	toFlexSchema,
+	type InsertableTreeFieldFromImplicitField,
+	mapTreeFromNodeData,
 } from "../simple-tree/index.js";
 import {
 	type JsonCompatible,
@@ -166,8 +166,6 @@ import {
 } from "../util/index.js";
 import { isFluidHandle, toFluidHandleInternal } from "@fluidframework/runtime-utils/internal";
 import type { Client } from "@fluid-private/test-dds-utils";
-// eslint-disable-next-line import/no-internal-modules
-import { cursorFromNodeData } from "../simple-tree/toMapTree.js";
 
 // Testing utilities
 
@@ -1389,28 +1387,21 @@ export function validateUsageError(expectedErrorMsg: string | RegExp): (error: E
  * and the schema would come from the unhydrated node.
  * For now though, this is the only case that's needed, and we do have the data to make it work, so this is fine.
  */
-export function cursorFromUnhydratedRoot(
+export function cursorFromInsertableTreeField(
 	schema: ImplicitFieldSchema,
-	tree: InsertableTreeNodeFromImplicitAllowedTypes,
+	tree: InsertableTreeFieldFromImplicitField,
 	nodeKeyManager: NodeKeyManager,
-): ITreeCursorSynchronous {
-	const data = tree as InsertableContent;
-	const normalizedFieldSchema = normalizeFieldSchema(schema);
+): ITreeCursorSynchronous | undefined {
+	const data = tree as InsertableContent | undefined;
 
-	const flexSchema = toFlexSchema(normalizedFieldSchema);
+	const flexSchema = toFlexSchema(schema);
 	const storedSchema: SchemaAndPolicy = {
 		policy: defaultSchemaPolicy,
 		schema: intoStoredSchema(flexSchema),
 	};
 
-	return (
-		cursorFromNodeData(
-			data,
-			normalizedFieldSchema.allowedTypes,
-			nodeKeyManager,
-			storedSchema,
-		) ?? assert.fail("failed to decode tree")
-	);
+	const mappedContent = mapTreeFromNodeData(data, schema, nodeKeyManager, storedSchema);
+	return mappedContent === undefined ? undefined : cursorForMapTreeNode(mappedContent);
 }
 
 function normalizeNewFieldContent(


### PR DESCRIPTION
## Description

cursorFromNodeData duplicated logic found in mapTreeFromNodeData,

This change removes cursorFromNodeData, and fixes handling of undefined in mapTreeFromNodeData (issue existed in both) where the undefined case wasn't schema validated and the schema didn't allow field schema which are needed to support the undefined case.

There is still an issue where fields passed in undefined which should get a default don't get one: this was preexisting and is not documented. It now errors at runtime instead of invalidly retuning undefined without the default being applied.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

