### PR TITLE
tree: Remove use of typedJsonCursor in lazyField tests

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -123,8 +123,7 @@ export function makeField(
 }
 
 /**
- * A Proxy target, which together with a `fieldProxyHandler` implements a basic access to
- * the nodes of {@link EditableField} by means of the cursors.
+ * Base type for fields implementing {@link FlexTreeField} using cursors.
  */
 export abstract class LazyField<
 		out TKind extends FlexFieldKind,

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -60,8 +60,8 @@ const detachedFieldAnchor: FieldAnchor = { parent: undefined, fieldKey: detached
  * Test {@link LazyField} implementation.
  */
 class TestLazyField<
+	TKind extends FlexFieldKind,
 	TTypes extends FlexAllowedTypes,
-	TKind extends FlexFieldKind = typeof FieldKinds.optional,
 > extends LazyField<TKind, TTypes> {}
 
 describe("LazyField", () => {
@@ -261,7 +261,7 @@ describe("LazyField", () => {
 
 	it("Disposes when parent is disposed", () => {
 		const factory = new SchemaFactory("LazyField");
-		const Holder = factory.object("holder", { f: factory.number });
+		class Holder extends factory.object("holder", { f: factory.number }) {}
 		const schema = toFlexSchema(Holder);
 		const forest = forestWithContent({
 			schema,

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -20,7 +20,6 @@ import {
 	leaf,
 	leaf as leafDomain,
 	singleJsonCursor,
-	typedJsonCursor,
 } from "../../../domains/index.js";
 import { isFreedSymbol } from "../../../feature-libraries/flex-tree/lazyEntity.js";
 import {
@@ -35,8 +34,8 @@ import {
 	type FlexAllowedTypes,
 	FlexFieldSchema,
 	cursorForJsonableTreeNode,
-	SchemaBuilderBase,
 	mapTreeFromCursor,
+	type FlexFieldKind,
 } from "../../../feature-libraries/index.js";
 import { brand, disposeSymbol } from "../../../util/index.js";
 import { flexTreeViewWithContent, forestWithContent } from "../../utils.js";
@@ -47,6 +46,12 @@ import {
 	readonlyTreeWithContent,
 	rootFieldAnchor,
 } from "./utils.js";
+import {
+	cursorFromInsertable,
+	SchemaFactory,
+	toFlexSchema,
+} from "../../../simple-tree/index.js";
+import { getFlexSchema } from "../../../simple-tree/toFlexSchema.js";
 
 const detachedField: FieldKey = brand("detached");
 const detachedFieldAnchor: FieldAnchor = { parent: undefined, fieldKey: detachedField };
@@ -54,10 +59,10 @@ const detachedFieldAnchor: FieldAnchor = { parent: undefined, fieldKey: detached
 /**
  * Test {@link LazyField} implementation.
  */
-class TestLazyField<TTypes extends FlexAllowedTypes> extends LazyField<
-	typeof FieldKinds.optional,
-	TTypes
-> {}
+class TestLazyField<
+	TTypes extends FlexAllowedTypes,
+	TKind extends FlexFieldKind = typeof FieldKinds.optional,
+> extends LazyField<TKind, TTypes> {}
 
 describe("LazyField", () => {
 	it("LazyField implementations do not allow edits to detached trees", () => {
@@ -190,22 +195,23 @@ describe("LazyField", () => {
 	});
 
 	it("parent", () => {
-		const builder = new SchemaBuilder({ scope: "test", libraries: [leafDomain.library] });
-		const struct = builder.object("object", {
-			foo: FlexFieldSchema.create(FieldKinds.optional, leafDomain.primitives),
-		});
-		const rootSchema = FlexFieldSchema.create(FieldKinds.optional, [struct]);
-		const schema = builder.intoSchema(rootSchema);
+		const factory = new SchemaFactory("test");
+		class Struct extends factory.object("Struct", {
+			foo: factory.number,
+		}) {}
+		const schema = toFlexSchema(Struct);
 
 		const { context, cursor } = readonlyTreeWithContent({
 			schema,
-			initialTree: typedJsonCursor({
-				[typedJsonCursor.type]: struct,
-				foo: "Hello world",
-			}),
+			initialTree: cursorFromInsertable(Struct, { foo: 5 }),
 		});
 
-		const rootField = new TestLazyField(context, rootSchema, cursor, rootFieldAnchor);
+		const rootField = new TestLazyField(
+			context,
+			schema.rootFieldSchema,
+			cursor,
+			rootFieldAnchor,
+		);
 		assert.equal(rootField.parent, undefined);
 
 		const parentPath: UpPath = {
@@ -221,7 +227,7 @@ describe("LazyField", () => {
 
 		const leafField = new TestLazyField(
 			context,
-			FlexFieldSchema.create(FieldKinds.optional, leafDomain.primitives),
+			toFlexSchema(factory.number).rootFieldSchema,
 			cursor,
 			{
 				parent: parentAnchor,
@@ -232,19 +238,18 @@ describe("LazyField", () => {
 	});
 
 	it("Disposes when context is disposed", () => {
-		const builder = new SchemaBuilderBase(FieldKinds.required, {
-			scope: "LazyField",
-			libraries: [leafDomain.library],
+		const factory = new SchemaFactory("LazyField");
+		const schema = toFlexSchema(factory.number);
+		const forest = forestWithContent({
+			schema,
+			initialTree: cursorFromInsertable(factory.number, 5),
 		});
-		builder.object("empty", {});
-		const schema = builder.intoSchema(FlexFieldSchema.create(FieldKinds.optional, [Any]));
-		const forest = forestWithContent({ schema, initialTree: singleJsonCursor({}) });
 		const context = getReadonlyContext(forest, schema);
 		const cursor = initializeCursor(context, detachedFieldAnchor);
 
-		const field = new LazyOptionalField(
+		const field = new TestLazyField(
 			context,
-			FlexFieldSchema.create(FieldKinds.optional, [Any]),
+			schema.rootFieldSchema,
 			cursor,
 			detachedFieldAnchor,
 		);
@@ -255,21 +260,18 @@ describe("LazyField", () => {
 	});
 
 	it("Disposes when parent is disposed", () => {
-		const builder = new SchemaBuilderBase(FieldKinds.required, {
-			scope: "LazyField",
-			libraries: [leafDomain.library],
-		});
-		const Holder = builder.object("holder", { f: leafDomain.number });
-		const schema = builder.intoSchema(FlexFieldSchema.create(FieldKinds.optional, [Any]));
+		const factory = new SchemaFactory("LazyField");
+		const Holder = factory.object("holder", { f: factory.number });
+		const schema = toFlexSchema(Holder);
 		const forest = forestWithContent({
 			schema,
-			initialTree: typedJsonCursor({ [typedJsonCursor.type]: Holder, f: 5 }),
+			initialTree: cursorFromInsertable(Holder, { f: 5 }),
 		});
 		const context = getReadonlyContext(forest, schema);
 
 		const holder = [...context.root.boxedIterator()][0];
-		assert(holder.is(Holder));
-		const field = holder.boxedF;
+		assert(holder.is(getFlexSchema(Holder)));
+		const field = holder.getBoxed(brand("f"));
 		assert(field instanceof LazyField);
 
 		assert(!field[isFreedSymbol]());
@@ -282,21 +284,18 @@ describe("LazyField", () => {
 	});
 
 	it("Disposes when context then parent is disposed", () => {
-		const builder = new SchemaBuilderBase(FieldKinds.required, {
-			scope: "LazyField",
-			libraries: [leafDomain.library],
-		});
-		const Holder = builder.object("holder", { f: leafDomain.number });
-		const schema = builder.intoSchema(FlexFieldSchema.create(FieldKinds.optional, [Any]));
+		const factory = new SchemaFactory("LazyField");
+		const Holder = factory.object("holder", { f: factory.number });
+		const schema = toFlexSchema(Holder);
 		const forest = forestWithContent({
 			schema,
-			initialTree: typedJsonCursor({ [typedJsonCursor.type]: Holder, f: 5 }),
+			initialTree: cursorFromInsertable(Holder, { f: 5 }),
 		});
 		const context = getReadonlyContext(forest, schema);
 
 		const holder = [...context.root.boxedIterator()][0];
-		assert(holder.is(Holder));
-		const field = holder.boxedF;
+		assert(holder.is(getFlexSchema(Holder)));
+		const field = holder.getBoxed(brand("f"));
 		assert(field instanceof LazyField);
 
 		assert(!field[isFreedSymbol]());

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -285,7 +285,7 @@ describe("LazyField", () => {
 
 	it("Disposes when context then parent is disposed", () => {
 		const factory = new SchemaFactory("LazyField");
-		const Holder = factory.object("holder", { f: factory.number });
+		class Holder extends factory.object("holder", { f: factory.number }) {}
 		const schema = toFlexSchema(Holder);
 		const forest = forestWithContent({
 			schema,


### PR DESCRIPTION
## Description

Remove use of typedJsonCursor in lazyField tests

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
