### PR TITLE
ci: Use outFile flag instead of stdout redirection in flub list

### DIFF
--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -26,7 +26,7 @@ fi
 # This saves a list of the packages in the working directory in topological order to a temporary file.
 # Packages will be published in this order to avoid dependency issues.
 # See tools/pipelines/templates/include-publish-npm-package-steps.yml for details about how this file is used.
-flub list $RELEASE_GROUP --no-private --feed public > $STAGING_PATH/pack/packagePublishOrder-public.txt
-flub list $RELEASE_GROUP --no-private --feed internal-build > $STAGING_PATH/pack/packagePublishOrder-internal-build.txt
-flub list $RELEASE_GROUP --no-private --feed internal-dev > $STAGING_PATH/pack/packagePublishOrder-internal-dev.txt
-flub list $RELEASE_GROUP --no-private --feed internal-test > $STAGING_PATH/pack/packagePublishOrder-internal-test.txt
+flub list $RELEASE_GROUP --no-private --feed public --outFile $STAGING_PATH/pack/packagePublishOrder-public.txt
+flub list $RELEASE_GROUP --no-private --feed internal-build --outFile $STAGING_PATH/pack/packagePublishOrder-internal-build.txt
+flub list $RELEASE_GROUP --no-private --feed internal-dev --outFile $STAGING_PATH/pack/packagePublishOrder-internal-dev.txt
+flub list $RELEASE_GROUP --no-private --feed internal-test --outFile $STAGING_PATH/pack/packagePublishOrder-internal-test.txt

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -400,10 +400,10 @@ extends:
                 targetType: 'inline'
                 workingDirectory: ${{ parameters.buildDirectory }}
                 script: |
-                  flub list --no-private $RELEASE_GROUP --tarball --feed public > $STAGING_PATH/pack/packagePublishOrder-public.txt
-                  flub list --no-private $RELEASE_GROUP --tarball --feed internal-build > $STAGING_PATH/pack/packagePublishOrder-internal-build.txt
-                  flub list --no-private $RELEASE_GROUP --tarball --feed internal-dev > $STAGING_PATH/pack/packagePublishOrder-internal-dev.txt
-                  flub list --no-private $RELEASE_GROUP --tarball --feed internal-test > $STAGING_PATH/pack/packagePublishOrder-internal-test.txt
+                  flub list --no-private $RELEASE_GROUP --tarball --feed public --outFile $STAGING_PATH/pack/packagePublishOrder-public.txt
+                  flub list --no-private $RELEASE_GROUP --tarball --feed internal-build --outFile $STAGING_PATH/pack/packagePublishOrder-internal-build.txt
+                  flub list --no-private $RELEASE_GROUP --tarball --feed internal-dev --outFile $STAGING_PATH/pack/packagePublishOrder-internal-dev.txt
+                  flub list --no-private $RELEASE_GROUP --tarball --feed internal-test --outFile $STAGING_PATH/pack/packagePublishOrder-internal-test.txt
 
           # At this point we want to publish the artifact with npm-packed packages, but as part of 1ES migration that's
           # now part of templateContext.outputs below.


### PR DESCRIPTION
`flub list` recently started outputting a new warning, which was expected, but broke the publish pipeline because it was using stdout stream redirection to write to the file instead of the `--outFile` flag. That meant that the warning text made it into the package lists, breaking the downstream steps. Now it uses the flag, so the resulting file won't have the warning.