### PR TITLE
Revert exclusion of dist/lib from autoimport paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,8 +9,6 @@
 	// We prefer to use type-only imports, so we want the autoimporter to do that by default.
 	"typescript.preferences.preferTypeOnlyAutoImports": true,
 	"typescript.preferences.autoImportFileExcludePatterns": [
-		"**/dist/**",
-		"**/lib/**",
 		// Avoid suggesting autoimports for the 'previous' version packages which are used for typetesting.
 		"**/node_modules/**/@fluid*/*-previous",
 		"**/node_modules/**/@fluid*/*-previous/*",

--- a/packages/dds/tree/.vscode/Tree.code-workspace
+++ b/packages/dds/tree/.vscode/Tree.code-workspace
@@ -12,8 +12,6 @@
 	"settings": {
 		"search.followSymlinks": false,
 		"typescript.preferences.autoImportFileExcludePatterns": [
-			"**/dist/**",
-			"**/lib/**",
 			// Avoid suggesting autoimports for the 'previous' version packages which are used for typetesting.
 			"**/node_modules/**/@fluid*/*-previous",
 			"**/node_modules/**/@fluid*/*-previous/*"


### PR DESCRIPTION
## Description

These two exclusions cause imports to dependent packages to fail, evidently since VSCode considers the 'correct' import paths for JS in dist/lib to still be included.

Net effect here is we get import paths back, but the correct one needs to be selected:

![image](https://github.com/user-attachments/assets/93834c88-bb6f-4054-a6d8-03a79df73324)

Further investigation in this space would be nice, but while that happens the experience of having too many autoimports is preferable to having none.
