### PR TITLE
(fix) ItExpects exception for OpRoundtripTime error log is using an old eventName

### DIFF
--- a/packages/test/test-utils/src/testObjectProvider.ts
+++ b/packages/test/test-utils/src/testObjectProvider.ts
@@ -326,7 +326,7 @@ export class EventAndErrorTrackingLogger
 			downgrade: true,
 		},
 		// This log's category changes depending on the op latency. test results shouldn't be affected but if we see lots we'd like an alert from the logs.
-		{ eventName: "fluid:telemetry:OpPerf:OpRoundtripTime" },
+		{ eventName: "fluid:telemetry:OpRoundtripTime" },
 	];
 
 	constructor(private readonly baseLogger?: ITelemetryBaseLogger) {}


### PR DESCRIPTION
## Description

The fix: The event name changed at some point but this wasn't updated.

Background: This is a convenience especially when debugging - this event will fail many itExpects tests if you pause the debugger on a breakpoint.  It only triggers after 5s, no test should be depending on this behavior (way too slow of a test strategy).

