### PR TITLE
Revert "Enable noUncheckedIndexedAccess for DDSes excluding tree and merge-tree (#21420)" and disable noUncheckedIndexedAccess

### DIFF
--- a/packages/dds/ink/src/inkCanvas.ts
+++ b/packages/dds/ink/src/inkCanvas.ts
@@ -40,24 +40,21 @@ class Vector {
 }
 
 function drawPolygon(context: CanvasRenderingContext2D, points: IPoint[]) {
-	const firstPoint = points[0];
-	if (firstPoint === undefined) {
+	if (points.length === 0) {
 		return;
 	}
 
 	context.beginPath();
 	// Move to the first point
-	context.moveTo(firstPoint.x, firstPoint.y);
+	context.moveTo(points[0].x, points[0].y);
 
 	// Draw the rest of the segments
 	for (let i = 1; i < points.length; i++) {
-		// Non null asserting, this must exist because the we are iterating through the length of points
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		context.lineTo(points[i]!.x, points[i]!.y);
+		context.lineTo(points[i].x, points[i].y);
 	}
 
 	// And then close the shape
-	context.lineTo(firstPoint.x, firstPoint.y);
+	context.lineTo(points[0].x, points[0].y);
 	context.closePath();
 	context.fill();
 }
@@ -155,10 +152,7 @@ export class InkCanvas {
 		const strokes = this.model.getStrokes();
 
 		// Time of the first operation in stroke 0 is our starting time
-		const startTime = strokes[0]?.points[0]?.time;
-		if (startTime === undefined) {
-			throw new Error("Couldn't get start time");
-		}
+		const startTime = strokes[0].points[0].time;
 		for (const stroke of strokes) {
 			this.animateStroke(stroke, 0, startTime);
 		}
@@ -230,12 +224,8 @@ export class InkCanvas {
 		}
 
 		// Draw the requested stroke
-		// Non null asserting, this must exist because the operationIndex must be less than the length of stroke.points
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const current = stroke.points[operationIndex]!;
-		// Non null asserting, this must exist because its either the first index or operationIndex minus one which is less than the length of stroke.points
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const previous = stroke.points[Math.max(0, operationIndex - 1)]!;
+		const current = stroke.points[operationIndex];
+		const previous = stroke.points[Math.max(0, operationIndex - 1)];
 		const time =
 			operationIndex === 0 ? current.time - startTime : current.time - previous.time;
 
@@ -257,9 +247,7 @@ export class InkCanvas {
 
 		const strokes = this.model.getStrokes();
 		for (const stroke of strokes) {
-			// Non null asserting since previous would not be used if stroke.points is empty
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			let previous = stroke.points[0]!;
+			let previous = stroke.points[0];
 			for (const current of stroke.points) {
 				// For the down, current === previous === stroke.operations[0]
 				this.drawStrokeSegment(stroke.pen, current, previous);
@@ -281,9 +269,7 @@ export class InkCanvas {
 		const stroke = this.model.getStroke(dirtyStrokeId);
 		// If this is the only point in the stroke, we'll use it for both the start and end of the segment
 		const prevPoint =
-			// Non null asserting, this must exist its within the length of stroke.points
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			stroke.points[stroke.points.length - (stroke.points.length >= 2 ? 2 : 1)]!;
+			stroke.points[stroke.points.length - (stroke.points.length >= 2 ? 2 : 1)];
 		this.drawStrokeSegment(stroke.pen, prevPoint, operation.point);
 	}
 }

--- a/packages/dds/ink/src/snapshot.ts
+++ b/packages/dds/ink/src/snapshot.ts
@@ -55,9 +55,7 @@ export class InkData {
 	 * {@inheritDoc IInk.getStroke}
 	 */
 	public getStroke(key: string): IInkStroke {
-		// Non null asserting, it should be okay that a bad key results in an error being thrown
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return this.strokes[this.strokeIndex[key]!]!;
+		return this.strokes[this.strokeIndex[key]];
 	}
 
 	/**

--- a/packages/dds/ink/tsconfig.json
+++ b/packages/dds/ink/tsconfig.json
@@ -5,6 +5,7 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
+		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/dds/map/src/directory.ts
+++ b/packages/dds/map/src/directory.ts
@@ -867,9 +867,7 @@ export class SharedDirectory
 		const nodeList = absolutePath.split(posix.sep);
 		let start = 1;
 		while (start < nodeList.length) {
-			// Non null asserting, this loop only runs while start in in the bounds of the array
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const subDirName = nodeList[start]!;
+			const subDirName = nodeList[start];
 			if (currentParent.isSubDirectoryDeletePending(subDirName)) {
 				return true;
 			}
@@ -1494,10 +1492,7 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 			dirs: this._subdirectories,
 			next(): IteratorResult<[string, IDirectory]> {
 				if (this.index < subdirNames.length) {
-					// Non null asserting, we've checked that the index is inside the bounds of the array.
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					const subdirName = subdirNames[this.index]!;
-					this.index++;
+					const subdirName = subdirNames[this.index++];
 					const subdir = this.dirs.get(subdirName);
 					assert(subdir !== undefined, 0x8ac /* Could not find expected sub-directory. */);
 					return { value: [subdirName, subdir], done: false };
@@ -2188,22 +2183,18 @@ class SubDirectory extends TypedEventEmitter<IDirectoryEvents> implements IDirec
 	): boolean {
 		if (this.pendingClearMessageIds.length > 0) {
 			if (local) {
-				// Remove all pendingMessageIds lower than first pendingClearMessageId.
-				// Non null asserting, because of pendingClearMessageIds length check above
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				const firstPendingClearMessageId = this.pendingClearMessageIds[0]!;
 				assert(
 					localOpMetadata !== undefined &&
 						isKeyEditLocalOpMetadata(localOpMetadata) &&
-						localOpMetadata.pendingMessageId < firstPendingClearMessageId,
+						localOpMetadata.pendingMessageId < this.pendingClearMessageIds[0],
 					0x010 /* "Received out of order storage op when there is an unackd clear message" */,
 				);
+				// Remove all pendingMessageIds lower than first pendingClearMessageId.
+				const lowestPendingClearMessageId = this.pendingClearMessageIds[0];
 				const pendingKeyMessageIdArray = this.pendingKeys.get(op.key);
 				if (pendingKeyMessageIdArray !== undefined) {
 					let index = 0;
-					// Non-null asserting because we maintain that the pendingKeyMessageIdArray will only exist if it is non-empty.
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					while (pendingKeyMessageIdArray[index]! < firstPendingClearMessageId) {
+					while (pendingKeyMessageIdArray[index] < lowestPendingClearMessageId) {
 						index += 1;
 					}
 					const newPendingKeyMessageId = pendingKeyMessageIdArray.splice(index);

--- a/packages/dds/map/src/map.ts
+++ b/packages/dds/map/src/map.ts
@@ -202,22 +202,23 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 		//    and result in non-incremental snapshot.
 		//    This can be improved in the future, without being format breaking change, as loading sequence
 		//    loads all blobs at once and partitioning schema has no impact on that process.
-		for (const [key, { value, type }] of Object.entries(data)) {
-			if (value && value.length >= MinValueSizeSeparateSnapshotBlob) {
+		for (const key of Object.keys(data)) {
+			const value = data[key];
+			if (value.value && value.value.length >= MinValueSizeSeparateSnapshotBlob) {
 				const blobName = `blob${counter}`;
 				counter++;
 				blobs.push(blobName);
 				const content: IMapDataObjectSerializable = {
 					[key]: {
-						type,
-						value: JSON.parse(value) as unknown,
+						type: value.type,
+						value: JSON.parse(value.value) as unknown,
 					},
 				};
 				builder.addBlob(blobName, JSON.stringify(content));
 			} else {
-				currentSize += type.length + 21; // Approximation cost of property header
-				if (value) {
-					currentSize += value.length;
+				currentSize += value.type.length + 21; // Approximation cost of property header
+				if (value.value) {
+					currentSize += value.value.length;
 				}
 
 				if (currentSize > MaxSnapshotBlobSize) {
@@ -229,8 +230,8 @@ export class SharedMap extends SharedObject<ISharedMapEvents> implements IShared
 					currentSize = 0;
 				}
 				headerBlob[key] = {
-					type,
-					value: value === undefined ? undefined : (JSON.parse(value) as unknown),
+					type: value.type,
+					value: value.value === undefined ? undefined : (JSON.parse(value.value) as unknown),
 				};
 			}
 		}

--- a/packages/dds/map/src/mapKernel.ts
+++ b/packages/dds/map/src/mapKernel.ts
@@ -612,9 +612,7 @@ export class MapKernel {
 				assert(
 					localOpMetadata !== undefined &&
 						isMapKeyLocalOpMetadata(localOpMetadata) &&
-						// Non null asserting, above we checked that the length is greater than 0.
-						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-						localOpMetadata.pendingMessageId < this.pendingClearMessageIds[0]!,
+						localOpMetadata.pendingMessageId < this.pendingClearMessageIds[0],
 					0x013 /* "Received out of order op when there is an unackd clear message" */,
 				);
 			}

--- a/packages/dds/map/tsconfig.json
+++ b/packages/dds/map/tsconfig.json
@@ -5,6 +5,7 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
+		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/dds/matrix/src/handlecache.ts
+++ b/packages/dds/matrix/src/handlecache.ts
@@ -40,7 +40,7 @@ export class HandleCache implements IVectorConsumer<Handle> {
 	 * @throws A 'RangeError' if the provided 'position' is out-of-bounds with regards to the
 	 * PermutationVector's length.
 	 */
-	public getHandle(position: number): Handle {
+	public getHandle(position: number) {
 		const index = this.getIndex(position);
 
 		// Perf: To encourage inlining, handling of the 'cacheMiss(..)' case has been extracted
@@ -50,11 +50,7 @@ export class HandleCache implements IVectorConsumer<Handle> {
 		//       checking that 'position' is in bounds until 'cacheMiss(..)'.  This yields an
 		//       ~40% speedup when the position is in the cache (node v12 x64).
 
-		const handle = this.handles[index];
-		if (handle !== undefined) {
-			return handle;
-		}
-		return this.cacheMiss(position);
+		return index < this.handles.length ? this.handles[index] : this.cacheMiss(position);
 	}
 
 	/**
@@ -66,9 +62,7 @@ export class HandleCache implements IVectorConsumer<Handle> {
 		const index = this.getIndex(position);
 		if (index < this.handles.length) {
 			assert(
-				// Non null asserting, above we checked that the index is less than the length.
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				!isHandleValid(this.handles[index]!),
+				!isHandleValid(this.handles[index]),
 				0x018 /* "Trying to insert handle into position with already valid handle!" */,
 			);
 			this.handles[index] = handle;
@@ -95,7 +89,7 @@ export class HandleCache implements IVectorConsumer<Handle> {
 		return handles;
 	}
 
-	private cacheMiss(position: number): Handle {
+	private cacheMiss(position: number) {
 		// Coercing 'position' to an Uint32 allows us to handle a negative 'position' value
 		// with the same logic that handles 'position' >= length.
 		const _position = position >>> 0;
@@ -110,9 +104,7 @@ export class HandleCache implements IVectorConsumer<Handle> {
 		if (_position < this.start) {
 			this.handles = [...this.getHandles(_position, this.start), ...this.handles];
 			this.start = _position;
-			// TODO why are we non null asserting here?
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			return this.handles[0]!;
+			return this.handles[0];
 		} else {
 			ensureRange(_position, this.vector.getLength());
 
@@ -120,9 +112,7 @@ export class HandleCache implements IVectorConsumer<Handle> {
 				...this.handles,
 				...this.getHandles(this.start + this.handles.length, _position + 1),
 			];
-			// TODO why are we non null asserting here?
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			return this.handles[this.handles.length - 1]!;
+			return this.handles[this.handles.length - 1];
 		}
 	}
 

--- a/packages/dds/matrix/src/handlecache.ts
+++ b/packages/dds/matrix/src/handlecache.ts
@@ -83,7 +83,7 @@ export class HandleCache implements IVectorConsumer<Handle> {
 			const { segment, offset } = vector.getContainingSegment(pos);
 			const asPerm = segment as PermutationSegment;
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			handles.push(asPerm.start + offset);
+			handles.push(asPerm.start + offset!);
 		}
 
 		return handles;

--- a/packages/dds/matrix/src/handlecache.ts
+++ b/packages/dds/matrix/src/handlecache.ts
@@ -40,7 +40,7 @@ export class HandleCache implements IVectorConsumer<Handle> {
 	 * @throws A 'RangeError' if the provided 'position' is out-of-bounds with regards to the
 	 * PermutationVector's length.
 	 */
-	public getHandle(position: number) {
+	public getHandle(position: number): Handle {
 		const index = this.getIndex(position);
 
 		// Perf: To encourage inlining, handling of the 'cacheMiss(..)' case has been extracted
@@ -83,13 +83,13 @@ export class HandleCache implements IVectorConsumer<Handle> {
 			const { segment, offset } = vector.getContainingSegment(pos);
 			const asPerm = segment as PermutationSegment;
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			handles.push(asPerm.start + offset!);
+			handles.push(asPerm.start + offset);
 		}
 
 		return handles;
 	}
 
-	private cacheMiss(position: number) {
+	private cacheMiss(position: number): Handle {
 		// Coercing 'position' to an Uint32 allows us to handle a negative 'position' value
 		// with the same logic that handles 'position' >= length.
 		const _position = position >>> 0;

--- a/packages/dds/matrix/src/matrix.ts
+++ b/packages/dds/matrix/src/matrix.ts
@@ -621,9 +621,7 @@ export class SharedMatrix<T = any>
 		const rowCount = inserted.cachedLength;
 		for (let row = rowStart; row < rowStart + rowCount; row++, rowHandle++) {
 			for (let col = 0; col < this.colCount; col++) {
-				// TODO Non null asserting, why is this not null?
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				const colHandle = this.colHandles.getHandle(col)!;
+				const colHandle = this.colHandles.getHandle(col);
 				const value = this.cells.getCell(rowHandle, colHandle);
 				if (this.isAttached() && value !== undefined && value !== null) {
 					this.sendSetCellOp(row, col, value, rowHandle, colHandle);
@@ -647,9 +645,7 @@ export class SharedMatrix<T = any>
 		const colCount = inserted.cachedLength;
 		for (let col = colStart; col < colStart + colCount; col++, colHandle++) {
 			for (let row = 0; row < this.rowCount; row++) {
-				// TODO Non null asserting, why is this not null?
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				const rowHandle = this.rowHandles.getHandle(row)!;
+				const rowHandle = this.rowHandles.getHandle(row);
 				const value = this.cells.getCell(rowHandle, colHandle);
 				if (this.isAttached() && value !== undefined && value !== null) {
 					this.sendSetCellOp(row, col, value, rowHandle, colHandle);

--- a/packages/dds/matrix/src/permutationvector.ts
+++ b/packages/dds/matrix/src/permutationvector.ts
@@ -170,9 +170,7 @@ export class PermutationVector extends Client {
 			0x027 /* "Trying to get handle of out-of-bounds position!" */,
 		);
 
-		// TODO Non null asserting, why is this not null?
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return this.handleCache.getHandle(pos)!;
+		return this.handleCache.getHandle(pos);
 	}
 
 	public getAllocatedHandle(pos: number): Handle {

--- a/packages/dds/matrix/src/sparsearray2d.ts
+++ b/packages/dds/matrix/src/sparsearray2d.ts
@@ -32,9 +32,7 @@ const byte3 = (x32: number): number => (x32 << 24) >>> 24;
 // Given a uint16 returns the corresponding uint32 integer where 0s are
 // interleaved between the original bits. (e.g., 1111... -> 01010101...).
 const interlaceBitsX16 = (x16: number): number =>
-	// TODO Non null asserting, why is this not null?
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	(x8ToInterlacedX16[byte2(x16)]! << 16) | x8ToInterlacedX16[byte3(x16)]!;
+	(x8ToInterlacedX16[byte2(x16)] << 16) | x8ToInterlacedX16[byte3(x16)];
 
 const r0ToMorton16 = (row: number): number => (interlaceBitsX16(row) << 1) >>> 0;
 const c0ToMorton16 = (col: number): number => interlaceBitsX16(col) >>> 0;

--- a/packages/dds/matrix/src/undoprovider.ts
+++ b/packages/dds/matrix/src/undoprovider.ts
@@ -110,9 +110,7 @@ export class VectorUndoProvider {
 				try {
 					if (removedTrackingGroup !== undefined) {
 						while (removedTrackingGroup.size > 0) {
-							// TODO Non null asserting, why is this not null?
-							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-							const tracked = removedTrackingGroup.tracked[0]!;
+							const tracked = removedTrackingGroup.tracked[0];
 							removedTrackingGroup.unlink(tracked);
 							// if there are groups tracked, this in a revert of a remove.
 							// this means we are about to re-insert the row/column
@@ -133,9 +131,7 @@ export class VectorUndoProvider {
 			discard: (): void => {
 				if (removedTrackingGroup !== undefined) {
 					while (removedTrackingGroup.size > 0) {
-						// TODO Non null asserting, why is this not null?
-						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-						removedTrackingGroup.unlink(removedTrackingGroup.tracked[0]!);
+						removedTrackingGroup.unlink(removedTrackingGroup.tracked[0]);
 					}
 				}
 				discardMergeTreeDeltaRevertible(revertibles);

--- a/packages/dds/matrix/tsconfig.json
+++ b/packages/dds/matrix/tsconfig.json
@@ -6,6 +6,7 @@
 		"rootDir": "./src",
 		"outDir": "./lib",
 		"noImplicitAny": true,
+		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/dds/register-collection/src/consensusRegisterCollection.ts
+++ b/packages/dds/register-collection/src/consensusRegisterCollection.ts
@@ -303,9 +303,7 @@ export class ConsensusRegisterCollection<T>
 		}
 
 		// Remove versions that were known to the remote client at the time of write
-		// TODO Non null asserting, why is this not null?
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		while (data.versions.length > 0 && refSeq >= data.versions[0]!.sequenceNumber) {
+		while (data.versions.length > 0 && refSeq >= data.versions[0].sequenceNumber) {
 			data.versions.shift();
 		}
 
@@ -320,9 +318,7 @@ export class ConsensusRegisterCollection<T>
 		} else if (data.versions.length > 0) {
 			assert(
 				// seqNum should always be increasing, except for the case of grouped batches (seqNum will be the same)
-				// TODO Non null asserting, why is this not null?
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				sequenceNumber >= data.versions[data.versions.length - 1]!.sequenceNumber,
+				sequenceNumber >= data.versions[data.versions.length - 1].sequenceNumber,
 				0x071 /* "Versions should naturally be ordered by sequenceNumber" */,
 			);
 		}

--- a/packages/dds/register-collection/tsconfig.json
+++ b/packages/dds/register-collection/tsconfig.json
@@ -5,6 +5,7 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
+		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/dds/sequence/src/intervalCollection.ts
+++ b/packages/dds/sequence/src/intervalCollection.ts
@@ -597,9 +597,7 @@ class IntervalCollectionIterator<TInterval extends ISerializableInterval>
 	public next(): IteratorResult<TInterval> {
 		if (this.index < this.results.length) {
 			return {
-				// TODO Non null asserting, why is this not null?
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				value: this.results[this.index++]!,
+				value: this.results[this.index++],
 				done: false,
 			};
 		}

--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -324,9 +324,7 @@ export function appendSharedStringDeltaToRevertibles(
 				event: IntervalOpType.POSITION_REMOVE,
 				intervals: [],
 				revertibleRefs,
-				// TODO Non null asserting, why is this not null?
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				mergeTreeRevertible: removeRevertibles[0]!,
+				mergeTreeRevertible: removeRevertibles[0],
 			};
 
 			// add an interval for each startInterval, accounting for any corresponding endIntervals
@@ -337,9 +335,7 @@ export function appendSharedStringDeltaToRevertibles(
 				});
 				let endOffset: number | undefined;
 				if (endIntervalIndex !== -1) {
-					// TODO Non null asserting, why is this not null?
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					endOffset = endIntervals[endIntervalIndex]!.offset;
+					endOffset = endIntervals[endIntervalIndex].offset;
 					endIntervals.splice(endIntervalIndex, 1);
 				}
 
@@ -589,9 +585,7 @@ interface RangeInfo {
 // eslint-disable-next-line import/no-deprecated
 class SortedRangeSet extends SortedSet<RangeInfo, string> {
 	protected getKey(item: RangeInfo): string {
-		// TODO Non null asserting, why is this not null?
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return item.ranges[0]!.segment.ordinal;
+		return item.ranges[0].segment.ordinal;
 	}
 }
 

--- a/packages/dds/sequence/src/sequence.ts
+++ b/packages/dds/sequence/src/sequence.ts
@@ -941,9 +941,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 			// Do GC every once in a while...
 			if (
 				this.messagesSinceMSNChange.length > 20 &&
-				// TODO Non null asserting, why is this not null?
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				this.messagesSinceMSNChange[20]!.sequenceNumber < message.minimumSequenceNumber
+				this.messagesSinceMSNChange[20].sequenceNumber < message.minimumSequenceNumber
 			) {
 				this.processMinSequenceNumberChanged(message.minimumSequenceNumber);
 			}
@@ -953,9 +951,7 @@ export abstract class SharedSegmentSequence<T extends ISegment>
 	private processMinSequenceNumberChanged(minSeq: number) {
 		let index = 0;
 		for (; index < this.messagesSinceMSNChange.length; index++) {
-			// TODO Non null asserting, why is this not null?
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			if (this.messagesSinceMSNChange[index]!.sequenceNumber > minSeq) {
+			if (this.messagesSinceMSNChange[index].sequenceNumber > minSeq) {
 				break;
 			}
 		}

--- a/packages/dds/sequence/src/sequenceDeltaEvent.ts
+++ b/packages/dds/sequence/src/sequenceDeltaEvent.ts
@@ -67,15 +67,11 @@ export abstract class SequenceEvent<
 		});
 
 		this.pFirst = new Lazy<ISequenceDeltaRange<TOperation>>(
-			// TODO Non null asserting, why is this not null?
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			() => this.sortedRanges.value.items[0]!,
+			() => this.sortedRanges.value.items[0],
 		);
 
 		this.pLast = new Lazy<ISequenceDeltaRange<TOperation>>(
-			// TODO Non null asserting, why is this not null?
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			() => this.sortedRanges.value.items[this.sortedRanges.value.size - 1]!,
+			() => this.sortedRanges.value.items[this.sortedRanges.value.size - 1],
 		);
 	}
 

--- a/packages/dds/sequence/tsconfig.json
+++ b/packages/dds/sequence/tsconfig.json
@@ -6,6 +6,7 @@
 		"rootDir": "./src",
 		"outDir": "./lib",
 		"noImplicitAny": true,
+		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
 	},
 }

--- a/packages/dds/shared-object-base/tsconfig.json
+++ b/packages/dds/shared-object-base/tsconfig.json
@@ -5,6 +5,7 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
+		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
 	},
 }


### PR DESCRIPTION
This reverts commit c76b99c0faf82c6c2762c503d5d73738e391178a.
Since we now have a lint rule that replaces our need for noUncheckedIndexedAccess, removing the code we added when enabling noUncheckedIndexedAccess
[AB#11815](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/11815)