### PR TITLE
tree: De-register 'afterSchemaChange' handler when disposing simple tree view

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -252,12 +252,20 @@ export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitField
 				}
 			};
 
-			this.view = requireSchema(
+			const view = requireSchema(
 				this.checkout,
 				this.viewSchema,
 				onViewDispose,
 				this.nodeKeyManager,
 			);
+			this.view = view;
+
+			const unregister = this.checkout.storedSchema.on("afterSchemaChange", () => {
+				unregister();
+				this.unregisterCallbacks.delete(unregister);
+				view[disposeSymbol]();
+			});
+			this.unregisterCallbacks.add(unregister);
 		} else {
 			this.view = undefined;
 
@@ -359,11 +367,5 @@ export function requireSchema<TRoot extends FlexFieldSchema>(
 		onDispose,
 	);
 	assert(slots.has(ContextSlot), 0x90d /* Context should be tracked in slot */);
-
-	const unregister = checkout.storedSchema.on("afterSchemaChange", () => {
-		unregister();
-		view[disposeSymbol]();
-	});
-
 	return view;
 }

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -80,7 +80,7 @@ import {
 	type TreeView,
 	TreeViewConfiguration,
 } from "../../simple-tree/index.js";
-import { fail } from "../../util/index.js";
+import { disposeSymbol, fail } from "../../util/index.js";
 import {
 	type ConnectionSetter,
 	type ITestTreeProvider,
@@ -225,7 +225,17 @@ describe("SharedTree", () => {
 			onDispose: () => void = () => assert.fail(),
 		): FlexTreeView<TRoot> {
 			const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, schema);
-			return requireSchema(tree.checkout, viewSchema, onDispose, new MockNodeKeyManager());
+			const view = requireSchema(
+				tree.checkout,
+				viewSchema,
+				onDispose,
+				new MockNodeKeyManager(),
+			);
+			const unregister = tree.checkout.storedSchema.on("afterSchemaChange", () => {
+				unregister();
+				view[disposeSymbol]();
+			});
+			return view;
 		}
 
 		const factory = new SharedTreeFactory({

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -714,7 +714,7 @@ describe("sharedTreeView", () => {
 
 			// Create and initialize a view.
 			const sf1 = new SchemaFactory("schema1");
-			const schema1 = sf1.array([sf1.string]);
+			const schema1 = sf1.array(sf1.string);
 			const view1 = provider.trees[0].viewWith(
 				new TreeViewConfiguration({ schema: schema1, enableSchemaValidation }),
 			);
@@ -725,7 +725,7 @@ describe("sharedTreeView", () => {
 
 			// Create another view with a new schema using the same checkout as the main view.
 			const sf2 = new SchemaFactory("schema1");
-			const schema2 = [sf1.array([sf1.string]), sf2.array([sf2.string, sf2.number])];
+			const schema2 = [sf1.array(sf1.string), sf2.array([sf2.string, sf2.number])];
 			const view2 = viewCheckout(
 				view1.checkout,
 				new TreeViewConfiguration({ schema: schema2, enableSchemaValidation }),


### PR DESCRIPTION
## Bug
After a `SchematizingSimpleTreeView` is explicitly disposed, upgrading its schema via a new view results in double disposal of the original view.

**Repro:**
1. Create a view via `viewWith`.
2. Dispose the view.
3. Create a second view with the same checkout and upgrade the schema via `upgradeSchema()`.

## Root-cause
When a `SchematizingSimpleTreeView` creates a `CheckoutFlexTreeView`, it registers an `"afterSchemaChange"` event handler which disposes the flex view. However, when the `SchematizingSimpleTreeView` is explicitly disposed, the event handler is not de-registered. So, when the schema is upgraded, this event handler is called resulting in disposing it again.

## Fix
Moved the registration of `"afterSchemaChange"` event handlers from `requireSchema` into the callsite `SchematizingSimpleTreeView::update` where it is set up to be de-registered when the view is disposed.

Added a test to validate this scenario.


[AB#8916](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8916)