### PR TITLE
fix(azure-end-to-end-tests): Skip broken tests until fixed

### DIFF
--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/viewContainerVersion.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/viewContainerVersion.spec.ts
@@ -94,7 +94,7 @@ for (const testOpts of testMatrix) {
 		 *
 		 * Skipped for now - see ADO:13967
 		 */
-		it("can handle bad document id when requesting versions", async () => {
+		it.skip("can handle bad document id when requesting versions", async () => {
 			const resources = client.getContainerVersions("badid");
 			const errorFn = (error: Error): boolean => {
 				assert.notStrictEqual(error.message, undefined, "Azure Client error is undefined");

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/viewContainerVersion.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/viewContainerVersion.spec.ts
@@ -91,6 +91,8 @@ for (const testOpts of testMatrix) {
 		 * Scenario: test if Azure Client can handle bad document ID when versions are requested.
 		 *
 		 * Expected behavior: Client should throw an error.
+		 *
+		 * Skipped for now - see ADO:13967
 		 */
 		it("can handle bad document id when requesting versions", async () => {
 			const resources = client.getContainerVersions("badid");
@@ -209,8 +211,10 @@ for (const testOpts of testMatrix) {
 		 * Scenario: test if Azure Client can handle non-existing container when trying to view a version
 		 *
 		 * Expected behavior: client should throw an error.
+		 *
+		 * Skipped for now - see ADO:13967
 		 */
-		it("can handle non-existing container", async () => {
+		it.skip("can handle non-existing container", async () => {
 			const resources = client.viewContainerVersion(
 				"badidonviewversion",
 				schema,


### PR DESCRIPTION
## Description

This PR skips two tests that are currently broken (see [pipelines](https://dev.azure.com/fluidframework/internal/_build?definitionId=80&_a=suammary)). An [ADO repair item](https://dev.azure.com/fluidframework/internal/_workitems/edit/13967) has been opened to fix this.