### PR TITLE
refactor: Address CredScan warning in server pipelines

### DIFF
--- a/CredScanSuppressions.json
+++ b/CredScanSuppressions.json
@@ -4,6 +4,18 @@
 		{
 			"file": "server/routerlicious/packages/routerlicious/config/telegraf/telegraf.conf",
 			"_justification": "Sample username password placeholders as part of code comments"
+		},
+		{
+			"file": "server/routerlicious/node_modules/.pnpm/secure-keys@1.0.0/node_modules/secure-keys/test/test.secret.key",
+			"_justification": "Test file for dependency"
+		},
+		{
+			"file": "server/routerlicious/node_modules/.pnpm/node-rdkafka@3.0.1/node_modules/node-rdkafka/deps/librdkafka/tests/fixtures/ssl/client.keystore.p12",
+			"_justification": "Test file for dependency"
+		},
+		{
+			"file": "server/routerlicious/node_modules/.pnpm/node-rdkafka@3.0.1/node_modules/node-rdkafka/deps/librdkafka/tests/fixtures/ssl/client2.key",
+			"_justification": "Test file for dependency"
 		}
 	]
 }

--- a/CredScanSuppressions.json
+++ b/CredScanSuppressions.json
@@ -2,20 +2,16 @@
 	"tool": "Credential Scanner",
 	"suppressions": [
 		{
-			"file": "server/routerlicious/packages/routerlicious/config/telegraf/telegraf.conf",
-			"_justification": "Sample username password placeholders as part of code comments"
-		},
-		{
 			"file": "server/routerlicious/node_modules/.pnpm/secure-keys@1.0.0/node_modules/secure-keys/test/test.secret.key",
-			"_justification": "Test file for dependency"
+			"_justification": "Test file from a dependency"
 		},
 		{
 			"file": "server/routerlicious/node_modules/.pnpm/node-rdkafka@3.0.1/node_modules/node-rdkafka/deps/librdkafka/tests/fixtures/ssl/client.keystore.p12",
-			"_justification": "Test file for dependency"
+			"_justification": "Test file from a dependency"
 		},
 		{
 			"file": "server/routerlicious/node_modules/.pnpm/node-rdkafka@3.0.1/node_modules/node-rdkafka/deps/librdkafka/tests/fixtures/ssl/client2.key",
-			"_justification": "Test file for dependency"
+			"_justification": "Test file from a dependency"
 		}
 	]
 }

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -28,8 +28,6 @@ RUN chmod +x /tini
 WORKDIR /usr
 COPY --from=root packages/tools/changelog-generator-wrapper/package*.json packages/tools/changelog-generator-wrapper/
 
-COPY --from=root CredScanSuppressions.json src/
-
 # Copy over and build the server
 WORKDIR /usr/src/server
 

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -28,6 +28,8 @@ RUN chmod +x /tini
 WORKDIR /usr
 COPY --from=root packages/tools/changelog-generator-wrapper/package*.json packages/tools/changelog-generator-wrapper/
 
+COPY --from=root CredScanSuppressions.json src/
+
 # Copy over and build the server
 WORKDIR /usr/src/server
 

--- a/server/routerlicious/packages/routerlicious/config/telegraf/telegraf.conf
+++ b/server/routerlicious/packages/routerlicious/config/telegraf/telegraf.conf
@@ -340,8 +340,8 @@
 #   topic_prefix = "telegraf"
 #
 #   ## username and password to connect MQTT server.
-#   # username = "telegraf"
-#   # password = "metricsmetricsmetricsmetrics"
+#   # username = "PLACEHOLDER"
+#   # password = "PLACEHOLDER"
 #
 #   ## Optional SSL Config
 #   # ssl_ca = "/etc/telegraf/ca.pem"
@@ -943,8 +943,8 @@
 #     name = "as-server-01"
 #     host = "127.0.0.1"
 #     port = "8080"
-#     # username = "myuser"
-#     # password = "mypassword"
+#     # username = "PLACEHOLDER"
+#     # password = "PLACEHOLDER"
 #
 #   ## List of metrics collected on above servers
 #   ## Each metric consists in a name, a jmx path and either
