### PR TITLE
Allow inserts and removes in unhydrated arrays

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -434,7 +434,7 @@ class EagerMapTreeOptionalField<T extends FlexAllowedTypes>
 	extends EagerMapTreeField<T>
 	implements FlexTreeOptionalField<T>
 {
-	public editor = {
+	public readonly editor = {
 		set: (newContent: ExclusiveMapTree | undefined) => {
 			// If the new content is a MapTreeNode, it needs to have its parent pointer updated
 			if (newContent !== undefined) {
@@ -482,7 +482,7 @@ class EagerMapTreeSequenceField<T extends FlexAllowedTypes>
 	extends EagerMapTreeField<T>
 	implements FlexTreeSequenceField<T>
 {
-	public editor: SequenceFieldEditBuilder<ExclusiveMapTree[]> = {
+	public readonly editor: SequenceFieldEditBuilder<ExclusiveMapTree[]> = {
 		insert: (index, newContent) => {
 			for (let i = 0; i < newContent.length; i++) {
 				const c = newContent[i];

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -644,7 +644,7 @@ export interface FlexTreeSequenceField<in out TTypes extends FlexAllowedTypes>
 	/**
 	 * Get an editor for this sequence.
 	 */
-	editor: SequenceFieldEditBuilder<FlexibleFieldContent>;
+	readonly editor: SequenceFieldEditBuilder<FlexibleFieldContent>;
 
 	boxedIterator(): IterableIterator<FlexTreeTypedNodeUnion<TTypes>>;
 
@@ -666,7 +666,7 @@ export interface FlexTreeRequiredField<in out TTypes extends FlexAllowedTypes>
 	extends FlexTreeField {
 	get content(): FlexTreeUnboxNodeUnion<TTypes>;
 
-	editor: ValueFieldEditBuilder<FlexibleNodeContent>;
+	readonly editor: ValueFieldEditBuilder<FlexibleNodeContent>;
 }
 
 /**
@@ -686,7 +686,7 @@ export interface FlexTreeOptionalField<in out TTypes extends FlexAllowedTypes>
 	extends FlexTreeField {
 	get content(): FlexTreeUnboxNodeUnion<TTypes> | undefined;
 
-	editor: OptionalFieldEditBuilder<FlexibleNodeContent>;
+	readonly editor: OptionalFieldEditBuilder<FlexibleNodeContent>;
 }
 
 // #endregion

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -833,7 +833,7 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		const destinationField = getSequenceField(this);
 		if (destinationField.context === undefined) {
 			throw new UsageError(
-				`Array elements cannot be moved before being inserted into the tree`,
+				`Cannot move elements of an array before the array is inserted into the tree`,
 			);
 		}
 

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -12,7 +12,6 @@ import {
 	type MapTreeNode,
 	getOrCreateMapTreeNode,
 	getSchemaAndPolicy,
-	isMapTreeNode,
 	isFlexTreeNode,
 } from "../feature-libraries/index.js";
 import {
@@ -683,10 +682,6 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 	}
 
 	#mapTreesFromFieldData(value: Insertable<T>): ExclusiveMapTree[] {
-		if (isMapTreeNode(getOrCreateInnerNode(this))) {
-			throw new UsageError(`An array cannot be mutated before being inserted into the tree`);
-		}
-
 		const sequenceField = getSequenceField(this);
 		// TODO: this is not valid since this is a value field schema, not a sequence one (which does not exist in the simple tree layer),
 		// but it works since cursorFromFieldData special cases arrays.
@@ -837,7 +832,9 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 	): void {
 		const destinationField = getSequenceField(this);
 		if (destinationField.context === undefined) {
-			throw new UsageError(`An array cannot be mutated before being inserted into the tree`);
+			throw new UsageError(
+				`Array elements cannot be moved before being inserted into the tree`,
+			);
 		}
 
 		validateIndex(destinationIndex, destinationField, "moveRangeToIndex", true);

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -833,13 +833,18 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		const destinationField = getSequenceField(this);
 		if (destinationField.context === undefined) {
 			throw new UsageError(
-				`Cannot move elements of an array before the array is inserted into the tree`,
+				`Cannot move elements into an array before the array is inserted into the tree`,
 			);
 		}
 
 		validateIndex(destinationIndex, destinationField, "moveRangeToIndex", true);
 		validateIndexRange(sourceStart, sourceEnd, source ?? destinationField, "moveRangeToIndex");
 		const sourceField = source !== undefined ? getSequenceField(source) : destinationField;
+		if (sourceField.context === undefined) {
+			throw new UsageError(
+				`Cannot move elements from an array before the array is inserted into the tree`,
+			);
+		}
 		// TODO: determine support for move across different sequence types
 		if (destinationField.schema.types !== undefined && sourceField !== destinationField) {
 			for (let i = sourceStart; i < sourceEnd; i++) {

--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -210,8 +210,8 @@ describe("MapTreeNodes", () => {
 			assert.throws(() => object.anchorNode);
 		});
 
-		it("mutate arrays", () => {
-			assert.throws(() => fieldNode.content.editor);
+		it("move elements in arrays", () => {
+			assert.throws(() => fieldNode.content.editor.move(0, 1, 0));
 		});
 	});
 
@@ -252,6 +252,27 @@ describe("MapTreeNodes", () => {
 			assert.notEqual(newValue, oldValue);
 			field.editor.set(undefined, false);
 			assert.equal(field.boxedAt(0)?.value, undefined);
+		});
+
+		it("arrays", () => {
+			const mutableFieldNode = getOrCreateNode(
+				fieldNodeSchema,
+				deepCopyMapTree(fieldNodeMapTree),
+			);
+			const field = mutableFieldNode.getBoxed(EmptyKey);
+			const values = () => Array.from(field.boxedIterator(), (n) => n.value);
+			assert.deepEqual(values(), [childValue]);
+			field.editor.insert(1, [
+				{ ...mapChildMapTree, value: "c" },
+				{ ...mapChildMapTree, value: "d" },
+			]);
+			field.editor.insert(0, [
+				{ ...mapChildMapTree, value: "a" },
+				{ ...mapChildMapTree, value: "b" },
+			]);
+			assert.deepEqual(values(), ["a", "b", childValue, "c", "d"]);
+			field.editor.remove(2, 1);
+			assert.deepEqual(values(), ["a", "b", "c", "d"]);
 		});
 	});
 });

--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -274,5 +274,24 @@ describe("MapTreeNodes", () => {
 			field.editor.remove(2, 1);
 			assert.deepEqual(values(), ["a", "b", "c", "d"]);
 		});
+
+		it("arrays with a large sequence of new content", () => {
+			// This exercises a special code path for inserting large arrays, since large arrays are treated differently to avoid overflow with `splice` + spread.
+			const mutableFieldNode = getOrCreateNode(fieldNodeSchema, {
+				...fieldNodeMapTree,
+				fields: new Map(),
+			});
+			const field = mutableFieldNode.getBoxed(EmptyKey);
+			const newContent: ExclusiveMapTree[] = [];
+			for (let i = 0; i < 1000000; i++) {
+				newContent.push({ ...mapChildMapTree, value: String(i) });
+			}
+			field.editor.insert(0, newContent);
+			assert.equal(field.length, newContent.length);
+			assert.deepEqual(
+				Array.from(field.boxedIterator(), (n) => n.value),
+				newContent.map((c) => c.value),
+			);
+		});
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
@@ -22,624 +22,632 @@ const PojoEmulationNumberArray = schemaFactory.array(schemaFactory.number);
 const CustomizableNumberArray = schemaFactory.array("Array", schemaFactory.number);
 
 describe("ArrayNode", () => {
-	describe("created in pojo-emulation mode", () => {
-		testArrayFromSchemaType(PojoEmulationNumberArray);
-	});
+	testArrayFromSchemaType("created in pojo-emulation mode", PojoEmulationNumberArray);
+	testArrayFromSchemaType("created in customizable mode", CustomizableNumberArray);
 
-	describeHydration(
-		"created in customizable mode",
-		(init) => {
-			testArrayFromSchemaType(CustomizableNumberArray);
+	describeHydration("customizable", (init) => {
+		it("doesn't stringify extra properties", () => {
+			class ExtraArray extends schemaFactory.array("ArrayWithExtra", schemaFactory.number) {
+				public extra = "foo";
+			}
 
-			it("doesn't stringify extra properties", () => {
-				class ExtraArray extends schemaFactory.array("ArrayWithExtra", schemaFactory.number) {
-					public extra = "foo";
-				}
-
-				const jsArray = [0, 1, 2];
-				const array = init(ExtraArray, jsArray);
-				assert.equal(array.extra, "foo");
-				// "extra" should not be stringified
-				assert.equal(JSON.stringify(array), JSON.stringify(jsArray));
-			});
-		},
-		() => {
-			it("accessor local properties", () => {
-				const thisList: unknown[] = [];
-				class Test extends schemaFactory.array("test", schemaFactory.number) {
-					public get y() {
-						assert.equal(this, n);
-						thisList.push(this);
-						return this[0];
-					}
-					public set y(value: number) {
-						assert.equal(this, n);
-						thisList.push(this);
-						this.insertAtStart(value);
-					}
-				}
-
-				const n = hydrate(Test, [1]);
-				n.y = 2;
-				assert.equal(n[0], 2);
-				n.insertAtStart(3);
-				assert.equal(n.y, 3);
-				assert.deepEqual(thisList, [n, n]);
-			});
-		},
-	);
-
-	// Tests which should behave the same for both "structurally named" "POJO emulation mode" arrays and "customizable" arrays can be added in this function to avoid duplication.
-	function testArrayFromSchemaType(
-		schemaType: typeof PojoEmulationNumberArray | typeof CustomizableNumberArray,
-	): void {
-		it("fails at runtime if attempting to set content via index assignment", () => {
-			const array = hydrate(schemaType, [0]);
-			const mutableArray = array as Mutable<typeof array>;
-			assert.equal(mutableArray.length, 1);
-			assert.throws(
-				() => (mutableArray[0] = 3),
-				validateUsageError(/Use array node mutation APIs/),
-			); // An index within the array that already has an element
-			assert.throws(
-				() => (mutableArray[1] = 3),
-				validateUsageError(/Use array node mutation APIs/),
-			); // An index just past the end of the array, where a new element would be pushed
-			assert.throws(
-				() => (mutableArray[2] = 3),
-				validateUsageError(/Use array node mutation APIs/),
-			); // An index that would leave a "gap" past the current end of the array if a set occurred
-		});
-
-		it("stringifies in the same way as a JS array", () => {
 			const jsArray = [0, 1, 2];
-			const array = hydrate(schemaType, jsArray);
+			const array = init(ExtraArray, jsArray);
+			assert.equal(array.extra, "foo");
+			// "extra" should not be stringified
 			assert.equal(JSON.stringify(array), JSON.stringify(jsArray));
 		});
 
-		describe("removeAt", () => {
-			it("valid index", () => {
-				const array = hydrate(schemaType, [0, 1, 2]);
-				array.removeAt(1);
-				assert.deepEqual([...array], [0, 2]);
-			});
+		it("accessor local properties", () => {
+			const thisList: unknown[] = [];
+			class Test extends schemaFactory.array("test", schemaFactory.number) {
+				public get y() {
+					assert.equal(this, n);
+					thisList.push(this);
+					return this[0];
+				}
+				public set y(value: number) {
+					assert.equal(this, n);
+					thisList.push(this);
+					this.insertAtStart(value);
+				}
+			}
 
-			it("invalid index", () => {
-				const array = hydrate(schemaType, [0, 1, 2]);
-				// Index too large
-				assert.throws(
-					() => array.removeAt(3),
-					validateUsageError(/Index value passed to TreeArrayNode.removeAt is out of bounds./),
-				);
-				// Index is negative
-				assert.throws(
-					() => array.removeAt(-1),
-					validateUsageError(/Expected non-negative index, got -1./),
-				);
-			});
+			const n = init(Test, [1]);
+			n.y = 2;
+			assert.equal(n[0], 2);
+			n.insertAtStart(3);
+			assert.equal(n.y, 3);
+			assert.deepEqual(thisList, [n, n]);
 		});
+	});
 
-		describe("insertAt", () => {
-			it("valid index", () => {
-				const array = hydrate(schemaType, [1, 2, 3]);
-				array.insertAt(0, 0);
-				assert.deepEqual([...array], [0, 1, 2, 3]);
-			});
-
-			it("invalid index", () => {
-				const array = hydrate(schemaType, [0, 1, 2]);
-				// Index too large
-				assert.throws(
-					() => array.insertAt(4, 0),
-					validateUsageError(/Index value passed to TreeArrayNode.insertAt is out of bounds./),
-				);
-				// Index is negative
-				assert.throws(
-					() => array.insertAt(-1, 0),
-					validateUsageError(/Expected non-negative index, got -1./),
-				);
-			});
-		});
-
-		describe("moveToStart", () => {
-			it("move element to start of empty array", () => {
-				const schema = schemaFactory.object("parent", {
-					array1: schemaFactory.array(schemaFactory.number),
-					array2: schemaFactory.array(schemaFactory.number),
+	// Tests which should behave the same for both "structurally named" "POJO emulation mode" arrays and "customizable" arrays can be added in this function to avoid duplication.
+	function testArrayFromSchemaType(
+		title: string,
+		schemaType: typeof PojoEmulationNumberArray | typeof CustomizableNumberArray,
+	): void {
+		describeHydration(
+			title,
+			(init) => {
+				it("fails at runtime if attempting to set content via index assignment", () => {
+					const array = init(schemaType, [0]);
+					const mutableArray = array as Mutable<typeof array>;
+					assert.equal(mutableArray.length, 1);
+					assert.throws(
+						() => (mutableArray[0] = 3),
+						validateUsageError(/Use array node mutation APIs/),
+					); // An index within the array that already has an element
+					assert.throws(
+						() => (mutableArray[1] = 3),
+						validateUsageError(/Use array node mutation APIs/),
+					); // An index just past the end of the array, where a new element would be pushed
+					assert.throws(
+						() => (mutableArray[2] = 3),
+						validateUsageError(/Use array node mutation APIs/),
+					); // An index that would leave a "gap" past the current end of the array if a set occurred
 				});
-				const { array1, array2 } = hydrate(schema, { array1: [], array2: [1, 2, 3] });
-				array1.moveToStart(1, array2);
-				assert.deepEqual([...array1], [2]);
-				assert.deepEqual([...array2], [1, 3]);
-			});
 
-			it("move within field", () => {
-				const array = hydrate(schemaType, [1, 2, 3]);
-				array.moveToStart(1);
-				assert.deepEqual([...array], [2, 1, 3]);
-			});
-
-			it("cross-field move", () => {
-				const schema = schemaFactory.object("parent", {
-					array1: schemaFactory.array(schemaFactory.number),
-					array2: schemaFactory.array(schemaFactory.number),
+				it("stringifies in the same way as a JS array", () => {
+					const jsArray = [0, 1, 2];
+					const array = init(schemaType, jsArray);
+					assert.equal(JSON.stringify(array), JSON.stringify(jsArray));
 				});
-				const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
-				array1.moveToStart(1, array2);
-				assert.deepEqual([...array1], [2, 1, 2]);
-			});
 
-			it("invalid index", () => {
-				const array = hydrate(schemaType, [1, 2, 3]);
-				// Index too large
-				assert.throws(
-					() => array.moveToStart(4),
-					validateUsageError(
-						/Index value passed to TreeArrayNode.moveToStart is out of bounds./,
-					),
-				);
-				// Index is negative
-				assert.throws(
-					() => array.moveToStart(-1),
-					validateUsageError(/Expected non-negative index, got -1./),
-				);
-			});
-		});
-
-		describe("moveToEnd", () => {
-			it("move element to end of empty array", () => {
-				const schema = schemaFactory.object("parent", {
-					array1: schemaFactory.array(schemaFactory.number),
-					array2: schemaFactory.array(schemaFactory.number),
-				});
-				const { array1, array2 } = hydrate(schema, { array1: [], array2: [1, 2, 3] });
-				array1.moveToEnd(1, array2);
-				assert.deepEqual([...array1], [2]);
-				assert.deepEqual([...array2], [1, 3]);
-			});
-
-			it("move within field", () => {
-				const array = hydrate(schemaType, [1, 2, 3]);
-				array.moveToEnd(1);
-				assert.deepEqual([...array], [1, 3, 2]);
-			});
-
-			it("cross-field move", () => {
-				const schema = schemaFactory.object("parent", {
-					array1: schemaFactory.array(schemaFactory.number),
-					array2: schemaFactory.array(schemaFactory.number),
-				});
-				const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
-				array1.moveToEnd(1, array2);
-				assert.deepEqual([...array1], [1, 2, 2]);
-			});
-
-			it("invalid index", () => {
-				const array = hydrate(schemaType, [1, 2, 3]);
-				// Index too large
-				assert.throws(
-					() => array.moveToEnd(4),
-					validateUsageError(
-						/Index value passed to TreeArrayNode.moveToEnd is out of bounds./,
-					),
-				);
-				// Index is negative
-				assert.throws(
-					() => array.moveToEnd(-1),
-					validateUsageError(/Expected non-negative index, got -1./),
-				);
-			});
-		});
-
-		describe("moveToIndex", () => {
-			it("move element to start of empty array", () => {
-				const schema = schemaFactory.object("parent", {
-					array1: schemaFactory.array(schemaFactory.number),
-					array2: schemaFactory.array(schemaFactory.number),
-				});
-				const { array1, array2 } = hydrate(schema, { array1: [], array2: [1, 2, 3] });
-				array1.moveToIndex(0, 1, array2);
-				assert.deepEqual([...array1], [2]);
-				assert.deepEqual([...array2], [1, 3]);
-			});
-
-			for (const specifySource of [false, true]) {
-				describe(`move within field ${
-					specifySource ? "(specified source)" : "(implicit source)"
-				}`, () => {
-					it("moves node to the destination index when valid", () => {
-						const initialState = [0, 1, 2];
-						for (let sourceIndex = 0; sourceIndex < initialState.length; sourceIndex += 1) {
-							const movedValue = initialState[sourceIndex];
-							for (
-								let destinationIndex = 0;
-								destinationIndex < initialState.length;
-								destinationIndex += 1
-							) {
-								const array = hydrate(schemaType, initialState);
-								if (specifySource) {
-									array.moveToIndex(destinationIndex, sourceIndex, array);
-								} else {
-									array.moveToIndex(destinationIndex, sourceIndex);
-								}
-								const actual = [...array];
-								const expected =
-									sourceIndex < destinationIndex
-										? [
-												...initialState.slice(0, sourceIndex),
-												...initialState.slice(sourceIndex + 1, destinationIndex),
-												movedValue,
-												...initialState.slice(destinationIndex),
-											]
-										: [
-												...initialState.slice(0, destinationIndex),
-												movedValue,
-												...initialState.slice(destinationIndex, sourceIndex),
-												...initialState.slice(sourceIndex + 1),
-											];
-								assert.deepEqual(actual, expected);
-							}
-						}
+				describe("removeAt", () => {
+					it("valid index", () => {
+						const array = init(schemaType, [0, 1, 2]);
+						array.removeAt(1);
+						assert.deepEqual([...array], [0, 2]);
 					});
 
-					it("throws when the source index is invalid", () => {
+					it("invalid index", () => {
+						const array = init(schemaType, [0, 1, 2]);
+						// Index too large
+						assert.throws(
+							() => array.removeAt(3),
+							validateUsageError(
+								/Index value passed to TreeArrayNode.removeAt is out of bounds./,
+							),
+						);
+						// Index is negative
+						assert.throws(
+							() => array.removeAt(-1),
+							validateUsageError(/Expected non-negative index, got -1./),
+						);
+					});
+				});
+
+				describe("insertAt", () => {
+					it("valid index", () => {
+						const array = init(schemaType, [1, 2, 3]);
+						array.insertAt(0, 0);
+						assert.deepEqual([...array], [0, 1, 2, 3]);
+					});
+
+					it("invalid index", () => {
+						const array = init(schemaType, [0, 1, 2]);
+						// Index too large
+						assert.throws(
+							() => array.insertAt(4, 0),
+							validateUsageError(
+								/Index value passed to TreeArrayNode.insertAt is out of bounds./,
+							),
+						);
+						// Index is negative
+						assert.throws(
+							() => array.insertAt(-1, 0),
+							validateUsageError(/Expected non-negative index, got -1./),
+						);
+					});
+				});
+
+				describe("removeRange", () => {
+					it("no arguments", () => {
+						const jsArray = [0, 1, 2];
+						const array = init(schemaType, jsArray);
+						assert.equal(array.length, 3);
+						array.removeRange();
+						assert.equal(array.length, 0);
+						assert.deepEqual([...array], []);
+					});
+
+					it("empty array no arguments", () => {
+						const array = init(schemaType, []);
+						array.removeRange();
+					});
+
+					it("middle", () => {
+						const list = init(schemaType, [0, 1, 2, 3]);
+						list.removeRange(/* start: */ 1, /* end: */ 3);
+						assert.deepEqual([...list], [0, 3]);
+					});
+
+					it("all", () => {
+						const list = init(schemaType, [0, 1, 2, 3]);
+						list.removeRange(0, 4);
+						assert.deepEqual([...list], []);
+					});
+
+					it("past end", () => {
+						const list = init(schemaType, [0, 1, 2, 3]);
+						list.removeRange(1, Number.POSITIVE_INFINITY);
+						assert.deepEqual([...list], [0]);
+					});
+
+					it("empty range", () => {
+						const list = init(schemaType, [0, 1, 2, 3]);
+						list.removeRange(2, 2);
+						assert.deepEqual([...list], [0, 1, 2, 3]);
+					});
+
+					it("empty range - at start", () => {
+						const list = init(schemaType, [0, 1, 2, 3]);
+						list.removeRange(0, 0);
+						assert.deepEqual([...list], [0, 1, 2, 3]);
+					});
+
+					it("empty range - at end", () => {
+						const list = init(schemaType, [0, 1, 2, 3]);
+						list.removeRange(4, 4);
+						assert.deepEqual([...list], [0, 1, 2, 3]);
+					});
+
+					it("invalid", () => {
+						const list = init(schemaType, [0, 1, 2, 3]);
+						// Past end
+						assert.throws(() => list.removeRange(5, 6), validateUsageError(/Too large/));
+						// start after end
+						assert.throws(() => list.removeRange(3, 2), validateUsageError(/Too large/));
+						// negative index
+						assert.throws(() => list.removeRange(-1, 2), validateUsageError(/index/));
+						// non-integer index
+						assert.throws(() => list.removeRange(1.5, 2), validateUsageError(/integer/));
+					});
+
+					it("invalid empty range", () => {
+						// If someday someone optimized empty ranges to no op earlier, they still need to error in these cases:
+						const list = init(schemaType, [0, 1, 2, 3]);
+						// Past end
+						assert.throws(() => list.removeRange(5, 5), validateUsageError(/Too large/));
+						// negative index
+						assert.throws(() => list.removeRange(-1, -1), validateUsageError(/index/));
+						// non-integer index
+						assert.throws(
+							() => list.removeRange(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY),
+							validateUsageError(/safe integer/),
+						);
+						assert.throws(() => list.removeRange(1.5, 1.5), validateUsageError(/integer/));
+					});
+				});
+			},
+			() => {
+				describe("moveToStart", () => {
+					it("move element to start of empty array", () => {
+						const schema = schemaFactory.object("parent", {
+							array1: schemaFactory.array(schemaFactory.number),
+							array2: schemaFactory.array(schemaFactory.number),
+						});
+						const { array1, array2 } = hydrate(schema, { array1: [], array2: [1, 2, 3] });
+						array1.moveToStart(1, array2);
+						assert.deepEqual([...array1], [2]);
+						assert.deepEqual([...array2], [1, 3]);
+					});
+
+					it("move within field", () => {
+						const array = hydrate(schemaType, [1, 2, 3]);
+						array.moveToStart(1);
+						assert.deepEqual([...array], [2, 1, 3]);
+					});
+
+					it("cross-field move", () => {
+						const schema = schemaFactory.object("parent", {
+							array1: schemaFactory.array(schemaFactory.number),
+							array2: schemaFactory.array(schemaFactory.number),
+						});
+						const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
+						array1.moveToStart(1, array2);
+						assert.deepEqual([...array1], [2, 1, 2]);
+					});
+
+					it("invalid index", () => {
+						const array = hydrate(schemaType, [1, 2, 3]);
+						// Index too large
+						assert.throws(
+							() => array.moveToStart(4),
+							validateUsageError(
+								/Index value passed to TreeArrayNode.moveToStart is out of bounds./,
+							),
+						);
+						// Index is negative
+						assert.throws(
+							() => array.moveToStart(-1),
+							validateUsageError(/Expected non-negative index, got -1./),
+						);
+					});
+				});
+
+				describe("moveToEnd", () => {
+					it("move element to end of empty array", () => {
+						const schema = schemaFactory.object("parent", {
+							array1: schemaFactory.array(schemaFactory.number),
+							array2: schemaFactory.array(schemaFactory.number),
+						});
+						const { array1, array2 } = hydrate(schema, { array1: [], array2: [1, 2, 3] });
+						array1.moveToEnd(1, array2);
+						assert.deepEqual([...array1], [2]);
+						assert.deepEqual([...array2], [1, 3]);
+					});
+
+					it("move within field", () => {
+						const array = hydrate(schemaType, [1, 2, 3]);
+						array.moveToEnd(1);
+						assert.deepEqual([...array], [1, 3, 2]);
+					});
+
+					it("cross-field move", () => {
+						const schema = schemaFactory.object("parent", {
+							array1: schemaFactory.array(schemaFactory.number),
+							array2: schemaFactory.array(schemaFactory.number),
+						});
+						const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
+						array1.moveToEnd(1, array2);
+						assert.deepEqual([...array1], [1, 2, 2]);
+					});
+
+					it("invalid index", () => {
+						const array = hydrate(schemaType, [1, 2, 3]);
+						// Index too large
+						assert.throws(
+							() => array.moveToEnd(4),
+							validateUsageError(
+								/Index value passed to TreeArrayNode.moveToEnd is out of bounds./,
+							),
+						);
+						// Index is negative
+						assert.throws(
+							() => array.moveToEnd(-1),
+							validateUsageError(/Expected non-negative index, got -1./),
+						);
+					});
+				});
+
+				describe("moveToIndex", () => {
+					it("move element to start of empty array", () => {
+						const schema = schemaFactory.object("parent", {
+							array1: schemaFactory.array(schemaFactory.number),
+							array2: schemaFactory.array(schemaFactory.number),
+						});
+						const { array1, array2 } = hydrate(schema, { array1: [], array2: [1, 2, 3] });
+						array1.moveToIndex(0, 1, array2);
+						assert.deepEqual([...array1], [2]);
+						assert.deepEqual([...array2], [1, 3]);
+					});
+
+					for (const specifySource of [false, true]) {
+						describe(`move within field ${
+							specifySource ? "(specified source)" : "(implicit source)"
+						}`, () => {
+							it("moves node to the destination index when valid", () => {
+								const initialState = [0, 1, 2];
+								for (
+									let sourceIndex = 0;
+									sourceIndex < initialState.length;
+									sourceIndex += 1
+								) {
+									const movedValue = initialState[sourceIndex];
+									for (
+										let destinationIndex = 0;
+										destinationIndex < initialState.length;
+										destinationIndex += 1
+									) {
+										const array = hydrate(schemaType, initialState);
+										if (specifySource) {
+											array.moveToIndex(destinationIndex, sourceIndex, array);
+										} else {
+											array.moveToIndex(destinationIndex, sourceIndex);
+										}
+										const actual = [...array];
+										const expected =
+											sourceIndex < destinationIndex
+												? [
+														...initialState.slice(0, sourceIndex),
+														...initialState.slice(sourceIndex + 1, destinationIndex),
+														movedValue,
+														...initialState.slice(destinationIndex),
+													]
+												: [
+														...initialState.slice(0, destinationIndex),
+														movedValue,
+														...initialState.slice(destinationIndex, sourceIndex),
+														...initialState.slice(sourceIndex + 1),
+													];
+										assert.deepEqual(actual, expected);
+									}
+								}
+							});
+
+							it("throws when the source index is invalid", () => {
+								const array = hydrate(schemaType, [1, 2, 3]);
+								// Destination index too large
+								assert.throws(
+									() => array.moveToIndex(4, 0),
+									validateUsageError(
+										/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
+									),
+								);
+								// Source index too large
+								assert.throws(
+									() => array.moveToIndex(0, 4),
+									validateUsageError(
+										/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
+									),
+								);
+								// Destination index is negative
+								assert.throws(
+									() => array.moveToIndex(-1, 0),
+									validateUsageError(/Expected non-negative index, got -1./),
+								);
+								// Source index is negative
+								assert.throws(
+									() => array.moveToIndex(0, -1),
+									validateUsageError(/Expected non-negative index, got -1./),
+								);
+							});
+						});
+					}
+
+					describe("move across fields", () => {
+						it("moves node to the destination index when valid", () => {
+							const schema = schemaFactory.object("parent", {
+								source: schemaFactory.array(schemaFactory.number),
+								destination: schemaFactory.array(schemaFactory.number),
+							});
+							for (const [initialSourceState, initialDestinationState] of [
+								[[1, 2, 3], []],
+								[
+									[1, 2, 3],
+									[4, 5],
+								],
+								[
+									[1, 2],
+									[3, 4, 5],
+								],
+							]) {
+								for (
+									let sourceIndex = 0;
+									sourceIndex < initialSourceState.length;
+									sourceIndex += 1
+								) {
+									const movedValue = initialSourceState[sourceIndex];
+									for (
+										let destinationIndex = 0;
+										destinationIndex < initialDestinationState.length;
+										destinationIndex += 1
+									) {
+										const { source, destination } = hydrate(schema, {
+											source: initialSourceState,
+											destination: initialDestinationState,
+										});
+										destination.moveToIndex(destinationIndex, sourceIndex, source);
+										const actualSource = [...source];
+										const actualDestination = [...destination];
+										const expectedSource = [
+											...initialSourceState.slice(0, sourceIndex),
+											...initialSourceState.slice(sourceIndex + 1),
+										];
+										const expectedDestination = [
+											...initialDestinationState.slice(0, destinationIndex),
+											movedValue,
+											...initialDestinationState.slice(destinationIndex),
+										];
+										assert.deepEqual(actualSource, expectedSource);
+										assert.deepEqual(actualDestination, expectedDestination);
+									}
+								}
+							}
+						});
+
+						it("throws when the source index is invalid", () => {
+							const schema = schemaFactory.object("parent", {
+								source: schemaFactory.array(schemaFactory.number),
+								destination: schemaFactory.array(schemaFactory.number),
+							});
+							const { source, destination } = hydrate(schema, {
+								source: [1, 2, 3],
+								destination: [4, 5, 6, 7],
+							});
+							// Destination index too large
+							assert.throws(
+								() => destination.moveToIndex(5, 0, source),
+								validateUsageError(
+									/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
+								),
+							);
+							// Source index too large
+							assert.throws(
+								() => destination.moveToIndex(0, 4, source),
+								validateUsageError(
+									/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
+								),
+							);
+							// Destination index is negative
+							assert.throws(
+								() => destination.moveToIndex(-1, 0, source),
+								validateUsageError(/Expected non-negative index, got -1./),
+							);
+							// Source index is negative
+							assert.throws(
+								() => destination.moveToIndex(0, -1, source),
+								validateUsageError(/Expected non-negative index, got -1./),
+							);
+						});
+					});
+				});
+
+				describe("moveRangeToStart", () => {
+					it("move within field", () => {
+						const array = hydrate(schemaType, [1, 2, 3]);
+						array.moveRangeToStart(1, 3);
+						assert.deepEqual([...array], [2, 3, 1]);
+					});
+
+					it("cross-field move", () => {
+						const schema = schemaFactory.object("parent", {
+							array1: schemaFactory.array(schemaFactory.number),
+							array2: schemaFactory.array(schemaFactory.number),
+						});
+						const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
+						array1.moveRangeToStart(0, 2, array2);
+						assert.deepEqual([...array1], [1, 2, 1, 2]);
+					});
+
+					it("move within empty field", () => {
+						const array = hydrate(schemaType, []);
+						array.moveRangeToStart(0, 0);
+						assert.deepEqual([...array], []);
+					});
+
+					it("invalid index", () => {
+						const array = hydrate(schemaType, [1, 2, 3]);
+						// End index too large
+						assert.throws(
+							() => array.moveRangeToStart(0, 4),
+							validateUsageError(
+								/Index value passed to TreeArrayNode.moveRangeToStart is out of bounds./,
+							),
+						);
+						// Start index is larger than end index
+						assert.throws(
+							() => array.moveRangeToStart(2, 1),
+							validateUsageError(
+								/Index value passed to TreeArrayNode.moveRangeToStart is out of bounds./,
+							),
+						);
+						// Index is negative
+						assert.throws(
+							() => array.moveRangeToStart(-1, 0),
+							validateUsageError(/Expected non-negative index, got -1./),
+						);
+					});
+				});
+
+				describe("moveRangeToEnd", () => {
+					it("move within field", () => {
+						const array = hydrate(schemaType, [1, 2, 3]);
+						array.moveRangeToEnd(0, 2);
+						assert.deepEqual([...array], [3, 1, 2]);
+					});
+
+					it("cross-field move", () => {
+						const schema = schemaFactory.object("parent", {
+							array1: schemaFactory.array(schemaFactory.number),
+							array2: schemaFactory.array(schemaFactory.number),
+						});
+						const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
+						array1.moveRangeToEnd(0, 2, array2);
+						assert.deepEqual([...array1], [1, 2, 1, 2]);
+					});
+
+					it("move within empty field", () => {
+						const array = hydrate(schemaType, []);
+						array.moveRangeToEnd(0, 0);
+						assert.deepEqual([...array], []);
+					});
+
+					it("invalid index", () => {
+						const array = hydrate(schemaType, [1, 2, 3]);
+						// End index too large
+						assert.throws(
+							() => array.moveRangeToEnd(0, 4),
+							validateUsageError(
+								/Index value passed to TreeArrayNode.moveRangeToEnd is out of bounds./,
+							),
+						);
+						// Start index is larger than the end index
+						assert.throws(
+							() => array.moveRangeToEnd(2, 1),
+							validateUsageError(
+								/Index value passed to TreeArrayNode.moveRangeToEnd is out of bounds./,
+							),
+						);
+						// Index is negative
+						assert.throws(
+							() => array.moveRangeToEnd(-1, 0),
+							validateUsageError(/Expected non-negative index, got -1./),
+						);
+					});
+				});
+
+				describe("moveRangeToIndex", () => {
+					it("move within field", () => {
+						const array = hydrate(schemaType, [1, 2, 3]);
+						array.moveRangeToIndex(0, 1, 3);
+						assert.deepEqual([...array], [2, 3, 1]);
+					});
+
+					it("cross-field move", () => {
+						const schema = schemaFactory.object("parent", {
+							array1: schemaFactory.array(schemaFactory.number),
+							array2: schemaFactory.array(schemaFactory.number),
+						});
+						const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
+						array1.moveRangeToIndex(0, 0, 2, array2);
+						assert.deepEqual([...array1], [1, 2, 1, 2]);
+					});
+
+					it("move within empty field", () => {
+						const array = hydrate(schemaType, []);
+						array.moveRangeToIndex(0, 0, 0);
+						assert.deepEqual([...array], []);
+					});
+
+					it("invalid content type", () => {
+						const schema = schemaFactory.object("parent", {
+							array1: schemaFactory.array([schemaFactory.number, schemaFactory.string]),
+							array2: schemaFactory.array(schemaFactory.number),
+						});
+						const { array1, array2 } = hydrate(schema, { array1: [1, "bad", 2], array2: [] });
+						const expected = validateUsageError(
+							/Type in source sequence is not allowed in destination./,
+						);
+						assert.throws(() => array2.moveRangeToIndex(0, 1, 3, array1), expected);
+						assert.throws(() => array2.moveRangeToIndex(0, 0, 2, array1), expected);
+						assert.throws(() => array2.moveRangeToIndex(0, 0, 3, array1), expected);
+					});
+
+					it("invalid index", () => {
 						const array = hydrate(schemaType, [1, 2, 3]);
 						// Destination index too large
 						assert.throws(
-							() => array.moveToIndex(4, 0),
+							() => array.moveRangeToIndex(4, 0, 2),
 							validateUsageError(
-								/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
+								/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
 							),
 						);
-						// Source index too large
+						// End index is too large
 						assert.throws(
-							() => array.moveToIndex(0, 4),
+							() => array.moveRangeToIndex(0, 0, 4),
 							validateUsageError(
-								/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
+								/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
 							),
 						);
-						// Destination index is negative
+						// Start index larger than end index
 						assert.throws(
-							() => array.moveToIndex(-1, 0),
+							() => array.moveRangeToIndex(0, 2, 1),
+							validateUsageError(
+								/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
+							),
+						);
+						// Index is negative
+						assert.throws(
+							() => array.moveRangeToIndex(-1, 0, 1),
 							validateUsageError(/Expected non-negative index, got -1./),
 						);
-						// Source index is negative
-						assert.throws(
-							() => array.moveToIndex(0, -1),
-							validateUsageError(/Expected non-negative index, got -1./),
-						);
 					});
 				});
-			}
-
-			describe("move across fields", () => {
-				it("moves node to the destination index when valid", () => {
-					const schema = schemaFactory.object("parent", {
-						source: schemaFactory.array(schemaFactory.number),
-						destination: schemaFactory.array(schemaFactory.number),
-					});
-					for (const [initialSourceState, initialDestinationState] of [
-						[[1, 2, 3], []],
-						[
-							[1, 2, 3],
-							[4, 5],
-						],
-						[
-							[1, 2],
-							[3, 4, 5],
-						],
-					]) {
-						for (
-							let sourceIndex = 0;
-							sourceIndex < initialSourceState.length;
-							sourceIndex += 1
-						) {
-							const movedValue = initialSourceState[sourceIndex];
-							for (
-								let destinationIndex = 0;
-								destinationIndex < initialDestinationState.length;
-								destinationIndex += 1
-							) {
-								const { source, destination } = hydrate(schema, {
-									source: initialSourceState,
-									destination: initialDestinationState,
-								});
-								destination.moveToIndex(destinationIndex, sourceIndex, source);
-								const actualSource = [...source];
-								const actualDestination = [...destination];
-								const expectedSource = [
-									...initialSourceState.slice(0, sourceIndex),
-									...initialSourceState.slice(sourceIndex + 1),
-								];
-								const expectedDestination = [
-									...initialDestinationState.slice(0, destinationIndex),
-									movedValue,
-									...initialDestinationState.slice(destinationIndex),
-								];
-								assert.deepEqual(actualSource, expectedSource);
-								assert.deepEqual(actualDestination, expectedDestination);
-							}
-						}
-					}
-				});
-
-				it("throws when the source index is invalid", () => {
-					const schema = schemaFactory.object("parent", {
-						source: schemaFactory.array(schemaFactory.number),
-						destination: schemaFactory.array(schemaFactory.number),
-					});
-					const { source, destination } = hydrate(schema, {
-						source: [1, 2, 3],
-						destination: [4, 5, 6, 7],
-					});
-					// Destination index too large
-					assert.throws(
-						() => destination.moveToIndex(5, 0, source),
-						validateUsageError(
-							/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
-						),
-					);
-					// Source index too large
-					assert.throws(
-						() => destination.moveToIndex(0, 4, source),
-						validateUsageError(
-							/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
-						),
-					);
-					// Destination index is negative
-					assert.throws(
-						() => destination.moveToIndex(-1, 0, source),
-						validateUsageError(/Expected non-negative index, got -1./),
-					);
-					// Source index is negative
-					assert.throws(
-						() => destination.moveToIndex(0, -1, source),
-						validateUsageError(/Expected non-negative index, got -1./),
-					);
-				});
-			});
-		});
-
-		describe("moveRangeToStart", () => {
-			it("move within field", () => {
-				const array = hydrate(schemaType, [1, 2, 3]);
-				array.moveRangeToStart(1, 3);
-				assert.deepEqual([...array], [2, 3, 1]);
-			});
-
-			it("cross-field move", () => {
-				const schema = schemaFactory.object("parent", {
-					array1: schemaFactory.array(schemaFactory.number),
-					array2: schemaFactory.array(schemaFactory.number),
-				});
-				const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
-				array1.moveRangeToStart(0, 2, array2);
-				assert.deepEqual([...array1], [1, 2, 1, 2]);
-			});
-
-			it("move within empty field", () => {
-				const array = hydrate(schemaType, []);
-				array.moveRangeToStart(0, 0);
-				assert.deepEqual([...array], []);
-			});
-
-			it("invalid index", () => {
-				const array = hydrate(schemaType, [1, 2, 3]);
-				// End index too large
-				assert.throws(
-					() => array.moveRangeToStart(0, 4),
-					validateUsageError(
-						/Index value passed to TreeArrayNode.moveRangeToStart is out of bounds./,
-					),
-				);
-				// Start index is larger than end index
-				assert.throws(
-					() => array.moveRangeToStart(2, 1),
-					validateUsageError(
-						/Index value passed to TreeArrayNode.moveRangeToStart is out of bounds./,
-					),
-				);
-				// Index is negative
-				assert.throws(
-					() => array.moveRangeToStart(-1, 0),
-					validateUsageError(/Expected non-negative index, got -1./),
-				);
-			});
-		});
-
-		describe("moveRangeToEnd", () => {
-			it("move within field", () => {
-				const array = hydrate(schemaType, [1, 2, 3]);
-				array.moveRangeToEnd(0, 2);
-				assert.deepEqual([...array], [3, 1, 2]);
-			});
-
-			it("cross-field move", () => {
-				const schema = schemaFactory.object("parent", {
-					array1: schemaFactory.array(schemaFactory.number),
-					array2: schemaFactory.array(schemaFactory.number),
-				});
-				const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
-				array1.moveRangeToEnd(0, 2, array2);
-				assert.deepEqual([...array1], [1, 2, 1, 2]);
-			});
-
-			it("move within empty field", () => {
-				const array = hydrate(schemaType, []);
-				array.moveRangeToEnd(0, 0);
-				assert.deepEqual([...array], []);
-			});
-
-			it("invalid index", () => {
-				const array = hydrate(schemaType, [1, 2, 3]);
-				// End index too large
-				assert.throws(
-					() => array.moveRangeToEnd(0, 4),
-					validateUsageError(
-						/Index value passed to TreeArrayNode.moveRangeToEnd is out of bounds./,
-					),
-				);
-				// Start index is larger than the end index
-				assert.throws(
-					() => array.moveRangeToEnd(2, 1),
-					validateUsageError(
-						/Index value passed to TreeArrayNode.moveRangeToEnd is out of bounds./,
-					),
-				);
-				// Index is negative
-				assert.throws(
-					() => array.moveRangeToEnd(-1, 0),
-					validateUsageError(/Expected non-negative index, got -1./),
-				);
-			});
-		});
-
-		describe("moveRangeToIndex", () => {
-			it("move within field", () => {
-				const array = hydrate(schemaType, [1, 2, 3]);
-				array.moveRangeToIndex(0, 1, 3);
-				assert.deepEqual([...array], [2, 3, 1]);
-			});
-
-			it("cross-field move", () => {
-				const schema = schemaFactory.object("parent", {
-					array1: schemaFactory.array(schemaFactory.number),
-					array2: schemaFactory.array(schemaFactory.number),
-				});
-				const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
-				array1.moveRangeToIndex(0, 0, 2, array2);
-				assert.deepEqual([...array1], [1, 2, 1, 2]);
-			});
-
-			it("move within empty field", () => {
-				const array = hydrate(schemaType, []);
-				array.moveRangeToIndex(0, 0, 0);
-				assert.deepEqual([...array], []);
-			});
-
-			it("invalid content type", () => {
-				const schema = schemaFactory.object("parent", {
-					array1: schemaFactory.array([schemaFactory.number, schemaFactory.string]),
-					array2: schemaFactory.array(schemaFactory.number),
-				});
-				const { array1, array2 } = hydrate(schema, { array1: [1, "bad", 2], array2: [] });
-				const expected = validateUsageError(
-					/Type in source sequence is not allowed in destination./,
-				);
-				assert.throws(() => array2.moveRangeToIndex(0, 1, 3, array1), expected);
-				assert.throws(() => array2.moveRangeToIndex(0, 0, 2, array1), expected);
-				assert.throws(() => array2.moveRangeToIndex(0, 0, 3, array1), expected);
-			});
-
-			it("invalid index", () => {
-				const array = hydrate(schemaType, [1, 2, 3]);
-				// Destination index too large
-				assert.throws(
-					() => array.moveRangeToIndex(4, 0, 2),
-					validateUsageError(
-						/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
-					),
-				);
-				// End index is too large
-				assert.throws(
-					() => array.moveRangeToIndex(0, 0, 4),
-					validateUsageError(
-						/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
-					),
-				);
-				// Start index larger than end index
-				assert.throws(
-					() => array.moveRangeToIndex(0, 2, 1),
-					validateUsageError(
-						/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
-					),
-				);
-				// Index is negative
-				assert.throws(
-					() => array.moveRangeToIndex(-1, 0, 1),
-					validateUsageError(/Expected non-negative index, got -1./),
-				);
-			});
-		});
-
-		describe("removeRange", () => {
-			it("no arguments", () => {
-				const jsArray = [0, 1, 2];
-				const array = hydrate(schemaType, jsArray);
-				assert.equal(array.length, 3);
-				array.removeRange();
-				assert.equal(array.length, 0);
-				assert.deepEqual([...array], []);
-			});
-
-			it("empty array no arguments", () => {
-				const array = hydrate(schemaType, []);
-				array.removeRange();
-			});
-
-			it("middle", () => {
-				const list = hydrate(schemaType, [0, 1, 2, 3]);
-				list.removeRange(/* start: */ 1, /* end: */ 3);
-				assert.deepEqual([...list], [0, 3]);
-			});
-
-			it("all", () => {
-				const list = hydrate(schemaType, [0, 1, 2, 3]);
-				list.removeRange(0, 4);
-				assert.deepEqual([...list], []);
-			});
-
-			it("past end", () => {
-				const list = hydrate(schemaType, [0, 1, 2, 3]);
-				list.removeRange(1, Number.POSITIVE_INFINITY);
-				assert.deepEqual([...list], [0]);
-			});
-
-			it("empty range", () => {
-				const list = hydrate(schemaType, [0, 1, 2, 3]);
-				list.removeRange(2, 2);
-				assert.deepEqual([...list], [0, 1, 2, 3]);
-			});
-
-			it("empty range - at start", () => {
-				const list = hydrate(schemaType, [0, 1, 2, 3]);
-				list.removeRange(0, 0);
-				assert.deepEqual([...list], [0, 1, 2, 3]);
-			});
-
-			it("empty range - at end", () => {
-				const list = hydrate(schemaType, [0, 1, 2, 3]);
-				list.removeRange(4, 4);
-				assert.deepEqual([...list], [0, 1, 2, 3]);
-			});
-
-			it("invalid", () => {
-				const list = hydrate(schemaType, [0, 1, 2, 3]);
-				// Past end
-				assert.throws(() => list.removeRange(5, 6), validateUsageError(/Too large/));
-				// start after end
-				assert.throws(() => list.removeRange(3, 2), validateUsageError(/Too large/));
-				// negative index
-				assert.throws(() => list.removeRange(-1, 2), validateUsageError(/index/));
-				// non-integer index
-				assert.throws(() => list.removeRange(1.5, 2), validateUsageError(/integer/));
-			});
-
-			it("invalid empty range", () => {
-				// If someday someone optimized empty ranges to no op earlier, they still need to error in these cases:
-				const list = hydrate(schemaType, [0, 1, 2, 3]);
-				// Past end
-				assert.throws(() => list.removeRange(5, 5), validateUsageError(/Too large/));
-				// negative index
-				assert.throws(() => list.removeRange(-1, -1), validateUsageError(/index/));
-				// non-integer index
-				assert.throws(
-					() => list.removeRange(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY),
-					validateUsageError(/safe integer/),
-				);
-				assert.throws(() => list.removeRange(1.5, 1.5), validateUsageError(/integer/));
-			});
-		});
+			},
+		);
 	}
 
 	it("asIndex helper returns expected values", () => {

--- a/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
@@ -87,19 +87,42 @@ describe("Unhydrated nodes", () => {
 	});
 
 	it("get their parent", () => {
-		const mapLeaf = new TestLeaf({ value: "mapValue" });
+		const mapLeaf = new TestLeaf({ value: "value" });
 		assert.equal(Tree.parent(mapLeaf), undefined);
-		const map = new TestMap([["key", mapLeaf]]);
-		assert.equal(Tree.parent(map), undefined);
+		const map = new TestMap({ key: mapLeaf });
 		assert.equal(Tree.parent(mapLeaf), map);
-		const arrayLeaf = new TestLeaf({ value: "arrayValue" });
+		map.delete("key");
+		assert.equal(Tree.parent(mapLeaf), undefined);
+		const newMapLeaf = new TestLeaf({ value: "value" });
+		assert.equal(Tree.parent(newMapLeaf), undefined);
+		map.set("key", newMapLeaf);
+		assert.equal(Tree.parent(newMapLeaf), map);
+
+		const arrayLeaf = new TestLeaf({ value: "value" });
+		assert.equal(Tree.parent(arrayLeaf), undefined);
 		const array = new TestArray([arrayLeaf]);
-		assert.equal(Tree.parent(array), undefined);
 		assert.equal(Tree.parent(arrayLeaf), array);
-		const object = new TestObject({ map, array });
+		array.removeRange();
+		assert.equal(Tree.parent(arrayLeaf), undefined);
+		const newArrayLeaf = new TestLeaf({ value: "value" });
+		assert.equal(Tree.parent(newArrayLeaf), undefined);
+		array.insertAtEnd(newArrayLeaf);
+		assert.equal(Tree.parent(newArrayLeaf), array);
+
+		const object = new TestObject({ array, map });
 		assert.equal(Tree.parent(object), undefined);
 		assert.equal(Tree.parent(map), object);
 		assert.equal(Tree.parent(array), object);
+		const newMap = new TestMap({});
+		const newArray = new TestArray([]);
+		assert.equal(Tree.parent(newMap), undefined);
+		assert.equal(Tree.parent(newArray), undefined);
+		object.map = newMap;
+		object.array = newArray;
+		assert.equal(Tree.parent(newMap), object);
+		assert.equal(Tree.parent(newArray), object);
+		assert.equal(Tree.parent(map), undefined);
+		assert.equal(Tree.parent(array), undefined);
 	});
 
 	it("get their key", () => {
@@ -134,21 +157,6 @@ describe("Unhydrated nodes", () => {
 		const object = new TestObject({ map, array });
 		assert.equal(Tree.is(object, TestObject), true);
 		assert.equal(Tree.schema(object), TestObject);
-	});
-
-	it("disallow mutation of sequences", () => {
-		function validateUnhydratedMutationError(error: Error): boolean {
-			return validateAssertionError(
-				error,
-				/cannot be mutated before being inserted into the tree/,
-			);
-		}
-
-		const leaf = new TestLeaf({ value: "value" });
-		const array = new TestArray([]);
-		assert.throws(() => array.insertAtStart(leaf), validateUnhydratedMutationError);
-		assert.throws(() => array.insertAtEnd(leaf), validateUnhydratedMutationError);
-		assert.throws(() => array.insertAt(0, leaf), validateUnhydratedMutationError);
 	});
 
 	it("have the correct tree status", () => {

--- a/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
@@ -87,6 +87,10 @@ describe("Unhydrated nodes", () => {
 	});
 
 	it("get their parent", () => {
+		// For each node type, this test checks that the parent of each newly created nodes is correct.
+		// It also creates children and checks that the parent of each is updated when the child is inserted under a node, and again when it is removed.
+
+		// Map
 		const mapLeaf = new TestLeaf({ value: "value" });
 		assert.equal(Tree.parent(mapLeaf), undefined);
 		const map = new TestMap({ key: mapLeaf });
@@ -97,7 +101,7 @@ describe("Unhydrated nodes", () => {
 		assert.equal(Tree.parent(newMapLeaf), undefined);
 		map.set("key", newMapLeaf);
 		assert.equal(Tree.parent(newMapLeaf), map);
-
+		// Array
 		const arrayLeaf = new TestLeaf({ value: "value" });
 		assert.equal(Tree.parent(arrayLeaf), undefined);
 		const array = new TestArray([arrayLeaf]);
@@ -108,7 +112,7 @@ describe("Unhydrated nodes", () => {
 		assert.equal(Tree.parent(newArrayLeaf), undefined);
 		array.insertAtEnd(newArrayLeaf);
 		assert.equal(Tree.parent(newArrayLeaf), array);
-
+		// Object
 		const object = new TestObject({ array, map });
 		assert.equal(Tree.parent(object), undefined);
 		assert.equal(Tree.parent(map), object);


### PR DESCRIPTION
## Description

This [continues adding support](https://github.com/microsoft/FluidFramework/pull/22186) for mutation of unhydrated tree nodes. Arrays can now have elements inserted and removed. Support for moving elements within an array will be added in a future PR. Some news tests have been added, but the changes to arrayNode.spec.ts consist of moving the existing tests for arrayNode.insert and arrayNode.remove into the hydrated/unhdyrated test delegate.