### PR TITLE
ci: Use pull_request_target in release branch warning workflow

### DIFF
--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -25,12 +25,6 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - name: Read warning template file
-        id: templateFile
-        uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # ratchet:juliangruber/read-file-action@v1
-        with:
-          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
-
       - name: Post warning in comment
         # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -1,8 +1,9 @@
 name: Release branch warning
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
+      - synchronize
 
       # This is triggered when the base branch changes; handles the case where you open a PR against main then change the
       # base branch to a release branch.
@@ -10,17 +11,32 @@ on:
     branches:
       - release/client/**
       - release/server/**
+      - test/release/**
 
 permissions:
+  # Needed to write the comments to the PRs themselves
   pull-requests: write
 
 jobs:
   warning:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - name: Read warning template file
+        id: templateFile
+        uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58 # ratchet:juliangruber/read-file-action@v1
+        with:
+          path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
+
       - name: Post warning in comment
         # release notes: https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.0
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # ratchet:marocchino/sticky-pull-request-comment@v2.9.0
         with:
+          header: release-warning
           path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
+          # message: ${{ steps.templateFile.outputs.content }}
           only_create: true

--- a/.github/workflows/pr-release-branch-warning.yml
+++ b/.github/workflows/pr-release-branch-warning.yml
@@ -3,7 +3,6 @@ on:
   pull_request_target:
     types:
       - opened
-      - synchronize
 
       # This is triggered when the base branch changes; handles the case where you open a PR against main then change the
       # base branch to a release branch.
@@ -38,5 +37,4 @@ jobs:
         with:
           header: release-warning
           path: ${{ github.workspace }}/.github/workflows/data/release-branch-warning.md
-          # message: ${{ steps.templateFile.outputs.content }}
           only_create: true


### PR DESCRIPTION
The release branch warning workflow needs to use the pull_request_target trigger instead of the pull_request trigger, so it can post to the PR.

This is safe because the PR does not build anything or use content from the submitted PR. When using pull_request_target the checked-out code is the base branch, not the PR branch, so there's no access to content from the PR itself.