### PR TITLE
Fix flaky test for attribution for r11s

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/cellAttributionEndToEnd.spec.ts
@@ -137,11 +137,6 @@ describeCompat("Attributor for SharedCell", "NoCompat", (getTestObjectProvider, 
 			const container2 = await provider.loadTestContainer(getTestConfig(true));
 			const sharedCell2 = await sharedCellFromContainer(container2);
 
-			assert(
-				container1.clientId !== undefined && container2.clientId !== undefined,
-				"Both containers should have client ids.",
-			);
-
 			const attributor1 = await getAttributorFromContainer(container1);
 			const attributor2 = await getAttributorFromContainer(container2);
 			sharedCell1.set(1);
@@ -151,6 +146,10 @@ describeCompat("Attributor for SharedCell", "NoCompat", (getTestObjectProvider, 
 			sharedCell2.set(2);
 			await provider.ensureSynchronized();
 
+			assert(
+				container1.clientId !== undefined && container2.clientId !== undefined,
+				"Both containers should have client ids.",
+			);
 			assertAttributionMatches(sharedCell1, attributor1, {
 				user: container1.audience.getMember(container2.clientId)?.user,
 			});


### PR DESCRIPTION
## Description

[ADO Task Link](https://dev.azure.com/fluidframework/internal/_workitems/edit/10969)

Fix flaky test for attribution for r11s. Move clientid check after ensureSynchronized so that we can make sure we are connected.