### PR TITLE
refactor(ci): Cache dependencies for full-compat e2e tests installs

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -323,6 +323,16 @@ jobs:
             customCommand: 'install'
             customRegistry: 'useNpmrc'
 
+      - task: Cache@2
+        displayName: Cache compat versions install location
+        timeoutInMinutes: 3
+        continueOnError: true
+        inputs:
+          key: 'compat-version-installs | "$(Agent.OS)"'
+          path: $(Build.SourcesDirectory)/packages/test/test-version-utils/node_modules/.legacy/
+          restoreKeys: |
+            compat-version-installs | "$(Agent.OS)"
+
       # run the test
       - task: Npm@1
         displayName: '[test] ${{ parameters.testCommand }} ${{ variant.flags }}'

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -328,10 +328,11 @@ jobs:
         timeoutInMinutes: 3
         continueOnError: true
         inputs:
-          key: 'compat-version-installs | "$(Agent.OS)"'
+          key: '"compat-version-installs" | "$(Agent.OS)" | "${{ parameters.testCommand }}" | "${{ variant.name }}"'
           path: $(Build.SourcesDirectory)/packages/test/test-version-utils/node_modules/.legacy/
           restoreKeys: |
-            compat-version-installs | "$(Agent.OS)"
+            "compat-version-installs" | "$(Agent.OS)" | "${{ parameters.testCommand }}"
+            "compat-version-installs" | "$(Agent.OS)"
 
       # run the test
       - task: Npm@1

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -329,7 +329,7 @@ jobs:
         continueOnError: true
         inputs:
           key: '"compat-version-installs" | "$(Agent.OS)" | "${{ parameters.testCommand }}" | "${{ variant.name }}"'
-          path: $(Build.SourcesDirectory)/packages/test/test-version-utils/node_modules/.legacy/
+          path: ${{ parameters.testWorkspace }}/node_modules/@fluid-private/test-version-utils/node_modules/.legacy/
           restoreKeys: |
             "compat-version-installs" | "$(Agent.OS)" | "${{ parameters.testCommand }}"
             "compat-version-installs" | "$(Agent.OS)"

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -330,9 +330,6 @@ jobs:
         inputs:
           key: '"compat-version-installs" | "$(Agent.OS)" | "${{ parameters.testCommand }}" | "${{ variant.name }}"'
           path: ${{ parameters.testWorkspace }}/node_modules/@fluid-private/test-version-utils/node_modules/.legacy/
-          restoreKeys: |
-            "compat-version-installs" | "$(Agent.OS)" | "${{ parameters.testCommand }}"
-            "compat-version-installs" | "$(Agent.OS)"
 
       # run the test
       - task: Npm@1


### PR DESCRIPTION
## Description

Adds a caching step/task in the e2e tests pipeline to cache the installs of older FF versions that we do when we run compat testing.

Using the `parameters.testCommand` and `variant.name` as part of the cache key should ensure that the caches don't "overlap" between tests for different services which might do different levels of compat testing. E.g., ODSP/routerlicious tests don't run for the full compat matrix, so they install fewer older versions of FF than local-server/tinylicious tests; if the latter used the older FF versions cached by the former, they'd still have to spend time installing the remaining versions on the spot.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

(Links below are msft internal).

Tried this with a test/ branch. [Here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=286243&view=logs&j=26483432-40f5-552c-5792-70aed8cde738&t=77425d62-706f-5f2b-026e-4259752c8ef9)'s the first run (when the cache didn't exist yet), where the step that runs tests (and installs the older FF versions) took 23m2s. Then [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=286244&view=logs&j=26483432-40f5-552c-5792-70aed8cde738&t=77425d62-706f-5f2b-026e-4259752c8ef9) is a second run after the previous one created the cache, and the same step took 5m36s (and didn't log anything about having to install older versions).

The logs of the second run indicate that it takes ~15s to download the cache even when it's ~1GB in size:

```console
2024-08-12T15:09:56.9531018Z Downloaded 0.0 MB out of 1,060.2 MB (0%).
2024-08-12T15:10:01.9582666Z Downloaded 0.0 MB out of 1,060.2 MB (0%).
2024-08-12T15:10:06.9604372Z Downloaded 592.6 MB out of 1,060.2 MB (56%).
2024-08-12T15:10:11.2293423Z Downloaded 1,094.7 MB out of 1,060.2 MB (103%).
```

Note that I didn't use any file path as part of the cache key because in this case we don't have a good one (like we have pnpm-lock.yaml for the global pnpm store). The install location does end up with an `installed.json` file but it doesn't exist until _after_ the versions get installed, so when the pipeline runs and tries to find a cached entry, the file wouldn't exist so no matching cache key would be found.

I believe this will work fine as we release new versions, with the only "problem" that immediately after a version release, the cached entry would be missing that newest version, but that one (and only that one) would get installed on the spot, and the updated cached entry would be persisted at the end of that pipeline run, so subsequent runs would have it available. The only side-effect would be that the cache would have more and more older versions as time goes by, which isn't a terrible problem.

### Easily-mitigated risk

If at some point our installed dependencies for compat-matrix testing include more things (e.g. today we install package X, tomorrow we need X and Y), the cache will not have the new stuff, and the way our tools check if we need to install a given version would currently just skip any further installs because the `installed.json` file in the cache contents will say "this version is already installed", which could cause the tests to fail when they can't find the additional dependency. This occurring seems pretty unlikely to me and would be easily mitigated by updating the cache key, to get fresh dependency installs, so I think it's worth moving forward with this change.