### PR TITLE
WIP - Expose API to pick SharedTree persisted format version

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -425,6 +425,25 @@ type ScopedSchemaName<TScope extends string | undefined, TName extends number | 
 // @alpha
 export const SharedTree: ISharedObjectKind<ITree> & SharedObjectKind<ITree>;
 
+// @alpha
+export interface SharedTreeConfiguration {
+    // (undocumented)
+    readonly persistedFormatVersion?: SharedTreeFormatVersion[keyof SharedTreeFormatVersion] | undefined;
+}
+
+// @alpha
+export const SharedTreeFormatVersion: {
+    readonly v1: 1;
+    readonly v2: 2;
+    readonly v3: 3;
+};
+
+// @alpha
+export type SharedTreeFormatVersion = typeof SharedTreeFormatVersion;
+
+// @alpha
+export const SharedTreeWithConfiguration: (options: SharedTreeConfiguration) => SharedObjectKind<ITree>;
+
 // @public
 export type TransactionConstraint = NodeInDocumentConstraint;
 

--- a/packages/dds/tree/src/codec/index.ts
+++ b/packages/dds/tree/src/codec/index.ts
@@ -30,4 +30,5 @@ export {
 	makeVersionedCodec,
 	makeVersionedValidatedCodec,
 	makeVersionDispatchingCodec,
+	makeStrictVersionCodec,
 } from "./versioned/index.js";

--- a/packages/dds/tree/src/codec/versioned/index.ts
+++ b/packages/dds/tree/src/codec/versioned/index.ts
@@ -8,4 +8,5 @@ export {
 	makeVersionedCodec,
 	makeVersionedValidatedCodec,
 	makeVersionDispatchingCodec,
+	makeStrictVersionCodec,
 } from "./codec.js";

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -140,7 +140,12 @@ export {
 	type JsonLeafSchemaType,
 	getJsonSchema,
 } from "./simple-tree/index.js";
-export { SharedTree, configuredSharedTree } from "./treeFactory.js";
+export {
+	SharedTree,
+	configuredSharedTree,
+	SharedTreeWithConfiguration,
+	type SharedTreeConfiguration,
+} from "./treeFactory.js";
 
 export type { ICodecOptions, JsonValidator, SchemaValidationFunction } from "./codec/index.js";
 export { noopValidator } from "./codec/index.js";

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -12,7 +12,7 @@ import {
 	makeCodecFamily,
 	withSchemaValidation,
 } from "../codec/index.js";
-import { makeVersionDispatchingCodec } from "../codec/index.js";
+import { makeStrictVersionCodec } from "../codec/index.js";
 import type {
 	ChangeEncodingContext,
 	EncodedRevisionTag,
@@ -55,7 +55,7 @@ export function makeEditManagerCodec<TChangeset>(
 	EditManagerEncodingContext
 > {
 	const family = makeEditManagerCodecs(changeCodecs, revisionTagCodec, options);
-	return makeVersionDispatchingCodec(family, { ...options, writeVersion });
+	return makeStrictVersionCodec(family, { ...options, writeVersion });
 }
 
 export function makeEditManagerCodecs<TChangeset>(

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -315,7 +315,7 @@ export class SharedTree
  * Format versions supported by SharedTree.
  *
  * Each version documents a required minimum version of the \@fluidframework/tree package.
- * @internal
+ * @alpha
  */
 export const SharedTreeFormatVersion = {
 	/**
@@ -328,6 +328,10 @@ export const SharedTreeFormatVersion = {
 
 	/**
 	 * Requires \@fluidframework/tree \>= 2.0.0.
+	 *
+	 * @deprecated - FF does not currently plan on supporting this format long-term.
+	 * Do not write production documents using this format, as they may not be loadable in the future.
+	 *
 	 */
 	v2: 2,
 
@@ -341,7 +345,7 @@ export const SharedTreeFormatVersion = {
  * Format versions supported by SharedTree.
  *
  * Each version documents a required minimum version of the \@fluidframework/tree package.
- * @internal
+ * @alpha
  * @privateRemarks
  * See packages/dds/tree/docs/main/compatibility.md for information on how to add support for a new format.
  */

--- a/packages/dds/tree/src/treeFactory.ts
+++ b/packages/dds/tree/src/treeFactory.ts
@@ -16,7 +16,11 @@ import {
 } from "@fluidframework/shared-object-base/internal";
 
 import { pkgVersion } from "./packageVersion.js";
-import { SharedTree as SharedTreeImpl, type SharedTreeOptions } from "./shared-tree/index.js";
+import {
+	SharedTreeFormatVersion,
+	SharedTree as SharedTreeImpl,
+	type SharedTreeOptions,
+} from "./shared-tree/index.js";
 import type { ITree } from "./simple-tree/index.js";
 
 /**
@@ -96,3 +100,31 @@ export function configuredSharedTree(
 	}
 	return createSharedObjectKind<ITree>(ConfiguredFactory);
 }
+
+/**
+ * Configuration options for a SharedTree
+ * @alpha
+ */
+export interface SharedTreeConfiguration {
+	readonly persistedFormatVersion?:
+		| SharedTreeFormatVersion[keyof SharedTreeFormatVersion]
+		| undefined;
+}
+
+/**
+ * Produces a SharedTree that allows for a non-default configuration.
+ *
+ * @param options - The configuration options for SharedTree.
+ * @remarks You can use the object returned from this function as a value in the initial objects
+ * map of your Fluid container, so that all SharedTree instances created for the specified key have the custom configuration
+ * passed to this function.
+ *
+ * @alpha
+ */
+export const SharedTreeWithConfiguration: (
+	options: SharedTreeConfiguration,
+) => SharedObjectKind<ITree> = (options: SharedTreeConfiguration) => {
+	return configuredSharedTree({
+		formatVersion: options.persistedFormatVersion ?? SharedTreeFormatVersion.v3,
+	});
+};


### PR DESCRIPTION
## Description

Proof of concept of a way in which we could expose the SharedTree persisted format version so users could choose which one to use. Maybe this approach does a bit more work than necessary (exposing `configuredSharedTree()` as `@alpha` instead of `@internal` might be ok, although that exposes more options than just the persisted format version).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

One thing that feels particularly tricky to me is that the single format version gets mapped internally to multiple codec versions for different parts of SharedTree, and not all of them necessarily get exercised at the time we load the container (the one for loading the summary does, for example; but the one for ops might not... unless there are trailing ops; not entirely sure what the others are for). So ensuring a) that we fail when _any_ version mismatch is encountered (under the assumption that we expose the format very conservatively to begin with, in a "_only_ work with this version" way) and b) quick enough so that the container cannot be used at all in case of mismatch, seems potentially complicated and brittle.

[AB#8902](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8902)