### PR TITLE
refactor(ci): Remove redundant component detection task in server pipelines

### DIFF
--- a/tools/pipelines/templates/include-generate-notice-steps.yml
+++ b/tools/pipelines/templates/include-generate-notice-steps.yml
@@ -8,14 +8,6 @@ parameters:
   type: boolean
 
 steps:
-- task: ComponentGovernanceComponentDetection@0
-  displayName: Component Detection
-  inputs:
-    sourceScanPath: ${{ parameters.buildDirectory }}
-    verbosity: Verbose
-    scanType: Register
-    alertWarningLevel: High
-
 - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
   displayName: 'NOTICE File Generator'
   continueOnError: ${{ parameters.requireNotice }}


### PR DESCRIPTION
## Description

Since we moved to 1ES templates, out pipelines get an auto-injected Component Governance task that seems to be doing the same thing as this one, and just alerting us in a different way (ADO's Compliance section, instead of warnings output to the logs of the pipeline run).

Removing the redundant task we were adding ourselves saves 19s of runtime for server pipelines (the only ones that use this template).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

(msft internal) [Here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=286222&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=bff7f4f2-2340-5950-d875-356dbea38511&l=9134) is the Component Detection task (the one removed in this PR) in a pipeline run in the internal project, and [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=286222&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=6bbf8318-e666-552f-378a-a2ff05702b3a&l=43003) is the auto-injected Component Governance one.