### PR TITLE
Update array test to avoid timeouts

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -295,7 +295,7 @@ describe("MapTreeNodes", () => {
 			}) as EagerMapTreeFieldNode<typeof fieldNodeSchema>;
 			const field = mutableFieldNode.getBoxed(EmptyKey);
 			const newContent: ExclusiveMapTree[] = [];
-			for (let i = 0; i < 1000000; i++) {
+			for (let i = 0; i < 10000; i++) {
 				newContent.push({ ...mapChildMapTree, value: String(i) });
 			}
 			field.editor.insert(0, newContent);


### PR DESCRIPTION
The content array made by the test is large enough that it can cause the test to lag and timeout. This reduces the size to a number which, while not problematic when passed to splice (as was the original array), still exercises the "non-splice" code path of `insert`.