### PR TITLE
Fix SessionInfoManager bugs

### DIFF
--- a/packages/drivers/routerlicious-driver/src/sessionInfoManager.ts
+++ b/packages/drivers/routerlicious-driver/src/sessionInfoManager.ts
@@ -96,15 +96,17 @@ export class SessionInfoManager {
 			Date.now() - this.sessionLastDiscoveredMap.get(url)! >
 			RediscoverAfterTimeSinceDiscoveryMs;
 		if (this.enableDiscovery && shouldRediscover) {
-			await this.fetchAndUpdateSessionInfo(params).catch(() => {
+			await this.fetchAndUpdateSessionInfo(params).catch((error) => {
 				// Undo discovery time set on failure, so that next check refreshes.
 				this.sessionLastDiscoveredMap.set(url, 0);
+				throw error;
 			});
 			refreshed = true;
 		}
 		return {
 			refreshed,
-			resolvedUrl: this.sessionInfoMap.get(url)!,
+			// ! Shallow copy is important as some mechanisms may rely on object comparison
+			resolvedUrl: { ...this.sessionInfoMap.get(url)! },
 		};
 	}
 


### PR DESCRIPTION
This PR contains 2 main fixes:
1. Returning a shallow copy: The `FaultInjectionDocumentServiceFactory` relies on `resolvedUrl` object comparison. This broke because the same object was used for both Container and Summarizer. Thus, summarizers weren't being created and the test timed out because there was a huge list of ops each client would have to load.
2. Re-throwing the error: This was behavior copied over from the original code ([see](https://github.com/microsoft/FluidFramework/pull/22249#discussion_r1720478881)), but there was a minor difference which caused these errors to be hidden unexpectedly. The better decision is to simply throw these errors.
 
Original PR: https://github.com/microsoft/FluidFramework/pull/22249
 
Broken tinylicious service load tests: https://github.com/microsoft/FluidFramework/pull/22331
Broken AzureClient tests: https://github.com/microsoft/FluidFramework/pull/22330