### PR TITLE
Prevent moist insertion

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -366,10 +366,9 @@ class EagerMapTreeField<T extends FlexAllowedTypes> implements MapTreeField {
 		for (const [i, mapTree] of this.mapTrees.entries()) {
 			const mapTreeNodeChild = nodeCache.get(mapTree);
 			if (mapTreeNodeChild !== undefined) {
-				assert(
-					mapTreeNodeChild.parentField === unparentedLocation,
-					0x991 /* Node is already parented under a different field */,
-				);
+				if (mapTreeNodeChild.parentField !== unparentedLocation) {
+					throw new UsageError("A node may not be in more than one place in the tree");
+				}
 				mapTreeNodeChild.adoptBy(this, i);
 			}
 		}

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -4,6 +4,7 @@
  */
 
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { assert } from "@fluidframework/core-utils/internal";
 
 import {
@@ -139,26 +140,23 @@ function prepareArrayContentForHydration(
 	content: readonly MapTree[],
 	forest: IForestSubscription,
 ): void {
-	const proxies: RootedProxyPaths[] = [];
-	for (const [i, item] of content.entries()) {
-		proxies.push({
+	const proxyPaths: RootedProxyPaths[] = [];
+	for (const item of content) {
+		const proxyPath: RootedProxyPaths = {
 			rootPath: {
 				parent: undefined,
 				parentField: EmptyKey,
 				parentIndex: 0,
 			},
 			proxyPaths: [],
-		});
-		// Non null asserting here because we are iterating over content and pushing into proxies for every content
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		walkMapTree(item, proxies[i]!.rootPath, (p, proxy) => {
-			// Non null asserting here because we are iterating over content and pushing into proxies for every content
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			proxies[i]!.proxyPaths.push({ path: p, proxy });
+		};
+		proxyPaths.push(proxyPath);
+		walkMapTree(item, proxyPath.rootPath, (p, proxy) => {
+			proxyPath.proxyPaths.push({ path: p, proxy });
 		});
 	}
 
-	bindProxies(proxies, forest);
+	bindProxies(proxyPaths, forest);
 }
 
 function walkMapTree(
@@ -166,25 +164,35 @@ function walkMapTree(
 	path: UpPath,
 	onVisitTreeNode: (path: UpPath, treeNode: TreeNode) => void,
 ): void {
-	const mapTreeNode = tryGetMapTreeNode(mapTree);
-	if (mapTreeNode !== undefined) {
-		const treeNode = tryGetCachedTreeNode(mapTreeNode);
-		if (treeNode !== undefined) {
-			onVisitTreeNode(path, treeNode);
-		}
+	if (tryGetMapTreeNode(mapTree)?.parentField.parent.parent !== undefined) {
+		throw new UsageError(
+			"Attempted to insert a node which is already under a parent. If this is desired, remove the node from its parent before inserting it elsewhere.",
+		);
 	}
 
-	for (const [key, field] of mapTree.fields) {
-		for (const [i, item] of field.entries()) {
-			walkMapTree(
-				item,
-				{
-					parent: path,
-					parentField: key,
-					parentIndex: i,
-				},
-				onVisitTreeNode,
-			);
+	type Next = [path: UpPath, tree: MapTree];
+	const nexts: Next[] = [];
+	for (let next: Next | undefined = [path, mapTree]; next !== undefined; next = nexts.pop()) {
+		const [p, m] = next;
+		const mapTreeNode = tryGetMapTreeNode(m);
+		if (mapTreeNode !== undefined) {
+			const treeNode = tryGetCachedTreeNode(mapTreeNode);
+			if (treeNode !== undefined) {
+				onVisitTreeNode(p, treeNode);
+			}
+		}
+
+		for (const [key, field] of m.fields) {
+			for (const [i, child] of field.entries()) {
+				nexts.push([
+					{
+						parent: p,
+						parentField: key,
+						parentIndex: i,
+					},
+					child,
+				]);
+			}
 		}
 	}
 }

--- a/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
@@ -321,6 +321,38 @@ describe("Unhydrated nodes", () => {
 		const object = new TestObjectWithId({ id, autoId: undefined });
 		assert.deepEqual(Object.entries(object), [["id", id]]);
 	});
+
+	it("cannot be used twice in the same tree", () => {
+		const leaf = new TestLeaf({ value: "3" });
+		assert.throws(
+			() => new TestArray([leaf, leaf]),
+			(e: Error) =>
+				validateAssertionError(e, /A node may not be in more than one place in the tree/),
+		);
+	});
+
+	it("cannot be partially hydrated", () => {
+		const view = hydrate(
+			TestObject,
+			new TestObject({ array: new TestArray([]), map: new TestMap({}) }),
+		);
+
+		const leaf = new TestLeaf({ value: "3" });
+		const array = new TestArray([leaf]);
+		assert.equal(array[0], leaf);
+
+		// Attempt to insert `leaf`, which is underneath `array`. Both are unhydrated.
+		// If `leaf` were to succeed, then it would become hydrated, but `array` would remain unhydrated.
+		// This would be confusing, as the user's reference to `leaf` is now a different object than `array[0]`, whereas prior to the insert they were the same.
+		assert.throws(
+			() => view.map.set("key", leaf),
+			(e: Error) =>
+				validateAssertionError(
+					e,
+					/Attempted to insert a node which is already under a parent/,
+				),
+		);
+	});
 });
 
 function createDefaultFieldProps(provider: FieldProvider): FieldProps {


### PR DESCRIPTION
"Moist" trees - trees composed of both hydrated _and_ unhydrated nodes - are currently impossible to construct, but the degrees of freedom permitted when inserting nodes into a SharedTree can imply otherwise to a user.

For example, it is currently possible to construct an unhydrated tree, then insert some (non-root) subtree of that tree into the document. This results in the _subtree_ becoming hydrated, but not the root tree. If the user retains an existing reference to the subtree then that reference will now be hydrated, but walking down from the still-unhydrated root tree will yield a new, different unhydrated subtree. This is confusing and undocumented behavior - see the new unit test for a concrete example.

This also:
* Updates one of our asserts to a user error, as it can be easily caused by user error
* Updates the recursive MapTree walk during proxy binding to be iterative
* Various code cleanup