### PR TITLE
Fix describeCompat.noCompat

### DIFF
--- a/packages/test/test-version-utils/src/describeCompat.ts
+++ b/packages/test/test-version-utils/src/describeCompat.ts
@@ -30,7 +30,6 @@ import {
 	getVersionedTestObjectProviderFromApis,
 	getCompatVersionedTestObjectProviderFromApis,
 } from "./compatUtils.js";
-import { pkgVersion } from "./packageVersion.js";
 import {
 	getContainerRuntimeApi,
 	getDataRuntimeApi,
@@ -258,7 +257,7 @@ function createCompatDescribe(): DescribeCompat {
 		describe.only(name, createCompatSuiteWithDefault(tests, compatVersion));
 
 	d.noCompat = (name, _, tests) =>
-		describe(name, createCompatSuite(tests, undefined, pkgVersion));
+		describe(name, createCompatSuiteWithDefault(tests, "NoCompat"));
 
 	return d;
 }


### PR DESCRIPTION
## Description

The previous implementation of `.noCompat` seems to filter out all the tests, but passing `"NoCompat"` as a string argument to `describeCompat` appears to work fine.