### PR TITLE
ci: Update workflow permissions

### DIFF
--- a/.github/workflows/required-reviewers-release.yml
+++ b/.github/workflows/required-reviewers-release.yml
@@ -14,6 +14,8 @@ on:
       # This is triggered when the base branch changes; handles the case where you open a PR against one branch
       # then change the base branch to a release branch.
       - edited
+
+      - synchronize
     branches:
       - release/client/**
       - release/server/**
@@ -61,6 +63,10 @@ jobs:
     needs: check_branch
     runs-on: ubuntu-latest
     steps:
+      - name: Debug output
+        if: needs.check_branch.outputs.is_release_branch == true
+        run: |
+          echo "needs.check_branch.outputs.is_release_branch: ${{ needs.check_branch.outputs.is_release_branch }}" >> $GITHUB_STEP_SUMMARY
       - name: Approval is required
         if: needs.check_branch.outputs.is_release_branch == true
         run: |

--- a/.github/workflows/required-reviewers-release.yml
+++ b/.github/workflows/required-reviewers-release.yml
@@ -62,18 +62,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Approval is required
-        if: needs.check_branch.outputs.is_release_branch == 'true'
+        if: needs.check_branch.outputs.is_release_branch == true
         run: |
           echo ":vertical_traffic_light: Approval is required" >> $GITHUB_STEP_SUMMARY
       - name: No special approval requirements
-        if: needs.check_branch.outputs.is_release_branch != 'true'
+        if: needs.check_branch.outputs.is_release_branch != true
         run: |
           echo ":white_check_mark: No special approval required!" >> $GITHUB_STEP_SUMMARY
 
   check_approval:
     name: Approved by required reviewers
     needs: check_branch
-    if: needs.check_branch.outputs.is_release_branch == 'true'
+    if: needs.check_branch.outputs.is_release_branch == true
     runs-on: ubuntu-latest
     steps:
       # release notes: https://github.com/actions/checkout/releases/tag/v4.1.7

--- a/.github/workflows/required-reviewers-release.yml
+++ b/.github/workflows/required-reviewers-release.yml
@@ -36,8 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # This output will be set to true if the target branch is a release branch; false otherwise.
-      is_release_branch: |
-        ${{ steps.is-release-branch.outputs.is_release_branch || steps.not-release-branch.outputs.is_release_branch }}
+      is_release_branch: ${{ steps.is-release-branch.outputs.is_release_branch || steps.not-release-branch.outputs.is_release_branch }}
     steps:
       - name: Target is a release branch
         id: is-release-branch
@@ -67,18 +66,18 @@ jobs:
         run: |
           echo "needs.check_branch.outputs.is_release_branch: ${{ needs.check_branch.outputs.is_release_branch }}" >> $GITHUB_STEP_SUMMARY
       - name: Approval is required
-        if: needs.check_branch.outputs.is_release_branch == true
+        if: needs.check_branch.outputs.is_release_branch == 'true'
         run: |
           echo ":vertical_traffic_light: Approval is required" >> $GITHUB_STEP_SUMMARY
       - name: No special approval requirements
-        if: needs.check_branch.outputs.is_release_branch != true
+        if: needs.check_branch.outputs.is_release_branch != 'true'
         run: |
           echo ":white_check_mark: No special approval required!" >> $GITHUB_STEP_SUMMARY
 
   check_approval:
     name: Approved by required reviewers
     needs: [check_branch, not_release_branch]
-    if: needs.check_branch.outputs.is_release_branch == true
+    if: needs.check_branch.outputs.is_release_branch == 'true'
     runs-on: ubuntu-latest
     steps:
       # release notes: https://github.com/actions/checkout/releases/tag/v4.1.7

--- a/.github/workflows/required-reviewers-release.yml
+++ b/.github/workflows/required-reviewers-release.yml
@@ -79,6 +79,7 @@ jobs:
     needs: [check_branch, not_release_branch]
     if: needs.check_branch.outputs.is_release_branch == 'true'
     runs-on: ubuntu-latest
+
     steps:
       # release notes: https://github.com/actions/checkout/releases/tag/v4.1.7
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # ratchet:actions/checkout@v4
@@ -121,7 +122,9 @@ jobs:
 
       - name: Check PR approval
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The standard token doesn't have org:read permissions, and that scope can't be added using permissions in
+          # the workflow.
+          GITHUB_TOKEN: ${{ secrets.ORGANIZATION_READ_PAT }}
         run: |
           # This command will fail with an error if the PR is not approved, which
           # will in turn cause the CI job to fail.

--- a/.github/workflows/required-reviewers-release.yml
+++ b/.github/workflows/required-reviewers-release.yml
@@ -15,6 +15,7 @@ on:
       # then change the base branch to a release branch.
       - edited
 
+      # This is triggered when the PR branch has new commits pushed to it.
       - synchronize
     branches:
       - release/client/**

--- a/.github/workflows/required-reviewers-release.yml
+++ b/.github/workflows/required-reviewers-release.yml
@@ -77,7 +77,7 @@ jobs:
 
   check_approval:
     name: Approved by required reviewers
-    needs: check_branch
+    needs: [check_branch, not_release_branch]
     if: needs.check_branch.outputs.is_release_branch == true
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/required-reviewers-release.yml
+++ b/.github/workflows/required-reviewers-release.yml
@@ -64,7 +64,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Debug output
-        if: needs.check_branch.outputs.is_release_branch == true
         run: |
           echo "needs.check_branch.outputs.is_release_branch: ${{ needs.check_branch.outputs.is_release_branch }}" >> $GITHUB_STEP_SUMMARY
       - name: Approval is required

--- a/.github/workflows/required-reviewers-release.yml
+++ b/.github/workflows/required-reviewers-release.yml
@@ -63,9 +63,6 @@ jobs:
     needs: check_branch
     runs-on: ubuntu-latest
     steps:
-      - name: Debug output
-        run: |
-          echo "needs.check_branch.outputs.is_release_branch: ${{ needs.check_branch.outputs.is_release_branch }}" >> $GITHUB_STEP_SUMMARY
       - name: Approval is required
         if: needs.check_branch.outputs.is_release_branch == 'true'
         run: |
@@ -80,7 +77,6 @@ jobs:
     needs: [check_branch, not_release_branch]
     if: needs.check_branch.outputs.is_release_branch == 'true'
     runs-on: ubuntu-latest
-
     steps:
       # release notes: https://github.com/actions/checkout/releases/tag/v4.1.7
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # ratchet:actions/checkout@v4


### PR DESCRIPTION
One of the output variables had an empty line in it, which meant the checks weren't getting triggered since the value wasn't the expected one. Also, the GitHub Actions token doesn't have org:read permissions, and those can't be given using the `permissions` block in the workflow, so I created a new narrowly scoped PAT and added it as a secret.