### PR TITLE
Use TextEncoder byte length to calcaulte body size in odsp driver

### DIFF
--- a/packages/drivers/odsp-driver/src/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createNewUtils.ts
@@ -253,7 +253,8 @@ export async function createNewFluidContainerCore<T>(args: {
 					`\r\n--${formBoundary}--`;
 
 				let postBody = snapshotBody;
-				// We use the byte length of the post body to determine if we should use the multipart/form-data or not.
+				// We use the byte length of the post body to determine if we should use the multipart/form-data or not. This helps
+				// in cases where the body contains data with different language where 1 char could be multiple code points.
 				if (
 					new TextEncoder().encode(postBodyWithAuth).length <= maxUmpPostBodySize &&
 					authHeader?.startsWith("Bearer")

--- a/packages/drivers/odsp-driver/src/createNewUtils.ts
+++ b/packages/drivers/odsp-driver/src/createNewUtils.ts
@@ -253,8 +253,9 @@ export async function createNewFluidContainerCore<T>(args: {
 					`\r\n--${formBoundary}--`;
 
 				let postBody = snapshotBody;
+				// We use the byte length of the post body to determine if we should use the multipart/form-data or not.
 				if (
-					postBodyWithAuth.length <= maxUmpPostBodySize &&
+					new TextEncoder().encode(postBodyWithAuth).length <= maxUmpPostBodySize &&
 					authHeader?.startsWith("Bearer")
 				) {
 					url = authInBodyUrl;


### PR DESCRIPTION
## Description

Use TextEncoder byte length to calcaulte body size in odsp driver to determine if we should use the form data request or not. This helps in cases where the body contains data with different language where 1 char could be multiple code points.