### PR TITLE
Update stack trace limit for local change error

### DIFF
--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -971,11 +971,6 @@ export abstract class FluidDataStoreContext
 			return;
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-		const originalStackTraceLimit = (Error as any).stackTraceLimit;
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-		(Error as any).stackTraceLimit = 30;
-
 		// Log a telemetry if there are local changes in the summarizer. This will give us data on how often
 		// this is happening and which data stores do this. The eventual goal is to disallow local changes
 		// in the summarizer and the data will help us plan this.
@@ -983,12 +978,8 @@ export abstract class FluidDataStoreContext
 			eventName,
 			type,
 			isSummaryInProgress: this.summarizerNode.isSummaryInProgress?.(),
-			stack: generateStack(),
+			stack: generateStack(30),
 		});
-
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-		(Error as any).stackTraceLimit = originalStackTraceLimit;
-
 		this.localChangesTelemetryCount--;
 	}
 

--- a/packages/runtime/container-runtime/src/dataStoreContext.ts
+++ b/packages/runtime/container-runtime/src/dataStoreContext.ts
@@ -971,6 +971,11 @@ export abstract class FluidDataStoreContext
 			return;
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+		const originalStackTraceLimit = (Error as any).stackTraceLimit;
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+		(Error as any).stackTraceLimit = 30;
+
 		// Log a telemetry if there are local changes in the summarizer. This will give us data on how often
 		// this is happening and which data stores do this. The eventual goal is to disallow local changes
 		// in the summarizer and the data will help us plan this.
@@ -980,6 +985,10 @@ export abstract class FluidDataStoreContext
 			isSummaryInProgress: this.summarizerNode.isSummaryInProgress?.(),
 			stack: generateStack(),
 		});
+
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+		(Error as any).stackTraceLimit = originalStackTraceLimit;
+
 		this.localChangesTelemetryCount--;
 	}
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1183,11 +1183,6 @@ export class FluidDataStoreRuntime
 			return;
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-		const originalStackTraceLimit = (Error as any).stackTraceLimit;
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-		(Error as any).stackTraceLimit = 30;
-
 		// Log a telemetry if there are local changes in the summarizer. This will give us data on how often
 		// this is happening and which data stores do this. The eventual goal is to disallow local changes
 		// in the summarizer and the data will help us plan this.
@@ -1199,12 +1194,8 @@ export class FluidDataStoreRuntime
 				fluidDataStoreId: this.id,
 				fluidDataStorePackagePath: this.dataStoreContext.packagePath.join("/"),
 			}),
-			stack: generateStack(),
+			stack: generateStack(30),
 		});
-
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-		(Error as any).stackTraceLimit = originalStackTraceLimit;
-
 		this.localChangesTelemetryCount--;
 	}
 

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1183,6 +1183,11 @@ export class FluidDataStoreRuntime
 			return;
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+		const originalStackTraceLimit = (Error as any).stackTraceLimit;
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+		(Error as any).stackTraceLimit = 30;
+
 		// Log a telemetry if there are local changes in the summarizer. This will give us data on how often
 		// this is happening and which data stores do this. The eventual goal is to disallow local changes
 		// in the summarizer and the data will help us plan this.
@@ -1196,6 +1201,10 @@ export class FluidDataStoreRuntime
 			}),
 			stack: generateStack(),
 		});
+
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+		(Error as any).stackTraceLimit = originalStackTraceLimit;
+
 		this.localChangesTelemetryCount--;
 	}
 

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -181,11 +181,17 @@ let stackPopulatedOnCreation: boolean | undefined;
  * stack property is not accessed.
  * For such cases it's better to not read stack property right away, but rather delay it until / if it's needed
  * Some browsers will populate stack right away, others require throwing Error, so we do auto-detection on the fly.
+ * @param stackTraceLimit - stack trace limit for an error
  * @returns Error object that has stack populated.
  *
  * @internal
  */
-export function generateErrorWithStack(): Error {
+export function generateErrorWithStack(stackTraceLimit?: number): Error {
+	const ErrorConfig = Error as unknown as { stackTraceLimit: number };
+	const originalStackTraceLimit = ErrorConfig.stackTraceLimit;
+	if (stackTraceLimit !== undefined) {
+		ErrorConfig.stackTraceLimit = stackTraceLimit;
+	}
 	const err = new Error("<<generated stack>>");
 
 	if (stackPopulatedOnCreation === undefined) {
@@ -193,24 +199,27 @@ export function generateErrorWithStack(): Error {
 	}
 
 	if (stackPopulatedOnCreation) {
+		ErrorConfig.stackTraceLimit = originalStackTraceLimit;
 		return err;
 	}
 
 	try {
 		throw err;
 	} catch (error) {
+		ErrorConfig.stackTraceLimit = originalStackTraceLimit;
 		return error as Error;
 	}
 }
 
 /**
  * Generate a stack at this callsite as if an error were thrown from here.
+ * @param stackTraceLimit - stack trace limit for an error
  * @returns the callstack (does not throw)
  *
  * @internal
  */
-export function generateStack(): string | undefined {
-	return generateErrorWithStack().stack;
+export function generateStack(stackTraceLimit?: number): string | undefined {
+	return generateErrorWithStack(stackTraceLimit).stack;
 }
 
 /**


### PR DESCRIPTION
## Description

Investigating leaky ops issues based on stack traces for `DDSCreatedInSummarizer`, `DataStoreCreatedInSummarizer`, and `DataStoreMessageSubmittedInSummarizer` and realize stack traces are limited to 10 for browsers other than Safari. Therefore, increase the limit in this PR to help the investigation.
