### PR TITLE
Revert "Enable noUncheckedIndexedAccess for routerlicious-driver" and disable noUncheckedIndexedAccess

### DIFF
--- a/packages/drivers/routerlicious-driver/src/createNewUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/createNewUtils.ts
@@ -12,7 +12,10 @@ import { ISummaryTree, SummaryType } from "@fluidframework/driver-definitions";
  * @returns Modified summary tree where the blob contents could be utf8 string only.
  */
 export function convertSummaryToCreateNewSummary(summary: ISummaryTree): ISummaryTree {
-	for (const [key, summaryObject] of Object.entries(summary.tree)) {
+	const keys = Object.keys(summary.tree);
+	for (const key of keys) {
+		const summaryObject = summary.tree[key];
+
 		switch (summaryObject.type) {
 			case SummaryType.Tree: {
 				summary.tree[key] = convertSummaryToCreateNewSummary(summaryObject);

--- a/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/deltaStorageService.ts
@@ -83,7 +83,7 @@ export class DocumentDeltaStorageService implements IDocumentDeltaStorageService
 					(op) => op.sequenceNumber >= from && op.sequenceNumber < to,
 				);
 				validateMessages("snapshotOps", messages, from, this.logger, false /* strict */);
-				if (messages.length > 0 && messages[0] && messages[0].sequenceNumber === from) {
+				if (messages.length > 0 && messages[0].sequenceNumber === from) {
 					this.snapshotOps = this.snapshotOps.filter((op) => op.sequenceNumber >= to);
 					opsFromSnapshot += messages.length;
 					return { messages, partialResult: true };

--- a/packages/drivers/routerlicious-driver/src/documentService.ts
+++ b/packages/drivers/routerlicious-driver/src/documentService.ts
@@ -299,12 +299,9 @@ export class DocumentService
 		}
 		const fluidResolvedUrl = response.resolvedUrl;
 		this._resolvedUrl = fluidResolvedUrl;
-		// TODO why are we non null asserting here?
-		this.storageUrl = fluidResolvedUrl.endpoints.storageUrl!;
-		// TODO why are we non null asserting here?
-		this.ordererUrl = fluidResolvedUrl.endpoints.ordererUrl!;
-		// TODO why are we non null asserting here?
-		this.deltaStorageUrl = fluidResolvedUrl.endpoints.deltaStorageUrl!;
+		this.storageUrl = fluidResolvedUrl.endpoints.storageUrl;
+		this.ordererUrl = fluidResolvedUrl.endpoints.ordererUrl;
+		this.deltaStorageUrl = fluidResolvedUrl.endpoints.deltaStorageUrl;
 		this.deltaStreamUrl = fluidResolvedUrl.endpoints.deltaStreamUrl ?? this.ordererUrl;
 		return true;
 	}

--- a/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
+++ b/packages/drivers/routerlicious-driver/src/documentServiceFactory.ts
@@ -115,7 +115,6 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			throw new Error("Parsed url should contain tenant and doc Id!!");
 		}
 		const [, tenantId] = parsedUrl.pathname.split("/");
-		assert(tenantId !== undefined, 0x9ac /* "Missing tenant ID!" */);
 
 		if (!isCombinedAppAndProtocolSummary(createNewSummary)) {
 			throw new Error("Protocol and App Summary required in the full summary");
@@ -304,12 +303,10 @@ export class RouterliciousDocumentServiceFactory implements IDocumentServiceFact
 			},
 		);
 
-		// TODO why are we non null asserting here?
-		const storageUrl = fluidResolvedUrl.endpoints.storageUrl!;
-		// TODO why are we non null asserting here?
-		const ordererUrl = fluidResolvedUrl.endpoints.ordererUrl!;
+		const storageUrl = fluidResolvedUrl.endpoints.storageUrl;
+		const ordererUrl = fluidResolvedUrl.endpoints.ordererUrl;
 		const deltaStorageUrl = fluidResolvedUrl.endpoints.deltaStorageUrl;
-		const deltaStreamUrl = fluidResolvedUrl.endpoints.deltaStreamUrl ?? ordererUrl; // backward compatibility
+		const deltaStreamUrl = fluidResolvedUrl.endpoints.deltaStreamUrl || ordererUrl; // backward compatibility
 		if (!ordererUrl || !deltaStorageUrl) {
 			throw new Error(
 				`All endpoints urls must be provided. [ordererUrl:${ordererUrl}][deltaStorageUrl:${deltaStorageUrl}]`,

--- a/packages/drivers/routerlicious-driver/src/r11sSnapshotParser.ts
+++ b/packages/drivers/routerlicious-driver/src/r11sSnapshotParser.ts
@@ -36,8 +36,7 @@ function buildHierarchy(
 		const entryPathBase = entryPath.slice(lastIndex + 1);
 
 		// The flat output is breadth-first so we can assume we see tree nodes prior to their contents
-		// TODO why are we non null asserting here?
-		const node = lookup[entryPathDir]!;
+		const node = lookup[entryPathDir];
 
 		// Add in either the blob or tree
 		if (entry.type === "tree") {
@@ -76,9 +75,8 @@ export function convertWholeFlatSnapshotToSnapshotTreeAndBlobs(
 			blobs.set(blob.id, stringToBuffer(blob.content, blob.encoding ?? "utf-8"));
 		});
 	}
-	// TODO why are we non null asserting here?
-	const flatSnapshotTree = flatSnapshot.trees[0]!;
-	const sequenceNumber = flatSnapshotTree.sequenceNumber;
+	const flatSnapshotTree = flatSnapshot.trees?.[0];
+	const sequenceNumber = flatSnapshotTree?.sequenceNumber;
 	const snapshotTree = buildHierarchy(flatSnapshotTree, treePrefixToRemove);
 
 	return {

--- a/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/shreddedSummaryDocumentStorageService.ts
@@ -98,14 +98,13 @@ export class ShreddedSummaryDocumentStorageService implements IDocumentStorageSe
 
 	public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTreeEx | null> {
 		let requestVersion = version;
-		if (requestVersion === undefined) {
+		if (!requestVersion) {
 			const versions = await this.getVersions(this.id, 1);
-			const firstVersion = versions[0];
-			if (firstVersion === undefined) {
+			if (versions.length === 0) {
 				return null;
 			}
 
-			requestVersion = firstVersion;
+			requestVersion = versions[0];
 		}
 
 		const cachedSnapshotTree = await this.snapshotTreeCache?.get(

--- a/packages/drivers/routerlicious-driver/src/summaryTreeUploadManager.ts
+++ b/packages/drivers/routerlicious-driver/src/summaryTreeUploadManager.ts
@@ -41,7 +41,8 @@ export class SummaryTreeUploadManager implements ISummaryUploadManager {
 		previousFullSnapshot: ISnapshotTreeEx | undefined,
 	): Promise<string> {
 		const entries = await Promise.all(
-			Object.entries(summaryTree.tree).map(async ([key, entry]) => {
+			Object.keys(summaryTree.tree).map(async (key) => {
+				const entry = summaryTree.tree[key];
 				const pathHandle = await this.writeSummaryTreeObject(entry, previousFullSnapshot);
 				const treeEntry: IGitCreateTreeEntry = {
 					mode: getGitMode(entry),
@@ -122,8 +123,8 @@ export class SummaryTreeUploadManager implements ISummaryUploadManager {
 		/** Previous snapshot, subtree relative to this path part */
 		previousSnapshot: ISnapshotTreeEx,
 	): string {
+		assert(path.length > 0, 0x0b3 /* "Expected at least 1 path part" */);
 		const key = path[0];
-		assert(path.length > 0 && key !== undefined, 0x0b3 /* "Expected at least 1 path part" */);
 		if (path.length === 1) {
 			switch (handleType) {
 				case SummaryType.Blob: {
@@ -146,7 +147,6 @@ export class SummaryTreeUploadManager implements ISummaryUploadManager {
 					throw Error(`Unexpected handle summary object type: "${handleType}".`);
 			}
 		}
-		// TODO why are we non null asserting here?
-		return this.getIdFromPathCore(handleType, path.slice(1), previousSnapshot.trees[key]!);
+		return this.getIdFromPathCore(handleType, path.slice(1), previousSnapshot.trees[key]);
 	}
 }

--- a/packages/drivers/routerlicious-driver/src/urlUtils.ts
+++ b/packages/drivers/routerlicious-driver/src/urlUtils.ts
@@ -20,13 +20,11 @@ export const getDiscoveredFluidResolvedUrl = (
 	session: ISession,
 ): IResolvedUrl => {
 	const discoveredOrdererUrl = new URL(session.ordererUrl);
-	// TODO why are we non null asserting here?
-	const deltaStorageUrl = new URL(resolvedUrl.endpoints.deltaStorageUrl!);
+	const deltaStorageUrl = new URL(resolvedUrl.endpoints.deltaStorageUrl);
 	deltaStorageUrl.host = discoveredOrdererUrl.host;
 
 	const discoveredStorageUrl = new URL(session.historianUrl);
-	// TODO why are we non null asserting here?
-	const storageUrl = new URL(resolvedUrl.endpoints.storageUrl!);
+	const storageUrl = new URL(resolvedUrl.endpoints.storageUrl);
 	storageUrl.host = discoveredStorageUrl.host;
 
 	const parsedUrl = new URL(resolvedUrl.url);

--- a/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
+++ b/packages/drivers/routerlicious-driver/src/wholeSummaryDocumentStorageService.ts
@@ -161,14 +161,13 @@ export class WholeSummaryDocumentStorageService implements IDocumentStorageServi
 	// eslint-disable-next-line @rushstack/no-new-null
 	public async getSnapshotTree(version?: IVersion): Promise<ISnapshotTree | null> {
 		let requestVersion = version;
-		if (requestVersion === undefined) {
+		if (!requestVersion) {
 			const versions = await this.getVersions(this.id, 1);
-			const firstVersion = versions[0];
-			if (firstVersion === undefined) {
+			if (versions.length === 0) {
 				return null;
 			}
 
-			requestVersion = firstVersion;
+			requestVersion = versions[0];
 		}
 
 		let normalizedWholeSnapshot = await this.snapshotTreeCache.get(

--- a/packages/drivers/routerlicious-driver/tsconfig.json
+++ b/packages/drivers/routerlicious-driver/tsconfig.json
@@ -6,5 +6,6 @@
 		"rootDir": "./src",
 		"outDir": "./lib",
 		"exactOptionalPropertyTypes": false,
+		"noUncheckedIndexedAccess": false,
 	},
 }

--- a/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
+++ b/packages/drivers/routerlicious-urlResolver/src/urlResolver.ts
@@ -62,17 +62,11 @@ export class RouterliciousUrlResolver implements IUrlResolver {
 			documentId = this.config.documentId;
 			provider = this.config.provider;
 		} else if (path.length >= 4) {
-			// Non null asserting here because of the length check above
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			tenantId = path[2]!;
-			// Non null asserting here because of the length check above
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			documentId = path[3]!;
+			tenantId = path[2];
+			documentId = path[3];
 		} else {
 			tenantId = "fluid";
-			// TODO why are we non null asserting here?
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			documentId = path[2]!;
+			documentId = path[2];
 		}
 
 		const token = await this.getToken();

--- a/packages/drivers/routerlicious-urlResolver/tsconfig.json
+++ b/packages/drivers/routerlicious-urlResolver/tsconfig.json
@@ -6,5 +6,6 @@
 		"rootDir": "./src",
 		"outDir": "./lib",
 		"types": ["node"],
+		"noUncheckedIndexedAccess": false,
 	},
 }


### PR DESCRIPTION
reverts https://github.com/microsoft/FluidFramework/pull/21487
Since we now have a lint rule that replaces our need for noUncheckedIndexedAccess, removing the code we added when enabling noUncheckedIndexedAccess
[AB#11815](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/11815)