### PR TITLE
server: Switch Ephemeral Container expired to document deleted message

### DIFF
--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -216,7 +216,8 @@ async function checkAndCacheIsEphemeral({
 		if (currentTime > documentExpirationTime) {
 			// If the document is ephemeral and older than the max ephemeral document TTL, throw an error indicating that it can't be accessed.
 			const documentExpiredByMs = currentTime - documentExpirationTime;
-			const error = new NetworkError(404, "Ephemeral Container Expired");
+			// TODO: switch back to "Ephemeral Container Expired" once clients update to use errorType, not error message. AB#12867
+			const error = new NetworkError(404, "Document is deleted and cannot be accessed.");
 			Lumberjack.warning(
 				"Document is older than the max ephemeral document TTL.",
 				{

--- a/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
+++ b/server/routerlicious/packages/routerlicious-base/src/utils/sessionHelper.ts
@@ -296,7 +296,8 @@ export async function getSession(
 		if (currentTime > documentExpirationTime) {
 			// If the document is ephemeral and older than the max ephemeral document TTL, throw an error indicating that it can't be accessed.
 			const documentExpiredByMs = currentTime - documentExpirationTime;
-			const error = new NetworkError(404, "Ephemeral Container Expired");
+			// TODO: switch back to "Ephemeral Container Expired" once clients update to use errorType, not error message. AB#12867
+			const error = new NetworkError(404, "Document is deleted and cannot be accessed.");
 			Lumberjack.warning(
 				"Document is older than the max ephemeral document TTL.",
 				{


### PR DESCRIPTION
## Description

Customers depend on the "Document is deleted..." message, not the error code. Some of our E2E tests do to. When an EC is considered expired, just say it's "deleted" to match existing client logic.

Follow-up to move to a better message: [ADO #12867](https://dev.azure.com/fluidframework/internal/_workitems/edit/12867)
