### PR TITLE
docs(website): Expand "Fluid Releases and API Support Levels" documentation

### DIFF
--- a/docs/content/docs/build/releases-and-apitags.md
+++ b/docs/content/docs/build/releases-and-apitags.md
@@ -40,18 +40,31 @@ There are no guarantees for API breakages or Fluid document compatibility among 
 For packages that are part of the `@fluidframework` scope and the `fluid-framework` package, we use import paths to communicate the stability and guarantees associated with those APIs.
 
 -   **Public APIs** - These APIs are officially supported and any breaking changes to these APIs will be done in a major release and go through a deprecation phase before being removed.
--   **Beta APIs** (`/beta` import path) - These APIs are on the path to being officially supported but can still change before becoming a Public API in a future release. They are meant as a preview for developers to experiment with and provide feedback. These APIs can be changed in minor releases. Production usage of these APIs is discouraged.
--   **Legacy APIs** (`/legacy` import path) - These APIs were used by the early adopters of Fluid Framework, and we strongly discourage new applications from using these APIs. We will continue to support use of SharedMap & SharedDirectory DDSes until we provide a migration path to SharedTree in a future release.
-    -   For existing users of these Legacy APIs, you will have to use the /legacy import path. This is intentional to highlight that we do not encourage new development using these APIs and plan to provide a graceful path away from them in future.
+-   **Beta APIs** (`/beta` import path) - These APIs are on the path to being officially supported but can still change before becoming a Public API in a future release.
+    They are meant as a preview for developers to experiment with and provide feedback.
+    These APIs can be changed in minor releases.
+    Production usage of these APIs is discouraged.
+    -   For JavaScript users, such APIs can be identified via the `@beta` tag included in their documentation.
+-   **Legacy APIs** (`/legacy` import path) - These APIs were used by the early adopters of Fluid Framework, and we strongly discourage new applications from using these APIs.
+    We will continue to support use of SharedMap & SharedDirectory DDSes until we provide a migration path to SharedTree in a future release.
+    -   For existing users of these Legacy APIs, you will have to use the /legacy import path.
+        This is intentional to highlight that we do not encourage new development using these APIs and plan to provide a graceful path away from them in future.
     -   For example, SharedMap is now a Legacy API and should be imported as follows:
 
         ```typescript
         import { SharedMap } from "fluid-framework/legacy"
         ```
 
+    -   For JavaScript users, such APIs can be identified via the `@legacy` tag included in their documentation.
 -   **System APIs** - These APIs are reserved for internal system use and are not meant to be used directly.
     These may change at any time without notice.
     For cases in which such a type must be referenced, the contents should never be inspected.
+    -   For JavaScript users, such APIs can be identified via the `@system` tag included in their documentation.
+-   **Internal APIs** - These APIs are *strictly* for internal system use and should not be used.
+    These may change at any time without notice.
+    -   Do not import any APIs from the `/internal` import path.
+    -   For JavaScript users, such APIs can be identified via the `@internal` tag included in their documentation.
+        Such APIs should not be used.
 
 There are no API stability guarantees for packages in the `@fluid-experimental` and `@fluid-internal` scopes.
 `@fluid-experimental` APIs are for developers to try experimental features and provide feedback. It's possible that these APIs can get completely scrapped or drastically changed in a minor release based on developer feedback.

--- a/docs/content/docs/build/releases-and-apitags.md
+++ b/docs/content/docs/build/releases-and-apitags.md
@@ -49,7 +49,9 @@ For packages that are part of the `@fluidframework` scope and the `fluid-framewo
         import { SharedMap } from "fluid-framework/legacy"
         ```
 
--   **System APIs** - These APIs are reserved for internal system use and are not meant to be used directly. These may change at any time without notice. In cases that a type must be referenced, the contents should never be inspected.
+-   **System APIs** - These APIs are reserved for internal system use and are not meant to be used directly.
+    These may change at any time without notice.
+    For cases in which such a type must be referenced, the contents should never be inspected.
 
 There are no API stability guarantees for packages in the `@fluid-experimental` and `@fluid-internal` scopes.
 `@fluid-experimental` APIs are for developers to try experimental features and provide feedback. It's possible that these APIs can get completely scrapped or drastically changed in a minor release based on developer feedback.


### PR DESCRIPTION
Includes:
* Notes about associated TSDoc tags
* Explicit notes about `/internal` (and that such APIs should not be used)