### PR TITLE
Revert "Enable noUncheckedIndexedAccess for container-runtime (#21488)"

### DIFF
--- a/packages/runtime/container-runtime/src/channelCollection.ts
+++ b/packages/runtime/container-runtime/src/channelCollection.ts
@@ -558,9 +558,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 		return {
 			id: localContext.id,
 			snapshot,
-			// TODO why are we non null asserting here?
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			type: getLocalDataStoreType(localContext)!,
+			type: getLocalDataStoreType(localContext),
 		} satisfies IAttachMessage;
 	}
 
@@ -1111,9 +1109,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 						0x166 /* "BaseSnapshot should be there as detached container loaded from snapshot" */,
 					);
 					dataStoreSummary = convertSnapshotTreeToSummaryTree(
-						// TODO why are we non null asserting here?
-						// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-						getSnapshotTree(this.baseSnapshot).trees[contextId]!,
+						getSnapshotTree(this.baseSnapshot).trees[contextId],
 					);
 				}
 				builder.addWithStats(contextId, dataStoreSummary);
@@ -1322,9 +1318,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 	): readonly string[] {
 		for (const route of sweepReadyDataStoreRoutes) {
 			const pathParts = route.split("/");
-			// TODO why are we non null asserting here?
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const dataStoreId = pathParts[1]!;
+			const dataStoreId = pathParts[1];
 
 			// Ignore sub-data store routes because a data store and its sub-routes are deleted together, so, we only
 			// need to delete the data store.
@@ -1369,9 +1363,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 			if (pathParts.length > 2) {
 				continue;
 			}
-			// TODO why are we non null asserting here?
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const dataStoreId = pathParts[1]!;
+			const dataStoreId = pathParts[1];
 			assert(this.contexts.has(dataStoreId), 0x510 /* No data store with specified id */);
 			tombstonedDataStoresSet.add(dataStoreId);
 		}
@@ -1406,9 +1398,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 	): Promise<readonly string[] | undefined> {
 		// If the node belongs to a data store, return its package path. For DDSes, we return the package path of the
 		// data store that contains it.
-		// TODO why are we non null asserting here?
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const context = this.contexts.get(nodePath.split("/")[1]!);
+		const context = this.contexts.get(nodePath.split("/")[1]);
 		return (await context?.getInitialSnapshotDetails())?.pkg;
 	}
 
