### PR TITLE
itExpects: More concise output when unexpected error logs cause a test to fail

### DIFF
--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -1094,6 +1094,20 @@ export class TestObjectProviderWithVersionedLoad implements ITestObjectProvider 
 	}
 }
 
+/** Summarize the event with just the primary properties, for succinct output in case of test failure */
+const primaryEventProps = ({
+	category,
+	eventName,
+	error,
+	errorType,
+}: ITelemetryBaseEvent) => ({
+	category,
+	eventName,
+	error,
+	errorType,
+	["..."]: "*** Additional properties not shown, see full log for details ***",
+});
+
 /**
  * @internal
  */
@@ -1108,7 +1122,7 @@ export function getUnexpectedLogErrorException(
 	if (results.unexpectedErrors.length > 0) {
 		return new Error(
 			`${prefix ?? ""}Unexpected Errors in Logs:\n${JSON.stringify(
-				results.unexpectedErrors,
+				results.unexpectedErrors.map(primaryEventProps),
 				undefined,
 				2,
 			)}`,


### PR DESCRIPTION
## Description

I got confused by the output of itExpects when unexpected errors were logged, because the output was too big but I didn't notice the `...` at the end, so even after adding the errors it printed the first time, there were still more!

This change makes each error event more concise in the output, but will be good enough to get you oriented (and it's easy to tweak the `primaryEventProps` function if you want to check other properties).