### PR TITLE
[main -> 2.2] ci: Bump marocchino/sticky-pull-request-comment action to latest version (2.9.0)

### DIFF
--- a/.github/workflows/changeset-reporter.yml
+++ b/.github/workflows/changeset-reporter.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Required but missing
         if: fromJson(steps.changeset.outputs.CHANGESET).required == true && fromJson(steps.changeset.outputs.CHANGESET).changesetFound == false
-        uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
           header: changeset
           number: ${{ fromJson(steps.changeset.outputs.CHANGESET).pr }}
@@ -43,7 +44,8 @@ jobs:
 
       - name: Required and present
         if: fromJson(steps.changeset.outputs.CHANGESET).required == true && fromJson(steps.changeset.outputs.CHANGESET).changesetFound == true
-        uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
           header: changeset
           number: ${{ fromJson(steps.changeset.outputs.CHANGESET).pr }}
@@ -53,7 +55,8 @@ jobs:
 
       - name: Changeset not required
         if: fromJson(steps.changeset.outputs.CHANGESET).required == false && fromJson(steps.changeset.outputs.CHANGESET).changesetFound == true
-        uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
           header: changeset
           number: ${{ fromJson(steps.changeset.outputs.CHANGESET).pr }}

--- a/.github/workflows/linkcheck-reporter.yml
+++ b/.github/workflows/linkcheck-reporter.yml
@@ -26,7 +26,8 @@ jobs:
         run: echo "pr=$(cat pr)" >> $GITHUB_OUTPUT
         working-directory: ./results
       - name: Post report in comment
-        uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
           header: linkreport
           recreate: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -28,5 +28,5 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
           header: release-warning
-          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
+          path: .github/workflows/data/release-branch-warning.md
           only_create: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -23,10 +23,18 @@ jobs:
   warning:
     runs-on: ubuntu-latest
     steps:
+      # Read the release notes file that we just generated into an output variable.
+      - name: Read warning template file
+        id: templateFile
+        uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # ratchet:juliangruber/read-file-action@v1
+        with:
+          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.mdv
+
       - name: Post warning in comment
         # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
           header: release-warning
-          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
+          # path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
+          message: ${{ steps.templateFile.outputs.content }}
           only_create: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -1,6 +1,6 @@
 name: Release branch warning
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -11,11 +11,9 @@ on:
     branches:
       - release/client/**
       - release/server/**
+      - test/release/**
 
 permissions:
-  # Needed to read the message template from the repo
-  contents: read
-
   # Needed to write the comments to the PRs themselves
   pull-requests: write
 

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   # Needed to read the message template from the repo
-  # contents: read
+  contents: read
 
   # Needed to write the comments to the PRs themselves
   pull-requests: write

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -19,7 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post warning in comment
-        uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # ratchet:marocchino/sticky-pull-request-comment@v2.3.1
+        # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
           path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
           only_create: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -28,18 +28,17 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      # Read the release notes file that we just generated into an output variable.
-      # - name: Read warning template file
-      #   id: templateFile
-      #   uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # ratchet:juliangruber/read-file-action@v1
-      #   with:
-      #     path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.mdv
+      - name: Read warning template file
+        id: templateFile
+        uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # ratchet:juliangruber/read-file-action@v1
+        with:
+          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.mdv
 
       - name: Post warning in comment
         # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
           header: release-warning
-          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
-          # message: ${{ steps.templateFile.outputs.content }}
+          # path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
+          message: ${{ steps.templateFile.outputs.content }}
           only_create: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -26,17 +26,10 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - name: Read warning template file
-        id: templateFile
-        uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # ratchet:juliangruber/read-file-action@v1
-        with:
-          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
-
       - name: Post warning in comment
         # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
           header: release-warning
-          # path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
-          message: ${{ steps.templateFile.outputs.content }}
+          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
           only_create: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   # Needed to read the message template from the repo
-  # contents: read
+  contents: read
 
   # Needed to write the comments to the PRs themselves
   pull-requests: write
@@ -28,5 +28,5 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
           header: release-warning
-          path: .github/workflows/data/release-branch-warning.md
+          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
           only_create: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -24,3 +24,4 @@ jobs:
         with:
           path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
           only_create: true
+          ignore_empty: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
 
       # This is triggered when the base branch changes; handles the case where you open a PR against main then change the
       # base branch to a release branch.

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -12,6 +12,10 @@ on:
       - release/server/**
 
 permissions:
+  # Needed to read the message template from the repo
+  contents: read
+
+  # Needed to write the comments to the PRs themselves
   pull-requests: write
 
 jobs:
@@ -24,4 +28,3 @@ jobs:
         with:
           path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
           only_create: true
-          ignore_empty: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   # Needed to read the message template from the repo
-  contents: read
+  # contents: read
 
   # Needed to write the comments to the PRs themselves
   pull-requests: write
@@ -23,18 +23,23 @@ jobs:
   warning:
     runs-on: ubuntu-latest
     steps:
-      # Read the release notes file that we just generated into an output variable.
-      - name: Read warning template file
-        id: templateFile
-        uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # ratchet:juliangruber/read-file-action@v1
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # ratchet:actions/checkout@v4
         with:
-          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.mdv
+          persist-credentials: false
+          submodules: false
+
+      # Read the release notes file that we just generated into an output variable.
+      # - name: Read warning template file
+      #   id: templateFile
+      #   uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # ratchet:juliangruber/read-file-action@v1
+      #   with:
+      #     path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.mdv
 
       - name: Post warning in comment
         # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
           header: release-warning
-          # path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
-          message: ${{ steps.templateFile.outputs.content }}
+          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
+          # message: ${{ steps.templateFile.outputs.content }}
           only_create: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   # Needed to read the message template from the repo
-  contents: read
+  # contents: read
 
   # Needed to write the comments to the PRs themselves
   pull-requests: write
@@ -27,5 +27,6 @@ jobs:
         # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
+          header: release-warning
           path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
           only_create: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -32,7 +32,7 @@ jobs:
         id: templateFile
         uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # ratchet:juliangruber/read-file-action@v1
         with:
-          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.mdv
+          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
 
       - name: Post warning in comment
         # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0


### PR DESCRIPTION
Cherry-pick of #22259 and #22264 to the 2.2 release branch.

Updates the marocchino/sticky-pull-request-comment action to its latest version, 2.9.0. This upgrade was needed because some options used in recent workflows are not available in the older version.

I confirmed that the commit 331f8f5b4215f0445d3c07b4967662a32a2d3e31 corresponds to the v2.9.0 tag in the
marocchino/sticky-pull-request-comment repo:
https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0

I also updated the triggering event to pull_request_target from pull_request.