@@ -1418,9 +1408,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 	 */
 	public getGCNodeType(nodePath: string): GCNodeType | undefined {
 		const pathParts = nodePath.split("/");
-		// TODO why are we non null asserting here?
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		if (!this.contexts.has(pathParts[1]!)) {
+		if (!this.contexts.has(pathParts[1])) {
 			return undefined;
 		}
 
@@ -1438,9 +1426,7 @@ export class ChannelCollection implements IFluidDataStoreChannel, IDisposable {
 
 	public async request(request: IRequest): Promise<IResponse> {
 		const requestParser = RequestParser.create(request);
-		// TODO why are we non null asserting here?
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const id = requestParser.pathParts[0]!;
+		const id = requestParser.pathParts[0];
 
 		// Differentiate between requesting the dataStore directly, or one of its children
 		const requestForChild = !requestParser.isLeaf(1);

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -2254,13 +2254,9 @@ export class ContainerRuntime
 		let childTree = snapshotTree;
 		for (const part of pathParts) {
 			if (hasIsolatedChannels) {
-				// TODO Why are we non null asserting here
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				childTree = childTree.trees[channelsTreeName]!;
+				childTree = childTree?.trees[channelsTreeName];
 			}
-			// TODO Why are we non null asserting here
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			childTree = childTree.trees[part]!;
+			childTree = childTree?.trees[part];
 		}
 		return childTree;
 	}
@@ -2312,9 +2308,7 @@ export class ContainerRuntime
 			}
 
 			if (id === blobManagerBasePath && requestParser.isLeaf(2)) {
-				// TODO why are we non null asserting here?
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				const blob = await this.blobManager.getBlob(requestParser.pathParts[1]!);
+				const blob = await this.blobManager.getBlob(requestParser.pathParts[1]);
 				return blob
 					? {
 							status: 200,
@@ -3923,9 +3917,7 @@ export class ContainerRuntime
 			// Counting dataStores and handles
 			// Because handles are unchanged dataStores in the current logic,
 			// summarized dataStore count is total dataStore count minus handle count
-			// TODO why are we non null asserting here
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const dataStoreTree = summaryTree.tree[channelsTreeName]!;
+			const dataStoreTree = summaryTree.tree[channelsTreeName];
 
 			assert(dataStoreTree.type === SummaryType.Tree, 0x1fc /* "summary is not a tree" */);
 			const handleCount = Object.values(dataStoreTree.tree).filter(

--- a/packages/runtime/container-runtime/src/gc/garbageCollection.ts
+++ b/packages/runtime/container-runtime/src/gc/garbageCollection.ts
@@ -789,9 +789,7 @@ export class GarbageCollector implements IGarbageCollector {
 				if (gcDataSuperSet.gcNodes[sourceNodeId] === undefined) {
 					gcDataSuperSet.gcNodes[sourceNodeId] = outboundRoutes;
 				} else {
-					// Non null asserting here because we are checking if it is undefined above.
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					gcDataSuperSet.gcNodes[sourceNodeId]!.push(...outboundRoutes);
+					gcDataSuperSet.gcNodes[sourceNodeId].push(...outboundRoutes);
 				}
 				newOutboundRoutesSinceLastRun.push(...outboundRoutes);
 			},

--- a/packages/runtime/container-runtime/src/gc/gcHelpers.ts
+++ b/packages/runtime/container-runtime/src/gc/gcHelpers.ts
@@ -166,9 +166,7 @@ export function concatGarbageCollectionData(
 		if (combinedGCData.gcNodes[id] === undefined) {
 			combinedGCData.gcNodes[id] = Array.from(routes);
 		} else {
-			// Non null asserting here since we are checking if combinedGCData.gcNodes[id] is not undefined above.
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const combinedRoutes = [...routes, ...combinedGCData.gcNodes[id]!];
+			const combinedRoutes = [...routes, ...combinedGCData.gcNodes[id]];
 			combinedGCData.gcNodes[id] = [...new Set(combinedRoutes)];
 		}
 	}
@@ -189,17 +187,13 @@ export async function getGCDataFromSnapshot(
 	for (const key of Object.keys(gcSnapshotTree.blobs)) {
 		// Update deleted nodes blob.
 		if (key === gcDeletedBlobKey) {
-			// Non null asserting here, we can change this to Object.entries later
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			deletedNodes = await readAndParseBlob<string[]>(gcSnapshotTree.blobs[key]!);
+			deletedNodes = await readAndParseBlob<string[]>(gcSnapshotTree.blobs[key]);
 			continue;
 		}
 
 		// Update tombstone blob.
 		if (key === gcTombstoneBlobKey) {
-			// Non null asserting here, we can change this to Object.entries later
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			tombstones = await readAndParseBlob<string[]>(gcSnapshotTree.blobs[key]!);
+			tombstones = await readAndParseBlob<string[]>(gcSnapshotTree.blobs[key]);
 			continue;
 		}
 
@@ -302,9 +296,7 @@ function trimLeadingAndTrailingSlashes(str: string) {
 
 /** Reformats a request URL to match expected format for a GC node path */
 export function urlToGCNodePath(url: string): string {
-	// TODO Why are we non null asserting here
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	return `/${trimLeadingAndTrailingSlashes(url.split("?")[0]!)}`;
+	return `/${trimLeadingAndTrailingSlashes(url.split("?")[0])}`;
 }
 
 /**

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -64,9 +64,7 @@ export class BatchManager {
 	private get referenceSequenceNumber(): number | undefined {
 		return this.pendingBatch.length === 0
 			? undefined
-			: // Non null asserting here since we are checking the length above
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				this.pendingBatch[this.pendingBatch.length - 1]!.referenceSequenceNumber;
+			: this.pendingBatch[this.pendingBatch.length - 1].referenceSequenceNumber;
 	}
 
 	/**
@@ -138,9 +136,7 @@ export class BatchManager {
 			rollback: (process: (message: BatchMessage) => void) => {
 				for (let i = this.pendingBatch.length; i > startPoint; ) {
 					i--;
-					// Non null asserting here since we are iterating though pendingBatch
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					const message = this.pendingBatch[i]!;
+					const message = this.pendingBatch[i];
 					this.batchContentSize -= message.contents?.length ?? 0;
 					process(message);
 				}

--- a/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opCompressor.ts
@@ -47,13 +47,9 @@ export class OpCompressor {
 
 		const messages: BatchMessage[] = [];
 		messages.push({
-			// Non null asserting here because of the length assert above
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			...batch.messages[0]!,
+			...batch.messages[0],
 			contents: JSON.stringify({ packedContents: compressedContent }),
-			// Non null asserting here because of the length assert above
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			metadata: batch.messages[0]!.metadata,
+			metadata: batch.messages[0].metadata,
 			compression: CompressionAlgorithms.lz4,
 		});
 

--- a/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opGroupingManager.ts
@@ -99,9 +99,7 @@ export class OpGroupingManager {
 				length: batch.messages.length,
 				threshold: this.config.opCountThreshold,
 				reentrant: batch.hasReentrantOps,
-				// Non null asserting here because of the length check above
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				referenceSequenceNumber: batch.messages[0]!.referenceSequenceNumber,
+				referenceSequenceNumber: batch.messages[0].referenceSequenceNumber,
 			});
 		}
 		// We expect this will be on the first message, if present at all.
@@ -130,9 +128,7 @@ export class OpGroupingManager {
 			messages: [
 				{
 					metadata: { batchId: groupedBatchId },
-					// TODO why are we non null asserting here?
-					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-					referenceSequenceNumber: batch.messages[0]!.referenceSequenceNumber,
+					referenceSequenceNumber: batch.messages[0].referenceSequenceNumber,
 					contents: serializedContent,
 				},
 			],

--- a/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opSplitter.ts
@@ -134,9 +134,7 @@ export class OpSplitter {
 			0x516 /* Chunk size needs to be smaller than the max batch size */,
 		);
 
-		// Non null asserting here because of the length check above
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		const firstMessage = batch.messages[0]!; // we expect this to be the large compressed op, which needs to be split
+		const firstMessage = batch.messages[0]; // we expect this to be the large compressed op, which needs to be split
 		assert(
 			(firstMessage.contents?.length ?? 0) >= this.chunkSizeInBytes,
 			0x518 /* First message in the batch needs to be chunkable */,
@@ -165,9 +163,7 @@ export class OpSplitter {
 		// The last chunk will be part of the new batch and needs to
 		// preserve the batch metadata of the original batch
 		const lastChunk = chunkToBatchMessage(
-			// Non null asserting here because of the length assert above
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			chunks[chunks.length - 1]!,
+			chunks[chunks.length - 1],
 			batch.referenceSequenceNumber,
 			{ batch: firstMessage.metadata?.batch },
 		);

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -446,9 +446,7 @@ export class Outbox {
 			// Legacy path - supporting old loader versions. Can be removed only when LTS moves above
 			// version that has support for batches (submitBatchFn)
 			assert(
-				// Non null asserting here because of the length check above
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				batch.messages[0]!.compression === undefined,
+				batch.messages[0].compression === undefined,
 				0x5a6 /* Compression should not have happened if the loader does not support it */,
 			);
 

--- a/packages/runtime/container-runtime/src/scheduleManager.ts
+++ b/packages/runtime/container-runtime/src/scheduleManager.ts
@@ -124,9 +124,7 @@ class ScheduleManagerCore {
 			}
 
 			// First message will have the batch flag set to true if doing a batched send
-			// Non null asserting because of the length check above
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const firstMessageMetadata = messages[0]!.metadata as IRuntimeMessageMetadata;
+			const firstMessageMetadata = messages[0].metadata as IRuntimeMessageMetadata;
 			if (!firstMessageMetadata?.batch) {
 				return;
 			}
@@ -138,9 +136,7 @@ class ScheduleManagerCore {
 			}
 
 			// Set the batch flag to false on the last message to indicate the end of the send batch
-			// Non null asserting here because of the length check at the start of the function
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const lastMessage = messages[messages.length - 1]!;
+			const lastMessage = messages[messages.length - 1];
 			// TODO: It's not clear if this shallow clone is required, as opposed to just setting "batch" to false.
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 			lastMessage.metadata = { ...(lastMessage.metadata as any), batch: false };

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNodeUtils.ts
@@ -73,9 +73,7 @@ export class EscapedPath {
 	public static createAndConcat(pathParts: string[]): EscapedPath {
 		let ret = EscapedPath.create(pathParts[0] ?? "");
 		for (let i = 1; i < pathParts.length; i++) {
-			// Non null asserting here since we are iterating over pathParts
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			ret = ret.concat(EscapedPath.create(pathParts[i]!));
+			ret = ret.concat(EscapedPath.create(pathParts[i]));
 		}
 		return ret;
 	}

--- a/packages/runtime/container-runtime/src/summary/summaryFormat.ts
+++ b/packages/runtime/container-runtime/src/summary/summaryFormat.ts
@@ -281,9 +281,7 @@ export async function getFluidDataStoreAttributes(
 ): Promise<ReadFluidDataStoreAttributes> {
 	const attributes = await readAndParse<ReadFluidDataStoreAttributes>(
 		storage,
-		// TODO why are we non null asserting here?
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		snapshot.blobs[dataStoreAttributesBlobName]!,
+		snapshot.blobs[dataStoreAttributesBlobName],
 	);
 	// Use the snapshotFormatVersion to determine how the pkg is encoded in the snapshot.
 	// For snapshotFormatVersion = "0.1" (1) or above, pkg is jsonified, otherwise it is just a string.

--- a/packages/runtime/container-runtime/tsconfig.json
+++ b/packages/runtime/container-runtime/tsconfig.json
@@ -5,6 +5,7 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
+		"noUncheckedIndexedAccess": false,
 		"exactOptionalPropertyTypes": false,
 	},
 }


### PR DESCRIPTION
This reverts commit db45810ced6dd5289799ec21a93181209212c9c4.
Since we now have a lint rule that replaces our need for noUncheckedIndexedAccess, removing the code we added when enabling noUncheckedIndexedAccess
[AB#11815](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/11815)