### PR TITLE
build(client): Remove check:format from lint task

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -37,6 +37,7 @@ module.exports = {
 		},
 		"build": {
 			dependsOn: [
+				"check:format",
 				"compile",
 				"lint",
 				"build:api-reports",
@@ -55,14 +56,7 @@ module.exports = {
 			script: false,
 		},
 		"lint": {
-			dependsOn: [
-				"check:format",
-				"eslint",
-				"good-fences",
-				"depcruise",
-				"check:exports",
-				"check:release-tags",
-			],
+			dependsOn: ["eslint", "good-fences", "depcruise", "check:exports", "check:release-tags"],
 			script: false,
 		},
 		"checks": {


### PR DESCRIPTION
Removes the `check:format` task from the `lint` task/phase of the build. Instead, it's now part of the `build` task.

This has no effect on the local build experience, but in CI, this effectively means that `check:format` will _only_ run as part of the separate "checks" stage. It will no longer run as part of the main build. In fact, we were doing duplicate work, because `check:format` was running in both the main build and the checks stage.