### PR TITLE
FluidStatic: Remove unused code from rootDataObject

### DIFF
--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -9,16 +9,9 @@ import {
 	DataObjectFactory,
 } from "@fluidframework/aqueduct/internal";
 import type { IRuntimeFactory } from "@fluidframework/container-definitions/internal";
-import type { ContainerRuntime } from "@fluidframework/container-runtime/internal";
 import type { IContainerRuntime } from "@fluidframework/container-runtime-definitions/internal";
-import type {
-	FluidObject,
-	IFluidLoadable,
-	IRequest,
-	IResponse,
-} from "@fluidframework/core-interfaces";
+import type { FluidObject, IFluidLoadable } from "@fluidframework/core-interfaces";
 import type { IDirectory } from "@fluidframework/map/internal";
-import { RequestParser } from "@fluidframework/runtime-utils/internal";
 import type { SharedObjectKind } from "@fluidframework/shared-object-base";
 import type { ISharedObjectKind } from "@fluidframework/shared-object-base/internal";
 
@@ -214,24 +207,8 @@ class DOProviderContainerRuntimeFactory extends BaseContainerRuntimeFactory {
 			}
 			return entryPoint.get();
 		};
-		const getDefaultObject = async (
-			request: IRequest,
-			runtime: IContainerRuntime,
-			// eslint-disable-next-line unicorn/consistent-function-scoping
-		): Promise<IResponse | undefined> => {
-			const parser = RequestParser.create(request);
-			if (parser.pathParts.length === 0) {
-				// This cast is safe as ContainerRuntime.loadRuntime is called in the base class
-				return (runtime as ContainerRuntime).resolveHandle({
-					url: `/${rootDataStoreId}${parser.query}`,
-					headers: request.headers,
-				});
-			}
-			return undefined; // continue search
-		};
 		super({
 			registryEntries: [rootDataObjectFactory.registryEntry],
-			requestHandlers: [getDefaultObject],
 			runtimeOptions: compatibilityModeRuntimeOptions[compatibilityMode],
 			provideEntryPoint,
 		});


### PR DESCRIPTION
Remove the code to handle requests from DOProviderContainerRuntimeFactory  which is unnecessary for the rootDataObject as the request pattern is no longer used to access the rootDataObject in any of our service clients.