### PR TITLE
test(tree): Check for errors differently in recent tests

### DIFF
--- a/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
@@ -19,6 +19,7 @@ import type {
 	FieldProvider,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../simple-tree/schemaTypes.js";
+import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 import { hydrate } from "./utils.js";
 import { isMapTreeNode, TreeStatus } from "../../feature-libraries/index.js";
@@ -330,7 +331,8 @@ describe("Unhydrated nodes", () => {
 		assert.throws(
 			() => new TestArray([leaf, leaf]),
 			(e: Error) =>
-				validateAssertionError(e, /A node may not be in more than one place in the tree/),
+				e instanceof UsageError &&
+				e.message.includes("A node may not be in more than one place in the tree"),
 		);
 	});
 
@@ -350,10 +352,8 @@ describe("Unhydrated nodes", () => {
 		assert.throws(
 			() => view.map.set("key", leaf),
 			(e: Error) =>
-				validateAssertionError(
-					e,
-					/Attempted to insert a node which is already under a parent/,
-				),
+				e instanceof UsageError &&
+				e.message.includes("Attempted to insert a node which is already under a parent"),
 		);
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedNode.spec.ts
@@ -19,10 +19,10 @@ import type {
 	FieldProvider,
 	// eslint-disable-next-line import/no-internal-modules
 } from "../../simple-tree/schemaTypes.js";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 import { hydrate } from "./utils.js";
 import { isMapTreeNode, TreeStatus } from "../../feature-libraries/index.js";
+import { validateUsageError } from "../utils.js";
 
 describe("Unhydrated nodes", () => {
 	const schemaFactory = new SchemaFactory("undefined");
@@ -330,9 +330,7 @@ describe("Unhydrated nodes", () => {
 		const leaf = new TestLeaf({ value: "3" });
 		assert.throws(
 			() => new TestArray([leaf, leaf]),
-			(e: Error) =>
-				e instanceof UsageError &&
-				e.message.includes("A node may not be in more than one place in the tree"),
+			validateUsageError("A node may not be in more than one place in the tree"),
 		);
 	});
 
@@ -351,9 +349,9 @@ describe("Unhydrated nodes", () => {
 		// This would be confusing, as the user's reference to `leaf` is now a different object than `array[0]`, whereas prior to the insert they were the same.
 		assert.throws(
 			() => view.map.set("key", leaf),
-			(e: Error) =>
-				e instanceof UsageError &&
-				e.message.includes("Attempted to insert a node which is already under a parent"),
+			validateUsageError(
+				"Attempted to insert a node which is already under a parent. If this is desired, remove the node from its parent before inserting it elsewhere.",
+			),
 		);
 	});
 });


### PR DESCRIPTION
## Description

`validateAssertionError()` is intended to be used for errors thrown by `assert()`. The two tests updated in this PR were added in https://github.com/microsoft/FluidFramework/pull/22219 and are checking for `UsageError`s, so this PR replaces the validation using `validateAssertionError()` with a more appropriate alternative.
 
## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
