### PR TITLE
Allow mutation of unhydrated optional/required fields

### DIFF
--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -9,7 +9,6 @@ import {
 	type MapTreeNode,
 	getOrCreateMapTreeNode,
 	getSchemaAndPolicy,
-	isMapTreeNode,
 } from "../feature-libraries/index.js";
 import {
 	type FactoryContent,
@@ -36,7 +35,6 @@ import {
 } from "./core/index.js";
 import { mapTreeFromNodeData } from "./toMapTree.js";
 import { getFlexSchema } from "./toFlexSchema.js";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { brand, count, type RestrictiveReadonlyRecord } from "../util/index.js";
 import { TreeNodeValid, type MostDerivedData } from "./treeNodeValid.js";
 
@@ -139,12 +137,7 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 		return this.entries();
 	}
 	public delete(key: string): void {
-		const node = getOrCreateInnerNode(this);
-		if (isMapTreeNode(node)) {
-			throw new UsageError(`A map cannot be mutated before being inserted into the tree`);
-		}
-
-		const field = node.getBoxed(key);
+		const field = getOrCreateInnerNode(this).getBoxed(key);
 		field.editor.set(undefined, field.length === 0);
 	}
 	public *entries(): IterableIterator<[string, TreeNodeFromImplicitAllowedTypes<T>]> {
@@ -170,10 +163,6 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 	}
 	public set(key: string, value: InsertableTreeNodeFromImplicitAllowedTypes<T>): TreeMapNode {
 		const node = getOrCreateInnerNode(this);
-		if (isMapTreeNode(node)) {
-			throw new UsageError(`A map cannot be mutated before being inserted into the tree`);
-		}
-
 		const classSchema = getSimpleNodeSchema(node.schema);
 		const mapTree = mapTreeFromNodeData(
 			value as InsertableContent | undefined,

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -197,14 +197,11 @@ function createProxyHandler(
 				return allowAdditionalProperties ? Reflect.set(target, viewKey, value, proxy) : false;
 			}
 
-			const flexNode = getOrCreateInnerNode(proxy);
-			if (isMapTreeNode(flexNode)) {
-				throw new UsageError(
-					`An object cannot be mutated before being inserted into the tree`,
-				);
-			}
-
-			setField(flexNode.getBoxed(fieldInfo.storedKey), fieldInfo.schema, value);
+			setField(
+				getOrCreateInnerNode(proxy).getBoxed(fieldInfo.storedKey),
+				fieldInfo.schema,
+				value,
+			);
 			return true;
 		},
 		deleteProperty(target, viewKey): boolean {

--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -9,8 +9,15 @@ import {
 	FieldKinds,
 	FlexFieldSchema,
 	SchemaBuilderBase,
+	type FlexAllowedTypes,
+	type FlexTreeOptionalField,
 } from "../../../feature-libraries/index.js";
-import { EmptyKey, type ExclusiveMapTree, type FieldKey } from "../../../core/index.js";
+import {
+	deepCopyMapTree,
+	EmptyKey,
+	type ExclusiveMapTree,
+	type FieldKey,
+} from "../../../core/index.js";
 import { leaf as leafDomain } from "../../../domains/index.js";
 import { brand } from "../../../util/index.js";
 // eslint-disable-next-line import/no-internal-modules
@@ -30,9 +37,11 @@ describe("MapTreeNodes", () => {
 		"FieldNode",
 		FlexFieldSchema.create(FieldKinds.sequence, [leafDomain.string]),
 	);
+	const objectMapKey = "map" as FieldKey;
+	const objectFieldNodeKey = "fieldNode" as FieldKey;
 	const objectSchema = schemaBuilder.object("Object", {
-		map: mapSchema,
-		field: fieldNodeSchema,
+		[objectMapKey]: mapSchema,
+		[objectFieldNodeKey]: fieldNodeSchema,
 	});
 	// #endregion
 
@@ -45,7 +54,7 @@ describe("MapTreeNodes", () => {
 	};
 	const mapKey = "key" as FieldKey;
 	const mapMapTree: ExclusiveMapTree = {
-		type: brand("map"),
+		type: mapSchema.name,
 		fields: new Map([[mapKey, [mapChildMapTree]]]),
 	};
 	const fieldNodeChildMapTree: ExclusiveMapTree = {
@@ -54,13 +63,11 @@ describe("MapTreeNodes", () => {
 		fields: new Map(),
 	};
 	const fieldNodeMapTree: ExclusiveMapTree = {
-		type: brand("array"),
+		type: fieldNodeSchema.name,
 		fields: new Map([[EmptyKey, [fieldNodeChildMapTree]]]),
 	};
-	const objectMapKey = "map" as FieldKey;
-	const objectFieldNodeKey = "fieldNode" as FieldKey;
 	const objectMapTree: ExclusiveMapTree = {
-		type: brand("object"),
+		type: objectSchema.name,
 		fields: new Map([
 			[objectMapKey, [mapMapTree]],
 			[objectFieldNodeKey, [fieldNodeMapTree]],
@@ -203,9 +210,48 @@ describe("MapTreeNodes", () => {
 			assert.throws(() => object.anchorNode);
 		});
 
-		it("be mutated", () => {
-			assert.throws(() => map.getBoxed(mapKey).editor);
+		it("mutate arrays", () => {
 			assert.throws(() => fieldNode.content.editor);
+		});
+	});
+
+	describe("can mutate", () => {
+		it("required fields", () => {
+			const mutableObjectMapTree = deepCopyMapTree(objectMapTree);
+			const mutableObjectMapTreeMap = mutableObjectMapTree.fields.get(objectMapKey)?.[0];
+			assert(mutableObjectMapTreeMap !== undefined);
+			const mutableObject = getOrCreateNode(objectSchema, mutableObjectMapTree);
+			const field = mutableObject.getBoxed(
+				objectMapKey,
+			) as FlexTreeOptionalField<FlexAllowedTypes>;
+			const oldMap = field.boxedAt(0);
+			assert(oldMap !== undefined);
+			assert.equal(oldMap.parentField.parent.parent, mutableObject);
+			const newMap = getOrCreateNode(mapSchema, deepCopyMapTree(mapMapTree));
+			assert.notEqual(newMap, oldMap);
+			assert.equal(newMap.parentField.parent.parent, undefined);
+			// Replace the old map with a new map
+			field.editor.set(newMap.mapTree, false);
+			assert.equal(oldMap.parentField.parent.parent, undefined);
+			assert.equal(newMap.parentField.parent.parent, mutableObject);
+			assert.equal(field.boxedAt(0), newMap);
+			// Replace the new map with the old map again
+			field.editor.set(mutableObjectMapTreeMap, false);
+			assert.equal(oldMap.parentField.parent.parent, mutableObject);
+			assert.equal(newMap.parentField.parent.parent, undefined);
+			assert.equal(field.boxedAt(0), oldMap);
+		});
+
+		it("optional fields", () => {
+			const mutableMap = getOrCreateNode(mapSchema, deepCopyMapTree(mapMapTree));
+			const field = mutableMap.getBoxed(mapKey);
+			const oldValue = field.boxedAt(0);
+			const newValue = `new ${childValue}`;
+			field.editor.set({ ...mapChildMapTree, value: newValue }, false);
+			assert.equal(field.boxedAt(0)?.value, newValue);
+			assert.notEqual(newValue, oldValue);
+			field.editor.set(undefined, false);
+			assert.equal(field.boxedAt(0)?.value, undefined);
 		});
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/objectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/objectNode.spec.ts
@@ -133,6 +133,128 @@ describeHydration(
 				});
 			});
 		});
+
+		describe("supports setting", () => {
+			describe("primitives", () => {
+				function check<const TNode>(
+					schema: TreeNodeSchema<string, NodeKind, TNode>,
+					before: TNode,
+					after: TNode,
+				) {
+					describe(`required ${typeof before} `, () => {
+						it(`(${pretty(before)} -> ${pretty(after)})`, () => {
+							const Root = schemaFactory.object("", { value: schema });
+							const root = init(Root, { value: before });
+							assert.equal(root.value, before);
+							root.value = after;
+							assert.equal(root.value, after);
+						});
+					});
+
+					describe(`optional ${typeof before}`, () => {
+						it(`(undefined -> ${pretty(before)} -> ${pretty(after)})`, () => {
+							const root = init(
+								schemaFactory.object("", { value: schemaFactory.optional(schema) }),
+								{ value: undefined },
+							);
+							assert.equal(root.value, undefined);
+							root.value = before;
+							assert.equal(root.value, before);
+							root.value = after;
+							assert.equal(root.value, after);
+						});
+					});
+				}
+
+				check(schemaFactory.boolean, false, true);
+				check(schemaFactory.number, 0, 1);
+				check(schemaFactory.string, "", "!");
+			});
+
+			describe("required object", () => {
+				const Child = schemaFactory.object("child", {
+					objId: schemaFactory.number,
+				});
+				const Schema = schemaFactory.object("parent", {
+					child: Child,
+				});
+
+				const before = { objId: 0 };
+				const after = { objId: 1 };
+
+				it(`(${pretty(before)} -> ${pretty(after)})`, () => {
+					const root = init(Schema, { child: before });
+					assert.equal(root.child.objId, 0);
+					root.child = new Child(after);
+					assert.equal(root.child.objId, 1);
+				});
+			});
+
+			describe("optional object", () => {
+				const Child = schemaFactory.object("child", {
+					objId: schemaFactory.number,
+				});
+				const Schema = schemaFactory.object("parent", {
+					child: schemaFactory.optional(Child),
+				});
+
+				const before = { objId: 0 };
+				const after = { objId: 1 };
+
+				it(`(undefined -> ${pretty(before)} -> ${pretty(after)})`, () => {
+					const root = init(Schema, { child: undefined });
+					assert.equal(root.child, undefined);
+					root.child = new Child(before);
+					assert.equal(root.child.objId, 0);
+					root.child = new Child(after);
+					assert.equal(root.child.objId, 1);
+				});
+			});
+
+			describe.skip("required list", () => {
+				// const _ = new SchemaFactory("test");
+				// const list = _.fieldNode("List<string>", _.sequence(_.string));
+				// const parent = _.struct("parent", {
+				// 	list,
+				// });
+				// const schema = _.intoSchema(parent);
+				// const before: string[] = [];
+				// const after = ["A"];
+				// it(`(${pretty(before)} -> ${pretty(after)})`, () => {
+				// 	const root = getRoot(schema, { list: before });
+				// 	assert.deepEqual(root.list, before);
+				// 	root.list = after;
+				// 	assert.deepEqual(root.list, after);
+				// });
+			});
+
+			describe.skip("optional list", () => {
+				// const _ = new SchemaFactory("test");
+				// const list = _.fieldNode("List<string>", _.sequence(_.string));
+				// const parent = _.struct("parent", {
+				// 	list: _.optional(list),
+				// });
+				// const schema = _.intoSchema(parent);
+				// const before: string[] = [];
+				// const after = ["A"];
+				// it(`(undefined -> ${pretty(before)} -> ${pretty(after)})`, () => {
+				// 	const root = getRoot(schema, { list: undefined });
+				// 	assert.equal(root.list, undefined);
+				// 	root.list = before;
+				// 	assert.deepEqual(root.list, before);
+				// 	root.list = after;
+				// 	assert.deepEqual(root.list, after);
+				// });
+			});
+
+			describe.skip("required map", () => {
+				// TODO
+			});
+
+			describe.skip("optional map", () => {
+				// TODO
+			});
+		});
 	},
 	() => {
 		describe("shadowing", () => {
@@ -192,128 +314,6 @@ describeHydration(
 					() => new Schema({ foo: undefined }),
 					(e: Error) => validateAssertionError(e, /this shadowing will not work/),
 				);
-			});
-		});
-
-		describe("supports setting", () => {
-			describe("primitives", () => {
-				function check<const TNode>(
-					schema: TreeNodeSchema<string, NodeKind, TNode>,
-					before: TNode,
-					after: TNode,
-				) {
-					describe(`required ${typeof before} `, () => {
-						it(`(${pretty(before)} -> ${pretty(after)})`, () => {
-							const Root = schemaFactory.object("", { value: schema });
-							const root = hydrate(Root, { value: before });
-							assert.equal(root.value, before);
-							root.value = after;
-							assert.equal(root.value, after);
-						});
-					});
-
-					describe(`optional ${typeof before}`, () => {
-						it(`(undefined -> ${pretty(before)} -> ${pretty(after)})`, () => {
-							const root = hydrate(
-								schemaFactory.object("", { value: schemaFactory.optional(schema) }),
-								{ value: undefined },
-							);
-							assert.equal(root.value, undefined);
-							root.value = before;
-							assert.equal(root.value, before);
-							root.value = after;
-							assert.equal(root.value, after);
-						});
-					});
-				}
-
-				check(schemaFactory.boolean, false, true);
-				check(schemaFactory.number, 0, 1);
-				check(schemaFactory.string, "", "!");
-			});
-
-			describe("required object", () => {
-				const Child = schemaFactory.object("child", {
-					objId: schemaFactory.number,
-				});
-				const Schema = schemaFactory.object("parent", {
-					child: Child,
-				});
-
-				const before = { objId: 0 };
-				const after = { objId: 1 };
-
-				it(`(${pretty(before)} -> ${pretty(after)})`, () => {
-					const root = hydrate(Schema, { child: before });
-					assert.equal(root.child.objId, 0);
-					root.child = new Child(after);
-					assert.equal(root.child.objId, 1);
-				});
-			});
-
-			describe("optional object", () => {
-				const Child = schemaFactory.object("child", {
-					objId: schemaFactory.number,
-				});
-				const Schema = schemaFactory.object("parent", {
-					child: schemaFactory.optional(Child),
-				});
-
-				const before = { objId: 0 };
-				const after = { objId: 1 };
-
-				it(`(undefined -> ${pretty(before)} -> ${pretty(after)})`, () => {
-					const root = hydrate(Schema, { child: undefined });
-					assert.equal(root.child, undefined);
-					root.child = new Child(before);
-					assert.equal(root.child.objId, 0);
-					root.child = new Child(after);
-					assert.equal(root.child.objId, 1);
-				});
-			});
-
-			describe.skip("required list", () => {
-				// const _ = new SchemaFactory("test");
-				// const list = _.fieldNode("List<string>", _.sequence(_.string));
-				// const parent = _.struct("parent", {
-				// 	list,
-				// });
-				// const schema = _.intoSchema(parent);
-				// const before: string[] = [];
-				// const after = ["A"];
-				// it(`(${pretty(before)} -> ${pretty(after)})`, () => {
-				// 	const root = getRoot(schema, { list: before });
-				// 	assert.deepEqual(root.list, before);
-				// 	root.list = after;
-				// 	assert.deepEqual(root.list, after);
-				// });
-			});
-
-			describe.skip("optional list", () => {
-				// const _ = new SchemaFactory("test");
-				// const list = _.fieldNode("List<string>", _.sequence(_.string));
-				// const parent = _.struct("parent", {
-				// 	list: _.optional(list),
-				// });
-				// const schema = _.intoSchema(parent);
-				// const before: string[] = [];
-				// const after = ["A"];
-				// it(`(undefined -> ${pretty(before)} -> ${pretty(after)})`, () => {
-				// 	const root = getRoot(schema, { list: undefined });
-				// 	assert.equal(root.list, undefined);
-				// 	root.list = before;
-				// 	assert.deepEqual(root.list, before);
-				// 	root.list = after;
-				// 	assert.deepEqual(root.list, after);
-				// });
-			});
-
-			describe.skip("required map", () => {
-				// TODO
-			});
-
-			describe.skip("optional map", () => {
-				// TODO
 			});
 		});
 

--- a/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
@@ -136,7 +136,7 @@ describe("Unhydrated nodes", () => {
 		assert.equal(Tree.schema(object), TestObject);
 	});
 
-	it("disallow mutation", () => {
+	it("disallow mutation of sequences", () => {
 		function validateUnhydratedMutationError(error: Error): boolean {
 			return validateAssertionError(
 				error,
@@ -145,16 +145,10 @@ describe("Unhydrated nodes", () => {
 		}
 
 		const leaf = new TestLeaf({ value: "value" });
-		assert.throws(() => (leaf.value = "new value"), validateUnhydratedMutationError);
-		const map = new TestMap([]);
-		assert.throws(() => map.set("key", leaf), validateUnhydratedMutationError);
-		assert.throws(() => map.delete("key"), validateUnhydratedMutationError);
 		const array = new TestArray([]);
 		assert.throws(() => array.insertAtStart(leaf), validateUnhydratedMutationError);
 		assert.throws(() => array.insertAtEnd(leaf), validateUnhydratedMutationError);
 		assert.throws(() => array.insertAt(0, leaf), validateUnhydratedMutationError);
-		const object = new TestObject({ map, array });
-		assert.throws(() => (object.array = array), validateUnhydratedMutationError);
 	});
 
 	it("have the correct tree status", () => {


### PR DESCRIPTION
## Description

This PR implements the `editor`s of the unhydrated required and optional fields. Edits to these fields mutate their underlying `ExclusiveMapTree` arrays. 

In addition to adding unit tests for mutations to the unhydrated fields, it also updates the mutation tests for the object and map TreeNodes to run against unhydrated nodes as well as hydrated nodes.

Mutation for arrays/sequences will come in a later PR.