### PR TITLE
Refactor test to be more reliable

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -8,36 +8,27 @@ import { strict as assert } from "assert";
 import { describeCompat } from "@fluid-private/test-version-utils";
 import { IContainer, LoaderHeader } from "@fluidframework/container-definitions/internal";
 import { Loader } from "@fluidframework/container-loader/internal";
-import {
-	DefaultSummaryConfiguration,
-	IAckedSummary,
-	SummaryCollection,
-} from "@fluidframework/container-runtime/internal";
 import { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
-import { ConfigTypes, IConfigProviderBase } from "@fluidframework/core-interfaces";
 import { IDataStore } from "@fluidframework/runtime-definitions/internal";
-import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import {
+	createSummarizer,
 	DataObjectFactoryType,
 	ITestContainerConfig,
 	ITestFluidObject,
 	ITestObjectProvider,
 	getContainerEntryPointBackCompat,
+	summarizeNow,
 } from "@fluidframework/test-utils/internal";
 
-describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) => {
-	let provider: ITestObjectProvider;
-	beforeEach("getTestObjectProvider", () => {
-		provider = getTestObjectProvider();
-	});
+import { TestSnapshotCache } from "../testSnapshotCache.js";
 
+describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) => {
 	let container1: IContainer;
 	let container2: IContainer;
 	let dataObject1: ITestFluidObject;
 	let dataObject2: ITestFluidObject;
 
 	const packageName = "default";
-	const IdleDetectionTime = 100;
 	const testContainerConfig: ITestContainerConfig = {
 		fluidDataObjectType: DataObjectFactoryType.Test,
 		runtimeOptions: {
@@ -49,31 +40,19 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 		},
 	};
 
-	const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => {
-		return {
-			getRawConfig: (name: string): ConfigTypes => settings[name],
-		};
-	};
-
-	const setupContainers = async (
-		containerConfig: ITestContainerConfig = testContainerConfig,
-		featureGates: Record<string, ConfigTypes> = {},
-	) => {
-		provider.reset();
-		const configWithFeatureGates = {
-			...containerConfig,
-			loaderProps: { configProvider: configProvider(featureGates) },
-		};
-		container1 = await provider.makeTestContainer(configWithFeatureGates);
+	let provider: ITestObjectProvider;
+	const testSnapshotCache = new TestSnapshotCache();
+	beforeEach("getTestObjectProvider", async () => {
+		provider = getTestObjectProvider({ persistedCache: testSnapshotCache });
+		container1 = await provider.makeTestContainer(testContainerConfig);
 		dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
 
-		container2 = await provider.loadTestContainer(configWithFeatureGates);
+		container2 = await provider.loadTestContainer(testContainerConfig);
 		dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
-
-		await provider.ensureSynchronized();
-	};
-
-	const reset = async () => provider.reset();
+	});
+	afterEach("clearTestSnapshotCache", async () => {
+		testSnapshotCache.reset();
+	});
 
 	const runtimeOf = (dataObject: ITestFluidObject): IContainerRuntime =>
 		dataObject.context.containerRuntime as IContainerRuntime;
@@ -96,9 +75,6 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 	}
 
 	describe("Legacy APIs", () => {
-		beforeEach("setupContainers", async () => setupContainers(testContainerConfig));
-		afterEach(async () => reset());
-
 		it("Datastore creation with legacy API returns datastore which can be aliased", async () => {
 			const ds = await createDataStoreWithProps(dataObject1, "1");
 			const aliasResult = await ds.trySetAlias("2");
@@ -107,9 +83,6 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 	});
 
 	describe("Aliasing", () => {
-		beforeEach("setupContainers", async () => setupContainers());
-		afterEach(async () => reset());
-
 		const alias = "alias";
 
 		it("Assign multiple data stores to the same alias, first write wins, same container - detached", async function () {
@@ -311,74 +284,6 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 			assert.ok(await getAliasedDataStoreEntryPoint(dataObject3, alias));
 		});
 
-		it(
-			"Assign multiple data stores to the same alias, first write wins, " +
-				"different containers from snapshot",
-			async function () {
-				// TODO: Re-enable after cross version compat bugs are fixed - ADO:6978
-				if (provider.type === "TestObjectProviderWithVersionedLoad") {
-					this.skip();
-				}
-
-				await setupContainers({
-					...testContainerConfig,
-					runtimeOptions: {
-						summaryOptions: {
-							summaryConfigOverrides: {
-								...DefaultSummaryConfiguration,
-								...{
-									minIdleTime: IdleDetectionTime,
-									maxIdleTime: IdleDetectionTime,
-									maxTime: IdleDetectionTime * 12,
-									initialSummarizerDelayMs: 10,
-								},
-							},
-						},
-					},
-				});
-
-				// andre4i: Move this into test utils or something. Same as for other
-				// flavors of this function across the end to end tests
-				const waitForSummary = async (
-					testObjectProvider: ITestObjectProvider,
-					container: IContainer,
-					summaryCollection: SummaryCollection,
-				): Promise<string> => {
-					await testObjectProvider.ensureSynchronized();
-					const ackedSummary: IAckedSummary = await summaryCollection.waitSummaryAck(
-						container.deltaManager.lastSequenceNumber,
-					);
-					return ackedSummary.summaryAck.contents.handle;
-				};
-
-				const sc = new SummaryCollection(container1.deltaManager, createChildLogger());
-				const ds1 = await runtimeOf(dataObject1).createDataStore(packageName);
-				const ds2 = await runtimeOf(dataObject2).createDataStore(packageName);
-
-				const aliasResult1 = await ds1.trySetAlias(alias);
-				const aliasResult2 = await ds2.trySetAlias(alias);
-				assert.equal(aliasResult1, "Success");
-				assert.equal(aliasResult2, "Conflict");
-
-				await provider.ensureSynchronized();
-				const version = await waitForSummary(provider, container1, sc);
-
-				const container3 = await provider.loadTestContainer(
-					testContainerConfig,
-					{
-						[LoaderHeader.version]: version,
-					}, // requestHeader
-				);
-				const dataObject3 =
-					await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
-				const ds3 = await runtimeOf(dataObject3).createDataStore(packageName);
-				const aliasResult3 = await ds3.trySetAlias(alias);
-
-				assert.equal(aliasResult3, "Conflict");
-				assert.ok(await getAliasedDataStoreEntryPoint(dataObject3, alias));
-			},
-		);
-
 		it("getAliasedDataStoreEntryPoint only returns aliased data stores", async function () {
 			// TODO: Re-enable after cross version compat bugs are fixed - ADO:6978
 			if (provider.type === "TestObjectProviderWithVersionedLoad") {
@@ -413,5 +318,50 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 				"A local aliased datastore should be a root datastore",
 			);
 		});
+	});
+
+	describe.only("Aliasing with summary", () => {
+		const alias = "alias";
+		it(
+			"Assign multiple data stores to the same alias, first write wins, " +
+				"different containers from snapshot",
+			async function () {
+				// TODO: Re-enable after cross version compat bugs are fixed - ADO:6978
+				if (provider.type === "TestObjectProviderWithVersionedLoad") {
+					this.skip();
+				}
+
+				const ds1 = await runtimeOf(dataObject1).createDataStore(packageName);
+				const ds2 = await runtimeOf(dataObject2).createDataStore(packageName);
+
+				const aliasResult1 = await ds1.trySetAlias(alias);
+				const aliasResult2 = await ds2.trySetAlias(alias);
+				assert.equal(aliasResult1, "Success");
+				assert.equal(aliasResult2, "Conflict");
+
+				await provider.ensureSynchronized();
+
+				const { summarizer } = await createSummarizer(provider, container1, {
+					fluidDataObjectType: DataObjectFactoryType.Test,
+				});
+				const { summaryVersion } = await summarizeNow(summarizer);
+
+				// For the ODSP driver, we need to clear the cache to ensure we get the latest snapshot
+				testSnapshotCache.clearCache();
+				const container3 = await provider.loadTestContainer(
+					testContainerConfig,
+					{
+						[LoaderHeader.version]: summaryVersion,
+					}, // requestHeader
+				);
+				const dataObject3 =
+					await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
+				const ds3 = await runtimeOf(dataObject3).createDataStore(packageName);
+				const aliasResult3 = await ds3.trySetAlias(alias);
+
+				assert.equal(aliasResult3, "Conflict");
+				assert.ok(await getAliasedDataStoreEntryPoint(dataObject3, alias));
+			},
+		);
 	});
 });

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -47,6 +47,8 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 		container1 = await provider.makeTestContainer(testContainerConfig);
 		dataObject1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
 
+		await provider.ensureSynchronized();
+
 		container2 = await provider.loadTestContainer(testContainerConfig);
 		dataObject2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
 	});

--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -320,7 +320,7 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 		});
 	});
 
-	describe.only("Aliasing with summary", () => {
+	describe("Aliasing with summary", () => {
 		const alias = "alias";
 		it(
 			"Assign multiple data stores to the same alias, first write wins, " +


### PR DESCRIPTION
During [AB#8354](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8354)

I took the liberty to refactor the test a little. This was a flakey failure caused by tinylicious.

I moved the provider.ensureSynchronized() function down to ensure that the container attach is seen, but it should be seen with the basic attach flow.