@@ -1419,7 +1419,7 @@
 #   # SNMPv3 parameters
 #   #sec_name = "myuser"
 #   #auth_protocol = "md5"         # Values: "MD5", "SHA", ""
-#   #auth_password = "password123"
+#   #auth_password = "PLACEHOLDER"
 #   #sec_level = "authNoPriv"      # Values: "noAuthNoPriv", "authNoPriv", "authPriv"
 #   #context_name = ""
 #   #priv_protocol = ""            # Values: "DES", "AES", ""

--- a/server/routerlicious/packages/routerlicious/config/telegraf/telegraf.conf
+++ b/server/routerlicious/packages/routerlicious/config/telegraf/telegraf.conf
@@ -12,7 +12,9 @@
 # Environment variables can be used anywhere in this config file, simply prepend
 # them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
 # for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)
-
+#
+# NOTE: We use the "PLACEHOLDER" string for credentials because that's the value that the CredScan
+# task in our pipelines automatically understands is not a leaked credential, and won't flag it.
 
 # Global tags can be specified here in key="value" format.
 [global_tags]

--- a/server/routerlicious/packages/routerlicious/config/telegraf/telegraf.conf
+++ b/server/routerlicious/packages/routerlicious/config/telegraf/telegraf.conf
@@ -89,8 +89,8 @@
   ## Write timeout (for the InfluxDB client), formatted as a string.
   ## If not provided, will default to 5s. 0s means no timeout (not recommended).
   timeout = "5s"
-  # username = "telegraf"
-  # password = "metricsmetricsmetricsmetrics"
+  # username = "PLACEHOLDER"
+  # password = "PLACEHOLDER"
   ## Set the user agent for HTTP POSTs (can be useful for log differentiation)
   # user_agent = "telegraf"
   ## Set UDP payload size, defaults to InfluxDB UDP Client default (512 bytes)
@@ -919,7 +919,7 @@
 #   ##  e.g.
 #   ##    root:passwd@lan(127.0.0.1)
 #   ##
-#   servers = ["USERID:PASSW0RD@lan(192.168.1.1)"]
+#   servers = ["USERID:PLACEHOLDER@lan(192.168.1.1)"]
 
 
 # # Read JMX metrics through Jolokia
@@ -1765,8 +1765,8 @@
 #   client_id = ""
 #
 #   ## username and password to connect MQTT server.
-#   # username = "telegraf"
-#   # password = "metricsmetricsmetricsmetrics"
+#   # username = "PLACEHOLDER"
+#   # password = "PLACEHOLDER"
 #
 #   ## Optional SSL Config
 #   # ssl_ca = "/etc/telegraf/ca.pem"

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -336,6 +336,14 @@ extends:
                 echo "$(containerTagSuffix)"
                 echo "##vso[task.setvariable variable=version;isOutput=true]$(containerTagSuffix)"
 
+        # Is this what's missing, because the context for the docker build task is ${{ parameters.buildDirectory }}?
+        - task: CopyFiles@2
+          displayName: Copy CredScan suppressions file to root directory for container build
+          inputs:
+            sourceFolder: $(Build.SourcesDirectory)
+            contents: 'CredScanSuppressions.json'
+            targetFolder: ${{ parameters.buildDirectory }}
+
         # The GitSSH Dockerfile does not have a 'base' target nor does it run pack/lint/test/docs tasks, so skip
         # all that for it. This feels hacky but it's a simple solution for now to the issue of trying to use variables
         # which aren't available at compile-time, for expression-syntax conditionals that are evaluated at compile-time.

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -337,12 +337,15 @@ extends:
                 echo "##vso[task.setvariable variable=version;isOutput=true]$(containerTagSuffix)"
 
         # Is this what's missing, because the context for the docker build task is ${{ parameters.buildDirectory }}?
