### PR TITLE
Renable after cross version compat bugs were fixed

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/rootDatastores.spec.ts
@@ -213,10 +213,6 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 		);
 
 		it("Aliasing a datastore during an alias operation with the same name", async function () {
-			// TODO: Re-enable after cross version compat bugs are fixed - ADO:6978
-			if (provider.type === "TestObjectProviderWithVersionedLoad") {
-				this.skip();
-			}
 			const ds1 = await runtimeOf(dataObject1).createDataStore(packageName);
 			const ds2 = await runtimeOf(dataObject1).createDataStore(packageName);
 
@@ -250,10 +246,6 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 		});
 
 		it("Aliasing a datastore which previously failed to alias will succeed", async function () {
-			// TODO: Re-enable after cross version compat bugs are fixed - ADO:6978
-			if (provider.type === "TestObjectProviderWithVersionedLoad") {
-				this.skip();
-			}
 			const ds1 = await runtimeOf(dataObject1).createDataStore(packageName);
 			const ds2 = await runtimeOf(dataObject1).createDataStore(packageName);
 
@@ -287,10 +279,6 @@ describeCompat("Named root data stores", "FullCompat", (getTestObjectProvider) =
 		});
 
 		it("getAliasedDataStoreEntryPoint only returns aliased data stores", async function () {
-			// TODO: Re-enable after cross version compat bugs are fixed - ADO:6978
-			if (provider.type === "TestObjectProviderWithVersionedLoad") {
-				this.skip();
-			}
 			const dataStore = await runtimeOf(dataObject1).createDataStore(packageName);
 			const dataObject = (await dataStore.entryPoint?.get()) as ITestFluidObject;
 			assert(dataObject !== undefined, "could not create data store");


### PR DESCRIPTION
[AB#6978](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/6978)

This task was completed, so we can renable these tests for version load