### PR TITLE
tree: Remove strong typing from flex tree fields and unboxed flex tree unions

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/index.ts
@@ -20,7 +20,6 @@ export {
 	type FlexTreeTypedNodeUnion,
 	TreeStatus,
 	type FlexTreeUnknownUnboxed,
-	type FlexTreeUnboxField,
 	flexTreeMarker,
 	FlexTreeEntityKind,
 	isFlexTreeNode,
@@ -38,8 +37,6 @@ export {
 export { getTreeContext, type FlexTreeContext, Context, ContextSlot } from "./context.js";
 
 export { type FlexTreeNodeEvents } from "./treeEvents.js";
-
-export type { FlexTreeUnboxNodeUnion } from "./flexTreeTypes.js";
 
 export {
 	assertFlexTreeEntityNotFreed,

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -37,8 +37,7 @@ import {
 	type FlexTreeRequiredField,
 	type FlexTreeSequenceField,
 	type FlexTreeTypedField,
-	type FlexTreeTypedNodeUnion,
-	type FlexTreeUnboxNodeUnion,
+	type FlexTreeUnknownUnboxed,
 	TreeStatus,
 	flexTreeMarker,
 	flexTreeSlot,
@@ -125,11 +124,8 @@ export function makeField(
 /**
  * Base type for fields implementing {@link FlexTreeField} using cursors.
  */
-export abstract class LazyField<
-		out TKind extends FlexFieldKind,
-		TTypes extends FlexAllowedTypes,
-	>
-	extends LazyEntity<FlexFieldSchema<TKind, TTypes>, FieldAnchor>
+export abstract class LazyField<out TKind extends FlexFieldKind>
+	extends LazyEntity<FlexFieldSchema<TKind>, FieldAnchor>
 	implements FlexTreeField
 {
 	public get [flexTreeMarker](): FlexTreeEntityKind.Field {
@@ -145,7 +141,7 @@ export abstract class LazyField<
 
 	public constructor(
 		context: Context,
-		schema: FlexFieldSchema<TKind, TTypes>,
+		schema: FlexFieldSchema<TKind>,
 		cursor: ITreeSubscriptionCursor,
 		fieldAnchor: FieldAnchor,
 	) {
@@ -164,9 +160,16 @@ export abstract class LazyField<
 		}
 	}
 
-	public is<TSchema extends FlexFieldSchema>(
-		schema: TSchema,
-	): this is FlexTreeTypedField<TSchema> {
+	public is<TKind2 extends FlexFieldKind>(kind: TKind2): this is FlexTreeTypedField<TKind2> {
+		assert(
+			this.context.schema.policy.fieldKinds.get(kind.identifier) === kind,
+			"Narrowing must be done to a kind that exists in this context",
+		);
+
+		return this.schema.kind === (kind as unknown);
+	}
+
+	public isExactly<TSchema extends FlexFieldSchema>(schema: TSchema): boolean {
 		assert(
 			this.context.schema.policy.fieldKinds.get(schema.kind.identifier) === schema.kind,
 			0x77c /* Narrowing must be done to a kind that exists in this context */,
@@ -203,13 +206,13 @@ export abstract class LazyField<
 		return this[cursorSymbol].getFieldLength();
 	}
 
-	public atIndex(index: number): FlexTreeUnboxNodeUnion<TTypes> {
+	public atIndex(index: number): FlexTreeUnknownUnboxed {
 		return inCursorNode(this[cursorSymbol], index, (cursor) =>
 			unboxedUnion(this.context, this.schema, cursor),
 		);
 	}
 
-	public boxedAt(index: number): FlexTreeTypedNodeUnion<TTypes> | undefined {
+	public boxedAt(index: number): FlexTreeNode | undefined {
 		const finalIndex = indexForAt(index, this.length);
 
 		if (finalIndex === undefined) {
@@ -218,21 +221,18 @@ export abstract class LazyField<
 
 		return inCursorNode(this[cursorSymbol], finalIndex, (cursor) =>
 			makeTree(this.context, cursor),
-		) as unknown as FlexTreeTypedNodeUnion<TTypes>;
-	}
-
-	public map<U>(callbackfn: (value: FlexTreeUnboxNodeUnion<TTypes>, index: number) => U): U[] {
-		return Array.from(this, callbackfn);
-	}
-
-	public boxedIterator(): IterableIterator<FlexTreeTypedNodeUnion<TTypes>> {
-		return iterateCursorField(
-			this[cursorSymbol],
-			(cursor) => makeTree(this.context, cursor) as unknown as FlexTreeTypedNodeUnion<TTypes>,
 		);
 	}
 
-	public [Symbol.iterator](): IterableIterator<FlexTreeUnboxNodeUnion<TTypes>> {
+	public map<U>(callbackfn: (value: FlexTreeUnknownUnboxed, index: number) => U): U[] {
+		return Array.from(this, callbackfn);
+	}
+
+	public boxedIterator(): IterableIterator<FlexTreeNode> {
+		return iterateCursorField(this[cursorSymbol], (cursor) => makeTree(this.context, cursor));
+	}
+
+	public [Symbol.iterator](): IterableIterator<FlexTreeUnknownUnboxed> {
 		return iterateCursorField(this[cursorSymbol], (cursor) =>
 			unboxedUnion(this.context, this.schema, cursor),
 		);
@@ -263,20 +263,20 @@ export abstract class LazyField<
 	}
 }
 
-export class LazySequence<TTypes extends FlexAllowedTypes>
-	extends LazyField<typeof FieldKinds.sequence, TTypes>
-	implements FlexTreeSequenceField<TTypes>
+export class LazySequence
+	extends LazyField<typeof FieldKinds.sequence>
+	implements FlexTreeSequenceField
 {
 	public constructor(
 		context: Context,
-		schema: FlexFieldSchema<typeof FieldKinds.sequence, TTypes>,
+		schema: FlexFieldSchema<typeof FieldKinds.sequence>,
 		cursor: ITreeSubscriptionCursor,
 		fieldAnchor: FieldAnchor,
 	) {
 		super(context, schema, cursor, fieldAnchor);
 	}
 
-	public at(index: number): FlexTreeUnboxNodeUnion<TTypes> | undefined {
+	public at(index: number): FlexTreeUnknownUnboxed | undefined {
 		const finalIndex = indexForAt(index, this.length);
 
 		if (finalIndex === undefined) {
@@ -287,7 +287,7 @@ export class LazySequence<TTypes extends FlexAllowedTypes>
 			unboxedUnion(this.context, this.schema, cursor),
 		);
 	}
-	public get asArray(): readonly FlexTreeUnboxNodeUnion<TTypes>[] {
+	public get asArray(): readonly FlexTreeUnknownUnboxed[] {
 		return this.map((x) => x);
 	}
 
@@ -306,13 +306,13 @@ export class LazySequence<TTypes extends FlexAllowedTypes>
 	}
 }
 
-export class ReadonlyLazyValueField<TTypes extends FlexAllowedTypes>
-	extends LazyField<typeof FieldKinds.required, TTypes>
-	implements FlexTreeRequiredField<TTypes>
+export class ReadonlyLazyValueField
+	extends LazyField<typeof FieldKinds.required>
+	implements FlexTreeRequiredField
 {
 	public constructor(
 		context: Context,
-		schema: FlexFieldSchema<typeof FieldKinds.required, TTypes>,
+		schema: FlexFieldSchema<typeof FieldKinds.required>,
 		cursor: ITreeSubscriptionCursor,
 		fieldAnchor: FieldAnchor,
 	) {
@@ -325,18 +325,15 @@ export class ReadonlyLazyValueField<TTypes extends FlexAllowedTypes>
 		},
 	};
 
-	public get content(): FlexTreeUnboxNodeUnion<TTypes> {
+	public get content(): FlexTreeUnknownUnboxed {
 		return this.atIndex(0);
 	}
 }
 
-export class LazyValueField<TTypes extends FlexAllowedTypes>
-	extends ReadonlyLazyValueField<TTypes>
-	implements FlexTreeRequiredField<TTypes>
-{
+export class LazyValueField extends ReadonlyLazyValueField implements FlexTreeRequiredField {
 	public constructor(
 		context: Context,
-		schema: FlexFieldSchema<typeof FieldKinds.required, TTypes>,
+		schema: FlexFieldSchema<typeof FieldKinds.required>,
 		cursor: ITreeSubscriptionCursor,
 		fieldAnchor: FieldAnchor,
 	) {
@@ -355,18 +352,18 @@ export class LazyValueField<TTypes extends FlexAllowedTypes>
 		return fieldEditor;
 	}
 
-	public override get content(): FlexTreeUnboxNodeUnion<TTypes> {
+	public override get content(): FlexTreeUnknownUnboxed {
 		return this.atIndex(0);
 	}
 }
 
-export class LazyIdentifierField<TTypes extends FlexAllowedTypes>
-	extends ReadonlyLazyValueField<TTypes>
-	implements FlexTreeRequiredField<TTypes>
+export class LazyIdentifierField
+	extends ReadonlyLazyValueField
+	implements FlexTreeRequiredField
 {
 	public constructor(
 		context: Context,
-		schema: FlexFieldSchema<typeof FieldKinds.required, TTypes>,
+		schema: FlexFieldSchema<typeof FieldKinds.required>,
 		cursor: ITreeSubscriptionCursor,
 		fieldAnchor: FieldAnchor,
 	) {
@@ -375,8 +372,8 @@ export class LazyIdentifierField<TTypes extends FlexAllowedTypes>
 }
 
 export class LazyOptionalField<TTypes extends FlexAllowedTypes>
-	extends LazyField<typeof FieldKinds.optional, TTypes>
-	implements FlexTreeOptionalField<TTypes>
+	extends LazyField<typeof FieldKinds.optional>
+	implements FlexTreeOptionalField
 {
 	public constructor(
 		context: Context,
@@ -402,15 +399,12 @@ export class LazyOptionalField<TTypes extends FlexAllowedTypes>
 		return fieldEditor;
 	}
 
-	public get content(): FlexTreeUnboxNodeUnion<TTypes> | undefined {
+	public get content(): FlexTreeUnknownUnboxed | undefined {
 		return this.length === 0 ? undefined : this.atIndex(0);
 	}
 }
 
-export class LazyForbiddenField<TTypes extends FlexAllowedTypes> extends LazyField<
-	typeof FieldKinds.forbidden,
-	TTypes
-> {}
+export class LazyForbiddenField extends LazyField<typeof FieldKinds.forbidden> {}
 
 type Builder = new <TTypes extends FlexAllowedTypes>(
 	context: Context,
@@ -421,7 +415,7 @@ type Builder = new <TTypes extends FlexAllowedTypes>(
 	schema: FlexFieldSchema<any, TTypes>,
 	cursor: ITreeSubscriptionCursor,
 	fieldAnchor: FieldAnchor,
-) => LazyField<FlexFieldKind, TTypes>;
+) => LazyField<FlexFieldKind>;
 
 const builderList: [FlexFieldKind, Builder][] = [
 	[FieldKinds.forbidden, LazyForbiddenField],

--- a/packages/dds/tree/src/feature-libraries/flex-tree/unboxed.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/unboxed.ts
@@ -16,7 +16,7 @@ import type { Context } from "./context.js";
 import type {
 	FlexTreeNode,
 	FlexTreeUnboxNode,
-	FlexTreeUnboxNodeUnion,
+	FlexTreeUnknownUnboxed,
 } from "./flexTreeTypes.js";
 import { makeTree } from "./lazyNode.js";
 
@@ -42,10 +42,10 @@ export function unboxedUnion<TTypes extends FlexAllowedTypes>(
 	context: Context,
 	schema: FlexFieldSchema<FlexFieldKind, TTypes>,
 	cursor: ITreeSubscriptionCursor,
-): FlexTreeUnboxNodeUnion<TTypes> {
+): FlexTreeUnknownUnboxed {
 	const type = schema.monomorphicChildType;
 	if (type !== undefined) {
-		return unboxedTree(context, type, cursor) as FlexTreeUnboxNodeUnion<TTypes>;
+		return unboxedTree(context, type, cursor);
 	}
-	return makeTree(context, cursor) as FlexTreeUnboxNodeUnion<TTypes>;
+	return makeTree(context, cursor);
 }

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -238,7 +238,6 @@ export {
 	isFlexTreeNode,
 	ContextSlot,
 	// Internal
-	type FlexTreeUnboxField,
 	flexTreeMarker,
 	FlexTreeEntityKind,
 	assertFlexTreeEntityNotFreed,

--- a/packages/dds/tree/src/shared-tree/treeView.ts
+++ b/packages/dds/tree/src/shared-tree/treeView.ts
@@ -51,7 +51,7 @@ export interface FlexTreeView<in out TRoot extends FlexFieldSchema>
 	/**
 	 * Get a typed view of the tree content using the flex-tree API.
 	 */
-	readonly flexTree: FlexTreeTypedField<TRoot>;
+	readonly flexTree: FlexTreeTypedField<TRoot["kind"]>;
 
 	/**
 	 * Spawn a new view which is based off of the current state of this view.
@@ -79,7 +79,7 @@ export class CheckoutFlexTreeView<
 > implements FlexTreeView<TRoot>
 {
 	public readonly context: Context;
-	public readonly flexTree: FlexTreeTypedField<TRoot>;
+	public readonly flexTree: FlexTreeTypedField<TRoot["kind"]>;
 	public constructor(
 		public readonly checkout: TCheckout,
 		public readonly schema: FlexTreeSchema<TRoot>,
@@ -88,7 +88,7 @@ export class CheckoutFlexTreeView<
 	) {
 		this.context = getTreeContext(schema, this.checkout, nodeKeyManager);
 		contextToTreeView.set(this.context, this);
-		this.flexTree = this.context.root as FlexTreeTypedField<TRoot>;
+		this.flexTree = this.context.root as FlexTreeTypedField<TRoot["kind"]>;
 	}
 
 	public [disposeSymbol](): void {

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -6,7 +6,6 @@
 import { oob } from "@fluidframework/core-utils/internal";
 import { EmptyKey, type ExclusiveMapTree } from "../core/index.js";
 import {
-	type FlexAllowedTypes,
 	type FlexTreeNodeSchema,
 	type FlexTreeNode,
 	type FlexTreeSequenceField,
@@ -288,11 +287,10 @@ export class IterableTreeArrayContent<T> implements Iterable<T> {
 /**
  * Given a array node proxy, returns its underlying LazySequence field.
  */
-function getSequenceField<
-	TTypes extends FlexAllowedTypes,
-	TSimpleType extends ImplicitAllowedTypes,
->(arrayNode: TreeArrayNode<TSimpleType>): FlexTreeSequenceField<TTypes> {
-	return getOrCreateInnerNode(arrayNode).getBoxed(EmptyKey) as FlexTreeSequenceField<TTypes>;
+function getSequenceField<TSimpleType extends ImplicitAllowedTypes>(
+	arrayNode: TreeArrayNode<TSimpleType>,
+): FlexTreeSequenceField {
+	return getOrCreateInnerNode(arrayNode).getBoxed(EmptyKey) as FlexTreeSequenceField;
 }
 
 // For compatibility, we are initially implement 'readonly T[]' by applying the Array.prototype methods

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -5,7 +5,6 @@
 
 import {
 	type FieldKinds,
-	type FlexAllowedTypes,
 	type FlexFieldSchema,
 	type FlexMapNodeSchema,
 	type FlexTreeMapNode,
@@ -153,9 +152,7 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 	}
 
 	private editor(key: string): OptionalFieldEditBuilder<ExclusiveMapTree> {
-		const field = this.innerNode.getBoxed(
-			brand(key),
-		) as FlexTreeOptionalField<FlexAllowedTypes>;
+		const field = this.innerNode.getBoxed(brand(key)) as FlexTreeOptionalField;
 		return field.editor;
 	}
 

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -9,7 +9,6 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import type { FieldKey } from "../core/index.js";
 import {
 	FieldKinds,
-	type FlexAllowedTypes,
 	type FlexObjectNodeSchema,
 	type FlexTreeField,
 	type FlexTreeNode,
@@ -274,12 +273,12 @@ export function setField(
 	switch (field.schema.kind) {
 		case FieldKinds.required: {
 			assert(mapTree !== undefined, 0xa04 /* Cannot set a required field to undefined */);
-			const typedField = field as FlexTreeRequiredField<FlexAllowedTypes>;
+			const typedField = field as FlexTreeRequiredField;
 			typedField.editor.set(mapTree);
 			break;
 		}
 		case FieldKinds.optional: {
-			const typedField = field as FlexTreeOptionalField<FlexAllowedTypes>;
+			const typedField = field as FlexTreeOptionalField;
 			typedField.editor.set(mapTree, typedField.length === 0);
 			break;
 		}

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -17,12 +17,12 @@ import {
 
 import {
 	FieldKinds,
-	type FlexFieldSchema,
 	type FlexTreeField,
 	type FlexTreeNode,
-	type FlexTreeTypedField,
 	tryGetMapTreeNode,
 	isFlexTreeNode,
+	type FlexTreeRequiredField,
+	type FlexTreeOptionalField,
 } from "../feature-libraries/index.js";
 import { type Mutable, fail, isReadonlyArray } from "../util/index.js";
 
@@ -34,9 +34,7 @@ import { tryGetSimpleNodeSchema, type TreeNode, type Unhydrated } from "./core/i
  */
 export function getTreeNodeForField(field: FlexTreeField): TreeNode | TreeValue | undefined {
 	function tryToUnboxLeaves(
-		flexField: FlexTreeTypedField<
-			FlexFieldSchema<typeof FieldKinds.required | typeof FieldKinds.optional>
-		>,
+		flexField: FlexTreeOptionalField | FlexTreeRequiredField,
 	): TreeNode | TreeValue | undefined {
 		const maybeContent = flexField.content;
 		return isFlexTreeNode(maybeContent)
@@ -45,21 +43,16 @@ export function getTreeNodeForField(field: FlexTreeField): TreeNode | TreeValue 
 	}
 	switch (field.schema.kind) {
 		case FieldKinds.required: {
-			const typedField = field as FlexTreeTypedField<
-				FlexFieldSchema<typeof FieldKinds.required>
-			>;
+			const typedField = field as FlexTreeRequiredField;
 			return tryToUnboxLeaves(typedField);
 		}
 		case FieldKinds.optional: {
-			const typedField = field as FlexTreeTypedField<
-				FlexFieldSchema<typeof FieldKinds.optional>
-			>;
+			const typedField = field as FlexTreeOptionalField;
 			return tryToUnboxLeaves(typedField);
 		}
 		case FieldKinds.identifier: {
 			// Identifier fields are just value fields that hold strings
-			return (field as FlexTreeTypedField<FlexFieldSchema<typeof FieldKinds.required>>)
-				.content as string;
+			return (field as FlexTreeRequiredField).content as string;
 		}
 
 		default:

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -152,7 +152,7 @@ describe("End to end chunked encoding", () => {
 		);
 
 		const root = flexTree.root;
-		assert(root.is(numberSequenceRootSchema.rootFieldSchema));
+		assert(root.isExactly(numberSequenceRootSchema.rootFieldSchema));
 		checkout.editor.sequenceField(root.getFieldPath()).insert(0, chunk.cursor());
 
 		// Check that inserted change contains chunk which is reference equal to the original chunk.

--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -9,7 +9,6 @@ import {
 	FieldKinds,
 	FlexFieldSchema,
 	SchemaBuilderBase,
-	type FlexAllowedTypes,
 	type FlexTreeOptionalField,
 } from "../../../feature-libraries/index.js";
 import {
@@ -137,7 +136,8 @@ describe("MapTreeNodes", () => {
 
 		assert.equal(arrayNode.getBoxed(EmptyKey).length, 1);
 		const field = arrayNode.getBoxed(EmptyKey);
-		assert(field.is(arrayNodeSchema.info[EmptyKey]));
+		assert(field.isExactly(arrayNodeSchema.info[EmptyKey]));
+		assert(field.is(arrayNodeSchema.info[EmptyKey].kind));
 		assert.equal(arrayNode.tryGetField(brand("unknown key")), undefined);
 		assert.equal(arrayNode.getBoxed("unknown key").length, 0);
 		assert.equal(field.at(-1), childValue);
@@ -221,9 +221,7 @@ describe("MapTreeNodes", () => {
 			const mutableObjectMapTreeMap = mutableObjectMapTree.fields.get(objectMapKey)?.[0];
 			assert(mutableObjectMapTreeMap !== undefined);
 			const mutableObject = getOrCreateMapTreeNode(objectSchema, mutableObjectMapTree);
-			const field = mutableObject.getBoxed(
-				objectMapKey,
-			) as FlexTreeOptionalField<FlexAllowedTypes>;
+			const field = mutableObject.getBoxed(objectMapKey) as FlexTreeOptionalField;
 			const oldMap = field.boxedAt(0);
 			assert(oldMap !== undefined);
 			assert.equal(oldMap.parentField.parent.parent, mutableObject);
@@ -247,7 +245,7 @@ describe("MapTreeNodes", () => {
 				mapSchema,
 				deepCopyMapTree(mapMapTree),
 			) as EagerMapTreeNode<typeof mapSchema>;
-			const field = mutableMap.getBoxed(mapKey) as FlexTreeOptionalField<FlexAllowedTypes>;
+			const field = mutableMap.getBoxed(mapKey) as FlexTreeOptionalField;
 			const oldValue = field.boxedAt(0);
 			const newValue = `new ${childValue}`;
 			field.editor.set({ ...mapChildMapTree, value: newValue }, false);
@@ -263,7 +261,7 @@ describe("MapTreeNodes", () => {
 				deepCopyMapTree(fieldNodeMapTree),
 			) as EagerMapTreeNode<typeof arrayNodeSchema>;
 			const field = mutableFieldNode.getBoxed(EmptyKey);
-			assert(field.is(arrayNodeSchema.info[EmptyKey]));
+			assert(field.is(arrayNodeSchema.info[EmptyKey].kind));
 			const values = () => Array.from(field.boxedIterator(), (n) => n.value);
 			assert.deepEqual(values(), [childValue]);
 			field.editor.insert(1, [
@@ -286,7 +284,7 @@ describe("MapTreeNodes", () => {
 				fields: new Map(),
 			}) as EagerMapTreeNode<typeof arrayNodeSchema>;
 			const field = mutableFieldNode.getBoxed(EmptyKey);
-			assert(field.is(arrayNodeSchema.info[EmptyKey]));
+			assert(field.is(arrayNodeSchema.info[EmptyKey].kind));
 			const newContent: ExclusiveMapTree[] = [];
 			for (let i = 0; i < 10000; i++) {
 				newContent.push({ ...mapChildMapTree, value: String(i) });

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/editableTreeTypes.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/editableTreeTypes.spec.ts
@@ -15,8 +15,6 @@ import type {
 	FlexTreeObjectNode,
 	FlexTreeTypedNode,
 	FlexTreeTypedNodeUnion,
-	FlexTreeUnboxNodeUnion,
-	FlexTreeUnknownUnboxed,
 	IsArrayOfOne,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../../feature-libraries/flex-tree/flexTreeTypes.js";
@@ -203,60 +201,6 @@ describe("flexTreeTypes", () => {
 			>;
 		}
 	}
-
-	// UnboxNodeUnion
-	{
-		// Any
-		{
-			type _1 = requireTrue<areSafelyAssignable<FlexTreeUnboxNodeUnion<[Any]>, FlexTreeNode>>;
-		}
-
-		// Union
-		{
-			type _1 = requireTrue<
-				areSafelyAssignable<
-					FlexTreeUnboxNodeUnion<[typeof basicStruct, typeof emptyStruct]>,
-					BasicStruct | EmptyStruct
-				>
-			>;
-		}
-
-		// Type-Erased
-		{
-			type _1 = requireTrue<
-				areSafelyAssignable<
-					FlexTreeUnboxNodeUnion<[FlexTreeNodeSchema]>,
-					FlexTreeUnknownUnboxed
-				>
-			>;
-
-			type _3 = requireTrue<
-				areSafelyAssignable<
-					FlexTreeUnboxNodeUnion<[FlexTreeNodeSchema, FlexTreeNodeSchema]>,
-					FlexTreeNode
-				>
-			>;
-			type _4 = requireTrue<areSafelyAssignable<FlexTreeUnboxNodeUnion<[Any]>, FlexTreeNode>>;
-			type _5 = requireTrue<
-				areSafelyAssignable<
-					FlexTreeUnboxNodeUnion<FlexTreeNodeSchema[]>,
-					FlexTreeUnknownUnboxed
-				>
-			>;
-			type _6 = requireTrue<
-				areSafelyAssignable<FlexTreeUnboxNodeUnion<FlexAllowedTypes>, FlexTreeUnknownUnboxed>
-			>;
-		}
-
-		// Generic
-		// eslint-disable-next-line no-inner-declarations
-		function genericTest<T extends FlexAllowedTypes>(t: T) {
-			type Unboxed = FlexTreeUnboxNodeUnion<T>;
-			// @ts-expect-error union can unbox to undefined or a sequence
-			type _1 = requireAssignableTo<Unboxed, FlexTreeNode>;
-		}
-	}
-
 	// IsArrayOfOne
 	{
 		type _1 = requireFalse<IsArrayOfOne<[FlexTreeNodeSchema, FlexTreeNodeSchema]>>;

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -31,7 +31,6 @@ import {
 import {
 	Any,
 	FieldKinds,
-	type FlexAllowedTypes,
 	FlexFieldSchema,
 	cursorForJsonableTreeNode,
 	mapTreeFromCursor,
@@ -59,10 +58,7 @@ const detachedFieldAnchor: FieldAnchor = { parent: undefined, fieldKey: detached
 /**
  * Test {@link LazyField} implementation.
  */
-class TestLazyField<
-	TKind extends FlexFieldKind,
-	TTypes extends FlexAllowedTypes,
-> extends LazyField<TKind, TTypes> {}
+class TestLazyField<TKind extends FlexFieldKind> extends LazyField<TKind> {}
 
 describe("LazyField", () => {
 	it("LazyField implementations do not allow edits to detached trees", () => {
@@ -125,21 +121,27 @@ describe("LazyField", () => {
 			detachedFieldAnchor,
 		);
 
-		assert(anyOptionalField.is(FlexFieldSchema.create(FieldKinds.optional, [Any])));
+		assert(anyOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.optional, [Any])));
 
-		assert(!anyOptionalField.is(FlexFieldSchema.create(FieldKinds.optional, [])));
+		assert(!anyOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.optional, [])));
 		assert(
-			!anyOptionalField.is(FlexFieldSchema.create(FieldKinds.optional, [leafDomain.boolean])),
+			!anyOptionalField.isExactly(
+				FlexFieldSchema.create(FieldKinds.optional, [leafDomain.boolean]),
+			),
 		);
-		assert(!anyOptionalField.is(FlexFieldSchema.create(FieldKinds.required, [])));
-		assert(!anyOptionalField.is(FlexFieldSchema.create(FieldKinds.required, [Any])));
+		assert(!anyOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.required, [])));
+		assert(!anyOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.required, [Any])));
 		assert(
-			!anyOptionalField.is(FlexFieldSchema.create(FieldKinds.required, [leafDomain.boolean])),
+			!anyOptionalField.isExactly(
+				FlexFieldSchema.create(FieldKinds.required, [leafDomain.boolean]),
+			),
 		);
-		assert(!anyOptionalField.is(FlexFieldSchema.create(FieldKinds.sequence, [])));
-		assert(!anyOptionalField.is(FlexFieldSchema.create(FieldKinds.sequence, [Any])));
+		assert(!anyOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.sequence, [])));
+		assert(!anyOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.sequence, [Any])));
 		assert(
-			!anyOptionalField.is(FlexFieldSchema.create(FieldKinds.sequence, [leafDomain.boolean])),
+			!anyOptionalField.isExactly(
+				FlexFieldSchema.create(FieldKinds.sequence, [leafDomain.boolean]),
+			),
 		);
 
 		// #endregion
@@ -154,42 +156,48 @@ describe("LazyField", () => {
 		);
 
 		assert(
-			booleanOptionalField.is(
+			booleanOptionalField.isExactly(
 				FlexFieldSchema.create(FieldKinds.optional, [leafDomain.boolean]),
 			),
 		);
 
-		assert(!booleanOptionalField.is(FlexFieldSchema.create(FieldKinds.optional, [Any])));
 		assert(
-			!booleanOptionalField.is(
+			!booleanOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.optional, [Any])),
+		);
+		assert(
+			!booleanOptionalField.isExactly(
 				FlexFieldSchema.create(FieldKinds.optional, [leafDomain.number]),
 			),
 		);
-		assert(!booleanOptionalField.is(FlexFieldSchema.create(FieldKinds.required, [])));
-		assert(!booleanOptionalField.is(FlexFieldSchema.create(FieldKinds.required, [Any])));
+		assert(!booleanOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.required, [])));
 		assert(
-			!booleanOptionalField.is(
+			!booleanOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.required, [Any])),
+		);
+		assert(
+			!booleanOptionalField.isExactly(
 				FlexFieldSchema.create(FieldKinds.required, [leafDomain.boolean]),
 			),
 		);
 		assert(
-			!booleanOptionalField.is(
+			!booleanOptionalField.isExactly(
 				FlexFieldSchema.create(FieldKinds.required, [leafDomain.number]),
 			),
 		);
-		assert(!booleanOptionalField.is(FlexFieldSchema.create(FieldKinds.sequence, [])));
-		assert(!booleanOptionalField.is(FlexFieldSchema.create(FieldKinds.sequence, [Any])));
+		assert(!booleanOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.sequence, [])));
 		assert(
-			!booleanOptionalField.is(
+			!booleanOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.sequence, [Any])),
+		);
+		assert(
+			!booleanOptionalField.isExactly(
 				FlexFieldSchema.create(FieldKinds.sequence, [leafDomain.boolean]),
 			),
 		);
 		assert(
-			!booleanOptionalField.is(
+			!booleanOptionalField.isExactly(
 				FlexFieldSchema.create(FieldKinds.sequence, [leafDomain.number]),
 			),
 		);
-		assert(!booleanOptionalField.is(FlexFieldSchema.create(FieldKinds.optional, [])));
+		assert(!booleanOptionalField.isExactly(FlexFieldSchema.create(FieldKinds.optional, [])));
 
 		// #endregion
 	});
@@ -504,7 +512,7 @@ describe("LazySequence", () => {
 
 	it("map", () => {
 		const sequence = testSequence([1, 2]);
-		const mapResult = sequence.map((value) => value * 2);
+		const mapResult = sequence.map((value) => (value as number) * 2);
 		assert.deepEqual(mapResult, [2, 4]);
 	});
 

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/unboxed.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/unboxed.spec.ts
@@ -25,6 +25,7 @@ import {
 	Any,
 	type FlexAllowedTypes,
 	type FlexFieldKind,
+	type FlexTreeNode,
 } from "../../../feature-libraries/index.js";
 import type { TreeContent } from "../../../shared-tree/index.js";
 
@@ -93,7 +94,7 @@ describe("unboxedUnion", () => {
 		cursor.enterNode(0); // Root node field has 1 node; move into it
 
 		// Type is not known based on schema, so node will not be unboxed.
-		const unboxed = unboxedUnion(context, fieldSchema, cursor);
+		const unboxed = unboxedUnion(context, fieldSchema, cursor) as FlexTreeNode;
 		assert.equal(unboxed.schema, leaf.number);
 		assert.equal(unboxed.value, 42);
 	});
@@ -124,7 +125,7 @@ describe("unboxedUnion", () => {
 		cursor.enterNode(0); // Root node field has 1 node; move into it
 
 		// Type is not known based on schema, so node will not be unboxed.
-		const unboxed = unboxedUnion(context, fieldSchema, cursor);
+		const unboxed = unboxedUnion(context, fieldSchema, cursor) as FlexTreeNode;
 		assert.equal(unboxed.schema, leaf.string);
 		assert.equal(unboxed.value, "Hello world");
 	});

--- a/packages/dds/tree/src/test/scalableTestTrees.ts
+++ b/packages/dds/tree/src/test/scalableTestTrees.ts
@@ -13,7 +13,12 @@ import {
 	rootFieldKey,
 } from "../core/index.js";
 import { jsonSchema, leaf } from "../domains/index.js";
-import { FieldKinds, FlexFieldSchema, SchemaBuilderBase } from "../feature-libraries/index.js";
+import {
+	FieldKinds,
+	FlexFieldSchema,
+	SchemaBuilderBase,
+	type FlexTreeNode,
+} from "../feature-libraries/index.js";
 import type { FlexTreeView, TreeContent } from "../shared-tree/index.js";
 import { brand } from "../util/index.js";
 import {
@@ -255,11 +260,12 @@ export function readWideFlexTree(tree: FlexTreeView<typeof wideSchema.rootFieldS
 	let sum = 0;
 	let nodesCount = 0;
 	const root = tree.flexTree;
-	const field = root.content.getBoxed(EmptyKey);
+	const field = (root.content as FlexTreeNode).getBoxed(EmptyKey);
 	assert(field.length !== 0);
-	assert(field.is(wideRootSchema.info[EmptyKey]));
-	for (const currentNode of field) {
-		sum += currentNode;
+	assert(field.isExactly(wideRootSchema.info[EmptyKey]));
+	for (const currentNode of field.boxedIterator()) {
+		assert(currentNode.is(leaf.number));
+		sum += currentNode.value;
 		nodesCount += 1;
 	}
 	return { nodesCount, sum };
@@ -270,11 +276,11 @@ export function readDeepFlexTree(tree: FlexTreeView<typeof deepSchema.rootFieldS
 	value: number;
 } {
 	let depth = 0;
-	let currentNode = tree.flexTree.content;
+	let currentNode = tree.flexTree.content as FlexTreeNode;
 	while (currentNode.is(linkedListSchema)) {
 		const read = currentNode.getBoxed(brand("foo"));
-		assert(read.is(linkedListSchema.info.foo));
-		currentNode = read.content;
+		assert(read.is(FieldKinds.required));
+		currentNode = read.content as FlexTreeNode;
 		depth++;
 	}
 	assert(currentNode.is(leaf.number));

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -152,7 +152,10 @@ describe("SharedTree", () => {
 			schematizeFlexTree(provider.trees[1], content);
 			provider.processMessages();
 
-			assert.deepEqual([...tree1.flexTree], ["x"]);
+			assert.deepEqual(
+				Array.from(tree1.flexTree.boxedIterator(), (f) => f.value),
+				["x"],
+			);
 		});
 
 		it("initialize tree", () => {

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -769,7 +769,7 @@ export function flexTreeFromForest<TRoot extends FlexFieldSchema>(
 			IEmitter<CheckoutEvents> &
 			HasListeners<CheckoutEvents>;
 	},
-): FlexTreeTypedField<TRoot> {
+): FlexTreeTypedField<TRoot["kind"]> {
 	const branch = createTreeCheckout(testIdCompressor, mintRevisionTag, testRevisionTagCodec, {
 		...args,
 		forest,


### PR DESCRIPTION
## Description

More progress toward removing the schema aware-ness of flex tree.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
