### PR TITLE
fix(build-tools): Filter out empty responses from git ls-files

### DIFF
--- a/build-tools/packages/build-cli/src/library/git.ts
+++ b/build-tools/packages/build-cli/src/library/git.ts
@@ -237,7 +237,13 @@ export class Repository {
 
 		// This includes paths to deleted, unstaged files, so we get the list of deleted files from git status and remove
 		// those from the full list.
-		const allFiles = new Set(results.split("\n").map((line) => line.trim()));
+		const allFiles = new Set(
+			results
+				.split("\n")
+				.map((line) => line.trim())
+				// filter out empty lines
+				.filter((line) => line !== ""),
+		);
 		const status = await this.gitClient.status();
 		for (const deletedFile of status.deleted) {
 			allFiles.delete(deletedFile);

--- a/build-tools/packages/build-tools/src/common/gitRepo.ts
+++ b/build-tools/packages/build-tools/src/common/gitRepo.ts
@@ -253,7 +253,13 @@ export class GitRepo {
 
 		// This includes paths to deleted, unstaged files, so we get the list of deleted files from git status and remove
 		// those from the full list.
-		const allFiles = new Set(fileResults.split("\n").map((line) => line.trim()));
+		const allFiles = new Set(
+			fileResults
+				.split("\n")
+				.map((line) => line.trim())
+				// filter out empty lines
+				.filter((line) => line !== ""),
+		);
 
 		for (const deletedFile of deletedFiles) {
 			allFiles.delete(deletedFile);


### PR DESCRIPTION
#22226 introduced a bug that caused directory paths to get into the list of cached files in the Biome task. The root cause was incomplete handling of the response from `git ls-files`. Empty strings made it into the list of files, which later resolved as a path to the working directory - the root of the repo.

The fix is to remove empty strings from the results array.