### PR TITLE
Break up counter end to end test beforeEach hook for more granular error info

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -49,6 +49,8 @@ describeCompat("SharedCounter", "FullCompat", (getTestObjectProvider, apis) => {
 
 	// To help narrow down test flakiness, the beforeEach is broken into tiny phases.  These phase names will
 	// show up in error logs to help identify where timeouts are occurring.
+	// Note that their execution order matters.  Mocha runs them in the order they are defined:
+	// https://mochajs.org/#hooks
 
 	// Create a container representing the first client
 	beforeEach("Create container", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/counterEndToEndTests.spec.ts
@@ -37,27 +37,46 @@ describeCompat("SharedCounter", "FullCompat", (getTestObjectProvider, apis) => {
 	beforeEach("getTestObjectProvider", () => {
 		provider = getTestObjectProvider();
 	});
+	let container1: IContainer;
+	let container2: IContainer;
+	let container3: IContainer;
 	let dataStore1: ITestFluidObject;
+	let dataStore2: ITestFluidObject;
+	let dataStore3: ITestFluidObject;
 	let sharedCounter1: ISharedCounter;
 	let sharedCounter2: ISharedCounter;
 	let sharedCounter3: ISharedCounter;
 
-	beforeEach("setup", async () => {
-		// Create a Container for the first client.
-		const container1 = await provider.makeTestContainer(testContainerConfig);
+	// To help narrow down test flakiness, the beforeEach is broken into tiny phases.  These phase names will
+	// show up in error logs to help identify where timeouts are occurring.
+
+	// Create a container representing the first client
+	beforeEach("Create container", async () => {
+		container1 = await provider.makeTestContainer(testContainerConfig);
+	});
+
+	// Load the container that was created by the first client
+	beforeEach("Load containers", async () => {
+		container2 = await provider.loadTestContainer(testContainerConfig);
+		container3 = await provider.loadTestContainer(testContainerConfig);
+	});
+
+	// Get all three data stores
+	beforeEach("Get data stores", async () => {
 		dataStore1 = await getContainerEntryPointBackCompat<ITestFluidObject>(container1);
+		dataStore2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
+		dataStore3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
+	});
+
+	// Get all three counters
+	beforeEach("Get counters", async () => {
 		sharedCounter1 = await dataStore1.getSharedObject<SharedCounter>(counterId);
-
-		// Load the Container that was created by the first client.
-		const container2 = await provider.loadTestContainer(testContainerConfig);
-		const dataStore2 = await getContainerEntryPointBackCompat<ITestFluidObject>(container2);
 		sharedCounter2 = await dataStore2.getSharedObject<SharedCounter>(counterId);
-
-		// Load the Container that was created by the first client.
-		const container3 = await provider.loadTestContainer(testContainerConfig);
-		const dataStore3 = await getContainerEntryPointBackCompat<ITestFluidObject>(container3);
 		sharedCounter3 = await dataStore3.getSharedObject<SharedCounter>(counterId);
+	});
 
+	// Ensure the clients are synchronized
+	beforeEach("Ensure synchronized", async () => {
 		await provider.ensureSynchronized();
 	});
 


### PR DESCRIPTION
Counter increment/decrement has been flagged as a flaky test.  Nothing seems to indicate it is a counter-specific issue, but it's a reasonable one to try and diagnose further (relatively simple feature and test).

This PR just breaks up the beforeEach hook into multiple stages which will show up in failure logs to better understand where the flakiness occurs.  Currently we just see that "setup" is timing out, but with this PR we should see more specifically what part of that setup.

Locally, testing with t9s (one of the failing environments, see run 271404) I actually get *mostly* reliable failures.  Specifically I get almost-consistent failure with 1.4.0 LOADER ONLY to either (1) load container2 & container3 or (2) synchronize the "increment 7" counter op across clients (times out with the sending client still dirty).  I want to merge this change to see how similar the results are both for t9s but also for other services too.

[AB#8335](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8335)