### PR TITLE
Disable 'migrates after summarizer has connected' test for investigation

### DIFF
--- a/examples/version-migration/separate-container/tests/separateContainer.test.ts
+++ b/examples/version-migration/separate-container/tests/separateContainer.test.ts
@@ -97,6 +97,7 @@ describe("separate-container migration", () => {
 			await page.waitForFunction(() => window["fluidStarted"]);
 		});
 
+		// TODO:AB#14341: Investigate flakiness and re-enable.
 		it.skip("migrates after summarizer has connected", async () => {
 			// Validate the migration status shows "one" initially
 			await Promise.all([

--- a/examples/version-migration/separate-container/tests/separateContainer.test.ts
+++ b/examples/version-migration/separate-container/tests/separateContainer.test.ts
@@ -97,7 +97,7 @@ describe("separate-container migration", () => {
 			await page.waitForFunction(() => window["fluidStarted"]);
 		});
 
-		it("migrates after summarizer has connected", async () => {
+		it.skip("migrates after summarizer has connected", async () => {
 			// Validate the migration status shows "one" initially
 			await Promise.all([
 				page.waitForSelector("#sbs-left .migration-status"),


### PR DESCRIPTION
## Description

Temporarily disables a test that has been regularly failing the `build client pipeline`. 