### PR TITLE
build(docs): Update dependency on `api-markdown-documenter` from `0.15` to `0.16`.

### DIFF
--- a/docs/api-markdown-documenter/api-documentation-layout.js
+++ b/docs/api-markdown-documenter/api-documentation-layout.js
@@ -33,25 +33,6 @@ const supportDocsLinkSpan = new SpanNode([
 ]);
 
 /**
- * Checks if the provided API item or any ancestors is tagged with the specified
- * {@link https://tsdoc.org/pages/spec/tag_kinds/#modifier-tags | modifier tag}.
- *
- * @param apiItem - The API item whose documentation is being queried.
- * @param tagName - The TSDoc tag name being queried for.
- * Must be a valid TSDoc tag (including starting with `@`).
- *
- * @throws If the provided TSDoc tag name is invalid.
- *
- * @privateRemarks import from `@fluid-tools/api-markdown-documenter` once available.
- */
-export function ancestryHasModifierTag(apiItem, tagName) {
-	return (
-		ApiItemUtilities.hasModifierTag(apiItem, tagName) ||
-		(apiItem.parent !== undefined && ancestryHasModifierTag(apiItem.parent, tagName))
-	);
-}
-
-/**
  * Creates a special import notice for the provided API item, if one is appropriate.
  *
  * If the item is tagged as "@legacy", displays a legacy notice with import instructions.
@@ -112,7 +93,7 @@ function createImportNotice(apiItem) {
  * If the item is tagged as "@system", displays an internal notice with use notes.
  */
 function createSystemNotice(apiItem) {
-	if (ancestryHasModifierTag(apiItem, "@system")) {
+	if (ApiItemUtilities.ancestryHasModifierTag(apiItem, "@system")) {
 		return new AlertNode(
 			[supportDocsLinkSpan],
 			/* alertKind: */ "warning",

--- a/docs/api-markdown-documenter/render-api-documentation.js
+++ b/docs/api-markdown-documenter/render-api-documentation.js
@@ -19,7 +19,7 @@ import fs from "fs-extra";
 import path from "path";
 
 import { alertNodeType } from "./alert-node.js";
-import { ancestryHasModifierTag, layoutContent } from "./api-documentation-layout.js";
+import { layoutContent } from "./api-documentation-layout.js";
 import { buildNavBar } from "./build-api-nav.js";
 import { renderAlertNode, renderBlockQuoteNode, renderTableNode } from "./custom-renderers.js";
 import { createHugoFrontMatter } from "./front-matter.js";
@@ -58,7 +58,7 @@ export async function renderApiDocumentation(inputDir, outputDir, uriRootDir, ap
 	// Process API reports
 	logProgress("Loading API model...");
 
-	const apiModel = await loadModel(inputDir);
+	const apiModel = await loadModel({ modelDirectoryPath: inputDir });
 
 	// Custom renderers that utilize Hugo syntax for certain kinds of documentation elements.
 	const customRenderers = {
@@ -83,7 +83,7 @@ export async function renderApiDocumentation(inputDir, outputDir, uriRootDir, ap
 		createDefaultLayout: layoutContent,
 		getAlertsForItem: (apiItem) => {
 			const alerts = [];
-			if (ancestryHasModifierTag(apiItem, "@system")) {
+			if (ApiItemUtilities.ancestryHasModifierTag(apiItem, "@system")) {
 				alerts.push("System");
 			} else {
 				if (ApiItemUtilities.isDeprecated(apiItem)) {

--- a/docs/package.json
+++ b/docs/package.json
@@ -39,7 +39,7 @@
 		"start": "hugo server"
 	},
 	"dependencies": {
-		"@fluid-tools/api-markdown-documenter": "^0.15.0",
+		"@fluid-tools/api-markdown-documenter": "^0.16.0",
 		"@fluid-tools/markdown-magic": "file:../tools/markdown-magic",
 		"@fluidframework/build-common": "^2.0.3",
 		"@rushstack/node-core-library": "^4.0.2",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@fluid-tools/api-markdown-documenter':
-        specifier: ^0.15.0
-        version: 0.15.0
+        specifier: ^0.16.0
+        version: 0.16.0
       '@fluid-tools/markdown-magic':
         specifier: file:../tools/markdown-magic
         version: file:../tools/markdown-magic(markdown-magic@2.6.1)
@@ -143,8 +143,8 @@ packages:
       regenerator-runtime: 0.13.11
     dev: false
 
-  /@fluid-tools/api-markdown-documenter@0.15.0:
-    resolution: {integrity: sha512-6vRyuVLFDjKSb9D1Qi4kjq1og+e8gCdeTnJZSKapfSdoIqywVFsTdo9avz0ay1tW/H6z3hZaq+DxeYX2BsK+mA==}
+  /@fluid-tools/api-markdown-documenter@0.16.0:
+    resolution: {integrity: sha512-A8tVCxr296QgoKLeZHcZtf5hClffpWvI2L2PAl9BnNZYQbVR9TOAXWBDi4Py0E42Mes10LyscO+FFvbVHKISbw==}
     dependencies:
       '@microsoft/api-extractor-model': 7.28.2
       '@microsoft/tsdoc': 0.14.2


### PR DESCRIPTION
Updates API docs build to accommodate API changes and leverage new functionality.