### PR TITLE
Revert "refactor(ci): Remove redundant component detection task in server pipelines"

### DIFF
--- a/tools/pipelines/templates/include-generate-notice-steps.yml
+++ b/tools/pipelines/templates/include-generate-notice-steps.yml
@@ -8,6 +8,9 @@ parameters:
   type: boolean
 
 steps:
+# Note: even though we get component governance tasks auto-injected through the 1ES pipeline template, this one is
+# currently necessary because the NOTICE file generation task right below requires that CG has run first.
+# We're trying to see if we could leverage the auto-injected ones for that.
 - task: ComponentGovernanceComponentDetection@0
   displayName: Component Detection
   inputs:

--- a/tools/pipelines/templates/include-generate-notice-steps.yml
+++ b/tools/pipelines/templates/include-generate-notice-steps.yml
@@ -8,6 +8,14 @@ parameters:
   type: boolean
 
 steps:
+- task: ComponentGovernanceComponentDetection@0
+  displayName: Component Detection
+  inputs:
+    sourceScanPath: ${{ parameters.buildDirectory }}
+    verbosity: Verbose
+    scanType: Register
+    alertWarningLevel: High
+
 - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
   displayName: 'NOTICE File Generator'
   continueOnError: ${{ parameters.requireNotice }}


### PR DESCRIPTION
Reverts microsoft/FluidFramework#22180.

Turns out the extra component governance task is currently necessary for the NOTICE file generation to succeed. We're exploring if we can make that work with the auto-injected component governance tasks, but in the meantime we want this back.