### PR TITLE
tree: Expose and sometimes use stored schema from flex tree

### DIFF
--- a/packages/dds/tree/src/feature-libraries/flex-tree/context.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/context.ts
@@ -9,6 +9,7 @@ import {
 	type FieldKey,
 	type ForestEvents,
 	type TreeFieldStoredSchema,
+	type TreeStoredSchema,
 	anchorSlot,
 	moveToDetachedField,
 } from "../../core/index.js";
@@ -37,7 +38,13 @@ export interface FlexTreeContext extends Listenable<ForestEvents> {
 	 * Schema used within this context.
 	 * All data must conform to these schema.
 	 */
-	readonly schema: FlexTreeSchema;
+	readonly flexSchema: FlexTreeSchema;
+
+	/**
+	 * Schema used within this context.
+	 * All data must conform to these schema.
+	 */
+	readonly schema: TreeStoredSchema;
 
 	// TODO: Add more members:
 	// - transaction APIs
@@ -73,12 +80,12 @@ export class Context implements FlexTreeContext, IDisposable {
 	private disposed = false;
 
 	/**
-	 * @param schema - Schema to use when working with the  tree.
+	 * @param flexSchema - Schema to use when working with the  tree.
 	 * @param checkout - The checkout.
 	 * @param nodeKeyManager - An object which handles node key generation and conversion
 	 */
 	public constructor(
-		public readonly schema: FlexTreeSchema,
+		public readonly flexSchema: FlexTreeSchema,
 		public readonly checkout: ITreeCheckout,
 		public readonly nodeKeyManager: NodeKeyManager,
 	) {
@@ -93,6 +100,10 @@ export class Context implements FlexTreeContext, IDisposable {
 			0x92b /* Cannot create second flex-tree from checkout */,
 		);
 		this.checkout.forest.anchors.slots.set(ContextSlot, this);
+	}
+
+	public get schema(): TreeStoredSchema {
+		return this.checkout.storedSchema;
 	}
 
 	/**
@@ -138,7 +149,7 @@ export class Context implements FlexTreeContext, IDisposable {
 		assert(this.disposed === false, 0x804 /* use after dispose */);
 		const cursor = this.checkout.forest.allocateCursor("root");
 		moveToDetachedField(this.checkout.forest, cursor);
-		const field = makeField(this, this.schema.rootFieldSchema, cursor);
+		const field = makeField(this, this.flexSchema.rootFieldSchema, cursor);
 		cursor.free();
 		return field;
 	}

--- a/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/flexTreeTypes.ts
@@ -8,6 +8,8 @@ import {
 	type ExclusiveMapTree,
 	type FieldKey,
 	type FieldUpPath,
+	type TreeFieldStoredSchema,
+	type TreeNodeSchemaIdentifier,
 	type TreeValue,
 	anchorSlot,
 } from "../../core/index.js";
@@ -39,7 +41,7 @@ export const flexTreeSlot = anchorSlot<FlexTreeNode>();
  */
 export const flexTreeMarker = Symbol("flexTreeMarker");
 
-export function isFlexTreeEntity(t: unknown): t is FlexTreeEntity {
+function isFlexTreeEntity(t: unknown): t is FlexTreeEntity {
 	return typeof t === "object" && t !== null && flexTreeMarker in t;
 }
 
@@ -79,21 +81,13 @@ export interface FlexTreeEntity<out TSchema = unknown> {
 	 * Schema for this entity.
 	 * If well-formed, it must follow this schema.
 	 */
-	readonly schema: TSchema;
+	readonly flexSchema: TSchema;
 
 	/**
 	 * A common context of a "forest" of FlexTrees.
 	 * @remarks This is `undefined` for unhydrated nodes or fields that have not yet been inserted into the tree.
 	 */
 	readonly context?: FlexTreeContext;
-
-	/**
-	 * Iterate through all nodes/fields in this field/node.
-	 *
-	 * @remarks
-	 * No mutations to the current view of the shared tree are permitted during iteration.
-	 */
-	boxedIterator(): IterableIterator<FlexTreeEntity>;
 }
 
 /**
@@ -193,6 +187,12 @@ export interface FlexTreeNode extends FlexTreeEntity<FlexTreeNodeSchema> {
 	 * No guarantees are made regarding the order of the keys returned.
 	 */
 	keys(): IterableIterator<FieldKey>;
+
+	/**
+	 * Schema for this entity.
+	 * If well-formed, it must follow this schema.
+	 */
+	readonly schema: TreeNodeSchemaIdentifier;
 }
 
 /**
@@ -261,6 +261,12 @@ export interface FlexTreeField extends FlexTreeEntity<FlexFieldSchema> {
 	 * Gets the FieldUpPath of a field.
 	 */
 	getFieldPath(): FieldUpPath;
