### PR TITLE
(fix) getSingleUseLegacyLogCallback would never log in practice

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -767,14 +767,14 @@ function lastMessageFromMetadata(metadata: IContainerRuntimeMetadata | undefined
  * We only want to log this once, to avoid spamming telemetry if we are wrong and these cases are hit commonly.
  */
 let getSingleUseLegacyLogCallback = (logger: ITelemetryLoggerExt, type: string) => {
-	// We only want to log this once per ContainerRuntime instance, to avoid spamming telemetry.
-	getSingleUseLegacyLogCallback = () => () => {};
-
 	return (codePath: string) => {
 		logger.sendTelemetryEvent({
 			eventName: "LegacyMessageFormat",
 			details: { codePath, type },
 		});
+
+		// Now that we've logged, prevent future logging (globally).
+		getSingleUseLegacyLogCallback = () => () => {};
 	};
 };
 


### PR DESCRIPTION
## Description

The function `getSingleUseLegacyLogCallback` clears itself the first time it's called - but it should actually clear itself the first time it actually logs, otherwise it will likely never log (only if the very first time through happened to be this case)

## Reviewer Guidance

Note that this function is global, not tied to ContainerRuntime instance.  In application usage, this is fine.  In tests, it's potentially problematic, but only if multiple tests are exercising the legacy codepath, which shouldn't be the case.