### PR TITLE
Prototype unhydrated node events

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-map-tree/mapTreeNode.ts
@@ -51,8 +51,13 @@ import { type FlexImplicitAllowedTypes, normalizeAllowedTypes } from "../schemaB
 import type { FlexFieldKind } from "../modular-schema/index.js";
 import { FieldKinds, type SequenceFieldEditBuilder } from "../default-schema/index.js";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { createEmitter, type Listenable } from "../../events/index.js";
 
 // #region Nodes
+
+export interface MapTreeNodeEvents {
+	changed(): void;
+}
 
 /**
  * A readonly {@link FlexTreeNode} which wraps a {@link MapTree}.
@@ -61,6 +66,7 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
  */
 export interface MapTreeNode extends FlexTreeNode {
 	readonly mapTree: MapTree;
+	readonly events: Listenable<MapTreeNodeEvents>;
 }
 
 /**
@@ -114,6 +120,7 @@ interface LocationInField {
  */
 export class EagerMapTreeNode<TSchema extends FlexTreeNodeSchema> implements MapTreeNode {
 	public readonly [flexTreeMarker] = FlexTreeEntityKind.Node as const;
+	public readonly events = createEmitter<MapTreeNodeEvents>();
 
 	/**
 	 * Create a new MapTreeNode.
@@ -461,6 +468,8 @@ class EagerMapTreeField<T extends FlexAllowedTypes> implements MapTreeField {
 		} else {
 			this.parent.mapTree.fields.delete(this.key);
 		}
+
+		this.parent.events.emit("changed");
 	}
 }
 

--- a/packages/dds/tree/src/simple-tree/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/treeNodeValid.ts
@@ -159,7 +159,7 @@ export abstract class TreeNodeValid<TInput> extends TreeNode {
 		);
 
 		const result = schema.prepareInstance(this, node);
-		new TreeNodeKernel(result, schema);
+		new TreeNodeKernel(node, result, schema);
 		setInnerNode(result, node);
 		return result;
 	}

--- a/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
@@ -177,6 +177,43 @@ describe("Unhydrated nodes", () => {
 		assert.equal(Tree.status(object), TreeStatus.New);
 	});
 
+	it("emit events when edited before hydration", () => {
+		const leaf = new TestLeaf({ value: "value" });
+		const map = new TestMap([]);
+		const array = new TestArray([leaf]);
+		const object = new TestObject({ map, array });
+
+		const log: string[] = [];
+		Tree.on(leaf, "nodeChanged", () => log.push("leaf nodeChanged"));
+		Tree.on(leaf, "treeChanged", () => log.push("leaf treeChanged"));
+		Tree.on(map, "nodeChanged", () => log.push("map nodeChanged"));
+		Tree.on(map, "treeChanged", () => log.push("map treeChanged"));
+		Tree.on(array, "nodeChanged", () => log.push("array nodeChanged"));
+		Tree.on(array, "treeChanged", () => log.push("array treeChanged"));
+		Tree.on(object, "nodeChanged", () => log.push("object nodeChanged"));
+		Tree.on(object, "treeChanged", () => log.push("object treeChanged"));
+
+		leaf.value = "value 2";
+		map.set("key", { value: "value 3" });
+		array.removeRange();
+		object.map = new TestMap({});
+
+		assert.deepEqual(log, [
+			"leaf nodeChanged",
+			"leaf treeChanged",
+			"array treeChanged",
+			"object treeChanged",
+			"map nodeChanged",
+			"map treeChanged",
+			"object treeChanged",
+			"array nodeChanged",
+			"array treeChanged",
+			"object treeChanged",
+			"object nodeChanged",
+			"object treeChanged",
+		]);
+	});
+
 	it("preserve events after hydration", () => {
 		function registerEvents(node: TreeNode): () => void {
 			let deepEvent = false;


### PR DESCRIPTION
This is a prototype of one possible way to implement event emitters for unhydrated nodes. It contains a layering violation (namely, that `tryGetCachedTreeNode` is imported into treeKernel.ts) which would need to be addressed by moving the node cache or creating another node cache inside of the treeKernel.ts.
