### PR TITLE
Allow import of internal module from other Fluid scopes

### DIFF
--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -8,7 +8,12 @@
  */
 const permittedImports = [
 	// Within Fluid Framework allow import of '/internal' from other FF packages.
-	"@fluid*/*/internal",
+	"@fluid-example/*/internal",
+	"@fluid-experimental/*/internal",
+	"@fluid-internal/*/internal",
+	"@fluid-private/*/internal",
+	"@fluid-tools/*/internal",
+	"@fluidframework/*/internal",
 
 	// Experimental package APIs and exports are unknown, so allow any imports from them.
 	"@fluid-experimental/**",

--- a/common/build/eslint-config-fluid/minimal-deprecated.js
+++ b/common/build/eslint-config-fluid/minimal-deprecated.js
@@ -8,7 +8,7 @@
  */
 const permittedImports = [
 	// Within Fluid Framework allow import of '/internal' from other FF packages.
-	"@fluidframework/*/internal",
+	"@fluid*/*/internal",
 
 	// Experimental package APIs and exports are unknown, so allow any imports from them.
 	"@fluid-experimental/**",

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -601,7 +601,12 @@
             "error",
             {
                 "allow": [
-                    "@fluid*/*/internal",
+                    "@fluid-example/*/internal",
+                    "@fluid-experimental/*/internal",
+                    "@fluid-internal/*/internal",
+                    "@fluid-private/*/internal",
+                    "@fluid-tools/*/internal",
+                    "@fluidframework/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/default.json
+++ b/common/build/eslint-config-fluid/printed-configs/default.json
@@ -601,7 +601,7 @@
             "error",
             {
                 "allow": [
-                    "@fluidframework/*/internal",
+                    "@fluid*/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -591,7 +591,12 @@
             "error",
             {
                 "allow": [
-                    "@fluid*/*/internal",
+                    "@fluid-example/*/internal",
+                    "@fluid-experimental/*/internal",
+                    "@fluid-internal/*/internal",
+                    "@fluid-private/*/internal",
+                    "@fluid-tools/*/internal",
+                    "@fluidframework/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/minimal.json
+++ b/common/build/eslint-config-fluid/printed-configs/minimal.json
@@ -591,7 +591,7 @@
             "error",
             {
                 "allow": [
-                    "@fluidframework/*/internal",
+                    "@fluid*/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -603,7 +603,7 @@
             "error",
             {
                 "allow": [
-                    "@fluidframework/*/internal",
+                    "@fluid*/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/react.json
+++ b/common/build/eslint-config-fluid/printed-configs/react.json
@@ -603,7 +603,12 @@
             "error",
             {
                 "allow": [
-                    "@fluid*/*/internal",
+                    "@fluid-example/*/internal",
+                    "@fluid-experimental/*/internal",
+                    "@fluid-internal/*/internal",
+                    "@fluid-private/*/internal",
+                    "@fluid-tools/*/internal",
+                    "@fluidframework/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -601,7 +601,12 @@
             "error",
             {
                 "allow": [
-                    "@fluid*/*/internal",
+                    "@fluid-example/*/internal",
+                    "@fluid-experimental/*/internal",
+                    "@fluid-internal/*/internal",
+                    "@fluid-private/*/internal",
+                    "@fluid-tools/*/internal",
+                    "@fluidframework/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/recommended.json
+++ b/common/build/eslint-config-fluid/printed-configs/recommended.json
@@ -601,7 +601,7 @@
             "error",
             {
                 "allow": [
-                    "@fluidframework/*/internal",
+                    "@fluid*/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -620,7 +620,12 @@
             "error",
             {
                 "allow": [
-                    "@fluid*/*/internal",
+                    "@fluid-example/*/internal",
+                    "@fluid-experimental/*/internal",
+                    "@fluid-internal/*/internal",
+                    "@fluid-private/*/internal",
+                    "@fluid-tools/*/internal",
+                    "@fluidframework/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/strict.json
+++ b/common/build/eslint-config-fluid/printed-configs/strict.json
@@ -620,7 +620,7 @@
             "error",
             {
                 "allow": [
-                    "@fluidframework/*/internal",
+                    "@fluid*/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -603,7 +603,7 @@
                 "allow": [
                     "@fluid*/*/test*",
                     "@fluid*/*/internal/test*",
-                    "@fluidframework/*/internal",
+                    "@fluid*/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]

--- a/common/build/eslint-config-fluid/printed-configs/test.json
+++ b/common/build/eslint-config-fluid/printed-configs/test.json
@@ -603,7 +603,12 @@
                 "allow": [
                     "@fluid*/*/test*",
                     "@fluid*/*/internal/test*",
-                    "@fluid*/*/internal",
+                    "@fluid-example/*/internal",
+                    "@fluid-experimental/*/internal",
+                    "@fluid-internal/*/internal",
+                    "@fluid-private/*/internal",
+                    "@fluid-tools/*/internal",
+                    "@fluidframework/*/internal",
                     "@fluid-experimental/**",
                     "*/index.js"
                 ]


### PR DESCRIPTION
While looking at #22267, I tried updating the migration-tools package's `types` to point at `public.d.ts` and then consuming from `@fluid-example/migration-tools/internal` in the `separate-container` example.  However, this hits no-internal-modules in lint because we only carve out the exception for `@fluidframework`.  This would expand that carveout for any `@fluid*` scope (similar to the [test carveout on L445](https://github.com/microsoft/FluidFramework/blob/f143f057d6871c76eb79ced7fbb451c21c41f18c/common/build/eslint-config-fluid/minimal-deprecated.js#L445)).

I mostly expect this would be useful for example-to-example dependencies like my case, but could maybe also be useful for `@fluid-tools` to `@fluid-tools`, etc.