### PR TITLE
Implement moves between unhydrated array nodes

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/index.ts
@@ -5,7 +5,9 @@
 
 export {
 	type MapTreeNode,
+	type MapTreeSequenceField,
 	isMapTreeNode,
+	isMapTreeSequenceField,
 	getOrCreateMapTreeNode,
 	tryGetMapTreeNode,
 } from "./mapTreeNode.js";

--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -70,6 +70,35 @@ export function isMapTreeNode(flexNode: FlexTreeNode): flexNode is MapTreeNode {
 	return flexNode instanceof EagerMapTreeNode;
 }
 
+/**
+ * Checks if the given {@link FlexTreeField} is a {@link MapTreeSequenceField}.
+ */
+export function isMapTreeSequenceField<T extends FlexAllowedTypes>(
+	field: FlexTreeSequenceField<T> | FlexTreeField,
+): field is MapTreeSequenceField<T> {
+	return field instanceof EagerMapTreeSequenceField;
+}
+
+/**
+ * An unhydrated {@link FlexTreeSequenceField}, which has additional editing capabilities.
+ * @remarks When doing a removal edit, a {@link MapTreeSequenceField}'s `editor` returns ownership of the removed {@link ExclusiveMapTree}s to the caller.
+ */
+export interface MapTreeSequenceField<T extends FlexAllowedTypes>
+	extends FlexTreeSequenceField<T> {
+	readonly editor: MapTreeSequenceFieldEditBuilder;
+}
+
+interface MapTreeSequenceFieldEditBuilder
+	extends SequenceFieldEditBuilder<ExclusiveMapTree[]> {
+	/**
+	 * Issues a change which removes `count` elements starting at the given `index`.
+	 * @param index - The index of the first removed element.
+	 * @param count - The number of elements to remove.
+	 * @returns the MapTrees that were removed
+	 */
+	remove(index: number, count: number): ExclusiveMapTree[];
+}
+
 /** A node's parent field and its index in that field */
 interface LocationInField {
 	readonly parent: MapTreeField;
@@ -440,7 +469,7 @@ class EagerMapTreeOptionalField<T extends FlexAllowedTypes>
 	implements FlexTreeOptionalField<T>
 {
 	public readonly editor = {
-		set: (newContent: ExclusiveMapTree | undefined) => {
+		set: (newContent: ExclusiveMapTree | undefined): void => {
 			// If the new content is a MapTreeNode, it needs to have its parent pointer updated
 			if (newContent !== undefined) {
 				nodeCache.get(newContent)?.adoptBy(this, 0);
@@ -487,8 +516,8 @@ class EagerMapTreeSequenceField<T extends FlexAllowedTypes>
 	extends EagerMapTreeField<T>
 	implements FlexTreeSequenceField<T>
 {
-	public readonly editor: SequenceFieldEditBuilder<ExclusiveMapTree[]> = {
-		insert: (index, newContent) => {
+	public readonly editor: MapTreeSequenceFieldEditBuilder = {
+		insert: (index, newContent): void => {
 			for (let i = 0; i < newContent.length; i++) {
 				const c = newContent[i];
 				assert(c !== undefined, "Unexpected sparse array content");
@@ -504,15 +533,17 @@ class EagerMapTreeSequenceField<T extends FlexAllowedTypes>
 				}
 			});
 		},
-		remove: (index, count) => {
+		remove: (index, count): ExclusiveMapTree[] => {
 			for (let i = index; i < index + count; i++) {
 				const c = this.mapTrees[i];
 				assert(c !== undefined, "Unexpected sparse array");
 				nodeCache.get(c)?.adoptBy(undefined);
 			}
+			let removed: ExclusiveMapTree[] | undefined;
 			this.edit((mapTrees) => {
-				mapTrees.splice(index, count);
+				removed = mapTrees.splice(index, count);
 			});
+			return removed ?? fail("Expected removed to be set by edit");
 		},
 	};
 

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -286,7 +286,9 @@ export { makeMitigatedChangeFamily } from "./mitigatedChangeFamily.js";
 
 export {
 	type MapTreeNode,
+	type MapTreeSequenceField,
 	isMapTreeNode,
+	isMapTreeSequenceField,
 	getOrCreateMapTreeNode,
 	tryGetMapTreeNode,
 } from "./flex-map-tree/index.js";

--- a/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/arrayNode.spec.ts
@@ -67,587 +67,579 @@ describe("ArrayNode", () => {
 		title: string,
 		schemaType: typeof PojoEmulationNumberArray | typeof CustomizableNumberArray,
 	): void {
-		describeHydration(
-			title,
-			(init) => {
-				it("fails at runtime if attempting to set content via index assignment", () => {
-					const array = init(schemaType, [0]);
-					const mutableArray = array as Mutable<typeof array>;
-					assert.equal(mutableArray.length, 1);
-					assert.throws(
-						() => (mutableArray[0] = 3),
-						validateUsageError(/Use array node mutation APIs/),
-					); // An index within the array that already has an element
-					assert.throws(
-						() => (mutableArray[1] = 3),
-						validateUsageError(/Use array node mutation APIs/),
-					); // An index just past the end of the array, where a new element would be pushed
-					assert.throws(
-						() => (mutableArray[2] = 3),
-						validateUsageError(/Use array node mutation APIs/),
-					); // An index that would leave a "gap" past the current end of the array if a set occurred
+		describeHydration(title, (init) => {
+			it("fails at runtime if attempting to set content via index assignment", () => {
+				const array = init(schemaType, [0]);
+				const mutableArray = array as Mutable<typeof array>;
+				assert.equal(mutableArray.length, 1);
+				assert.throws(
+					() => (mutableArray[0] = 3),
+					validateUsageError(/Use array node mutation APIs/),
+				); // An index within the array that already has an element
+				assert.throws(
+					() => (mutableArray[1] = 3),
+					validateUsageError(/Use array node mutation APIs/),
+				); // An index just past the end of the array, where a new element would be pushed
+				assert.throws(
+					() => (mutableArray[2] = 3),
+					validateUsageError(/Use array node mutation APIs/),
+				); // An index that would leave a "gap" past the current end of the array if a set occurred
+			});
+
+			it("stringifies in the same way as a JS array", () => {
+				const jsArray = [0, 1, 2];
+				const array = init(schemaType, jsArray);
+				assert.equal(JSON.stringify(array), JSON.stringify(jsArray));
+			});
+
+			describe("removeAt", () => {
+				it("valid index", () => {
+					const array = init(schemaType, [0, 1, 2]);
+					array.removeAt(1);
+					assert.deepEqual([...array], [0, 2]);
 				});
 
-				it("stringifies in the same way as a JS array", () => {
+				it("invalid index", () => {
+					const array = init(schemaType, [0, 1, 2]);
+					// Index too large
+					assert.throws(
+						() => array.removeAt(3),
+						validateUsageError(
+							/Index value passed to TreeArrayNode.removeAt is out of bounds./,
+						),
+					);
+					// Index is negative
+					assert.throws(
+						() => array.removeAt(-1),
+						validateUsageError(/Expected non-negative index, got -1./),
+					);
+				});
+			});
+
+			describe("insertAt", () => {
+				it("valid index", () => {
+					const array = init(schemaType, [1, 2, 3]);
+					array.insertAt(0, 0);
+					assert.deepEqual([...array], [0, 1, 2, 3]);
+				});
+
+				it("invalid index", () => {
+					const array = init(schemaType, [0, 1, 2]);
+					// Index too large
+					assert.throws(
+						() => array.insertAt(4, 0),
+						validateUsageError(
+							/Index value passed to TreeArrayNode.insertAt is out of bounds./,
+						),
+					);
+					// Index is negative
+					assert.throws(
+						() => array.insertAt(-1, 0),
+						validateUsageError(/Expected non-negative index, got -1./),
+					);
+				});
+			});
+
+			describe("removeRange", () => {
+				it("no arguments", () => {
 					const jsArray = [0, 1, 2];
 					const array = init(schemaType, jsArray);
-					assert.equal(JSON.stringify(array), JSON.stringify(jsArray));
+					assert.equal(array.length, 3);
+					array.removeRange();
+					assert.equal(array.length, 0);
+					assert.deepEqual([...array], []);
 				});
 
-				describe("removeAt", () => {
-					it("valid index", () => {
-						const array = init(schemaType, [0, 1, 2]);
-						array.removeAt(1);
-						assert.deepEqual([...array], [0, 2]);
-					});
-
-					it("invalid index", () => {
-						const array = init(schemaType, [0, 1, 2]);
-						// Index too large
-						assert.throws(
-							() => array.removeAt(3),
-							validateUsageError(
-								/Index value passed to TreeArrayNode.removeAt is out of bounds./,
-							),
-						);
-						// Index is negative
-						assert.throws(
-							() => array.removeAt(-1),
-							validateUsageError(/Expected non-negative index, got -1./),
-						);
-					});
+				it("empty array no arguments", () => {
+					const array = init(schemaType, []);
+					array.removeRange();
 				});
 
-				describe("insertAt", () => {
-					it("valid index", () => {
-						const array = init(schemaType, [1, 2, 3]);
-						array.insertAt(0, 0);
-						assert.deepEqual([...array], [0, 1, 2, 3]);
-					});
-
-					it("invalid index", () => {
-						const array = init(schemaType, [0, 1, 2]);
-						// Index too large
-						assert.throws(
-							() => array.insertAt(4, 0),
-							validateUsageError(
-								/Index value passed to TreeArrayNode.insertAt is out of bounds./,
-							),
-						);
-						// Index is negative
-						assert.throws(
-							() => array.insertAt(-1, 0),
-							validateUsageError(/Expected non-negative index, got -1./),
-						);
-					});
+				it("middle", () => {
+					const list = init(schemaType, [0, 1, 2, 3]);
+					list.removeRange(/* start: */ 1, /* end: */ 3);
+					assert.deepEqual([...list], [0, 3]);
 				});
 
-				describe("removeRange", () => {
-					it("no arguments", () => {
-						const jsArray = [0, 1, 2];
-						const array = init(schemaType, jsArray);
-						assert.equal(array.length, 3);
-						array.removeRange();
-						assert.equal(array.length, 0);
-						assert.deepEqual([...array], []);
-					});
-
-					it("empty array no arguments", () => {
-						const array = init(schemaType, []);
-						array.removeRange();
-					});
-
-					it("middle", () => {
-						const list = init(schemaType, [0, 1, 2, 3]);
-						list.removeRange(/* start: */ 1, /* end: */ 3);
-						assert.deepEqual([...list], [0, 3]);
-					});
-
-					it("all", () => {
-						const list = init(schemaType, [0, 1, 2, 3]);
-						list.removeRange(0, 4);
-						assert.deepEqual([...list], []);
-					});
-
-					it("past end", () => {
-						const list = init(schemaType, [0, 1, 2, 3]);
-						list.removeRange(1, Number.POSITIVE_INFINITY);
-						assert.deepEqual([...list], [0]);
-					});
-
-					it("empty range", () => {
-						const list = init(schemaType, [0, 1, 2, 3]);
-						list.removeRange(2, 2);
-						assert.deepEqual([...list], [0, 1, 2, 3]);
-					});
-
-					it("empty range - at start", () => {
-						const list = init(schemaType, [0, 1, 2, 3]);
-						list.removeRange(0, 0);
-						assert.deepEqual([...list], [0, 1, 2, 3]);
-					});
-
-					it("empty range - at end", () => {
-						const list = init(schemaType, [0, 1, 2, 3]);
-						list.removeRange(4, 4);
-						assert.deepEqual([...list], [0, 1, 2, 3]);
-					});
-
-					it("invalid", () => {
-						const list = init(schemaType, [0, 1, 2, 3]);
-						// Past end
-						assert.throws(() => list.removeRange(5, 6), validateUsageError(/Too large/));
-						// start after end
-						assert.throws(() => list.removeRange(3, 2), validateUsageError(/Too large/));
-						// negative index
-						assert.throws(() => list.removeRange(-1, 2), validateUsageError(/index/));
-						// non-integer index
-						assert.throws(() => list.removeRange(1.5, 2), validateUsageError(/integer/));
-					});
-
-					it("invalid empty range", () => {
-						// If someday someone optimized empty ranges to no op earlier, they still need to error in these cases:
-						const list = init(schemaType, [0, 1, 2, 3]);
-						// Past end
-						assert.throws(() => list.removeRange(5, 5), validateUsageError(/Too large/));
-						// negative index
-						assert.throws(() => list.removeRange(-1, -1), validateUsageError(/index/));
-						// non-integer index
-						assert.throws(
-							() => list.removeRange(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY),
-							validateUsageError(/safe integer/),
-						);
-						assert.throws(() => list.removeRange(1.5, 1.5), validateUsageError(/integer/));
-					});
-				});
-			},
-			() => {
-				describe("moveToStart", () => {
-					it("move element to start of empty array", () => {
-						const schema = schemaFactory.object("parent", {
-							array1: schemaFactory.array(schemaFactory.number),
-							array2: schemaFactory.array(schemaFactory.number),
-						});
-						const { array1, array2 } = hydrate(schema, { array1: [], array2: [1, 2, 3] });
-						array1.moveToStart(1, array2);
-						assert.deepEqual([...array1], [2]);
-						assert.deepEqual([...array2], [1, 3]);
-					});
-
-					it("move within field", () => {
-						const array = hydrate(schemaType, [1, 2, 3]);
-						array.moveToStart(1);
-						assert.deepEqual([...array], [2, 1, 3]);
-					});
-
-					it("cross-field move", () => {
-						const schema = schemaFactory.object("parent", {
-							array1: schemaFactory.array(schemaFactory.number),
-							array2: schemaFactory.array(schemaFactory.number),
-						});
-						const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
-						array1.moveToStart(1, array2);
-						assert.deepEqual([...array1], [2, 1, 2]);
-					});
-
-					it("invalid index", () => {
-						const array = hydrate(schemaType, [1, 2, 3]);
-						// Index too large
-						assert.throws(
-							() => array.moveToStart(4),
-							validateUsageError(
-								/Index value passed to TreeArrayNode.moveToStart is out of bounds./,
-							),
-						);
-						// Index is negative
-						assert.throws(
-							() => array.moveToStart(-1),
-							validateUsageError(/Expected non-negative index, got -1./),
-						);
-					});
+				it("all", () => {
+					const list = init(schemaType, [0, 1, 2, 3]);
+					list.removeRange(0, 4);
+					assert.deepEqual([...list], []);
 				});
 
-				describe("moveToEnd", () => {
-					it("move element to end of empty array", () => {
-						const schema = schemaFactory.object("parent", {
-							array1: schemaFactory.array(schemaFactory.number),
-							array2: schemaFactory.array(schemaFactory.number),
-						});
-						const { array1, array2 } = hydrate(schema, { array1: [], array2: [1, 2, 3] });
-						array1.moveToEnd(1, array2);
-						assert.deepEqual([...array1], [2]);
-						assert.deepEqual([...array2], [1, 3]);
-					});
-
-					it("move within field", () => {
-						const array = hydrate(schemaType, [1, 2, 3]);
-						array.moveToEnd(1);
-						assert.deepEqual([...array], [1, 3, 2]);
-					});
-
-					it("cross-field move", () => {
-						const schema = schemaFactory.object("parent", {
-							array1: schemaFactory.array(schemaFactory.number),
-							array2: schemaFactory.array(schemaFactory.number),
-						});
-						const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
-						array1.moveToEnd(1, array2);
-						assert.deepEqual([...array1], [1, 2, 2]);
-					});
-
-					it("invalid index", () => {
-						const array = hydrate(schemaType, [1, 2, 3]);
-						// Index too large
-						assert.throws(
-							() => array.moveToEnd(4),
-							validateUsageError(
-								/Index value passed to TreeArrayNode.moveToEnd is out of bounds./,
-							),
-						);
-						// Index is negative
-						assert.throws(
-							() => array.moveToEnd(-1),
-							validateUsageError(/Expected non-negative index, got -1./),
-						);
-					});
+				it("past end", () => {
+					const list = init(schemaType, [0, 1, 2, 3]);
+					list.removeRange(1, Number.POSITIVE_INFINITY);
+					assert.deepEqual([...list], [0]);
 				});
 
-				describe("moveToIndex", () => {
-					it("move element to start of empty array", () => {
-						const schema = schemaFactory.object("parent", {
-							array1: schemaFactory.array(schemaFactory.number),
-							array2: schemaFactory.array(schemaFactory.number),
-						});
-						const { array1, array2 } = hydrate(schema, { array1: [], array2: [1, 2, 3] });
-						array1.moveToIndex(0, 1, array2);
-						assert.deepEqual([...array1], [2]);
-						assert.deepEqual([...array2], [1, 3]);
+				it("empty range", () => {
+					const list = init(schemaType, [0, 1, 2, 3]);
+					list.removeRange(2, 2);
+					assert.deepEqual([...list], [0, 1, 2, 3]);
+				});
+
+				it("empty range - at start", () => {
+					const list = init(schemaType, [0, 1, 2, 3]);
+					list.removeRange(0, 0);
+					assert.deepEqual([...list], [0, 1, 2, 3]);
+				});
+
+				it("empty range - at end", () => {
+					const list = init(schemaType, [0, 1, 2, 3]);
+					list.removeRange(4, 4);
+					assert.deepEqual([...list], [0, 1, 2, 3]);
+				});
+
+				it("invalid", () => {
+					const list = init(schemaType, [0, 1, 2, 3]);
+					// Past end
+					assert.throws(() => list.removeRange(5, 6), validateUsageError(/Too large/));
+					// start after end
+					assert.throws(() => list.removeRange(3, 2), validateUsageError(/Too large/));
+					// negative index
+					assert.throws(() => list.removeRange(-1, 2), validateUsageError(/index/));
+					// non-integer index
+					assert.throws(() => list.removeRange(1.5, 2), validateUsageError(/integer/));
+				});
+
+				it("invalid empty range", () => {
+					// If someday someone optimized empty ranges to no op earlier, they still need to error in these cases:
+					const list = init(schemaType, [0, 1, 2, 3]);
+					// Past end
+					assert.throws(() => list.removeRange(5, 5), validateUsageError(/Too large/));
+					// negative index
+					assert.throws(() => list.removeRange(-1, -1), validateUsageError(/index/));
+					// non-integer index
+					assert.throws(
+						() => list.removeRange(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY),
+						validateUsageError(/safe integer/),
+					);
+					assert.throws(() => list.removeRange(1.5, 1.5), validateUsageError(/integer/));
+				});
+			});
+
+			describe("moveToStart", () => {
+				it("move element to start of empty array", () => {
+					const schema = schemaFactory.object("parent", {
+						array1: schemaFactory.array(schemaFactory.number),
+						array2: schemaFactory.array(schemaFactory.number),
 					});
+					const { array1, array2 } = init(schema, { array1: [], array2: [1, 2, 3] });
+					array1.moveToStart(1, array2);
+					assert.deepEqual([...array1], [2]);
+					assert.deepEqual([...array2], [1, 3]);
+				});
 
-					for (const specifySource of [false, true]) {
-						describe(`move within field ${
-							specifySource ? "(specified source)" : "(implicit source)"
-						}`, () => {
-							it("moves node to the destination index when valid", () => {
-								const initialState = [0, 1, 2];
-								for (
-									let sourceIndex = 0;
-									sourceIndex < initialState.length;
-									sourceIndex += 1
-								) {
-									const movedValue = initialState[sourceIndex];
-									for (
-										let destinationIndex = 0;
-										destinationIndex < initialState.length;
-										destinationIndex += 1
-									) {
-										const array = hydrate(schemaType, initialState);
-										if (specifySource) {
-											array.moveToIndex(destinationIndex, sourceIndex, array);
-										} else {
-											array.moveToIndex(destinationIndex, sourceIndex);
-										}
-										const actual = [...array];
-										const expected =
-											sourceIndex < destinationIndex
-												? [
-														...initialState.slice(0, sourceIndex),
-														...initialState.slice(sourceIndex + 1, destinationIndex),
-														movedValue,
-														...initialState.slice(destinationIndex),
-													]
-												: [
-														...initialState.slice(0, destinationIndex),
-														movedValue,
-														...initialState.slice(destinationIndex, sourceIndex),
-														...initialState.slice(sourceIndex + 1),
-													];
-										assert.deepEqual(actual, expected);
-									}
-								}
-							});
+				it("move within field", () => {
+					const array = init(schemaType, [1, 2, 3]);
+					array.moveToStart(1);
+					assert.deepEqual([...array], [2, 1, 3]);
+				});
 
-							it("throws when the source index is invalid", () => {
-								const array = hydrate(schemaType, [1, 2, 3]);
-								// Destination index too large
-								assert.throws(
-									() => array.moveToIndex(4, 0),
-									validateUsageError(
-										/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
-									),
-								);
-								// Source index too large
-								assert.throws(
-									() => array.moveToIndex(0, 4),
-									validateUsageError(
-										/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
-									),
-								);
-								// Destination index is negative
-								assert.throws(
-									() => array.moveToIndex(-1, 0),
-									validateUsageError(/Expected non-negative index, got -1./),
-								);
-								// Source index is negative
-								assert.throws(
-									() => array.moveToIndex(0, -1),
-									validateUsageError(/Expected non-negative index, got -1./),
-								);
-							});
-						});
-					}
+				it("cross-field move", () => {
+					const schema = schemaFactory.object("parent", {
+						array1: schemaFactory.array(schemaFactory.number),
+						array2: schemaFactory.array(schemaFactory.number),
+					});
+					const { array1, array2 } = init(schema, { array1: [1, 2], array2: [1, 2] });
+					array1.moveToStart(1, array2);
+					assert.deepEqual([...array1], [2, 1, 2]);
+				});
 
-					describe("move across fields", () => {
+				it("invalid index", () => {
+					const array = init(schemaType, [1, 2, 3]);
+					// Index too large
+					assert.throws(
+						() => array.moveToStart(4),
+						validateUsageError(
+							/Index value passed to TreeArrayNode.moveToStart is out of bounds./,
+						),
+					);
+					// Index is negative
+					assert.throws(
+						() => array.moveToStart(-1),
+						validateUsageError(/Expected non-negative index, got -1./),
+					);
+				});
+			});
+
+			describe("moveToEnd", () => {
+				it("move element to end of empty array", () => {
+					const schema = schemaFactory.object("parent", {
+						array1: schemaFactory.array(schemaFactory.number),
+						array2: schemaFactory.array(schemaFactory.number),
+					});
+					const { array1, array2 } = init(schema, { array1: [], array2: [1, 2, 3] });
+					array1.moveToEnd(1, array2);
+					assert.deepEqual([...array1], [2]);
+					assert.deepEqual([...array2], [1, 3]);
+				});
+
+				it("move within field", () => {
+					const array = init(schemaType, [1, 2, 3]);
+					array.moveToEnd(1);
+					assert.deepEqual([...array], [1, 3, 2]);
+				});
+
+				it("cross-field move", () => {
+					const schema = schemaFactory.object("parent", {
+						array1: schemaFactory.array(schemaFactory.number),
+						array2: schemaFactory.array(schemaFactory.number),
+					});
+					const { array1, array2 } = init(schema, { array1: [1, 2], array2: [1, 2] });
+					array1.moveToEnd(1, array2);
+					assert.deepEqual([...array1], [1, 2, 2]);
+				});
+
+				it("invalid index", () => {
+					const array = init(schemaType, [1, 2, 3]);
+					// Index too large
+					assert.throws(
+						() => array.moveToEnd(4),
+						validateUsageError(
+							/Index value passed to TreeArrayNode.moveToEnd is out of bounds./,
+						),
+					);
+					// Index is negative
+					assert.throws(
+						() => array.moveToEnd(-1),
+						validateUsageError(/Expected non-negative index, got -1./),
+					);
+				});
+			});
+
+			describe("moveToIndex", () => {
+				it("move element to start of empty array", () => {
+					const schema = schemaFactory.object("parent", {
+						array1: schemaFactory.array(schemaFactory.number),
+						array2: schemaFactory.array(schemaFactory.number),
+					});
+					const { array1, array2 } = init(schema, { array1: [], array2: [1, 2, 3] });
+					array1.moveToIndex(0, 1, array2);
+					assert.deepEqual([...array1], [2]);
+					assert.deepEqual([...array2], [1, 3]);
+				});
+
+				for (const specifySource of [false, true]) {
+					describe(`move within field ${
+						specifySource ? "(specified source)" : "(implicit source)"
+					}`, () => {
 						it("moves node to the destination index when valid", () => {
-							const schema = schemaFactory.object("parent", {
-								source: schemaFactory.array(schemaFactory.number),
-								destination: schemaFactory.array(schemaFactory.number),
-							});
-							for (const [initialSourceState, initialDestinationState] of [
-								[[1, 2, 3], []],
-								[
-									[1, 2, 3],
-									[4, 5],
-								],
-								[
-									[1, 2],
-									[3, 4, 5],
-								],
-							]) {
+							const initialState = [0, 1, 2];
+							for (let sourceIndex = 0; sourceIndex < initialState.length; sourceIndex += 1) {
+								const movedValue = initialState[sourceIndex];
 								for (
-									let sourceIndex = 0;
-									sourceIndex < initialSourceState.length;
-									sourceIndex += 1
+									let destinationIndex = 0;
+									destinationIndex < initialState.length;
+									destinationIndex += 1
 								) {
-									const movedValue = initialSourceState[sourceIndex];
-									for (
-										let destinationIndex = 0;
-										destinationIndex < initialDestinationState.length;
-										destinationIndex += 1
-									) {
-										const { source, destination } = hydrate(schema, {
-											source: initialSourceState,
-											destination: initialDestinationState,
-										});
-										destination.moveToIndex(destinationIndex, sourceIndex, source);
-										const actualSource = [...source];
-										const actualDestination = [...destination];
-										const expectedSource = [
-											...initialSourceState.slice(0, sourceIndex),
-											...initialSourceState.slice(sourceIndex + 1),
-										];
-										const expectedDestination = [
-											...initialDestinationState.slice(0, destinationIndex),
-											movedValue,
-											...initialDestinationState.slice(destinationIndex),
-										];
-										assert.deepEqual(actualSource, expectedSource);
-										assert.deepEqual(actualDestination, expectedDestination);
+									const array = init(schemaType, initialState);
+									if (specifySource) {
+										array.moveToIndex(destinationIndex, sourceIndex, array);
+									} else {
+										array.moveToIndex(destinationIndex, sourceIndex);
 									}
+									const actual = [...array];
+									const expected =
+										sourceIndex < destinationIndex
+											? [
+													...initialState.slice(0, sourceIndex),
+													...initialState.slice(sourceIndex + 1, destinationIndex),
+													movedValue,
+													...initialState.slice(destinationIndex),
+												]
+											: [
+													...initialState.slice(0, destinationIndex),
+													movedValue,
+													...initialState.slice(destinationIndex, sourceIndex),
+													...initialState.slice(sourceIndex + 1),
+												];
+									assert.deepEqual(actual, expected);
 								}
 							}
 						});
 
 						it("throws when the source index is invalid", () => {
-							const schema = schemaFactory.object("parent", {
-								source: schemaFactory.array(schemaFactory.number),
-								destination: schemaFactory.array(schemaFactory.number),
-							});
-							const { source, destination } = hydrate(schema, {
-								source: [1, 2, 3],
-								destination: [4, 5, 6, 7],
-							});
+							const array = init(schemaType, [1, 2, 3]);
 							// Destination index too large
 							assert.throws(
-								() => destination.moveToIndex(5, 0, source),
+								() => array.moveToIndex(4, 0),
 								validateUsageError(
 									/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
 								),
 							);
 							// Source index too large
 							assert.throws(
-								() => destination.moveToIndex(0, 4, source),
+								() => array.moveToIndex(0, 4),
 								validateUsageError(
 									/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
 								),
 							);
 							// Destination index is negative
 							assert.throws(
-								() => destination.moveToIndex(-1, 0, source),
+								() => array.moveToIndex(-1, 0),
 								validateUsageError(/Expected non-negative index, got -1./),
 							);
 							// Source index is negative
 							assert.throws(
-								() => destination.moveToIndex(0, -1, source),
+								() => array.moveToIndex(0, -1),
 								validateUsageError(/Expected non-negative index, got -1./),
 							);
 						});
 					});
-				});
+				}
 
-				describe("moveRangeToStart", () => {
-					it("move within field", () => {
-						const array = hydrate(schemaType, [1, 2, 3]);
-						array.moveRangeToStart(1, 3);
-						assert.deepEqual([...array], [2, 3, 1]);
-					});
-
-					it("cross-field move", () => {
+				describe("move across fields", () => {
+					it("moves node to the destination index when valid", () => {
 						const schema = schemaFactory.object("parent", {
-							array1: schemaFactory.array(schemaFactory.number),
-							array2: schemaFactory.array(schemaFactory.number),
+							source: schemaFactory.array(schemaFactory.number),
+							destination: schemaFactory.array(schemaFactory.number),
 						});
-						const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
-						array1.moveRangeToStart(0, 2, array2);
-						assert.deepEqual([...array1], [1, 2, 1, 2]);
+						for (const [initialSourceState, initialDestinationState] of [
+							[[1, 2, 3], []],
+							[
+								[1, 2, 3],
+								[4, 5],
+							],
+							[
+								[1, 2],
+								[3, 4, 5],
+							],
+						]) {
+							for (
+								let sourceIndex = 0;
+								sourceIndex < initialSourceState.length;
+								sourceIndex += 1
+							) {
+								const movedValue = initialSourceState[sourceIndex];
+								for (
+									let destinationIndex = 0;
+									destinationIndex < initialDestinationState.length;
+									destinationIndex += 1
+								) {
+									const { source, destination } = init(schema, {
+										source: initialSourceState,
+										destination: initialDestinationState,
+									});
+									destination.moveToIndex(destinationIndex, sourceIndex, source);
+									const actualSource = [...source];
+									const actualDestination = [...destination];
+									const expectedSource = [
+										...initialSourceState.slice(0, sourceIndex),
+										...initialSourceState.slice(sourceIndex + 1),
+									];
+									const expectedDestination = [
+										...initialDestinationState.slice(0, destinationIndex),
+										movedValue,
+										...initialDestinationState.slice(destinationIndex),
+									];
+									assert.deepEqual(actualSource, expectedSource);
+									assert.deepEqual(actualDestination, expectedDestination);
+								}
+							}
+						}
 					});
 
-					it("move within empty field", () => {
-						const array = hydrate(schemaType, []);
-						array.moveRangeToStart(0, 0);
-						assert.deepEqual([...array], []);
-					});
-
-					it("invalid index", () => {
-						const array = hydrate(schemaType, [1, 2, 3]);
-						// End index too large
-						assert.throws(
-							() => array.moveRangeToStart(0, 4),
-							validateUsageError(
-								/Index value passed to TreeArrayNode.moveRangeToStart is out of bounds./,
-							),
-						);
-						// Start index is larger than end index
-						assert.throws(
-							() => array.moveRangeToStart(2, 1),
-							validateUsageError(
-								/Index value passed to TreeArrayNode.moveRangeToStart is out of bounds./,
-							),
-						);
-						// Index is negative
-						assert.throws(
-							() => array.moveRangeToStart(-1, 0),
-							validateUsageError(/Expected non-negative index, got -1./),
-						);
-					});
-				});
-
-				describe("moveRangeToEnd", () => {
-					it("move within field", () => {
-						const array = hydrate(schemaType, [1, 2, 3]);
-						array.moveRangeToEnd(0, 2);
-						assert.deepEqual([...array], [3, 1, 2]);
-					});
-
-					it("cross-field move", () => {
+					it("throws when the source index is invalid", () => {
 						const schema = schemaFactory.object("parent", {
-							array1: schemaFactory.array(schemaFactory.number),
-							array2: schemaFactory.array(schemaFactory.number),
+							source: schemaFactory.array(schemaFactory.number),
+							destination: schemaFactory.array(schemaFactory.number),
 						});
-						const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
-						array1.moveRangeToEnd(0, 2, array2);
-						assert.deepEqual([...array1], [1, 2, 1, 2]);
-					});
-
-					it("move within empty field", () => {
-						const array = hydrate(schemaType, []);
-						array.moveRangeToEnd(0, 0);
-						assert.deepEqual([...array], []);
-					});
-
-					it("invalid index", () => {
-						const array = hydrate(schemaType, [1, 2, 3]);
-						// End index too large
-						assert.throws(
-							() => array.moveRangeToEnd(0, 4),
-							validateUsageError(
-								/Index value passed to TreeArrayNode.moveRangeToEnd is out of bounds./,
-							),
-						);
-						// Start index is larger than the end index
-						assert.throws(
-							() => array.moveRangeToEnd(2, 1),
-							validateUsageError(
-								/Index value passed to TreeArrayNode.moveRangeToEnd is out of bounds./,
-							),
-						);
-						// Index is negative
-						assert.throws(
-							() => array.moveRangeToEnd(-1, 0),
-							validateUsageError(/Expected non-negative index, got -1./),
-						);
-					});
-				});
-
-				describe("moveRangeToIndex", () => {
-					it("move within field", () => {
-						const array = hydrate(schemaType, [1, 2, 3]);
-						array.moveRangeToIndex(0, 1, 3);
-						assert.deepEqual([...array], [2, 3, 1]);
-					});
-
-					it("cross-field move", () => {
-						const schema = schemaFactory.object("parent", {
-							array1: schemaFactory.array(schemaFactory.number),
-							array2: schemaFactory.array(schemaFactory.number),
+						const { source, destination } = init(schema, {
+							source: [1, 2, 3],
+							destination: [4, 5, 6, 7],
 						});
-						const { array1, array2 } = hydrate(schema, { array1: [1, 2], array2: [1, 2] });
-						array1.moveRangeToIndex(0, 0, 2, array2);
-						assert.deepEqual([...array1], [1, 2, 1, 2]);
-					});
-
-					it("move within empty field", () => {
-						const array = hydrate(schemaType, []);
-						array.moveRangeToIndex(0, 0, 0);
-						assert.deepEqual([...array], []);
-					});
-
-					it("invalid content type", () => {
-						const schema = schemaFactory.object("parent", {
-							array1: schemaFactory.array([schemaFactory.number, schemaFactory.string]),
-							array2: schemaFactory.array(schemaFactory.number),
-						});
-						const { array1, array2 } = hydrate(schema, { array1: [1, "bad", 2], array2: [] });
-						const expected = validateUsageError(
-							/Type in source sequence is not allowed in destination./,
-						);
-						assert.throws(() => array2.moveRangeToIndex(0, 1, 3, array1), expected);
-						assert.throws(() => array2.moveRangeToIndex(0, 0, 2, array1), expected);
-						assert.throws(() => array2.moveRangeToIndex(0, 0, 3, array1), expected);
-					});
-
-					it("invalid index", () => {
-						const array = hydrate(schemaType, [1, 2, 3]);
 						// Destination index too large
 						assert.throws(
-							() => array.moveRangeToIndex(4, 0, 2),
+							() => destination.moveToIndex(5, 0, source),
 							validateUsageError(
-								/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
+								/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
 							),
 						);
-						// End index is too large
+						// Source index too large
 						assert.throws(
-							() => array.moveRangeToIndex(0, 0, 4),
+							() => destination.moveToIndex(0, 4, source),
 							validateUsageError(
-								/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
+								/Index value passed to TreeArrayNode.moveToIndex is out of bounds./,
 							),
 						);
-						// Start index larger than end index
+						// Destination index is negative
 						assert.throws(
-							() => array.moveRangeToIndex(0, 2, 1),
-							validateUsageError(
-								/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
-							),
+							() => destination.moveToIndex(-1, 0, source),
+							validateUsageError(/Expected non-negative index, got -1./),
 						);
-						// Index is negative
+						// Source index is negative
 						assert.throws(
-							() => array.moveRangeToIndex(-1, 0, 1),
+							() => destination.moveToIndex(0, -1, source),
 							validateUsageError(/Expected non-negative index, got -1./),
 						);
 					});
 				});
-			},
-		);
+			});
+
+			describe("moveRangeToStart", () => {
+				it("move within field", () => {
+					const array = init(schemaType, [1, 2, 3]);
+					array.moveRangeToStart(1, 3);
+					assert.deepEqual([...array], [2, 3, 1]);
+				});
+
+				it("cross-field move", () => {
+					const schema = schemaFactory.object("parent", {
+						array1: schemaFactory.array(schemaFactory.number),
+						array2: schemaFactory.array(schemaFactory.number),
+					});
+					const { array1, array2 } = init(schema, { array1: [1, 2], array2: [1, 2] });
+					array1.moveRangeToStart(0, 2, array2);
+					assert.deepEqual([...array1], [1, 2, 1, 2]);
+				});
+
+				it("move within empty field", () => {
+					const array = init(schemaType, []);
+					array.moveRangeToStart(0, 0);
+					assert.deepEqual([...array], []);
+				});
+
+				it("invalid index", () => {
+					const array = init(schemaType, [1, 2, 3]);
+					// End index too large
+					assert.throws(
+						() => array.moveRangeToStart(0, 4),
+						validateUsageError(
+							/Index value passed to TreeArrayNode.moveRangeToStart is out of bounds./,
+						),
+					);
+					// Start index is larger than end index
+					assert.throws(
+						() => array.moveRangeToStart(2, 1),
+						validateUsageError(
+							/Index value passed to TreeArrayNode.moveRangeToStart is out of bounds./,
+						),
+					);
+					// Index is negative
+					assert.throws(
+						() => array.moveRangeToStart(-1, 0),
+						validateUsageError(/Expected non-negative index, got -1./),
+					);
+				});
+			});
+
+			describe("moveRangeToEnd", () => {
+				it("move within field", () => {
+					const array = init(schemaType, [1, 2, 3]);
+					array.moveRangeToEnd(0, 2);
+					assert.deepEqual([...array], [3, 1, 2]);
+				});
+
+				it("cross-field move", () => {
+					const schema = schemaFactory.object("parent", {
+						array1: schemaFactory.array(schemaFactory.number),
+						array2: schemaFactory.array(schemaFactory.number),
+					});
+					const { array1, array2 } = init(schema, { array1: [1, 2], array2: [1, 2] });
+					array1.moveRangeToEnd(0, 2, array2);
+					assert.deepEqual([...array1], [1, 2, 1, 2]);
+				});
+
+				it("move within empty field", () => {
+					const array = init(schemaType, []);
+					array.moveRangeToEnd(0, 0);
+					assert.deepEqual([...array], []);
+				});
+
+				it("invalid index", () => {
+					const array = init(schemaType, [1, 2, 3]);
+					// End index too large
+					assert.throws(
+						() => array.moveRangeToEnd(0, 4),
+						validateUsageError(
+							/Index value passed to TreeArrayNode.moveRangeToEnd is out of bounds./,
+						),
+					);
+					// Start index is larger than the end index
+					assert.throws(
+						() => array.moveRangeToEnd(2, 1),
+						validateUsageError(
+							/Index value passed to TreeArrayNode.moveRangeToEnd is out of bounds./,
+						),
+					);
+					// Index is negative
+					assert.throws(
+						() => array.moveRangeToEnd(-1, 0),
+						validateUsageError(/Expected non-negative index, got -1./),
+					);
+				});
+			});
+
+			describe("moveRangeToIndex", () => {
+				it("move within field", () => {
+					const array = init(schemaType, [1, 2, 3]);
+					array.moveRangeToIndex(0, 1, 3);
+					assert.deepEqual([...array], [2, 3, 1]);
+				});
+
+				it("cross-field move", () => {
+					const schema = schemaFactory.object("parent", {
+						array1: schemaFactory.array(schemaFactory.number),
+						array2: schemaFactory.array(schemaFactory.number),
+					});
+					const { array1, array2 } = init(schema, { array1: [1, 2], array2: [1, 2] });
+					array1.moveRangeToIndex(0, 0, 2, array2);
+					assert.deepEqual([...array1], [1, 2, 1, 2]);
+				});
+
+				it("move within empty field", () => {
+					const array = init(schemaType, []);
+					array.moveRangeToIndex(0, 0, 0);
+					assert.deepEqual([...array], []);
+				});
+
+				it("invalid content type", () => {
+					const schema = schemaFactory.object("parent", {
+						array1: schemaFactory.array([schemaFactory.number, schemaFactory.string]),
+						array2: schemaFactory.array(schemaFactory.number),
+					});
+					const { array1, array2 } = init(schema, { array1: [1, "bad", 2], array2: [] });
+					const expected = validateUsageError(
+						/Type in source sequence is not allowed in destination./,
+					);
+					assert.throws(() => array2.moveRangeToIndex(0, 1, 3, array1), expected);
+					assert.throws(() => array2.moveRangeToIndex(0, 0, 2, array1), expected);
+					assert.throws(() => array2.moveRangeToIndex(0, 0, 3, array1), expected);
+				});
+
+				it("invalid index", () => {
+					const array = init(schemaType, [1, 2, 3]);
+					// Destination index too large
+					assert.throws(
+						() => array.moveRangeToIndex(4, 0, 2),
+						validateUsageError(
+							/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
+						),
+					);
+					// End index is too large
+					assert.throws(
+						() => array.moveRangeToIndex(0, 0, 4),
+						validateUsageError(
+							/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
+						),
+					);
+					// Start index larger than end index
+					assert.throws(
+						() => array.moveRangeToIndex(0, 2, 1),
+						validateUsageError(
+							/Index value passed to TreeArrayNode.moveRangeToIndex is out of bounds./,
+						),
+					);
+					// Index is negative
+					assert.throws(
+						() => array.moveRangeToIndex(-1, 0, 1),
+						validateUsageError(/Expected non-negative index, got -1./),
+					);
+				});
+			});
+		});
 	}
 
 	it("asIndex helper returns expected values", () => {

--- a/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
@@ -112,6 +112,9 @@ describe("Unhydrated nodes", () => {
 		assert.equal(Tree.parent(newArrayLeaf), undefined);
 		array.insertAtEnd(newArrayLeaf);
 		assert.equal(Tree.parent(newArrayLeaf), array);
+		const array2 = new TestArray([]);
+		array2.moveToEnd(0, array);
+		assert.equal(Tree.parent(newArrayLeaf), array2);
 		// Object
 		const object = new TestObject({ array, map });
 		assert.equal(Tree.parent(object), undefined);


### PR DESCRIPTION
## Description

This updates the ArrayNode tests to run all move tests suites against both hydrated and unhydrated nodes.
