### PR TITLE
Revert test timeout back to 2 seconds for local server

### DIFF
--- a/packages/test/test-end-to-end-tests/package.json
+++ b/packages/test/test-end-to-end-tests/package.json
@@ -40,7 +40,7 @@
 		"test:realsvc": "npm run test:realsvc:local && npm run test:realsvc:tinylicious",
 		"test:realsvc:frs": "npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=frs --timeout=20s",
 		"test:realsvc:frs:report": "npm run test:realsvc:frs --",
-		"test:realsvc:local": "npm run test:realsvc:run -- --driver=local --timeout=15s && echo TEMP: Revert to 2s when AB#8942 is fixed",
+		"test:realsvc:local": "npm run test:realsvc:run -- --driver=local --timeout=2s",
 		"test:realsvc:local:report": "npm run test:realsvc:local --",
 		"test:realsvc:local:report:full": "cross-env fluid__test__backCompat=FULL npm run test:realsvc:local --",
 		"test:realsvc:odsp": "npm run test:realsvc:run -- --driver=odsp --timeout=20s",


### PR DESCRIPTION
Fixes [AB#8942](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/8942)

Reverts local server e2e test timeout back to 2 seconds.

Depends on this PR: https://github.com/microsoft/FluidFramework/pull/22390