### PR TITLE
tree: Reduce use of flex tree schema

### DIFF
--- a/packages/dds/tree/src/domains/schemaBuilder.ts
+++ b/packages/dds/tree/src/domains/schemaBuilder.ts
@@ -71,56 +71,6 @@ export class SchemaBuilder extends SchemaBuilderBase<string, typeof FieldKinds.r
 	 * This method is also available as an instance method on {@link SchemaBuilder}.
 	 */
 	public static required = fieldHelper(FieldKinds.required);
-
-	/**
-	 * Define a schema for a {@link FieldKinds.required|required field}.
-	 * @remarks
-	 * Shorthand for passing `FieldKinds.required` to {@link FlexFieldSchema.create}.
-	 * Note that `FieldKinds.required` is the current default field kind, so APIs accepting {@link FlexImplicitFieldSchema}
-	 * can be passed the `allowedTypes` and will implicitly wrap it up in a {@link FieldKinds.required|required field}.
-	 *
-	 * Since this creates a {@link FlexFieldSchema} (and not a {@link FlexTreeNodeSchema}), the resulting schema is structurally typed, and not impacted by the {@link SchemaBuilderBase.scope}:
-	 * therefore this method is the same as the static version.
-	 */
-	public readonly required = SchemaBuilder.required;
-
-	/**
-	 * Define a schema for a {@link FieldKinds.sequence|sequence field}.
-	 * @remarks
-	 * Shorthand for passing `FieldKinds.sequence` to {@link FlexFieldSchema.create}.
-	 *
-	 * This method is also available as an instance method on {@link SchemaBuilder}
-	 */
-	public static sequence = fieldHelper(FieldKinds.sequence);
-
-	/**
-	 * Define a schema for a {@link FieldKinds.sequence|sequence field}.
-	 * @remarks
-	 * Shorthand for passing `FieldKinds.sequence` to {@link FlexFieldSchema.create}.
-	 *
-	 * Since this creates a {@link FlexFieldSchema} (and not a {@link FlexTreeNodeSchema}), the resulting schema is structurally typed, and not impacted by the {@link SchemaBuilderBase.scope}:
-	 * therefore this method is the same as the static version.
-	 */
-	public readonly sequence = SchemaBuilder.sequence;
-
-	/**
-	 * Define a schema for an {@link FieldKinds.identifier|identifier field}.
-	 * @remarks
-	 * Shorthand for passing `FieldKinds.identifier` to {@link TreeFieldSchema.create}.
-	 *
-	 * This method is also available as an instance method on {@link SchemaBuilder}
-	 */
-	public static identifier = fieldHelper(FieldKinds.identifier);
-
-	/**
-	 * Define a schema for a {@link FieldKinds.identifier|identifier field}.
-	 * @remarks
-	 * Shorthand for passing `FieldKinds.identifier` to {@link TreeFieldSchema.create}.
-	 *
-	 * Since this creates a {@link TreeFieldSchema} (and not a {@link FlexTreeNodeSchema}), the resulting schema is structurally typed, and not impacted by the {@link SchemaBuilderBase.scope}:
-	 * therefore this method is the same as the static version.
-	 */
-	public readonly identifier = SchemaBuilder.identifier;
 }
 
 /**

--- a/packages/dds/tree/src/feature-libraries/typed-schema/typedTreeSchema.ts
+++ b/packages/dds/tree/src/feature-libraries/typed-schema/typedTreeSchema.ts
@@ -237,8 +237,6 @@ export type LazyTreeNodeSchema = FlexTreeNodeSchema | (() => FlexTreeNodeSchema)
 
 /**
  * Types for use in fields.
- *
- * "Any" is boxed in an array to allow use as variadic parameter.
  */
 export type FlexAllowedTypes = readonly LazyItem<FlexTreeNodeSchema>[];
 

--- a/packages/dds/tree/src/feature-libraries/typed-schema/view.ts
+++ b/packages/dds/tree/src/feature-libraries/typed-schema/view.ts
@@ -19,27 +19,18 @@ import {
 	isNeverTree,
 } from "../modular-schema/index.js";
 
-import {
-	type FlexFieldSchema,
-	type FlexTreeSchema,
-	intoStoredSchema,
-} from "./typedTreeSchema.js";
-
 /**
  * A collection of View information for schema, including policy.
  */
