### PR TITLE
fix(ci): Make caching of compat version install location conditional

### DIFF
--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -72,6 +72,7 @@ parameters:
   type: stepList
   default: []
 
+# If true, the versions of our packages installed for compat testing will be cached.
 - name: cacheCompatVersionsInstalls
   type: boolean
   default: false

--- a/tools/pipelines/templates/include-test-real-service.yml
+++ b/tools/pipelines/templates/include-test-real-service.yml
@@ -72,6 +72,10 @@ parameters:
   type: stepList
   default: []
 
+- name: cacheCompatVersionsInstalls
+  type: boolean
+  default: false
+
 jobs:
   - ${{ each variant in parameters.splitTestVariants }}:
     - job:
@@ -323,13 +327,14 @@ jobs:
             customCommand: 'install'
             customRegistry: 'useNpmrc'
 
-      - task: Cache@2
-        displayName: Cache compat versions install location
-        timeoutInMinutes: 3
-        continueOnError: true
-        inputs:
-          key: '"compat-version-installs" | "$(Agent.OS)" | "${{ parameters.testCommand }}" | "${{ variant.name }}"'
-          path: ${{ parameters.testWorkspace }}/node_modules/@fluid-private/test-version-utils/node_modules/.legacy/
+      - ${{ if eq(parameters.cacheCompatVersionsInstalls, true) }}:
+        - task: Cache@2
+          displayName: Cache compat versions install location
+          timeoutInMinutes: 3
+          continueOnError: true
+          inputs:
+            key: '"compat-version-installs" | "$(Agent.OS)" | "${{ parameters.testCommand }}" | "${{ variant.name }}"'
+            path: ${{ parameters.testWorkspace }}/node_modules/@fluid-private/test-version-utils/node_modules/.legacy/
 
       # run the test
       - task: Npm@1

--- a/tools/pipelines/test-real-service.yml
+++ b/tools/pipelines/test-real-service.yml
@@ -45,6 +45,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         testCommand: test:realsvc:local:report:full
+        cacheCompatVersionsInstalls: true
         env:
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
 
@@ -60,6 +61,7 @@ stages:
         testWorkspace: ${{ variables.testWorkspace }}
         artifactBuildId: $(resources.pipeline.client.runID)
         testCommand: test:realsvc:tinylicious:report:full
+        cacheCompatVersionsInstalls: true
         # TODO: AB#8968 tracks figuring out the root cause of the extended delay, and restoring this timeout to 90m or less
         timeoutInMinutes: 120
         env:
@@ -94,6 +96,7 @@ stages:
             flags: --compatVersion=LTS
           - name: Cross-version
             flags: --compatVersion=CROSS_VERSION
+        cacheCompatVersionsInstalls: true
         env:
           fluid__test__driver__r11s: $(automation-fluid-test-driver-r11s)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
@@ -124,6 +127,7 @@ stages:
             flags: --compatVersion=LTS
           - name: Cross-Version
             flags: --compatVersion=CROSS_VERSION
+        cacheCompatVersionsInstalls: true
         env:
           fluid__test__driver__frs: $(automation-fluid-test-driver-frs)
           FLUID_TEST_LOGGER_PKG_PATH: ${{ variables.testWorkspace }}/node_modules/@ff-internal/aria-logger # Contains getTestLogger impl to inject
@@ -157,6 +161,7 @@ stages:
           # Tests N-2 to LTS+3 back compat for loader + driver
           - name: N-2ToLTS+1-back-compat
             flags: --compatVersion=V2_INT_3 --tenantIndex=3
+        cacheCompatVersionsInstalls: true
         env:
           login__microsoft__clientId: $(login-microsoft-clientId)
           login__odsp__test__tenants: $(automation-e2e-login-odsp-test-tenants)


### PR DESCRIPTION
## Description

Follow up to https://github.com/microsoft/FluidFramework/pull/22181

The "service client e2e tests", "real service stress tests", and "Test - DDS Stress" pipelines use the same template as the (non-service-client) e2e tests pipeline and don't do compat of any kind, so they never creates the install location for compat versions and the caching task is completing unsuccessfully due to that. This PR makes the caching behavior opt-in through a parameter that only the e2e tests pipeline sets to the necessary value.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
