### PR TITLE
tools: Don't only require FFAPI reviews for report changes in specific directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,10 +51,10 @@
 /packages/tools/devtools/**/src                @microsoft/fluid-cr-devtools
 
 # API report changes
+# TODO: if we ever add `.internal` API reports, we will want to omit them here
 /**/api-report/*.api.md                        @microsoft/fluid-cr-api
-/build/**/api-report/*.api.md                  @microsoft/fluid-cr-infra
-/**/api-report/*.internal.api.md               # Do not require API review of internal API report changes
-/tool/**/api-report/*.api.md                   # Do not require API review for tools packages
+/build-tools/**/api-report/*.api.md            @microsoft/fluid-cr-infra
+/tools/**/api-report/*.api.md                  # Do not require API review for tools packages
 /common/build/**/api-report/*.api.md           # Do not require API review for build tooling packages
 
 # Changesets and release notes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,8 @@
 #
 # ------------------------------------------------------------------------
 
-/.github/CODEOWNERS                            @microsoft/fluid-cr-api
+# Temporarily remove for testing purposes
+# /.github/CODEOWNERS                            @microsoft/fluid-cr-api
 
 # ID compressor source
 /packages/runtime/id-compressor/src            @microsoft/fluid-cr-id-compressor

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,7 +55,6 @@
 /**/api-report/*.api.md                        @microsoft/fluid-cr-api
 /build-tools/**/api-report/*.api.md            @microsoft/fluid-cr-infra
 /tools/**/api-report/*.api.md                  # Do not require API review for tools packages
-/common/build/**/api-report/*.api.md           # Do not require API review for build tooling packages
 
 # Changesets and release notes
 /**/.changeset/*.md                            @microsoft/fluid-cr-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,9 +51,9 @@
 /packages/tools/devtools/**/src                @microsoft/fluid-cr-devtools
 
 # Non-internal API changes
-/**/api-report/*.public.api.md                 @microsoft/fluid-cr-api
-/**/api-report/*.beta.api.md                   @microsoft/fluid-cr-api
-/**/api-report/*.alpha.api.md                  @microsoft/fluid-cr-api
+/{common,experimental,packages,server}/**/api-report/*.public.api.md   @microsoft/fluid-cr-api
+/{common,experimental,packages,server}/**/api-report/*.beta.api.md     @microsoft/fluid-cr-api
+/{common,experimental,packages,server}/**/api-report/*.alpha.api.md    @microsoft/fluid-cr-api
 
 # Changesets and release notes
 /**/.changeset/*.md                            @microsoft/fluid-cr-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,10 +50,12 @@
 # Fluid Devtools source
 /packages/tools/devtools/**/src                @microsoft/fluid-cr-devtools
 
-# Non-internal API changes
-/{common,experimental,packages,server}/**/api-report/*.public.api.md   @microsoft/fluid-cr-api
-/{common,experimental,packages,server}/**/api-report/*.beta.api.md     @microsoft/fluid-cr-api
-/{common,experimental,packages,server}/**/api-report/*.alpha.api.md    @microsoft/fluid-cr-api
+# API report changes
+/**/api-report/*.api.md                        @microsoft/fluid-cr-api
+/build/**/api-report/*.api.md                  @microsoft/fluid-cr-infra
+/**/api-report/*.internal.api.md               # Do not require API review of internal API report changes
+/tool/**/api-report/*.api.md                   # Do not require API review for tools packages
+/common/build/**/api-report/*.api.md           # Do not require API review for build tooling packages
 
 # Changesets and release notes
 /**/.changeset/*.md                            @microsoft/fluid-cr-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,8 +32,7 @@
 #
 # ------------------------------------------------------------------------
 
-# Temporarily remove for testing purposes
-# /.github/CODEOWNERS                            @microsoft/fluid-cr-api
+/.github/CODEOWNERS                            @microsoft/fluid-cr-api
 
 # ID compressor source
 /packages/runtime/id-compressor/src            @microsoft/fluid-cr-id-compressor

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,7 @@
 # TODO: if we ever add `.internal` API reports, we will want to omit them here
 /**/api-report/*.api.md                        @microsoft/fluid-cr-api
 /build-tools/**/api-report/*.api.md            @microsoft/fluid-cr-infra
+/server/**/api-report/*.api.md                 @microsoft/fluid-cr-server
 /tools/**/api-report/*.api.md                  # Do not require API review for tools packages
 
 # Changesets and release notes


### PR DESCRIPTION
Don't require API reviews for API report changes in `/tools` packages. Also simplify specification patterns for CODEOWNERS, and...
* Require `fluid-cr-infra` review for API changes in `/build-tools` packages
* Require `fluid-cr-server` review for API changes in `/server` packages