### PR TITLE
ci: Bump node version used in CI to 18.20.4

### DIFF
--- a/tools/pipelines/templates/include-use-node-version.yml
+++ b/tools/pipelines/templates/include-use-node-version.yml
@@ -7,7 +7,7 @@ parameters:
 # The node version required. The version must already be installed in the image.
 - name: version
   type: string
-  default: '18.17.1'
+  default: '18.20.4'
 
 steps:
 - task: Bash@3


### PR DESCRIPTION
18.20.4 is the latest node18 version, and it is already contained in our build image. I did not change any of our "engines" fields or dependency versions (for \@types/node, for example) - this _only_ changes the version used to build CI.

My motivation is to unblock #22146.