### PR TITLE
[routerlicious-driver] Reuse already retrieved session information

### DIFF
--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -46,15 +46,8 @@ import {
 	TokenFetcher,
 } from "./restWrapper.js";
 import { RestWrapper } from "./restWrapperBase.js";
+import type { IGetSessionInfoResponse } from "./sessionInfoManager.js";
 import { ITokenProvider } from "./tokens.js";
-
-/**
- * Amount of time between discoveries within which we don't need to rediscover on re-connect.
- * Currently, R11s defines session length at 10 minutes. To avoid any weird unknown edge-cases though,
- * we set the limit to 5 minutes here.
- * In the future, we likely want to retrieve this information from service's "inactive session" definition.
- */
-const RediscoverAfterTimeSinceDiscoveryMs = 5 * 60000; // 5 minute
 
 /**
  * The DocumentService manages the Socket.IO connection and manages routing requests to connected
@@ -65,9 +58,6 @@ export class DocumentService
 	// eslint-disable-next-line import/namespace
 	implements IDocumentService
 {
-	private lastDiscoveredAt: number = Date.now();
-	private discoverP: Promise<void> | undefined;
-
 	private storageManager: GitManager | undefined;
 	private noCacheStorageManager: GitManager | undefined;
 
@@ -93,7 +83,7 @@ export class DocumentService
 		private readonly blobCache: ICache<ArrayBufferLike>,
 		private readonly wholeSnapshotTreeCache: ICache<INormalizedWholeSnapshot>,
 		private readonly shreddedSummaryTreeCache: ICache<ISnapshotTreeVersion>,
-		private readonly discoverFluidResolvedUrl: () => Promise<IResolvedUrl>,
+		private readonly getSessionInfo: () => Promise<IGetSessionInfoResponse>,
 		private storageRestWrapper: RouterliciousStorageRestWrapper,
 		private readonly storageTokenFetcher: TokenFetcher,
 		private readonly ordererTokenFetcher: TokenFetcher,
@@ -124,16 +114,9 @@ export class DocumentService
 		}
 
 		const getStorageManager = async (disableCache?: boolean): Promise<GitManager> => {
-			const shouldUpdateDiscoveredSessionInfo = this.shouldUpdateDiscoveredSessionInfo();
-			if (shouldUpdateDiscoveredSessionInfo) {
-				await this.refreshDiscovery();
-			}
-			if (
-				!this.storageManager ||
-				!this.noCacheStorageManager ||
-				shouldUpdateDiscoveredSessionInfo
-			) {
-				if (shouldUpdateDiscoveredSessionInfo) {
+			const refreshed = await this.maybeRefreshDiscovery();
+			if (!this.storageManager || !this.noCacheStorageManager || refreshed) {
+				if (refreshed) {
 					const rateLimiter = new RateLimiter(
 						this.driverPolicies.maxConcurrentStorageRequests,
 					);
@@ -182,10 +165,9 @@ export class DocumentService
 		assert(!!this.documentStorageService, 0x0b1 /* "Storage service not initialized" */);
 
 		const getRestWrapper = async (): Promise<RestWrapper> => {
-			const shouldUpdateDiscoveredSessionInfo = this.shouldUpdateDiscoveredSessionInfo();
+			const refreshed = await this.maybeRefreshDiscovery();
 
-			if (shouldUpdateDiscoveredSessionInfo) {
-				await this.refreshDiscovery();
+			if (refreshed) {
 				const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentOrdererRequests);
 				this.ordererRestWrapper = RouterliciousOrdererRestWrapper.load(
 					this.ordererTokenFetcher,
@@ -221,9 +203,7 @@ export class DocumentService
 	public async connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection> {
 		const connect = async (refreshToken?: boolean) => {
 			let ordererToken = await this.ordererRestWrapper.getToken();
-			if (this.shouldUpdateDiscoveredSessionInfo()) {
-				await this.refreshDiscovery();
-			}
+			await this.maybeRefreshDiscovery();
 
 			if (refreshToken) {
 				ordererToken = await PerformanceEvent.timedExecAsync(
@@ -310,22 +290,14 @@ export class DocumentService
 
 	/**
 	 * Re-discover session URLs if necessary.
+	 * @returns boolean - true if session info was refreshed
 	 */
-	private async refreshDiscovery(): Promise<void> {
-		if (!this.discoverP) {
-			this.discoverP = PerformanceEvent.timedExecAsync(
-				this.logger,
-				{
-					eventName: "RefreshDiscovery",
-				},
-				async () => this.refreshDiscoveryCore(),
-			);
+	private async maybeRefreshDiscovery(): Promise<boolean> {
+		const response = await this.getSessionInfo();
+		if (!response.refreshed) {
+			return false;
 		}
-		return this.discoverP;
-	}
-
-	private async refreshDiscoveryCore(): Promise<void> {
-		const fluidResolvedUrl = await this.discoverFluidResolvedUrl();
+		const fluidResolvedUrl = response.resolvedUrl;
 		this._resolvedUrl = fluidResolvedUrl;
 		// TODO why are we non null asserting here?
 		this.storageUrl = fluidResolvedUrl.endpoints.storageUrl!;
@@ -334,31 +306,6 @@ export class DocumentService
 		// TODO why are we non null asserting here?
 		this.deltaStorageUrl = fluidResolvedUrl.endpoints.deltaStorageUrl!;
 		this.deltaStreamUrl = fluidResolvedUrl.endpoints.deltaStreamUrl ?? this.ordererUrl;
-	}
-
-	/**
-	 * Whether enough time has passed since last disconnect to warrant a new discovery call on reconnect.
-	 */
-	private shouldUpdateDiscoveredSessionInfo(): boolean {
-		if (!this.driverPolicies.enableDiscovery) {
-			return false;
-		}
-		const now = Date.now();
-		// When connection is disconnected, we cannot know if session has moved or document has been deleted
-		// without re-doing discovery on the next attempt to connect.
-		// Disconnect event is not so reliable in local testing. To ensure re-discovery when necessary,
-		// re-discover if enough time has passed since last discovery.
-		const pastLastDiscoveryTimeThreshold =
-			now - this.lastDiscoveredAt > RediscoverAfterTimeSinceDiscoveryMs;
-		if (pastLastDiscoveryTimeThreshold) {
-			// Reset discover promise and refresh discovery.
-			this.lastDiscoveredAt = Date.now();
-			this.discoverP = undefined;
-			this.refreshDiscovery().catch(() => {
-				// Undo discovery time set on failure, so that next check refreshes.
-				this.lastDiscoveredAt = 0;
-			});
-		}
-		return pastLastDiscoveryTimeThreshold;
+		return true;
 	}
 }

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -114,7 +114,7 @@ export class DocumentService
 		}
 
 		const getStorageManager = async (disableCache?: boolean): Promise<GitManager> => {
-			const refreshed = await this.maybeRefreshDiscovery();
+			const refreshed = await this.refreshSessionInfoIfNeeded();
 			if (!this.storageManager || !this.noCacheStorageManager || refreshed) {
 				if (refreshed) {
 					const rateLimiter = new RateLimiter(
@@ -165,7 +165,7 @@ export class DocumentService
 		assert(!!this.documentStorageService, 0x0b1 /* "Storage service not initialized" */);
 
 		const getRestWrapper = async (): Promise<RestWrapper> => {
-			const refreshed = await this.maybeRefreshDiscovery();
+			const refreshed = await this.refreshSessionInfoIfNeeded();
 
 			if (refreshed) {
 				const rateLimiter = new RateLimiter(this.driverPolicies.maxConcurrentOrdererRequests);
@@ -203,7 +203,7 @@ export class DocumentService
 	public async connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection> {
 		const connect = async (refreshToken?: boolean) => {
 			let ordererToken = await this.ordererRestWrapper.getToken();
-			await this.maybeRefreshDiscovery();
+			await this.refreshSessionInfoIfNeeded();
 
 			if (refreshToken) {
 				ordererToken = await PerformanceEvent.timedExecAsync(
@@ -289,10 +289,10 @@ export class DocumentService
 	}
 
 	/**
-	 * Re-discover session URLs if necessary.
+	 * Refresh session info URLs if necessary.
 	 * @returns boolean - true if session info was refreshed
 	 */
-	private async maybeRefreshDiscovery(): Promise<boolean> {
+	private async refreshSessionInfoIfNeeded(): Promise<boolean> {
 		const response = await this.getSessionInfo();
 		if (!response.refreshed) {
 			return false;

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -5,7 +5,6 @@
 
 import { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
-import { getW3CData } from "@fluidframework/driver-base/internal";
 import { ISummaryTree } from "@fluidframework/driver-definitions";
 import {
 	FiveDaysMs,
@@ -40,8 +39,9 @@ import {
 	toInstrumentedR11sStorageTokenFetcher,
 } from "./restWrapper.js";
 import { isRouterliciousResolvedUrl } from "./routerliciousResolvedUrl.js";
+import { SessionInfoManager, type IGetSessionInfoResponse } from "./sessionInfoManager.js";
 import { ITokenProvider } from "./tokens.js";
-import { getDiscoveredFluidResolvedUrl, replaceDocumentIdInPath } from "./urlUtils.js";
+import { replaceDocumentIdInPath } from "./urlUtils.js";
 
 const maximumSnapshotCacheDurationMs: FiveDaysMs = 432_000_000; // 5 days in ms
 
@@ -66,6 +66,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 	private readonly blobCache: ICache<ArrayBufferLike>;
 	private readonly wholeSnapshotTreeCache: ICache<INormalizedWholeSnapshot> = new NullCache();
 	private readonly shreddedSummaryTreeCache: ICache<ISnapshotTreeVersion> = new NullCache();
+	private readonly sessionInfoManager: SessionInfoManager;
 
 	constructor(
 		private readonly tokenProvider: ITokenProvider,
@@ -90,6 +91,7 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 				);
 			}
 		}
+		this.sessionInfoManager = new SessionInfoManager(this.driverPolicies.enableDiscovery);
 	}
 
 	/**
@@ -291,35 +293,16 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			ordererTokenP,
 		);
 
-		const discoverFluidResolvedUrl = async (): Promise<IResolvedUrl> => {
-			if (!this.driverPolicies.enableDiscovery) {
-				return resolvedUrl;
-			}
-
-			const discoveredSession = await PerformanceEvent.timedExecAsync(
-				logger2,
-				{
-					eventName: "DiscoverSession",
-					docId: documentId,
-				},
-				async (event) => {
-					// The service responds with the current document session associated with the container.
-					const response = await ordererRestWrapper.get<ISession>(
-						`${resolvedUrl.endpoints.ordererUrl}/documents/${tenantId}/session/${documentId}`,
-					);
-					event.end({
-						...response.propsToLog,
-						...getW3CData(response.requestUrl, "xmlhttprequest"),
-					});
-					return response.content;
-				},
-			);
-			return getDiscoveredFluidResolvedUrl(resolvedUrl, discoveredSession);
-		};
-		const fluidResolvedUrl: IResolvedUrl =
-			session !== undefined
-				? getDiscoveredFluidResolvedUrl(resolvedUrl, session)
-				: await discoverFluidResolvedUrl();
+		const fluidResolvedUrl: IResolvedUrl = await this.sessionInfoManager.initializeSessionInfo(
+			{
+				session,
+				resolvedUrl,
+				documentId,
+				tenantId,
+				ordererRestWrapper,
+				logger: logger2,
+			},
+		);
 
 		// TODO why are we non null asserting here?
 		const storageUrl = fluidResolvedUrl.endpoints.storageUrl!;
@@ -366,7 +349,15 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			this.blobCache,
 			this.wholeSnapshotTreeCache,
 			this.shreddedSummaryTreeCache,
-			discoverFluidResolvedUrl,
+			async (): Promise<IGetSessionInfoResponse> => {
+				return this.sessionInfoManager.getSessionInfo({
+					resolvedUrl,
+					documentId,
+					tenantId,
+					ordererRestWrapper,
+					logger: logger2,
+				});
+			},
 			storageRestWrapper,
 			storageTokenFetcher,
 			ordererTokenFetcher,

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -39,7 +39,7 @@ import {
 	toInstrumentedR11sStorageTokenFetcher,
 } from "./restWrapper.js";
 import { isRouterliciousResolvedUrl } from "./routerliciousResolvedUrl.js";
-import { SessionInfoManager, type IGetSessionInfoResponse } from "./sessionInfoManager.js";
+import { SessionInfoManager } from "./sessionInfoManager.js";
 import { ITokenProvider } from "./tokens.js";
 import { replaceDocumentIdInPath } from "./urlUtils.js";
 
@@ -349,15 +349,14 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			this.blobCache,
 			this.wholeSnapshotTreeCache,
 			this.shreddedSummaryTreeCache,
-			async (): Promise<IGetSessionInfoResponse> => {
-				return this.sessionInfoManager.getSessionInfo({
+			async () =>
+				this.sessionInfoManager.getSessionInfo({
 					resolvedUrl,
 					documentId,
 					tenantId,
 					ordererRestWrapper,
 					logger: logger2,
-				});
-			},
+				}),
 			storageRestWrapper,
 			storageTokenFetcher,
 			ordererTokenFetcher,

--- a/packages/drivers/routerlicious-driver/src/sessionInfoManager.ts
+++ b/packages/drivers/routerlicious-driver/src/sessionInfoManager.ts
@@ -1,0 +1,145 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert } from "@fluidframework/core-utils/internal";
+import { getW3CData } from "@fluidframework/driver-base/internal";
+import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
+import { ISession } from "@fluidframework/server-services-client";
+import {
+	PerformanceEvent,
+	ITelemetryLoggerExt,
+} from "@fluidframework/telemetry-utils/internal";
+
+import { RouterliciousOrdererRestWrapper } from "./restWrapper.js";
+import { getDiscoveredFluidResolvedUrl } from "./urlUtils.js";
+
+/**
+ * Amount of time between discoveries within which we don't need to rediscover on re-connect.
+ * Currently, R11s defines session length at 10 minutes. To avoid any weird unknown edge-cases though,
+ * we set the limit to 5 minutes here.
+ * In the future, we likely want to retrieve this information from service's "inactive session" definition.
+ */
+export const RediscoverAfterTimeSinceDiscoveryMs = 5 * 60000; // 5 minutes
+
+interface IGetSessionInfoParams {
+	resolvedUrl: IResolvedUrl;
+	documentId: string;
+	tenantId: string;
+	ordererRestWrapper: RouterliciousOrdererRestWrapper;
+	logger: ITelemetryLoggerExt;
+}
+
+export interface IGetSessionInfoResponse {
+	refreshed: boolean;
+	resolvedUrl: IResolvedUrl;
+}
+
+export class SessionInfoManager {
+	/**
+	 * Stored session info
+	 * Key: URL for given session (see "getDiscoverSessionUrl")
+	 * Value: session info stored as an IResolvedUrl
+	 */
+	private readonly sessionFluidUrls: Map<string, IResolvedUrl> = new Map();
+
+	/**
+	 * Stored dates of when a session was last discovered/refreshed
+	 * Key: URL for given session (see "getDiscoverSessionUrl")
+	 * Value: date last discovered
+	 */
+	private readonly sessionLastDiscovered: Map<string, number> = new Map();
+
+	constructor(private readonly enableDiscovery: boolean) {}
+
+	/**
+	 * Start tracking info for a given session
+	 */
+	public async initializeSessionInfo(
+		params: IGetSessionInfoParams & { session: ISession | undefined },
+	): Promise<IResolvedUrl> {
+		const { resolvedUrl, session } = params;
+
+		const url = getDiscoverSessionUrl(params);
+		assert(
+			this.sessionFluidUrls.has(url) === this.sessionLastDiscovered.has(url),
+			"Session map state mismatch",
+		);
+
+		if (session !== undefined) {
+			this.sessionFluidUrls.set(url, getDiscoveredFluidResolvedUrl(resolvedUrl, session));
+			this.sessionLastDiscovered.set(url, Date.now());
+		} else if (!this.sessionFluidUrls.has(url)) {
+			this.sessionFluidUrls.set(url, resolvedUrl);
+			// Force a refresh
+			this.sessionLastDiscovered.set(url, 0);
+		}
+
+		return (await this.getSessionInfo(params)).resolvedUrl;
+	}
+
+	/**
+	 * Retrieve, and potentially refresh, info of a given session
+	 */
+	public async getSessionInfo(
+		params: IGetSessionInfoParams,
+	): Promise<IGetSessionInfoResponse> {
+		const url = getDiscoverSessionUrl(params);
+		assert(
+			this.sessionFluidUrls.has(url) && this.sessionLastDiscovered.has(url),
+			"Unexpected discover session URL",
+		);
+
+		let refreshed = false;
+		const shouldRediscover =
+			Date.now() - this.sessionLastDiscovered.get(url)! > RediscoverAfterTimeSinceDiscoveryMs;
+		if (this.enableDiscovery && shouldRediscover) {
+			await this.updateSessionInfo(params).catch(() => {
+				// Undo discovery time set on failure, so that next check refreshes.
+				this.sessionLastDiscovered.set(url, 0);
+			});
+			refreshed = true;
+		}
+		return {
+			refreshed,
+			resolvedUrl: this.sessionFluidUrls.get(url)!,
+		};
+	}
+
+	private async updateSessionInfo(params: IGetSessionInfoParams): Promise<void> {
+		const { documentId, ordererRestWrapper, logger, resolvedUrl } = params;
+
+		const url = getDiscoverSessionUrl(params);
+		const discoveredSession = await PerformanceEvent.timedExecAsync(
+			logger,
+			{
+				eventName: "DiscoverSession",
+				docId: documentId,
+			},
+			async (event) => {
+				// The service responds with the current document session associated with the container.
+				const response = await ordererRestWrapper.get<ISession>(url);
+				event.end({
+					...response.propsToLog,
+					...getW3CData(response.requestUrl, "xmlhttprequest"),
+				});
+				return response.content;
+			},
+		);
+		this.sessionFluidUrls.set(
+			url,
+			getDiscoveredFluidResolvedUrl(resolvedUrl, discoveredSession),
+		);
+		this.sessionLastDiscovered.set(url, Date.now());
+	}
+}
+
+function getDiscoverSessionUrl(params: {
+	resolvedUrl: IResolvedUrl;
+	tenantId: string;
+	documentId: string;
+}): string {
+	const { resolvedUrl, tenantId, documentId } = params;
+	return `${resolvedUrl.endpoints.ordererUrl}/documents/${tenantId}/session/${documentId}`;
+}

--- a/packages/drivers/routerlicious-driver/src/test/sessionInfoManager.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/sessionInfoManager.spec.ts
@@ -1,0 +1,341 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { IResolvedUrl } from "@fluidframework/driver-definitions/internal";
+import { ISession } from "@fluidframework/server-services-client";
+import { MockLogger } from "@fluidframework/telemetry-utils/internal";
+import { SinonFakeTimers, useFakeTimers } from "sinon";
+
+import { RouterliciousOrdererRestWrapper } from "../restWrapper.js";
+import {
+	RediscoverAfterTimeSinceDiscoveryMs,
+	SessionInfoManager,
+} from "../sessionInfoManager.js";
+
+describe("SessionInfoManager", () => {
+	let clock: SinonFakeTimers;
+	let ordererRestWrapper: RouterliciousOrdererRestWrapper;
+	let mockOrdererCalls = 0;
+
+	const documentIdA = "documentA";
+	const documentIdB = "documentB";
+
+	before(() => {
+		clock = useFakeTimers();
+	});
+
+	beforeEach(() => {
+		clock.tick(1000000); // ! Need to set to large number to trigger initializeSessionInfo calls correctly (Date.now() is 0 by default)
+		mockOrdererCalls = 0;
+		ordererRestWrapper =
+			new MockOrdererRestWrapper() as unknown as RouterliciousOrdererRestWrapper;
+	});
+
+	afterEach(() => {
+		clock.reset();
+	});
+
+	class MockOrdererRestWrapper {
+		get() {
+			mockOrdererCalls++;
+			return {
+				content: createSession(numberToFakeUrl(mockOrdererCalls)),
+			};
+		}
+	}
+
+	const exampleHostUrl = "https://examplehost.com";
+	function createSession(url: string): ISession {
+		return {
+			deltaStreamUrl: url, // ! This endpoint will be hijacked to detect a change in the session
+			ordererUrl: exampleHostUrl,
+			historianUrl: exampleHostUrl,
+			isSessionAlive: true,
+			isSessionActive: true,
+		};
+	}
+
+	function createGetSessionInfoParams(documentId: string, session?: ISession) {
+		return {
+			resolvedUrl: {
+				type: "fluid",
+				id: "id",
+				url: exampleHostUrl,
+				tokens: {},
+				endpoints: {
+					deltaStreamUrl: exampleHostUrl, // ! This endpoint will be hijacked to detect changes
+					ordererUrl: exampleHostUrl,
+					storageUrl: exampleHostUrl,
+					deltaStorageUrl: exampleHostUrl,
+				},
+			} satisfies IResolvedUrl,
+			documentId,
+			tenantId: "fakeTenant",
+			ordererRestWrapper,
+			logger: new MockLogger().toTelemetryLogger(),
+			session,
+		};
+	}
+
+	function numberToFakeUrl(num: number): string {
+		return `https://${num}.com`;
+	}
+
+	function assertResolvedUrlMatch(
+		resolvedUrl: IResolvedUrl,
+		expectedUrl: string,
+		errorMessage?: string,
+	) {
+		// ! The deltaStreamUrl endpoint is hijacked by these tests to detect session info changes
+		assert.strictEqual(resolvedUrl.endpoints.deltaStreamUrl, expectedUrl, errorMessage);
+	}
+
+	describe("initializeSessionInfo", () => {
+		describe("session provided", () => {
+			[true, false].forEach((enableDiscovery) => {
+				describe(`discovery ${enableDiscovery ? "enabled" : "disabled"}`, () => {
+					it("uses provided session", async () => {
+						const manager = new SessionInfoManager(enableDiscovery);
+
+						const url = "https://providedSession.com";
+
+						const resolvedUrl = await manager.initializeSessionInfo(
+							createGetSessionInfoParams(documentIdA, createSession(url)),
+						);
+
+						assert.strictEqual(mockOrdererCalls, 0);
+						assertResolvedUrlMatch(resolvedUrl, url);
+					});
+
+					it("URL already exists", async () => {
+						const manager = new SessionInfoManager(enableDiscovery);
+
+						const originalUrl = "https://original.com";
+						const newUrl = "https://new.com";
+
+						let resolvedUrl = await manager.initializeSessionInfo(
+							createGetSessionInfoParams(documentIdA, createSession(originalUrl)),
+						);
+
+						const getParams = createGetSessionInfoParams(documentIdA);
+
+						assert.strictEqual(mockOrdererCalls, 0);
+						assertResolvedUrlMatch(resolvedUrl, originalUrl);
+						assertResolvedUrlMatch(
+							(await manager.getSessionInfo(getParams)).resolvedUrl,
+							originalUrl,
+						);
+
+						resolvedUrl = await manager.initializeSessionInfo(
+							createGetSessionInfoParams(documentIdA, createSession(newUrl)),
+						);
+
+						assert.strictEqual(mockOrdererCalls, 0);
+						assertResolvedUrlMatch(resolvedUrl, newUrl);
+						assertResolvedUrlMatch(
+							(await manager.getSessionInfo(getParams)).resolvedUrl,
+							newUrl,
+							"expected session info to be overwritten",
+						);
+					});
+				});
+			});
+		});
+
+		it("discovery enabled", async () => {
+			const manager = new SessionInfoManager(true);
+
+			const resolvedUrl = await manager.initializeSessionInfo(
+				createGetSessionInfoParams(documentIdA),
+			);
+
+			assert.strictEqual(mockOrdererCalls, 1);
+			assertResolvedUrlMatch(resolvedUrl, numberToFakeUrl(mockOrdererCalls));
+		});
+
+		it("discovery enabled, URL already exists", async () => {
+			const manager = new SessionInfoManager(true);
+
+			let resolvedUrl = await manager.initializeSessionInfo(
+				createGetSessionInfoParams(documentIdA),
+			);
+
+			assert.strictEqual(mockOrdererCalls, 1);
+			assertResolvedUrlMatch(resolvedUrl, numberToFakeUrl(mockOrdererCalls));
+
+			resolvedUrl = await manager.initializeSessionInfo(
+				createGetSessionInfoParams(documentIdA),
+			);
+
+			// Value should remain unchanged
+			assert.strictEqual(
+				mockOrdererCalls,
+				1,
+				"number of update calls should remain unchanged",
+			);
+			assertResolvedUrlMatch(resolvedUrl, numberToFakeUrl(mockOrdererCalls));
+		});
+
+		it("discovery disabled", async () => {
+			const manager = new SessionInfoManager(false);
+
+			const resolvedUrl = await manager.initializeSessionInfo(
+				createGetSessionInfoParams(documentIdA),
+			);
+
+			assert.strictEqual(mockOrdererCalls, 0);
+			assertResolvedUrlMatch(resolvedUrl, exampleHostUrl);
+		});
+	});
+
+	describe("getSessionInfo", () => {
+		const initialUrl = "https://initial.com";
+		async function createSessionInfoManager(
+			enableDiscovery: boolean,
+		): Promise<SessionInfoManager> {
+			const manager = new SessionInfoManager(enableDiscovery);
+
+			const resolvedUrl = await manager.initializeSessionInfo(
+				createGetSessionInfoParams(documentIdA, createSession(initialUrl)),
+			);
+
+			assert.strictEqual(mockOrdererCalls, 0);
+			assertResolvedUrlMatch(resolvedUrl, initialUrl);
+
+			return manager;
+		}
+
+		it("no rediscovery needed", async () => {
+			const manager = await createSessionInfoManager(true);
+
+			clock.tick(1000);
+
+			const response = await manager.getSessionInfo(createGetSessionInfoParams(documentIdA));
+			assert.strictEqual(mockOrdererCalls, 0);
+			assert.strictEqual(response.refreshed, false);
+			assertResolvedUrlMatch(response.resolvedUrl, initialUrl);
+		});
+
+		it("rediscovery needed", async () => {
+			const manager = await createSessionInfoManager(true);
+
+			clock.tick(RediscoverAfterTimeSinceDiscoveryMs);
+
+			let response = await manager.getSessionInfo(createGetSessionInfoParams(documentIdA));
+			assert.strictEqual(mockOrdererCalls, 0);
+			assert.strictEqual(response.refreshed, false);
+			assertResolvedUrlMatch(response.resolvedUrl, initialUrl);
+
+			clock.tick(1);
+
+			response = await manager.getSessionInfo(createGetSessionInfoParams(documentIdA));
+			assert.strictEqual(mockOrdererCalls, 1);
+			assert.strictEqual(response.refreshed, true);
+			assertResolvedUrlMatch(response.resolvedUrl, numberToFakeUrl(mockOrdererCalls));
+		});
+
+		it("rediscovery needed, but discovery is disabled", async () => {
+			const manager = await createSessionInfoManager(false);
+
+			clock.tick(RediscoverAfterTimeSinceDiscoveryMs + 1);
+
+			const response = await manager.getSessionInfo(createGetSessionInfoParams(documentIdA));
+			assert.strictEqual(mockOrdererCalls, 0);
+			assert.strictEqual(response.refreshed, false);
+			assertResolvedUrlMatch(response.resolvedUrl, initialUrl);
+		});
+
+		it("multiple documents active scenario", async () => {
+			const manager = await createSessionInfoManager(true);
+
+			// Offset document refresh timers by 1 tick
+			clock.tick(1);
+
+			// Start tracking a second document's session
+			const resolvedUrl = await manager.initializeSessionInfo(
+				createGetSessionInfoParams(documentIdB, createSession(initialUrl)),
+			);
+			assert.strictEqual(mockOrdererCalls, 0);
+			assertResolvedUrlMatch(resolvedUrl, initialUrl);
+
+			// 1 off threshold for document A
+			clock.tick(RediscoverAfterTimeSinceDiscoveryMs - 1);
+
+			const getSessionParamsA = createGetSessionInfoParams(documentIdA);
+			const getSessionParamsB = createGetSessionInfoParams(documentIdB);
+
+			{
+				const responseA = await manager.getSessionInfo(getSessionParamsA);
+				const responseB = await manager.getSessionInfo(getSessionParamsB);
+
+				assert.strictEqual(mockOrdererCalls, 0);
+				assert.strictEqual(responseA.refreshed, false);
+				assert.strictEqual(responseB.refreshed, false);
+
+				assertResolvedUrlMatch(responseA.resolvedUrl, initialUrl);
+				assertResolvedUrlMatch(responseB.resolvedUrl, initialUrl);
+			}
+
+			clock.tick(1);
+
+			{
+				const responseA = await manager.getSessionInfo(getSessionParamsA);
+				const responseB = await manager.getSessionInfo(getSessionParamsB);
+
+				assert.strictEqual(mockOrdererCalls, 1);
+				assert.strictEqual(responseA.refreshed, true);
+				assert.strictEqual(responseB.refreshed, false);
+
+				assertResolvedUrlMatch(responseA.resolvedUrl, numberToFakeUrl(1));
+				assertResolvedUrlMatch(responseB.resolvedUrl, initialUrl);
+			}
+
+			clock.tick(1);
+
+			{
+				const responseA = await manager.getSessionInfo(getSessionParamsA);
+				const responseB = await manager.getSessionInfo(getSessionParamsB);
+
+				assert.strictEqual(mockOrdererCalls, 2);
+				assert.strictEqual(responseA.refreshed, false);
+				assert.strictEqual(responseB.refreshed, true);
+
+				assertResolvedUrlMatch(responseA.resolvedUrl, numberToFakeUrl(1));
+				assertResolvedUrlMatch(responseB.resolvedUrl, numberToFakeUrl(2));
+			}
+
+			// 1 off threshold for document A
+			clock.tick(RediscoverAfterTimeSinceDiscoveryMs - 1);
+
+			{
+				const responseA = await manager.getSessionInfo(getSessionParamsA);
+				const responseB = await manager.getSessionInfo(getSessionParamsB);
+
+				assert.strictEqual(mockOrdererCalls, 2);
+				assert.strictEqual(responseA.refreshed, false);
+				assert.strictEqual(responseB.refreshed, false);
+
+				assertResolvedUrlMatch(responseA.resolvedUrl, numberToFakeUrl(1));
+				assertResolvedUrlMatch(responseB.resolvedUrl, numberToFakeUrl(2));
+			}
+
+			clock.tick(1);
+
+			{
+				const responseA = await manager.getSessionInfo(getSessionParamsA);
+				const responseB = await manager.getSessionInfo(getSessionParamsB);
+
+				assert.strictEqual(mockOrdererCalls, 3);
+				assert.strictEqual(responseA.refreshed, true);
+				assert.strictEqual(responseB.refreshed, false);
+
+				assertResolvedUrlMatch(responseA.resolvedUrl, numberToFakeUrl(3));
+				assertResolvedUrlMatch(responseB.resolvedUrl, numberToFakeUrl(2));
+			}
+		});
+	});
+});


### PR DESCRIPTION
We are currently re-making session discovery calls for summarizer containers even though the parent container already has that information. We should be trying to share relevant information across `DocumentService` instances to reduce the amount of duplicate session discovery calls.

Pulling all this logic out into a separate class `SessionInfoManager` helps keep the `DocumentService` and `RouterliciousDocumentServiceFactory` code clean.

[AB#12893](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/12893)