### PR TITLE
tree: Disallow creating multiple simple tree views from the same checkout

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -89,6 +89,10 @@ export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitField
 		public readonly nodeKeyManager: NodeKeyManager,
 		public readonly breaker: Breakable = new Breakable("SchematizingSimpleTreeView"),
 	) {
+		if (checkout.forest.anchors.slots.has(ContextSlot)) {
+			throw new UsageError("Cannot create a second view from the same branch");
+		}
+
 		const policy = {
 			...defaultSchemaPolicy,
 			validateSchema: config.enableSchemaValidation,

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -6,7 +6,7 @@
 import { assert } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { AllowedUpdateType, Compatibility } from "../core/index.js";
+import { AllowedUpdateType, anchorSlot, Compatibility } from "../core/index.js";
 import {
 	type HasListeners,
 	type IEmitter,
@@ -44,6 +44,12 @@ import { Breakable, breakingClass, disposeSymbol, type WithBreakable } from "../
 import { canInitialize, ensureSchema, initialize } from "./schematizeTree.js";
 import type { ITreeCheckout } from "./treeCheckout.js";
 import { CheckoutFlexTreeView } from "./treeView.js";
+
+/**
+ * Creating multiple tree views from the same checkout is not supported. This slot is used to detect if one already
+ * exists and error if creating a second.
+ */
+export const ViewSlot = anchorSlot<TreeView<ImplicitFieldSchema>>();
 
 /**
  * Implementation of TreeView wrapping a FlexTreeView.
@@ -89,9 +95,10 @@ export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitField
 		public readonly nodeKeyManager: NodeKeyManager,
 		public readonly breaker: Breakable = new Breakable("SchematizingSimpleTreeView"),
 	) {
-		if (checkout.forest.anchors.slots.has(ContextSlot)) {
-			throw new UsageError("Cannot create a second view from the same branch");
+		if (checkout.forest.anchors.slots.has(ViewSlot)) {
+			throw new UsageError("Cannot create a second tree view from the same checkout");
 		}
+		checkout.forest.anchors.slots.set(ViewSlot, this);
 
 		const policy = {
 			...defaultSchemaPolicy,

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -323,6 +323,7 @@ export class SchematizingSimpleTreeView<in out TRootSchema extends ImplicitField
 	public dispose(): void {
 		this.disposed = true;
 		this.disposeView();
+		this.checkout.forest.anchors.slots.delete(ViewSlot);
 		this.currentCompatibility = undefined;
 	}
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -557,6 +557,7 @@ describe("SharedTree", () => {
 				view.root.insertAtStart("A");
 				await provider.ensureSynchronized();
 				await validateSchemaStringType(provider, provider.trees[0].id, SummaryType.Handle);
+				view.dispose();
 				const view2 = tree.viewWith(
 					new TreeViewConfiguration({ schema: JsonArray, enableSchemaValidation }),
 				);
@@ -1815,6 +1816,8 @@ describe("SharedTree", () => {
 			tree1.setConnected(false);
 
 			view1.root.insertAtEnd("43");
+			view1.dispose();
+
 			const view1Json = tree1.viewWith(
 				new TreeViewConfiguration({ schema: JsonArray, enableSchemaValidation }),
 			);

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -513,7 +513,7 @@ describe("sharedTreeView", () => {
 		});
 
 		it("cannot create a second view from an uninitialized simple tree view's checkout", () => {
-			const sf = new SchemaFactory("no squash commits schema");
+			const sf = new SchemaFactory("schema1");
 			const provider = new TestTreeProviderLite(1);
 			const view1 = provider.trees[0].viewWith(
 				new TreeViewConfiguration({
@@ -537,7 +537,7 @@ describe("sharedTreeView", () => {
 		});
 
 		it("cannot create a second view from an initialized simple tree view's checkout", () => {
-			const sf = new SchemaFactory("no squash commits schema");
+			const sf = new SchemaFactory("schema1");
 			const provider = new TestTreeProviderLite(1);
 			const view1 = provider.trees[0].viewWith(
 				new TreeViewConfiguration({

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -868,7 +868,10 @@ describe("sharedTreeView", () => {
 			const schema2 = [sf2.array(sf2.string), sf2.array([sf2.string, sf2.number])];
 
 			// Create a new view with the main branch's checkout and schema2.
-			const view2 = viewCheckout(checkout1, new TreeViewConfiguration({ schema: schema2, enableSchemaValidation }));
+			const view2 = viewCheckout(
+				checkout1,
+				new TreeViewConfiguration({ schema: schema2, enableSchemaValidation }),
+			);
 			// Upgrade the schema on the new view and remove "B".
 			view2.upgradeSchema();
 			view2.root.removeAt(1);
@@ -878,32 +881,23 @@ describe("sharedTreeView", () => {
 			const schema3 = [sf3.array(sf3.string), sf3.array([sf3.string, sf3.boolean])];
 
 			// Create a new branch view with the forked checkout and schema3.
-			const view3 = viewCheckout(checkout2, new TreeViewConfiguration({ schema: schema3, enableSchemaValidation }));
+			const view3 = viewCheckout(
+				checkout2,
+				new TreeViewConfiguration({ schema: schema3, enableSchemaValidation }),
+			);
 			// Upgrade the schema on the new view and remove "C".
 			view3.upgradeSchema();
 			view3.root.removeAt(0);
 
-			expectSchemaEqual(
-				intoStoredSchema(toFlexSchema(schema2)),
-				view2.checkout.storedSchema,
-			);
-			expectSchemaEqual(
-				intoStoredSchema(toFlexSchema(schema3)),
-				view3.checkout.storedSchema,
-			);
+			expectSchemaEqual(intoStoredSchema(toFlexSchema(schema2)), view2.checkout.storedSchema);
+			expectSchemaEqual(intoStoredSchema(toFlexSchema(schema3)), view3.checkout.storedSchema);
 
 			// Rebase view3 onto view2.
 			(view3.checkout as ITreeCheckoutFork).rebaseOnto(view2.checkout);
 
 			// All changes on view3 should be dropped but the schema change and edit in view2 should be preserved.
-			expectSchemaEqual(
-				intoStoredSchema(toFlexSchema(schema2)),
-				view2.checkout.storedSchema,
-			);
-			assert.deepEqual(
-				view2.root,
-				["B"],
-			);
+			expectSchemaEqual(intoStoredSchema(toFlexSchema(schema2)), view2.checkout.storedSchema);
+			assert.deepEqual(view2.root, ["B"]);
 		});
 	});
 

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -877,7 +877,7 @@ describe("sharedTreeView", () => {
 			const sf3 = new SchemaFactory("schema1");
 			const schema3 = [sf3.array(sf3.string), sf3.array([sf3.string, sf3.boolean])];
 
-			// Create a new view with the forked checkout and schema3.
+			// Create a new branch view with the forked checkout and schema3.
 			const view3 = viewCheckout(checkout2, new TreeViewConfiguration({ schema: schema3, enableSchemaValidation }));
 			// Upgrade the schema on the new view and remove "C".
 			view3.upgradeSchema();
@@ -903,60 +903,6 @@ describe("sharedTreeView", () => {
 			assert.deepEqual(
 				view2.root,
 				["B"],
-			);
-		});
-
-		it.skip("over schema changes", () => {
-			const sf1 = new SchemaFactory("schema1");
-			const oldSchema = sf1.array(sf1.string);
-
-			const provider = new TestTreeProviderLite(1);
-			const view1 = provider.trees[0].viewWith(
-				new TreeViewConfiguration({ schema: oldSchema, enableSchemaValidation }),
-			);
-			view1.initialize(["A", "B", "C"]);
-
-			// Create a new schema
-			const sf2 = new SchemaFactory("schema1");
-			const newSchema = [sf2.array(sf2.string), sf2.array([sf2.string, sf2.number])];
-
-			// Create a new branch with the new schema
-			const branchView = forkView(view1, newSchema);
-
-			// Remove "A" and change the schema on the parent branch
-			view1.root.removeAt(0);
-			view1.checkout.updateSchema(intoStoredSchema(toFlexSchema(newSchema)));
-			view1.upgradeSchema();
-			// provider.trees[0]
-			// 	.viewWith(new TreeViewConfiguration({ schema: newSchema, enableSchemaValidation }))
-			// 	.upgradeSchema();
-
-			// Remove "B" on the child branch
-			branchView.root.removeAt(1);
-
-			// Upgrade the schema on the child branch.
-			branchView.upgradeSchema();
-			// Remove "C" on the child branch
-			branchView.root.removeAt(1);
-			expectSchemaEqual(
-				intoStoredSchema(toFlexSchema(newSchema)),
-				branchView.checkout.storedSchema,
-			);
-			assert.deepEqual(branchView.root, ["A"]);
-
-			branchView.checkout.rebaseOnto(view1.checkout);
-
-			// All changes on the branch should be dropped
-			expectSchemaEqual(
-				intoStoredSchema(toFlexSchema(newSchema)),
-				branchView.checkout.storedSchema,
-			);
-			assert.deepEqual(
-				viewCheckout(
-					branchView.checkout,
-					new TreeViewConfiguration({ schema: newSchema, enableSchemaValidation }),
-				).root,
-				["B", "C"],
 			);
 		});
 	});


### PR DESCRIPTION
## Bug
Currently, it's possible to create multiple tree views (SchematizingSimpleTreeView) from the same checkout by simply calling viewWith or via its constructor.
This can result in failures later, such as when the schema is upgraded. A schema upgrade emits `"afterSchemaChange"` event on which all the views are updated and it ends up with multiple `Context` for the same checkout.
We have couple of unit tests failing because of this. These tests are currently skipped.

## Fix
When a new `SchematizingSimpleTreeView` is created, throw a usage error if one already exists for the checkout it is created with.
 
[AB#11436](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/11436)