### PR TITLE
refator: Make e2e tests for OpRoundtripTime telemetry more robust

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/opPerfTelemetry.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/opPerfTelemetry.spec.ts
@@ -3,9 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import { describeCompat, itExpects } from "@fluid-private/test-version-utils";
+import { describeCompat } from "@fluid-private/test-version-utils";
 import { ILoaderProps } from "@fluidframework/container-loader/internal";
 import { type SharedString } from "@fluidframework/sequence/internal";
+import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 import {
 	DataObjectFactoryType,
 	ITestContainerConfig,
@@ -24,10 +25,12 @@ describeCompat(
 	"NoCompat",
 	(getTestObjectProvider, apis) => {
 		const { SharedString } = apis.dds;
+		const mockLogger = new MockLogger();
 
 		const customConfigProvider = createTestConfigProvider();
 		customConfigProvider.set("Fluid.Container.ForceWriteConnection", true);
 		const loaderPropsThatForceWriteConnection: Partial<ILoaderProps> = {
+			logger: mockLogger,
 			configProvider: customConfigProvider,
 		};
 
@@ -35,6 +38,7 @@ describeCompat(
 		const configWithReadConnection: ITestContainerConfig = {
 			fluidDataObjectType: DataObjectFactoryType.Test,
 			registry: [[stringId, SharedString.getFactory()]],
+			loaderProps: { logger: mockLogger },
 		};
 		const configWithWriteConnection = {
 			...configWithReadConnection,
@@ -44,102 +48,96 @@ describeCompat(
 		let provider: ITestObjectProvider;
 		beforeEach("getTestObjectProvider", () => {
 			provider = getTestObjectProvider();
+			// Clear logger passed to loaders so we can validate the expected events correctly within each test
+			mockLogger.clear();
 		});
 
-		itExpects(
-			"Create with read connection and load with read connection",
-			[
-				// Expect one OpRoundtripTime event from each client
+		it("Create with read connection and load with read connection", async () => {
+			// Create container with read-connection
+			const container1 = await provider.makeTestContainer(configWithReadConnection);
+			const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
+			const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+			sharedString1.insertText(0, "a");
+			await provider.ensureSynchronized();
+			mockLogger.assertMatch([
 				{ eventName: "fluid:telemetry:OpRoundtripTime", clientType: "interactive" },
+			]);
+
+			// Load the container with read-connection
+			const container2 = await provider.loadTestContainer(configWithReadConnection);
+			const dataObject2 = (await container2.getEntryPoint()) as ITestFluidObject;
+			const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
+			sharedString2.insertText(0, "b");
+			await provider.ensureSynchronized();
+			mockLogger.assertMatch([
 				{ eventName: "fluid:telemetry:OpRoundtripTime", clientType: "interactive" },
-			],
-			async () => {
-				// Create container with read-connection
-				const container1 = await provider.makeTestContainer(configWithReadConnection);
-				const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
-				const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
-				sharedString1.insertText(0, "a");
+			]);
+		});
 
-				// Load the container with read-connection
-				const container2 = await provider.loadTestContainer(configWithReadConnection);
-				const dataObject2 = (await container2.getEntryPoint()) as ITestFluidObject;
-				const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
-				sharedString2.insertText(0, "b");
-
-				await provider.ensureSynchronized();
-			},
-		);
-
-		itExpects(
-			"Create with read connection and load with write connection",
-			[
-				// Expect one OpRoundtripTime event from each client
+		it("Create with read connection and load with write connection", async () => {
+			// Create container with read-connection
+			const container1 = await provider.makeTestContainer(configWithReadConnection);
+			const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
+			const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+			sharedString1.insertText(0, "a");
+			await provider.ensureSynchronized();
+			mockLogger.assertMatch([
 				{ eventName: "fluid:telemetry:OpRoundtripTime", clientType: "interactive" },
+			]);
+
+			// Load the container with write-connection
+			const container2 = await provider.loadTestContainer(configWithWriteConnection);
+			const dataObject2 = (await container2.getEntryPoint()) as ITestFluidObject;
+			const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
+			sharedString2.insertText(0, "b");
+			await provider.ensureSynchronized();
+			mockLogger.assertMatch([
 				{ eventName: "fluid:telemetry:OpRoundtripTime", clientType: "interactive" },
-			],
-			async () => {
-				// Create container with read-connection
-				const container1 = await provider.makeTestContainer(configWithReadConnection);
-				const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
-				const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
-				sharedString1.insertText(0, "a");
+			]);
+		});
 
-				// Load the container with write-connection
-				const container2 = await provider.loadTestContainer(configWithWriteConnection);
-				const dataObject2 = (await container2.getEntryPoint()) as ITestFluidObject;
-				const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
-				sharedString2.insertText(0, "b");
-
-				await provider.ensureSynchronized();
-			},
-		);
-
-		itExpects(
-			"Create with write connection and load with read connection",
-			[
-				// Expect one OpRoundtripTime event from each client
+		it("Create with write connection and load with read connection", async () => {
+			// Create container with write-connection
+			const container1 = await provider.makeTestContainer(configWithWriteConnection);
+			const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
+			const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+			sharedString1.insertText(0, "a");
+			await provider.ensureSynchronized();
+			mockLogger.assertMatch([
 				{ eventName: "fluid:telemetry:OpRoundtripTime", clientType: "interactive" },
+			]);
+
+			// Load the container with read-connection
+			const container2 = await provider.loadTestContainer(configWithReadConnection);
+			const dataObject2 = (await container2.getEntryPoint()) as ITestFluidObject;
+			const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
+			sharedString2.insertText(0, "b");
+			await provider.ensureSynchronized();
+			mockLogger.assertMatch([
 				{ eventName: "fluid:telemetry:OpRoundtripTime", clientType: "interactive" },
-			],
-			async () => {
-				// Create container with write-connection
-				const container1 = await provider.makeTestContainer(configWithWriteConnection);
-				const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
-				const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
-				sharedString1.insertText(0, "a");
+			]);
+		});
 
-				// Load the container with read-connection
-				const container2 = await provider.loadTestContainer(configWithReadConnection);
-				const dataObject2 = (await container2.getEntryPoint()) as ITestFluidObject;
-				const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
-				sharedString2.insertText(0, "b");
-
-				await provider.ensureSynchronized();
-			},
-		);
-
-		itExpects(
-			"Create with write connection and load with write connection",
-			[
-				// Expect one OpRoundtripTime event from each client
+		it("Create with write connection and load with write connection", async () => {
+			// Create container with write-connection
+			const container1 = await provider.makeTestContainer(configWithWriteConnection);
+			const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
+			const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
+			sharedString1.insertText(0, "a");
+			await provider.ensureSynchronized();
+			mockLogger.assertMatch([
 				{ eventName: "fluid:telemetry:OpRoundtripTime", clientType: "interactive" },
+			]);
+
+			// Load the container with write-connection
+			const container2 = await provider.loadTestContainer(configWithWriteConnection);
+			const dataObject2 = (await container2.getEntryPoint()) as ITestFluidObject;
+			const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
+			sharedString2.insertText(0, "b");
+			await provider.ensureSynchronized();
+			mockLogger.assertMatch([
 				{ eventName: "fluid:telemetry:OpRoundtripTime", clientType: "interactive" },
-			],
-			async () => {
-				// Create container with write-connection
-				const container1 = await provider.makeTestContainer(configWithWriteConnection);
-				const dataObject1 = (await container1.getEntryPoint()) as ITestFluidObject;
-				const sharedString1 = await dataObject1.getSharedObject<SharedString>(stringId);
-				sharedString1.insertText(0, "a");
-
-				// Load the container with write-connection
-				const container2 = await provider.loadTestContainer(configWithWriteConnection);
-				const dataObject2 = (await container2.getEntryPoint()) as ITestFluidObject;
-				const sharedString2 = await dataObject2.getSharedObject<SharedString>(stringId);
-				sharedString2.insertText(0, "b");
-
-				await provider.ensureSynchronized();
-			},
-		);
+			]);
+		});
 	},
 );


### PR DESCRIPTION
## Description

Refactors the tests for robustness. They are trying to validate that a `OpRoundtripTime` log is emitted both when a container is created and when it is loaded. Currently it could happen that if the log was emitted twice during the creation flow and never by the load flow, the test would still pass. Now checks are done more explicitly and at better points during the test execution to prevent this potential false positive (which, for the record, we don't have evidence ever occurred).

Prompted by [this comment](https://github.com/microsoft/FluidFramework/pull/19427/files#r1739294835).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
