### PR TITLE
Expose groupId on SummaryTreeBuilder

### DIFF
--- a/packages/runtime/runtime-utils/api-report/runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/runtime-utils/api-report/runtime-utils.legacy.alpha.api.md
@@ -65,7 +65,9 @@ export abstract class RuntimeFactoryHelper<T = IContainerRuntime> implements IRu
 
 // @alpha (undocumented)
 export class SummaryTreeBuilder implements ISummaryTreeWithStats {
-    constructor();
+    constructor(params?: {
+        groupId?: string;
+    });
     // (undocumented)
     addAttachment(id: string): void;
     // (undocumented)

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -167,11 +167,14 @@ export class SummaryTreeBuilder implements ISummaryTreeWithStats {
 	private readonly groupId?: string;
 
 	public get summary(): ISummaryTree {
-		return {
+		const summary: ISummaryTree = {
 			type: SummaryType.Tree,
 			tree: { ...this.summaryTree },
-			groupId: this.groupId,
 		};
+		if (this.groupId !== undefined) {
+			summary.groupId = this.groupId;
+		}
+		return summary;
 	}
 
 	public get stats(): Readonly<ISummaryStats> {

--- a/packages/runtime/runtime-utils/src/summaryUtils.ts
+++ b/packages/runtime/runtime-utils/src/summaryUtils.ts
@@ -147,16 +147,30 @@ export function addSummarizeResultToSummary(
 }
 
 /**
+ * An object who's properties are used to initialize a {@link SummaryTreeBuilder}
+ * @legacy
+ * @alpha
+ */
+export interface SummaryTreeBuilderParams {
+	/**
+	 * This value will become the {@link @fluidframework/driver-definitions#ISummaryTree.groupId}
+	 * of the {@link @fluidframework/driver-definitions#ISummaryTree} built by the {@link SummaryTreeBuilder}.
+	 */
+	groupId?: string;
+}
+/**
  * @legacy
  * @alpha
  */
 export class SummaryTreeBuilder implements ISummaryTreeWithStats {
 	private attachmentCounter: number = 0;
+	private readonly groupId?: string;
 
 	public get summary(): ISummaryTree {
 		return {
 			type: SummaryType.Tree,
 			tree: { ...this.summaryTree },
+			groupId: this.groupId,
 		};
 	}
 
@@ -164,9 +178,10 @@ export class SummaryTreeBuilder implements ISummaryTreeWithStats {
 		return { ...this.summaryStats };
 	}
 
-	constructor() {
+	constructor(params?: { groupId?: string }) {
 		this.summaryStats = mergeStats();
 		this.summaryStats.treeNodeCount++;
+		this.groupId = params?.groupId;
 	}
 
 	private readonly summaryTree: { [path: string]: SummaryObject } = {};


### PR DESCRIPTION
This change exposes groupId on the SummaryTreeBuilder class to allow creating SummaryTree with groupIds.  Also adds some test for the SummaryTreeBuilder