### PR TITLE
feat(build-cli): New re-usable flag for parsing version strings

### DIFF
--- a/build-tools/packages/build-cli/docs/modify.md
+++ b/build-tools/packages/build-cli/docs/modify.md
@@ -47,7 +47,8 @@ FLAGS
   -g, --releaseGroup=<option>   (required) Name of a release group.
                                 <options: client|server|azure|build-tools|gitrest|historian>
       --dependencyName=<value>  (required) Name of the dependency (npm package) to update.
-      --version=<value>         (required) Semver range specifier to use when updating the dependency.
+      --version=<value>         (required) A semver version or range specifier (e.g. ^1.2.3) to use when updating the
+                                dependency.
 
 LOGGING FLAGS
   -v, --verbose  Enable verbose logging.

--- a/build-tools/packages/build-cli/src/commands/check/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/check/buildVersion.ts
@@ -8,6 +8,7 @@ import { Package } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
 
 import { PackageCommand } from "../../BasePackageCommand.js";
+import { semverFlag } from "../../flags.js";
 
 export default class CheckBuildVersionCommand extends PackageCommand<
 	typeof CheckBuildVersionCommand
@@ -16,7 +17,7 @@ export default class CheckBuildVersionCommand extends PackageCommand<
 		`Checks that all packages have the same version set in package.json. The packages checked can be filtered by standard criteria. THIS COMMAND IS INTENDED FOR USE IN FLUID FRAMEWORK CI PIPELINES ONLY.`;
 
 	static readonly flags = {
-		version: Flags.string({
+		version: semverFlag({
 			description: "The version against which to check all the packages.",
 			exclusive: ["path"],
 		}),
@@ -46,7 +47,7 @@ export default class CheckBuildVersionCommand extends PackageCommand<
 			const pkg = new Package(path.join(this.flags.path, "package.json"), "none");
 			this.versionToCheck = pkg.version;
 		} else {
-			this.versionToCheck = this.flags.version;
+			this.versionToCheck = this.flags.version.version;
 		}
 	}
 

--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -8,6 +8,7 @@ import { Flags } from "@oclif/core";
 
 import { getIsLatest, getSimpleVersion } from "@fluid-tools/version-tools";
 
+import { semverFlag } from "../../flags.js";
 import { BaseCommand } from "../../library/index.js";
 
 /**
@@ -62,7 +63,7 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
 			default: "none",
 			env: "PACKAGE_TYPES_FIELD",
 		}),
-		fileVersion: Flags.string({
+		fileVersion: semverFlag({
 			description:
 				"Will be used as the version instead of reading from package.json/lerna.json. Used for testing.",
 			hidden: true,
@@ -90,7 +91,7 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
 		let fileVersion = "";
 
 		if (flags.base === undefined) {
-			fileVersion = flags.fileVersion ?? this.getFileVersion();
+			fileVersion = flags.fileVersion?.version ?? this.getFileVersion();
 			if (!fileVersion) {
 				this.error("Missing version in lerna.json/package.json");
 			}

--- a/build-tools/packages/build-cli/src/commands/generate/changelog.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/changelog.ts
@@ -6,12 +6,11 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { fromInternalScheme, isInternalVersionScheme } from "@fluid-tools/version-tools";
 import { FluidRepo, Package } from "@fluidframework/build-tools";
-import { Flags } from "@oclif/core";
 import { command as execCommand } from "execa";
 import { inc } from "semver";
 import { CleanOptions } from "simple-git";
 
-import { checkFlags, releaseGroupFlag } from "../../flags.js";
+import { checkFlags, releaseGroupFlag, semverFlag } from "../../flags.js";
 import { BaseCommand, Repository } from "../../library/index.js";
 import { isReleaseGroup } from "../../releaseGroups.js";
 
@@ -30,7 +29,7 @@ export default class GenerateChangeLogCommand extends BaseCommand<
 		releaseGroup: releaseGroupFlag({
 			required: true,
 		}),
-		version: Flags.string({
+		version: semverFlag({
 			description:
 				"The version for which to generate the changelog. If this is not provided, the version of the package according to package.json will be used.",
 		}),
@@ -57,7 +56,7 @@ export default class GenerateChangeLogCommand extends BaseCommand<
 		const changesetsCalculatedVersion = isInternalVersionScheme(pkgVersion)
 			? fromInternalScheme(pkgVersion)[0].version
 			: inc(pkgVersion, "major");
-		const versionToUse = this.flags.version ?? pkgVersion;
+		const versionToUse = this.flags.version?.version ?? pkgVersion;
 
 		// Replace the changeset version with the correct version.
 		await replaceInFile(

--- a/build-tools/packages/build-cli/src/commands/modify/lockfile.ts
+++ b/build-tools/packages/build-cli/src/commands/modify/lockfile.ts
@@ -38,7 +38,8 @@ export default class UpdateDependencyInLockfileCommand extends BaseCommand<
 			required: true,
 		}),
 		version: Flags.string({
-			description: "A semver version or range specifier (e.g. ^1.2.3) to use when updating the dependency.",
+			description:
+				"A semver version or range specifier (e.g. ^1.2.3) to use when updating the dependency.",
 			required: true,
 			// Future improvement: use 'parse:' to validate that this is a valid semver range.
 		}),

--- a/build-tools/packages/build-cli/src/commands/modify/lockfile.ts
+++ b/build-tools/packages/build-cli/src/commands/modify/lockfile.ts
@@ -7,7 +7,7 @@ import { updatePackageJsonFile } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
 import execa from "execa";
 
-import { releaseGroupFlag } from "../../flags.js";
+import { releaseGroupFlag, semverFlag } from "../../flags.js";
 import { BaseCommand } from "../../library/index.js";
 
 /**
@@ -37,7 +37,7 @@ export default class UpdateDependencyInLockfileCommand extends BaseCommand<
 			description: "Name of the dependency (npm package) to update.",
 			required: true,
 		}),
-		version: Flags.string({
+		version: semverFlag({
 			description: "Semver range specifier to use when updating the dependency.",
 			required: true,
 			// Future improvement: use 'parse:' to validate that this is a valid semver range.
@@ -55,7 +55,7 @@ export default class UpdateDependencyInLockfileCommand extends BaseCommand<
 
 		// Add override to package.json
 		this.info(
-			`Adding pnpm override for ${this.flags.dependencyName}: ${this.flags.version} to package.json`,
+			`Adding pnpm override for ${this.flags.dependencyName}: ${this.flags.version.version} to package.json`,
 		);
 		updatePackageJsonFile(releaseGroup.directory, (json) => {
 			if (json.pnpm === undefined) {
@@ -73,7 +73,7 @@ export default class UpdateDependencyInLockfileCommand extends BaseCommand<
 					{ exit: 1 },
 				);
 			}
-			json.pnpm.overrides[this.flags.dependencyName] = this.flags.version;
+			json.pnpm.overrides[this.flags.dependencyName] = this.flags.version.version;
 		});
 
 		// Update lockfile

--- a/build-tools/packages/build-cli/src/commands/modify/lockfile.ts
+++ b/build-tools/packages/build-cli/src/commands/modify/lockfile.ts
@@ -7,7 +7,7 @@ import { updatePackageJsonFile } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
 import execa from "execa";
 
-import { releaseGroupFlag, semverFlag } from "../../flags.js";
+import { releaseGroupFlag } from "../../flags.js";
 import { BaseCommand } from "../../library/index.js";
 
 /**
@@ -37,8 +37,8 @@ export default class UpdateDependencyInLockfileCommand extends BaseCommand<
 			description: "Name of the dependency (npm package) to update.",
 			required: true,
 		}),
-		version: semverFlag({
-			description: "Semver range specifier to use when updating the dependency.",
+		version: Flags.string({
+			description: "A semver version or range specifier (e.g. ^1.2.3) to use when updating the dependency.",
 			required: true,
 			// Future improvement: use 'parse:' to validate that this is a valid semver range.
 		}),
@@ -55,7 +55,7 @@ export default class UpdateDependencyInLockfileCommand extends BaseCommand<
 
 		// Add override to package.json
 		this.info(
-			`Adding pnpm override for ${this.flags.dependencyName}: ${this.flags.version.version} to package.json`,
+			`Adding pnpm override for ${this.flags.dependencyName}: ${this.flags.version} to package.json`,
 		);
 		updatePackageJsonFile(releaseGroup.directory, (json) => {
 			if (json.pnpm === undefined) {
@@ -73,7 +73,7 @@ export default class UpdateDependencyInLockfileCommand extends BaseCommand<
 					{ exit: 1 },
 				);
 			}
-			json.pnpm.overrides[this.flags.dependencyName] = this.flags.version.version;
+			json.pnpm.overrides[this.flags.dependencyName] = this.flags.version;
 		});
 
 		// Update lockfile

--- a/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
+++ b/build-tools/packages/build-cli/src/commands/release/report-unreleased.ts
@@ -9,6 +9,8 @@ import { isInternalTestVersion } from "@fluid-tools/version-tools";
 import type { Logger } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
 import { formatISO } from "date-fns";
+
+import { semverFlag } from "../../flags.js";
 import { BaseCommand, type ReleaseReport, toReportKind } from "../../library/index.js";
 
 export class UnreleasedReportCommand extends BaseCommand<typeof UnreleasedReportCommand> {
@@ -19,7 +21,7 @@ export class UnreleasedReportCommand extends BaseCommand<typeof UnreleasedReport
 		`This command is primarily used to upload reports for non-PR main branch builds so that downstream pipelines can easily consume them.`;
 
 	static readonly flags = {
-		version: Flags.string({
+		version: semverFlag({
 			description:
 				"Version to generate a report for. Typically, this version is the version of a dev build.",
 			required: true,
@@ -52,7 +54,7 @@ export class UnreleasedReportCommand extends BaseCommand<typeof UnreleasedReport
 		try {
 			await generateReleaseReport(
 				fullReleaseReport,
-				flags.version,
+				flags.version.version,
 				flags.outDir,
 				flags.branchName,
 				this.logger,

--- a/build-tools/packages/build-cli/src/flags.ts
+++ b/build-tools/packages/build-cli/src/flags.ts
@@ -79,6 +79,21 @@ export const packageSelectorFlag = Flags.custom({
 });
 
 /**
+ * A re-usable CLI flag to parse semver version strings.
+ */
+export const semverFlag = Flags.custom<semver.SemVer, { loose?: boolean }>({
+	description:
+		"A semantic versioning (semver) version string. Values are verified to be valid semvers during flag parsing.",
+	parse: async (input, _, opts) => {
+		const parsed = semver.parse(input, opts.loose);
+		if (parsed === null) {
+			throw new Error(`Invalid semver: ${input}`);
+		}
+		return parsed;
+	},
+});
+
+/**
  * A re-usable CLI flag to parse semver ranges.
  */
 export const semverRangeFlag = Flags.custom<string | undefined>({

--- a/build-tools/packages/build-cli/src/flags.ts
+++ b/build-tools/packages/build-cli/src/flags.ts
@@ -79,7 +79,7 @@ export const packageSelectorFlag = Flags.custom({
 });
 
 /**
- * A re-usable CLI flag to parse semver version strings.
+ * A re-usable CLI flag to parse semver version strings. Values are verified to be valid semvers during flag parsing.
  */
 export const semverFlag = Flags.custom<semver.SemVer, { loose?: boolean }>({
 	description:


### PR DESCRIPTION
Adds a new custom flag, `semverFlag`, which parses the provided value as a semver. This enables input validation at flag parsing time and ensures that the command receives a semver.SemVer object instead of just a string as the version value.

All commands that had a string-type version flag have been updated to use the new flag.