### PR TITLE
Revert "ci(client): Trigger client on any edit to root files"

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -60,16 +60,20 @@ trigger:
     - release/*
   paths:
     include:
-    # Trigger on any edits to files in the root
-    - "*"
+    - .prettierignore
+    - biome.json
+    - biome.jsonc
+    - packages
     - azure
-    - common/build/build-common
     - examples
     - experimental
-    - packages
-    - scripts
+    - common/build/build-common
+    - lerna.json
+    - package.json
+    - pnpm-lock.yaml
+    - pnpm-workspace.yaml
     # markdown-magic is part of the client release group
-    - tools/markdown-magic
+    - tools/markdown-magic/*
     - tools/pipelines/build-client.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
@@ -82,6 +86,7 @@ trigger:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - scripts/*
 
 pr:
   branches:
@@ -92,16 +97,19 @@ pr:
     - release/*
   paths:
     include:
-    # Trigger on any edits to files in the root
-    - "*"
+    - .prettierignore
+    - packages
     - azure
-    - common/build/build-common
     - examples
     - experimental
-    - packages
-    - scripts
+    - common/build/build-common
+    - lerna.json
+    - package.json
+    - pnpm-lock.yaml
+    - pnpm-workspace.yaml
+    - fluidBuild.config.cjs
     # markdown-magic is part of the client release group
-    - tools/markdown-magic
+    - tools/markdown-magic/*
     - tools/pipelines/build-client.yml
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-policy-check.yml
@@ -111,6 +119,7 @@ pr:
     - tools/pipelines/templates/include-use-node-version.yml
     - tools/pipelines/templates/include-process-test-results.yml
     - tools/pipelines/templates/upload-dev-manifest.yml
+    - scripts/*
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self


### PR DESCRIPTION
This reverts commit 9ec2c94bc2152e0ac8bd6a7b3d4aaa52a14f937b.

Unfortunately the change in #22133 is causing the client build to always be triggered for PRs, which was not the intended behavior. Reverting is safest while we evaluate alternatives (see #22203).