-        - task: CopyFiles@2
-          displayName: Copy CredScan suppressions file to root directory for container build
+        # Note: ADO's CopyFiles task is unusable to copy files when the source folder has a lot of subfolders/files
+        # because it tries to enumerate *everything* (.git, node_modules, etc) before deciding what to copy.
+        - task: Bash@3
+          displayName: Copy CredScan suppressions file to root context directory used by container build
           inputs:
-            sourceFolder: '$(Build.SourcesDirectory)'
-            contents: './CredScanSuppressions.json'
-            targetFolder: '${{ parameters.buildDirectory }}'
+            targetType: 'inline'
+            workingDirectory: $(Build.SourcesDirectory)
+            script: |
+              cp ./CredScanSuppressions.json ${{ parameters.buildDirectory }}
 
         # The GitSSH Dockerfile does not have a 'base' target nor does it run pack/lint/test/docs tasks, so skip
         # all that for it. This feels hacky but it's a simple solution for now to the issue of trying to use variables

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -340,9 +340,9 @@ extends:
         - task: CopyFiles@2
           displayName: Copy CredScan suppressions file to root directory for container build
           inputs:
-            sourceFolder: $(Build.SourcesDirectory)
-            contents: 'CredScanSuppressions.json'
-            targetFolder: ${{ parameters.buildDirectory }}
+            sourceFolder: '$(Build.SourcesDirectory)'
+            contents: './CredScanSuppressions.json'
+            targetFolder: '${{ parameters.buildDirectory }}'
 
         # The GitSSH Dockerfile does not have a 'base' target nor does it run pack/lint/test/docs tasks, so skip
         # all that for it. This feels hacky but it's a simple solution for now to the issue of trying to use variables

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -336,11 +336,12 @@ extends:
                 echo "$(containerTagSuffix)"
                 echo "##vso[task.setvariable variable=version;isOutput=true]$(containerTagSuffix)"
 
-        # Is this what's missing, because the context for the docker build task is ${{ parameters.buildDirectory }}?
+        # The 1ES.BuildContainerImage task apparently expects to see the CredScan suppressions file not in the root of
+        # the repo, but in the folder used as its 'context' input. So we need to copy it there before building any images.
         # Note: ADO's CopyFiles task is unusable to copy files when the source folder has a lot of subfolders/files
         # because it tries to enumerate *everything* (.git, node_modules, etc) before deciding what to copy.
         - task: Bash@3
-          displayName: Copy CredScan suppressions file to root context directory used by container build
+          displayName: Copy CredScan suppressions file for container builds
           inputs:
             targetType: 'inline'
             workingDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
## Description

This PR fixes the CredScan warnings we were getting in the server pipelines, before they become a blocker that makes the pipeline runs fail.

The auto-injected CredScan task in server pipelines was complaining about things that we had already indicated should be skipped (through the CredScanSuppressions.json file). Turns out that for docker builds, the file is expected in the "root context" for the docker build, not at the root of the repo like it is for some other auto-injected tasks. This PR makes it so we copy the file to the necessary new location in the server pipelines.

It also replaces a bunch of fake usernames/passwords in a file's comments with "PLACEHOLDER" which the CredScan task automatically skips (pro-tip: don't use "PLACEHOLDER" as your actual password 😄).

Finally, it adds more suppressions for files that are part of test code in some server dependencies.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Runs in the internal ADO project (where all auto-injected tasks run as they should, which they might not in the public ADO project) for a test/ branch with this changes that produced no more warnings (msft internal):
- For [build - client packages](https://dev.azure.com/fluidframework/internal/_build/results?buildId=286221&view=results)
- For [server-routerlicious](https://dev.azure.com/fluidframework/internal/_build/results?buildId=286222&view=results) (compare with [a recent one with warnings](https://dev.azure.com/fluidframework/internal/_build/results?buildId=285917&view=results)). Sample of CSCAN Warnings that show up without this change (note that this PR does not attempt to address the Component Governance warnings):

![image](https://github.com/user-attachments/assets/4986fdc1-ecf9-4e00-8097-1559ddd0fe95)


[AB#10202](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/10202)