### PR TITLE
fix(client): declare IFluidLoadable requirement for SharedObjectKind

### DIFF
--- a/experimental/framework/data-objects/api-report/data-objects.alpha.api.md
+++ b/experimental/framework/data-objects/api-report/data-objects.alpha.api.md
@@ -16,7 +16,7 @@ export const Signaler: {
     readonly factory: IFluidDataStoreFactory & {
         readonly registryEntry: NamedFluidDataStoreRegistryEntry;
     };
-} & SharedObjectKind<ISignaler>;
+} & SharedObjectKind<ISignaler & IFluidLoadable>;
 
 // @alpha
 export type SignalListener<T> = (clientId: string, local: boolean, payload: Jsonable<T>) => void;

--- a/experimental/framework/data-objects/src/signaler/signaler.ts
+++ b/experimental/framework/data-objects/src/signaler/signaler.ts
@@ -9,7 +9,11 @@ import {
 	DataObjectFactory,
 	createDataObjectKind,
 } from "@fluidframework/aqueduct/internal";
-import { IErrorEvent, type IEventProvider } from "@fluidframework/core-interfaces";
+import type {
+	IErrorEvent,
+	IEventProvider,
+	IFluidLoadable,
+} from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import { Jsonable } from "@fluidframework/datastore-definitions/internal";
 import type {
@@ -203,4 +207,4 @@ export const Signaler: {
 	readonly factory: IFluidDataStoreFactory & {
 		readonly registryEntry: NamedFluidDataStoreRegistryEntry;
 	};
-} & SharedObjectKind<ISignaler> = createDataObjectKind(SignalerClass);
+} & SharedObjectKind<ISignaler & IFluidLoadable> = createDataObjectKind(SignalerClass);

--- a/packages/dds/shared-object-base/api-report/shared-object-base.beta.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.beta.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public @sealed
-export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
+export interface SharedObjectKind<out TSharedObject extends IFluidLoadable = IFluidLoadable> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
 }
 

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.alpha.api.md
@@ -90,7 +90,7 @@ export abstract class SharedObjectCore<TEvent extends ISharedObjectEvents = ISha
 }
 
 // @public @sealed
-export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
+export interface SharedObjectKind<out TSharedObject extends IFluidLoadable = IFluidLoadable> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
 }
 

--- a/packages/dds/shared-object-base/api-report/shared-object-base.legacy.public.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.legacy.public.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public @sealed
-export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
+export interface SharedObjectKind<out TSharedObject extends IFluidLoadable = IFluidLoadable> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
 }
 

--- a/packages/dds/shared-object-base/api-report/shared-object-base.public.api.md
+++ b/packages/dds/shared-object-base/api-report/shared-object-base.public.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public @sealed
-export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
+export interface SharedObjectKind<out TSharedObject extends IFluidLoadable = IFluidLoadable> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
 }
 

