### PR TITLE
build(client): add `@beta` support to core-interfaces"

### DIFF
--- a/packages/common/core-interfaces/README.md
+++ b/packages/common/core-interfaces/README.md
@@ -32,6 +32,8 @@ For more information on the related support guarantees, see [API Support Levels]
 
 To access the `public` ([SemVer](https://semver.org/)) APIs, import via `@fluidframework/core-interfaces` like normal.
 
+To access the `beta` APIs, import via `@fluidframework/core-interfaces/beta`.
+
 To access the `legacy` APIs, import via `@fluidframework/core-interfaces/legacy`.
 
 ## API Documentation

--- a/packages/common/core-interfaces/api-extractor/api-extractor-lint-beta.cjs.json
+++ b/packages/common/core-interfaces/api-extractor/api-extractor-lint-beta.cjs.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
+	"mainEntryPointFilePath": "<projectFolder>/dist/beta.d.ts"
+}

--- a/packages/common/core-interfaces/api-extractor/api-extractor-lint-beta.esm.json
+++ b/packages/common/core-interfaces/api-extractor/api-extractor-lint-beta.esm.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-report.esm.current.json",
+	"extends": "<projectFolder>/../../../common/build/build-common/api-extractor-lint.entrypoint.json",
 	"mainEntryPointFilePath": "<projectFolder>/lib/beta.d.ts"
 }

--- a/packages/common/core-interfaces/package.json
+++ b/packages/common/core-interfaces/package.json
@@ -23,6 +23,16 @@
 				"default": "./dist/index.js"
 			}
 		},
+		"./beta": {
+			"import": {
+				"types": "./lib/beta.d.ts",
+				"default": "./lib/index.js"
+			},
+			"require": {
+				"types": "./dist/beta.d.ts",
+				"default": "./dist/index.js"
+			}
+		},
 		"./legacy": {
 			"import": {
 				"types": "./lib/legacy.d.ts",
@@ -65,8 +75,10 @@
 		"check:biome": "biome check .",
 		"check:exports": "concurrently \"npm:check:exports:*\"",
 		"check:exports:bundle-release-tags": "api-extractor run --config api-extractor/api-extractor-lint-bundle.json",
+		"check:exports:cjs:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.cjs.json",
 		"check:exports:cjs:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.cjs.json",
 		"check:exports:cjs:public": "api-extractor run --config api-extractor/api-extractor-lint-public.cjs.json",
+		"check:exports:esm:beta": "api-extractor run --config api-extractor/api-extractor-lint-beta.esm.json",
 		"check:exports:esm:legacy": "api-extractor run --config api-extractor/api-extractor-lint-legacy.esm.json",
 		"check:exports:esm:public": "api-extractor run --config api-extractor/api-extractor-lint-public.esm.json",
 		"check:format": "npm run check:biome",


### PR DESCRIPTION
This PR is an example of how to add `@beta` API support to package that currently supports `@legacy` APIs.