### PR TITLE
Reduce flex MapNode interface

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -31,7 +31,6 @@ import {
 	type FlexTreeTypedNodeUnion,
 	type FlexTreeUnboxField,
 	type FlexTreeUnboxNodeUnion,
-	type FlexibleFieldContent,
 	flexTreeMarker,
 	indexForAt,
 } from "../flex-tree/index.js";
@@ -236,22 +235,6 @@ export class EagerMapTreeMapNode<TSchema extends FlexMapNodeSchema>
 	extends EagerMapTreeNode<TSchema>
 	implements FlexTreeMapNode<TSchema>
 {
-	public get size(): number {
-		return this.mapTree.fields.size;
-	}
-
-	public has(key: string): boolean {
-		return this.tryGetField(brand(key)) !== undefined;
-	}
-
-	public get(key: string): FlexTreeUnboxField<TSchema["info"]> {
-		const field = this.tryGetField(brand(key));
-		if (field === undefined) {
-			return undefined as FlexTreeUnboxField<TSchema["info"]>;
-		}
-		return unboxedField(field, brand(key), this.mapTree, this);
-	}
-
 	public keys(): IterableIterator<FieldKey> {
 		return this.mapTree.fields.keys();
 	}
@@ -299,16 +282,6 @@ export class EagerMapTreeMapNode<TSchema extends FlexMapNodeSchema>
 
 	public override getBoxed(key: string): FlexTreeTypedField<TSchema["info"]> {
 		return super.getBoxed(key) as FlexTreeTypedField<TSchema["info"]>;
-	}
-
-	public set(key: string, value: FlexibleFieldContent | undefined): void {
-		// `MapTreeNode`s cannot be mutated
-		throw unsupportedUsageError("Setting a map entry");
-	}
-
-	public delete(key: string): void {
-		// `MapTreeNode`s cannot be mutated
-		throw unsupportedUsageError("Deleting a map entry");
 	}
 
 	public [Symbol.iterator](): IterableIterator<

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -269,29 +269,6 @@ export interface FlexTreeMapNode<in out TSchema extends FlexMapNodeSchema>
 	readonly schema: TSchema;
 
 	/**
-	 * The number of elements in the map.
-	 *
-	 * @remarks
-	 * All fields under a map implicitly exist, but `size` will count only the fields which contain one or more nodes.
-	 */
-	readonly size: number;
-
-	/**
-	 * Checks whether a value exists for the given key.
-	 * @param key - Which map entry to look up.
-	 *
-	 * @remarks
-	 * All fields under a map implicitly exist, but `has` will only return true if there are one or more nodes present in the given field.
-	 */
-	has(key: string): boolean;
-
-	/**
-	 * Get the value associated with `key`.
-	 * @param key - which map entry to look up.
-	 */
-	get(key: string): FlexTreeUnboxField<TSchema["info"]>;
-
-	/**
 	 * Get the field for `key`.
 	 * @param key - which map entry to look up.
 	 *
@@ -350,30 +327,6 @@ export interface FlexTreeMapNode<in out TSchema extends FlexMapNodeSchema>
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		thisArg?: any,
 	): void;
-
-	/**
-	 * Adds or updates an entry in the map with a specified `key` and a `value`.
-	 *
-	 * @param key - The key of the element to add to the map.
-	 * @param value - The value of the element to add to the map.
-	 */
-	set(key: string, value: FlexibleFieldContent | undefined): void;
-
-	/**
-	 * Removes the specified element from this map by its `key`.
-	 *
-	 * @remarks
-	 * Note: unlike JavaScript's Map API, this method does not return a flag indicating whether or not the value was
-	 * deleted.
-	 *
-	 * @privateRemarks
-	 * Regarding the choice to not return a boolean: Since this data structure is distributed in nature, it isn't
-	 * possible to tell whether or not the item was deleted as a result of this method call. Returning a "best guess"
-	 * is more likely to create issues / promote bad usage patterns than offer useful information.
-	 *
-	 * @param key - The key of the element to remove from the map.
-	 */
-	delete(key: string): void;
 
 	/**
 	 * Iterate through all fields in the map.

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyNode.ts
@@ -16,7 +16,6 @@ import {
 	type TreeNodeSchemaIdentifier,
 	type TreeValue,
 	type Value,
-	forEachField,
 	inCursorField,
 	mapCursorFields,
 	rootFieldKey,
@@ -52,7 +51,6 @@ import {
 	type FlexTreeTypedField,
 	type FlexTreeTypedNode,
 	type FlexTreeUnboxField,
-	type FlexibleFieldContent,
 	type FlexibleNodeContent,
 	type PropertyNameFromFieldKey,
 	flexTreeMarker,
@@ -268,12 +266,6 @@ export class LazyMap<TSchema extends FlexMapNodeSchema>
 		super(context, schema, cursor, anchorNode, anchor);
 	}
 
-	public get size(): number {
-		let fieldCount = 0;
-		forEachField(this[cursorSymbol], () => (fieldCount += 1));
-		return fieldCount;
-	}
-
 	public keys(): IterableIterator<FieldKey> {
 		return mapCursorFields(this[cursorSymbol], (cursor) => cursor.getFieldKey()).values();
 	}
@@ -318,40 +310,8 @@ export class LazyMap<TSchema extends FlexMapNodeSchema>
 		}
 	}
 
-	public has(key: string): boolean {
-		return this.tryGetField(brand(key)) !== undefined;
-	}
-
-	public get(key: string): FlexTreeUnboxField<TSchema["info"]> {
-		return inCursorField(this[cursorSymbol], brand(key), (cursor) =>
-			unboxedField(this.context, this.schema.info, cursor),
-		) as FlexTreeUnboxField<TSchema["info"]>;
-	}
-
 	public override getBoxed(key: string): FlexTreeTypedField<TSchema["info"]> {
 		return super.getBoxed(brand(key)) as FlexTreeTypedField<TSchema["info"]>;
-	}
-
-	public set(key: string, content: FlexibleFieldContent | undefined): void {
-		const field = this.getBoxed(key);
-		const fieldSchema = this.schema.info;
-
-		if (fieldSchema.kind === FieldKinds.optional) {
-			const optionalField = field as FlexTreeOptionalField<FlexAllowedTypes>;
-			optionalField.editor.set(content?.[0], optionalField.length === 0);
-		} else {
-			assert(fieldSchema.kind === FieldKinds.sequence, 0x807 /* Unexpected map field kind */);
-
-			// TODO: implement setting of sequence fields once we have defined clear merged semantics for doing so.
-			// For now, we will throw an error, since the public API does not currently expose a way to do this anyways.
-			throw new Error("Setting of sequence values in maps is not yet supported.");
-		}
-	}
-
-	public delete(key: FieldKey): void {
-		// Since all keys implicitly exist under a Map node, and we represent "no value" with `undefined`,
-		// "deleting" a key/value pair is the same as setting the value to `undefined`.
-		this.set(key, undefined);
 	}
 
 	public override boxedIterator(): IterableIterator<FlexTreeTypedField<TSchema["info"]>> {

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -35,7 +35,7 @@ import {
 import { mapTreeFromNodeData } from "./toMapTree.js";
 import { getFlexSchema } from "./toFlexSchema.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
-import type { RestrictiveReadonlyRecord } from "../util/index.js";
+import { brand, count, type RestrictiveReadonlyRecord } from "../util/index.js";
 import { TreeNodeValid, type MostDerivedData } from "./treeNodeValid.js";
 
 /**
@@ -142,7 +142,8 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 			throw new UsageError(`A map cannot be mutated before being inserted into the tree`);
 		}
 
-		node.delete(key);
+		const field = node.getBoxed(key);
+		field.editor.set(undefined, field.length === 0);
 	}
 	public *entries(): IterableIterator<[string, TreeNodeFromImplicitAllowedTypes<T>]> {
 		const node = getOrCreateInnerNode(this);
@@ -159,8 +160,7 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 		return getTreeNodeForField(field) as TreeNodeFromImplicitAllowedTypes<T>;
 	}
 	public has(key: string): boolean {
-		const node = getOrCreateInnerNode(this);
-		return node.has(key);
+		return getOrCreateInnerNode(this).tryGetField(brand(key)) !== undefined;
 	}
 	public keys(): IterableIterator<string> {
 		const node = getOrCreateInnerNode(this);
@@ -180,20 +180,16 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 			getSchemaAndPolicy(node),
 		);
 
-		if (mapTree === undefined) {
-			node.delete(key);
-			return this;
-		}
-
+		const field = node.getBoxed(key);
 		if (node.context !== undefined) {
 			prepareContentForHydration(mapTree, node.context.checkout.forest);
 		}
 
-		node.set(key, [mapTree]);
+		field.editor.set(mapTree, field.length === 0);
 		return this;
 	}
 	public get size(): number {
-		return getOrCreateInnerNode(this).size;
+		return count(getOrCreateInnerNode(this).keys());
 	}
 	public *values(): IterableIterator<TreeNodeFromImplicitAllowedTypes<T>> {
 		for (const [, value] of this.entries()) {

--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -108,7 +108,6 @@ describe("MapTreeNodes", () => {
 		assert.equal(map.getBoxed(mapKey).length, 1);
 		assert.equal(map.tryGetField(brand("unknown key")), undefined);
 		assert.equal(map.getBoxed("unknown key").length, 0);
-		assert.equal(map.get(mapKey), childValue);
 		assert.equal([...map.boxedIterator()].length, 1);
 		assert.equal([...map.boxedIterator()][0].boxedAt(0)?.value, childValue);
 		assert.deepEqual([...map.keys()], [mapKey]);
@@ -205,7 +204,7 @@ describe("MapTreeNodes", () => {
 		});
 
 		it("be mutated", () => {
-			assert.throws(() => map.delete(mapKey));
+			assert.throws(() => map.getBoxed(mapKey).editor);
 			assert.throws(() => fieldNode.content.editor);
 		});
 	});

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/editableTreeTypes.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/editableTreeTypes.spec.ts
@@ -78,7 +78,7 @@ describe("flexTreeTypes", () => {
 				const a: FlexTreeSequenceField<typeof jsonRoot> = tree.content;
 				jsonExample(a);
 			} else if (tree.is(jsonObject)) {
-				const x = tree.get(EmptyKey);
+				const x = tree.getBoxed(EmptyKey);
 			} else if (tree.is(leaf.null)) {
 				const x: null = tree.value;
 			} else {

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyNode.spec.ts
@@ -367,26 +367,6 @@ describe("LazyNode", () => {
 			assert.equal(node.tryGetField(brand("baz")), undefined);
 		});
 
-		it("set", () => {
-			const view = flexTreeViewWithContent({
-				schema,
-				initialTree: typedJsonCursor({ [typedJsonCursor.type]: mapNodeSchema }),
-			});
-			const mapNode = view.flexTree.content;
-			assert(mapNode.is(mapNodeSchema));
-
-			mapNode.set("baz", [mapTreeFromCursor(singleJsonCursor("First edit"))]);
-			mapNode.set("foo", [mapTreeFromCursor(singleJsonCursor("Second edit"))]);
-			assert.equal(mapNode.get("baz"), "First edit");
-			assert.equal(mapNode.get("foo"), "Second edit");
-
-			mapNode.set("foo", [mapTreeFromCursor(singleJsonCursor("X"))]);
-			assert.equal(mapNode.get("foo"), "X");
-			mapNode.set("foo", undefined);
-			assert.equal(mapNode.get("foo"), undefined);
-			assert.equal(mapNode.has("foo"), false);
-		});
-
 		it("getBoxed empty", () => {
 			const view = flexTreeViewWithContent({
 				schema,
@@ -398,18 +378,6 @@ describe("LazyNode", () => {
 			const empty = mapNode.getBoxed("foo");
 			assert.equal(empty.parent, mapNode);
 			assert.equal(empty.key, "foo");
-		});
-
-		it("delete", () => {
-			assert.equal(editCallCount, 0);
-
-			// Even though there is no value currently associated with "baz", we still need to
-			// emit a delete op, so this should generate an edit.
-			node.delete(brand("baz"));
-			assert.equal(editCallCount, 1);
-
-			node.delete(brand("foo"));
-			assert.equal(editCallCount, 2);
 		});
 	});
 

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/unboxed.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/unboxed.spec.ts
@@ -180,28 +180,6 @@ describe("unboxedTree", () => {
 		assert.equal(unboxedTree(context, leafDomain.string, cursor), "Hello world");
 	});
 
-	it("Map", () => {
-		const builder = new SchemaBuilder({ scope: "test" });
-		const mapSchema = builder.map("map", builder.optional(leafDomain.string));
-		const rootSchema = SchemaBuilder.optional(mapSchema);
-		const schema = builder.intoSchema(rootSchema);
-
-		const { context, cursor } = initializeTreeWithContent({
-			schema,
-			initialTree: typedJsonCursor({
-				[typedJsonCursor.type]: mapSchema,
-				foo: "Hello",
-				bar: "world",
-			}),
-		});
-		cursor.enterNode(0); // Root node field has 1 node; move into it
-
-		const unboxed = unboxedTree(context, mapSchema, cursor);
-		assert.equal(unboxed.size, 2);
-		assert.equal(unboxed.get("foo"), "Hello");
-		assert.equal(unboxed.get("bar"), "world");
-	});
-
 	it("ObjectNode", () => {
 		const builder = new SchemaBuilder({ scope: "test" });
 		const objectSchema = builder.objectRecursive("object", {

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -89,6 +89,7 @@ export {
 	transformObjectMap,
 	compareStrings,
 	find,
+	count,
 } from "./utils.js";
 export { ReferenceCountedBase, type ReferenceCounted } from "./referenceCounting.js";
 

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -205,6 +205,19 @@ export function find<T>(iterable: Iterable<T>, predicate: (t: T) => boolean): T 
 }
 
 /**
+ * Counts the number of elements in the given iterable.
+ * @param iterable - the iterable to enumerate
+ * @returns the number of elements that were iterated after exhausting the iterable
+ */
+export function count(iterable: Iterable<unknown>): number {
+	let n = 0;
+	for (const _ of iterable) {
+		n += 1;
+	}
+	return n;
+}
+
+/**
  * Use for Json compatible data.
  *
  * Note that this does not robustly forbid non json comparable data via type checking,


### PR DESCRIPTION
## Description

This is part of an ongoing effort to reduce the redundant APIs in the Flex API layer. This removes `get`, `set`, `delete`, `has` and `size` from the flex map interface, and removes the implementations, which can be trivially re-implemented outside of the flex layer.