--- a/packages/dds/shared-object-base/src/sharedObject.ts
+++ b/packages/dds/shared-object-base/src/sharedObject.ts
@@ -870,7 +870,7 @@ export interface ISharedObjectKind<TSharedObject> {
  * @sealed
  * @public
  */
-export interface SharedObjectKind<out TSharedObject = unknown>
+export interface SharedObjectKind<out TSharedObject extends IFluidLoadable = IFluidLoadable>
 	extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
 	/**
 	 * Check whether an {@link @fluidframework/core-interfaces#IFluidLoadable} is an instance of this shared object kind.
@@ -888,7 +888,7 @@ export interface SharedObjectKind<out TSharedObject = unknown>
  * See {@link @fluidframework/fluid-static#ContainerSchema} for how this is used in the declarative API.
  * @internal
  */
-export function createSharedObjectKind<TSharedObject>(
+export function createSharedObjectKind<TSharedObject extends IFluidLoadable>(
 	factory: (new () => IChannelFactory<TSharedObject>) & { readonly Type: string },
 ): ISharedObjectKind<TSharedObject> & SharedObjectKind<TSharedObject> {
 	const result: ISharedObjectKind<TSharedObject> &
@@ -898,7 +898,7 @@ export function createSharedObjectKind<TSharedObject>(
 		},
 
 		create(runtime: IFluidDataStoreRuntime, id?: string): TSharedObject {
-			return runtime.createChannel(id, factory.Type) as TSharedObject;
+			return runtime.createChannel(id, factory.Type) as unknown as TSharedObject;
 		},
 
 		is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject {

--- a/packages/dds/shared-object-base/src/test/createSharedObjectKind.spec.ts
+++ b/packages/dds/shared-object-base/src/test/createSharedObjectKind.spec.ts
@@ -46,7 +46,7 @@ class SharedFooFactory implements IChannelFactory<IFoo> {
 	}
 }
 
-const SharedFoo = createSharedObjectKind<IFoo>(SharedFooFactory);
+const SharedFoo = createSharedObjectKind<IFoo & IFluidLoadable>(SharedFooFactory);
 
 describe("createSharedObjectKind's return type", () => {
 	it("delegates to runtime.createChannel on creation", () => {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -705,7 +705,7 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
 // @public @sealed
-export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
+export interface SharedObjectKind<out TSharedObject extends IFluidLoadable = IFluidLoadable> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
 }
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.alpha.api.md
@@ -1091,7 +1091,7 @@ export const SharedMap: ISharedObjectKind<ISharedMap> & SharedObjectKind_2<IShar
 export type SharedMap = ISharedMap;
 
 // @public @sealed
-export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
+export interface SharedObjectKind<out TSharedObject extends IFluidLoadable = IFluidLoadable> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
 }
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.public.api.md
@@ -743,7 +743,7 @@ type ScopedSchemaName<TScope extends string | undefined, TName extends number | 
 export { SequencePlace }
 
 // @public @sealed
-export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
+export interface SharedObjectKind<out TSharedObject extends IFluidLoadable = IFluidLoadable> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
 }
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.public.api.md
@@ -705,7 +705,7 @@ export class SchemaFactory<out TScope extends string | undefined = string | unde
 type ScopedSchemaName<TScope extends string | undefined, TName extends number | string> = TScope extends undefined ? `${TName}` : `${TScope}.${TName}`;
 
 // @public @sealed
-export interface SharedObjectKind<out TSharedObject = unknown> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
+export interface SharedObjectKind<out TSharedObject extends IFluidLoadable = IFluidLoadable> extends ErasedType<readonly ["SharedObjectKind", TSharedObject]> {
     is(value: IFluidLoadable): value is IFluidLoadable & TSharedObject;
 }
 

--- a/packages/framework/fluid-static/package.json
+++ b/packages/framework/fluid-static/package.json
@@ -139,6 +139,10 @@
 		"typescript": "~5.4.5"
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"TypeAlias_InitialObjects": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/framework/fluid-static/src/rootDataObject.ts
+++ b/packages/framework/fluid-static/src/rootDataObject.ts
@@ -79,9 +79,7 @@ class RootDataObject
 		const initialObjectsP: Promise<void>[] = [];
 		for (const [id, objectClass] of Object.entries(props.initialObjects)) {
 			const createObject = async (): Promise<void> => {
-				const obj = await this.create<IFluidLoadable>(
-					objectClass as SharedObjectKind<IFluidLoadable>,
-				);
+				const obj = await this.create(objectClass);
 				this.initialObjectsDir.set(id, obj.handle);
 			};
 			initialObjectsP.push(createObject());
@@ -111,9 +109,6 @@ class RootDataObject
 		await Promise.all(loadInitialObjectsP);
 	}
 
-	/**
-	 * {@inheritDoc IRootDataObject.initialObjects}
-	 */
 	public get initialObjects(): LoadableObjectRecord {
 		if (Object.keys(this._initialObjects).length === 0) {
 			throw new Error("Initial Objects were not correctly initialized");
@@ -121,10 +116,7 @@ class RootDataObject
 		return this._initialObjects;
 	}
 
-	/**
-	 * {@inheritDoc IRootDataObject.create}
-	 */
-	public async create<T>(objectClass: SharedObjectKind<T>): Promise<T> {
+	public async create<T extends IFluidLoadable>(objectClass: SharedObjectKind<T>): Promise<T> {
 		const internal = objectClass as unknown as LoadableObjectClass<T & IFluidLoadable>;
 		if (isDataObjectClass(internal)) {
 			return this.createDataObject(internal);

--- a/packages/framework/fluid-static/src/test/fluidContainer.spec.ts
+++ b/packages/framework/fluid-static/src/test/fluidContainer.spec.ts
@@ -42,8 +42,8 @@ export type requireAssignableTo<_A extends B, B> = true;
 	// SharedObjectKind case
 	{
 		type _a = InitialObjects<ContainerSchemaWith<SharedObjectKind>>["item"];
-		type _b = requireAssignableTo<_a, unknown>;
-		type _c = requireAssignableTo<unknown, _a>;
+		type _b = requireAssignableTo<_a, IFluidLoadable>;
+		type _c = requireAssignableTo<IFluidLoadable, _a>;
 	}
 
 	// SharedObject case

--- a/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
+++ b/packages/framework/fluid-static/src/test/types/validateFluidStaticPrevious.generated.ts
@@ -220,6 +220,7 @@ declare type current_as_old_for_Interface_IServiceAudienceEvents = requireAssign
  * typeValidation.broken:
  * "TypeAlias_InitialObjects": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_InitialObjects = requireAssignableTo<TypeOnly<old.InitialObjects<any>>, TypeOnly<current.InitialObjects<any>>>
 
 /*

--- a/packages/framework/fluid-static/src/types.ts
+++ b/packages/framework/fluid-static/src/types.ts
@@ -131,7 +131,7 @@ export interface IRootDataObject extends IProvideRootDataObject {
 	 *
 	 * @typeParam T - The class of the `DataObject` or `SharedObject`.
 	 */
-	create<T>(objectClass: SharedObjectKind<T>): Promise<T>;
+	create<T extends IFluidLoadable>(objectClass: SharedObjectKind<T>): Promise<T>;
 }
 
 /**

--- a/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/handleValidation.spec.ts
@@ -137,7 +137,7 @@ async function dereferenceToTestFluidObject(handle: IFluidHandle): Promise<ITest
 /**
  * IFluidHandle.get() with additional runtime validation that it returns SharedObject of the expected kind.
  */
-async function dereferenceToSharedObject<TSharedObject>(
+async function dereferenceToSharedObject<TSharedObject extends IFluidLoadable>(
 	handle: IFluidHandle,
 	sharedObjectKind: ISharedObjectKind<TSharedObject> & SharedObjectKind<TSharedObject>,
 ): Promise<TSharedObject> {

--- a/packages/tools/devtools/devtools/package.json
+++ b/packages/tools/devtools/devtools/package.json
@@ -158,6 +158,13 @@
 		}
 	},
 	"typeValidation": {
-		"broken": {}
+		"broken": {
+			"Interface_ContainerDevtoolsProps": {
+				"forwardCompat": false
+			},
+			"Interface_DevtoolsProps": {
+				"forwardCompat": false
+			}
+		}
 	}
 }

--- a/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
+++ b/packages/tools/devtools/devtools/src/test/types/validateDevtoolsPrevious.generated.ts
@@ -22,6 +22,7 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Interface_ContainerDevtoolsProps": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ContainerDevtoolsProps = requireAssignableTo<TypeOnly<old.ContainerDevtoolsProps>, TypeOnly<current.ContainerDevtoolsProps>>
 
 /*
@@ -58,6 +59,7 @@ declare type current_as_old_for_TypeAlias_ContainerKey = requireAssignableTo<Typ
  * typeValidation.broken:
  * "Interface_DevtoolsProps": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_DevtoolsProps = requireAssignableTo<TypeOnly<old.DevtoolsProps>, TypeOnly<current.DevtoolsProps>>
 
 /*


### PR DESCRIPTION
`ShareObjectKind` now explicitly requires `IFluidLoadable` as it always implicitly did. Any construct without that support would not be properly handled by `RootDataObject.initializingFirstTime` (had been doing a cast that is no longer required).

Update related constraints.

Update experimental `Signaler` to declare that support, which it already has as a `DataObject`.