-export class ViewSchema<out TSchema extends FlexFieldSchema = FlexFieldSchema> {
+export class ViewSchema {
 	/**
-	 * Cached conversion of `schema` into a stored schema.
+	 * @param storedSchema - Cached conversion of view schema into a stored schema.
 	 */
-	public readonly storedSchema: TreeStoredSchema;
 	public constructor(
 		public readonly policy: FullSchemaPolicy,
 		public readonly adapters: Adapters,
-		public readonly schema: FlexTreeSchema<TSchema>,
-	) {
-		this.storedSchema = intoStoredSchema(schema);
-	}
+		public readonly storedSchema: TreeStoredSchema,
+	) {}
 
 	/**
 	 * Determines the compatibility of a stored document

--- a/packages/dds/tree/src/shared-tree/index.ts
+++ b/packages/dds/tree/src/shared-tree/index.ts
@@ -28,6 +28,7 @@ export {
 export {
 	type SchematizeConfiguration,
 	type TreeContent,
+	type TreeStoredContent,
 	type InitializeAndSchematizeConfiguration,
 	type SchemaConfiguration,
 	buildTreeConfiguration,

--- a/packages/dds/tree/src/shared-tree/treeView.ts
+++ b/packages/dds/tree/src/shared-tree/treeView.ts
@@ -5,11 +5,9 @@
 
 import {
 	type Context,
-	type FlexFieldSchema,
 	type FlexTreeContext,
 	type FlexTreeField,
 	type FlexTreeSchema,
-	type FlexTreeTypedField,
 	type NodeKeyManager,
 	getTreeContext,
 } from "../feature-libraries/index.js";
@@ -61,22 +59,20 @@ export interface ITreeViewFork extends FlexTreeView {
 /**
  * Implementation of FlexTreeView wrapping a ITreeCheckout.
  */
-export class CheckoutFlexTreeView<
-	in out TRoot extends FlexFieldSchema,
-	out TCheckout extends ITreeCheckout = ITreeCheckout,
-> implements FlexTreeView
+export class CheckoutFlexTreeView<out TCheckout extends ITreeCheckout = ITreeCheckout>
+	implements FlexTreeView
 {
 	public readonly context: Context;
-	public readonly flexTree: FlexTreeTypedField<TRoot["kind"]>;
+	public readonly flexTree: FlexTreeField;
 	public constructor(
 		public readonly checkout: TCheckout,
-		public readonly schema: FlexTreeSchema<TRoot>,
+		public readonly schema: FlexTreeSchema,
 		public readonly nodeKeyManager: NodeKeyManager,
 		private readonly onDispose?: () => void,
 	) {
 		this.context = getTreeContext(schema, this.checkout, nodeKeyManager);
 		contextToTreeView.set(this.context, this);
-		this.flexTree = this.context.root as FlexTreeTypedField<TRoot["kind"]>;
+		this.flexTree = this.context.root;
 	}
 
 	public [disposeSymbol](): void {
@@ -88,7 +84,7 @@ export class CheckoutFlexTreeView<
 		this.onDispose?.();
 	}
 
-	public fork(): CheckoutFlexTreeView<TRoot, ITreeCheckout & ITreeCheckoutFork> {
+	public fork(): CheckoutFlexTreeView<ITreeCheckout & ITreeCheckoutFork> {
 		const branch = this.checkout.fork();
 		return new CheckoutFlexTreeView(branch, this.schema, this.nodeKeyManager);
 	}

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -748,7 +748,7 @@ export function structuralName<const T extends string>(
 		names.sort();
 		// Ensure name can't have collisions by quoting and escaping any quotes in the names of types.
 		// Using JSON is a simple way to accomplish this.
-		// The outer `[]` around the result are also needed so that a single type name "Any" would not collide with the "any" case above.
+		// The outer `[]` around the result were needed so that a single type name "Any" would not collide with the "any" case which used to exist.
 		inner = JSON.stringify(names);
 	}
 	return `${collectionName}<${inner}>`;

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -45,8 +45,8 @@ import {
 } from "../../../feature-libraries/index.js";
 import {
 	ForestType,
+	type TreeStoredContent,
 	type ISharedTreeEditor,
-	type TreeContent,
 } from "../../../shared-tree/index.js";
 import {
 	MockTreeCheckout,
@@ -58,7 +58,7 @@ import {
 } from "../../utils.js";
 import { SchemaFactory } from "../../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
-import { toFlexSchema } from "../../../simple-tree/toFlexSchema.js";
+import { toStoredSchema } from "../../../simple-tree/toFlexSchema.js";
 import { SummaryType } from "@fluidframework/driver-definitions";
 // eslint-disable-next-line import/no-internal-modules
 import type { Format } from "../../../feature-libraries/forest-summary/format.js";
@@ -94,8 +94,8 @@ function getIdentifierEncodingContext(id: string) {
 		new HasIdentifier({ identifier: id }),
 		new MockNodeKeyManager(),
 	);
-	const flexSchema = toFlexSchema(HasIdentifier);
-	const flexConfig: TreeContent = {
+	const flexSchema = toStoredSchema(HasIdentifier);
+	const flexConfig: TreeStoredContent = {
 		schema: flexSchema,
 		initialTree,
 	};
@@ -106,7 +106,7 @@ function getIdentifierEncodingContext(id: string) {
 		idCompressor: testIdCompressor,
 		originatorId: testIdCompressor.localSessionId,
 		schema: {
-			schema: intoStoredSchema(flexSchema),
+			schema: flexSchema,
 			policy: defaultSchemaPolicy,
 		},
 	};

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -322,6 +322,7 @@ describe("LazyOptionalField", () => {
 			schema,
 			initialTree: singleJsonCursor(5),
 		});
+		assert(view.flexTree.is(FieldKinds.optional));
 		assert.equal(view.flexTree.content, 5);
 		view.flexTree.editor.set(
 			mapTreeFromCursor(singleJsonCursor(6)),
@@ -383,6 +384,7 @@ describe("LazyValueField", () => {
 			schema,
 			initialTree: singleJsonCursor("X"),
 		});
+		assert(view.flexTree.is(FieldKinds.required));
 		assert.equal(view.flexTree.content, "X");
 		view.flexTree.editor.set(mapTreeFromCursor(singleJsonCursor("Y")));
 		assert.equal(view.flexTree.content, "Y");

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/schemaEvolutionExamples.spec.ts
@@ -20,10 +20,10 @@ import { SchemaBuilder, leaf } from "../../../domains/index.js";
 import {
 	FieldKinds,
 	FlexFieldSchema,
-	type FlexTreeSchema,
 	type FullSchemaPolicy,
 	ViewSchema,
 	defaultSchemaPolicy,
+	intoStoredSchema,
 } from "../../../feature-libraries/index.js";
 import {
 	allowsFieldSuperset,
@@ -133,11 +133,13 @@ describe("Schema Evolution Examples", () => {
 	it("basic usage", () => {
 		// Collect our view schema.
 		// This will represent our view schema for a simple canvas application.
-		const viewCollection: FlexTreeSchema = new SchemaBuilder({
-			scope: "test",
-			name: "basic usage",
-			libraries: [treeViewSchema],
-		}).intoSchema(root);
+		const viewCollection = intoStoredSchema(
+			new SchemaBuilder({
+				scope: "test",
+				name: "basic usage",
+				libraries: [treeViewSchema],
+			}).intoSchema(root),
+		);
 
 		// This is where legacy schema handling logic for schematize.
 		const adapters: Adapters = {};
@@ -184,11 +186,13 @@ describe("Schema Evolution Examples", () => {
 
 			// This example picks the first approach.
 			// Lets simulate the developers of the app making this change by modifying the view schema:
-			const viewCollection2 = new SchemaBuilder({
-				scope: "test",
-				name: "basic usage2",
-				libraries: [treeViewSchema],
-			}).intoSchema(tolerantRoot);
+			const viewCollection2 = intoStoredSchema(
+				new SchemaBuilder({
+					scope: "test",
+					name: "basic usage2",
+					libraries: [treeViewSchema],
+				}).intoSchema(tolerantRoot),
+			);
 			const view2 = new ViewSchema(defaultSchemaPolicy, adapters, viewCollection2);
 			// When we open this document, we should check it's compatibility with our application:
 			const compat = view2.checkCompatibility(stored);
@@ -267,8 +271,8 @@ describe("Schema Evolution Examples", () => {
 				items: FlexFieldSchema.create(FieldKinds.sequence, [positionedCanvasItem2]),
 			});
 			// Once again we will simulate reloading the app with different schema by modifying the view schema.
-			const viewCollection3: FlexTreeSchema = builderWithCounter.intoSchema(
-				FlexFieldSchema.create(FieldKinds.optional, [canvas2]),
+			const viewCollection3 = intoStoredSchema(
+				builderWithCounter.intoSchema(FlexFieldSchema.create(FieldKinds.optional, [canvas2])),
 			);
 			const view3 = new ViewSchema(defaultSchemaPolicy, adapters, viewCollection3);
 

--- a/packages/dds/tree/src/test/feature-libraries/schema-index/codec.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schema-index/codec.spec.ts
@@ -9,7 +9,7 @@ import { strict as assert } from "assert";
 
 import { makeCodecFamily } from "../../../codec/index.js";
 import type { FieldKindIdentifier, TreeStoredSchema } from "../../../core/index.js";
-import { SchemaBuilder, jsonRoot, jsonSchema, leaf } from "../../../domains/index.js";
+import { SchemaBuilder, leaf } from "../../../domains/index.js";
 import { typeboxValidator } from "../../../external-utilities/index.js";
 import {
 	allowsRepoSuperset,
@@ -22,14 +22,11 @@ import { makeSchemaCodec } from "../../../feature-libraries/schema-index/codec.j
 import { Format } from "../../../feature-libraries/schema-index/format.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "../../snapshots/index.js";
 import { library } from "../../testTrees.js";
-import { type EncodingTestData, makeEncodingTestSuite } from "../../utils.js";
+import { type EncodingTestData, JsonUnion, makeEncodingTestSuite } from "../../utils.js";
+// eslint-disable-next-line import/no-internal-modules
+import { toStoredSchema } from "../../../simple-tree/toFlexSchema.js";
 
 const codec = makeSchemaCodec({ jsonValidator: typeboxValidator });
-
-const schema1 = new SchemaBuilder({
-	scope: "json",
-	libraries: [jsonSchema],
-}).intoSchema(SchemaBuilder.optional(jsonRoot));
 
 const jsonPrimitives = [...leaf.primitives, leaf.null] as const;
 const schema2 = new SchemaBuilder({
@@ -39,7 +36,7 @@ const schema2 = new SchemaBuilder({
 
 const testCases: EncodingTestData<TreeStoredSchema, Format> = {
 	successes: [
-		["json", intoStoredSchema(schema1)],
+		["json", toStoredSchema(JsonUnion)],
 		["testSchemas", intoStoredSchema(schema2)],
 	],
 };

--- a/packages/dds/tree/src/test/scalableTestTrees.ts
+++ b/packages/dds/tree/src/test/scalableTestTrees.ts
@@ -107,7 +107,7 @@ export function makeDeepContent(depth: number, leafValue: number = 1): TreeConte
 	// Implicit type conversion is needed here to make this compile.
 	const initialTree = makeJsDeepTree(depth, leafValue);
 	return {
-		// Types do now allow implicitly constructing recursive types, so cast is required.
+		// Types do not allow implicitly constructing recursive types, so cast is required.
 		// TODO: Find a better alternative.
 		initialTree: cursorFromInsertable(LinkedList, initialTree as LinkedList),
 		schema: deepSchema,
@@ -147,7 +147,6 @@ export function makeWideContentWithEndValue(
 }
 
 /**
- *
  * @param numberOfNodes - number of nodes of the tree
  * @param endLeafValue - the value of the end leaf of the tree. If not provided its index is used.
  * @returns a tree with specified number of nodes, with the end leaf node set to the endLeafValue

--- a/packages/dds/tree/src/test/scalableTestTrees.ts
+++ b/packages/dds/tree/src/test/scalableTestTrees.ts
@@ -27,6 +27,10 @@ import {
 	SchemaFactory,
 	type ValidateRecursiveSchema,
 } from "../simple-tree/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import type { TreeStoredContent } from "../shared-tree/schematizeTree.js";
+// eslint-disable-next-line import/no-internal-modules
+import { toStoredSchema } from "../simple-tree/toFlexSchema.js";
 
 /**
  * Test trees which can be parametrically scaled to any size.
@@ -99,10 +103,7 @@ export function makeJsDeepTree(depth: number, leafValue: number): JSDeepTree | n
 	return depth === 0 ? leafValue : { foo: makeJsDeepTree(depth - 1, leafValue) };
 }
 
-export function makeDeepContent(
-	depth: number,
-	leafValue: number = 1,
-): TreeContent<typeof deepSchema.rootFieldSchema> {
+export function makeDeepContent(depth: number, leafValue: number = 1): TreeContent {
 	// Implicit type conversion is needed here to make this compile.
 	const initialTree = makeJsDeepTree(depth, leafValue);
 	return {
@@ -110,6 +111,20 @@ export function makeDeepContent(
 		// TODO: Find a better alternative.
 		initialTree: cursorFromInsertable(LinkedList, initialTree as LinkedList),
 		schema: deepSchema,
+	};
+}
+
+export function makeDeepStoredContent(
+	depth: number,
+	leafValue: number = 1,
+): TreeStoredContent {
+	// Implicit type conversion is needed here to make this compile.
+	const initialTree = makeJsDeepTree(depth, leafValue);
+	return {
+		// Types do now allow implicitly constructing recursive types, so cast is required.
+		// TODO: Find a better alternative.
+		initialTree: cursorFromInsertable(LinkedList, initialTree as LinkedList),
+		schema: toStoredSchema(LinkedList),
 	};
 }
 
@@ -122,12 +137,30 @@ export function makeDeepContent(
 export function makeWideContentWithEndValue(
 	numberOfNodes: number,
 	endLeafValue?: number,
-): TreeContent<typeof wideSchema.rootFieldSchema> {
+): TreeContent {
 	// Implicit type conversion is needed here to make this compile.
 	const initialTree = makeJsWideTreeWithEndValue(numberOfNodes, endLeafValue);
 	return {
 		initialTree: cursorFromInsertable(WideRoot, initialTree),
 		schema: wideSchema,
+	};
+}
+
+/**
+ *
+ * @param numberOfNodes - number of nodes of the tree
+ * @param endLeafValue - the value of the end leaf of the tree. If not provided its index is used.
+ * @returns a tree with specified number of nodes, with the end leaf node set to the endLeafValue
+ */
+export function makeWideStoredContentWithEndValue(
+	numberOfNodes: number,
+	endLeafValue?: number,
+): TreeStoredContent {
+	// Implicit type conversion is needed here to make this compile.
+	const initialTree = makeJsWideTreeWithEndValue(numberOfNodes, endLeafValue);
+	return {
+		initialTree: cursorFromInsertable(WideRoot, initialTree),
+		schema: toStoredSchema(WideRoot),
 	};
 }
 

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -18,11 +18,11 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import type { FieldKey, Value } from "../../core/index.js";
+import type { Value } from "../../core/index.js";
 import { typeboxValidator } from "../../external-utilities/index.js";
 import { TreeCompressionStrategy } from "../../feature-libraries/index.js";
 import { Tree, type ISharedTree, type SharedTree } from "../../shared-tree/index.js";
-import { type JsonCompatibleReadOnly, brand, getOrAddEmptyToMap } from "../../util/index.js";
+import { type JsonCompatibleReadOnly, getOrAddEmptyToMap } from "../../util/index.js";
 import { treeTestFactory } from "../utils.js";
 import {
 	SchemaFactory,
@@ -42,14 +42,12 @@ import {
 // 4. "large" node just get a long repeated string value, not a complex tree, so tree encoding is not really covered here.
 // TODO: fix above issues.
 
-const builder = new SchemaFactory("opSize");
+const schemaFactory = new SchemaFactory("opSize");
 
-class Child extends builder.object("Test:Opsize-Bench-Child", {
-	data: builder.string,
+class Child extends schemaFactory.object("Test:Opsize-Bench-Child", {
+	data: schemaFactory.string,
 }) {}
-class Parent extends builder.array("Test:Opsize-Bench-Root", Child) {}
-
-const childrenFieldKey: FieldKey = brand("children");
+class Parent extends schemaFactory.array("Test:Opsize-Bench-Root", Child) {}
 
 /**
  * Create a default attached tree for op submission
@@ -528,7 +526,7 @@ describe("Op Size", () => {
 		];
 
 		withTransactionsOrNot((run) => {
-			const benchmarkInsertRemoveEditNodesWithInvidiualTxs = (
+			const benchmarkInsertRemoveEditNodesWithIndividualTxs = (
 				percentile: number,
 				distribution: OpKindDistribution,
 			) => {
@@ -586,7 +584,7 @@ describe("Op Size", () => {
 				describe(suiteDescription, () => {
 					for (const { percentile } of sizes) {
 						it(`Percentile: ${percentile}`, () => {
-							benchmarkInsertRemoveEditNodesWithInvidiualTxs(percentile, distribution);
+							benchmarkInsertRemoveEditNodesWithIndividualTxs(percentile, distribution);
 						});
 					}
 				});

--- a/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/opSize.bench.ts
@@ -18,50 +18,36 @@ import {
 	MockStorage,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import {
-	AllowedUpdateType,
-	type FieldKey,
-	type JsonableTree,
-	type Value,
-	forEachNode,
-	moveToDetachedField,
-	rootFieldKey,
-} from "../../core/index.js";
-import { SchemaBuilder, leaf } from "../../domains/index.js";
+import type { FieldKey, Value } from "../../core/index.js";
 import { typeboxValidator } from "../../external-utilities/index.js";
-import {
-	TreeCompressionStrategy,
-	cursorForJsonableTreeNode,
-} from "../../feature-libraries/index.js";
-import type { ISharedTree, ITreeCheckout, SharedTree } from "../../shared-tree/index.js";
+import { TreeCompressionStrategy } from "../../feature-libraries/index.js";
+import { Tree, type ISharedTree, type SharedTree } from "../../shared-tree/index.js";
 import { type JsonCompatibleReadOnly, brand, getOrAddEmptyToMap } from "../../util/index.js";
-import { schematizeFlexTree, treeTestFactory } from "../utils.js";
+import { treeTestFactory } from "../utils.js";
+import {
+	SchemaFactory,
+	TreeViewConfiguration,
+	type InsertableTreeNodeFromImplicitAllowedTypes,
+	type ITree,
+	type TreeView,
+} from "../../simple-tree/index.js";
 
 // Notes:
 // 1. Within this file "percentile" is commonly used, and seems to refer to a portion (0 to 1) or some maximum size.
 // While it would be useful and interesting to have some distribution of op sizes and measure some percentile from that distribution,
 // that does not appear to be what these tests are doing.
-// 2. Data from these tests are just printed: no other data collection is done. If a comparison is desired, manually run the tests before and after.
-// 3. Major changes in these sizes (regressions, optimizations or the tests not collecting what they should) do not make these tests fail.
-// 4. These tests are currently implemented as integration tests, meaning they use lots of dependencies and high level APIs.
-// They could be reimplemented targeted the lower level APIs if desired.
-// 5. "large" node just get a long repeated string value, not a complex tree, so tree encoding is not really covered here.
+// 2. Major changes in these sizes (regressions, optimizations or the tests not collecting what they should) do not make these tests fail.
+// 3. These tests are currently implemented as integration tests, meaning they use lots of dependencies and high level APIs.
+// They could be reimplemented targeted the lower level APIs if desired (just call the op encoding functions)
+// 4. "large" node just get a long repeated string value, not a complex tree, so tree encoding is not really covered here.
 // TODO: fix above issues.
 
-const builder = new SchemaBuilder({ scope: "opSize" });
+const builder = new SchemaFactory("opSize");
 
-const childSchema = builder.object("Test:Opsize-Bench-Child", {
-	data: leaf.string,
-});
-const parentSchema = builder.object("Test:Opsize-Bench-Root", {
-	children: builder.sequence(childSchema),
-});
-
-const fullSchemaData = builder.intoSchema(parentSchema);
-
-const initialTestJsonTree = {
-	type: parentSchema.name,
-};
+class Child extends builder.object("Test:Opsize-Bench-Child", {
+	data: builder.string,
+}) {}
+class Parent extends builder.array("Test:Opsize-Bench-Root", Child) {}
 
 const childrenFieldKey: FieldKey = brand("children");
 
@@ -88,19 +74,22 @@ function createConnectedTree(): SharedTree {
 	return tree;
 }
 
+const config = new TreeViewConfiguration({
+	schema: Parent,
+	preventAmbiguity: true,
+	enableSchemaValidation: true,
+});
+
 /*
  * Updates the given `tree` to the given `schema` and inserts `state` as its root.
  */
 function initializeTestTree(
-	tree: SharedTree,
-	state: JsonableTree = initialTestJsonTree,
-): ITreeCheckout {
-	const writeCursor = cursorForJsonableTreeNode(state);
-	return schematizeFlexTree(tree, {
-		allowedSchemaModifications: AllowedUpdateType.Initialize,
-		initialTree: [writeCursor],
-		schema: fullSchemaData,
-	}).checkout;
+	tree: ITree,
+	state: InsertableTreeNodeFromImplicitAllowedTypes<typeof Parent> = [],
+): TreeView<typeof Parent> {
+	const view = tree.viewWith(config);
+	view.initialize(state);
+	return view;
 }
 
 function utf8Length(data: JsonCompatibleReadOnly): number {
@@ -108,197 +97,99 @@ function utf8Length(data: JsonCompatibleReadOnly): number {
 }
 
 /**
- * Creates a {@link JsonableTree} that matches the `parentSchema` and when run through `JSON.stringify` has the requested length in bytes when encoded as utf8.
+ * Creates an insertable child with a string of the provided length
  */
-function createTreeWithSize(desiredByteSize: number): JsonableTree {
-	const node = {
-		type: childSchema.name,
-		fields: {
-			data: [{ value: "", type: leaf.string.name }],
-		},
+function createTreeWithSize(
+	desiredByteSize: number,
+): InsertableTreeNodeFromImplicitAllowedTypes<typeof Child> {
+	return {
+		data: createStringFromLength(desiredByteSize),
 	};
-
-	const initialNodeByteSize = utf8Length(node);
-	node.fields.data[0].value = createStringFromLength(desiredByteSize - initialNodeByteSize);
-	assert(utf8Length(node) === desiredByteSize);
-	return node;
 }
 
-function getChildrenLength(tree: ITreeCheckout): number {
-	const cursor = tree.forest.allocateCursor();
-	moveToDetachedField(tree.forest, cursor);
-	cursor.enterNode(0);
-	cursor.enterField(childrenFieldKey);
-	const length = cursor.getFieldLength();
-	cursor.free();
-	return length;
-}
-
-function assertChildNodeCount(tree: ITreeCheckout, nodeCount: number): void {
-	const cursor = tree.forest.allocateCursor();
-	moveToDetachedField(tree.forest, cursor);
-	cursor.enterNode(0);
-	cursor.enterField(childrenFieldKey);
-	assert.equal(cursor.getFieldLength(), nodeCount);
-	cursor.free();
+function assertChildNodeCount(tree: TreeView<typeof Parent>, nodeCount: number): void {
+	assert.equal(tree.root.length, nodeCount);
 }
 
 /**
  * Checks that the first `childCount` values under "children" have the provided value.
  */
-function expectChildrenValues(tree: ITreeCheckout, expected: Value, childCount: number): void {
-	const cursor = tree.forest.allocateCursor();
-	moveToDetachedField(tree.forest, cursor);
-	cursor.enterNode(0);
-	cursor.enterField(childrenFieldKey);
-	assert(cursor.getFieldLength() >= childCount);
-	forEachNode(cursor, () => {
-		if (cursor.fieldIndex < childCount) {
-			assert.equal(cursor.value, expected);
-		}
-	});
-	cursor.free();
+function expectChildrenValues(
+	tree: TreeView<typeof Parent>,
+	expected: Value,
+	childCount: number,
+): void {
+	for (let index = 0; index < childCount; index++) {
+		assert.equal(tree.root[index].data, expected);
+	}
 }
 
 /**
- * Creates a jsonable tree with the desired number of children and the size of each child in bytes.
+ * Creates a tree with the desired number of children and the size of each child's string in bytes.
  */
-function createInitialTree(childNodes: number, childNodeByteSize: number): JsonableTree {
+function createInitialTree(
+	childNodes: number,
+	childNodeByteSize: number,
+): InsertableTreeNodeFromImplicitAllowedTypes<typeof Parent> {
 	const childNode = createTreeWithSize(childNodeByteSize);
-	const jsonTree: JsonableTree = {
-		type: parentSchema.name,
-		fields: {
-			children: new Array(childNodes).fill(childNode),
-		},
-	};
-	return jsonTree;
+	const children: InsertableTreeNodeFromImplicitAllowedTypes<typeof Child>[] = new Array(
+		childNodes,
+	).fill(childNode);
+	return children;
 }
 
-function insertNodesWithIndividualTransactions(
-	tree: ITreeCheckout,
-	jsonNode: JsonableTree,
+function insertNodes(
+	tree: TreeView<typeof Parent>,
+	content: InsertableTreeNodeFromImplicitAllowedTypes<typeof Child>,
 	count: number,
 ): void {
 	for (let i = 0; i < count; i++) {
-		tree.transaction.start();
-		const path = {
-			parent: undefined,
-			parentField: rootFieldKey,
-			parentIndex: 0,
-		};
-		const writeCursor = cursorForJsonableTreeNode(jsonNode);
-		const field = tree.editor.sequenceField({ parent: path, field: childrenFieldKey });
-		field.insert(0, writeCursor);
-		tree.transaction.commit();
+		tree.root.insertAt(0, content);
 	}
 }
 
 function insertNodesWithSingleTransaction(
-	tree: ITreeCheckout,
-	jsonNode: JsonableTree,
+	tree: TreeView<typeof Parent>,
+	content: InsertableTreeNodeFromImplicitAllowedTypes<typeof Child>,
 	count: number,
 ): void {
-	tree.transaction.start();
-	const path = {
-		parent: undefined,
-		parentField: rootFieldKey,
-		parentIndex: 0,
-	};
-	const field = tree.editor.sequenceField({ parent: path, field: childrenFieldKey });
-	for (let i = 0; i < count; i++) {
-		field.insert(0, cursorForJsonableTreeNode(jsonNode));
-	}
-	tree.transaction.commit();
+	Tree.runTransaction(tree, () => {
+		insertNodes(tree, content, count);
+	});
 }
 
-function removeNodesWithIndividualTransactions(
-	tree: ITreeCheckout,
+function removeNodes(
+	tree: TreeView<typeof Parent>,
 	numRemovals: number,
-	removalsPerTransaction: number,
+	removalsPerOp: number,
 ): void {
 	for (let i = 0; i < numRemovals; i++) {
-		tree.transaction.start();
-		const path = {
-			parent: undefined,
-			parentField: rootFieldKey,
-			parentIndex: 0,
-		};
-		const field = tree.editor.sequenceField({ parent: path, field: childrenFieldKey });
-		field.remove(getChildrenLength(tree) - 1, removalsPerTransaction);
-		tree.transaction.commit();
+		tree.root.removeRange(tree.root.length - 1, tree.root.length - 1 + removalsPerOp);
 	}
 }
 
-function removeNodesWithSingleTransaction(tree: ITreeCheckout, numRemoved: number): void {
-	tree.transaction.start();
-	const path = {
-		parent: undefined,
-		parentField: rootFieldKey,
-		parentIndex: 0,
-	};
-	const field = tree.editor.sequenceField({ parent: path, field: childrenFieldKey });
-	field.remove(0, numRemoved);
-	tree.transaction.commit();
+function removeNodesWithSingleTransaction(
+	tree: TreeView<typeof Parent>,
+	numRemoved: number,
+): void {
+	tree.root.removeRange(0, numRemoved);
 }
 
 function createStringFromLength(numberOfBytes: number): string {
 	return "a".repeat(numberOfBytes);
 }
 
-function editNodesWithIndividualTransactions(
-	tree: ITreeCheckout,
+function editNodes(
+	tree: TreeView<typeof Parent>,
 	numChildrenToEdit: number,
-	editPayload: Value,
+	childData: string,
 ): void {
-	const rootPath = {
-		parent: undefined,
-		parentField: rootFieldKey,
-		parentIndex: 0,
-	};
-	const editor = tree.editor.sequenceField({ parent: rootPath, field: childrenFieldKey });
 	for (let i = 0; i < numChildrenToEdit; i++) {
-		tree.transaction.start();
-		editor.remove(i, 1);
-		editor.insert(
-			i,
-			cursorForJsonableTreeNode({
-				type: childSchema.name,
-				value: editPayload,
-				fields: {
-					data: [{ value: "", type: leaf.string.name }],
-				},
-			}),
-		);
-		tree.transaction.commit();
+		Tree.runTransaction(tree, () => {
+			tree.root.removeAt(i);
+			tree.root.insertAt(i, { data: childData });
+		});
 	}
-}
-
-function editNodesWithSingleTransaction(
-	tree: ITreeCheckout,
-	numChildrenToEdit: number,
-	editPayload: Value,
-): void {
-	const rootPath = {
-		parent: undefined,
-		parentField: rootFieldKey,
-		parentIndex: 0,
-	};
-	const editor = tree.editor.sequenceField({ parent: rootPath, field: childrenFieldKey });
-	tree.transaction.start();
-	for (let i = 0; i < numChildrenToEdit; i++) {
-		editor.remove(i, 1);
-		editor.insert(
-			i,
-			cursorForJsonableTreeNode({
-				type: childSchema.name,
-				value: editPayload,
-				fields: {
-					data: [{ value: "", type: leaf.string.name }],
-				},
-			}),
-		);
-	}
-	tree.transaction.commit();
 }
 
 enum Operation {
@@ -392,6 +283,18 @@ const styles = [
 	},
 ];
 
+// TODO: replace use of TransactionStyle with this.
+function withTransactionsOrNot(
+	fn: (run: <T>(view: TreeView<typeof Parent>, op: () => T) => T) => void,
+): void {
+	describe("Many Ops", () => {
+		fn((view, op) => op());
+	});
+	describe("Single Transaction", () => {
+		fn((view, op) => Tree.runTransaction(view, () => op()));
+	});
+}
+
 describe("Op Size", () => {
 	const opsByBenchmarkName: Map<string, ISequencedDocumentMessage[]> = new Map();
 	let currentBenchmarkName = "";
@@ -452,9 +355,11 @@ describe("Op Size", () => {
 		currentTestOps.length = 0;
 	});
 
-	afterEach(() => {
-		// Currently tests can pass when no data is collected, so throw here in that case to ensure tests don't break and start collecting no data.
-		assert(currentTestOps.length !== 0);
+	afterEach(function () {
+		if (this.currentTest?.isFailed() === false) {
+			// Currently tests can pass when no data is collected, so throw here in that case to ensure tests don't break and start collecting no data.
+			assert(currentTestOps.length !== 0);
+		}
 		currentTestOps.forEach((op) =>
 			getOrAddEmptyToMap(opsByBenchmarkName, currentBenchmarkName).push(op),
 		);
@@ -467,15 +372,18 @@ describe("Op Size", () => {
 			initializeOpDataCollection(tree);
 			const view = initializeTestTree(tree);
 			deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
-			const jsonNode = createTreeWithSize(
-				getSuccessfulOpByteSize(Operation.Insert, transactionStyle, percentile),
-			);
 			const apply =
 				transactionStyle === TransactionStyle.Individual
-					? insertNodesWithIndividualTransactions
+					? insertNodes
 					: insertNodesWithSingleTransaction;
 
-			apply(view, jsonNode, BENCHMARK_NODE_COUNT);
+			apply(
+				view,
+				createTreeWithSize(
+					getSuccessfulOpByteSize(Operation.Insert, transactionStyle, percentile),
+				),
+				BENCHMARK_NODE_COUNT,
+			);
 			assertChildNodeCount(view, BENCHMARK_NODE_COUNT);
 		}
 
@@ -511,7 +419,7 @@ describe("Op Size", () => {
 			const view = initializeTestTree(tree, createInitialTree(100, childByteSize));
 			deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
 			if (transactionStyle === TransactionStyle.Individual) {
-				removeNodesWithIndividualTransactions(view, 100, 1);
+				removeNodes(view, 100, 1);
 			} else {
 				removeNodesWithSingleTransaction(view, 100);
 			}
@@ -550,15 +458,18 @@ describe("Op Size", () => {
 			// Note that the child node byte size for the initial tree here should be arbitrary.
 			const view = initializeTestTree(tree, createInitialTree(BENCHMARK_NODE_COUNT, 1000));
 			deleteCurrentOps(); // We don't want to record any ops from initializing the tree.
-			const editPayload = createStringFromLength(
+			const childData = createStringFromLength(
 				getSuccessfulOpByteSize(Operation.Edit, transactionStyle, percentile),
 			);
+			const action = () => {
+				editNodes(view, BENCHMARK_NODE_COUNT, childData);
+			};
 			if (transactionStyle === TransactionStyle.Individual) {
-				editNodesWithIndividualTransactions(view, BENCHMARK_NODE_COUNT, editPayload);
+				action();
 			} else {
-				editNodesWithSingleTransaction(view, BENCHMARK_NODE_COUNT, editPayload);
+				Tree.runTransaction(view, action);
 			}
-			expectChildrenValues(view, editPayload, BENCHMARK_NODE_COUNT);
+			expectChildrenValues(view, childData, BENCHMARK_NODE_COUNT);
 		}
 
 		for (const { description, style, extraDescription } of styles) {
@@ -616,7 +527,7 @@ describe("Op Size", () => {
 			},
 		];
 
-		describe("Individual Transactions", () => {
+		withTransactionsOrNot((run) => {
 			const benchmarkInsertRemoveEditNodesWithInvidiualTxs = (
 				percentile: number,
 				distribution: OpKindDistribution,
@@ -641,33 +552,33 @@ describe("Op Size", () => {
 					createInitialTree(removeNodeCount, childByteSize),
 				);
 				deleteCurrentOps(); // We don't want to record the ops from initializing the tree.
-				removeNodesWithIndividualTransactions(view, removeNodeCount, 1);
-				assertChildNodeCount(view, 0);
 
-				// insert
-				const insertChildNode = createTreeWithSize(
-					getSuccessfulOpByteSize(Operation.Insert, TransactionStyle.Individual, percentile),
-				);
-				insertNodesWithIndividualTransactions(view, insertChildNode, insertNodeCount);
-				assertChildNodeCount(view, insertNodeCount);
-
-				// edit
-				// The editing function iterates over each child node and performs an edit so we have to make sure we have enough children to avoid going out of bounds.
-				if (insertNodeCount < editNodeCount) {
-					const remainder = editNodeCount - insertNodeCount;
-					saveAndResetCurrentOps();
-					insertNodesWithIndividualTransactions(
-						view,
-						createTreeWithSize(childByteSize),
-						remainder,
-					);
-					deleteCurrentOps(); // We don't want to record the ops from re-initializing the tree.
-				}
-				const editPayload = createStringFromLength(
+				const childData = createStringFromLength(
 					getSuccessfulOpByteSize(Operation.Edit, TransactionStyle.Individual, percentile),
 				);
-				editNodesWithIndividualTransactions(view, editNodeCount, editPayload);
-				expectChildrenValues(view, editPayload, editNodeCount);
+
+				run(view, () => {
+					removeNodes(view, removeNodeCount, 1);
+					assertChildNodeCount(view, 0);
+
+					// insert
+					const insertChildNode = createTreeWithSize(
+						getSuccessfulOpByteSize(Operation.Insert, TransactionStyle.Individual, percentile),
+					);
+					insertNodes(view, insertChildNode, insertNodeCount);
+					assertChildNodeCount(view, insertNodeCount);
+
+					// edit
+					// The editing function iterates over each child node and performs an edit so we have to make sure we have enough children to avoid going out of bounds.
+					if (insertNodeCount < editNodeCount) {
+						const remainder = editNodeCount - insertNodeCount;
+						saveAndResetCurrentOps();
+						insertNodes(view, createTreeWithSize(childByteSize), remainder);
+						deleteCurrentOps(); // We don't want to record the ops from re-initializing the tree.
+					}
+					editNodes(view, editNodeCount, childData);
+				});
+				expectChildrenValues(view, childData, editNodeCount);
 			};
 
 			for (const distribution of distributions) {
@@ -676,79 +587,6 @@ describe("Op Size", () => {
 					for (const { percentile } of sizes) {
 						it(`Percentile: ${percentile}`, () => {
 							benchmarkInsertRemoveEditNodesWithInvidiualTxs(percentile, distribution);
-						});
-					}
-				});
-			}
-		});
-
-		// TODO:
-		// These tests don't actually do a single transaction (they do one per edit type).
-		// Therefor they are failing to test the size of transactions mixing inserts, removals and edits.
-		// These tests also fail to clarify if the nodes being removed are ones which were inserted or edited earlier,
-		// so it can't be used to test compaction of transient data within a transaction even if it was a single transaction.
-		// Instead correctness tests should cover that, and maybe this suite should simply be removed?
-		describe("Single Transactions", () => {
-			const benchmarkInsertRemoveEditNodesWithSingleTxs = (
-				percentile: number,
-				distribution: OpKindDistribution,
-			) => {
-				const {
-					Remove: removedNodeCount,
-					Insert: insertNodeCount,
-					Edit: editNodeCount,
-				} = distribution;
-
-				const tree = createConnectedTree();
-				initializeOpDataCollection(tree);
-
-				// remove
-				const childByteSize = getSuccessfulOpByteSize(
-					Operation.Remove,
-					TransactionStyle.Single,
-					percentile,
-				);
-				const view = initializeTestTree(
-					tree,
-					createInitialTree(removedNodeCount, childByteSize),
-				);
-				deleteCurrentOps(); // We don't want to record the ops from initializing the tree.
-				removeNodesWithSingleTransaction(view, removedNodeCount);
-				assertChildNodeCount(view, 0);
-
-				// insert
-				const insertChildNode = createTreeWithSize(
-					getSuccessfulOpByteSize(Operation.Insert, TransactionStyle.Single, percentile),
-				);
-				insertNodesWithSingleTransaction(view, insertChildNode, insertNodeCount);
-				assertChildNodeCount(view, insertNodeCount);
-
-				// edit
-				// The editing function iterates over each child node and performs an edit so we have to make sure we have enough children to avoid going out of bounds.
-				// TODO: if actually making this do a single transaction like its supposed to, this would be an issue as it would get included in that transaction.
-				if (insertNodeCount < editNodeCount) {
-					const remainder = editNodeCount - insertNodeCount;
-					saveAndResetCurrentOps();
-					insertNodesWithIndividualTransactions(
-						view,
-						createTreeWithSize(childByteSize),
-						remainder,
-					);
-					deleteCurrentOps(); // We don't want to record the ops from re-initializing the tree.
-				}
-				const editPayload = createStringFromLength(
-					getSuccessfulOpByteSize(Operation.Edit, TransactionStyle.Single, percentile),
-				);
-				editNodesWithSingleTransaction(view, editNodeCount, editPayload);
-				expectChildrenValues(view, editPayload, editNodeCount);
-			};
-
-			for (const distribution of distributions) {
-				const suiteDescription = `Distribution: ${distribution.Insert}% insert, ${distribution.Edit}% edit, ${distribution.Remove}% remove`;
-				describe(suiteDescription, () => {
-					for (const { percentile } of sizes) {
-						it(`Percentile: ${percentile}`, () => {
-							benchmarkInsertRemoveEditNodesWithSingleTxs(percentile, distribution);
 						});
 					}
 				});

--- a/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizeTree.spec.ts
@@ -15,11 +15,10 @@ import {
 	TreeStoredSchemaRepository,
 	type AnchorSetRootEvents,
 } from "../../core/index.js";
-import { SchemaBuilder, leaf, singleJsonCursor } from "../../domains/index.js";
+import { singleJsonCursor } from "../../domains/index.js";
 import {
 	FieldKinds,
 	FlexFieldSchema,
-	type FlexTreeSchema,
 	SchemaBuilderBase,
 	ViewSchema,
 	allowsRepoSuperset,
@@ -34,7 +33,7 @@ import type {
 	ITransaction,
 } from "../../shared-tree/index.js";
 import {
-	type TreeContent,
+	type TreeStoredContent,
 	UpdateType,
 	canInitialize,
 	ensureSchema,
@@ -48,32 +47,27 @@ import {
 	validateViewConsistency,
 } from "../utils.js";
 import type { Listenable } from "../../events/index.js";
+import { SchemaFactory } from "../../simple-tree/index.js";
+// eslint-disable-next-line import/no-internal-modules
+import { toStoredSchema } from "../../simple-tree/toFlexSchema.js";
 
-const builder = new SchemaBuilder({ scope: "test", name: "Schematize Tree Tests" });
-const root = leaf.number;
-const schema = builder.intoSchema(SchemaBuilder.optional(root));
+const builder = new SchemaFactory("test");
+const root = builder.number;
+const schema = toStoredSchema(root);
 
-const builderGeneralized = new SchemaBuilder({
-	scope: "test",
-	name: "Schematize Tree Tests Generalized",
-});
-
-const schemaGeneralized = builderGeneralized.intoSchema(
-	SchemaBuilder.optional([root, leaf.string]),
-);
-
-const builderValue = new SchemaBuilder({ scope: "test", name: "Schematize Tree Tests2" });
-
-const schemaValueRoot = builderValue.intoSchema(SchemaBuilder.required([root, leaf.string]));
+const schemaGeneralized = toStoredSchema(builder.optional([root, builder.string]));
+const schemaValueRoot = toStoredSchema([root, builder.string]);
 
 // Schema for tree that must always be empty.
-const emptySchema = new SchemaBuilderBase(FieldKinds.required, {
-	scope: "Empty",
-	lint: {
-		rejectEmpty: false,
-		rejectForbidden: false,
-	},
-}).intoSchema(FlexFieldSchema.empty);
+const emptySchema = intoStoredSchema(
+	new SchemaBuilderBase(FieldKinds.required, {
+		scope: "Empty",
+		lint: {
+			rejectEmpty: false,
+			rejectForbidden: false,
+		},
+	}).intoSchema(FlexFieldSchema.empty),
+);
 
 function expectSchema(actual: TreeStoredSchema, expected: TreeStoredSchema): void {
 	// Check schema match
@@ -96,10 +90,7 @@ function makeSchemaRepository(repository: TreeStoredSchemaRepository): {
 
 describe("schematizeTree", () => {
 	describe("initializeContent", () => {
-		function testInitialize<TRoot extends FlexFieldSchema>(
-			name: string,
-			content: TreeContent<TRoot>,
-		): void {
+		function testInitialize(name: string, content: TreeStoredContent): void {
 			describe(`Initialize ${name}`, () => {
 				it("correct output", () => {
 					const storedSchema = new TreeStoredSchemaRepository();
@@ -108,7 +99,7 @@ describe("schematizeTree", () => {
 						count++;
 					});
 					assert.equal(count, 1);
-					expectSchema(storedSchema, intoStoredSchema(content.schema));
+					expectSchema(storedSchema, content.schema);
 				});
 
 				it("is compatible", () => {
@@ -149,7 +140,7 @@ describe("schematizeTree", () => {
 
 					assert.deepEqual(
 						log,
-						content.schema.rootFieldSchema.kind === FieldKinds.required
+						content.schema.rootFieldSchema.kind === FieldKinds.required.identifier
 							? ["schema", "content", "schema"]
 							: ["schema", "content"],
 					);
@@ -164,8 +155,8 @@ describe("schematizeTree", () => {
 		// TODO: Test schema validation of initial tree (once we have a utility for it)
 	});
 
-	function mockCheckout(InputSchema: FlexTreeSchema, isEmpty: boolean): ITreeCheckout {
-		const storedSchema = new TreeStoredSchemaRepository(intoStoredSchema(InputSchema));
+	function mockCheckout(InputSchema: TreeStoredSchema, isEmpty: boolean): ITreeCheckout {
+		const storedSchema = new TreeStoredSchemaRepository(InputSchema);
 		const checkout: ITreeCheckout = {
 			storedSchema,
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -198,13 +189,13 @@ describe("schematizeTree", () => {
 
 	describe("evaluateUpdate", () => {
 		describe("test cases", () => {
-			const testCases: [string, FlexTreeSchema, boolean][] = [
+			const testCases: [string, TreeStoredSchema, boolean][] = [
 				["empty", emptySchema, true],
 				["basic-optional-empty", schema, true],
 				["basic-optional", schema, false],
 				["basic-value", schemaValueRoot, false],
-				["complex-empty", jsonSequenceRootSchema, true],
-				["complex", jsonSequenceRootSchema, false],
+				["complex-empty", intoStoredSchema(jsonSequenceRootSchema), true],
+				["complex", intoStoredSchema(jsonSequenceRootSchema), false],
 			];
 			for (const [name, data, isEmpty] of testCases) {
 				it(name, () => {
@@ -274,7 +265,7 @@ describe("schematizeTree", () => {
 				initialTree: undefined,
 			};
 			const emptyCheckout = checkoutWithContent(emptyContent);
-			const content: TreeContent<typeof schemaGeneralized.rootFieldSchema> = {
+			const content: TreeStoredContent = {
 				schema: schemaGeneralized,
 				initialTree: singleJsonCursor(5),
 			};
@@ -356,7 +347,7 @@ describe("schematizeTree", () => {
 				initialTree: undefined,
 			};
 			const emptyCheckout = checkoutWithContent(emptyContent);
-			const content: TreeContent<typeof schemaValueRoot.rootFieldSchema> = {
+			const content: TreeStoredContent = {
 				schema: schemaValueRoot,
 				initialTree: singleJsonCursor(5),
 			};
@@ -418,7 +409,7 @@ describe("schematizeTree", () => {
 				},
 			};
 			const initialCheckout = checkoutWithContent(initialContent);
-			const content: TreeContent<typeof schemaGeneralized.rootFieldSchema> = {
+			const content: TreeStoredContent = {
 				schema: schemaGeneralized,
 				initialTree: singleJsonCursor("Should not be used"),
 			};

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -25,7 +25,7 @@ import {
 	type InsertableTreeFieldFromImplicitField,
 } from "../../simple-tree/index.js";
 // eslint-disable-next-line import/no-internal-modules
-import { toFlexSchema } from "../../simple-tree/toFlexSchema.js";
+import { toFlexSchema, toStoredSchema } from "../../simple-tree/toFlexSchema.js";
 import {
 	checkoutWithContent,
 	createTestUndoRedoStacks,
@@ -33,7 +33,7 @@ import {
 	insert,
 	validateUsageError,
 } from "../utils.js";
-import type { TreeContent, TreeCheckout } from "../../shared-tree/index.js";
+import type { TreeCheckout, TreeStoredContent } from "../../shared-tree/index.js";
 
 const schema = new SchemaFactory("com.example");
 const config = new TreeViewConfiguration({ schema: schema.number });
@@ -54,8 +54,8 @@ function checkoutWithInitialTree(
 		unhydratedInitialTree,
 		nodeKeyManager,
 	);
-	const treeContent: TreeContent = {
-		schema: toFlexSchema(viewConfig.schema),
+	const treeContent: TreeStoredContent = {
+		schema: toStoredSchema(viewConfig.schema),
 		initialTree,
 	};
 	return checkoutWithContent(treeContent);
@@ -73,7 +73,7 @@ const emptySchema = new SchemaBuilderBase(FieldKinds.required, {
 describe("SchematizingSimpleTreeView", () => {
 	it("Initialize document", () => {
 		const emptyContent = {
-			schema: emptySchema,
+			schema: intoStoredSchema(emptySchema),
 			initialTree: undefined,
 		};
 		const checkout = checkoutWithContent(emptyContent);
@@ -90,7 +90,7 @@ describe("SchematizingSimpleTreeView", () => {
 
 	it("Initialize errors", () => {
 		const emptyContent = {
-			schema: emptySchema,
+			schema: intoStoredSchema(emptySchema),
 			initialTree: undefined,
 		};
 		const checkout = checkoutWithContent(emptyContent);
@@ -259,7 +259,7 @@ describe("SchematizingSimpleTreeView", () => {
 
 	it("supports revertibles", () => {
 		const emptyContent = {
-			schema: emptySchema,
+			schema: intoStoredSchema(emptySchema),
 			initialTree: undefined,
 		};
 		const checkout = checkoutWithContent(emptyContent);

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.bench.ts
@@ -29,9 +29,11 @@ import {
 	deepPath,
 	localFieldKey,
 	makeDeepContent,
+	makeDeepStoredContent,
 	makeJsDeepTree,
 	makeJsWideTreeWithEndValue,
 	makeWideContentWithEndValue,
+	makeWideStoredContentWithEndValue,
 	readDeepCursorTree,
 	readDeepFlexTree,
 	readDeepTreeAsJSObject,
@@ -237,7 +239,7 @@ describe("SharedTree benchmarks", () => {
 						assert.equal(state.iterationsPerBatch, 1);
 
 						// Setup
-						const tree = checkoutWithContent(makeDeepContent(numberOfNodes));
+						const tree = checkoutWithContent(makeDeepStoredContent(numberOfNodes));
 						const path = deepPath(numberOfNodes);
 
 						// Measure
@@ -278,7 +280,7 @@ describe("SharedTree benchmarks", () => {
 						assert.equal(state.iterationsPerBatch, 1);
 
 						// Setup
-						const tree = checkoutWithContent(makeWideContentWithEndValue(numberOfNodes));
+						const tree = checkoutWithContent(makeWideStoredContentWithEndValue(numberOfNodes));
 
 						const rootPath = {
 							parent: undefined,

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -166,7 +166,8 @@ describe("SharedTree", () => {
 				initialTree: singleJsonCursor(10),
 				schema,
 			});
-			assert.equal(view.flexTree.content, 10);
+			assert.equal(view.flexTree.length, 1);
+			assert.equal(view.flexTree.boxedAt(0)?.value, 10);
 		});
 
 		it("noop upgrade", () => {
@@ -180,7 +181,7 @@ describe("SharedTree", () => {
 				schema,
 			});
 			// And does not add initial tree:
-			assert.equal(schematized.flexTree.content, undefined);
+			assert.equal(schematized.flexTree.length, 0);
 		});
 
 		it("incompatible upgrade errors", () => {
@@ -204,7 +205,7 @@ describe("SharedTree", () => {
 				schema: schemaGeneralized,
 			});
 			// Initial tree should not be applied
-			assert.equal(schematized.flexTree.content, undefined);
+			assert.equal(schematized.flexTree.length, 0);
 		});
 
 		it("unhydrated tree input", () => {
@@ -226,12 +227,13 @@ describe("SharedTree", () => {
 			schema: FlexTreeSchema<TRoot>,
 			onDispose: () => void = () => assert.fail(),
 		): FlexTreeView {
-			const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, schema);
+			const viewSchema = new ViewSchema(defaultSchemaPolicy, {}, intoStoredSchema(schema));
 			const view = requireSchema(
 				tree.checkout,
 				viewSchema,
 				onDispose,
 				new MockNodeKeyManager(),
+				schema,
 			);
 			const unregister = tree.checkout.storedSchema.on("afterSchemaChange", () => {
 				unregister();


### PR DESCRIPTION
## Description

Flex tree schema abstraction is planned for removal. This reduces use of it in a few places, migrating to stored or simple tree schema based on usage.

This also did some simplifications and cleanup to the op size tests, changing what they measure a little.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