+
+	/**
+	 * Schema for this entity.
+	 * If well-formed, it must follow this schema.
+	 */
+	readonly schema: TreeFieldStoredSchema;
 }
 
 // #region Node Kinds
@@ -277,7 +283,7 @@ export interface FlexTreeField extends FlexTreeEntity<FlexFieldSchema> {
  * This differs from JavaScript Maps which have a subtle distinction between storing undefined as a value in the map and deleting an entry from the map.
  */
 export interface FlexTreeMapNode extends FlexTreeNode {
-	readonly schema: FlexMapNodeSchema;
+	readonly flexSchema: FlexMapNodeSchema;
 }
 
 /**
@@ -299,7 +305,7 @@ export interface FlexTreeMapNode extends FlexTreeNode {
  * putting its semantics half way between this library's "Object" schema and {@link FlexTreeMapNode}.
  */
 export interface FlexTreeObjectNode extends FlexTreeNode {
-	readonly schema: FlexObjectNodeSchema;
+	readonly flexSchema: FlexObjectNodeSchema;
 }
 
 /**
@@ -310,7 +316,7 @@ export interface FlexTreeObjectNode extends FlexTreeNode {
  * Leaf unboxes its content, so in schema aware APIs which do unboxing, the Leaf itself will be skipped over and its value will be returned directly.
  */
 export interface FlexTreeLeafNode<in out TSchema extends LeafNodeSchema> extends FlexTreeNode {
-	readonly schema: TSchema;
+	readonly flexSchema: TSchema;
 
 	/**
 	 * Value stored on this node.

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyEntity.ts
@@ -51,7 +51,7 @@ export abstract class LazyEntity<TSchema = unknown, TAnchor = unknown>
 
 	protected constructor(
 		public readonly context: Context,
-		public readonly schema: TSchema,
+		public readonly flexSchema: TSchema,
 		cursor: ITreeSubscriptionCursor,
 		anchor: TAnchor,
 	) {

--- a/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/lazyField.ts
@@ -13,6 +13,7 @@ import {
 	type FieldUpPath,
 	type ITreeCursorSynchronous,
 	type ITreeSubscriptionCursor,
+	type TreeFieldStoredSchema,
 	type TreeNavigationResult,
 	inCursorNode,
 	iterateCursorField,
@@ -133,6 +134,10 @@ export abstract class LazyField<out TKind extends FlexFieldKind>
 	}
 	public readonly key: FieldKey;
 
+	public get schema(): TreeFieldStoredSchema {
+		return this.flexSchema.stored;
+	}
+
 	/**
 	 * If this field ends its lifetime before the Anchor does, this needs to be invoked to avoid a double free
 	 * if/when the Anchor is destroyed.
@@ -162,20 +167,20 @@ export abstract class LazyField<out TKind extends FlexFieldKind>
 
 	public is<TKind2 extends FlexFieldKind>(kind: TKind2): this is FlexTreeTypedField<TKind2> {
 		assert(
-			this.context.schema.policy.fieldKinds.get(kind.identifier) === kind,
+			this.context.flexSchema.policy.fieldKinds.get(kind.identifier) === kind,
 			"Narrowing must be done to a kind that exists in this context",
 		);
 
-		return this.schema.kind === (kind as unknown);
+		return this.flexSchema.kind === (kind as unknown);
 	}
 
 	public isExactly<TSchema extends FlexFieldSchema>(schema: TSchema): boolean {
 		assert(
-			this.context.schema.policy.fieldKinds.get(schema.kind.identifier) === schema.kind,
+			this.context.flexSchema.policy.fieldKinds.get(schema.kind.identifier) === schema.kind,
 			0x77c /* Narrowing must be done to a kind that exists in this context */,
 		);
 
-		return this.schema.equals(schema);
+		return this.flexSchema.equals(schema);
 	}
 
 	public get parent(): FlexTreeNode | undefined {

--- a/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
+++ b/packages/dds/tree/src/feature-libraries/flex-tree/utilities.ts
@@ -86,8 +86,8 @@ export function getSchemaAndPolicy(nodeOrField: FlexTreeEntity): SchemaAndPolicy
 	}
 
 	return {
-		schema: nodeOrField.context.checkout.storedSchema,
-		policy: nodeOrField.context.schema.policy,
+		schema: nodeOrField.context.schema,
+		policy: nodeOrField.context.flexSchema.policy,
 	};
 }
 

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -218,7 +218,6 @@ export {
 	ContextSlot,
 	// Internal
 	flexTreeMarker,
-	FlexTreeEntityKind,
 	assertFlexTreeEntityNotFreed,
 	flexTreeSlot,
 	getSchemaAndPolicy,

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -231,7 +231,7 @@ export const treeNodeApi: TreeNodeApi = {
 	},
 	shortId(node: TreeNode): number | string | undefined {
 		const flexNode = getOrCreateInnerNode(node);
-		const flexSchema = flexNode.schema;
+		const flexSchema = flexNode.flexSchema;
 		const identifierFieldKeys =
 			flexSchema instanceof FlexObjectNodeSchema ? flexSchema.identifierFieldKeys : [];
 
@@ -299,7 +299,7 @@ function getStoredKey(node: TreeNode): string | number {
 	// Note: the flex domain strictly works with "stored keys", and knows nothing about the developer-facing
 	// "property keys".
 	const parentField = getOrCreateInnerNode(node).parentField;
-	if (parentField.parent.schema.kind.multiplicity === Multiplicity.Sequence) {
+	if (parentField.parent.flexSchema.kind.multiplicity === Multiplicity.Sequence) {
 		// The parent of `node` is an array node
 		return parentField.index;
 	}

--- a/packages/dds/tree/src/simple-tree/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/arrayNode.ts
@@ -827,10 +827,10 @@ abstract class CustomArrayNodeBase<const T extends ImplicitAllowedTypes>
 		validateIndexRange(sourceStart, sourceEnd, source ?? destinationField, "moveRangeToIndex");
 
 		// TODO: determine support for move across different sequence types
-		if (destinationField.schema.types !== undefined && sourceField !== destinationField) {
+		if (sourceField !== destinationField) {
 			for (let i = sourceStart; i < sourceEnd; i++) {
 				const sourceNode = sourceField.boxedAt(i) ?? oob();
-				if (!destinationField.schema.types.has(sourceNode.schema.name)) {
+				if (!destinationField.schema.types.has(sourceNode.schema)) {
 					throw new UsageError("Type in source sequence is not allowed in destination.");
 				}
 			}

--- a/packages/dds/tree/src/simple-tree/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/mapNode.ts
@@ -20,7 +20,7 @@ import {
 	prepareContentForHydration,
 } from "./proxies.js";
 import { getOrCreateInnerNode, type InnerNode } from "./proxyBinding.js";
-import { getSimpleNodeSchema } from "./core/index.js";
+import { getKernel } from "./core/index.js";
 import {
 	createFieldSchema,
 	FieldKind,
@@ -178,11 +178,11 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 		return node.keys();
 	}
 	public set(key: string, value: InsertableTreeNodeFromImplicitAllowedTypes<T>): TreeMapNode {
+		const kernel = getKernel(this);
 		const node = this.innerNode;
-		const classSchema = getSimpleNodeSchema(node.schema);
 		const mapTree = mapTreeFromNodeData(
 			value as InsertableContent | undefined,
-			createFieldSchema(FieldKind.Optional, classSchema.info as ImplicitAllowedTypes),
+			createFieldSchema(FieldKind.Optional, kernel.schema.info as ImplicitAllowedTypes),
 			node.context?.nodeKeyManager,
 			getSchemaAndPolicy(node),
 		);

--- a/packages/dds/tree/src/simple-tree/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/objectNode.ts
@@ -273,13 +273,13 @@ export function setField(
 	}
 
 	switch (field.schema.kind) {
-		case FieldKinds.required: {
+		case FieldKinds.required.identifier: {
 			assert(mapTree !== undefined, 0xa04 /* Cannot set a required field to undefined */);
 			const typedField = field as FlexTreeRequiredField;
 			typedField.editor.set(mapTree);
 			break;
 		}
-		case FieldKinds.optional: {
+		case FieldKinds.optional.identifier: {
 			const typedField = field as FlexTreeOptionalField;
 			typedField.editor.set(mapTree, typedField.length === 0);
 			break;

--- a/packages/dds/tree/src/simple-tree/proxies.ts
+++ b/packages/dds/tree/src/simple-tree/proxies.ts
@@ -42,15 +42,15 @@ export function getTreeNodeForField(field: FlexTreeField): TreeNode | TreeValue 
 			: maybeContent;
 	}
 	switch (field.schema.kind) {
-		case FieldKinds.required: {
+		case FieldKinds.required.identifier: {
 			const typedField = field as FlexTreeRequiredField;
 			return tryToUnboxLeaves(typedField);
 		}
-		case FieldKinds.optional: {
+		case FieldKinds.optional.identifier: {
 			const typedField = field as FlexTreeOptionalField;
 			return tryToUnboxLeaves(typedField);
 		}
-		case FieldKinds.identifier: {
+		case FieldKinds.identifier.identifier: {
 			// Identifier fields are just value fields that hold strings
 			return (field as FlexTreeRequiredField).content as string;
 		}
@@ -66,7 +66,7 @@ export function getOrCreateNodeFromFlexTreeNode(flexNode: FlexTreeNode): TreeNod
 		return cachedProxy;
 	}
 
-	const schema = flexNode.schema;
+	const schema = flexNode.flexSchema;
 	const classSchema = tryGetSimpleNodeSchema(schema);
 	assert(classSchema !== undefined, 0x91b /* node without schema */);
 	if (typeof classSchema === "function") {

--- a/packages/dds/tree/src/simple-tree/toMapTree.ts
+++ b/packages/dds/tree/src/simple-tree/toMapTree.ts
@@ -152,7 +152,9 @@ function nodeDataToMapTree(
 	if (flexNode !== undefined) {
 		if (isMapTreeNode(flexNode)) {
 			if (
-				!allowedTypes.has(tryGetSimpleNodeSchema(flexNode.schema) ?? fail("missing schema"))
+				!allowedTypes.has(
+					tryGetSimpleNodeSchema(flexNode.flexSchema) ?? fail("missing schema"),
+				)
 			) {
 				throw new UsageError("Invalid schema for this context.");
 			}

--- a/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-map-tree/mapTreeNode.spec.ts
@@ -91,16 +91,13 @@ describe("MapTreeNodes", () => {
 	});
 
 	it("can get their schema", () => {
-		assert.equal(map.schema, mapSchema);
-		assert.equal(arrayNode.schema, arrayNodeSchema);
-		assert.equal(object.schema, objectSchema);
-		assert.equal(
-			map.tryGetField(mapKey)?.boxedAt(0)?.schema,
-			getFlexSchema(schemaFactory.string),
-		);
+		assert.equal(map.schema, mapSchema.name);
+		assert.equal(arrayNode.schema, arrayNodeSchema.name);
+		assert.equal(object.schema, objectSchema.name);
+		assert.equal(map.tryGetField(mapKey)?.boxedAt(0)?.schema, schemaFactory.string.identifier);
 		assert.equal(
 			arrayNode.tryGetField(EmptyKey)?.boxedAt(0)?.schema,
-			getFlexSchema(schemaFactory.string),
+			schemaFactory.string.identifier,
 		);
 	});
 

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyField.spec.ts
@@ -272,7 +272,7 @@ describe("LazyOptionalField", () => {
 
 		it("boxedAt", () => {
 			const boxedResult = field.boxedAt(0) ?? assert.fail();
-			assert.equal(boxedResult.schema, getFlexSchema(numberSchema));
+			assert.equal(boxedResult.schema, numberSchema.identifier);
 			assert.equal(boxedResult.value, 42);
 		});
 
@@ -362,7 +362,7 @@ describe("LazyValueField", () => {
 
 	it("boxedAt", () => {
 		const boxedResult = field.boxedAt(0) ?? assert.fail();
-		assert.equal(boxedResult.schema, getFlexSchema(stringSchema));
+		assert.equal(boxedResult.schema, stringSchema.identifier);
 		assert.equal(boxedResult.value, initialTree);
 	});
 
@@ -439,15 +439,15 @@ describe("LazySequence", () => {
 	it("boxedAt", () => {
 		const sequence = testSequence([37, 42]);
 		const boxedResult0 = sequence.boxedAt(0) ?? assert.fail();
-		assert.equal(boxedResult0.schema, getFlexSchema(numberSchema));
+		assert.equal(boxedResult0.schema, numberSchema.identifier);
 		assert.equal(boxedResult0.value, 37);
 
 		const boxedResult1 = sequence.boxedAt(1) ?? assert.fail();
-		assert.equal(boxedResult1.schema, getFlexSchema(numberSchema));
+		assert.equal(boxedResult1.schema, numberSchema.identifier);
 		assert.equal(boxedResult1.value, 42);
 
 		const boxedResultNeg1 = sequence.boxedAt(-1) ?? assert.fail();
-		assert.equal(boxedResultNeg1.schema, getFlexSchema(numberSchema));
+		assert.equal(boxedResultNeg1.schema, numberSchema.identifier);
 		assert.equal(boxedResultNeg1.value, 42);
 
 		assert.equal(sequence.boxedAt(2), undefined);

--- a/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyNode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/flex-tree/lazyNode.spec.ts
@@ -210,5 +210,5 @@ function nodeToMapTree(node: FlexTreeNode): MapTree {
 		fields.set(field.key, fieldToMapTree(field));
 	}
 
-	return { fields, type: node.schema.name, value: node.value };
+	return { fields, type: node.schema, value: node.value };
 }


### PR DESCRIPTION
## Description

Part of the migration away from having and using flex tree schema. This migrates several usages to stored schema. Once all usages are migrated, the flex tree schema system can be removed.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

