### PR TITLE
refactor(ci): Add retries to steps that could fail due to network hiccups

### DIFF
--- a/tools/pipelines/templates/include-telemetry-setup.yml
+++ b/tools/pipelines/templates/include-telemetry-setup.yml
@@ -76,6 +76,7 @@ steps:
 # Auth to internal ADO feeds
 - task: npmAuthenticate@0
   displayName: 'npm authenticate (internal ADO feeds)'
+  retryCountOnTaskFailure: 1
   inputs:
     workingFile: ${{ parameters.pathToTelemetryGenerator }}/.npmrc
 
@@ -91,6 +92,7 @@ steps:
 
 - task: Bash@3
   displayName: 'Prepare telemetry-generator'
+  retryCountOnTaskFailure: 1
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.pathToTelemetryGenerator }}

--- a/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks-install-package.yml
@@ -46,6 +46,7 @@ steps:
 # Download package that has performance tests
 - task: DownloadPipelineArtifact@2
   displayName: Download package with perf tests - ${{ parameters.testPackageName }}
+  retryCountOnTaskFailure: 1
   inputs:
     # It seems there's a bug and preferTriggeringPipeline is not respected.
     # We force the behavior by explicitly specifying:

--- a/tools/pipelines/templates/include-test-perf-benchmarks.yml
+++ b/tools/pipelines/templates/include-test-perf-benchmarks.yml
@@ -62,6 +62,7 @@ steps:
 # Download artifact with test files
 - task: DownloadPipelineArtifact@2
   displayName: Download test files
+  retryCountOnTaskFailure: 1
   inputs:
     # It seems there's a bug and preferTriggeringPipeline is not respected.
     # We force the behavior by explicitly specifying:
@@ -111,6 +112,7 @@ steps:
 # Auth to internal feed
 - task: npmAuthenticate@0
   displayName: 'npm authenticate (internal feed)'
+  retryCountOnTaskFailure: 1
   inputs:
     workingFile: ${{ parameters.testWorkspace }}/.npmrc
 

--- a/tools/pipelines/test-perf-benchmarks.yml
+++ b/tools/pipelines/test-perf-benchmarks.yml
@@ -142,6 +142,7 @@ stages:
             targetFolder: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}
         - task: Npm@1
           displayName: Install dependencies - ${{ testPackage }}
+          retryCountOnTaskFailure: 1
           inputs:
             command: 'install'
             workingDir: ${{ variables.testWorkspace }}/node_modules/${{ testPackage }}


### PR DESCRIPTION
## Description

Adds `retryCountOnTaskFailure` to several tasks in ADO pipelines (mostly related to the performance benchmarks pipeline) that could fail due to network hiccups and are safe to retry. This is a pattern we already use, mostly for `npm i`.

This was motivated by a recent transient failure (ECONNRESET during an npm install) in the performance benchmarks pipeline.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
